### PR TITLE
fix(agent-runner): escape the attachment type in agent-facing XML

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -149,6 +149,36 @@ describe('structured chat links', () => {
   });
 });
 
+describe('attachment rendering', () => {
+  it('escapes XML special characters in the attachment type', () => {
+    insertMessage('m1', 'chat', {
+      sender: 'Alice',
+      text: 'see attached',
+      attachments: [{ type: 'text/x & <special>', name: 'report.txt', localPath: 'inbox/report.txt' }],
+    });
+
+    const result = formatMessages(getPendingMessages());
+
+    expect(result).toContain('[text/x &amp; &lt;special&gt;: report.txt — saved to /workspace/inbox/report.txt]');
+  });
+
+  it('escapes the type on the url and bare variants too', () => {
+    insertMessage('m1', 'chat', {
+      sender: 'Alice',
+      text: 'two more',
+      attachments: [
+        { type: 'a<b', name: 'linked.txt', url: 'https://example.com/f' },
+        { type: 'c&d', name: 'bare.txt' },
+      ],
+    });
+
+    const result = formatMessages(getPendingMessages());
+
+    expect(result).toContain('[a&lt;b: linked.txt (https://example.com/f)]');
+    expect(result).toContain('[c&amp;d: bare.txt]');
+  });
+});
+
 describe('timestamp formatting', () => {
   it('renders time via formatLocalTime (user TZ)', () => {
     // 2026-06-15T12:00:00Z — timezone-agnostic assertions (year is stable)

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -354,7 +354,7 @@ function formatAttachments(attachments: any[] | undefined): string {
   if (!Array.isArray(attachments) || attachments.length === 0) return '';
   const parts = attachments.map((a) => {
     const name = a.name || a.filename || 'attachment';
-    const type = a.type || 'file';
+    const type = escapeXml(a.type || 'file');
     const localPath = a.localPath ? `/workspace/${a.localPath}` : '';
     const url = a.url || '';
     if (localPath) {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

`formatAttachments` in `container/agent-runner/src/formatter.ts` escapes every rendered field except `type`:

```ts
const name = a.name || a.filename || 'attachment';
const type = a.type || 'file';                    // <- not escaped
const localPath = a.localPath ? `/workspace/${a.localPath}` : '';
const url = a.url || '';
if (localPath) {
  return `[${type}: ${escapeXml(name)} — saved to ${escapeXml(localPath)}]`;
}
return url ? `[${type}: ${escapeXml(name)} (${escapeXml(url)})]` : `[${type}: ${escapeXml(name)}]`;
```

`name`, `localPath`, and `url` all go through `escapeXml`; `type` does not. A MIME/type string containing `<`, `>`, `&`, or `"` therefore lands unescaped inside the `<message>` block the agent parses — in all three return branches.

Channels populate this field from platform-supplied attachment metadata, so its content isn't fully under our control. This makes `type` consistent with its siblings: one call, no behavior change for well-formed types.

**Testing:** three assertions added covering the `localPath`, `url`, and bare branches. Full container suite passes (301 pass / 1 skip), `tsc --noEmit` clean.