### PR TITLE
Delivery: registerDeliveryBatchPreview hook over each undelivered batch (A2)

### DIFF
--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -36,7 +36,7 @@ import {
 } from './db/index.js';
 import { getDeliveredIds } from './db/session-db.js';
 import { resolveSession, resolveTaskSession, outboundDbPath, openInboundDb } from './session-manager.js';
-import { deliverSessionMessages, setDeliveryAdapter } from './delivery.js';
+import { deliverSessionMessages, registerDeliveryBatchPreview, setDeliveryAdapter } from './delivery.js';
 import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
 
 function now(): string {
@@ -406,5 +406,37 @@ describe('deliverSessionMessages — task_log rows (one-door task delivery)', ()
     // Marked delivered — the row is not retried.
     const delivered = getDeliveredIds(openInboundDb('ag-1', session.id));
     expect(delivered.has('log-1')).toBe(true);
+  });
+});
+
+describe('deliverSessionMessages — batch preview hooks', () => {
+  it('hooks see the whole undelivered batch before row processing; a throwing hook never breaks delivery', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'bp-1');
+    insertOutbound('ag-1', session.id, 'bp-2');
+
+    const seen: Array<{ kinds: string[]; sessionId: string }> = [];
+    registerDeliveryBatchPreview((batch, s) => {
+      seen.push({ kinds: batch.map((m) => m.kind), sessionId: s.id });
+    });
+    registerDeliveryBatchPreview(() => {
+      throw new Error('hook exploded');
+    });
+
+    const sent: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_channelType, _platformId, _threadId, _kind, content) {
+        sent.push(content);
+        return undefined;
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    expect(seen.length).toBe(1);
+    expect(seen[0].kinds).toEqual(['chat', 'chat']);
+    expect(seen[0].sessionId).toBe(session.id);
+    expect(sent.length).toBe(2); // the throwing hook did not block delivery
   });
 });

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -206,6 +206,23 @@ async function drainSession(session: Session): Promise<void> {
     // Ensure platform_message_id column exists (migration for existing sessions)
     migrateDeliveredTable(inDb);
 
+    // Batch preview: registered modules peek at the whole undelivered batch
+    // before rows are processed one-by-one — e.g. a module prefetching an
+    // expensive per-message resource in parallel when the batch contains
+    // several rows that would otherwise each pay the cost sequentially.
+    // Hooks see kind+content only, must be fast, and must never break
+    // delivery.
+    for (const hook of batchPreviewHooks) {
+      try {
+        hook(
+          undelivered.map((m) => ({ kind: m.kind, content: m.content })),
+          session,
+        );
+      } catch (err) {
+        log.warn('Delivery batch-preview hook failed', { sessionId: session.id, err });
+      }
+    }
+
     for (const msg of undelivered) {
       try {
         const platformMsgId = await deliverMessage(msg, session, inDb);
@@ -455,6 +472,13 @@ const deliveryActions = new Map<string, DeliveryEntry>();
 
 function isUnguardedEntry(entry: DeliveryEntry): entry is Extract<DeliveryEntry, { guard: Unguarded }> {
   return isUnguarded(entry.guard);
+}
+
+/** See the batch-preview invocation in the delivery poll for semantics. */
+type DeliveryBatchPreviewHook = (batch: Array<{ kind: string; content: string }>, session: Session) => void;
+const batchPreviewHooks: DeliveryBatchPreviewHook[] = [];
+export function registerDeliveryBatchPreview(hook: DeliveryBatchPreviewHook): void {
+  batchPreviewHooks.push(hook);
 }
 
 export function registerDeliveryAction(action: string, handler: DeliveryActionHandler, unguardedDecl: Unguarded): void;

--- a/src/modules/agent-to-agent/create-agent.notify.test.ts
+++ b/src/modules/agent-to-agent/create-agent.notify.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for createAgent's CreateAgentOptions.suppressCreatedNotify (D5).
+ *
+ * The upstream success notify ("created — you can now message it") fires
+ * before any wrapper post-processing (e.g. slack-agent-flow provisioning), so
+ * wrappers that own the completion signal pass suppressCreatedNotify to keep
+ * the requester from hearing "done" early. Error notifies (collision) must
+ * still fire — they are the only signal on those paths.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Session } from '../../types.js';
+
+// vi.hoisted: the module import below runs before this file's const
+// initializers, and the mock factories close over this state.
+const { mockNotifyWrite, destinations } = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  destinations: new Map<string, { target_type: string; target_id: string }>(),
+}));
+
+vi.mock('../approvals/index.js', () => ({
+  requestApproval: vi.fn().mockResolvedValue(undefined),
+  notifyAgent: vi.fn(),
+  registerApprovalHandler: vi.fn(),
+}));
+vi.mock('../../db/container-configs.js', () => ({
+  getContainerConfig: () => ({ cli_scope: 'global' }),
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  getAgentGroup: (id: string) => ({ id, name: id.toUpperCase(), folder: id, agent_provider: null, created_at: '' }),
+  getAgentGroupByFolder: () => undefined,
+  createAgentGroup: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({ initGroupFilesystem: vi.fn() }));
+vi.mock('./write-destinations.js', () => ({ writeDestinations: vi.fn() }));
+vi.mock('./db/agent-destinations.js', () => ({
+  getDestinationByName: (group: string, name: string) => destinations.get(`${group}/${name}`),
+  createDestination: vi.fn(),
+  normalizeName: (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../db/sessions.js', () => ({
+  getSession: (id: string) => ({ id, agent_group_id: 'ag-1' }),
+}));
+
+import { createAgent } from './create-agent.js';
+
+const SESSION = { id: 'sess-1', agent_group_id: 'ag-1' } as Session;
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  destinations.clear();
+});
+
+describe('createAgent — suppressCreatedNotify option', () => {
+  it('default: the success notify fires', async () => {
+    await createAgent({ name: 'Scout' }, SESSION);
+
+    expect(notifyTexts().some((t) => t.includes('Agent "scout" created'))).toBe(true);
+  });
+
+  it('suppressCreatedNotify: creation runs but the success notify is silenced', async () => {
+    await createAgent({ name: 'Scout' }, SESSION, { suppressCreatedNotify: true });
+
+    expect(notifyTexts()).toHaveLength(0);
+  });
+
+  it('suppressCreatedNotify does NOT silence the collision error notify', async () => {
+    destinations.set('ag-1/scout', { target_type: 'agent', target_id: 'ag-existing' });
+
+    await createAgent({ name: 'Scout' }, SESSION, { suppressCreatedNotify: true });
+
+    expect(notifyTexts().some((t) => t.includes('already have a destination named "scout"'))).toBe(true);
+  });
+});

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -77,14 +77,29 @@ export async function requestCreateAgentHold(content: Record<string, unknown>, s
   });
 }
 
