### PR TITLE
Add webchat channel: local browser chat via native HTTP bridge

### DIFF
--- a/.claude/skills/add-webchat/REMOVE.md
+++ b/.claude/skills/add-webchat/REMOVE.md
@@ -1,0 +1,44 @@
+# Remove Web Chat Channel
+
+Reverses everything `/add-webchat` applied. Safe to run partially — every step
+is a no-op if the thing is already gone.
+
+## 1. Unwire the channel (host service running)
+
+```bash
+pnpm run ncl wirings list          # find the wiring for the webchat messaging group
+pnpm run ncl wirings delete <wiring-id>
+pnpm run ncl messaging-groups list # find the webchat messaging group
+pnpm run ncl messaging-groups delete <mg-id>
+```
+
+## 2. Remove the source files
+
+```bash
+rm -f src/channels/webchat.ts src/channels/webchat.test.ts src/channels/webchat-registration.test.ts
+```
+
+## 3. Remove the barrel import
+
+Delete this line from `src/channels/index.ts`:
+
+```typescript
+import './webchat.js';
+```
+
+## 4. Remove the .env entries
+
+Delete the `WEBCHAT_ENABLED`, `WEBCHAT_CHANNEL_PORT`, `WEBCHAT_AUTH_TOKEN`,
+and `WEBCHAT_PLATFORM_ID` lines from `.env`.
+
+## 5. Rebuild and restart
+
+```bash
+pnpm run build
+systemctl --user restart <your-nanoclaw-unit>   # or launchctl on macOS
+```
+
+## Verify removal
+
+`pnpm exec vitest run src/channels/` passes with no webchat files, and
+`curl http://127.0.0.1:8767/` refuses to connect after the restart.

