### PR TITLE
setup/tooling: skill-apply heading-ordinal strip, headless browser URL surfacing, inherit-script extraction

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -247,3 +247,53 @@ describe('stripInternalTags', () => {
     );
   });
 });
+
+describe('app_context rendering (Slack agent mode, contract C4)', () => {
+  it('renders a compact single (viewing: …) line inside the message block', () => {
+    insertMessage('m1', 'chat-sdk', {
+      sender: 'Gavriel',
+      text: 'what do you think?',
+      app_context: { entities: [{ type: 'channel', id: 'C0DESIGN' }] },
+    });
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain('what do you think?\n(viewing: channel C0DESIGN)</message>');
+  });
+
+  it('joins multiple entities in order with commas', () => {
+    insertMessage('m1', 'chat-sdk', {
+      sender: 'Gavriel',
+      text: 'here',
+      app_context: {
+        entities: [
+          { type: 'channel', id: 'C0DESIGN' },
+          { type: 'canvas', id: 'F0CANVAS' },
+        ],
+      },
+    });
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain('(viewing: channel C0DESIGN, canvas F0CANVAS)');
+  });
+
+  it('renders nothing for absent, empty, or malformed app_context', () => {
+    insertMessage('m1', 'chat-sdk', { sender: 'A', text: 'no context' });
+    insertMessage('m2', 'chat-sdk', { sender: 'A', text: 'empty', app_context: { entities: [] } });
+    insertMessage('m3', 'chat-sdk', { sender: 'A', text: 'malformed', app_context: 'C0DESIGN' });
+    insertMessage('m4', 'chat-sdk', {
+      sender: 'A',
+      text: 'idless',
+      app_context: { entities: [{ type: 'channel' }] },
+    });
+    const result = formatMessages(getPendingMessages());
+    expect(result).not.toContain('(viewing:');
+  });
+
+  it('escapes XML-significant characters in entity values', () => {
+    insertMessage('m1', 'chat-sdk', {
+      sender: 'A',
+      text: 'x',
+      app_context: { entities: [{ type: 'channel', id: 'C1<&>' }] },
+    });
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain('(viewing: channel C1&lt;&amp;&gt;)');
+  });
+});

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -180,10 +180,11 @@ function formatSingleChat(msg: MessageInRow): string {
   const replyAttr = content.replyTo?.id ? ` reply_to="${escapeXml(String(content.replyTo.id))}"` : '';
   const replyPrefix = formatReplyContext(content.replyTo);
   const attachmentsSuffix = formatAttachments(content.attachments);
+  const appContextSuffix = formatAppContext(content.app_context);
 
   const fromAttr = originAttr(msg);
 
-  return `<message${idAttr}${fromAttr} sender="${escapeXml(sender)}" time="${escapeXml(time)}"${replyAttr}>${replyPrefix}${escapeXml(text)}${attachmentsSuffix}</message>`;
+  return `<message${idAttr}${fromAttr} sender="${escapeXml(sender)}" time="${escapeXml(time)}"${replyAttr}>${replyPrefix}${escapeXml(text)}${attachmentsSuffix}${appContextSuffix}</message>`;
 }
 
 /**
@@ -268,6 +269,24 @@ function formatReplyContext(replyTo: any): string {
   const text = replyTo.text;
   if (!sender || !text) return '';
   return `\n  <quoted_message from="${escapeXml(sender)}">${escapeXml(text)}</quoted_message>\n`;
+}
+
+/**
+ * Render agent-mode app context — the entities the user was viewing when
+ * they sent this message (content.app_context = { entities: [{ type, id },
+ * …] }, attached by the chat-sdk bridge). One compact line inside the
+ * message block; malformed/empty context renders nothing.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatAppContext(appContext: any): string {
+  if (!appContext || !Array.isArray(appContext.entities)) return '';
+  const items = appContext.entities
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((e: any) => typeof e?.type === 'string' && e.type && typeof e?.id === 'string' && e.id)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((e: any) => `${e.type} ${e.id}`);
+  if (items.length === 0) return '';
+  return `\n(viewing: ${escapeXml(items.join(', '))})`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -394,7 +394,17 @@ function proseFor(md: string, fenceLine1: number): string {
 function headingAbove(md: string, fenceLine1: number): string {
   const lines = md.split('\n');
   for (let h = fenceLine1 - 2; h >= 0; h--) {
-    if (lines[h].startsWith('#')) return lines[h].replace(/^#+\s*/, '').trim();
+    if (lines[h].startsWith('#')) {
+      // Drop a leading authoring ordinal ("### 2. Copy the adapter" → "Copy the
+      // adapter"). Those numbers index the SKILL.md for a READER; as step
+      // captions they are actively wrong. A skipped step leaves a hole (1, 3,
+      // 4…), a heading with several directives repeats its number, headings
+      // without one render bare, and a flow that applies several skills in
+      // sequence restarts the count mid-run — so the operator sees
+      // "1, 3, 4, 4, Restart, 2, 4". The engine's own (i/n) suffix
+      // (labelOrdinals) already disambiguates repeats, and it stays correct.
+      return lines[h].replace(/^#+\s*/, '').replace(/^\d+[.)]\s+/, '').trim();
+    }
   }
   return '';
 }

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -34,6 +34,7 @@ import k from 'kleur';
 
 import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runChannelSkill } from './channels/run-channel-skill.js';
+import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
@@ -1896,37 +1897,6 @@ function detectExistingOnecli(): { version: string; apiHost: string } | null {
   } catch {
     return null;
   }
-}
-
-function runInheritScript(cmd: string, args: string[]): Promise<number> {
-  return new Promise((resolve) => {
-    // Hand the terminal over before spawning, or the child's first prompt eats
-    // a keystroke that never reaches it.
-    //
-    // `stdio: 'inherit'` gives the child our own fd 0 — the same file
-    // description, not a copy. clack leaves stdin resumed between prompts and
-    // puts the TTY in raw mode during one, so this process is still reading
-    // that fd when the child starts. Bytes it pulls in are buffered here and
-    // are gone as far as the child is concerned, which is why "Press Enter"
-    // needed pressing twice: the first went to a parent nobody was asking.
-    const tty = Boolean(process.stdin.isTTY);
-    const wasRaw = tty && process.stdin.isRaw;
-    if (wasRaw) process.stdin.setRawMode(false);
-    process.stdin.pause();
-
-    // Tells the child it has a UI in front of it, so it can leave the
-    // reporting to us instead of printing its own alongside ours.
-    const child = spawn(cmd, args, {
-      stdio: 'inherit',
-      env: { ...process.env, NANOCLAW_SETUP_WIZARD: '1' },
-    });
-    child.on('close', (code) => {
-      // Deliberately not restoring raw mode: clack sets it per prompt, and
-      // handing it back a cooked TTY is the state it expects to find.
-      process.stdin.resume();
-      resolve(code ?? 1);
-    });
-  });
 }
 
 /**

--- a/setup/lib/browser.ts
+++ b/setup/lib/browser.ts
@@ -71,7 +71,15 @@ export async function confirmThenOpen(
   url: string,
   message = 'Press Enter to open your browser',
 ): Promise<void> {
-  if (isHeadless()) return;
+  if (isHeadless()) {
+    // No browser to open here — ALWAYS surface the URL itself, and print it
+    // RAW on stdout: clack notes wrap long lines and inject gutter pipes and
+    // spaces mid-URL, breaking copy-paste (live-hit). Plain stdout is the
+    // only rendering that keeps the URL contiguous.
+    p.log.info('Open this URL in a browser on any device:');
+    process.stdout.write(`\n${url}\n\n`);
+    return;
+  }
   const fallback = `\n${k.dim(`If browser does not appear, please visit: ${url}`)}`;
   ensureAnswer(
     await p.confirm({

--- a/setup/lib/inherit-script.ts
+++ b/setup/lib/inherit-script.ts
@@ -1,0 +1,37 @@
+import { spawn } from 'child_process';
+
+/**
+ * Run a script with the terminal handed over (inherited stdio). Extracted from
+ * setup/auto.ts so channel flows can reuse it without importing the driver.
+ *
+ * Hand the terminal over before spawning, or the child's first prompt eats
+ * a keystroke that never reaches it.
+ *
+ * `stdio: 'inherit'` gives the child our own fd 0 — the same file
+ * description, not a copy. clack leaves stdin resumed between prompts and
+ * puts the TTY in raw mode during one, so this process is still reading
+ * that fd when the child starts. Bytes it pulls in are buffered here and
+ * are gone as far as the child is concerned, which is why "Press Enter"
+ * needed pressing twice: the first went to a parent nobody was asking.
+ */
+export function runInheritScript(cmd: string, args: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const tty = Boolean(process.stdin.isTTY);
+    const wasRaw = tty && process.stdin.isRaw;
+    if (wasRaw) process.stdin.setRawMode(false);
+    process.stdin.pause();
+
+    // Tells the child it has a UI in front of it, so it can leave the
+    // reporting to us instead of printing its own alongside ours.
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env: { ...process.env, NANOCLAW_SETUP_WIZARD: '1' },
+    });
+    child.on('close', (code) => {
+      // Deliberately not restoring raw mode: clack sets it per prompt, and
+      // handing it back a cooked TTY is the state it expects to find.
+      process.stdin.resume();
+      resolve(code ?? 1);
+    });
+  });
+}

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -56,11 +56,11 @@ interface RegisterArgs {
   /** Explicit engage mode override; omitted = channel declaration / heuristic */
   engageMode?: 'pattern' | 'mention' | 'mention-sticky';
   /** Explicit unknown_sender_policy override; omitted = channel declaration / 'strict' */
-  unknownSenderPolicy?: 'strict' | 'request_approval' | 'public';
+  unknownSenderPolicy?: 'strict' | 'request_approval' | 'decline_notify' | 'public';
 }
 
 const ENGAGE_MODES = ['pattern', 'mention', 'mention-sticky'] as const;
