### PR TITLE
slack: shared channel-layer library + canvas cluster (wave A, includes main sync)

### DIFF
--- a/container/agent-runner/src/mcp-tools/canvas.instructions.md
+++ b/container/agent-runner/src/mcp-tools/canvas.instructions.md
@@ -1,0 +1,36 @@
+## Canvases
+
+Slack canvases are shared documents that live alongside a conversation. The **room canvas** is the room's shared working surface: chat is for coordination, the canvas is for state. It has named sections — **Members**, **Tasks** (a checklist), **Decisions**, and **Notes** — and both humans and agents edit it. The canvas id (`F…`) for a room is in your destinations list — the `<room> canvas comments (canvas F0…)` destination carries it (canvas ids are uppercase, starting `F`). If you can't find it, ask in the room — never guess an id.
+
+Two tools:
+
+- `mcp__nanoclaw__canvas_update({ canvas_id, op, markdown, section_text? })` — fire-and-forget edit. `op` is `append` (at document end), `replace_section`, or `insert_after_section`; the last two need `section_text` — the target section's **exact heading text**. Outcomes: a FAILED edit wakes you with a system note saying why — fix and retry from a fresh read. A successful edit's note is silent (it rides along on your next wake), so verify structural changes with `canvas_read`.
+- `mcp__nanoclaw__canvas_read({ canvas_id, timeout? })` — blocking read; `timeout` is in **seconds** (default 20 — never pass milliseconds). Returns the canvas as readable text, checkboxes rendered as `[ ]` / `[x]`, truncated at ~8000 chars — a `…[truncated at N chars]` suffix marks the cut, and sections may exist below it, so never conclude a section is absent from a truncated read. A "timed out" error can occur even when the host read succeeded — retry once, with a larger `timeout` on slow canvases.
+
+Section targeting: `section_text` must be the exact heading text (matching is case-insensitive and trimmed; exact match beats contains; ties go to the first matching heading in document order). If it matches only body text — or the host's pre-read transiently fails — the op silently degrades to a **single-block** edit that can corrupt the section. Full mechanics live in the `canvas-work` skill; follow it for every edit.
+
+Working rules:
+
+- **Keep Tasks and Decisions current.** When work is agreed, ADD it under Tasks with `insert_after_section` (markdown = just the new `- [ ]` line — existing items and their ticks stay intact). Checkbox tick state is **UI-only**: the API ignores `- [x]` and a section rewrite resets every ticked box, so mark completion by editing the item's own text (see the `canvas-work` skill) and leave box-ticking to humans. When a decision lands in chat, record it under Decisions — quote the ask, name who decided.
+- **Section-scoped edits only.** Always target one section (`replace_section` / `insert_after_section`) or append. Never try to rewrite the whole document — whole-document replace is destructive to everyone else's edits and the tools will not do it.
+- **Read before your edits, read after structural ones.** Human edits fire no events, so your memory of the canvas is stale by default. One fresh `canvas_read` covers all the edits you compose in the same turn; after adding or reordering sections, `canvas_read` again to confirm. Humans may also tick checkboxes — re-reading is how you notice.
+- **Batch small edits.** Each bot edit posts a (debounced, but real) "updated the canvas" notice in the conversation. Compose one edit per section per work burst, not one edit per line.
+- Rich content that works well in canvas markdown: checklists, tables, user cards `![](@U…)`, message permalinks (paste the link — it becomes a card), code blocks, and blockquotes for decisions.
+
+### Canvas comments
+
+Comments people leave on a canvas reach the room's agents as ordinary messages in a separate channel named `<room> canvas comments` — one per canvas, wired to EVERY agent in the room. If you created the canvas, you are its default responder: every comment engages you. Otherwise comments reach you as ambient context only, and you respond when @-mentioned in one. A comment that @-mentions a sibling wakes BOTH that sibling and the creator — creator: when a comment tags someone else, let them answer; stay silent unless you're needed.
+
+- Comments arrive as **threads**. The thread's ROOT message is from **USLACKBOT** and its text is the exact canvas text the person commented on (e.g. the checklist line) — that is your anchor context for what the comment is about. The human comments are the replies under it.
+- **Reply in the same thread** to answer a comment. Your reply may appear to the commenter as a native canvas comment reply — treat the thread as the comment conversation.
+- **Never reply to messages authored by USLACKBOT itself.** The anchor roots and the `<@…> was mentioned in a canvas` notices are system noise. If you are the creator, one of these can itself be the message that WOKE you — being woken by it is not a request to answer it. Read it for context (e.g. `canvas_read` on a mention notice), reply only to human messages that need one, and if nothing does, ending your turn with no message is the correct outcome.
+- When woken in a comments channel without any @-mention (creator), your prompt is the **newest human comment** in the batch.
+- After addressing feedback: update the relevant canvas section (via `canvas_update`), then reply briefly in the comment thread so the commenter knows it's done.
+
+## Mention notices and finding context
+
+- The comments channel name carries the canvas id: `<room> canvas comments (canvas F0…)`.
+- When a "<@…> was mentioned in a canvas" notice arrives (or a comment lacks enough
+  anchor context), do NOT ask the user what they mean first — call `canvas_read` with
+  that canvas id, find the mention or the referenced section yourself, then respond
+  with the context in hand. Only ask if the canvas genuinely doesn't disambiguate.

--- a/container/agent-runner/src/mcp-tools/canvas.test.ts
+++ b/container/agent-runner/src/mcp-tools/canvas.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Canvas MCP tool tests: canvas_update arg validation + system-action row
+ * shape, and canvas_read's blocking poll round trip against a host-written
+ * canvas_response row (the ncl / ask_user_question pattern).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '../db/connection.js';
+import { canvasRead, canvasUpdate } from './canvas.js';
+
+function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
+  return (
+    getOutboundDb().prepare('SELECT id, kind, content FROM messages_out ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, content: JSON.parse(r.content) }));
+}
+
+function seedCanvasResponse(requestId: string, body: Record<string, unknown>): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, content)
+       VALUES ($id, $seq, 'system', $timestamp, 'pending', $content)`,
+    )
+    .run({
+      $id: `canvas-resp-${requestId}`,
+      $seq: 2,
+      $timestamp: new Date().toISOString(),
+      $content: JSON.stringify({ type: 'canvas_response', requestId, action: 'canvas_read', ...body }),
+    });
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+describe('canvas_update — arg validation', () => {
+  it('requires canvas_id and markdown', async () => {
+    const r1 = await canvasUpdate.handler({ op: 'append', markdown: 'x' });
+    expect(r1.isError).toBe(true);
+    const r2 = await canvasUpdate.handler({ canvas_id: 'F1', op: 'append' });
+    expect(r2.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('rejects unknown ops', async () => {
+    const r = await canvasUpdate.handler({ canvas_id: 'F1', op: 'replace', markdown: 'x' });
+    expect(r.isError).toBe(true);
+    expect((r.content[0] as { text: string }).text).toContain('op must be one of');
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('rejects section ops without section_text — nothing is submitted', async () => {
+    for (const op of ['replace_section', 'insert_after_section']) {
+      const r = await canvasUpdate.handler({ canvas_id: 'F1', op, markdown: 'x' });
+      expect(r.isError).toBe(true);
+      expect((r.content[0] as { text: string }).text).toContain('section_text');
+    }
+    expect(outboundActions()).toHaveLength(0);
+  });
+});
+
+describe('canvas_update — submission', () => {
+  it('writes a canvas_edit system action and returns fire-and-forget text', async () => {
+    const r = await canvasUpdate.handler({
+      canvas_id: 'F1',
+      op: 'replace_section',
+      section_text: 'Tasks',
+      markdown: '## Tasks\n\n- [x] done',
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toBe(
+      'Edit submitted. If it fails you will be woken with a system note saying why; verify structural changes with canvas_read.',
+    );
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({
+      action: 'canvas_edit',
+      canvas_id: 'F1',
+      op: 'replace_section',
+      section_text: 'Tasks',
+      markdown: '## Tasks\n\n- [x] done',
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+
+  it('append needs no section_text', async () => {
+    const r = await canvasUpdate.handler({ canvas_id: 'F1', op: 'append', markdown: '- [ ] new' });
+    expect(r.isError).toBeUndefined();
+    const rows = outboundActions();
+    expect(rows[0].content).toMatchObject({ action: 'canvas_edit', op: 'append' });
+    expect(rows[0].content.section_text).toBeUndefined();
+  });
+});
+
+describe('canvas_read — blocking round trip', () => {
+  it('requires canvas_id', async () => {
+    const r = await canvasRead.handler({});
+    expect(r.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('submits canvas_read, polls, and returns the host-fetched text', async () => {
+    const pending = canvasRead.handler({ canvas_id: 'F1', timeout: 5 });
+
+    // Let the tool write its request row, then answer it like the host would.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toMatchObject({ action: 'canvas_read', canvas_id: 'F1' });
+    const requestId = rows[0].content.requestId as string;
+    seedCanvasResponse(requestId, { status: 'ok', result: { canvas_id: 'F1', text: '# Room\n\n- [x] done' } });
+
+    const r = await pending;
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toBe('# Room\n\n- [x] done');
+
+    // The response row is acked so the poll loop won't re-deliver it.
+    const acked = getOutboundDb()
+      .prepare('SELECT status FROM processing_ack WHERE message_id = ?')
+      .get(`canvas-resp-${requestId}`) as { status: string } | null;
+    expect(acked?.status).toBe('completed');
+  });
+
+  it('surfaces host-side errors as tool errors', async () => {
+    const pending = canvasRead.handler({ canvas_id: 'F1', timeout: 5 });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const requestId = outboundActions()[0].content.requestId as string;
+    seedCanvasResponse(requestId, { status: 'error', result: { error: 'canvas_not_found' } });
+
+    const r = await pending;
+    expect(r.isError).toBe(true);
+    expect((r.content[0] as { text: string }).text).toContain('canvas_not_found');
+  });
+
+  it('times out when no response arrives', async () => {
+    const r = await canvasRead.handler({ canvas_id: 'F1', timeout: 1 });
+    expect(r.isError).toBe(true);
+    expect((r.content[0] as { text: string }).text).toContain('timed out');
+  });
+});

--- a/container/agent-runner/src/mcp-tools/canvas.ts
+++ b/container/agent-runner/src/mcp-tools/canvas.ts
@@ -1,0 +1,178 @@
+/**
+ * Canvas MCP tools: canvas_update, canvas_read.
+ *
+ * canvas_update is fire-and-forget (self-mod.ts pattern): it writes a
+ * `canvas_edit` system action and returns immediately — the host applies the
+ * edit as this session's bot identity and the outcome arrives later as a
+ * system note (a `canvas_response` inbound row).
+ *
+ * canvas_read is blocking (ncl / ask_user_question pattern): it writes a
+ * `canvas_read` system action, then polls inbound.db by requestId for the
+ * host's response row and returns the canvas text inline.
+ */
+import { openInboundDb, getOutboundDb } from '../db/connection.js';
+import { markCompleted, type MessageInRow } from '../db/messages-in.js';
+import { writeMessageOut } from '../db/messages-out.js';
+import { registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `canvas-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const EDIT_OPS = ['append', 'replace_section', 'insert_after_section'] as const;
+type EditOp = (typeof EDIT_OPS)[number];
+
+/**
+ * Find the host's canvas_response row for a requestId (findQuestionResponse
+ * pattern — pending inbound row, not yet acked in processing_ack).
+ */
+function findCanvasResponse(requestId: string): MessageInRow | undefined {
+  const inbound = openInboundDb();
+  const outbound = getOutboundDb();
+  try {
+    const response = inbound
+      .prepare("SELECT * FROM messages_in WHERE status = 'pending' AND content LIKE ?")
+      .get(`%"requestId":"${requestId}"%`) as MessageInRow | undefined;
+    if (!response) return undefined;
+    const acked = outbound.prepare('SELECT 1 FROM processing_ack WHERE message_id = ?').get(response.id);
+    if (acked) return undefined;
+    return response;
+  } finally {
+    inbound.close();
+  }
+}
+
+export const canvasUpdate: McpToolDefinition = {
+  tool: {
+    name: 'canvas_update',
+    description:
+      "Edit a Slack canvas by id — append markdown at the end, replace one named section, or insert new content after a section. Section targeting uses section_text: for section-wide edits the target section's EXACT heading text (from a fresh canvas_read); for a single checklist item, the item's exact text (that deliberately targets just the item — how you mark items done, since checkbox tick state is UI-only and cannot be set via the API). Fire-and-forget: the host applies the edit as your bot identity; a failure wakes you with a system note explaining why, a success note rides along silently on your next wake. Whole-document replace is not possible — edits are always section-scoped. Discipline (canvas-work skill): canvas_read first; replace_section for updating existing content; insert_after_section for new sections or new checklist items; never a heading the canvas already has.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        canvas_id: {
+          type: 'string',
+          description:
+            "Canvas id (F…) — for a room canvas, it is in your destinations list ('<room> canvas comments (canvas F…)')",
+        },
+        op: {
+          type: 'string',
+          enum: [...EDIT_OPS],
+          description: 'append (at document end), replace_section, or insert_after_section',
+        },
+        markdown: { type: 'string', description: 'Markdown content for the edit' },
+        section_text: {
+          type: 'string',
+          description:
+            "Required for replace_section / insert_after_section: the target section's exact heading text",
+        },
+      },
+      required: ['canvas_id', 'op', 'markdown'],
+    },
+  },
+  async handler(args) {
+    const canvasId = args.canvas_id as string;
+    const op = args.op as EditOp;
+    const markdown = args.markdown as string;
+    const sectionText = (args.section_text as string) || '';
+
+    if (!canvasId || !markdown) return err('canvas_id and markdown are required');
+    if (!EDIT_OPS.includes(op)) return err(`op must be one of: ${EDIT_OPS.join(', ')}`);
+    if (op !== 'append' && !sectionText) {
+      return err(`section_text is required for ${op} — the target section's exact heading text`);
+    }
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'canvas_edit',
+        requestId,
+        canvas_id: canvasId,
+        op,
+        section_text: sectionText || undefined,
+        markdown,
+      }),
+    });
+
+    log(`canvas_update: ${requestId} → ${op} on ${canvasId}`);
+    return ok(
+      'Edit submitted. If it fails you will be woken with a system note saying why; verify structural changes with canvas_read.',
+    );
+  },
+};
+
+export const canvasRead: McpToolDefinition = {
+  tool: {
+    name: 'canvas_read',
+    description:
+      'Read a Slack canvas as text (blocking, default 20s; timeout is in SECONDS). A timeout error can fire while the host read still succeeds — on timeout, retry once with a larger timeout. Output over ~8000 chars is truncated with an explicit marker: never conclude a section is absent from a truncated read. Read-before-write is mandatory (canvas-work skill): call this before EVERY edit — human edits produce no events, so your last view is stale by default.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        canvas_id: { type: 'string', description: 'Canvas id (F…) to read' },
+        timeout: { type: 'number', description: 'Timeout in seconds (default: 20)' },
+      },
+      required: ['canvas_id'],
+    },
+  },
+  async handler(args) {
+    const canvasId = args.canvas_id as string;
+    if (!canvasId) return err('canvas_id is required');
+    const timeout = ((args.timeout as number) || 20) * 1000;
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'canvas_read',
+        requestId,
+        canvas_id: canvasId,
+      }),
+    });
+
+    log(`canvas_read: ${requestId} → ${canvasId}`);
+
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const response = findCanvasResponse(requestId);
+      if (response) {
+        markCompleted([response.id]);
+        const parsed = JSON.parse(response.content) as {
+          status?: string;
+          result?: { text?: string; error?: string };
+        };
+        if (parsed.status === 'ok' && typeof parsed.result?.text === 'string') {
+          log(`canvas_read response: ${requestId} (${parsed.result.text.length} chars)`);
+          return ok(parsed.result.text);
+        }
+        return err(parsed.result?.error || 'canvas read failed');
+      }
+      await sleep(500);
+    }
+
+    log(`canvas_read timeout: ${requestId}`);
+    return err(`Canvas read timed out after ${timeout / 1000}s`);
+  },
+};
+
+registerTools([canvasUpdate, canvasRead]);

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -9,6 +9,9 @@ import './core.js';
 import './interactive.js';
 import './agents.js';
 import './self-mod.js';
