### PR TITLE
delivery: post-delivery hook with first-delivery context

### DIFF
--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -36,7 +36,12 @@ import {
 } from './db/index.js';
 import { getDeliveredIds } from './db/session-db.js';
 import { resolveSession, resolveTaskSession, outboundDbPath, openInboundDb } from './session-manager.js';
-import { deliverSessionMessages, registerDeliveryBatchPreview, setDeliveryAdapter } from './delivery.js';
+import {
+  deliverSessionMessages,
+  registerDeliveryBatchPreview,
+  registerPostDeliveryHook,
+  setDeliveryAdapter,
+} from './delivery.js';
 import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
 import { createDestination } from './modules/agent-to-agent/db/agent-destinations.js';
 
@@ -568,5 +573,112 @@ describe('deliverSessionMessages — batch preview hooks', () => {
     expect(seen[0].kinds).toEqual(['chat', 'chat']);
     expect(seen[0].sessionId).toBe(session.id);
     expect(sent.length).toBe(2); // the throwing hook did not block delivery
+  });
+});
+
+describe('deliverSessionMessages — post-delivery hooks', () => {
+  function insertOutboundRow(
+    agentGroupId: string,
+    sessionId: string,
+    msgId: string,
+    kind: string,
+    timestamp: string,
+    content: Record<string, unknown> = { text: 'hello' },
+  ): void {
+    const db = new Database(outboundDbPath(agentGroupId, sessionId));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+       VALUES (?, ?, ?, 'telegram:123', 'telegram', ?)`,
+    ).run(msgId, timestamp, kind, JSON.stringify(content));
+    db.close();
+  }
+
+  function passthroughAdapter(): void {
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+  }
+
+  it('fires only for user-facing kinds — system and task_log rows are skipped', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    // Unknown system action: handled internally, marked delivered, no hook.
+    insertOutboundRow('ag-1', session.id, 'pd-sys', 'system', '2026-01-01T00:00:01.000Z', { action: 'nope' });
+    // task_log outside a task session: ignored + marked delivered, no hook.
+    insertOutboundRow('ag-1', session.id, 'pd-log', 'task_log', '2026-01-01T00:00:02.000Z', { text: 'log line' });
+    insertOutboundRow('ag-1', session.id, 'pd-chat', 'chat', '2026-01-01T00:00:03.000Z');
+
+    const seen: string[] = [];
+    registerPostDeliveryHook((msg) => {
+      if (msg.id.startsWith('pd-')) seen.push(msg.id);
+    });
+    passthroughAdapter();
+
+    await deliverSessionMessages(session);
+
+    expect(seen).toEqual(['pd-chat']);
+    // All three rows were still marked delivered.
+    const delivered = getDeliveredIds(openInboundDb('ag-1', session.id));
+    expect(delivered.has('pd-sys')).toBe(true);
+    expect(delivered.has('pd-log')).toBe(true);
+    expect(delivered.has('pd-chat')).toBe(true);
+  });
+
+  it('firstDelivery is true exactly on the first delivered row of a fresh session', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutboundRow('ag-1', session.id, 'fd-1', 'chat', '2026-01-01T00:00:01.000Z');
+    insertOutboundRow('ag-1', session.id, 'fd-2', 'chat', '2026-01-01T00:00:02.000Z');
+
+    const seen: Array<{ id: string; firstDelivery: boolean; sessionId: string }> = [];
+    registerPostDeliveryHook((msg, s, info) => {
+      if (msg.id.startsWith('fd-')) seen.push({ id: msg.id, firstDelivery: info.firstDelivery, sessionId: s.id });
+    });
+    passthroughAdapter();
+
+    await deliverSessionMessages(session);
+    expect(seen).toEqual([
+      { id: 'fd-1', firstDelivery: true, sessionId: session.id },
+      { id: 'fd-2', firstDelivery: false, sessionId: session.id },
+    ]);
+
+    // A later drain of the same session never reports firstDelivery again.
+    insertOutboundRow('ag-1', session.id, 'fd-3', 'chat', '2026-01-01T00:00:03.000Z');
+    await deliverSessionMessages(session);
+    expect(seen[2]).toEqual({ id: 'fd-3', firstDelivery: false, sessionId: session.id });
+  });
+
+  it('a throwing hook never breaks delivery or markDelivered', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutboundRow('ag-1', session.id, 'th-1', 'chat', '2026-01-01T00:00:01.000Z');
+    insertOutboundRow('ag-1', session.id, 'th-2', 'chat', '2026-01-01T00:00:02.000Z');
+
+    registerPostDeliveryHook(() => {
+      throw new Error('hook exploded');
+    });
+    // A hook registered after the throwing one still runs.
+    const after: string[] = [];
+    registerPostDeliveryHook((msg) => {
+      if (msg.id.startsWith('th-')) after.push(msg.id);
+    });
+
+    const sent: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_channelType, _platformId, _threadId, _kind, content) {
+        sent.push(content);
+        return 'pm';
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    expect(sent).toHaveLength(2); // the throwing hook did not block delivery
+    expect(after).toEqual(['th-1', 'th-2']);
+    const delivered = getDeliveredIds(openInboundDb('ag-1', session.id));
+    expect(delivered.has('th-1')).toBe(true);
+    expect(delivered.has('th-2')).toBe(true);
   });
 });

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -30,6 +30,7 @@ import {
   markDelivered,
   markDeliveryFailed,
   migrateDeliveredTable,
+  type OutboundMessage,
 } from './db/session-db.js';
 import { runGuarded, type DeliveryGuardSpec, type GuardedDeliveryHandler } from './delivery-guard.js';
 import { isUnguarded, type Unguarded } from './guard/index.js';
@@ -232,6 +233,11 @@ async function drainSession(session: Session): Promise<void> {
       try {
         const platformMsgId = await deliverMessage(msg, session, inDb);
         markDelivered(inDb, msg.id, platformMsgId ?? null);
+        // firstDelivery: nothing had ever been delivered in this session
+        // before this row. Computed before the row joins the local
+        // delivered set, so exactly one row per session carries the flag.
+        const firstDelivery = delivered.size === 0;
+        delivered.add(msg.id);
         deliveryAttempts.delete(msg.id);
 
         // Pause the typing indicator after a real user-facing message
@@ -249,6 +255,16 @@ async function drainSession(session: Session): Promise<void> {
           // retry never double-fans.
           if (msg.kind !== 'task_log') {
             fanOutboundMessage(msg, session, agentGroup);
+            // Post-delivery hooks: user-facing rows only, same exclusions
+            // as the fan above. Hooks are decoration: failures log and can
+            // never affect delivery or retries.
+            for (const hook of postDeliveryHooks) {
+              try {
+                hook(msg, session, { firstDelivery });
+              } catch (err) {
+                log.warn('Post-delivery hook failed', { messageId: msg.id, sessionId: session.id, err });
+              }
+            }
           }
         }
       } catch (err) {
@@ -464,6 +480,37 @@ async function deliverMessage(
   clearOutbox(session.agent_group_id, session.id, msg.id);
 
   return platformMsgId;
+}
+
+/**
+ * Post-delivery hooks.
+ *
+ * Registered modules observe each successfully delivered user-facing
+ * message (non-system, non-agent, non-task_log) right after it is marked
+ * delivered, with a first-delivery flag. This gives channel modules a
+ * supported seam for one-time follow-through on a session's first outbound
+ * message (e.g. onboarding affordances) without hardcoding platform
+ * behavior in the delivery core.
+ *
+ * Hooks are decoration only: each invocation is wrapped in try/catch, so a
+ * failing hook can never affect delivery, markDelivered, or retries.
+ */
+export interface PostDeliveryInfo {
+  /**
+   * True when this is the first message ever marked delivered in this
+   * session — exactly one row per session carries it. Every delivered row
+   * counts toward the flag (including system rows the hook itself never
+   * fires for); the hook only ever observes user-facing rows.
+   */
+  firstDelivery: boolean;
+}
+
+export type PostDeliveryHook = (msg: OutboundMessage, session: Session, info: PostDeliveryInfo) => void;
+
+const postDeliveryHooks: PostDeliveryHook[] = [];
+
+export function registerPostDeliveryHook(hook: PostDeliveryHook): void {
+  postDeliveryHooks.push(hook);
 }
 
 /**


### PR DESCRIPTION
Adds a post-delivery hook to the outbound drain loop: registered modules observe each successfully delivered user-facing message with a first-delivery flag. This gives channel modules a supported seam for one-time follow-through on a session's first outbound message (e.g. onboarding affordances) instead of hardcoding platform behavior in the delivery core. Hooks are isolated so a failure can never affect delivery or retries.

## What's in here

- `registerPostDeliveryHook(hook)` where `hook: (msg, session, { firstDelivery }) => void` — invoked in `drainSession` after `markDelivered` for non-system, non-agent, non-task_log messages, alongside the existing cross-session fan.
- `firstDelivery` is true exactly on the first row ever marked delivered in a session (every delivered row counts toward the flag, including system rows the hook never fires for; the hook only observes user-facing rows).
- Each hook invocation is wrapped in try/catch — decoration only; failures log and never affect delivery, markDelivered, or retries.
- New `delivery.test.ts` describe exercising the real `deliverSessionMessages` path: fires only for user-facing kinds (system/task_log rows still marked delivered, no hook); firstDelivery=true exactly on the first delivered row of a fresh session, false within the batch and across later drains; a throwing hook blocks neither delivery nor markDelivered nor later hooks.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm run build` — clean
- `pnpm exec vitest run src/delivery.test.ts` — 16 passed (3 new)
- `pnpm test` — 119 files, 1521 tests, 0 failed
- Gate: no behavior change with zero hooks registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