--- a/.claude/skills/add-webchat/SKILL.md
+++ b/.claude/skills/add-webchat/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: add-webchat
+description: Add a local browser chat as a channel. Serves a self-contained chat page on localhost — persistent GUI conversation with your agent, no bot token, no external service, no phone.
+---
+
+# Add Web Chat Channel
+
+Adds a local browser chat via a native HTTP bridge. The daemon serves a single
+self-contained page (no assets, no framework) plus a JSON API on
+`127.0.0.1:8767`. On Windows/WSL2, localhost forwarding makes it reachable from
+a normal Windows browser tab.
+
+## What you can do with this
+
+- **Persistent GUI conversation** — a real chat window: history on screen, Enter to send, replies appear as they arrive (1s poll)
+- **No pairing** — unlike Telegram/WhatsApp channels there is no bot to create and no QR to scan
+- **Same conversation everywhere** — wired `agent-shared`, the browser continues the same session as the CLI channel
+
+## Install
+
+NanoClaw doesn't ship channels in trunk. This skill copies the webchat adapter
+in from the `channels` branch. Native HTTP bridge — no Chat SDK, no adapter
+package, Node builtins only.
+
+### Pre-flight (idempotent)
+
+Skip to **Enable** if all of these are already in place:
+
+- `src/channels/webchat.ts` exists
+- `src/channels/webchat.test.ts` exists
+- `src/channels/webchat-registration.test.ts` exists
+- `src/channels/index.ts` contains `import './webchat.js';`
+
+Otherwise continue. Every step below is safe to re-run.
+
+### 1. Fetch the channels branch
+
+```bash
+git fetch origin channels
+```
+
+### 2. Copy the adapter and tests
+
+```bash
+git show origin/channels:src/channels/webchat.ts                   > src/channels/webchat.ts
+git show origin/channels:src/channels/webchat.test.ts              > src/channels/webchat.test.ts
+git show origin/channels:src/channels/webchat-registration.test.ts > src/channels/webchat-registration.test.ts
+```
+
+### 3. Append the self-registration import
+
+Append to `src/channels/index.ts` (skip if the line is already present):
+
+```typescript
+import './webchat.js';
+```
+
+### 4. Build and validate
+
+```bash
+pnpm run build
+pnpm exec vitest run src/channels/webchat.test.ts src/channels/webchat-registration.test.ts
+```
+
+Both must be clean before proceeding. `webchat-registration.test.ts` is the one
+integration test: it imports the real channel barrel and asserts the registry
+contains `webchat` — red if the barrel import is deleted or drifts, or if the
+barrel fails to evaluate. The adapter uses only Node builtins (`http`), so
+there is no npm dependency to guard for this channel.
+
+## Enable
+
+The adapter is gated by `WEBCHAT_ENABLED` so the port isn't opened on hosts
+that don't want it. Add to `.env`:
+
+```bash
+WEBCHAT_ENABLED=true
+WEBCHAT_CHANNEL_PORT=8767     # optional — change only if 8767 is taken
+WEBCHAT_AUTH_TOKEN=           # recommended — random string; gates the JSON API
+WEBCHAT_PLATFORM_ID=default   # optional — only change for a non-default chat id
+```
+
+Generate a token (recommended even on single-user machines — prevents other
+local processes from poking the endpoint; the page itself is served without
+auth and holds no secrets):
+
+```bash
+node -e "console.log(require('crypto').randomBytes(16).toString('hex'))"
+```
+
+Restart the host service afterwards.
+
+## Wire the channel
+
+Web chat is a single-user, single-chat channel: one adapter instance = one
+messaging group with `platform_id = "default"` (override with
+`WEBCHAT_PLATFORM_ID`).
+
+### If this is your first agent group
+
+Run `/init-first-agent` — pick **Web Chat** as the channel and the skill will
+create the agent group, wire the channel, and deliver a welcome message to the
+browser page.
+
+### Otherwise — wire to an existing agent group
+
+With the host service running (`ncl` connects to it over a Unix socket):
+
+```bash
+ncl messaging-groups create --channel-type webchat --platform-id "default" --name "Web Chat"
+ncl wirings create --messaging-group-id <mg-id-from-above> --agent-group-id <ag-id> \
+  --session-mode agent-shared
+```
+
+`agent-shared` puts browser messages in the same session as any other channel
+wired to the same agent group — a conversation you started in Telegram
+continues in the browser. Use `shared` for an independent browser thread, or a
+new agent group for a dedicated web-only agent.
+
+## Verify
+
+Open `http://localhost:<port>/?token=<your token>` in a browser and send a
+message. The header shows `connected` when the poll succeeds; the reply
+arrives as a chat bubble. First message after idle may take ~30–60s (container
+cold start); subsequent replies are seconds.
+
+## Troubleshooting
+
+- **Page loads, replies never arrive** — check the wiring exists
+  (`ncl messaging-groups list`) and tail `logs/nanoclaw.log` for
+  `Message routed` / `Message delivered` lines with `channelType="webchat"`.
+- **`unauthorized` in the header** — the `?token=` query param doesn't match
+  `WEBCHAT_AUTH_TOKEN` in `.env`.
+- **Port in use** — change `WEBCHAT_CHANNEL_PORT` and restart the service.

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -7,3 +7,4 @@
 // self-registration import below.
 
 import './cli.js';
+import './webchat.js';

--- a/src/channels/webchat-registration.test.ts
+++ b/src/channels/webchat-registration.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Integration test for the webchat channel's single reach-in: the self-registration
+ * import in the `src/channels/index.ts` barrel. Importing the barrel runs webchat.ts's
+ * top-level `registerChannelAdapter('webchat', …)`; without the import the channel is
+ * silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel — red if `import './webchat.js';` is deleted or the
+ * barrel fails to evaluate (so the channel genuinely would not register).
+ *
+ * webchat is a native adapter with no npm dependency (Node http builtin only); it
+ * serves its own browser client. Importing the barrel is safe: registration is a pure
+ * top-level call and webchat.ts opens its listener only inside setup() (run at host
+ * startup), never at import.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('webchat channel registration', () => {
+  it('registers webchat via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('webchat');
+  });
+});

