### PR TITLE
fix(container-runner): re-point a shared skill symlink when its target moves

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -419,8 +419,18 @@ function syncSkillSymlinks(claudeDir: string, containerConfig: import('./contain
     } catch {
       /* missing */
     }
+    const target = `/app/skills/${skill}`;
     if (!entry) {
-      fs.symlinkSync(`/app/skills/${skill}`, linkPath);
+      fs.symlinkSync(target, linkPath);
+    } else if (entry.isSymbolicLink() && fs.readlinkSync(linkPath) !== target) {
+      // Re-point a symlink whose target has moved. Targets are container paths,
+      // so a stale one is dangling *inside* the container while resolving to
+      // nothing on the host either — the skill is simply absent and the agent
+      // reports the script as missing. Reconciling presence alone (create
+      // missing, drop unwanted) left these untouched and silently broken.
+      fs.unlinkSync(linkPath);
+      fs.symlinkSync(target, linkPath);
+      log.info('Re-pointed shared skill symlink to current target', { skill, target });
     } else if (!entry.isSymbolicLink()) {
       // A real entry here is either a template overlay (intentional; see
       // src/group-skills.ts) or a stale pre-refactor skill copy that shadows


### PR DESCRIPTION
## Problem

`syncSkillSymlinks` reconciles **presence** only — it creates links that are missing and removes ones no longer desired — but never re-points an existing symlink whose target has changed.

Because the targets are *container* paths (`/app/skills/<name>`), a stale link is invisible on the host: `ls` shows the entry, and nothing in the reconcile loop objects. Inside the container it dangles, so `/home/node/.claude/skills/<name>/` is empty and any script under it is simply absent.

The failure is silent from the operator's side. Nothing logs, the container starts normally, and the only symptom is the agent reporting that a skill's script is missing — or quietly falling back to another code path, which is what happened to us:

> Note: RSS skill scripts remain broken since last container restart. Running via YouTube Data API fallback.

Every previously created link is affected by any change to the shared-skills mount path, across every group. In our case one path change left 66 stale links across 6 agent groups; two groups reference skills via the `/home/node/.claude/skills/` symlink path and lost them, and it went unnoticed for a week because the host logs were clean throughout.

## Fix

Compare `readlink()` against the intended target and recreate the link when they disagree. Unchanged links are untouched, so this is a no-op on a healthy install and self-heals an affected one on the next spawn.

The existing `!isSymbolicLink()` branch (the #3001 template-overlay/stale-copy warning) is unchanged — a real directory still warns rather than being replaced.

## Verification

- `pnpm run build`, `pnpm test` (1262 passing), `prettier --check` clean on a fresh branch off `main`
- Reproduced against a real install: 66 stale links across 6 groups, agent reporting missing scripts
- After the fix, verified inside the container that `python3 /home/node/.claude/skills/youtube-rss/youtube-rss-check.py <feed>` resolves and returns data

No unit test included: `syncSkillSymlinks` is module-private, and exporting it purely for a test seemed a bigger change than the fix. Happy to add one with the export if you'd prefer.