### PR TITLE
fix: bound pending message polling

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -203,6 +203,7 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
       content        TEXT NOT NULL,
       on_wake        INTEGER NOT NULL DEFAULT 0
     );
+    CREATE INDEX idx_messages_in_poll ON messages_in(status, trigger, seq);
     CREATE TABLE delivered (
       message_out_id      TEXT PRIMARY KEY,
       platform_message_id TEXT,

--- a/container/agent-runner/src/db/messages-in.test.ts
+++ b/container/agent-runner/src/db/messages-in.test.ts
@@ -9,8 +9,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
-import { initTestSessionDb, closeSessionDb, getInboundDb } from './connection.js';
-import { getPendingMessages, markProcessing } from './messages-in.js';
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './connection.js';
+import { getPendingMessages, markCompleted, markProcessing } from './messages-in.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -110,13 +110,35 @@ describe('claimed-but-unsynced rows never hide new work', () => {
   // window, the filter empties it, and newer rows are invisible all turn.
   it('a new message arriving after a full claimed batch is returned immediately', () => {
     const claimed: string[] = [];
-    for (let i = 1; i <= CAP; i++) {
+    for (let i = 1; i <= CAP * 2; i++) {
       insertMessage(`claimed-${i}`, i * 2, 'chat', { sender: 'A', text: `msg ${i}` });
       claimed.push(`claimed-${i}`);
     }
     markProcessing(claimed);
 
-    insertMessage('fresh', (CAP + 1) * 2, 'chat', { sender: 'A', text: 'follow-up' });
+    insertMessage('fresh', (CAP * 2 + 1) * 2, 'chat', { sender: 'A', text: 'follow-up' });
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['fresh']);
+  });
+
+  it('never redelivers a completed ack whose inbound row is still pending', () => {
+    insertMessage('done', 2, 'chat', { sender: 'A', text: 'already handled' });
+    markCompleted(['done']);
+    getOutboundDb()
+      .prepare("UPDATE processing_ack SET status_changed = '2000-01-01T00:00:00.000Z' WHERE message_id = 'done'")
+      .run();
+    insertMessage('fresh', 4, 'chat', { sender: 'A', text: 'new work' });
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['fresh']);
+  });
+
+  it('never redelivers a stale processing ack', () => {
+    insertMessage('claimed-old', 2, 'chat', { sender: 'A', text: 'still running' });
+    markProcessing(['claimed-old']);
+    getOutboundDb()
+      .prepare("UPDATE processing_ack SET status_changed = '2000-01-01T00:00:00.000Z' WHERE message_id = 'claimed-old'")
+      .run();
+    insertMessage('fresh', 4, 'chat', { sender: 'A', text: 'new work' });
 
     expect(getPendingMessages().map((m) => m.id)).toEqual(['fresh']);
   });