--- a/src/channels/webchat.test.ts
+++ b/src/channels/webchat.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the v2 webchat channel adapter.
+ *
+ * Exercises the HTTP surface (GET /, POST /api/message, GET /api/messages),
+ * bearer-token auth, and the ChannelAdapter lifecycle (setup / teardown /
+ * isConnected / deliver). Mirrors the emacs adapter's test conventions.
+ */
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createWebchatAdapter } from './webchat.js';
+import type { ChannelAdapter, ChannelSetup } from './adapter.js';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function makeSetup(overrides: Partial<ChannelSetup> = {}): ChannelSetup {
+  return {
+    onInbound: vi.fn(),
+    onInboundEvent: vi.fn(),
+    onMetadata: vi.fn(),
+    onAction: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Ask the OS for a free port, then immediately release it. Small race window
+ * before the adapter grabs it, but sufficient for local test use. */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = http.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function req(
+  port: number,
+  method: string,
+  path: string,
+  body?: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ status: number; data: unknown }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...extraHeaders };
+    const request = http.request({ host: '127.0.0.1', port, method, path, headers }, (res) => {
+      let raw = '';
+      res.on('data', (chunk: Buffer) => (raw += chunk.toString()));
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode!, data: JSON.parse(raw) });
+        } catch {
+          resolve({ status: res.statusCode!, data: raw });
+        }
+      });
+    });
+    request.on('error', reject);
+    if (body) request.write(body);
+    request.end();
+  });
+}
+
+describe('webchat adapter', () => {
+  let adapter: ChannelAdapter;
+  let port: number;
+
+  beforeEach(async () => {
+    port = await getFreePort();
+    adapter = createWebchatAdapter({ port, authToken: null, platformId: 'default' });
+  });
+
+  afterEach(async () => {
+    if (adapter.isConnected()) await adapter.teardown();
+  });
+
+  describe('lifecycle', () => {
+    it('isConnected is false before setup', () => {
+      expect(adapter.isConnected()).toBe(false);
+    });
+
+    it('isConnected is true after setup', async () => {
+      await adapter.setup(makeSetup());
+      expect(adapter.isConnected()).toBe(true);
+    });
+
+    it('isConnected is false after teardown', async () => {
+      await adapter.setup(makeSetup());
+      await adapter.teardown();
+      expect(adapter.isConnected()).toBe(false);
+    });
+
+    it('teardown is a no-op before setup', async () => {
+      await expect(adapter.teardown()).resolves.not.toThrow();
+    });
+
+    it('calls onMetadata after setup with channel name', async () => {
+      const onMetadata = vi.fn();
+      await adapter.setup(makeSetup({ onMetadata }));
+      expect(onMetadata).toHaveBeenCalledWith('default', 'Web Chat', false);
+    });
+  });
+
+  describe('GET / (chat page)', () => {
+    beforeEach(async () => {
+      await adapter.setup(makeSetup());
+    });
+
+    it('serves the chat UI', async () => {
+      const { status, data } = await req(port, 'GET', '/');
+      expect(status).toBe(200);
+      expect(String(data)).toContain('<!doctype html');
+      expect(String(data)).toContain('NanoClaw');
+    });
+
+    it('serves the page at /index.html too', async () => {
+      const { status } = await req(port, 'GET', '/index.html');
+      expect(status).toBe(200);
+    });
+  });
+
+  describe('POST /api/message', () => {
+    let onInbound: ChannelSetup['onInbound'] & { mock: { calls: unknown[][] } };
+
+    beforeEach(async () => {
+      onInbound = vi.fn() as unknown as typeof onInbound;
+      await adapter.setup(makeSetup({ onInbound }));
+    });
+
+    it('fires onInbound with chat kind and sender metadata', async () => {
+      const { status, data } = await req(port, 'POST', '/api/message', JSON.stringify({ text: 'hello' }));
+      expect(status).toBe(200);
+      expect((data as { messageId: string }).messageId).toMatch(/^webchat-/);
+      expect(onInbound).toHaveBeenCalledOnce();
+      const [platformId, threadId, msg] = onInbound.mock.calls[0] as [string, string | null, { content: unknown }];
+      expect(platformId).toBe('default');
+      expect(threadId).toBeNull();
+      expect(msg).toMatchObject({
+        kind: 'chat',
+        content: { text: 'hello', sender: 'Web', senderId: 'webchat:default' },
+      });
+    });
+
+    it('returns 400 for empty text', async () => {
+      const { status } = await req(port, 'POST', '/api/message', JSON.stringify({ text: '' }));
+      expect(status).toBe(400);
+      expect(onInbound).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid JSON', async () => {
+      const { status } = await req(port, 'POST', '/api/message', 'not-json');
+      expect(status).toBe(400);
+    });
+
+    it('returns 404 for unknown paths', async () => {
+      const { status } = await req(port, 'POST', '/api/unknown', JSON.stringify({ text: 'hi' }));
+      expect(status).toBe(404);
+    });
+  });
+
+  describe('GET /api/messages + deliver', () => {
+    beforeEach(async () => {
+      await adapter.setup(makeSetup());
+    });
+
+    it('returns empty buffer initially', async () => {
+      const { status, data } = await req(port, 'GET', '/api/messages?since=0');
+      expect(status).toBe(200);
+      expect(data).toEqual({ messages: [] });
+    });
+
+    it('deliver pushes text for the poll endpoint to return', async () => {
+      await adapter.deliver('default', null, { kind: 'chat', content: { text: 'reply' } });
+      const { data } = await req(port, 'GET', '/api/messages?since=0');
+      const messages = (data as { messages: { text: string; timestamp: number }[] }).messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.text).toBe('reply');
+      expect(typeof messages[0]?.timestamp).toBe('number');
+    });
+
+    it('since filters out already-seen messages', async () => {
+      await adapter.deliver('default', null, { kind: 'chat', content: { text: 'old' } });
+      const future = Date.now() + 60_000;
+      const { data } = await req(port, 'GET', `/api/messages?since=${future}`);
+      expect(data).toEqual({ messages: [] });
+    });
+
+    it('deliver returns undefined for an unknown platformId', async () => {
+      const id = await adapter.deliver('other', null, { kind: 'chat', content: { text: 'x' } });
+      expect(id).toBeUndefined();
+    });
+  });
+
+  describe('auth', () => {
+    beforeEach(async () => {
+      await adapter.teardown();
+      adapter = createWebchatAdapter({ port, authToken: 'sekrit', platformId: 'default' });
+      await adapter.setup(makeSetup());
+    });
+
+    it('serves the page without auth (it holds no secrets)', async () => {
+      const { status } = await req(port, 'GET', '/');
+      expect(status).toBe(200);
+    });
+
+    it('rejects API calls without the bearer token', async () => {
+      const post = await req(port, 'POST', '/api/message', JSON.stringify({ text: 'hi' }));
+      expect(post.status).toBe(401);
+      const poll = await req(port, 'GET', '/api/messages?since=0');
+      expect(poll.status).toBe(401);
+    });
+
+    it('accepts API calls with the bearer token', async () => {
+      const headers = { Authorization: 'Bearer sekrit' };
+      const post = await req(port, 'POST', '/api/message', JSON.stringify({ text: 'hi' }), headers);
+      expect(post.status).toBe(200);
+      const poll = await req(port, 'GET', '/api/messages?since=0', undefined, headers);
+      expect(poll.status).toBe(200);
+    });
+  });
+});

