### PR TITLE
setup: per-channel pre-step and companion-skill declarations for the wizard

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -33,7 +33,10 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
-import { runChannelSkill } from './channels/run-channel-skill.js';
+// The pre-step-aware entry point consults each channel's registered wizard
+// extensions (setup/channels/companions.ts) before running its install skill
+// — the wizard itself stays free of channel-specific imports.
+import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
 import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
@@ -675,22 +678,22 @@ async function main(): Promise<void> {
       // Every channel now runs through the SKILL.md-driven flow — the whole
       // connect+wire procedure lives in each add-<channel>/SKILL.md.
       if (channelChoice === 'telegram') {
-        result = await runChannelSkill('telegram', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('telegram', displayName!, { offerBack: true });
       } else if (channelChoice === 'discord') {
-        result = await runChannelSkill('discord', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('discord', displayName!, { offerBack: true });
       } else if (channelChoice === 'whatsapp') {
-        result = await runChannelSkill('whatsapp', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('whatsapp', displayName!, { offerBack: true });
       } else if (channelChoice === 'signal') {
-        result = await runChannelSkill('signal', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('signal', displayName!, { offerBack: true });
       } else if (channelChoice === 'teams') {
         // Fresh create resolves the owner DM proactively and wires inline (the
         // welcome message reaches the human first); a drop-through re-run
         // resolves nothing and falls back to the deferred-wire ending.
-        result = await runChannelSkill('teams', displayName!, { wireIfResolved: true, offerBack: true });
+        result = await runChannelSkillWithPreStep('teams', displayName!, { wireIfResolved: true, offerBack: true });
       } else if (channelChoice === 'slack') {
-        result = await runChannelSkill('slack', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('slack', displayName!, { offerBack: true });
       } else if (channelChoice === 'imessage') {
-        result = await runChannelSkill('imessage', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('imessage', displayName!, { offerBack: true });
       } else if (channelChoice === 'other') {
         result = await askOtherChannelName();
       } else {

--- a/setup/channels/companions.ts
+++ b/setup/channels/companions.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-channel wizard extension registries — the trunk seams that keep
+ * setup/auto.ts and run-channel-skill.ts free of channel-specific imports
+ * and conditionals.
+ *
+ * Two registrations, both consulted generically by the channel flow:
+ *
+ *  - Auto-provision pre-step: runs BEFORE the channel's install skill
+ *    and may return pre-bound skill `inputs` (e.g. when the channel's app /
+ *    credentials can be obtained programmatically). The resolved agent name
+ *    is passed in — for platforms where it doubles as the provisioned app's
+ *    name. Returning undefined means "walk the manual path"; the skill flow
+ *    then prompts as usual. Pre-steps own their prompts and must never throw
+ *    for expected declines.
+ *
+ *  - Companion skills: additional skills applied right after the
+ *    channel's main install skill, each with per-skill restarts skipped and
+ *    ONE deferred service restart after all of them (see
+ *    run-channel-skill.ts). For channels whose full payload is bigger than
+ *    the adapter install itself.
+ *
+ * Registration import point: a channel feature payload appends its
+ * self-registration import below (same discipline as the src/channels/index.ts
+ * adapter barrel) — trunk ships none.
+ */
+
+/**
+ * A channel's auto-provision pre-step. `agentName` is the operator's resolved
+ * assistant name. Resolves to the skill inputs to pre-bind, or undefined for
+ * the manual walkthrough.
+ */
+export type ChannelPreStep = (agentName: string) => Promise<Record<string, string> | undefined>;
+
+const preSteps = new Map<string, ChannelPreStep>();
+const companionSkills = new Map<string, readonly string[]>();
+
+/** Register the auto-provision pre-step for a channel (last write wins). */
+export function registerChannelPreStep(channel: string, step: ChannelPreStep): void {
+  preSteps.set(channel, step);
+}
+
+export function getChannelPreStep(channel: string): ChannelPreStep | undefined {
+  return preSteps.get(channel);
+}
+
+/**
+ * Declare the companion skills applied after a channel's main install skill,
+ * in order (skill directory names under `.claude/skills/`; last write wins).
+ */
+export function registerCompanionSkills(channel: string, skills: readonly string[]): void {
+  companionSkills.set(channel, skills);
+}
+
+export function getCompanionSkills(channel: string): readonly string[] {
+  return companionSkills.get(channel) ?? [];
+}
+
+// ── Feature self-registration imports (appended by channel install skills) ──

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -24,10 +24,73 @@ import * as setupLog from '../logs.js';
 import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../lib/back-nav.js';
 import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
-import { runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
+import { hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
 import { clearTemplatePick } from '../templates.js';
+import { getChannelPreStep, getCompanionSkills } from './companions.js';
 
 const DEFAULT_AGENT_NAME = 'Nano';
+
+/**
+ * Apply a channel's declared companion skills (setup/channels/companions.ts)
+ * after its main install skill. Some channel payloads are bigger than the
+ * adapter install itself — capabilities that live in their own skills and
+ * used to be applied by hand, which is exactly how a fresh install ships a
+ * half-working channel. Applying the declared list here makes finishing setup
+ * mean the whole payload actually works.
+ *
+ * Per-skill restarts are skipped and ONE deferred restart runs after all of
+ * them — MANDATORY, and the reason `skipEffects: ['restart']` is safe: the
+ * main channel skill restarts the host BEFORE the companions run, so without
+ * a restart HERE nothing ever reloads after them. That failure mode is
+ * invisible on disk and brutal to diagnose — every file is correct, but the
+ * live process still holds the ESM-cached pre-edit modules.
+ *
+ * A companion that doesn't fully apply degrades, not fails: the channel's
+ * main install still works, so warn with the exact re-apply command instead
+ * of aborting setup.
+ */
+async function applyCompanionSkills(
+  channel: string,
+  projectRoot: string,
+  overrides: ChannelSkillOverrides,
+): Promise<void> {
+  const companions = getCompanionSkills(channel);
+  let applied = false;
+  for (const skill of companions) {
+    const res = await runSkill(`.claude/skills/${skill}`, {
+      projectRoot,
+      exec: overrides.exec,
+      resolveRemote: overrides.resolveRemote,
+      // Skip per-skill restarts; this function performs ONE after all, below.
+      skipEffects: overrides.skipEffects ?? ['restart'],
+      onEvent: overrides.onEvent,
+      confirm: overrides.confirm,
+      openUrl: overrides.openUrl,
+      step: `${channel}-${skill}`,
+    });
+    if (fullyApplied(res)) {
+      applied = true;
+      continue;
+    }
+    // Degraded, not fatal: the main channel install still works. Name the
+    // skill and the exact re-apply command so the warning is actionable.
+    p.log.warn(
+      `Couldn't fully apply companion skill ${skill}. The ${channel} channel works, but the ` +
+        `capability that skill adds stays degraded until you re-apply it: ` +
+        `pnpm exec tsx scripts/skill-apply.ts .claude/skills/${skill}`,
+    );
+  }
+
+  if (!applied) return;
+  try {
+    await (overrides.exec ?? hostExec(projectRoot))('bash setup/lib/restart.sh');
+  } catch {
+    p.log.warn(
+      'Applied the companion skills but could not restart the service. Their changes stay ' +
+        'inactive until you restart it: bash setup/lib/restart.sh',
+    );
+  }
+}
 
 interface WireArgs {
   channel: string;
@@ -41,7 +104,7 @@ interface WireArgs {
   engagePattern?: string;
 }
 
-async function resolveAgentName(): Promise<string> {
+export async function resolveAgentName(): Promise<string> {
   const preset = process.env.NANOCLAW_AGENT_NAME?.trim();
   if (preset) return preset;
   const answer = ensureAnswer(
@@ -189,6 +252,11 @@ export async function runChannelSkill(
     );
   }
 
+  // Declared companion skills: apply the rest of the channel's payload (see
+  // setup/channels/companions.ts). After the main install, so files the
+  // companions edit or import already exist.
+  await applyCompanionSkills(channel, projectRoot, overrides);
+
   // Identity confirmation captured by the skill (e.g. add-slack's auth.test).
   if (res.vars.connected_as) p.log.success(`Connected to ${channel} as ${res.vars.connected_as}.`);
 
@@ -238,4 +306,41 @@ export async function runChannelSkill(
   // setup run re-enter template setup. Pinned by run-channel-skill.test.ts
   // ("clears the template pick…").
   if (templateAgentGroupId) (overrides.clearTemplatePick ?? clearTemplatePick)();
+}
+
+/**
+ * The wizard's channel entry point: consult the channel's registered
+ * auto-provision pre-step (setup/channels/companions.ts) before its install
+ * skill. No registration ⇒ exactly runChannelSkill — the common case, and
+ * every channel's behavior today.
+ *
+ * With a pre-step, the opening order mirrors runChannelSkill's own: the back
+ * gate first (before any side effect — the pre-step owns prompts of its own),
+ * then the agent name — resolved up front because it doubles as the
+ * provisioned app's name — then the pre-step. Whatever inputs it returns
+ * pre-bind the skill's prompts; undefined means the manual path, and the
+ * skill flow prompts as usual. Explicit `overrides.inputs` win over pre-bound
+ * values.
+ */
+export async function runChannelSkillWithPreStep(
+  channel: string,
+  displayName: string,
+  overrides: ChannelSkillOverrides = {},
+): Promise<ChannelFlowResult> {
+  const preStep = getChannelPreStep(channel);
+  if (!preStep) return runChannelSkill(channel, displayName, overrides);
+
+  if (overrides.offerBack) {
+    const label = channel.charAt(0).toUpperCase() + channel.slice(1);
+    const gate = await (overrides.backGate ?? backGate)(label);
+    if (gate === BACK_TO_CHANNEL_SELECTION) return BACK_TO_CHANNEL_SELECTION;
+  }
+  const agentName = overrides.agentName ?? (await resolveAgentName());
+  const preBound = await preStep(agentName);
+  return runChannelSkill(channel, displayName, {
+    ...overrides,
+    offerBack: false,
+    agentName,
+    inputs: { ...preBound, ...overrides.inputs },
+  });
 }

--- a/setup/channels/wizard-hooks.test.ts
+++ b/setup/channels/wizard-hooks.test.ts
@@ -1,0 +1,284 @@
+/**
+ * The wizard's per-channel extension points, driven by fixtures.
+ *
+ *  - Pre-step: a channel feature registers an auto-provision pre-step;
+ *    runChannelSkillWithPreStep resolves the agent name, hands it to the
+ *    pre-step, and pre-binds whatever inputs it returns onto the install
+ *    skill — no channel-name conditionals anywhere in the flow.
+ *  - Companion skills: a channel feature declares companion skills;
+ *    runChannelSkill applies each after the main install with per-skill
+ *    restarts skipped, then performs ONE deferred restart, and degrades with
+ *    an actionable re-apply warning on partial failure.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as p from '@clack/prompts';
+
+import { runChannelSkill, runChannelSkillWithPreStep } from './run-channel-skill.js';
+import { registerChannelPreStep, registerCompanionSkills } from './companions.js';
+import { BACK_TO_CHANNEL_SELECTION } from '../lib/back-nav.js';
+
+/** Write a channel install skill that resolves the wire inputs and, when the
+ *  channel needs one, consumes a `token` prompt (validate-gated so only a
+ *  `tok-` value binds). Relative skill paths resolve against cwd, so tests
+ *  chdir into the scratch root (restored in afterEach). */
+function writeChannelSkill(root: string, channel: string): void {
+  const dir = join(root, `.claude/skills/add-${channel}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `# Add ${channel}
+
+## Credentials
+
+\`\`\`nc:prompt token validate:^tok-
+Paste your ${channel} token.
+\`\`\`
+
+## Resolve the owner DM
+
+\`\`\`nc:run capture:owner_handle
+${channel}-resolve-owner {{token}}
+\`\`\`
+
+\`\`\`nc:run capture:platform_id
+${channel}-resolve-dm
+\`\`\`
+`,
+  );
+}
+
+/** A companion skill: one install command plus its own effect:restart fence
+ *  (skipped by the mechanism, which owns the single deferred restart). */
+function writeCompanionSkill(root: string, name: string): void {
+  const dir = join(root, `.claude/skills/${name}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `# ${name}
+
+## Install
+
+\`\`\`nc:run
+${name}-install
+\`\`\`
+
+## Restart
+
+\`\`\`nc:run effect:restart
+bash setup/lib/restart.sh
+\`\`\`
+`,
+  );
+}
+
+function scratchRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  writeFileSync(join(root, '.env'), '');
+  writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+  return root;
+}
+
+/** Exec fixture: records commands, answers the channel skill's resolve runs. */
+function makeExec(channel: string, cmds: string[], failOn?: string) {
+  return (c: string): string | void => {
+    cmds.push(c);
+    if (failOn && c.includes(failOn)) throw new Error(`boom: ${failOn}`);
+    if (c.startsWith(`${channel}-resolve-owner`)) return 'U777\n';
+    if (c === `${channel}-resolve-dm`) return `${channel}:D777\n`;
+  };
+}
+
+/** failWith seam that throws instead of exiting the process. */
+const throwingFail = async (step: string, msg: string): Promise<never> => {
+  throw new Error(`fail(${step}): ${msg}`);
+};
+
+const originalCwd = process.cwd();
+const roots: string[] = [];
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  delete process.env.NANOCLAW_AGENT_NAME;
+});
+
+describe('runChannelSkillWithPreStep', () => {
+  it('a registered pre-step gets the resolved agent name and pre-binds the skill inputs', async () => {
+    const root = scratchRoot('wh-prestep-');
+    roots.push(root);
+    writeChannelSkill(root, 'fixturechan');
+    process.chdir(root);
+
+    const preStep = vi.fn(async (_agentName: string) => ({ token: 'tok-prestep' }));
+    registerChannelPreStep('fixturechan', preStep);
+    // The resolveAgentName pass-through: the preset name reaches the pre-step.
+    process.env.NANOCLAW_AGENT_NAME = 'Fixie';
+
+    const cmds: string[] = [];
+    const resolveInput = vi.fn(async () => undefined);
+    const wired: Array<Record<string, unknown>> = [];
+
+    await runChannelSkillWithPreStep('fixturechan', 'Bob Smith', {
+      projectRoot: root,
+      exec: makeExec('fixturechan', cmds),
+      resolveRemote: () => 'origin',
+      resolveInput,
+      role: 'owner',
+      fail: throwingFail,
+      wire: (a) => {
+        wired.push(a);
+        return true;
+      },
+    });
+
+    expect(preStep).toHaveBeenCalledExactlyOnceWith('Fixie');
+    // The pre-bound token satisfied the prompt — nothing was asked.
+    expect(resolveInput).not.toHaveBeenCalled();
+    // ...and fed the skill's own resolve step.
+    expect(cmds).toContain('fixturechan-resolve-owner tok-prestep');
+    expect(wired).toHaveLength(1);
+    expect(wired[0]).toMatchObject({
+      channel: 'fixturechan',
+      userId: 'fixturechan:U777',
+      platformId: 'fixturechan:D777',
+      agentName: 'Fixie',
+      role: 'owner',
+    });
+    // No companion declaration for this channel — no deferred restart either.
+    expect(cmds.filter((c) => c.includes('restart.sh'))).toHaveLength(0);
+  });
+
+  it('offerBack: the back gate is consumed before the pre-step runs', async () => {
+    const preStep = vi.fn(async () => ({}));
+    registerChannelPreStep('fixturechan-back', preStep);
+
+    const result = await runChannelSkillWithPreStep('fixturechan-back', 'Bob Smith', {
+      offerBack: true,
+      backGate: async () => BACK_TO_CHANNEL_SELECTION,
+      fail: throwingFail,
+    });
+
+    expect(result).toBe(BACK_TO_CHANNEL_SELECTION);
+    expect(preStep).not.toHaveBeenCalled();
+  });
+
+  it('no registered pre-step: delegates to the plain skill flow unchanged', async () => {
+    const root = scratchRoot('wh-noprestep-');
+    roots.push(root);
+    writeChannelSkill(root, 'fixtureplain');
+    process.chdir(root);
+
+    const cmds: string[] = [];
+    const wired: Array<Record<string, unknown>> = [];
+
+    await runChannelSkillWithPreStep('fixtureplain', 'Bob Smith', {
+      projectRoot: root,
+      exec: makeExec('fixtureplain', cmds),
+      resolveRemote: () => 'origin',
+      agentName: 'Nano',
+      role: 'owner',
+      inputs: { token: 'tok-manual' },
+      fail: throwingFail,
+      wire: (a) => {
+        wired.push(a);
+        return true;
+      },
+    });
+
+    expect(cmds).toContain('fixtureplain-resolve-owner tok-manual');
+    expect(wired).toHaveLength(1);
+    expect(wired[0]).toMatchObject({ userId: 'fixtureplain:U777', platformId: 'fixtureplain:D777' });
+  });
+});
+
+describe('companion skills', () => {
+  it('declared companions apply after the main install, with ONE deferred restart', async () => {
+    const root = scratchRoot('wh-companions-');
+    roots.push(root);
+    writeChannelSkill(root, 'fixturecomp');
+    writeCompanionSkill(root, 'fixture-companion-a');
+    writeCompanionSkill(root, 'fixture-companion-b');
+    process.chdir(root);
+    registerCompanionSkills('fixturecomp', ['fixture-companion-a', 'fixture-companion-b']);
+
+    const cmds: string[] = [];
+    await runChannelSkill('fixturecomp', 'Bob Smith', {
+      projectRoot: root,
+      exec: makeExec('fixturecomp', cmds),
+      resolveRemote: () => 'origin',
+      agentName: 'Nano',
+      role: 'owner',
+      inputs: { token: 'tok-x' },
+      fail: throwingFail,
+      wire: () => true,
+    });
+
+    // Both companions ran, after the main skill's resolve steps.
+    const aAt = cmds.indexOf('fixture-companion-a-install');
+    const bAt = cmds.indexOf('fixture-companion-b-install');
+    expect(aAt).toBeGreaterThan(cmds.indexOf('fixturecomp-resolve-dm'));
+    expect(bAt).toBeGreaterThan(aAt);
+    // Each companion's own effect:restart fence was skipped; the mechanism
+    // performed exactly ONE restart, after both.
+    const restarts = cmds.filter((c) => c === 'bash setup/lib/restart.sh');
+    expect(restarts).toHaveLength(1);
+    expect(cmds.indexOf('bash setup/lib/restart.sh')).toBeGreaterThan(bAt);
+  });
+
+  it('a partially-failed companion degrades with the exact re-apply command; the restart still runs', async () => {
+    const root = scratchRoot('wh-degraded-');
+    roots.push(root);
+    writeChannelSkill(root, 'fixturedeg');
+    writeCompanionSkill(root, 'fixture-companion-ok');
+    writeCompanionSkill(root, 'fixture-companion-bad');
+    process.chdir(root);
+    registerCompanionSkills('fixturedeg', ['fixture-companion-ok', 'fixture-companion-bad']);
+
+    const warn = vi.spyOn(p.log, 'warn').mockImplementation(() => {});
+    const cmds: string[] = [];
+    await runChannelSkill('fixturedeg', 'Bob Smith', {
+      projectRoot: root,
+      exec: makeExec('fixturedeg', cmds, 'fixture-companion-bad-install'),
+      resolveRemote: () => 'origin',
+      agentName: 'Nano',
+      role: 'owner',
+      inputs: { token: 'tok-x' },
+      fail: throwingFail,
+      wire: () => true,
+    });
+
+    // Degraded, not fatal: the warning names the skill and the re-apply command.
+    const degraded = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('fixture-companion-bad'));
+    expect(degraded).toHaveLength(1);
+    expect(degraded[0]).toContain('pnpm exec tsx scripts/skill-apply.ts .claude/skills/fixture-companion-bad');
+    // The applied companion still triggers the single deferred restart.
+    expect(cmds.filter((c) => c === 'bash setup/lib/restart.sh')).toHaveLength(1);
+  });
+
+  it('no declaration: no companion runs, no deferred restart (unchanged flow)', async () => {
+    const root = scratchRoot('wh-nocomp-');
+    roots.push(root);
+    writeChannelSkill(root, 'fixturenone');
+    process.chdir(root);
+
+    const cmds: string[] = [];
+    await runChannelSkill('fixturenone', 'Bob Smith', {
+      projectRoot: root,
+      exec: makeExec('fixturenone', cmds),
+      resolveRemote: () => 'origin',
+      agentName: 'Nano',
+      role: 'owner',
+      inputs: { token: 'tok-x' },
+      fail: throwingFail,
+      wire: () => true,
+    });
+
+    expect(cmds.some((c) => c.includes('restart.sh'))).toBe(false);
+    expect(cmds.some((c) => c.includes('companion'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Gives the setup wizard two generic extension points: a per-channel pre-step that can run before a channel's install skill and pre-bind its inputs (e.g. when credentials can be obtained programmatically), and a per-channel companion-skill declaration applied after the main install with a single deferred service restart and actionable degraded-mode warnings. Trunk wizard code carries no channel-specific imports or gates for these paths; channels with no declarations behave exactly as today.

- **`setup/channels/companions.ts` (new):** tiny registration module — `registerChannelPreStep`/`getChannelPreStep` and `registerCompanionSkills`/`getCompanionSkills`. Feature payloads append self-registration imports at the marked point (modules-barrel discipline); trunk ships none.
- **`runChannelSkillWithPreStep`** (exported from `run-channel-skill.ts`, adopted by every channel arm in `setup/auto.ts`): consults the registered pre-step before the install skill. With one registered, the opening order mirrors the flow's own — back gate, then the agent name (resolved up front because it doubles as the provisioned app's name, via the newly exported `resolveAgentName`), then the pre-step; returned inputs pre-bind the skill's prompts (`undefined` = manual path; explicit `overrides.inputs` win). No registration ⇒ exactly `runChannelSkill`.
- **Declaration-driven companion skills** in `runChannelSkill`: each declared companion applies after the main install with `skipEffects: ['restart']`, then ONE deferred restart after all of them — mandatory because the main channel skill restarts the host *before* the companions run, so without it the live process keeps serving the ESM-cached pre-edit modules while every file on disk is correct. A partially-applied companion degrades (never aborts setup) with a warning naming the skill and the exact re-apply command.

**Verification:** `pnpm run build && pnpm exec vitest run setup/channels/wizard-hooks.test.ts && pnpm test` — new suite drives both mechanisms with fixtures: a fixture pre-step receives the resolved agent name and its returned inputs satisfy the skill's validate-gated prompt (no interactive ask); back gate consumed before the pre-step; no-registration delegation unchanged; a fixture companion list applies in order after the main install with exactly one deferred restart; partial failure warns with the re-apply command while the restart still runs; no declaration ⇒ no restart. Full host suite: 120 files / 1524 tests, 0 failed. Gate: `setup/auto.ts` and `run-channel-skill.ts` contain no channel-name conditionals for these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
