### PR TITLE
channels: bridge inbound-policy registration seam

### DIFF
--- a/src/channels/chat-sdk-bridge-inbound-policy.test.ts
+++ b/src/channels/chat-sdk-bridge-inbound-policy.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the bridge inbound-policy registration seam.
+ *
+ * `registerBridgeInboundPolicy(channelType, wrap)` lets an installed module
+ * wrap the host's ChannelSetup for one channel type at bridge setup — the
+ * single point every inbound dispatch path (onSubscribedMessage /
+ * onNewMention / onDirectMessage / onNewMessage) reads back through — instead
+ * of editing the bridge source. Bridges whose channel type has no registered
+ * policy are unaffected.
+ *
+ * Inbound is driven through the REAL bridge path: a stub adapter captures the
+ * ChatInstance during `chat.initialize()` and pushes duck-typed messages via
+ * `chat.processMessage(...)`, so the Chat SDK's own dispatch (dedupe,
+ * pattern routing) delivers them to the bridge's handlers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Adapter } from 'chat';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import { createChatSdkBridge, registerBridgeInboundPolicy } from './chat-sdk-bridge.js';
+
+vi.mock('../webhook-server.js', () => ({
+  registerWebhookAdapter: vi.fn(),
+}));
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+/** Minimal ChatInstance surface the test drives. */
+interface ChatDriver {
+  processMessage(adapter: Adapter, threadId: string, message: unknown): Promise<void>;
+}
+
+/**
+ * Stub adapter that captures the ChatInstance at initialize so tests can
+ * push messages through the SDK's real dispatch into the bridge handlers.
+ */
+function makeStubAdapter(name: string): { adapter: Adapter; chat: () => ChatDriver } {
+  let captured: ChatDriver | null = null;
+  const adapter = {
+    name,
+    initialize: async (chat: ChatDriver) => {
+      captured = chat;
+    },
+    channelIdFromThreadId: (threadId: string) => threadId.split(':').slice(0, 2).join(':'),
+  } as unknown as Adapter;
+  return {
+    adapter,
+    chat: () => {
+      if (!captured) throw new Error('adapter not initialized — call bridge.setup() first');
+      return captured;
+    },
+  };
+}
+
+let nextMessageId = 0;
+
+/** Duck-typed Chat SDK message — the fields the SDK dispatch + bridge read. */
+function makeMessage(text: string): Record<string, unknown> {
+  const id = `msg-${++nextMessageId}`;
+  const payload = {
+    id,
+    text,
+    author: { userId: 'U123', userName: 'human', fullName: 'A Human', isBot: false, isMe: false },
+  };
+  return {
+    ...payload,
+    attachments: [],
+    isMention: false,
+    metadata: { dateSent: new Date('2026-01-01T00:00:00.000Z') },
+    raw: undefined,
+    toJSON: () => ({ ...payload }),
+  };
+}
+
+interface InboundCall {
+  platformId: string;
+  threadId: string | null;
+  message: InboundMessage;
+}
+
+function makeHostConfig(): { hostConfig: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const hostConfig: ChannelSetup = {
+    onInbound: (platformId, threadId, message) => {
+      calls.push({ platformId, threadId, message });
+    },
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { hostConfig, calls };
+}
+
+beforeEach(async () => {
+  const { initTestDb } = await import('../db/connection.js');
+  const { runMigrations } = await import('../db/migrations/index.js');
+  runMigrations(initTestDb());
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../db/connection.js');
+  closeDb();
+});
+
+// One policy for the whole file (module-level registry, one per channelType):
+// blocks messages containing BLOCK, tags everything else with the instance
+// key it was wrapped for, and records each wrap application.
+const wrapApplications: string[] = [];
+registerBridgeInboundPolicy('slack', (setup, instanceKey) => {
+  wrapApplications.push(instanceKey);
+  return {
+    ...setup,
+    onInbound(platformId, threadId, message) {
+      const content = message.content as Record<string, unknown>;
+      if (typeof content.text === 'string' && content.text.includes('BLOCK')) {
+        return; // policy drop — never reaches the host
+      }
+      content.policyTag = `wrapped:${instanceKey}`;
+      return setup.onInbound(platformId, threadId, message);
+    },
+  };
+});
+
+describe('registerBridgeInboundPolicy', () => {
+  it('wraps inbound through the real bridge path: pass-through is tagged, policy drop never reaches the host', async () => {
+    const { adapter, chat } = makeStubAdapter('slack');
+    const { hostConfig, calls } = makeHostConfig();
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await chat().processMessage(adapter, 'slack:C1:T1', makeMessage('hello there'));
+    await chat().processMessage(adapter, 'slack:C1:T2', makeMessage('please BLOCK me'));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].platformId).toBe('slack:C1');
+    expect(calls[0].threadId).toBe('slack:C1:T1');
+    const content = calls[0].message.content as Record<string, unknown>;
+    expect(content.text).toBe('hello there');
+    expect(content.policyTag).toBe('wrapped:slack');
+
+    await bridge.teardown();
+  });
+
+  it('leaves unregistered channel types untouched (no wrap, no tag, no drop)', async () => {
+    const { adapter, chat } = makeStubAdapter('discord');
+    const { hostConfig, calls } = makeHostConfig();
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    const applicationsBefore = wrapApplications.length;
+    await bridge.setup(hostConfig);
+
+    await chat().processMessage(adapter, 'discord:C1:T1', makeMessage('please BLOCK me'));
+
+    expect(wrapApplications).toHaveLength(applicationsBefore);
+    expect(calls).toHaveLength(1);
+    const content = calls[0].message.content as Record<string, unknown>;
+    expect(content.text).toBe('please BLOCK me');
+    expect(content.policyTag).toBeUndefined();
+
+    await bridge.teardown();
+  });
+
+  it('applies the wrap once per bridge instance, passing each instance key', async () => {
+    const applicationsBefore = wrapApplications.length;
+
+    const def = makeStubAdapter('slack');
+    const defBridge = createChatSdkBridge({ adapter: def.adapter, supportsThreads: true });
+    const defHost = makeHostConfig();
+    await defBridge.setup(defHost.hostConfig);
+
+    const named = makeStubAdapter('slack');
+    const namedBridge = createChatSdkBridge({
+      adapter: named.adapter,
+      instance: 'slack-tester',
+      supportsThreads: true,
+    });
+    const namedHost = makeHostConfig();
+    await namedBridge.setup(namedHost.hostConfig);
+
+    expect(wrapApplications.slice(applicationsBefore)).toEqual(['slack', 'slack-tester']);
+
+    // Each instance's inbound is tagged with ITS OWN key — per-instance
+    // closures, not one shared wrapped setup.
+    await named.chat().processMessage(named.adapter, 'slack:C9:T9', makeMessage('to the named instance'));
+    expect(namedHost.calls).toHaveLength(1);
+    expect((namedHost.calls[0].message.content as Record<string, unknown>).policyTag).toBe('wrapped:slack-tester');
+    expect(defHost.calls).toHaveLength(0);
+
+    await defBridge.teardown();
+    await namedBridge.teardown();
+  });
+});

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -271,6 +271,39 @@ function dispatchMembership(event: MembershipEvent): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Inbound policy registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap of the host's `ChannelSetup`, applied at bridge setup time. Every
+ * inbound dispatch path (onSubscribedMessage / onNewMention / onDirectMessage
+ * / onNewMessage) funnels through the stored setup's `onInbound`, so a policy
+ * that wraps `onInbound` intercepts them all at a single point — e.g. to
+ * drop, re-attribute, or rate-limit bot-authored messages before routing.
+ *
+ * `instanceKey` is the bridge's registry key (`config.instance ??
+ * adapter.name`): the wrap runs once per bridge instance, so policy state
+ * captured in the returned closure is naturally per-instance (= per bot
+ * identity when several bridges share one platform).
+ */
+export type BridgeInboundPolicy = (setup: ChannelSetup, instanceKey: string) => ChannelSetup;
+
+const bridgeInboundPolicies = new Map<string, BridgeInboundPolicy>();
+
+/**
+ * Register THE inbound policy for a channel type (single registration — the
+ * owning module registers on barrel import; a second registration overwrites
+ * with a warning, mirroring the router's hook discipline). Bridges whose
+ * channel type has no registered policy are unaffected.
+ */
+export function registerBridgeInboundPolicy(channelType: string, wrap: BridgeInboundPolicy): void {
+  if (bridgeInboundPolicies.has(channelType)) {
+    log.warn('Bridge inbound policy overwritten', { channelType });
+  }
+  bridgeInboundPolicies.set(channelType, wrap);
+}
+
 export interface ChatSdkBridgeConfig {
   adapter: Adapter;
   /**
@@ -483,7 +516,12 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     defaults: config.defaults,
 
     async setup(hostConfig: ChannelSetup) {
-      setupConfig = hostConfig;
+      // Apply the registered inbound policy (if any) for this channel type.
+      // Wrapping here — the single point every dispatch path reads back
+      // through — means one policy covers onSubscribedMessage, onNewMention,
+      // onDirectMessage and onNewMessage alike.
+      const inboundPolicy = bridgeInboundPolicies.get(adapter.name);
+      setupConfig = inboundPolicy ? inboundPolicy(hostConfig, instanceKey) : hostConfig;
 
       // State namespace: ONLY for a named non-default instance. A skill
       // that explicitly names the primary instance after the platform


### PR DESCRIPTION
Adds a registration seam for inbound policy on the Chat SDK bridge: a module can wrap the host's `ChannelSetup` for one channel type, intercepting every inbound dispatch path at a single point. This turns what previously required editing the bridge source (e.g. bot-authored-message policies) into a self-registering module concern. Bridges with no registered policy are byte-for-byte unaffected.

## Changes

| File | Notes |
|---|---|
| `src/channels/chat-sdk-bridge.ts` | `registerBridgeInboundPolicy(channelType, wrap)` where `wrap: (setup: ChannelSetup, instanceKey: string) => ChannelSetup`. Applied at the `setupConfig = hostConfig;` assignment for `adapter.name`, passing the bridge's registry key (`config.instance ?? adapter.name`) as the instance key. One policy per channelType (overwrite warns, mirroring the router's hook discipline); every inbound dispatch path funnels through `setupConfig.onInbound`, so one seam covers onSubscribedMessage / onNewMention / onDirectMessage / onNewMessage. |
| `src/channels/chat-sdk-bridge-inbound-policy.test.ts` | New: fixture policy wraps (tags) and blocks inbound through the real bridge path (SDK `processMessage` dispatch over a stub adapter); unregistered channel types untouched; wrap applied once per bridge instance with its own instance key. |

## Verification

- `pnpm run build` — clean
- `pnpm exec vitest run src/channels/chat-sdk-bridge-inbound-policy.test.ts` — 3 passed
- `pnpm test` — 120 files, 1521 tests, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
