### PR TITLE
fix(onecli): correct default OneCLI gateway bind address (#2903)

### DIFF
--- a/setup/onecli.test.ts
+++ b/setup/onecli.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { verifyGatewayV1 } from './onecli.js';
+import { resolveOnecliBindHostEnv, verifyGatewayV1 } from './onecli.js';
 
 function fakeFetch(behavior: 'ok' | '404' | 'down'): typeof fetch {
   return (async () => {
@@ -25,5 +25,41 @@ describe('verifyGatewayV1', () => {
   });
   it('unreachable on connection failure', async () => {
     expect(await verifyGatewayV1('http://x', fakeFetch('down'))).toBe('unreachable');
+  });
+});
+
+describe('resolveOnecliBindHostEnv', () => {
+  it('adds ONECLI_BIND_HOST when the api-host is the docker bridge address (#2903)', () => {
+    const result = resolveOnecliBindHostEnv('', 'http://10.0.0.1:10254');
+    expect(result).toBe('ONECLI_BIND_HOST=10.0.0.1\n');
+  });
+
+  it('replaces a stale ONECLI_BIND_HOST value in place', () => {
+    const result = resolveOnecliBindHostEnv('ONECLI_BIND_HOST=192.168.1.5\nOTHER=1\n', 'http://10.0.0.1:10254');
+    expect(result).toBe('ONECLI_BIND_HOST=10.0.0.1\nOTHER=1\n');
+  });
+
+  it('is a no-op when the value already matches', () => {
+    const result = resolveOnecliBindHostEnv('ONECLI_BIND_HOST=10.0.0.1\n', 'http://10.0.0.1:10254');
+    expect(result).toBeNull();
+  });
+
+  it('does not rewrite for a loopback api-host', () => {
+    expect(resolveOnecliBindHostEnv('', 'http://127.0.0.1:10254')).toBeNull();
+    expect(resolveOnecliBindHostEnv('', 'http://localhost:10254')).toBeNull();
+  });
+
+  it('is a no-op on an unparseable api-host', () => {
+    expect(resolveOnecliBindHostEnv('', 'not-a-url')).toBeNull();
+  });
+
+  it('appends without a leading newline to an empty file', () => {
+    const result = resolveOnecliBindHostEnv('', 'http://10.0.0.1:10254');
+    expect(result?.startsWith('\n')).toBe(false);
+  });
+
+  it('appends after existing content, preserving it', () => {
+    const result = resolveOnecliBindHostEnv('FOO=bar\n', 'http://10.0.0.1:10254');
+    expect(result).toBe('FOO=bar\nONECLI_BIND_HOST=10.0.0.1\n');
   });
 });

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -103,6 +103,61 @@ function writeEnvOnecliUrl(url: string): void {
   writeEnvVar('ONECLI_URL', url);
 }
 
+/**
+ * Compute the updated contents of ~/.onecli/.env so ONECLI_BIND_HOST matches
+ * the host clients are told to use (api-host/ONECLI_URL). The gateway's
+ * docker-compose.yml publishes ports on `${ONECLI_BIND_HOST:-127.0.0.1}`; if
+ * nothing sets that var (the common case — nothing wires up ~/.onecli/.env
+ * during a fresh install), the gateway binds to loopback while clients,
+ * including agent containers, are configured to reach it on the docker
+ * bridge address. That mismatch makes every agent call fail with
+ * "fetch failed" despite the install reporting success (#2903).
+ *
+ * Returns null when no write is needed (loopback host, or already correct).
+ */
+export function resolveOnecliBindHostEnv(currentEnvContent: string, apiHost: string): string | null {
+  let hostname: string;
+  try {
+    hostname = new URL(apiHost).hostname;
+  } catch {
+    return null;
+  }
+  // Loopback clients need no bridge bind — compose's own 127.0.0.1 default
+  // already matches, and rewriting to 0.0.0.0 would expose the vault publicly.
+  if (hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1') return null;
+
+  const line = `ONECLI_BIND_HOST=${hostname}`;
+  const re = /^ONECLI_BIND_HOST=.*$/m;
+  if (re.test(currentEnvContent)) {
+    if (new RegExp(`^${line}$`, 'm').test(currentEnvContent)) return null;
+    return currentEnvContent.replace(re, line);
+  }
+  return currentEnvContent.trimEnd() + (currentEnvContent ? '\n' : '') + line + '\n';
+}
+
+/**
+ * Reconcile ~/.onecli/.env and the running stack so the gateway actually
+ * binds on the same address the client is configured to reach it at. No-op
+ * when the client targets loopback. Recreating the stack is required — the
+ * compose var is read at container start, not live.
+ */
+function ensureOnecliBindHost(apiHost: string): void {
+  const onecliDir = path.join(os.homedir(), '.onecli');
+  const envFile = path.join(onecliDir, '.env');
+  const current = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf-8') : '';
+  const updated = resolveOnecliBindHostEnv(current, apiHost);
+  if (updated === null) return;
+
+  fs.mkdirSync(onecliDir, { recursive: true });
+  fs.writeFileSync(envFile, updated);
+  log.info('Wrote ONECLI_BIND_HOST to ~/.onecli/.env to match api-host', { apiHost });
+  try {
+    execSync('docker compose up -d', { cwd: onecliDir, stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    log.warn('docker compose up -d failed while applying ONECLI_BIND_HOST', { err });
+  }
+}
+
 // The SANCTIONED gateway version: fresh installs pin to it. Upgrading an
 // existing gateway is NOT done here — the gateway is a separate out-of-band
 // component, and the migrator is the user's coding agent following
@@ -439,6 +494,7 @@ export async function run(args: string[]): Promise<void> {
 
   writeEnvOnecliUrl(url);
   log.info('Wrote ONECLI_URL to .env', { url });
+  ensureOnecliBindHost(url);
 
   const healthy = await pollHealth(url, 15000);
   const v1Hint = healthy ? gatewayV1Hint(await verifyGatewayV1(url)) : null;


### PR DESCRIPTION
Fixes #2903

## Root cause

`setup/onecli.ts` installs the OneCLI gateway, discovers the client-facing `api-host` (e.g. `http://10.0.0.1:10254`, the docker bridge address so agent containers can reach it), and writes it to `.env` as `ONECLI_URL`. But nothing ever tells the gateway's own `docker-compose.yml` to bind on that same address — its published ports default to `${ONECLI_BIND_HOST:-127.0.0.1}`, and nanoclaw's setup never populates `~/.onecli/.env` with `ONECLI_BIND_HOST`. Net effect: the gateway binds to loopback while every client (including the host process and agent containers) is configured to reach it on the bridge IP, so `fetch failed` / connection-refused errors happen on every agent call despite setup reporting success.

This is already documented as a known failure mode + manual fix in `docs/onecli-upgrades.md` ("if it can't connect while the host-side check passed, set the bind address in `~/.onecli/.env` to the docker-bridge IP ... and `docker compose up -d`") — this PR automates that step for a fresh install so it isn't left as a manual workaround.

## Fix

- Added `resolveOnecliBindHostEnv()` (pure, unit-tested): given the current `~/.onecli/.env` contents and the discovered `api-host`, computes the updated `.env` content that sets `ONECLI_BIND_HOST` to the same hostname the client targets. No-op for loopback hosts (`127.0.0.1`/`localhost`/`::1`) — deliberately never defaults to `0.0.0.0`, per the issue's guidance, to avoid exposing the credential vault on hosts with a public interface.
- Added `ensureOnecliBindHost()`, called from the fresh-install path in `run()` right after `ONECLI_URL` is written: applies the computed `.env` update and runs `docker compose up -d` in `~/.onecli` so the running stack picks up the corrected bind before the health poll runs.
- `--reuse` and `--remote-url` modes are untouched — reuse mode intentionally never touches an existing gateway's bind (other apps may depend on it), and remote mode has no local compose stack.

## Test plan

- Added `setup/onecli.test.ts` cases for `resolveOnecliBindHostEnv`: adds the var for a bridge-address api-host, replaces a stale value in place, no-ops when already correct, no-ops for loopback/unparseable hosts, and preserves existing `.env` content when appending.
- `npx vitest run setup/onecli.test.ts` → 10 passed (10), all green.
- `npx tsc --noEmit` → clean.