### PR TITLE
agent-runner: extendTool — additive MCP tool schema and description extension

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -4,6 +4,8 @@
  * Writes to outbound.db (container-owned).
  * The host polls this DB (read-only) for undelivered messages.
  */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import { getInboundDb, getOutboundDb } from './connection.js';
 
 export interface MessageOutRow {
@@ -30,6 +32,49 @@ export interface WriteMessageOut {
   channel_type?: string | null;
   thread_id?: string | null;
   content: string;
+}
+
+/**
+ * Extra entries merged into system-action payloads for the duration of a
+ * call, without the writing handler knowing about them. This is the seam
+ * `extendTool` (../mcp-tools/server.ts) uses so an installed module can
+ * add params to a base tool and have them land in the tool's outbound
+ * payload while the base tool's source stays untouched.
+ *
+ * Scope is deliberately narrow: only `kind: 'system'` messages whose
+ * content parses to a JSON object are decorated, and entries never
+ * overwrite keys the handler wrote itself. Everything else passes through
+ * byte-identical. With no active context (the default), this is a no-op.
+ */
+const outboundPassthrough = new AsyncLocalStorage<Record<string, unknown>>();
+
+/** Run `fn` with `entries` merged into system-action payloads it writes. */
+export function withOutboundPassthrough<T>(entries: Record<string, unknown>, fn: () => T): T {
+  return outboundPassthrough.run(entries, fn);
+}
+
+/** Apply any active passthrough entries to a system-action JSON payload. */
+function decorateContent(msg: WriteMessageOut): string {
+  const entries = outboundPassthrough.getStore();
+  if (!entries || msg.kind !== 'system') return msg.content;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(msg.content);
+  } catch {
+    return msg.content;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return msg.content;
+
+  const payload = parsed as Record<string, unknown>;
+  let changed = false;
+  for (const [key, value] of Object.entries(entries)) {
+    if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+      payload[key] = value;
+      changed = true;
+    }
+  }
+  return changed ? JSON.stringify(payload) : msg.content;
 }
 
 /**
@@ -71,7 +116,7 @@ export function writeMessageOut(msg: WriteMessageOut): number {
       $platform_id: msg.platform_id ?? null,
       $channel_type: msg.channel_type ?? null,
       $thread_id: msg.thread_id ?? null,
-      $content: msg.content,
+      $content: decorateContent(msg),
     });
 
   return nextSeq;

--- a/container/agent-runner/src/mcp-tools/server.extend.test.ts
+++ b/container/agent-runner/src/mcp-tools/server.extend.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for `extendTool` — the additive extension point feature modules use
+ * to enrich a base MCP tool's input schema, description, and outbound
+ * system-action payload without editing the base tool's source file.
+ *
+ * Uses synthetic fixture tools for the merge/passthrough semantics (module
+ * state is process-wide, so each fixture gets a unique name), plus one
+ * end-to-end fixture extension of the real `create_agent` tool proving the
+ * mechanism covers the motivating case: an installed module adding params
+ * that must land in the payload the host reads from outbound.db.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb } from '../db/connection.js';
+import { getUndeliveredMessages, writeMessageOut } from '../db/messages-out.js';
+import { createAgent } from './agents.js';
+import { extendTool, registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+let fixtureCount = 0;
+
+/**
+ * Register a fresh fixture tool that writes one system-action payload the
+ * way real system tools do (create_agent, scheduling, self-mod): base args
+ * only — anything an extension adds is invisible to the handler.
+ */
+function fixtureTool(): McpToolDefinition {
+  const n = ++fixtureCount;
+  const def: McpToolDefinition = {
+    tool: {
+      name: `fixture_tool_${n}`,
+      description: 'Base description.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          name: { type: 'string', description: 'base param' },
+        },
+        required: ['name'],
+      },
+    },
+    async handler(args) {
+      writeMessageOut({
+        id: `msg-fixture-${n}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        kind: 'system',
+        content: JSON.stringify({ action: 'fixture_action', name: args.name as string }),
+      });
+      return { content: [{ type: 'text' as const, text: 'ok' }] };
+    },
+  };
+  registerTools([def]);
+  return def;
+}
+
+function schemaProps(def: McpToolDefinition): Record<string, unknown> {
+  return (def.tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+}
+
+function lastPayload(): Record<string, unknown> {
+  const rows = getUndeliveredMessages();
+  expect(rows.length).toBeGreaterThan(0);
+  return JSON.parse(rows[rows.length - 1].content) as Record<string, unknown>;
+}
+
+describe('extendTool — schema and description merge', () => {
+  it('merges extra properties additively, leaving base schema intact', () => {
+    const def = fixtureTool();
+
+    extendTool(def.tool.name, {
+      properties: { purpose: { type: 'string', description: 'public purpose line' } },
+    });
+
+    const props = schemaProps(def);
+    expect(Object.keys(props).sort()).toEqual(['name', 'purpose']);
+    expect(props.name).toEqual({ type: 'string', description: 'base param' });
+    expect((def.tool.inputSchema as { required?: string[] }).required).toEqual(['name']);
+  });
+
+  it('appends the description suffix after the base description', () => {
+    const def = fixtureTool();
+
+    extendTool(def.tool.name, { descriptionSuffix: 'Suffix one.' });
+
+    expect(def.tool.description).toBe('Base description. Suffix one.');
+  });
+
+  it('throws on an unknown tool', () => {
+    expect(() => extendTool('no_such_tool', { descriptionSuffix: 'x' })).toThrow(/unknown tool "no_such_tool"/);
+  });
+
+  it('throws when an extension property collides with a base property', () => {
+    const def = fixtureTool();
+
+    expect(() => extendTool(def.tool.name, { properties: { name: { type: 'string' } } })).toThrow(
+      /property "name" already exists/,
+    );
+  });
+
+  it('double extension is deterministic: suffixes append in order, properties merge, collisions throw', () => {
+    const def = fixtureTool();
+
+    extendTool(def.tool.name, {
+      properties: { purpose: { type: 'string' } },
+      descriptionSuffix: 'First.',
+    });
+    extendTool(def.tool.name, {
+      properties: { room: { type: 'string', enum: ['own', 'none'] } },
+      descriptionSuffix: 'Second.',
+    });
+
+    expect(def.tool.description).toBe('Base description. First. Second.');
+    expect(Object.keys(schemaProps(def)).sort()).toEqual(['name', 'purpose', 'room']);
+    // A third extension re-adding a key from an earlier one fails loudly.
+    expect(() => extendTool(def.tool.name, { properties: { purpose: { type: 'string' } } })).toThrow(
+      /property "purpose" already exists/,
+    );
+  });
+});
+
+describe('extendTool — passthrough keys land in the written payload', () => {
+  beforeEach(() => {
+    initTestSessionDb();
+  });
+
+  afterEach(() => {
+    closeSessionDb();
+  });
+
+  it('copies registered passthrough keys from args into the system payload', async () => {
+    const def = fixtureTool();
+    extendTool(def.tool.name, {
+      properties: { purpose: { type: 'string' } },
+      passthroughKeys: ['purpose'],
+    });
+
+    await def.handler({ name: 'Scout', purpose: 'Deep research' });
+
+    const payload = lastPayload();
+    expect(payload.action).toBe('fixture_action');
+    expect(payload.name).toBe('Scout');
+    expect(payload.purpose).toBe('Deep research');
+  });
+
+  it('ignores unregistered args and keys absent from the call', async () => {
+    const def = fixtureTool();
+    extendTool(def.tool.name, { passthroughKeys: ['purpose'] });
+
+    await def.handler({ name: 'Scout', sneaky: 'nope' });
+
+    const payload = lastPayload();
+    expect(payload).not.toHaveProperty('purpose'); // registered but not passed
+    expect(payload).not.toHaveProperty('sneaky'); // passed but not registered
+  });
+
+  it('never overwrites keys the base handler wrote itself', async () => {
+    const def = fixtureTool();
+    extendTool(def.tool.name, { passthroughKeys: ['action', 'name'] });
+
+    await def.handler({ name: 'Scout', action: 'evil_override' });
+
+    const payload = lastPayload();
+    expect(payload.action).toBe('fixture_action'); // handler wins
+    expect(payload.name).toBe('Scout'); // handler wrote it from args anyway
+  });
+
+  it('unions passthrough keys across double extension without stacking wrappers', async () => {
+    const def = fixtureTool();
+    extendTool(def.tool.name, { passthroughKeys: ['purpose'] });
+    extendTool(def.tool.name, { passthroughKeys: ['room'] });
+
+    await def.handler({ name: 'Scout', purpose: 'Research', room: 'none' });
+
+    const payload = lastPayload();
+    expect(payload.purpose).toBe('Research');
+    expect(payload.room).toBe('none');
+  });
+
+  it('leaves non-system and non-JSON writes byte-identical during an extended call', async () => {
+    const n = ++fixtureCount;
+    const def: McpToolDefinition = {
+      tool: {
+        name: `fixture_tool_${n}`,
+        description: 'Base description.',
+        inputSchema: { type: 'object' as const, properties: {} },
+      },
+      async handler() {
+        writeMessageOut({ id: `msg-plain-${n}`, kind: 'message', content: 'plain text reply' });
+        writeMessageOut({ id: `msg-rawsys-${n}`, kind: 'system', content: 'not json at all' });
+        return { content: [{ type: 'text' as const, text: 'ok' }] };
+      },
+    };
+    registerTools([def]);
+    extendTool(def.tool.name, { passthroughKeys: ['purpose'] });
+
+    await def.handler({ purpose: 'Research' });
+
+    const rows = getUndeliveredMessages();
+    const plain = rows.find((r) => r.id === `msg-plain-${n}`);
+    const rawSys = rows.find((r) => r.id === `msg-rawsys-${n}`);
+    expect(plain?.content).toBe('plain text reply');
+    expect(rawSys?.content).toBe('not json at all');
+  });
+});
+
+describe('extendTool — fixture extension of create_agent (end to end)', () => {
+  beforeEach(() => {
+    initTestSessionDb();
+  });
+
+  afterEach(() => {
+    closeSessionDb();
+  });
+
+  it('extends the real create_agent schema/description and passes params into its payload', async () => {
+    // What an installed feature module would run at import time instead of
+    // editing agents.ts (fixture values — the real extension ships with the
+    // feature payload, never on trunk).
+    extendTool('create_agent', {
+      properties: {
+        purpose: { type: 'string', description: 'One short public line saying what this agent is for.' },
+      },
+      passthroughKeys: ['purpose'],
+      descriptionSuffix: 'The purpose line is shown publicly.',
+    });
+
+    const props = schemaProps(createAgent);
+    expect(Object.keys(props).sort()).toEqual(['instructions', 'name', 'purpose']);
+    expect(createAgent.tool.description?.endsWith('The purpose line is shown publicly.')).toBe(true);
+
+    await createAgent.handler({ name: 'Scout', purpose: 'Deep research' });
+
+    const payload = lastPayload();
+    expect(payload.action).toBe('create_agent');
+    expect(payload.name).toBe('Scout');
+    expect(payload.instructions).toBeNull();
+    expect(payload.purpose).toBe('Deep research');
+  });
+
+  it('omits extension keys from the payload when the caller does not pass them', async () => {
+    // create_agent is already extended by the previous test (module state is
+    // process-wide); a call without the param must stay byte-identical to base.
+    await createAgent.handler({ name: 'Plain' });
+
+    const payload = lastPayload();
+    expect(payload.name).toBe('Plain');
+    expect(payload).not.toHaveProperty('purpose');
+  });
+});

--- a/container/agent-runner/src/mcp-tools/server.ts
+++ b/container/agent-runner/src/mcp-tools/server.ts
@@ -7,11 +7,18 @@
  *
  * Default when only `core.ts` is imported: the core `send_message` /
  * `send_file` / `edit_message` / `add_reaction` tools are available.
+ *
+ * Installed feature modules can additively extend an already-registered
+ * tool via `extendTool()` instead of editing the base tool's source —
+ * see the doc comment on `extendTool` below. With no extensions
+ * registered, tool definitions and behavior are byte-identical to the
+ * base modules.
  */
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
+import { withOutboundPassthrough } from '../db/messages-out.js';
 import type { McpToolDefinition } from './types.js';
 
 function log(msg: string): void {
@@ -29,6 +36,89 @@ export function registerTools(tools: McpToolDefinition[]): void {
     }
     allTools.push(t);
     toolMap.set(t.tool.name, t);
+  }
+}
+
+/** Additive extension of an already-registered tool. All fields optional. */
+export interface ToolExtension {
+  /**
+   * Extra `inputSchema.properties` merged into the base tool's schema.
+   * Keys must not collide with base properties or earlier extensions —
+   * a collision throws so a bad install fails loudly and deterministically.
+   */
+  properties?: Record<string, unknown>;
+  /**
+   * Arg keys copied verbatim from the call args into any system-action
+   * JSON payload the base handler writes via `writeMessageOut` during the
+   * call (see `withOutboundPassthrough` in ../db/messages-out.ts). Keys the
+   * handler already set in its payload are never overwritten.
+   */
+  passthroughKeys?: string[];
+  /** Text appended (space-separated) to the base tool's description. */
+  descriptionSuffix?: string;
+}
+
+const passthroughKeysByTool = new Map<string, Set<string>>();
+
+/**
+ * Extend a registered tool's input schema, description, and outbound
+ * payload additively — the mechanism feature modules use instead of
+ * editing base tool files. The base tool's source stays channel-neutral;
+ * an installed module (e.g. dropped in by an /add-<channel> skill) calls
+ * `extendTool` at import time to enrich it.
+ *
+ * Extensions are additive and deterministic: description suffixes append
+ * in call order, schema properties merge (collisions throw), and
+ * passthrough key sets union. Calling `extendTool` twice for the same
+ * tool never stacks handler wrappers.
+ *
+ * Must be called after the base tool's module has registered it (the
+ * barrel imports base tool modules before extension modules).
+ */
+export function extendTool(name: string, extension: ToolExtension): void {
+  const def = toolMap.get(name);
+  if (!def) {
+    throw new Error(`extendTool: unknown tool "${name}" — the base tool must be registered before it can be extended`);
+  }
+
+  const { properties, passthroughKeys, descriptionSuffix } = extension;
+
+  if (properties) {
+    const schema = def.tool.inputSchema as { type: 'object'; properties?: Record<string, unknown> };
+    const existing = (schema.properties ??= {});
+    for (const [key, value] of Object.entries(properties)) {
+      if (Object.prototype.hasOwnProperty.call(existing, key)) {
+        throw new Error(`extendTool: property "${key}" already exists on tool "${name}"`);
+      }
+      existing[key] = value;
+    }
+  }
+
+  if (descriptionSuffix) {
+    def.tool.description = def.tool.description ? `${def.tool.description} ${descriptionSuffix}` : descriptionSuffix;
+  }
+
+  if (passthroughKeys && passthroughKeys.length > 0) {
+    const known = passthroughKeysByTool.get(name);
+    if (known) {
+      // Already wrapped — the wrapper reads the live key set, so a second
+      // extension only needs to add its keys (no wrapper stacking).
+      for (const key of passthroughKeys) known.add(key);
+      return;
+    }
+    passthroughKeysByTool.set(name, new Set(passthroughKeys));
+
+    const base = def.handler;
+    def.handler = (args) => {
+      const entries: Record<string, unknown> = {};
+      for (const key of passthroughKeysByTool.get(name) ?? []) {
+        if (Object.prototype.hasOwnProperty.call(args, key) && args[key] !== undefined) {
+          entries[key] = args[key];
+        }
+      }
+      if (Object.keys(entries).length === 0) return base(args);
+      return withOutboundPassthrough(entries, () => base(args));
+    };
   }
 }
 


### PR DESCRIPTION
Adds an extension point to the container's MCP tool registry: an installed module can additively extend a base tool's input schema, description, and payload passthrough keys without editing the base tool's source. `extendTool(name, {properties, passthroughKeys, descriptionSuffix})` merges extra `inputSchema` properties into a registered tool (collisions throw), appends description text, and registers arg keys that are copied into the system-action JSON payload the base handler writes — via an AsyncLocalStorage seam in `messages-out.ts` scoped to the call, so the base handler stays untouched and handler-written keys are never overwritten. This keeps core tool definitions channel-neutral while letting feature installs enrich them; no registered extensions means byte-identical tool definitions and payloads.

Extensions are deterministic: description suffixes append in call order, schema property collisions fail loudly, passthrough key sets union, and double extension never stacks handler wrappers.

The motivating case is a feature install (e.g. an `/add-<channel>` skill) that needs to add params like a purpose or room id to `create_agent` and have them land in the tool's outbound system payload. With `extendTool`, base `agents.ts` stays channel-neutral and the extension ships with the installed module. The passthrough needs one small generic seam in `container/agent-runner/src/db/messages-out.ts` (`withOutboundPassthrough` + system-payload decoration) — the outbound writer is the only place registered keys can reach the payload without patching each base handler.

The bun:test suite proves the motivating case end-to-end with a fixture extension of the real `create_agent` tool: merge semantics, passthrough keys landing in the written payload (registered keys only, handler wins on conflict, non-system/non-JSON writes untouched), unknown-tool errors, and double-extension determinism.

Verification run: `pnpm run build` clean · host `pnpm test` 1518 pass / 0 fail · `bun test` 311 pass / 1 skip / 0 fail · `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