-const SENDER_POLICIES = ['strict', 'request_approval', 'public'] as const;
+const SENDER_POLICIES = ['strict', 'request_approval', 'decline_notify', 'public'] as const;
 
 function parseArgs(args: string[]): RegisterArgs {
   const result: RegisterArgs = {

--- a/src/channels/adapter-hot-start.test.ts
+++ b/src/channels/adapter-hot-start.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Pins the slack-agent-flow hot-start seam in channel-registry.ts:
+ * the `hotStartSetupFn` capture in initChannelAdapters plus the
+ * `startChannelAdapter` export. The seam is installed by the
+ * slack-agent-flow skill's registry edit — a red run here means that
+ * edit is missing (or an upstream update dropped it).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { ChannelAdapter, ChannelSetup } from './adapter.js';
+
+/** Fake adapter recording every setup() config so tests can assert identity
+ *  with the object the captured setupFn produced. */
+function createFakeAdapter(channelType: string, instance?: string): ChannelAdapter & { setupConfigs: ChannelSetup[] } {
+  const setupConfigs: ChannelSetup[] = [];
+  return {
+    name: instance ?? channelType,
+    channelType,
+    instance,
+    supportsThreads: false,
+    setupConfigs,
+    async setup(config: ChannelSetup) {
+      setupConfigs.push(config);
+    },
+    async teardown() {},
+    isConnected() {
+      return setupConfigs.length > 0;
+    },
+    async deliver() {
+      return undefined;
+    },
+  };
+}
+
+/** setupFn stand-in that memoizes its per-adapter return value, so tests can
+ *  assert the adapter's setup() received exactly setupFn(adapter)'s result. */
+function createSetupFn() {
+  const byAdapter = new Map<ChannelAdapter, ChannelSetup>();
+  const setupFn = (adapter: ChannelAdapter): ChannelSetup => {
+    const setup: ChannelSetup = {
+      onInbound() {},
+      onInboundEvent() {},
+      onMetadata() {},
+      onAction() {},
+    };
+    byAdapter.set(adapter, setup);
+    return setup;
+  };
+  return { setupFn, byAdapter };
+}
+
+describe('startChannelAdapter (hot-start seam)', () => {
+  // The registry and activeAdapters maps are module-level, as is the captured
+  // hotStartSetupFn — fresh module per test so ordering can't leak state.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    const { teardownChannelAdapters } = await import('./channel-registry.js');
+    await teardownChannelAdapters();
+    vi.resetModules();
+  });
+
+  it('throws before initChannelAdapters has run', async () => {
+    const reg = await import('./channel-registry.js');
+    reg.registerChannelAdapter('slack-hot', { factory: () => createFakeAdapter('slack', 'slack-hot') });
+
+    await expect(reg.startChannelAdapter('slack-hot')).rejects.toThrow(
+      'startChannelAdapter: initChannelAdapters has not run',
+    );
+  });
+
+  it('throws on a key with no registration', async () => {
+    const reg = await import('./channel-registry.js');
+    await reg.initChannelAdapters(createSetupFn().setupFn);
+
+    await expect(reg.startChannelAdapter('slack-ghost')).rejects.toThrow(
+      "startChannelAdapter: no registration for 'slack-ghost'",
+    );
+  });
+
+  it('hot-starts a post-init registration with the captured setupFn', async () => {
+    const reg = await import('./channel-registry.js');
+    const { setupFn, byAdapter } = createSetupFn();
+    await reg.initChannelAdapters(setupFn);
+
+    // Registered AFTER boot — the exact shape of a freshly provisioned instance.
+    const adapter = createFakeAdapter('slack', 'slack-hot');
+    reg.registerChannelAdapter('slack-hot', { factory: () => adapter });
+
+    await expect(reg.startChannelAdapter('slack-hot')).resolves.toBe('started');
+    expect(reg.getChannelAdapterExact('slack-hot')).toBe(adapter);
+    expect(adapter.setupConfigs).toHaveLength(1);
+    expect(adapter.setupConfigs[0]).toBe(byAdapter.get(adapter));
+  });
+
+  it('returns already-active on a second call without re-running setup', async () => {
+    const reg = await import('./channel-registry.js');
+    await reg.initChannelAdapters(createSetupFn().setupFn);
+    const adapter = createFakeAdapter('slack', 'slack-hot');
+    reg.registerChannelAdapter('slack-hot', { factory: () => adapter });
+
+    await expect(reg.startChannelAdapter('slack-hot')).resolves.toBe('started');
+    await expect(reg.startChannelAdapter('slack-hot')).resolves.toBe('already-active');
+    expect(adapter.setupConfigs).toHaveLength(1);
+  });
+
+  it('returns no-credentials when the factory yields null', async () => {
+    const reg = await import('./channel-registry.js');
+    await reg.initChannelAdapters(createSetupFn().setupFn);
+    reg.registerChannelAdapter('slack-nocreds', { factory: () => null });
+
+    await expect(reg.startChannelAdapter('slack-nocreds')).resolves.toBe('no-credentials');
+    expect(reg.getChannelAdapterExact('slack-nocreds')).toBeUndefined();
+  });
+
+  it('retries setup on NetworkError and still starts', async () => {
+    vi.useFakeTimers();
+    const reg = await import('./channel-registry.js');
+    await reg.initChannelAdapters(createSetupFn().setupFn);
+
+    const base = createFakeAdapter('slack', 'slack-flaky');
+    let attempts = 0;
+    const adapter: typeof base = {
+      ...base,
+      async setup(config: ChannelSetup) {
+        attempts += 1;
+        if (attempts === 1) {
+          const err = new Error('socket hiccup');
+          err.name = 'NetworkError';
+          throw err;
+        }
+        base.setupConfigs.push(config);
+      },
+    };
+    reg.registerChannelAdapter('slack-flaky', { factory: () => adapter });
+
+    const pending = reg.startChannelAdapter('slack-flaky');
+    // First retry delay is 2000ms — advance past it so the second attempt runs.
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect(pending).resolves.toBe('started');
+    expect(attempts).toBe(2);
+    expect(reg.getChannelAdapterExact('slack-flaky')).toBe(adapter);
+  });
+});

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -138,8 +138,11 @@ export interface ChannelContextDefaults {
   /**
    * unknown_sender_policy stamped on messaging_groups rows auto-created by
    * the router or created by wizard/CLI paths in this context.
+   * 'decline_notify' (DM-shaped channels): the host politely declines the
+   * unknown sender in-channel and sends the owner a one-line FYI — no
+   * approval card; access grants stay explicit (`ncl members add`).
    */
-  unknownSenderPolicy: 'strict' | 'request_approval' | 'public';
+  unknownSenderPolicy: 'strict' | 'request_approval' | 'decline_notify' | 'public';
 }
 
 /**

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -200,9 +200,31 @@ export interface ChannelAdapter {
   deliver(platformId: string, threadId: string | null, message: OutboundMessage): Promise<string | undefined>;
 
   // Optional
-  setTyping?(platformId: string, threadId: string | null): Promise<void>;
+  setTyping?(
+    platformId: string,
+    threadId: string | null,
+    status?: string,
+    statusKind?: 'auto' | 'agent',
+  ): Promise<void>;
   syncConversations?(): Promise<ConversationInfo[]>;
   resolveChannelName?(platformId: string): Promise<string | null>;
+
+  /**
+   * Set a human-readable title on a conversation thread. Platforms with a
+   * thread-title concept render this in the conversation list; the router
+   * fires it once when a brand-new per-thread DM session is created, titled
+   * after the first user message.
+   *
+   * Only adapters whose platform has a thread-title concept expose this —
+   * everyone else omits it and callers no-op via optional chaining
+   * (setThreadTitle in channel-registry.ts).
+   */
+  setThreadTitle?(platformId: string, threadId: string, title: string): Promise<void>;
+  setSuggestedPrompts?(
+    platformId: string,
+    prompts: Array<{ title: string; message: string }>,
+    title?: string,
+  ): Promise<void>;
 
   /**
    * Subscribe the bot to a thread so follow-up messages route via the

--- a/src/channels/channel-defaults.ts
+++ b/src/channels/channel-defaults.ts
@@ -82,7 +82,7 @@ export function resolveUnknownSenderPolicy(
   channelKey: string,
   isGroup: boolean,
   channelType?: string,
-): 'strict' | 'request_approval' | 'public' {
+): 'strict' | 'request_approval' | 'decline_notify' | 'public' {
   const decl = getChannelDefaults(channelKey, channelType);
   return (isGroup ? decl.group : decl.dm).unknownSenderPolicy;
 }

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -115,11 +115,40 @@ export function createChannelDeliveryAdapter(): ChannelDeliveryAdapter {
       platformId: string,
       threadId: string | null,
       instance?: string,
+      status?: string,
+      statusKind?: 'auto' | 'agent',
     ): Promise<void> {
       const adapter = getChannelAdapterExact(instance ?? channelType);
-      await adapter?.setTyping?.(platformId, threadId);
+      await adapter?.setTyping?.(platformId, threadId, status, statusKind);
     },
   };
+}
+
+/**
+ * Registry passthrough for the optional per-thread title API. Exact-key
+ * resolution only (`mg.instance ?? mg.channel_type` — same discipline as
+ * delivery/typing dispatch: a named instance must never re-title through a
+ * sibling bot). Missing adapter or missing capability is a silent no-op —
+ * titles are decoration, never worth a delivery failure.
+ */
+export async function setThreadTitle(key: string, platformId: string, threadId: string, title: string): Promise<void> {
+  const adapter = getChannelAdapterExact(key);
+  await adapter?.setThreadTitle?.(platformId, threadId, title);
+}
+
+/**
+ * Registry passthrough for agent-view suggested prompts. Exact-key
+ * resolution; missing adapter/capability is a silent no-op — prompts are
+ * onboarding decoration, never worth a failure.
+ */
+export async function setSuggestedPrompts(
+  key: string,
+  platformId: string,
+  prompts: Array<{ title: string; message: string }>,
+  title?: string,
+): Promise<void> {
+  const adapter = getChannelAdapterExact(key);
+  await adapter?.setSuggestedPrompts?.(platformId, prompts, title);
 }
 
 /**

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -262,6 +262,7 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
  * Skips adapters that return null (missing credentials).
  */
 export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => ChannelSetup): Promise<void> {
+  hotStartSetupFn = setupFn;
   for (const [name, registration] of registry) {
     try {
       const adapter = await registration.factory();
@@ -323,4 +324,52 @@ export async function teardownChannelAdapters(): Promise<void> {
     }
   }
   activeAdapters.clear();
+}
+
+/**
+ * slack-agent-flow seam — hot-start ONE registered adapter after boot.
+ * Captures the host's setupFn from initChannelAdapters and replays the same
+ * four boot steps (factory → setupFn(adapter) → setup with NetworkError retry
+ * → activeAdapters.set) for a single registry entry, so a freshly provisioned
+ * instance (e.g. `slack-<name>`) comes online without a host restart.
+ * Installed by the slack-agent-flow skill; adapter-hot-start.test.ts pins it.
+ */
+let hotStartSetupFn: ((adapter: ChannelAdapter) => ChannelSetup) | null = null;
+
+export async function startChannelAdapter(key: string): Promise<'started' | 'already-active' | 'no-credentials'> {
+  if (activeAdapters.has(key)) return 'already-active';
+  const registration = registry.get(key);
+  if (!registration) throw new Error(`startChannelAdapter: no registration for '${key}'`);
+  if (!hotStartSetupFn) throw new Error('startChannelAdapter: initChannelAdapters has not run');
+  const adapter = await registration.factory();
+  if (!adapter) return 'no-credentials';
+  const setup = hotStartSetupFn(adapter);
+  let attempt = 0;
+  while (true) {
+    try {
+      await adapter.setup(setup);
+      break;
+    } catch (err) {
+      if (isNetworkError(err) && attempt < SETUP_RETRY_DELAYS_MS.length) {
+        const delay = SETUP_RETRY_DELAYS_MS[attempt]!;
+        log.warn('Hot-start adapter setup failed with network error, retrying', {
+          channel: key,
+          attempt: attempt + 1,
+          delayMs: delay,
+          err: err.message,
+        });
+        await sleep(delay);
+        attempt += 1;
+        continue;
+      }
+      throw err;
+    }
+  }
+  const activeKey = adapter.instance ?? adapter.channelType;
+  if (activeAdapters.has(activeKey)) {
+    log.warn('Duplicate adapter instance key — overwriting previous adapter', { key: activeKey, channel: key });
+  }
+  activeAdapters.set(activeKey, adapter);
+  log.info('Channel adapter hot-started', { channel: key, type: adapter.channelType, instance: activeKey });
+  return 'started';
 }

--- a/src/channels/chat-sdk-bridge-agent-mode.test.ts
+++ b/src/channels/chat-sdk-bridge-agent-mode.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Agent-mode bridge surfaces:
+ *  - app_context: assistant_thread_started / app_context_changed events cache
+ *    the latest context per (instance, channel, user); the next inbound DM
+ *    message consumes it as content.app_context = { entities }.
+ *  - agent-DM opened hook: assistant_thread_started additionally notifies the
+ *    registered dm-opened handler, fire-and-forget with error logging.
+ *
+ * SDK dispatch runs through the REAL Chat instance (the bridge's `_chat` test
+ * seam) so the handler registrations in setup() are exercised, not simulated.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Adapter, Chat } from 'chat';
+
+import {
+  appContextEntities,
+  attachAppContext,
+  cacheAppContext,
+  createChatSdkBridge,
+  setAgentDmOpenedHandler,
+  takeAppContext,
+  type AgentDmOpenedEvent,
+} from './chat-sdk-bridge.js';
+
+vi.mock('../webhook-server.js', () => ({
+  registerWebhookAdapter: vi.fn(),
+}));
+
+function stubAdapter(partial: Partial<Adapter> = {}): Adapter {
+  return { name: 'slack', initialize: async () => {}, ...partial } as unknown as Adapter;
+}
+
+const hostConfig = {
+  onInbound: () => {},
+  onInboundEvent: () => {},
+  onMetadata: () => {},
+  onAction: () => {},
+};
+
+/** Drive a Chat process* dispatcher and await its internal task. */
+async function dispatch(fire: (options: { waitUntil: (p: Promise<unknown>) => void }) => void): Promise<void> {
+  let task: Promise<unknown> | undefined;
+  fire({ waitUntil: (p) => (task = p) });
+  await task;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const chatOf = (bridge: unknown): Chat => (bridge as any)._chat as Chat;
+
+beforeEach(async () => {
+  const { initTestDb } = await import('../db/connection.js');
+  const { runMigrations } = await import('../db/migrations/index.js');
+  runMigrations(initTestDb());
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../db/connection.js');
+  closeDb();
+  // Module-level singleton: leave no handler behind for the next test file.
+  setAgentDmOpenedHandler(() => {});
+});
+
+describe('app context cache', () => {
+  it('caches per (instance, channel, user) and consumes single-shot', () => {
+    cacheAppContext('slack-pixel', 'D0DM1', 'U1', [{ type: 'channel', id: 'C0DESIGN' }]);
+    expect(takeAppContext('slack-pixel', 'D0DM1', 'U1')).toEqual([{ type: 'channel', id: 'C0DESIGN' }]);
+    // Consumed: the context describes the NEXT message only.
+    expect(takeAppContext('slack-pixel', 'D0DM1', 'U1')).toBeUndefined();
+  });
+
+  it('matches raw and platform-encoded channel ids (slack:D… vs D…)', () => {
+    cacheAppContext('slack-pixel', 'D0DM1', 'U1', [{ type: 'channel', id: 'C9' }]);
+    expect(takeAppContext('slack-pixel', 'slack:D0DM1', 'U1')).toEqual([{ type: 'channel', id: 'C9' }]);
+  });
+
+  it('is instance- and user-scoped', () => {
+    cacheAppContext('slack-pixel', 'D1', 'U1', [{ type: 'channel', id: 'C1' }]);
+    expect(takeAppContext('slack-mark', 'D1', 'U1')).toBeUndefined();
+    expect(takeAppContext('slack-pixel', 'D1', 'U2')).toBeUndefined();
+    expect(takeAppContext('slack-pixel', 'D1', 'U1')).toEqual([{ type: 'channel', id: 'C1' }]);
+  });
+
+  it('expires after the TTL (~5min)', () => {
+    const t0 = 1_000_000;
+    cacheAppContext('slack-pixel', 'D1', 'U1', [{ type: 'channel', id: 'C1' }], t0);
+    expect(takeAppContext('slack-pixel', 'D1', 'U1', t0 + 5 * 60 * 1000 + 1)).toBeUndefined();
+  });
+
+  it('appContextEntities derives a channel entity from the SDK context shape', () => {
+    const event = {
+      channelId: 'D1',
+      threadId: 'D1:171',
+      threadTs: '171',
+      userId: 'U1',
+      context: { channelId: 'C0DESIGN', teamId: 'T1' },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(appContextEntities(event as any)).toEqual([{ type: 'channel', id: 'C0DESIGN' }]);
+  });
+
+  it('appContextEntities prefers a real entities array when a future SDK forwards one', () => {
+    const event = {
+      channelId: 'D1',
+      userId: 'U1',
+      context: {
+        channelId: 'C0DESIGN',
+        entities: [
+          { type: 'thread', id: 'C0DESIGN:171' },
+          { type: 'canvas', id: 'F0CANVAS' },
+          { type: 'bogus' }, // no id — dropped
+        ],
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(appContextEntities(event as any)).toEqual([
+      { type: 'thread', id: 'C0DESIGN:171' },
+      { type: 'canvas', id: 'F0CANVAS' },
+    ]);
+  });
+
+  it('attachAppContext attaches { entities } once and never overwrites SDK-provided context', () => {
+    cacheAppContext('slack-pixel', 'D1', 'U1', [{ type: 'channel', id: 'C1' }]);
+    const content: Record<string, unknown> = { text: 'hi' };
+    attachAppContext(content, 'slack-pixel', 'slack:D1', 'U1');
+    expect(content.app_context).toEqual({ entities: [{ type: 'channel', id: 'C1' }] });
+
+    cacheAppContext('slack-pixel', 'D1', 'U1', [{ type: 'channel', id: 'C2' }]);
+    const preAttached: Record<string, unknown> = {
+      text: 'hi',
+      app_context: { entities: [{ type: 'list', id: 'L1' }] },
+    };
+    attachAppContext(preAttached, 'slack-pixel', 'slack:D1', 'U1');
+    expect(preAttached.app_context).toEqual({ entities: [{ type: 'list', id: 'L1' }] });
+
+    const noUser: Record<string, unknown> = { text: 'hi' };
+    attachAppContext(noUser, 'slack-pixel', 'slack:D1', undefined);
+    expect(noUser.app_context).toBeUndefined();
+  });
+
+  it('assistant events dispatched through the real Chat instance land in the cache', async () => {
+    const adapter = stubAdapter();
+    const bridge = createChatSdkBridge({ adapter, instance: 'slack-pixel', supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await dispatch((options) =>
+      chatOf(bridge).processAssistantContextChanged(
+        {
+          adapter,
+          channelId: 'D0DM1',
+          context: { channelId: 'C0DESIGN' },
+          threadId: 'D0DM1:171',
+          threadTs: '171',
+          userId: 'U1',
+        },
+        options,
+      ),
+    );
+
+    expect(takeAppContext('slack-pixel', 'D0DM1', 'U1')).toEqual([{ type: 'channel', id: 'C0DESIGN' }]);
+    await bridge.teardown();
+  });
+});
+
+describe('agent-DM opened hook', () => {
+  it('assistant_thread_started notifies the registered handler and caches the context', async () => {
+    const events: AgentDmOpenedEvent[] = [];
+    setAgentDmOpenedHandler((event) => {
+      events.push(event);
+    });
+
+    const adapter = stubAdapter();
+    const bridge = createChatSdkBridge({ adapter, instance: 'slack-pixel', supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await dispatch((options) =>
+      chatOf(bridge).processAssistantThreadStarted(
+        {
+          adapter,
+          channelId: 'D0DM1',
+          context: { channelId: 'C0DESIGN' },
+          threadId: 'D0DM1:171',
+          threadTs: '171',
+          userId: 'U1',
+        },
+        options,
+      ),
+    );
+
+    expect(events).toEqual([{ instance: 'slack-pixel', channelId: 'D0DM1' }]);
+    expect(takeAppContext('slack-pixel', 'D0DM1', 'U1')).toEqual([{ type: 'channel', id: 'C0DESIGN' }]);
+    await bridge.teardown();
+  });
+
+  it('a throwing handler is contained (fire-and-forget, dispatch survives)', async () => {
+    setAgentDmOpenedHandler(() => {
+      throw new Error('boom');
+    });
+    const adapter = stubAdapter();
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await expect(
+      dispatch((options) =>
+        chatOf(bridge).processAssistantThreadStarted(
+          { adapter, channelId: 'D1', context: {}, threadId: 'D1:1', threadTs: '1', userId: 'U1' },
+          options,
+        ),
+      ),
+    ).resolves.toBeUndefined();
+    await bridge.teardown();
+  });
+});

--- a/src/channels/chat-sdk-bridge-dm-thread.test.ts
+++ b/src/channels/chat-sdk-bridge-dm-thread.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeDmThreadId } from './chat-sdk-bridge.js';
+
+// Agent-view DMs: top-level messages arrive with an empty threadTs
+// (`…:<channel>:`) — the normalization roots the conversation thread on the
+// message's own ts so status/replies/titles have a thread to land in.
+describe('normalizeDmThreadId', () => {
+  it('roots a top-level DM message on its own ts', () => {
+    expect(normalizeDmThreadId('slack:D0123ABC:', '1724264405.531769')).toBe('slack:D0123ABC:1724264405.531769');
+  });
+
+  it('leaves an already-threaded reply untouched', () => {
+    expect(normalizeDmThreadId('slack:D0123ABC:1724264405.531769', '1724264999.000100')).toBe(
+      'slack:D0123ABC:1724264405.531769',
+    );
+  });
+
+  it('ignores encoded (non-ts) message ids', () => {
+    expect(normalizeDmThreadId('slack:D0123ABC:', 'ephemeral:1724:url')).toBe('slack:D0123ABC:');
+  });
+
+  it('ignores empty message ids', () => {
+    expect(normalizeDmThreadId('slack:D0123ABC:', '')).toBe('slack:D0123ABC:');
+  });
+});

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -15,6 +15,8 @@ import {
   LinkButton,
   type CardChild,
   type Adapter,
+  type AssistantContextChangedEvent,
+  type AssistantThreadStartedEvent,
   type ConcurrencyStrategy,
   type Message as ChatMessage,
 } from 'chat';
@@ -39,6 +41,164 @@ interface GatewayAdapter extends Adapter {
 export interface ReplyContext {
   text: string;
   sender: string;
+}
+
+// ---------------------------------------------------------------------------
+// Agent-DM opened hook (assistant_thread_started)
+// ---------------------------------------------------------------------------
+
+/** The user opened an agent DM (assistant thread started). Registered by the
+ *  host to (re)assert onboarding prompts at a moment the user is provably
+ *  looking — prompt sets made before the DM was ever opened may not render. */
+export interface AgentDmOpenedEvent {
+  instance: string;
+  channelId: string;
+}
+
+let agentDmOpenedHandler: ((event: AgentDmOpenedEvent) => void | Promise<void>) | null = null;
+
+export function setAgentDmOpenedHandler(fn: (event: AgentDmOpenedEvent) => void | Promise<void>): void {
+  agentDmOpenedHandler = fn;
+}
+
+function dispatchAgentDmOpened(event: AgentDmOpenedEvent): void {
+  if (!agentDmOpenedHandler) return;
+  try {
+    Promise.resolve(agentDmOpenedHandler(event)).catch((err) =>
+      log.warn('Agent-DM opened handler failed', { channelId: event.channelId, err }),
+    );
+  } catch (err) {
+    log.warn('Agent-DM opened handler threw', { channelId: event.channelId, err });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent-mode app context
+// ---------------------------------------------------------------------------
+
+/** One "what the user is viewing" entity, rendered by the container formatter. */
+export interface AppContextEntity {
+  type: string;
+  id: string;
+}
+
+/**
+ * Latest assistant context per (instance, DM channel, user), attached to the
+ * NEXT inbound DM message as content.app_context and consumed. Platforms
+ * whose DM surface materializes threads and reports client context send
+ * app_context as its own event (assistant_thread_started legacy /
+ * app_context_changed in agent view), not on the message payload, so the
+ * bridge has to hold it across the event → message gap. Short TTL: a stale
+ * "viewing X" is worse than none.
+ */
+const APP_CONTEXT_TTL_MS = 5 * 60 * 1000;
+const appContextCache = new Map<string, { entities: AppContextEntity[]; at: number }>();
+
+/** Channel ids arrive both raw ("D0123") and platform-encoded ("slack:D0123")
+ *  depending on the emitting path — key on the final segment so both match. */
+function appContextKey(instance: string, channelId: string, userId: string): string {
+  const channel = channelId.includes(':') ? channelId.slice(channelId.lastIndexOf(':') + 1) : channelId;
+  return `${instance}|${channel}|${userId}`;
+}
+
+/**
+ * Derive ordered entities from an SDK assistant event. The installed chat
+ * core (4.29.0) parses assistant_thread_started / app_context_changed into a
+ * `context` object (channelId/teamId/threadEntryPoint — the legacy assistant
+ * context shape) with no entities array; prefer a real `entities` array
+ * whenever a future SDK forwards the platform's ordered agent-context
+ * entities.
+ */
+export function appContextEntities(
+  event: AssistantThreadStartedEvent | AssistantContextChangedEvent,
+): AppContextEntity[] {
+  const raw = event as unknown as Record<string, unknown>;
+  const direct = raw.entities ?? (raw.context as Record<string, unknown> | undefined)?.entities;
+  if (Array.isArray(direct)) {
+    return direct
+      .map((e) => {
+        const entity = e as Record<string, unknown> | null;
+        const type = typeof entity?.type === 'string' ? entity.type : '';
+        const idValue = entity?.id ?? entity?.channel_id ?? entity?.entity_id;
+        const id = typeof idValue === 'string' ? idValue : '';
+        return { type, id };
+      })
+      .filter((e) => e.type !== '' && e.id !== '');
+  }
+  const channelId = event.context?.channelId;
+  return typeof channelId === 'string' && channelId ? [{ type: 'channel', id: channelId }] : [];
+}
+
+export function cacheAppContext(
+  instance: string,
+  channelId: string,
+  userId: string,
+  entities: AppContextEntity[],
+  now = Date.now(),
+): void {
+  const key = appContextKey(instance, channelId, userId);
+  if (entities.length === 0) {
+    appContextCache.delete(key);
+    return;
+  }
+  appContextCache.set(key, { entities, at: now });
+}
+
+/** Consume the cached context (single-shot: it describes what the user was
+ *  viewing when they sent the NEXT message, not every message after). */
+export function takeAppContext(
+  instance: string,
+  channelId: string,
+  userId: string,
+  now = Date.now(),
+): AppContextEntity[] | undefined {
+  const key = appContextKey(instance, channelId, userId);
+  const hit = appContextCache.get(key);
+  if (!hit) return undefined;
+  appContextCache.delete(key);
+  if (now - hit.at > APP_CONTEXT_TTL_MS) return undefined;
+  return hit.entities;
+}
+
+/**
+ * Attach the cached app context to an inbound DM message's content JSON
+ * (content.app_context = { entities: [...] }). A context the SDK attached
+ * directly on the message payload wins — the cache only fills the
+ * event → message gap.
+ */
+export function attachAppContext(
+  content: Record<string, unknown>,
+  instance: string,
+  channelId: string,
+  userId: string | undefined,
+): void {
+  if (content.app_context) return;
+  if (!userId) return;
+  const entities = takeAppContext(instance, channelId, userId);
+  if (entities && entities.length > 0) {
+    content.app_context = { entities };
+  }
+}
+
+/**
+ * Root-thread a top-level DM message: on platforms whose DM surface
+ * materializes conversation threads (agent-view semantics), every top-level
+ * DM message is the root of a conversation thread — replying in-thread and
+ * setting per-thread status on that ts is what OPENS the thread in the
+ * client. Such adapters map top-level DM messages to an EMPTY threadTs
+ * (`…:<channel>:`), so without this the thread never materializes: no
+ * in-thread reply, no status target, no per-thread session.
+ *
+ * The message id is the platform ts for chat-sdk adapters, so appending it to
+ * the dangling `:` yields the canonical thread id. Plain (non-agent) DM
+ * wirings are unaffected downstream: the router strips thread ids when the
+ * wiring's thread policy is off, restoring today's top-level behavior.
+ */
+export function normalizeDmThreadId(threadId: string, messageId: string): string {
+  if (threadId.endsWith(':') && messageId && !messageId.includes(':')) {
+    return threadId + messageId;
+  }
+  return threadId;
 }
 
 /** Extract reply context from a platform-specific raw message. Return null if no reply. */
@@ -175,6 +335,9 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     );
   }
   const transformText = (t: string): string => (config.transformOutboundText ? config.transformOutboundText(t) : t);
+  /** Registry/routing key for this bridge — also the app-context cache
+   *  namespace. Default instances key by the platform name. */
+  const instanceKey = config.instance ?? adapter.name;
   let chat: Chat;
   let state: SqliteStateAdapter;
   let setupConfig: ChannelSetup;
@@ -310,7 +473,17 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           sender: (message.author as any)?.fullName ?? (message.author as any)?.userId ?? 'unknown',
           threadId: thread.id,
         });
-        await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, true, false));
+        const inbound = await messageToInbound(message, true, false);
+        // Agent-mode app context: DM-only by platform design.
+        attachAppContext(
+          inbound.content as Record<string, unknown>,
+          instanceKey,
+          channelId,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (message.author as any)?.userId,
+        );
+        const dmThreadId = normalizeDmThreadId(thread.id, message.id);
+        await setupConfig.onInbound(channelId, dmThreadId, inbound);
       });
 
       // Plain messages in unsubscribed threads.
@@ -327,6 +500,19 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         const channelId = adapter.channelIdFromThreadId(thread.id);
         await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, false, true));
       });