@@ -144,6 +166,35 @@ describe('claimed-but-unsynced rows never hide new work', () => {
     insertContextRow('ctx-new', 102, 'fresh ambient');
 
     expect(getPendingMessages().map((m) => m.id)).toEqual(['chat-new', 'ctx-new']);
+  });
+});
+
+describe('context backlog draining', () => {
+  it('drains newest blocks first across repeated wakes', () => {
+    for (let i = 1; i <= 30; i++) {
+      insertContextRow(`ctx-${i}`, i * 2, `ambient ${i}`);
+    }
+
+    const contextByWake: string[][] = [];
+    for (let wake = 1; wake <= 4; wake++) {
+      const wakeId = `wake-${wake}`;
+      insertMessage(wakeId, 100 + wake * 2, 'chat', { sender: 'A', text: `wake ${wake}` });
+      const batch = getPendingMessages();
+      contextByWake.push(batch.filter((m) => m.trigger === 0).map((m) => m.id));
+
+      const placeholders = batch.map(() => '?').join(', ');
+      getInboundDb()
+        .prepare(`UPDATE messages_in SET status = 'completed' WHERE id IN (${placeholders})`)
+        .run(...batch.map((m) => m.id));
+    }
+
+    expect(contextByWake).toEqual([
+      ['ctx-22', 'ctx-23', 'ctx-24', 'ctx-25', 'ctx-26', 'ctx-27', 'ctx-28', 'ctx-29', 'ctx-30'],
+      ['ctx-13', 'ctx-14', 'ctx-15', 'ctx-16', 'ctx-17', 'ctx-18', 'ctx-19', 'ctx-20', 'ctx-21'],
+      ['ctx-4', 'ctx-5', 'ctx-6', 'ctx-7', 'ctx-8', 'ctx-9', 'ctx-10', 'ctx-11', 'ctx-12'],
+      ['ctx-1', 'ctx-2', 'ctx-3'],
+    ]);
+    expect(getPendingMessages()).toHaveLength(0);
   });
 });
 

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -65,12 +65,12 @@ function getMaxMessagesPerPrompt(): number {
  * order (oldest first). Host's countDueMessages gates waking on trigger=1
  * separately (see src/db/session-db.ts).
  *
- * ORDER MATTERS: the processing_ack filter runs BEFORE the cap windowing.
  * Rows this container already claimed stay status='pending' in inbound.db
- * until the host sweep syncs the ack back (up to ~60s) — windowing first
- * would let a cap-sized batch of those claimed rows fill the window, the
- * ack filter would then empty it, and genuinely new rows beyond the window
- * would be invisible for the rest of the turn.
+ * until the host sweep syncs the ack back. Each phase therefore reads a
+ * bounded window of `cap + ackedIds.size`: even if every acknowledged row
+ * appears in that window, enough room remains for a full unclaimed batch.
+ * The complete ack set is required here — age-based filtering can redeliver
+ * completed rows when the host sweep is delayed or fails.
  */
 export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
   const inbound = openInboundDb();
@@ -79,30 +79,39 @@ export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
   try {
     const cap = getMaxMessagesPerPrompt();
     const hasOnWake = hasOnWakeColumn(inbound);
-    const stmt = inbound.prepare(
-      `SELECT * FROM messages_in
-       WHERE status = 'pending'
-         AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
-         ${hasOnWake ? 'AND (on_wake = 0 OR ?1 = 1)' : ''}
-       ORDER BY seq ASC`,
-    );
-    const due = (hasOnWake ? stmt.all(isFirstPoll ? 1 : 0) : stmt.all()) as MessageInRow[];
-    if (due.length === 0) return [];
-
-    // Drop rows already acknowledged in outbound.db (claimed by this or a
-    // previous container run) BEFORE windowing — see the doc comment above.
     const ackedIds = new Set(
       (outbound.prepare('SELECT message_id FROM processing_ack').all() as Array<{ message_id: string }>).map(
         (r) => r.message_id,
       ),
     );
-    const unclaimed = due.filter((m) => !ackedIds.has(m.id));
+    const window = cap + ackedIds.size;
+
+    const selectPhase = (trigger: 0 | 1, order: 'ASC' | 'DESC'): MessageInRow[] => {
+      const stmt = inbound.prepare(
+        `SELECT * FROM messages_in
+         WHERE status = 'pending'
+           AND trigger = ?1
+           AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
+           ${hasOnWake ? 'AND (on_wake = 0 OR ?2 = 1)' : ''}
+         ORDER BY seq ${order}
+         LIMIT ${hasOnWake ? '?3' : '?2'}`,
+      );
+      return (hasOnWake ? stmt.all(trigger, isFirstPoll ? 1 : 0, window) : stmt.all(trigger, window)) as MessageInRow[];
+    };
 
     // Phase 1: wake-eligible rows, oldest-first — these always make the batch.
-    const wakeRows = unclaimed.filter((m) => m.trigger === 1).slice(0, cap);
+    const wakeRows = selectPhase(1, 'ASC')
+      .filter((m) => !ackedIds.has(m.id))
+      .slice(0, cap);
     // Phase 2: fill remaining slots with the NEWEST context-only rows.
     const remaining = cap - wakeRows.length;
-    const contextRows = remaining > 0 ? unclaimed.filter((m) => m.trigger === 0).slice(-remaining) : [];
+    const contextRows =
+      remaining > 0
+        ? selectPhase(0, 'DESC')
+            .filter((m) => !ackedIds.has(m.id))
+            .slice(0, remaining)
+            .reverse()
+        : [];
 
     // Merge oldest-first. JS sort is stable, so ties (null seq in tests)
     // keep wake rows ahead of context rows.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -190,6 +190,7 @@ CREATE TABLE IF NOT EXISTS messages_in (
                -- Dying containers (past first poll) skip these rows.
 );
 CREATE INDEX IF NOT EXISTS idx_messages_in_series ON messages_in(series_id);
+CREATE INDEX IF NOT EXISTS idx_messages_in_poll ON messages_in(status, trigger, seq);
 
 -- Host tracks delivery outcomes for messages_out IDs.
 -- Avoids writing to outbound.db (container-owned).

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -53,6 +53,10 @@ describe('migrateMessagesInTable', () => {
       series_id: string;
     };
     expect(row.series_id).toBe('legacy-1');
+    const indexes = (db.prepare("PRAGMA index_list('messages_in')").all() as Array<{ name: string }>).map(
+      (index) => index.name,
+    );
+    expect(indexes).toContain('idx_messages_in_poll');
     db.close();
   });
 

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -332,6 +332,10 @@ export function migrateMessagesInTable(db: Database.Database): void {
     // All existing rows are normal messages, so default 0.
     db.prepare('ALTER TABLE messages_in ADD COLUMN on_wake INTEGER NOT NULL DEFAULT 0').run();
   }
+  // Supports the container's bounded wake/context selection. Keep this in
+  // the lazy migration as well as the baseline schema so existing session
+  // DBs gain the index on their next host-side open.
+  db.prepare('CREATE INDEX IF NOT EXISTS idx_messages_in_poll ON messages_in(status, trigger, seq)').run();
 }
 
 /**


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3289.

This bounds pending-message selection without weakening `processing_ack` correctness. Wake rows and accumulated-context rows are queried separately so wake work keeps priority. The poll index is added to new session DBs and migrated into existing sessions on their next host-side open.

The container currently loads every due inbound row before applying the prompt cap. In rooms that accumulate context, each poll therefore scales with the full backlog. The bounded window includes the complete `processing_ack` set because an age cutoff can redeliver completed work when the host sync is delayed. The new index lets SQLite stop after the bounded window instead of scanning the backlog.

Verified against [`nanocoai/nanoclaw@1e149b3f`](https://github.com/nanocoai/nanoclaw/commit/1e149b3f58496d5e76bc25085d7d35e6ea918117).

Verification:

- `pnpm test`: 1,518 tests passed
- `pnpm typecheck`
- `bun run typecheck`
- `bun test src/db/messages-in.test.ts src/cross-session-echo.test.ts`: 26 tests passed
- full `bun test`: 300 passed, 1 skipped, 2 failed, and 1 error in timing-sensitive poll-loop tests. The same 2 failures and 1 error occur on a clean `main` checkout, and the affected test file passed 17/17 in isolation.
- 1,000,000-row local benchmark: 0.116 ms median poll; the query plan uses `idx_messages_in_poll`

Assisted by Claude; reviewed and verified by a human before submission.
