### PR TITLE
channels: adapter-declared session-mode context defaults (threads stamp derived)

### DIFF
--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -168,20 +168,29 @@ function wireIfMissing(mg: MessagingGroup, ag: AgentGroup, now: string, label: s
     console.log(`Wiring already exists: ${existing.id} (${label})`);
     return;
   }
+  // Wiring defaults come from the channel's declaration when it has one
+  // (resolveWiringDefaults: engage fields + session_mode + the threads stamp
+  // derived from it — a context whose conversations are thread-rooted
+  // declares per-thread sessions and gets correct session identity from the
+  // first message); stale (undeclared) adapters keep the legacy behavior
+  // exactly: shared sessions, threads column NULL (inherit).
+  const isGroup = mg.is_group === 1;
+  const channelKey = mg.instance ?? mg.channel_type;
+  const resolved = hasDeclaredChannelDefaults(channelKey, mg.channel_type)
+    ? resolveWiringDefaults(channelKey, isGroup, ag.name, mg.channel_type)
+    : undefined;
   // Engage defaults, first hit wins: explicit --engage-pattern → the
   // channel's declared defaults → the legacy heuristic for stale
   // (undeclared) adapters: DMs (is_group=0) respond to everything via a '.'
   // regex, group chats are mention-only; admins can reconfigure via
-  // /manage-channels once the agent is in use.
-  const isGroup = mg.is_group === 1;
-  const channelKey = mg.instance ?? mg.channel_type;
+  // /manage-channels once the agent is in use. An explicit pattern only
+  // overrides the engage fields — the declared session defaults still apply.
   const engage = engagePattern
     ? { engage_mode: 'pattern' as const, engage_pattern: engagePattern }