+// slack canvas tools (canvas_update / canvas_read). On user installs this
+// import is appended by /add-slack; kept live here — the fully-loaded branch.
+import './canvas.js';
 import { startMcpServer } from './server.js';
 
 function log(msg: string): void {

--- a/container/skills/canvas-work/SKILL.md
+++ b/container/skills/canvas-work/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: canvas-work
+description: >-
+  Edit Slack canvases without corrupting them — read-before-write, section
+  targeting by heading, replace vs insert discipline. Use EVERY time you
+  edit a canvas with canvas_update (room canvases, task lists, deliverable
+  docs), not just the first time.
+---
+
+# Canvas Work
+
+Canvases are shared documents. Human edits fire no events, so your last view
+is stale by default. Every edit is section-scoped; the wrong op duplicates
+content instead of updating it.
+
+## When to use a canvas
+
+- **Large outputs go in the canvas, not chat.** Any prose or code deliverable
+  longer than ~a dozen lines — a plan, report, spec, analysis, draft, long
+  diff — goes into the canvas (the right existing section, or a new one) and
+  the chat message shrinks to a 1-3 line summary plus a pointer ("Full plan
+  in the canvas under Rollout"). Chat is for coordination; canvas is for
+  content. Binary artifacts (charts, PDFs, images) still go via `send_file`.
+- **Placement for a new deliverable**: a genuinely new section, not stuffed
+  into Notes — `insert_after_section` after the most related section, or
+  `append` when it belongs at the document end.
+- **Collaborative state lives there**: task lists, decisions, running notes
+  that humans and agents co-edit.
+- In a DM with no canvas, a long deliverable may stay a chat message — but
+  where a canvas exists, prefer it (there is no canvas-create tool; "new
+  structure" means a new section on an existing canvas).
+
+## The loop
+
+1. **Read first.** `canvas_read` before editing — never edit from memory or
+   a previous turn's read. One fresh read covers all the edits you compose
+   in the same turn. Read-backs truncate at ~8000 chars with an explicit
+   `…[truncated at N chars]` marker: if you see it, the canvas continues
+   below what you read — never conclude a section is absent from a
+   truncated read (heading-anchored edits still resolve against the full
+   canvas host-side, so editing below the cut is safe).
+2. **Locate the target** in the read-back. For section-wide edits,
+   `section_text` is the exact heading text — a body-text anchor silently
+   degrades a section rewrite into a single-block edit that corrupts the
+   section. For checklist items, a body-text anchor (the item's exact
+   text) is the CORRECT, deliberate way to target that one item (see
+   Checklists).
+3. **Pick the op:**
+   - `replace_section` — the content EXISTS and you are changing it (ticking
+     a box, updating status, rewriting a paragraph). Updates always use this.
+   - `insert_after_section` — a genuinely NEW section, one whose heading
+     appears nowhere in the canvas, placed after a specific section.
+   - `append` — content for the document END: log entries, list additions,
+     or a new final section (markdown starting with its new heading).
+4. **Never create a heading that already exists** — anywhere in your
+   markdown, not just the first line. A best-effort host guard refuses
+   obvious duplicate-heading inserts (the refusal wakes you with a note),
+   but it is narrow — the rule is yours to enforce, the guard is not a
+   backstop. Note: appending log entries whose markdown repeats the log
+   section's heading is the classic way to trip it — append entry lines
+   only, no heading.
+5. **Batch small edits**: one `canvas_update` per section with the complete
+   new section markdown, not a burst of tiny ops.
+6. **Verify structural changes.** A FAILED edit wakes you with a system
+   note saying why — fix from a fresh read. A success note only rides along
+   on your next wake, so after adding, reordering, or rewriting sections,
+   `canvas_read` and confirm the result before reporting done. Never report
+   a structural edit as landed that you haven't re-read.
+
+## Checklists: item-level ops only
+
+Tick state is **UI-only** — a hard platform limit, live-probed: `- [x]` in
+edit markdown is silently ignored (items always land unticked), and any
+section rewrite RESETS every ticked box (the host warns you when that
+happens). So on checklists:
+
+- **Add an item**: `insert_after_section` on the section heading, markdown
+  = just the new `- [ ] item` line. Existing items and their ticks stay
+  intact. Never re-send the whole list to add one item.
+- **Mark an item done**: you cannot tick its box. Edit the ITEM itself —
+  `section_text` = the item's exact text (a non-heading match targets that
+  single item), op `replace_section`, markdown like
+  `- ✅ deploy the site (done)`. Humans tick boxes; agents mark done in
+  the item text.
+- **Remove or reword an item**: same item-level targeting.
+- **Rewrite the whole section only when resetting it is the point** (e.g.
+  replacing placeholder content) — every ticked box comes back unticked.
+
+### Worked example: mark a task done
+
+User: "mark the deploy task done."
+
+1. `canvas_read` → Tasks contains `- [ ] deploy the site` and
+   `- [ ] write the announcement`.
+2. Item-level edit — target the item, not the section:
+
+   ```
+   canvas_update  op=replace_section  section_text="deploy the site"  markdown:
+   - ✅ deploy the site (done)
+   ```
+
+   A full-section rewrite here would land, but with every checkbox reset
+   and no way to express the tick.
+
+For NON-list sections, `replace_section` on the heading swaps the whole
+section region — send the complete section markdown, heading included.
+Lines you omit are deleted.
+
+## Section model
+
+- A section region is a heading plus every block down to the NEXT heading
+  (canvases have three heading levels; any of them ends the region).
+  Sub-headings end the region: `replace_section` on `## Tasks`
+  when it contains `### Sprint 1` replaces only the blocks above the `###`
+  and leaves every subsection in place — resending subsection markdown
+  duplicates it below the new content. Edit the parent's intro and each
+  subsection as separate ops.
+- **Always include the heading line** in `replace_section` markdown. The
+  heading block itself gets replaced: omit it and the section visually
+  merges into the one above and can never be heading-targeted again.
+- These region semantics apply only when `section_text` matches a heading.
+  A body-text match targets ONE block — deliberate and correct for
+  checklist items, silently corrupting for section rewrites. Know which
+  edit you are making.
+- `insert_after_section` inserts after the region's last block, not directly
+  after the heading.
+
+## Pitfalls
+
+- Heading matching: case-insensitive, trimmed; exact match beats contains;
+  contains ties go to the FIRST matching heading in document order (`Task`
+  hits `Tasks` before `Task archive`). Use the full exact heading.
+- Section ids are ephemeral; the host re-resolves them on every edit.
+  Heading text from a fresh read is the only reliable addressing.
+- `canvas_update` is fire-and-forget: failures wake you with a system note
+  (fix from a fresh read); success notes arrive silently on your next wake.
+  For anything structural, `canvas_read` is the confirmation.
+- **Partial replace**: if a read-back (or a failure note) shows your new
+  content in place with old blocks of the same section still sitting below
+  it, re-issue the SAME `replace_section` on the same heading — the
+  leftovers are now that region's body, so the identical retry is the
+  idempotent fix. If the retry leaves the SAME leftovers again, those
+  blocks are unaddressable host-side — stop retrying and tell the human
+  (they can delete them in the canvas UI). For anything else that looks
+  wrong, re-read and compose a fresh edit.
+- `canvas_read`'s `timeout` is in seconds (default 20). A timeout error can
+  fire even though the host read succeeded — retry, optionally with a
+  larger timeout.

--- a/src/channels/slack-lib.test.ts
+++ b/src/channels/slack-lib.test.ts
@@ -1,0 +1,255 @@
+/**
+ * slack-lib — request/error shaping of the shared fetch-based Web API client
+ * and the per-instance bot-token env-key convention.
+ *
+ * Pinned invariants: Slack's error strings surface in thrown messages; token
+ * values never do (Authorization header is the only place a token travels).
+ * All fetches are mocked — no live Slack calls.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  botTokenKeyForInstance,
+  SlackApiError,
+  slackAuthTest,
+  slackCall,
+  slackConversationsInfo,
+  slackConversationsMembers,
+  slackConversationsOpen,
+  slackPostMessage,
+} from './slack-lib.js';
+
+const TOKEN = 'xoxb-secret-test-token-value';
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function mockFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
+  const fn = vi.fn(impl as (...args: unknown[]) => Promise<Response>);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+async function captureError(promise: Promise<unknown>): Promise<SlackApiError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(SlackApiError);
+    return err as SlackApiError;
+  }
+  throw new Error('expected the call to throw');
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('slackCall request shaping', () => {
+  it('POSTs the method to slack.com/api with a JSON body, bearer token, and a timeout signal', async () => {
+    const fetchMock = mockFetch(async () => jsonResponse({ ok: true, stuff: 1 }));
+
+    const json = await slackCall(TOKEN, 'chat.postMessage', { channel: 'C1', text: 'hi' }, 'my-step');
+
+    expect(json).toMatchObject({ ok: true, stuff: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+    expect((init.headers as Record<string, string>)['Content-Type']).toContain('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({ channel: 'C1', text: 'hi' });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('slackCall error shaping', () => {
+  it("surfaces Slack's error string with the method and step — never the token", async () => {
+    mockFetch(async () => jsonResponse({ ok: false, error: 'channel_not_found' }));
+
+    const err = await captureError(slackCall(TOKEN, 'conversations.info', { channel: 'C9' }, 'room-lookup'));
+
+    expect(err.name).toBe('SlackApiError');
+    expect(err.step).toBe('room-lookup');
+    expect(err.message).toBe('slack conversations.info failed: channel_not_found');
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it('falls back to the HTTP status when ok:false carries no error string', async () => {
+    mockFetch(async () => jsonResponse({ ok: false }, 429));
+
+    const err = await captureError(slackCall(TOKEN, 'auth.test', {}, 's'));
+
+    expect(err.message).toBe('slack auth.test failed: HTTP 429');
+  });
+
+  it('wraps fetch-level failures (network error / timeout abort) without leaking the token', async () => {
+    mockFetch(async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    });
+
+    const err = await captureError(slackCall(TOKEN, 'auth.test', {}, 'origin-auth'));
+
+    expect(err.step).toBe('origin-auth');
+    expect(err.message).toBe('slack auth.test failed: The operation was aborted due to timeout');
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it('reports non-JSON bodies as HTTP <status>, non-JSON body', async () => {
+    mockFetch(async () => new Response('<html>bad gateway</html>', { status: 502 }));
+
+    const err = await captureError(slackCall(TOKEN, 'chat.postMessage', { channel: 'C1' }, 's'));
+
+    expect(err.message).toBe('slack chat.postMessage failed: HTTP 502, non-JSON body');
+  });
+});
+
+describe('slackAuthTest', () => {
+  it('maps user_id/team_id/team/url from the response', async () => {
+    mockFetch(async () =>
+      jsonResponse({ ok: true, user_id: 'U123', team_id: 'T456', team: 'acme', url: 'https://acme.slack.com/' }),
+    );
+
+    await expect(slackAuthTest(TOKEN, 's')).resolves.toEqual({
+      userId: 'U123',
+      teamId: 'T456',
+      team: 'acme',
+      url: 'https://acme.slack.com/',
+    });
+  });
+
+  it('throws when the response has no user_id', async () => {
+    mockFetch(async () => jsonResponse({ ok: true }));
+
+    const err = await captureError(slackAuthTest(TOKEN, 'origin-auth'));
+
+    expect(err.step).toBe('origin-auth');
+    expect(err.message).toBe('slack auth.test failed: no user_id in response');
+  });
+});
+
+describe('slackConversationsOpen', () => {
+  it('joins user ids with commas and returns the channel id', async () => {
+    const fetchMock = mockFetch(async () => jsonResponse({ ok: true, channel: { id: 'D777' } }));
+
+    await expect(slackConversationsOpen(TOKEN, ['U1', 'U2', 'U3'], 's')).resolves.toBe('D777');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ users: 'U1,U2,U3' });
+  });
+
+  it('throws when the response has no channel id', async () => {
+    mockFetch(async () => jsonResponse({ ok: true, channel: {} }));
+
+    const err = await captureError(slackConversationsOpen(TOKEN, ['U1'], 'dm-open'));
+
+    expect(err.step).toBe('dm-open');
+    expect(err.message).toBe('slack conversations.open failed: no channel id in response');
+  });
+});
+
+describe('slackPostMessage', () => {
+  it('posts channel and text', async () => {
+    const fetchMock = mockFetch(async () => jsonResponse({ ok: true }));
+
+    await slackPostMessage(TOKEN, 'C1', 'hello there');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    expect(JSON.parse(init.body as string)).toEqual({ channel: 'C1', text: 'hello there' });
+  });
+
+  it('tags failures with the generic default step unless the caller passes one', async () => {
+    mockFetch(async () => jsonResponse({ ok: false, error: 'not_in_channel' }));
+
+    const defaulted = await captureError(slackPostMessage(TOKEN, 'C1', 'x'));
+    expect(defaulted.step).toBe('post-message');
+
+    mockFetch(async () => jsonResponse({ ok: false, error: 'not_in_channel' }));
+    const explicit = await captureError(slackPostMessage(TOKEN, 'C1', 'x', 'welcome-post'));
+    expect(explicit.step).toBe('welcome-post');
+  });
+});
+
+describe('slackConversationsInfo', () => {
+  it('classifies MPIMs and passes name/creator through', async () => {
+    mockFetch(async () =>
+      jsonResponse({ ok: true, channel: { is_mpim: true, name: 'mpdm-a--b--c-1', creator: 'U1' } }),
+    );
+
+    await expect(slackConversationsInfo(TOKEN, 'G123', 's')).resolves.toEqual({
+      isMpim: true,
+      name: 'mpdm-a--b--c-1',
+      creator: 'U1',
+    });
+  });
+
+  it('defaults isMpim to false and omits absent fields', async () => {
+    mockFetch(async () => jsonResponse({ ok: true, channel: {} }));
+
+    await expect(slackConversationsInfo(TOKEN, 'C123', 's')).resolves.toEqual({
+      isMpim: false,
+      name: undefined,
+      creator: undefined,
+    });
+  });
+});
+
+describe('slackConversationsMembers', () => {
+  it('follows next_cursor pagination and concatenates string member ids', async () => {
+    const pages = [
+      jsonResponse({ ok: true, members: ['U1', 'U2', 42], response_metadata: { next_cursor: 'cur2' } }),
+      jsonResponse({ ok: true, members: ['U3'], response_metadata: { next_cursor: '' } }),
+    ];
+    const fetchMock = mockFetch(async () => {
+      const page = pages.shift();
+      if (!page) throw new Error('unexpected extra page fetch');
+      return page;
+    });
+
+    await expect(slackConversationsMembers(TOKEN, 'G1', 's')).resolves.toEqual(['U1', 'U2', 'U3']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const secondBody = JSON.parse((fetchMock.mock.calls[1] as [string, RequestInit])[1].body as string);
+    expect(firstBody).toEqual({ channel: 'G1', limit: 200 });
+    expect(secondBody).toEqual({ channel: 'G1', limit: 200, cursor: 'cur2' });
+  });
+
+  it('stops at the page cap even if Slack keeps returning cursors', async () => {
+    const fetchMock = mockFetch(async () =>
+      jsonResponse({ ok: true, members: ['U1'], response_metadata: { next_cursor: 'again' } }),
+    );
+
+    const members = await slackConversationsMembers(TOKEN, 'G1', 's');
+
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+    expect(members).toHaveLength(10);
+  });
+});
+
+describe('botTokenKeyForInstance', () => {
+  it('maps the default instance to SLACK_BOT_TOKEN', () => {
+    expect(botTokenKeyForInstance('slack')).toBe('SLACK_BOT_TOKEN');
+  });
+
+  it('strips a leading slack- prefix and uppercases the remainder', () => {
+    expect(botTokenKeyForInstance('slack-zulu')).toBe('SLACK_BOT_TOKEN_ZULU');
+  });
+
+  it('normalizes dashes to underscores', () => {
+    expect(botTokenKeyForInstance('slack-growth-bot')).toBe('SLACK_BOT_TOKEN_GROWTH_BOT');
+  });
+
+  it('normalizes case', () => {
+    expect(botTokenKeyForInstance('slack-Zulu')).toBe('SLACK_BOT_TOKEN_ZULU');
+  });
+
+  it('handles keys without the slack- prefix', () => {
+    expect(botTokenKeyForInstance('ops-bot')).toBe('SLACK_BOT_TOKEN_OPS_BOT');
+  });
+
+  it('strips only the leading slack- prefix, not interior occurrences', () => {
+    expect(botTokenKeyForInstance('slack-slack-two')).toBe('SLACK_BOT_TOKEN_SLACK_TWO');
+  });
+});

--- a/src/channels/slack-lib.ts
+++ b/src/channels/slack-lib.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared Slack channel-layer library — the minimal fetch-based Slack Web API
+ * client plus the per-instance bot-token .env key convention. Channel-layer
+ * modules import Slack HTTP plumbing from here so it has exactly one home
+ * (and so nothing in the channel layer reaches into feature modules for it).
+ *
+ * Failures become SlackApiError(step, `slack ${method} failed: ${error}`),
+ * where `step` is a caller-supplied context tag naming where in the caller's
+ * flow the call happened — callers with typed step ids pass them through
+ * (any string union narrows to string).
+ *
+ * Slack's error strings are safe to surface; token values never are — tokens
+ * travel only in the Authorization header and are never interpolated into
+ * messages or logs.
+ */
+
+const SLACK_API = 'https://slack.com/api';
+
+/**
+ * Typed failure for Slack Web API calls. `step` is the caller's context tag
+ * for the call site. `message` MUST never contain a token value.
+ */
+export class SlackApiError extends Error {
+  constructor(
+    readonly step: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SlackApiError';
+  }
+}
+
+/**
+ * POST one Web API method with a JSON body. Returns the parsed response when
+ * `ok: true`; throws SlackApiError otherwise (network failure, timeout,
+ * non-JSON body, or a Slack-side error string).
+ */
+export async function slackCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+  step: string,
+): Promise<Record<string, unknown>> {
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API}/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new SlackApiError(step, `slack ${method} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  let json: Record<string, unknown>;
+  try {
+    json = (await res.json()) as Record<string, unknown>;
+  } catch {
+    throw new SlackApiError(step, `slack ${method} failed: HTTP ${res.status}, non-JSON body`);
+  }
+  if (json.ok !== true) {
+    throw new SlackApiError(step, `slack ${method} failed: ${String(json.error ?? `HTTP ${res.status}`)}`);
+  }
+  return json;
+}
+
+/** auth.test — the calling bot's own identity. `url` is the workspace URL
+ *  (`https://<domain>.slack.com/`) — canvas permalinks hang off it. */
+export async function slackAuthTest(
+  token: string,
+  step: string,
+): Promise<{ userId: string; teamId?: string; team?: string; url?: string }> {
+  const json = await slackCall(token, 'auth.test', {}, step);
+  const userId = typeof json.user_id === 'string' ? json.user_id : null;
+  if (!userId) throw new SlackApiError(step, 'slack auth.test failed: no user_id in response');
+  return {
+    userId,
+    teamId: typeof json.team_id === 'string' ? json.team_id : undefined,
+    team: typeof json.team === 'string' ? json.team : undefined,
+    url: typeof json.url === 'string' ? json.url : undefined,
+  };
+}
+
+/**
+ * conversations.open — one user id opens (or fetches) the 1:1 IM; two or
+ * more open an MPIM. Idempotent on Slack's side. Returns the channel id.
+ */
+export async function slackConversationsOpen(token: string, userIds: string[], step: string): Promise<string> {
+  const json = await slackCall(token, 'conversations.open', { users: userIds.join(',') }, step);
+  const channel = json.channel as Record<string, unknown> | undefined;
+  const channelId = typeof channel?.id === 'string' ? channel.id : null;
+  if (!channelId) throw new SlackApiError(step, 'slack conversations.open failed: no channel id in response');
+  return channelId;
+}
+
+/** chat.postMessage — plain-text post into a channel, DM, or MPIM. */
+export async function slackPostMessage(
+  token: string,
+  channel: string,
+  text: string,
+  step = 'post-message',
+): Promise<void> {
+  await slackCall(token, 'chat.postMessage', { channel, text }, step);
+}
+
+/**
+ * conversations.info — minimal channel classification: is this an MPIM
+ * (group DM), and what is it called?
+ */
+export async function slackConversationsInfo(
+  token: string,
+  channelId: string,
+  step: string,
+): Promise<{ isMpim: boolean; name?: string; creator?: string }> {
+  const json = await slackCall(token, 'conversations.info', { channel: channelId }, step);
+  const channel = json.channel as Record<string, unknown> | undefined;
+  return {
+    isMpim: channel?.is_mpim === true,
+    name: typeof channel?.name === 'string' ? channel.name : undefined,
+    creator: typeof channel?.creator === 'string' ? channel.creator : undefined,
+  };
+}
+
+/**
+ * conversations.members — the channel's full member set (user ids, bots
+ * included). Cursor-paginated; the page cap bounds pathological channels —
+ * membership comparisons only run over small rooms (MPIMs are ≤9 members).
+ */
+export async function slackConversationsMembers(token: string, channelId: string, step: string): Promise<string[]> {
+  const members: string[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < 10; page++) {
+    const json = await slackCall(
+      token,
+      'conversations.members',
+      { channel: channelId, limit: 200, ...(cursor ? { cursor } : {}) },
+      step,
+    );
+    for (const m of (json.members as unknown[] | undefined) ?? []) {
+      if (typeof m === 'string') members.push(m);
+    }
+    const meta = json.response_metadata as { next_cursor?: string } | undefined;
+    cursor = meta?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+  return members;
+}
+
+/** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix shape. */
+function envSuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * .env bot-token key for an adapter-instance key. The default instance
+ * ('slack') maps to SLACK_BOT_TOKEN; any other instance key maps to
+ * SLACK_BOT_TOKEN_<NAME> with a leading 'slack-' prefix stripped and the
+ * remainder uppercased with dashes as underscores (the same suffix shape
+ * multi-instance registration writes). Returns the key name only — reading
+ * the value stays with the caller.
+ */
+export function botTokenKeyForInstance(instanceKey: string): string {
+  if (instanceKey === 'slack') return 'SLACK_BOT_TOKEN';
+  return `SLACK_BOT_TOKEN_${envSuffix(instanceKey.replace(/^slack-/, ''))}`;
+}

--- a/src/env-file.test.ts
+++ b/src/env-file.test.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+
+describe('env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-file-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'ENVF_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'ENVF_PLAIN=value1',
+          '  ENVF_INDENTED = spaced ',
+          'ENVF_DQUOTED="double quoted"',
+          "ENVF_SQUOTED='single quoted'",
+          'ENVF_EMPTY=',
+          '# ENVF_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'ENVF_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'ENVF_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'ENVF_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'ENVF_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'ENVF_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'ENVF_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('ENVF_PREFERS=file-value\n');
+      vi.stubEnv('ENVF_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'ENVF_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('ENVF_BLANK_ENV=file-value\n');
+      vi.stubEnv('ENVF_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'ENVF_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('ENVF_DUP=first\nENVF_DUP=second\n');
+      expect(readEnvValue(rootDir, 'ENVF_DUP')).toBe('second');
+    });
+  });
+
+  describe('upsertEnvKey', () => {
+    it('creates .env when absent', () => {
+      upsertEnvKey(rootDir, 'ENVF_NEW', 'v1');
+      expect(read()).toBe('ENVF_NEW=v1\n');
+      expect(readEnvValue(rootDir, 'ENVF_NEW')).toBe('v1');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      upsertEnvKey(rootDir, 'ENVF_APPENDED', 'v2');
+      expect(read()).toBe('EXISTING=x\nENVF_APPENDED=v2\n');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nENVF_TARGET=old\nLAST=9\n');
+      upsertEnvKey(rootDir, 'ENVF_TARGET', 'new');
+      expect(read()).toBe('# keep me\nFIRST=1\nENVF_TARGET=new\nLAST=9\n');
+    });
+
+    it('does not touch keys that merely share a prefix', () => {
+      write('ENVF_KEY=keep\nENVF_KEY_LONGER=keep-too\n');
+      upsertEnvKey(rootDir, 'ENVF_KEY', 'changed');
+      expect(read()).toBe('ENVF_KEY=changed\nENVF_KEY_LONGER=keep-too\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('ENVF_DUP=first\nENVF_DUP=second\n');
+      upsertEnvKey(rootDir, 'ENVF_DUP', 'final');
+      expect(read()).toBe('ENVF_DUP=final\nENVF_DUP=final\n');
+      expect(readEnvValue(rootDir, 'ENVF_DUP')).toBe('final');
+    });
+
+    it('replaces an indented assignment (readable lines are writable lines)', () => {
+      write('  ENVF_INDENTED=old\n');
+      upsertEnvKey(rootDir, 'ENVF_INDENTED', 'new');
+      expect(readEnvValue(rootDir, 'ENVF_INDENTED')).toBe('new');
+      expect(read()).not.toContain('old');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates the key and reports the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'alpha')).toBe(true);
+      expect(readEnvValue(rootDir, 'ENVF_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('ENVF_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'ENVF_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('ENVF_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys parse .env only, so the union must be based on
+      // the file, not a stale process.env copy.
+      write('ENVF_LIST=alpha\n');
+      vi.stubEnv('ENVF_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('ENVF_LIST=alpha,beta');
+    });
+  });
+});

--- a/src/env-file.ts
+++ b/src/env-file.ts
@@ -1,0 +1,93 @@
+/**
+ * .env read/write helpers shared by host code that manages .env keys.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — everything written here is read back through
+ * that parser. Write conventions for module and skill code that manages .env
+ * keys: replace the key's line in place, preserve every other line (comments
+ * and blanks included), append with a clean trailing newline.
+ *
+ * Values written here include live credentials: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value.
+ */
+export function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/src/modules/canvas-actions/canvas-actions.test.ts
+++ b/src/modules/canvas-actions/canvas-actions.test.ts
@@ -1,0 +1,770 @@
+/**
+ * Canvas-actions tests: the safe op mapping (mocked fetch — lookup+edit
+ * sequences, whole-doc replace unconstructible), token resolution, response
+ * rows into inbound.db, and the HTML→text read-back.
+ */
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { INBOUND_SCHEMA } from '../../db/schema.js';
+import type { MessagingGroup, Session } from '../../types.js';
+import { editCanvas, htmlToReadableText, parseCanvasBlocks, resolveHeadingRegion } from './canvas-api.js';
+import { handleCanvasEdit, handleCanvasRead, resolveSessionBotToken } from './handlers.js';
+
+const NOW = new Date().toISOString();
+const MG_ID = 'mg-canvas';
+
+function makeSession(messagingGroupId: string | null = MG_ID): Session {
+  return {
+    id: 'sess-canvas',
+    agent_group_id: 'ag-canvas',
+    messaging_group_id: messagingGroupId,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: NOW,
+  };
+}
+
+function makeMg(overrides: Partial<MessagingGroup> = {}): MessagingGroup {
+  return {
+    id: MG_ID,
+    channel_type: 'slack',
+    platform_id: 'slack:C0ROOM',
+    instance: 'slack-pixel',
+    name: 'Pixel room',
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    denied_at: null,
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+function responseRows(
+  inDb: Database.Database,
+): Array<{ id: string; kind: string; trigger: number; content: Record<string, unknown> }> {
+  return (
+    inDb.prepare('SELECT id, kind, "trigger", content FROM messages_in ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      trigger: number;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, trigger: r.trigger, content: JSON.parse(r.content) }));
+}
+
+/** The chat-note text of an edit-outcome row (canvas_edit notes are kind='chat'). */
+function editNoteText(row: { kind: string; content: Record<string, unknown> }): string {
+  expect(row.kind).toBe('chat');
+  return row.content.text as string;
+}
+
+function slackJson(body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+const fetchMock = vi.fn();
+let inDb: Database.Database;
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  createMessagingGroup(makeMg());
+  inDb = new Database(':memory:');
+  inDb.exec(INBOUND_SCHEMA);
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  process.env.SLACK_BOT_TOKEN_PIXEL = 'xoxb-pixel-token';
+});
+
+afterEach(() => {
+  delete process.env.SLACK_BOT_TOKEN_PIXEL;
+  vi.unstubAllGlobals();
+  inDb.close();
+  closeDb();
+});
+
+describe('resolveSessionBotToken', () => {
+  it('maps the mg instance to its .env token key', () => {
+    expect(resolveSessionBotToken(makeSession())).toEqual({ token: 'xoxb-pixel-token' });
+  });
+
+  it('errors (naming the key, not any value) when the token is absent', () => {
+    delete process.env.SLACK_BOT_TOKEN_PIXEL;
+    const result = resolveSessionBotToken(makeSession());
+    expect(result).toHaveProperty('error');
+    expect((result as { error: string }).error).toContain('SLACK_BOT_TOKEN_PIXEL');
+  });
+
+  it('rejects sessions with no messaging group and non-Slack channels', () => {
+    expect(resolveSessionBotToken(makeSession(null))).toHaveProperty('error');
+    createMessagingGroup(makeMg({ id: 'mg-tg', channel_type: 'telegram', platform_id: 'tg:1', instance: 'telegram' }));
+    expect(resolveSessionBotToken({ ...makeSession(), messaging_group_id: 'mg-tg' })).toHaveProperty('error');
+  });
+});
+
+describe('handleCanvasEdit', () => {
+  it('append maps to a single insert_at_end canvases.edit (no lookup)', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-1', canvas_id: 'F0C', op: 'append', markdown: '- [ ] new task' },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/canvases.edit');
+    const body = JSON.parse(init.body as string);
+    expect(body.canvas_id).toBe('F0C');
+    expect(body.changes).toEqual([
+      { operation: 'insert_at_end', document_content: { type: 'markdown', markdown: '- [ ] new task' } },
+    ]);
+
+    const rows = responseRows(inDb);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('canvas-resp-req-1');
+    expect(rows[0].trigger).toBe(0);
+    expect(editNoteText(rows[0])).toContain('Canvas edit applied');
+  });
+
+  it('replace_section falls back to sections.lookup when the HTML read-back fails', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('offline')) // files.info → no read-back
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [{ id: 'temp:C:SEC1' }] }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-2',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [lookupUrl, lookupInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(lookupUrl).toBe('https://slack.com/api/canvases.sections.lookup');
+    expect(JSON.parse(lookupInit.body as string)).toEqual({
+      canvas_id: 'F0C',
+      criteria: { contains_text: 'Tasks' },
+    });
+    const [, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const editBody = JSON.parse(editInit.body as string);
+    expect(editBody.changes).toEqual([
+      {
+        operation: 'replace',
+        section_id: 'temp:C:SEC1',
+        document_content: { type: 'markdown', markdown: '## Tasks\n\n- [x] done' },
+      },
+    ]);
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+  });
+
+  it('insert_after_section falls back to insert_after with the looked-up id when the read-back fails', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [{ id: 'temp:C:SEC9' }] }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-3',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Decisions',
+        markdown: '> We ship MPIM rooms.',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    const [, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(JSON.parse(editInit.body as string).changes[0]).toMatchObject({
+      operation: 'insert_after',
+      section_id: 'temp:C:SEC9',
+    });
+  });
+
+  it('replace_section WITHOUT section_text fails before any Slack call — whole-doc replace is impossible', async () => {
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-4', canvas_id: 'F0C', op: 'replace_section', markdown: 'boom' },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(1);
+    const note4 = editNoteText(rows[0]);
+    expect(note4).toContain('Canvas edit FAILED');
+    expect(note4).toContain('section_text');
+  });
+
+  it('a lookup with no match errors without ever calling canvases.edit', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('offline')) // files.info → no read-back
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [] }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-5',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Nonexistent',
+        markdown: 'x',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // failed files.info + lookup only
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(1);
+    expect(editNoteText(rows[0])).toContain('Nonexistent');
+  });
+
+  it('a Slack API error becomes a trigger=1 error row', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: false, error: 'canvas_not_found' }));
+
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-6', canvas_id: 'F0C', op: 'append', markdown: 'x' },
+      makeSession(),
+      inDb,
+    );
+
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(1);
+    expect(editNoteText(rows[0])).toContain('canvas_not_found');
+  });
+
+  it('editCanvas refuses a sectioned op with an empty section id (belt and braces)', async () => {
+    await expect(editCanvas('xoxb-t', 'F0C', { operation: 'replace', sectionId: '', markdown: 'x' })).rejects.toThrow(
+      /without a resolved section_id/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('duplicate-heading guard (B4)', () => {
+  /** files.info + HTML download pair for a canvas whose read-back has the given body. */
+  function mockReadBack(html: string): void {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(new Response(html, { status: 200 }));
+  }
+
+  it('insert_after_section with a duplicate first heading is refused before any lookup/edit', async () => {
+    mockReadBack('<h1 id="temp:C:A">Room</h1><h2 id="temp:C:B">Tasks</h2><p>- [ ] x</p>');
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g1',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Room',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // files.info + download only — no lookup, no edit
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(1);
+    const guardNote = editNoteText(rows[0]);
+    expect(guardNote).toContain('Canvas edit FAILED');
+    expect(guardNote).toContain('replace_section');
+    expect(guardNote).toContain('Tasks');
+  });
+
+  it('matches case-insensitively and trimmed', async () => {
+    mockReadBack('<h2 id="temp:C:B">Tasks</h2>');
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g2',
+        canvas_id: 'F0C',
+        op: 'append',
+        markdown: '##   tasks  \n\n- [ ] again',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit FAILED');
+  });
+
+  it('a non-duplicate heading passes through — region path, no lookup needed', async () => {
+    mockReadBack('<h2 id="temp:C:B">Tasks</h2>');
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g3',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Tasks',
+        markdown: '## Retro notes\n\n- went well',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // files.info, download, edit — section id from the read-back
+    const [editUrl, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(editUrl).toBe('https://slack.com/api/canvases.edit');
+    expect(JSON.parse(editInit.body as string).changes[0]).toMatchObject({
+      operation: 'insert_after',
+      section_id: 'temp:C:B',
+    });
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+  });
+
+  it('a failed read-back never blocks the edit (guard is best-effort)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: false, error: 'file_not_found' })) // files.info fails
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [{ id: 'temp:C:SEC1' }] }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g4',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // files.info (failed), lookup, edit
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+  });
+
+  it('markdown without a heading skips the read-back entirely', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-g5', canvas_id: 'F0C', op: 'append', markdown: '- [ ] plain item' },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // straight to canvases.edit
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+  });
+
+  it('replace_section is exempt — replacing a section with its own heading is the point', async () => {
+    mockReadBack('<h2 id="temp:C:B">Tasks</h2><p id="temp:C:P1" class="line">- [ ] old</p>');
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace heading
+      .mockResolvedValueOnce(slackJson({ ok: true })); // delete old body
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g6',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4); // files.info, download, replace, delete — no refusal
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+  });
+});
+
+describe('heading-region ops (Slack sections are blocks, not regions)', () => {
+  /** Trimmed from the live canvas HTML that produced the duplicated-section bug. */
+  const REGION_HTML =
+    '<div class="quip-canvas-content">' +
+    '<h2 id="temp:C:NOTES">Notes</h2>' +
+    '<h2 id="temp:C:OQ">Open Questions</h2>' +
+    '<p id="temp:C:P1" class="line">Questions that need answers:</p>' +
+    "<div data-section-style='5'><ul id='temp:C:L1'><li id='temp:C:LI1'><span id=\"temp:C:LI1\">item</span></li></ul></div>" +
+    '<p id="temp:C:NB" class="line"><i>Working notes</i></p>' +
+    '</div>';
+
+  function mockReadBack(html: string): void {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(new Response(html, { status: 200 }));
+  }
+
+  function editBodies(fromCall: number): Array<Record<string, unknown>> {
+    return fetchMock.mock.calls
+      .slice(fromCall)
+      .map((c) => JSON.parse((c as [string, RequestInit])[1].body as string).changes[0] as Record<string, unknown>);
+  }
+
+  it('replace_section replaces the heading block then deletes every old body block, one call each', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace temp:C:OQ
+      .mockResolvedValueOnce(slackJson({ ok: true })) // delete temp:C:P1
+      .mockResolvedValueOnce(slackJson({ ok: true })) // delete temp:C:L1
+      .mockResolvedValueOnce(slackJson({ ok: true })); // delete temp:C:NB
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h1',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Open Questions',
+        markdown: '## Open Questions\n\n- new list',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    const changes = editBodies(2);
+    expect(changes[0]).toMatchObject({ operation: 'replace', section_id: 'temp:C:OQ' });
+    expect(changes.slice(1)).toEqual([
+      { operation: 'delete', section_id: 'temp:C:P1' },
+      { operation: 'delete', section_id: 'temp:C:LI1' },
+      { operation: 'delete', section_id: 'temp:C:NB' },
+    ]);
+    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+  });
+
+  it('insert_after_section lands after the LAST block of the region, not the heading', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h2',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Open Questions',
+        markdown: 'A follow-up paragraph.',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(editBodies(2)[0]).toMatchObject({ operation: 'insert_after', section_id: 'temp:C:NB' });
+  });
+
+  it('an empty region (heading directly followed by another heading) targets the heading itself', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h3',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Notes',
+        markdown: 'Right under the Notes heading.',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    expect(editBodies(2)[0]).toMatchObject({ operation: 'insert_after', section_id: 'temp:C:NOTES' });
+  });
+
+  it('a mid-sequence delete failure reports a partial apply (new content in, leftovers named)', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace ok
+      .mockResolvedValueOnce(slackJson({ ok: false, error: 'section_not_found' })); // first delete fails
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h4',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Open Questions',
+        markdown: '## Open Questions\n\n- new list',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(1);
+    const partialNote = editNoteText(rows[0]);
+    expect(partialNote).toContain('partially applied');
+    expect(partialNote).toContain('3 old block(s)');
+  });
+});
+
+describe('checklist tick-state platform limit', () => {
+  it('counts ticked items in the region and warns on rewrite (state is UI-only)', async () => {
+    // Live checklist with one ticked item (li class='checked').
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          '<h2 id="temp:C:T">Tasks</h2>' +
+            "<div data-section-style='7'><ul id='temp:C:U'>" +
+            "<li id='temp:C:SA' class='checked' value='1'><span id=\"temp:C:SA\">done one</span></li>" +
+            '<li id=\'temp:C:SB\'><span id="temp:C:SB">open one</span></li>' +
+            '</ul></div>',
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace heading
+      .mockResolvedValueOnce(slackJson({ ok: true })) // delete SA
+      .mockResolvedValueOnce(slackJson({ ok: true })); // delete SB
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-t1',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done one\n- [ ] open one\n- [ ] new one',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(1); // warning must wake the agent
+    const note = editNoteText(rows[0]);
+    expect(note).toContain('Canvas edit applied');
+    expect(note).toContain('[x] states in your markdown were NOT applied');
+    expect(note).toContain('1 ticked item(s)');
+  });
+
+  it('a rewrite of an untick-free checklist without [x] markdown stays a silent success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          '<h2 id="temp:C:T">Tasks</h2>' +
+            "<div data-section-style='7'><ul id='temp:C:U'><li id='temp:C:SB'><span id=\"temp:C:SB\">open one</span></li></ul></div>",
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(slackJson({ ok: true }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-t2',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [ ] open one\n- [ ] new one',
+      },
+      makeSession(),
+      inDb,
+    );
+
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(0);
+    expect(editNoteText(rows[0])).toContain('Canvas edit applied');
+  });
+});
+
+describe('htmlToReadableText checklists', () => {
+  it('renders live-export checklist items as [x]/[ ] from li class, not inputs', () => {
+    const html =
+      '<h2 id="temp:C:T">Tasks</h2>' +
+      '<div data-section-style=\'7\' class="list-numbering-restart-at" style="--indent0: 0">' +
+      "<ul id='temp:C:U'>" +
+      "<li id='temp:C:LA' class='checked' value='1'><span id=\"temp:C:LA\">Draft launch checklist</span><br/></li>" +
+      '<li id=\'temp:C:LB\'><span id="temp:C:LB">Verify canvas scopes</span><br/></li>' +
+      '</ul></div>';
+    const text = htmlToReadableText(html);
+    expect(text).toContain('- [x] Draft launch checklist');
+    expect(text).toContain('- [ ] Verify canvas scopes');
+  });
+
+  it('plain lists keep plain bullets', () => {
+    const html =
+      "<div data-section-style='5'><ul id='temp:C:U'><li id='temp:C:L'><span>plain item</span></li></ul></div>";
+    const text = htmlToReadableText(html);
+    expect(text).toContain('- plain item');
+    expect(text).not.toContain('[ ]');
+  });
+});
+
+describe('handleCanvasRead', () => {
+  it('fetches files.info, downloads the HTML, and returns stripped text (trigger=0)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response('<h1 id="temp:C:X">Room</h1><ul><li><input type="checkbox" checked>done</li></ul>', {
+          status: 200,
+        }),
+      );
+
+    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r1', canvas_id: 'F0C' }, makeSession(), inDb);
+
+    const [infoUrl] = fetchMock.mock.calls[0] as [string];
+    expect(infoUrl).toBe('https://slack.com/api/files.info?file=F0C');
+    const [dlUrl, dlInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(dlUrl).toBe('https://files.slack.com/canvas.html');
+    expect((dlInit.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-pixel-token');
+
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(0);
+    expect(rows[0].content).toMatchObject({ type: 'canvas_response', requestId: 'req-r1', status: 'ok' });
+    const text = (rows[0].content.result as { text: string }).text;
+    expect(text).toContain('# Room');
+    expect(text).toContain('- [x] done');
+    expect(text).not.toContain('temp:C:X');
+  });
+
+  it('read failures come back as trigger=0 error rows (the tool is polling)', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: false, error: 'file_not_found' }));
+
+    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r2', canvas_id: 'F0C' }, makeSession(), inDb);
+
+    const rows = responseRows(inDb);
+    expect(rows[0].trigger).toBe(0);
+    expect(rows[0].content).toMatchObject({ status: 'error' });
+    expect((rows[0].content.result as { error: string }).error).toContain('file_not_found');
+  });
+});
+
+describe('htmlToReadableText', () => {
+  it('keeps heading levels, bullets, checkboxes, and table pipes; drops tags and entities', () => {
+    const html =
+      '<style>.x{}</style><h1 id="temp:C:A">Title</h1><h2 id="temp:C:B">Tasks</h2>' +
+      '<ul><li><input type="checkbox">open item</li><li><input type="checkbox" checked>closed item</li></ul>' +
+      '<table><tr><td>a &amp; b</td><td>c</td></tr></table><p>tail &lt;ok&gt;</p>';
+    const text = htmlToReadableText(html);
+    expect(text).toContain('# Title');
+    expect(text).toContain('## Tasks');
+    expect(text).toContain('- [ ] open item');
+    expect(text).toContain('- [x] closed item');
+    expect(text).toContain('a & b | c |');
+    expect(text).toContain('tail <ok>'); // entities decode after tag stripping
+    expect(text).not.toContain('<h1');
+    expect(text).not.toContain('<style>');
+    expect(text).not.toContain('temp:C:');
+  });
+
+  it('caps at maxChars with a truncation note (via fetchCanvasText cap path)', () => {
+    // The cap lives in fetchCanvasText; here just sanity-check big input survives stripping.
+    const text = htmlToReadableText(`<p>${'x'.repeat(10_000)}</p>`);
+    expect(text.length).toBe(10_000);
+  });
+});
+
+describe('parseCanvasBlocks / resolveHeadingRegion', () => {
+  it('parses top-level blocks in order, folding nested structure into its outermost block', () => {
+    const html =
+      '<div class="quip-canvas-content">' +
+      '<h1 id="temp:C:T">Q&amp;A Room</h1>' +
+      '<blockquote><p id="temp:C:BQ" class="line">purpose line</p></blockquote>' +
+      '<h2 id="temp:C:M">Members</h2>' +
+      '<table><tr><td><p id="temp:C:CELL" class="line">cell</p></td></tr></table>' +
+      '<h2 id="temp:C:TK">Tasks</h2>' +
+      "<div data-section-style='7'><ul id='temp:C:UL'><li id='temp:C:LI'><span>item</span><ul><li>nested</li></ul></li></ul></div>" +
+      '<p id="temp:C:TAIL" class="line">tail</p>' +
+      '</div>';
+    const blocks = parseCanvasBlocks(html);
+    expect(blocks.map((b) => `${b.tag}:${b.id}`)).toEqual([
+      'h1:temp:C:T',
+      'blockquote:temp:C:BQ', // quote addressed via its inner <p> id
+      'h2:temp:C:M',
+      'table:null', // cell paragraphs fold into the table block
+      'h2:temp:C:TK',
+      'ul:temp:C:UL', // nested list folds into the outermost ul
+      'p:temp:C:TAIL',
+    ]);
+    expect(blocks[0].text).toBe('Q&A Room'); // heading text entity-decoded, tag-stripped
+  });
+
+  it('resolves a heading region: exact match wins, body stops at the next heading', () => {
+    const html =
+      '<h2 id="temp:C:A">Notes</h2><p id="temp:C:P" class="line">body</p>' +
+      "<ul id='temp:C:U'><li id='temp:C:LX'><span id=\"temp:C:SX\">x</span></li></ul>" +
+      '<h2 id="temp:C:B">Notes archive</h2><p id="temp:C:Q">other</p>';
+    const region = resolveHeadingRegion(html, 'Notes');
+    expect(region).toEqual({
+      headingId: 'temp:C:A',
+      bodyIds: ['temp:C:P', 'temp:C:SX'],
+      lastId: 'temp:C:SX',
+      hasUnaddressableBlocks: false,
+      checkedItemCount: 0,
+    });
+  });
+
+  it('lists resolve to their item span ids — the ul wrapper id is a canvases.edit no-op (live-observed)', () => {
+    // The live checklist export shape: styled wrapper div, one ul per item,
+    // item text in an id-bearing span. Deleting the ul id silently no-ops
+    // (ok:true, canvas unchanged) — the region must carry the span ids.
+    const html =
+      '<h2 id="temp:C:T">Tasks</h2>' +
+      "<div data-section-style='7'><ul id='temp:C:U1'><li id='temp:C:LA'><span id=\"temp:C:SA\">Draft launch checklist</span></li></ul>" +
+      "<ul id='temp:C:U2'><li id='temp:C:LB'><span id=\"temp:C:SB\">Verify canvas scopes</span></li></ul></div>" +
+      '<h2 id="temp:C:D">Decisions</h2>';
+    const region = resolveHeadingRegion(html, 'Tasks');
+    expect(region).toEqual({
+      headingId: 'temp:C:T',
+      bodyIds: ['temp:C:SA', 'temp:C:SB'],
+      lastId: 'temp:C:SB',
+      hasUnaddressableBlocks: false,
+      checkedItemCount: 0,
+    });
+  });
+
+  it('a list without item span ids is flagged unaddressable, not deleted by wrapper id', () => {
+    const html = '<h2 id="temp:C:A">Tasks</h2><ul id=\'temp:C:U\'><li>x</li></ul><p id="temp:C:P">tail</p>';
+    const region = resolveHeadingRegion(html, 'Tasks');
+    expect(region?.bodyIds).toEqual(['temp:C:P']);
+    expect(region?.hasUnaddressableBlocks).toBe(true);
+  });
+
+  it('flags unaddressable body blocks (an id-less table) and falls back to contains-match', () => {
+    const html = '<h2 id="temp:C:A">Member Roster</h2><table><tr><td>x</td></tr></table><p id="temp:C:P">tail</p>';
+    const region = resolveHeadingRegion(html, 'roster');
+    expect(region?.headingId).toBe('temp:C:A');
+    expect(region?.bodyIds).toEqual(['temp:C:P']);
+    expect(region?.hasUnaddressableBlocks).toBe(true);
+  });
+
+  it('returns null when no heading matches (caller falls back to sections.lookup)', () => {
+    expect(resolveHeadingRegion('<h2 id="temp:C:A">Tasks</h2>', 'Decisions')).toBeNull();
+    expect(resolveHeadingRegion('<p id="temp:C:P">Decisions happen here</p>', 'Decisions')).toBeNull();
+  });
+});