+
+      // Agent-mode assistant context: cache the latest "what the user is
+      // viewing" per (channel, user). The installed chat core (4.29.0)
+      // dispatches both the legacy assistant_thread_started and the
+      // agent_view app_context_changed events into these handlers.
+      const rememberAppContext = (event: AssistantThreadStartedEvent | AssistantContextChangedEvent): void => {
+        cacheAppContext(instanceKey, event.channelId, event.userId, appContextEntities(event));
+      };
+      chat.onAssistantThreadStarted((event) => {
+        rememberAppContext(event);
+        dispatchAgentDmOpened({ instance: instanceKey, channelId: event.channelId });
+      });
+      chat.onAssistantContextChanged(rememberAppContext);
 
       // Handle button clicks (ask_user_question)
       chat.onAction(async (event) => {
@@ -367,6 +553,12 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       });
 
       await chat.initialize();
+
+      // Test seam: unit tests drive the SDK's public process* dispatchers
+      // (processAssistantContextChanged, …) against the handlers registered
+      // above without a live platform. Not part of the ChannelAdapter
+      // contract.
+      (bridge as unknown as { _chat?: Chat })._chat = chat;
 
       // Start Gateway listener for adapters that support it (e.g., Discord)
       const gatewayAdapter = adapter as GatewayAdapter;