--- a/src/channels/webchat.ts
+++ b/src/channels/webchat.ts
@@ -1,0 +1,336 @@
+/**
+ * Web Chat channel adapter (v2) — native local browser chat.
+ *
+ * Serves a self-contained chat page and a JSON API on localhost:
+ *  - GET  /                        — the chat UI (single inline HTML page, no assets)
+ *  - POST /api/message             — user sent a message from the page; fires onInbound
+ *  - GET  /api/messages?since=<ms> — page polls for agent replies
+ *
+ * Single-user, single-chat: one adapter instance = one messaging group with
+ * `platform_id = "default"` (override with WEBCHAT_PLATFORM_ID). No threads,
+ * no cold DM. Self-registers on import. Modeled on the emacs channel — the
+ * other local, credential-free HTTP bridge; the page is served without auth
+ * (it holds no secrets), the API requires the bearer token when one is set.
+ */
+import http from 'http';
+
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { registerChannelAdapter } from './channel-registry.js';
+import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
+
+const OUTBOUND_BUFFER_MAX = 200;
+
+/**
+ * Single-operator localhost transport: every line is for the agent (pattern
+ * '.'), and possession of the port + bearer token is the operator gate, the
+ * same trust class as the CLI channel's 0600 socket — hence 'public'.
+ */
+const WEBCHAT_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'public' },
+  group: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'public' },
+  mentions: 'never',
+};
+
+interface BufferedMessage {
+  text: string;
+  timestamp: number;
+}
+
+interface WebchatAdapterOptions {
+  port: number;
+  authToken: string | null;
+  platformId: string;
+}
+
+function createWebchatAdapter(opts: WebchatAdapterOptions): ChannelAdapter {
+  let server: http.Server | null = null;
+  let setupConfig: ChannelSetup | null = null;
+  const outboundBuffer: BufferedMessage[] = [];
+
+  function checkAuth(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+    if (!opts.authToken) return true;
+    if (req.headers['authorization'] === `Bearer ${opts.authToken}`) return true;
+    res
+      .writeHead(401, { 'Content-Type': 'application/json; charset=utf-8' })
+      .end(JSON.stringify({ error: 'Unauthorized' }));
+    return false;
+  }
+
+  function handlePost(req: http.IncomingMessage, res: http.ServerResponse): void {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      let text: string;
+      try {
+        const parsed = JSON.parse(body) as { text?: string };
+        text = parsed.text ?? '';
+      } catch {
+        res
+          .writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' })
+          .end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      if (!text.trim()) {
+        res
+          .writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' })
+          .end(JSON.stringify({ error: 'text required' }));
+        return;
+      }
+
+      const timestamp = new Date().toISOString();
+      const id = `webchat-${Date.now()}`;
+
+      const inbound: InboundMessage = {
+        id,
+        kind: 'chat',
+        content: {
+          text,
+          sender: 'Web',
+          senderId: `webchat:${opts.platformId}`,
+        },
+        timestamp,
+      };
+
+      try {
+        setupConfig?.onInbound(opts.platformId, null, inbound);
+      } catch (err) {
+        log.error('Webchat onInbound failed', { err });
+      }
+
+      res
+        .writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' })
+        .end(JSON.stringify({ messageId: id, timestamp: Date.now() }));
+    });
+  }
+
+  function handlePoll(url: URL, res: http.ServerResponse): void {
+    const since = parseInt(url.searchParams.get('since') ?? '0', 10);
+    const messages = outboundBuffer.filter((m) => m.timestamp > since);
+    res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' }).end(JSON.stringify({ messages }));
+  }
+
+  function handlePage(res: http.ServerResponse): void {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }).end(PAGE);
+  }
+
+  return {
+    name: 'webchat',
+    channelType: 'webchat',
+    supportsThreads: false,
+    defaults: WEBCHAT_DEFAULTS,
+
+    async setup(config: ChannelSetup): Promise<void> {
+      setupConfig = config;
+
+      server = http.createServer((req, res) => {
+        const url = new URL(req.url ?? '/', `http://localhost:${opts.port}`);
+        if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
+          handlePage(res); // no auth: static page, holds no secrets
+        } else if (req.method === 'POST' && url.pathname === '/api/message') {
+          if (!checkAuth(req, res)) return;
+          handlePost(req, res);
+        } else if (req.method === 'GET' && url.pathname === '/api/messages') {
+          if (!checkAuth(req, res)) return;
+          handlePoll(url, res);
+        } else {
+          res
+            .writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' })
+            .end(JSON.stringify({ error: 'Not found' }));
+        }
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server!.once('error', reject);
+        server!.listen(opts.port, '127.0.0.1', () => {
+          log.info('Webchat channel listening', { port: opts.port, platformId: opts.platformId });
+          resolve();
+        });
+      });
+
+      // Stamp a human-readable name on the messaging_groups row on first boot.
+      config.onMetadata(opts.platformId, 'Web Chat', false);
+    },
+
+    async teardown(): Promise<void> {
+      if (!server) return;
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = null;
+      log.info('Webchat channel stopped');
+    },
+
+    isConnected(): boolean {
+      return server?.listening ?? false;
+    },
+
+    async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
+      if (platformId !== opts.platformId) {
+        log.warn('Webchat deliver called with unknown platformId', { platformId });
+        return undefined;
+      }
+      const text = extractText(message.content);
+      if (!text) return undefined;
+
+      const id = `webchat-out-${Date.now()}`;
+      outboundBuffer.push({ text, timestamp: Date.now() });
+      while (outboundBuffer.length > OUTBOUND_BUFFER_MAX) outboundBuffer.shift();
+      return id;
+    },
+  };
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (content && typeof content === 'object') {
+    const c = content as { text?: unknown };
+    if (typeof c.text === 'string') return c.text;
+  }
+  return '';
+}
+
+/**
+ * The chat UI. One inline page, no external assets (survives tsc: it lives
+ * in the module, not beside it). Deliberately backtick- and `${}`-free so it
+ * can sit inside this template literal without escaping games.
+ */
+const PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>NanoClaw</title>
+<style>
+  :root { color-scheme: light dark;
+    --bg: #f5f5f4; --fg: #1c1917; --card: #ffffff; --accent: #b45309; --muted: #78716c; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #1c1917; --fg: #e7e5e4; --card: #292524; --accent: #f59e0b; --muted: #a8a29e; }
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: var(--bg); color: var(--fg);
+    font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+    display: flex; flex-direction: column; height: 100dvh; }
+  header { padding: 10px 16px; border-bottom: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
+    display: flex; align-items: baseline; gap: 10px; }
+  header h1 { font-size: 15px; font-weight: 600; }
+  header span { font-size: 12px; color: var(--muted); }
+  #log { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+  .msg { max-width: 72%; padding: 8px 12px; border-radius: 12px; white-space: pre-wrap; word-wrap: break-word; }
+  .you { align-self: flex-end; background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
+  .claw { align-self: flex-start; background: var(--card); border-bottom-left-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0,0,0,.08); }
+  .sys { align-self: center; color: var(--muted); font-size: 12px; }
+  form { display: flex; gap: 8px; padding: 12px 16px;
+    border-top: 1px solid color-mix(in srgb, var(--fg) 12%, transparent); }
+  textarea { flex: 1; resize: none; border: 1px solid color-mix(in srgb, var(--fg) 18%, transparent);
+    border-radius: 10px; padding: 9px 12px; font: inherit; background: var(--card); color: var(--fg);
+    max-height: 40dvh; }
+  textarea:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+  button { border: 0; border-radius: 10px; padding: 0 18px; background: var(--accent); color: #fff;
+    font: inherit; font-weight: 600; cursor: pointer; }
+  button:disabled { opacity: .5; cursor: default; }
+</style>
+</head>
+<body>
+<header><h1>NanoClaw</h1><span id="status">connecting…</span></header>
+<div id="log"></div>
+<form id="composer">
+  <textarea id="input" rows="1" placeholder="Message… (Enter to send, Shift+Enter for newline)" autofocus></textarea>
+  <button id="send" type="submit">Send</button>
+</form>
+<script>
+(function () {
+  var token = new URLSearchParams(location.search).get('token');
+  var log = document.getElementById('log');
+  var input = document.getElementById('input');
+  var form = document.getElementById('composer');
+  var status = document.getElementById('status');
+  var since = Date.now();
+  var pending = null;
+
+  function headers(json) {
+    var h = {};
+    if (json) h['Content-Type'] = 'application/json';
+    if (token) h['Authorization'] = 'Bearer ' + token;
+    return h;
+  }
+
+  function add(cls, text) {
+    var el = document.createElement('div');
+    el.className = 'msg ' + cls;
+    el.textContent = text;
+    log.appendChild(el);
+    log.scrollTop = log.scrollHeight;
+    return el;
+  }
+
+  function setPending() {
+    if (!pending) pending = add('sys', 'thinking…');
+  }
+  function clearPending() {
+    if (pending) { pending.remove(); pending = null; }
+  }
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    var text = input.value.trim();
+    if (!text) return;
+    input.value = '';
+    add('you', text);
+    setPending();
+    fetch('/api/message', { method: 'POST', headers: headers(true), body: JSON.stringify({ text: text }) })
+      .then(function (r) {
+        if (r.status === 401) { clearPending(); add('sys', 'unauthorized — reopen the page with ?token=<your token>'); }
+      })
+      .catch(function () { clearPending(); add('sys', 'send failed — is the service running?'); });
+  });
+
+  input.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      form.requestSubmit();
+    }
+  });
+
+  function poll() {
+    fetch('/api/messages?since=' + since, { headers: headers(false) })
+      .then(function (r) {
+        if (r.status === 401) { status.textContent = 'unauthorized'; return null; }
+        status.textContent = 'connected';
+        return r.json();
+      })
+      .then(function (data) {
+        if (!data || !data.messages) return;
+        data.messages.forEach(function (m) {
+          clearPending();
+          add('claw', m.text);
+          if (m.timestamp > since) since = m.timestamp;
+        });
+      })
+      .catch(function () { status.textContent = 'disconnected'; });
+  }
+  setInterval(poll, 1000);
+  poll();
+})();
+</script>
+</body>
+</html>
+`;
+
+registerChannelAdapter('webchat', {
+  factory: () => {
+    const env = readEnvFile(['WEBCHAT_ENABLED', 'WEBCHAT_CHANNEL_PORT', 'WEBCHAT_AUTH_TOKEN', 'WEBCHAT_PLATFORM_ID']);
+    const enabled = process.env.WEBCHAT_ENABLED || env.WEBCHAT_ENABLED;
+    if (!enabled || enabled === 'false') return null;
+
+    const portStr = process.env.WEBCHAT_CHANNEL_PORT || env.WEBCHAT_CHANNEL_PORT || '8767';
+    const port = parseInt(portStr, 10);
+    const authToken = process.env.WEBCHAT_AUTH_TOKEN || env.WEBCHAT_AUTH_TOKEN || null;
+    const platformId = process.env.WEBCHAT_PLATFORM_ID || env.WEBCHAT_PLATFORM_ID || 'default';
+
+    return createWebchatAdapter({ port, authToken, platformId });
+  },
+  defaults: WEBCHAT_DEFAULTS,
+});
+
+export { createWebchatAdapter };


### PR DESCRIPTION
## What

A new channel: **webchat** — a local browser chat served by the daemon itself. One self-contained page (no assets, no framework, no npm dependency) plus a JSON API on `127.0.0.1`, Node `http` builtin only.

Today every conversational surface except the one-shot CLI routes through an external messaging service. This fills the gap between `pnpm run chat` (fire-and-exit) and pairing a messenger: a persistent GUI conversation with history on screen — no bot token, no QR, no phone. On Windows/WSL2 installs, localhost forwarding puts the page in a normal Windows browser tab.

## Design

Follows the emacs adapter — the existing local, credential-free HTTP bridge:

- Self-registering module + one appended barrel import + registration test that imports the real barrel
- Env-gated (`WEBCHAT_ENABLED`) so the port is never opened unless asked
- `GET /` serves the chat UI (unauthenticated — the page holds no secrets); `POST /api/message` and `GET /api/messages?since=<ms>` require the bearer token when `WEBCHAT_AUTH_TOKEN` is set
- Outbound buffer + 1s poll, same shape as the emacs adapter's poll surface
- Channel defaults: pattern `.`, no threads, `unknownSenderPolicy: 'public'` — possession of the localhost port + token is the operator gate, the same trust class as the CLI channel's 0600 socket

## Skill

`.claude/skills/add-webchat/` follows the registry fetch-and-copy shape (`git show origin/channels:…`) for the code portion to land on the `channels` branch, with a `REMOVE.md` that reverses every step. Wiring docs cover both `/init-first-agent` and `ncl` against an existing agent group, with `agent-shared` as the recommended session mode.

## Testing

- 18 behavior tests: lifecycle, page serving, inbound POST validation, poll filtering, bearer auth (page open / API 401 / API 200), deliver targeting
- 1 registration test guarding the barrel import
- Full `src/channels/` suite: 103/103 passing
- Verified end-to-end on a live install (WSL2/Ubuntu, Docker Desktop): message → router → agent container → reply rendered in the browser, sharing a session with the CLI channel via `agent-shared`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
