### PR TITLE
fix(setup): detect package manager in install-node.sh

### DIFF
--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -38,10 +38,42 @@ else
       brew install node@22
       ;;
     Linux)
-      echo "STEP: nodesource-setup"
-      curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-      echo "STEP: apt-install-nodejs"
-      sudo apt-get install -y nodejs
+      ID_LIKE=""
+      ID=""
+      if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+      fi
+      case "$ID_LIKE $ID" in
+        *debian*|*ubuntu*)
+          echo "STEP: nodesource-setup"
+          curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+          echo "STEP: apt-install-nodejs"
+          sudo apt-get install -y nodejs
+          ;;
+        *rhel*|*fedora*|*centos*)
+          echo "STEP: nodesource-setup-rpm"
+          curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo -E bash -
+          echo "STEP: dnf-install-nodejs"
+          if command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y nodejs
+          else
+            sudo yum install -y nodejs
+          fi
+          ;;
+        *suse*)
+          echo "STEP: zypper-install-nodejs"
+          sudo zypper --non-interactive install nodejs22
+          ;;
+        *)
+          echo "STATUS: failed"
+          echo "ERROR: Unsupported Linux distro: ID=$ID ID_LIKE=$ID_LIKE"
+          echo "ERROR: This script supports Debian/Ubuntu and RHEL/Fedora/CentOS/openSUSE out of the box."
+          echo "ERROR: On other distros, install Node 22 via your distro's package manager (or nvm/uv/fnm), then re-run this script."
+          echo "=== END ==="
+          exit 1
+          ;;
+      esac
       ;;
     *)
       echo "STATUS: failed"


### PR DESCRIPTION
Closes #2462

## Summary

`setup/install-node.sh`'s Linux branch unconditionally piped NodeSource's Debian-only setup script (`deb.nodesource.com/setup_22.x`) through `sudo bash`, then ran `apt-get install`. On any non-Debian Linux (Fedora, RHEL, CentOS, openSUSE, Arch, Alpine) this fails with NodeSource's own "This script is only supported on Debian-based systems." error and leaves the user with no next step.

This implements Option 2 from the issue (distro-aware branching), with a fallback to Option 1's fail-fast helpful error for distros not covered:

- Source `/etc/os-release` to read `ID`/`ID_LIKE`.
- Debian/Ubuntu (`*debian*|*ubuntu*`): unchanged existing NodeSource deb installer + `apt-get install`.
- RHEL/Fedora/CentOS (`*rhel*|*fedora*|*centos*`): NodeSource's RPM installer (`rpm.nodesource.com/setup_22.x`), then `dnf install` (falling back to `yum` if `dnf` isn't present).
- openSUSE (`*suse*`): `zypper install nodejs22`.
- Anything else: fail fast with a clear message pointing the user to their distro's package manager or `nvm`/`uv`/`fnm`, then re-run the script — instead of surfacing NodeSource's cryptic Debian-only error.

The pre-existing `uvx nodeenv` fast path (when `uv` is already on `PATH`) and the macOS `brew` path are untouched.

## Test plan

- [x] `bash -n setup/install-node.sh` — syntax check passes.
- [ ] `shellcheck` — not available in this environment; not run.
- [x] Manual trace of both branches against representative `/etc/os-release` values:
  - Debian/Ubuntu (`ID=debian`/`ubuntu`, `ID_LIKE=debian`) → matches `*debian*` → unchanged apt path.
  - Fedora (`ID=fedora`, `ID_LIKE=fedora`) and RHEL/CentOS (`ID_LIKE` containing `rhel`/`fedora`) → matches `*rhel*|*fedora*|*centos*` → RPM installer + `dnf`/`yum`.
  - openSUSE (`ID_LIKE=suse`) → matches `*suse*` → `zypper` path.
  - Arch/Alpine (no matching `ID`/`ID_LIKE`) → falls through to the helpful fail-fast error instead of NodeSource's Debian-only failure.
- [ ] Not executed on an actual Fedora/RHEL/openSUSE box — no such environment available here, so the RPM/zypper install commands themselves are unverified end-to-end, only traced against NodeSource's documented RPM setup script and each distro's documented package manager syntax.

No other files changed. `uvx nodeenv` and macOS `brew` paths are untouched.