### PR TITLE
feat(channels): add multi-agent local web chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "setup:auto": "tsx setup/auto.ts",
     "ncl": "tsx src/cli/client.ts",
     "chat": "tsx scripts/chat.ts",
+    "local-web": "tsx scripts/local-web-url.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chat-adapter-imessage": "^0.1.1",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
+    "markdown-it": "15.0.0",
     "pino": "^9.6.0",
     "qrcode": "^1.5.4",
     "wechat-ilink-client": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      markdown-it:
+        specifier: 15.0.0
+        version: 15.0.0
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -1421,6 +1424,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  argparse@3.0.0:
+    resolution: {integrity: sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1784,6 +1790,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2344,6 +2354,9 @@ packages:
   limiter@1.1.5:
     resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
 
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2419,6 +2432,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it@15.0.0:
+    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -2476,6 +2493,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
@@ -2838,6 +2858,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3207,6 +3231,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
@@ -4754,6 +4781,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  argparse@3.0.0: {}
+
   assertion-error@2.0.1: {}
 
   async-mutex@0.5.0:
@@ -5127,6 +5156,8 @@ snapshots:
   engine.io-parser@5.2.3: {}
 
   entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -5756,6 +5787,10 @@ snapshots:
 
   limiter@1.1.5: {}
 
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -5812,6 +5847,15 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it@15.0.0:
+    dependencies:
+      argparse: 3.0.0
+      entities: 8.0.0
+      linkify-it: 6.1.0
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 3.0.0
 
   markdown-table@3.0.4: {}
 
@@ -5955,6 +5999,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdurl@2.1.0: {}
 
   media-typer@1.1.1: {}
 
@@ -6422,6 +6468,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   qified@0.10.1:
@@ -6881,6 +6929,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uc.micro@3.0.0: {}
 
   uint8array-extras@1.5.0: {}
 

--- a/scripts/local-web-preview.ts
+++ b/scripts/local-web-preview.ts
@@ -1,0 +1,91 @@
+/** Isolated browser fixture for the local-web UI. Never touches the checkout's data/ or groups/. */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const requestedRoot = process.env.NANOCLAW_LOCAL_WEB_PREVIEW_ROOT?.trim();
+const previewRoot = requestedRoot
+  ? path.resolve(requestedRoot)
+  : fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-local-web-preview-'));
+const isFresh = !fs.existsSync(path.join(previewRoot, 'data', 'v2.db'));
+const port = Number(process.env.NANOCLAW_LOCAL_WEB_PORT ?? 3219);
+if (!Number.isInteger(port) || port < 1 || port > 65_535) throw new Error('Invalid NANOCLAW_LOCAL_WEB_PORT');
+
+fs.mkdirSync(path.join(previewRoot, 'src'), { recursive: true });
+fs.mkdirSync(path.join(previewRoot, 'data'), { recursive: true });
+if (!fs.existsSync(path.join(previewRoot, 'src', 'channels'))) {
+  fs.symlinkSync(path.join(projectRoot, 'src', 'channels'), path.join(previewRoot, 'src', 'channels'));
+}
+if (!fs.existsSync(path.join(previewRoot, 'container'))) {
+  fs.symlinkSync(path.join(projectRoot, 'container'), path.join(previewRoot, 'container'));
+}
+process.chdir(previewRoot);
+process.env.NANOCLAW_LOCAL_WEB_PORT = String(port);
+
+await import('../src/mailbox/compose.js');
+await import('../src/cli/resources/groups.js');
+await import('../src/cli/resources/messaging-groups.js');
+await import('../src/cli/resources/wirings.js');
+await import('../src/providers/index.js');
+const { createAgentGroup } = await import('../src/db/agent-groups.js');
+const { initDb } = await import('../src/db/connection.js');
+const { createMessagingGroup, createMessagingGroupAgent } = await import('../src/db/messaging-groups.js');
+const { runMigrations } = await import('../src/db/migrations/index.js');
+const { initGroupFilesystem } = await import('../src/group-init.js');
+const registry = await import('../src/channels/channel-registry.js');
+const { readOrCreateToken } = await import('../src/channels/local-web.js');
+
+await runMigrations(await initDb(path.join(previewRoot, 'data', 'v2.db')));
+if (isFresh) {
+  const now = new Date().toISOString();
+  for (const group of [
+    { id: 'ag-preview-claude', name: 'Claude Base', folder: 'claude-base' },
+    { id: 'ag-preview-writer', name: 'Writer', folder: 'writer' },
+  ]) {
+    await createAgentGroup({ ...group, agent_provider: null, created_at: now });
+    await initGroupFilesystem({ ...group, agent_provider: null, created_at: now });
+  }
+  await createMessagingGroup({
+    id: 'mg-preview-claude',
+    channel_type: 'local-web',
+    platform_id: 'local-web:local',
+    name: 'Claude Base',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now,
+  });
+  await createMessagingGroupAgent({
+    id: 'mga-preview-claude',
+    messaging_group_id: 'mg-preview-claude',
+    agent_group_id: 'ag-preview-claude',
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+}
+
+await registry.initChannelAdapters(() => ({
+  onInbound: () => {},
+  onInboundEvent: () => {},
+  onMetadata: () => {},
+  onAction: () => {},
+}));
+
+const token = readOrCreateToken();
+process.stdout.write(`PREVIEW_ROOT=${previewRoot}\n`);
+process.stdout.write(`PREVIEW_URL=http://127.0.0.1:${port}/#token=${encodeURIComponent(token)}\n`);
+
+async function shutdown(): Promise<void> {
+  await registry.teardownChannelAdapters();
+  process.exit(0);
+}
+
+process.on('SIGINT', () => void shutdown());
+process.on('SIGTERM', () => void shutdown());
+await new Promise(() => {});

--- a/scripts/local-web-url.ts
+++ b/scripts/local-web-url.ts
@@ -1,0 +1,6 @@
+import { configuredPort, readOrCreateToken } from '../src/channels/local-web.js';
+
+const token = readOrCreateToken();
+const url = `http://127.0.0.1:${configuredPort()}/#token=${encodeURIComponent(token)}`;
+
+process.stdout.write(`${url}\n`);

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -65,5 +65,8 @@ import './dial.js';
 // emacs (native HTTP bridge, no Chat SDK)
 // import './emacs.js';
 
+// local web (native loopback HTTP, no Chat SDK)
+import './local-web.js';
+
 // deltachat (native, no Chat SDK)
 // import './deltachat.js'

--- a/src/channels/local-web-chat.css
+++ b/src/channels/local-web-chat.css
@@ -1,0 +1,596 @@
+/* ---- transcript -------------------------------------------------------- */
+
+.log-wrap {
+  position: absolute;
+  inset: 0;
+}
+#messages {
+  height: 100%;
+  overflow-y: auto;
+  /* No mask here on purpose: content stays sharp so the chrome above it has
+     something real to blur. The scrollbar is left at the window edge. */
+  padding: calc(var(--header-h) + 10px) var(--gutter) calc(var(--dock-h) + 18px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 26px;
+  overscroll-behavior: contain;
+}
+
+.turn,
+.question-card,
+.empty {
+  width: var(--column);
+}
+.turn {
+  display: grid;
+  gap: 7px;
+  animation: none;
+}
+.turn.enter {
+  animation: rise 380ms var(--ease-spring) both;
+}
+.role {
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+
+.message {
+  max-width: var(--measure);
+  font-size: var(--fs-body);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+.message.user {
+  justify-self: end;
+  max-width: min(var(--measure), 82%);
+  padding: 12px 17px;
+  border: 1px solid var(--hairline);
+  border-radius: 18px 18px 6px 18px;
+  background: var(--wash);
+  color: var(--ink);
+  white-space: pre-wrap;
+}
+.turn.user {
+  justify-items: end;
+}
+.message.system {
+  justify-self: center;
+  max-width: 62ch;
+  padding: 11px 15px;
+  border: 1px dashed var(--rule);
+  border-radius: 12px;
+  color: var(--ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-align: center;
+  text-wrap: balance;
+}
+
+/* ---- agent markdown ---------------------------------------------------- */
+
+.message.agent {
+  color: var(--ink-body);
+}
+.message.agent > :first-child {
+  margin-top: 0;
+}
+.message.agent > :last-child {
+  margin-bottom: 0;
+}
+.message.agent p {
+  margin: 0 0 0.85em;
+}
+.message.agent h1,
+.message.agent h2,
+.message.agent h3,
+.message.agent h4 {
+  margin: 1.5em 0 0.5em;
+  color: var(--ink);
+  font-weight: 700;
+  line-height: 1.22;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+.message.agent h1 {
+  font-size: 1.34em;
+}
+.message.agent h2 {
+  font-size: 1.2em;
+}
+.message.agent h3 {
+  font-size: 1.06em;
+}
+.message.agent h4 {
+  font-size: 1em;
+}
+.message.agent strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+.message.agent a {
+  color: var(--action);
+  text-decoration-color: color-mix(in oklab, var(--action) 40%, transparent);
+  text-underline-offset: 3px;
+}
+.message.agent a:hover {
+  text-decoration-color: currentcolor;
+}
+.message.agent ul,
+.message.agent ol {
+  margin: 0 0 0.9em;
+  padding-left: 1.35em;
+}
+.message.agent li {
+  margin-bottom: 0.32em;
+  padding-left: 0.15em;
+}
+.message.agent li::marker {
+  color: var(--ink-muted);
+}
+.message.agent blockquote {
+  margin: 1em 0;
+  padding: 2px 0 2px 1.1em;
+  border-left: 2px solid var(--brand);
+  color: var(--ink-muted);
+}
+.message.agent hr {
+  height: 1px;
+  margin: 1.6em 0;
+  border: 0;
+  background: var(--hairline);
+}
+.message.agent img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 10px;
+}
+
+.message.agent code {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: 0.83em;
+}
+.message.agent :not(pre) > code {
+  padding: 0.14em 0.4em;
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  background: var(--wash);
+  color: var(--ink);
+}
+.message.agent pre {
+  position: relative;
+  margin: 0 0 1em;
+  padding: 14px 16px;
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  background: var(--linen-soft);
+  overflow-x: auto;
+}
+.message.agent pre code {
+  display: block;
+  color: var(--ink);
+  font-size: 0.78em;
+  line-height: 1.6;
+  white-space: pre;
+}
+.copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 9px;
+  border: 1px solid var(--hairline);
+  border-radius: 7px;
+  background: var(--paper);
+  color: var(--ink-muted);
+  font: 600 11px/1 inherit;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 160ms var(--ease-out),
+    color 160ms var(--ease-out);
+}
+pre:hover .copy,
+.copy:focus-visible {
+  opacity: 1;
+}
+.copy:hover {
+  color: var(--ink);
+}
+.copy:active {
+  transform: scale(0.94);
+}
+
+.message.agent table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  font-size: 0.84em;
+  line-height: 1.45;
+}
+.message.agent thead th {
+  padding: 7px 12px 7px 0;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-muted);
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+}
+.message.agent tbody td {
+  padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--hairline);
+  vertical-align: top;
+}
+.message.agent tbody tr:last-child td {
+  border-bottom: 0;
+}
+.message.agent th:last-child,
+.message.agent td:last-child {
+  padding-right: 0;
+}
+.table-scroll {
+  margin: 0 0 1em;
+  overflow-x: auto;
+}
+.table-scroll table {
+  margin: 0;
+}
+
+/* ---- approval card ----------------------------------------------------- */
+
+.question-card {
+  max-width: 560px;
+  padding: 16px 18px 18px;
+  border: 1px solid var(--hairline);
+  border-left: 3px solid var(--brand);
+  border-radius: 6px 16px 16px 6px;
+  background: var(--paper);
+  box-shadow: var(--shadow-lg);
+}
+.question-card.enter {
+  animation: rise 380ms var(--ease-spring) both;
+}
+.question-kicker {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 7px;
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+}
+.question-kicker::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+}
+.question-title {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  line-height: 1.28;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+.question-body {
+  margin: 7px 0 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  text-wrap: pretty;
+}
+.question-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 15px;
+}
+.question-option {
+  padding: 9px 14px;
+  border: 1px solid var(--rule);
+  border-radius: 9px;
+  background: var(--paper);
+  color: var(--ink);
+  font: 600 14px/1 inherit;
+  cursor: pointer;
+  transition:
+    transform 110ms var(--ease-out),
+    border-color 160ms var(--ease-out),
+    background 160ms var(--ease-out);
+}
+.question-option:hover:not(:disabled) {
+  border-color: var(--ink-muted);
+}
+.question-option:active:not(:disabled) {
+  transform: scale(0.97);
+}
+.question-option.primary {
+  border-color: var(--action);
+  background: var(--action);
+  color: var(--on-action);
+}
+.question-option.primary:hover:not(:disabled) {
+  border-color: var(--action);
+  background: color-mix(in oklab, var(--action) 88%, var(--ink));
+}
+.question-option.danger {
+  color: var(--highlight);
+}
+.question-option.danger:hover:not(:disabled) {
+  border-color: var(--highlight);
+}
+.question-option:disabled {
+  opacity: 0.42;
+  cursor: default;
+}
+.question-resolution {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--hairline);
+  color: var(--ink-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+.question-resolution::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+  flex-shrink: 0;
+}
+.question-resolution[hidden] {
+  display: none;
+}
+.question-error {
+  color: var(--highlight);
+}
+.question-error::before {
+  background: var(--highlight);
+}
+
+/* ---- empty state ------------------------------------------------------- */
+
+.empty {
+  margin: auto;
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  max-width: 44ch;
+  text-align: center;
+}
+.empty h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.3125rem;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+.empty p {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.empty-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--hairline);
+  background: var(--linen-soft);
+  display: grid;
+  place-items: center;
+  margin-bottom: 4px;
+}
+.empty-mark::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--brand);
+  animation: pulse 3.2s ease-in-out infinite;
+}
+.empty.locked .empty-mark::after {
+  background: var(--ink-muted);
+  animation: none;
+  opacity: 0.55;
+}
+.empty code {
+  margin-top: 4px;
+  padding: 6px 11px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: var(--linen-soft);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: 0.8125rem;
+}
+
+/* ---- floating affordances ---------------------------------------------- */
+
+.jump {
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--dock-h) - 34px);
+  translate: -50% 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  background: var(--glass);
+  backdrop-filter: blur(16px) saturate(180%);
+  color: var(--ink);
+  font: 600 13px/1 inherit;
+  cursor: pointer;
+  box-shadow: var(--shadow-lg);
+  transition:
+    opacity 200ms var(--ease-out),
+    translate 260ms var(--ease-spring);
+}
+.jump[hidden] {
+  display: none;
+}
+.jump.entering {
+  opacity: 0;
+  translate: -50% 10px;
+}
+.jump:active {
+  transform: scale(0.96);
+}
+.jump svg {
+  width: 13px;
+  height: 13px;
+}
+
+/* Floats over the log rather than sitting in the grid: an in-flow pill would
+   shove the composer down and back up on every single turn. */
+.activity {
+  position: absolute;
+  z-index: 3;
+  left: max(var(--gutter), calc((100% - var(--column-max)) / 2));
+  bottom: calc(var(--dock-h) - 34px);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 13px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  color: var(--ink-muted);
+  background: var(--glass);
+  backdrop-filter: blur(16px) saturate(180%);
+  box-shadow: var(--shadow-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1;
+  /* Materialise rather than fade: the pill scales in as it sharpens. */
+  animation: materialise 300ms var(--ease-spring) both;
+}
+.activity[hidden] {
+  display: none;
+}
+.activity-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--brand);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.activity.tool .activity-dot {
+  background: var(--highlight);
+}
+.activity.stalled .activity-dot {
+  background: var(--ink-muted);
+  animation-duration: 3.4s;
+}
+
+/* ---- composer ---------------------------------------------------------- */
+
+form {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  /* Nested radius: 20 outer − 10 padding = 10 inner. */
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--hairline);
+  border-radius: 20px;
+  background: var(--paper);
+  box-shadow: var(--shadow-lg);
+  transition: border-color 200ms var(--ease-out);
+}
+form:focus-within {
+  border-color: var(--action);
+  box-shadow:
+    var(--shadow-lg),
+    0 0 0 3px var(--ring);
+}
+textarea:focus-visible {
+  outline: 0;
+}
+textarea {
+  width: 100%;
+  min-height: 46px;
+  max-height: 200px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  padding: 12px 12px 10px;
+  color: var(--ink);
+  background: transparent;
+  font: inherit;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+}
+textarea::placeholder {
+  color: var(--ink-muted);
+}
+#send {
+  min-width: 76px;
+  height: 46px;
+  border: 0;
+  border-radius: 10px;
+  background: var(--action);
+  color: var(--on-action);
+  font: 700 14px/1 inherit;
+  cursor: pointer;
+  transition:
+    transform 110ms var(--ease-out),
+    opacity 200ms var(--ease-out),
+    background 160ms var(--ease-out);
+}
+#send:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--action) 88%, var(--ink));
+}
+#send:active:not(:disabled) {
+  transform: scale(0.96);
+}
+#send:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 14px;
+  margin: 10px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+  line-height: 1;
+}
+.counter {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.counter[hidden] {
+  display: none;
+}
+.counter.over {
+  color: var(--highlight);
+}
+kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--hairline);
+  border-radius: 5px;
+  background: var(--wash);
+  font: inherit;
+  font-size: 0.6875rem;
+}