--- a/src/cli/resources/messaging-groups.ts
+++ b/src/cli/resources/messaging-groups.ts
@@ -55,8 +55,8 @@ registerResource({
       name: 'unknown_sender_policy',
       type: 'string',
       description:
-        'What happens when an unrecognized sender posts. "strict" drops silently. "request_approval" sends an approval card to an admin. "public" allows anyone. Default: declared by the channel adapter for this context (DM vs group); "strict" when the channel has no declaration.',
-      enum: ['strict', 'request_approval', 'public'],
+        'What happens when an unrecognized sender posts. "strict" drops silently. "request_approval" sends an approval card to an admin. "decline_notify" declines the sender politely and sends the owner a one-line FYI. "public" allows anyone. Default: declared by the channel adapter for this context (DM vs group); "strict" when the channel has no declaration.',
+      enum: ['strict', 'request_approval', 'decline_notify', 'public'],
       default: 'strict',
       updatable: true,
     },

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -36,7 +36,7 @@ import {
 } from './db/index.js';
 import { getDeliveredIds } from './db/session-db.js';
 import { resolveSession, resolveTaskSession, outboundDbPath, openInboundDb } from './session-manager.js';
-import { deliverSessionMessages, setDeliveryAdapter } from './delivery.js';
+import { deliverSessionMessages, registerDeliveryBatchPreview, setDeliveryAdapter } from './delivery.js';
 import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
 
 function now(): string {
@@ -406,5 +406,37 @@ describe('deliverSessionMessages — task_log rows (one-door task delivery)', ()
     // Marked delivered — the row is not retried.
     const delivered = getDeliveredIds(openInboundDb('ag-1', session.id));
     expect(delivered.has('log-1')).toBe(true);
+  });
+});
+
+describe('deliverSessionMessages — batch preview hooks', () => {
+  it('hooks see the whole undelivered batch before row processing; a throwing hook never breaks delivery', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'bp-1');
+    insertOutbound('ag-1', session.id, 'bp-2');
+
+    const seen: Array<{ kinds: string[]; sessionId: string }> = [];
+    registerDeliveryBatchPreview((batch, s) => {
+      seen.push({ kinds: batch.map((m) => m.kind), sessionId: s.id });
+    });
+    registerDeliveryBatchPreview(() => {
+      throw new Error('hook exploded');
+    });
+
+    const sent: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_channelType, _platformId, _threadId, _kind, content) {
+        sent.push(content);
+        return undefined;
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    expect(seen.length).toBe(1);
+    expect(seen[0].kinds).toEqual(['chat', 'chat']);
+    expect(seen[0].sessionId).toBe(session.id);
+    expect(sent.length).toBe(2); // the throwing hook did not block delivery
   });
 });

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -206,6 +206,23 @@ async function drainSession(session: Session): Promise<void> {
     // Ensure platform_message_id column exists (migration for existing sessions)
     migrateDeliveredTable(inDb);
 
+    // Batch preview: registered modules peek at the whole undelivered batch
+    // before rows are processed one-by-one — e.g. a module prefetching an
+    // expensive per-message resource in parallel when the batch contains
+    // several rows that would otherwise each pay the cost sequentially.
+    // Hooks see kind+content only, must be fast, and must never break
+    // delivery.
+    for (const hook of batchPreviewHooks) {
+      try {
+        hook(
+          undelivered.map((m) => ({ kind: m.kind, content: m.content })),
+          session,
+        );
+      } catch (err) {
+        log.warn('Delivery batch-preview hook failed', { sessionId: session.id, err });
+      }
+    }
+
     for (const msg of undelivered) {
       try {
         const platformMsgId = await deliverMessage(msg, session, inDb);
@@ -455,6 +472,13 @@ const deliveryActions = new Map<string, DeliveryEntry>();
 
 function isUnguardedEntry(entry: DeliveryEntry): entry is Extract<DeliveryEntry, { guard: Unguarded }> {
   return isUnguarded(entry.guard);
+}
+
+/** See the batch-preview invocation in the delivery poll for semantics. */
+type DeliveryBatchPreviewHook = (batch: Array<{ kind: string; content: string }>, session: Session) => void;
+const batchPreviewHooks: DeliveryBatchPreviewHook[] = [];
+export function registerDeliveryBatchPreview(hook: DeliveryBatchPreviewHook): void {
+  batchPreviewHooks.push(hook);
 }
 
 export function registerDeliveryAction(action: string, handler: DeliveryActionHandler, unguardedDecl: Unguarded): void;

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -70,7 +70,14 @@ export interface ChannelDeliveryAdapter {
      *  Host-internal only — containers never see instance. */
     instance?: string,
   ): Promise<string | undefined>;
-  setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
+  setTyping?(
+    channelType: string,
+    platformId: string,
+    threadId: string | null,
+    instance?: string,
+    status?: string,
+    statusKind?: 'auto' | 'agent',
+  ): Promise<void>;
 }
 
 let deliveryAdapter: ChannelDeliveryAdapter | null = null;

--- a/src/modules/agent-to-agent/create-agent.notify.test.ts
+++ b/src/modules/agent-to-agent/create-agent.notify.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for createAgent's CreateAgentOptions.suppressCreatedNotify (D5).
+ *
+ * The upstream success notify ("created — you can now message it") fires
+ * before any wrapper post-processing (e.g. slack-agent-flow provisioning), so
+ * wrappers that own the completion signal pass suppressCreatedNotify to keep
+ * the requester from hearing "done" early. Error notifies (collision) must
+ * still fire — they are the only signal on those paths.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Session } from '../../types.js';
+
+// vi.hoisted: the module import below runs before this file's const
+// initializers, and the mock factories close over this state.
+const { mockNotifyWrite, destinations } = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  destinations: new Map<string, { target_type: string; target_id: string }>(),
+}));
+
+vi.mock('../approvals/index.js', () => ({
+  requestApproval: vi.fn().mockResolvedValue(undefined),
+  notifyAgent: vi.fn(),
+  registerApprovalHandler: vi.fn(),
+}));
+vi.mock('../../db/container-configs.js', () => ({
+  getContainerConfig: () => ({ cli_scope: 'global' }),
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  getAgentGroup: (id: string) => ({ id, name: id.toUpperCase(), folder: id, agent_provider: null, created_at: '' }),
+  getAgentGroupByFolder: () => undefined,
+  createAgentGroup: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({ initGroupFilesystem: vi.fn() }));
+vi.mock('./write-destinations.js', () => ({ writeDestinations: vi.fn() }));
+vi.mock('./db/agent-destinations.js', () => ({
+  getDestinationByName: (group: string, name: string) => destinations.get(`${group}/${name}`),
+  createDestination: vi.fn(),
+  normalizeName: (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../db/sessions.js', () => ({
+  getSession: (id: string) => ({ id, agent_group_id: 'ag-1' }),
+}));
+
+import { createAgent } from './create-agent.js';
+
+const SESSION = { id: 'sess-1', agent_group_id: 'ag-1' } as Session;
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  destinations.clear();
+});
+
+describe('createAgent — suppressCreatedNotify option', () => {
+  it('default: the success notify fires', async () => {
+    await createAgent({ name: 'Scout' }, SESSION);
+
+    expect(notifyTexts().some((t) => t.includes('Agent "scout" created'))).toBe(true);
+  });
+
+  it('suppressCreatedNotify: creation runs but the success notify is silenced', async () => {
+    await createAgent({ name: 'Scout' }, SESSION, { suppressCreatedNotify: true });
+
+    expect(notifyTexts()).toHaveLength(0);
+  });
+
+  it('suppressCreatedNotify does NOT silence the collision error notify', async () => {
+    destinations.set('ag-1/scout', { target_type: 'agent', target_id: 'ag-existing' });
+
+    await createAgent({ name: 'Scout' }, SESSION, { suppressCreatedNotify: true });
+
+    expect(notifyTexts().some((t) => t.includes('already have a destination named "scout"'))).toBe(true);
+  });
+});

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -77,14 +77,29 @@ export async function requestCreateAgentHold(content: Record<string, unknown>, s
   });
 }
 
