### PR TITLE
container: mid-turn streaming is the single delivery door — cross-segment assembly, DB-backed echo suppression, no result-door sends

### DIFF
--- a/container/agent-runner/scripts/sdk-capture/.gitignore
+++ b/container/agent-runner/scripts/sdk-capture/.gitignore
@@ -1,0 +1,5 @@
+# Raw capture transcripts stay local: they are full SDK payloads and can
+# embed machine-local text (e.g. a scenario that ran `ls /tmp`). The
+# committed, reviewed subset lives in src/providers/__fixtures__/ via
+# extract-fixtures.ts.
+recordings/

--- a/container/agent-runner/scripts/sdk-capture/analyze.ts
+++ b/container/agent-runner/scripts/sdk-capture/analyze.ts
@@ -1,0 +1,110 @@
+/**
+ * Analyze SDK capture recordings: for each scenario JSONL, compute the
+ * containment relation between the turn's result text and the streamed
+ * assistant text, and account for <message> block boundaries.
+ *
+ * Usage: cd container/agent-runner && bun scripts/sdk-capture/analyze.ts
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RECORDINGS_DIR = path.join(import.meta.dir, 'recordings');
+const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
+
+function completeBlocks(text: string): string[] {
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  const re = new RegExp(MESSAGE_RE.source, 'g');
+  while ((m = re.exec(text)) !== null) out.push(m[0]);
+  return out;
+}
+
+interface TurnAccount {
+  turn: number;
+  segments: string[]; // one per assistant message (text blocks joined with '')
+  textBlockCounts: number[]; // raw text-block count per assistant message
+  resultText: string | null;
+  isError: boolean;
+  subtype: string | undefined;
+}
+
+function analyzeFile(file: string): void {
+  const lines = fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+
+  const meta = lines.find((l) => l._harness === 'meta') as { scenario: string; gist: string } | undefined;
+  const end = lines.find((l) => l._harness === 'end') as { error: string | null } | undefined;
+
+  const turns: TurnAccount[] = [];
+  let cur: TurnAccount = { turn: 1, segments: [], textBlockCounts: [], resultText: null, isError: false, subtype: undefined };
+  for (const msg of lines) {
+    if (msg.type === 'assistant') {
+      const content = (msg as { message?: { content?: Array<{ type?: string; text?: string }> } }).message?.content;
+      if (Array.isArray(content)) {
+        const texts = content.filter((b) => b.type === 'text' && b.text).map((b) => b.text!);
+        if (texts.length > 0) {
+          cur.segments.push(texts.join(''));
+          cur.textBlockCounts.push(texts.length);
+        }
+      }
+    } else if (msg.type === 'result') {
+      const m = msg as { result?: string; is_error?: boolean; errors?: string[]; subtype?: string };
+      cur.resultText = m.result ?? (m.errors && m.errors.length > 0 ? m.errors.join('\n') : null);
+      cur.isError = m.is_error === true;
+      cur.subtype = m.subtype;
+      turns.push(cur);
+      cur = { turn: turns.length + 1, segments: [], textBlockCounts: [], resultText: null, isError: false, subtype: undefined };
+    }
+  }
+  if (cur.segments.length > 0) turns.push(cur); // aborted turn with no result
+
+  console.log(`\n=== ${meta?.scenario ?? path.basename(file)} — ${meta?.gist ?? ''}${end?.error ? `  [RUN ERROR: ${end.error}]` : ''}`);
+  for (const t of turns) {
+    const last = t.segments[t.segments.length - 1] ?? null;
+    const concat = t.segments.join('');
+    const r = t.resultText;
+    let containment: string;
+    if (r === null) containment = 'NO RESULT (turn had no result event)';
+    else if (t.segments.length === 0) containment = r === '' ? 'empty result, zero segments' : 'RESULT WITH ZERO STREAMED SEGMENTS';
+    else if (r === last) containment = 'result === LAST segment (exact)';
+    else if (r === concat) containment = 'result === CONCAT of all segments';
+    else if (last !== null && r.endsWith(last)) containment = 'result ends-with last segment (superset!)';
+    else if (concat.includes(r)) containment = 'result is substring of concat';
+    else containment = 'DIVERGENT (result text not derivable from segments)';
+
+    const resultBlocks = r ? completeBlocks(r) : [];
+    const segBlockSets = t.segments.map((s) => new Set(completeBlocks(s)));
+    const unstreamedComplete = resultBlocks.filter((b) => !segBlockSets.some((set) => set.has(b)));
+    const splitSegs = t.segments
+      .map((s, i) => {
+        const opens = (s.match(/<message\s+to=/g) ?? []).length;
+        const closes = (s.match(/<\/message>/g) ?? []).length;
+        return opens !== closes ? `seg${i}(open=${opens},close=${closes})` : null;
+      })
+      .filter(Boolean);
+
+    console.log(
+      `  turn ${t.turn}: segments=${t.segments.length} (textBlocks/msg: ${t.textBlockCounts.join(',') || '-'}) ` +
+        `resultLen=${r?.length ?? 'null'} subtype=${t.subtype ?? '-'} isError=${t.isError}`,
+    );
+    console.log(`    containment: ${containment}`);
+    console.log(
+      `    blocks: result=${resultBlocks.length}, complete-in-result-but-never-complete-in-a-segment=${unstreamedComplete.length}` +
+        (splitSegs.length ? `, UNBALANCED segments: ${splitSegs.join(' ')}` : ''),
+    );
+    if (unstreamedComplete.length > 0) {
+      for (const b of unstreamedComplete) console.log(`    !! unstreamed complete block: ${b.slice(0, 120)}`);
+    }
+    for (const [i, s] of t.segments.entries()) {
+      console.log(`    seg${i}: ${JSON.stringify(s.slice(0, 110))}${s.length > 110 ? '…' : ''}`);
+    }
+    if (r !== null && r !== last) console.log(`    result: ${JSON.stringify(r.slice(0, 110))}${r.length > 110 ? '…' : ''}`);
+  }
+}
+
+for (const f of fs.readdirSync(RECORDINGS_DIR).filter((f) => f.endsWith('.jsonl')).sort()) {
+  analyzeFile(path.join(RECORDINGS_DIR, f));
+}

--- a/container/agent-runner/scripts/sdk-capture/doh-proxy.ts
+++ b/container/agent-runner/scripts/sdk-capture/doh-proxy.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal local HTTP CONNECT proxy with DNS-over-HTTPS resolution.
+ *
+ * Why: on the capture machine the macOS system resolver (configd) is broken
+ * ("No DNS configuration available" from `scutil --dns`), so getaddrinfo —
+ * and with it curl, git, Node/Bun fetch — cannot resolve ANY hostname, while
+ * raw DNS servers answer fine and TCP to resolved IPs works. The Claude Code
+ * CLI honors HTTPS_PROXY, and a CONNECT proxy receives the target as a
+ * hostname it can resolve itself — here via DoH to 1.1.1.1 BY IP LITERAL, so
+ * no local resolution is ever needed.
+ *
+ * Capture-harness support only. Never used by the agent-runner at runtime.
+ */
+import net from 'node:net';
+
+const cache = new Map<string, string>();
+
+async function resolveHost(host: string): Promise<string> {
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return host;
+  const hit = cache.get(host);
+  if (hit) return hit;
+  const res = await fetch(`https://1.1.1.1/dns-query?name=${encodeURIComponent(host)}&type=A`, {
+    headers: { accept: 'application/dns-json' },
+  });
+  if (!res.ok) throw new Error(`DoH HTTP ${res.status} for ${host}`);
+  const body = (await res.json()) as { Answer?: Array<{ type: number; data: string }> };
+  const a = (body.Answer ?? []).find((x) => x.type === 1)?.data;
+  if (!a) throw new Error(`DoH: no A record for ${host}`);
+  cache.set(host, a);
+  return a;
+}
+
+/** Start the proxy on 127.0.0.1:<random>. Returns the port and a closer. */
+export function startDohProxy(): Promise<{ port: number; close: () => void }> {
+  const server = net.createServer((sock) => {
+    sock.once('data', (buf) => {
+      void (async () => {
+        const head = buf.toString('utf8');
+        const m = head.match(/^CONNECT ([^ :]+):(\d+) /);
+        if (!m) {
+          sock.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+          return;
+        }
+        try {
+          const ip = await resolveHost(m[1]);
+          const up = net.connect(Number(m[2]), ip, () => {
+            sock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+            sock.pipe(up);
+            up.pipe(sock);
+          });
+          up.on('error', () => sock.destroy());
+          sock.on('error', () => up.destroy());
+        } catch {
+          sock.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+        }
+      })();
+    });
+    sock.on('error', () => {});
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as net.AddressInfo;
+      resolve({ port: addr.port, close: () => server.close() });
+    });
+  });
+}

--- a/container/agent-runner/scripts/sdk-capture/extract-fixtures.ts
+++ b/container/agent-runner/scripts/sdk-capture/extract-fixtures.ts
@@ -1,0 +1,95 @@
+/**
+ * Convert probative capture recordings into the deterministic fixture file
+ * replayed by src/providers/claude.recorded.test.ts.
+ *
+ * Message TEXT is kept verbatim; non-text noise (usage, ids, tool inputs) is
+ * trimmed to the shape the provider actually reads, so the fixtures stay
+ * small and free of machine-local leakage. Deterministic: re-running over the
+ * same recordings produces the same JSON.
+ *
+ * Usage: cd container/agent-runner && bun scripts/sdk-capture/extract-fixtures.ts
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RECORDINGS_DIR = path.join(import.meta.dir, 'recordings');
+const OUT_FILE = path.join(import.meta.dir, '..', '..', 'src', 'providers', '__fixtures__', 'sdk-midturn-recordings.json');
+
+// s04c is excluded: its message text embeds local /tmp directory listings.
+// s01/s11 (trivial unwrapped), s04a/s05/s07 (shapes duplicated by s08/s02)
+// are omitted to keep the fixture minimal.
+const PICK = [
+  's02-single-block',
+  's03-block-then-tool',
+  's04b-tool-inside-block',
+  's06-only-final',
+  's08-long-block',
+  's09-repeat-in-summary',
+  's10-summarize-no-repeat',
+  's12-abort-midstream',
+  's13-internal-draft',
+  's14-two-turns-stream',
+];
+
+type Raw = Record<string, unknown> & {
+  type?: string;
+  subtype?: string;
+  session_id?: string;
+  message?: { content?: Array<{ type?: string; text?: string; name?: string }> };
+  result?: string;
+  is_error?: boolean;
+  errors?: string[];
+  rate_limit_info?: unknown;
+  _harness?: string;
+};
+
+function trim(msg: Raw): unknown | null {
+  if (msg._harness) return null;
+  switch (msg.type) {
+    case 'system':
+      return msg.subtype === 'init'
+        ? { type: 'system', subtype: 'init', session_id: msg.session_id }
+        : { type: 'system', subtype: msg.subtype };
+    case 'assistant': {
+      const content = (msg.message?.content ?? []).map((b) =>
+        b.type === 'text' ? { type: 'text', text: b.text ?? '' } : { type: b.type, name: b.name },
+      );
+      return { type: 'assistant', message: { content } };
+    }
+    case 'user':
+      // Tool results — the provider yields only 'activity' for these; keep a
+      // stub to preserve the stream cadence.
+      return { type: 'user' };
+    case 'result': {
+      const out: Record<string, unknown> = { type: 'result', subtype: msg.subtype };
+      if (msg.result !== undefined) out.result = msg.result;
+      if (msg.is_error !== undefined) out.is_error = msg.is_error;
+      if (msg.errors !== undefined) out.errors = msg.errors;
+      return out;
+    }
+    case 'rate_limit_event':
+      return { type: 'rate_limit_event', rate_limit_info: msg.rate_limit_info };
+    default:
+      return { type: msg.type };
+  }
+}
+
+const fixtures: Record<string, { gist: string; capturedAt: string; messages: unknown[] }> = {};
+for (const id of PICK) {
+  const file = path.join(RECORDINGS_DIR, `${id}.jsonl`);
+  const lines = fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Raw);
+  const meta = lines.find((l) => l._harness === 'meta') as unknown as { gist: string; startedAt: string };
+  fixtures[id] = {
+    gist: meta.gist,
+    capturedAt: meta.startedAt,
+    messages: lines.map(trim).filter((m) => m !== null),
+  };
+}
+
+fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
+fs.writeFileSync(OUT_FILE, JSON.stringify(fixtures, null, 2) + '\n');
+console.error(`Wrote ${OUT_FILE} (${Object.keys(fixtures).length} scenarios)`);

--- a/container/agent-runner/scripts/sdk-capture/extract-fixtures.ts
+++ b/container/agent-runner/scripts/sdk-capture/extract-fixtures.ts
@@ -29,6 +29,7 @@ const PICK = [
   's12-abort-midstream',
   's13-internal-draft',
   's14-two-turns-stream',
+  's16-three-way-split',
 ];
 
 type Raw = Record<string, unknown> & {

--- a/container/agent-runner/scripts/sdk-capture/run-battery.ts
+++ b/container/agent-runner/scripts/sdk-capture/run-battery.ts
@@ -149,6 +149,18 @@ const SCENARIOS: Scenario[] = [
     prompt: '<message from="discord-main">Send me a one-line message block saying "turn one".</message>',
     followUp: '<message from="discord-main">Now send me a one-line message block saying "turn two".</message>',
   },
+  {
+    id: 's15-midtoken-split',
+    gist: 'open tag literally split mid-token across assistant messages',
+    prompt:
+      '<message from="discord-main">Streaming protocol test — emit EXACTLY this sequence, no commentary: (1) the text `<mess` and NOTHING else (stop your text there), (2) a Bash call `echo tick`, (3) the text `age to="discord-main">reassembled greeting</message>` and nothing else. The tag is intentionally split mid-token; do not repair it in either step.</message>',
+  },
+  {
+    id: 's16-three-way-split',
+    gist: 'block spread across three assistant messages with two tool calls between',
+    prompt:
+      '<message from="discord-main">Streaming protocol test — emit EXACTLY this sequence, no commentary: (1) the text `<message to="discord-main">alpha ` and nothing else, (2) a Bash call `echo one`, (3) the text `beta ` and nothing else, (4) a Bash call `echo two`, (5) the text `gamma</message>` and nothing else. Do not merge the text steps.</message>',
+  },
 ];
 
 /** Push-based input stream (mirrors the provider's MessageStream). */

