### PR TITLE
engine: bump OneCLI gateway pin to 1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **New NanoClaw installs now use OneCLI gateway 1.41.0.** Existing 1.36.0 gateways remain compatible because NanoClaw does not depend on any 1.41-only behavior. See [the OneCLI upgrade guide](docs/onecli-upgrades.md) to upgrade an existing gateway.
+
 ## [2.2.0] - 2026-08-13
 
 - **Stamped plugins update in place through `ncl groups create --template <ref>`.** When a group already carries the template's plugin, the same command becomes an in-place update instead of minting a duplicate agent: a dry run prints a plan of every plugin-owned surface (plugin files, skills, MCP servers, persona, context files, tasks), flagging locally customized files whose edits would be lost; `--yes` applies, `--id` picks among several stamped groups, `--new` deliberately stamps another agent. Agent state the plugin does not own (memory, `plugin-data/`, user-added MCP servers, task pause/resume state, wiring) is never touched. Plugin-stamped MCP servers now carry an ownership marker and refuse direct edits via `ncl groups config add-mcp-server` / `remove-mcp-server` or the agent's `add_mcp_server` tool: update the plugin and restamp instead.

--- a/docs/onecli-upgrades.md
+++ b/docs/onecli-upgrades.md
@@ -25,7 +25,7 @@ The gateway runs as a Docker service in `~/.onecli`. Upgrade just that container
 **Local gateway (the common case):**
 
 ```bash
-cd ~/.onecli && ONECLI_VERSION=<onecli-gateway pin from versions.json> docker compose pull onecli && docker compose up -d
+cd ~/.onecli && ONECLI_VERSION=<onecli-gateway pin from versions.json> docker compose pull onecli && ONECLI_VERSION=<onecli-gateway pin from versions.json> docker compose up -d
 ```
 
 **Remote gateway** — run the same command on the gateway's host (NanoClaw can't reach it over SSH).
@@ -45,7 +45,7 @@ docker run --rm --add-host=host.docker.internal:host-gateway \
   curlimages/curl -s -o /dev/null -w '%{http_code}' http://host.docker.internal:10254/v1/health
 ```
 
-This must print `200`. If it can't connect while the host-side check passed, set the bind address in `~/.onecli/.env` to the docker-bridge IP (or `0.0.0.0` on a host with a closed firewall) and `cd ~/.onecli && docker compose up -d`. Symptom if skipped: host log clean, agents fail all API calls.
+This must print `200`. If it can't connect while the host-side check passed, set the bind address in `~/.onecli/.env` to the docker-bridge IP (or `0.0.0.0` on a host with a closed firewall) and `cd ~/.onecli && ONECLI_VERSION=<onecli-gateway pin from versions.json> docker compose up -d`. Symptom if skipped: host log clean, agents fail all API calls.
 
 Finally, restart the NanoClaw service (per-install names — derive with `setup/lib/install-slug.sh`):
 

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "onecli-gateway": "1.36.0",
+  "onecli-gateway": "1.41.0",
   "onecli-cli": "2.2.5",
   "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:ccde3d9c86fb655be66c93e07bc38a62faab2d951651a1fba345a7a47defeb85"
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix**

## Description

New NanoClaw installs now use OneCLI gateway 1.41.0. Existing 1.36.0 gateways remain compatible because NanoClaw does not depend on any 1.41-only behavior.

The upgrade guide now keeps the requested version in scope for every version-sensitive `docker compose up`, preventing Compose from falling back to `latest`. The OneCLI CLI and agent image pins are unchanged.

## Testing

- Host formatting, typecheck, and full test suite: 109 files and 1,441 tests passed
- Container typecheck and full test suite: 172 passed, 1 skipped
- Focused version-pin and OneCLI setup tests: 8 passed
- Rehearsed the 1.36.0 → 1.41.0 upgrade, rollback, and roll-forward
- Verified 1.41.0 host and container health, authentication, agent setup and reply, and the approval connection