-    : hasDeclaredChannelDefaults(channelKey, mg.channel_type)
-      ? resolveWiringDefaults(channelKey, isGroup, ag.name, mg.channel_type)
-      : isGroup
+    : (resolved ??
+      (isGroup
         ? { engage_mode: 'mention' as const, engage_pattern: null }
-        : { engage_mode: 'pattern' as const, engage_pattern: '.' };
+        : { engage_mode: 'pattern' as const, engage_pattern: '.' }));
   createMessagingGroupAgent({
     id: generateId('mga'),
     messaging_group_id: mg.id,
@@ -193,7 +202,8 @@ function wireIfMissing(mg: MessagingGroup, ag: AgentGroup, now: string, label: s
     // messages carry no value ('drop').
     sender_scope: 'all',
     ignored_message_policy: 'drop',
-    session_mode: 'shared',
+    session_mode: resolved?.session_mode ?? 'shared',
+    ...(resolved?.threads !== undefined && resolved?.threads !== null ? { threads: resolved.threads } : {}),
     priority: 0,
     created_at: now,
   });

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -136,6 +136,25 @@ export interface ChannelContextDefaults {
    */
   threads: boolean;
   /**
+   * Default session_mode stamped on wirings created in this context
+   * (messaging_group_agents.session_mode). Declared by a context whose
+   * conversations are thread-rooted — each thread is its own conversation, so
+   * each should root its own session from the first message. Applies to
+   * whichever context declares it (dm, group, or both); omitting it means
+   * 'shared', which is today's behavior for every existing adapter. Same
+   * two-level model as the engage fields: this declaration, and the
+   * per-wiring value chosen at creation.
+   *
+   * Declaring 'per-thread' also derives the wiring's threads stamp:
+   * resolveWiringDefaults stamps messaging_group_agents.threads = 1 at
+   * creation (per-thread sessions structurally require honored thread ids);
+   * otherwise the column is left NULL (inherit `threads` — today's behavior).
+   * There is deliberately no independent threads declaration: the stamp is a
+   * code invariant of the session mode, so the incoherent pairing
+   * (per-thread sessions with thread ids stripped) is unrepresentable here.
+   */
+  sessionMode?: 'shared' | 'per-thread';
+  /**
    * unknown_sender_policy stamped on messaging_groups rows auto-created by
    * the router or created by wizard/CLI paths in this context.
    * 'decline_notify' (DM-shaped channels): the host politely declines the

--- a/src/channels/channel-defaults.test.ts
+++ b/src/channels/channel-defaults.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup } from './adapter.js';
+import type { MessagingGroup } from '../types.js';
 
 function makeDefaults(marker: string, threads = true): ChannelDefaults {
   return {
@@ -181,11 +182,15 @@ describe('resolveWiringDefaults', () => {
     expect(resolveWiringDefaults('mock', true, 'C-3PO (dev)')).toEqual({
       engage_mode: 'pattern',
       engage_pattern: '\\bC-3PO \\(dev\\)',
+      session_mode: 'shared',
+      threads: null,
     });
     // DM context: no token, pattern passes through untouched.
     expect(resolveWiringDefaults('mock', false, 'C-3PO (dev)')).toEqual({
       engage_mode: 'pattern',
       engage_pattern: '.',
+      session_mode: 'shared',
+      threads: null,
     });
   });
 
@@ -221,6 +226,8 @@ describe('resolveWiringDefaults', () => {
     expect(resolveWiringDefaults('mock', true, 'Andy')).toEqual({
       engage_mode: 'mention',
       engage_pattern: null,
+      session_mode: 'shared',
+      threads: null,
     });
   });
 
@@ -234,6 +241,8 @@ describe('resolveWiringDefaults', () => {
     expect(resolveWiringDefaults('mock', true, 'Andy')).toEqual({
       engage_mode: 'mention-sticky',
       engage_pattern: null,
+      session_mode: 'shared',
+      threads: null,
     });
   });
 
@@ -245,6 +254,111 @@ describe('resolveWiringDefaults', () => {
     });
 
     expect(() => resolveWiringDefaults('mock', false, 'Andy')).toThrow(/without an engagePattern/);
+  });
+
+  it("a declared per-thread sessionMode always derives the threads=1 stamp (the field can't disagree)", async () => {
+    const { resolveWiringDefaults } = await withDeclaration({
+      dm: {
+        engageMode: 'pattern',
+        engagePattern: '.',
+        threads: false,
+        sessionMode: 'per-thread',
+        unknownSenderPolicy: 'public',
+      },
+      group: { engageMode: 'mention', threads: true, unknownSenderPolicy: 'strict' },
+      mentions: 'platform',
+    });
+
+    expect(resolveWiringDefaults('mock', false, 'Andy')).toEqual({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      session_mode: 'per-thread',
+      threads: 1,
+    });
+    // No sessionMode declared in the group context → shared, threads NULL.
+    expect(resolveWiringDefaults('mock', true, 'Andy')).toEqual({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      session_mode: 'shared',
+      threads: null,
+    });
+  });
+});
+
+describe('validateEngageAgainstChannel — per-thread/threads coherence (ncl update path)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const { teardownChannelAdapters } = await import('./channel-registry.js');
+    await teardownChannelAdapters();
+    vi.resetModules();
+  });
+
+  function makeMg(channelType: string, isGroup = false): MessagingGroup {
+    return {
+      id: 'mg-1',
+      channel_type: channelType,
+      platform_id: `${channelType}:@me:owner`,
+      name: 'Owner DM',
+      is_group: isGroup ? 1 : 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    };
+  }
+
+  async function withDeclaration(defaults?: ChannelDefaults) {
+    const reg = await import('./channel-registry.js');
+    reg.registerChannelAdapter('mock', { factory: () => null, ...(defaults ? { defaults } : {}) });
+    return import('./channel-defaults.js');
+  }
+
+  const dmThreadsFalse: ChannelDefaults = {
+    dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'public' },
+    group: { engageMode: 'mention', threads: true, unknownSenderPolicy: 'strict' },
+    mentions: 'platform',
+  };
+
+  it("rejects session_mode 'per-thread' when the inherited (NULL) thread policy resolves off", async () => {
+    const { validateEngageAgainstChannel } = await withDeclaration(dmThreadsFalse);
+
+    expect(() => validateEngageAgainstChannel({ session_mode: 'per-thread' }, makeMg('mock'))).toThrow(
+      /session_mode 'per-thread' requires honored thread ids/,
+    );
+  });
+
+  it("rejects an explicit threads=false alongside session_mode 'per-thread' even on a threads:true context", async () => {
+    const { validateEngageAgainstChannel } = await withDeclaration(dmThreadsFalse);
+
+    expect(() =>
+      validateEngageAgainstChannel({ session_mode: 'per-thread', threads: 0 }, makeMg('mock', true)),
+    ).toThrow(/explicit threads=false/);
+  });
+
+  it('accepts per-thread when the pairing is coherent (explicit threads=1, or a threads:true context)', async () => {
+    const { validateEngageAgainstChannel } = await withDeclaration(dmThreadsFalse);
+
+    // Explicit stamp beats the false dm inherit.
+    expect(() =>
+      validateEngageAgainstChannel({ session_mode: 'per-thread', threads: 1 }, makeMg('mock')),
+    ).not.toThrow();
+    // Group context inherits threads: true.
+    expect(() => validateEngageAgainstChannel({ session_mode: 'per-thread' }, makeMg('mock', true))).not.toThrow();
+    // Non-per-thread modes are untouched by the check.
+    expect(() => validateEngageAgainstChannel({ session_mode: 'shared', threads: 0 }, makeMg('mock'))).not.toThrow();
+  });
+
+  it('stays lenient on the inherit arm for undeclared (stale) adapters, but still rejects an explicit threads=false', async () => {
+    const { validateEngageAgainstChannel } = await withDeclaration(undefined);
+
+    // The conservative fallback declaration has threads:false, but rejecting
+    // on it would wrongly block offline-managed wirings — mirror the mention
+    // checks' hasDeclaredChannelDefaults gate.
+    expect(() => validateEngageAgainstChannel({ session_mode: 'per-thread' }, makeMg('mock'))).not.toThrow();
+    expect(() => validateEngageAgainstChannel({ session_mode: 'per-thread', threads: 0 }, makeMg('mock'))).toThrow(
+      /session_mode 'per-thread' requires honored thread ids/,
+    );
   });
 });
 

--- a/src/channels/channel-defaults.ts
+++ b/src/channels/channel-defaults.ts
@@ -2,9 +2,10 @@
  * Wiring-creation helpers over channel default declarations.
  *
  * Every path that creates a messaging_group_agents row (ncl, setup wizard,
- * card-approval flow, bootstrap scripts) resolves its engage defaults through
- * resolveWiringDefaults; every path that auto-creates a messaging_groups row
- * resolves its policy through resolveUnknownSenderPolicy. The router's fanout
+ * card-approval flow, bootstrap scripts) resolves its defaults through
+ * resolveWiringDefaults, taking the columns it doesn't set itself; every path
+ * that auto-creates a messaging_groups row resolves its policy through
+ * resolveUnknownSenderPolicy. The router's fanout
  * consults resolveThreadPolicy at runtime — threading is the one per-wiring
  * setting that stays live (NULL = inherit the declaration) rather than being
  * snapshotted at creation.
@@ -36,8 +37,24 @@ function substituteName(pattern: string, name: string): string {
   return out.replaceAll('{name}', escapeRegex(name));
 }
 
+/** What resolveWiringDefaults produces — the wiring-row columns a creation
+ *  path stamps from the channel declaration. `threads` null = leave the
+ *  column NULL (inherit the declaration at fanout time). */
+export interface WiringDefaults {
+  engage_mode: 'pattern' | 'mention' | 'mention-sticky';
+  engage_pattern: string | null;
+  session_mode: 'shared' | 'per-thread';
+  threads: number | null;
+}
+
 /**
- * Resolve the engage defaults a new wiring should be created with.
+ * Resolve the defaults a new wiring should be created with: the engage
+ * fields, plus the declared session_mode (ChannelContextDefaults.sessionMode)
+ * and the threads stamp it derives — sessionMode 'per-thread' stamps
+ * threads = 1 (per-thread sessions structurally require honored thread ids),
+ * anything else leaves the column NULL (inherit). Undeclared adapters resolve
+ * behavior-faithfully — session_mode 'shared', threads null (column stays
+ * NULL = inherit) — so a trunk update alone changes nothing.
  *
  * @param channelKey mg.instance ?? mg.channel_type (getChannelAdapter key discipline)
  * @param isGroup event.message.isGroup ?? mg.is_group === 1 — never derived from threadId
@@ -46,23 +63,36 @@ function substituteName(pattern: string, name: string): string {
  *   instance so a dead instance still resolves its platform's declaration
  *   (getChannelDefaults' second-arg discipline)
  *
- * mention-sticky is downgraded to mention when the context's declared threads
- * value is false: sticky engagement is keyed on per-thread session existence,
- * so without thread ids it could engage once and never disengage.
+ * mention-sticky is downgraded to mention when the wiring being created
+ * won't honor thread ids — the derived threads stamp when present, else the
+ * context's inherit `threads` value: sticky engagement is keyed on
+ * per-thread session existence, so without thread ids it could engage once
+ * and never disengage.
  */
 export function resolveWiringDefaults(
   channelKey: string,
   isGroup: boolean,
   agentGroupName: string,
   channelType?: string,
-): { engage_mode: 'pattern' | 'mention' | 'mention-sticky'; engage_pattern: string | null } {
+): WiringDefaults {
   const decl = getChannelDefaults(channelKey, channelType);
   const ctx = isGroup ? decl.group : decl.dm;
 
-  let mode = ctx.engageMode;
-  if (mode === 'mention-sticky' && !ctx.threads) mode = 'mention';
+  const session: Pick<WiringDefaults, 'session_mode' | 'threads'> = {
+    session_mode: ctx.sessionMode ?? 'shared',
+    // Derived, not declared: per-thread sessions structurally require honored
+    // thread ids, so the stamp is a code invariant of the session mode.
+    threads: ctx.sessionMode === 'per-thread' ? 1 : null,
+  };
 
-  if (mode !== 'pattern') return { engage_mode: mode, engage_pattern: null };
+  // The effective thread policy for the wiring being created: the derived
+  // stamp wins over the inherit value (mirrors validateEngageAgainstChannel).
+  const effectiveThreads = session.threads === null ? ctx.threads : true;
+
+  let mode = ctx.engageMode;
+  if (mode === 'mention-sticky' && !effectiveThreads) mode = 'mention';
+
+  if (mode !== 'pattern') return { engage_mode: mode, engage_pattern: null, ...session };
 
   if (!ctx.engagePattern) {
     throw new Error(
@@ -72,6 +102,7 @@ export function resolveWiringDefaults(
   return {
     engage_mode: 'pattern',
     engage_pattern: substituteName(ctx.engagePattern, agentGroupName),
+    ...session,
   };
 }
 
@@ -112,13 +143,15 @@ export interface EngageValues {
   engage_mode?: unknown;
   engage_pattern?: unknown;
   threads?: unknown;
+  session_mode?: unknown;
 }
 
 /**
  * Cross-column validation against the channel's declaration. Shared by every
  * wiring-creation surface (`ncl wirings` create/update, the setup wizard's
  * register step) so a partial update or an explicit flag can't produce a
- * combination create would reject. May mutate `w.engage_mode`: the
+ * combination create would reject — including session_mode 'per-thread' on a
+ * wiring whose thread policy resolves off. May mutate `w.engage_mode`: the
  * mention-sticky→mention coercion when the effective thread policy is off —
  * sticky engagement is keyed on per-thread session existence, so without
  * thread ids it would engage once and never disengage.
@@ -135,6 +168,35 @@ export function validateEngageAgainstChannel(w: EngageValues, mg: MessagingGroup
   ) {
     throw new Error(`engage_mode 'pattern' requires --engage-pattern (use "." to match every message)`);
   }
+
+  // per-thread sessions structurally require honored thread ids — reject the
+  // incoherent combination rather than storing it. Creation paths that resolve
+  // through the declaration derive threads=1 from sessionMode 'per-thread'
+  // (resolveWiringDefaults), so only explicit flags can reach this: an
+  // explicit threads=false, or NULL-inherit on a context whose declared
+  // `threads` is false. Undeclared (stale) adapters stay lenient on the
+  // inherit arm, same as the mention checks below.
+  if (w.session_mode === 'per-thread') {
+    const key = mg.instance ?? mg.channel_type;
+    const explicit = w.threads !== undefined && w.threads !== null;
+    const honored = explicit
+      ? w.threads !== 0 && w.threads !== false
+      : !hasDeclaredChannelDefaults(key, mg.channel_type) ||
+        (mg.is_group === 1
+          ? getChannelDefaults(key, mg.channel_type).group
+          : getChannelDefaults(key, mg.channel_type).dm
+        ).threads;
+    if (!honored) {
+      throw new Error(
+        `session_mode 'per-thread' requires honored thread ids, but this wiring's thread policy resolves off ` +
+          (explicit
+            ? `(explicit threads=false)`
+            : `(threads is NULL and channel '${key}' declares threads: false for its ${mg.is_group === 1 ? 'group' : 'dm'} context)`) +
+          ` — set --threads true, or keep session_mode 'shared'`,
+      );
+    }
+  }
+
   if (w.engage_mode !== 'mention' && w.engage_mode !== 'mention-sticky') return;
 
   const channelKey = mg.instance ?? mg.channel_type;

--- a/src/channels/channel-session-defaults.test.ts
+++ b/src/channels/channel-session-defaults.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Adapter-declared session-mode wiring defaults, per conversation context.
+ *
+ * The declaration → resolution → wiring-creation path: a fixture adapter
+ * declaring `sessionMode: 'per-thread'` on a context flows through
+ * resolveWiringDefaults into the created messaging_group_agents row —
+ * session_mode column plus the derived threads=1 stamp (per-thread sessions
+ * structurally require honored thread ids, so the stamp is a code invariant
+ * of the session mode, not a declared field). The declaration is per-context:
+ * dm and group resolve independently, and declaring one leaves the other at
+ * today's values. Undeclared adapters resolve to today's behavior exactly —
+ * session_mode 'shared', threads column NULL (inherit) — so a trunk update
+ * alone changes nothing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { ChannelAdapter, ChannelContextDefaults, ChannelDefaults, ChannelSetup } from './adapter.js';
+import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from '../types.js';
+
+/** A declaration whose `context` roots each conversation in its own thread
+ *  (what a platform with thread-rooted conversations would declare): plain
+ *  inherit `threads` stays false there (existing NULL wirings keep top-level
+ *  replies) while new wirings are stamped per-thread at creation — the
+ *  threads=1 stamp is derived from sessionMode by resolveWiringDefaults, not
+ *  declared. The other context is left at ordinary values so each arm shows
+ *  the declaration is scoped to the context that carries it. */
+function perThreadDefaults(
+  context: 'dm' | 'group' = 'dm',
+  overrides: Partial<ChannelContextDefaults> = {},
+): ChannelDefaults {
+  const perThread: ChannelContextDefaults = {
+    engageMode: context === 'dm' ? 'pattern' : 'mention',
+    ...(context === 'dm' ? { engagePattern: '.' } : {}),
+    threads: false,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'request_approval',
+    ...overrides,
+  };
+  const plain: ChannelContextDefaults =
+    context === 'dm'
+      ? { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' }
+      : { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'request_approval' };
+  return {
+    dm: context === 'dm' ? perThread : plain,
+    group: context === 'group' ? perThread : plain,
+    mentions: 'platform',
+  };
+}
+
+function makeAdapter(
+  channelType: string,
+  opts: { supportsThreads?: boolean; defaults?: ChannelDefaults } = {},
+): ChannelAdapter {
+  return {
+    name: channelType,
+    channelType,
+    supportsThreads: opts.supportsThreads ?? true,
+    defaults: opts.defaults,
+    async setup(_config: ChannelSetup) {},
+    async teardown() {},
+    isConnected: () => true,
+    async deliver() {
+      return undefined;
+    },
+  };
+}
+
+const mockSetup = () => ({
+  onInbound: () => {},
+  onInboundEvent: () => {},
+  onMetadata: () => {},
+  onAction: () => {},
+});
+
+/** Register a fixture adapter and return the resolution helpers, all from one
+ *  fresh module graph (the registry maps are module-level state). */
+async function registerFixture(defaults?: ChannelDefaults) {
+  const reg = await import('./channel-registry.js');
+  reg.registerChannelAdapter('fixture', { factory: () => makeAdapter('fixture', { defaults }) });
+  await reg.initChannelAdapters(mockSetup);
+  return import('./channel-defaults.js');
+}
+
+// The registry maps and the DB connection handle are module-level; fresh
+// module graph per test so registrations and DBs don't leak across arms.
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  const { teardownChannelAdapters } = await import('./channel-registry.js');
+  await teardownChannelAdapters();
+  const { closeDb } = await import('../db/index.js');
+  try {
+    closeDb();
+  } catch {
+    // Test didn't open a DB.
+  }
+  vi.resetModules();
+});
+
+describe('resolveWiringDefaults — declared session mode and its derived threads stamp', () => {
+  it('a per-thread DM declaration resolves into session_mode + the derived threads=1 stamp', async () => {
+    const { resolveWiringDefaults } = await registerFixture(perThreadDefaults('dm'));
+
+    expect(resolveWiringDefaults('fixture', false, 'Nano')).toEqual({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      session_mode: 'per-thread',
+      threads: 1,
+    });
+  });
+
+  it('a per-thread group declaration resolves the same way — the field is per-context, not DM-only', async () => {
+    const { resolveWiringDefaults } = await registerFixture(perThreadDefaults('group'));
+
+    expect(resolveWiringDefaults('fixture', true, 'Nano')).toEqual({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      session_mode: 'per-thread',
+      threads: 1,
+    });
+  });
+
+  it('the context without the declaration is untouched by it', async () => {
+    const dmDeclared = await registerFixture(perThreadDefaults('dm'));
+    expect(dmDeclared.resolveWiringDefaults('fixture', true, 'Nano')).toMatchObject({
+      session_mode: 'shared',
+      threads: null,
+    });
+
+    vi.resetModules();
+    const groupDeclared = await registerFixture(perThreadDefaults('group'));
+    expect(groupDeclared.resolveWiringDefaults('fixture', false, 'Nano')).toMatchObject({
+      session_mode: 'shared',
+      threads: null,
+    });
+  });
+
+  it('undeclared adapters resolve behavior-faithfully: shared, NULL threads', async () => {
+    const { resolveWiringDefaults } = await registerFixture(undefined);
+
+    // Fallback declaration (dm pattern '.'), and no session stamps: shared
+    // sessions, threads left NULL to inherit at fanout time.
+    expect(resolveWiringDefaults('fixture', false, 'Nano')).toEqual({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      session_mode: 'shared',
+      threads: null,
+    });
+  });
+
+  it('the derived threads stamp keeps mention-sticky from downgrading when the inherit value is false', async () => {
+    const { resolveWiringDefaults } = await registerFixture(
+      perThreadDefaults('dm', { engageMode: 'mention-sticky', engagePattern: undefined }),
+    );
+
+    // dm.threads is false, but sessionMode 'per-thread' derives a threads=1
+    // stamp for the wiring being created, so sticky engagement (keyed on
+    // per-thread session existence) works.
+    expect(resolveWiringDefaults('fixture', false, 'Nano')).toEqual({
+      engage_mode: 'mention-sticky',
+      engage_pattern: null,
+      session_mode: 'per-thread',
+      threads: 1,
+    });
+  });
+
+  it('without a per-thread sessionMode, mention-sticky still downgrades on a threads:false context (unchanged behavior)', async () => {
+    const { resolveWiringDefaults } = await registerFixture(
+      perThreadDefaults('dm', {
+        engageMode: 'mention-sticky',
+        engagePattern: undefined,
+        sessionMode: undefined,
+      }),
+    );
+
+    expect(resolveWiringDefaults('fixture', false, 'Nano')).toEqual({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      session_mode: 'shared',
+      threads: null,
+    });
+  });
+});
+
+describe('wiring creation — resolved defaults persist onto the row', () => {
+  /** In-memory central DB + one agent group and messaging group. */
+  async function seedDb(channelType: string, isGroup = false) {
+    const { initTestDb, runMigrations } = await import('../db/index.js');
+    const db = initTestDb();
+    runMigrations(db);
+
+    const { createAgentGroup } = await import('../db/agent-groups.js');
+    const { createMessagingGroup } = await import('../db/messaging-groups.js');
+    const now = new Date().toISOString();
+    const ag: AgentGroup = { id: 'ag-1', name: 'Nano', folder: 'nano', agent_provider: null, created_at: now };
+    createAgentGroup(ag);
+    const mg: MessagingGroup = {
+      id: 'mg-1',
+      channel_type: channelType,
+      platform_id: `${channelType}:@me:owner`,
+      name: isGroup ? 'Project channel' : 'Owner DM',
+      is_group: isGroup ? 1 : 0,
+      unknown_sender_policy: 'strict',
+      created_at: now,
+    };
+    createMessagingGroup(mg);
+    return { db, ag, mg, now };
+  }
+
+  /** Mirror of init-first-agent's wireIfMissing consumption: resolve the
+   *  declaration, stamp engage + session_mode, and persist the explicit
+   *  threads value only when the declaration derives one. */
+  async function wire(
+    mg: MessagingGroup,
+    ag: AgentGroup,
+    now: string,
+    resolved: {
+      engage_mode: 'pattern' | 'mention' | 'mention-sticky';
+      engage_pattern: string | null;
+      session_mode: 'shared' | 'per-thread';
+      threads: number | null;
+    },
+  ): Promise<MessagingGroupAgent> {
+    const { createMessagingGroupAgent, getMessagingGroupAgent } = await import('../db/messaging-groups.js');
+    createMessagingGroupAgent({
+      id: 'mga-1',
+      messaging_group_id: mg.id,
+      agent_group_id: ag.id,
+      engage_mode: resolved.engage_mode,
+      engage_pattern: resolved.engage_pattern,
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: resolved.session_mode,
+      ...(resolved.threads !== null ? { threads: resolved.threads } : {}),
+      priority: 0,
+      created_at: now,
+    });
+    return getMessagingGroupAgent('mga-1')!;
+  }
+
+  it('declared per-thread DM defaults flow into the created wiring', async () => {
+    const { resolveWiringDefaults } = await registerFixture(perThreadDefaults('dm'));
+    const { ag, mg, now } = await seedDb('fixture');
+
+    const resolved = resolveWiringDefaults(mg.instance ?? mg.channel_type, mg.is_group === 1, ag.name, mg.channel_type);
+    const row = await wire(mg, ag, now, resolved);
+
+    expect(row.session_mode).toBe('per-thread');
+    expect(row.threads).toBe(1);
+    expect(row.engage_mode).toBe('pattern');
+    expect(row.engage_pattern).toBe('.');
+  });
+
+  it('declared per-thread group defaults flow into the created wiring the same way', async () => {
+    const { resolveWiringDefaults } = await registerFixture(perThreadDefaults('group'));
+    const { ag, mg, now } = await seedDb('fixture', true);
+
+    const resolved = resolveWiringDefaults(mg.instance ?? mg.channel_type, mg.is_group === 1, ag.name, mg.channel_type);
+    const row = await wire(mg, ag, now, resolved);
+
+    expect(row.session_mode).toBe('per-thread');
+    expect(row.threads).toBe(1);
+    expect(row.engage_mode).toBe('mention');
+  });
+
+  it("undeclared adapter: the created wiring keeps today's shape — shared, threads NULL", async () => {
+    const { resolveWiringDefaults } = await registerFixture(undefined);
+    const { ag, mg, now } = await seedDb('fixture');
+
+    const resolved = resolveWiringDefaults(mg.instance ?? mg.channel_type, mg.is_group === 1, ag.name, mg.channel_type);
+    const row = await wire(mg, ag, now, resolved);
+
+    expect(row.session_mode).toBe('shared');
+    expect(row.threads).toBeNull();
+  });
+
+  it('updateMessagingGroupAgent accepts a threads override (key widening)', async () => {
+    const { resolveWiringDefaults } = await registerFixture(perThreadDefaults('dm'));
+    const { ag, mg, now } = await seedDb('fixture');
+    const resolved = resolveWiringDefaults(mg.instance ?? mg.channel_type, mg.is_group === 1, ag.name, mg.channel_type);
+    await wire(mg, ag, now, resolved);
+
+    const { updateMessagingGroupAgent, getMessagingGroupAgent } = await import('../db/messaging-groups.js');
+    updateMessagingGroupAgent('mga-1', { threads: 0 });
+    expect(getMessagingGroupAgent('mga-1')!.threads).toBe(0);
+  });
+});

--- a/src/cli/resources/wirings.ts
+++ b/src/cli/resources/wirings.ts
@@ -105,7 +105,7 @@ registerResource({
       name: 'session_mode',
       type: 'string',
       description:
-        '"shared" — one session per (agent, messaging group). "per-thread" — separate session per thread/topic. "agent-shared" — one session across all messaging groups wired to this agent. Note: threaded adapters in group chats force per-thread regardless of this setting.',
+        '"shared" — one session per (agent, messaging group). "per-thread" — separate session per thread/topic; requires the wiring to honor thread ids (rejected when its thread policy resolves off — pair with --threads true where the channel context does not honor them). "agent-shared" — one session across all messaging groups wired to this agent. Note: threaded adapters in group chats force per-thread regardless of this setting.',
       enum: ['shared', 'per-thread', 'agent-shared'],
       default: 'shared',
       updatable: true,
@@ -149,6 +149,13 @@ registerResource({
       (merged.engage_pattern === undefined || merged.engage_pattern === null)
     ) {
       merged.engage_pattern = '.';
+    }
+    // Same treatment for the session/threads pairing: pre-existing rows may
+    // hold session_mode='per-thread' with a false-resolving thread policy
+    // (stamped before the coherence check existed). Don't reject unrelated
+    // updates to them — enforce only when either side of the pairing changes.
+    if (updates.session_mode === undefined && updates.threads === undefined) {
+      merged.session_mode = undefined;
     }
     validateEngageAgainstChannel(merged, mg);
     // Carry the sticky→mention coercion (if any) back into the update set.

--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -239,6 +239,14 @@ export function createMessagingGroupAgent(mga: MessagingGroupAgent): void {
     )
     .run(mga);
 
+  // `threads` (migration 019) is written separately so existing callers that
+  // omit it keep passing named-param sets that match the INSERT exactly
+  // (better-sqlite3 rejects missing named params). Omitted/NULL = column
+  // stays NULL = inherit the channel declaration at fanout time.
+  if (mga.threads !== undefined && mga.threads !== null) {
+    getDb().prepare('UPDATE messaging_group_agents SET threads = ? WHERE id = ?').run(mga.threads, mga.id);
+  }
+
   ensureAgentDestinationForWiring(mga);
 }
 
@@ -321,7 +329,13 @@ export function updateMessagingGroupAgent(
   updates: Partial<
     Pick<
       MessagingGroupAgent,
-      'engage_mode' | 'engage_pattern' | 'sender_scope' | 'ignored_message_policy' | 'session_mode' | 'priority'
+      | 'engage_mode'
+      | 'engage_pattern'
+      | 'sender_scope'
+      | 'ignored_message_policy'
+      | 'session_mode'
+      | 'priority'
+      | 'threads'
     >
   >,
 ): void {


### PR DESCRIPTION
Adds an optional `sessionMode` (`'shared' | 'per-thread'`) to the adapter-declared per-context channel defaults, so a platform whose conversations materialize as threads can declare thread-per-conversation sessions for a context (DM or group) instead of call sites hardcoding it.

**The `threads` stamp is derived, never declared.** When the effective session mode resolves to `per-thread`, wiring creation stamps `threads=1`; otherwise the wiring inherits (`NULL`). This makes the incoherent per-thread-with-threads-off combination unrepresentable at creation, and the wiring update path extends the existing pairing-change validation (from the engagement-consistency work) with the same session/threads coherence rule — no parallel mechanism.

`scripts/init-first-agent.ts` wiring creation becomes fully declaration-driven: the hardcoded `session_mode: 'shared'` is replaced by resolution through the channel declaration. Adapters that declare nothing are behavior-identical to today — resolution falls back to `'shared'`, and every existing adapter type-checks and behaves unchanged.

Scope note for reviewers: `ncl wirings create` still applies its static `session_mode` default and only consults the declaration for engagement — widening that guarded path to honor a declared session mode is a natural follow-up; it is inert today since no in-tree adapter declares `sessionMode`.

## Verification

`pnpm install --frozen-lockfile`, `pnpm run build`, `pnpm run format:check`, full `pnpm test` — 124 files, 1555 tests, 0 failures. 15 new tests cover: per-thread declarations deriving the stamp for both DM and group contexts, non-declaring contexts staying at today's values, the update-path coherence rule, and declaration-driven init-first-agent wiring. (Repo-wide `pnpm run lint` fails on 10 pre-existing errors in `src/channels/cli.ts` / `src/circuit-breaker.*` that fail identically on main — untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