--- a/src/channels/local-web-conversation-ui.js
+++ b/src/channels/local-web-conversation-ui.js
@@ -1,0 +1,192 @@
+/** Browser-side conversation state and API client for the local-web page. */
+
+/* global sessionStorage */
+
+const selectedKey = 'nanoclaw-local-web-selected-conversation';
+const transcriptPrefix = 'nanoclaw-local-web-history:';
+const maxVisibleItems = 100;
+
+function readSession(key) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(key, value) {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    // Storage can be unavailable; live chat still works for this page load.
+  }
+}
+
+function validConversation(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    typeof value.conversationId === 'string' &&
+    typeof value.agentName === 'string' &&
+    typeof value.provider === 'string'
+  );
+}
+
+function parseCatalog(value) {
+  if (!value || typeof value !== 'object' || !Array.isArray(value.conversations)) {
+    throw new Error('The conversation list is unavailable.');
+  }
+  const conversations = value.conversations.filter(validConversation);
+  const installedProviders = Array.isArray(value.installedProviders)
+    ? value.installedProviders.filter((provider) => typeof provider === 'string')
+    : [];
+  if (conversations.length === 0) throw new Error('No local agents are available.');
+  return {
+    conversations,
+    installedProviders,
+    installationDefault: typeof value.installationDefault === 'string' ? value.installationDefault : 'claude',
+    isInstallationDefaultInstalled: value.isInstallationDefaultInstalled === true,
+  };
+}
+
+async function responseJson(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(typeof body.error === 'string' ? body.error : `Request failed (${response.status})`);
+  }
+  return body;
+}
+
+export function createConversationController({ token, tokenHeader, onCatalog, onSelected, onEvent, onConnection }) {
+  let catalog = null;
+  let selected = null;
+  let streamAbort = null;
+
+  function headers(extra = {}) {
+    return { ...extra, [tokenHeader]: token };
+  }
+
+  function transcriptKey(conversationId) {
+    return `${transcriptPrefix}${conversationId}`;
+  }
+
+  function loadTranscript(conversationId) {
+    try {
+      const parsed = JSON.parse(readSession(transcriptKey(conversationId)) || '[]');
+      return Array.isArray(parsed) ? parsed.slice(-maxVisibleItems) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function saveTranscript(items) {
+    if (!selected) return;
+    writeSession(transcriptKey(selected.conversationId), JSON.stringify(items.slice(-maxVisibleItems)));
+  }
+
+  async function loadCatalog() {
+    const response = await fetch('/api/conversations', { headers: headers() });
+    catalog = parseCatalog(await responseJson(response));
+    onCatalog(catalog);
+    return catalog;
+  }
+
+  async function stream(conversationId, signal) {
+    let retryDelay = 1_000;
+    for (;;) {
+      if (signal.aborted) return;
+      try {
+        const response = await fetch(`/events?conversationId=${encodeURIComponent(conversationId)}`, {
+          headers: headers(),
+          signal,
+        });
+        if (response.status === 401) {
+          onConnection('unauthorized');
+          return;
+        }
+        if (!response.ok || !response.body) throw new Error(`Stream failed (${response.status})`);
+        onConnection('ready');
+        retryDelay = 1_000;
+        const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+        let buffer = '';
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += value;
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+          for (const frame of frames) {
+            if (!frame.startsWith('data: ')) continue;
+            try {
+              onEvent(JSON.parse(frame.slice(6)));
+            } catch {
+              // One malformed event never stops the selected conversation.
+            }
+          }
+        }
+      } catch {
+        if (signal.aborted) return;
+      }
+      onConnection('reconnecting');
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+      retryDelay = Math.min(retryDelay * 2, 30_000);
+    }
+  }
+
+  async function select(conversationId) {
+    const next = catalog?.conversations.find((conversation) => conversation.conversationId === conversationId);
+    if (!next) throw new Error('Conversation not found.');
+    streamAbort?.abort();
+    selected = next;
+    writeSession(selectedKey, conversationId);
+    onSelected(next, loadTranscript(conversationId));
+    streamAbort = new AbortController();
+    void stream(conversationId, streamAbort.signal);
+  }
+
+  async function initialize() {
+    const loaded = await loadCatalog();
+    const stored = readSession(selectedKey);
+    const initial =
+      loaded.conversations.find((conversation) => conversation.conversationId === stored) ??
+      loaded.conversations.find((conversation) => conversation.isLegacy) ??
+      loaded.conversations[0];
+    await select(initial.conversationId);
+  }
+
+  async function createAgent(input) {
+    const body = { name: input.name, ...(selected && { sourceConversationId: selected.conversationId }) };
+    if (input.provider) body.provider = input.provider;
+    if (Object.hasOwn(input, 'model')) body.model = input.model;
+    if (Object.hasOwn(input, 'effort')) body.effort = input.effort;
+    const response = await fetch('/api/agents', {
+      method: 'POST',
+      headers: headers({ 'content-type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    const result = await responseJson(response);
+    const createdId = result?.conversation?.conversationId;
+    if (typeof createdId !== 'string') throw new Error('Agent was created without a conversation. Retry to resume.');
+    await loadCatalog();
+    await select(createdId);
+    return result;
+  }
+
+  function dispose() {
+    streamAbort?.abort();
+  }
+
+  return {
+    initialize,
+    select,
+    createAgent,
+    saveTranscript,
+    dispose,
+    get catalog() {
+      return catalog;
+    },
+    get selected() {
+      return selected;
+    },
+  };
+}

--- a/src/channels/local-web-conversations.css
+++ b/src/channels/local-web-conversations.css
@@ -1,0 +1,468 @@
+/* Agent navigation and creation. The chat document remains in local-web-chat.css. */
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 17rem minmax(0, 1fr);
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+.agent-sidebar {
+  position: relative;
+  z-index: 4;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 1.1rem;
+  min-width: 0;
+  padding: max(1.25rem, env(safe-area-inset-top)) 0.9rem max(1.1rem, env(safe-area-inset-bottom));
+  border-right: 1px solid var(--hairline);
+  background: color-mix(in oklab, var(--ground) 88%, var(--paper));
+}
+
+.sidebar-brand {
+  padding: 0.25rem 0.65rem 0.1rem;
+}
+
+.sidebar-brand .logotype {
+  width: 8.4rem;
+}
+
+.create-agent-button,
+.agent-row,
+.primary-button,
+.secondary-button {
+  font-family: inherit;
+  touch-action: manipulation;
+}
+
+.create-agent-button {
+  width: 100%;
+  padding: 0.72rem 0.85rem;
+  border: 1px solid var(--action);
+  border-radius: 0.8rem;
+  color: var(--on-action);
+  background: var(--action);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 100ms var(--ease-out),
+    background 160ms var(--ease-out);
+}
+
+.create-agent-button::before {
+  content: '+';
+  display: inline-block;
+  width: 1.2rem;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.create-agent-button:hover {
+  background: color-mix(in oklab, var(--action) 88%, var(--ink));
+}
+
+.create-agent-button:active,
+.agent-row:active,
+.primary-button:active,
+.secondary-button:active {
+  transform: scale(0.97);
+}
+
+.agent-list {
+  display: grid;
+  align-content: start;
+  gap: 0.28rem;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.agent-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: center;
+  width: 100%;
+  padding: 0.68rem 0.62rem;
+  border: 1px solid transparent;
+  border-radius: 0.85rem;
+  color: var(--ink-body);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 100ms var(--ease-out),
+    background 160ms var(--ease-out),
+    border-color 160ms var(--ease-out);
+}
+
+.agent-row:hover {
+  background: color-mix(in oklab, var(--paper) 62%, transparent);
+}
+
+.agent-row[aria-current='true'] {
+  border-color: color-mix(in oklab, var(--action) 28%, var(--hairline));
+  background: color-mix(in oklab, var(--brand) 12%, var(--paper));
+  color: var(--ink);
+}
+
+.agent-avatar {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--hairline);
+  border-radius: 50%;
+  color: var(--ink);
+  background: var(--paper);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.02em;
+}
+
+.agent-row-copy {
+  display: grid;
+  gap: 0.16rem;
+  min-width: 0;
+}
+
+.agent-row-name {
+  overflow: hidden;
+  font-size: 0.88rem;
+  font-weight: 680;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-row-runtime,
+.sidebar-local,
+.agent-runtime,
+.single-provider,
+.inheritance-summary {
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.agent-row-state {
+  width: 0.44rem;
+  height: 0.44rem;
+  border-radius: 50%;
+  background: var(--rule);
+}
+
+.agent-row[aria-current='true'] .agent-row-state {
+  background: var(--brand);
+}
+
+.sidebar-local {
+  margin: 0;
+  padding: 0.2rem 0.65rem 0;
+  letter-spacing: 0.01em;
+}
+
+.header-identity {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.icon-button.agents-toggle {
+  display: none;
+  flex: 0 0 auto;
+}
+
+#agent-title {
+  margin: 0.15rem 0 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: clamp(1.2rem, 2vw, 1.45rem);
+  font-weight: 730;
+  line-height: 1.1;
+  letter-spacing: -0.018em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-runtime {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-scrim {
+  display: none;
+}
+
+.sidebar-scrim[hidden] {
+  display: none;
+}
+
+.create-agent-dialog {
+  width: min(31rem, calc(100vw - 2rem));
+  max-height: min(44rem, calc(100dvh - 2rem));
+  padding: 0;
+  border: 0;
+  border-radius: 1.4rem;
+  color: var(--ink-body);
+  background: var(--paper);
+  box-shadow: 0 1.5rem 4rem rgb(26 22 18 / 24%);
+}
+
+.create-agent-dialog::backdrop {
+  background: rgb(0 0 0 / 34%);
+  backdrop-filter: blur(0.35rem);
+}
+
+.create-agent-dialog form {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  padding: 1.35rem;
+  border: 0;
+  border-radius: inherit;
+  box-shadow: none;
+}
+
+.create-agent-dialog form:focus-within {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.dialog-heading,
+.dialog-actions,
+.inheritance-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dialog-heading h2 {
+  margin: 0.15rem 0 0;
+  color: var(--ink);
+  font-size: 1.5rem;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.dialog-kicker {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.form-field[hidden] {
+  display: none;
+}
+
+.form-field > span {
+  color: var(--ink-muted);
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+.form-field input,
+.form-field select {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.68rem 0.75rem;
+  border: 1px solid var(--hairline);
+  border-radius: 0.7rem;
+  color: var(--ink);
+  background: var(--wash);
+  font: inherit;
+  font-size: 0.94rem;
+}
+
+.form-field input:focus-visible,
+.form-field select:focus-visible {
+  border-color: var(--action);
+  outline: 3px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.inheritance-summary {
+  align-items: flex-start;
+  padding: 0.8rem 0.85rem;
+  border: 1px solid var(--hairline);
+  border-radius: 0.8rem;
+  background: var(--linen-soft);
+}
+
+.inheritance-summary strong {
+  color: var(--ink);
+}
+
+.single-provider {
+  margin: -0.35rem 0 0;
+}
+
+.advanced-options {
+  border-top: 1px solid var(--hairline);
+  padding-top: 0.85rem;
+}
+
+.advanced-options summary {
+  color: var(--action);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.advanced-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(8rem, 0.65fr);
+  gap: 0.85rem;
+  margin-top: 0.9rem;
+}
+
+.form-error {
+  margin: 0;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid color-mix(in oklab, var(--highlight) 42%, var(--hairline));
+  border-radius: 0.7rem;
+  color: var(--highlight);
+  background: color-mix(in oklab, var(--highlight) 8%, var(--paper));
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.dialog-actions {
+  justify-content: flex-end;
+  margin-top: 0.25rem;
+}
+
+.primary-button,
+.secondary-button {
+  min-height: 2.6rem;
+  padding: 0.7rem 1rem;
+  border-radius: 0.7rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 100ms var(--ease-out);
+}
+
+.primary-button {
+  border: 1px solid var(--action);
+  color: var(--on-action);
+  background: var(--action);
+}
+
+.secondary-button {
+  border: 1px solid var(--hairline);
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.primary-button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+@media (max-width: 780px) {
+  .app-shell {
+    display: block;
+  }
+
+  .agent-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(86vw, 20rem);
+    border-right: 1px solid var(--hairline);
+    background: color-mix(in oklab, var(--paper) 94%, var(--ground));
+    box-shadow: 1rem 0 3rem rgb(26 22 18 / 20%);
+    transform: translate3d(-104%, 0, 0);
+    transition: transform 220ms cubic-bezier(0.22, 0.61, 0.36, 1);
+    will-change: transform;
+  }
+
+  .app-shell.sidebar-open .agent-sidebar {
+    transform: translate3d(0, 0, 0);
+  }
+
+  .sidebar-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 3;
+    display: block;
+    border: 0;
+    background: rgb(0 0 0 / 30%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 220ms ease-out;
+  }
+
+  .app-shell.sidebar-open .sidebar-scrim {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .icon-button.agents-toggle {
+    display: grid;
+  }
+}
+
+@media (max-width: 520px) {
+  .advanced-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .inheritance-summary {
+    display: grid;
+  }
+
+  .create-agent-dialog form {
+    padding: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-sidebar,
+  .sidebar-scrim,
+  .create-agent-button,
+  .agent-row,
+  .primary-button,
+  .secondary-button {
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .agent-sidebar,
+  .create-agent-dialog,
+  .create-agent-dialog::backdrop {
+    backdrop-filter: none;
+  }
+
+  .agent-sidebar,
+  .create-agent-dialog {
+    background: var(--paper);
+  }
+}
+
+@media (prefers-contrast: more) {
+  .agent-sidebar,
+  .agent-row[aria-current='true'],
+  .create-agent-dialog,
+  .form-field input,
+  .form-field select {
+    border-color: var(--ink);
+  }
+}

--- a/src/channels/local-web-conversations.test.ts
+++ b/src/channels/local-web-conversations.test.ts
@@ -1,0 +1,306 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { TEST_ROOT } = vi.hoisted(() => ({ TEST_ROOT: '/tmp/nanoclaw-test-local-web-conversations' }));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return {
+    ...actual,
+    DATA_DIR: path.join(TEST_ROOT, 'data'),
+    GROUPS_DIR: path.join(TEST_ROOT, 'groups'),
+    DEFAULT_AGENT_PROVIDER: 'claude',
+  };
+});
+
+vi.mock('../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../modules/agent-to-agent/write-destinations.js', () => ({ writeDestinations: vi.fn() }));
+
+import { materializeContainerJson } from '../container-config.js';
+import { getAgentGroupByFolder, createAgentGroup } from '../db/agent-groups.js';
+import { getContainerConfig, updateContainerConfigScalars } from '../db/container-configs.js';
+import { closeDb, getDb, initTestDb } from '../db/connection.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupByPlatform,
+} from '../db/messaging-groups.js';
+import { runMigrations } from '../db/migrations/index.js';
+import { initGroupFilesystem } from '../group-init.js';
+import '../cli/resources/groups.js';
+import '../cli/resources/messaging-groups.js';
+import '../cli/resources/wirings.js';
+import './local-web.js';
+import {
+  createLocalWebAgent,
+  ensureLocalWebConversations,
+  listLocalWebCatalog,
+  parseCreateLocalWebAgentRequest,
+} from './local-web-conversations.js';
+
+async function createGroup(id: string, name: string, folder: string): Promise<void> {
+  const group = { id, name, folder, agent_provider: null, created_at: new Date().toISOString() };
+  await createAgentGroup(group);
+  await initGroupFilesystem(group);
+}
+
+async function wireLegacy(agentGroupId: string): Promise<void> {
+  const now = new Date().toISOString();
+  await createMessagingGroup({
+    id: 'mg-legacy',
+    channel_type: 'local-web',
+    platform_id: 'local-web:local',
+    name: 'Legacy',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now,
+  });
+  await createMessagingGroupAgent({
+    id: 'mga-legacy',
+    messaging_group_id: 'mg-legacy',
+    agent_group_id: agentGroupId,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+}
+
+async function count(sql: string, ...values: unknown[]): Promise<number> {
+  const row = await getDb().get<{ count: number }>(sql, ...values);
+  return row?.count ?? 0;
+}
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+  await runMigrations(await initTestDb());
+});
+
+afterEach(async () => {
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('local web create request parsing', () => {
+  it('accepts only the bounded product fields', () => {
+    expect(parseCreateLocalWebAgentRequest({ name: ' Researcher ' })).toEqual({
+      ok: true,
+      value: { name: 'Researcher' },
+    });
+    expect(
+      parseCreateLocalWebAgentRequest({
+        name: 'Researcher',
+        sourceConversationId: 'mg-legacy',
+        provider: 'CLAUDE',
+        model: 'sonnet',
+        effort: 'HIGH',
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        name: 'Researcher',
+        sourceConversationId: 'mg-legacy',
+        provider: 'claude',
+        model: 'sonnet',
+        effort: 'high',
+      },
+    });
+    expect(parseCreateLocalWebAgentRequest({ name: 'Researcher', model: '', effort: '' })).toEqual({
+      ok: true,
+      value: { name: 'Researcher', model: null, effort: null },
+    });
+  });
+
+  it.each([
+    [{ name: 'Researcher', agent_group_id: 'ag-target' }, 'Unknown field'],
+    [{ name: '   ' }, '1 to 64'],
+    [{ name: '———' }, 'ASCII letter or digit'],
+    [{ name: 'bad\u0000name' }, 'control characters'],
+    [{ name: 'Researcher', model: 'bad model' }, 'model must be'],
+    [{ name: 'Researcher', effort: 'minimal' }, 'effort must be'],
+    [{ name: 'Researcher', sourceConversationId: 42 }, 'sourceConversationId must be a string'],
+  ])('rejects invalid input %#', (input, message) => {
+    expect(parseCreateLocalWebAgentRequest(input)).toMatchObject({
+      ok: false,
+      message: expect.stringContaining(message),
+    });
+  });
+});
+
+describe('local web conversation backfill', () => {
+  it('creates one stable conversation per group without sessions or duplicates', async () => {
+    await createGroup('ag-legacy', 'Legacy', 'legacy');
+    await createGroup('ag-beta', 'Beta', 'beta');
+    await createGroup('ag-alpha', 'alpha', 'alpha');
+    await wireLegacy('ag-legacy');
+    await updateContainerConfigScalars('ag-alpha', { model: 'sonnet', effort: 'high' });
+
+    await ensureLocalWebConversations();
+    await ensureLocalWebConversations();
+
+    const catalog = await listLocalWebCatalog();
+    expect(catalog).toMatchObject({
+      installedProviders: expect.arrayContaining(['claude']),
+      installationDefault: 'claude',
+      isInstallationDefaultInstalled: true,
+    });
+    expect(catalog.conversations.map((conversation) => conversation.agentName)).toEqual(['alpha', 'Beta', 'Legacy']);
+    expect(catalog.conversations.find((conversation) => conversation.agentName === 'alpha')).toMatchObject({
+      provider: 'claude',
+      model: 'sonnet',
+      effort: 'high',
+    });
+    expect(catalog.conversations.find((conversation) => conversation.agentName === 'Legacy')?.isLegacy).toBe(true);
+    expect(await count("SELECT COUNT(*) count FROM messaging_groups WHERE channel_type = 'local-web'")).toBe(3);
+    expect(
+      await count(
+        `SELECT COUNT(*) count
+           FROM messaging_group_agents mga
+           JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+          WHERE mg.channel_type = 'local-web'`,
+      ),
+    ).toBe(3);
+    expect(await count("SELECT COUNT(*) count FROM agent_destinations WHERE target_type = 'channel'")).toBe(3);
+    expect(await count('SELECT COUNT(*) count FROM sessions')).toBe(0);
+    expect((await getMessagingGroupByPlatform('local-web', 'local-web:local', 'local-web'))?.id).toBe('mg-legacy');
+  });
+});
+
+describe('local web agent creation', () => {
+  it('inherits selected Claude overrides while leaving provider-default storage unset', async () => {
+    await createGroup('ag-legacy', 'Legacy', 'legacy');
+    await wireLegacy('ag-legacy');
+    await updateContainerConfigScalars('ag-legacy', { model: 'sonnet', effort: 'high' });
+
+    const first = await createLocalWebAgent({ name: 'Writer', sourceConversationId: 'mg-legacy' });
+    const second = await createLocalWebAgent({ name: ' writer ', sourceConversationId: 'mg-legacy' });
+
+    expect(first).toMatchObject({ ok: true, created: true, conversation: { agentName: 'Writer', provider: 'claude' } });
+    expect(second).toMatchObject({
+      ok: true,
+      created: false,
+      conversation: { conversationId: first.ok ? first.conversation.conversationId : '' },
+    });
+    const group = await getAgentGroupByFolder('web-writer');
+    expect(group).toBeDefined();
+    const config = await getContainerConfig(group!.id);
+    expect(config).toMatchObject({ provider: null, model: 'sonnet', effort: 'high' });
+    expect(await materializeContainerJson(group!.id)).toMatchObject({
+      provider: undefined,
+      model: 'sonnet',
+      effort: 'high',
+    });
+    expect(await count("SELECT COUNT(*) count FROM agent_groups WHERE folder = 'web-writer'")).toBe(1);
+    expect(await count('SELECT COUNT(*) count FROM sessions')).toBe(0);
+  });
+
+  it('stores explicit Claude provider, model, and effort before first spawn', async () => {
+    const result = await createLocalWebAgent({
+      name: 'Claude Analyst',
+      provider: 'claude',
+      model: 'sonnet',
+      effort: 'xhigh',
+    });
+    expect(result).toMatchObject({ ok: true, created: true, conversation: { provider: 'claude' } });
+    const group = await getAgentGroupByFolder('web-claude-analyst');
+    const config = group && (await getContainerConfig(group.id));
+    expect(config).toMatchObject({ provider: 'claude', model: 'sonnet', effort: 'xhigh' });
+    expect(await materializeContainerJson(group!.id)).toMatchObject({
+      provider: 'claude',
+      model: 'sonnet',
+      effort: 'xhigh',
+    });
+  });
+
+  it('uses provider defaults when inherited model and effort choices are cleared', async () => {
+    await createGroup('ag-legacy', 'Legacy', 'legacy');
+    await wireLegacy('ag-legacy');
+    await updateContainerConfigScalars('ag-legacy', { model: 'sonnet', effort: 'high' });
+
+    const result = await createLocalWebAgent({
+      name: 'Default Writer',
+      sourceConversationId: 'mg-legacy',
+      model: null,
+      effort: null,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      created: true,
+      conversation: { agentName: 'Default Writer', provider: 'claude' },
+    });
+    const group = await getAgentGroupByFolder('web-default-writer');
+    expect(group).toBeDefined();
+    expect(await getContainerConfig(group!.id)).toMatchObject({ provider: null, model: null, effort: null });
+    expect(await materializeContainerJson(group!.id)).toMatchObject({
+      provider: undefined,
+      model: undefined,
+      effort: undefined,
+    });
+  });
+
+  it('rejects an uninstalled provider before writing durable state', async () => {
+    expect(await createLocalWebAgent({ name: 'Researcher', provider: 'missing-provider' })).toMatchObject({
+      ok: false,
+      reason: 'provider_not_installed',
+    });
+    expect(await getAgentGroupByFolder('web-researcher')).toBeUndefined();
+  });
+
+  it('resumes a partial group and conversation without duplicating durable state', async () => {
+    await createGroup('ag-partial', 'Researcher', 'web-researcher');
+    await createMessagingGroup({
+      id: 'mg-partial',
+      channel_type: 'local-web',
+      platform_id: 'local-web:agent:ag-partial',
+      name: 'Researcher',
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: new Date().toISOString(),
+    });
+
+    const result = await createLocalWebAgent({ name: 'Researcher', provider: 'claude', model: 'sonnet' });
+    expect(result).toMatchObject({ ok: true, created: false, conversation: { agentName: 'Researcher' } });
+    expect(await count("SELECT COUNT(*) count FROM agent_groups WHERE folder = 'web-researcher'")).toBe(1);
+    expect(
+      await count("SELECT COUNT(*) count FROM messaging_groups WHERE platform_id = 'local-web:agent:ag-partial'"),
+    ).toBe(1);
+    expect(await count("SELECT COUNT(*) count FROM messaging_group_agents WHERE agent_group_id = 'ag-partial'")).toBe(
+      1,
+    );
+    expect(await count("SELECT COUNT(*) count FROM agent_destinations WHERE agent_group_id = 'ag-partial'")).toBe(1);
+  });
+
+  it('serializes concurrent duplicate normalized names onto one agent', async () => {
+    const [first, second] = await Promise.all([
+      createLocalWebAgent({ name: 'Sales Writer' }),
+      createLocalWebAgent({ name: 'sales---writer' }),
+    ]);
+    expect(first.ok && second.ok).toBe(true);
+    expect(first.ok && second.ok && first.conversation.conversationId).toBe(
+      second.ok ? second.conversation.conversationId : '',
+    );
+    expect(await count("SELECT COUNT(*) count FROM agent_groups WHERE folder = 'web-sales-writer'")).toBe(1);
+  });
+
+  it('does not fall back when an explicit source conversation is unknown', async () => {
+    expect(await createLocalWebAgent({ name: 'Writer', sourceConversationId: 'missing' })).toMatchObject({
+      ok: false,
+      reason: 'source_not_found',
+    });
+    expect(await getAgentGroupByFolder('web-writer')).toBeUndefined();
+  });
+});

--- a/src/channels/local-web-conversations.ts
+++ b/src/channels/local-web-conversations.ts
@@ -1,0 +1,447 @@
+import { randomUUID } from 'node:crypto';
+
+import { dispatch } from '../cli/dispatch.js';
+import { DEFAULT_AGENT_PROVIDER } from '../config.js';
+import { getAgentGroupByFolder } from '../db/agent-groups.js';
+import { getContainerConfig } from '../db/container-configs.js';
+import { getDb } from '../db/connection.js';
+import { getPendingApproval, getPendingQuestion } from '../db/sessions.js';
+import { assertValidGroupFolder } from '../group-folder.js';
+import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
+import '../providers/index.js';
+import { listProviderContainerConfigNames } from '../providers/provider-container-registry.js';
+import type { AgentGroup } from '../types.js';
+
+export const LOCAL_WEB_CHANNEL_TYPE = 'local-web';
+export const LOCAL_WEB_LEGACY_PLATFORM_ID = 'local-web:local';
+export const LOCAL_WEB_USER_ID = LOCAL_WEB_LEGACY_PLATFORM_ID;
+
+const MODEL_PATTERN = /^[A-Za-z0-9._:/-]{1,128}$/;
+const CONTROL_CHARACTER_PATTERN = /\p{Cc}/u;
+const ALLOWED_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
+const ALLOWED_CREATE_FIELDS = new Set(['name', 'sourceConversationId', 'provider', 'model', 'effort']);
+
+export interface LocalWebConversation {
+  conversationId: string;
+  agentName: string;
+  provider: string;
+  model?: string;
+  effort?: string;
+  isLegacy: boolean;
+}
+
+export interface LocalWebCatalog {
+  conversations: LocalWebConversation[];
+  installedProviders: string[];
+  installationDefault: string;
+  isInstallationDefaultInstalled: boolean;
+}
+
+export interface CreateLocalWebAgentRequest {
+  name: string;
+  sourceConversationId?: string;
+  provider?: string;
+  model?: string | null;
+  effort?: string | null;
+}
+
+export type ParseCreateLocalWebAgentRequestResult =
+  | { ok: true; value: CreateLocalWebAgentRequest }
+  | { ok: false; message: string };
+
+type CreateStage = 'agent group' | 'runtime configuration' | 'web conversation' | 'web wiring';
+
+export type CreateLocalWebAgentResult =
+  | { ok: true; created: boolean; conversation: LocalWebConversation }
+  | {
+      ok: false;
+      reason: 'source_not_found' | 'provider_not_installed' | 'stage_failed';
+      status: number;
+      message: string;
+      stage?: CreateStage;
+      detail?: string;
+    };
+
+interface ConversationRow {
+  conversation_id: string;
+  platform_id: string;
+  agent_group_id: string;
+  agent_name: string;
+  folder: string;
+  provider: string | null;
+  model: string | null;
+  effort: string | null;
+}
+
+interface ResolvedRuntime {
+  provider: string;
+  model?: string;
+  effort?: string;
+  providerWasExplicit: boolean;
+}
+
+type StageResult = { ok: true; data: unknown } | { ok: false; stage: CreateStage; detail: string };
+
+const creationLocks = new Map<string, Promise<void>>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function optionalString(value: unknown, field: string): { ok: true; value?: string } | { ok: false; message: string } {
+  if (value === undefined) return { ok: true };
+  if (typeof value !== 'string') return { ok: false, message: `${field} must be a string.` };
+  return { ok: true, value: value.trim() };
+}
+
+function optionalRuntimeOverride(
+  value: unknown,
+  field: string,
+): { ok: true; value?: string | null } | { ok: false; message: string } {
+  const parsed = optionalString(value, field);
+  if (!parsed.ok || parsed.value === undefined) return parsed;
+  return { ok: true, value: parsed.value || null };
+}
+
+export function parseCreateLocalWebAgentRequest(value: unknown): ParseCreateLocalWebAgentRequestResult {
+  if (!isRecord(value)) return { ok: false, message: 'Expected an agent object.' };
+  const unexpected = Object.keys(value).find((field) => !ALLOWED_CREATE_FIELDS.has(field));
+  if (unexpected) return { ok: false, message: `Unknown field: ${unexpected}.` };
+
+  if (typeof value.name !== 'string') return { ok: false, message: 'Agent name is required.' };
+  const name = value.name.trim();
+  if (name.length === 0 || name.length > 64) return { ok: false, message: 'Agent name must be 1 to 64 characters.' };
+  if (CONTROL_CHARACTER_PATTERN.test(name))
+    return { ok: false, message: 'Agent name cannot contain control characters.' };
+  if (!/[A-Za-z0-9]/.test(name)) {
+    return { ok: false, message: 'Agent name must contain at least one ASCII letter or digit.' };
+  }
+
+  const source = optionalString(value.sourceConversationId, 'sourceConversationId');
+  if (!source.ok) return source;
+  if (source.value !== undefined && (source.value.length === 0 || source.value.length > 128)) {
+    return { ok: false, message: 'sourceConversationId must be 1 to 128 characters.' };
+  }
+  const provider = optionalString(value.provider, 'provider');
+  if (!provider.ok) return provider;
+  if (provider.value !== undefined && provider.value.length === 0) {
+    return { ok: false, message: 'provider cannot be empty.' };
+  }
+  const model = optionalRuntimeOverride(value.model, 'model');
+  if (!model.ok) return model;
+  if (model.value !== undefined && model.value !== null && !MODEL_PATTERN.test(model.value)) {
+    return {
+      ok: false,
+      message: 'model must be 1 to 128 characters using letters, digits, dot, underscore, colon, slash, or hyphen.',
+    };
+  }
+  const effort = optionalRuntimeOverride(value.effort, 'effort');
+  if (!effort.ok) return effort;
+  const normalizedEffort = effort.value?.toLowerCase() ?? effort.value;
+  if (normalizedEffort !== undefined && normalizedEffort !== null && !ALLOWED_EFFORTS.has(normalizedEffort)) {
+    return { ok: false, message: 'effort must be low, medium, high, or xhigh.' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name,
+      ...(source.value !== undefined && { sourceConversationId: source.value }),
+      ...(provider.value !== undefined && { provider: provider.value.toLowerCase() }),
+      ...(model.value !== undefined && { model: model.value }),
+      ...(normalizedEffort !== undefined && { effort: normalizedEffort }),
+    },
+  };
+}
+
+function toConversation(row: ConversationRow): LocalWebConversation {
+  return {
+    conversationId: row.conversation_id,
+    agentName: row.agent_name,
+    provider: (row.provider ?? 'claude').toLowerCase(),
+    ...(row.model && { model: row.model }),
+    ...(row.effort && { effort: row.effort }),
+    isLegacy: row.platform_id === LOCAL_WEB_LEGACY_PLATFORM_ID,
+  };
+}
+
+function installedProviders(): string[] {
+  const optional = listProviderContainerConfigNames()
+    .map((provider) => provider.toLowerCase())
+    .filter((provider) => provider !== 'claude')
+    .sort((a, b) => a.localeCompare(b));
+  return ['claude', ...new Set(optional)];
+}
+
+const CONVERSATION_SELECT = `
+  SELECT mg.id AS conversation_id,
+         mg.platform_id,
+         ag.id AS agent_group_id,
+         ag.name AS agent_name,
+         ag.folder,
+         cc.provider,
+         cc.model,
+         cc.effort
+    FROM messaging_groups mg
+    JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
+    JOIN agent_groups ag ON ag.id = mga.agent_group_id
+    LEFT JOIN container_configs cc ON cc.agent_group_id = ag.id
+   WHERE mg.channel_type = ? AND mg.instance = ?`;
+
+export async function listLocalWebCatalog(): Promise<LocalWebCatalog> {
+  const rows = await getDb().all<ConversationRow>(
+    `${CONVERSATION_SELECT}
+     ORDER BY lower(ag.name) ASC, ag.id ASC`,
+    LOCAL_WEB_CHANNEL_TYPE,
+    LOCAL_WEB_CHANNEL_TYPE,
+  );
+  const providers = installedProviders();
+  const installationDefault = DEFAULT_AGENT_PROVIDER.toLowerCase();
+  return {
+    conversations: rows.map(toConversation),
+    installedProviders: providers,
+    installationDefault,
+    isInstallationDefaultInstalled: providers.includes(installationDefault),
+  };
+}
+
+export async function getLocalWebConversation(conversationId: string): Promise<LocalWebConversation | undefined> {
+  const rows = await getDb().all<ConversationRow>(
+    `${CONVERSATION_SELECT} AND mg.id = ?`,
+    LOCAL_WEB_CHANNEL_TYPE,
+    LOCAL_WEB_CHANNEL_TYPE,
+    conversationId,
+  );
+  return rows.length === 1 ? toConversation(rows[0]!) : undefined;
+}
+
+async function conversationByAgent(agentGroupId: string): Promise<LocalWebConversation | undefined> {
+  const rows = await getDb().all<ConversationRow>(
+    `${CONVERSATION_SELECT} AND ag.id = ?
+     ORDER BY (mg.platform_id = ?) DESC, mg.id ASC`,
+    LOCAL_WEB_CHANNEL_TYPE,
+    LOCAL_WEB_CHANNEL_TYPE,
+    agentGroupId,
+    LOCAL_WEB_LEGACY_PLATFORM_ID,
+  );
+  return rows.length === 1 ? toConversation(rows[0]!) : undefined;
+}
+
+export async function localWebPlatformIdForConversation(conversationId: string): Promise<string | undefined> {
+  const row = await getDb().get<{ platform_id: string }>(
+    `SELECT mg.platform_id
+       FROM messaging_groups mg
+       JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
+      WHERE mg.channel_type = ? AND mg.instance = ? AND mg.id = ?
+      GROUP BY mg.id
+     HAVING COUNT(mga.id) = 1`,
+    LOCAL_WEB_CHANNEL_TYPE,
+    LOCAL_WEB_CHANNEL_TYPE,
+    conversationId,
+  );
+  return row?.platform_id;
+}
+
+export async function isKnownLocalWebPlatformId(platformId: string): Promise<boolean> {
+  if (platformId === LOCAL_WEB_LEGACY_PLATFORM_ID) return true;
+  const row = await getDb().get(
+    `SELECT 1 FROM messaging_groups
+      WHERE channel_type = ? AND instance = ? AND platform_id = ?
+      LIMIT 1`,
+    LOCAL_WEB_CHANNEL_TYPE,
+    LOCAL_WEB_CHANNEL_TYPE,
+    platformId,
+  );
+  return row !== undefined;
+}
+
+export async function localWebQuestionBelongsToConversation(
+  questionId: string,
+  conversationId: string,
+): Promise<boolean> {
+  const platformId = await localWebPlatformIdForConversation(conversationId);
+  if (!platformId) return false;
+  const question = await getPendingQuestion(questionId);
+  if (question) return question.channel_type === LOCAL_WEB_CHANNEL_TYPE && question.platform_id === platformId;
+  const approval = await getPendingApproval(questionId);
+  return approval?.channel_type === LOCAL_WEB_CHANNEL_TYPE && approval.platform_id === platformId;
+}
+
+function platformIdForAgent(agentGroupId: string): string {
+  return `local-web:agent:${agentGroupId}`;
+}
+
+function folderForAgentName(name: string): string {
+  const normalized = normalizeName(name)
+    .slice(0, 59)
+    .replace(/[-_]+$/, '');
+  const folder = `web-${normalized}`;
+  assertValidGroupFolder(folder);
+  return folder;
+}
+
+async function runStage(stage: CreateStage, command: string, args: Record<string, unknown>): Promise<StageResult> {
+  const response = await dispatch({ id: `local-web-${randomUUID()}`, command, args }, { caller: 'host' });
+  return response.ok ? { ok: true, data: response.data } : { ok: false, stage, detail: response.error.message };
+}
+
+function parseAgentGroup(value: unknown): AgentGroup {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== 'string' ||
+    typeof value.name !== 'string' ||
+    typeof value.folder !== 'string' ||
+    typeof value.created_at !== 'string'
+  ) {
+    throw new Error('groups-create returned an invalid agent group');
+  }
+  return {
+    id: value.id,
+    name: value.name,
+    folder: value.folder,
+    agent_provider: typeof value.agent_provider === 'string' ? value.agent_provider : null,
+    created_at: value.created_at,
+  };
+}
+
+async function ensureConversation(agent: AgentGroup): Promise<StageResult> {
+  const platformId = platformIdForAgent(agent.id);
+  const conversation = await runStage('web conversation', 'messaging-groups-create', {
+    channel_type: LOCAL_WEB_CHANNEL_TYPE,
+    instance: LOCAL_WEB_CHANNEL_TYPE,
+    platform_id: platformId,
+    name: agent.name,
+    is_group: 0,
+  });
+  if (!conversation.ok) return conversation;
+  return runStage('web wiring', 'wirings-create', {
+    channel_type: LOCAL_WEB_CHANNEL_TYPE,
+    instance: LOCAL_WEB_CHANNEL_TYPE,
+    platform_id: platformId,
+    agent_group_id: agent.id,
+  });
+}
+
+export async function ensureLocalWebConversations(): Promise<void> {
+  const missing = await getDb().all<AgentGroup>(
+    `SELECT ag.*
+       FROM agent_groups ag
+      WHERE NOT EXISTS (
+        SELECT 1
+          FROM messaging_group_agents mga
+          JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+         WHERE mga.agent_group_id = ag.id
+           AND mg.channel_type = ?
+           AND mg.instance = ?
+      )
+      ORDER BY lower(ag.name) ASC, ag.id ASC`,
+    LOCAL_WEB_CHANNEL_TYPE,
+    LOCAL_WEB_CHANNEL_TYPE,
+  );
+  for (const agent of missing) {
+    const result = await ensureConversation(agent);
+    if (!result.ok) {
+      throw new Error(`Local web backfill failed during ${result.stage}`, { cause: new Error(result.detail) });
+    }
+  }
+}
+
+function resolveRuntime(
+  request: CreateLocalWebAgentRequest,
+  source: LocalWebConversation | undefined,
+): ResolvedRuntime {
+  const provider = request.provider ?? source?.provider ?? DEFAULT_AGENT_PROVIDER.toLowerCase();
+  const providerChanged = request.provider !== undefined && request.provider !== source?.provider;
+  const inheritedModel = providerChanged ? undefined : source?.model;
+  const inheritedEffort = providerChanged ? undefined : source?.effort;
+  const model = request.model === undefined ? inheritedModel : (request.model ?? undefined);
+  const effort = request.effort === undefined ? inheritedEffort : (request.effort ?? undefined);
+  return {
+    provider,
+    ...(model !== undefined && { model }),
+    ...(effort !== undefined && { effort }),
+    providerWasExplicit: request.provider !== undefined,
+  };
+}
+
+async function withCreationLock<T>(folder: string, action: () => Promise<T>): Promise<T> {
+  const previous = creationLocks.get(folder) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.then(() => current);
+  creationLocks.set(folder, tail);
+  await previous;
+  try {
+    return await action();
+  } finally {
+    release();
+    if (creationLocks.get(folder) === tail) creationLocks.delete(folder);
+  }
+}
+
+function stageFailure(result: Extract<StageResult, { ok: false }>): CreateLocalWebAgentResult {
+  return {
+    ok: false,
+    reason: 'stage_failed',
+    status: 409,
+    stage: result.stage,
+    detail: result.detail,
+    message: `Agent creation stopped during ${result.stage}. Retry to resume.`,
+  };
+}
+
+export async function createLocalWebAgent(request: CreateLocalWebAgentRequest): Promise<CreateLocalWebAgentResult> {
+  const source = request.sourceConversationId ? await getLocalWebConversation(request.sourceConversationId) : undefined;
+  if (request.sourceConversationId && !source) {
+    return {
+      ok: false,
+      reason: 'source_not_found',
+      status: 404,
+      message: 'The selected conversation is no longer available.',
+    };
+  }
+  const runtime = resolveRuntime(request, source);
+  const providers = installedProviders();
+  if (!providers.includes(runtime.provider)) {
+    return {
+      ok: false,
+      reason: 'provider_not_installed',
+      status: 409,
+      message: `Provider "${runtime.provider}" is not installed. Choose an installed provider.`,
+    };
+  }
+
+  const folder = folderForAgentName(request.name);
+  return withCreationLock(folder, async () => {
+    const existing = await getAgentGroupByFolder(folder);
+    if (existing) {
+      const complete = await conversationByAgent(existing.id);
+      if (complete) return { ok: true, created: false, conversation: complete };
+    }
+
+    const createdGroup = await runStage('agent group', 'groups-create', { name: request.name, folder });
+    if (!createdGroup.ok) return stageFailure(createdGroup);
+    const agent = parseAgentGroup(createdGroup.data);
+    const currentConfig = await getContainerConfig(agent.id);
+    if (!currentConfig) throw new Error(`Container config missing after groups-create: ${agent.id}`);
+
+    const configUpdates: Record<string, unknown> = { id: agent.id };
+    if (runtime.providerWasExplicit || (currentConfig.provider ?? 'claude').toLowerCase() !== runtime.provider) {
+      configUpdates.provider = runtime.provider;
+    }
+    if (runtime.model !== undefined && currentConfig.model !== runtime.model) configUpdates.model = runtime.model;
+    if (runtime.effort !== undefined && currentConfig.effort !== runtime.effort) configUpdates.effort = runtime.effort;
+    if (Object.keys(configUpdates).length > 1) {
+      const configured = await runStage('runtime configuration', 'groups-config-update', configUpdates);
+      if (!configured.ok) return stageFailure(configured);
+    }
+
+    const wired = await ensureConversation(agent);
+    if (!wired.ok) return stageFailure(wired);
+    const conversation = await conversationByAgent(agent.id);
+    if (!conversation) throw new Error(`Local web conversation missing after wiring: ${agent.id}`);
+    return { ok: true, created: existing === undefined, conversation };
+  });
+}

--- a/src/channels/local-web-default-provider.test.ts
+++ b/src/channels/local-web-default-provider.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { TEST_ROOT } = vi.hoisted(() => ({ TEST_ROOT: '/tmp/nanoclaw-test-local-web-default-provider' }));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return {
+    ...actual,
+    DATA_DIR: path.join(TEST_ROOT, 'data'),
+    GROUPS_DIR: path.join(TEST_ROOT, 'groups'),
+    DEFAULT_AGENT_PROVIDER: 'missing-provider',
+  };
+});
+
+import { getAgentGroupByFolder } from '../db/agent-groups.js';
+import { closeDb, initTestDb } from '../db/connection.js';
+import { runMigrations } from '../db/migrations/index.js';
+import { createLocalWebAgent, listLocalWebCatalog } from './local-web-conversations.js';
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+  await runMigrations(await initTestDb());
+});
+
+afterEach(async () => {
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('local web installation default mismatch', () => {
+  it('exposes the mismatch and requires an installed provider choice', async () => {
+    expect(await listLocalWebCatalog()).toMatchObject({
+      installedProviders: expect.arrayContaining(['claude']),
+      installationDefault: 'missing-provider',
+      isInstallationDefaultInstalled: false,
+    });
+    expect(await createLocalWebAgent({ name: 'Writer' })).toMatchObject({
+      ok: false,
+      reason: 'provider_not_installed',
+      message: expect.stringContaining('missing-provider'),
+    });
+    expect(await getAgentGroupByFolder('web-writer')).toBeUndefined();
+  });
+});

--- a/src/channels/local-web-isolation.test.ts
+++ b/src/channels/local-web-isolation.test.ts
@@ -1,0 +1,341 @@
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { outboundDbPath } from '../mailbox/sqlite/paths.js';
+import { openOutboundDbRw } from '../mailbox/sqlite/session-db.js';
+import type { InboundMessage } from './adapter.js';
+
+const { TEST_DATA_DIR } = vi.hoisted(() => ({ TEST_DATA_DIR: '/tmp/nanoclaw-test-local-web-isolation' }));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return { ...actual, DATA_DIR: TEST_DATA_DIR };
+});
+
+async function unusedPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('failed to allocate test port');
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+async function startAdapter(): Promise<{
+  registry: typeof import('./channel-registry.js');
+  url: string;
+  auth: Record<string, string>;
+  actions: Array<{ questionId: string; selectedOption: string; userId: string }>;
+}> {
+  const port = await unusedPort();
+  process.env.NANOCLAW_LOCAL_WEB_PORT = String(port);
+  vi.resetModules();
+  await import('../mailbox/compose.js');
+  const { initTestDb } = await import('../db/connection.js');
+  const { runMigrations } = await import('../db/migrations/index.js');
+  await runMigrations(await initTestDb());
+  const registry = await import('./channel-registry.js');
+  await import('./local-web.js');
+  const actions: Array<{ questionId: string; selectedOption: string; userId: string }> = [];
+  await registry.initChannelAdapters(() => ({
+    onInbound: (_platformId: string, _threadId: string | null, _message: InboundMessage) => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: (questionId, selectedOption, userId) => void actions.push({ questionId, selectedOption, userId }),
+  }));
+  return {
+    registry,
+    url: `http://127.0.0.1:${port}`,
+    auth: {
+      'x-nanoclaw-local-web-token': fs.readFileSync(path.join(TEST_DATA_DIR, 'local-web', 'token'), 'utf8').trim(),
+    },
+    actions,
+  };
+}
+
+async function seedConversations(): Promise<void> {
+  const { createAgentGroup } = await import('../db/agent-groups.js');
+  const { createMessagingGroup, createMessagingGroupAgent } = await import('../db/messaging-groups.js');
+  const now = new Date().toISOString();
+  for (const conversation of [
+    { agentId: 'ag-one', groupId: 'mg-one', platformId: 'local-web:local', name: 'One' },
+    { agentId: 'ag-two', groupId: 'mg-two', platformId: 'local-web:ag-two', name: 'Two' },
+  ]) {
+    await createAgentGroup({
+      id: conversation.agentId,
+      name: conversation.name,
+      folder: conversation.agentId,
+      agent_provider: null,
+      created_at: now,
+    });
+    await createMessagingGroup({
+      id: conversation.groupId,
+      channel_type: 'local-web',
+      platform_id: conversation.platformId,
+      name: conversation.name,
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: now,
+    });
+    await createMessagingGroupAgent({
+      id: `mga-${conversation.agentId}`,
+      messaging_group_id: conversation.groupId,
+      agent_group_id: conversation.agentId,
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: now,
+    });
+  }
+}
+
+async function seedSession(agentGroupId: string, messagingGroupId: string, tool: string): Promise<void> {
+  const { resolveSession } = await import('../session-manager.js');
+  const { session } = await resolveSession(agentGroupId, messagingGroupId, null, 'shared');
+  const outDb = openOutboundDbRw(outboundDbPath(agentGroupId, session.id));
+  try {
+    const now = new Date().toISOString();
+    outDb
+      .prepare(
+        `INSERT INTO container_state
+           (id, current_tool, tool_declared_timeout_ms, tool_started_at, updated_at)
+         VALUES (1, ?, NULL, ?, ?)`,
+      )
+      .run(tool, now, now);
+  } finally {
+    outDb.close();
+  }
+}
+
+async function postMessage(
+  url: string,
+  auth: Record<string, string>,
+  conversationId: string,
+  text: string,
+): Promise<Response> {
+  return fetch(`${url}/api/messages`, {
+    method: 'POST',
+    headers: { ...auth, 'content-type': 'application/json', origin: url },
+    body: JSON.stringify({ conversationId, text }),
+  });
+}
+
+type CapturedStream = {
+  events: Array<Record<string, unknown>>;
+  close(): void;
+};
+
+async function captureStream(
+  url: string,
+  auth: Record<string, string>,
+  conversationId: string,
+): Promise<CapturedStream> {
+  const abort = new AbortController();
+  const response = await fetch(`${url}/events?conversationId=${encodeURIComponent(conversationId)}`, {
+    headers: { ...auth, origin: url },
+    signal: abort.signal,
+  });
+  expect(response.status).toBe(200);
+  const events: Array<Record<string, unknown>> = [];
+  void (async () => {
+    const reader = response.body!.pipeThrough(new TextDecoderStream()).getReader();
+    let buffer = '';
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        buffer += value;
+        const frames = buffer.split('\n\n');
+        buffer = frames.pop() ?? '';
+        for (const frame of frames) {
+          if (frame.startsWith('data: ')) events.push(JSON.parse(frame.slice(6)) as Record<string, unknown>);
+        }
+      }
+    } catch (error: unknown) {
+      if (!abort.signal.aborted) throw error;
+    }
+  })();
+  await vi.waitFor(() => expect(events.some((event) => event.type === 'ready')).toBe(true));
+  return { events, close: () => abort.abort() };
+}
+
+afterEach(async () => {
+  delete process.env.NANOCLAW_LOCAL_WEB_PORT;
+  const { closeDb } = await import('../db/connection.js');
+  await closeDb();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+describe('local web conversation isolation', () => {
+  it('delivers each reply only to the stream for its platform identity', async () => {
+    const { registry, url, auth } = await startAdapter();
+    await seedConversations();
+    const one = await captureStream(url, auth, 'mg-one');
+    const two = await captureStream(url, auth, 'mg-two');
+    try {
+      const delivery = registry.createChannelDeliveryAdapter();
+      await delivery.deliver(
+        'local-web',
+        'local-web:local',
+        null,
+        'chat',
+        JSON.stringify({ text: 'reply one' }),
+        undefined,
+        'local-web',
+      );
+      await vi.waitFor(() => expect(one.events.some((event) => event.text === 'reply one')).toBe(true));
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      expect(two.events.some((event) => event.text === 'reply one')).toBe(false);
+
+      await delivery.deliver(
+        'local-web',
+        'local-web:ag-two',
+        null,
+        'chat',
+        JSON.stringify({ text: 'reply two' }),
+        undefined,
+        'local-web',
+      );
+      await vi.waitFor(() => expect(two.events.some((event) => event.text === 'reply two')).toBe(true));
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      expect(one.events.some((event) => event.text === 'reply two')).toBe(false);
+    } finally {
+      one.close();
+      two.close();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('samples and emits tool activity only for the addressed conversation', async () => {
+    const { registry, url, auth } = await startAdapter();
+    await seedConversations();
+    await seedSession('ag-one', 'mg-one', 'Bash');
+    await seedSession('ag-two', 'mg-two', 'Read');
+    const one = await captureStream(url, auth, 'mg-one');
+    const two = await captureStream(url, auth, 'mg-two');
+    try {
+      expect((await postMessage(url, auth, 'mg-one', 'one')).status).toBe(202);
+      expect((await postMessage(url, auth, 'mg-two', 'two')).status).toBe(202);
+      const delivery = registry.createChannelDeliveryAdapter();
+      if (!delivery.setTyping) throw new Error('delivery adapter does not support typing');
+
+      await delivery.setTyping('local-web', 'local-web:local', null, 'local-web');
+      await vi.waitFor(() =>
+        expect(one.events.some((event) => event.type === 'tool' && event.name === 'Bash')).toBe(true),
+      );
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      expect(two.events.some((event) => event.type === 'tool' && event.name === 'Bash')).toBe(false);
+
+      await delivery.setTyping('local-web', 'local-web:ag-two', null, 'local-web');
+      await vi.waitFor(() =>
+        expect(two.events.some((event) => event.type === 'tool' && event.name === 'Read')).toBe(true),
+      );
+      expect(one.events.some((event) => event.type === 'tool' && event.name === 'Read')).toBe(false);
+    } finally {
+      one.close();
+      two.close();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('keeps questions and their resolutions in the owning conversation', async () => {
+    const { registry, url, auth, actions } = await startAdapter();
+    await seedConversations();
+    const { createPendingApproval } = await import('../db/sessions.js');
+    await createPendingApproval({
+      approval_id: 'appr-one',
+      request_id: 'appr-one',
+      action: 'create_agent',
+      payload: '{}',
+      agent_group_id: 'ag-one',
+      channel_type: 'local-web',
+      platform_id: 'local-web:local',
+      instance: 'local-web',
+      created_at: new Date().toISOString(),
+      title: 'Create one?',
+      question: 'Only conversation one owns this.',
+      options_json: JSON.stringify([{ label: 'Approve', selectedLabel: 'Approved', value: 'approve' }]),
+    });
+    const one = await captureStream(url, auth, 'mg-one');
+    const two = await captureStream(url, auth, 'mg-two');
+    try {
+      await registry
+        .createChannelDeliveryAdapter()
+        .deliver(
+          'local-web',
+          'local-web:local',
+          null,
+          'chat-sdk',
+          JSON.stringify({ type: 'ask_question', questionId: 'appr-one', title: 'Create one?', options: [] }),
+          undefined,
+          'local-web',
+        );
+      await vi.waitFor(() => expect(one.events.some((event) => event.type === 'question')).toBe(true));
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      expect(two.events.some((event) => event.type === 'question')).toBe(false);
+
+      const crossConversation = await fetch(`${url}/api/actions`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ conversationId: 'mg-two', questionId: 'appr-one', option: 0 }),
+      });
+      expect(crossConversation.status).toBe(404);
+      expect(actions).toEqual([]);
+
+      const action = await fetch(`${url}/api/actions`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ conversationId: 'mg-one', questionId: 'appr-one', option: 0 }),
+      });
+      expect(action.status).toBe(202);
+      expect(actions).toEqual([{ questionId: 'appr-one', selectedOption: 'approve', userId: 'local-web:local' }]);
+      await vi.waitFor(() =>
+        expect(
+          one.events.some((event) => event.type === 'question-resolution' && event.questionId === 'appr-one'),
+        ).toBe(true),
+      );
+      expect(two.events.some((event) => event.type === 'question-resolution')).toBe(false);
+    } finally {
+      one.close();
+      two.close();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('queues a background reply until its conversation is selected', async () => {
+    const { registry, url, auth } = await startAdapter();
+    await seedConversations();
+    const one = await captureStream(url, auth, 'mg-one');
+    let two: CapturedStream | undefined;
+    try {
+      await registry
+        .createChannelDeliveryAdapter()
+        .deliver(
+          'local-web',
+          'local-web:ag-two',
+          null,
+          'chat',
+          JSON.stringify({ text: 'waiting for two' }),
+          undefined,
+          'local-web',
+        );
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      expect(one.events.some((event) => event.text === 'waiting for two')).toBe(false);
+
+      two = await captureStream(url, auth, 'mg-two');
+      expect(two.events.some((event) => event.text === 'waiting for two')).toBe(true);
+    } finally {
+      one.close();
+      two?.close();
+      await registry.teardownChannelAdapters();
+    }
+  });
+});

--- a/src/channels/local-web-page.css
+++ b/src/channels/local-web-page.css
@@ -1,0 +1,337 @@
+:root {
+  color-scheme: light;
+  --paper: #ffffff;
+  --linen-soft: #faf5ea;
+  --ink: #1a1612;
+  --ink-body: #3a332b;
+  --ink-muted: #5c5349;
+  --hairline: #e7e0d3;
+  --brand: #1fb8b0;
+  --action: #0f756d;
+  --highlight: #e85d3a;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--linen-soft);
+  color: var(--ink-body);
+}
+.shell {
+  width: min(880px, 100%);
+  height: 100dvh;
+  min-height: 0;
+  margin: auto;
+  padding: clamp(18px, 4vw, 42px);
+  display: grid;
+  grid-template-rows: auto 1fr auto auto;
+  gap: 18px;
+  overflow: hidden;
+  background: var(--paper);
+  border-inline: 1px solid var(--hairline);
+}
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--hairline);
+}
+.identity {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+}
+.breath {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  border: 1px solid var(--action);
+  display: grid;
+  place-items: center;
+  background: var(--brand);
+  box-shadow: 0 7px 20px rgb(15 117 109 / 14%);
+}
+.breath::after {
+  content: '';
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ink);
+}
+.breath.thinking::after {
+  animation: breathe 1.2s ease-in-out infinite;
+}
+h1 {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(22px, 3vw, 28px);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+}
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--ink-muted);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+}
+.status {
+  color: var(--ink-muted);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+}
+#messages {
+  min-height: 0;
+  overflow-y: auto;
+  padding: clamp(18px, 4vw, 34px) 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overscroll-behavior: contain;
+  scroll-behavior: smooth;
+}
+.message {
+  max-width: min(76ch, 88%);
+  padding: 13px 16px;
+  border: 1px solid var(--hairline);
+  border-radius: 16px 16px 16px 6px;
+  background: var(--linen-soft);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.55;
+}
+.message.user {
+  align-self: flex-end;
+  color: white;
+  background: var(--action);
+  border-color: var(--action);
+  border-radius: 16px 16px 6px 16px;
+}
+.message.agent {
+  white-space: normal;
+}
+.message.agent p {
+  margin: 0 0 0.75em;
+}
+.message.agent > :first-child {
+  margin-top: 0;
+}
+.message.agent > :last-child {
+  margin-bottom: 0;
+}
+.message.agent pre {
+  overflow-x: auto;
+}
+.message.system {
+  align-self: center;
+  padding: 8px 12px;
+  color: var(--ink-muted);
+  background: transparent;
+  border-style: dashed;
+  font-size: 13px;
+}
+.question-card {
+  width: min(620px, 92%);
+  padding: 16px 18px 18px;
+  border: 1px solid var(--hairline);
+  border-left: 4px solid var(--brand);
+  border-radius: 6px 16px 16px 6px;
+  background: var(--linen-soft);
+  box-shadow: 0 10px 28px rgb(26 22 18 / 7%);
+}
+.question-kicker {
+  margin: 0 0 6px;
+  color: var(--action);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.question-title {
+  margin: 0;
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1.3;
+}
+.question-body {
+  margin: 8px 0 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.question-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+.question-option {
+  min-width: 0;
+  height: auto;
+  padding: 9px 13px;
+  border: 1px solid var(--action);
+  background: var(--paper);
+  color: var(--action);
+  font-size: 13px;
+}
+.question-option.primary {
+  background: var(--action);
+  color: white;
+}
+.question-option.danger {
+  border-color: var(--highlight);
+  color: var(--highlight);
+}
+.question-option:disabled {
+  cursor: default;
+}
+.question-resolution {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--hairline);
+  color: var(--ink-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+.question-error {
+  color: var(--highlight);
+}
+.activity {
+  justify-self: start;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 34px;
+  padding: 8px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  color: var(--ink-muted);
+  background: var(--linen-soft);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+.activity[hidden] {
+  display: none;
+}
+.activity-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--action);
+  animation: breathe 1.2s ease-in-out infinite;
+}
+.activity.tool .activity-dot {
+  background: var(--highlight);
+}
+form {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--hairline);
+  border-radius: 18px;
+  background: var(--paper);
+  box-shadow: 0 12px 34px rgb(26 22 18 / 8%);
+}
+textarea {
+  width: 100%;
+  min-height: 48px;
+  max-height: 180px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  padding: 13px 12px 10px;
+  color: var(--ink);
+  background: transparent;
+  font: inherit;
+  line-height: 1.45;
+}
+textarea::placeholder {
+  color: var(--ink-muted);
+}
+button {
+  min-width: 78px;
+  height: 44px;
+  border: 0;
+  border-radius: 8px;
+  background: var(--action);
+  color: white;
+  font: 700 14px/1 inherit;
+  cursor: pointer;
+}
+button:hover {
+  filter: brightness(0.94);
+}
+button:disabled {
+  cursor: wait;
+  opacity: 0.52;
+}
+button:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid rgb(31 184 176 / 42%);
+  outline-offset: 2px;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@keyframes breathe {
+  0%,
+  100% {
+    transform: scale(0.72);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scale(1.22);
+    opacity: 1;
+  }
+}
+@media (max-width: 600px) {
+  .shell {
+    padding: 18px 14px 12px;
+    border-inline: 0;
+  }
+  .status {
+    display: none;
+  }
+  .message {
+    max-width: 94%;
+  }
+  form {
+    position: sticky;
+    bottom: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation: none !important;
+  }
+}

--- a/src/channels/local-web-page.css
+++ b/src/channels/local-web-page.css
@@ -1,3 +1,6 @@
+@import url('/local-web-chat.css');
+@import url('/local-web-conversations.css');
+
 /* Local web chat.
 
    Two ideas hold this page together. Agent replies are documents, not chat
@@ -34,8 +37,8 @@
   --column: min(var(--column-max), 100%);
   --gutter: clamp(18px, 5vw, 40px);
   --measure: 66ch;
-  --fs-body: 19px;
-  --fs-chrome: 14px;
+  --fs-body: 1.1875rem;
+  --fs-chrome: 0.875rem;
 
   /* Critically damped by default. The overshoot curve is reserved for things
      that arrive with momentum, which here is only a message landing. */
@@ -43,13 +46,12 @@
   --ease-spring: cubic-bezier(0.22, 1.08, 0.36, 1);
 
   font-family:
-    Inter,
     ui-sans-serif,
     -apple-system,
     BlinkMacSystemFont,
     'Segoe UI',
     sans-serif;
-  font-size: 16px;
+  font-size: 100%;
   font-synthesis-weight: none;
 }
 @media (prefers-color-scheme: dark) {
@@ -145,7 +147,7 @@ header::before,
 }
 header {
   top: 0;
-  background: linear-gradient(to bottom, var(--paper) 42%, transparent);
+  background: linear-gradient(to bottom, var(--paper) 78%, transparent);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -153,7 +155,10 @@ header {
   padding-block: 18px 14px;
 }
 header::before {
-  mask-image: linear-gradient(to bottom, #000 58%, transparent);
+  /* Keep transcript text from ghosting behind the selected agent's two-line
+     identity. The material still releases at its inner edge, after the chrome. */
+  background: color-mix(in oklab, var(--paper) 96%, transparent);
+  mask-image: linear-gradient(to bottom, #000 86%, transparent);
 }
 header > * {
   position: relative;
@@ -181,12 +186,12 @@ header > * {
 .eyebrow {
   margin: 0;
   color: var(--ink-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
   letter-spacing: 0.01em;
 }
-h1 {
+.sidebar-brand h1 {
   margin: 0;
   font-size: 0;
   line-height: 0;
@@ -224,7 +229,7 @@ h1 {
   align-items: center;
   gap: 7px;
   color: var(--ink-muted);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -300,603 +305,6 @@ h1 {
   }
 }
 
-/* ---- transcript -------------------------------------------------------- */
-
-.log-wrap {
-  position: absolute;
-  inset: 0;
-}
-#messages {
-  height: 100%;
-  overflow-y: auto;
-  /* No mask here on purpose: content stays sharp so the chrome above it has
-     something real to blur. The scrollbar is left at the window edge. */
-  padding: calc(var(--header-h) + 10px) var(--gutter) calc(var(--dock-h) + 18px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 26px;
-  overscroll-behavior: contain;
-}
-
-.turn,
-.question-card,
-.empty {
-  width: var(--column);
-}
-.turn {
-  display: grid;
-  gap: 7px;
-  animation: none;
-}
-.turn.enter {
-  animation: rise 380ms var(--ease-spring) both;
-}
-.role {
-  color: var(--ink-muted);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1;
-  letter-spacing: 0.01em;
-}
-
-.message {
-  max-width: var(--measure);
-  font-size: var(--fs-body);
-  line-height: 1.6;
-  overflow-wrap: anywhere;
-  text-wrap: pretty;
-}
-.message.user {
-  justify-self: end;
-  max-width: min(var(--measure), 82%);
-  padding: 12px 17px;
-  border: 1px solid var(--hairline);
-  border-radius: 18px 18px 6px 18px;
-  background: var(--wash);
-  color: var(--ink);
-  white-space: pre-wrap;
-}
-.turn.user {
-  justify-items: end;
-}
-.message.system {
-  justify-self: center;
-  max-width: 62ch;
-  padding: 11px 15px;
-  border: 1px dashed var(--rule);
-  border-radius: 12px;
-  color: var(--ink-muted);
-  font-size: 14px;
-  line-height: 1.5;
-  text-align: center;
-  text-wrap: balance;
-}
-
-/* ---- agent markdown ---------------------------------------------------- */
-
-.message.agent {
-  color: var(--ink-body);
-}
-.message.agent > :first-child {
-  margin-top: 0;
-}
-.message.agent > :last-child {
-  margin-bottom: 0;
-}
-.message.agent p {
-  margin: 0 0 0.85em;
-}
-.message.agent h1,
-.message.agent h2,
-.message.agent h3,
-.message.agent h4 {
-  margin: 1.5em 0 0.5em;
-  color: var(--ink);
-  font-weight: 700;
-  line-height: 1.22;
-  letter-spacing: -0.015em;
-  text-wrap: balance;
-}
-.message.agent h1 {
-  font-size: 1.34em;
-}
-.message.agent h2 {
-  font-size: 1.2em;
-}
-.message.agent h3 {
-  font-size: 1.06em;
-}
-.message.agent h4 {
-  font-size: 1em;
-}
-.message.agent strong {
-  color: var(--ink);
-  font-weight: 600;
-}
-.message.agent a {
-  color: var(--action);
-  text-decoration-color: color-mix(in oklab, var(--action) 40%, transparent);
-  text-underline-offset: 3px;
-}
-.message.agent a:hover {
-  text-decoration-color: currentcolor;
-}
-.message.agent ul,
-.message.agent ol {
-  margin: 0 0 0.9em;
-  padding-left: 1.35em;
-}
-.message.agent li {
-  margin-bottom: 0.32em;
-  padding-left: 0.15em;
-}
-.message.agent li::marker {
-  color: var(--ink-muted);
-}
-.message.agent blockquote {
-  margin: 1em 0;
-  padding: 2px 0 2px 1.1em;
-  border-left: 2px solid var(--brand);
-  color: var(--ink-muted);
-}
-.message.agent hr {
-  height: 1px;
-  margin: 1.6em 0;
-  border: 0;
-  background: var(--hairline);
-}
-.message.agent img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 10px;
-}
-
-.message.agent code {
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
-  font-size: 0.83em;
-}
-.message.agent :not(pre) > code {
-  padding: 0.14em 0.4em;
-  border: 1px solid var(--hairline);
-  border-radius: 6px;
-  background: var(--wash);
-  color: var(--ink);
-}
-.message.agent pre {
-  position: relative;
-  margin: 0 0 1em;
-  padding: 14px 16px;
-  border: 1px solid var(--hairline);
-  border-radius: 12px;
-  background: var(--linen-soft);
-  overflow-x: auto;
-}
-.message.agent pre code {
-  display: block;
-  color: var(--ink);
-  font-size: 0.78em;
-  line-height: 1.6;
-  white-space: pre;
-}
-.copy {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  padding: 4px 9px;
-  border: 1px solid var(--hairline);
-  border-radius: 7px;
-  background: var(--paper);
-  color: var(--ink-muted);
-  font: 600 11px/1 inherit;
-  cursor: pointer;
-  opacity: 0;
-  transition:
-    opacity 160ms var(--ease-out),
-    color 160ms var(--ease-out);
-}
-pre:hover .copy,
-.copy:focus-visible {
-  opacity: 1;
-}
-.copy:hover {
-  color: var(--ink);
-}
-.copy:active {
-  transform: scale(0.94);
-}
-
-.message.agent table {
-  width: 100%;
-  margin: 0 0 1em;
-  border-collapse: collapse;
-  font-size: 0.84em;
-  line-height: 1.45;
-}
-.message.agent thead th {
-  padding: 7px 12px 7px 0;
-  border-bottom: 1px solid var(--rule);
-  color: var(--ink-muted);
-  font-weight: 600;
-  text-align: left;
-  white-space: nowrap;
-}
-.message.agent tbody td {
-  padding: 9px 12px 9px 0;
-  border-bottom: 1px solid var(--hairline);
-  vertical-align: top;
-}
-.message.agent tbody tr:last-child td {
-  border-bottom: 0;
-}
-.message.agent th:last-child,
-.message.agent td:last-child {
-  padding-right: 0;
-}
-.table-scroll {
-  margin: 0 0 1em;
-  overflow-x: auto;
-}
-.table-scroll table {
-  margin: 0;
-}
-
-/* ---- approval card ----------------------------------------------------- */
-
-.question-card {
-  max-width: 560px;
-  padding: 16px 18px 18px;
-  border: 1px solid var(--hairline);
-  border-left: 3px solid var(--brand);
-  border-radius: 6px 16px 16px 6px;
-  background: var(--paper);
-  box-shadow: var(--shadow-lg);
-}
-.question-card.enter {
-  animation: rise 380ms var(--ease-spring) both;
-}
-.question-kicker {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  margin: 0 0 7px;
-  color: var(--ink-muted);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1;
-}
-.question-kicker::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--brand);
-}
-.question-title {
-  margin: 0;
-  color: var(--ink);
-  font-size: 17px;
-  font-weight: 700;
-  line-height: 1.28;
-  letter-spacing: -0.01em;
-  text-wrap: balance;
-}
-.question-body {
-  margin: 7px 0 0;
-  font-size: 15px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  text-wrap: pretty;
-}
-.question-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 15px;
-}
-.question-option {
-  padding: 9px 14px;
-  border: 1px solid var(--rule);
-  border-radius: 9px;
-  background: var(--paper);
-  color: var(--ink);
-  font: 600 14px/1 inherit;
-  cursor: pointer;
-  transition:
-    transform 110ms var(--ease-out),
-    border-color 160ms var(--ease-out),
-    background 160ms var(--ease-out);
-}
-.question-option:hover:not(:disabled) {
-  border-color: var(--ink-muted);
-}
-.question-option:active:not(:disabled) {
-  transform: scale(0.97);
-}
-.question-option.primary {
-  border-color: var(--action);
-  background: var(--action);
-  color: var(--on-action);
-}
-.question-option.primary:hover:not(:disabled) {
-  border-color: var(--action);
-  background: color-mix(in oklab, var(--action) 88%, var(--ink));
-}
-.question-option.danger {
-  color: var(--highlight);
-}
-.question-option.danger:hover:not(:disabled) {
-  border-color: var(--highlight);
-}
-.question-option:disabled {
-  opacity: 0.42;
-  cursor: default;
-}
-.question-resolution {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  margin: 14px 0 0;
-  padding-top: 12px;
-  border-top: 1px solid var(--hairline);
-  color: var(--ink-muted);
-  font-size: 13px;
-  font-weight: 600;
-}
-.question-resolution::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--brand);
-  flex-shrink: 0;
-}
-.question-resolution[hidden] {
-  display: none;
-}
-.question-error {
-  color: var(--highlight);
-}
-.question-error::before {
-  background: var(--highlight);
-}
-
-/* ---- empty state ------------------------------------------------------- */
-
-.empty {
-  margin: auto;
-  display: grid;
-  justify-items: center;
-  gap: 10px;
-  max-width: 44ch;
-  text-align: center;
-}
-.empty h2 {
-  margin: 0;
-  color: var(--ink);
-  font-size: 21px;
-  font-weight: 700;
-  line-height: 1.25;
-  letter-spacing: -0.015em;
-  text-wrap: balance;
-}
-.empty p {
-  margin: 0;
-  color: var(--ink-muted);
-  font-size: 15px;
-  line-height: 1.5;
-  text-wrap: pretty;
-}
-.empty-mark {
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  border: 1px solid var(--hairline);
-  background: var(--linen-soft);
-  display: grid;
-  place-items: center;
-  margin-bottom: 4px;
-}
-.empty-mark::after {
-  content: '';
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--brand);
-  animation: pulse 3.2s ease-in-out infinite;
-}
-.empty.locked .empty-mark::after {
-  background: var(--ink-muted);
-  animation: none;
-  opacity: 0.55;
-}
-.empty code {
-  margin-top: 4px;
-  padding: 6px 11px;
-  border: 1px solid var(--hairline);
-  border-radius: 8px;
-  background: var(--linen-soft);
-  color: var(--ink);
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
-  font-size: 13px;
-}
-
-/* ---- floating affordances ---------------------------------------------- */
-
-.jump {
-  position: absolute;
-  left: 50%;
-  bottom: calc(var(--dock-h) - 34px);
-  translate: -50% 0;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  padding: 8px 14px;
-  border: 1px solid var(--hairline);
-  border-radius: 999px;
-  background: var(--glass);
-  backdrop-filter: blur(16px) saturate(180%);
-  color: var(--ink);
-  font: 600 13px/1 inherit;
-  cursor: pointer;
-  box-shadow: var(--shadow-lg);
-  transition:
-    opacity 200ms var(--ease-out),
-    translate 260ms var(--ease-spring);
-}
-.jump[hidden] {
-  display: none;
-}
-.jump.entering {
-  opacity: 0;
-  translate: -50% 10px;
-}
-.jump:active {
-  transform: scale(0.96);
-}
-.jump svg {
-  width: 13px;
-  height: 13px;
-}
-
-/* Floats over the log rather than sitting in the grid: an in-flow pill would
-   shove the composer down and back up on every single turn. */
-.activity {
-  position: absolute;
-  z-index: 3;
-  left: max(var(--gutter), calc((100% - var(--column-max)) / 2));
-  bottom: calc(var(--dock-h) - 34px);
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 7px 13px;
-  border: 1px solid var(--hairline);
-  border-radius: 999px;
-  color: var(--ink-muted);
-  background: var(--glass);
-  backdrop-filter: blur(16px) saturate(180%);
-  box-shadow: var(--shadow-sm);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1;
-  /* Materialise rather than fade: the pill scales in as it sharpens. */
-  animation: materialise 300ms var(--ease-spring) both;
-}
-.activity[hidden] {
-  display: none;
-}
-.activity-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--brand);
-  animation: pulse 1.4s ease-in-out infinite;
-}
-.activity.tool .activity-dot {
-  background: var(--highlight);
-}
-.activity.stalled .activity-dot {
-  background: var(--ink-muted);
-  animation-duration: 3.4s;
-}
-
-/* ---- composer ---------------------------------------------------------- */
-
-form {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: end;
-  /* Nested radius: 20 outer − 10 padding = 10 inner. */
-  gap: 10px;
-  padding: 10px;
-  border: 1px solid var(--hairline);
-  border-radius: 20px;
-  background: var(--paper);
-  box-shadow: var(--shadow-lg);
-  transition: border-color 200ms var(--ease-out);
-}
-form:focus-within {
-  border-color: var(--action);
-  box-shadow:
-    var(--shadow-lg),
-    0 0 0 3px var(--ring);
-}
-textarea:focus-visible {
-  outline: 0;
-}
-textarea {
-  width: 100%;
-  min-height: 46px;
-  max-height: 200px;
-  resize: none;
-  border: 0;
-  outline: 0;
-  padding: 12px 12px 10px;
-  color: var(--ink);
-  background: transparent;
-  font: inherit;
-  font-size: 17px;
-  line-height: 1.5;
-}
-textarea::placeholder {
-  color: var(--ink-muted);
-}
-#send {
-  min-width: 76px;
-  height: 46px;
-  border: 0;
-  border-radius: 10px;
-  background: var(--action);
-  color: var(--on-action);
-  font: 700 14px/1 inherit;
-  cursor: pointer;
-  transition:
-    transform 110ms var(--ease-out),
-    opacity 200ms var(--ease-out),
-    background 160ms var(--ease-out);
-}
-#send:hover:not(:disabled) {
-  background: color-mix(in oklab, var(--action) 88%, var(--ink));
-}
-#send:active:not(:disabled) {
-  transform: scale(0.96);
-}
-#send:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-.hint {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  min-height: 14px;
-  margin: 10px 0 0;
-  color: var(--ink-muted);
-  font-size: 12px;
-  line-height: 1;
-}
-.counter {
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-.counter[hidden] {
-  display: none;
-}
-.counter.over {
-  color: var(--highlight);
-}
-kbd {
-  padding: 1px 5px;
-  border: 1px solid var(--hairline);
-  border-radius: 5px;
-  background: var(--wash);
-  font: inherit;
-  font-size: 11px;
-}
-
 /* ---- shared ------------------------------------------------------------ */
 
 :focus-visible {
@@ -951,7 +359,7 @@ kbd {
 
 @media (max-width: 640px) {
   :root {
-    --fs-body: 17px;
+    --fs-body: 1.0625rem;
     --measure: 100%;
   }
   header {

--- a/src/channels/local-web-page.css
+++ b/src/channels/local-web-page.css
@@ -119,7 +119,7 @@ body {
   /* Measured from the live chrome so the transcript can scroll the full height
      underneath it without ever resting behind it. */
   --header-h: 74px;
-  --dock-h: 104px;
+  --dock-h: 112px;
 }
 
 /* Floating chrome: a translucent layer the transcript passes under, with the
@@ -162,7 +162,7 @@ header > * {
 .dock {
   bottom: 0;
   background: linear-gradient(to top, var(--paper) 48%, transparent);
-  padding-block: 46px 14px;
+  padding-block: 46px max(22px, env(safe-area-inset-bottom));
 }
 .dock::before {
   mask-image: linear-gradient(to top, #000 62%, transparent);
@@ -763,6 +763,7 @@ pre:hover .copy,
    shove the composer down and back up on every single turn. */
 .activity {
   position: absolute;
+  z-index: 3;
   left: max(var(--gutter), calc((100% - var(--column-max)) / 2));
   bottom: calc(var(--dock-h) - 34px);
   display: flex;
@@ -957,7 +958,7 @@ kbd {
     padding-block: 14px 18px;
   }
   .dock {
-    padding-block: 34px 12px;
+    padding-block: 34px max(18px, env(safe-area-inset-bottom));
   }
   .logotype {
     width: 124px;

--- a/src/channels/local-web-page.css
+++ b/src/channels/local-web-page.css
@@ -30,6 +30,9 @@
   --shadow-lg: 0 1px 2px rgb(26 22 18 / 5%), 0 14px 38px rgb(26 22 18 / 9%);
   --ring: rgb(31 184 176 / 40%);
 
+  --column-max: 760px;
+  --column: min(var(--column-max), 100%);
+  --gutter: clamp(18px, 5vw, 40px);
   --measure: 66ch;
   --fs-body: 19px;
   --fs-chrome: 14px;
@@ -99,7 +102,9 @@ body {
   margin: 0;
   height: 100dvh;
   overflow: hidden;
-  background: var(--ground);
+  /* One surface. There is no card floating on a ground: the window is the
+     surface, chrome floats on it, and the reading column is centred within it. */
+  background: var(--paper);
   color: var(--ink-body);
   -webkit-font-smoothing: antialiased;
 }
@@ -108,24 +113,65 @@ body {
 
 .shell {
   position: relative;
-  width: min(900px, 100%);
+  width: 100%;
   height: 100dvh;
-  min-height: 0;
-  margin: auto;
-  padding: 22px clamp(18px, 4vw, 40px) clamp(16px, 3vw, 26px);
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
-  background: var(--paper);
-  border-inline: 1px solid var(--hairline);
+  /* Measured from the live chrome so the transcript can scroll the full height
+     underneath it without ever resting behind it. */
+  --header-h: 74px;
+  --dock-h: 104px;
 }
 
+/* Floating chrome: a translucent layer the transcript passes under, with the
+   material fading out at its inner edge instead of ending on a 1px rule. */
+header,
+.dock {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  padding-inline: max(var(--gutter), calc((100% - var(--column-max)) / 2));
+}
+header::before,
+.dock::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  /* Opaque enough that the logotype and status stay legible over whatever
+     scrolls beneath them, translucent enough to still read as material. */
+  background: color-mix(in oklab, var(--paper) 82%, transparent);
+  backdrop-filter: blur(24px) saturate(180%);
+  pointer-events: none;
+}
 header {
+  top: 0;
+  background: linear-gradient(to bottom, var(--paper) 42%, transparent);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  padding-bottom: 10px;
+  padding-block: 18px 14px;
+}
+header::before {
+  mask-image: linear-gradient(to bottom, #000 58%, transparent);
+}
+header > * {
+  position: relative;
+  z-index: 1;
+}
+.dock {
+  bottom: 0;
+  background: linear-gradient(to top, var(--paper) 48%, transparent);
+  padding-block: 46px 14px;
+}
+.dock::before {
+  mask-image: linear-gradient(to top, #000 62%, transparent);
+}
+.dock > * {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  margin-inline: auto;
 }
 .identity {
   display: grid;
@@ -257,33 +303,27 @@ h1 {
 /* ---- transcript -------------------------------------------------------- */
 
 .log-wrap {
-  position: relative;
-  min-height: 0;
-  display: grid;
+  position: absolute;
+  inset: 0;
 }
 #messages {
-  --fade: 34px;
-  min-height: 0;
+  height: 100%;
   overflow-y: auto;
-  /* The bottom padding is deeper than the fade, so at rest the gradient lands
-     on empty space and never dims the newest message. */
-  padding: 20px 2px 46px;
+  /* No mask here on purpose: content stays sharp so the chrome above it has
+     something real to blur. The scrollbar is left at the window edge. */
+  padding: calc(var(--header-h) + 10px) var(--gutter) calc(var(--dock-h) + 18px);
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 26px;
   overscroll-behavior: contain;
-  scroll-behavior: smooth;
-  /* Scroll edge effect: content dissolves into the chrome above and below
-     instead of being sliced by a hard edge. */
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent 100%
-  );
 }
 
+.turn,
+.question-card,
+.empty {
+  width: var(--column);
+}
 .turn {
   display: grid;
   gap: 7px;
@@ -504,7 +544,7 @@ pre:hover .copy,
 /* ---- approval card ----------------------------------------------------- */
 
 .question-card {
-  width: min(560px, 100%);
+  max-width: 560px;
   padding: 16px 18px 18px;
   border: 1px solid var(--hairline);
   border-left: 3px solid var(--brand);
@@ -686,7 +726,7 @@ pre:hover .copy,
 .jump {
   position: absolute;
   left: 50%;
-  bottom: 12px;
+  bottom: calc(var(--dock-h) - 34px);
   translate: -50% 0;
   display: flex;
   align-items: center;
@@ -723,8 +763,8 @@ pre:hover .copy,
    shove the composer down and back up on every single turn. */
 .activity {
   position: absolute;
-  left: 2px;
-  bottom: 12px;
+  left: max(var(--gutter), calc((100% - var(--column-max)) / 2));
+  bottom: calc(var(--dock-h) - 34px);
   display: flex;
   align-items: center;
   gap: 9px;
@@ -832,7 +872,7 @@ textarea::placeholder {
   justify-content: center;
   gap: 12px;
   min-height: 14px;
-  margin: 10px 2px 0;
+  margin: 10px 0 0;
   color: var(--ink-muted);
   font-size: 12px;
   line-height: 1;
@@ -913,9 +953,11 @@ kbd {
     --fs-body: 17px;
     --measure: 100%;
   }
-  .shell {
-    padding: 16px 15px 12px;
-    border-inline: 0;
+  header {
+    padding-block: 14px 18px;
+  }
+  .dock {
+    padding-block: 34px 12px;
   }
   .logotype {
     width: 124px;
@@ -928,10 +970,6 @@ kbd {
   }
   .hint-keys {
     display: none;
-  }
-  form {
-    position: sticky;
-    bottom: 0;
   }
   #messages {
     gap: 22px;
@@ -966,6 +1004,16 @@ kbd {
   .activity {
     background: var(--paper);
     backdrop-filter: none;
+  }
+  header,
+  .dock {
+    background: var(--paper);
+  }
+  header::before,
+  .dock::before {
+    background: var(--paper);
+    backdrop-filter: none;
+    mask-image: none;
   }
 }
 @media (prefers-contrast: more) {

--- a/src/channels/local-web-page.css
+++ b/src/channels/local-web-page.css
@@ -1,14 +1,44 @@
+/* Local web chat.
+
+   Two ideas hold this page together. Agent replies are documents, not chat
+   blobs, so they sit directly on the paper with a real type scale rather than
+   inside a tinted bubble that crushes tables and code. And teal is the only
+   saturated colour on screen, reserved for things you can press, so linen is
+   demoted to what the brand actually calls it: code, insets, quiet media. */
+
 :root {
   color-scheme: light;
+
   --paper: #ffffff;
+  --ground: #f4f2ef;
   --linen-soft: #faf5ea;
   --ink: #1a1612;
   --ink-body: #3a332b;
   --ink-muted: #5c5349;
   --hairline: #e7e0d3;
+  --rule: #d7cfbf;
+  --wash: #f7f6f4;
   --brand: #1fb8b0;
   --action: #0f756d;
-  --highlight: #e85d3a;
+  --on-action: #ffffff;
+  /* Brand highlight is #E85D3A. On white that is 3.5:1, which fails AA for the
+     danger label, so light darkens it; dark keeps the brand value exactly. */
+  --highlight: #c14a26;
+
+  --glass: rgb(255 255 255 / 76%);
+  --shadow-sm: 0 1px 2px rgb(26 22 18 / 6%);
+  --shadow-lg: 0 1px 2px rgb(26 22 18 / 5%), 0 14px 38px rgb(26 22 18 / 9%);
+  --ring: rgb(31 184 176 / 40%);
+
+  --measure: 66ch;
+  --fs-body: 19px;
+  --fs-chrome: 14px;
+
+  /* Critically damped by default. The overshoot curve is reserved for things
+     that arrive with momentum, which here is only a message landing. */
+  --ease-out: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --ease-spring: cubic-bezier(0.22, 1.08, 0.36, 1);
+
   font-family:
     Inter,
     ui-sans-serif,
@@ -16,7 +46,52 @@
     BlinkMacSystemFont,
     'Segoe UI',
     sans-serif;
+  font-size: 16px;
+  font-synthesis-weight: none;
 }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    color-scheme: dark;
+    --paper: #101010;
+    --ground: #000000;
+    --linen-soft: #191919;
+    --ink: #ffffff;
+    --ink-body: #e8e8e8;
+    --ink-muted: #b0b0b0;
+    --hairline: #2c2c2c;
+    --rule: #3a3a3a;
+    --wash: #1c1c1c;
+    --brand: #56edd6;
+    --action: #56edd6;
+    --on-action: #101010;
+    --highlight: #e85d3a;
+    --glass: rgb(16 16 16 / 78%);
+    --shadow-sm: 0 1px 2px rgb(0 0 0 / 50%);
+    --shadow-lg: 0 1px 2px rgb(0 0 0 / 40%), 0 14px 38px rgb(0 0 0 / 55%);
+    --ring: rgb(86 237 214 / 42%);
+  }
+}
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --paper: #101010;
+  --ground: #000000;
+  --linen-soft: #191919;
+  --ink: #ffffff;
+  --ink-body: #e8e8e8;
+  --ink-muted: #b0b0b0;
+  --hairline: #2c2c2c;
+  --rule: #3a3a3a;
+  --wash: #1c1c1c;
+  --brand: #56edd6;
+  --action: #56edd6;
+  --on-action: #101010;
+  --highlight: #e85d3a;
+  --glass: rgb(16 16 16 / 78%);
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 50%);
+  --shadow-lg: 0 1px 2px rgb(0 0 0 / 40%), 0 14px 38px rgb(0 0 0 / 55%);
+  --ring: rgb(86 237 214 / 42%);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -24,109 +99,244 @@ body {
   margin: 0;
   height: 100dvh;
   overflow: hidden;
-  background: var(--linen-soft);
+  background: var(--ground);
   color: var(--ink-body);
+  -webkit-font-smoothing: antialiased;
 }
+
+/* ---- shell ------------------------------------------------------------- */
+
 .shell {
-  width: min(880px, 100%);
+  position: relative;
+  width: min(900px, 100%);
   height: 100dvh;
   min-height: 0;
   margin: auto;
-  padding: clamp(18px, 4vw, 42px);
+  padding: 22px clamp(18px, 4vw, 40px) clamp(16px, 3vw, 26px);
   display: grid;
-  grid-template-rows: auto 1fr auto auto;
-  gap: 18px;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
   background: var(--paper);
   border-inline: 1px solid var(--hairline);
 }
+
 header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  padding-bottom: 18px;
-  border-bottom: 1px solid var(--hairline);
+  padding-bottom: 10px;
 }
 .identity {
-  display: flex;
-  align-items: center;
-  gap: 13px;
-}
-.breath {
-  width: 40px;
-  height: 40px;
-  border-radius: 14px;
-  border: 1px solid var(--action);
   display: grid;
-  place-items: center;
-  background: var(--brand);
-  box-shadow: 0 7px 20px rgb(15 117 109 / 14%);
+  gap: 5px;
+  min-width: 0;
 }
-.breath::after {
-  content: '';
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--ink);
-}
-.breath.thinking::after {
-  animation: breathe 1.2s ease-in-out infinite;
+.eyebrow {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
 }
 h1 {
   margin: 0;
-  color: var(--ink);
-  font-size: clamp(22px, 3vw, 28px);
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-  text-wrap: balance;
+  font-size: 0;
+  line-height: 0;
 }
-.eyebrow {
-  margin: 0 0 4px;
-  color: var(--ink-muted);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1;
+.logotype {
+  display: block;
+  width: 152px;
+  height: auto;
+}
+/* The wordmark is two-tone by design: mint claw on dark, one ink weight on
+   light. Driving both halves from tokens keeps a single copy of the artwork. */
+.logotype .mark-word {
+  fill: var(--ink);
+}
+.logotype .mark-claw {
+  fill: var(--ink);
+}
+:root[data-theme='dark'] .logotype .mark-claw {
+  fill: var(--brand);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .logotype .mark-claw {
+    fill: var(--brand);
+  }
+}
+
+.header-tools {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
 }
 .status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
   color: var(--ink-muted);
   font-size: 13px;
   font-weight: 600;
   line-height: 1;
+  white-space: nowrap;
+}
+.status::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ink-muted);
+  transition: background 260ms var(--ease-out);
+}
+.status[data-state='ready']::before {
+  background: var(--brand);
+}
+.status[data-state='busy']::before {
+  background: var(--brand);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+.status[data-state='attention']::before {
+  background: var(--highlight);
+}
+.status[data-state='down']::before {
+  background: var(--rule);
+}
+
+.icon-button {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  background: var(--paper);
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition:
+    transform 110ms var(--ease-out),
+    color 160ms var(--ease-out),
+    border-color 160ms var(--ease-out);
+}
+.icon-button:hover {
+  color: var(--ink);
+  border-color: var(--rule);
+}
+.icon-button:active {
+  transform: scale(0.94);
+}
+.icon-button svg {
+  width: 17px;
+  height: 17px;
+}
+/* The button offers the theme you are not in, so light shows a moon. */
+.icon-sun {
+  display: none;
+}
+.icon-moon {
+  display: block;
+}
+:root[data-theme='dark'] .icon-sun {
+  display: block;
+}
+:root[data-theme='dark'] .icon-moon {
+  display: none;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .icon-sun {
+    display: block;
+  }
+  :root:not([data-theme='light']) .icon-moon {
+    display: none;
+  }
+}
+
+/* ---- transcript -------------------------------------------------------- */
+
+.log-wrap {
+  position: relative;
+  min-height: 0;
+  display: grid;
 }
 #messages {
+  --fade: 34px;
   min-height: 0;
   overflow-y: auto;
-  padding: clamp(18px, 4vw, 34px) 2px;
+  /* The bottom padding is deeper than the fade, so at rest the gradient lands
+     on empty space and never dims the newest message. */
+  padding: 20px 2px 46px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 26px;
   overscroll-behavior: contain;
   scroll-behavior: smooth;
+  /* Scroll edge effect: content dissolves into the chrome above and below
+     instead of being sliced by a hard edge. */
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--fade),
+    #000 calc(100% - var(--fade)),
+    transparent 100%
+  );
 }
+
+.turn {
+  display: grid;
+  gap: 7px;
+  animation: none;
+}
+.turn.enter {
+  animation: rise 380ms var(--ease-spring) both;
+}
+.role {
+  color: var(--ink-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+
 .message {
-  max-width: min(76ch, 88%);
-  padding: 13px 16px;
-  border: 1px solid var(--hairline);
-  border-radius: 16px 16px 16px 6px;
-  background: var(--linen-soft);
-  white-space: pre-wrap;
+  max-width: var(--measure);
+  font-size: var(--fs-body);
+  line-height: 1.6;
   overflow-wrap: anywhere;
-  line-height: 1.55;
+  text-wrap: pretty;
 }
 .message.user {
-  align-self: flex-end;
-  color: white;
-  background: var(--action);
-  border-color: var(--action);
-  border-radius: 16px 16px 6px 16px;
+  justify-self: end;
+  max-width: min(var(--measure), 82%);
+  padding: 12px 17px;
+  border: 1px solid var(--hairline);
+  border-radius: 18px 18px 6px 18px;
+  background: var(--wash);
+  color: var(--ink);
+  white-space: pre-wrap;
 }
+.turn.user {
+  justify-items: end;
+}
+.message.system {
+  justify-self: center;
+  max-width: 62ch;
+  padding: 11px 15px;
+  border: 1px dashed var(--rule);
+  border-radius: 12px;
+  color: var(--ink-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: center;
+  text-wrap: balance;
+}
+
+/* ---- agent markdown ---------------------------------------------------- */
+
 .message.agent {
-  white-space: normal;
-}
-.message.agent p {
-  margin: 0 0 0.75em;
+  color: var(--ink-body);
 }
 .message.agent > :first-child {
   margin-top: 0;
@@ -134,96 +344,402 @@ h1 {
 .message.agent > :last-child {
   margin-bottom: 0;
 }
+.message.agent p {
+  margin: 0 0 0.85em;
+}
+.message.agent h1,
+.message.agent h2,
+.message.agent h3,
+.message.agent h4 {
+  margin: 1.5em 0 0.5em;
+  color: var(--ink);
+  font-weight: 700;
+  line-height: 1.22;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+.message.agent h1 {
+  font-size: 1.34em;
+}
+.message.agent h2 {
+  font-size: 1.2em;
+}
+.message.agent h3 {
+  font-size: 1.06em;
+}
+.message.agent h4 {
+  font-size: 1em;
+}
+.message.agent strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+.message.agent a {
+  color: var(--action);
+  text-decoration-color: color-mix(in oklab, var(--action) 40%, transparent);
+  text-underline-offset: 3px;
+}
+.message.agent a:hover {
+  text-decoration-color: currentcolor;
+}
+.message.agent ul,
+.message.agent ol {
+  margin: 0 0 0.9em;
+  padding-left: 1.35em;
+}
+.message.agent li {
+  margin-bottom: 0.32em;
+  padding-left: 0.15em;
+}
+.message.agent li::marker {
+  color: var(--ink-muted);
+}
+.message.agent blockquote {
+  margin: 1em 0;
+  padding: 2px 0 2px 1.1em;
+  border-left: 2px solid var(--brand);
+  color: var(--ink-muted);
+}
+.message.agent hr {
+  height: 1px;
+  margin: 1.6em 0;
+  border: 0;
+  background: var(--hairline);
+}
+.message.agent img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 10px;
+}
+
+.message.agent code {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: 0.83em;
+}
+.message.agent :not(pre) > code {
+  padding: 0.14em 0.4em;
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  background: var(--wash);
+  color: var(--ink);
+}
 .message.agent pre {
+  position: relative;
+  margin: 0 0 1em;
+  padding: 14px 16px;
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  background: var(--linen-soft);
   overflow-x: auto;
 }
-.message.system {
-  align-self: center;
-  padding: 8px 12px;
-  color: var(--ink-muted);
-  background: transparent;
-  border-style: dashed;
-  font-size: 13px;
+.message.agent pre code {
+  display: block;
+  color: var(--ink);
+  font-size: 0.78em;
+  line-height: 1.6;
+  white-space: pre;
 }
+.copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 9px;
+  border: 1px solid var(--hairline);
+  border-radius: 7px;
+  background: var(--paper);
+  color: var(--ink-muted);
+  font: 600 11px/1 inherit;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 160ms var(--ease-out),
+    color 160ms var(--ease-out);
+}
+pre:hover .copy,
+.copy:focus-visible {
+  opacity: 1;
+}
+.copy:hover {
+  color: var(--ink);
+}
+.copy:active {
+  transform: scale(0.94);
+}
+
+.message.agent table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  font-size: 0.84em;
+  line-height: 1.45;
+}
+.message.agent thead th {
+  padding: 7px 12px 7px 0;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-muted);
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+}
+.message.agent tbody td {
+  padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--hairline);
+  vertical-align: top;
+}
+.message.agent tbody tr:last-child td {
+  border-bottom: 0;
+}
+.message.agent th:last-child,
+.message.agent td:last-child {
+  padding-right: 0;
+}
+.table-scroll {
+  margin: 0 0 1em;
+  overflow-x: auto;
+}
+.table-scroll table {
+  margin: 0;
+}
+
+/* ---- approval card ----------------------------------------------------- */
+
 .question-card {
-  width: min(620px, 92%);
+  width: min(560px, 100%);
   padding: 16px 18px 18px;
   border: 1px solid var(--hairline);
-  border-left: 4px solid var(--brand);
+  border-left: 3px solid var(--brand);
   border-radius: 6px 16px 16px 6px;
-  background: var(--linen-soft);
-  box-shadow: 0 10px 28px rgb(26 22 18 / 7%);
+  background: var(--paper);
+  box-shadow: var(--shadow-lg);
+}
+.question-card.enter {
+  animation: rise 380ms var(--ease-spring) both;
 }
 .question-kicker {
-  margin: 0 0 6px;
-  color: var(--action);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 7px;
+  color: var(--ink-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+.question-kicker::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
 }
 .question-title {
   margin: 0;
   color: var(--ink);
   font-size: 17px;
-  line-height: 1.3;
+  font-weight: 700;
+  line-height: 1.28;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
 }
 .question-body {
-  margin: 8px 0 0;
+  margin: 7px 0 0;
+  font-size: 15px;
   line-height: 1.5;
   white-space: pre-wrap;
+  text-wrap: pretty;
 }
 .question-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 14px;
+  margin-top: 15px;
 }
 .question-option {
-  min-width: 0;
-  height: auto;
-  padding: 9px 13px;
-  border: 1px solid var(--action);
+  padding: 9px 14px;
+  border: 1px solid var(--rule);
+  border-radius: 9px;
   background: var(--paper);
-  color: var(--action);
-  font-size: 13px;
+  color: var(--ink);
+  font: 600 14px/1 inherit;
+  cursor: pointer;
+  transition:
+    transform 110ms var(--ease-out),
+    border-color 160ms var(--ease-out),
+    background 160ms var(--ease-out);
+}
+.question-option:hover:not(:disabled) {
+  border-color: var(--ink-muted);
+}
+.question-option:active:not(:disabled) {
+  transform: scale(0.97);
 }
 .question-option.primary {
+  border-color: var(--action);
   background: var(--action);
-  color: white;
+  color: var(--on-action);
+}
+.question-option.primary:hover:not(:disabled) {
+  border-color: var(--action);
+  background: color-mix(in oklab, var(--action) 88%, var(--ink));
 }
 .question-option.danger {
-  border-color: var(--highlight);
   color: var(--highlight);
 }
+.question-option.danger:hover:not(:disabled) {
+  border-color: var(--highlight);
+}
 .question-option:disabled {
+  opacity: 0.42;
   cursor: default;
 }
 .question-resolution {
+  display: flex;
+  align-items: center;
+  gap: 7px;
   margin: 14px 0 0;
   padding-top: 12px;
   border-top: 1px solid var(--hairline);
   color: var(--ink-muted);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
+}
+.question-resolution::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+  flex-shrink: 0;
+}
+.question-resolution[hidden] {
+  display: none;
 }
 .question-error {
   color: var(--highlight);
 }
+.question-error::before {
+  background: var(--highlight);
+}
+
+/* ---- empty state ------------------------------------------------------- */
+
+.empty {
+  margin: auto;
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  max-width: 44ch;
+  text-align: center;
+}
+.empty h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 21px;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+.empty p {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 15px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.empty-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--hairline);
+  background: var(--linen-soft);
+  display: grid;
+  place-items: center;
+  margin-bottom: 4px;
+}
+.empty-mark::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--brand);
+  animation: pulse 3.2s ease-in-out infinite;
+}
+.empty.locked .empty-mark::after {
+  background: var(--ink-muted);
+  animation: none;
+  opacity: 0.55;
+}
+.empty code {
+  margin-top: 4px;
+  padding: 6px 11px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: var(--linen-soft);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: 13px;
+}
+
+/* ---- floating affordances ---------------------------------------------- */
+
+.jump {
+  position: absolute;
+  left: 50%;
+  bottom: 12px;
+  translate: -50% 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  background: var(--glass);
+  backdrop-filter: blur(16px) saturate(180%);
+  color: var(--ink);
+  font: 600 13px/1 inherit;
+  cursor: pointer;
+  box-shadow: var(--shadow-lg);
+  transition:
+    opacity 200ms var(--ease-out),
+    translate 260ms var(--ease-spring);
+}
+.jump[hidden] {
+  display: none;
+}
+.jump.entering {
+  opacity: 0;
+  translate: -50% 10px;
+}
+.jump:active {
+  transform: scale(0.96);
+}
+.jump svg {
+  width: 13px;
+  height: 13px;
+}
+
+/* Floats over the log rather than sitting in the grid: an in-flow pill would
+   shove the composer down and back up on every single turn. */
 .activity {
-  justify-self: start;
+  position: absolute;
+  left: 2px;
+  bottom: 12px;
   display: flex;
   align-items: center;
   gap: 9px;
-  min-height: 34px;
-  padding: 8px 12px;
+  padding: 7px 13px;
   border: 1px solid var(--hairline);
-  border-radius: 12px;
+  border-radius: 999px;
   color: var(--ink-muted);
-  background: var(--linen-soft);
-  font-size: 12px;
+  background: var(--glass);
+  backdrop-filter: blur(16px) saturate(180%);
+  box-shadow: var(--shadow-sm);
+  font-size: 13px;
   font-weight: 600;
   line-height: 1;
+  /* Materialise rather than fade: the pill scales in as it sharpens. */
+  animation: materialise 300ms var(--ease-spring) both;
 }
 .activity[hidden] {
   display: none;
@@ -232,61 +748,118 @@ h1 {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--action);
-  animation: breathe 1.2s ease-in-out infinite;
+  background: var(--brand);
+  animation: pulse 1.4s ease-in-out infinite;
 }
 .activity.tool .activity-dot {
   background: var(--highlight);
 }
+.activity.stalled .activity-dot {
+  background: var(--ink-muted);
+  animation-duration: 3.4s;
+}
+
+/* ---- composer ---------------------------------------------------------- */
+
 form {
   position: relative;
   z-index: 1;
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: end;
+  /* Nested radius: 20 outer − 10 padding = 10 inner. */
   gap: 10px;
   padding: 10px;
   border: 1px solid var(--hairline);
-  border-radius: 18px;
+  border-radius: 20px;
   background: var(--paper);
-  box-shadow: 0 12px 34px rgb(26 22 18 / 8%);
+  box-shadow: var(--shadow-lg);
+  transition: border-color 200ms var(--ease-out);
+}
+form:focus-within {
+  border-color: var(--action);
+  box-shadow:
+    var(--shadow-lg),
+    0 0 0 3px var(--ring);
+}
+textarea:focus-visible {
+  outline: 0;
 }
 textarea {
   width: 100%;
-  min-height: 48px;
-  max-height: 180px;
+  min-height: 46px;
+  max-height: 200px;
   resize: none;
   border: 0;
   outline: 0;
-  padding: 13px 12px 10px;
+  padding: 12px 12px 10px;
   color: var(--ink);
   background: transparent;
   font: inherit;
-  line-height: 1.45;
+  font-size: 17px;
+  line-height: 1.5;
 }
 textarea::placeholder {
   color: var(--ink-muted);
 }
-button {
-  min-width: 78px;
-  height: 44px;
+#send {
+  min-width: 76px;
+  height: 46px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--action);
-  color: white;
+  color: var(--on-action);
   font: 700 14px/1 inherit;
   cursor: pointer;
+  transition:
+    transform 110ms var(--ease-out),
+    opacity 200ms var(--ease-out),
+    background 160ms var(--ease-out);
 }
-button:hover {
-  filter: brightness(0.94);
+#send:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--action) 88%, var(--ink));
 }
-button:disabled {
-  cursor: wait;
-  opacity: 0.52;
+#send:active:not(:disabled) {
+  transform: scale(0.96);
 }
-button:focus-visible,
-textarea:focus-visible {
-  outline: 3px solid rgb(31 184 176 / 42%);
+#send:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 14px;
+  margin: 10px 2px 0;
+  color: var(--ink-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+.counter {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.counter[hidden] {
+  display: none;
+}
+.counter.over {
+  color: var(--highlight);
+}
+kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--hairline);
+  border-radius: 5px;
+  background: var(--wash);
+  font: inherit;
+  font-size: 11px;
+}
+
+/* ---- shared ------------------------------------------------------------ */
+
+:focus-visible {
+  outline: 3px solid var(--ring);
   outline-offset: 2px;
 }
 .sr-only {
@@ -296,42 +869,109 @@ textarea:focus-visible {
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }
-@keyframes breathe {
-  0%,
-  100% {
-    transform: scale(0.72);
-    opacity: 0.55;
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 12px, 0);
   }
-  50% {
-    transform: scale(1.22);
+  to {
     opacity: 1;
+    transform: none;
   }
 }
-@media (max-width: 600px) {
+@keyframes materialise {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+    filter: blur(3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
+@media (max-width: 640px) {
+  :root {
+    --fs-body: 17px;
+    --measure: 100%;
+  }
   .shell {
-    padding: 18px 14px 12px;
+    padding: 16px 15px 12px;
     border-inline: 0;
   }
-  .status {
+  .logotype {
+    width: 124px;
+  }
+  .status span {
     display: none;
   }
-  .message {
-    max-width: 94%;
+  .message.user {
+    max-width: 90%;
+  }
+  .hint-keys {
+    display: none;
   }
   form {
     position: sticky;
     bottom: 0;
   }
+  #messages {
+    gap: 22px;
+  }
 }
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
   *::after {
     scroll-behavior: auto !important;
-    animation: none !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+  .turn.enter,
+  .question-card.enter,
+  .activity {
+    animation: fade 150ms linear both !important;
+  }
+  @keyframes fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .jump,
+  .activity {
+    background: var(--paper);
+    backdrop-filter: none;
+  }
+}
+@media (prefers-contrast: more) {
+  :root {
+    --hairline: var(--ink-muted);
+    --rule: var(--ink);
+    --ink-body: var(--ink);
   }
 }

--- a/src/channels/local-web-page.html
+++ b/src/channels/local-web-page.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>NanoClaw · Local web chat</title>
+    <link rel="stylesheet" href="/local-web-page.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <div class="identity">
+          <div id="breath" class="breath" aria-hidden="true"></div>
+          <div>
+            <p class="eyebrow">Local only · 127.0.0.1</p>
+            <h1>NanoClaw</h1>
+          </div>
+        </div>
+        <div id="status" class="status" role="status">Connecting…</div>
+      </header>
+      <section id="messages" role="log" aria-live="polite" aria-label="Conversation"></section>
+      <div id="activity" class="activity" role="status" hidden>
+        <span class="activity-dot" aria-hidden="true"></span>
+        <span id="activity-label">Thinking…</span>
+      </div>
+      <form id="composer">
+        <label class="sr-only" for="message">Message your agent</label>
+        <textarea
+          id="message"
+          maxlength="8000"
+          rows="1"
+          placeholder="Message your agent…"
+          autocomplete="off"
+        ></textarea>
+        <button id="send" type="submit" disabled>Send</button>
+      </form>
+    </main>
+    <script src="/local-web-page.js" defer></script>
+  </body>
+</html>

--- a/src/channels/local-web-page.html
+++ b/src/channels/local-web-page.html
@@ -10,30 +10,119 @@
     <main class="shell">
       <header>
         <div class="identity">
-          <div id="breath" class="breath" aria-hidden="true"></div>
-          <div>
-            <p class="eyebrow">Local only · 127.0.0.1</p>
-            <h1>NanoClaw</h1>
-          </div>
+          <p class="eyebrow">Local only · 127.0.0.1</p>
+          <!-- Inline, not <img>: the page's CSP allows data: images only, and the
+               adapter serves no route for an SVG file. -->
+          <h1>
+            <svg
+              class="logotype"
+              viewBox="0 0 793 116"
+              role="img"
+              aria-label="NanoClaw"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M461.184 2C482.307 2 497.92 10.0173 506.645 25.3649C508.864 29.1827 510.012 33.2296 510.012 37.1237C510.012 45.3702 504.425 50.7153 495.93 50.7153C488.889 50.7153 484.603 47.9666 481.083 41.1709C476.185 31.7791 470.062 27.4266 461.567 27.4266C448.25 27.4266 439.832 39.1856 439.832 58.8855C439.832 78.8144 448.174 90.5734 461.644 90.5734C470.521 90.5733 476.72 86.0682 481.389 76.2946C484.68 69.3462 488.583 66.6737 495.394 66.6737C504.655 66.6738 510.701 72.3242 510.701 80.9525C510.701 83.7013 510.089 86.6028 508.941 89.4279C502.512 105.386 483.915 116 462.409 116C427.357 116 406.77 95.3073 406.77 58.9617C406.77 22.6162 427.816 2 461.184 2Z"
+                class="mark-claw"
+              />
+              <path
+                d="M541.429 2C572.606 2.00013 557.118 81.4572 557.118 99.8123C557.118 110.884 550.613 116 541.429 116C513.535 116 513.535 2 541.429 2Z"
+                class="mark-claw"
+              />
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M615.124 27.6556C638.543 27.6556 654.232 39.3383 654.232 56.4421V100.271C654.232 111.113 647.727 116 638.696 116C630.43 116 624.614 111.953 623.619 102.79H623.006C618.568 111.037 608.312 115.313 598.516 115.313C583.133 115.313 570.046 104.776 570.046 89.5807C570.046 73.3932 582.521 64.6123 605.098 63.2379L623.619 62.0924V57.969C623.619 52.3188 619.333 49.2646 613.44 49.2646C608.542 49.2646 606.093 50.5627 600.659 55.5259C596.985 58.8855 593.006 60.5652 588.337 60.5652C580.914 60.5652 575.633 55.9839 575.633 49.4936C575.633 47.5847 575.786 46.3631 576.245 44.836C579.459 34.0698 594.077 27.6556 615.124 27.6556ZM610.302 79.7308C604.332 80.1889 600.965 83.014 600.965 87.1373C600.965 91.7186 604.715 94.391 610.225 94.391C617.19 94.391 623.619 90.4969 623.619 84.3121V78.8143L610.302 79.7308Z"
+                class="mark-claw"
+              />
+              <path
+                d="M777.679 27.8848C786.174 27.8848 792.297 33.4589 792.297 41.0181C792.297 44.1487 791.685 46.7449 790.46 51.1735L776.837 98.8961C773.47 110.731 767.653 116 756.25 116C744.311 116 738.188 110.808 735.586 98.7433L727.168 59.8017H726.555L718.213 99.0488C715.688 110.96 709.642 116 697.932 116C686.758 116 681.095 110.731 677.727 99.0488L664.105 51.5553C662.803 47.0502 662.191 44.4541 662.191 41.2471C662.191 33.5352 668.62 27.8849 677.268 27.8848C698.754 27.8848 698.109 72.3775 700.84 86.679H701.453L710.101 42.3926C711.937 33.0008 718.06 27.8848 727.55 27.8848C736.964 27.8849 743.163 33.0007 745 42.4688L753.724 86.679H754.337L763.061 41.0944C764.592 33.0006 769.949 27.8848 777.679 27.8848Z"
+                class="mark-claw"
+              />
+              <path
+                d="M144.664 112.991C129.285 112.991 116.202 102.456 116.202 87.2638C116.202 71.0795 128.673 62.3004 151.244 60.9262L169.76 59.7811V55.6587C169.76 50.0095 165.475 46.9559 159.584 46.9559C154.687 46.9559 152.239 48.2537 146.806 53.2158C143.134 56.5748 139.155 58.2543 134.488 58.2543C127.067 58.2543 121.787 53.6739 121.787 47.1849C121.787 45.2764 121.94 44.0549 122.399 42.5281C125.613 31.7641 140.227 25.3515 161.267 25.3515C184.68 25.3515 200.365 37.0316 200.365 54.1319V97.9515C200.365 108.792 193.861 113.678 184.833 113.678C176.569 113.678 170.755 109.632 169.76 100.471H169.148C164.71 108.715 154.458 112.991 144.664 112.991ZM156.37 92.0732C163.333 92.0732 169.76 88.1798 169.76 81.9963V76.4997L156.447 77.4158C150.479 77.8739 147.113 80.6985 147.113 84.8209C147.113 89.4013 150.862 92.0732 156.37 92.0732ZM227.909 113.678C218.727 113.678 212.224 108.563 212.224 97.4934V41.3067C212.224 31.306 217.656 25.5805 227.45 25.5805C237.243 25.5805 243.594 31.306 243.594 41.383V43.2915H244.206C248.49 31.4587 256.524 25.8095 269.378 25.8095C288.353 25.8095 298.758 37.566 298.758 57.7963V97.4934C298.758 108.563 292.255 113.678 283.073 113.678C273.892 113.678 267.389 108.563 267.389 97.4934V64.7433C267.389 56.2694 263.41 51.0783 255.529 51.0783C248.108 51.0783 243.594 56.8038 243.594 64.6669V97.4934C243.594 108.563 237.09 113.678 227.909 113.678ZM352.393 113.907C324.849 113.907 308.016 98.0278 308.016 69.5527C308.016 41.841 325.308 25.3515 352.393 25.3515C379.631 25.3515 396.846 41.6884 396.846 69.5527C396.846 98.1041 380.013 113.907 352.393 113.907ZM352.393 91.5388C360.197 91.5388 365.017 83.7521 365.017 69.6291C365.017 55.8877 360.12 47.7193 352.393 47.7193C344.742 47.7193 339.845 55.8877 339.845 69.6291C339.845 83.7521 344.512 91.5388 352.393 91.5388Z"
+                class="mark-word"
+              />
+              <path
+                d="M35.6947 8.85552C31.0275 2.67192 26.5133 0 20.6219 0C-7.14729 0 -6.59928 113.977 20.6219 113.977C30.2624 113.977 35.9242 108.327 35.9242 97.9451V54.0492L74.2565 105.121C78.8471 111.381 83.2083 113.977 89.4057 113.977C116.426 113.977 116.358 0 89.0232 0C79.3827 0 73.7209 5.64921 73.7209 16.0315V59.0114L35.6947 8.85552Z"
+                class="mark-word"
+              />
+            </svg>
+          </h1>
         </div>
-        <div id="status" class="status" role="status">Connecting…</div>
+        <div class="header-tools">
+          <p id="status" class="status" role="status" data-state="down"><span>Connecting…</span></p>
+          <button id="theme" class="icon-button" type="button" aria-label="Switch theme" title="Switch theme">
+            <svg
+              class="icon-moon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.9"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.8 6.8 0 0 0 10.5 10.5Z" />
+            </svg>
+            <svg
+              class="icon-sun"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.9"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="4" />
+              <path
+                d="M12 2.5v2M12 19.5v2M4.6 4.6l1.4 1.4M18 18l1.4 1.4M2.5 12h2M19.5 12h2M4.6 19.4 6 18M18 6l1.4-1.4"
+              />
+            </svg>
+          </button>
+        </div>
       </header>
-      <section id="messages" role="log" aria-live="polite" aria-label="Conversation"></section>
-      <div id="activity" class="activity" role="status" hidden>
-        <span class="activity-dot" aria-hidden="true"></span>
-        <span id="activity-label">Thinking…</span>
+
+      <div class="log-wrap">
+        <section id="messages" role="log" aria-live="polite" aria-label="Conversation"></section>
+        <div id="activity" class="activity" role="status" hidden>
+          <span class="activity-dot" aria-hidden="true"></span>
+          <span id="activity-label">Thinking…</span>
+        </div>
+        <button id="jump" class="jump" type="button" hidden>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 4v15M5.5 12.5 12 19l6.5-6.5" />
+          </svg>
+          Latest
+        </button>
       </div>
-      <form id="composer">
-        <label class="sr-only" for="message">Message your agent</label>
-        <textarea
-          id="message"
-          maxlength="8000"
-          rows="1"
-          placeholder="Message your agent…"
-          autocomplete="off"
-        ></textarea>
-        <button id="send" type="submit" disabled>Send</button>
-      </form>
+
+      <div class="dock">
+        <form id="composer">
+          <label class="sr-only" for="message">Message your agent</label>
+          <textarea
+            id="message"
+            maxlength="8000"
+            rows="1"
+            placeholder="Message your agent…"
+            autocomplete="off"
+          ></textarea>
+          <button id="send" type="submit" disabled>Send</button>
+        </form>
+        <p class="hint">
+          <span class="hint-keys"><kbd>Enter</kbd> to send · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line</span>
+          <span id="counter" class="counter" hidden></span>
+        </p>
+      </div>
     </main>
     <script src="/local-web-page.js" defer></script>
   </body>

--- a/src/channels/local-web-page.html
+++ b/src/channels/local-web-page.html
@@ -7,10 +7,9 @@
     <link rel="stylesheet" href="/local-web-page.css" />
   </head>
   <body>
-    <main class="shell">
-      <header>
-        <div class="identity">
-          <p class="eyebrow">Local only · 127.0.0.1</p>
+    <main class="app-shell">
+      <aside id="agent-sidebar" class="agent-sidebar" aria-label="Agents">
+        <div class="sidebar-brand">
           <!-- Inline, not <img>: the page's CSP allows data: images only, and the
                adapter serves no route for an SVG file. -->
           <h1>
@@ -50,80 +49,159 @@
             </svg>
           </h1>
         </div>
-        <div class="header-tools">
-          <p id="status" class="status" role="status" data-state="down"><span>Connecting…</span></p>
-          <button id="theme" class="icon-button" type="button" aria-label="Switch theme" title="Switch theme">
+        <button id="create-agent" class="create-agent-button" type="button">Create agent</button>
+        <nav id="agent-list" class="agent-list" aria-label="Agent conversations"></nav>
+        <p class="sidebar-local">Local only · 127.0.0.1</p>
+      </aside>
+      <button id="sidebar-scrim" class="sidebar-scrim" type="button" aria-label="Close agent selector" hidden></button>
+
+      <section class="shell">
+        <header>
+          <div class="header-identity">
+            <button
+              id="agents-toggle"
+              class="icon-button agents-toggle"
+              type="button"
+              aria-label="Choose agent"
+              aria-controls="agent-sidebar"
+              aria-expanded="false"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" aria-hidden="true">
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+            <div class="identity">
+              <p class="eyebrow">Current agent</p>
+              <h1 id="agent-title">Loading…</h1>
+              <p id="agent-runtime" class="agent-runtime"></p>
+            </div>
+          </div>
+          <div class="header-tools">
+            <p id="status" class="status" role="status" data-state="down"><span>Connecting…</span></p>
+            <button id="theme" class="icon-button" type="button" aria-label="Switch theme" title="Switch theme">
+              <svg
+                class="icon-moon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.8 6.8 0 0 0 10.5 10.5Z" />
+              </svg>
+              <svg
+                class="icon-sun"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="4" />
+                <path
+                  d="M12 2.5v2M12 19.5v2M4.6 4.6l1.4 1.4M18 18l1.4 1.4M2.5 12h2M19.5 12h2M4.6 19.4 6 18M18 6l1.4-1.4"
+                />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        <div class="log-wrap">
+          <section id="messages" role="log" aria-live="polite" aria-label="Conversation"></section>
+          <div id="activity" class="activity" role="status" hidden>
+            <span class="activity-dot" aria-hidden="true"></span>
+            <span id="activity-label">Thinking…</span>
+          </div>
+          <button id="jump" class="jump" type="button" hidden>
             <svg
-              class="icon-moon"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
-              stroke-width="1.9"
+              stroke-width="2.4"
               stroke-linecap="round"
               stroke-linejoin="round"
               aria-hidden="true"
             >
-              <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.8 6.8 0 0 0 10.5 10.5Z" />
+              <path d="M12 4v15M5.5 12.5 12 19l6.5-6.5" />
             </svg>
-            <svg
-              class="icon-sun"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.9"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="12" cy="12" r="4" />
-              <path
-                d="M12 2.5v2M12 19.5v2M4.6 4.6l1.4 1.4M18 18l1.4 1.4M2.5 12h2M19.5 12h2M4.6 19.4 6 18M18 6l1.4-1.4"
-              />
-            </svg>
+            Latest
           </button>
         </div>
-      </header>
 
-      <div class="log-wrap">
-        <section id="messages" role="log" aria-live="polite" aria-label="Conversation"></section>
-        <div id="activity" class="activity" role="status" hidden>
-          <span class="activity-dot" aria-hidden="true"></span>
-          <span id="activity-label">Thinking…</span>
+        <div class="dock">
+          <form id="composer">
+            <label class="sr-only" for="message">Message your agent</label>
+            <textarea
+              id="message"
+              maxlength="8000"
+              rows="1"
+              placeholder="Message your agent…"
+              autocomplete="off"
+            ></textarea>
+            <button id="send" type="submit" disabled>Send</button>
+          </form>
+          <p class="hint">
+            <span class="hint-keys"><kbd>Enter</kbd> to send · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line</span>
+            <span id="counter" class="counter" hidden></span>
+          </p>
         </div>
-        <button id="jump" class="jump" type="button" hidden>
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.4"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M12 4v15M5.5 12.5 12 19l6.5-6.5" />
-          </svg>
-          Latest
-        </button>
-      </div>
-
-      <div class="dock">
-        <form id="composer">
-          <label class="sr-only" for="message">Message your agent</label>
-          <textarea
-            id="message"
-            maxlength="8000"
-            rows="1"
-            placeholder="Message your agent…"
-            autocomplete="off"
-          ></textarea>
-          <button id="send" type="submit" disabled>Send</button>
-        </form>
-        <p class="hint">
-          <span class="hint-keys"><kbd>Enter</kbd> to send · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line</span>
-          <span id="counter" class="counter" hidden></span>
-        </p>
-      </div>
+      </section>
     </main>
-    <script src="/local-web-page.js" defer></script>
+
+    <dialog id="create-agent-dialog" class="create-agent-dialog" aria-labelledby="create-agent-title">
+      <form id="create-agent-form">
+        <div class="dialog-heading">
+          <div>
+            <p class="dialog-kicker">New conversation</p>
+            <h2 id="create-agent-title">Create agent</h2>
+          </div>
+          <button id="close-create-agent" class="icon-button" type="button" aria-label="Close create agent dialog">
+            ×
+          </button>
+        </div>
+        <p id="create-agent-error" class="form-error" role="alert" hidden></p>
+        <label class="form-field">
+          <span>Name</span>
+          <input id="agent-name" name="name" maxlength="64" autocomplete="off" required />
+        </label>
+        <div class="inheritance-summary">
+          <span>Inherit from <strong id="inherit-agent"></strong></span>
+          <span id="inherit-runtime"></span>
+        </div>
+        <label id="provider-field" class="form-field">
+          <span>Provider</span>
+          <select id="agent-provider" name="provider"></select>
+        </label>
+        <p id="single-provider" class="single-provider" hidden></p>
+        <details id="advanced-options" class="advanced-options">
+          <summary>Advanced</summary>
+          <div class="advanced-fields">
+            <label class="form-field">
+              <span>Model</span>
+              <input id="agent-model" name="model" maxlength="128" placeholder="Default" autocomplete="off" />
+            </label>
+            <label class="form-field">
+              <span>Effort</span>
+              <select id="agent-effort" name="effort">
+                <option value="">Default</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="xhigh">XHigh</option>
+              </select>
+            </label>
+          </div>
+        </details>
+        <div class="dialog-actions">
+          <button id="cancel-create-agent" class="secondary-button" type="button">Cancel</button>
+          <button id="submit-create-agent" class="primary-button" type="submit">Create agent</button>
+        </div>
+      </form>
+    </dialog>
+    <script src="/local-web-page.js" type="module"></script>
   </body>
 </html>

--- a/src/channels/local-web-page.js
+++ b/src/channels/local-web-page.js
@@ -16,7 +16,6 @@
   const counterThreshold = 400;
   const stickyBottomPx = 96;
   const activityIdleMs = 10_000;
-  const silentTurnMs = 180_000;
 
   const root = document.documentElement;
   const messages = document.querySelector('#messages');
@@ -34,7 +33,6 @@
   const activity = document.querySelector('#activity');
   const activityLabel = document.querySelector('#activity-label');
   let activityTimer = null;
-  let silentTurnTimer = null;
 
   // ---- theme ------------------------------------------------------------
   // No stored choice means follow the OS; the button writes an explicit one.
@@ -320,24 +318,6 @@
       activity.classList.remove('tool');
     }, activityIdleMs);
   }
-  // A turn can complete backend-side and deliver nothing, with no error event.
-  // Rather than leave the pill spinning forever, say so after a long silence.
-  function beginTurn() {
-    clearTimeout(silentTurnTimer);
-    silentTurnTimer = setTimeout(() => {
-      setActivity(null);
-      setState('Ready', 'ready');
-      addMessage(
-        'system',
-        'No reply yet. The turn may still be running, or it may have finished without sending one.',
-        false,
-      );
-    }, silentTurnMs);
-  }
-  function endTurn() {
-    clearTimeout(silentTurnTimer);
-    silentTurnTimer = null;
-  }
   /** The full-height state the log shows when it holds no conversation. */
   function renderEmptyState({ heading, body, note, locked = false }) {
     clearEmptyState();
@@ -451,7 +431,6 @@
         setActivity(`Using ${data.name}`, true);
       }
       if (data.type === 'reply' && typeof data.text === 'string') {
-        endTurn();
         clearEmptyState();
         addMessage('agent', data.text, true, typeof data.html === 'string' ? data.html : null);
         send.disabled = false;
@@ -465,7 +444,6 @@
         typeof data.title === 'string' &&
         Array.isArray(data.options)
       ) {
-        endTurn();
         clearEmptyState();
         addQuestion({
           type: 'question',
@@ -519,7 +497,6 @@
     send.disabled = true;
     setState('Working', 'busy');
     setActivity('Thinking…');
-    beginTurn();
     try {
       const response = await fetch('/api/messages', {
         method: 'POST',
@@ -533,7 +510,6 @@
       send.disabled = false;
       input.focus();
     } catch (error) {
-      endTurn();
       addMessage('system', error instanceof Error ? error.message : 'Message could not be sent.', false);
       send.disabled = false;
       setState('Ready', 'ready');

--- a/src/channels/local-web-page.js
+++ b/src/channels/local-web-page.js
@@ -2,26 +2,67 @@
  * Browser asset for the local-web chat page. Served to the browser at
  * /local-web-page.js; never imported by the host process.
  */
-/* global document, history, location, localStorage, sessionStorage */
+/* global document, history, location, localStorage, matchMedia, navigator, sessionStorage */
 /* eslint-disable no-catch-all/no-catch-all -- every catch here degrades the page
    instead of failing it: storage denied, a torn frame, an aborted stream. */
 
 (() => {
   const historyKey = 'nanoclaw-local-web-history';
   const tokenKey = 'nanoclaw-local-web-token';
+  const themeKey = 'nanoclaw-local-web-theme';
   const tokenHeader = 'x-nanoclaw-local-web-token';
   const maxVisibleItems = 100;
+  const maxLength = 8000;
+  const counterThreshold = 400;
+  const stickyBottomPx = 96;
+  const activityIdleMs = 10_000;
+  const silentTurnMs = 180_000;
+
+  const root = document.documentElement;
   const messages = document.querySelector('#messages');
   const form = document.querySelector('#composer');
   const input = document.querySelector('#message');
   const send = document.querySelector('#send');
   const status = document.querySelector('#status');
-  const breath = document.querySelector('#breath');
+  const statusLabel = status.querySelector('span');
+  const themeButton = document.querySelector('#theme');
+  const jump = document.querySelector('#jump');
+  const counter = document.querySelector('#counter');
   const activity = document.querySelector('#activity');
   const activityLabel = document.querySelector('#activity-label');
-  const activityIdleMs = 10_000;
   let activityTimer = null;
+  let silentTurnTimer = null;
 
+  // ---- theme ------------------------------------------------------------
+  // No stored choice means follow the OS; the button writes an explicit one.
+  try {
+    const stored = localStorage.getItem(themeKey);
+    if (stored === 'light' || stored === 'dark') root.dataset.theme = stored;
+  } catch {
+    // a browser with site data blocked simply follows the OS every load
+  }
+  function prefersDark() {
+    return root.dataset.theme ? root.dataset.theme === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  function syncThemeLabel() {
+    const next = prefersDark() ? 'light' : 'dark';
+    themeButton.setAttribute('aria-label', `Switch to ${next} theme`);
+    themeButton.setAttribute('title', `Switch to ${next} theme`);
+  }
+  themeButton.addEventListener('click', () => {
+    const next = prefersDark() ? 'light' : 'dark';
+    root.dataset.theme = next;
+    try {
+      localStorage.setItem(themeKey, next);
+    } catch {
+      // the choice still applies to this page load
+    }
+    syncThemeLabel();
+  });
+  matchMedia('(prefers-color-scheme: dark)').addEventListener('change', syncThemeLabel);
+  syncThemeLabel();
+
+  // ---- token ------------------------------------------------------------
   // The launcher hands the token over in the fragment, which never reaches
   // the server. Strip it immediately: the address bar is the one place it
   // could leave this machine, since browsers sync history and bookmarks.
@@ -41,6 +82,7 @@
     }
   }
 
+  // ---- transcript -------------------------------------------------------
   let transcript = [];
   try {
     const parsed = JSON.parse(sessionStorage.getItem(historyKey) || '[]');
@@ -60,23 +102,99 @@
       // losing the transcript must never block sending
     }
   }
+
+  // ---- scroll -----------------------------------------------------------
+  // Only follow new content when the reader is already at the bottom.
+  // Yanking someone out of scrollback to show a message they can see the
+  // arrival of is the single most irritating thing a chat log can do.
+  function isAtBottom() {
+    return messages.scrollHeight - messages.scrollTop - messages.clientHeight < stickyBottomPx;
+  }
+  function scrollToLatest(smooth = true) {
+    messages.scrollTo({ top: messages.scrollHeight, behavior: smooth ? 'smooth' : 'auto' });
+    jump.hidden = true;
+  }
+  function settleScroll(wasAtBottom) {
+    if (wasAtBottom) scrollToLatest();
+    else jump.hidden = false;
+  }
+  messages.addEventListener('scroll', () => {
+    if (isAtBottom()) jump.hidden = true;
+  });
+  jump.addEventListener('click', () => {
+    scrollToLatest();
+    input.focus();
+  });
+
+  // ---- rendering --------------------------------------------------------
+  function labelFor(role) {
+    if (role === 'user') return 'You';
+    return role === 'agent' ? 'NanoClaw' : '';
+  }
+  /** Copy buttons and horizontal table scrollers over server-rendered Markdown. */
+  function enhanceMarkdown(node) {
+    for (const table of node.querySelectorAll('table')) {
+      const wrap = document.createElement('div');
+      wrap.className = 'table-scroll';
+      table.replaceWith(wrap);
+      wrap.append(table);
+    }
+    for (const pre of node.querySelectorAll('pre')) {
+      const source = (pre.querySelector('code') || pre).textContent;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'copy';
+      button.textContent = 'Copy';
+      button.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(source);
+          button.textContent = 'Copied';
+        } catch {
+          button.textContent = 'Copy failed';
+        }
+        setTimeout(() => (button.textContent = 'Copy'), 1600);
+      });
+      pre.append(button);
+    }
+  }
   function addMessage(role, text, save = true, html = null) {
-    if (role !== 'system') clearPlaceholder();
+    const wasAtBottom = isAtBottom();
+    if (role !== 'system') clearEmptyState();
+
+    const turn = document.createElement('div');
+    turn.className = `turn ${role}${save ? ' enter' : ''}`;
+
+    const label = labelFor(role);
+    if (label) {
+      const roleTag = document.createElement('p');
+      roleTag.className = 'role';
+      roleTag.textContent = label;
+      turn.append(roleTag);
+    }
+
     const node = document.createElement('div');
     node.className = `message ${role}`;
     // Agent HTML is produced by the server's raw-HTML-disabled Markdown renderer.
-    if (role === 'agent' && typeof html === 'string') node.innerHTML = html;
-    else node.textContent = text;
-    messages.append(node);
+    if (role === 'agent' && typeof html === 'string') {
+      node.innerHTML = html;
+      enhanceMarkdown(node);
+    } else {
+      node.textContent = text;
+    }
+    turn.append(node);
+    messages.append(turn);
+
     if (save) {
       transcript.push({ role, text, ...(typeof html === 'string' && { html }) });
       persist();
     }
-    messages.scrollTop = messages.scrollHeight;
+    settleScroll(wasAtBottom || !save);
   }
   function addQuestion(card, save = true) {
+    const wasAtBottom = isAtBottom();
+    clearEmptyState();
     const node = document.createElement('article');
-    node.className = 'question-card';
+    node.className = `question-card${save ? ' enter' : ''}`;
     node.dataset.questionId = card.questionId;
 
     const kicker = document.createElement('p');
@@ -117,7 +235,7 @@
             throw new Error(responseBody.error || `Action failed (${response.status})`);
           }
           resolveQuestion(card.questionId, option.selectedLabel || option.label);
-          setState('Ready');
+          setState('Ready', 'ready');
         } catch (error) {
           resolution.textContent = error instanceof Error ? error.message : 'Action could not be sent.';
           resolution.hidden = false;
@@ -141,7 +259,7 @@
       transcript.push(card);
       persist();
     }
-    messages.scrollTop = messages.scrollHeight;
+    settleScroll(wasAtBottom || !save);
   }
   function resolveQuestion(questionId, value) {
     const card = transcript.find((item) => item.type === 'question' && item.questionId === questionId);
@@ -157,51 +275,103 @@
     resolution.classList.remove('question-error');
     persist();
   }
+
   // Header status is connection state; turn activity lives in the pill.
-  function setState(label) {
-    status.textContent = label;
+  function setState(label, state) {
+    statusLabel.textContent = label;
+    status.dataset.state = state;
   }
   function setActivity(label, isTool = false) {
     clearTimeout(activityTimer);
     activityTimer = null;
     activity.hidden = !label;
     activity.classList.toggle('tool', isTool);
-    breath.classList.toggle('thinking', Boolean(label));
-    if (label) {
-      activityLabel.textContent = label;
-      activityTimer = setTimeout(() => setActivity(null), activityIdleMs);
-    }
+    activity.classList.remove('stalled');
+    if (!label) return;
+    activityLabel.textContent = label;
+    // The backend stops emitting thinking/tool events roughly 15s into a turn
+    // while the turn itself runs on. Hiding the pill there reads as "finished",
+    // so it degrades to the only thing the page still honestly knows.
+    activityTimer = setTimeout(() => {
+      activityLabel.textContent = 'Still working';
+      activity.classList.add('stalled');
+      activity.classList.remove('tool');
+    }, activityIdleMs);
   }
-  function showPlaceholder() {
-    if (messages.querySelector('.placeholder')) return;
+  // A turn can complete backend-side and deliver nothing, with no error event.
+  // Rather than leave the pill spinning forever, say so after a long silence.
+  function beginTurn() {
+    clearTimeout(silentTurnTimer);
+    silentTurnTimer = setTimeout(() => {
+      setActivity(null);
+      setState('Ready', 'ready');
+      addMessage(
+        'system',
+        'No reply yet. The turn may still be running, or it may have finished without sending one.',
+        false,
+      );
+    }, silentTurnMs);
+  }
+  function endTurn() {
+    clearTimeout(silentTurnTimer);
+    silentTurnTimer = null;
+  }
+  /** The full-height state the log shows when it holds no conversation. */
+  function renderEmptyState({ heading, body, note, locked = false }) {
+    clearEmptyState();
     const node = document.createElement('div');
-    node.className = 'message system placeholder';
-    node.textContent = 'Starting your local conversation…';
+    node.className = `empty${locked ? ' locked' : ''}`;
+
+    const mark = document.createElement('div');
+    mark.className = 'empty-mark';
+    mark.setAttribute('aria-hidden', 'true');
+    node.append(mark);
+
+    const title = document.createElement('h2');
+    title.textContent = heading;
+    node.append(title);
+
+    const text = document.createElement('p');
+    text.textContent = body;
+    node.append(text);
+
+    if (note) {
+      const code = document.createElement('code');
+      code.textContent = note;
+      node.append(code);
+    }
     messages.append(node);
   }
-  function clearPlaceholder() {
-    messages.querySelector('.placeholder')?.remove();
+  function showEmptyState() {
+    if (messages.querySelector('.empty')) return;
+    renderEmptyState({
+      heading: 'Nothing here yet',
+      body: 'This chat runs entirely on your machine. Nothing you type leaves 127.0.0.1.',
+    });
+  }
+  function clearEmptyState() {
+    messages.querySelector('.empty')?.remove();
   }
   for (const item of transcript) {
     if (item.type === 'question') addQuestion(item, false);
     else addMessage(item.role === 'user' ? 'user' : 'agent', item.text, false, item.html);
   }
-  if (transcript.length === 0) showPlaceholder();
+  if (transcript.length === 0) showEmptyState();
+  else scrollToLatest(false);
 
   function showNotAuthorized() {
     send.disabled = true;
     input.disabled = true;
     setActivity(null);
-    setState('Not connected');
-    clearPlaceholder();
+    setState('Not connected', 'down');
     // This screen is the recovery path when a browser opened the bare address,
     // so it has to name the token rather than any one installer's command.
-    addMessage(
-      'system',
-      'This browser has no access token. Reopen the chat using the link its install prints, which ends in ' +
-        '#token=…; the token is in data/local-web/token on the host.',
-      false,
-    );
+    renderEmptyState({
+      heading: 'This browser has no access token',
+      body: 'Reopen the chat using the link your install prints; its address ends with a #token= fragment. On the host, the token itself lives at:',
+      note: 'data/local-web/token',
+      locked: true,
+    });
   }
 
   // A hand-read stream rather than EventSource: EventSource cannot send the
@@ -217,7 +387,7 @@
           return;
         }
         if (!response.ok || !response.body) throw new Error(`Stream failed (${response.status})`);
-        setState('Ready');
+        setState('Ready', 'ready');
         send.disabled = false;
         retryDelay = 1_000;
         const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
@@ -235,7 +405,7 @@
         // the connection failed or dropped; the retry below is the recovery
       }
       send.disabled = true;
-      setState('Reconnecting…');
+      setState('Reconnecting…', 'down');
       await new Promise((resolve) => setTimeout(resolve, retryDelay));
       // back off, so a stopped host is not one failed fetch per second forever
       retryDelay = Math.min(retryDelay * 2, 30_000);
@@ -246,22 +416,25 @@
     try {
       const data = JSON.parse(raw);
       if (data.type === 'ready') {
-        setState('Ready');
+        setState('Ready', 'ready');
         setActivity(null);
         send.disabled = false;
       }
       if (data.type === 'thinking') {
+        setState('Working', 'busy');
         setActivity('Thinking…');
       }
       if (data.type === 'tool' && typeof data.name === 'string') {
+        setState('Working', 'busy');
         setActivity(`Using ${data.name}`, true);
       }
       if (data.type === 'reply' && typeof data.text === 'string') {
-        clearPlaceholder();
+        endTurn();
+        clearEmptyState();
         addMessage('agent', data.text, true, typeof data.html === 'string' ? data.html : null);
         send.disabled = false;
         input.focus();
-        setState('Ready');
+        setState('Ready', 'ready');
         setActivity(null);
       }
       if (
@@ -270,7 +443,8 @@
         typeof data.title === 'string' &&
         Array.isArray(data.options)
       ) {
-        clearPlaceholder();
+        endTurn();
+        clearEmptyState();
         addQuestion({
           type: 'question',
           questionId: data.questionId,
@@ -281,7 +455,7 @@
           ),
         });
         send.disabled = false;
-        setState('Action required');
+        setState('Action required', 'attention');
         setActivity(null);
       }
       if (
@@ -290,7 +464,7 @@
         typeof data.resolution === 'string'
       ) {
         resolveQuestion(data.questionId, data.resolution);
-        setState('Ready');
+        setState('Ready', 'ready');
       }
     } catch {
       // same: one bad frame never stops the page
@@ -300,15 +474,29 @@
   if (token) void streamEvents();
   else showNotAuthorized();
 
+  // ---- composer ---------------------------------------------------------
+  function resize() {
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(input.scrollHeight, 200)}px`;
+  }
+  function updateCounter() {
+    const remaining = maxLength - input.value.length;
+    counter.hidden = remaining > counterThreshold;
+    counter.textContent = `${remaining} left`;
+    counter.classList.toggle('over', remaining <= 0);
+  }
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
     const text = input.value.trim();
     if (!text || send.disabled) return;
     addMessage('user', text);
     input.value = '';
-    input.style.height = 'auto';
+    resize();
+    updateCounter();
     send.disabled = true;
+    setState('Working', 'busy');
     setActivity('Thinking…');
+    beginTurn();
     try {
       const response = await fetch('/api/messages', {
         method: 'POST',
@@ -322,9 +510,10 @@
       send.disabled = false;
       input.focus();
     } catch (error) {
+      endTurn();
       addMessage('system', error instanceof Error ? error.message : 'Message could not be sent.', false);
       send.disabled = false;
-      setState('Ready');
+      setState('Ready', 'ready');
       setActivity(null);
     }
   });
@@ -335,8 +524,8 @@
     }
   });
   input.addEventListener('input', () => {
-    input.style.height = 'auto';
-    input.style.height = `${Math.min(input.scrollHeight, 180)}px`;
+    resize();
+    updateCounter();
   });
   input.focus();
 })();

--- a/src/channels/local-web-page.js
+++ b/src/channels/local-web-page.js
@@ -2,12 +2,13 @@
  * Browser asset for the local-web chat page. Served to the browser at
  * /local-web-page.js; never imported by the host process.
  */
-/* global document, history, location, localStorage, matchMedia, navigator, sessionStorage */
+import { createConversationController } from './local-web-conversation-ui.js';
+
+/* global document, history, location, localStorage, matchMedia, window */
 /* eslint-disable no-catch-all/no-catch-all -- every catch here degrades the page
    instead of failing it: storage denied, a torn frame, an aborted stream. */
 
 (() => {
-  const historyKey = 'nanoclaw-local-web-history';
   const tokenKey = 'nanoclaw-local-web-token';
   const themeKey = 'nanoclaw-local-web-theme';
   const tokenHeader = 'x-nanoclaw-local-web-token';
@@ -32,7 +33,33 @@
   const dock = document.querySelector('.dock');
   const activity = document.querySelector('#activity');
   const activityLabel = document.querySelector('#activity-label');
+  const appShell = document.querySelector('.app-shell');
+  const agentSidebar = document.querySelector('#agent-sidebar');
+  const agentList = document.querySelector('#agent-list');
+  const agentTitle = document.querySelector('#agent-title');
+  const agentRuntime = document.querySelector('#agent-runtime');
+  const agentsToggle = document.querySelector('#agents-toggle');
+  const sidebarScrim = document.querySelector('#sidebar-scrim');
+  const createAgentButton = document.querySelector('#create-agent');
+  const createDialog = document.querySelector('#create-agent-dialog');
+  const createForm = document.querySelector('#create-agent-form');
+  const closeCreateAgent = document.querySelector('#close-create-agent');
+  const cancelCreateAgent = document.querySelector('#cancel-create-agent');
+  const submitCreateAgent = document.querySelector('#submit-create-agent');
+  const createError = document.querySelector('#create-agent-error');
+  const agentName = document.querySelector('#agent-name');
+  const inheritAgent = document.querySelector('#inherit-agent');
+  const inheritRuntime = document.querySelector('#inherit-runtime');
+  const providerField = document.querySelector('#provider-field');
+  const providerSelect = document.querySelector('#agent-provider');
+  const singleProvider = document.querySelector('#single-provider');
+  const modelInput = document.querySelector('#agent-model');
+  const effortSelect = document.querySelector('#agent-effort');
+  const advancedOptions = document.querySelector('#advanced-options');
+  const mobileSidebar = window.matchMedia('(max-width: 780px)');
   let activityTimer = null;
+  let conversationController = null;
+  let providerWasChanged = false;
 
   // ---- theme ------------------------------------------------------------
   // No stored choice means follow the OS; the button writes an explicit one.
@@ -85,23 +112,13 @@
 
   // ---- transcript -------------------------------------------------------
   let transcript = [];
-  try {
-    const parsed = JSON.parse(sessionStorage.getItem(historyKey) || '[]');
-    if (Array.isArray(parsed)) transcript = parsed.slice(-maxVisibleItems);
-  } catch {
-    // unreadable transcript just starts the conversation empty
-  }
   function trimConversation() {
     if (transcript.length > maxVisibleItems) transcript.splice(0, transcript.length - maxVisibleItems);
     while (messages.children.length > maxVisibleItems) messages.firstElementChild?.remove();
   }
   function persist() {
     trimConversation();
-    try {
-      sessionStorage.setItem(historyKey, JSON.stringify(transcript));
-    } catch {
-      // losing the transcript must never block sending
-    }
+    conversationController?.saveTranscript(transcript);
   }
 
   // ---- scroll -----------------------------------------------------------
@@ -248,7 +265,11 @@
           const response = await fetch('/api/actions', {
             method: 'POST',
             headers: { 'content-type': 'application/json', [tokenHeader]: token },
-            body: JSON.stringify({ questionId: card.questionId, option: index }),
+            body: JSON.stringify({
+              conversationId: conversationController?.selected?.conversationId,
+              questionId: card.questionId,
+              option: index,
+            }),
           });
           if (!response.ok) {
             const responseBody = await response.json().catch(() => ({}));
@@ -348,18 +369,23 @@
     if (messages.querySelector('.empty')) return;
     renderEmptyState({
       heading: 'Nothing here yet',
-      body: 'This chat runs entirely on your machine. Nothing you type leaves 127.0.0.1.',
+      body: 'This page is local to this machine. Your agent may use configured models, tools, and connected services.',
     });
   }
   function clearEmptyState() {
     messages.querySelector('.empty')?.remove();
   }
-  for (const item of transcript) {
-    if (item.type === 'question') addQuestion(item, false);
-    else addMessage(item.role === 'user' ? 'user' : 'agent', item.text, false, item.html);
+  function renderTranscript(items) {
+    messages.replaceChildren();
+    transcript = items.slice(-maxVisibleItems);
+    for (const item of transcript) {
+      if (item.type === 'question') addQuestion(item, false);
+      else addMessage(item.role === 'user' ? 'user' : 'agent', item.text, false, item.html);
+    }
+    if (transcript.length === 0) showEmptyState();
+    else scrollToLatest();
+    syncChrome();
   }
-  if (transcript.length === 0) showEmptyState();
-  else scrollToLatest();
 
   function showNotAuthorized() {
     send.disabled = true;
@@ -370,53 +396,14 @@
     // so it has to name the token rather than any one installer's command.
     renderEmptyState({
       heading: 'This browser has no access token',
-      body: 'Reopen the chat using the link your install prints; its address ends with a #token= fragment. On the host, the token itself lives at:',
-      note: 'data/local-web/token',
+      body: 'Run this command in the NanoClaw folder, then open the authenticated link it prints:',
+      note: 'pnpm local-web',
       locked: true,
     });
   }
 
-  // A hand-read stream rather than EventSource: EventSource cannot send the
-  // token header, and its onerror reports no status, so a rejected token
-  // would be indistinguishable from the server being down.
-  async function streamEvents() {
-    let retryDelay = 1_000;
-    for (;;) {
-      try {
-        const response = await fetch('/events', { headers: { [tokenHeader]: token } });
-        if (response.status === 401) {
-          showNotAuthorized();
-          return;
-        }
-        if (!response.ok || !response.body) throw new Error(`Stream failed (${response.status})`);
-        setState('Ready', 'ready');
-        send.disabled = false;
-        retryDelay = 1_000;
-        const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-        let buffer = '';
-        for (;;) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += value;
-          // split leaves an incomplete trailing frame as the last element
-          const frames = buffer.split('\n\n');
-          buffer = frames.pop();
-          for (const frame of frames) if (frame.startsWith('data: ')) handleEvent(frame.slice(6));
-        }
-      } catch {
-        // the connection failed or dropped; the retry below is the recovery
-      }
-      send.disabled = true;
-      setState('Reconnecting…', 'down');
-      await new Promise((resolve) => setTimeout(resolve, retryDelay));
-      // back off, so a stopped host is not one failed fetch per second forever
-      retryDelay = Math.min(retryDelay * 2, 30_000);
-    }
-  }
-
-  function handleEvent(raw) {
+  function handleEvent(data) {
     try {
-      const data = JSON.parse(raw);
       if (data.type === 'ready') {
         setState('Ready', 'ready');
         setActivity(null);
@@ -471,8 +458,210 @@
     }
   }
 
-  if (token) void streamEvents();
-  else showNotAuthorized();
+  // ---- conversations ---------------------------------------------------
+  function runtimeLabel(conversation) {
+    const details = [conversation.provider];
+    if (conversation.model) details.push(conversation.model);
+    if (conversation.effort) details.push(conversation.effort);
+    return details.join(' · ');
+  }
+
+  function initials(name) {
+    return (
+      name
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase())
+        .join('') || 'A'
+    );
+  }
+
+  function setSidebarOpen(open, { focusDrawer = false, restoreFocus = false } = {}) {
+    const drawerOpen = mobileSidebar.matches && open;
+    const drawerIsClosed = mobileSidebar.matches && !drawerOpen;
+    appShell.classList.toggle('sidebar-open', drawerOpen);
+    agentsToggle.setAttribute('aria-expanded', String(drawerOpen));
+    if (drawerIsClosed && (restoreFocus || agentSidebar.contains(document.activeElement))) agentsToggle.focus();
+    agentSidebar.inert = drawerIsClosed;
+    if (drawerIsClosed) agentSidebar.setAttribute('aria-hidden', 'true');
+    else agentSidebar.removeAttribute('aria-hidden');
+    sidebarScrim.hidden = !drawerOpen;
+    if (drawerOpen && focusDrawer) createAgentButton.focus();
+  }
+
+  agentsToggle.addEventListener('click', () => {
+    const open = !appShell.classList.contains('sidebar-open');
+    setSidebarOpen(open, { focusDrawer: open });
+  });
+  sidebarScrim.addEventListener('click', () => setSidebarOpen(false, { restoreFocus: true }));
+  mobileSidebar.addEventListener('change', () => setSidebarOpen(false));
+  setSidebarOpen(false);
+  document.addEventListener('keydown', (event) => {
+    if (
+      event.key === 'Escape' &&
+      mobileSidebar.matches &&
+      appShell.classList.contains('sidebar-open') &&
+      !createDialog.open
+    ) {
+      event.preventDefault();
+      setSidebarOpen(false, { restoreFocus: true });
+    }
+  });
+
+  function renderCatalog(catalog) {
+    agentList.replaceChildren();
+    for (const conversation of catalog.conversations) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'agent-row';
+      button.dataset.conversationId = conversation.conversationId;
+      button.setAttribute(
+        'aria-current',
+        String(conversationController?.selected?.conversationId === conversation.conversationId),
+      );
+
+      const avatar = document.createElement('span');
+      avatar.className = 'agent-avatar';
+      avatar.textContent = initials(conversation.agentName);
+      button.append(avatar);
+
+      const copy = document.createElement('span');
+      copy.className = 'agent-row-copy';
+      const name = document.createElement('span');
+      name.className = 'agent-row-name';
+      name.textContent = conversation.agentName;
+      const runtime = document.createElement('span');
+      runtime.className = 'agent-row-runtime';
+      runtime.textContent = runtimeLabel(conversation);
+      copy.append(name, runtime);
+      button.append(copy);
+
+      const state = document.createElement('span');
+      state.className = 'agent-row-state';
+      state.setAttribute('aria-hidden', 'true');
+      button.append(state);
+      button.addEventListener('click', async () => {
+        try {
+          await conversationController.select(conversation.conversationId);
+          setSidebarOpen(false);
+          input.focus();
+        } catch (error) {
+          addMessage('system', error instanceof Error ? error.message : 'Conversation could not be selected.', false);
+        }
+      });
+      agentList.append(button);
+    }
+  }
+
+  function selectConversation(conversation, items) {
+    agentTitle.textContent = conversation.agentName;
+    agentRuntime.textContent = runtimeLabel(conversation);
+    input.placeholder = `Message ${conversation.agentName}…`;
+    setActivity(null);
+    setState('Connecting…', 'down');
+    renderTranscript(items);
+    if (conversationController?.catalog) renderCatalog(conversationController.catalog);
+  }
+
+  function handleConnection(state) {
+    if (state === 'unauthorized') {
+      showNotAuthorized();
+      return;
+    }
+    if (state === 'reconnecting') {
+      send.disabled = true;
+      setState('Reconnecting…', 'down');
+      return;
+    }
+    setState('Ready', 'ready');
+    setActivity(null);
+    send.disabled = false;
+  }
+
+  function showCreateError(message) {
+    createError.textContent = message;
+    createError.hidden = !message;
+  }
+
+  function setCreating(creating) {
+    submitCreateAgent.disabled = creating;
+    submitCreateAgent.textContent = creating ? 'Creating…' : 'Create agent';
+  }
+
+  function openCreateDialog() {
+    const selected = conversationController?.selected;
+    const catalog = conversationController?.catalog;
+    if (!selected || !catalog) return;
+    createForm.reset();
+    advancedOptions.open = false;
+    showCreateError('');
+    setCreating(false);
+    inheritAgent.textContent = selected.agentName;
+    inheritRuntime.textContent = runtimeLabel(selected);
+
+    providerSelect.replaceChildren();
+    for (const provider of catalog.installedProviders) {
+      const option = document.createElement('option');
+      option.value = provider;
+      option.textContent = provider;
+      providerSelect.append(option);
+    }
+    const selectedProviderInstalled = catalog.installedProviders.includes(selected.provider);
+    const fallbackProvider = catalog.isInstallationDefaultInstalled
+      ? catalog.installationDefault
+      : catalog.installedProviders[0];
+    providerSelect.value = selectedProviderInstalled ? selected.provider : fallbackProvider;
+    providerWasChanged = providerSelect.value !== selected.provider;
+    providerField.hidden = catalog.installedProviders.length <= 1;
+    singleProvider.hidden = catalog.installedProviders.length > 1;
+    singleProvider.textContent = `Provider: ${providerSelect.value}`;
+    modelInput.value = providerWasChanged ? '' : selected.model || '';
+    effortSelect.value = providerWasChanged ? '' : selected.effort || '';
+    if (!selectedProviderInstalled) {
+      showCreateError(
+        `The selected agent uses ${selected.provider}, which is not installed. Choose an installed provider.`,
+      );
+    }
+    createDialog.showModal();
+    agentName.focus();
+  }
+
+  function closeCreateDialog() {
+    createDialog.close();
+    createAgentButton.focus();
+  }
+
+  providerSelect.addEventListener('change', () => {
+    const selected = conversationController?.selected;
+    providerWasChanged = providerSelect.value !== selected?.provider;
+    modelInput.value = providerWasChanged ? '' : selected?.model || '';
+    effortSelect.value = providerWasChanged ? '' : selected?.effort || '';
+    showCreateError('');
+  });
+  createAgentButton.addEventListener('click', openCreateDialog);
+  closeCreateAgent.addEventListener('click', closeCreateDialog);
+  cancelCreateAgent.addEventListener('click', closeCreateDialog);
+  createForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    showCreateError('');
+    setCreating(true);
+    try {
+      await conversationController.createAgent({
+        name: agentName.value,
+        ...(providerWasChanged && { provider: providerSelect.value }),
+        model: modelInput.value.trim(),
+        effort: effortSelect.value,
+      });
+      createDialog.close();
+      setSidebarOpen(false);
+      input.focus();
+    } catch (error) {
+      showCreateError(error instanceof Error ? error.message : 'Agent could not be created.');
+    } finally {
+      setCreating(false);
+    }
+  });
 
   // ---- composer ---------------------------------------------------------
   function resize() {
@@ -501,7 +690,7 @@
       const response = await fetch('/api/messages', {
         method: 'POST',
         headers: { 'content-type': 'application/json', [tokenHeader]: token },
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({ conversationId: conversationController?.selected?.conversationId, text }),
       });
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
@@ -526,6 +715,35 @@
     resize();
     updateCounter();
   });
-  input.focus();
-  syncChrome();
+
+  async function bootstrap() {
+    if (!token) {
+      showNotAuthorized();
+      return;
+    }
+    conversationController = createConversationController({
+      token,
+      tokenHeader,
+      onCatalog: renderCatalog,
+      onSelected: selectConversation,
+      onEvent: handleEvent,
+      onConnection: handleConnection,
+    });
+    try {
+      await conversationController.initialize();
+      input.focus();
+    } catch (error) {
+      send.disabled = true;
+      setState('Not connected', 'down');
+      renderEmptyState({
+        heading: 'Agents could not be loaded',
+        body: error instanceof Error ? error.message : 'Reload the page to try again.',
+        locked: true,
+      });
+    }
+    syncChrome();
+  }
+
+  window.addEventListener('beforeunload', () => conversationController?.dispose());
+  void bootstrap();
 })();

--- a/src/channels/local-web-page.js
+++ b/src/channels/local-web-page.js
@@ -28,6 +28,9 @@
   const themeButton = document.querySelector('#theme');
   const jump = document.querySelector('#jump');
   const counter = document.querySelector('#counter');
+  const shell = document.querySelector('.shell');
+  const header = document.querySelector('header');
+  const dock = document.querySelector('.dock');
   const activity = document.querySelector('#activity');
   const activityLabel = document.querySelector('#activity-label');
   let activityTimer = null;
@@ -110,8 +113,14 @@
   function isAtBottom() {
     return messages.scrollHeight - messages.scrollTop - messages.clientHeight < stickyBottomPx;
   }
-  function scrollToLatest(smooth = true) {
-    messages.scrollTo({ top: messages.scrollHeight, behavior: smooth ? 'smooth' : 'auto' });
+  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)');
+  // 'instant', never 'auto': 'auto' defers to CSS scroll-behavior, and an
+  // animated follow leaves isAtBottom() reading false while it runs, so a burst
+  // of appends would stop following after the first one. A scrollTo behavior
+  // also outranks the stylesheet, so reduced motion has to be checked here.
+  function scrollToLatest(smooth = false) {
+    const animate = smooth && !reducedMotion.matches;
+    messages.scrollTo({ top: messages.scrollHeight, behavior: animate ? 'smooth' : 'instant' });
     jump.hidden = true;
   }
   function settleScroll(wasAtBottom) {
@@ -122,9 +131,22 @@
     if (isAtBottom()) jump.hidden = true;
   });
   jump.addEventListener('click', () => {
-    scrollToLatest();
+    scrollToLatest(true);
     input.focus();
   });
+
+  // The transcript scrolls the full height of the window, under chrome that
+  // floats on top of it, so its padding has to track the real chrome heights:
+  // the composer alone grows from 46px to 200px as you type. Called from the
+  // two things that change those heights rather than from a ResizeObserver,
+  // which only delivers while the tab is actually rendering.
+  function syncChrome() {
+    const pinned = isAtBottom();
+    shell.style.setProperty('--header-h', `${header.offsetHeight}px`);
+    shell.style.setProperty('--dock-h', `${dock.offsetHeight}px`);
+    if (pinned) scrollToLatest();
+  }
+  window.addEventListener('resize', syncChrome);
 
   // ---- rendering --------------------------------------------------------
   function labelFor(role) {
@@ -357,7 +379,7 @@
     else addMessage(item.role === 'user' ? 'user' : 'agent', item.text, false, item.html);
   }
   if (transcript.length === 0) showEmptyState();
-  else scrollToLatest(false);
+  else scrollToLatest();
 
   function showNotAuthorized() {
     send.disabled = true;
@@ -478,6 +500,7 @@
   function resize() {
     input.style.height = 'auto';
     input.style.height = `${Math.min(input.scrollHeight, 200)}px`;
+    syncChrome();
   }
   function updateCounter() {
     const remaining = maxLength - input.value.length;
@@ -528,4 +551,5 @@
     updateCounter();
   });
   input.focus();
+  syncChrome();
 })();

--- a/src/channels/local-web-page.js
+++ b/src/channels/local-web-page.js
@@ -1,0 +1,342 @@
+/**
+ * Browser asset for the local-web chat page. Served to the browser at
+ * /local-web-page.js; never imported by the host process.
+ */
+/* global document, history, location, localStorage, sessionStorage */
+/* eslint-disable no-catch-all/no-catch-all -- every catch here degrades the page
+   instead of failing it: storage denied, a torn frame, an aborted stream. */
+
+(() => {
+  const historyKey = 'nanoclaw-local-web-history';
+  const tokenKey = 'nanoclaw-local-web-token';
+  const tokenHeader = 'x-nanoclaw-local-web-token';
+  const maxVisibleItems = 100;
+  const messages = document.querySelector('#messages');
+  const form = document.querySelector('#composer');
+  const input = document.querySelector('#message');
+  const send = document.querySelector('#send');
+  const status = document.querySelector('#status');
+  const breath = document.querySelector('#breath');
+  const activity = document.querySelector('#activity');
+  const activityLabel = document.querySelector('#activity-label');
+  const activityIdleMs = 10_000;
+  let activityTimer = null;
+
+  // The launcher hands the token over in the fragment, which never reaches
+  // the server. Strip it immediately: the address bar is the one place it
+  // could leave this machine, since browsers sync history and bookmarks.
+  let token = new URLSearchParams(location.hash.slice(1)).get('token');
+  if (token) {
+    try {
+      localStorage.setItem(tokenKey, token);
+    } catch {
+      // a browser with site data blocked keeps the token for this page load only
+    }
+    history.replaceState(null, '', location.pathname);
+  } else {
+    try {
+      token = localStorage.getItem(tokenKey);
+    } catch {
+      // no stored token reads the same as never having had one
+    }
+  }
+
+  let transcript = [];
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(historyKey) || '[]');
+    if (Array.isArray(parsed)) transcript = parsed.slice(-maxVisibleItems);
+  } catch {
+    // unreadable transcript just starts the conversation empty
+  }
+  function trimConversation() {
+    if (transcript.length > maxVisibleItems) transcript.splice(0, transcript.length - maxVisibleItems);
+    while (messages.children.length > maxVisibleItems) messages.firstElementChild?.remove();
+  }
+  function persist() {
+    trimConversation();
+    try {
+      sessionStorage.setItem(historyKey, JSON.stringify(transcript));
+    } catch {
+      // losing the transcript must never block sending
+    }
+  }
+  function addMessage(role, text, save = true, html = null) {
+    if (role !== 'system') clearPlaceholder();
+    const node = document.createElement('div');
+    node.className = `message ${role}`;
+    // Agent HTML is produced by the server's raw-HTML-disabled Markdown renderer.
+    if (role === 'agent' && typeof html === 'string') node.innerHTML = html;
+    else node.textContent = text;
+    messages.append(node);
+    if (save) {
+      transcript.push({ role, text, ...(typeof html === 'string' && { html }) });
+      persist();
+    }
+    messages.scrollTop = messages.scrollHeight;
+  }
+  function addQuestion(card, save = true) {
+    const node = document.createElement('article');
+    node.className = 'question-card';
+    node.dataset.questionId = card.questionId;
+
+    const kicker = document.createElement('p');
+    kicker.className = 'question-kicker';
+    kicker.textContent = 'Action required';
+    node.append(kicker);
+
+    const title = document.createElement('h2');
+    title.className = 'question-title';
+    title.textContent = card.title;
+    node.append(title);
+
+    if (card.question) {
+      const body = document.createElement('p');
+      body.className = 'question-body';
+      body.textContent = card.question;
+      node.append(body);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'question-actions';
+    const buttons = card.options.map((option, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `question-option ${option.style || ''}`;
+      button.textContent = option.label;
+      button.disabled = Boolean(card.resolution);
+      button.addEventListener('click', async () => {
+        buttons.forEach((item) => (item.disabled = true));
+        try {
+          const response = await fetch('/api/actions', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', [tokenHeader]: token },
+            body: JSON.stringify({ questionId: card.questionId, option: index }),
+          });
+          if (!response.ok) {
+            const responseBody = await response.json().catch(() => ({}));
+            throw new Error(responseBody.error || `Action failed (${response.status})`);
+          }
+          resolveQuestion(card.questionId, option.selectedLabel || option.label);
+          setState('Ready');
+        } catch (error) {
+          resolution.textContent = error instanceof Error ? error.message : 'Action could not be sent.';
+          resolution.hidden = false;
+          resolution.classList.add('question-error');
+          buttons.forEach((item) => (item.disabled = false));
+        }
+      });
+      actions.append(button);
+      return button;
+    });
+    node.append(actions);
+
+    const resolution = document.createElement('p');
+    resolution.className = 'question-resolution';
+    resolution.textContent = card.resolution || '';
+    resolution.hidden = !card.resolution;
+    node.append(resolution);
+
+    messages.append(node);
+    if (save) {
+      transcript.push(card);
+      persist();
+    }
+    messages.scrollTop = messages.scrollHeight;
+  }
+  function resolveQuestion(questionId, value) {
+    const card = transcript.find((item) => item.type === 'question' && item.questionId === questionId);
+    if (card) card.resolution = value;
+    const node = [...messages.querySelectorAll('.question-card')].find(
+      (item) => item.dataset.questionId === questionId,
+    );
+    if (!node) return;
+    node.querySelectorAll('.question-option').forEach((button) => (button.disabled = true));
+    const resolution = node.querySelector('.question-resolution');
+    resolution.textContent = value;
+    resolution.hidden = false;
+    resolution.classList.remove('question-error');
+    persist();
+  }
+  // Header status is connection state; turn activity lives in the pill.
+  function setState(label) {
+    status.textContent = label;
+  }
+  function setActivity(label, isTool = false) {
+    clearTimeout(activityTimer);
+    activityTimer = null;
+    activity.hidden = !label;
+    activity.classList.toggle('tool', isTool);
+    breath.classList.toggle('thinking', Boolean(label));
+    if (label) {
+      activityLabel.textContent = label;
+      activityTimer = setTimeout(() => setActivity(null), activityIdleMs);
+    }
+  }
+  function showPlaceholder() {
+    if (messages.querySelector('.placeholder')) return;
+    const node = document.createElement('div');
+    node.className = 'message system placeholder';
+    node.textContent = 'Starting your local conversation…';
+    messages.append(node);
+  }
+  function clearPlaceholder() {
+    messages.querySelector('.placeholder')?.remove();
+  }
+  for (const item of transcript) {
+    if (item.type === 'question') addQuestion(item, false);
+    else addMessage(item.role === 'user' ? 'user' : 'agent', item.text, false, item.html);
+  }
+  if (transcript.length === 0) showPlaceholder();
+
+  function showNotAuthorized() {
+    send.disabled = true;
+    input.disabled = true;
+    setActivity(null);
+    setState('Not connected');
+    clearPlaceholder();
+    // This screen is the recovery path when a browser opened the bare address,
+    // so it has to name the token rather than any one installer's command.
+    addMessage(
+      'system',
+      'This browser has no access token. Reopen the chat using the link its install prints, which ends in ' +
+        '#token=…; the token is in data/local-web/token on the host.',
+      false,
+    );
+  }
+
+  // A hand-read stream rather than EventSource: EventSource cannot send the
+  // token header, and its onerror reports no status, so a rejected token
+  // would be indistinguishable from the server being down.
+  async function streamEvents() {
+    let retryDelay = 1_000;
+    for (;;) {
+      try {
+        const response = await fetch('/events', { headers: { [tokenHeader]: token } });
+        if (response.status === 401) {
+          showNotAuthorized();
+          return;
+        }
+        if (!response.ok || !response.body) throw new Error(`Stream failed (${response.status})`);
+        setState('Ready');
+        send.disabled = false;
+        retryDelay = 1_000;
+        const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+        let buffer = '';
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += value;
+          // split leaves an incomplete trailing frame as the last element
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop();
+          for (const frame of frames) if (frame.startsWith('data: ')) handleEvent(frame.slice(6));
+        }
+      } catch {
+        // the connection failed or dropped; the retry below is the recovery
+      }
+      send.disabled = true;
+      setState('Reconnecting…');
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+      // back off, so a stopped host is not one failed fetch per second forever
+      retryDelay = Math.min(retryDelay * 2, 30_000);
+    }
+  }
+
+  function handleEvent(raw) {
+    try {
+      const data = JSON.parse(raw);
+      if (data.type === 'ready') {
+        setState('Ready');
+        setActivity(null);
+        send.disabled = false;
+      }
+      if (data.type === 'thinking') {
+        setActivity('Thinking…');
+      }
+      if (data.type === 'tool' && typeof data.name === 'string') {
+        setActivity(`Using ${data.name}`, true);
+      }
+      if (data.type === 'reply' && typeof data.text === 'string') {
+        clearPlaceholder();
+        addMessage('agent', data.text, true, typeof data.html === 'string' ? data.html : null);
+        send.disabled = false;
+        input.focus();
+        setState('Ready');
+        setActivity(null);
+      }
+      if (
+        data.type === 'question' &&
+        typeof data.questionId === 'string' &&
+        typeof data.title === 'string' &&
+        Array.isArray(data.options)
+      ) {
+        clearPlaceholder();
+        addQuestion({
+          type: 'question',
+          questionId: data.questionId,
+          title: data.title,
+          question: typeof data.question === 'string' ? data.question : '',
+          options: data.options.filter(
+            (option) => option && typeof option.label === 'string' && typeof option.selectedLabel === 'string',
+          ),
+        });
+        send.disabled = false;
+        setState('Action required');
+        setActivity(null);
+      }
+      if (
+        data.type === 'question-resolution' &&
+        typeof data.questionId === 'string' &&
+        typeof data.resolution === 'string'
+      ) {
+        resolveQuestion(data.questionId, data.resolution);
+        setState('Ready');
+      }
+    } catch {
+      // same: one bad frame never stops the page
+    }
+  }
+
+  if (token) void streamEvents();
+  else showNotAuthorized();
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const text = input.value.trim();
+    if (!text || send.disabled) return;
+    addMessage('user', text);
+    input.value = '';
+    input.style.height = 'auto';
+    send.disabled = true;
+    setActivity('Thinking…');
+    try {
+      const response = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', [tokenHeader]: token },
+        body: JSON.stringify({ text }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || `Request failed (${response.status})`);
+      }
+      send.disabled = false;
+      input.focus();
+    } catch (error) {
+      addMessage('system', error instanceof Error ? error.message : 'Message could not be sent.', false);
+      send.disabled = false;
+      setState('Ready');
+      setActivity(null);
+    }
+  });
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      form.requestSubmit();
+    }
+  });
+  input.addEventListener('input', () => {
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(input.scrollHeight, 180)}px`;
+  });
+  input.focus();
+})();

--- a/src/channels/local-web-page.test.ts
+++ b/src/channels/local-web-page.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('local web page assets', () => {
+  it('labels unset model and effort choices as Default', () => {
+    const html = fs.readFileSync(path.join(process.cwd(), 'src/channels/local-web-page.html'), 'utf8');
+
+    expect(html).toContain('placeholder="Default"');
+    expect(html).toContain('<option value="">Default</option>');
+    expect(html).not.toContain('Provider default');
+  });
+
+  it('keeps the current chat contract behind one split stylesheet entry', () => {
+    const root = path.join(process.cwd(), 'src/channels');
+    const html = fs.readFileSync(path.join(root, 'local-web-page.html'), 'utf8');
+    const script = fs.readFileSync(path.join(root, 'local-web-page.js'), 'utf8');
+    const shellStyles = fs.readFileSync(path.join(root, 'local-web-page.css'), 'utf8');
+    const chatStyles = fs.readFileSync(path.join(root, 'local-web-chat.css'), 'utf8');
+    const conversationStyles = fs.readFileSync(path.join(root, 'local-web-conversations.css'), 'utf8');
+    const conversationScript = fs.readFileSync(path.join(root, 'local-web-conversation-ui.js'), 'utf8');
+    const adapter = fs.readFileSync(path.join(root, 'local-web.ts'), 'utf8');
+
+    expect(html).toContain('href="/local-web-page.css"');
+    expect(shellStyles).toContain("@import url('/local-web-chat.css');");
+    expect(shellStyles).toContain("@import url('/local-web-conversations.css');");
+    expect(adapter).toContain("'/local-web-chat.css'");
+    expect(adapter).toContain("'/local-web-conversation-ui.js'");
+    expect(html).toContain('type="module"');
+    expect(script).toContain("activityLabel.textContent = 'Still working'");
+    expect(script).toContain('This page is local to this machine');
+    expect(script).not.toContain('Nothing you type leaves');
+    expect(script).not.toContain('No reply yet');
+    expect(chatStyles).toContain('z-index: 3');
+    expect(shellStyles).toContain('env(safe-area-inset-bottom)');
+    expect(conversationStyles).toContain('prefers-reduced-transparency');
+    expect(conversationStyles).toContain('prefers-contrast');
+    expect(conversationScript).toContain('nanoclaw-local-web-history:');
+    expect(conversationScript).toContain("Object.hasOwn(input, 'model')");
+    expect(conversationScript).toContain("Object.hasOwn(input, 'effort')");
+    expect(script).toContain("event.key === 'Escape'");
+    expect(script).toContain('createAgentButton.focus()');
+    expect(script).toContain("modelInput.value = providerWasChanged ? '' : selected?.model || ''");
+    expect(script).toContain('model: modelInput.value.trim()');
+    expect(script).toContain('effort: effortSelect.value');
+    expect(script).toContain('agentSidebar.inert = drawerIsClosed');
+    expect(script).toContain('sidebarScrim.hidden = !drawerOpen');
+    expect(script).toContain("mobileSidebar.addEventListener('change'");
+    expect(script).toContain('pnpm local-web');
+  });
+});

--- a/src/channels/local-web-provider-inheritance.test.ts
+++ b/src/channels/local-web-provider-inheritance.test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { TEST_ROOT } = vi.hoisted(() => ({ TEST_ROOT: '/tmp/nanoclaw-test-local-web-provider-inheritance' }));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return {
+    ...actual,
+    DATA_DIR: path.join(TEST_ROOT, 'data'),
+    GROUPS_DIR: path.join(TEST_ROOT, 'groups'),
+    DEFAULT_AGENT_PROVIDER: 'claude',
+  };
+});
+
+vi.mock('../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../modules/agent-to-agent/write-destinations.js', () => ({ writeDestinations: vi.fn() }));
+
+import { materializeContainerJson } from '../container-config.js';
+import { DEFAULT_AGENT_PROVIDER } from '../config.js';
+import { createAgentGroup, getAgentGroupByFolder } from '../db/agent-groups.js';
+import { getContainerConfig, updateContainerConfigScalars } from '../db/container-configs.js';
+import { closeDb, initTestDb } from '../db/connection.js';
+import { createMessagingGroup, createMessagingGroupAgent } from '../db/messaging-groups.js';
+import { runMigrations } from '../db/migrations/index.js';
+import { initGroupFilesystem } from '../group-init.js';
+import {
+  getProviderContainerConfig,
+  registerProviderContainerConfig,
+} from '../providers/provider-container-registry.js';
+import '../cli/resources/groups.js';
+import '../cli/resources/messaging-groups.js';
+import '../cli/resources/wirings.js';
+import './local-web.js';
+import { createLocalWebAgent, listLocalWebCatalog } from './local-web-conversations.js';
+
+if (!getProviderContainerConfig('ollama')) registerProviderContainerConfig('ollama', () => ({}));
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+  await runMigrations(await initTestDb());
+  const source = {
+    id: 'ag-ollama',
+    name: 'Ollama',
+    folder: 'ollama',
+    agent_provider: null,
+    created_at: new Date().toISOString(),
+  };
+  await createAgentGroup(source);
+  await initGroupFilesystem(source, { provider: 'ollama' });
+  await updateContainerConfigScalars(source.id, { provider: 'ollama', model: 'qwen3.8:27b-mlx' });
+  await createMessagingGroup({
+    id: 'mg-ollama',
+    channel_type: 'local-web',
+    platform_id: 'local-web:local',
+    name: 'Ollama',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: new Date().toISOString(),
+  });
+  await createMessagingGroupAgent({
+    id: 'mga-ollama',
+    messaging_group_id: 'mg-ollama',
+    agent_group_id: source.id,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: new Date().toISOString(),
+  });
+});
+
+afterEach(async () => {
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('local web provider inheritance', () => {
+  it('inherits selected Ollama runtime without changing installation defaults', async () => {
+    expect(await listLocalWebCatalog()).toMatchObject({
+      installedProviders: expect.arrayContaining(['claude', 'ollama']),
+      installationDefault: 'claude',
+      isInstallationDefaultInstalled: true,
+    });
+    const result = await createLocalWebAgent({ name: 'Researcher', sourceConversationId: 'mg-ollama' });
+    expect(result).toMatchObject({
+      ok: true,
+      created: true,
+      conversation: { provider: 'ollama', model: 'qwen3.8:27b-mlx' },
+    });
+    const group = await getAgentGroupByFolder('web-researcher');
+    expect(group).toBeDefined();
+    expect(await getContainerConfig(group!.id)).toMatchObject({ provider: 'ollama', model: 'qwen3.8:27b-mlx' });
+    expect(await materializeContainerJson(group!.id)).toMatchObject({ provider: 'ollama', model: 'qwen3.8:27b-mlx' });
+    expect(DEFAULT_AGENT_PROVIDER).toBe('claude');
+  });
+});

--- a/src/channels/local-web-registration.test.ts
+++ b/src/channels/local-web-registration.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import './index.js';
+import { getChannelDefaults, getRegisteredChannelNames } from './channel-registry.js';
+
+describe('local web registration', () => {
+  it('registers local-web through the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('local-web');
+    expect(getChannelDefaults('local-web').dm).toMatchObject({
+      engageMode: 'pattern',
+      engagePattern: '.',
+      unknownSenderPolicy: 'public',
+    });
+  });
+});

--- a/src/channels/local-web.test.ts
+++ b/src/channels/local-web.test.ts
@@ -96,6 +96,16 @@ afterEach(async () => {
 });
 
 describe('local web adapter', () => {
+  it('keeps long-running progress visible without adding a speculative transcript message', () => {
+    const script = fs.readFileSync(path.join(process.cwd(), 'src/channels/local-web-page.js'), 'utf8');
+    const styles = fs.readFileSync(path.join(process.cwd(), 'src/channels/local-web-page.css'), 'utf8');
+
+    expect(script).toContain("activityLabel.textContent = 'Still working'");
+    expect(script).not.toContain('No reply yet');
+    expect(styles).toContain('z-index: 3');
+    expect(styles).toContain('env(safe-area-inset-bottom)');
+  });
+
   it('resolves host-initiated DMs to the live chat id so approval cards reach the browser', async () => {
     const { registry } = await startAdapter();
     try {

--- a/src/channels/local-web.test.ts
+++ b/src/channels/local-web.test.ts
@@ -12,8 +12,10 @@ const { TEST_DATA_DIR } = vi.hoisted(() => ({ TEST_DATA_DIR: '/tmp/nanoclaw-test
 
 vi.mock('../config.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../config.js')>();
-  return { ...actual, DATA_DIR: TEST_DATA_DIR };
+  return { ...actual, DATA_DIR: TEST_DATA_DIR, GROUPS_DIR: path.join(TEST_DATA_DIR, 'groups') };
 });
+
+vi.mock('../request-wake.js', () => ({ requestWake: vi.fn().mockResolvedValue(true) }));
 
 async function unusedPort(): Promise<number> {
   const server = net.createServer();
@@ -27,7 +29,7 @@ async function unusedPort(): Promise<number> {
   return address.port;
 }
 
-async function startAdapter() {
+async function startAdapter(options: { routeMessages?: boolean } = {}) {
   const port = await unusedPort();
   process.env.NANOCLAW_LOCAL_WEB_PORT = String(port);
   vi.resetModules();
@@ -36,12 +38,34 @@ async function startAdapter() {
   const { runMigrations } = await import('../db/migrations/index.js');
   const db = await connection.initTestDb();
   await runMigrations(db);
+  await seedLegacyConversation();
+  await import('../cli/resources/groups.js');
+  await import('../cli/resources/messaging-groups.js');
+  await import('../cli/resources/wirings.js');
   const registry = await import('./channel-registry.js');
   await import('./local-web.js');
   const inbound: Array<{ platformId: string; threadId: string | null; message: InboundMessage }> = [];
   const actions: Array<{ questionId: string; selectedOption: string; userId: string }> = [];
   await registry.initChannelAdapters(() => ({
-    onInbound: (platformId, threadId, message) => void inbound.push({ platformId, threadId, message }),
+    onInbound: async (platformId, threadId, message) => {
+      inbound.push({ platformId, threadId, message });
+      if (options.routeMessages) {
+        const { routeInbound } = await import('../router.js');
+        await routeInbound({
+          channelType: 'local-web',
+          instance: 'local-web',
+          platformId,
+          threadId,
+          message: {
+            id: message.id,
+            kind: message.kind,
+            content: JSON.stringify(message.content),
+            timestamp: message.timestamp,
+            isGroup: message.isGroup,
+          },
+        });
+      }
+    },
     onInboundEvent: () => {},
     onMetadata: () => {},
     onAction: (questionId, selectedOption, userId) => void actions.push({ questionId, selectedOption, userId }),
@@ -52,10 +76,9 @@ async function startAdapter() {
   return { registry, inbound, actions, url: `http://127.0.0.1:${port}`, auth };
 }
 
-async function seedWebSession() {
+async function seedLegacyConversation(): Promise<void> {
   const { createAgentGroup } = await import('../db/agent-groups.js');
   const { createMessagingGroup, createMessagingGroupAgent } = await import('../db/messaging-groups.js');
-  const { resolveSession } = await import('../session-manager.js');
   const now = new Date().toISOString();
   await createAgentGroup({
     id: 'ag-web',
@@ -85,6 +108,10 @@ async function seedWebSession() {
     priority: 0,
     created_at: now,
   });
+}
+
+async function seedWebSession() {
+  const { resolveSession } = await import('../session-manager.js');
   return resolveSession('ag-web', 'mg-web', null, 'shared');
 }
 
@@ -92,20 +119,11 @@ afterEach(async () => {
   delete process.env.NANOCLAW_LOCAL_WEB_PORT;
   const { closeDb } = await import('../db/connection.js');
   await closeDb();
+  vi.clearAllMocks();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
 describe('local web adapter', () => {
-  it('keeps long-running progress visible without adding a speculative transcript message', () => {
-    const script = fs.readFileSync(path.join(process.cwd(), 'src/channels/local-web-page.js'), 'utf8');
-    const styles = fs.readFileSync(path.join(process.cwd(), 'src/channels/local-web-page.css'), 'utf8');
-
-    expect(script).toContain("activityLabel.textContent = 'Still working'");
-    expect(script).not.toContain('No reply yet');
-    expect(styles).toContain('z-index: 3');
-    expect(styles).toContain('env(safe-area-inset-bottom)');
-  });
-
   it('resolves host-initiated DMs to the live chat id so approval cards reach the browser', async () => {
     const { registry } = await startAdapter();
     try {
@@ -126,14 +144,17 @@ describe('local web adapter', () => {
     const firstAbort = new AbortController();
     const secondAbort = new AbortController();
     try {
-      const first = await fetch(`${url}/events?welcome=1`, {
+      const first = await fetch(`${url}/events?conversationId=mg-web&welcome=1`, {
         headers: { ...auth, origin: url },
         signal: firstAbort.signal,
       });
       const firstReady = new TextDecoder().decode((await first.body!.getReader().read()).value);
       expect(firstReady).toContain('{"type":"ready"}');
 
-      const second = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: secondAbort.signal });
+      const second = await fetch(`${url}/events?conversationId=mg-web`, {
+        headers: { ...auth, origin: url },
+        signal: secondAbort.signal,
+      });
       const secondReady = new TextDecoder().decode((await second.body!.getReader().read()).value);
       expect(secondReady).toContain('{"type":"ready"}');
       expect(inbound).toEqual([]);
@@ -154,25 +175,28 @@ describe('local web adapter', () => {
       const click = await fetch(`${url}/api/actions`, {
         method: 'POST',
         headers: forged,
-        body: JSON.stringify({ questionId: 'q-1', option: 0 }),
+        body: JSON.stringify({ conversationId: 'mg-web', questionId: 'q-1', option: 0 }),
       });
       expect(click.status).toBe(401);
 
       const wrongToken = await fetch(`${url}/api/actions`, {
         method: 'POST',
         headers: { ...forged, 'x-nanoclaw-local-web-token': 'not-the-token' },
-        body: JSON.stringify({ questionId: 'q-1', option: 0 }),
+        body: JSON.stringify({ conversationId: 'mg-web', questionId: 'q-1', option: 0 }),
       });
       expect(wrongToken.status).toBe(401);
 
       const message = await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: forged,
-        body: JSON.stringify({ text: 'hello' }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'hello' }),
       });
       expect(message.status).toBe(401);
 
-      const stream = await fetch(`${url}/events`, { headers: { origin: url }, signal: abort.signal });
+      const stream = await fetch(`${url}/events?conversationId=mg-web`, {
+        headers: { origin: url },
+        signal: abort.signal,
+      });
       expect(stream.status).toBe(401);
 
       expect(actions).toEqual([]);
@@ -181,9 +205,17 @@ describe('local web adapter', () => {
       // The shell must load before it can report having no token; the authorized
       // stream is the control that this is a gate and not a blanket 401.
       expect((await fetch(`${url}/`)).status).toBe(200);
-      expect((await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal })).status).toBe(
-        200,
-      );
+      expect((await fetch(`${url}/local-web-chat.css`)).status).toBe(200);
+      expect((await fetch(`${url}/local-web-conversations.css`)).status).toBe(200);
+      expect((await fetch(`${url}/local-web-conversation-ui.js`)).status).toBe(200);
+      expect(
+        (
+          await fetch(`${url}/events?conversationId=mg-web`, {
+            headers: { ...auth, origin: url },
+            signal: abort.signal,
+          })
+        ).status,
+      ).toBe(200);
     } finally {
       abort.abort();
       await registry.teardownChannelAdapters();
@@ -217,6 +249,93 @@ describe('local web adapter', () => {
     }
   });
 
+  it('lists only opaque conversation records behind the browser token', async () => {
+    const { registry, url, auth } = await startAdapter();
+    try {
+      const response = await fetch(`${url}/api/conversations`, { headers: { ...auth, origin: url } });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body).toMatchObject({
+        installedProviders: expect.arrayContaining(['claude']),
+        installationDefault: 'claude',
+        isInstallationDefaultInstalled: true,
+      });
+      expect(body.conversations).toEqual([
+        expect.objectContaining({ conversationId: 'mg-web', agentName: 'Web Agent', provider: 'claude' }),
+      ]);
+      expect(JSON.stringify(body)).not.toContain('platform_id');
+      expect(JSON.stringify(body)).not.toContain('local-web:local');
+      expect(JSON.stringify(body)).not.toContain('agentGroupId');
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('creates and resumes an agent through the narrow browser endpoint', async () => {
+    const { registry, url, auth } = await startAdapter();
+    try {
+      const headers = { ...auth, 'content-type': 'application/json', origin: url };
+      const extraAuthority = await fetch(`${url}/api/agents`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: 'Writer', agent_group_id: 'ag-picked-by-browser' }),
+      });
+      expect(extraAuthority.status).toBe(400);
+
+      const missingSource = await fetch(`${url}/api/agents`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: 'Writer', sourceConversationId: 'missing' }),
+      });
+      expect(missingSource.status).toBe(404);
+
+      const uninstalledProvider = await fetch(`${url}/api/agents`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: 'Researcher', provider: 'missing-provider' }),
+      });
+      expect(uninstalledProvider.status).toBe(409);
+
+      const created = await fetch(`${url}/api/agents`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: 'Writer', sourceConversationId: 'mg-web' }),
+      });
+      expect(created.status).toBe(201);
+      const first = (await created.json()) as { conversation: { conversationId: string } };
+      const resumed = await fetch(`${url}/api/agents`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: ' writer ', sourceConversationId: 'mg-web' }),
+      });
+      expect(resumed.status).toBe(200);
+      expect(await resumed.json()).toMatchObject({
+        created: false,
+        conversation: { conversationId: first.conversation.conversationId, agentName: 'Writer', provider: 'claude' },
+      });
+
+      const { getDb } = await import('../db/connection.js');
+      expect(
+        await getDb().get<{
+          groups: number;
+          conversations: number;
+          wirings: number;
+          destinations: number;
+          sessions: number;
+        }>(
+          `SELECT
+             (SELECT COUNT(*) FROM agent_groups WHERE folder = 'web-writer') AS groups,
+             (SELECT COUNT(*) FROM messaging_groups WHERE channel_type = 'local-web') AS conversations,
+             (SELECT COUNT(*) FROM messaging_group_agents) AS wirings,
+             (SELECT COUNT(*) FROM agent_destinations) AS destinations,
+             (SELECT COUNT(*) FROM sessions) AS sessions`,
+        ),
+      ).toEqual({ groups: 1, conversations: 2, wirings: 2, destinations: 2, sessions: 0 });
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
   it('routes browser messages through the web adapter', async () => {
     const { registry, inbound, url, auth } = await startAdapter();
     try {
@@ -227,7 +346,7 @@ describe('local web adapter', () => {
       const response = await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: url },
-        body: JSON.stringify({ text: 'hello' }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'hello' }),
       });
       expect(response.status).toBe(202);
       expect(inbound).toHaveLength(1);
@@ -240,10 +359,38 @@ describe('local web adapter', () => {
       const blocked = await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: 'https://attacker.example' },
-        body: JSON.stringify({ text: 'forged' }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'forged' }),
       });
       expect(blocked.status).toBe(403);
       expect(inbound).toHaveLength(1);
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('lets the first real message create the normal session and request a wake', async () => {
+    const { registry, url, auth } = await startAdapter({ routeMessages: true });
+    try {
+      const response = await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'first turn' }),
+      });
+      expect(response.status).toBe(202);
+
+      const { getSessionsByAgentGroup } = await import('../db/sessions.js');
+      const sessions = await getSessionsByAgentGroup('ag-web');
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]).toMatchObject({ messaging_group_id: 'mg-web', container_status: 'stopped' });
+      const { withExistingMailboxSession } = await import('../session-manager.js');
+      const history = await withExistingMailboxSession('ag-web', sessions[0]!.id, (mailbox) =>
+        mailbox.getInboundHistory(10),
+      );
+      expect(history).toEqual([
+        expect.objectContaining({ kind: 'chat', content: expect.stringContaining('first turn') }),
+      ]);
+      const { requestWake } = await import('../request-wake.js');
+      expect(requestWake).toHaveBeenCalledOnce();
     } finally {
       await registry.teardownChannelAdapters();
     }
@@ -255,12 +402,12 @@ describe('local web adapter', () => {
       const accepted = await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: url },
-        body: JSON.stringify({ text: 'a'.repeat(8_000) }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'a'.repeat(8_000) }),
       });
       const rejected = await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: url },
-        body: JSON.stringify({ text: 'a'.repeat(8_001) }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'a'.repeat(8_001) }),
       });
 
       expect(accepted.status).toBe(202);
@@ -275,7 +422,10 @@ describe('local web adapter', () => {
     const { registry, url, auth } = await startAdapter();
     const abort = new AbortController();
     try {
-      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const response = await fetch(`${url}/events?conversationId=mg-web`, {
+        headers: { ...auth, origin: url },
+        signal: abort.signal,
+      });
       expect(response.status).toBe(200);
       const reader = response.body!.getReader();
       await reader.read();
@@ -323,7 +473,10 @@ describe('local web adapter', () => {
           'local-web',
         );
 
-      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const response = await fetch(`${url}/events?conversationId=mg-web`, {
+        headers: { ...auth, origin: url },
+        signal: abort.signal,
+      });
       const reader = response.body!.getReader();
       const frames = new TextDecoder().decode((await reader.read()).value);
       expect(frames).toContain('waiting reply');
@@ -344,6 +497,10 @@ describe('local web adapter', () => {
         request_id: 'appr-local-web',
         action: 'create_agent',
         payload: '{}',
+        agent_group_id: 'ag-web',
+        channel_type: 'local-web',
+        platform_id: 'local-web:local',
+        instance: 'local-web',
         created_at: new Date().toISOString(),
         title: 'Create ynet-researcher?',
         question: 'This creates a persistent agent.',
@@ -353,7 +510,10 @@ describe('local web adapter', () => {
         ]),
       });
 
-      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const response = await fetch(`${url}/events?conversationId=mg-web`, {
+        headers: { ...auth, origin: url },
+        signal: abort.signal,
+      });
       const reader = response.body!.getReader();
       await reader.read();
       const messageId = await registry.createChannelDeliveryAdapter().deliver(
@@ -380,7 +540,7 @@ describe('local web adapter', () => {
       const blocked = await fetch(`${url}/api/actions`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: 'https://attacker.example' },
-        body: JSON.stringify({ questionId: 'appr-local-web', option: 0 }),
+        body: JSON.stringify({ conversationId: 'mg-web', questionId: 'appr-local-web', option: 0 }),
       });
       expect(blocked.status).toBe(403);
       expect(actions).toEqual([]);
@@ -388,7 +548,7 @@ describe('local web adapter', () => {
       const action = await fetch(`${url}/api/actions`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: url },
-        body: JSON.stringify({ questionId: 'appr-local-web', option: 0 }),
+        body: JSON.stringify({ conversationId: 'mg-web', questionId: 'appr-local-web', option: 0 }),
       });
       expect(action.status).toBe(202);
       expect(actions).toEqual([{ questionId: 'appr-local-web', selectedOption: 'approve', userId: 'local-web:local' }]);
@@ -435,7 +595,10 @@ describe('local web adapter', () => {
         outDb.close();
       }
 
-      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const response = await fetch(`${url}/events?conversationId=mg-web`, {
+        headers: { ...auth, origin: url },
+        signal: abort.signal,
+      });
       const reader = response.body!.getReader();
       await reader.read();
       const delivery = registry.createChannelDeliveryAdapter();
@@ -443,7 +606,7 @@ describe('local web adapter', () => {
       await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: url },
-        body: JSON.stringify({ text: 'hello' }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'hello' }),
       });
       await delivery.setTyping('local-web', 'local-web:local', null, 'local-web');
       const delivered = await reader.read();
@@ -470,7 +633,7 @@ describe('local web adapter', () => {
       await fetch(`${url}/api/messages`, {
         method: 'POST',
         headers: { ...auth, 'content-type': 'application/json', origin: url },
-        body: JSON.stringify({ text: 'next' }),
+        body: JSON.stringify({ conversationId: 'mg-web', text: 'next' }),
       });
       const nextDb = openOutboundDbRw(outboundDbPath('ag-web', session.id));
       try {

--- a/src/channels/local-web.test.ts
+++ b/src/channels/local-web.test.ts
@@ -1,0 +1,478 @@
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { outboundDbPath } from '../mailbox/sqlite/paths.js';
+import { openOutboundDbRw } from '../mailbox/sqlite/session-db.js';
+import type { InboundMessage } from './adapter.js';
+
+const { TEST_DATA_DIR } = vi.hoisted(() => ({ TEST_DATA_DIR: '/tmp/nanoclaw-test-local-web' }));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return { ...actual, DATA_DIR: TEST_DATA_DIR };
+});
+
+async function unusedPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('failed to allocate test port');
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+async function startAdapter() {
+  const port = await unusedPort();
+  process.env.NANOCLAW_LOCAL_WEB_PORT = String(port);
+  vi.resetModules();
+  await import('../mailbox/compose.js');
+  const connection = await import('../db/connection.js');
+  const { runMigrations } = await import('../db/migrations/index.js');
+  const db = await connection.initTestDb();
+  await runMigrations(db);
+  const registry = await import('./channel-registry.js');
+  await import('./local-web.js');
+  const inbound: Array<{ platformId: string; threadId: string | null; message: InboundMessage }> = [];
+  const actions: Array<{ questionId: string; selectedOption: string; userId: string }> = [];
+  await registry.initChannelAdapters(() => ({
+    onInbound: (platformId, threadId, message) => void inbound.push({ platformId, threadId, message }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: (questionId, selectedOption, userId) => void actions.push({ questionId, selectedOption, userId }),
+  }));
+  const auth = {
+    'x-nanoclaw-local-web-token': fs.readFileSync(path.join(TEST_DATA_DIR, 'local-web', 'token'), 'utf8').trim(),
+  };
+  return { registry, inbound, actions, url: `http://127.0.0.1:${port}`, auth };
+}
+
+async function seedWebSession() {
+  const { createAgentGroup } = await import('../db/agent-groups.js');
+  const { createMessagingGroup, createMessagingGroupAgent } = await import('../db/messaging-groups.js');
+  const { resolveSession } = await import('../session-manager.js');
+  const now = new Date().toISOString();
+  await createAgentGroup({
+    id: 'ag-web',
+    name: 'Web Agent',
+    folder: 'web-agent',
+    agent_provider: null,
+    created_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-web',
+    channel_type: 'local-web',
+    platform_id: 'local-web:local',
+    name: 'Local Web',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now,
+  });
+  await createMessagingGroupAgent({
+    id: 'mga-web',
+    messaging_group_id: 'mg-web',
+    agent_group_id: 'ag-web',
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+  return resolveSession('ag-web', 'mg-web', null, 'shared');
+}
+
+afterEach(async () => {
+  delete process.env.NANOCLAW_LOCAL_WEB_PORT;
+  const { closeDb } = await import('../db/connection.js');
+  await closeDb();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+describe('local web adapter', () => {
+  it('resolves host-initiated DMs to the live chat id so approval cards reach the browser', async () => {
+    const { registry } = await startAdapter();
+    try {
+      // The approver handle parsed from user id `local-web:local` is the bare
+      // `local`; without openDM the host delivers approval cards to a phantom
+      // `local` messaging group that deliver() rejects. openDM must map any
+      // handle back to the single id deliver() accepts.
+      const adapter = registry.getChannelAdapter('local-web');
+      expect(adapter?.openDM).toBeDefined();
+      expect(await adapter!.openDM!('local')).toBe('local-web:local');
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('never turns browser connections into inbound messages', async () => {
+    const { registry, inbound, url, auth } = await startAdapter();
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    try {
+      const first = await fetch(`${url}/events?welcome=1`, {
+        headers: { ...auth, origin: url },
+        signal: firstAbort.signal,
+      });
+      const firstReady = new TextDecoder().decode((await first.body!.getReader().read()).value);
+      expect(firstReady).toContain('{"type":"ready"}');
+
+      const second = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: secondAbort.signal });
+      const secondReady = new TextDecoder().decode((await second.body!.getReader().read()).value);
+      expect(secondReady).toContain('{"type":"ready"}');
+      expect(inbound).toEqual([]);
+    } finally {
+      firstAbort.abort();
+      secondAbort.abort();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  // An agent container reaches this port through host.docker.internal, so an
+  // unauthenticated /api/actions let a model resolve its own approval cards.
+  it('rejects data and approval requests that do not carry the token', async () => {
+    const { registry, actions, inbound, url, auth } = await startAdapter();
+    const abort = new AbortController();
+    try {
+      const forged = { 'content-type': 'application/json', origin: url };
+      const click = await fetch(`${url}/api/actions`, {
+        method: 'POST',
+        headers: forged,
+        body: JSON.stringify({ questionId: 'q-1', option: 0 }),
+      });
+      expect(click.status).toBe(401);
+
+      const wrongToken = await fetch(`${url}/api/actions`, {
+        method: 'POST',
+        headers: { ...forged, 'x-nanoclaw-local-web-token': 'not-the-token' },
+        body: JSON.stringify({ questionId: 'q-1', option: 0 }),
+      });
+      expect(wrongToken.status).toBe(401);
+
+      const message = await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: forged,
+        body: JSON.stringify({ text: 'hello' }),
+      });
+      expect(message.status).toBe(401);
+
+      const stream = await fetch(`${url}/events`, { headers: { origin: url }, signal: abort.signal });
+      expect(stream.status).toBe(401);
+
+      expect(actions).toEqual([]);
+      expect(inbound).toEqual([]);
+
+      // The shell must load before it can report having no token; the authorized
+      // stream is the control that this is a gate and not a blanket 401.
+      expect((await fetch(`${url}/`)).status).toBe(200);
+      expect((await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal })).status).toBe(
+        200,
+      );
+    } finally {
+      abort.abort();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('mints a 0600 token once and returns the same value on a re-read', async () => {
+    const { registry, auth } = await startAdapter();
+    try {
+      const file = path.join(TEST_DATA_DIR, 'local-web', 'token');
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+      const { readOrCreateToken } = await import('./local-web.js');
+      expect(readOrCreateToken()).toBe(auth['x-nanoclaw-local-web-token']);
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('reads the service port persisted in .env', async () => {
+    const originalCwd = process.cwd();
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-local-web-'));
+    try {
+      fs.writeFileSync(path.join(directory, '.env'), 'NANOCLAW_LOCAL_WEB_PORT=43210\n');
+      process.chdir(directory);
+      vi.resetModules();
+      const { configuredPort } = await import('./local-web.js');
+      expect(configuredPort()).toBe(43210);
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(directory, { recursive: true });
+    }
+  });
+
+  it('routes browser messages through the web adapter', async () => {
+    const { registry, inbound, url, auth } = await startAdapter();
+    try {
+      const health = (await (await fetch(`${url}/healthz`)).json()) as Record<string, unknown>;
+      expect(health).toMatchObject({ ok: true, channel: 'local-web' });
+      expect(typeof health.install).toBe('string');
+
+      const response = await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ text: 'hello' }),
+      });
+      expect(response.status).toBe(202);
+      expect(inbound).toHaveLength(1);
+      expect(inbound[0]).toMatchObject({
+        platformId: 'local-web:local',
+        threadId: null,
+      });
+      expect(inbound[0].message.content).toMatchObject({ text: 'hello', senderId: 'local-web:local' });
+
+      const blocked = await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: 'https://attacker.example' },
+        body: JSON.stringify({ text: 'forged' }),
+      });
+      expect(blocked.status).toBe(403);
+      expect(inbound).toHaveLength(1);
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('accepts the message limit and rejects one character over it', async () => {
+    const { registry, inbound, url, auth } = await startAdapter();
+    try {
+      const accepted = await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ text: 'a'.repeat(8_000) }),
+      });
+      const rejected = await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ text: 'a'.repeat(8_001) }),
+      });
+
+      expect(accepted.status).toBe(202);
+      expect(rejected.status).toBe(413);
+      expect(inbound).toHaveLength(1);
+    } finally {
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('streams replies delivered through the real channel delivery bridge', async () => {
+    const { registry, url, auth } = await startAdapter();
+    const abort = new AbortController();
+    try {
+      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      expect(response.status).toBe(200);
+      const reader = response.body!.getReader();
+      await reader.read();
+      await registry.createChannelDeliveryAdapter().deliver(
+        'local-web',
+        'local-web:local',
+        null,
+        'chat',
+        JSON.stringify({
+          text: '# Agent reply\n\n[Safe](https://example.com) [unsafe](javascript:alert(1)) <script>x</script>',
+        }),
+        undefined,
+        'local-web',
+      );
+      const delivered = new TextDecoder().decode((await reader.read()).value);
+      const event = JSON.parse(delivered.slice(delivered.indexOf('data: ') + 6).trim()) as {
+        text: string;
+        html: string;
+      };
+      expect(event.text).toContain('# Agent reply');
+      expect(event.html).toContain('<h1>Agent reply</h1>');
+      expect(event.html).toContain('<a href="https://example.com">Safe</a>');
+      expect(event.html).toContain('&lt;script&gt;x&lt;/script&gt;');
+      expect(event.html).not.toContain('href="javascript:');
+      expect(event.html).not.toContain('<script>');
+    } finally {
+      abort.abort();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('delivers a queued reply without generating a browser message', async () => {
+    const { registry, inbound, url, auth } = await startAdapter();
+    const abort = new AbortController();
+    try {
+      await registry
+        .createChannelDeliveryAdapter()
+        .deliver(
+          'local-web',
+          'local-web:local',
+          null,
+          'chat',
+          JSON.stringify({ text: 'waiting reply' }),
+          undefined,
+          'local-web',
+        );
+
+      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const reader = response.body!.getReader();
+      const frames = new TextDecoder().decode((await reader.read()).value);
+      expect(frames).toContain('waiting reply');
+      expect(inbound).toEqual([]);
+    } finally {
+      abort.abort();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('renders pending questions and resolves their server-owned option value', async () => {
+    const { registry, actions, url, auth } = await startAdapter();
+    const abort = new AbortController();
+    try {
+      const { createPendingApproval } = await import('../db/sessions.js');
+      await createPendingApproval({
+        approval_id: 'appr-local-web',
+        request_id: 'appr-local-web',
+        action: 'create_agent',
+        payload: '{}',
+        created_at: new Date().toISOString(),
+        title: 'Create ynet-researcher?',
+        question: 'This creates a persistent agent.',
+        options_json: JSON.stringify([
+          { label: 'Approve', selectedLabel: 'Approved', value: 'approve', style: 'primary' },
+          { label: 'Reject', selectedLabel: 'Rejected', value: 'reject', style: 'danger' },
+        ]),
+      });
+
+      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const reader = response.body!.getReader();
+      await reader.read();
+      const messageId = await registry.createChannelDeliveryAdapter().deliver(
+        'local-web',
+        'local-web:local',
+        null,
+        'chat-sdk',
+        JSON.stringify({
+          type: 'ask_question',
+          questionId: 'appr-local-web',
+          title: 'Create ynet-researcher?',
+          question: 'This creates a persistent agent.',
+          options: [],
+        }),
+        undefined,
+        'local-web',
+      );
+      const delivered = new TextDecoder().decode((await reader.read()).value);
+      expect(delivered).toContain('"type":"question"');
+      expect(delivered).toContain('Create ynet-researcher?');
+      expect(delivered).not.toContain('"value":"approve"');
+      expect(messageId).toBe('appr-local-web');
+
+      const blocked = await fetch(`${url}/api/actions`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: 'https://attacker.example' },
+        body: JSON.stringify({ questionId: 'appr-local-web', option: 0 }),
+      });
+      expect(blocked.status).toBe(403);
+      expect(actions).toEqual([]);
+
+      const action = await fetch(`${url}/api/actions`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ questionId: 'appr-local-web', option: 0 }),
+      });
+      expect(action.status).toBe(202);
+      expect(actions).toEqual([{ questionId: 'appr-local-web', selectedOption: 'approve', userId: 'local-web:local' }]);
+      expect(new TextDecoder().decode((await reader.read()).value)).toContain(
+        '"type":"question-resolution","questionId":"appr-local-web","resolution":"Approved"',
+      );
+
+      await registry.createChannelDeliveryAdapter().deliver(
+        'local-web',
+        'local-web:local',
+        null,
+        'chat-sdk',
+        JSON.stringify({
+          operation: 'edit',
+          messageId: 'appr-local-web',
+          terminalCard: { resolution: 'Timed out' },
+        }),
+        undefined,
+        'local-web',
+      );
+      expect(new TextDecoder().decode((await reader.read()).value)).toContain('"resolution":"Timed out"');
+    } finally {
+      abort.abort();
+      await registry.teardownChannelAdapters();
+    }
+  });
+
+  it('shows activity only until the first visible turn output', async () => {
+    const { registry, url, auth } = await startAdapter();
+    const abort = new AbortController();
+    try {
+      const { session } = await seedWebSession();
+      const outDb = openOutboundDbRw(outboundDbPath('ag-web', session.id));
+      try {
+        const now = new Date().toISOString();
+        outDb
+          .prepare(
+            `INSERT INTO container_state
+               (id, current_tool, tool_declared_timeout_ms, tool_started_at, updated_at)
+             VALUES (1, 'Bash', NULL, ?, ?)`,
+          )
+          .run(now, now);
+      } finally {
+        outDb.close();
+      }
+
+      const response = await fetch(`${url}/events`, { headers: { ...auth, origin: url }, signal: abort.signal });
+      const reader = response.body!.getReader();
+      await reader.read();
+      const delivery = registry.createChannelDeliveryAdapter();
+      if (!delivery.setTyping) throw new Error('delivery adapter does not support typing');
+      await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ text: 'hello' }),
+      });
+      await delivery.setTyping('local-web', 'local-web:local', null, 'local-web');
+      const delivered = await reader.read();
+      expect(new TextDecoder().decode(delivered.value)).toContain('{"type":"tool","name":"Bash"}');
+
+      await delivery.deliver(
+        'local-web',
+        'local-web:local',
+        null,
+        'chat',
+        JSON.stringify({ text: 'done' }),
+        undefined,
+        'local-web',
+      );
+      await reader.read();
+      const settledDb = openOutboundDbRw(outboundDbPath('ag-web', session.id));
+      try {
+        settledDb.prepare('UPDATE container_state SET current_tool = NULL WHERE id = 1').run();
+      } finally {
+        settledDb.close();
+      }
+      await delivery.setTyping('local-web', 'local-web:local', null, 'local-web');
+
+      await fetch(`${url}/api/messages`, {
+        method: 'POST',
+        headers: { ...auth, 'content-type': 'application/json', origin: url },
+        body: JSON.stringify({ text: 'next' }),
+      });
+      const nextDb = openOutboundDbRw(outboundDbPath('ag-web', session.id));
+      try {
+        nextDb.prepare("UPDATE container_state SET current_tool = 'Read' WHERE id = 1").run();
+      } finally {
+        nextDb.close();
+      }
+      await delivery.setTyping('local-web', 'local-web:local', null, 'local-web');
+      expect(new TextDecoder().decode((await reader.read()).value)).toContain('{"type":"tool","name":"Read"}');
+    } finally {
+      abort.abort();
+      await registry.teardownChannelAdapters();
+    }
+  });
+});

--- a/src/channels/local-web.ts
+++ b/src/channels/local-web.ts
@@ -1,0 +1,424 @@
+import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import fs from 'node:fs';
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import path from 'node:path';
+
+import MarkdownIt from 'markdown-it';
+
+import { DATA_DIR, INSTALL_SLUG } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { getMessagingGroupAgents, getMessagingGroupByPlatform } from '../db/messaging-groups.js';
+import { findSessionForAgent } from '../db/sessions.js';
+import { log } from '../log.js';
+import { withExistingMailboxSession } from '../session-manager.js';
+import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
+import { registerChannelAdapter } from './channel-registry.js';
+import { resolveQuestionRender } from './question-render-registry.js';
+
+const CHANNEL_TYPE = 'local-web';
+const PLATFORM_ID = 'local-web:local';
+const LOCAL_USER_ID = PLATFORM_ID;
+const LISTEN_HOST = '127.0.0.1';
+const DEFAULT_PORT = 3210;
+const MAX_BODY_BYTES = 32 * 1024;
+const MAX_MESSAGE_CHARS = 8_000;
+const MAX_QUESTION_ID_CHARS = 256;
+const TOKEN_HEADER = 'x-nanoclaw-local-web-token';
+const TOKEN_FILE = path.join(DATA_DIR, 'local-web', 'token');
+
+const LOCAL_WEB_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'public' },
+  group: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'public' },
+  mentions: 'never',
+};
+
+type ParseFailure = { ok: false; status: number; message: string };
+type ParsedObject = { ok: true; value: Record<string, unknown> } | ParseFailure;
+type ParsedMessage = { ok: true; text: string } | ParseFailure;
+
+type WebEvent =
+  | { type: 'reply'; text: string; html: string }
+  | { type: 'question-resolution'; questionId: string; resolution: string }
+  | {
+      type: 'question';
+      questionId: string;
+      title: string;
+      question: string;
+      options: Array<{ label: string; selectedLabel: string; style?: string }>;
+    };
+
+const markdown = new MarkdownIt({ breaks: true, html: false, linkify: true });
+markdown.validateLink = (url) => /^(?:https?:|mailto:)/i.test(url.trim());
+
+export function configuredPort(): number {
+  const raw = process.env.NANOCLAW_LOCAL_WEB_PORT ?? readEnvFile(['NANOCLAW_LOCAL_WEB_PORT']).NANOCLAW_LOCAL_WEB_PORT;
+  if (!raw) return DEFAULT_PORT;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`NANOCLAW_LOCAL_WEB_PORT must be an integer from 1 to 65535: ${raw}`);
+  }
+  return port;
+}
+
+/**
+ * The browser's authenticator, and the reason this channel can hold approval
+ * buttons at all. Agent containers reach this loopback port through
+ * host.docker.internal, the same route they use for Ollama, so it cannot be
+ * closed, and every click resolves as the hardcoded owner LOCAL_USER_ID. The
+ * shared secret is what separates the browser from the model.
+ *
+ * Minted once and reused for the life of the install. `data/` is never mounted
+ * into a container, which is what keeps the file out of the agent's reach; the
+ * 0600 mode is the same tier as `data/cli.sock`. The value is read once at
+ * startup, so revoking means deleting the file and restarting the host.
+ */
+export function readOrCreateToken(): string {
+  if (fs.existsSync(TOKEN_FILE)) {
+    const existing = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+    if (existing) return existing;
+  }
+  const token = randomBytes(32).toString('base64url');
+  fs.mkdirSync(path.dirname(TOKEN_FILE), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(TOKEN_FILE, `${token}\n`, { mode: 0o600 });
+  // writeFileSync's mode only applies when it creates the file; an empty or
+  // group-readable leftover keeps its old mode without this.
+  fs.chmodSync(TOKEN_FILE, 0o600);
+  return token;
+}
+
+function isAuthorized(req: IncomingMessage, expected: string): boolean {
+  const supplied = req.headers[TOKEN_HEADER];
+  if (typeof supplied !== 'string') return false;
+  const a = Buffer.from(supplied);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function requestAuthority(req: IncomingMessage, port: number): string | null {
+  const host = req.headers.host?.toLowerCase();
+  if (host !== `${LISTEN_HOST}:${port}` && host !== `localhost:${port}`) return null;
+  return `http://${host}`;
+}
+
+function requestOriginAllowed(req: IncomingMessage, authority: string): boolean {
+  const origin = req.headers.origin;
+  if (origin && origin !== authority) return false;
+  const fetchSite = req.headers['sec-fetch-site'];
+  return fetchSite === undefined || fetchSite === 'same-origin' || fetchSite === 'none';
+}
+
+async function parseObject(req: IncomingMessage): Promise<ParsedObject> {
+  if (!req.headers['content-type']?.toLowerCase().startsWith('application/json')) {
+    return { ok: false, status: 415, message: 'Expected application/json.' };
+  }
+
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  for await (const chunk of req) {
+    const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    bytes += data.length;
+    if (bytes > MAX_BODY_BYTES) return { ok: false, status: 413, message: 'Message is too large.' };
+    chunks.push(data);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) throw error;
+    return { ok: false, status: 400, message: 'Invalid JSON.' };
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ok: false, status: 400, message: 'Expected a message object.' };
+  }
+  return { ok: true, value: value as Record<string, unknown> };
+}
+
+async function parseMessage(req: IncomingMessage): Promise<ParsedMessage> {
+  const parsed = await parseObject(req);
+  if (!parsed.ok) return parsed;
+  const text = parsed.value.text;
+  if (typeof text !== 'string' || text.trim().length === 0) {
+    return { ok: false, status: 400, message: 'Message text is required.' };
+  }
+  if (text.length > MAX_MESSAGE_CHARS) {
+    return { ok: false, status: 413, message: `Messages are limited to ${MAX_MESSAGE_CHARS} characters.` };
+  }
+  return { ok: true, text: text.trim() };
+}
+
+function responseHeaders(contentType: string): Record<string, string> {
+  return {
+    'cache-control': 'no-store',
+    'content-type': contentType,
+    'cross-origin-opener-policy': 'same-origin',
+    'referrer-policy': 'no-referrer',
+    'x-content-type-options': 'nosniff',
+    'x-frame-options': 'DENY',
+    'content-security-policy':
+      "default-src 'none'; style-src 'self'; script-src 'self'; connect-src 'self'; img-src data:; base-uri 'none'; frame-ancestors 'none'; form-action 'self'",
+  };
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, responseHeaders('application/json; charset=utf-8'));
+  res.end(JSON.stringify(body));
+}
+
+function extractText(message: OutboundMessage): string | null {
+  if (typeof message.content === 'string') return message.content;
+  if (!message.content || typeof message.content !== 'object') return null;
+  const content = message.content as Record<string, unknown>;
+  if (typeof content.text === 'string') return content.text;
+  return null;
+}
+
+async function toWebEvent(message: OutboundMessage): Promise<WebEvent | null> {
+  if (message.content && typeof message.content === 'object') {
+    const content = message.content as Record<string, unknown>;
+    if (content.operation === 'edit' && typeof content.messageId === 'string') {
+      const terminalCard = content.terminalCard;
+      const resolution =
+        terminalCard && typeof terminalCard === 'object' && !Array.isArray(terminalCard)
+          ? (terminalCard as Record<string, unknown>).resolution
+          : undefined;
+      if (typeof resolution === 'string') {
+        return { type: 'question-resolution', questionId: content.messageId, resolution };
+      }
+    }
+    if (content.type === 'ask_question' && typeof content.questionId === 'string') {
+      const render = await resolveQuestionRender(content.questionId);
+      if (render) {
+        return {
+          type: 'question',
+          questionId: content.questionId,
+          title: render.title,
+          question: render.question ?? (typeof content.question === 'string' ? content.question : ''),
+          options: render.options.map(({ label, selectedLabel, style }) => ({
+            label,
+            selectedLabel,
+            ...(style && { style }),
+          })),
+        };
+      }
+    }
+  }
+  const text = extractText(message);
+  return text === null ? null : { type: 'reply', text, html: markdown.render(text) };
+}
+
+async function currentTool(): Promise<string | null> {
+  const messagingGroup = await getMessagingGroupByPlatform(CHANNEL_TYPE, PLATFORM_ID);
+  if (!messagingGroup) return null;
+
+  for (const wiring of await getMessagingGroupAgents(messagingGroup.id)) {
+    const session = await findSessionForAgent(wiring.agent_group_id, messagingGroup.id, null);
+    if (!session) continue;
+    try {
+      const state = await withExistingMailboxSession(wiring.agent_group_id, session.id, (mailbox) =>
+        mailbox.getContainerState(),
+      );
+      if (state?.currentTool) return state.currentTool;
+      // eslint-disable-next-line no-catch-all/no-catch-all -- activity is advisory; a transient DB read failure must never break chat delivery
+    } catch {
+      // A session may disappear while its activity is sampled.
+    }
+  }
+  return null;
+}
+
+function createAdapter(): ChannelAdapter {
+  const port = configuredPort();
+  const token = readOrCreateToken();
+  // Exact-match table, so no request path ever reaches the filesystem. Splitting
+  // the stylesheet and script out of the document is what lets the CSP name
+  // 'self' instead of 'unsafe-inline'.
+  const readAsset = (file: string): string => fs.readFileSync(path.join(process.cwd(), 'src/channels', file), 'utf8');
+  const assets: Record<string, { body: string; contentType: string }> = {
+    '/': { body: readAsset('local-web-page.html'), contentType: 'text/html; charset=utf-8' },
+    '/local-web-page.css': { body: readAsset('local-web-page.css'), contentType: 'text/css; charset=utf-8' },
+    '/local-web-page.js': { body: readAsset('local-web-page.js'), contentType: 'text/javascript; charset=utf-8' },
+  };
+  const clients = new Set<ServerResponse>();
+  // Server-side buffer while no browser is connected; unrelated to the page's own 100-item view cap.
+  const MAX_PENDING_EVENTS = 100;
+  const pendingEvents: WebEvent[] = [];
+  let server: http.Server | null = null;
+  let awaitingReply = false;
+
+  function publish(event: unknown): void {
+    const frame = `data: ${JSON.stringify(event)}\n\n`;
+    for (const client of clients) client.write(frame);
+  }
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse, setup: ChannelSetup): Promise<void> {
+    const authority = requestAuthority(req, port);
+    if (!authority) {
+      sendJson(res, 403, { error: 'Local requests only.' });
+      return;
+    }
+    const url = new URL(req.url ?? '/', authority);
+    const pathname = url.pathname;
+
+    if (req.method === 'GET' && pathname === '/healthz') {
+      sendJson(res, 200, { ok: true, channel: CHANNEL_TYPE, install: INSTALL_SLUG });
+      return;
+    }
+    const asset = req.method === 'GET' ? assets[pathname] : undefined;
+    if (asset) {
+      res.writeHead(200, responseHeaders(asset.contentType));
+      res.end(asset.body);
+      return;
+    }
+
+    // Everything below carries conversation data or resolves an approval, so it
+    // is token-gated. The page assets and `/healthz` stay open deliberately:
+    // they expose neither, a subresource request cannot carry a header anyway,
+    // and the shell has to load before it can present its token or explain that
+    // it has none. The Origin/Host checks above and below are defense-in-depth
+    // only: an HTTP client sets those headers freely.
+    if (!isAuthorized(req, token)) {
+      sendJson(res, 401, {
+        error: 'This browser is not authorized. Reopen the chat from the token link its install prints.',
+      });
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/events') {
+      if (!requestOriginAllowed(req, authority)) {
+        sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
+        return;
+      }
+      res.writeHead(200, {
+        ...responseHeaders('text/event-stream; charset=utf-8'),
+        connection: 'keep-alive',
+      });
+      clients.add(res);
+      req.on('close', () => clients.delete(res));
+      for (const event of pendingEvents.splice(0)) res.write(`data: ${JSON.stringify(event)}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'ready' })}\n\n`);
+      return;
+    }
+    if (req.method === 'POST' && pathname === '/api/messages') {
+      if (!requestOriginAllowed(req, authority) || req.headers.origin !== authority) {
+        sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
+        return;
+      }
+      const parsed = await parseMessage(req);
+      if (!parsed.ok) {
+        sendJson(res, parsed.status, { error: parsed.message });
+        return;
+      }
+      await setup.onInbound(PLATFORM_ID, null, {
+        id: `local-web-${randomUUID()}`,
+        kind: 'chat',
+        timestamp: new Date().toISOString(),
+        content: { text: parsed.text, sender: 'browser', senderId: LOCAL_USER_ID },
+        isGroup: false,
+      });
+      awaitingReply = true;
+      sendJson(res, 202, { ok: true });
+      return;
+    }
+    if (req.method === 'POST' && pathname === '/api/actions') {
+      if (!requestOriginAllowed(req, authority) || req.headers.origin !== authority) {
+        sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
+        return;
+      }
+      const parsed = await parseObject(req);
+      if (!parsed.ok) {
+        sendJson(res, parsed.status, { error: parsed.message });
+        return;
+      }
+      const { questionId, option } = parsed.value;
+      if (typeof questionId !== 'string' || questionId.length === 0 || questionId.length > MAX_QUESTION_ID_CHARS) {
+        sendJson(res, 400, { error: 'A valid question ID is required.' });
+        return;
+      }
+      const render = await resolveQuestionRender(questionId);
+      if (!render) {
+        sendJson(res, 404, { error: 'This question is no longer pending.' });
+        return;
+      }
+      if (!Number.isInteger(option) || (option as number) < 0 || (option as number) >= render.options.length) {
+        sendJson(res, 400, { error: 'A valid option is required.' });
+        return;
+      }
+      setup.onAction(questionId, render.options[option as number].value, LOCAL_USER_ID);
+      publish({
+        type: 'question-resolution',
+        questionId,
+        resolution: render.options[option as number].selectedLabel,
+      });
+      sendJson(res, 202, { ok: true });
+      return;
+    }
+
+    sendJson(res, 404, { error: 'Not found.' });
+  }
+
+  return {
+    name: CHANNEL_TYPE,
+    channelType: CHANNEL_TYPE,
+    supportsThreads: false,
+
+    async setup(config): Promise<void> {
+      server = http.createServer((req, res) => {
+        void handleRequest(req, res, config).catch((err: unknown) => {
+          log.error('Local web chat request failed', { err });
+          if (!res.headersSent) sendJson(res, 500, { error: 'Request failed.' });
+          else res.end();
+        });
+      });
+      await new Promise<void>((resolve, reject) => {
+        server!.once('error', reject);
+        server!.listen(port, LISTEN_HOST, resolve);
+      });
+      log.info('Local web chat listening', { url: `http://${LISTEN_HOST}:${port}` });
+    },
+
+    async teardown(): Promise<void> {
+      for (const client of clients) client.end();
+      clients.clear();
+      if (!server) return;
+      const active = server;
+      server = null;
+      await new Promise<void>((resolve) => active.close(() => resolve()));
+    },
+
+    isConnected(): boolean {
+      return server?.listening === true;
+    },
+
+    // There is one machine-local browser identity. Host-initiated DMs
+    // (approval cards) resolve the approver's handle through ensureUserDm;
+    // without openDM it would derive the bare handle and mint a phantom
+    // messaging group that deliver() rejects, so the card is never rendered.
+    async openDM(): Promise<string> {
+      return PLATFORM_ID;
+    },
+
+    async deliver(platformId, _threadId, message): Promise<string | undefined> {
+      if (platformId !== PLATFORM_ID) return undefined;
+      const event = await toWebEvent(message);
+      if (event === null) return undefined;
+      const completesTurn = event.type === 'reply' || event.type === 'question';
+      if (completesTurn) awaitingReply = false;
+      if (clients.size === 0) {
+        pendingEvents.push(event);
+        if (pendingEvents.length > MAX_PENDING_EVENTS) pendingEvents.shift();
+      } else {
+        publish(event);
+      }
+      return event.type === 'question' ? event.questionId : undefined;
+    },
+
+    async setTyping(platformId): Promise<void> {
+      if (platformId !== PLATFORM_ID || !awaitingReply) return;
+      const tool = await currentTool();
+      publish(tool ? { type: 'tool', name: tool } : { type: 'thinking' });
+    },
+  };
+}
+
+registerChannelAdapter(CHANNEL_TYPE, { factory: createAdapter, defaults: LOCAL_WEB_DEFAULTS });

--- a/src/channels/local-web.ts
+++ b/src/channels/local-web.ts
@@ -13,11 +13,21 @@ import { log } from '../log.js';
 import { withExistingMailboxSession } from '../session-manager.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import {
+  createLocalWebAgent,
+  ensureLocalWebConversations,
+  isKnownLocalWebPlatformId,
+  listLocalWebCatalog,
+  LOCAL_WEB_CHANNEL_TYPE,
+  LOCAL_WEB_LEGACY_PLATFORM_ID,
+  LOCAL_WEB_USER_ID,
+  localWebPlatformIdForConversation,
+  localWebQuestionBelongsToConversation,
+  parseCreateLocalWebAgentRequest,
+} from './local-web-conversations.js';
 import { resolveQuestionRender } from './question-render-registry.js';
 
-const CHANNEL_TYPE = 'local-web';
-const PLATFORM_ID = 'local-web:local';
-const LOCAL_USER_ID = PLATFORM_ID;
+const CHANNEL_TYPE = LOCAL_WEB_CHANNEL_TYPE;
 const LISTEN_HOST = '127.0.0.1';
 const DEFAULT_PORT = 3210;
 const MAX_BODY_BYTES = 32 * 1024;
@@ -34,7 +44,8 @@ const LOCAL_WEB_DEFAULTS: ChannelDefaults = {
 
 type ParseFailure = { ok: false; status: number; message: string };
 type ParsedObject = { ok: true; value: Record<string, unknown> } | ParseFailure;
-type ParsedMessage = { ok: true; text: string } | ParseFailure;
+type ParsedMessage = { ok: true; conversationId: string; text: string } | ParseFailure;
+type ParsedAction = { ok: true; conversationId: string; questionId: string; option: number } | ParseFailure;
 
 type WebEvent =
   | { type: 'reply'; text: string; html: string }
@@ -137,6 +148,12 @@ async function parseObject(req: IncomingMessage): Promise<ParsedObject> {
 async function parseMessage(req: IncomingMessage): Promise<ParsedMessage> {
   const parsed = await parseObject(req);
   if (!parsed.ok) return parsed;
+  const unexpected = Object.keys(parsed.value).find((field) => field !== 'conversationId' && field !== 'text');
+  if (unexpected) return { ok: false, status: 400, message: `Unknown field: ${unexpected}.` };
+  const conversationId = parsed.value.conversationId;
+  if (typeof conversationId !== 'string' || conversationId.length === 0 || conversationId.length > 128) {
+    return { ok: false, status: 400, message: 'A valid conversation ID is required.' };
+  }
   const text = parsed.value.text;
   if (typeof text !== 'string' || text.trim().length === 0) {
     return { ok: false, status: 400, message: 'Message text is required.' };
@@ -144,7 +161,27 @@ async function parseMessage(req: IncomingMessage): Promise<ParsedMessage> {
   if (text.length > MAX_MESSAGE_CHARS) {
     return { ok: false, status: 413, message: `Messages are limited to ${MAX_MESSAGE_CHARS} characters.` };
   }
-  return { ok: true, text: text.trim() };
+  return { ok: true, conversationId, text: text.trim() };
+}
+
+async function parseAction(req: IncomingMessage): Promise<ParsedAction> {
+  const parsed = await parseObject(req);
+  if (!parsed.ok) return parsed;
+  const unexpected = Object.keys(parsed.value).find(
+    (field) => field !== 'conversationId' && field !== 'questionId' && field !== 'option',
+  );
+  if (unexpected) return { ok: false, status: 400, message: `Unknown field: ${unexpected}.` };
+  const { conversationId, questionId, option } = parsed.value;
+  if (typeof conversationId !== 'string' || conversationId.length === 0 || conversationId.length > 128) {
+    return { ok: false, status: 400, message: 'A valid conversation ID is required.' };
+  }
+  if (typeof questionId !== 'string' || questionId.length === 0 || questionId.length > MAX_QUESTION_ID_CHARS) {
+    return { ok: false, status: 400, message: 'A valid question ID is required.' };
+  }
+  if (typeof option !== 'number' || !Number.isInteger(option) || option < 0) {
+    return { ok: false, status: 400, message: 'A valid option is required.' };
+  }
+  return { ok: true, conversationId, questionId, option };
 }
 
 function responseHeaders(contentType: string): Record<string, string> {
@@ -207,8 +244,8 @@ async function toWebEvent(message: OutboundMessage): Promise<WebEvent | null> {
   return text === null ? null : { type: 'reply', text, html: markdown.render(text) };
 }
 
-async function currentTool(): Promise<string | null> {
-  const messagingGroup = await getMessagingGroupByPlatform(CHANNEL_TYPE, PLATFORM_ID);
+async function currentTool(platformId: string): Promise<string | null> {
+  const messagingGroup = await getMessagingGroupByPlatform(CHANNEL_TYPE, platformId, CHANNEL_TYPE);
   if (!messagingGroup) return null;
 
   for (const wiring of await getMessagingGroupAgents(messagingGroup.id)) {
@@ -237,18 +274,34 @@ function createAdapter(): ChannelAdapter {
   const assets: Record<string, { body: string; contentType: string }> = {
     '/': { body: readAsset('local-web-page.html'), contentType: 'text/html; charset=utf-8' },
     '/local-web-page.css': { body: readAsset('local-web-page.css'), contentType: 'text/css; charset=utf-8' },
+    '/local-web-chat.css': { body: readAsset('local-web-chat.css'), contentType: 'text/css; charset=utf-8' },
+    '/local-web-conversations.css': {
+      body: readAsset('local-web-conversations.css'),
+      contentType: 'text/css; charset=utf-8',
+    },
+    '/local-web-conversation-ui.js': {
+      body: readAsset('local-web-conversation-ui.js'),
+      contentType: 'text/javascript; charset=utf-8',
+    },
     '/local-web-page.js': { body: readAsset('local-web-page.js'), contentType: 'text/javascript; charset=utf-8' },
   };
-  const clients = new Set<ServerResponse>();
+  const clients = new Map<string, Set<ServerResponse>>();
   // Server-side buffer while no browser is connected; unrelated to the page's own 100-item view cap.
   const MAX_PENDING_EVENTS = 100;
-  const pendingEvents: WebEvent[] = [];
+  const pendingEvents = new Map<string, WebEvent[]>();
   let server: http.Server | null = null;
-  let awaitingReply = false;
+  const awaitingReplies = new Set<string>();
 
-  function publish(event: unknown): void {
+  function publish(platformId: string, event: unknown): void {
     const frame = `data: ${JSON.stringify(event)}\n\n`;
-    for (const client of clients) client.write(frame);
+    for (const client of clients.get(platformId) ?? []) client.write(frame);
+  }
+
+  function queue(platformId: string, event: WebEvent): void {
+    const pending = pendingEvents.get(platformId) ?? [];
+    pending.push(event);
+    if (pending.length > MAX_PENDING_EVENTS) pending.shift();
+    pendingEvents.set(platformId, pending);
   }
 
   async function handleRequest(req: IncomingMessage, res: ServerResponse, setup: ChannelSetup): Promise<void> {
@@ -279,23 +332,49 @@ function createAdapter(): ChannelAdapter {
     // only: an HTTP client sets those headers freely.
     if (!isAuthorized(req, token)) {
       sendJson(res, 401, {
-        error: 'This browser is not authorized. Reopen the chat from the token link its install prints.',
+        error: 'This browser is not authorized. Run `pnpm local-web` in the NanoClaw folder and open its link.',
       });
       return;
     }
 
+    if (req.method === 'GET' && pathname === '/api/conversations') {
+      if (!requestOriginAllowed(req, authority)) {
+        sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
+        return;
+      }
+      sendJson(res, 200, await listLocalWebCatalog());
+      return;
+    }
     if (req.method === 'GET' && pathname === '/events') {
       if (!requestOriginAllowed(req, authority)) {
         sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
+        return;
+      }
+      const conversationId = url.searchParams.get('conversationId');
+      if (!conversationId || conversationId.length > 128) {
+        sendJson(res, 400, { error: 'A valid conversation ID is required.' });
+        return;
+      }
+      const platformId = await localWebPlatformIdForConversation(conversationId);
+      if (!platformId) {
+        sendJson(res, 404, { error: 'Conversation not found.' });
         return;
       }
       res.writeHead(200, {
         ...responseHeaders('text/event-stream; charset=utf-8'),
         connection: 'keep-alive',
       });
-      clients.add(res);
-      req.on('close', () => clients.delete(res));
-      for (const event of pendingEvents.splice(0)) res.write(`data: ${JSON.stringify(event)}\n\n`);
+      const conversationClients = clients.get(platformId) ?? new Set<ServerResponse>();
+      conversationClients.add(res);
+      clients.set(platformId, conversationClients);
+      req.on('close', () => {
+        conversationClients.delete(res);
+        if (conversationClients.size === 0) clients.delete(platformId);
+      });
+      for (const event of pendingEvents.get(platformId) ?? []) {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+      }
+      pendingEvents.delete(platformId);
       res.write(`data: ${JSON.stringify({ type: 'ready' })}\n\n`);
       return;
     }
@@ -309,18 +388,23 @@ function createAdapter(): ChannelAdapter {
         sendJson(res, parsed.status, { error: parsed.message });
         return;
       }
-      await setup.onInbound(PLATFORM_ID, null, {
+      const platformId = await localWebPlatformIdForConversation(parsed.conversationId);
+      if (!platformId) {
+        sendJson(res, 404, { error: 'Conversation not found.' });
+        return;
+      }
+      await setup.onInbound(platformId, null, {
         id: `local-web-${randomUUID()}`,
         kind: 'chat',
         timestamp: new Date().toISOString(),
-        content: { text: parsed.text, sender: 'browser', senderId: LOCAL_USER_ID },
+        content: { text: parsed.text, sender: 'browser', senderId: LOCAL_WEB_USER_ID },
         isGroup: false,
       });
-      awaitingReply = true;
+      awaitingReplies.add(platformId);
       sendJson(res, 202, { ok: true });
       return;
     }
-    if (req.method === 'POST' && pathname === '/api/actions') {
+    if (req.method === 'POST' && pathname === '/api/agents') {
       if (!requestOriginAllowed(req, authority) || req.headers.origin !== authority) {
         sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
         return;
@@ -330,25 +414,56 @@ function createAdapter(): ChannelAdapter {
         sendJson(res, parsed.status, { error: parsed.message });
         return;
       }
-      const { questionId, option } = parsed.value;
-      if (typeof questionId !== 'string' || questionId.length === 0 || questionId.length > MAX_QUESTION_ID_CHARS) {
-        sendJson(res, 400, { error: 'A valid question ID is required.' });
+      const request = parseCreateLocalWebAgentRequest(parsed.value);
+      if (!request.ok) {
+        sendJson(res, 400, { error: request.message });
         return;
       }
-      const render = await resolveQuestionRender(questionId);
+      const result = await createLocalWebAgent(request.value);
+      if (!result.ok) {
+        if (result.detail) {
+          log.warn('Local web agent creation stopped', { stage: result.stage, detail: result.detail });
+        }
+        sendJson(res, result.status, { error: result.message, ...(result.stage && { stage: result.stage }) });
+        return;
+      }
+      sendJson(res, result.created ? 201 : 200, result);
+      return;
+    }
+    if (req.method === 'POST' && pathname === '/api/actions') {
+      if (!requestOriginAllowed(req, authority) || req.headers.origin !== authority) {
+        sendJson(res, 403, { error: 'Cross-origin requests are not allowed.' });
+        return;
+      }
+      const parsed = await parseAction(req);
+      if (!parsed.ok) {
+        sendJson(res, parsed.status, { error: parsed.message });
+        return;
+      }
+      const platformId = await localWebPlatformIdForConversation(parsed.conversationId);
+      if (!platformId) {
+        sendJson(res, 404, { error: 'Conversation not found.' });
+        return;
+      }
+      if (!(await localWebQuestionBelongsToConversation(parsed.questionId, parsed.conversationId))) {
+        sendJson(res, 404, { error: 'This question is not pending in this conversation.' });
+        return;
+      }
+      const render = await resolveQuestionRender(parsed.questionId);
       if (!render) {
         sendJson(res, 404, { error: 'This question is no longer pending.' });
         return;
       }
-      if (!Number.isInteger(option) || (option as number) < 0 || (option as number) >= render.options.length) {
+      if (parsed.option >= render.options.length) {
         sendJson(res, 400, { error: 'A valid option is required.' });
         return;
       }
-      setup.onAction(questionId, render.options[option as number].value, LOCAL_USER_ID);
-      publish({
+      const selected = render.options[parsed.option]!;
+      setup.onAction(parsed.questionId, selected.value, LOCAL_WEB_USER_ID);
+      publish(platformId, {
         type: 'question-resolution',
-        questionId,
-        resolution: render.options[option as number].selectedLabel,
+        questionId: parsed.questionId,
+        resolution: selected.selectedLabel,
       });
       sendJson(res, 202, { ok: true });
       return;
@@ -363,6 +478,7 @@ function createAdapter(): ChannelAdapter {
     supportsThreads: false,
 
     async setup(config): Promise<void> {
+      await ensureLocalWebConversations();
       server = http.createServer((req, res) => {
         void handleRequest(req, res, config).catch((err: unknown) => {
           log.error('Local web chat request failed', { err });
@@ -374,12 +490,16 @@ function createAdapter(): ChannelAdapter {
         server!.once('error', reject);
         server!.listen(port, LISTEN_HOST, resolve);
       });
-      log.info('Local web chat listening', { url: `http://${LISTEN_HOST}:${port}` });
+      log.info('Local web chat listening', { url: `http://${LISTEN_HOST}:${port}`, launchCommand: 'pnpm local-web' });
     },
 
     async teardown(): Promise<void> {
-      for (const client of clients) client.end();
+      for (const conversationClients of clients.values()) {
+        for (const client of conversationClients) client.end();
+      }
       clients.clear();
+      pendingEvents.clear();
+      awaitingReplies.clear();
       if (!server) return;
       const active = server;
       server = null;
@@ -395,28 +515,27 @@ function createAdapter(): ChannelAdapter {
     // without openDM it would derive the bare handle and mint a phantom
     // messaging group that deliver() rejects, so the card is never rendered.
     async openDM(): Promise<string> {
-      return PLATFORM_ID;
+      return LOCAL_WEB_LEGACY_PLATFORM_ID;
     },
 
     async deliver(platformId, _threadId, message): Promise<string | undefined> {
-      if (platformId !== PLATFORM_ID) return undefined;
+      if (!(await isKnownLocalWebPlatformId(platformId))) return undefined;
       const event = await toWebEvent(message);
       if (event === null) return undefined;
       const completesTurn = event.type === 'reply' || event.type === 'question';
-      if (completesTurn) awaitingReply = false;
-      if (clients.size === 0) {
-        pendingEvents.push(event);
-        if (pendingEvents.length > MAX_PENDING_EVENTS) pendingEvents.shift();
+      if (completesTurn) awaitingReplies.delete(platformId);
+      if ((clients.get(platformId)?.size ?? 0) === 0) {
+        queue(platformId, event);
       } else {
-        publish(event);
+        publish(platformId, event);
       }
       return event.type === 'question' ? event.questionId : undefined;
     },
 
     async setTyping(platformId): Promise<void> {
-      if (platformId !== PLATFORM_ID || !awaitingReply) return;
-      const tool = await currentTool();
-      publish(tool ? { type: 'tool', name: tool } : { type: 'thinking' });
+      if (!awaitingReplies.has(platformId)) return;
+      const tool = await currentTool(platformId);
+      publish(platformId, tool ? { type: 'tool', name: tool } : { type: 'thinking' });
     },
   };
 }


### PR DESCRIPTION
The loopback-only web channel gives every NanoClaw agent its own isolated browser conversation and lets a user create another agent from the same page.

## Why

Every existing channel requires an external account, token, app registration, QR scan, or linked device before the first message. `local-web` gives a fresh install a machine-local path through the same routing, session, delivery, and approval systems as every other channel.

The original PR supported one browser identity wired to one agent. That stopped being sufficient once an install had several agent groups: the browser could not switch agents, and adding a creation form without a server-owned conversation identity would risk routing messages, replies, activity, and approval cards through the wrong session.

## What

- `local-web-conversations.ts` maps every agent group to one deterministic local-web messaging group, backfills missing conversations idempotently, and creates a new agent through the existing `groups-create`, config, messaging-group, and wiring dispatch paths.
- The browser API is narrow and product-shaped: list conversations, create an agent, send a bounded message, open one conversation-scoped event stream, and resolve an option on a question owned by that conversation.
- Provider, model, and effort preserve three distinct choices: inherit the selected agent, use the selected provider's default, or apply an explicit override. The form labels the unset state simply as `Default`.
- Replies, activity, queued background events, questions, resolutions, and browser-local visible history are keyed by server-issued conversation IDs.
- The page adds a persistent desktop sidebar, an inert mobile drawer, and a focused Create Agent dialog without adding a frontend framework.
- `pnpm local-web` prints the authenticated loopback URL on demand. Normal service logs expose only the bare URL and the launch command; the token file remains mode `0600`.

## Screens

| Desktop, multiple agents | Mobile agent drawer |
|---|---|
| <img src="https://raw.githubusercontent.com/amit-shafnir/nanoclaw/assets/local-web-ui/v3/01-desktop-multi-agent-dark.jpg" alt="Dark local web chat showing several isolated agent conversations in the sidebar"> | <img src="https://raw.githubusercontent.com/amit-shafnir/nanoclaw/assets/local-web-ui/v3/02-mobile-agent-drawer-light.jpg" alt="Light mobile local web chat with the agent drawer open" width="390"> |

### Create Agent on mobile

<img src="https://raw.githubusercontent.com/amit-shafnir/nanoclaw/assets/local-web-ui/v3/03-mobile-create-agent-light.jpg" alt="Mobile Create Agent dialog showing inherited Claude runtime" width="390">

## Security and compatibility

The server still binds only to `127.0.0.1`. Every conversation-bearing request keeps the timing-safe token check, exact loopback `Host` restriction, same-origin checks, no-store response policy, CSP, frame denial, and bounded JSON bodies. Markdown is rendered server-side with raw HTML disabled and an allowlisted link scheme.

No database migration is added. Creating an agent does not spawn a model turn; its first real message creates and wakes the normal session. Existing `local-web:local` wiring remains the legacy conversation.

Deploy action: restart the host so it reloads the adapter and browser assets.

## Branch placement and deferred work

This PR targets `channels` because it is concrete channel payload and wiring. The authoritative `/add-local-web-chat` install skill belongs in a separate `main` PR. Template classification: no checkbox fits this registry-payload-only half until that install skill is paired.

Deferred: durable server-hydrated visible history, more than one conversation per agent, provider installation/authentication, agent rename/delete/restart, and a generic browser control plane.

Breaking changes: none.

## Review order

1. `src/channels/local-web-conversations.ts`: conversation identity, backfill, runtime inheritance, and creation orchestration.
2. `src/channels/local-web.ts`: loopback HTTP boundary, token/origin checks, per-conversation event delivery, and interactive actions.
3. `src/channels/local-web-conversation-ui.js` and `local-web-page.js`: selection, local transcript state, Create Agent behavior, and mobile accessibility state.
4. The colocated local-web test files: idempotency, provider inheritance, routing isolation, security, and browser asset contract.

## Verification

- Composed current-main local-web suite: **39/39 passed**.
- Dedicated current-main plus real Codex payload suite: **42/42 passed**.
- Fresh UI-created Claude agent returned `CLAUDE_FINAL_OK_0831`; fresh UI-created Codex agent returned `CODEX_FINAL_OK_0831` through separate sessions.
- Full composed host suite: **2208 passed**, with one pre-existing unrelated Slack skill/parser mismatch.
- PR-branch browser asset test: **2/2 passed**.
- Targeted ESLint for both browser assets: **0 errors**; Node syntax checks and Prettier checks passed.
- The maintainer leak classifier confirms this is channels lineage; the update does not modify the registry barrel, lockfile, shared ESLint configuration, other adapters, or provider wiring.

Declared gap: the `channels` registry branch does not build standalone because its frozen engine predates the current async DB/mailbox seams and its optional adapter dependencies are not materialized. The exact payload was composed onto current `main` for the build, automated tests, and live Claude/Codex journeys above.
