### PR TITLE
channels: generic membership-event hook on the Chat SDK bridge

### DIFF
--- a/src/channels/chat-sdk-bridge-membership.test.ts
+++ b/src/channels/chat-sdk-bridge-membership.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Generic bridge membership hook: platform member-joined events are
+ * forwarded to the single handler registered per channel type
+ * (setMembershipHandler), fire-and-forget with error logging.
+ *
+ * SDK dispatch runs through the REAL Chat instance built in setup() — the
+ * tests capture it via the mocked registerWebhookAdapter (setup hands the
+ * Chat instance to the webhook server for non-gateway adapters) — so the
+ * handler registrations in setup() are exercised, not simulated.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Adapter, Chat } from 'chat';
+
+import { log } from '../log.js';
+import { createChatSdkBridge, setMembershipHandler, type MembershipEvent } from './chat-sdk-bridge.js';
+
+vi.mock('../webhook-server.js', () => ({
+  registerWebhookAdapter: vi.fn(),
+}));
+
+import { registerWebhookAdapter } from '../webhook-server.js';
+
+function stubAdapter(name: string, partial: Partial<Adapter> = {}): Adapter {
+  return { name, initialize: async () => {}, ...partial } as unknown as Adapter;
+}
+
+const hostConfig = {
+  onInbound: () => {},
+  onInboundEvent: () => {},
+  onMetadata: () => {},
+  onAction: () => {},
+};
+
+/** The Chat instance setup() registered on the (mocked) webhook server. */
+function lastRegisteredChat(): Chat {
+  const calls = vi.mocked(registerWebhookAdapter).mock.calls;
+  return calls[calls.length - 1][0] as Chat;
+}
+
+/** Drive a Chat process* dispatcher and await its internal task. */
+async function dispatch(fire: (options: { waitUntil: (p: Promise<unknown>) => void }) => void): Promise<void> {
+  let task: Promise<unknown> | undefined;
+  fire({ waitUntil: (p) => (task = p) });
+  await task;
+}
+
+beforeEach(async () => {
+  const { initTestDb } = await import('../db/connection.js');
+  const { runMigrations } = await import('../db/migrations/index.js');
+  runMigrations(initTestDb());
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../db/connection.js');
+  closeDb();
+  vi.restoreAllMocks();
+});
+
+describe('setMembershipHandler', () => {
+  it('forwards member_joined_channel through the registered handler with instance identity', async () => {
+    const events: MembershipEvent[] = [];
+    setMembershipHandler('alpha', (event) => {
+      events.push(event);
+    });
+
+    const adapter = stubAdapter('alpha');
+    const bridge = createChatSdkBridge({ adapter, instance: 'alpha-two', supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await dispatch((options) =>
+      lastRegisteredChat().processMemberJoinedChannel(
+        { adapter, channelId: 'C0ROOM1', userId: 'U0NEW', inviterId: 'U0OWNER' },
+        options,
+      ),
+    );
+
+    expect(events).toEqual([
+      {
+        instance: 'alpha-two',
+        channelType: 'alpha',
+        channelId: 'C0ROOM1',
+        userId: 'U0NEW',
+        inviterId: 'U0OWNER',
+      },
+    ]);
+    await bridge.teardown();
+  });
+
+  it('default instances key by the platform name', async () => {
+    const events: MembershipEvent[] = [];
+    setMembershipHandler('bravo', (event) => {
+      events.push(event);
+    });
+
+    const adapter = stubAdapter('bravo');
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await dispatch((options) =>
+      lastRegisteredChat().processMemberJoinedChannel({ adapter, channelId: 'C2', userId: 'U2' }, options),
+    );
+
+    expect(events).toEqual([
+      { instance: 'bravo', channelType: 'bravo', channelId: 'C2', userId: 'U2', inviterId: undefined },
+    ]);
+    await bridge.teardown();
+  });
+
+  it('dispatch is keyed by channelType — a handler for another channel type never fires', async () => {
+    const wrongEvents: MembershipEvent[] = [];
+    setMembershipHandler('some-other-platform', (event) => {
+      wrongEvents.push(event);
+    });
+
+    const adapter = stubAdapter('charlie');
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    // No handler registered for 'charlie' → dispatch is a silent no-op.
+    await expect(
+      dispatch((options) =>
+        lastRegisteredChat().processMemberJoinedChannel({ adapter, channelId: 'C3', userId: 'U3' }, options),
+      ),
+    ).resolves.toBeUndefined();
+    expect(wrongEvents).toEqual([]);
+    await bridge.teardown();
+  });
+
+  it('a second registration for the same channel type overwrites with a warning', async () => {
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const first: MembershipEvent[] = [];
+    const second: MembershipEvent[] = [];
+    setMembershipHandler('delta', (event) => {
+      first.push(event);
+    });
+    setMembershipHandler('delta', (event) => {
+      second.push(event);
+    });
+    expect(warn).toHaveBeenCalledWith('Membership handler overwritten', { channelType: 'delta' });
+
+    const adapter = stubAdapter('delta');
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await dispatch((options) =>
+      lastRegisteredChat().processMemberJoinedChannel({ adapter, channelId: 'C4', userId: 'U4' }, options),
+    );
+
+    expect(first).toEqual([]);
+    expect(second).toHaveLength(1);
+    await bridge.teardown();
+  });
+
+  it('a throwing handler is contained (fire-and-forget, dispatch survives)', async () => {
+    setMembershipHandler('echo', () => {
+      throw new Error('boom');
+    });
+    const adapter = stubAdapter('echo');
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await expect(
+      dispatch((options) =>
+        lastRegisteredChat().processMemberJoinedChannel({ adapter, channelId: 'C5', userId: 'U5' }, options),
+      ),
+    ).resolves.toBeUndefined();
+    await bridge.teardown();
+  });
+
+  it('an async-rejecting handler is contained too', async () => {
+    setMembershipHandler('foxtrot', async () => {
+      throw new Error('async boom');
+    });
+    const adapter = stubAdapter('foxtrot');
+    const bridge = createChatSdkBridge({ adapter, supportsThreads: true });
+    await bridge.setup(hostConfig);
+
+    await expect(
+      dispatch((options) =>
+        lastRegisteredChat().processMemberJoinedChannel({ adapter, channelId: 'C6', userId: 'U6' }, options),
+      ),
+    ).resolves.toBeUndefined();
+    // Let the rejected handler promise settle (its .catch logs the error).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await bridge.teardown();
+  });
+});

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -205,6 +205,72 @@ export function normalizeDmThreadId(threadId: string, messageId: string): string
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ReplyContextExtractor = (raw: Record<string, any>) => ReplyContext | null;
 
+// ---------------------------------------------------------------------------
+// Membership hook
+// ---------------------------------------------------------------------------
+
+/**
+ * A member joined (or left) a channel/group conversation one of our bridge
+ * instances is in. Forwarded from the Chat SDK's member_joined_channel
+ * dispatch; `left` is reserved for member_left_channel, which the installed
+ * chat core (4.29.0) does NOT dispatch — see the TODO at the
+ * onMemberJoinedChannel registration in setup().
+ */
+export interface MembershipEvent {
+  /** Adapter-instance key of the bridge that saw the event (defaults to the
+   *  platform name for default instances). */
+  instance: string;
+  /** Semantic platform key (`adapter.name`) — the key membership handlers
+   *  are registered under. */
+  channelType: string;
+  channelId: string;
+  userId: string;
+  inviterId?: string;
+  left?: boolean;
+}
+
+export type MembershipHandler = (event: MembershipEvent) => void | Promise<void>;
+
+const membershipHandlers = new Map<string, MembershipHandler>();
+
+/**
+ * Register THE membership handler for a channel type (single registration —
+ * one channel-side module owns it; a second registration for the same
+ * channel type overwrites with a warning, mirroring the router's hook
+ * discipline). The bridge invokes it fire-and-forget for every membership
+ * event on every bridge instance of that channel type; errors are logged,
+ * never thrown into SDK dispatch. With no handler registered the bridge
+ * behaves exactly as before.
+ */
+export function setMembershipHandler(channelType: string, fn: MembershipHandler): void {
+  if (membershipHandlers.has(channelType)) {
+    log.warn('Membership handler overwritten', { channelType });
+  }
+  membershipHandlers.set(channelType, fn);
+}
+
+function dispatchMembership(event: MembershipEvent): void {
+  const handler = membershipHandlers.get(event.channelType);
+  if (!handler) return;
+  try {
+    Promise.resolve(handler(event)).catch((err) =>
+      log.error('Membership handler failed', {
+        channelType: event.channelType,
+        channelId: event.channelId,
+        userId: event.userId,
+        err,
+      }),
+    );
+  } catch (err) {
+    log.error('Membership handler threw', {
+      channelType: event.channelType,
+      channelId: event.channelId,
+      userId: event.userId,
+      err,
+    });
+  }
+}
+
 export interface ChatSdkBridgeConfig {
   adapter: Adapter;
   /**
@@ -513,6 +579,24 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         dispatchAgentDmOpened({ instance: instanceKey, channelId: event.channelId });
       });
       chat.onAssistantContextChanged(rememberAppContext);
+
+      // Membership events: forwarded to the handler registered for this
+      // channel type (setMembershipHandler); no-op when none is registered.
+      // The chat core dispatches only member_joined_channel;
+      // member_left_channel arrives at the adapter but has no SDK handler
+      // in 4.29.0.
+      // TODO(member-left): when the chat core grows an onMemberLeftChannel
+      // dispatch, register it here and forward with { left: true } — the
+      // MembershipEvent type and dispatchMembership already carry it.
+      chat.onMemberJoinedChannel((event) => {
+        dispatchMembership({
+          instance: instanceKey,
+          channelType: adapter.name,
+          channelId: event.channelId,
+          userId: event.userId,
+          inviterId: event.inviterId,
+        });
+      });
 
       // Handle button clicks (ask_user_question)
       chat.onAction(async (event) => {


### PR DESCRIPTION
Adds a generic membership-event seam to the Chat SDK bridge: platform member-joined events (chat 4.29.0's `onMemberJoinedChannel`) are forwarded to a single handler registered per channel type. This lets a channel-side module own room-membership behavior (adopt-on-invite, detach tracking) without the bridge knowing anything about any specific platform. Purely additive; with no handler registered the bridge behaves exactly as before.

## What's in here

- `MembershipEvent` — `{ instance, channelType, channelId, userId, inviterId?, left? }`. `left` is reserved for member_left_channel, which the installed chat core (4.29.0) does not dispatch yet (TODO left at the registration site).
- `setMembershipHandler(channelType, fn)` — channelType-keyed registry, single registration per channel type; a second registration overwrites with a warning, mirroring the router's hook discipline.
- Fire-and-forget dispatch that never throws into SDK dispatch — handler errors (sync throw or async rejection) are logged and contained.
- `chat.onMemberJoinedChannel` registration in the bridge's `setup()`, forwarding `{ instance: instanceKey, channelType: adapter.name, ... }` (instanceKey defaults to the platform name for default instances).
- `src/channels/chat-sdk-bridge-membership.test.ts` — dispatch runs through the REAL Chat instance built in `setup()` (captured via the mocked webhook-server registration): registration/overwrite-warn, fire-and-forget error isolation, channelType keying, instance identity.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm run build` — clean
- `pnpm test` — 120 files, 1524 tests, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
