### PR TITLE
fix: accept telegram pairing codes pasted with spaces

### DIFF
--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -61,6 +61,13 @@ describe('extractCode', () => {
     expect(extractCode('my pin is 034927', 'nanobot')).toBeNull();
     expect(extractCode('034927 thanks', 'nanobot')).toBeNull();
   });
+  it('accepts the code as copied from the setup card (spaced digits)', () => {
+    expect(extractCode('0   3   4   9   2   7', 'nanobot')).toBe('034927');
+    expect(extractCode(' 0 3 4 9 2 7 ', 'nanobot')).toBe('034927');
+  });
+  it('accepts spaced digits after @botname', () => {
+    expect(extractCode('@nanobot 0   3   4   9   2   7', 'nanobot')).toBe('034927');
+  });
 });
 
 describe('createPairing', () => {
@@ -106,6 +113,18 @@ describe('tryConsume', () => {
       isGroup: false,
     });
     expect(out).toBeNull();
+  });
+
+  it('consumes a code pasted as the setup card displays it (spaced)', async () => {
+    const r = await createPairing('main');
+    const out = await tryConsume({
+      text: r.code.split('').join('   '),
+      botUsername: 'nanobot',
+      platformId: 'x',
+      isGroup: false,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe('consumed');
   });
 
   it('matches a bare code without @botname addressing', async () => {

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -4,10 +4,8 @@
  * BotFather hands out tokens with no user binding, so anyone who guesses the
  * bot's username can DM it. Pairing closes that gap: setup creates a one-time
  * 6-digit code and the operator echoes it back from the chat they want to
- * register. The message must be exactly the 6 digits (optionally prefixed by
- * `@botname ` for groups with privacy ON) — arbitrary messages that happen to
- * contain a 6-digit number do NOT match. The inbound interceptor in
- * telegram.ts matches the code, records the chat, upserts the paired user,
+ * register (see extractCode for the exact match rule). The inbound interceptor
+ * in telegram.ts matches the code, records the chat, upserts the paired user,
  * and (if no owner exists yet) promotes them to owner — all before the
  * message ever reaches the router.
  *
@@ -165,13 +163,15 @@ export function extractAddressedText(text: string, botUsername: string): string 
 }
 
 /**
- * Extract a pairing code from an inbound message. The message must be exactly
- * 6 digits (optionally prefixed by `@botname `) — loose matches like
- * "my pin is 123456" are rejected to avoid false positives from chatter.
+ * Extract a pairing code from an inbound message. The message must contain
+ * nothing but the 6 digits (optionally prefixed by `@botname `) — loose
+ * matches like "my pin is 123456" are rejected to avoid false positives from
+ * chatter. Whitespace between the digits is allowed: the setup card displays
+ * the code spaced ("1   2   3   4   5   6"), and operators paste it verbatim.
  */
 export function extractCode(text: string, botUsername: string): string | null {
   const addressed = extractAddressedText(text, botUsername);
-  const candidate = (addressed !== null ? addressed : text).trim();
+  const candidate = (addressed !== null ? addressed : text).replace(/\s+/g, '');
   const m = candidate.match(/^(\d{6})$/);
   return m ? m[1] : null;
 }


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Telegram’s setup card displays the six-digit pairing code with spaces, but `extractCode` previously trimmed only the message edges and rejected that displayed value when pasted verbatim. This collapses whitespace before the existing exact six-digit check, while still rejecting surrounding chatter, and adds regression coverage through both `extractCode` and `tryConsume`.

## Testing

- `pnpm exec vitest run src/channels/telegram-pairing.test.ts -t "accepts the code as copied|accepts spaced digits|consumes a code pasted"`
- `pnpm exec eslint src/channels/telegram-pairing.ts src/channels/telegram-pairing.test.ts` (0 errors; existing warnings only)
- `pnpm exec prettier --check src/channels/telegram-pairing.ts src/channels/telegram-pairing.test.ts`

Repo-wide checks remain blocked by unrelated failures already present on the `channels` branch: a missing DeltaChat type dependency, existing lint/format errors, and `fs.watch` resource errors in unrelated Telegram waiter tests.