### PR TITLE
fix(ncl): let groups config update clear a nullable scalar

### DIFF
--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -345,3 +345,93 @@ describe('groups CLI MCP config', () => {
     expect(JSON.parse(getContainerConfig('ag-mcp')!.mcp_servers)).toEqual({});
   });
 });
+
+describe('groups config update clears nullable scalars', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    runMigrations(initTestDb());
+  });
+  afterEach(() => {
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  /**
+   * Pre-fix, `String(v)` stored the empty string rather than NULL, so a scalar
+   * could be set but never unset — and the empty string was handed to the agent
+   * runtime as if it were a real model/provider.
+   */
+  it('stores NULL, not the empty string, when a flag is cleared', async () => {
+    const GID = 'ag-clear';
+    createAgentGroup({ id: GID, name: 'c', folder: 'c', agent_provider: null, created_at: now() });
+    ensureContainerConfig(GID);
+
+    await dispatch(
+      {
+        id: 'r1',
+        command: 'groups-config-update',
+        args: { id: GID, model: 'opus', provider: 'claude', effort: 'high', assistant_name: 'Andy' },
+      },
+      { caller: 'host' },
+    );
+    expect(getContainerConfig(GID)!.model).toBe('opus');
+
+    const cleared = await dispatch(
+      {
+        id: 'r2',
+        command: 'groups-config-update',
+        args: { id: GID, model: '', provider: '', effort: '', assistant_name: '' },
+      },
+      { caller: 'host' },
+    );
+    expect(cleared.ok).toBe(true);
+
+    const row = getContainerConfig(GID)!;
+    expect(row.model).toBeNull();
+    expect(row.provider).toBeNull();
+    expect(row.effort).toBeNull();
+    expect(row.assistant_name).toBeNull();
+  });
+
+  it('leaves unmentioned fields untouched', async () => {
+    const GID = 'ag-partial';
+    createAgentGroup({ id: GID, name: 'p', folder: 'p', agent_provider: null, created_at: now() });
+    ensureContainerConfig(GID);
+
+    await dispatch(
+      { id: 'r1', command: 'groups-config-update', args: { id: GID, model: 'opus', effort: 'high' } },
+      { caller: 'host' },
+    );
+    await dispatch({ id: 'r2', command: 'groups-config-update', args: { id: GID, model: '' } }, { caller: 'host' });
+
+    const row = getContainerConfig(GID)!;
+    expect(row.model).toBeNull();
+    expect(row.effort).toBe('high');
+  });
+
+  /** `Number('')` is 0 — clearing the limit must not silently set a real limit of zero. */
+  it('clears max_messages_per_prompt to NULL rather than 0, and rejects non-numeric input', async () => {
+    const GID = 'ag-num';
+    createAgentGroup({ id: GID, name: 'n', folder: 'n', agent_provider: null, created_at: now() });
+    ensureContainerConfig(GID);
+
+    await dispatch(
+      { id: 'r1', command: 'groups-config-update', args: { id: GID, max_messages_per_prompt: 25 } },
+      { caller: 'host' },
+    );
+    expect(getContainerConfig(GID)!.max_messages_per_prompt).toBe(25);
+
+    await dispatch(
+      { id: 'r2', command: 'groups-config-update', args: { id: GID, max_messages_per_prompt: '' } },
+      { caller: 'host' },
+    );
+    expect(getContainerConfig(GID)!.max_messages_per_prompt).toBeNull();
+
+    const bad = await dispatch(
+      { id: 'r3', command: 'groups-config-update', args: { id: GID, max_messages_per_prompt: 'lots' } },
+      { caller: 'host' },
+    );
+    expect(bad.ok).toBe(false);
+  });
+});

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -32,6 +32,36 @@ import { registerResource } from '../crud.js';
 import { localizeIsoTimestamps } from '../format.js';
 
 /**
+ * Parse a nullable string flag: undefined = not passed, null = explicit clear
+ * (empty string → back to the column default), otherwise the value.
+ *
+ * Without this, `--model ""` stored the empty string rather than NULL, and the
+ * empty string reached the agent runtime as a real value — a config scalar
+ * could be set but never unset. `--timezone` already had these semantics; this
+ * is the same rule for its siblings.
+ */
+function parseNullableFlag(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  const str = String(value);
+  return str === '' ? null : str;
+}
+
+/**
+ * Parse a nullable numeric flag. Same clearing rule as `parseNullableFlag`,
+ * and it rejects non-numeric input rather than storing the `NaN`/`0` that a
+ * bare `Number(value)` yields (`Number('') === 0` silently set a real limit
+ * of zero where a clear was intended).
+ */
+function parseNullableNumberFlag(value: unknown, flag: string): number | null | undefined {
+  if (value === undefined) return undefined;
+  const str = String(value);
+  if (str === '') return null;
+  const num = Number(str);
+  if (!Number.isFinite(num)) throw new Error(`${flag} must be a number, or "" to clear it`);
+  return num;
+}
+
+/**
  * Parse a --timezone flag: undefined = not passed, null = explicit clear
  * (empty string → follow the install default), otherwise a validated IANA id.
  * Invalid ids throw here, in the handler — for agent callers that is after
@@ -336,7 +366,8 @@ registerResource({
       description:
         'Update container config scalar fields. Changes are saved but do NOT take effect until you run `ncl groups restart`. ' +
         'Use --id <group-id> and any of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, ' +
-        '--timezone (IANA id like "Europe/Lisbon"; "" clears back to the install default; scheduled-task times follow it immediately, message display after restart).',
+        '--timezone (IANA id like "Europe/Lisbon"; scheduled-task times follow it immediately, message display after restart). ' +
+        'Pass "" to any of these except --cli-scope to clear it back to the column default.',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
@@ -356,15 +387,20 @@ registerResource({
             | 'timezone'
           >
         > = {};
-        if (args.provider !== undefined) updates.provider = args.provider as string;
+        const provider = parseNullableFlag(args.provider);
+        if (provider !== undefined) updates.provider = provider;
         const timezone = parseTimezoneFlag(args.timezone);
         if (timezone !== undefined) updates.timezone = timezone;
-        if (args.model !== undefined) updates.model = args.model as string;
-        if (args.effort !== undefined) updates.effort = args.effort as string;
-        if (args.image_tag !== undefined) updates.image_tag = args.image_tag as string;
-        if (args.assistant_name !== undefined) updates.assistant_name = args.assistant_name as string;
-        if (args.max_messages_per_prompt !== undefined)
-          updates.max_messages_per_prompt = Number(args.max_messages_per_prompt);
+        const model = parseNullableFlag(args.model);
+        if (model !== undefined) updates.model = model;
+        const effort = parseNullableFlag(args.effort);
+        if (effort !== undefined) updates.effort = effort;
+        const imageTag = parseNullableFlag(args.image_tag);
+        if (imageTag !== undefined) updates.image_tag = imageTag;
+        const assistantName = parseNullableFlag(args.assistant_name);
+        if (assistantName !== undefined) updates.assistant_name = assistantName;
+        const maxMessages = parseNullableNumberFlag(args.max_messages_per_prompt, '--max-messages-per-prompt');
+        if (maxMessages !== undefined) updates.max_messages_per_prompt = maxMessages;
         if (args['cli-scope'] !== undefined || args.cli_scope !== undefined) {
           const scope = (args['cli-scope'] ?? args.cli_scope) as string;
           if (!['disabled', 'group', 'global'].includes(scope)) {


### PR DESCRIPTION
## Problem

`ncl groups config update` can set a container-config scalar but cannot unset one.

The handler casts each flag with `String(v)`, so `--model ""` stores the **empty string** rather than `NULL`. That value is then materialized into `container.json` and handed to the agent runtime as if it were a real model.

It fails quietly in both directions: nothing errors, and `ncl groups config get` renders `""` and `NULL` identically, so the operator has no way to tell from the CLI which state a group is in. Confirming it takes a direct query:

```sql
select case when model is null then 'NULL' when model = '' then 'EMPTY STRING' else model end
from container_configs where agent_group_id = '...';
```

I hit this reverting one agent group from `--model opus` back to the default.

## Why `""` is the right sentinel

`--timezone` **already works this way** — `parseTimezoneFlag` maps `""` to `NULL`, and the command's own description documents it: *"IANA id like `Europe/Lisbon`; `""` clears back to the install default"*. So the convention exists in this handler; it was just never applied to the sibling flags.

## Change

Two small helpers alongside `parseTimezoneFlag`, following the same `undefined` (not passed) / `null` (clear) / value contract, applied to the nullable columns:

- `provider`, `model`, `effort`, `image_tag`, `assistant_name` → `parseNullableFlag`
- `max_messages_per_prompt` → `parseNullableNumberFlag`

`cli_scope` is deliberately unchanged — it is non-nullable with a validated enum.

**`max_messages_per_prompt` was the sharper edge:** `Number('')` is `0`, so clearing it didn't merely store a junk value, it set a real per-prompt limit of **zero**. It now clears to `NULL`, and non-numeric input is rejected rather than stored as `NaN`.

The command description now states the clearing rule for the whole flag family instead of just `--timezone`.

## Tests

Three regression tests in `src/cli/resources/groups.test.ts`, dispatched through `dispatch()` with `caller: 'host'` to match the existing tests in that file:

- clearing stores `NULL`, not `""`
- clearing one field leaves unmentioned fields untouched
- `max_messages_per_prompt` clears to `NULL` rather than `0`, and rejects non-numeric input

**Verified they catch the bug:** all three fail against the unfixed handler (`3 failed | 7 passed`) and pass with the fix (`10 passed`).

`pnpm run build`, `pnpm test` (1444 passing), and `prettier --check` are clean on a fresh branch off `main`.