+export interface CreateAgentOptions {
+  /**
+   * Suppress the terminal `Agent "<name>" created…` success notify. Error
+   * notifies (collision, invalid path) still fire. For wrappers whose own
+   * completion text is the requester's only "done" signal — e.g.
+   * slack-agent-flow, where Slack provisioning runs AFTER this returns and
+   * relaying the upstream text would report "done" ~a minute early.
+   */
+  suppressCreatedNotify?: boolean;
+}
+
 /** Guard allow body: performs the creation (fresh global-scope call or approved replay). */
-export async function createAgent(content: Record<string, unknown>, session: Session): Promise<void> {
+export async function createAgent(
+  content: Record<string, unknown>,
+  session: Session,
+  options?: CreateAgentOptions,
+): Promise<void> {
   const name = typeof content.name === 'string' ? content.name : '';
   const instructions = typeof content.instructions === 'string' ? content.instructions : null;
   const sourceGroup = getAgentGroup(session.agent_group_id);
   if (!name || !sourceGroup) return; // precheck already answered the requester
 
-  await performCreateAgent(name, instructions, session, sourceGroup, (text) => notifyAgent(session, text));
+  await performCreateAgent(name, instructions, session, sourceGroup, (text) => notifyAgent(session, text), options);
 }
 
 /**
@@ -101,6 +116,7 @@ async function performCreateAgent(
   session: Session,
   sourceGroup: AgentGroup,
   notify: (text: string) => void,
+  options?: CreateAgentOptions,
 ): Promise<void> {
   const localName = normalizeName(name);
 
@@ -179,6 +195,8 @@ async function performCreateAgent(
   // tries to send to the newly-created child.
   writeDestinations(session.agent_group_id, session.id);
 
-  notify(`Agent "${localName}" created. You can now message it with send_message({ to: "${localName}", ... }).`);
+  if (!options?.suppressCreatedNotify) {
+    notify(`Agent "${localName}" created. You can now message it with send_message({ to: "${localName}", ... }).`);
+  }
   log.info('Agent group created', { agentGroupId, name, localName, folder, parent: sourceGroup.id });
 }

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -53,7 +53,7 @@ import { getDeliveryAdapter } from '../../delivery.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { log } from '../../log.js';
 import type { InboundEvent } from '../../channels/adapter.js';
-import type { AgentGroup } from '../../types.js';
+import type { AgentGroup, MessagingGroup } from '../../types.js';
 import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
 import { createPendingChannelApproval, hasInFlightChannelApproval } from './db/pending-channel-approvals.js';
 import { hasAdminPrivilege } from './db/user-roles.js';
@@ -64,6 +64,29 @@ export const CONNECT_PREFIX = 'connect:';
 export const NEW_AGENT_VALUE = 'new_agent';
 export const CHOOSE_EXISTING_VALUE = 'choose_existing';
 export const REJECT_VALUE = 'reject';
+
+// ── Channel-card interceptor seam (B2/D24) ──
+// A channel module can claim the escalation for its own channel type before
+// a registration card goes out — e.g. the slack-room-membership module's
+// owner-presence rule (owner in the room → auto-wire, no card) and its
+// Slackbot shadow-channel backstop. The seam is deliberately generic: this
+// module registers/consults by channel_type only and never imports channel
+// code. 'handled' = the interceptor consumed the escalation (wired, declined,
+// or deliberately ignored it); 'card' = proceed with today's card flow.
+// Interceptor errors fall back to the card — a broken module must never make
+// escalations silently vanish.
+
+export type ChannelCardDecision = 'card' | 'handled';
+export type ChannelCardInterceptor = (mg: MessagingGroup, event: InboundEvent) => Promise<ChannelCardDecision>;
+
+const channelCardInterceptors = new Map<string, ChannelCardInterceptor>();
+
+export function registerChannelCardInterceptor(channelType: string, fn: ChannelCardInterceptor): void {
+  if (channelCardInterceptors.has(channelType)) {
+    log.warn('Channel-card interceptor overwritten', { channelType });
+  }
+  channelCardInterceptors.set(channelType, fn);
+}
 
 // ── Utilities ──
 
@@ -172,6 +195,27 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     return;
   }
 
+  const originMg = getMessagingGroup(messagingGroupId);
+
+  // Channel-module interceptor: consulted before any card work so a module
+  // can auto-wire / decline / suppress for its own channel type. Runs after
+  // the in-flight dedupe (a pending card already owns this channel) and
+  // before the approver checks (an auto-wire needs no reachable approver).
+  const interceptor = originMg ? channelCardInterceptors.get(originMg.channel_type) : undefined;
+  if (originMg && interceptor) {
+    try {
+      if ((await interceptor(originMg, event)) === 'handled') {
+        log.debug('Channel registration handled by interceptor — no card', {
+          messagingGroupId,
+          channelType: originMg.channel_type,
+        });
+        return;
+      }
+    } catch (err) {
+      log.warn('Channel-card interceptor threw — falling back to the card', { messagingGroupId, err });
+    }
+  }
+
   const agentGroups = getAllAgentGroups();
   if (agentGroups.length === 0) {
     log.warn('Channel registration skipped — no agent groups configured. Run /init-first-agent.', {
@@ -192,7 +236,6 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     return;
   }
 
-  const originMg = getMessagingGroup(messagingGroupId);
   const originChannelType = originMg?.channel_type ?? '';
 
   // Resolve channel name if not yet persisted. Key by instance so a named

--- a/src/modules/permissions/channel-card-interceptor.test.ts
+++ b/src/modules/permissions/channel-card-interceptor.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the channel-card interceptor seam (B2/D24).
+ *
+ * Covers:
+ *  - registerChannelCardInterceptor + consult order: the interceptor runs
+ *    before any card work for its channel type only
+ *  - 'handled' → no card delivered, no pending_channel_approvals row
+ *  - 'card' → today's flow proceeds unchanged
+ *  - interceptor throw → card fallback (a broken module never makes
+ *    escalations vanish)
+ *  - in-flight dedupe still short-circuits before the interceptor
+ */
+import fs from 'fs';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import type { InboundEvent } from '../../channels/adapter.js';
+import type { MessagingGroup } from '../../types.js';
+import { upsertUser } from './db/users.js';
+import { grantRole } from './db/user-roles.js';
+
+// Mock container runner — prevent actual docker spawn.
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+// Mock delivery adapter.
+const deliverMock = vi.fn().mockResolvedValue('plat-msg-id');
+vi.mock('../../delivery.js', () => ({
+  getDeliveryAdapter: () => ({ deliver: deliverMock }),
+}));
+
+// Mock ensureUserDm — look up the owner's preconfigured DM row.
+vi.mock('./user-dm.js', () => ({
+  ensureUserDm: vi.fn(async (userId: string) => {
+    const { getDb } = await import('../../db/connection.js');
+    const row = getDb()
+      .prepare(
+        `SELECT mg.* FROM messaging_groups mg
+           JOIN user_dms ud ON ud.messaging_group_id = mg.id
+          WHERE ud.user_id = ?`,
+      )
+      .get(userId);
+    return row;
+  }),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-card-interceptor' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-card-interceptor';
+
+function now() {
+  return new Date().toISOString();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({ id: 'ag-1', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
+
+  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+  grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+  createMessagingGroup({
+    id: 'mg-dm-owner',
+    channel_type: 'telegram',
+    platform_id: 'dm-owner',
+    name: 'Owner DM',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  const { getDb } = await import('../../db/connection.js');
+  getDb()
+    .prepare(`INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at) VALUES (?, ?, ?, ?)`)
+    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+
+  deliverMock.mockClear();
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+function unwiredChannel(id: string, channelType = 'telegram'): MessagingGroup {
+  const mg: MessagingGroup = {
+    id,
+    channel_type: channelType,
+    platform_id: `chan-${id}`,
+    instance: channelType,
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: 'request_approval',
+    created_at: now(),
+  };
+  createMessagingGroup(mg);
+  return mg;
+}
+
+function mention(mg: MessagingGroup): InboundEvent {
+  return {
+    channelType: mg.channel_type,
+    platformId: mg.platform_id,
+    threadId: null,
+    message: {
+      id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+      kind: 'chat',
+      timestamp: now(),
+      isMention: true,
+      isGroup: true,
+      content: JSON.stringify({ senderId: 'caller', senderName: 'Caller', text: '@bot hi' }),
+    },
+  };
+}
+
+async function pendingCount(): Promise<number> {
+  const { getDb } = await import('../../db/connection.js');
+  return (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+}
+
+describe('channel-card interceptor seam', () => {
+  it("'handled' suppresses the card: no delivery, no pending row", async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    const interceptor = vi.fn().mockResolvedValue('handled');
+    registerChannelCardInterceptor('telegram', interceptor);
+
+    const mg = unwiredChannel('mg-a');
+    const event = mention(mg);
+    await requestChannelApproval({ messagingGroupId: mg.id, event });
+
+    expect(interceptor).toHaveBeenCalledTimes(1);
+    expect(interceptor).toHaveBeenCalledWith(expect.objectContaining({ id: mg.id }), event);
+    expect(deliverMock).not.toHaveBeenCalled();
+    expect(await pendingCount()).toBe(0);
+  });
+
+  it("'card' proceeds with today's flow", async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    registerChannelCardInterceptor('telegram', vi.fn().mockResolvedValue('card'));
+
+    const mg = unwiredChannel('mg-b');
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(deliverMock.mock.calls[0][4] as string);
+    expect(payload.type).toBe('ask_question');
+    expect(await pendingCount()).toBe(1);
+  });
+
+  it('interceptor throw falls back to the card', async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    registerChannelCardInterceptor('telegram', vi.fn().mockRejectedValue(new Error('boom')));
+
+    const mg = unwiredChannel('mg-c');
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    expect(await pendingCount()).toBe(1);
+  });
+
+  it('only consulted for its own channel type', async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    const interceptor = vi.fn().mockResolvedValue('handled');
+    registerChannelCardInterceptor('slack', interceptor);
+
+    const mg = unwiredChannel('mg-d'); // telegram
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(interceptor).not.toHaveBeenCalled();
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('in-flight dedupe short-circuits before the interceptor', async () => {
+    const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
+    const interceptor = vi.fn().mockResolvedValue('card');
+    registerChannelCardInterceptor('telegram', interceptor);
+
+    const mg = unwiredChannel('mg-e');
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+    await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
+
+    expect(interceptor).toHaveBeenCalledTimes(1); // second call died at the pending-row check
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Lets modules peek at a session's whole undelivered outbound batch before rows are delivered one-by-one. Hooks receive (kind, content) pairs plus the session, must be fast, and can never break delivery — each hook is wrapped in try/catch and failures only log. The motivating use is prefetching expensive per-message resources in parallel when a batch contains several rows that would otherwise each pay the cost sequentially.

---
Part 6/8 of a stacked series of independent trunk improvements; stacked for conflict-free review — each PR stands alone semantically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