--- a/container/agent-runner/scripts/sdk-capture/run-battery.ts
+++ b/container/agent-runner/scripts/sdk-capture/run-battery.ts
@@ -1,0 +1,275 @@
+/**
+ * Live SDK capture battery.
+ *
+ * Drives the REAL @anthropic-ai/claude-agent-sdk (the agent-runner's pinned
+ * dependency — run this from container/agent-runner so bun resolves that
+ * copy) through scenarios designed to elicit the mid-turn-delivery edge
+ * cases, and records EVERY raw SDK message verbatim as one JSONL transcript
+ * per scenario under scripts/sdk-capture/recordings/.
+ *
+ * Auth comes from the local environment (Claude Code keychain / ANTHROPIC_API_KEY)
+ * — nothing is hardcoded. Network goes through the local DoH CONNECT proxy
+ * (see doh-proxy.ts) because the capture machine's system resolver is broken.
+ *
+ * Usage:  cd container/agent-runner && bun scripts/sdk-capture/run-battery.ts [ids...]
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
+
+import { startDohProxy } from './doh-proxy.js';
+
+const RECORDINGS_DIR = path.join(import.meta.dir, 'recordings');
+
+// Mirrors container/agent-runner/src/destinations.ts buildDestinationsSection
+// (chat mode, two destinations) so the model actually uses the <message>
+// convention the agent-runner teaches.
+const INSTRUCTIONS = `# You are TestBot
+
+Your name is **TestBot**. Use it when the channel asks who you are.
+
+## Sending messages
+
+You can send messages to the following destinations:
+
+- \`discord-main\` (discord)
+- \`ops-log\` (slack)
+
+Wrap each delivered message in a \`<message to="name">…</message>\` block; include several blocks in one response to address several destinations. \`<internal>…</internal>\` marks thinking you don't want sent.
+
+When replying to an incoming message, default to addressing the destination it came \`from\` (every inbound \`<message>\` tag carries a \`from="name"\` attribute). Pick a different destination when the request asks for it (e.g., "tell Laura that…").
+
+For a short turn, do not narrate. For longer work, send one acknowledgment and then updates only at meaningful milestones, especially before slow operations. Never narrate micro-steps; finish with the outcome, not a play-by-play.`;
+
+interface Scenario {
+  id: string;
+  gist: string;
+  prompt: string;
+  /** Abort the SDK query as soon as the first tool_use block is observed. */
+  abortOnFirstToolUse?: boolean;
+  /** Push this follow-up prompt after the first result (streaming input). */
+  followUp?: string;
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    id: 's01-plain',
+    gist: 'plain reply, no blocks',
+    prompt: '<message from="discord-main">Reply with the single word: ok. Do not use any message block.</message>',
+  },
+  {
+    id: 's02-single-block',
+    gist: 'single block then end',
+    prompt: '<message from="discord-main">Send me a one-line greeting.</message>',
+  },
+  {
+    id: 's03-block-then-tool',
+    gist: 'block, THEN a tool call after it (SAF shape)',
+    prompt:
+      '<message from="discord-main">First send me a complete one-line message block saying the deploy is done. After closing that block, run the Bash command `echo status-updated` and then end your turn with no further text.</message>',
+  },
+  {
+    id: 's04a-tool-inside-block',
+    gist: 'tool call BETWEEN open and close of a block (half-message)',
+    prompt:
+      '<message from="discord-main">Compose a two-sentence status message to me, but split your work: write the opening <message to="discord-main"> tag and the first sentence, then run Bash `echo checkpoint` before writing anything else, then write the second sentence and the closing tag.</message>',
+  },
+  {
+    id: 's04b-tool-inside-block',
+    gist: 'half-message, phrasing 2 (explicit interleave)',
+    prompt:
+      '<message from="discord-main">I am testing your streaming. Emit EXACTLY this sequence: (1) the text `<message to="discord-main">part one` and nothing else, (2) a Bash call `echo mid`, (3) the text `part two</message>` and nothing else. Do not merge steps 1 and 3 into one text output.</message>',
+  },
+  {
+    id: 's04c-tool-inside-block',
+    gist: 'half-message, phrasing 3 (start now, finish after checking)',
+    prompt:
+      '<message from="discord-main">Start telling me the current directory contents in a message block — open the block and write "Checking now…", then (before closing the block) actually run `ls /tmp | head -2`, then finish the same message block with what you found.</message>',
+  },
+  {
+    id: 's05-two-blocks',
+    gist: 'two blocks to different destinations in one turn',
+    prompt:
+      '<message from="discord-main">Send me a one-line hello, and separately send ops-log a one-line note that says "capture test". Two message blocks, one turn.</message>',
+  },
+  {
+    id: 's06-only-final',
+    gist: 'tool first, block only in the very last text',
+    prompt:
+      '<message from="discord-main">Without writing any text first, run Bash `echo hi`. Then your ONLY text output should be a single one-line message block to me with the command output.</message>',
+  },
+  {
+    id: 's07-unclosed',
+    gist: 'never-completed block (no closing tag)',
+    prompt:
+      '<message from="discord-main">Protocol test: output the opening tag <message to="discord-main"> followed by the words "this stays open" and END YOUR TURN THERE. Deliberately do not emit the closing tag. Do not add anything else.</message>',
+  },
+  {
+    id: 's08-long-block',
+    gist: 'long multi-paragraph block (chunking)',
+    prompt:
+      '<message from="discord-main">Send me one message block containing a ~200-word four-paragraph update about a fictional deploy of a service called "orion" (rollout, metrics, one incident, next steps).</message>',
+  },
+  {
+    id: 's09-repeat-in-summary',
+    gist: 'instructed to repeat block verbatim in final text',
+    prompt:
+      '<message from="discord-main">Send me a one-line message block saying "backup finished". Then run Bash `echo logged`. Then, as your final text, repeat the exact same message block verbatim once more.</message>',
+  },
+  {
+    id: 's10-summarize-no-repeat',
+    gist: 'summary WITHOUT repeating the block',
+    prompt:
+      '<message from="discord-main">Send me a one-line message block saying "backup finished". Then run Bash `echo logged`. Then finish with one short unwrapped sentence (no message block) noting what you did.</message>',
+  },
+  {
+    id: 's11-unwrapped-only',
+    gist: 'unwrapped prose only',
+    prompt:
+      '<message from="discord-main">In two unwrapped sentences (no message block — this is a protocol test), explain why the sky is blue.</message>',
+  },
+  {
+    id: 's12-abort-midstream',
+    gist: 'abort during the tool call',
+    prompt:
+      '<message from="discord-main">Send me a complete one-line message block saying "starting the slow job", then run Bash `sleep 8 && echo slow-done`, then send a second message block saying it finished.</message>',
+    abortOnFirstToolUse: true,
+  },
+  {
+    id: 's13-internal-draft',
+    gist: 'internal-wrapped draft plus a real block',
+    prompt:
+      '<message from="discord-main">First, inside an <internal>…</internal> span, draft (but do not send) a too-blunt version of a message block telling me my report is late. Then, outside the internal span, send me the polite real message block.</message>',
+  },
+  {
+    id: 's14-two-turns-stream',
+    gist: 'streaming input: follow-up push after first result',
+    prompt: '<message from="discord-main">Send me a one-line message block saying "turn one".</message>',
+    followUp: '<message from="discord-main">Now send me a one-line message block saying "turn two".</message>',
+  },
+];
+
+/** Push-based input stream (mirrors the provider's MessageStream). */
+class Stream {
+  q: unknown[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+  push(text: string): void {
+    this.q.push({ type: 'user', message: { role: 'user', content: text }, parent_tool_use_id: null, session_id: '' });
+    this.waiting?.();
+  }
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+  async *[Symbol.asyncIterator](): AsyncGenerator<unknown> {
+    while (true) {
+      while (this.q.length > 0) yield this.q.shift()!;
+      if (this.done) return;
+      await new Promise<void>((r) => {
+        this.waiting = r;
+      });
+      this.waiting = null;
+    }
+  }
+}
+
+async function runScenario(s: Scenario, proxyPort: number, cwd: string): Promise<string> {
+  const outPath = path.join(RECORDINGS_DIR, `${s.id}.jsonl`);
+  const lines: string[] = [
+    JSON.stringify({
+      _harness: 'meta',
+      scenario: s.id,
+      gist: s.gist,
+      prompt: s.prompt,
+      followUp: s.followUp ?? null,
+      startedAt: new Date().toISOString(),
+    }),
+  ];
+
+  const abort = new AbortController();
+  const timeout = setTimeout(() => abort.abort(new Error('scenario timeout')), 240_000);
+
+  const stream = new Stream();
+  stream.push(s.prompt);
+
+  let resultCount = 0;
+  const wantResults = s.followUp ? 2 : 1;
+  let error: string | null = null;
+
+  try {
+    const q = sdkQuery({
+      prompt: stream as AsyncIterable<never>,
+      options: {
+        cwd,
+        abortController: abort,
+        systemPrompt: { type: 'preset', preset: 'claude_code', append: INSTRUCTIONS },
+        allowedTools: ['Bash'],
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        settingSources: [],
+        maxTurns: 8,
+        env: {
+          ...process.env,
+          HTTPS_PROXY: `http://127.0.0.1:${proxyPort}`,
+          HTTP_PROXY: `http://127.0.0.1:${proxyPort}`,
+          NO_PROXY: '127.0.0.1,localhost',
+        },
+      },
+    });
+
+    for await (const message of q) {
+      lines.push(JSON.stringify(message));
+      const m = message as { type?: string; message?: { content?: Array<{ type?: string }> } };
+      if (
+        s.abortOnFirstToolUse &&
+        m.type === 'assistant' &&
+        Array.isArray(m.message?.content) &&
+        m.message.content.some((b) => b.type === 'tool_use')
+      ) {
+        lines.push(JSON.stringify({ _harness: 'abort', reason: 'first tool_use observed', at: new Date().toISOString() }));
+        abort.abort(new Error('harness abort on first tool_use'));
+      }
+      if (m.type === 'result') {
+        resultCount++;
+        if (resultCount === 1 && s.followUp) stream.push(s.followUp);
+        if (resultCount >= wantResults) stream.end();
+      }
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    lines.push(JSON.stringify({ _harness: 'error', error, at: new Date().toISOString() }));
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  lines.push(JSON.stringify({ _harness: 'end', endedAt: new Date().toISOString(), results: resultCount, error }));
+  fs.writeFileSync(outPath, lines.join('\n') + '\n');
+  return `${s.id}: ${resultCount} result(s)${error ? ` ERROR: ${error.slice(0, 120)}` : ''}`;
+}
+
+async function main(): Promise<void> {
+  fs.mkdirSync(RECORDINGS_DIR, { recursive: true });
+  const only = new Set(process.argv.slice(2));
+  const picked = only.size > 0 ? SCENARIOS.filter((s) => only.has(s.id)) : SCENARIOS;
+
+  const { port, close } = await startDohProxy();
+  console.error(`[battery] DoH CONNECT proxy on 127.0.0.1:${port}`);
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sdk-capture-'));
+  console.error(`[battery] scenario cwd: ${cwd}`);
+
+  try {
+    for (const s of picked) {
+      console.error(`[battery] running ${s.id} — ${s.gist}`);
+      const line = await runScenario(s, port, cwd);
+      console.error(`[battery]   ${line}`);
+    }
+  } finally {
+    close();
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/container/agent-runner/src/harness-tag-strip.ts
+++ b/container/agent-runner/src/harness-tag-strip.ts
@@ -1,0 +1,20 @@
+/**
+ * Trailing run of orphan harness tags. The model occasionally leaks spurious
+ * tool syntax (e.g. `<invoke name="Bash">` or `</parameter>`) at the very end
+ * of a <message> body, and it reaches the user verbatim. Matches one or more
+ * known opening or closing harness tags — case-insensitive, optional opening-
+ * tag attributes and whitespace/newlines allowed — anchored to the END of the
+ * string only, so legitimate content that *discusses* these tags mid-text is
+ * never touched.
+ */
+const TRAILING_HARNESS_TAGS_RE =
+  /(?:\s*<\/?(?:parameter|invoke|function_calls|function_results|dispatch)(?:\s+[^<>]*?)?\s*>)+\s*$/i;
+
+/**
+ * Remove a trailing run of orphan opening or closing harness tags from text
+ * bound for delivery, along with the whitespace that separated them from the
+ * content. Text without a trailing run is returned unchanged.
+ */
+export function stripHarnessTagArtifacts(text: string): string {
+  return text.replace(TRAILING_HARNESS_TAGS_RE, '');
+}

--- a/container/agent-runner/src/poll-loop.harness-tag-strip.test.ts
+++ b/container/agent-runner/src/poll-loop.harness-tag-strip.test.ts
@@ -91,8 +91,10 @@ describe('stripHarnessTagArtifacts', () => {
 
 // Wiring guards: the sanitizer must be applied at BOTH delivery seams inside
 // the real processQuery path — the <message> block extraction in
-// dispatchResultText, and the bare error-result delivery. Removing either
-// call site (not just the helper) goes red here.
+// dispatchResultText (exercised here without emitsMidTurnText, where the
+// result is the delivery door; the mid-turn seam has its own sanitization
+// test in poll-loop.midturn.test.ts), and the bare error-result delivery.
+// Removing either call site (not just the helper) goes red here.
 describe('harness tag artifacts stripped from deliveries (wiring)', () => {
   it('sanitizes a <message> block body before it reaches messages_out', async () => {
     getInboundDb()

--- a/container/agent-runner/src/poll-loop.harness-tag-strip.test.ts
+++ b/container/agent-runner/src/poll-loop.harness-tag-strip.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { stripHarnessTagArtifacts } from './harness-tag-strip.js';
+import { processQuery } from './poll-loop.js';
+import type { AgentQuery, ProviderEvent } from './providers/types.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+/**
+ * Build a one-shot stub query that yields init + a single result event, then
+ * ends. `pushes` records any follow-ups the loop tried to inject (e.g. the
+ * re-wrap nudge), so a test can assert the loop did NOT re-hammer.
+ */
+function makeResultQuery(result: ProviderEvent): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  async function* events(): AsyncGenerator<ProviderEvent> {
+    yield { type: 'init', continuation: 'sess-1' };
+    yield result;
+  }
+  return {
+    pushes,
+    query: {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events: events(),
+      abort: () => {},
+    },
+  };
+}
+
+const ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+  taskRun: false,
+};
+
+describe('stripHarnessTagArtifacts', () => {
+  it('strips a single trailing orphan closing tag', () => {
+    expect(stripHarnessTagArtifacts('Deploy is done.\n</parameter>')).toBe('Deploy is done.');
+  });
+
+  it('strips a single trailing orphan opening tag', () => {
+    expect(stripHarnessTagArtifacts('Deploy is done.\n<parameter>')).toBe('Deploy is done.');
+  });
+
+  it('strips opening tags with attributes', () => {
+    expect(stripHarnessTagArtifacts('Deploy is done.\n<invoke name="Bash">')).toBe('Deploy is done.');
+  });
+
+  it('strips a mixed trailing run with whitespace and newlines between tags', () => {
+    expect(stripHarnessTagArtifacts('All set.\n<invoke name="Bash">\n </parameter>\n<dispatch>\n')).toBe('All set.');
+  });
+
+  it('is case-insensitive', () => {
+    expect(stripHarnessTagArtifacts('ok <PARAMETER NAME="VALUE">')).toBe('ok');
+  });
+
+  it('preserves tags that appear mid-text', () => {
+    const text = 'the <parameter> and </parameter> tags delimit a parameter element';
+    expect(stripHarnessTagArtifacts(text)).toBe(text);
+  });
+
+  it('preserves mid-text tags while stripping the trailing run', () => {
+    expect(stripHarnessTagArtifacts('use <invoke> to open it\n</parameter>')).toBe('use <invoke> to open it');
+  });
+
+  it('collapses text consisting only of tags to empty', () => {
+    expect(stripHarnessTagArtifacts('<invoke name="Bash"></parameter>')).toBe('');
+  });
+
+  it('leaves unrelated trailing opening and closing tags alone', () => {
+    expect(stripHarnessTagArtifacts('done <message></message>')).toBe('done <message></message>');
+  });
+
+  it('leaves text without any tags unchanged', () => {
+    expect(stripHarnessTagArtifacts('a perfectly normal reply')).toBe('a perfectly normal reply');
+  });
+});
+
+// Wiring guards: the sanitizer must be applied at BOTH delivery seams inside
+// the real processQuery path — the <message> block extraction in
+// dispatchResultText, and the bare error-result delivery. Removing either
+// call site (not just the helper) goes red here.
+describe('harness tag artifacts stripped from deliveries (wiring)', () => {
+  it('sanitizes a <message> block body before it reaches messages_out', async () => {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+         VALUES ('discord-main', 'discord-main', 'channel', 'discord', 'chan-1', NULL)`,
+      )
+      .run();
+
+    const { query, pushes } = makeResultQuery({
+      type: 'result',
+      text: '<message to="discord-main">Deploy is done.\n<invoke name="Bash"></parameter></message>',
+    });
+
+    await processQuery(query, ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('Deploy is done.');
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('sanitizes bare error-result text before it reaches messages_out', async () => {
+    const { query, pushes } = makeResultQuery({
+      type: 'result',
+      text: 'Spending limit reached.\n<dispatch>',
+      isError: true,
+    });
+
+    await processQuery(query, ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('Spending limit reached.');
+    // No re-wrap nudge — an error result must not re-hammer the gateway.
+    expect(pushes).toHaveLength(0);
+  });
+});

--- a/container/agent-runner/src/poll-loop.midturn-assembly.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-assembly.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { processQuery, unresolvedTailStart } from './poll-loop.js';
+import type { AgentQuery, ProviderEvent } from './providers/types.js';
+
+// Cross-segment assembly: a frame-local parse buffer carries the unresolved
+// tail of one text event into the next, so a <message> block opened in one
+// assistant message and closed in a later one (live-captured: SDK battery
+// s04b, a tool call riding between open and close) is assembled and
+// delivered ONCE, mid-turn, when its close arrives. The buffer carries ONLY
+// the unresolved tail — settled text is consumed exactly once, so delivered
+// blocks never re-match — and dies at the turn boundary: a block that never
+// closes anywhere is the wrap-nudge's job (see the resultdoor test file).
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+const CHAT_ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+  taskRun: false,
+};
+
+function seedDest(name = 'discord-main', channelType = 'discord', platformId = 'chan-1'): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES (?, ?, 'channel', ?, ?, NULL)`,
+    )
+    .run(name, name, channelType, platformId);
+}
+
+function makeStubQuery(events: AsyncGenerator<ProviderEvent>): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  return {
+    pushes,
+    query: {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events,
+      abort: () => {},
+    },
+  };
+}
+
+function deliveredTexts(): string[] {
+  return getUndeliveredMessages()
+    .filter((m) => m.kind === 'chat')
+    .map((m) => (JSON.parse(m.content) as { text: string }).text);
+}
+
+async function run(events: AsyncGenerator<ProviderEvent>): Promise<string[]> {
+  const { query, pushes } = makeStubQuery(events);
+  await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+  return pushes;
+}
+
+describe('cross-segment block assembly', () => {
+  it('a block split across two text events assembles and delivers once, with no nudge', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">part one, ' };
+      yield { type: 'text', text: 'part two</message>' };
+      // SDK premise: result = last assistant text = the tail fragment.
+      yield { type: 'result', text: 'part two</message>' };
+    }
+    const pushes = await run(events());
+
+    expect(deliveredTexts()).toEqual(['part one, part two']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('a block split across THREE events (open / body / close) assembles once', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: 'On it.\n<message to="discord-main">step one done, ' };
+      yield { type: 'text', text: 'step two done, ' };
+      yield { type: 'text', text: 'all green.</message>' };
+      yield { type: 'result', text: 'all green.</message>' };
+    }
+    const pushes = await run(events());
+
+    expect(deliveredTexts()).toEqual(['step one done, step two done, all green.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('an open tag literally split mid-token ("<mess" / "age to=…") reunites and the block delivers', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: 'prose before <mess' };
+      yield { type: 'text', text: 'age to="discord-main">assembled across the wire</message>' };
+      yield { type: 'result', text: '' };
+    }
+    const pushes = await run(events());
+
+    expect(deliveredTexts()).toEqual(['assembled across the wire']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('a complete block delivers immediately even when the same event ends in a new unclosed open', async () => {
+    seedDest();
+    let deliveredAfterFirstEvent = -1;
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield {
+        type: 'text',
+        text: '<message to="discord-main">first, complete</message>\n<message to="discord-main">second, still open ',
+      };
+      // The complete block must have gone out before the next event —
+      // assembly defers only the unresolved tail, never settled content.
+      deliveredAfterFirstEvent = getUndeliveredMessages().length;
+      yield { type: 'text', text: 'and now closed</message>' };
+      yield { type: 'result', text: '' };
+    }
+    await run(events());
+
+    expect(deliveredAfterFirstEvent).toBe(1);
+    expect(deliveredTexts()).toEqual(['first, complete', 'second, still open and now closed']);
+  });
+
+  it('the carried tail never re-matches the already-delivered block that preceded it', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // One event: complete block A, then an open fragment. If the buffer
+      // carried more than the tail, block A could re-match on the next scan.
+      yield { type: 'text', text: '<message to="discord-main">A</message><message to="discord-main">B' };
+      yield { type: 'text', text: ' continued</message>' };
+      yield { type: 'result', text: '' };
+    }
+    await run(events());
+
+    expect(deliveredTexts()).toEqual(['A', 'B continued']);
+  });
+
+  it('echo-of-assembled: a later verbatim repeat of the assembled body is suppressed by the DB check', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">assembled ' };
+      yield { type: 'text', text: 'once</message>' }; // assembled → delivered
+      // Final text repeats the whole block verbatim in one segment — the
+      // cross-segment echo guard must recognize the assembled delivery.
+      yield { type: 'text', text: '<message to="discord-main">assembled once</message>' };
+      yield { type: 'result', text: '<message to="discord-main">assembled once</message>' };
+    }
+    const pushes = await run(events());
+
+    expect(deliveredTexts()).toEqual(['assembled once']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('an <internal> span split across events must not promote a quoted draft via assembly', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // The internal span opens in event 1 and closes in event 2; the draft
+      // block inside completes ACROSS the boundary. Assembly must defer
+      // judgment until the span closes, then exclude the draft.
+      yield { type: 'text', text: '<internal>draft: <message to="discord-main">not for sending' };
+      yield { type: 'text', text: '</message></internal>\n<message to="discord-main">the real one</message>' };
+      yield { type: 'result', text: '' };
+    }
+    await run(events());
+
+    expect(deliveredTexts()).toEqual(['the real one']);
+  });
+
+  it('a block opened before an unclosed <internal> assembles correctly once both close', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // The block opens first, then an internal span opens inside it —
+      // the unresolved region must start at the BLOCK open (earliest), so
+      // the whole construct is carried and the internal content is excluded
+      // from the delivered body.
+      yield { type: 'text', text: '<message to="discord-main">body <internal>note to self' };
+      yield { type: 'text', text: '</internal> rest</message>' };
+      yield { type: 'result', text: '' };
+    }
+    await run(events());
+
+    expect(deliveredTexts()).toEqual(['body  rest']);
+  });
+
+  it('the buffer dies at the turn boundary: a fragment is not resurrected by the next turn', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // Turn 1 ends with an unclosed fragment (delivered nothing → nudge).
+      yield { type: 'text', text: '<message to="discord-main">turn-one fragment' };
+      yield { type: 'result', text: '<message to="discord-main">turn-one fragment' };
+      // Turn 2 emits text that would CLOSE the fragment if the buffer
+      // leaked across turns — it must instead be plain scratchpad prose.
+      yield { type: 'text', text: 'stray text</message>' };
+      yield { type: 'result', text: '' };
+    }
+    const pushes = await run(events());
+
+    expect(deliveredTexts()).toEqual([]);
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+  });
+
+  it('task runs never buffer: fragments across events stay inert', async () => {
+    seedDest();
+    const TASK_ROUTING = {
+      platformId: null,
+      channelType: null,
+      threadId: 'system:tasks:ser-1',
+      inReplyTo: 't1',
+      taskRun: true,
+    };
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">split in a ' };
+      yield { type: 'text', text: 'task run</message>' };
+      yield { type: 'result', text: 'run finished' };
+    }
+    const { query } = makeStubQuery(events());
+    await processQuery(query, TASK_ROUTING, ['t1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(getUndeliveredMessages().filter((m) => m.kind === 'chat')).toHaveLength(0);
+  });
+});
+
+describe('unresolvedTailStart', () => {
+  it('fully settled text returns input.length', () => {
+    for (const s of ['plain prose', '<message to="x">done</message>', 'a < b and 5 > 4', '']) {
+      expect(unresolvedTailStart(s)).toBe(s.length);
+    }
+  });
+
+  it('an unclosed <message open starts the tail', () => {
+    const s = 'settled <message to="x">still open';
+    expect(unresolvedTailStart(s)).toBe('settled '.length);
+  });
+
+  it('an open with a close AFTER it is settled even when malformed', () => {
+    // No to="…" attribute — MESSAGE_RE will never match it, but it is
+    // finished text, not a growing block: buffering it would swallow
+    // everything after it for the rest of the turn.
+    const s = '<message bad>text</message> trailing prose';
+    expect(unresolvedTailStart(s)).toBe(s.length);
+  });
+
+  it('a bare tag prefix at the end starts the tail (mid-token split)', () => {
+    expect(unresolvedTailStart('prose <mess')).toBe('prose '.length);
+    expect(unresolvedTailStart('prose <')).toBe('prose '.length);
+    expect(unresolvedTailStart('prose <inter')).toBe('prose '.length);
+  });
+
+  it('an unclosed <internal span starts the tail even before a later <message open', () => {
+    const s = 'ok <internal>hmm <message to="x">draft';
+    expect(unresolvedTailStart(s)).toBe('ok '.length);
+  });
+
+  it('an unclosed <message before a later unclosed <internal wins (earliest unresolved)', () => {
+    const s = '<message to="x">body <internal>note';
+    expect(unresolvedTailStart(s)).toBe(0);
+  });
+
+  it('constructs inside COMPLETE internal spans are settled garbage, not buffer triggers', () => {
+    const s = '<internal>quoting: <message to="x">unclosed draft</internal> after';
+    expect(unresolvedTailStart(s)).toBe(s.length);
+  });
+});

--- a/container/agent-runner/src/poll-loop.midturn-fallback.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-fallback.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { processQuery } from './poll-loop.js';
+import type { AgentQuery, ProviderEvent } from './providers/types.js';
+
+// Adversarial verification of the structural-strip premise: "any complete
+// deliverable <message> block in the result text was already streamed as a
+// text event, hence already delivered at the mid-turn door."
+//
+// The premise is an SDK-behavioral claim, NOT enforceable from provider code:
+// ClaudeProvider's result event takes its text verbatim from the SDK's own
+// `result` / `errors[]` fields (providers/claude.ts), while text events come
+// from assistant messages — two independent sources. These tests construct
+// the divergence cases and pin the stateless fallback that makes them safe:
+// the strip is armed only when the turn delivered at least one block
+// mid-turn (midTurnSent > 0); a turn with zero mid-turn deliveries keeps the
+// result door fully live. The fallback cannot double-deliver — midTurnSent
+// === 0 means nothing was sent that a result-door send could duplicate.
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+const CHAT_ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+  taskRun: false,
+};
+
+function seedDest(name = 'discord-main', channelType = 'discord', platformId = 'chan-1'): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES (?, ?, 'channel', ?, ?, NULL)`,
+    )
+    .run(name, name, channelType, platformId);
+}
+
+function removeDest(name: string): void {
+  getInboundDb().prepare('DELETE FROM destinations WHERE name = ?').run(name);
+}
+
+function makeStubQuery(events: AsyncGenerator<ProviderEvent>): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  return {
+    pushes,
+    query: {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events,
+      abort: () => {},
+    },
+  };
+}
+
+function deliveredTexts(): string[] {
+  return getUndeliveredMessages()
+    .filter((m) => m.kind === 'chat')
+    .map((m) => (JSON.parse(m.content) as { text: string }).text);
+}
+
+// ── A4: SDK-drift guard (the catastrophic total-silence case) ──
+
+describe('result-door fallback when the turn delivered nothing mid-turn', () => {
+  it('capability=true but ZERO text events: a deliverable result block is delivered, not stripped', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // SDK drift: the capability says text streams, but this turn emitted
+      // none — the result is the only carrier of the reply. Stripping it
+      // would be total silence with no log trail the user ever sees.
+      yield { type: 'result', text: '<message to="discord-main">Only exists in the result.</message>' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['Only exists in the result.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('streamed text WITHOUT deliverable blocks + result WITH a block: fallback delivers once', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: 'thinking out loud, nothing wrapped yet' };
+      yield { type: 'result', text: '<message to="discord-main">The reply.</message>' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['The reply.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('fallback resets per turn: a later drift turn still delivers after an earlier streamed turn', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      // Turn 1: normal streaming — strip armed, one delivery.
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">turn one</message>' };
+      yield { type: 'result', text: '<message to="discord-main">turn one</message>' };
+      // Turn 2: drift — no text events. midTurnSent was reset at the turn
+      // boundary, so the fallback must arm again.
+      yield { type: 'result', text: '<message to="discord-main">turn two</message>' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['turn one', 'turn two']);
+  });
+});
+
+// ── A2: multi-segment turns and partial-overlap results ──
+
+describe('multi-segment turns: strip against partial and full overlap', () => {
+  it('result repeating ALL segments blocks (not just the last) strips them all — each already delivered', async () => {
+    seedDest();
+    const a = '<message to="discord-main">segment A</message>';
+    const b = '<message to="discord-main">segment B</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: a };
+      yield { type: 'text', text: b };
+      yield { type: 'result', text: `${a}\n${b}` };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['segment A', 'segment B']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('result carrying only the LAST segment: earlier deliveries stand, the repeat is stripped', async () => {
+    seedDest();
+    const a = '<message to="discord-main">segment A</message>';
+    const b = '<message to="discord-main">segment B</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: a };
+      yield { type: 'text', text: b };
+      yield { type: 'result', text: b };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['segment A', 'segment B']);
+    expect(pushes).toHaveLength(0);
+  });
+});
+
+// ── A3: interrupted / error turns ──
+
+describe('error and interrupted turns', () => {
+  it('error result whose block never streamed (errors[] shape), nothing sent mid-turn: fallback delivers', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: 'partial progress narration, unwrapped' };
+      // The claude provider builds error-result text from the SDK's errors[]
+      // field — content that NEVER streamed as assistant text. If it carries
+      // a deliverable block, stripping it would silently eat the notice.
+      yield { type: 'result', text: '<message to="discord-main">Run aborted: quota.</message>', isError: true };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['Run aborted: quota.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('a stream that throws after a mid-turn delivery: the delivered row survives, processQuery rejects', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Sent before the crash.</message>' };
+      throw new Error('SDK stream died');
+    }
+    const { query } = makeStubQuery(events());
+
+    await expect(
+      processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true),
+    ).rejects.toThrow('SDK stream died');
+
+    // The mid-turn write is durable — an interrupted turn cannot claw it back.
+    expect(deliveredTexts()).toEqual(['Sent before the crash.']);
+  });
+});
+
+// ── B: predicate timing — destinations changing intra-turn ──
+
+describe('destination set changes between stream time and result time', () => {
+  it('dest unknown at stream time but present at result time, nothing else delivered: fallback delivers', async () => {
+    // Destinations are live-queried from inbound.db (the host writes the
+    // table on demand, mid-session). A block skipped at the mid-turn door for
+    // unknown destination must not be strip-dropped at the result once the
+    // destination exists — with zero mid-turn deliveries the strip stays
+    // unarmed and the result door delivers.
+    const block = '<message to="discord-main">Hello, new channel.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block }; // door: unknown dest → skipped
+      seedDest(); // host wires the destination mid-turn
+      yield { type: 'result', text: block };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['Hello, new channel.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('KNOWN RESIDUAL (pinned): dest appears late while ANOTHER block already delivered — the late block is stripped', async () => {
+    // Stateless bound, accepted by design: once any block delivered mid-turn
+    // the strip is armed for the whole result, and without content-keyed
+    // state (or an outbound-DB consult per block) the result door cannot
+    // tell "already delivered at the door" from "skipped at the door for a
+    // reason that no longer holds". Reaching this shape requires a
+    // destination write landing inside the sub-second window between the
+    // last streamed segment and the result, in a turn that also delivered
+    // another block. If this trade-off is ever revisited, the exact fix is a
+    // per-block messages_out lookup (rows written since the turn started,
+    // same platform/channel, same content) instead of the structural strip.
+    seedDest('discord-main');
+    const known = '<message to="discord-main">to the known channel</message>';
+    const late = '<message to="late-dest">to the late channel</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: `${known}\n${late}` }; // known delivers; late skipped (unknown)
+      seedDest('late-dest', 'discord', 'chan-2'); // appears inside the window
+      yield { type: 'result', text: `${known}\n${late}` };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    // Only the known-at-stream-time block goes out; the late one is stripped.
+    expect(deliveredTexts()).toEqual(['to the known channel']);
+  });
+
+  it('dest removed between stream and result: the delivered block is not re-sent and no nudge fires', async () => {
+    seedDest();
+    const block = '<message to="discord-main">delivered before removal</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block }; // delivers
+      removeDest('discord-main');
+      yield { type: 'result', text: block }; // result-door: unknown dest → dropped-note, no strip needed
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['delivered before removal']);
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+  });
+});
+
+// ── HALF-MESSAGES: blocks split across streamed text events ──
+//
+// The claude provider emits ONE text event per assistant message (text blocks
+// joined) — a <message> block can still open in one assistant message and
+// close in a later one when a tool call rides between them. The mid-turn door
+// parses each event independently and keeps NO cross-event buffer, so a
+// cross-event block is never delivered mid-turn. Under the SDK premise the
+// result repeats only the LAST message's text, so the block is incomplete
+// there too — the wrap-nudge is the recovery path. If drift ever hands the
+// result a healed (complete) copy, the midTurnSent===0 fallback delivers it.
+
+describe('half-messages: block split across streamed text events', () => {
+  it('no cross-event buffering: split block undelivered mid-turn; a tail-only result fires the wrap-nudge', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">part one, ' };
+      yield { type: 'text', text: 'part two</message>' };
+      // SDK premise: result = last assistant text = the tail, incomplete.
+      yield { type: 'result', text: 'part two</message>' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    // Nothing half-formed is ever delivered…
+    expect(deliveredTexts()).toEqual([]);
+    // …and the turn is not silent: the wrap-nudge asks the agent to re-send.
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+  });
+
+  it('healing drift: block incomplete in every streamed event but complete in the result → fallback delivers once', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">first half, ' };
+      yield { type: 'text', text: 'second half</message>' };
+      // Drift shape: the result carries the concatenation. No streamed event
+      // parsed a complete block (midTurnSent === 0), so the strip must stay
+      // unarmed and the result door must deliver — stripping here was the
+      // total-loss case.
+      yield { type: 'result', text: '<message to="discord-main">first half, second half</message>' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['first half, second half']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('never-completed block alongside a delivered block: fragment stays scratchpad, no nudge, no loss of anything complete', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">complete reply</message>' };
+      yield { type: 'text', text: '<message to="discord-main">opened but never closed…' };
+      yield { type: 'result', text: '' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['complete reply']);
+    // A block was delivered this turn — the unfinished fragment is treated as
+    // scratchpad, not as an undelivered reply.
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+  });
+});
+
+// ── Cross-segment echo guard (live-captured: SDK battery s03) ──
+//
+// The model, after a trailing tool call, often re-emits the ALREADY-SENT
+// block verbatim as its final text — which streams as its own text event.
+// The door consults the outbound DB over the frame-local seq window
+// (turnStartSeq, segStartSeq] to recognize the repeat; no in-process content
+// ledger. Intra-segment doubles and cross-turn repeats stay deliverable.
+
+describe('cross-segment echo guard', () => {
+  it('a later segment re-emitting the identical block delivers once (s03 recording shape)', async () => {
+    seedDest();
+    const block = '<message to="discord-main">✅ Deploy is done.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block }; // composed + delivered before the tool call
+      yield { type: 'text', text: block }; // final text: verbatim echo after the tool call
+      yield { type: 'result', text: block }; // result === last segment (live invariant)
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['✅ Deploy is done.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('two identical blocks in ONE segment are an explicit double-send and both deliver (s09 shape)', async () => {
+    seedDest();
+    const twice =
+      '<message to="discord-main">backup finished</message>\n\n<message to="discord-main">backup finished</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: twice };
+      yield { type: 'result', text: twice };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['backup finished', 'backup finished']);
+  });
+
+  it('the same body to a DIFFERENT destination is not an echo', async () => {
+    seedDest('discord-main');
+    seedDest('ops-log', 'slack', 'chan-ops');
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">capture test</message>' };
+      yield { type: 'text', text: '<message to="ops-log">capture test</message>' };
+      yield { type: 'result', text: '' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['capture test', 'capture test']);
+  });
+
+  it('the window closes at the turn boundary: the next turn may genuinely repeat the body', async () => {
+    seedDest();
+    const block = '<message to="discord-main">The answer is 4.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: block };
+      // Turn 2: same body again, on purpose. Must deliver.
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: 'sent above' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['The answer is 4.', 'The answer is 4.']);
+  });
+});
+
+// ── C: failure ordering — mid-turn outbound write fails ──
+
+describe('mid-turn delivery write failure', () => {
+  it('fails the turn loudly: processQuery rejects, the stream never reaches its result, nothing is strip-dropped', async () => {
+    seedDest();
+    let reachedResult = false;
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // Break the outbound DB before the delivery attempt — the next
+      // writeMessageOut throws (fresh prepare per call, so the rename bites).
+      getOutboundDb().exec('ALTER TABLE messages_out RENAME TO messages_out_broken');
+      yield { type: 'text', text: '<message to="discord-main">will fail to write</message>' };
+      reachedResult = true;
+      yield { type: 'result', text: '<message to="discord-main">will fail to write</message>' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await expect(
+      processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true),
+    ).rejects.toThrow();
+
+    // The turn died at the failed write: the result was never processed, so
+    // the block was NOT silently stripped as "already delivered" — the
+    // caller's error path (runPollLoop) surfaces the failure to the user.
+    expect(reachedResult).toBe(false);
+    getOutboundDb().exec('ALTER TABLE messages_out_broken RENAME TO messages_out');
+    expect(deliveredTexts()).toEqual([]);
+  });
+});
+
+// ── D: result-door handling for blocks the mid-turn door skips ──
+
+describe('capability=true keeps base result-door handling for door-skipped blocks', () => {
+  it('unknown destination at both doors: dropped with the wrap-nudge, never silently stripped', async () => {
+    // No destination seeded at all.
+    const block = '<message to="nobody-home">is anyone there?</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: block };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual([]);
+    // The drop lands in the scratchpad and the turn counts as undelivered —
+    // the nudge (listing real destinations) is the base-behavior surface.
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+  });
+});

--- a/container/agent-runner/src/poll-loop.midturn-recovery.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-recovery.test.ts
@@ -74,7 +74,7 @@ describe('mid-turn <internal> exclusion', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual([]);
   });
@@ -91,7 +91,7 @@ describe('mid-turn <internal> exclusion', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual([]);
   });
@@ -110,25 +110,25 @@ describe('mid-turn <internal> exclusion', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual(['Here is the brief.']);
   });
 
-  it('an internal draft does not poison dedup — the same body still sends when meant', async () => {
+  it('an internal draft does not suppress the same body genuinely sent later in the turn', async () => {
     seedDest();
     const body = 'The answer is 4.';
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
       // Drafted inside <internal> first, then genuinely sent in the same turn.
-      // The draft must not have registered a dedup key.
+      // The draft must have left no trace that blocks the real send.
       yield { type: 'text', text: `<internal><message to="discord-main">${body}</message></internal>` };
       yield { type: 'text', text: `<message to="discord-main">${body}</message>` };
       yield { type: 'result', text: '' };
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual([body]);
   });
@@ -146,7 +146,7 @@ describe('unwrapped final summary after a delivered reply', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual(['Real reply.']);
     expect(pushes.filter((p) => p.includes('was not delivered'))).toEqual([]);
@@ -160,7 +160,7 @@ describe('unwrapped final summary after a delivered reply', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(pushes.length).toBeGreaterThan(0);
   });
@@ -177,7 +177,7 @@ describe('mid-turn recovery when the final result is empty', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual(['Here is the brief: three pillars.']);
     expect(pushes).toHaveLength(0);
@@ -189,20 +189,23 @@ describe('mid-turn recovery when the final result is empty', () => {
       yield { type: 'init', continuation: 's1' };
       yield { type: 'text', text: '<message to="discord-main">turn one</message>' };
       yield { type: 'result', text: '' };
-      // Turn 2 composes nothing addressed and ends empty — turn 1's block must
-      // not be resurrected by the reset-at-turn-boundary bookkeeping.
+      // Turn 2 composes nothing addressed and ends empty — nothing carried
+      // across the turn boundary may resurrect turn 1's block.
       yield { type: 'text', text: 'just thinking' };
       yield { type: 'result', text: '' };
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual(['turn one']);
   });
 });
 
-describe('final-text <internal> exclusion (the result-path half of the guarantee)', () => {
+// The result door is still a live delivery path for providers that do NOT
+// declare emitsMidTurnText — these run without the capability so the final
+// text actually delivers, and the <internal> exclusion must hold there too.
+describe('final-text <internal> exclusion (the result-door half of the guarantee)', () => {
   it('never delivers a block wrapped in <internal> in the FINAL result text', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
@@ -214,7 +217,7 @@ describe('final-text <internal> exclusion (the result-path half of the guarantee
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, false);
 
     expect(deliveredTexts()).toEqual([]);
   });
@@ -232,7 +235,7 @@ describe('final-text <internal> exclusion (the result-path half of the guarantee
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, false);
 
     expect(deliveredTexts()).toEqual(['Here is the final version.']);
   });
@@ -245,7 +248,7 @@ describe('final-text <internal> exclusion (the result-path half of the guarantee
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, false);
 
     expect(deliveredTexts()).toEqual([]);
     expect(pushes.filter((p) => p.includes('must be wrapped'))).toEqual([]);

--- a/container/agent-runner/src/poll-loop.midturn-recovery.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-recovery.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { processQuery } from './poll-loop.js';
+import type { AgentQuery, ProviderEvent } from './providers/types.js';
+
+// Two properties of the mid-turn delivery path that the skill's own guard
+// tests do not cover, both carried over from the merge-based fix this design
+// replaced:
+//
+//  - <internal>...</internal> is not-for-delivery scratchpad. A <message>
+//    block quoted inside one is a DRAFT; promoting it to a real send was the
+//    failure the exclusion exists to prevent.
+//  - The incident shape itself: the model composes the wrapped reply, a tool
+//    call rides after the composed message, and the turn's final text is
+//    EMPTY. The reply reaches the user only if the mid-turn text event
+//    delivered it.
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+const CHAT_ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+  taskRun: false,
+};
+
+function seedDest(name = 'discord-main'): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES (?, ?, 'channel', 'discord', 'chan-1', NULL)`,
+    )
+    .run(name, name);
+}
+
+function makeStubQuery(events: AsyncGenerator<ProviderEvent>): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  return {
+    pushes,
+    query: {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events,
+      abort: () => {},
+    },
+  };
+}
+
+function deliveredTexts(): string[] {
+  return getUndeliveredMessages().map((m) => (JSON.parse(m.content) as { text: string }).text);
+}
+
+describe('mid-turn <internal> exclusion', () => {
+  it('never delivers a block quoted inside an <internal> span', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield {
+        type: 'text',
+        text: '<internal>draft: <message to="discord-main">not for sending</message></internal>',
+      };
+      yield { type: 'result', text: '' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual([]);
+  });
+
+  it('excludes internal spans that carry attributes, in any case', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield {
+        type: 'text',
+        text: '<INTERNAL note="draft"><message to="discord-main">not for sending</message></Internal>',
+      };
+      yield { type: 'result', text: '' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual([]);
+  });
+
+  it('delivers a real block that shares its text segment with an internal draft', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield {
+        type: 'text',
+        text:
+          '<internal>considering: <message to="discord-main">too blunt</message></internal>\n' +
+          '<message to="discord-main">Here is the brief.</message>',
+      };
+      yield { type: 'result', text: '' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual(['Here is the brief.']);
+  });
+
+  it('an internal draft does not poison dedup — the same body still sends when meant', async () => {
+    seedDest();
+    const body = 'The answer is 4.';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // Drafted inside <internal> first, then genuinely sent in the same turn.
+      // The draft must not have registered a dedup key.
+      yield { type: 'text', text: `<internal><message to="discord-main">${body}</message></internal>` };
+      yield { type: 'text', text: `<message to="discord-main">${body}</message>` };
+      yield { type: 'result', text: '' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual([body]);
+  });
+});
+
+describe('unwrapped final summary after a delivered reply', () => {
+  it('does not fire the wrap-nudge or deliver the summary when a block already went out', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Real reply.</message>' };
+      // Unwrapped self-summary as the final text — the live-observed shape
+      // that used to trigger the wrap-nudge and a redundant second message.
+      yield { type: 'result', text: 'Flagged it to Joe rather than guessing.' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual(['Real reply.']);
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toEqual([]);
+  });
+
+  it('still nudges when nothing at all was delivered', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'result', text: 'plain unwrapped text, nothing sent' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(pushes.length).toBeGreaterThan(0);
+  });
+});
+
+describe('mid-turn recovery when the final result is empty', () => {
+  it('delivers the wrapped reply composed before a trailing tool call', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Here is the brief: three pillars.</message>' };
+      // A tool call rides after the composed message; final text is empty.
+      yield { type: 'result', text: '' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual(['Here is the brief: three pillars.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('does not re-deliver across turns when only the first turn composed a block', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">turn one</message>' };
+      yield { type: 'result', text: '' };
+      // Turn 2 composes nothing addressed and ends empty — turn 1's block must
+      // not be resurrected by the reset-at-turn-boundary bookkeeping.
+      yield { type: 'text', text: 'just thinking' };
+      yield { type: 'result', text: '' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual(['turn one']);
+  });
+});
+
+describe('final-text <internal> exclusion (the result-path half of the guarantee)', () => {
+  it('never delivers a block wrapped in <internal> in the FINAL result text', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield {
+        type: 'result',
+        text: '<internal>draft: <message to="discord-main">final-text secret</message></internal>',
+      };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual([]);
+  });
+
+  it('delivers the real sibling block and drops only the internal draft', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield {
+        type: 'result',
+        text:
+          '<internal>too blunt: <message to="discord-main">rejected draft</message></internal>\n' +
+          '<message to="discord-main">Here is the final version.</message>',
+      };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual(['Here is the final version.']);
+  });
+
+  it('an internal-only final text does not fire the unwrapped nudge', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'result', text: '<internal>just thinking out loud</internal>' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(deliveredTexts()).toEqual([]);
+    expect(pushes.filter((p) => p.includes('must be wrapped'))).toEqual([]);
+  });
+});