--- a/src/modules/canvas-actions/canvas-api.ts
+++ b/src/modules/canvas-actions/canvas-api.ts
@@ -1,0 +1,360 @@
+/**
+ * Slack canvas API calls for the canvas-actions module — sections.lookup,
+ * canvases.edit, and the HTML read-back path (files.info →
+ * url_private_download).
+ *
+ * Safety property (09: whole-doc `replace` confirmed destructive): the
+ * `CanvasChange` type makes an unsectioned `replace` UNREPRESENTABLE —
+ * `replace` and `insert_after` structurally require a sectionId, and
+ * `editCanvas` re-checks it at runtime as belt and braces. `insert_at_end`
+ * (append) is the only sectionless operation this module can emit.
+ *
+ * JSON-body Web API calls go through `slackCall` in src/channels/slack-lib.ts
+ * (same message shape: `slack <method> failed: <error>`). The files.info
+ * read-back stays local — it is a legacy GET-arg method (no JSON body), and
+ * the download itself is a raw file fetch, not a Web API call. Error strings
+ * from Slack are safe to surface; token values never are — tokens travel
+ * only in Authorization headers.
+ */
+import { slackCall } from '../../channels/slack-lib.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export type CanvasChange =
+  | { operation: 'insert_at_end'; markdown: string }
+  | { operation: 'replace' | 'insert_after'; sectionId: string; markdown: string }
+  | { operation: 'delete'; sectionId: string };
+
+/**
+ * canvases.sections.lookup by contains_text. Returns the FIRST matching
+ * section id, or null when nothing matches. Ids are ephemeral (`temp:` — 09):
+ * look up fresh before every edit, never cache.
+ */
+export async function lookupCanvasSection(
+  token: string,
+  canvasId: string,
+  containsText: string,
+): Promise<string | null> {
+  const json = await slackCall(
+    token,
+    'canvases.sections.lookup',
+    { canvas_id: canvasId, criteria: { contains_text: containsText } },
+    'canvas-section-lookup',
+  );
+  const sections = Array.isArray(json.sections) ? (json.sections as Array<Record<string, unknown>>) : [];
+  const first = sections[0];
+  return typeof first?.id === 'string' && first.id ? first.id : null;
+}
+
+/** canvases.edit with exactly one change — the API rejects multi-change
+ *  arrays ("no more than 1 items allowed", live-probed), so region-scoped
+ *  edits are sequences of calls. Throws on any Slack error. */
+export async function editCanvas(token: string, canvasId: string, change: CanvasChange): Promise<void> {
+  let payload: Record<string, unknown>;
+  if (change.operation === 'insert_at_end') {
+    payload = {
+      operation: 'insert_at_end',
+      document_content: { type: 'markdown', markdown: change.markdown },
+    };
+  } else if (change.operation === 'delete') {
+    if (!change.sectionId) {
+      throw new Error('canvases.edit refused: delete without a resolved section_id');
+    }
+    payload = { operation: 'delete', section_id: change.sectionId };
+  } else {
+    // Runtime re-check of the structural guarantee: a replace/insert_after
+    // without a section id must never reach the wire (whole-doc replace).
+    if (!change.sectionId) {
+      throw new Error(`canvases.edit refused: ${change.operation} without a resolved section_id`);
+    }
+    payload = {
+      operation: change.operation,
+      section_id: change.sectionId,
+      document_content: { type: 'markdown', markdown: change.markdown },
+    };
+  }
+  await slackCall(token, 'canvases.edit', { canvas_id: canvasId, changes: [payload] }, 'canvas-edit');
+}
+
+/**
+ * Read a canvas back as readable text: files.info → url_private_download →
+ * HTML → stripped text (09: the download carries the full body; section ids
+ * live in tag attributes and are stripped along with the tags). Capped at
+ * `maxChars`. Throws on any failure.
+ */
+export async function fetchCanvasText(token: string, canvasId: string, maxChars = 8000): Promise<string> {
+  const text = htmlToReadableText(await fetchCanvasHtml(token, canvasId));
+  return text.length > maxChars ? `${text.slice(0, maxChars)}\n…[truncated at ${maxChars} chars]` : text;
+}
+
+/**
+ * The raw canvas HTML export (files.info → url_private_download). Block ids
+ * (`temp:C:…`) ride the tag attributes — this is the addressing source for
+ * region-scoped edits. Throws on any failure.
+ */
+export async function fetchCanvasHtml(token: string, canvasId: string): Promise<string> {
+  // files.info is a legacy GET-arg method (does not accept JSON bodies).
+  let infoRes: Response;
+  try {
+    infoRes = await fetch(`${SLACK_API}/files.info?file=${encodeURIComponent(canvasId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(`slack files.info failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  let info: Record<string, unknown>;
+  try {
+    info = (await infoRes.json()) as Record<string, unknown>;
+  } catch {
+    throw new Error(`slack files.info failed: HTTP ${infoRes.status}, non-JSON body`);
+  }
+  if (info.ok !== true) {
+    throw new Error(`slack files.info failed: ${String(info.error ?? `HTTP ${infoRes.status}`)}`);
+  }
+  const file = info.file as Record<string, unknown> | undefined;
+  const url = typeof file?.url_private_download === 'string' ? file.url_private_download : null;
+  if (!url) throw new Error('slack files.info failed: no url_private_download on file');
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(`canvas download failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok) throw new Error(`canvas download failed: HTTP ${res.status}`);
+  return res.text();
+}
+
+// ── Block/region model of the canvas HTML ──
+//
+// Live-observed platform fact (post-e2e fix): a Slack canvas "section" is an
+// individual BLOCK — a heading and the paragraphs/lists under it are separate
+// sections with separate ids. A naive `replace` on a heading match therefore
+// replaces only the heading block and leaves the old body behind (observed as
+// a duplicated section). The helpers below rebuild the heading-scoped REGION
+// from the HTML export so handlers can edit whole sections.
+
+export interface CanvasBlock {
+  tag: 'h1' | 'h2' | 'h3' | 'p' | 'ul' | 'ol' | 'table' | 'blockquote';
+  /** Slack section id (`temp:C:…`) when the block carries one. */
+  id: string | null;
+  /** Inner text for headings (tag-stripped, entity-decoded); '' otherwise. */
+  text: string;
+  /**
+   * List blocks only: the per-item `<span id=…>` ids. Live-probed platform
+   * fact: a list's addressable sections are its ITEMS — `canvases.edit`
+   * silently no-ops (ok:true, nothing happens) when given the `<ul>`/`<ol>`
+   * wrapper id, while the item span ids (the same ids sections.lookup
+   * returns) delete and anchor correctly. Deleting every item collapses the
+   * list wrapper automatically.
+   */
+  itemIds?: string[];
+  /**
+   * List blocks only: item ids whose `<li>` carries `class='checked'` — a
+   * ticked checklist item. Live-probed: `- [x]` markdown is IGNORED by
+   * canvases.edit (insert, section replace, and item replace all land
+   * unticked), so tick state is UI-only and a section rewrite RESETS it.
+   */
+  checkedItemIds?: string[];
+}
+
+const BLOCK_TAG_RE = /<(\/?)(h1|h2|h3|p|ul|ol|table|blockquote)\b([^>]*)>/gi;
+
+function idFromAttrs(attrs: string): string | null {
+  const m = /\bid=["']([^"']+)["']/.exec(attrs);
+  return m ? m[1] : null;
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'");
+}
+
+/**
+ * Top-level blocks of a canvas HTML export, in document order. Nested
+ * structure folds into its outermost block: everything inside a table is the
+ * table, nested lists are the outermost ul/ol, a blockquote is addressed by
+ * its inner `<p>` id (the quote tag itself carries none).
+ */
+export function parseCanvasBlocks(html: string): CanvasBlock[] {
+  const blocks: CanvasBlock[] = [];
+  let tableDepth = 0;
+  let listDepth = 0;
+  let openBlockquote: CanvasBlock | null = null;
+  let openList: CanvasBlock | null = null;
+  let openListStart = 0;
+  BLOCK_TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = BLOCK_TAG_RE.exec(html)) !== null) {
+    const closing = m[1] === '/';
+    const tag = m[2].toLowerCase() as CanvasBlock['tag'];
+    const attrs = m[3] ?? '';
+    if (closing) {
+      if (tag === 'table') tableDepth = Math.max(0, tableDepth - 1);
+      else if (tag === 'ul' || tag === 'ol') {
+        listDepth = Math.max(0, listDepth - 1);
+        if (listDepth === 0 && openList) {
+          // The list's addressable sections are its item spans (see
+          // CanvasBlock.itemIds) — harvest them from the outermost extent,
+          // plus which items are ticked (li class='checked'; li id == span id).
+          const inner = html.slice(openListStart, m.index);
+          openList.itemIds = [...inner.matchAll(/<span id=["']([^"']+)["']/g)].map((sm) => sm[1]);
+          openList.checkedItemIds = [...inner.matchAll(/<li\b[^>]*>/g)]
+            .filter((lm) => /\bclass=["'][^"']*\bchecked\b/.test(lm[0]))
+            .map((lm) => /\bid=["']([^"']+)["']/.exec(lm[0])?.[1])
+            .filter((id): id is string => Boolean(id));
+          openList = null;
+        }
+      } else if (tag === 'blockquote') openBlockquote = null;
+      continue;
+    }
+    if (tag === 'table') {
+      if (tableDepth === 0) blocks.push({ tag, id: idFromAttrs(attrs), text: '' });
+      tableDepth++;
+      continue;
+    }
+    if (tableDepth > 0) {
+      if (tag === 'ul' || tag === 'ol') listDepth++;
+      continue; // cell contents are part of the table block
+    }
+    if (tag === 'ul' || tag === 'ol') {
+      if (listDepth === 0) {
+        openList = { tag, id: idFromAttrs(attrs), text: '', itemIds: [] };
+        openListStart = BLOCK_TAG_RE.lastIndex;
+        blocks.push(openList);
+      }
+      listDepth++;
+      continue;
+    }
+    if (listDepth > 0) continue; // paragraphs inside list items are part of the list
+    if (tag === 'blockquote') {
+      openBlockquote = { tag, id: idFromAttrs(attrs), text: '' };
+      blocks.push(openBlockquote);
+      continue;
+    }
+    if (tag === 'p') {
+      const id = idFromAttrs(attrs);
+      if (openBlockquote) {
+        if (!openBlockquote.id) openBlockquote.id = id;
+        continue;
+      }
+      blocks.push({ tag, id, text: '' });
+      continue;
+    }
+    // h1-h3: capture inner text up to the matching close tag.
+    const close = html.indexOf(`</${tag}>`, BLOCK_TAG_RE.lastIndex);
+    const inner = close === -1 ? '' : html.slice(BLOCK_TAG_RE.lastIndex, close);
+    blocks.push({ tag, id: idFromAttrs(attrs), text: decodeEntities(inner.replace(/<[^>]+>/g, '')).trim() });
+  }
+  return blocks;
+}
+
+export interface HeadingRegion {
+  headingId: string;
+  /** Ids of the region's body blocks (heading excluded), document order. */
+  bodyIds: string[];
+  /** Last id-bearing block of the region (the heading when the body is empty). */
+  lastId: string;
+  /** True when a body block carried no id (it cannot be edited or deleted). */
+  hasUnaddressableBlocks: boolean;
+  /** Ticked checklist items in the region body — state a rewrite will reset. */
+  checkedItemCount: number;
+}
+
+/**
+ * Resolve a heading-scoped region: the h1-h3 whose text matches `sectionText`
+ * (exact first, then contains — both case-insensitive) plus every following
+ * block up to the next heading. Null when no heading matches — the caller
+ * falls back to single-block sections.lookup behavior.
+ */
+export function resolveHeadingRegion(html: string, sectionText: string): HeadingRegion | null {
+  const wanted = sectionText.trim().toLowerCase();
+  if (!wanted) return null;
+  const blocks = parseCanvasBlocks(html);
+  const isHeading = (b: CanvasBlock): boolean => b.tag === 'h1' || b.tag === 'h2' || b.tag === 'h3';
+  let start = blocks.findIndex((b) => isHeading(b) && b.id !== null && b.text.toLowerCase() === wanted);
+  if (start === -1) {
+    start = blocks.findIndex((b) => isHeading(b) && b.id !== null && b.text.toLowerCase().includes(wanted));
+  }
+  if (start === -1) return null;
+  const headingId = blocks[start].id as string;
+  const bodyIds: string[] = [];
+  let lastId = headingId;
+  let hasUnaddressableBlocks = false;
+  let checkedItemCount = 0;
+  for (let i = start + 1; i < blocks.length; i++) {
+    const b = blocks[i];
+    if (isHeading(b)) break;
+    if (b.tag === 'ul' || b.tag === 'ol') {
+      // Lists are addressed per ITEM: the wrapper ul/ol id is a silent no-op
+      // for canvases.edit, so a list contributes its item span ids instead.
+      if (b.itemIds && b.itemIds.length > 0) {
+        bodyIds.push(...b.itemIds);
+        lastId = b.itemIds[b.itemIds.length - 1];
+      } else {
+        hasUnaddressableBlocks = true;
+      }
+      checkedItemCount += b.checkedItemIds?.length ?? 0;
+      continue;
+    }
+    if (b.id) {
+      bodyIds.push(b.id);
+      lastId = b.id;
+    } else {
+      hasUnaddressableBlocks = true;
+    }
+  }
+  return { headingId, bodyIds, lastId, hasUnaddressableBlocks, checkedItemCount };
+}
+
+/**
+ * Best-effort HTML → readable text: headings keep their markdown level,
+ * list items get bullets, checklist items render as [ ] / [x], table cells
+ * separate with pipes, all other tags (and their id attributes) drop.
+ *
+ * Checklists in the live export are NOT inputs: they are
+ * `<div data-section-style='7'>` wrappers whose `<li>`s carry
+ * `class='checked'` when ticked (live-observed — an agent that can't see
+ * tick states re-issues edits it can't verify).
+ */
+export function htmlToReadableText(html: string): string {
+  const text = html
+    .replace(/<(script|style)\b[\s\S]*?<\/\1>/gi, '')
+    .replace(/<div[^>]*data-section-style=["']?7["']?[^>]*>([\s\S]*?)<\/div>/gi, (_m, inner: string) =>
+      inner.replace(/<li\b[^>]*>/gi, (tag) => (/\bclass=["'][^"']*\bchecked\b/i.test(tag) ? '\n- [x] ' : '\n- [ ] ')),
+    )
+    .replace(/<input\b[^>]*>/gi, (tag) => {
+      if (!/type\s*=\s*["']?checkbox/i.test(tag)) return '';
+      return /\bchecked\b/i.test(tag) ? '[x] ' : '[ ] ';
+    })
+    .replace(/<h1\b[^>]*>/gi, '\n# ')
+    .replace(/<h2\b[^>]*>/gi, '\n## ')
+    .replace(/<h3\b[^>]*>/gi, '\n### ')
+    .replace(/<li\b[^>]*>/gi, '\n- ')
+    .replace(/<blockquote\b[^>]*>/gi, '\n> ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/t[dh]>/gi, ' | ')
+    .replace(/<\/(h1|h2|h3|p|li|div|tr|table|ul|ol|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'");
+  return text
+    .split('\n')
+    .map((line) => line.replace(/\s+$/, ''))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/src/modules/canvas-actions/handlers.ts
+++ b/src/modules/canvas-actions/handlers.ts
@@ -1,0 +1,363 @@
+/**
+ * Delivery-action handlers for agent canvas access: `canvas_edit`
+ * (fire-and-forget section-scoped edits) and `canvas_read` (blocking
+ * read-back the container tool polls for).
+ *
+ * Both act AS the session's own Slack bot identity: session →
+ * messaging group → adapter instance → the instance's bot token from
+ * .env (the SLACK_BOT_TOKEN / SLACK_BOT_TOKEN_<SUFFIX> key convention
+ * from src/channels/slack-lib.ts). No privileged effect: the
+ * agent can only touch canvases its own bot can already see.
+ *
+ * Outcome plumbing differs by action — this is load-bearing:
+ *
+ * - `canvas_read` outcomes are `kind:'system'` rows carrying `requestId`;
+ *   the container tool polls inbound.db for exactly that row and consumes
+ *   it. They are trigger=0 always (the requester is already polling) and
+ *   the poll loop deliberately filters system rows out of agent prompts.
+ * - `canvas_edit` outcomes are `kind:'chat'` system notes (sender
+ *   'system', channelType 'agent') — the membership-note shape. NOT
+ *   `kind:'system'`: nothing polls for them, and the poll loop would
+ *   filter them out of every batch, so the agent would never learn an
+ *   edit failed (and an unconsumed trigger=1 system row keeps the session
+ *   permanently "due" for the host sweep — wake churn). As chat rows they
+ *   render like any message: successes are trigger=0 (ambient, next
+ *   wake); FAILURES are trigger=1 so the agent wakes to correct course —
+ *   it already told the user the edit was submitted.
+ */
+import type Database from 'better-sqlite3';
+
+import { botTokenKeyForInstance } from '../../channels/slack-lib.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { insertMessage } from '../../db/session-db.js';
+import { readEnvValue } from '../../env-file.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import {
+  editCanvas,
+  fetchCanvasHtml,
+  fetchCanvasText,
+  htmlToReadableText,
+  lookupCanvasSection,
+  resolveHeadingRegion,
+  type CanvasChange,
+  type HeadingRegion,
+} from './canvas-api.js';
+
+const CANVAS_EDIT_OPS = ['append', 'replace_section', 'insert_after_section'] as const;
+type CanvasEditOp = (typeof CANVAS_EDIT_OPS)[number];
+
+/**
+ * The session's own Slack bot token: session → mg → instance → .env.
+ * Error strings are agent-facing — they name the key, never the value.
+ */
+export function resolveSessionBotToken(session: Session): { token: string } | { error: string } {
+  if (!session.messaging_group_id) {
+    return { error: 'session has no messaging group — cannot resolve a Slack bot identity' };
+  }
+  const mg = getMessagingGroup(session.messaging_group_id);
+  if (!mg) {
+    return { error: `messaging group ${session.messaging_group_id} not found` };
+  }
+  if (mg.channel_type !== 'slack') {
+    return { error: `canvas actions need a Slack session (this session's channel is ${mg.channel_type})` };
+  }
+  const instanceKey = mg.instance ?? 'slack';
+  const tokenKey = botTokenKeyForInstance(instanceKey);
+  const token = readEnvValue(process.cwd(), tokenKey);
+  if (!token) {
+    return { error: `missing ${tokenKey} in .env for instance '${instanceKey}'` };
+  }
+  return { token };
+}
+
+/** First ATX heading in a markdown fragment (raw text, trimmed), or null. */
+function firstMarkdownHeading(markdown: string): string | null {
+  for (const line of markdown.split('\n')) {
+    const m = /^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/.exec(line);
+    if (m) return m[1].trim();
+  }
+  return null;
+}
+
+/**
+ * Heading texts present in a canvas read-back (the htmlToReadableText shape:
+ * headings are `#`-prefixed lines), normalized for comparison (lowercased,
+ * trimmed).
+ */
+function readBackHeadings(text: string): Set<string> {
+  const headings = new Set<string>();
+  for (const line of text.split('\n')) {
+    const m = /^#{1,6}\s+(.+?)\s*$/.exec(line);
+    if (m) headings.add(m[1].trim().toLowerCase());
+  }
+  return headings;
+}
+
+/** canvas_read outcome — a system row the container tool polls for by requestId. */
+function writeCanvasResponse(
+  inDb: Database.Database,
+  args: {
+    requestId: string;
+    action: 'canvas_read';
+    status: 'ok' | 'error';
+    result: Record<string, unknown>;
+  },
+): void {
+  insertMessage(inDb, {
+    id: `canvas-resp-${args.requestId}`,
+    kind: 'system',
+    timestamp: new Date().toISOString(),
+    platformId: null,
+    channelType: null,
+    threadId: null,
+    content: JSON.stringify({
+      type: 'canvas_response',
+      requestId: args.requestId,
+      action: args.action,
+      status: args.status,
+      result: args.result,
+    }),
+    processAfter: null,
+    recurrence: null,
+    trigger: 0,
+  });
+}
+
+/**
+ * canvas_edit outcome — a renderable chat note (membership-note shape).
+ * trigger=1 failures wake the agent with the reason; trigger=0 successes
+ * ride along as ambient context on the next wake.
+ */
+function writeCanvasEditNote(inDb: Database.Database, args: { requestId: string; text: string; trigger: 0 | 1 }): void {
+  insertMessage(inDb, {
+    id: `canvas-resp-${args.requestId}`,
+    kind: 'chat',
+    timestamp: new Date().toISOString(),
+    platformId: null,
+    channelType: 'agent',
+    threadId: null,
+    content: JSON.stringify({ text: args.text, sender: 'system', senderId: 'system' }),
+    processAfter: null,
+    recurrence: null,
+    trigger: args.trigger,
+  });
+}
+
+export async function handleCanvasEdit(
+  content: Record<string, unknown>,
+  session: Session,
+  inDb: Database.Database,
+): Promise<void> {
+  const requestId =
+    typeof content.requestId === 'string' && content.requestId ? content.requestId : `canvas-${Date.now()}`;
+  const canvasId = typeof content.canvas_id === 'string' ? content.canvas_id : '';
+  const op = content.op as CanvasEditOp;
+  const markdown = typeof content.markdown === 'string' ? content.markdown : '';
+  const sectionText = typeof content.section_text === 'string' ? content.section_text : '';
+
+  const editLabel = `${typeof op === 'string' && op ? op : 'canvas_edit'}${
+    canvasId ? ` on canvas ${canvasId}` : ''
+  }${sectionText ? `, section "${sectionText}"` : ''}`;
+  const fail = (message: string): void => {
+    log.warn('canvas_edit failed', { sessionId: session.id, requestId, error: message });
+    writeCanvasEditNote(inDb, {
+      requestId,
+      text: `Canvas edit FAILED (${editLabel}): ${message}`,
+      trigger: 1,
+    });
+  };
+  const succeed = (note?: string): void => {
+    writeCanvasEditNote(inDb, {
+      requestId,
+      text: `Canvas edit applied (${editLabel}).${note ? ` ${note}` : ''}`,
+      trigger: 0,
+    });
+  };
+
+  if (!canvasId || !markdown || !CANVAS_EDIT_OPS.includes(op)) {
+    fail(`canvas_edit needs canvas_id, markdown, and op (one of ${CANVAS_EDIT_OPS.join(', ')})`);
+    return;
+  }
+  if (op !== 'append' && !sectionText) {
+    // The safe-op invariant: a section-targeted op without lookup criteria
+    // can never fall through to an unsectioned (whole-doc) replace.
+    fail(`${op} requires section_text (text the target section contains)`);
+    return;
+  }
+
+  const auth = resolveSessionBotToken(session);
+  if ('error' in auth) {
+    fail(auth.error);
+    return;
+  }
+
+  // One HTML read-back serves both the duplicate-heading guard and region
+  // resolution. Best-effort: an unreadable canvas skips the guard and falls
+  // back to single-block sections.lookup — never block an edit on a read
+  // failure.
+  let html: string | null = null;
+  if (op !== 'append' || firstMarkdownHeading(markdown)) {
+    try {
+      html = await fetchCanvasHtml(auth.token, canvasId);
+    } catch {
+      /* unreadable canvas → no guard, lookup fallback */
+    }
+  }
+
+  // Duplicate-heading guard (B4): an insert op (append / insert_after_section)
+  // whose markdown opens with a heading the canvas already has is almost always
+  // a misfired update — refuse and point at replace_section.
+  if (op !== 'replace_section' && html) {
+    const newHeading = firstMarkdownHeading(markdown);
+    if (newHeading && readBackHeadings(htmlToReadableText(html)).has(newHeading.toLowerCase())) {
+      fail(
+        `${op} refused: the canvas already has a "${newHeading}" section — inserting would create a duplicate heading. Use replace_section with section_text "${newHeading}" to update that section instead.`,
+      );
+      return;
+    }
+  }
+
+  // Live-probed platform limit: canvases.edit markdown IGNORES `- [x]` —
+  // every path (insert, section replace, item replace) lands unticked, so
+  // tick state is UI-only and a checklist rewrite RESETS it. Landing the
+  // edit and hiding that would be a silent lie; the note is trigger=1 so
+  // the agent can adjust (item-level edits preserve ticks).
+  const tickWarnings: string[] = [];
+  if (/^\s*[-*]\s+\[[xX]\]\s/m.test(markdown)) {
+    tickWarnings.push(
+      'the [x] states in your markdown were NOT applied — the canvas API cannot set tick state; those items landed unticked',
+    );
+  }
+  const finish = (note?: string): void => {
+    if (tickWarnings.length === 0) {
+      succeed(note);
+      return;
+    }
+    writeCanvasEditNote(inDb, {
+      requestId,
+      text: `Canvas edit applied (${editLabel}), BUT ${tickWarnings.join('; also ')}.${note ? ` ${note}` : ''} To preserve or mark checklist state, edit items individually (see the canvas-work skill) and leave ticking to humans.`,
+      trigger: 1,
+    });
+  };
+
+  try {
+    if (op === 'append') {
+      await editCanvas(auth.token, canvasId, { operation: 'insert_at_end', markdown });
+      log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
+      finish();
+      return;
+    }
+
+    // Section-scoped ops. Slack "sections" are individual BLOCKS — a heading
+    // and its body are separate sections — so a heading-matched op must cover
+    // the whole heading REGION or the old body is left behind (live-observed
+    // as a duplicated section). When section_text names a heading, resolve
+    // the region from the HTML export; otherwise (or when the read-back
+    // failed) fall back to the original single-block lookup.
+    const region: HeadingRegion | null = html ? resolveHeadingRegion(html, sectionText) : null;
+    if (op === 'replace_section' && region && region.checkedItemCount > 0) {
+      tickWarnings.push(
+        `${region.checkedItemCount} ticked item(s) in the old section lost their tick state — rewrites reset checkboxes (tick state is UI-only)`,
+      );
+    }
+
+    if (region && op === 'replace_section') {
+      // Replace the heading block FIRST (the new content lands), then delete
+      // the old body. canvases.edit takes one change per call, so a
+      // mid-sequence failure leaves a partial duplicate plus an error nudge —
+      // never content loss.
+      await editCanvas(auth.token, canvasId, { operation: 'replace', sectionId: region.headingId, markdown });
+      let deleted = 0;
+      try {
+        for (const id of region.bodyIds) {
+          await editCanvas(auth.token, canvasId, { operation: 'delete', sectionId: id });
+          deleted++;
+        }
+      } catch (err) {
+        fail(
+          `replace_section partially applied: the new content is in place but ${region.bodyIds.length - deleted} old block(s) of the previous section remain below it — read the canvas and remove the leftovers. Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return;
+      }
+      log.info('canvas_edit applied', {
+        sessionId: session.id,
+        requestId,
+        canvasId,
+        op,
+        blocksReplaced: region.bodyIds.length + 1,
+      });
+      finish(
+        region.hasUnaddressableBlocks
+          ? 'Note: some blocks in the old section could not be addressed and were left in place — re-read to verify.'
+          : undefined,
+      );
+      return;
+    }
+
+    if (region && op === 'insert_after_section') {
+      // Insert after the END of the region (its last block), not after the
+      // heading — inserting right after the heading splits the section body.
+      await editCanvas(auth.token, canvasId, { operation: 'insert_after', sectionId: region.lastId, markdown });
+      log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
+      finish();
+      return;
+    }
+
+    // section_text does not name a heading (or the read-back failed):
+    // single-block behavior via sections.lookup, as before.
+    const sectionId = await lookupCanvasSection(auth.token, canvasId, sectionText);
+    if (!sectionId) {
+      fail(
+        `no section matching "${sectionText}" found in canvas ${canvasId} — re-read the canvas and retry with text the section actually contains`,
+      );
+      return;
+    }
+    const change: CanvasChange = {
+      operation: op === 'replace_section' ? 'replace' : 'insert_after',
+      sectionId,
+      markdown,
+    };
+    await editCanvas(auth.token, canvasId, change);
+    log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
+    finish();
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleCanvasRead(
+  content: Record<string, unknown>,
+  session: Session,
+  inDb: Database.Database,
+): Promise<void> {
+  const requestId =
+    typeof content.requestId === 'string' && content.requestId ? content.requestId : `canvas-${Date.now()}`;
+  // Reader responses never wake: the container tool is already polling for
+  // this row (errors included — a wake would double-charge the outcome).
+  const respond = (status: 'ok' | 'error', result: Record<string, unknown>): void => {
+    writeCanvasResponse(inDb, { requestId, action: 'canvas_read', status, result });
+  };
+
+  const canvasId = typeof content.canvas_id === 'string' ? content.canvas_id : '';
+  if (!canvasId) {
+    respond('error', { error: 'canvas_read needs canvas_id' });
+    return;
+  }
+
+  const auth = resolveSessionBotToken(session);
+  if ('error' in auth) {
+    respond('error', { error: auth.error });
+    return;
+  }
+
+  try {
+    const text = await fetchCanvasText(auth.token, canvasId);
+    log.info('canvas_read served', { sessionId: session.id, requestId, canvasId, chars: text.length });
+    respond('ok', { canvas_id: canvasId, text });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn('canvas_read failed', { sessionId: session.id, requestId, error: message });
+    respond('error', { error: message });
+  }
+}

--- a/src/modules/canvas-actions/index.ts
+++ b/src/modules/canvas-actions/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Canvas-actions module — host side of the container's canvas tools
+ * (plan: slack-native 06/09, D19).
+ *
+ * Registers two delivery actions:
+ *  - `canvas_edit` — section-scoped canvas edits (append / replace_section /
+ *    insert_after_section). The op mapping is safe by construction: whole-doc
+ *    replace is unrepresentable (see canvas-api.ts CanvasChange).
+ *  - `canvas_read` — files.info → HTML download → readable text, returned as
+ *    an inbound system row the container tool blocks on.
+ *
+ * Both run unguarded: they act via the session's OWN bot identity (the same
+ * token that delivers this session's ordinary messages), so they can reach
+ * exactly what that bot can already reach — no privileged effect, nothing to
+ * hold for approval.
+ *
+ * Registration targets the trunk guard registry (src/guard/, three-arg
+ * registerDeliveryAction) — on this branch it resolves after the next
+ * main → channels sync; the barrel import stays commented until then.
+ */
+import { registerDeliveryAction } from '../../delivery.js';
+import { unguarded } from '../../guard/index.js';
+import { handleCanvasEdit, handleCanvasRead } from './handlers.js';
+
+registerDeliveryAction(
+  'canvas_edit',
+  handleCanvasEdit,
+  unguarded("canvas content edit via the session's own bot identity; no privileged effect"),
+);
+
+registerDeliveryAction(
+  'canvas_read',
+  handleCanvasRead,
+  unguarded("read-only canvas fetch via the session's own bot identity; no privileged effect"),
+);

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -21,3 +21,10 @@ import './interactive/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+
+// slack canvas actions (canvas_edit / canvas_read delivery actions).
+// Installed on user installs by /add-slack (skill-appended import). Commented
+// here — like `// import './slack.js'` in src/channels/index.ts — until the
+// trunk guard registry (src/guard/, 3-arg registerDeliveryAction) lands in
+// this branch's next main sync; the module registers through it.
+// import './canvas-actions/index.js';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -23,8 +23,8 @@ import './agent-to-agent/index.js';
 import './self-mod/index.js';
 
 // slack canvas actions (canvas_edit / canvas_read delivery actions).
-// Installed on user installs by /add-slack (skill-appended import). Commented
-// here — like `// import './slack.js'` in src/channels/index.ts — until the
-// trunk guard registry (src/guard/, 3-arg registerDeliveryAction) lands in
-// this branch's next main sync; the module registers through it.
-// import './canvas-actions/index.js';
+// Active here per this branch's fully-loaded convention; /add-slack appends
+// the same import on user installs. Registers through the trunk guard
+// registry (src/guard/, 3-arg registerDeliveryAction), on this branch since
+// the main sync underneath this commit.
+import './canvas-actions/index.js';


### PR DESCRIPTION
Syncs main into channels (merge commit, brings the newly merged trunk hooks) and lands the first two channel-layer modules: the shared Slack Web API client + token-key convention (src/channels/slack-lib.ts, standalone), and the canvas cluster (canvas actions module registering via the existing registerDeliveryAction seam, the container canvas MCP tool via registerTools, and the canvas-work skill). Later waves (membership, onboarding/titles, defaults factory, a2a guard) follow as their trunk counterparts merge.

Verification: the two commits' own suites, the full container tree (321 tests + typecheck), and all trunk suites pass on the branch. Note: the channels branch fails a whole-tree build at its own baseline (the lockfile has never covered the branch-only adapter deps — e.g. @deltachat/stdio-rpc-server); this PR neither worsens nor fixes that pre-existing state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)