+export interface CreateAgentOptions {
+  /**
+   * Suppress the terminal `Agent "<name>" created…` success notify. Error
+   * notifies (collision, invalid path) still fire. For wrappers whose own
+   * completion text is the requester's only "done" signal — e.g.
+   * slack-agent-flow, where Slack provisioning runs AFTER this returns and
+   * relaying the upstream text would report "done" ~a minute early.
+   */
+  suppressCreatedNotify?: boolean;
+}
+
 /** Guard allow body: performs the creation (fresh global-scope call or approved replay). */
-export async function createAgent(content: Record<string, unknown>, session: Session): Promise<void> {
+export async function createAgent(
+  content: Record<string, unknown>,
+  session: Session,
+  options?: CreateAgentOptions,
+): Promise<void> {
   const name = typeof content.name === 'string' ? content.name : '';
   const instructions = typeof content.instructions === 'string' ? content.instructions : null;
   const sourceGroup = getAgentGroup(session.agent_group_id);
   if (!name || !sourceGroup) return; // precheck already answered the requester
 
-  await performCreateAgent(name, instructions, session, sourceGroup, (text) => notifyAgent(session, text));
+  await performCreateAgent(name, instructions, session, sourceGroup, (text) => notifyAgent(session, text), options);
 }
 
 /**
@@ -101,6 +116,7 @@ async function performCreateAgent(
   session: Session,
   sourceGroup: AgentGroup,
   notify: (text: string) => void,
+  options?: CreateAgentOptions,
 ): Promise<void> {
   const localName = normalizeName(name);
 
@@ -179,6 +195,8 @@ async function performCreateAgent(
   // tries to send to the newly-created child.
   writeDestinations(session.agent_group_id, session.id);
 
-  notify(`Agent "${localName}" created. You can now message it with send_message({ to: "${localName}", ... }).`);
+  if (!options?.suppressCreatedNotify) {
+    notify(`Agent "${localName}" created. You can now message it with send_message({ to: "${localName}", ... }).`);
+  }
   log.info('Agent group created', { agentGroupId, name, localName, folder, parent: sourceGroup.id });
 }

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -53,7 +53,7 @@ import { getDeliveryAdapter } from '../../delivery.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { log } from '../../log.js';
 import type { InboundEvent } from '../../channels/adapter.js';
-import type { AgentGroup } from '../../types.js';
+import type { AgentGroup, MessagingGroup } from '../../types.js';
 import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
 import { createPendingChannelApproval, hasInFlightChannelApproval } from './db/pending-channel-approvals.js';
 import { hasAdminPrivilege } from './db/user-roles.js';
@@ -64,6 +64,29 @@ export const CONNECT_PREFIX = 'connect:';
 export const NEW_AGENT_VALUE = 'new_agent';
 export const CHOOSE_EXISTING_VALUE = 'choose_existing';
 export const REJECT_VALUE = 'reject';
+
+// ── Channel-card interceptor seam (B2/D24) ──
+// A channel module can claim the escalation for its own channel type before
+// a registration card goes out — e.g. the slack-room-membership module's
+// owner-presence rule (owner in the room → auto-wire, no card) and its
+// Slackbot shadow-channel backstop. The seam is deliberately generic: this
+// module registers/consults by channel_type only and never imports channel
+// code. 'handled' = the interceptor consumed the escalation (wired, declined,
+// or deliberately ignored it); 'card' = proceed with today's card flow.
+// Interceptor errors fall back to the card — a broken module must never make
+// escalations silently vanish.
+
+export type ChannelCardDecision = 'card' | 'handled';
+export type ChannelCardInterceptor = (mg: MessagingGroup, event: InboundEvent) => Promise<ChannelCardDecision>;
+
+const channelCardInterceptors = new Map<string, ChannelCardInterceptor>();
+
+export function registerChannelCardInterceptor(channelType: string, fn: ChannelCardInterceptor): void {
+  if (channelCardInterceptors.has(channelType)) {
+    log.warn('Channel-card interceptor overwritten', { channelType });
+  }
+  channelCardInterceptors.set(channelType, fn);
+}
 
 // ── Utilities ──
 
@@ -172,6 +195,27 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     return;
   }
 
+  const originMg = getMessagingGroup(messagingGroupId);
+
+  // Channel-module interceptor: consulted before any card work so a module
+  // can auto-wire / decline / suppress for its own channel type. Runs after
+  // the in-flight dedupe (a pending card already owns this channel) and
+  // before the approver checks (an auto-wire needs no reachable approver).
+  const interceptor = originMg ? channelCardInterceptors.get(originMg.channel_type) : undefined;
+  if (originMg && interceptor) {
+    try {
+      if ((await interceptor(originMg, event)) === 'handled') {
+        log.debug('Channel registration handled by interceptor — no card', {
+          messagingGroupId,
+          channelType: originMg.channel_type,
+        });
+        return;
+      }
+    } catch (err) {
+      log.warn('Channel-card interceptor threw — falling back to the card', { messagingGroupId, err });
+    }
+  }
+
   const agentGroups = getAllAgentGroups();
   if (agentGroups.length === 0) {
     log.warn('Channel registration skipped — no agent groups configured. Run /init-first-agent.', {
@@ -192,7 +236,6 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     return;
   }
 
-  const originMg = getMessagingGroup(messagingGroupId);
   const originChannelType = originMg?.channel_type ?? '';
 
   // Resolve channel name if not yet persisted. Key by instance so a named

--- a/src/modules/permissions/channel-card-interceptor.test.ts
+++ b/src/modules/permissions/channel-card-interceptor.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the channel-card interceptor seam (B2/D24).
+ *
+ * Covers:
+ *  - registerChannelCardInterceptor + consult order: the interceptor runs
+ *    before any card work for its channel type only
+ *  - 'handled' → no card delivered, no pending_channel_approvals row
+ *  - 'card' → today's flow proceeds unchanged
+ *  - interceptor throw → card fallback (a broken module never makes
+ *    escalations vanish)
+ *  - in-flight dedupe still short-circuits before the interceptor
+ */
+import fs from 'fs';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import type { InboundEvent } from '../../channels/adapter.js';
+import type { MessagingGroup } from '../../types.js';
+import { upsertUser } from './db/users.js';
+import { grantRole } from './db/user-roles.js';
+
+// Mock container runner — prevent actual docker spawn.
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+// Mock delivery adapter.
+const deliverMock = vi.fn().mockResolvedValue('plat-msg-id');
+vi.mock('../../delivery.js', () => ({
+  getDeliveryAdapter: () => ({ deliver: deliverMock }),
+}));
+
+// Mock ensureUserDm — look up the owner's preconfigured DM row.
+vi.mock('./user-dm.js', () => ({
+  ensureUserDm: vi.fn(async (userId: string) => {
+    const { getDb } = await import('../../db/connection.js');
+    const row = getDb()
+      .prepare(
+        `SELECT mg.* FROM messaging_groups mg
+           JOIN user_dms ud ON ud.messaging_group_id = mg.id
+          WHERE ud.user_id = ?`,
+      )
+      .get(userId);
+    return row;
+  }),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-card-interceptor' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-card-interceptor';
+
+function now() {
+  return new Date().toISOString();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({ id: 'ag-1', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
+
+  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+  grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+  createMessagingGroup({
+    id: 'mg-dm-owner',
+    channel_type: 'telegram',
+    platform_id: 'dm-owner',
+    name: 'Owner DM',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  const { getDb } = await import('../../db/connection.js');
+  getDb()
+    .prepare(`INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at) VALUES (?, ?, ?, ?)`)
+    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+
+  deliverMock.mockClear();
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+function unwiredChannel(id: string, channelType = 'telegram'): MessagingGroup {
+  const mg: MessagingGroup = {
+    id,
+    channel_type: channelType,
+    platform_id: `chan-${id}`,
+    instance: channelType,
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: 'request_approval',
+    created_at: now(),
+  };
+  createMessagingGroup(mg);
+  return mg;
+}
+
+function mention(mg: MessagingGroup): InboundEvent {
+  return {
+    channelType: mg.channel_type,
+    platformId: mg.platform_id,
+    threadId: null,
+    message: {
+      id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+      kind: 'chat',
+      timestamp: now(),
+      isMention: true,
+      isGroup: true,
+      content: JSON.stringify({ senderId: 'caller', senderName: 'Caller', text: '@bot hi' }),
+    },
+  };
+}
+
+async function pendingCount(): Promise<number> {
+  const { getDb } = await import('../../db/connection.js');
+  return (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+}
+
+describe('channel-card interceptor seam', () => {
+  it("'handled' suppresses the card: no delivery, no pending row", async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    const interceptor = vi.fn().mockResolvedValue('handled');
+    registerChannelCardInterceptor('telegram', interceptor);
+
+    const mg = unwiredChannel('mg-a');
+    const event = mention(mg);
+    await requestChannelApproval({ messagingGroupId: mg.id, event });
+
+    expect(interceptor).toHaveBeenCalledTimes(1);
+    expect(interceptor).toHaveBeenCalledWith(expect.objectContaining({ id: mg.id }), event);
+    expect(deliverMock).not.toHaveBeenCalled();
+    expect(await pendingCount()).toBe(0);
+  });
+
+  it("'card' proceeds with today's flow", async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    registerChannelCardInterceptor('telegram', vi.fn().mockResolvedValue('card'));
+
+    const mg = unwiredChannel('mg-b');
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(deliverMock.mock.calls[0][4] as string);
+    expect(payload.type).toBe('ask_question');
+    expect(await pendingCount()).toBe(1);
+  });
+
+  it('interceptor throw falls back to the card', async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    registerChannelCardInterceptor('telegram', vi.fn().mockRejectedValue(new Error('boom')));
+
+    const mg = unwiredChannel('mg-c');
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    expect(await pendingCount()).toBe(1);
+  });
+
+  it('only consulted for its own channel type', async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    const interceptor = vi.fn().mockResolvedValue('handled');
+    registerChannelCardInterceptor('slack', interceptor);
+
+    const mg = unwiredChannel('mg-d'); // telegram
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(interceptor).not.toHaveBeenCalled();
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('in-flight dedupe short-circuits before the interceptor', async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    const interceptor = vi.fn().mockResolvedValue('card');
+    registerChannelCardInterceptor('telegram', interceptor);
+
+    const mg = unwiredChannel('mg-e');
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(interceptor).toHaveBeenCalledTimes(1); // second call died at the pending-row check
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/permissions/db/pending-sender-approvals.ts
+++ b/src/modules/permissions/db/pending-sender-approvals.ts
@@ -60,3 +60,72 @@ export function hasInFlightSenderApproval(messagingGroupId: string, senderIdenti
 export function deletePendingSenderApproval(id: string): void {
   getDb().prepare('DELETE FROM pending_sender_approvals WHERE id = ?').run(id);
 }
+
+// ── Decline stamps (decline_notify dedupe) ──
+// The decline-and-notify flow persists "last declined at" per (messaging
+// group, sender) by reusing this table's UNIQUE key — an id prefix
+// distinguishes stamps from real card rows. Stamps never render a card and
+// no click can resolve them (response handlers look up by exact id). A
+// policy flip back to request_approval clears the stamp before carding
+// (clearDeclineStamp in requestSenderApproval) so the UNIQUE key is free.
+// The mirror collision (a card row left pending when the policy flipped TO
+// decline_notify) is resolved by upsertDeclineStamp converting the row into
+// the stamp shape — the card is obsolete once the policy no longer cards.
+
+const DECLINE_STAMP_ID_PREFIX = 'decline:';
+
+/** ISO timestamp of the last decline for this pair, if any. */
+export function getDeclineStampAt(messagingGroupId: string, senderIdentity: string): string | undefined {
+  const row = getDb()
+    .prepare(
+      `SELECT created_at FROM pending_sender_approvals
+        WHERE messaging_group_id = ? AND sender_identity = ? AND id LIKE '${DECLINE_STAMP_ID_PREFIX}%'`,
+    )
+    .get(messagingGroupId, senderIdentity) as { created_at: string } | undefined;
+  return row?.created_at;
+}
+
+/** Record (or refresh) the decline stamp. `agent_group_id` must reference a
+ *  real agent group (FK). title/options_json keep their '' / '[]' defaults. */
+export function upsertDeclineStamp(stamp: {
+  messaging_group_id: string;
+  agent_group_id: string;
+  sender_identity: string;
+  sender_name: string | null;
+  original_message: string;
+}): void {
+  getDb()
+    .prepare(
+      `INSERT INTO pending_sender_approvals (
+         id, messaging_group_id, agent_group_id, sender_identity,
+         sender_name, original_message, approver_user_id, created_at
+       )
+       VALUES (
+         @id, @messaging_group_id, @agent_group_id, @sender_identity,
+         @sender_name, @original_message, '', @created_at
+       )
+       ON CONFLICT(messaging_group_id, sender_identity) DO UPDATE SET
+         id = excluded.id,
+         created_at = excluded.created_at,
+         sender_name = excluded.sender_name,
+         original_message = excluded.original_message,
+         approver_user_id = excluded.approver_user_id,
+         title = excluded.title,
+         options_json = excluded.options_json`,
+    )
+    .run({
+      id: `${DECLINE_STAMP_ID_PREFIX}${stamp.messaging_group_id}:${stamp.sender_identity}`,
+      ...stamp,
+      created_at: new Date().toISOString(),
+    });
+}
+
+/** Remove any decline stamp for this pair — real card rows are untouched. */
+export function clearDeclineStamp(messagingGroupId: string, senderIdentity: string): void {
+  getDb()
+    .prepare(
+      `DELETE FROM pending_sender_approvals
+        WHERE messaging_group_id = ? AND sender_identity = ? AND id LIKE '${DECLINE_STAMP_ID_PREFIX}%'`,
+    )
+    .run(messagingGroupId, senderIdentity);
+}

--- a/src/modules/permissions/guard.ts
+++ b/src/modules/permissions/guard.ts
@@ -4,7 +4,9 @@
  *
  * senders.admit — the `unknown_sender_policy` switch moved verbatim out of
  * handleUnknownSender: `public` allows (short-circuited before the gate
- * anyway), `request_approval` holds, `strict` denies. The hold is executed by
+ * anyway), `request_approval` holds, `strict` and `decline_notify` deny
+ * (decline_notify's decline + owner-FYI side effects are the caller's — the
+ * message stays dropped either way). The hold is executed by
  * the caller through the module's own pending_sender_approvals flow (card,
  * in-flight dedup) — not the approvals primitive — so this entry has no
  * grantActionName: the approve continuation adds the member and replays
@@ -32,6 +34,11 @@ export const sendersAdmit = defineGuardedAction({
       return HOLD(
         `unknown sender requires admin approval on messaging group ${String(input.payload.messagingGroupId)}`,
       );
+    }
+    if (policy === 'decline_notify') {
+      // Deny, not hold: nothing pends and no grant path exists — the caller
+      // sends the polite decline + owner FYI itself (sender-approval.ts).
+      return DENY('unknown sender declined (decline-and-notify policy)');
     }
     return DENY('unknown sender on a strict messaging group');
   },

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -7,7 +7,7 @@
  *      sight. Returns null when the payload doesn't carry enough to identify
  *      a sender.
  *   2. setAccessGate — runs after agent resolution. Enforces the
- *      unknown_sender_policy (strict/request_approval/public) and the
+ *      unknown_sender_policy (strict/request_approval/decline_notify/public) and the
  *      owner/global-admin/scoped-admin/member access hierarchy. Records its
  *      own `dropped_messages` row on refusal (structural drops are recorded
  *      by core).
@@ -55,7 +55,7 @@ import {
 import { deletePendingSenderApproval, getPendingSenderApproval } from './db/pending-sender-approvals.js';
 import { hasAdminPrivilege } from './db/user-roles.js';
 import { getUser, upsertUser } from './db/users.js';
-import { requestSenderApproval } from './sender-approval.js';
+import { declineAndNotify, requestSenderApproval } from './sender-approval.js';
 import { ensureUserDm } from './user-dm.js';
 
 // ── Free-text name input state ──
@@ -149,10 +149,14 @@ function handleUnknownSender(
 
   if (decision.effect === 'allow') return; // 'public' — handled before the gate; fall through silently.
 
+  const isDeclineNotify = mg.unknown_sender_policy === 'decline_notify';
+
   log.info(
-    decision.effect === 'hold'
-      ? 'MESSAGE DROPPED — unknown sender (approval requested)'
-      : 'MESSAGE DROPPED — unknown sender (strict policy)',
+    isDeclineNotify
+      ? 'MESSAGE DROPPED — unknown sender (decline-and-notify policy)'
+      : decision.effect === 'hold'
+        ? 'MESSAGE DROPPED — unknown sender (approval requested)'
+        : 'MESSAGE DROPPED — unknown sender (strict policy)',
     {
       messagingGroupId: mg.id,
       agentGroupId,
@@ -161,6 +165,31 @@ function handleUnknownSender(
     },
   );
   recordDroppedMessage(dropRecord);
+
+  // decline_notify: polite in-DM decline + one-line owner FYI, no
+  // card. Fire-and-forget like the hold path — declineAndNotify dedupes
+  // itself (24h stamp) and logs failures internally; the sender's message
+  // stays dropped either way.
+  if (isDeclineNotify) {
+    // The decline copy assumes a 1:1 DM surface. The policy is
+    // settable on groups (ncl / setup register), where delivering it would
+    // post the decline publicly into the channel — treat groups as strict:
+    // the drop above stands, nothing is sent.
+    if (mg.is_group === 1) {
+      log.warn('decline_notify on a group messaging group — treated as strict (no public decline)', {
+        messagingGroupId: mg.id,
+      });
+      return;
+    }
+    declineAndNotify({
+      messagingGroupId: mg.id,
+      agentGroupId,
+      senderIdentity: userId,
+      senderName,
+      event,
+    }).catch((err) => log.error('decline_notify flow threw', { err }));
+    return;
+  }
 
   // Fire-and-forget; pick-approver + delivery + row-insert are all async.
   // If it fails it logs internally — the user's message still stays dropped

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -25,14 +25,28 @@
  * Dedup: `pending_sender_approvals` has UNIQUE(messaging_group_id,
  * sender_identity). A retry / rapid second message from the same unknown
  * sender is silently dropped (no duplicate card sent).
+ *
+ * This file also carries the `decline_notify` continuation: no
+ * card, no buttons — a polite in-DM decline plus a one-line owner FYI,
+ * deduped per (sender, messaging group) per 24h via a persisted decline
+ * stamp reusing this table's UNIQUE key. See declineAndNotify at the bottom.
  */
 import { normalizeOptions, type RawOption } from '../../channels/ask-question.js';
+import { getAllAgentGroups } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { log } from '../../log.js';
 import type { InboundEvent } from '../../channels/adapter.js';
 import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
-import { createPendingSenderApproval, hasInFlightSenderApproval } from './db/pending-sender-approvals.js';
+import {
+  clearDeclineStamp,
+  createPendingSenderApproval,
+  getDeclineStampAt,
+  hasInFlightSenderApproval,
+  upsertDeclineStamp,
+} from './db/pending-sender-approvals.js';
+import { getOwners } from './db/user-roles.js';
+import { getUser } from './db/users.js';
 
 const APPROVAL_OPTIONS: RawOption[] = [
   { label: 'Allow', selectedLabel: '✅ Allowed', value: 'approve', style: 'primary' },
@@ -53,6 +67,12 @@ export interface RequestSenderApprovalInput {
 
 export async function requestSenderApproval(input: RequestSenderApprovalInput): Promise<void> {
   const { messagingGroupId, agentGroupId, senderIdentity, senderName, event } = input;
+
+  // A stale decline stamp (mg was decline_notify before flipping back to
+  // request_approval) occupies the UNIQUE(messaging_group_id, sender_identity)
+  // key this flow needs — clear it so the in-flight check and the row insert
+  // see a clean slate.
+  clearDeclineStamp(messagingGroupId, senderIdentity);
 
   // In-flight dedup: don't spam the admin if the same unknown sender
   // retries while a card is already pending.
@@ -154,3 +174,129 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
  */
 export const APPROVE_VALUE = 'approve';
 export const REJECT_VALUE = 'reject';
+
+// ── Decline-and-notify (unknown_sender_policy = 'decline_notify') ──
+
+/** At most one decline + one FYI per (sender, messaging group) per this window. */
+export const DECLINE_NOTIFY_DEDUPE_MS = 24 * 60 * 60 * 1000;
+
+/** Stamp key for a sender the resolver couldn't identify — the messaging
+ *  group (a 1:1 DM) still keys the pair, so dedupe holds. */
+const UNKNOWN_SENDER_KEY = 'unknown';
+
+/** First owner with a display_name, for the decline copy. */
+function ownerDisplayName(): string | null {
+  for (const owner of getOwners()) {
+    const name = getUser(owner.user_id)?.display_name;
+    if (name && name.length > 0) return name;
+  }
+  return null;
+}
+
+export interface DeclineAndNotifyInput {
+  messagingGroupId: string;
+  /** Approver-resolution anchor; null falls back to global admins/owners. */
+  agentGroupId: string | null;
+  senderIdentity: string | null; // namespaced user id, when resolvable
+  senderName: string | null;
+  event: InboundEvent;
+}
+
+/**
+ * The decline_notify continuation: (a) a short polite decline sent as the
+ * bot into the sender's DM, (b) a one-line informational FYI to the owner's
+ * DM — plain text, NOT an approval card, no buttons. Grants stay explicit
+ * (`ncl members add` / a future allow affordance). Callers record the
+ * dropped message; dedupe is self-contained here — a persisted decline
+ * stamp (pending_sender_approvals shape) suppresses repeats for 24h.
+ */
+export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<void> {
+  const { messagingGroupId, agentGroupId, senderIdentity, senderName, event } = input;
+
+  // Dedupe: at most one decline + FYI per (sender, messaging group) per 24h.
+  const senderKey = senderIdentity ?? UNKNOWN_SENDER_KEY;
+  const stampedAt = getDeclineStampAt(messagingGroupId, senderKey);
+  if (stampedAt && Date.now() - new Date(stampedAt).getTime() < DECLINE_NOTIFY_DEDUPE_MS) {
+    log.debug('decline_notify deduped — declined within the last 24h', { messagingGroupId, senderIdentity });
+    return;
+  }
+
+  const adapter = getDeliveryAdapter();
+  if (!adapter) {
+    log.error('decline_notify skipped — no delivery adapter is wired', { messagingGroupId });
+    return;
+  }
+
+  // Persist the stamp before sending: a delivery hiccup must not turn into a
+  // decline storm on the sender's next message. FK needs a real agent group —
+  // fall back to the first one (same reference-group pattern as the channel
+  // card flow); with zero agent groups the stamp is skipped (no dedupe, rare
+  // bootstrap state) but the decline still goes out.
+  const stampAgentGroupId = agentGroupId ?? getAllAgentGroups()[0]?.id;
+  if (stampAgentGroupId) {
+    upsertDeclineStamp({
+      messaging_group_id: messagingGroupId,
+      agent_group_id: stampAgentGroupId,
+      sender_identity: senderKey,
+      sender_name: senderName,
+      original_message: JSON.stringify(event),
+    });
+  } else {
+    log.debug('decline_notify stamp skipped — no agent groups exist', { messagingGroupId });
+  }
+
+  const originMg = getMessagingGroup(messagingGroupId);
+
+  // (a) Polite decline in the sender's DM, as the bot. Instance-addressed so
+  // a per-agent bot identity registered as its own adapter instance
+  // answers as itself.
+  const owner = ownerDisplayName();
+  const declineText = `I'm ${owner ?? 'my owner'}'s personal agent — I can't help you directly.`;
+  try {
+    await adapter.deliver(
+      event.channelType,
+      event.platformId,
+      null,
+      'chat-sdk',
+      JSON.stringify({ text: declineText }),
+      undefined,
+      originMg?.instance ?? event.instance,
+    );
+  } catch (err) {
+    log.warn('decline_notify: decline delivery failed', { messagingGroupId, err });
+  }
+
+  // (b) Owner FYI — informational one-liner through the same approver-DM
+  // resolution the card flows use.
+  const approvers = pickApprover(agentGroupId);
+  if (approvers.length === 0) {
+    log.warn('decline_notify FYI skipped — no owner or admin configured', { messagingGroupId, senderIdentity });
+    return;
+  }
+  const target = await pickApprovalDelivery(approvers, event.channelType);
+  if (!target) {
+    log.warn('decline_notify FYI skipped — no DM channel for any approver', { messagingGroupId, senderIdentity });
+    return;
+  }
+
+  const senderDisplay = senderName && senderName.length > 0 ? senderName : (senderIdentity ?? 'An unknown sender');
+  const who =
+    senderIdentity && senderDisplay !== senderIdentity ? `${senderDisplay} (${senderIdentity})` : senderDisplay;
+  const fyiText = `FYI: ${who} DMed your agent on ${event.channelType} — I sent a polite decline. Allow them any time with \`ncl members add\`.`;
+  try {
+    await adapter.deliver(
+      target.messagingGroup.channel_type,
+      target.messagingGroup.platform_id,
+      null,
+      'chat-sdk',
+      JSON.stringify({ text: fyiText }),
+    );
+    log.info('decline_notify handled — decline sent, owner notified', {
+      messagingGroupId,
+      senderIdentity,
+      notified: target.userId,
+    });
+  } catch (err) {
+    log.error('decline_notify: owner FYI delivery failed', { messagingGroupId, err });
+  }
+}

--- a/src/modules/permissions/sender-decline-notify.test.ts
+++ b/src/modules/permissions/sender-decline-notify.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Integration tests for the unknown-sender decline_notify flow.
+ *
+ * Covers:
+ *  - decline_notify policy: unknown sender's message is dropped, the bot
+ *    sends a polite decline into the origin DM, the owner gets a one-line
+ *    FYI (plain text, not a card), and the drop is recorded
+ *  - No approval card / pending card row — only the decline stamp
+ *  - Dedupe: second message within 24h sends nothing further
+ *  - An expired (>24h) stamp declines again
+ *  - Policy flip back to request_approval: the stale stamp is cleared and
+ *    the normal card flow works
+ */
+import fs from 'fs';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createMessagingGroup, createMessagingGroupAgent, updateMessagingGroup } from '../../db/messaging-groups.js';
+import { upsertUser } from './db/users.js';
+import { grantRole } from './db/user-roles.js';
+
+// Mock container runner — prevent actual docker spawn.
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+// Mock delivery adapter — record decline + FYI sends for assertions.
+const deliverMock = vi.fn().mockResolvedValue('plat-msg-id');
+vi.mock('../../delivery.js', () => ({
+  getDeliveryAdapter: () => ({
+    deliver: deliverMock,
+  }),
+}));
+
+// Mock ensureUserDm to return the approver's existing messaging group
+// instead of hitting a real openDM RPC.
+vi.mock('./user-dm.js', () => ({
+  ensureUserDm: vi.fn(async (userId: string) => {
+    const { getDb } = await import('../../db/connection.js');
+    const row = getDb()
+      .prepare(
+        `SELECT mg.* FROM messaging_groups mg
+           JOIN user_dms ud ON ud.messaging_group_id = mg.id
+          WHERE ud.user_id = ?`,
+      )
+      .get(userId);
+    return row;
+  }),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-decline-notify' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-decline-notify';
+
+function now() {
+  return new Date().toISOString();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+
+  // Side-effect imports: register hooks (permissions module) AFTER the
+  // mocks are in place.
+  await import('./index.js');
+
+  // Fixtures: agent group, a wired 1:1 DM messaging group with
+  // decline_notify (a DM-shaped channel), owner + owner DM.
+  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+
+  createMessagingGroup({
+    id: 'mg-dm-stranger',
+    channel_type: 'telegram',
+    platform_id: 'dm-stranger',
+    name: null,
+    is_group: 0,
+    unknown_sender_policy: 'decline_notify',
+    created_at: now(),
+  });
+  createMessagingGroupAgent({
+    id: 'mga-1',
+    messaging_group_id: 'mg-dm-stranger',
+    agent_group_id: 'ag-1',
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now(),
+  });
+
+  // Owner user (with display name — feeds the decline copy) + their DM.
+  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Gavriel', created_at: now() });
+  grantRole({
+    user_id: 'telegram:owner',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now(),
+  });
+  createMessagingGroup({
+    id: 'mg-dm-owner',
+    channel_type: 'telegram',
+    platform_id: 'dm-owner',
+    name: 'Owner DM',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  const { getDb } = await import('../../db/connection.js');
+  getDb()
+    .prepare(
+      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+
+  deliverMock.mockClear();
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+function strangerDm(text: string) {
+  return {
+    channelType: 'telegram',
+    platformId: 'dm-stranger',
+    threadId: null,
+    message: {
+      id: `stranger-${Math.random().toString(36).slice(2, 8)}`,
+      kind: 'chat' as const,
+      content: JSON.stringify({
+        senderId: 'tg:stranger',
+        // handleUnknownSender reads `sender` for the display name (same
+        // extraction the request_approval card uses).
+        sender: 'Stranger',
+        text,
+      }),
+      timestamp: now(),
+    },
+  };
+}
+
+async function settle() {
+  // The decline flow is fire-and-forget off the access gate.
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe('unknown-sender decline_notify flow', () => {
+  it('declines in the DM, FYIs the owner, records the drop — no card', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(strangerDm('hi, can you book me a flight?'));
+    await settle();
+
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+
+    // (a) Polite decline into the stranger's DM, as the bot.
+    const [dChannel, dPlatform, dThread, dKind, dContent] = deliverMock.mock.calls[0];
+    expect(dChannel).toBe('telegram');
+    expect(dPlatform).toBe('dm-stranger');
+    expect(dThread).toBeNull();
+    expect(dKind).toBe('chat-sdk');
+    const decline = JSON.parse(dContent as string);
+    expect(decline.text).toBe("I'm Gavriel's personal agent — I can't help you directly.");
+    expect(decline.options).toBeUndefined(); // plain text, no buttons
+
+    // (b) One-line FYI to the owner's DM — informational, not a card.
+    const [fChannel, fPlatform, , fKind, fContent] = deliverMock.mock.calls[1];
+    expect(fChannel).toBe('telegram');
+    expect(fPlatform).toBe('dm-owner');
+    expect(fKind).toBe('chat-sdk');
+    const fyi = JSON.parse(fContent as string);
+    expect(fyi.type).toBeUndefined(); // not ask_question
+    expect(fyi.options).toBeUndefined();
+    expect(fyi.text).toContain('FYI');
+    expect(fyi.text).toContain('Stranger (tg:stranger)');
+    expect(fyi.text).toContain('ncl members add');
+
+    const { getDb } = await import('../../db/connection.js');
+    // Drop recorded. (The gate writes reason 'unknown_sender_decline_notify';
+    // core's structural no_agent_engaged record then upserts the same row —
+    // pre-existing behavior shared with every refusal path.)
+    const drop = getDb()
+      .prepare('SELECT user_id FROM unregistered_senders WHERE platform_id = ?')
+      .get('dm-stranger') as { user_id: string };
+    expect(drop.user_id).toBe('tg:stranger');
+
+    // No card rows anywhere — only the decline stamp.
+    const rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toMatch(/^decline:/);
+    const channelRows = getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number };
+    expect(channelRows.c).toBe(0);
+  });
+
+  it('dedupes: a second message within 24h sends no further decline or FYI', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(strangerDm('hello'));
+    await settle();
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+
+    await routeInbound(strangerDm('are you there?'));
+    await settle();
+
+    // Still just the original decline + FYI pair; both drops recorded (each
+    // message upserts twice: the gate's policy record + core's structural
+    // no_agent_engaged record — pre-existing double-count on refusals).
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+    const { getDb } = await import('../../db/connection.js');
+    const drop = getDb()
+      .prepare('SELECT message_count FROM unregistered_senders WHERE platform_id = ?')
+      .get('dm-stranger') as { message_count: number };
+    expect(drop.message_count).toBe(4);
+  });
+
+  it('declines again once the 24h stamp expires', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(strangerDm('hello'));
+    await settle();
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+
+    // Age the stamp past the window.
+    const { getDb } = await import('../../db/connection.js');
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    getDb().prepare(`UPDATE pending_sender_approvals SET created_at = ? WHERE id LIKE 'decline:%'`).run(old);
+
+    await routeInbound(strangerDm('hello again'));
+    await settle();
+
+    expect(deliverMock).toHaveBeenCalledTimes(4); // second decline + FYI pair
+    const stamp = getDb()
+      .prepare(`SELECT created_at FROM pending_sender_approvals WHERE id LIKE 'decline:%'`)
+      .get() as {
+      created_at: string;
+    };
+    expect(new Date(stamp.created_at).getTime()).toBeGreaterThan(Date.now() - 60_000); // refreshed
+  });
+
+  it('flip request_approval→decline_notify with a card pending: card row converts to a stamp, dedupe holds', async () => {
+    // Start on request_approval — the stranger's first message cards.
+    updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(strangerDm('hello'));
+    await settle();
+    expect(deliverMock).toHaveBeenCalledTimes(1); // the approval card
+
+    const { getDb } = await import('../../db/connection.js');
+    let rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toMatch(/^nsa-/);
+
+    // Operator flips the policy while the card is still pending.
+    updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'decline_notify' });
+    deliverMock.mockClear();
+
+    await routeInbound(strangerDm('are you there?'));
+    await settle();
+
+    // Decline + FYI went out; the pending card row became the stamp (the
+    // UNIQUE(messaging_group_id, sender_identity) collision converts it).
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+    rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toMatch(/^decline:/);
+
+    // And the stamp dedupes: a third message sends nothing further.
+    await routeInbound(strangerDm('hello??'));
+    await settle();
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('decline_notify on a group messaging group: silent drop — no public decline, no FYI', async () => {
+    createMessagingGroup({
+      id: 'mg-team',
+      channel_type: 'telegram',
+      platform_id: 'group-team',
+      name: 'Team',
+      is_group: 1,
+      unknown_sender_policy: 'decline_notify',
+      created_at: now(),
+    });
+    createMessagingGroupAgent({
+      id: 'mga-team',
+      messaging_group_id: 'mg-team',
+      agent_group_id: 'ag-1',
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: now(),
+    });
+
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound({ ...strangerDm('hi all'), platformId: 'group-team' });
+    await settle();
+
+    // Nothing delivered anywhere — the DM-phrased decline must never be
+    // posted publicly into the group channel; no stamp either.
+    expect(deliverMock).not.toHaveBeenCalled();
+    const { getDb } = await import('../../db/connection.js');
+    const drop = getDb()
+      .prepare('SELECT user_id FROM unregistered_senders WHERE platform_id = ?')
+      .get('group-team') as { user_id: string };
+    expect(drop.user_id).toBe('tg:stranger');
+    const stamps = getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number };
+    expect(stamps.c).toBe(0);
+  });
+
+  it('policy flip back to request_approval clears the stale stamp and cards normally', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(strangerDm('hello'));
+    await settle();
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+
+    updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
+    deliverMock.mockClear();
+
+    await routeInbound(strangerDm('let me in'));
+    await settle();
+
+    // One card to the owner — the decline stamp did not block the UNIQUE key.
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    const [, platform, , , content] = deliverMock.mock.calls[0];
+    expect(platform).toBe('dm-owner');
+    const payload = JSON.parse(content as string);
+    expect(payload.type).toBe('ask_question');
+
+    const { getDb } = await import('../../db/connection.js');
+    const rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toMatch(/^nsa-/); // real card row; stamp gone
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface ContainerConfigRow {
   updated_at: string;
 }
 
-export type UnknownSenderPolicy = 'strict' | 'request_approval' | 'public';
+export type UnknownSenderPolicy = 'strict' | 'request_approval' | 'decline_notify' | 'public';
 
 export interface MessagingGroup {
   id: string;


### PR DESCRIPTION
Three small wizard/engine fixes. (1) skill-apply's step captions took the SKILL.md heading verbatim, so authoring ordinals rendered as wrong step numbers across skipped steps and multi-skill runs — a leading '2.' / '2)' is now stripped; the engine's own (i/n) suffix already disambiguates repeats. (2) On headless installs confirmThenOpen silently returned, leaving the user with no URL at all; it now always prints the URL raw on stdout (clack notes wrap long lines and inject gutter pipes mid-URL, breaking copy-paste). (3) runInheritScript (terminal-handover child spawn) moves from setup/auto.ts to setup/lib/inherit-script.ts so channel flows can reuse it without importing the wizard driver; behavior unchanged.

---
Part 1/8 of a stacked series of independent trunk improvements; stacked for conflict-free review — each PR stands alone semantically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