--- a/container/agent-runner/src/poll-loop.midturn-resultdoor.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-resultdoor.test.ts
@@ -5,19 +5,19 @@ import { getUndeliveredMessages } from './db/messages-out.js';
 import { processQuery } from './poll-loop.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
-// Adversarial verification of the structural-strip premise: "any complete
-// deliverable <message> block in the result text was already streamed as a
-// text event, hence already delivered at the mid-turn door."
+// Adversarial verification of the one-door contract for emitsMidTurnText
+// providers: mid-turn streaming is the SINGLE content door. The result door
+// NEVER writes content to messages_out (error results excepted) — its only
+// other job is the nudge decision: a turn that delivered nothing (no door
+// delivery, no DB-visible send like MCP send_message) whose result still
+// carries content gets the wrap-nudge, so the model re-sends and the retry
+// streams through the mid-turn door. Streaming-door misses (SDK drift, a
+// destination appearing only after streaming) therefore degrade to
+// nudge-and-retry — deliberately, never to a direct result-door send.
 //
-// The premise is an SDK-behavioral claim, NOT enforceable from provider code:
-// ClaudeProvider's result event takes its text verbatim from the SDK's own
-// `result` / `errors[]` fields (providers/claude.ts), while text events come
-// from assistant messages — two independent sources. These tests construct
-// the divergence cases and pin the stateless fallback that makes them safe:
-// the strip is armed only when the turn delivered at least one block
-// mid-turn (midTurnSent > 0); a turn with zero mid-turn deliveries keeps the
-// result door fully live. The fallback cannot double-deliver — midTurnSent
-// === 0 means nothing was sent that a result-door send could duplicate.
+// The result text is an independent SDK field the provider cannot prove
+// equal to streamed content (see providers/claude.ts result branch), which
+// is why these divergence shapes are constructed and pinned here.
 
 beforeEach(() => {
   initTestSessionDb();
@@ -69,27 +69,32 @@ function deliveredTexts(): string[] {
     .map((m) => (JSON.parse(m.content) as { text: string }).text);
 }
 
-// ── A4: SDK-drift guard (the catastrophic total-silence case) ──
+function nudges(pushes: string[]): string[] {
+  return pushes.filter((p) => p.includes('was not delivered'));
+}
 
-describe('result-door fallback when the turn delivered nothing mid-turn', () => {
-  it('capability=true but ZERO text events: a deliverable result block is delivered, not stripped', async () => {
+// ── The result door never delivers: streaming-door misses degrade to the nudge ──
+
+describe('result door never delivers content — undelivered turns get the nudge', () => {
+  it('SDK drift (capability=true, ZERO text events): the result block is NOT written, the nudge fires', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
-      // SDK drift: the capability says text streams, but this turn emitted
-      // none — the result is the only carrier of the reply. Stripping it
-      // would be total silence with no log trail the user ever sees.
+      // The capability says text streams, but this turn emitted none — the
+      // result is the only carrier of the reply. The result door still does
+      // not send; the wrap-nudge asks the model to re-send, and the retry's
+      // text events go through the mid-turn door.
       yield { type: 'result', text: '<message to="discord-main">Only exists in the result.</message>' };
     }
     const { query, pushes } = makeStubQuery(events());
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    expect(deliveredTexts()).toEqual(['Only exists in the result.']);
-    expect(pushes).toHaveLength(0);
+    expect(deliveredTexts()).toEqual([]);
+    expect(nudges(pushes)).toHaveLength(1);
   });
 
-  it('streamed text WITHOUT deliverable blocks + result WITH a block: fallback delivers once', async () => {
+  it('streamed text WITHOUT deliverable blocks + result WITH a block: nothing written, nudge fires', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
@@ -100,33 +105,68 @@ describe('result-door fallback when the turn delivered nothing mid-turn', () => 
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    expect(deliveredTexts()).toEqual(['The reply.']);
-    expect(pushes).toHaveLength(0);
+    expect(deliveredTexts()).toEqual([]);
+    expect(nudges(pushes)).toHaveLength(1);
   });
 
-  it('fallback resets per turn: a later drift turn still delivers after an earlier streamed turn', async () => {
+  it('a nudged retry that re-streams the block delivers it through the mid-turn door (the recovery loop)', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
-      // Turn 1: normal streaming — strip armed, one delivery.
       yield { type: 'init', continuation: 's1' };
-      yield { type: 'text', text: '<message to="discord-main">turn one</message>' };
-      yield { type: 'result', text: '<message to="discord-main">turn one</message>' };
-      // Turn 2: drift — no text events. midTurnSent was reset at the turn
-      // boundary, so the fallback must arm again.
-      yield { type: 'result', text: '<message to="discord-main">turn two</message>' };
+      // Turn 1: drift — block only in the result. Nudge fires.
+      yield { type: 'result', text: '<message to="discord-main">Lost in the drift.</message>' };
+      // The retry turn streams properly — mid-turn door delivers.
+      yield { type: 'text', text: '<message to="discord-main">Lost in the drift.</message>' };
+      yield { type: 'result', text: '<message to="discord-main">Lost in the drift.</message>' };
     }
-    const { query } = makeStubQuery(events());
+    const { query, pushes } = makeStubQuery(events());
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    expect(deliveredTexts()).toEqual(['turn one', 'turn two']);
+    expect(deliveredTexts()).toEqual(['Lost in the drift.']);
+    expect(nudges(pushes)).toHaveLength(1);
+  });
+
+  it('the nudge decision resets per turn: a later drift turn nudges after an earlier delivered turn', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      // Turn 1: normal streaming — one delivery, no nudge.
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">turn one</message>' };
+      yield { type: 'result', text: '<message to="discord-main">turn one</message>' };
+      // Turn 2: drift — no text events. The per-turn state was reset at the
+      // boundary, so this undelivered turn must nudge (and not deliver).
+      yield { type: 'result', text: '<message to="discord-main">turn two</message>' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['turn one']);
+    expect(nudges(pushes)).toHaveLength(1);
+  });
+
+  it('a repeat of the mid-turn delivery in the result is inert: no second write, no nudge', async () => {
+    seedDest();
+    const block = '<message to="discord-main">The answer is 4.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: block };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['The answer is 4.']);
+    expect(pushes).toHaveLength(0);
   });
 });
 
-// ── A2: multi-segment turns and partial-overlap results ──
+// ── Multi-segment turns: repeats in the result stay inert ──
 
-describe('multi-segment turns: strip against partial and full overlap', () => {
-  it('result repeating ALL segments blocks (not just the last) strips them all — each already delivered', async () => {
+describe('multi-segment turns: result overlap never re-delivers', () => {
+  it('result repeating ALL segments blocks: each delivered once at the door, result inert', async () => {
     seedDest();
     const a = '<message to="discord-main">segment A</message>';
     const b = '<message to="discord-main">segment B</message>';
@@ -144,7 +184,7 @@ describe('multi-segment turns: strip against partial and full overlap', () => {
     expect(pushes).toHaveLength(0);
   });
 
-  it('result carrying only the LAST segment: earlier deliveries stand, the repeat is stripped', async () => {
+  it('result carrying only the LAST segment: earlier deliveries stand, the repeat is inert', async () => {
     seedDest();
     const a = '<message to="discord-main">segment A</message>';
     const b = '<message to="discord-main">segment B</message>';
@@ -163,24 +203,40 @@ describe('multi-segment turns: strip against partial and full overlap', () => {
   });
 });
 
-// ── A3: interrupted / error turns ──
+// ── Error and interrupted turns ──
 
 describe('error and interrupted turns', () => {
-  it('error result whose block never streamed (errors[] shape), nothing sent mid-turn: fallback delivers', async () => {
+  it('error result whose block never streamed (errors[] shape), nothing sent mid-turn: no write, nudge fires', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
       yield { type: 'text', text: 'partial progress narration, unwrapped' };
       // The claude provider builds error-result text from the SDK's errors[]
-      // field — content that NEVER streamed as assistant text. If it carries
-      // a deliverable block, stripping it would silently eat the notice.
+      // field — content that NEVER streamed. The result door still does not
+      // send it as a block; with nothing delivered this turn the nudge asks
+      // for a proper re-send instead.
       yield { type: 'result', text: '<message to="discord-main">Run aborted: quota.</message>', isError: true };
     }
     const { query, pushes } = makeStubQuery(events());
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    expect(deliveredTexts()).toEqual(['Run aborted: quota.']);
+    expect(deliveredTexts()).toEqual([]);
+    expect(nudges(pushes)).toHaveLength(1);
+  });
+
+  it('a bare (blockless) error result still surfaces via deliverErrorResult — the errors exception', async () => {
+    seedDest();
+    const errText = 'Spending limit reached. Add your own key at https://example.com/keys';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'result', text: errText, isError: true };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual([errText]);
     expect(pushes).toHaveLength(0);
   });
 
@@ -202,15 +258,14 @@ describe('error and interrupted turns', () => {
   });
 });
 
-// ── B: predicate timing — destinations changing intra-turn ──
+// ── Destinations changing between stream time and result time ──
 
 describe('destination set changes between stream time and result time', () => {
-  it('dest unknown at stream time but present at result time, nothing else delivered: fallback delivers', async () => {
+  it('dest unknown at stream time but present at result time, nothing else delivered: no write, nudge fires', async () => {
     // Destinations are live-queried from inbound.db (the host writes the
-    // table on demand, mid-session). A block skipped at the mid-turn door for
-    // unknown destination must not be strip-dropped at the result once the
-    // destination exists — with zero mid-turn deliveries the strip stays
-    // unarmed and the result door delivers.
+    // table on demand, mid-session). The result door does not deliver even
+    // once the destination exists — the nudge coaxes a re-send, and the
+    // retry's mid-turn scan sees the now-known destination.
     const block = '<message to="discord-main">Hello, new channel.</message>';
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
@@ -222,21 +277,16 @@ describe('destination set changes between stream time and result time', () => {
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    expect(deliveredTexts()).toEqual(['Hello, new channel.']);
-    expect(pushes).toHaveLength(0);
+    expect(deliveredTexts()).toEqual([]);
+    expect(nudges(pushes)).toHaveLength(1);
   });
 
-  it('KNOWN RESIDUAL (pinned): dest appears late while ANOTHER block already delivered — the late block is stripped', async () => {
-    // Stateless bound, accepted by design: once any block delivered mid-turn
-    // the strip is armed for the whole result, and without content-keyed
-    // state (or an outbound-DB consult per block) the result door cannot
-    // tell "already delivered at the door" from "skipped at the door for a
-    // reason that no longer holds". Reaching this shape requires a
-    // destination write landing inside the sub-second window between the
-    // last streamed segment and the result, in a turn that also delivered
-    // another block. If this trade-off is ever revisited, the exact fix is a
-    // per-block messages_out lookup (rows written since the turn started,
-    // same platform/channel, same content) instead of the structural strip.
+  it('KNOWN RESIDUAL (pinned): dest appears late while ANOTHER block already delivered — no delivery, no nudge', async () => {
+    // Accepted bound of the one-door contract: the turn DID deliver, so the
+    // nudge stays quiet, and the result door never sends — the late block is
+    // lost for this turn. Reaching this shape requires a destination write
+    // landing inside the sub-second window between the last streamed segment
+    // and the result, in a turn that also delivered another block.
     seedDest('discord-main');
     const known = '<message to="discord-main">to the known channel</message>';
     const late = '<message to="late-dest">to the late channel</message>';
@@ -246,12 +296,12 @@ describe('destination set changes between stream time and result time', () => {
       seedDest('late-dest', 'discord', 'chan-2'); // appears inside the window
       yield { type: 'result', text: `${known}\n${late}` };
     }
-    const { query } = makeStubQuery(events());
+    const { query, pushes } = makeStubQuery(events());
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    // Only the known-at-stream-time block goes out; the late one is stripped.
     expect(deliveredTexts()).toEqual(['to the known channel']);
+    expect(nudges(pushes)).toHaveLength(0);
   });
 
   it('dest removed between stream and result: the delivered block is not re-sent and no nudge fires', async () => {
@@ -261,69 +311,42 @@ describe('destination set changes between stream time and result time', () => {
       yield { type: 'init', continuation: 's1' };
       yield { type: 'text', text: block }; // delivers
       removeDest('discord-main');
-      yield { type: 'result', text: block }; // result-door: unknown dest → dropped-note, no strip needed
+      yield { type: 'result', text: block }; // result-door: unknown dest → dropped-note; turn delivered → no nudge
     }
     const { query, pushes } = makeStubQuery(events());
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual(['delivered before removal']);
-    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+    expect(nudges(pushes)).toHaveLength(0);
   });
 });
 
-// ── HALF-MESSAGES: blocks split across streamed text events ──
+// ── Half-messages: never-closed fragments are the nudge's job ──
 //
-// The claude provider emits ONE text event per assistant message (text blocks
-// joined) — a <message> block can still open in one assistant message and
-// close in a later one when a tool call rides between them. The mid-turn door
-// parses each event independently and keeps NO cross-event buffer, so a
-// cross-event block is never delivered mid-turn. Under the SDK premise the
-// result repeats only the LAST message's text, so the block is incomplete
-// there too — the wrap-nudge is the recovery path. If drift ever hands the
-// result a healed (complete) copy, the midTurnSent===0 fallback delivers it.
+// Blocks split across text events are ASSEMBLED and delivered mid-turn (see
+// poll-loop.midturn-assembly.test.ts). What assembly does NOT cover — a block
+// that never closes anywhere — stays undeliverable, and the wrap-nudge is
+// the recovery path when the turn delivered nothing.
 
-describe('half-messages: block split across streamed text events', () => {
-  it('no cross-event buffering: split block undelivered mid-turn; a tail-only result fires the wrap-nudge', async () => {
+describe('half-messages: never-closed fragments', () => {
+  it('a block that NEVER closes anywhere: nothing delivered, the wrap-nudge fires (nudge owns this case)', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
-      yield { type: 'text', text: '<message to="discord-main">part one, ' };
-      yield { type: 'text', text: 'part two</message>' };
-      // SDK premise: result = last assistant text = the tail, incomplete.
-      yield { type: 'result', text: 'part two</message>' };
+      yield { type: 'text', text: '<message to="discord-main">this stays open forever' };
+      // SDK premise: result = last assistant text = the same unclosed fragment.
+      yield { type: 'result', text: '<message to="discord-main">this stays open forever' };
     }
     const { query, pushes } = makeStubQuery(events());
 
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
-    // Nothing half-formed is ever delivered…
     expect(deliveredTexts()).toEqual([]);
-    // …and the turn is not silent: the wrap-nudge asks the agent to re-send.
-    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+    expect(nudges(pushes)).toHaveLength(1);
   });
 
-  it('healing drift: block incomplete in every streamed event but complete in the result → fallback delivers once', async () => {
-    seedDest();
-    async function* events(): AsyncGenerator<ProviderEvent> {
-      yield { type: 'init', continuation: 's1' };
-      yield { type: 'text', text: '<message to="discord-main">first half, ' };
-      yield { type: 'text', text: 'second half</message>' };
-      // Drift shape: the result carries the concatenation. No streamed event
-      // parsed a complete block (midTurnSent === 0), so the strip must stay
-      // unarmed and the result door must deliver — stripping here was the
-      // total-loss case.
-      yield { type: 'result', text: '<message to="discord-main">first half, second half</message>' };
-    }
-    const { query, pushes } = makeStubQuery(events());
-
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
-
-    expect(deliveredTexts()).toEqual(['first half, second half']);
-    expect(pushes).toHaveLength(0);
-  });
-
-  it('never-completed block alongside a delivered block: fragment stays scratchpad, no nudge, no loss of anything complete', async () => {
+  it('never-completed fragment alongside a delivered block: fragment dropped at turn end, no nudge, no loss of anything complete', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
       yield { type: 'init', continuation: 's1' };
@@ -336,9 +359,7 @@ describe('half-messages: block split across streamed text events', () => {
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual(['complete reply']);
-    // A block was delivered this turn — the unfinished fragment is treated as
-    // scratchpad, not as an undelivered reply.
-    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+    expect(nudges(pushes)).toHaveLength(0);
   });
 });
 
@@ -419,10 +440,41 @@ describe('cross-segment echo guard', () => {
   });
 });
 
-// ── C: failure ordering — mid-turn outbound write fails ──
+// ── MCP sends count as same-turn deliveries for the nudge decision ──
+
+describe('DB-visible sends gate the nudge', () => {
+  it('a chat row written this turn outside the door (MCP send_message shape) suppresses the nudge', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // Simulate an MCP send_message call landing mid-turn: a chat row
+      // appears in outbound.db without going through the mid-turn door.
+      const { writeMessageOut } = await import('./db/messages-out.js');
+      writeMessageOut({
+        id: 'mcp-1',
+        kind: 'chat',
+        platform_id: 'chan-1',
+        channel_type: 'discord',
+        thread_id: null,
+        content: JSON.stringify({ text: 'sent via tool' }),
+      });
+      // Final text is an unwrapped self-summary — with a DB-visible send
+      // this turn, nudging would coax a redundant repeat.
+      yield { type: 'result', text: 'Told them via the tool.' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(deliveredTexts()).toEqual(['sent via tool']);
+    expect(nudges(pushes)).toHaveLength(0);
+  });
+});
+
+// ── Failure ordering — mid-turn outbound write fails ──
 
 describe('mid-turn delivery write failure', () => {
-  it('fails the turn loudly: processQuery rejects, the stream never reaches its result, nothing is strip-dropped', async () => {
+  it('fails the turn loudly: processQuery rejects, the stream never reaches its result, nothing is silently dropped', async () => {
     seedDest();
     let reachedResult = false;
     async function* events(): AsyncGenerator<ProviderEvent> {
@@ -440,19 +492,18 @@ describe('mid-turn delivery write failure', () => {
       processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true),
     ).rejects.toThrow();
 
-    // The turn died at the failed write: the result was never processed, so
-    // the block was NOT silently stripped as "already delivered" — the
-    // caller's error path (runPollLoop) surfaces the failure to the user.
+    // The turn died at the failed write: the result was never processed, and
+    // the caller's error path (runPollLoop) surfaces the failure to the user.
     expect(reachedResult).toBe(false);
     getOutboundDb().exec('ALTER TABLE messages_out_broken RENAME TO messages_out');
     expect(deliveredTexts()).toEqual([]);
   });
 });
 
-// ── D: result-door handling for blocks the mid-turn door skips ──
+// ── Door-skipped blocks keep base result-door handling ──
 
 describe('capability=true keeps base result-door handling for door-skipped blocks', () => {
-  it('unknown destination at both doors: dropped with the wrap-nudge, never silently stripped', async () => {
+  it('unknown destination at both doors: dropped with the wrap-nudge, never silently swallowed', async () => {
     // No destination seeded at all.
     const block = '<message to="nobody-home">is anyone there?</message>';
     async function* events(): AsyncGenerator<ProviderEvent> {
@@ -465,8 +516,6 @@ describe('capability=true keeps base result-door handling for door-skipped block
     await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(deliveredTexts()).toEqual([]);
-    // The drop lands in the scratchpad and the turn counts as undelivered —
-    // the nudge (listing real destinations) is the base-behavior surface.
-    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+    expect(nudges(pushes)).toHaveLength(1);
   });
 });

--- a/container/agent-runner/src/poll-loop.midturn.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn.test.ts
@@ -15,10 +15,13 @@ afterEach(() => {
 });
 
 // --- Mid-turn <message> block delivery ---
-// The SDK's final result carries only the LAST assistant text. A wrapped
-// reply composed between tool calls must be delivered from the 'text' event
-// stream, deduped against its echo in the final result, and must suppress
-// the unwrapped-nudge when the final text is bare.
+// The SDK's final result carries only the LAST assistant text. For providers
+// declaring emitsMidTurnText, a wrapped reply composed between tool calls is
+// delivered from the 'text' event stream at parse time; the final result
+// structurally STRIPS complete blocks (they already streamed, so they were
+// already delivered — no runtime record consulted), and a bare final text
+// after a mid-turn delivery must not trigger the unwrapped-nudge. Providers
+// without the capability keep the single result-door delivery path.
 
 const CHAT_ROUTING = {
   platformId: 'chan-1',
@@ -91,7 +94,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(outCountBeforeResult).toBe(1);
     const out = getUndeliveredMessages();
@@ -101,7 +104,7 @@ describe('mid-turn <message> block delivery', () => {
     expect(out[0].channel_type).toBe('discord');
   });
 
-  it('does not deliver the same block twice when the final result echoes it', async () => {
+  it('a final result repeating a streamed block yields exactly one delivery (structural strip)', async () => {
     seedDest();
     const block = '<message to="discord-main">The answer is 4.</message>';
     async function* events(): AsyncGenerator<ProviderEvent> {
@@ -111,7 +114,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages()).toHaveLength(1);
     expect(pushes).toHaveLength(0);
@@ -126,7 +129,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages()).toHaveLength(1);
     expect(pushes).toHaveLength(0);
@@ -141,7 +144,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages()).toHaveLength(0);
     expect(pushes).toHaveLength(1);
@@ -157,14 +160,14 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
     expect(JSON.parse(out[0].content).text).toBe('Deploy is done.');
   });
 
-  it('echo dedup survives a follow-up pushed while the turn is still streaming', async () => {
+  it('a follow-up pushed while the turn is still streaming does not double-deliver the repeated block', async () => {
     seedDest();
     const block = '<message to="discord-main">The answer is 4.</message>';
     const pushes: string[] = [];
@@ -174,19 +177,19 @@ describe('mid-turn <message> block delivery', () => {
       yield { type: 'text', text: block };
 
       // A follow-up lands while the turn is STILL in flight — the poller
-      // pushes it into the open query before the turn's result arrives.
-      // The push must not wipe the mid-turn dedup state.
+      // pushes it into the open query before the turn's result arrives. The
+      // structural strip is stateless, so the push cannot disturb it.
       insertMessage('m2', 'chat', { sender: 'User', text: 'follow-up while busy' });
       const deadline = Date.now() + 5000;
       while (!pushes.some((p) => p.includes('follow-up while busy')) && Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, 50));
       }
 
-      // The in-flight turn's result echoes the mid-turn block — one delivery only.
+      // The in-flight turn's result repeats the mid-turn block — the strip
+      // leaves it as one delivery only.
       yield { type: 'result', text: block };
 
-      // The follow-up's own turn: state was reset at the turn boundary, so a
-      // fresh block still delivers.
+      // The follow-up's own turn: a fresh block still delivers.
       yield { type: 'text', text: '<message to="discord-main">Re: follow-up.</message>' };
       yield { type: 'result', text: 'sent above' };
     }
@@ -199,7 +202,7 @@ describe('mid-turn <message> block delivery', () => {
       abort: () => {},
     };
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(2);
@@ -208,23 +211,23 @@ describe('mid-turn <message> block delivery', () => {
     expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
   });
 
-  it('turn-boundary reset: a later turn re-emitting the same block body delivers again', async () => {
+  it('a later turn re-emitting the same block body delivers again (nothing content-keyed persists)', async () => {
     seedDest();
     const block = '<message to="discord-main">The answer is 4.</message>';
     async function* events(): AsyncGenerator<ProviderEvent> {
-      // Turn 1: mid-turn delivery, echoed in the result (one delivery).
+      // Turn 1: mid-turn delivery, repeated in the result (one delivery).
       yield { type: 'init', continuation: 's1' };
       yield { type: 'text', text: block };
       yield { type: 'result', text: block };
-      // Turn 2: the model legitimately sends the SAME body again. The dedup
-      // set was reset at the turn boundary, so this must deliver — stale keys
-      // from turn 1 must not swallow a genuine repeat.
+      // Turn 2: the model legitimately sends the SAME body again. Delivery
+      // keeps no memory of message content, so this must deliver — nothing
+      // from turn 1 may swallow a genuine repeat.
       yield { type: 'text', text: block };
       yield { type: 'result', text: 'sent above' };
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(2);
@@ -233,14 +236,14 @@ describe('mid-turn <message> block delivery', () => {
     expect(pushes).toHaveLength(0);
   });
 
-  it('turn-boundary reset: a later bare unwrapped turn still nudges after an earlier mid-turn send', async () => {
+  it('per-turn sent count resets: a later bare unwrapped turn still nudges after an earlier mid-turn send', async () => {
     seedDest();
     async function* events(): AsyncGenerator<ProviderEvent> {
       // Turn 1: mid-turn delivery; bare final text is scratchpad (no nudge).
       yield { type: 'init', continuation: 's1' };
       yield { type: 'text', text: '<message to="discord-main">Sent mid-turn.</message>' };
       yield { type: 'result', text: 'All done here.' };
-      // Turn 2: no mid-turn block, bare unwrapped result. The mid-turn sent
+      // Turn 2: no mid-turn block, bare unwrapped result. The per-turn sent
       // count was reset at the turn boundary, so the unwrapped-nudge must
       // fire — a stale count from turn 1 would silently suppress it.
       yield { type: 'text', text: 'just thinking out loud, no message block here' };
@@ -248,7 +251,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages()).toHaveLength(1);
     expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
@@ -264,7 +267,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(2);
@@ -273,7 +276,7 @@ describe('mid-turn <message> block delivery', () => {
     expect(pushes).toHaveLength(0);
   });
 
-  it('an error result that only echoes the mid-turn block is not delivered again', async () => {
+  it('an error result that only repeats the streamed block is not delivered again', async () => {
     seedDest();
     const block = '<message to="discord-main">Partial progress report.</message>';
     async function* events(): AsyncGenerator<ProviderEvent> {
@@ -283,7 +286,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query, pushes } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages()).toHaveLength(1);
     expect(pushes).toHaveLength(0);
@@ -299,7 +302,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages()).toHaveLength(0);
   });
@@ -313,7 +316,7 @@ describe('mid-turn <message> block delivery', () => {
     }
     const { query } = makeStubQuery(events());
 
-    await processQuery(query, TASK_ROUTING, ['t1'], 'claude', undefined, 'prompt', undefined);
+    await processQuery(query, TASK_ROUTING, ['t1'], 'claude', undefined, 'prompt', undefined, true);
 
     expect(getUndeliveredMessages().filter((m) => m.kind === 'chat')).toHaveLength(0);
     const logs = taskLogRows();
@@ -322,7 +325,61 @@ describe('mid-turn <message> block delivery', () => {
   });
 });
 
+// Providers that do NOT declare emitsMidTurnText keep the old single-door
+// behavior: text events are delivery-inert and <message> blocks deliver from
+// the final result. The capability is a static fact of the provider, threaded
+// into processQuery by runPollLoop — never inferred from runtime events.
+describe('provider without emitsMidTurnText: result door unchanged', () => {
+  it('ignores text events and delivers the result block exactly once', async () => {
+    seedDest();
+    const block = '<message to="discord-main">The answer is 4.</message>';
+    let outCountBeforeResult = -1;
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // A stray text event from a provider that never declared the
+      // capability must not open a second delivery door.
+      yield { type: 'text', text: block };
+      outCountBeforeResult = getUndeliveredMessages().length;
+      yield { type: 'result', text: block };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, false);
+
+    expect(outCountBeforeResult).toBe(0);
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('The answer is 4.');
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('mock-provider variant: same stream shape driven without the capability delivers once, at the result', async () => {
+    seedDest();
+    const block = '<message to="discord-main">Result-door delivery.</message>';
+    // A real MockProvider stream (text segment, then a result repeating the
+    // block), but driven the way runPollLoop drives a provider that does not
+    // declare emitsMidTurnText.
+    const provider = new MockProvider(
+      {},
+      () => block,
+      () => [block],
+    );
+    const query = provider.query({ prompt: 'hi', cwd: '/tmp' });
+    setTimeout(() => query.end(), 100);
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'mock', undefined, 'prompt', undefined, false);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('Result-door delivery.');
+  });
+});
+
 describe('mock provider mid-turn text events', () => {
+  it('declares the emitsMidTurnText capability', () => {
+    expect(new MockProvider().emitsMidTurnText).toBe(true);
+  });
+
   it('emits configured text events before each result', async () => {
     const provider = new MockProvider(
       {},
@@ -345,15 +402,20 @@ describe('mock provider mid-turn text events', () => {
     expect(events[resultIdx].text).toBe('Re: Hi');
   });
 
-  it('emits no text events when no factory is configured', async () => {
+  it('streams the result text as a text event even with no factory configured (the capability contract)', async () => {
     const provider = new MockProvider({}, () => 'ok');
     const query = provider.query({ prompt: 'Hi', cwd: '/tmp' });
     setTimeout(() => query.end(), 50);
 
-    const events: Array<{ type: string }> = [];
+    const events: Array<{ type: string; text?: string | null }> = [];
     for await (const event of query.events) {
       events.push(event);
     }
-    expect(events.filter((e) => e.type === 'text')).toHaveLength(0);
+    // The real SDK's result only repeats the final assistant text, which
+    // already streamed — a mock declaring emitsMidTurnText must match that,
+    // or the result-door strip would remove blocks that never delivered.
+    const texts = events.filter((e) => e.type === 'text');
+    expect(texts).toHaveLength(1);
+    expect(texts[0].text).toBe('ok');
   });
 });

--- a/container/agent-runner/src/poll-loop.midturn.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { processQuery } from './poll-loop.js';
+import { MockProvider } from './providers/mock.js';
+import type { AgentQuery, ProviderEvent } from './providers/types.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+// --- Mid-turn <message> block delivery ---
+// The SDK's final result carries only the LAST assistant text. A wrapped
+// reply composed between tool calls must be delivered from the 'text' event
+// stream, deduped against its echo in the final result, and must suppress
+// the unwrapped-nudge when the final text is bare.
+
+const CHAT_ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+  taskRun: false,
+};
+
+const TASK_ROUTING = {
+  platformId: null,
+  channelType: null,
+  threadId: 'system:tasks:ser-1',
+  inReplyTo: 't1',
+  taskRun: true,
+};
+
+function seedDest(name = 'discord-main', channelType = 'discord', platformId = 'chan-1'): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES (?, ?, 'channel', ?, ?, NULL)`,
+    )
+    .run(name, name, channelType, platformId);
+}
+
+function insertMessage(id: string, kind: string, content: object): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, process_after, trigger, on_wake, content)
+       VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', NULL, 1, 0, ?)`,
+    )
+    .run(id, kind, JSON.stringify(content));
+}
+
+function taskLogRows(): Array<{ text: string }> {
+  return (
+    getOutboundDb()
+      .prepare("SELECT content FROM messages_out WHERE kind = 'task_log' ORDER BY seq")
+      .all() as Array<{ content: string }>
+  ).map((r) => JSON.parse(r.content) as { text: string });
+}
+
+function makeStubQuery(events: AsyncGenerator<ProviderEvent>): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  return {
+    pushes,
+    query: {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events,
+      abort: () => {},
+    },
+  };
+}
+
+describe('mid-turn <message> block delivery', () => {
+  it('delivers a complete block from a mid-turn text event immediately', async () => {
+    seedDest();
+    let outCountBeforeResult = -1;
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: 'Let me check.\n<message to="discord-main">The answer is 4.</message>' };
+      // The generator only resumes after the loop consumed the text event —
+      // the delivery must already be in messages_out before the result.
+      outCountBeforeResult = getUndeliveredMessages().length;
+      yield { type: 'result', text: 'wrapped answer already sent above' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(outCountBeforeResult).toBe(1);
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('The answer is 4.');
+    expect(out[0].platform_id).toBe('chan-1');
+    expect(out[0].channel_type).toBe('discord');
+  });
+
+  it('does not deliver the same block twice when the final result echoes it', async () => {
+    seedDest();
+    const block = '<message to="discord-main">The answer is 4.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: block };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('final bare text after a mid-turn delivery does not trigger the unwrapped nudge', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Sent mid-turn.</message>' };
+      yield { type: 'result', text: 'All done here.' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('still nudges an unwrapped result when no mid-turn block was delivered', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: 'just thinking out loud, no message block here' };
+      yield { type: 'result', text: 'bare final text' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(0);
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0]).toContain('was not delivered');
+  });
+
+  it('sanitizes harness tag artifacts from mid-turn deliveries', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Deploy is done.\n</parameter></message>' };
+      yield { type: 'result', text: 'done' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('Deploy is done.');
+  });
+
+  it('echo dedup survives a follow-up pushed while the turn is still streaming', async () => {
+    seedDest();
+    const block = '<message to="discord-main">The answer is 4.</message>';
+    const pushes: string[] = [];
+
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+
+      // A follow-up lands while the turn is STILL in flight — the poller
+      // pushes it into the open query before the turn's result arrives.
+      // The push must not wipe the mid-turn dedup state.
+      insertMessage('m2', 'chat', { sender: 'User', text: 'follow-up while busy' });
+      const deadline = Date.now() + 5000;
+      while (!pushes.some((p) => p.includes('follow-up while busy')) && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      // The in-flight turn's result echoes the mid-turn block — one delivery only.
+      yield { type: 'result', text: block };
+
+      // The follow-up's own turn: state was reset at the turn boundary, so a
+      // fresh block still delivers.
+      yield { type: 'text', text: '<message to="discord-main">Re: follow-up.</message>' };
+      yield { type: 'result', text: 'sent above' };
+    }
+    const query: AgentQuery = {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events: events(),
+      abort: () => {},
+    };
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(2);
+    expect(JSON.parse(out[0].content).text).toBe('The answer is 4.');
+    expect(JSON.parse(out[1].content).text).toBe('Re: follow-up.');
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+  });
+
+  it('turn-boundary reset: a later turn re-emitting the same block body delivers again', async () => {
+    seedDest();
+    const block = '<message to="discord-main">The answer is 4.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      // Turn 1: mid-turn delivery, echoed in the result (one delivery).
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: block };
+      // Turn 2: the model legitimately sends the SAME body again. The dedup
+      // set was reset at the turn boundary, so this must deliver — stale keys
+      // from turn 1 must not swallow a genuine repeat.
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: 'sent above' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(2);
+    expect(JSON.parse(out[0].content).text).toBe('The answer is 4.');
+    expect(JSON.parse(out[1].content).text).toBe('The answer is 4.');
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('turn-boundary reset: a later bare unwrapped turn still nudges after an earlier mid-turn send', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      // Turn 1: mid-turn delivery; bare final text is scratchpad (no nudge).
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Sent mid-turn.</message>' };
+      yield { type: 'result', text: 'All done here.' };
+      // Turn 2: no mid-turn block, bare unwrapped result. The mid-turn sent
+      // count was reset at the turn boundary, so the unwrapped-nudge must
+      // fire — a stale count from turn 1 would silently suppress it.
+      yield { type: 'text', text: 'just thinking out loud, no message block here' };
+      yield { type: 'result', text: 'bare final text' };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+  });
+
+  it('delivers a bare error result even after a mid-turn delivery in the same turn', async () => {
+    seedDest();
+    const errText = 'Spending limit reached. Add your own key at https://example.com/keys';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">Started on it.</message>' };
+      yield { type: 'result', text: errText, isError: true };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(2);
+    expect(JSON.parse(out[0].content).text).toBe('Started on it.');
+    expect(JSON.parse(out[1].content).text).toBe(errText);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('an error result that only echoes the mid-turn block is not delivered again', async () => {
+    seedDest();
+    const block = '<message to="discord-main">Partial progress report.</message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: block };
+      yield { type: 'result', text: block, isError: true };
+    }
+    const { query, pushes } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('a block that sanitizes to empty is never delivered as a blank message', async () => {
+    seedDest();
+    const artifactOnly = '<message to="discord-main"></parameter></message>';
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: artifactOnly };
+      yield { type: 'result', text: artifactOnly };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(0);
+  });
+
+  it('task runs: mid-turn blocks are not delivered (one-door stays closed)', async () => {
+    seedDest();
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'text', text: '<message to="discord-main">digest is ready</message>' };
+      yield { type: 'result', text: 'run finished' };
+    }
+    const { query } = makeStubQuery(events());
+
+    await processQuery(query, TASK_ROUTING, ['t1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages().filter((m) => m.kind === 'chat')).toHaveLength(0);
+    const logs = taskLogRows();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].text).toBe('run finished');
+  });
+});
+
+describe('mock provider mid-turn text events', () => {
+  it('emits configured text events before each result', async () => {
+    const provider = new MockProvider(
+      {},
+      (prompt) => `Re: ${prompt}`,
+      (prompt) => [`segment about ${prompt}`],
+    );
+    const query = provider.query({ prompt: 'Hi', cwd: '/tmp' });
+    setTimeout(() => query.end(), 50);
+
+    const events: Array<{ type: string; text?: string | null }> = [];
+    for await (const event of query.events) {
+      events.push(event);
+    }
+
+    const textIdx = events.findIndex((e) => e.type === 'text');
+    const resultIdx = events.findIndex((e) => e.type === 'result');
+    expect(textIdx).toBeGreaterThan(-1);
+    expect(textIdx).toBeLessThan(resultIdx);
+    expect(events[textIdx].text).toBe('segment about Hi');
+    expect(events[resultIdx].text).toBe('Re: Hi');
+  });
+
+  it('emits no text events when no factory is configured', async () => {
+    const provider = new MockProvider({}, () => 'ok');
+    const query = provider.query({ prompt: 'Hi', cwd: '/tmp' });
+    setTimeout(() => query.end(), 50);
+
+    const events: Array<{ type: string }> = [];
+    for await (const event of query.events) {
+      events.push(event);
+    }
+    expect(events.filter((e) => e.type === 'text')).toHaveLength(0);
+  });
+});

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -296,10 +296,13 @@ describe('mock provider', () => {
     }
 
     const typed = events.filter((e) => e.type !== 'activity');
-    expect(typed.length).toBeGreaterThanOrEqual(2);
+    expect(typed.length).toBeGreaterThanOrEqual(3);
     expect(typed[0].type).toBe('init');
-    expect(typed[1].type).toBe('result');
-    expect((typed[1] as { text: string }).text).toBe('Echo: Hello');
+    // The mock declares emitsMidTurnText, so the turn's text streams as a
+    // text event before the result repeats it.
+    expect(typed[1].type).toBe('text');
+    expect(typed[2].type).toBe('result');
+    expect((typed[2] as { text: string }).text).toBe('Echo: Hello');
   });
 
   it('should handle push() during active query', async () => {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -24,6 +24,7 @@ import {
   stripInternalTags,
   type RoutingContext,
 } from './formatter.js';
+import { stripHarnessTagArtifacts } from './harness-tag-strip.js';
 import { isUploadTraceCommand, uploadTrace } from './upload-trace.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderExchange } from './providers/types.js';
 
@@ -365,6 +366,16 @@ export async function processQuery(
   // Once-per-turn guard for the task-run "<message> block was not delivered"
   // nudge — mirrors unwrappedNudged for chat turns.
   let taskBlockNudged = false;
+  // Mid-turn delivery bookkeeping (chat runs): (to, body) keys of <message>
+  // blocks already delivered from 'text' events this turn, plus how many.
+  // Lets the result path drop the echo when the model repeats a block in its
+  // final text, and suppresses the unwrapped-nudge when the wrapped reply was
+  // already sent mid-turn. Reset at the turn boundary (the 'result' event) —
+  // NOT at the follow-up push seam: query.push() does not end the in-flight
+  // turn, and its result (which may echo a mid-turn delivery) arrives after
+  // the push, so clearing there would double-deliver.
+  const midTurnDelivered = new Set<string>();
+  let midTurnSent = 0;
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
   // the same prompt again. Unused (and unmaintained) when the provider
@@ -507,6 +518,12 @@ export async function processQuery(
         // effectively orphaned and the next message started a blank
         // Claude session with no prior context.
         setContinuation(providerName, event.continuation);
+      } else if (event.type === 'text') {
+        // Assistant text emitted mid-turn (e.g. between tool calls). The
+        // final result only carries the LAST assistant text, so complete
+        // <message> blocks composed here would otherwise be lost — deliver
+        // them now (chat runs only; task runs stay one-door).
+        midTurnSent += deliverMidTurnBlocks(event.text, routing, midTurnDelivered);
       } else if (event.type === 'result') {
         // A result — with or without text — means the turn is done. Mark
         // the initial batch completed now so the host sweep doesn't see
@@ -516,7 +533,10 @@ export async function processQuery(
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
         if (event.text) {
-          const { sent, hasUnwrapped, taskBlocks } = dispatchResultText(event.text, routing);
+          const { sent, hasUnwrapped, taskBlocks, resultBlocks } = dispatchResultText(event.text, routing, {
+            deliveredKeys: midTurnDelivered,
+            sent: midTurnSent,
+          });
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
           // while explicit append-log calls remain optional additive notes.
@@ -524,7 +544,7 @@ export async function processQuery(
           // A corrective retry handles delivery only; its result is not a
           // second run summary.
           if (routing.taskRun && !taskBlockNudged) autoAppendTaskLog(event.text);
-          if (sent === 0 && event.isError === true && !routing.taskRun) {
+          if (resultBlocks === 0 && event.isError === true && !routing.taskRun) {
             // Non-retryable error turn (e.g. a 403 billing_error) with no
             // <message> envelope: deliver the notice instead of dropping it as
             // scratchpad, and skip the re-wrap nudge — it would just re-hammer
@@ -538,12 +558,18 @@ export async function processQuery(
             });
             archivePrompts.shift();
           } else {
-            const willRetryWrapping = hasUnwrapped && !unwrappedNudged;
+            // An unwrapped final text only warrants the wrap-nudge when NOTHING
+            // was delivered this turn. If a reply already went out as a
+            // mid-turn block (recorded in midTurnDelivered), the unwrapped
+            // tail is a self-summary; nudging coaxes a redundant second
+            // message (live-observed). It stays in the scratchpad log.
+            const trulyUndelivered = hasUnwrapped && midTurnDelivered.size === 0;
+            const willRetryWrapping = trulyUndelivered && !unwrappedNudged;
             notifyExchangeComplete(onExchangeComplete, {
               prompt: archivePrompts[0] ?? initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
-              status: hasUnwrapped || willRetryTaskBlocks ? 'undelivered' : 'completed',
+              status: trulyUndelivered || willRetryTaskBlocks ? 'undelivered' : 'completed',
             });
             if (willRetryWrapping) {
               unwrappedNudged = true;
@@ -569,6 +595,12 @@ export async function processQuery(
             if (!willRetryWrapping && !willRetryTaskBlocks) archivePrompts.shift();
           }
         } else archivePrompts.shift();
+        // Turn boundary: reset the mid-turn delivery state here, after the
+        // result's echo dedup and nudge decisions have used it. A nudge retry
+        // repopulates the set via its own text events before the retry result,
+        // so clearing on every result is safe.
+        midTurnDelivered.clear();
+        midTurnSent = 0;
       }
     }
   } catch (err) {
@@ -635,7 +667,7 @@ function deliverErrorResult(text: string, routing: RoutingContext): void {
     platform_id: routing.platformId,
     channel_type: routing.channelType,
     thread_id: routing.threadId,
-    content: JSON.stringify({ text }),
+    content: JSON.stringify({ text: stripHarnessTagArtifacts(text) }),
   });
 }
 
@@ -652,14 +684,94 @@ export interface TaskMessageBlock {
   body: string;
 }
 
+/** Per-turn record of blocks already delivered from mid-turn text events. */
+export interface MidTurnState {
+  /** Keys (see `midTurnKey`) of blocks delivered mid-turn this turn. */
+  deliveredKeys: Set<string>;
+  /** How many blocks were delivered mid-turn this turn. */
+  sent: number;
+}
+/**
+ * The poll-loop's canonical per-turn key for a delivered block. Both call
+ * sites already pass trimmed, artifact-stripped bodies; normalizing again
+ * here is an idempotent belt-and-suspenders that keeps the keys agreeing by
+ * construction.
+ */
+function midTurnKey(to: string, body: string): string {
+  return `${to}\u0000${stripHarnessTagArtifacts(body.trim())}`;
+}
+/**
+ * `<internal>…</internal>` spans are explicitly not-for-delivery scratchpad.
+ * Broader than `stripInternalTags` (which the scratchpad log uses): it also
+ * matches an opening tag carrying attributes, and is case-insensitive, so a
+ * draft quoted inside one can never be promoted to a real send by the
+ * mid-turn scan.
+ */
+const INTERNAL_SPAN_RE = /<internal\b[\s\S]*?<\/internal>/gi;
+/**
+ * Deliver complete <message to="...">...</message> blocks found in a mid-turn
+ * assistant text segment. The SDK's final result carries only the last
+ * assistant text, so a wrapped reply composed before a trailing tool call
+ * would otherwise never be seen (and the unwrapped-nudge would coax out only
+ * a mangled re-send of the final fragment). Chat runs only — in task runs
+ * mid-turn blocks stay inert exactly like final-text blocks (one-door: only
+ * the send_message tool delivers). Blocks inside an <internal> span are never
+ * delivered. Blocks to unknown destinations are left for the result path,
+ * which logs the drop into the scratchpad. Each delivery is recorded in
+ * `deliveredKeys` so the result path can drop the echo. Returns the number of
+ * blocks delivered.
+ */
+export function deliverMidTurnBlocks(text: string, routing: RoutingContext, deliveredKeys: Set<string>): number {
+  if (routing.taskRun) return 0;
+  const visible = text.replace(INTERNAL_SPAN_RE, '');
+  const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
+  let match: RegExpExecArray | null;
+  let delivered = 0;
+  while ((match = MESSAGE_RE.exec(visible)) !== null) {
+    const toName = match[1];
+    const rawBody = match[2];
+    const body = stripHarnessTagArtifacts(rawBody.trim());
+    const dest = findByName(toName);
+    if (!dest) continue;
+    // Never deliver a blank message: a body that is empty (or was only
+    // harness-tag artifacts) is skipped here; the result path logs it.
+    if (!body) {
+      log(`Mid-turn <message to="${toName}"> empty after sanitization — skipped`);
+      continue;
+    }
+    const key = midTurnKey(toName, body);
+    if (deliveredKeys.has(key)) continue;
+    deliveredKeys.add(key);
+    sendToDestination(dest, body, routing);
+    delivered++;
+    log(`Mid-turn delivery: <message to="${toName}"> (${body.length} chars)`);
+  }
+  return delivered;
+}
+
 export function dispatchResultText(
   text: string,
   routing: RoutingContext,
-): { sent: number; hasUnwrapped: boolean; taskBlocks: TaskMessageBlock[] } {
+  midTurn?: MidTurnState,
+): { sent: number; hasUnwrapped: boolean; taskBlocks: TaskMessageBlock[]; resultBlocks: number } {
+  // <internal> spans are not-for-delivery scratchpad. Remove them BEFORE block
+  // extraction so a <message> drafted inside one is never delivered from the
+  // final text either — the mid-turn seam already guarantees this; without the
+  // same strip here the guarantee had a final-text hole. Span content still
+  // never reaches the user (the closing stripInternalTags pass removed it from
+  // the scratchpad already), so nudge/scratchpad semantics are unchanged.
+  text = text.replace(INTERNAL_SPAN_RE, '');
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
 
   let match: RegExpExecArray | null;
-  let sent = 0;
+  // Blocks delivered mid-turn count toward this turn's sent total — a final
+  // text with no (new) blocks after a mid-turn delivery is scratchpad, not an
+  // undelivered reply.
+  let sent = midTurn?.sent ?? 0;
+  // <message> blocks present in THIS result text (delivered, echoed, task or
+  // dropped alike) — drives the bare-error-text delivery gate, which must key
+  // on the error result itself, not on earlier mid-turn deliveries.
+  let resultBlocks = 0;
   // <message to> blocks left inert in a task run — drives the same-turn
   // "use send_message" nudge in processQuery.
   const taskBlocks: TaskMessageBlock[] = [];
@@ -671,8 +783,9 @@ export function dispatchResultText(
       scratchpadParts.push(text.slice(lastIndex, match.index));
     }
     const toName = match[1];
-    const body = match[2].trim();
+    const body = stripHarnessTagArtifacts(match[2].trim());
     lastIndex = MESSAGE_RE.lastIndex;
+    resultBlocks++;
 
     // One-door delivery in task sessions: only the send_message tool delivers.
     // A final-text <message to> block here is either an echo of a tool send the
@@ -690,6 +803,20 @@ export function dispatchResultText(
     if (!dest) {
       log(`Unknown destination in <message to="${toName}">, dropping block`);
       scratchpadParts.push(`[dropped: unknown destination "${toName}"] ${body}`);
+      continue;
+    }
+    // Never deliver a blank message: a body that is empty (or was only
+    // harness-tag artifacts stripped by sanitization) goes to the scratchpad
+    // log instead of writing an empty chat row.
+    if (!body) {
+      log(`Empty <message to="${toName}"> body after sanitization — not delivered`);
+      scratchpadParts.push(`[not delivered — empty after sanitization; to="${toName}"]`);
+      continue;
+    }
+    // Echo dedup: this exact block already went out mid-turn this turn
+    // (already counted in the mid-turn sent total) — don't send it twice.
+    if (midTurn?.deliveredKeys.has(midTurnKey(toName, body))) {
+      log(`Echo of mid-turn delivery to "${toName}" — dropped`);
       continue;
     }
     sendToDestination(dest, body, routing);
@@ -711,7 +838,7 @@ export function dispatchResultText(
   if (hasUnwrapped) {
     log(`WARNING: agent output had no <message to="..."> blocks — nothing was sent`);
   }
-  return { sent, hasUnwrapped, taskBlocks };
+  return { sent, hasUnwrapped, taskBlocks, resultBlocks };
 }
 
 /**

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -362,10 +362,12 @@ export async function processQuery(
   initialContinuation: string | undefined,
   /**
    * The provider's declared `emitsMidTurnText` capability (see
-   * providers/types.ts). True → complete <message> blocks deliver exactly
-   * once, at parse time from streamed 'text' events, and the final result
-   * structurally strips them. False → text events are delivery-inert and the
-   * final result stays the single delivery door.
+   * providers/types.ts). True → mid-turn streaming is the single content
+   * door: complete <message> blocks deliver exactly once, at parse time from
+   * streamed 'text' events (with cross-segment assembly of split blocks),
+   * and the final result never delivers content — it only surfaces error
+   * results and decides the wrap-nudge. False → text events are
+   * delivery-inert and the final result stays the single delivery door.
    */
   emitsMidTurnText = false,
 ): Promise<QueryResult> {
@@ -377,22 +379,34 @@ export async function processQuery(
   let taskBlockNudged = false;
   // How many <message> blocks were delivered from 'text' events this turn
   // (chat runs, emitsMidTurnText providers only). A frame-local count, never
-  // keyed by content: it only feeds the unwrapped-nudge decision ("did this
-  // turn deliver anything?") and arms the result-door structural strip.
-  // Reset at the turn boundary (the 'result' event) — NOT at the follow-up
-  // push seam: query.push() does not end the in-flight turn, and its
-  // result's nudge decision still describes the turn that is streaming.
+  // keyed by content: it feeds the result door's nudge decision ("did this
+  // turn deliver anything?"). Reset at the turn boundary (the 'result'
+  // event) — NOT at the follow-up push seam: query.push() does not end the
+  // in-flight turn, and its result's nudge decision still describes the
+  // turn that is streaming.
   let midTurnSent = 0;
   // Outbound seq high-water mark at the turn boundary — a frame-local NUMBER,
-  // not a content record. The mid-turn door uses it to recognize a block that
-  // is a verbatim repeat of a message already written to outbound.db EARLIER
-  // THIS TURN by a previous streamed segment (live-observed: the model
-  // re-emits the identical block as its final text after a trailing tool
-  // call; delivering both copies is the double-send this design must not
-  // reintroduce). The "have we sent this?" truth lives in the outbound DB the
-  // door already writes to — no in-process delivery ledger. Reset alongside
-  // midTurnSent at each result.
+  // not a content record. Two uses: (1) the mid-turn door recognizes a block
+  // that is a verbatim repeat of a message already written to outbound.db
+  // EARLIER THIS TURN by a previous streamed segment (live-observed: the
+  // model re-emits the identical block as its final text after a trailing
+  // tool call; delivering both copies is the double-send this design must
+  // not reintroduce); (2) the result-door nudge decision asks "did ANYTHING
+  // user-visible go out this turn?" — which must also see MCP send_message
+  // rows the frame-local midTurnSent count never observes. The "have we sent
+  // this?" truth lives in the outbound DB the door already writes to — no
+  // in-process delivery ledger. Reset alongside midTurnSent at each result.
   let turnStartSeq = maxOutboundSeq();
+  // Cross-segment assembly buffer: the unresolved TAIL of the previous text
+  // event — an unclosed <message …> block (or a bare open-tag prefix like
+  // "<mess" literally split mid-token), or an unclosed <internal span. Frame-
+  // local and turn-local: it carries a fragment forward so a block opened in
+  // one assistant message and closed in a later one delivers ONCE, mid-turn,
+  // when its close arrives. Only the unresolved tail is ever carried —
+  // settled text is consumed exactly once, so already-delivered blocks are
+  // never re-matched. Dropped at the turn boundary: a block that never
+  // closes anywhere is the wrap-nudge's job, not the buffer's.
+  let midTurnTail = '';
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
   // the same prompt again. Unused (and unmaintained) when the provider
@@ -544,7 +558,9 @@ export async function processQuery(
         // emitsMidTurnText the result stays the only delivery door, so a
         // stray text event must not open a second one.
         if (emitsMidTurnText) {
-          midTurnSent += deliverMidTurnBlocks(event.text, routing, turnStartSeq);
+          const scan = deliverMidTurnBlocks(event.text, routing, turnStartSeq, midTurnTail);
+          midTurnSent += scan.delivered;
+          midTurnTail = scan.tail;
         }
       } else if (event.type === 'result') {
         // A result — with or without text — means the turn is done. Mark
@@ -557,19 +573,18 @@ export async function processQuery(
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = dispatchResultText(event.text, routing, {
             midTurnSent,
-            // Structural strip is armed only when this turn PROVED the
-            // streaming door worked (>=1 mid-turn delivery). midTurnSent === 0
-            // with a deliverable block in the result means the premise "every
-            // complete result block already streamed and was delivered" did
-            // NOT hold for this turn — SDK drift (result text from a field the
-            // stream never carried, e.g. errors[]), a block split across
-            // streamed segments that only the result text completes, or a
-            // destination created between stream time and result time. Fall
-            // back to base result-door delivery for exactly those turns.
-            // Provably duplicate-free: midTurnSent === 0 means zero blocks
-            // were delivered mid-turn, so the result door is the FIRST door —
-            // there is nothing a result-door send could duplicate.
-            stripStreamedBlocks: emitsMidTurnText && midTurnSent > 0,
+            // For emitsMidTurnText providers the result door NEVER delivers
+            // content (error results excepted, below): mid-turn streaming is
+            // the single content door. The result door's remaining job is
+            // the nudge decision — see turnDelivered.
+            suppressDelivery: emitsMidTurnText,
+            // "Did anything user-visible go out this turn?" — door
+            // deliveries (midTurnSent) plus any chat row written since the
+            // turn boundary (which also sees MCP send_message calls the
+            // frame-local count can't). When false and the result still
+            // carries content, the wrap-nudge fires so the model re-sends
+            // and the retry streams through the mid-turn door.
+            turnDelivered: emitsMidTurnText ? midTurnSent > 0 || chatRowWrittenSince(turnStartSeq) : undefined,
           });
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
@@ -633,11 +648,14 @@ export async function processQuery(
         // nudge decision has used it. A nudge retry re-counts via its own
         // text events before the retry result, so resetting on every result
         // is safe. The seq high-water mark advances past everything written
-        // this turn (door, result-door, error deliveries alike), so the next
-        // turn's echo check never reaches back across the boundary — a later
-        // turn genuinely re-sending the same body still delivers.
+        // this turn (door and error deliveries alike), so the next turn's
+        // echo check never reaches back across the boundary — a later turn
+        // genuinely re-sending the same body still delivers. The assembly
+        // buffer dies with the turn: a fragment that never closed is not
+        // carried into the next turn — the wrap-nudge owns that case.
         midTurnSent = 0;
         turnStartSeq = maxOutboundSeq();
+        midTurnTail = '';
       }
     }
   } catch (err) {
@@ -731,25 +749,31 @@ export interface ResultDispatchOptions {
    */
   midTurnSent?: number;
   /**
-   * Structural strip (providers declaring `emitsMidTurnText`): every
-   * assistant text segment streamed as a `text` event before this result, so
-   * any complete <message> block in the result text was — by construction —
-   * already part of a streamed segment and already delivered at the mid-turn
-   * door. Deliverable blocks are therefore stripped instead of sent; no
-   * record of which blocks went out is needed. Applies to exactly the blocks
-   * the mid-turn door delivers: chat runs, known destination, non-empty body.
-   * Blocks that door skips (task runs, unknown destination, empty after
-   * sanitization) keep their result-door handling.
-   *
-   * Caller contract: set this only when at least one mid-turn delivery
-   * actually happened this turn (`midTurnSent > 0`). A capability provider
-   * whose turn streamed no deliverable block (SDK drift, split blocks, a
-   * destination that appeared only after streaming) must keep the result
-   * door live — that stateless fallback is what makes "deliver mid-turn,
-   * strip at result" safe against a premise violation, and it can never
-   * double-deliver because nothing was sent mid-turn to duplicate.
+   * Providers declaring `emitsMidTurnText`: the result door NEVER delivers
+   * content. Mid-turn streaming (parse-time block delivery plus cross-
+   * segment assembly) is the single content door; a complete <message>
+   * block in the result text is at best a repeat of a mid-turn delivery and
+   * at worst content the streaming door missed — either way it is not sent
+   * from here. The result door keeps exactly two jobs: surfacing error
+   * results (see the isError branch in processQuery) and the wrap-nudge
+   * decision (`turnDelivered` below). Task runs, unknown destinations and
+   * empty bodies keep their existing result-door handling, none of which
+   * delivers content.
    */
-  stripStreamedBlocks?: boolean;
+  suppressDelivery?: boolean;
+  /**
+   * Did anything user-visible go out this turn? True when the mid-turn door
+   * delivered (midTurnSent > 0) OR any chat row landed in outbound.db since
+   * the turn boundary (covers MCP send_message calls the frame-local count
+   * cannot see). Only meaningful with `suppressDelivery`. When false and the
+   * result carries content — wrapped blocks or unwrapped prose — the turn
+   * counts as undelivered and the wrap-nudge fires, so the model re-sends
+   * and the retry streams through the mid-turn door. This is the deliberate
+   * degradation path for streaming-door misses (SDK drift, a destination
+   * appearing only after streaming, a block that never closed): nudge and
+   * retry, never a direct result-door send.
+   */
+  turnDelivered?: boolean;
 }
 /**
  * `<internal>…</internal>` spans are explicitly not-for-delivery scratchpad.
@@ -768,29 +792,53 @@ const INTERNAL_SPAN_RE = /<internal\b[\s\S]*?<\/internal>/gi;
  * mid-turn blocks stay inert exactly like final-text blocks (one-door: only
  * the send_message tool delivers). Blocks inside an <internal> span are never
  * delivered. Blocks to unknown destinations are left for the result path,
- * which logs the drop into the scratchpad. Stateless: each complete block in
- * a streamed segment delivers exactly once, at parse time — the result path
- * strips such blocks structurally rather than consulting any record of what
- * was sent. Returns the number of blocks delivered.
+ * which logs the drop into the scratchpad and lets the nudge decide.
+ *
+ * Cross-segment assembly: `carry` is the unresolved tail of the previous
+ * text event (frame-local, turn-local — see midTurnTail in processQuery).
+ * The scan runs over carry + text, delivers every complete block in the
+ * SETTLED prefix, and returns the new unresolved tail: an unclosed
+ * <message …> open (or a bare tag prefix literally split mid-token, e.g.
+ * "<mess" / "age to=…"), or an unclosed <internal span — a draft quoted
+ * inside one must never be promoted to a send by assembly, so judgment on
+ * everything from an open <internal is deferred until it closes. Settled
+ * text is consumed exactly once: already-delivered blocks are never inside
+ * the carried tail, so they cannot re-match. Net effect: mid-turn parsing
+ * behaves as if run over the concatenation of all streamed text, delivered
+ * incrementally. A block that never closes anywhere stays in the tail until
+ * the turn ends and is then dropped — the wrap-nudge owns that case.
  *
  * Failure ordering: a writeMessageOut failure here propagates and fails the
- * whole turn loudly — identical to a write failure at the result door, which
- * also propagates out of processQuery. runPollLoop's catch then surfaces an
- * error message to the user and acks the batch. The alternative (swallow the
- * error and continue the turn) would let a later successful block arm the
- * structural strip and silently strip-drop the failed block at the result —
- * a silent loss. An outbound write failure means the session DB is broken;
- * loud is correct.
+ * whole turn loudly — the result door never delivers content, so swallowing
+ * the error would silently lose the block. An outbound write failure means
+ * the session DB is broken; loud is correct.
  */
-export function deliverMidTurnBlocks(text: string, routing: RoutingContext, turnStartSeq?: number): number {
-  if (routing.taskRun) return 0;
-  // Seq high-water mark at THIS segment's start: the echo check below only
+export interface MidTurnScanResult {
+  delivered: number;
+  tail: string;
+}
+
+export function deliverMidTurnBlocks(
+  text: string,
+  routing: RoutingContext,
+  turnStartSeq?: number,
+  carry = '',
+): MidTurnScanResult {
+  if (routing.taskRun) return { delivered: 0, tail: '' };
+  const input = carry + text;
+  const tailStart = unresolvedTailStart(input);
+  const settled = input.slice(0, tailStart);
+  const tail = input.slice(tailStart);
+  if (tail && carry !== tail) {
+    log(`Mid-turn scan: carrying ${tail.length}-char unresolved tail to the next segment`);
+  }
+  // Seq high-water mark at THIS scan's start: the echo check below only
   // looks at rows written by EARLIER segments of the same turn — a verbatim
-  // duplicate within one segment (two identical blocks in one text) is an
-  // explicit double-send and still delivers twice, exactly as the result
+  // duplicate within one settled scan (two identical blocks in one text) is
+  // an explicit double-send and still delivers twice, exactly as the result
   // door always treated it.
   const segStartSeq = turnStartSeq === undefined ? 0 : maxOutboundSeq();
-  const visible = text.replace(INTERNAL_SPAN_RE, '');
+  const visible = settled.replace(INTERNAL_SPAN_RE, '');
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
   let match: RegExpExecArray | null;
   let delivered = 0;
@@ -823,12 +871,84 @@ export function deliverMidTurnBlocks(text: string, routing: RoutingContext, turn
     delivered++;
     log(`Mid-turn delivery: <message to="${toName}"> (${body.length} chars)`);
   }
-  return delivered;
+  return { delivered, tail };
+}
+
+const OPEN_INTERNAL_RE = /<internal\b/i;
+const OPEN_MESSAGE_RE = /<message\b/;
+
+/**
+ * Index where the UNRESOLVED tail of a mid-turn scan begins — everything
+ * before it is settled (safe to parse and deliver now), everything from it
+ * on must wait for the next text event. input.length when fully settled.
+ *
+ * Unresolved constructs, earliest wins:
+ *  - an unclosed <internal span (case-insensitive, attributes allowed):
+ *    blocks quoted inside must not deliver until the span closes and the
+ *    exclusion can apply — assembly must never promote a draft;
+ *  - an unclosed <message open after the last </message>: the growing block
+ *    the assembly exists for. Opens with a close somewhere after them are
+ *    finished text (a complete block, or malformed-and-done) — settled;
+ *  - a bare tag prefix at the very end ("<mess", "<inter"): a tag literally
+ *    split mid-token at the event boundary.
+ *
+ * Complete <internal> spans are blanked (same length, positions preserved)
+ * before looking: an unclosed construct inside a COMPLETED span is settled
+ * garbage, not a reason to buffer.
+ */
+export function unresolvedTailStart(input: string): number {
+  const masked = input.replace(INTERNAL_SPAN_RE, (m) => ' '.repeat(m.length));
+  const candidates: number[] = [];
+  const internalOpen = OPEN_INTERNAL_RE.exec(masked);
+  if (internalOpen) candidates.push(internalOpen.index);
+  const lastClose = masked.lastIndexOf('</message>');
+  const searchFrom = lastClose === -1 ? 0 : lastClose + '</message>'.length;
+  const msgOpen = OPEN_MESSAGE_RE.exec(masked.slice(searchFrom));
+  if (msgOpen) candidates.push(searchFrom + msgOpen.index);
+  if (candidates.length > 0) return Math.min(...candidates);
+  const prefixStart = trailingTagPrefixStart(masked);
+  return prefixStart === -1 ? input.length : prefixStart;
+}
+
+/**
+ * Start index of a proper prefix of '<message' (case-sensitive, mirroring
+ * MESSAGE_RE) or '<internal' (case-insensitive, mirroring INTERNAL_SPAN_RE)
+ * sitting at the very end of the string; -1 when the string does not end
+ * mid-token. Longest prefix wins.
+ */
+function trailingTagPrefixStart(masked: string): number {
+  const maxK = Math.min('<internal'.length - 1, masked.length);
+  for (let k = maxK; k >= 1; k--) {
+    const tailK = masked.slice(masked.length - k);
+    if (tailK === '<message'.slice(0, k)) return masked.length - k;
+    if (tailK.toLowerCase() === '<internal'.slice(0, k)) return masked.length - k;
+  }
+  return -1;
 }
 
 /** Current outbound seq high-water mark (0 when the table is empty). */
 function maxOutboundSeq(): number {
   return (getOutboundDb().prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out').get() as { m: number }).m;
+}
+
+/**
+ * Has ANY chat row been written to outbound.db after `afterSeq`? Feeds the
+ * result door's nudge decision: unlike the frame-local midTurnSent count,
+ * this also sees MCP send_message / send_file deliveries made this turn, so
+ * an agent that already replied via tools is not nudged into repeating
+ * itself. Fail-open to false: if the lookup breaks, the nudge may fire
+ * spuriously (a repeat coax), never silently swallow an undelivered turn.
+ */
+function chatRowWrittenSince(afterSeq: number): boolean {
+  try {
+    const row = getOutboundDb()
+      .prepare("SELECT 1 AS hit FROM messages_out WHERE seq > ? AND kind = 'chat' LIMIT 1")
+      .get(afterSeq);
+    return row !== undefined && row !== null;
+  } catch (err) {
+    log(`chatRowWrittenSince failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
 }
 
 /**
@@ -926,12 +1046,20 @@ export function dispatchResultText(
       scratchpadParts.push(`[not delivered — empty after sanitization; to="${toName}"]`);
       continue;
     }
-    // Structural strip: with an emitsMidTurnText provider, this deliverable
-    // block was part of an assistant text segment that already streamed as a
-    // 'text' event, where the mid-turn door delivered it — by construction,
-    // not by consulting any record. Strip it here instead of sending again.
-    if (options?.stripStreamedBlocks) {
-      log(`<message to="${toName}"> in final result was already streamed — stripped, not re-sent`);
+    // One content door: with an emitsMidTurnText provider the result door
+    // never sends. A deliverable block here is either a repeat of a mid-turn
+    // delivery (turnDelivered — keep it out of the scratchpad so it does not
+    // read as an undelivered reply) or content the streaming door missed —
+    // then it goes to the scratchpad as undelivered content, which makes the
+    // turn count as undelivered and fires the wrap-nudge: the model re-sends
+    // and the retry streams through the mid-turn door.
+    if (options?.suppressDelivery) {
+      if (options.turnDelivered) {
+        log(`<message to="${toName}"> in final result after a same-turn delivery — repeat, result door does not send`);
+      } else {
+        log(`<message to="${toName}"> in final result but nothing was delivered this turn — nudging for a mid-turn resend`);
+        scratchpadParts.push(`[not delivered — the result door does not send; to="${toName}"] ${body}`);
+      }
       continue;
     }
     sendToDestination(dest, body, routing);
@@ -949,7 +1077,11 @@ export function dispatchResultText(
 
   // In a task run, plain final text is the NORMAL ending (it becomes the run
   // log) — never treat it as an undelivered reply or nudge the agent to wrap it.
-  const hasUnwrapped = !routing.taskRun && sent === 0 && !!scratchpad;
+  // With suppressDelivery the delivered-this-turn question is answered by
+  // turnDelivered (door deliveries + DB-visible sends like MCP send_message);
+  // otherwise by this dispatch's own send count.
+  const anythingDelivered = options?.suppressDelivery ? options.turnDelivered === true : sent > 0;
+  const hasUnwrapped = !routing.taskRun && !anythingDelivered && !!scratchpad;
   if (hasUnwrapped) {
     log(`WARNING: agent output had no <message to="..."> blocks — nothing was sent`);
   }

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -7,7 +7,7 @@ import {
   type MessageInRow,
 } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
-import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
+import { getInboundDb, getOutboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import {
   clearContinuation,
   clearCurrentInReplyTo,
@@ -378,11 +378,21 @@ export async function processQuery(
   // How many <message> blocks were delivered from 'text' events this turn
   // (chat runs, emitsMidTurnText providers only). A frame-local count, never
   // keyed by content: it only feeds the unwrapped-nudge decision ("did this
-  // turn deliver anything?"). Reset at the turn boundary (the 'result'
-  // event) — NOT at the follow-up push seam: query.push() does not end the
-  // in-flight turn, and its result's nudge decision still describes the turn
-  // that is streaming.
+  // turn deliver anything?") and arms the result-door structural strip.
+  // Reset at the turn boundary (the 'result' event) — NOT at the follow-up
+  // push seam: query.push() does not end the in-flight turn, and its
+  // result's nudge decision still describes the turn that is streaming.
   let midTurnSent = 0;
+  // Outbound seq high-water mark at the turn boundary — a frame-local NUMBER,
+  // not a content record. The mid-turn door uses it to recognize a block that
+  // is a verbatim repeat of a message already written to outbound.db EARLIER
+  // THIS TURN by a previous streamed segment (live-observed: the model
+  // re-emits the identical block as its final text after a trailing tool
+  // call; delivering both copies is the double-send this design must not
+  // reintroduce). The "have we sent this?" truth lives in the outbound DB the
+  // door already writes to — no in-process delivery ledger. Reset alongside
+  // midTurnSent at each result.
+  let turnStartSeq = maxOutboundSeq();
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
   // the same prompt again. Unused (and unmaintained) when the provider
@@ -534,7 +544,7 @@ export async function processQuery(
         // emitsMidTurnText the result stays the only delivery door, so a
         // stray text event must not open a second one.
         if (emitsMidTurnText) {
-          midTurnSent += deliverMidTurnBlocks(event.text, routing);
+          midTurnSent += deliverMidTurnBlocks(event.text, routing, turnStartSeq);
         }
       } else if (event.type === 'result') {
         // A result — with or without text — means the turn is done. Mark
@@ -547,7 +557,19 @@ export async function processQuery(
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = dispatchResultText(event.text, routing, {
             midTurnSent,
-            stripStreamedBlocks: emitsMidTurnText,
+            // Structural strip is armed only when this turn PROVED the
+            // streaming door worked (>=1 mid-turn delivery). midTurnSent === 0
+            // with a deliverable block in the result means the premise "every
+            // complete result block already streamed and was delivered" did
+            // NOT hold for this turn — SDK drift (result text from a field the
+            // stream never carried, e.g. errors[]), a block split across
+            // streamed segments that only the result text completes, or a
+            // destination created between stream time and result time. Fall
+            // back to base result-door delivery for exactly those turns.
+            // Provably duplicate-free: midTurnSent === 0 means zero blocks
+            // were delivered mid-turn, so the result door is the FIRST door —
+            // there is nothing a result-door send could duplicate.
+            stripStreamedBlocks: emitsMidTurnText && midTurnSent > 0,
           });
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
@@ -610,8 +632,12 @@ export async function processQuery(
         // Turn boundary: reset the per-turn sent count after the result's
         // nudge decision has used it. A nudge retry re-counts via its own
         // text events before the retry result, so resetting on every result
-        // is safe.
+        // is safe. The seq high-water mark advances past everything written
+        // this turn (door, result-door, error deliveries alike), so the next
+        // turn's echo check never reaches back across the boundary — a later
+        // turn genuinely re-sending the same body still delivers.
         midTurnSent = 0;
+        turnStartSeq = maxOutboundSeq();
       }
     }
   } catch (err) {
@@ -714,6 +740,14 @@ export interface ResultDispatchOptions {
    * the mid-turn door delivers: chat runs, known destination, non-empty body.
    * Blocks that door skips (task runs, unknown destination, empty after
    * sanitization) keep their result-door handling.
+   *
+   * Caller contract: set this only when at least one mid-turn delivery
+   * actually happened this turn (`midTurnSent > 0`). A capability provider
+   * whose turn streamed no deliverable block (SDK drift, split blocks, a
+   * destination that appeared only after streaming) must keep the result
+   * door live — that stateless fallback is what makes "deliver mid-turn,
+   * strip at result" safe against a premise violation, and it can never
+   * double-deliver because nothing was sent mid-turn to duplicate.
    */
   stripStreamedBlocks?: boolean;
 }
@@ -738,9 +772,24 @@ const INTERNAL_SPAN_RE = /<internal\b[\s\S]*?<\/internal>/gi;
  * a streamed segment delivers exactly once, at parse time — the result path
  * strips such blocks structurally rather than consulting any record of what
  * was sent. Returns the number of blocks delivered.
+ *
+ * Failure ordering: a writeMessageOut failure here propagates and fails the
+ * whole turn loudly — identical to a write failure at the result door, which
+ * also propagates out of processQuery. runPollLoop's catch then surfaces an
+ * error message to the user and acks the batch. The alternative (swallow the
+ * error and continue the turn) would let a later successful block arm the
+ * structural strip and silently strip-drop the failed block at the result —
+ * a silent loss. An outbound write failure means the session DB is broken;
+ * loud is correct.
  */
-export function deliverMidTurnBlocks(text: string, routing: RoutingContext): number {
+export function deliverMidTurnBlocks(text: string, routing: RoutingContext, turnStartSeq?: number): number {
   if (routing.taskRun) return 0;
+  // Seq high-water mark at THIS segment's start: the echo check below only
+  // looks at rows written by EARLIER segments of the same turn — a verbatim
+  // duplicate within one segment (two identical blocks in one text) is an
+  // explicit double-send and still delivers twice, exactly as the result
+  // door always treated it.
+  const segStartSeq = turnStartSeq === undefined ? 0 : maxOutboundSeq();
   const visible = text.replace(INTERNAL_SPAN_RE, '');
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
   let match: RegExpExecArray | null;
@@ -757,11 +806,60 @@ export function deliverMidTurnBlocks(text: string, routing: RoutingContext): num
       log(`Mid-turn <message to="${toName}"> empty after sanitization — skipped`);
       continue;
     }
+    // Cross-segment echo guard (live-captured shape, SDK battery s03): after
+    // a tool call the model often re-emits the ALREADY-SENT block verbatim as
+    // its final text. That final text streams as its own text event, so
+    // without this check the door would deliver the same message twice. The
+    // check consults the outbound DB — the durable record of what this turn
+    // actually wrote — over the frame-local seq window (turnStartSeq,
+    // segStartSeq]: identical body, same destination, written this turn by an
+    // earlier segment ⇒ echo, skip. No in-process content ledger; cross-turn
+    // repeats are out of the window and deliver normally.
+    if (turnStartSeq !== undefined && wasWrittenInSeqWindow(dest, body, turnStartSeq, segStartSeq)) {
+      log(`Mid-turn <message to="${toName}"> is a verbatim repeat of a message already sent this turn — skipped`);
+      continue;
+    }
     sendToDestination(dest, body, routing);
     delivered++;
     log(`Mid-turn delivery: <message to="${toName}"> (${body.length} chars)`);
   }
   return delivered;
+}
+
+/** Current outbound seq high-water mark (0 when the table is empty). */
+function maxOutboundSeq(): number {
+  return (getOutboundDb().prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out').get() as { m: number }).m;
+}
+
+/**
+ * Does messages_out already hold a chat row with this exact destination and
+ * body, written in the seq window (afterSeq, uptoSeq]? Used by the mid-turn
+ * door's cross-segment echo guard. Content equality is exact: the door writes
+ * `JSON.stringify({ text: body })` after the same trim/sanitize pipeline, so
+ * a true door-written duplicate always matches; a body differing by even one
+ * character is a different message and delivers.
+ */
+function wasWrittenInSeqWindow(dest: DestinationEntry, body: string, afterSeq: number, uptoSeq: number): boolean {
+  if (uptoSeq <= afterSeq) return false;
+  try {
+    const platformId = dest.type === 'channel' ? dest.platformId! : dest.agentGroupId!;
+    const channelType = dest.type === 'channel' ? dest.channelType! : 'agent';
+    const row = getOutboundDb()
+      .prepare(
+        `SELECT 1 AS hit FROM messages_out
+         WHERE seq > ? AND seq <= ? AND kind = 'chat'
+           AND platform_id = ? AND channel_type = ? AND content = ?
+         LIMIT 1`,
+      )
+      .get(afterSeq, uptoSeq, platformId, channelType, JSON.stringify({ text: body }));
+    return row !== undefined && row !== null;
+  } catch (err) {
+    // The guard is an anti-duplication refinement; if the lookup itself
+    // fails, fall through to delivery (the write will surface any real DB
+    // breakage loudly).
+    log(`Echo-guard lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
 }
 
 export function dispatchResultText(

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -269,6 +269,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         config.provider.onExchangeComplete?.bind(config.provider),
         prompt,
         continuation,
+        config.provider.emitsMidTurnText === true,
       );
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
@@ -359,6 +360,14 @@ export async function processQuery(
   onExchangeComplete: ((exchange: ProviderExchange) => void) | undefined,
   initialPrompt: string,
   initialContinuation: string | undefined,
+  /**
+   * The provider's declared `emitsMidTurnText` capability (see
+   * providers/types.ts). True → complete <message> blocks deliver exactly
+   * once, at parse time from streamed 'text' events, and the final result
+   * structurally strips them. False → text events are delivery-inert and the
+   * final result stays the single delivery door.
+   */
+  emitsMidTurnText = false,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
@@ -366,15 +375,13 @@ export async function processQuery(
   // Once-per-turn guard for the task-run "<message> block was not delivered"
   // nudge — mirrors unwrappedNudged for chat turns.
   let taskBlockNudged = false;
-  // Mid-turn delivery bookkeeping (chat runs): (to, body) keys of <message>
-  // blocks already delivered from 'text' events this turn, plus how many.
-  // Lets the result path drop the echo when the model repeats a block in its
-  // final text, and suppresses the unwrapped-nudge when the wrapped reply was
-  // already sent mid-turn. Reset at the turn boundary (the 'result' event) —
-  // NOT at the follow-up push seam: query.push() does not end the in-flight
-  // turn, and its result (which may echo a mid-turn delivery) arrives after
-  // the push, so clearing there would double-deliver.
-  const midTurnDelivered = new Set<string>();
+  // How many <message> blocks were delivered from 'text' events this turn
+  // (chat runs, emitsMidTurnText providers only). A frame-local count, never
+  // keyed by content: it only feeds the unwrapped-nudge decision ("did this
+  // turn deliver anything?"). Reset at the turn boundary (the 'result'
+  // event) — NOT at the follow-up push seam: query.push() does not end the
+  // in-flight turn, and its result's nudge decision still describes the turn
+  // that is streaming.
   let midTurnSent = 0;
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
@@ -522,8 +529,13 @@ export async function processQuery(
         // Assistant text emitted mid-turn (e.g. between tool calls). The
         // final result only carries the LAST assistant text, so complete
         // <message> blocks composed here would otherwise be lost — deliver
-        // them now (chat runs only; task runs stay one-door).
-        midTurnSent += deliverMidTurnBlocks(event.text, routing, midTurnDelivered);
+        // them now (chat runs only; task runs stay one-door). Gated on the
+        // provider's static capability: for a provider that does not declare
+        // emitsMidTurnText the result stays the only delivery door, so a
+        // stray text event must not open a second one.
+        if (emitsMidTurnText) {
+          midTurnSent += deliverMidTurnBlocks(event.text, routing);
+        }
       } else if (event.type === 'result') {
         // A result — with or without text — means the turn is done. Mark
         // the initial batch completed now so the host sweep doesn't see
@@ -534,8 +546,8 @@ export async function processQuery(
         markCompleted(initialBatchIds);
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = dispatchResultText(event.text, routing, {
-            deliveredKeys: midTurnDelivered,
-            sent: midTurnSent,
+            midTurnSent,
+            stripStreamedBlocks: emitsMidTurnText,
           });
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
@@ -559,17 +571,17 @@ export async function processQuery(
             archivePrompts.shift();
           } else {
             // An unwrapped final text only warrants the wrap-nudge when NOTHING
-            // was delivered this turn. If a reply already went out as a
-            // mid-turn block (recorded in midTurnDelivered), the unwrapped
-            // tail is a self-summary; nudging coaxes a redundant second
-            // message (live-observed). It stays in the scratchpad log.
-            const trulyUndelivered = hasUnwrapped && midTurnDelivered.size === 0;
-            const willRetryWrapping = trulyUndelivered && !unwrappedNudged;
+            // was delivered this turn — hasUnwrapped already folds in the
+            // turn's mid-turn sent count. If a reply already went out as a
+            // mid-turn block, the unwrapped tail is a self-summary; nudging
+            // coaxes a redundant second message (live-observed). It stays in
+            // the scratchpad log.
+            const willRetryWrapping = hasUnwrapped && !unwrappedNudged;
             notifyExchangeComplete(onExchangeComplete, {
               prompt: archivePrompts[0] ?? initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
-              status: trulyUndelivered || willRetryTaskBlocks ? 'undelivered' : 'completed',
+              status: hasUnwrapped || willRetryTaskBlocks ? 'undelivered' : 'completed',
             });
             if (willRetryWrapping) {
               unwrappedNudged = true;
@@ -595,11 +607,10 @@ export async function processQuery(
             if (!willRetryWrapping && !willRetryTaskBlocks) archivePrompts.shift();
           }
         } else archivePrompts.shift();
-        // Turn boundary: reset the mid-turn delivery state here, after the
-        // result's echo dedup and nudge decisions have used it. A nudge retry
-        // repopulates the set via its own text events before the retry result,
-        // so clearing on every result is safe.
-        midTurnDelivered.clear();
+        // Turn boundary: reset the per-turn sent count after the result's
+        // nudge decision has used it. A nudge retry re-counts via its own
+        // text events before the retry result, so resetting on every result
+        // is safe.
         midTurnSent = 0;
       }
     }
@@ -684,21 +695,27 @@ export interface TaskMessageBlock {
   body: string;
 }
 
-/** Per-turn record of blocks already delivered from mid-turn text events. */
-export interface MidTurnState {
-  /** Keys (see `midTurnKey`) of blocks delivered mid-turn this turn. */
-  deliveredKeys: Set<string>;
-  /** How many blocks were delivered mid-turn this turn. */
-  sent: number;
-}
-/**
- * The poll-loop's canonical per-turn key for a delivered block. Both call
- * sites already pass trimmed, artifact-stripped bodies; normalizing again
- * here is an idempotent belt-and-suspenders that keeps the keys agreeing by
- * construction.
- */
-function midTurnKey(to: string, body: string): string {
-  return `${to}\u0000${stripHarnessTagArtifacts(body.trim())}`;
+/** Options for `dispatchResultText`, describing the turn it closes. */
+export interface ResultDispatchOptions {
+  /**
+   * How many <message> blocks were already delivered from streamed text
+   * events this turn. Folds into the returned `sent` total so a bare final
+   * text after a mid-turn delivery reads as a self-summary, not an
+   * undelivered reply.
+   */
+  midTurnSent?: number;
+  /**
+   * Structural strip (providers declaring `emitsMidTurnText`): every
+   * assistant text segment streamed as a `text` event before this result, so
+   * any complete <message> block in the result text was — by construction —
+   * already part of a streamed segment and already delivered at the mid-turn
+   * door. Deliverable blocks are therefore stripped instead of sent; no
+   * record of which blocks went out is needed. Applies to exactly the blocks
+   * the mid-turn door delivers: chat runs, known destination, non-empty body.
+   * Blocks that door skips (task runs, unknown destination, empty after
+   * sanitization) keep their result-door handling.
+   */
+  stripStreamedBlocks?: boolean;
 }
 /**
  * `<internal>…</internal>` spans are explicitly not-for-delivery scratchpad.
@@ -717,11 +734,12 @@ const INTERNAL_SPAN_RE = /<internal\b[\s\S]*?<\/internal>/gi;
  * mid-turn blocks stay inert exactly like final-text blocks (one-door: only
  * the send_message tool delivers). Blocks inside an <internal> span are never
  * delivered. Blocks to unknown destinations are left for the result path,
- * which logs the drop into the scratchpad. Each delivery is recorded in
- * `deliveredKeys` so the result path can drop the echo. Returns the number of
- * blocks delivered.
+ * which logs the drop into the scratchpad. Stateless: each complete block in
+ * a streamed segment delivers exactly once, at parse time — the result path
+ * strips such blocks structurally rather than consulting any record of what
+ * was sent. Returns the number of blocks delivered.
  */
-export function deliverMidTurnBlocks(text: string, routing: RoutingContext, deliveredKeys: Set<string>): number {
+export function deliverMidTurnBlocks(text: string, routing: RoutingContext): number {
   if (routing.taskRun) return 0;
   const visible = text.replace(INTERNAL_SPAN_RE, '');
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
@@ -739,9 +757,6 @@ export function deliverMidTurnBlocks(text: string, routing: RoutingContext, deli
       log(`Mid-turn <message to="${toName}"> empty after sanitization — skipped`);
       continue;
     }
-    const key = midTurnKey(toName, body);
-    if (deliveredKeys.has(key)) continue;
-    deliveredKeys.add(key);
     sendToDestination(dest, body, routing);
     delivered++;
     log(`Mid-turn delivery: <message to="${toName}"> (${body.length} chars)`);
@@ -752,7 +767,7 @@ export function deliverMidTurnBlocks(text: string, routing: RoutingContext, deli
 export function dispatchResultText(
   text: string,
   routing: RoutingContext,
-  midTurn?: MidTurnState,
+  options?: ResultDispatchOptions,
 ): { sent: number; hasUnwrapped: boolean; taskBlocks: TaskMessageBlock[]; resultBlocks: number } {
   // <internal> spans are not-for-delivery scratchpad. Remove them BEFORE block
   // extraction so a <message> drafted inside one is never delivered from the
@@ -767,10 +782,10 @@ export function dispatchResultText(
   // Blocks delivered mid-turn count toward this turn's sent total — a final
   // text with no (new) blocks after a mid-turn delivery is scratchpad, not an
   // undelivered reply.
-  let sent = midTurn?.sent ?? 0;
-  // <message> blocks present in THIS result text (delivered, echoed, task or
-  // dropped alike) — drives the bare-error-text delivery gate, which must key
-  // on the error result itself, not on earlier mid-turn deliveries.
+  let sent = options?.midTurnSent ?? 0;
+  // <message> blocks present in THIS result text (delivered, stripped, task
+  // or dropped alike) — drives the bare-error-text delivery gate, which must
+  // key on the error result itself, not on earlier mid-turn deliveries.
   let resultBlocks = 0;
   // <message to> blocks left inert in a task run — drives the same-turn
   // "use send_message" nudge in processQuery.
@@ -813,10 +828,12 @@ export function dispatchResultText(
       scratchpadParts.push(`[not delivered — empty after sanitization; to="${toName}"]`);
       continue;
     }
-    // Echo dedup: this exact block already went out mid-turn this turn
-    // (already counted in the mid-turn sent total) — don't send it twice.
-    if (midTurn?.deliveredKeys.has(midTurnKey(toName, body))) {
-      log(`Echo of mid-turn delivery to "${toName}" — dropped`);
+    // Structural strip: with an emitsMidTurnText provider, this deliverable
+    // block was part of an assistant text segment that already streamed as a
+    // 'text' event, where the mid-turn door delivered it — by construction,
+    // not by consulting any record. Strip it here instead of sending again.
+    if (options?.stripStreamedBlocks) {
+      log(`<message to="${toName}"> in final result was already streamed — stripped, not re-sent`);
       continue;
     }
     sendToDestination(dest, body, routing);

--- a/container/agent-runner/src/providers/__fixtures__/sdk-midturn-recordings.json
+++ b/container/agent-runner/src/providers/__fixtures__/sdk-midturn-recordings.json
@@ -638,5 +638,112 @@
         "is_error": false
       }
     ]
+  },
+  "s16-three-way-split": {
+    "gist": "block spread across three assistant messages with two tool calls between",
+    "capturedAt": "2026-08-16T19:29:32.559Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "ce8f9e9e-a723-4c8a-aedc-3e877f7e7816"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">alpha "
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "beta "
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "gamma</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "gamma</message>",
+        "is_error": false
+      }
+    ]
   }
 }

--- a/container/agent-runner/src/providers/__fixtures__/sdk-midturn-recordings.json
+++ b/container/agent-runner/src/providers/__fixtures__/sdk-midturn-recordings.json
@@ -1,0 +1,642 @@
+{
+  "s02-single-block": {
+    "gist": "single block then end",
+    "capturedAt": "2026-08-16T18:24:14.800Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "74f4dc2b-5571-47ca-a08c-66597bf46c4b"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">Hey there! 👋 TestBot here, ready to help.</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">Hey there! 👋 TestBot here, ready to help.</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s03-block-then-tool": {
+    "gist": "block, THEN a tool call after it (SAF shape)",
+    "capturedAt": "2026-08-16T18:24:17.060Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "cb26b0cc-d02e-4e42-9a0e-932a0b623d6a"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">✅ Deploy is done.</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">✅ Deploy is done.</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">✅ Deploy is done.</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s04b-tool-inside-block": {
+    "gist": "half-message, phrasing 2 (explicit interleave)",
+    "capturedAt": "2026-08-16T18:24:45.366Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "610bdeb5-da2f-4f1a-99e9-2867962e88e7"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">part one"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "part two</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "part two</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s06-only-final": {
+    "gist": "tool first, block only in the very last text",
+    "capturedAt": "2026-08-16T18:25:02.900Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "76115fe1-81aa-46e9-968a-13260bb7dc11"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">hi</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">hi</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s08-long-block": {
+    "gist": "long multi-paragraph block (chunking)",
+    "capturedAt": "2026-08-16T18:25:14.085Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "aedbe388-1459-4655-89ee-6fbbba188ef5"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "Here's the update.\n\n<message to=\"discord-main\">\n**Orion Deploy Update — 2026-08-16**\n\nRollout of orion v2.4.0 kicked off at 09:00 UTC using our standard progressive strategy. We started at 5% of traffic, held for 20 minutes to bake, then stepped through 25%, 50%, and full 100% by 11:15 UTC. All three regions (us-east, eu-west, ap-south) picked up the new build cleanly, and canary health checks stayed green throughout each stage.\n\nMetrics look solid post-rollout. P50 latency held at 42ms and P99 came in at 210ms, slightly better than the previous release's 235ms. Error rate settled at 0.03%, well under our 0.1% SLO, and throughput sustained ~14k requests/second at peak with no saturation on CPU or memory.\n\nWe did hit one incident: at 10:20 UTC, a stale connection pool in eu-west caused a brief spike in 503s (roughly 90 seconds, ~0.8% of regional traffic). Auto-remediation recycled the pool and traffic recovered before paging escalated. Root cause was a misconfigured idle timeout that we've since patched.\n\nNext steps: ship the idle-timeout fix in v2.4.1 this week, add a canary alert for connection-pool health, and schedule a brief retro on Thursday to close out the incident action items.\n</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "Here's the update.\n\n<message to=\"discord-main\">\n**Orion Deploy Update — 2026-08-16**\n\nRollout of orion v2.4.0 kicked off at 09:00 UTC using our standard progressive strategy. We started at 5% of traffic, held for 20 minutes to bake, then stepped through 25%, 50%, and full 100% by 11:15 UTC. All three regions (us-east, eu-west, ap-south) picked up the new build cleanly, and canary health checks stayed green throughout each stage.\n\nMetrics look solid post-rollout. P50 latency held at 42ms and P99 came in at 210ms, slightly better than the previous release's 235ms. Error rate settled at 0.03%, well under our 0.1% SLO, and throughput sustained ~14k requests/second at peak with no saturation on CPU or memory.\n\nWe did hit one incident: at 10:20 UTC, a stale connection pool in eu-west caused a brief spike in 503s (roughly 90 seconds, ~0.8% of regional traffic). Auto-remediation recycled the pool and traffic recovered before paging escalated. Root cause was a misconfigured idle timeout that we've since patched.\n\nNext steps: ship the idle-timeout fix in v2.4.1 this week, add a canary alert for connection-pool health, and schedule a brief retro on Thursday to close out the incident action items.\n</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s09-repeat-in-summary": {
+    "gist": "instructed to repeat block verbatim in final text",
+    "capturedAt": "2026-08-16T18:25:23.711Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "ce90c178-2936-4d45-b102-bba4fe459070"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">backup finished</message>\n\n<message to=\"discord-main\">backup finished</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">backup finished</message>\n\n<message to=\"discord-main\">backup finished</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s10-summarize-no-repeat": {
+    "gist": "summary WITHOUT repeating the block",
+    "capturedAt": "2026-08-16T18:25:30.010Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "866466ad-7de7-4964-a1e3-829b05548398"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">backup finished</message>\n\nSent the \"backup finished\" message and ran `echo logged`, which output `logged`."
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">backup finished</message>\n\nSent the \"backup finished\" message and ran `echo logged`, which output `logged`.",
+        "is_error": false
+      }
+    ]
+  },
+  "s12-abort-midstream": {
+    "gist": "abort during the tool call",
+    "capturedAt": "2026-08-16T18:25:40.091Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "16bcd134-df8e-4a1b-bb13-f8c34f094980"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "system",
+        "subtype": "thinking_tokens"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">starting the slow job</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_use",
+              "name": "Bash"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      }
+    ]
+  },
+  "s13-internal-draft": {
+    "gist": "internal-wrapped draft plus a real block",
+    "capturedAt": "2026-08-16T18:25:46.200Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "3dd54719-79f4-41b3-bfe1-1162eb876f5e"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "thinking"
+            }
+          ]
+        }
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<internal>\nBlunt draft (NOT sent):\n`<message to=\"discord-main\">Your report is late. Again. You said it'd be done, it isn't, and now everyone's waiting on you. Get it in.</message>`\n</internal>\n\n<message to=\"discord-main\">Hi! Just a friendly nudge — the report seems to be past its expected due date. No worries at all if something came up; could you let me know a rough ETA or if you need a hand with anything to get it wrapped up? Thanks so much!</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<internal>\nBlunt draft (NOT sent):\n`<message to=\"discord-main\">Your report is late. Again. You said it'd be done, it isn't, and now everyone's waiting on you. Get it in.</message>`\n</internal>\n\n<message to=\"discord-main\">Hi! Just a friendly nudge — the report seems to be past its expected due date. No worries at all if something came up; could you let me know a rough ETA or if you need a hand with anything to get it wrapped up? Thanks so much!</message>",
+        "is_error": false
+      }
+    ]
+  },
+  "s14-two-turns-stream": {
+    "gist": "streaming input: follow-up push after first result",
+    "capturedAt": "2026-08-16T18:25:51.160Z",
+    "messages": [
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "a32468a4-e628-40ae-9c5d-54015df32f28"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">turn one</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+          "status": "allowed",
+          "resetsAt": 1786921200,
+          "rateLimitType": "five_hour",
+          "overageStatus": "allowed",
+          "overageResetsAt": 1788220800,
+          "isUsingOverage": false
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">turn one</message>",
+        "is_error": false
+      },
+      {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "a32468a4-e628-40ae-9c5d-54015df32f28"
+      },
+      {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "<message to=\"discord-main\">turn two</message>"
+            }
+          ]
+        }
+      },
+      {
+        "type": "result",
+        "subtype": "success",
+        "result": "<message to=\"discord-main\">turn two</message>",
+        "is_error": false
+      }
+    ]
+  }
+}

--- a/container/agent-runner/src/providers/claude.midturn-text.test.ts
+++ b/container/agent-runner/src/providers/claude.midturn-text.test.ts
@@ -38,6 +38,10 @@ afterEach(() => {
 });
 
 describe('assistant text block surfacing', () => {
+  it('declares the emitsMidTurnText capability the poll-loop keys one-door delivery on', () => {
+    expect(new ClaudeProvider({}).emitsMidTurnText).toBe(true);
+  });
+
   it('yields a text event per non-empty assistant text block, before the result', async () => {
     sdkMessages.length = 0;
     sdkMessages.push(

--- a/container/agent-runner/src/providers/claude.midturn-text.test.ts
+++ b/container/agent-runner/src/providers/claude.midturn-text.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// ClaudeProvider must surface every non-empty assistant text block as a
+// 'text' provider event, in stream order, before the turn's result. The SDK's
+// final `result` event only carries the LAST assistant text — a complete
+// <message to> block composed between tool calls is invisible to the
+// poll-loop unless the provider emits it as a text event. Deleting the
+// assistant-message branch in claude.ts goes red here.
+
+const sdkMessages: unknown[] = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () =>
+    (async function* () {
+      for (const m of sdkMessages) yield m;
+    })(),
+}));
+
+const { ClaudeProvider } = await import('./claude.js');
+const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
+
+let tmp: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-midturn-'));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmp;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('assistant text block surfacing', () => {
+  it('yields a text event per non-empty assistant text block, before the result', async () => {
+    sdkMessages.length = 0;
+    sdkMessages.push(
+      { type: 'system', subtype: 'init', session_id: 'sess-1' },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: '<message to="user">mid-turn reply</message>' },
+            { type: 'tool_use', name: 'Bash', input: {} },
+            { type: 'text', text: '' },
+          ],
+        },
+      },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'second segment' }] } },
+      { type: 'result', subtype: 'success', result: 'final text' },
+    );
+
+    const provider = new ClaudeProvider({});
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const q = provider.query({ prompt: 'hi', cwd: tmp });
+
+    const events: { type: string; text?: string | null }[] = [];
+    for await (const e of q.events) events.push(e as { type: string; text?: string | null });
+
+    const texts = events.filter((e) => e.type === 'text');
+    expect(texts.map((e) => e.text)).toEqual(['<message to="user">mid-turn reply</message>', 'second segment']);
+    // Every text event precedes the result event.
+    const resultIdx = events.findIndex((e) => e.type === 'result');
+    const lastTextIdx = events.map((e) => e.type).lastIndexOf('text');
+    expect(resultIdx).toBeGreaterThan(-1);
+    expect(lastTextIdx).toBeLessThan(resultIdx);
+    expect(events[resultIdx]!.text).toBe('final text');
+  });
+
+  it('yields no text events for assistant messages without text blocks', async () => {
+    sdkMessages.length = 0;
+    sdkMessages.push(
+      { type: 'system', subtype: 'init', session_id: 'sess-2' },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] } },
+      { type: 'result', subtype: 'success', result: 'done' },
+    );
+
+    const provider = new ClaudeProvider({});
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const q = provider.query({ prompt: 'hi', cwd: tmp });
+
+    const events: { type: string }[] = [];
+    for await (const e of q.events) events.push(e as { type: string });
+
+    expect(events.filter((e) => e.type === 'text')).toHaveLength(0);
+  });
+});

--- a/container/agent-runner/src/providers/claude.midturn-text.test.ts
+++ b/container/agent-runner/src/providers/claude.midturn-text.test.ts
@@ -42,7 +42,7 @@ describe('assistant text block surfacing', () => {
     expect(new ClaudeProvider({}).emitsMidTurnText).toBe(true);
   });
 
-  it('yields a text event per non-empty assistant text block, before the result', async () => {
+  it('yields one text event per assistant message with text, before the result', async () => {
     sdkMessages.length = 0;
     sdkMessages.push(
       { type: 'system', subtype: 'init', session_id: 'sess-1' },
@@ -93,5 +93,107 @@ describe('assistant text block surfacing', () => {
     for await (const e of q.events) events.push(e as { type: string });
 
     expect(events.filter((e) => e.type === 'text')).toHaveLength(0);
+  });
+
+  it('joins text blocks of ONE assistant message: a <message> block split across them stays parseable', async () => {
+    // A block spanning two text blocks of the same assistant message would be
+    // a fragment in each per-block event — unparseable at the poll-loop's
+    // mid-turn door — while the SDK result reports the message's text whole.
+    // One joined event per message pins door granularity to result granularity.
+    sdkMessages.length = 0;
+    sdkMessages.push(
+      { type: 'system', subtype: 'init', session_id: 'sess-3' },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: '<message to="user">The answer' },
+            { type: 'text', text: ' is 4.</message>' },
+          ],
+        },
+      },
+      { type: 'result', subtype: 'success', result: '<message to="user">The answer is 4.</message>' },
+    );
+
+    const provider = new ClaudeProvider({});
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const q = provider.query({ prompt: 'hi', cwd: tmp });
+
+    const events: { type: string; text?: string | null }[] = [];
+    for await (const e of q.events) events.push(e as { type: string; text?: string | null });
+
+    const texts = events.filter((e) => e.type === 'text');
+    expect(texts.map((e) => e.text)).toEqual(['<message to="user">The answer is 4.</message>']);
+  });
+
+  it('passes fragments split across ASSISTANT MESSAGES through verbatim — no cross-message buffering or healing', async () => {
+    sdkMessages.length = 0;
+    sdkMessages.push(
+      { type: 'system', subtype: 'init', session_id: 'sess-4' },
+      { type: 'assistant', message: { content: [{ type: 'text', text: '<message to="user">opened here' }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] } },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'closed here</message>' }] } },
+      { type: 'result', subtype: 'success', result: 'closed here</message>' },
+    );
+
+    const provider = new ClaudeProvider({});
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const q = provider.query({ prompt: 'hi', cwd: tmp });
+
+    const events: { type: string; text?: string | null }[] = [];
+    for await (const e of q.events) events.push(e as { type: string; text?: string | null });
+
+    const texts = events.filter((e) => e.type === 'text');
+    expect(texts.map((e) => e.text)).toEqual(['<message to="user">opened here', 'closed here</message>']);
+  });
+});
+
+// The provider does NOT derive the result event's text from the streamed
+// assistant messages — it takes the SDK's own `result` / `errors[]` fields
+// verbatim (see the result branch in claude.ts). Containment of result text
+// in streamed text is therefore an SDK premise the provider cannot enforce.
+// These pin the two divergence shapes the poll-loop's midTurnSent===0
+// fallback exists for.
+describe('result text is an independent SDK field (divergence surface)', () => {
+  it('surfaces a result whose text never appeared in any assistant message', async () => {
+    sdkMessages.length = 0;
+    sdkMessages.push(
+      { type: 'system', subtype: 'init', session_id: 'sess-5' },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] } },
+      { type: 'result', subtype: 'success', result: '<message to="user">only in the result field</message>' },
+    );
+
+    const provider = new ClaudeProvider({});
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const q = provider.query({ prompt: 'hi', cwd: tmp });
+
+    const events: { type: string; text?: string | null }[] = [];
+    for await (const e of q.events) events.push(e as { type: string; text?: string | null });
+
+    expect(events.filter((e) => e.type === 'text')).toHaveLength(0);
+    const result = events.find((e) => e.type === 'result');
+    expect(result?.text).toBe('<message to="user">only in the result field</message>');
+  });
+
+  it('error-subtype results carry errors[] text that never streamed', async () => {
+    sdkMessages.length = 0;
+    sdkMessages.push(
+      { type: 'system', subtype: 'init', session_id: 'sess-6' },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'partial progress' }] } },
+      { type: 'result', subtype: 'error_during_execution', is_error: true, errors: ['billing hard-stop'] },
+    );
+
+    const provider = new ClaudeProvider({});
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const q = provider.query({ prompt: 'hi', cwd: tmp });
+
+    const events: { type: string; text?: string | null; isError?: boolean }[] = [];
+    for await (const e of q.events) events.push(e as { type: string; text?: string | null; isError?: boolean });
+
+    const result = events.find((e) => e.type === 'result');
+    expect(result?.text).toBe('billing hard-stop');
+    expect(result?.isError).toBe(true);
+    // 'billing hard-stop' never appeared in a text event — only 'partial progress' did.
+    expect(events.filter((e) => e.type === 'text').map((e) => e.text)).toEqual(['partial progress']);
   });
 });

--- a/container/agent-runner/src/providers/claude.recorded.test.ts
+++ b/container/agent-runner/src/providers/claude.recorded.test.ts
@@ -138,10 +138,14 @@ describe('captured end-to-end poll-loop outcomes', () => {
     expect(pushes).toHaveLength(0);
   });
 
-  it('s04b: genuine half-message split across assistant messages — no fragment delivered, wrap-nudge recovery', async () => {
+  it('s04b: genuine half-message split across assistant messages — assembled and delivered once, no nudge', async () => {
+    // Captured segments: "<message to=\"discord-main\">part one" then
+    // "part two</message>" (a Bash call between them). Assembly joins the
+    // fragments verbatim — the model put no separator at the boundary, so
+    // the delivered body is exactly the concatenation.
     const { delivered, pushes } = await runThroughPollLoop('s04b-tool-inside-block');
-    expect(delivered).toEqual([]);
-    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+    expect(delivered).toEqual(['part onepart two']);
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
   });
 
   it('s06: tool first, block only in the final text — delivered once', async () => {
@@ -180,9 +184,18 @@ describe('captured end-to-end poll-loop outcomes', () => {
     expect(delivered[0]).not.toContain('Blunt draft');
   });
 
-  it('s14: two streamed turns — one delivery each, repeats stripped per turn', async () => {
+  it('s14: two streamed turns — one delivery each, result repeats inert per turn', async () => {
     const { delivered, pushes } = await runThroughPollLoop('s14-two-turns-stream');
     expect(delivered).toEqual(['turn one', 'turn two']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('s16: block spread across THREE assistant messages (two tool calls between) — assembled, one delivery, no nudge', async () => {
+    // Captured segments: "<message to=\"discord-main\">alpha " / Bash /
+    // "beta " / Bash / "gamma</message>"; the SDK result carried only the
+    // tail fragment "gamma</message>".
+    const { delivered, pushes } = await runThroughPollLoop('s16-three-way-split');
+    expect(delivered).toEqual(['alpha beta gamma']);
     expect(pushes).toHaveLength(0);
   });
 });

--- a/container/agent-runner/src/providers/claude.recorded.test.ts
+++ b/container/agent-runner/src/providers/claude.recorded.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb } from '../db/connection.js';
+import { getUndeliveredMessages } from '../db/messages-out.js';
+import { processQuery } from '../poll-loop.js';
+
+import recordings from './__fixtures__/sdk-midturn-recordings.json';
+
+// Replays of REAL SDK message streams, captured live against
+// @anthropic-ai/claude-agent-sdk 0.3.197 (scripts/sdk-capture/run-battery.ts,
+// 2026-08-16, default model claude-opus-4-8). Message text is verbatim;
+// non-text noise was trimmed by scripts/sdk-capture/extract-fixtures.ts.
+//
+// Two layers:
+//  1. Provider invariant on real data — in every captured turn the SDK's
+//     result text was EXACTLY the last streamed assistant text (the
+//     containment premise the structural strip rests on).
+//  2. End-to-end poll-loop outcomes for the captured shapes, including the
+//     live-observed verbatim echo after a tool call (s03) that must deliver
+//     exactly once.
+
+const sdkMessages: unknown[] = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () =>
+    (async function* () {
+      for (const m of sdkMessages) yield m;
+    })(),
+}));
+
+const { ClaudeProvider } = await import('./claude.js');
+const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
+
+type Fixture = { gist: string; messages: unknown[] };
+const FIXTURES = recordings as Record<string, Fixture>;
+
+const CHAT_ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+  taskRun: false,
+};
+
+let tmp: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-recorded-'));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmp;
+  initTestSessionDb();
+  for (const [name, channelType, platformId] of [
+    ['discord-main', 'discord', 'chan-1'],
+    ['ops-log', 'slack', 'chan-ops'],
+  ]) {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+         VALUES (?, ?, 'channel', ?, ?, NULL)`,
+      )
+      .run(name, name, channelType, platformId);
+  }
+});
+
+afterEach(() => {
+  closeSessionDb();
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function load(id: string): void {
+  sdkMessages.length = 0;
+  sdkMessages.push(...FIXTURES[id].messages);
+}
+
+async function providerEvents(id: string): Promise<Array<{ type: string; text?: string | null }>> {
+  load(id);
+  const provider = new ClaudeProvider({});
+  provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+  const q = provider.query({ prompt: 'hi', cwd: tmp });
+  const events: Array<{ type: string; text?: string | null }> = [];
+  for await (const e of q.events) events.push(e as { type: string; text?: string | null });
+  return events;
+}
+
+async function runThroughPollLoop(id: string): Promise<{ delivered: string[]; pushes: string[] }> {
+  load(id);
+  const provider = new ClaudeProvider({});
+  provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+  const query = provider.query({ prompt: 'hi', cwd: tmp });
+  const pushes: string[] = [];
+  const origPush = query.push;
+  query.push = (m: string) => {
+    pushes.push(m);
+    origPush(m);
+  };
+  await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined, true);
+  const delivered = getUndeliveredMessages()
+    .filter((m) => m.kind === 'chat')
+    .map((m) => (JSON.parse(m.content) as { text: string }).text);
+  return { delivered, pushes };
+}
+
+describe('captured containment invariant', () => {
+  it('in every captured turn with a result, the result text is EXACTLY the last streamed text event', async () => {
+    for (const id of Object.keys(FIXTURES)) {
+      const events = await providerEvents(id);
+      let lastText: string | null = null;
+      let checkedResults = 0;
+      for (const e of events) {
+        if (e.type === 'text') lastText = e.text ?? null;
+        if (e.type === 'result') {
+          expect({ id, result: e.text }).toEqual({ id, result: lastText });
+          checkedResults++;
+          lastText = null; // next turn starts fresh
+        }
+      }
+      if (id !== 's12-abort-midstream') expect({ id, checkedResults }).not.toEqual({ id, checkedResults: 0 });
+    }
+  });
+});
+
+describe('captured end-to-end poll-loop outcomes', () => {
+  it('s02: simple block turn — one delivery, result repeat stripped', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s02-single-block');
+    expect(delivered).toEqual(['Hey there! 👋 TestBot here, ready to help.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('s03: verbatim echo of the block after a tool call — exactly ONE delivery (echo guard)', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s03-block-then-tool');
+    expect(delivered).toEqual(['✅ Deploy is done.']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('s04b: genuine half-message split across assistant messages — no fragment delivered, wrap-nudge recovery', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s04b-tool-inside-block');
+    expect(delivered).toEqual([]);
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+  });
+
+  it('s06: tool first, block only in the final text — delivered once', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s06-only-final');
+    expect(delivered).toEqual(['hi']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('s08: long block with leading prose — block delivered once, prose stays scratchpad, no nudge', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s08-long-block');
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]).toStartWith('**Orion Deploy Update');
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('s09: two identical blocks in ONE segment (instructed repeat) — both deliver', async () => {
+    const { delivered } = await runThroughPollLoop('s09-repeat-in-summary');
+    expect(delivered).toEqual(['backup finished', 'backup finished']);
+  });
+
+  it('s10: block then unwrapped self-summary — one delivery, summary is scratchpad, no nudge', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s10-summarize-no-repeat');
+    expect(delivered).toEqual(['backup finished']);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('s12: turn aborted mid tool call, no result event — the mid-turn delivery stands', async () => {
+    const { delivered } = await runThroughPollLoop('s12-abort-midstream');
+    expect(delivered).toEqual(['starting the slow job']);
+  });
+
+  it('s13: internal-wrapped blunt draft never delivers; the real block does', async () => {
+    const { delivered } = await runThroughPollLoop('s13-internal-draft');
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]).toStartWith('Hi! Just a friendly nudge');
+    expect(delivered[0]).not.toContain('Blunt draft');
+  });
+
+  it('s14: two streamed turns — one delivery each, repeats stripped per turn', async () => {
+    const { delivered, pushes } = await runThroughPollLoop('s14-two-turns-stream');
+    expect(delivered).toEqual(['turn one', 'turn two']);
+    expect(pushes).toHaveLength(0);
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -580,6 +580,20 @@ export class ClaudeProvider implements AgentProvider {
 
         if (message.type === 'system' && message.subtype === 'init') {
           yield { type: 'init', continuation: message.session_id };
+        } else if (message.type === 'assistant') {
+          // Surface every assistant text block as it streams in. The final
+          // `result` event only carries the LAST assistant text — a wrapped
+          // <message> block composed between tool calls would otherwise be
+          // invisible to the poll-loop and silently lost.
+          const content = (message as { message?: { content?: Array<{ type?: string; text?: string }> } }).message
+            ?.content;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (block.type === 'text' && block.text) {
+                yield { type: 'text', text: block.text };
+              }
+            }
+          }
         } else if (message.type === 'result') {
           // `result` text exists only on subtype:"success"; error subtypes
           // (e.g. a non-retryable 403 billing_error) carry their message in

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -472,9 +472,9 @@ export class ClaudeProvider implements AgentProvider {
    * provider enforces: the result event's text is taken verbatim from the
    * SDK's own `result` / `errors[]` fields, which the provider cannot prove
    * equal to streamed content. The poll-loop keys its one-door mid-turn
-   * delivery on this flag and keeps a stateless fallback (deliver at the
-   * result door when the turn delivered nothing mid-turn) for premise
-   * violations.
+   * delivery on this flag; the result door never delivers content — if the
+   * streaming door missed everything (premise violation), the poll-loop
+   * fires the wrap-nudge so the model re-sends through the mid-turn door.
    */
   readonly emitsMidTurnText = true;
 

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -464,10 +464,17 @@ export class ClaudeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = true;
   /**
    * Static capability, not runtime state: this provider yields a `text`
-   * event for every non-empty assistant text block (see the assistant-message
-   * branch in query()), so the final result text is always a repeat of an
-   * already-streamed segment. The poll-loop keys its one-door mid-turn
-   * delivery on this flag.
+   * event for every assistant message that carries non-empty text (see the
+   * assistant-message branch in query() — one event per message, text blocks
+   * joined). The SDK's result text repeats the final assistant message's
+   * text, so the final result is expected to repeat an already-streamed
+   * segment. NOTE this containment is an SDK premise, not something this
+   * provider enforces: the result event's text is taken verbatim from the
+   * SDK's own `result` / `errors[]` fields, which the provider cannot prove
+   * equal to streamed content. The poll-loop keys its one-door mid-turn
+   * delivery on this flag and keeps a stateless fallback (deliver at the
+   * result door when the turn delivered nothing mid-turn) for premise
+   * violations.
    */
   readonly emitsMidTurnText = true;
 
@@ -589,18 +596,30 @@ export class ClaudeProvider implements AgentProvider {
         if (message.type === 'system' && message.subtype === 'init') {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'assistant') {
-          // Surface every assistant text block as it streams in. The final
+          // Surface each assistant message's text as it streams in. The final
           // `result` event only carries the LAST assistant text — a wrapped
           // <message> block composed between tool calls would otherwise be
           // invisible to the poll-loop and silently lost.
+          //
+          // ONE text event per assistant message, joining its text blocks in
+          // content order ('' separator — the blocks are adjacent output).
+          // Emitting per-BLOCK events would hand the poll-loop's block parser
+          // fragments: a <message> block (or an <internal> span) spanning two
+          // text blocks of the same assistant message would look unterminated
+          // in each event, while the turn's result text — which reports the
+          // final message's text as a whole — could still contain it complete.
+          // Joining pins the containment premise at the granularity the
+          // result reports. Blocks split across ASSISTANT MESSAGES (a tool
+          // call between them) remain unparseable mid-turn by design; the
+          // poll-loop's midTurnSent===0 fallback and wrap-nudge cover that.
           const content = (message as { message?: { content?: Array<{ type?: string; text?: string }> } }).message
             ?.content;
           if (Array.isArray(content)) {
-            for (const block of content) {
-              if (block.type === 'text' && block.text) {
-                yield { type: 'text', text: block.text };
-              }
-            }
+            const text = content
+              .filter((block) => block.type === 'text' && block.text)
+              .map((block) => block.text)
+              .join('');
+            if (text) yield { type: 'text', text };
           }
         } else if (message.type === 'result') {
           // `result` text exists only on subtype:"success"; error subtypes

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -462,6 +462,14 @@ const STALE_SESSION_RE = /no conversation found|ENOENT.*\.jsonl|session.*not fou
 
 export class ClaudeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = true;
+  /**
+   * Static capability, not runtime state: this provider yields a `text`
+   * event for every non-empty assistant text block (see the assistant-message
+   * branch in query()), so the final result text is always a repeat of an
+   * already-streamed segment. The poll-loop keys its one-door mid-turn
+   * delivery on this flag.
+   */
+  readonly emitsMidTurnText = true;
 
   private assistantName?: string;
   private mcpServers: Record<string, McpServerConfig>;

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -10,9 +10,20 @@ export class MockProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
   private responseFactory: (prompt: string) => string;
+  private textFactory: ((prompt: string) => string[]) | undefined;
 
-  constructor(_options: ProviderOptions = {}, responseFactory?: (prompt: string) => string) {
+  constructor(
+    _options: ProviderOptions = {},
+    responseFactory?: (prompt: string) => string,
+    /**
+     * Optional mid-turn text segments: returns the `text` events to emit
+     * before the result for a given prompt (mirrors SDK assistant messages
+     * emitted between tool calls).
+     */
+    textFactory?: (prompt: string) => string[],
+  ) {
     this.responseFactory = responseFactory ?? ((prompt) => `Mock response to: ${prompt.slice(0, 100)}`);
+    this.textFactory = textFactory;
   }
 
   registerMemorySessionHook(_hook: MemorySessionHookRegistration): void {}
@@ -27,6 +38,15 @@ export class MockProvider implements AgentProvider {
     let ended = false;
     let aborted = false;
     const responseFactory = this.responseFactory;
+    const textFactory = this.textFactory;
+    // Mid-turn text segments (if configured) followed by the turn's result —
+    // mirrors the SDK's assistant-message → result ordering.
+    function* turnEvents(prompt: string): Generator<ProviderEvent> {
+      for (const text of textFactory?.(prompt) ?? []) {
+        yield { type: 'text', text };
+      }
+      yield { type: 'result', text: responseFactory(prompt) };
+    }
 
     const events: AsyncIterable<ProviderEvent> = {
       async *[Symbol.asyncIterator]() {
@@ -35,13 +55,13 @@ export class MockProvider implements AgentProvider {
 
         // Process initial prompt
         yield { type: 'activity' };
-        yield { type: 'result', text: responseFactory(input.prompt) };
+        yield* turnEvents(input.prompt);
 
         // Process any pushed follow-ups
         while (!ended && !aborted) {
           if (pending.length > 0) {
             const msg = pending.shift()!;
-            yield { type: 'result', text: responseFactory(msg) };
+            yield* turnEvents(msg);
             continue;
           }
           // Wait for push() or end()
@@ -54,7 +74,7 @@ export class MockProvider implements AgentProvider {
         // Drain remaining
         while (pending.length > 0) {
           const msg = pending.shift()!;
-          yield { type: 'result', text: responseFactory(msg) };
+          yield* turnEvents(msg);
         }
       },
     };

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -8,6 +8,12 @@ import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryIn
  */
 export class MockProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
+  /**
+   * Mirrors ClaudeProvider: turnEvents() emits every configured text segment
+   * before the turn's result, so the mock exercises the same one-door
+   * mid-turn delivery path as the real SDK.
+   */
+  readonly emitsMidTurnText = true;
 
   private responseFactory: (prompt: string) => string;
   private textFactory: ((prompt: string) => string[]) | undefined;
@@ -40,12 +46,17 @@ export class MockProvider implements AgentProvider {
     const responseFactory = this.responseFactory;
     const textFactory = this.textFactory;
     // Mid-turn text segments (if configured) followed by the turn's result —
-    // mirrors the SDK's assistant-message → result ordering.
+    // mirrors the SDK's assistant-message → result ordering. The result text
+    // itself streams as the LAST text event first: the real SDK's result only
+    // repeats the final assistant text, which already streamed — that is the
+    // emitsMidTurnText contract this mock declares.
     function* turnEvents(prompt: string): Generator<ProviderEvent> {
       for (const text of textFactory?.(prompt) ?? []) {
         yield { type: 'text', text };
       }
-      yield { type: 'result', text: responseFactory(prompt) };
+      const result = responseFactory(prompt);
+      if (result) yield { type: 'text', text: result };
+      yield { type: 'result', text: result };
     }
 
     const events: AsyncIterable<ProviderEvent> = {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -8,6 +8,20 @@ export interface AgentProvider {
    */
   readonly supportsNativeSlashCommands: boolean;
 
+  /**
+   * Optional capability: true when the provider surfaces EVERY assistant text
+   * segment as a streamed `text` event before the turn's `result` — so the
+   * result text is always a repeat of a segment that already streamed. When
+   * declared, the poll-loop delivers complete <message> blocks at parse time
+   * from the streamed events, and the final-result handler structurally
+   * strips deliverable blocks instead of sending them (they went out at the
+   * mid-turn door by construction — no runtime bookkeeping involved).
+   * Providers that omit this (or set false) keep the single result-door
+   * delivery path: text events are delivery-inert and blocks in the final
+   * result text are delivered from there.
+   */
+  readonly emitsMidTurnText?: boolean;
+
   /** Register shared memory through the provider's native session-start mechanism. */
   registerMemorySessionHook(hook: MemorySessionHookRegistration): void;
 
@@ -150,9 +164,11 @@ export type ProviderEvent =
    * An assistant text segment emitted mid-turn (e.g. between tool calls).
    * The SDK's final `result` carries only the LAST assistant text, so a
    * complete <message to="..."> block composed before a trailing tool call
-   * never reaches the result event. The poll-loop scans these segments for
-   * closed message blocks and delivers them as they are emitted (chat runs
-   * only), deduping the echo if the block reappears in the final result.
+   * never reaches the result event. For providers declaring
+   * `emitsMidTurnText`, the poll-loop scans these segments for closed
+   * message blocks and delivers them as they are emitted (chat runs only);
+   * the final result then structurally strips such blocks rather than
+   * delivering them again.
    */
   | { type: 'text'; text: string }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -146,6 +146,15 @@ export type ProviderEvent =
    * dropping it as un-wrapped scratchpad, and to skip the re-wrap nudge.
    */
   | { type: 'result'; text: string | null; isError?: boolean }
+  /**
+   * An assistant text segment emitted mid-turn (e.g. between tool calls).
+   * The SDK's final `result` carries only the LAST assistant text, so a
+   * complete <message to="..."> block composed before a trailing tool call
+   * never reaches the result event. The poll-loop scans these segments for
+   * closed message blocks and delivers them as they are emitted (chat runs
+   * only), deduping the echo if the block reappears in the final result.
+   */
+  | { type: 'text'; text: string }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }
   | { type: 'progress'; message: string }
   /**

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -11,14 +11,17 @@ export interface AgentProvider {
   /**
    * Optional capability: true when the provider surfaces EVERY assistant text
    * segment as a streamed `text` event before the turn's `result` — so the
-   * result text is always a repeat of a segment that already streamed. When
-   * declared, the poll-loop delivers complete <message> blocks at parse time
-   * from the streamed events, and the final-result handler structurally
-   * strips deliverable blocks instead of sending them (they went out at the
-   * mid-turn door by construction — no runtime bookkeeping involved).
-   * Providers that omit this (or set false) keep the single result-door
-   * delivery path: text events are delivery-inert and blocks in the final
-   * result text are delivered from there.
+   * result text is always a repeat of a segment that already streamed
+   * (empirically: the SDK result is exactly the last streamed segment). When
+   * declared, mid-turn streaming becomes the SINGLE content door: the
+   * poll-loop delivers complete <message> blocks at parse time from the
+   * streamed events (assembling blocks split across segments), and the
+   * final-result handler never delivers content — error results are
+   * surfaced, and a turn that delivered nothing while its result still
+   * carries content gets the wrap-nudge so the retry streams through the
+   * mid-turn door. Providers that omit this (or set false) keep the single
+   * result-door delivery path: text events are delivery-inert and blocks in
+   * the final result text are delivered from there.
    */
   readonly emitsMidTurnText?: boolean;
 
@@ -166,9 +169,10 @@ export type ProviderEvent =
    * complete <message to="..."> block composed before a trailing tool call
    * never reaches the result event. For providers declaring
    * `emitsMidTurnText`, the poll-loop scans these segments for closed
-   * message blocks and delivers them as they are emitted (chat runs only);
-   * the final result then structurally strips such blocks rather than
-   * delivering them again.
+   * message blocks and delivers them as they are emitted (chat runs only,
+   * with cross-segment assembly of split blocks); the final result never
+   * delivers content — repeats are inert there, and an undelivered turn
+   * gets the wrap-nudge instead.
    */
   | { type: 'text'; text: string }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }


### PR DESCRIPTION
# Mid-turn `<message>` delivery: one content door, no persistent dedupe state

Providers that stream assistant text declare `emitsMidTurnText`; for them, mid-turn streaming is the **single content door**. The final result never delivers content.

## The invariant

A `<message>` block is written to `messages_out` exactly once, at the moment the streamed text containing its closing tag is scanned — whether the block arrived whole in one text event or was **assembled from fragments** carried across events by a frame-local, turn-local buffer (unclosed opens, tag prefixes split mid-token, and unclosed `<internal` spans defer judgment; settled text is consumed exactly once). A verbatim repeat of a body already written this turn to the same destination is suppressed as an echo — detected against `messages_out` over the turn's seq window, so the delivery record itself is the dedupe authority; no content-keyed state lives in process memory.

The result door keeps exactly two jobs:

1. **Errors**: a blockless error result is surfaced via `deliverErrorResult` as before.
2. **The nudge decision**: if the turn delivered nothing — zero door deliveries *and* zero chat rows written to `outbound.db` since the turn boundary (which also accounts for MCP `send_message`) — while the result still carries content, the wrap-nudge fires once so the model re-sends and the retry streams through the mid-turn door.

Every streaming-door miss — SDK drift with zero text events, an `errors[]`-carried block, a destination appearing only between stream time and result time, a block that never closes anywhere — degrades to **nudge-and-retry, never a direct result-door send**. Providers without the capability keep the previous result-door behavior unchanged.

## Grounding: recorded live SDK behavior

The design premise (result text is a verbatim replay of the *last* streamed assistant segment) was verified against the pinned `@anthropic-ai/claude-agent-sdk` with a live capture battery — 16 scenarios including a tool call between a block's open and close tags, a three-way split across two tool calls, unclosed blocks, verbatim-repeat echoes, and mid-stream aborts. The result matched the last streamed segment exactly in every completed turn. The most probative recordings are committed as replayable fixtures (`src/providers/__fixtures__/sdk-midturn-recordings.json`) with a containment-invariant test across all of them, so the observed contract is pinned in CI without live API calls. The capture harness ships under `scripts/sdk-capture/` for future re-runs.

Because the result replays only the last segment, a block split across segments is never healed by the result — assembly at the streaming door is the only correct recovery, and the wrap-nudge's remaining job narrows to blocks that never close anywhere.

## Known residual (deliberate)

Cross-process same-turn double-post via the `send_message` MCP tool *plus* a `<message>` block with different content remains out of scope; cross-process idempotency follows separately. The spurious-nudge duplicate path (tool send invisible to the poll loop → nudge → re-send) is closed here by the DB-based nudge gate.

---
Independent trunk improvement; no dependency on other open PRs. Note: touches `container/agent-runner/src/providers/claude.ts`, which #2941 also modifies in a different region — whichever merges second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
