### PR TITLE
fix(poll-loop): stopped loops leaked their active query's follow-up poller

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -533,9 +533,20 @@ describe('task-run turn wiring (real processQuery)', () => {
       // A SECOND task run lands while the query is open — the follow-up poller
       // pushes it and must reset the per-turn correction state.
       insertMessage('t2', 'task', { prompt: 'fire two' });
-      const deadline = Date.now() + 5000;
+      // The poller ticks every ACTIVE_POLL_INTERVAL_MS (500ms), so this
+      // normally resolves in well under a second. The generous deadline is
+      // for slow shared CI runners — and it must stay well below the test's
+      // own timeout (set below), so exhaustion fails on the diagnostic throw
+      // rather than a mute test timeout.
+      const deadline = Date.now() + 15_000;
       while (!pushes.some((p) => p.includes('fire two')) && Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!pushes.some((p) => p.includes('fire two'))) {
+        throw new Error(
+          `follow-up poller never pushed the second task run within 15s; ` +
+            `pushes seen (${pushes.length}): ${JSON.stringify(pushes.map((p) => p.slice(0, 80)))}`,
+        );
       }
 
       // Turn 2 repeats the mistake. This receives a second independent nudge
@@ -566,5 +577,8 @@ describe('task-run turn wiring (real processQuery)', () => {
     expect(logs[1]).toContain('[undelivered → local-cli] fire two result');
     expect(logs).not.toContain('first delivery decision handled');
     expect(logs).not.toContain('second delivery decision handled');
-  });
+    // Explicit budget: the default 5s equalled the old inner deadline, so on
+    // slow runners the test died as a mute timeout instead of reaching the
+    // diagnostic throw above (observed consistently on CI-hosted runners).
+  }, 20_000);
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -249,6 +249,16 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // Publish the batch's in_reply_to so MCP tools (send_message, send_file)
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
+    // Forward a loop stop to the ACTIVE query. The stream deliberately stays
+    // open between turns, so the loop can be parked inside processQuery when
+    // config.signal fires; without this, the "stopped" loop's query — and its
+    // 500ms follow-up poller — outlives the stop and keeps polling (and
+    // claiming) messages from whatever inbound DB the process points at. In
+    // tests that leaked one immortal poller per loop-driven test, which could
+    // steal a later test's follow-up message into a dead query.
+    const abortActiveQuery = () => query.abort();
+    if (config.signal?.aborted) abortActiveQuery();
+    else config.signal?.addEventListener('abort', abortActiveQuery, { once: true });
     try {
       const result = await processQuery(
         query,
@@ -292,6 +302,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       log(`Errored batch will be acked completed — ${processingIds.length} message(s), no redelivery`);
     } finally {
       clearCurrentInReplyTo();
+      config.signal?.removeEventListener('abort', abortActiveQuery);
     }
 
     // Ensure completed even if processQuery ended without a result event


### PR DESCRIPTION
## What

Two commits:

1. **Root cause** — `runPollLoop` only checked `config.signal` between iterations, but the loop is usually parked inside `processQuery` on a stream that deliberately stays open between turns. An aborted loop therefore left its active query — and the 500ms follow-up poller inside `processQuery` — running forever. Fix: forward the signal to the active query (`query.abort()`, listener removed after the turn settles).

2. **Test hardening** — the task-run follow-up test's internal 5s deadline equalled bun's default test timeout, so failures surfaced as mute 5000ms timeouts. It now has a 15s inner deadline, a diagnostic throw reporting the pushes actually seen, and an explicit 20s budget.

## Why CI was red

The container suite failed consistently on CI-hosted runners (across unrelated PRs) on `task-run turn wiring › logs and conditionally nudges a second task run`. Instrumenting poller lifecycles showed **15 of 20 pollers never cleared** — every loop-driven test leaked one immortal poller. Leaked pollers keep polling the process-global inbound DB, so one of them can *claim a later test's follow-up message into its dead query*; the live test's poller then never sees the message and starves. Runner timing made the theft consistent on CI while local runs won the race.

The diagnostic commit proved this on CI before the fix: the test failed at 15s having seen only the turn-1 nudge, while a leaked poller logged `Pushing 1 follow-up message(s) into active query`, and dozens of `Follow-up poll error: unable to open database file` lines followed from leaked pollers hitting rotated test DBs.

## Verification

- Full container suite ×3 under linux/amd64, 2 CPUs, bun 1.3.12 (CI's pin): 171 pass / 0 fail, **zero** `Follow-up poll error` lines (previously dozens per run).
- Container typecheck clean. No production-behavior change: containers stop via process exit; any embedder using `config.signal` now gets a clean unwind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)