### PR TITLE
drivers: a session-runtime driver seam, with Docker as the built-in realization

### DIFF
--- a/src/drivers/cli.test.ts
+++ b/src/drivers/cli.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(() => ({
+    stderr: { on: vi.fn() },
+    stdout: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+
+import { spawn } from 'child_process';
+
+import { realCli } from './cli.js';
+
+describe('realCli.start', () => {
+  it('detaches the supervision process from the host process group', () => {
+    // A service manager restarting the host signals the host's WHOLE group,
+    // and `docker start --attach` forwards signals into the container — an
+    // undetached helper turns every host restart into the death of every
+    // `--rm` container, erasing the sessions adoption exists to preserve.
+    // (A launchd/systemd restart cannot be simulated in-suite; this pins the
+    // spawn option the behavior depends on.)
+    realCli('docker').start(['start', '--attach', 'ncl-x']);
+
+    expect(vi.mocked(spawn)).toHaveBeenCalledWith(
+      'docker',
+      ['start', '--attach', 'ncl-x'],
+      expect.objectContaining({ detached: true }),
+    );
+  });
+});

--- a/src/drivers/cli.ts
+++ b/src/drivers/cli.ts
@@ -1,0 +1,88 @@
+/**
+ * The one process-spawning seam both drivers sit on.
+ *
+ * Drivers take a `Cli` rather than importing child_process directly, which is
+ * what lets the conformance suite drive a real spec through real realization
+ * logic against a fake runtime.
+ */
+import { execFileSync, spawn } from 'child_process';
+
+export interface SupervisedProcess {
+  /** Fires once with the exit code (or null when killed by signal). */
+  onExit(cb: (code: number | null) => void): void;
+  /** Every stderr line, already split. */
+  onStderr(cb: (line: string) => void): void;
+  /** Every stdout line, already split. */
+  onStdout(cb: (line: string) => void): void;
+  kill(): void;
+}
+
+export interface Cli {
+  readonly bin: string;
+  /** Run to completion. Throws on a non-zero exit. */
+  run(args: string[], opts?: { input?: string; timeoutMs?: number }): string;
+  /** Start and supervise. */
+  start(args: string[], opts?: { captureStdout?: boolean }): SupervisedProcess;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export function realCli(bin: string): Cli {
+  return {
+    bin,
+    run(args, opts) {
+      return execFileSync(bin, args, {
+        stdio: 'pipe',
+        input: opts?.input,
+        timeout: opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        maxBuffer: 16 * 1024 * 1024,
+      }).toString();
+    },
+    start(args, opts) {
+      const child = spawn(bin, args, {
+        stdio: ['ignore', opts?.captureStdout ? 'pipe' : 'ignore', 'pipe'],
+        // Own process group. A service manager restarting the host signals the
+        // host's WHOLE group, and `docker start --attach` forwards signals into
+        // the container — undetached, every host restart would ride through
+        // the attach helpers into every `--rm` container, erasing the sessions
+        // adoption exists to preserve. Detached, the helpers sit outside the
+        // signaled group: kill() still reaches them directly, and one orphaned
+        // by host death lingers only until its container exits.
+        detached: true,
+      });
+      const exitCbs: Array<(code: number | null) => void> = [];
+      const stderrCbs: Array<(line: string) => void> = [];
+      const stdoutCbs: Array<(line: string) => void> = [];
+      let settled = false;
+      const settle = (code: number | null): void => {
+        if (settled) return;
+        settled = true;
+        for (const cb of exitCbs) cb(code);
+      };
+      child.stderr?.on('data', (chunk: Buffer) => {
+        for (const line of chunk.toString().split('\n')) {
+          if (line.trim()) for (const cb of stderrCbs) cb(line);
+        }
+      });
+      child.stdout?.on('data', (chunk: Buffer) => {
+        for (const cb of stdoutCbs) cb(chunk.toString());
+      });
+      child.on('close', (code) => settle(code));
+      child.on('error', () => settle(null));
+      return {
+        onExit: (cb) => exitCbs.push(cb),
+        onStderr: (cb) => stderrCbs.push(cb),
+        onStdout: (cb) => stdoutCbs.push(cb),
+        kill: () => child.kill('SIGKILL'),
+      };
+    },
+  };
+}
+
+/** Runtime object names are interpolated into argv; keep them boring. */
+export function validateRuntimeName(name: string, kind: string): string {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name)) {
+    throw new Error(`Invalid ${kind} name: ${name}`);
+  }
+  return name;
+}

--- a/src/drivers/conformance.test.ts
+++ b/src/drivers/conformance.test.ts
@@ -1,0 +1,664 @@
+/**
+ * The conformance floor — identical on every driver, forever.
+ *
+ * Every case here drives the same `SessionSpec` through a driver's realization
+ * and asserts the same observable outcome. Where two drivers must differ, the
+ * difference is a declared capability, never a branch on the driver's identity:
+ * `if (driver === 'x')` above this seam is the thing this file exists to make
+ * unnecessary.
+ *
+ * Only the Docker driver ships in this tree, so the harness list has one
+ * entry; an out-of-tree driver adds its own harness and must pass every case
+ * unchanged. The suite asserts spec-realization fidelity (including *absence*:
+ * no secret env, no extra mounts), the mount-class rules, prepare idempotency,
+ * adoption from labels alone, stop-is-full-teardown, and failure-taxonomy
+ * mapping.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DockerSessionDriver } from './docker-driver.js';
+import { FakeCli } from './fake-cli.js';
+import { withSessionEvents, type SessionEventsDriver } from './session-events.js';
+import { FIXTURE_POLICY, fixtureSpec, fixtureSpecWithAux } from './spec-fixture.js';
+import { GROUP_FOLDER_LABEL, LABELS, validateSpec, type SessionDriver, type SessionSpec } from './types.js';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+// The Docker realization re-checks that mount sources exist (a missing source
+// would silently become a fresh empty directory); fixture paths are not real
+// files on the test host.
+vi.mock('fs', () => ({ default: { existsSync: (): boolean => true } }));
+
+/**
+ * What a driver realized, in vocabulary no runtime owns. This is the
+ * translation layer that lets one assertion cover every driver.
+ */
+interface Realized {
+  containers: Array<{
+    role: string;
+    image: string;
+    env: Record<string, string>;
+    mounts: Array<{ hostPath: string; containerPath: string; ro: boolean }>;
+  }>;
+  labels: Record<string, string>;
+}
+
+type Harness = {
+  name: string;
+  driver: SessionEventsDriver;
+  cli: FakeCli;
+  realize(spec: SessionSpec): Promise<Realized>;
+  /** Make the next realization fail with a runtime message of the given shape. */
+  failWith(message: string): void;
+};
+
+function dockerHarness(): Harness {
+  const cli = new FakeCli('docker');
+  cli.responses = [{ match: /^inspect /, throws: new Error('No such object') }];
+  // Wrapped exactly as `createSessionDriver` wraps it in production: the
+  // conformance surface is the seam consumers see, and `onTerminal` lives in
+  // the session-events hub, not in any driver.
+  const driver = withSessionEvents(new DockerSessionDriver({ ...FIXTURE_POLICY, cli }));
+  return {
+    name: 'docker',
+    driver,
+    cli,
+    async realize(spec) {
+      await driver.prepare(spec);
+      // The Docker realization refuses specs carrying auxiliary containers
+      // (capabilities().auxiliaryContainers is false), so the one create per
+      // prepare IS the whole session; read back what it emitted.
+      const create = cli.callMatching(/^create /)!.args;
+      const env: Record<string, string> = {};
+      const mounts: Realized['containers'][number]['mounts'] = [];
+      const labels: Record<string, string> = {};
+      for (let i = 0; i < create.length; i++) {
+        if (create[i] === '-e') {
+          const eq = create[i + 1].indexOf('=');
+          env[create[i + 1].slice(0, eq)] = create[i + 1].slice(eq + 1);
+        }
+        if (create[i] === '-v') {
+          const parts = create[i + 1].split(':');
+          mounts.push({ hostPath: parts[0], containerPath: parts[1], ro: parts[2] === 'ro' });
+        }
+        if (create[i] === '--label') {
+          const eq = create[i + 1].indexOf('=');
+          labels[create[i + 1].slice(0, eq)] = create[i + 1].slice(eq + 1);
+        }
+      }
+      const agent = spec.containers.find((c) => c.role === 'agent')!;
+      return { containers: [{ role: 'agent', image: agent.image, env, mounts }], labels };
+    },
+    failWith(message) {
+      cli.responses = [
+        { match: /^inspect /, throws: new Error('No such object') },
+        { match: /^create /, throws: new Error(message) },
+      ];
+    },
+  };
+}
+
+let harnesses: Harness[];
+beforeEach(() => {
+  vi.clearAllMocks();
+  harnesses = [dockerHarness()];
+});
+
+/**
+ * Watch events are hints: the hub re-reads truth asynchronously before it
+ * fires `onTerminal`, so delivery lands a tick after the runtime's event.
+ */
+async function settled(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+function eachDriver(name: string, body: (h: Harness) => Promise<void> | void): void {
+  it(name, async () => {
+    for (const harness of harnesses) {
+      try {
+        await body(harness);
+      } catch (error) {
+        throw new Error(`[${harness.name}] ${error instanceof Error ? error.message : String(error)}`, {
+          cause: error,
+        });
+      }
+    }
+  });
+}
+
+describe('conformance: spec realization fidelity', () => {
+  eachDriver('realizes the agent image and env exactly as declared', async (h) => {
+    const realized = await h.realize(fixtureSpec());
+    const agent = realized.containers.find((c) => c.role === 'agent')!;
+
+    expect(agent.image).toBe('nanoclaw-agent:spike-p0');
+    // Declared env passes through byte-identical: composition keeps the last
+    // word on what a session's environment is, and no driver may add to it.
+    expect(agent.env).toEqual({ TZ: 'UTC', HTTPS_PROXY: 'http://127.0.0.1:15001' });
+  });
+
+  eachDriver('realizes every declared agent mount, with its mode, and no others', async (h) => {
+    const realized = await h.realize(fixtureSpec());
+    const agent = realized.containers.find((c) => c.role === 'agent')!;
+
+    expect(agent.mounts).toEqual([
+      { hostPath: '/install/data/v2-sessions/g1/s1', containerPath: '/workspace', ro: false },
+      { hostPath: '/install/container/agent-runner/src', containerPath: '/app/src', ro: true },
+      { hostPath: '/install/container/CLAUDE.md', containerPath: '/app/CLAUDE.md', ro: true },
+    ]);
+  });
+
+  eachDriver('never places identity material in the agent container', async (h) => {
+    const realized = await h.realize(fixtureSpec());
+    const agent = realized.containers.find((c) => c.role === 'agent')!;
+
+    expect(agent.mounts.some((m) => m.hostPath.includes('session-materials'))).toBe(false);
+    expect(JSON.stringify(agent.env)).not.toContain('session-key');
+  });
+
+  eachDriver('stamps the four canonical labels', async (h) => {
+    const realized = await h.realize(fixtureSpec());
+    expect(realized.labels).toMatchObject({
+      [LABELS.install]: 'spike',
+      [LABELS.group]: 'g1',
+      [LABELS.session]: 's1',
+      [LABELS.role]: 'agent',
+    });
+  });
+
+  eachDriver('carries the group-folder label byte-identical on every driver (D9)', async (h) => {
+    // Admission joins `groups/<folder>` hostPaths against this value verbatim,
+    // so any driver that mangles it (projection, truncation, case-folding)
+    // breaks the policy for every session of the group.
+    const realized = await h.realize(fixtureSpec());
+    expect(realized.labels[GROUP_FOLDER_LABEL]).toBe('agent-one');
+  });
+});
+
+describe('conformance: mount and env policy', () => {
+  const rejections: Array<[string, (spec: SessionSpec) => void]> = [
+    [
+      'identity material on the agent role',
+      (spec) =>
+        spec.containers[0].mounts.push({
+          class: 'identity-material',
+          hostPath: '/install/data/session-materials/c/session-key.pem',
+          containerPath: '/run/session/session-key.pem',
+          mode: 'ro',
+          groupScope: 'g1',
+        }),
+    ],
+    [
+      'a writable install surface',
+      (spec) =>
+        spec.containers[0].mounts.push({
+          class: 'install-surface',
+          hostPath: '/install/container/skills',
+          containerPath: '/app/skills',
+          mode: 'rw',
+          groupScope: 'g1',
+        }),
+    ],
+    [
+      'group state belonging to another group',
+      (spec) =>
+        spec.containers[0].mounts.push({
+          class: 'group-state',
+          hostPath: '/install/data/v2-sessions/g2/s2',
+          containerPath: '/workspace/other',
+          mode: 'rw',
+          groupScope: 'g1',
+        }),
+    ],
+    ['a secret-shaped env key', (spec) => (spec.containers[0].env.SERVICE_TOKEN = 'shhh')],
+  ];
+
+  for (const [what, mutate] of rejections) {
+    eachDriver(`rejects ${what} before allocating anything`, async (h) => {
+      const spec = fixtureSpec();
+      mutate(spec);
+      await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy', retryable: false });
+      expect(h.cli.calls.some((c) => c.args[0] === 'create' && !c.args.includes('--dry-run=server'))).toBe(false);
+    });
+  }
+});
+
+describe('conformance: the multi-container contract (validateSpec is the shared layer)', () => {
+  // Multi-container specs are contract-legal; this tree's Docker realization
+  // refuses to REALIZE them (the last case), so the validation rules over
+  // auxiliary containers are asserted at the shared layer every driver runs
+  // before allocating anything.
+  it('accepts the overlay-composed auxiliary container, its identity material, and its trust anchor', () => {
+    // The CA from outside the material root rides as an allowlisted extra:
+    // same file, correct class — it verifies an upstream's server certificate,
+    // carries no identity of ours, and is world-readable by design.
+    expect(() => validateSpec(fixtureSpecWithAux(), FIXTURE_POLICY)).not.toThrow();
+  });
+
+  it('accepts a container path under a credential-named key (material passed by reference)', () => {
+    // The invariant is that no credential VALUE rides in the environment. The
+    // design passes material by reference — mount the file read-only, put its
+    // path in an env var — so a key-name-only rule would deny every session
+    // whose auxiliary containers need their own client key.
+    const spec = fixtureSpecWithAux();
+    spec.containers[1].env.PROXY_CLIENT_KEY = '/run/session/session-key.pem';
+    expect(() => validateSpec(spec, FIXTURE_POLICY)).not.toThrow();
+  });
+
+  it('refuses identity material that does not live under the material root', () => {
+    // The shape that reached a live node: a file from the deployment's PKI
+    // root wearing the class of the material root. The class must be refused
+    // rather than trusted, because a driver that trusted it would mount an
+    // unpinned host path as though it were provisioner-emitted.
+    const spec = fixtureSpecWithAux();
+    spec.containers[1].mounts.push({
+      class: 'identity-material',
+      hostPath: '/pki/other-ca.pem',
+      containerPath: '/run/session/other-ca.pem',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    expect(() => validateSpec(spec, FIXTURE_POLICY)).toThrow(/denied-by-policy/);
+  });
+
+  it('keeps every auxiliary mount out of the agent container', () => {
+    // Which container holds a file is the mount list's job, not the class's —
+    // the aux fixture's material never widens the agent's surface.
+    const spec = fixtureSpecWithAux();
+    const agent = spec.containers.find((c) => c.role === 'agent')!;
+    expect(agent.mounts.map((m) => m.containerPath).some((p) => p.startsWith('/run/session/'))).toBe(false);
+    expect(() => validateSpec(spec, FIXTURE_POLICY)).not.toThrow();
+  });
+
+  eachDriver('a driver that does not manage auxiliary containers refuses the spec whole', async (h) => {
+    // Never a silent subset: realizing only the agent would validate
+    // containers that never exist — false semantics on a public contract.
+    if (h.driver.capabilities().auxiliaryContainers) {
+      await expect(h.driver.prepare(fixtureSpecWithAux())).resolves.toBeDefined();
+      return;
+    }
+    await expect(h.driver.prepare(fixtureSpecWithAux())).rejects.toMatchObject({
+      kind: 'spec-invalid',
+      retryable: false,
+    });
+    expect(h.cli.calls.some((c) => c.args[0] === 'create')).toBe(false);
+  });
+});
+
+describe('conformance: admission judges the path the runtime mounts', () => {
+  eachDriver('refuses a mount whose path escapes its root lexically', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      // Prefix-passes under the groups root, normalizes into another group's
+      // folder once the runtime resolves it.
+      class: 'group-state',
+      hostPath: '/install/groups/agent-one/../other-folder/CLAUDE.md',
+      containerPath: '/workspace/escape',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver('refuses a relative hostPath (a named volume in Docker vocabulary, not a bind)', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: 'projects/thing',
+      containerPath: '/workspace/extra/thing',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver("refuses another group's folder claimed as this session's group state", async (h) => {
+    // The groups root holds EVERY group's folder; the folder label pins the
+    // session to its own subtree. This exact mount was accepted before the pin.
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'group-state',
+      hostPath: '/install/groups/other-folder/CLAUDE.md',
+      containerPath: '/workspace/other-group',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver("still accepts this group's own folder as group state", async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'group-state',
+      hostPath: '/install/groups/agent-one/CLAUDE.md',
+      containerPath: '/workspace/group-claude.md',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).resolves.toBeDefined();
+  });
+
+  eachDriver('refuses two mounts claiming one containerPath', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: '/home/operator/projects/thing',
+      containerPath: '/workspace',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'spec-invalid' });
+  });
+
+  eachDriver('refuses a spec without exactly one agent container', async (h) => {
+    const zero = fixtureSpec();
+    zero.containers = [];
+    await expect(h.driver.prepare(zero)).rejects.toMatchObject({ kind: 'spec-invalid' });
+    const two = fixtureSpec();
+    two.containers = [...two.containers, { ...two.containers[0] }];
+    await expect(h.driver.prepare(two)).rejects.toMatchObject({ kind: 'spec-invalid' });
+  });
+});
+
+describe('conformance: the contributed-env lane (provenance as structure)', () => {
+  eachDriver('accepts a credential-NAMED key on the contributed lane', async (h) => {
+    // The lane exists for exactly this: a provider registers a bearer
+    // placeholder for the gateway to overwrite on the wire. The value is not a
+    // credential, and the name check alone would deny the install's every spawn.
+    const spec = fixtureSpec();
+    spec.containers[0].contributedEnv = { ANTHROPIC_AUTH_TOKEN: 'placeholder' };
+    const realized = await h.realize(spec);
+    const agent = realized.containers.find((c) => c.role === 'agent')!;
+    expect(agent.env.ANTHROPIC_AUTH_TOKEN).toBe('placeholder');
+  });
+
+  eachDriver('the contributed lane wins a key collision with composed env', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].contributedEnv = { HTTPS_PROXY: 'http://gateway.internal:15001' };
+    const realized = await h.realize(spec);
+    const agent = realized.containers.find((c) => c.role === 'agent')!;
+    expect(agent.env.HTTPS_PROXY).toBe('http://gateway.internal:15001');
+  });
+
+  eachDriver('still refuses a credential VALUE on the contributed lane', async (h) => {
+    // The lane exempts names, never bytes: real material rides mounts by
+    // reference, from every contributor.
+    const spec = fixtureSpec();
+    spec.containers[0].contributedEnv = { UPSTREAM: 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAA' };
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver(
+    'the composed lane still refuses credential-shaped names — the lane is the exemption, not the install',
+    async (h) => {
+      const spec = fixtureSpec();
+      spec.containers[0].env.SERVICE_TOKEN = 'placeholder';
+      await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+    },
+  );
+});
+
+describe('conformance: a class that grants cannot be claimed by a path that has not earned it', () => {
+  // Both of these were accepted before the path/class check existed, and both
+  // are one word in a mount literal away from a correctly-composed spec.
+  eachDriver('refuses a session private key relabelled as an allowlisted extra on the agent', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      // The no-credentials invariant is the seam's headline property, and
+      // `allowlisted-extra` is permitted unconditionally — so without the path
+      // check this mounts a private key into the agent and nothing objects.
+      class: 'allowlisted-extra',
+      hostPath: '/install/data/session-materials/channel-abc-XXXX/session-key.pem',
+      containerPath: '/run/session/session-key.pem',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver('refuses a writable runner source relabelled as an allowlisted extra', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      // `install-surface` forces read-only; `allowlisted-extra` does not. This
+      // is a writable mount of the code the agent executes.
+      class: 'allowlisted-extra',
+      hostPath: '/install/container/agent-runner/src',
+      containerPath: '/app/src-rw',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver('accepts the stamped plugins tree as a read-only install surface', async (h) => {
+    // `groups/<folder>/plugins` holds code the agent executes, stamped from a
+    // validated plugin. It is an install surface living inside the group
+    // folder, pinned by the group-folder label rather than by a surface root
+    // (see `stampedPluginsRoot`) — the fixture's folder label is 'agent-one'.
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'install-surface',
+      hostPath: '/install/groups/agent-one/plugins',
+      containerPath: '/workspace/agent/plugins',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).resolves.toBeDefined();
+  });
+
+  eachDriver('refuses a writable stamped plugins tree', async (h) => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'install-surface',
+      hostPath: '/install/groups/agent-one/plugins',
+      containerPath: '/workspace/agent/plugins',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver('refuses a stamped plugins tree relabelled as an allowlisted extra', async (h) => {
+    // The relabel that matters most here: `allowlisted-extra` is permitted
+    // unconditionally and carries no read-only rule, so without the path pin
+    // this is a writable mount of executed plugin code.
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: '/install/groups/agent-one/plugins',
+      containerPath: '/workspace/agent/plugins',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver("refuses another group's plugins tree claimed as this session's install surface", async (h) => {
+    // The pin is joined through the folder label, so it grants exactly one
+    // group's plugins subtree — not every group's.
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'install-surface',
+      hostPath: '/install/groups/some-other-group/plugins',
+      containerPath: '/workspace/agent/plugins',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  eachDriver('still accepts an operator-configured read-write mount outside those roots', async (h) => {
+    // The rule must not swallow the mount-allowlist feature, whose whole point
+    // is arbitrary vetted host paths, sometimes writable.
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: '/home/operator/projects/thing',
+      containerPath: '/workspace/extra/thing',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+    await expect(h.driver.prepare(spec)).resolves.toBeDefined();
+  });
+});
+
+describe('conformance: the no-secrets rule measures values, not names', () => {
+  // The name check alone catches `..._TOKEN` and misses the identical
+  // credential under any other name. An attacker or a careless composer picks
+  // the name, so the name is the wrong thing to measure.
+  const leaks: Array<[string, string]> = [
+    ['ANTHROPIC_AUTH', 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAA'],
+    ['GW_CRED', 'ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
+    ['SESSION_BEARER', 'eyJhbGciOiJIUzI1NiJ9.eyJhIjoxfQ.c2ln'],
+    ['INLINE', '-----BEGIN RSA PRIVATE KEY-----\nMIIE\n'],
+  ];
+  for (const [key, value] of leaks) {
+    eachDriver(`refuses a credential in ${key}, whatever the key is called`, async (h) => {
+      const spec = fixtureSpec();
+      spec.containers[0].env[key] = value;
+      await expect(h.driver.prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+    });
+  }
+
+  // The other half, and the one that matters more operationally: a false
+  // positive here does not warn, it denies every session at once. These are
+  // all values a real spec carries — material passed by reference is
+  // credential-NAMED on purpose and must stay exempt while `sk-`-anything
+  // stays denied.
+  const legitimate: Array<[string, string]> = [
+    ['PROXY_CLIENT_KEY', '/run/session/session-key.pem'],
+    ['NODE_EXTRA_CA_CERTS', '/run/session/proxy-ca.pem'],
+    ['HTTPS_PROXY', 'http://127.0.0.1:15001'],
+    ['TZ', 'Europe/London'],
+    ['PROXY_UPSTREAM_ADDR', 'egress.internal:9443'],
+    ['CONTAINER_IMAGE_DIGEST', 'sha256:9624d7f2e0b1c3a45566778899aabbccddeeff00112233445566778899aabbcc'],
+    ['SESSION_ID', 'a1b2c3d4-5566-7788-99aa-bbccddeeff00'],
+  ];
+  for (const [key, value] of legitimate) {
+    eachDriver(`accepts ${key}, which is configuration and not a credential`, async (h) => {
+      const spec = fixtureSpec();
+      spec.containers[0].env[key] = value;
+      await expect(h.driver.prepare(spec)).resolves.toBeDefined();
+    });
+  }
+});
+
+describe('conformance: failure taxonomy', () => {
+  eachDriver('maps a missing image to image-unavailable', async (h) => {
+    h.failWith('manifest unknown');
+    await expect(h.driver.prepare(fixtureSpec())).rejects.toMatchObject({ kind: 'image-unavailable', retryable: true });
+  });
+
+  eachDriver('maps an unreachable runtime to runtime-unavailable', async (h) => {
+    h.failWith('Cannot connect to the Docker daemon');
+    await expect(h.driver.prepare(fixtureSpec())).rejects.toMatchObject({
+      kind: 'runtime-unavailable',
+      retryable: true,
+    });
+  });
+
+  eachDriver('never lets a raw runtime error cross the seam', async (h) => {
+    h.failWith('/install/data/session-materials/c/session-key.pem: permission denied');
+    await expect(h.driver.prepare(fixtureSpec())).rejects.toThrow(/^session realization failed: /);
+  });
+});
+
+describe('conformance: lifecycle', () => {
+  eachDriver('prepare is idempotent on key', async (h) => {
+    // An existing live session for this key IS the session — this is also how
+    // adoption works.
+    h.cli.responses = [{ match: /^inspect /, output: 'spike|g1|s1\n' }];
+
+    const first = await h.driver.prepare(fixtureSpec());
+    const second = await h.driver.prepare(fixtureSpec());
+
+    expect(first.key).toEqual(second.key);
+    expect(first.name).toBe(second.name);
+    expect(h.cli.calls.some((c) => c.args[0] === 'create')).toBe(false);
+  });
+
+  eachDriver('fires at most one terminal event, however many hints the stream carries', async (h) => {
+    // Watch streams duplicate and replay (watch transports re-send existing
+    // state on reconnect; docker events double up) — the hub re-reads truth
+    // and delivers at most once per incarnation.
+    const handle = await h.driver.prepare(fixtureSpec());
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+    await handle.start();
+
+    const proc = h.cli.started.at(-1)!.proc;
+    proc.emitExit(1);
+    proc.emitExit(1);
+    await settled();
+
+    expect(terminal).toHaveBeenCalledOnce();
+  });
+
+  eachDriver('stop is full teardown and reports no terminal event', async (h) => {
+    // The driver still emits the end it observes — suppression is the hub's,
+    // keyed on the stop() intent it saw through the handle. Note (contract):
+    // that stop() blocks until the runtime object is gone is an implementation
+    // behavior of today's drivers, NOT a guarantee — callers must not rely on
+    // blocking-until-gone.
+    const handle = await h.driver.prepare(fixtureSpec());
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+    await handle.start();
+    await handle.stop('host-shutdown');
+    h.cli.started.at(-1)!.proc.emitExit(137);
+    await settled();
+
+    expect(terminal).not.toHaveBeenCalled();
+    const issued = h.cli.joined().join(' | ');
+    // Whatever the runtime calls it, nothing this key allocated may survive.
+    expect(issued).toMatch(/rm --force ncl-spike-s1/);
+  });
+
+  eachDriver('reconstructs adopted handles from labels alone', async (h) => {
+    h.cli.responses = [{ match: /^ps -a/, output: 'ncl-spike-s1|running|g1|s1\n' }];
+
+    const snapshots = await h.driver.listSessions('spike');
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].handle.key).toEqual({ installSlug: 'spike', agentGroupId: 'g1', sessionId: 's1' });
+    expect(snapshots[0].phase).toBe('running');
+  });
+
+  eachDriver('lists corpses honestly: a self-exited runtime is terminal, never dressed up as live', async (h) => {
+    // Fix 2's pinned behavior: adoption must tell adoptable sessions from
+    // corpses (and from prepared-not-started incarnations) WITHOUT a
+    // per-handle status() round trip.
+    h.cli.responses = [
+      {
+        match: /^ps -a/,
+        output: 'ncl-spike-s1|running|g1|s1\nncl-spike-s2|exited|g2|s2\nncl-spike-s3|created|g3|s3\n',
+      },
+    ];
+
+    const snapshots = await h.driver.listSessions('spike');
+
+    expect(snapshots.map((s) => [s.handle.key.sessionId, s.phase])).toEqual([
+      ['s1', 'running'],
+      ['s2', 'terminal'],
+      ['s3', 'starting'],
+    ]);
+  });
+});
+
+describe('conformance: capabilities are honest', () => {
+  eachDriver('declares what it cannot realize', (h) => {
+    const capabilities = h.driver.capabilities();
+    expect(capabilities.isolationTiers).toContain('container');
+    expect(capabilities.unrealized).toEqual([]);
+    expect(capabilities.admissionEnforced).toBe(false);
+    expect(capabilities.networkPolicy).toBe('topology');
+    expect(capabilities.sharedNetworkNamespace).toBe(false);
+    // Realizes the agent container only — and refuses, never drops, the rest.
+    expect(capabilities.auxiliaryContainers).toBe(false);
+    // The session daemon doubles as the build daemon: rebuild-in-place works.
+    expect(capabilities.imageBuild).toBe(true);
+  });
+});

--- a/src/drivers/docker-driver.test.ts
+++ b/src/drivers/docker-driver.test.ts
@@ -1,0 +1,674 @@
+/**
+ * Docker driver — behavioral tests.
+ *
+ * These replace the source-text assertions that used to live in
+ * `container-runner.test.ts` and `container-runtime.test.ts`. Those read the
+ * module as a string and regexed it, so a byte-identical move broke them while
+ * a behavior change could slip past. Everything here drives a real spec through
+ * the real realization path against an injected fake CLI and asserts on the
+ * commands the driver actually issued.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DockerSessionDriver, dockerEventToSessionEvent, ensureDockerRunning } from './docker-driver.js';
+import { FakeCli } from './fake-cli.js';
+import { withSessionEvents } from './session-events.js';
+import { FIXTURE_POLICY, fixtureSpec } from './spec-fixture.js';
+import { LABELS, type SessionEvent } from './types.js';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+// The driver re-checks mount sources exist; fixture paths are not real files
+// on the test host. A vi.fn so single tests can flip it to "missing".
+vi.mock('fs', () => ({ default: { existsSync: vi.fn(() => true) } }));
+
+import fs from 'fs';
+
+import { log } from '../log.js';
+
+let cli: FakeCli;
+
+function driver(): DockerSessionDriver {
+  return new DockerSessionDriver({ ...FIXTURE_POLICY, cli });
+}
+
+/** `inspect` is how the driver asks "does this exist?" — default to "no". */
+function createArgs(): string[] {
+  const call = cli.callMatching(/^create /);
+  expect(call, 'expected a `docker create` call').toBeDefined();
+  return call!.args;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cli = new FakeCli('docker');
+  cli.responses = [{ match: /^inspect /, throws: new Error('No such object') }];
+});
+
+describe('spec realization', () => {
+  it('emits the agent container with its image, entrypoint split and canonical labels', async () => {
+    await driver().prepare(fixtureSpec());
+    const args = createArgs();
+
+    expect(args.slice(0, 4)).toEqual(['create', '--rm', '--name', 'ncl-spike-s1']);
+    // Derived from the key, not from the timestamped lineage label — `prepare`
+    // cannot be idempotent on key if the name it allocates keeps changing.
+    // The four canonical labels are the adoption contract: a handle must be
+    // rebuildable from these alone.
+    expect(args).toContain(`${LABELS.install}=spike`);
+    expect(args).toContain(`${LABELS.group}=g1`);
+    expect(args).toContain(`${LABELS.session}=s1`);
+    expect(args).toContain(`${LABELS.role}=agent`);
+    // Lineage labels from the spec and from the egress contribution both land.
+    expect(args).toContain('nanoclaw-container-name=nanoclaw-v2-agent-one-1700000000000');
+    expect(args).toContain('session-channel=channel-abc');
+    // PID 1 is split across --entrypoint and the post-image argv.
+    expect(args).toContain('--entrypoint');
+    expect(args.slice(args.indexOf('nanoclaw-agent:spike-p0'))).toEqual([
+      'nanoclaw-agent:spike-p0',
+      '-c',
+      'exec bun run /app/src/index.ts',
+    ]);
+  });
+
+  it('applies the standard hardening posture, including --init', async () => {
+    await driver().prepare(fixtureSpec());
+    const args = createArgs();
+
+    expect(args).toContain('--cap-drop=ALL');
+    expect(args.join(' ')).toContain('--security-opt no-new-privileges');
+    // Not optional: overriding the entrypoint defeats the image's tini, and
+    // without docker-init SIGTERM to PID 1 is discarded and every stop ends in
+    // SIGKILL after the full grace period.
+    expect(args).toContain('--init');
+    expect(args.join(' ')).toContain('--pids-limit 2048');
+  });
+
+  it('omits the pids limit for 0, negatives and absent values', async () => {
+    for (const pidsLimit of [0, -1, undefined]) {
+      cli = new FakeCli('docker');
+      cli.responses = [{ match: /^inspect /, throws: new Error('No such object') }];
+      await driver().prepare(fixtureSpec({ resources: { pidsLimit, shmSizeMb: 1024 } }));
+      // cgroups v2 rejects `--pids-limit 0` with EINVAL and fails the spawn.
+      expect(createArgs().join(' ')).not.toContain('--pids-limit');
+    }
+  });
+
+  it('leaves cpu and memory unbounded unless the operator opted in', async () => {
+    await driver().prepare(fixtureSpec());
+    const args = createArgs().join(' ');
+
+    // Empty knobs emit no flag — today's behavior, and not something to change
+    // silently while porting.
+    expect(args).not.toContain('--cpus');
+    expect(args).not.toContain('--memory');
+    expect(args).not.toContain('--memory-swap');
+  });
+
+  it('emits cpu, memory and shm flags when the spec sets them', async () => {
+    await driver().prepare(fixtureSpec({ resources: { cpus: '2', memoryMb: 8192, shmSizeMb: 1024 } }));
+    const args = createArgs().join(' ');
+
+    expect(args).toContain('--cpus 2');
+    expect(args).toContain('--memory 8192m');
+    expect(args).toContain('--shm-size=1024m');
+    expect(args).not.toContain('--memory-swap');
+  });
+
+  it('maps the spec identity onto --user rather than trusting the image', async () => {
+    await driver().prepare(fixtureSpec());
+    expect(createArgs().join(' ')).toContain('--user 501:1000');
+  });
+
+  it('mounts read-only where the spec says ro, and read-write otherwise', async () => {
+    await driver().prepare(fixtureSpec());
+    const args = createArgs();
+
+    expect(args).toContain('/install/data/v2-sessions/g1/s1:/workspace');
+    expect(args).toContain('/install/container/agent-runner/src:/app/src:ro');
+  });
+
+  it('applies egress-contributed mounts after ordinary mounts and before the image', async () => {
+    // The invariant the old positional test guarded: a nested read-only public
+    // CA must not be shadowed by its writable parent.
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: '/pki/proxy-ca.pem',
+      containerPath: '/run/session/proxy-ca.pem',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+    await driver().prepare(spec);
+    const args = createArgs();
+
+    const workspace = args.indexOf('/install/data/v2-sessions/g1/s1:/workspace');
+    const proxyCa = args.indexOf('/pki/proxy-ca.pem:/run/session/proxy-ca.pem:ro');
+    const image = args.indexOf('nanoclaw-agent:spike-p0');
+    expect(workspace).toBeGreaterThan(-1);
+    expect(proxyCa).toBeGreaterThan(workspace);
+    expect(image).toBeGreaterThan(proxyCa);
+  });
+
+  it('carries exactly one value per env key, and never a credential', async () => {
+    const spec = fixtureSpec();
+    spec.containers[0].env = { TZ: 'UTC', HTTPS_PROXY: 'http://127.0.0.1:15001' };
+    await driver().prepare(spec);
+    const args = createArgs();
+
+    const proxies = args.filter((a) => a.startsWith('HTTPS_PROXY='));
+    expect(proxies).toEqual(['HTTPS_PROXY=http://127.0.0.1:15001']);
+    expect(args.join(' ')).not.toContain('Proxy-Authorization');
+  });
+
+  it('realizes the injected network topology after the spec env and mounts', async () => {
+    // Topology is driver-private: injected at registration (`drivers/index.ts`),
+    // never carried on the spec. Argv-shaped input has no channel through
+    // composition anymore.
+    const d = new DockerSessionDriver({
+      ...FIXTURE_POLICY,
+      cli,
+      networkArgsFor: () => ['--network', 'nc-spike-abcd-session'],
+    });
+    await d.prepare(fixtureSpec());
+    const args = createArgs();
+
+    const network = args.indexOf('nc-spike-abcd-session');
+    const lastMount = args.indexOf('/install/container/CLAUDE.md:/app/CLAUDE.md:ro');
+    const image = args.indexOf('nanoclaw-agent:spike-p0');
+    expect(network).toBeGreaterThan(lastMount);
+    expect(image).toBeGreaterThan(network);
+  });
+
+  it('emits contributed env after composed env, so the contributed value wins last-wins', async () => {
+    // The contract's override rule (ContainerSpec.contributedEnv), realized in
+    // Docker vocabulary: the later `-e` wins.
+    const spec = fixtureSpec();
+    spec.containers[0].contributedEnv = { HTTPS_PROXY: 'http://gateway-must-win:15001' };
+    await driver().prepare(spec);
+    const args = createArgs();
+
+    const proxies = args.filter((a) => a.startsWith('HTTPS_PROXY='));
+    expect(proxies).toHaveLength(2);
+    expect(proxies.at(-1)).toBe('HTTPS_PROXY=http://gateway-must-win:15001');
+  });
+
+  it('refuses to invent a missing mount source — Docker would mount a fresh empty directory', async () => {
+    vi.mocked(fs.existsSync).mockReturnValueOnce(false);
+    await expect(driver().prepare(fixtureSpec())).rejects.toMatchObject({ kind: 'spec-invalid', retryable: false });
+    expect(cli.callMatching(/^create /)).toBeUndefined();
+  });
+});
+
+describe('spec validation', () => {
+  it('rejects identity material on the agent container', async () => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'identity-material',
+      hostPath: '/install/data/session-materials/channel-abc-XXXX/session-key.pem',
+      containerPath: '/run/session/session-key.pem',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+
+    await expect(driver().prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+    expect(cli.callMatching(/^create /)).toBeUndefined();
+  });
+
+  it('rejects a group-state mount that escapes the group subtree', async () => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'group-state',
+      hostPath: '/install/data/v2-sessions/g2/s9',
+      containerPath: '/workspace/other',
+      mode: 'rw',
+      groupScope: 'g1',
+    });
+
+    await expect(driver().prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  it('rejects an install-surface mount outside the enumerated surface roots', async () => {
+    // The state roots nest inside the project root, so a bare prefix check would
+    // admit the central DB as a mountable "surface".
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'install-surface',
+      hostPath: '/install/data/v2.db',
+      containerPath: '/app/v2.db',
+      mode: 'ro',
+      groupScope: 'g1',
+    });
+
+    await expect(driver().prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  it('rejects a secret-shaped env key', async () => {
+    const spec = fixtureSpec();
+    spec.containers[0].env.ANTHROPIC_API_KEY = 'sk-live';
+
+    await expect(driver().prepare(spec)).rejects.toMatchObject({ kind: 'denied-by-policy' });
+  });
+
+  it('rejects a spec with no agent container', async () => {
+    const spec = fixtureSpec();
+    spec.containers = spec.containers.filter((c) => c.role !== 'agent');
+
+    await expect(driver().prepare(spec)).rejects.toMatchObject({ kind: 'spec-invalid' });
+  });
+});
+
+describe('failure normalization', () => {
+  const cases: Array<[string, string]> = [
+    ['manifest unknown', 'image-unavailable'],
+    ['Cannot connect to the Docker daemon at unix:///var/run/docker.sock', 'runtime-unavailable'],
+    ['no space left on device', 'resources-exhausted'],
+    ['something nobody predicted', 'unknown'],
+  ];
+
+  for (const [message, kind] of cases) {
+    it(`maps "${message}" to ${kind}`, async () => {
+      cli.responses = [
+        { match: /^inspect /, throws: new Error('No such object') },
+        { match: /^create /, throws: new Error(message) },
+      ];
+      await expect(driver().prepare(fixtureSpec())).rejects.toMatchObject({ kind });
+    });
+  }
+
+  it('never lets the raw runtime error cross the seam', async () => {
+    cli.responses = [
+      { match: /^inspect /, throws: new Error('No such object') },
+      { match: /^create /, throws: new Error('/secrets/session-key.pem: permission denied') },
+    ];
+    await expect(driver().prepare(fixtureSpec())).rejects.toThrow(/^session realization failed: unknown$/);
+  });
+
+  it('leaves nothing allocated when create fails', async () => {
+    cli.responses = [
+      { match: /^inspect /, throws: new Error('No such object') },
+      { match: /^create /, throws: new Error('boom') },
+    ];
+    await expect(driver().prepare(fixtureSpec())).rejects.toThrow();
+    expect(cli.joined().some((c) => c.startsWith('rm --force ncl-spike-s1'))).toBe(true);
+  });
+});
+
+describe('lifecycle', () => {
+  /** The hub delivers a tick after the runtime's event: it re-reads truth first. */
+  async function settled(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  it('supervises via start --attach and the hub reports the exit code once', async () => {
+    // onTerminal is hub sugar over the driver-level stream (r2): the attach
+    // exit rides watchSessions, and the wrapper — not this driver — owns
+    // at-most-once delivery.
+    const handle = await withSessionEvents(driver()).prepare(fixtureSpec());
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+    await handle.start();
+
+    const started = cli.started.at(-1)!;
+    expect(started.args).toEqual(['start', '--attach', 'ncl-spike-s1']);
+
+    started.proc.emitExit(3);
+    started.proc.emitExit(3);
+    await settled();
+
+    expect(terminal).toHaveBeenCalledExactlyOnceWith({ kind: 'started-then-died', retryable: false, exitCode: 3 });
+  });
+
+  it('surfaces the stderr tail at warn when the container exits non-zero', async () => {
+    // A container that dies at boot (unknown provider, missing binary, bad
+    // config) explains itself only on stderr, which logs at debug.
+    const handle = await driver().prepare(fixtureSpec());
+    await handle.start();
+
+    const proc = cli.started.at(-1)!.proc;
+    proc.emitStderr('Unknown provider: mock. Registered: claude');
+    proc.emitExit(1);
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'Container exited non-zero',
+      expect.objectContaining({ stderrTail: ['Unknown provider: mock. Registered: claude'] }),
+    );
+  });
+
+  it('does not report a terminal event for a stop the host asked for', async () => {
+    // The driver emits the end it observed (no intent filtering, r3); the
+    // hub saw stop() through the wrapped handle and suppresses delivery.
+    const handle = await withSessionEvents(driver()).prepare(fixtureSpec());
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+    await handle.start();
+
+    await handle.stop('host-shutdown');
+    cli.started.at(-1)!.proc.emitExit(137);
+    await settled();
+
+    expect(terminal).not.toHaveBeenCalled();
+  });
+
+  it('stops with the spec grace and then force-removes', async () => {
+    const handle = await driver().prepare(fixtureSpec());
+    await handle.start();
+    await handle.stop('sweep-kill');
+
+    expect(cli.joined()).toContain('stop -t 1 ncl-spike-s1');
+    expect(cli.joined()).toContain('rm --force ncl-spike-s1');
+  });
+
+  it('kills the attach process when docker stop fails, so supervision cannot hang', async () => {
+    const handle = await driver().prepare(fixtureSpec());
+    await handle.start();
+    cli.responses = [{ match: /^stop /, throws: new Error('daemon gone') }];
+
+    await handle.stop('sweep-kill');
+
+    expect(cli.started.at(-1)!.proc.killed).toBe(true);
+  });
+
+  it('start is idempotent', async () => {
+    const handle = await driver().prepare(fixtureSpec());
+    await handle.start();
+    await handle.start();
+    expect(cli.started).toHaveLength(1);
+  });
+
+  it('does not conclude status while the attach channel is alive and unresolved', async () => {
+    // The events stream can outrun the attach exit: 'die' lands, the hub
+    // truth-reads, and the `--rm` container is already gone — but the attach
+    // process holds the only record of HOW it ended. A 'stopped' here would
+    // spend the hub's at-most-once terminal delivery without the exit code.
+    const handle = await driver().prepare(fixtureSpec());
+    await handle.start();
+
+    expect((await handle.status()).phase).toBe('running');
+
+    cli.started.at(-1)!.proc.emitExit(137);
+    expect(await handle.status()).toEqual({
+      phase: 'failed',
+      failure: { kind: 'started-then-died', retryable: false, exitCode: 137 },
+    });
+  });
+});
+
+describe('idempotency and adoption', () => {
+  it('returns the existing session rather than creating a second one', async () => {
+    cli.responses = [{ match: /^inspect /, output: 'spike|g1|s1\n' }];
+
+    const handle = await driver().prepare(fixtureSpec());
+
+    expect(handle.name).toBe('ncl-spike-s1');
+    expect(cli.callMatching(/^create /)).toBeUndefined();
+  });
+
+  it('refuses a name collision with a container that is not this session', async () => {
+    // The name is key-derived, but a foreign container can wear it — another
+    // install whose truncated identity collides, or an operator's hand-made
+    // container. Adopting by name would attach the session to a runtime it
+    // does not own.
+    cli.responses = [{ match: /^inspect /, output: 'other-install|g9|s1\n' }];
+
+    await expect(driver().prepare(fixtureSpec())).rejects.toMatchObject({ kind: 'unknown', retryable: false });
+    expect(cli.callMatching(/^create /)).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
+      'Container name collision: existing container is not this session',
+      expect.objectContaining({ containerName: 'ncl-spike-s1' }),
+    );
+  });
+
+  it('scopes the container name by install, truncating-then-hashing over-length identities', async () => {
+    // Two peer installs holding the same session id must never alias one
+    // runtime object; distinct keys sharing a truncated prefix must not either.
+    const longA = fixtureSpec({ key: { installSlug: 'x'.repeat(60), agentGroupId: 'g1', sessionId: 'same' } });
+    const longB = fixtureSpec({ key: { installSlug: 'x'.repeat(61), agentGroupId: 'g1', sessionId: 'same' } });
+    await driver().prepare(longA);
+    const first = createArgs()[3];
+    cli = new FakeCli('docker');
+    cli.responses = [{ match: /^inspect /, throws: new Error('No such object') }];
+    await driver().prepare(longB);
+    const second = createArgs()[3];
+
+    expect(first).not.toBe(second);
+    expect(first.length).toBeLessThanOrEqual(52); // 'ncl-' + 48
+    expect(second.length).toBeLessThanOrEqual(52);
+  });
+
+  it('rebuilds handles from labels alone, filtered to this install and the agent role', async () => {
+    cli.responses = [{ match: /^ps -a/, output: 'ncl-spike-s1|running|g1|s1\nncl-spike-s2|running|g2|s2\n' }];
+
+    const snapshots = await driver().listSessions('spike');
+
+    const psArgs = cli.callMatching(/^ps -a/)!.args.join(' ');
+    // Scoped by install label so a crash-looping peer install cannot reap our
+    // containers, and we cannot reap theirs.
+    expect(psArgs).toContain(`label=${LABELS.install}=spike`);
+    expect(psArgs).toContain(`label=${LABELS.role}=agent`);
+    expect(snapshots.map((s) => s.handle.key)).toEqual([
+      { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's1' },
+      { installSlug: 'spike', agentGroupId: 'g2', sessionId: 's2' },
+    ]);
+  });
+
+  it('phases the listing itself: exited is a corpse, created is not', async () => {
+    // `ps -a` sees exited and created containers; the `{{.State}}` column is
+    // what lets adoption tell them apart without a status() per handle. A
+    // 'created' container is a prepared-not-started incarnation — calling it
+    // terminal would have adoption tear down freshly-prepared sessions.
+    cli.responses = [
+      {
+        match: /^ps -a/,
+        output: 'ncl-spike-s1|exited|g1|s1\nncl-spike-s2|created|g2|s2\nncl-spike-s3|running|g3|s3\n',
+      },
+    ];
+
+    const snapshots = await driver().listSessions('spike');
+
+    expect(snapshots.map((s) => [s.handle.key.sessionId, s.phase])).toEqual([
+      ['s1', 'terminal'],
+      ['s2', 'starting'],
+      ['s3', 'running'],
+    ]);
+  });
+
+  it('stops pre-seam containers, which carry the install label but no session label', async () => {
+    // Containers spawned before the seam cannot be adopted (no session label to
+    // rebuild a handle from) and cannot be matched to a session — left running
+    // they would race a freshly-named replacement for the same session
+    // directory. The old cleanupOrphans() stopped them on every start; this is
+    // that behavior, scoped to exactly the containers adoption cannot claim.
+    cli.responses = [{ match: /^ps --filter/, output: 'nanoclaw-v2-agent-one-1700000000000|\nncl-spike-s1|s1\n' }];
+
+    await driver().reapResidue('spike');
+
+    expect(cli.joined()).toContain('rm --force nanoclaw-v2-agent-one-1700000000000');
+    expect(cli.joined().some((c) => c === 'rm --force ncl-spike-s1')).toBe(false);
+  });
+
+  it('reaps install-owned networks whose containers are gone', async () => {
+    cli.responses = [{ match: /^network ls/, output: 'nc-spike-a-session\nnc-spike-a-uplink\n' }];
+
+    await driver().reapResidue('spike');
+
+    expect(cli.joined()).toContain('network rm nc-spike-a-session');
+    expect(cli.joined()).toContain('network rm nc-spike-a-uplink');
+    expect(log.info).toHaveBeenCalledWith('Removed orphaned networks', expect.objectContaining({ count: 2 }));
+  });
+
+  it('refuses a network name it did not shape', async () => {
+    cli.responses = [{ match: /^network ls/, output: 'network$(id)\n' }];
+
+    await driver().reapResidue('spike');
+
+    expect(cli.joined().some((c) => c.startsWith('network rm'))).toBe(false);
+  });
+});
+
+describe('watchSessions', () => {
+  function dieEvent(sessionId: string, action = 'die'): string {
+    return JSON.stringify({
+      status: action,
+      Type: 'container',
+      Action: action,
+      Actor: {
+        ID: 'abc123',
+        Attributes: {
+          name: `ncl-${sessionId}`,
+          [LABELS.install]: 'spike',
+          [LABELS.group]: 'g1',
+          [LABELS.session]: sessionId,
+          [LABELS.role]: 'agent',
+        },
+      },
+    });
+  }
+
+  it('is ONE lazy driver-level `docker events` subscription per install, shared by every subscriber', async () => {
+    const d = driver();
+    expect(cli.started.filter((s) => s.args[0] === 'events')).toHaveLength(0); // lazy
+
+    const seen: SessionEvent[] = [];
+    d.watchSessions('spike', (e) => seen.push(e));
+    d.watchSessions('spike', () => {});
+
+    // One subscription for the whole install — never a per-session process.
+    const events = cli.started.filter((s) => s.args[0] === 'events');
+    expect(events).toHaveLength(1);
+    const argv = events[0].args.join(' ');
+    expect(argv).toContain(`label=${LABELS.install}=spike`);
+    expect(argv).toContain(`label=${LABELS.role}=agent`);
+  });
+
+  it('emits terminal hints keyed from the labels the event carries', async () => {
+    const d = driver();
+    const seen: SessionEvent[] = [];
+    d.watchSessions('spike', (e) => seen.push(e));
+
+    const proc = cli.started.find((s) => s.args[0] === 'events')!.proc;
+    proc.emitStdout(`${dieEvent('s1')}\n${dieEvent('s2', 'start')}\n`);
+
+    expect(seen).toEqual([
+      { key: { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's1' }, kind: 'terminal' },
+      { key: { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's2' }, kind: 'phase' },
+    ]);
+  });
+
+  it('stop() unsubscribes one listener without tearing down the shared stream', async () => {
+    const d = driver();
+    const seen: SessionEvent[] = [];
+    const kept: SessionEvent[] = [];
+    const watch = d.watchSessions('spike', (e) => seen.push(e));
+    d.watchSessions('spike', (e) => kept.push(e));
+
+    watch.stop();
+    cli.started.find((s) => s.args[0] === 'events')!.proc.emitStdout(`${dieEvent('s1')}\n`);
+
+    expect(seen).toHaveLength(0);
+    expect(kept).toHaveLength(1);
+  });
+
+  it('reconnects with bounded backoff when the subscription process dies', async () => {
+    vi.useFakeTimers();
+    try {
+      const d = driver();
+      const seen: SessionEvent[] = [];
+      d.watchSessions('spike', (e) => seen.push(e));
+
+      cli.started.find((s) => s.args[0] === 'events')!.proc.emitExit(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const procs = cli.started.filter((s) => s.args[0] === 'events');
+      expect(procs).toHaveLength(2);
+      // The reconnected stream serves the same subscribers: supervision has no gap.
+      procs.at(-1)!.proc.emitStdout(`${dieEvent('s1')}\n`);
+      expect(seen).toEqual([{ key: { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's1' }, kind: 'terminal' }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('closes the gap on reconnect: corpses and vanished known keys get synthetic terminal hints', async () => {
+    // A terminal that happens while the subscription is down was never emitted,
+    // and the fresh `docker events` stream starts from now. For an adopted
+    // session the stream is the ONLY terminal source (no attach backstop), so
+    // an unreconciled gap would leave it 'active' forever.
+    vi.useFakeTimers();
+    try {
+      const d = driver();
+      // Two keys the driver knows: during the gap s1 dies and `--rm` removes
+      // it (absent from the re-list); s2 dies and sits exited (a corpse).
+      cli.responses = [{ match: /^ps -a/, output: 'ncl-spike-s1|running|g1|s1\nncl-spike-s2|running|g1|s2\n' }];
+      await d.listSessions('spike');
+
+      const seen: SessionEvent[] = [];
+      d.watchSessions('spike', (e) => seen.push(e));
+      expect(seen).toEqual([]); // the first connect is not a gap — nothing to replay
+
+      cli.responses = [{ match: /^ps -a/, output: 'ncl-spike-s2|exited|g1|s2\n' }];
+      cli.started.find((s) => s.args[0] === 'events')!.proc.emitExit(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // Hints, not transitions: the hub still truth-reads each one.
+      expect(seen).toEqual([
+        { key: { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's2' }, kind: 'terminal' },
+        { key: { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's1' }, kind: 'terminal' },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hints nothing when the daemon is still down at reconnect — no false terminals', async () => {
+    // With the daemon down, inspect cannot tell removed from unreachable, so a
+    // synthetic hint could fire a terminal for a live-restored container. The
+    // gate is the re-list: if `ps -a` fails, skip — that same dead daemon
+    // exits the events process too, and the next reconnect retries.
+    vi.useFakeTimers();
+    try {
+      const d = driver();
+      cli.responses = [{ match: /^ps -a/, output: 'ncl-spike-s1|running|g1|s1\n' }];
+      await d.listSessions('spike');
+      const seen: SessionEvent[] = [];
+      d.watchSessions('spike', (e) => seen.push(e));
+
+      cli.responses = [{ match: /^ps -a/, throws: new Error('Cannot connect to the Docker daemon') }];
+      cli.started.find((s) => s.args[0] === 'events')!.proc.emitExit(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(seen).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('dockerEventToSessionEvent', () => {
+  it('drops label-less documents and unknown actions — hints may drop', () => {
+    expect(dockerEventToSessionEvent({ Action: 'die', Actor: { Attributes: { name: 'x' } } }, 'spike')).toBeNull();
+    expect(
+      dockerEventToSessionEvent(
+        { Action: 'exec_create: bash', Actor: { Attributes: { [LABELS.group]: 'g1', [LABELS.session]: 's1' } } },
+        'spike',
+      ),
+    ).toBeNull();
+    expect(dockerEventToSessionEvent('not an object', 'spike')).toBeNull();
+  });
+});
+
+describe('ensureDockerRunning', () => {
+  it('passes when the daemon answers', () => {
+    expect(() => ensureDockerRunning(cli)).not.toThrow();
+    expect(cli.joined()).toContain('info');
+  });
+
+  it('throws a fatal startup error when it does not', () => {
+    cli.responses = [{ match: /^info$/, throws: new Error('Cannot connect to the Docker daemon') }];
+    expect(() => ensureDockerRunning(cli)).toThrow('Container runtime is required but failed to start');
+    expect(log.error).toHaveBeenCalled();
+  });
+});

--- a/src/drivers/docker-driver.ts
+++ b/src/drivers/docker-driver.ts
@@ -1,0 +1,714 @@
+/**
+ * Docker driver — the permanent OSS/dev realization.
+ *
+ * Everything an orchestrator-backed driver would get for free (ordering, GC,
+ * admission) is done here explicitly, in code. That asymmetry is the point:
+ * same spec in, same observable semantics out, different amount of
+ * choreography.
+ *
+ * This file is where `container-runtime.ts`'s helpers and the runtime half of
+ * `container-runner.ts` (argv assembly, kill/stop, orphan listing) end up.
+ * `container-runner.ts` keeps composition and lifecycle policy only.
+ *
+ * Network topology note: on Docker the containers of a session do NOT share a
+ * network namespace — an auxiliary container's uplink here is a routable bridge, so
+ * a netns-join would hand the agent the whole internet and delete the lockdown
+ * the private network provides. `capabilities.sharedNetworkNamespace = false`
+ * is how an egress overlay learns to address such a container by name here rather
+ * than by localhost.
+ */
+import { createHash } from 'crypto';
+import fs from 'fs';
+
+import { log } from '../log.js';
+
+import { realCli, validateRuntimeName, type Cli, type SupervisedProcess } from './cli.js';
+import { JsonDocumentStream } from './json-stream.js';
+import {
+  LABELS,
+  asFailureError,
+  labelsForKey,
+  specInvalid,
+  validateSpec,
+  type ContainerSpec,
+  type DriverCapabilities,
+  type MountPolicy,
+  type MountSpec,
+  type SessionDriver,
+  type SessionEvent,
+  type SessionFailure,
+  type SessionHandle,
+  type SessionKey,
+  type SessionPhase,
+  type SessionSnapshot,
+  type SessionSpec,
+  type SessionStatus,
+  type SessionWatch,
+} from './types.js';
+
+export interface DockerDriverOptions extends MountPolicy {
+  cli?: Cli;
+  /** Docker network the session's containers attach to, resolved by the overlay. */
+  networkArgsFor?: (spec: SessionSpec) => string[];
+}
+
+/** Watch reconnection: bounded backoff, never give up (see `watchSessions`). */
+const WATCH_RECOVERY_BASE_MS = 1_000;
+const WATCH_RECOVERY_MAX_MS = 30_000;
+
+interface InstallWatch {
+  subscribers: Set<(event: SessionEvent) => void>;
+  attempt: number;
+}
+
+export class DockerSessionDriver implements SessionDriver {
+  readonly kind = 'docker' as const;
+  readonly #cli: Cli;
+  readonly #policy: MountPolicy;
+  /** One `docker events` subscription per install slug — never per session. */
+  readonly #watches = new Map<string, InstallWatch>();
+  /**
+   * Every key this driver ever handed out (prepare or list), per install.
+   * `#reconcileWatchGap` hints these on watch reconnect: a `--rm` container
+   * that died while the subscription was down is gone from `ps -a` too, so
+   * the re-list alone cannot name it — only this registry can.
+   */
+  readonly #knownKeys = new Map<string, Map<string, SessionKey>>();
+
+  constructor(private readonly opts: DockerDriverOptions) {
+    this.#cli = opts.cli ?? realCli('docker');
+    this.#policy = opts;
+  }
+
+  capabilities(): DriverCapabilities {
+    return {
+      isolationTiers: ['container'],
+      admissionEnforced: false, // mount pinning is enforced in code, not structurally
+      networkPolicy: 'topology',
+      encryptedVolumes: false,
+      unrealized: [],
+      sharedNetworkNamespace: false,
+      // Realizes the agent container only, and REFUSES specs carrying more —
+      // see the role check in `prepare`. Flips only when this driver actually
+      // manages auxiliary containers, never before.
+      auxiliaryContainers: false,
+      // The daemon this driver shells for sessions is the same one
+      // buildAgentGroupImage builds against; rebuild-in-place is real here.
+      imageBuild: true,
+    };
+  }
+
+  async ensureReady(): Promise<void> {
+    ensureDockerRunning(this.#cli);
+  }
+
+  async prepare(spec: SessionSpec): Promise<SessionHandle> {
+    validateSpec(spec, this.#policy);
+
+    const extra = spec.containers.filter((c) => c.role !== 'agent');
+    if (extra.length > 0) {
+      // Refusal, not omission. This driver realizes the agent container only,
+      // and a spec is a statement of what the session IS — realizing a subset
+      // would validate containers that never exist, leaving (say) a dead proxy
+      // address in the agent's env to be discovered at first egress instead of
+      // here. Composition gates on capabilities().auxiliaryContainers, so this
+      // is the backstop for a composer that did not.
+      throw specInvalid(
+        `docker driver does not manage container role '${extra[0].role}'; ` +
+          `auxiliary containers require a driver with capabilities().auxiliaryContainers`,
+      );
+    }
+    const agent = spec.containers.find((c) => c.role === 'agent')!;
+    const name = validateRuntimeName(agentContainerName(spec), 'container');
+
+    this.#remember(spec.key);
+
+    // Idempotency on key: an existing live container for this key is the session.
+    if (this.#existingSession(name, spec.key)) {
+      return new DockerHandle(spec.key, name, this.#cli, null, this.#emit);
+    }
+
+    // Composition existsSync-gates mount sources; re-check here so a
+    // realization cannot silently invent one (Docker mounts a missing source
+    // as a fresh empty directory — see `assertMountSourcesExist`). After the
+    // idempotency return: an existing container's mounts are already bound,
+    // and a source deleted since must not refuse adoption of a live session.
+    assertMountSourcesExist(agent.mounts);
+
+    const args = ['create', '--rm', '--name', name];
+    args.push(...labelArgs(labelsForKey(spec.key, 'agent', { ...spec.labels, ...(agent.labels ?? {}) })));
+    args.push(...resourceArgs(spec));
+    args.push(...hardeningArgs(spec));
+    args.push(...userArgs(spec));
+    // Composed env first, contributed env second: on a duplicate `-e` key
+    // Docker's last flag wins, which realizes the contract rule that the
+    // contributed lane overrides composed literals (see ContainerSpec).
+    args.push(...envArgs(agent.env));
+    args.push(...envArgs(agent.contributedEnv ?? {}));
+    args.push(...mountArgs(agent.mounts));
+    // Network topology is driver-private: injected at registration (see
+    // `drivers/index.ts`), never carried on the spec. Argv-shaped input has no
+    // remaining channel through composition.
+    args.push(...(this.opts.networkArgsFor?.(spec) ?? []));
+    if (agent.command && agent.command.length > 0) {
+      // Docker splits PID 1 across --entrypoint (argv[0] + fixed flags) and the
+      // post-image argv. Keeping the split in the spec is what lets another
+      // realization preserve tini as PID 1 rather than inventing an entrypoint.
+      args.push('--entrypoint', agent.command[0]);
+      args.push(agent.image, ...agent.command.slice(1), ...(agent.args ?? []));
+    } else {
+      args.push(agent.image, ...(agent.args ?? []));
+    }
+
+    try {
+      this.#cli.run(args);
+    } catch (error) {
+      try {
+        this.#cli.run(['rm', '--force', name]);
+      } catch {
+        /* prepare is atomic: allocate all or leave nothing */
+      }
+      throw normalizeDockerError(error);
+    }
+    return new DockerHandle(spec.key, name, this.#cli, spec, this.#emit);
+  }
+
+  async listSessions(installSlug: string): Promise<SessionSnapshot[]> {
+    // Adoption contract: reconstruct handles from labels alone. `{{.State}}`
+    // rides along because `ps -a` includes exited/created containers, and a
+    // caller must be able to tell an adoptable session from a corpse without
+    // a per-handle status() round trip.
+    let out: string;
+    try {
+      out = this.#cli.run([
+        'ps',
+        '-a',
+        '--filter',
+        `label=${LABELS.install}=${installSlug}`,
+        '--filter',
+        `label=${LABELS.role}=agent`,
+        '--format',
+        `{{.Names}}|{{.State}}|{{.Label "${LABELS.group}"}}|{{.Label "${LABELS.session}"}}`,
+      ]);
+    } catch (error) {
+      throw normalizeDockerError(error);
+    }
+    return out
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [name, state, agentGroupId, sessionId] = line.split('|');
+        const key: SessionKey = { installSlug, agentGroupId, sessionId };
+        this.#remember(key);
+        return {
+          handle: new DockerHandle(key, name, this.#cli, null, this.#emit),
+          phase: dockerStatePhase(state),
+        };
+      });
+  }
+
+  watchSessions(installSlug: string, onEvent: (event: SessionEvent) => void): SessionWatch {
+    let watch = this.#watches.get(installSlug);
+    if (!watch) {
+      // Lazy: the subscription process exists only once someone is listening.
+      watch = { subscribers: new Set(), attempt: 0 };
+      this.#watches.set(installSlug, watch);
+      this.#connectWatch(installSlug, watch);
+    }
+    watch.subscribers.add(onEvent);
+    return {
+      stop: () => {
+        watch.subscribers.delete(onEvent);
+      },
+    };
+  }
+
+  /**
+   * The one driver-level watch: a `docker events` subscription filtered by the
+   * install and agent-role labels. Emits best-effort hints for every observed
+   * transition — including ends the host itself requested; intent filtering is
+   * the session-events hub's job, not this driver's.
+   */
+  #connectWatch(installSlug: string, watch: InstallWatch, reconnected = false): void {
+    const stream = new JsonDocumentStream();
+    const proc = this.#cli.start(
+      [
+        'events',
+        '--filter',
+        'type=container',
+        '--filter',
+        `label=${LABELS.install}=${installSlug}`,
+        '--filter',
+        `label=${LABELS.role}=agent`,
+        '--format',
+        '{{json .}}',
+      ],
+      { captureStdout: true },
+    );
+    proc.onStdout((chunk) => {
+      // Data flowing means the subscription is healthy again.
+      watch.attempt = 0;
+      for (const doc of stream.push(chunk)) {
+        const event = dockerEventToSessionEvent(doc, installSlug);
+        if (!event) continue;
+        for (const subscriber of watch.subscribers) subscriber(event);
+      }
+    });
+    proc.onExit(() => {
+      if (this.#watches.get(installSlug) !== watch) return;
+      // Bounded backoff, never give up: an unrecovered drop would end
+      // supervision for every session of the install at once.
+      const delay = Math.min(WATCH_RECOVERY_BASE_MS * 2 ** watch.attempt, WATCH_RECOVERY_MAX_MS);
+      watch.attempt += 1;
+      const timer = setTimeout(() => this.#connectWatch(installSlug, watch, true), delay);
+      timer.unref?.();
+    });
+    if (reconnected) void this.#reconcileWatchGap(installSlug, watch);
+  }
+
+  /**
+   * A dropped subscription is a gap: the fresh `docker events` stream starts
+   * from now, so a terminal that happened while it was down was never emitted
+   * — and for an adopted session the stream is the ONLY terminal source (no
+   * attach process backstop). Close the gap with synthetic hints: re-list
+   * once, hint every corpse the list shows and every known key it no longer
+   * shows (`--rm` already removed it), and let the hub's truth reads sort
+   * spurious from real — hints may duplicate, never fire directly. Gated on
+   * the re-list succeeding so a daemon that is still down (where inspect
+   * cannot tell removed from unreachable) produces no false terminals; that
+   * same dead daemon exits the events process too, and the next reconnect
+   * retries this.
+   */
+  async #reconcileWatchGap(installSlug: string, watch: InstallWatch): Promise<void> {
+    if (this.#watches.get(installSlug) !== watch) return;
+    let snapshots: SessionSnapshot[];
+    try {
+      snapshots = await this.listSessions(installSlug);
+    } catch {
+      return;
+    }
+    const listed = new Set(snapshots.map((s) => keyId(s.handle.key)));
+    const gapKeys = snapshots.filter((s) => s.phase === 'terminal').map((s) => s.handle.key);
+    for (const [id, key] of this.#knownKeys.get(installSlug) ?? []) {
+      if (!listed.has(id)) gapKeys.push(key);
+    }
+    for (const key of gapKeys) this.#emit({ key, kind: 'terminal' });
+  }
+
+  #remember(key: SessionKey): void {
+    let known = this.#knownKeys.get(key.installSlug);
+    if (!known) {
+      known = new Map();
+      this.#knownKeys.set(key.installSlug, known);
+    }
+    known.set(keyId(key), key);
+  }
+
+  /** Handle-observed transitions (the `start --attach` exit) ride the same stream. */
+  readonly #emit = (event: SessionEvent): void => {
+    const watch = this.#watches.get(event.key.installSlug);
+    if (!watch) return;
+    for (const subscriber of watch.subscribers) subscriber(event);
+  };
+
+  /**
+   * Residue a stopped session cannot clean up itself: install-labeled networks
+   * whose containers are already gone. `stop()` is full teardown for a live
+   * session; this covers a host that died between the two.
+   */
+  async reapResidue(installSlug: string): Promise<void> {
+    // Containers first: an auxiliary container whose host died has no owner left
+    // to close it. Only non-running ones — an adopted session's are still serving it.
+    try {
+      const out = this.#cli.run([
+        'ps',
+        '-a',
+        '--filter',
+        `label=${LABELS.install}=${installSlug}`,
+        '--filter',
+        'status=exited',
+        '--filter',
+        'status=created',
+        '--filter',
+        'status=dead',
+        '--format',
+        '{{.Names}}',
+      ]);
+      const stale = out.trim().split('\n').filter(Boolean);
+      for (const name of stale) {
+        try {
+          this.#cli.run(['rm', '--force', validateRuntimeName(name, 'container')]);
+        } catch {
+          /* already gone */
+        }
+      }
+      if (stale.length > 0) log.info('Removed orphaned containers', { count: stale.length, names: stale });
+    } catch (err) {
+      log.warn('Failed to clean up orphaned containers', { err });
+    }
+
+    // Pre-seam residue: containers spawned before the driver seam carry the
+    // install label but not the session label, so `listSessions` cannot see
+    // them — they can be neither adopted nor matched to a session. Left alone
+    // they would run forever AND race a freshly-named replacement for the same
+    // session directory. Stopping them is exactly what the old
+    // `cleanupOrphans()` did to every container on every start.
+    try {
+      const out = this.#cli.run([
+        'ps',
+        '--filter',
+        `label=${LABELS.install}=${installSlug}`,
+        '--format',
+        `{{.Names}}|{{.Label "${LABELS.session}"}}`,
+      ]);
+      const preSeam = out
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => line.split('|'))
+        .filter(([, sessionId]) => !sessionId)
+        .map(([name]) => name);
+      for (const name of preSeam) {
+        try {
+          this.#cli.run(['rm', '--force', validateRuntimeName(name, 'container')]);
+        } catch {
+          /* already gone */
+        }
+      }
+      if (preSeam.length > 0) log.info('Stopped pre-seam containers', { count: preSeam.length, names: preSeam });
+    } catch (err) {
+      log.warn('Failed to clean up pre-seam containers', { err });
+    }
+
+    let names: string[] = [];
+    try {
+      const out = this.#cli.run([
+        'network',
+        'ls',
+        '--filter',
+        `label=${LABELS.install}=${installSlug}`,
+        '--format',
+        '{{.Name}}',
+      ]);
+      names = out.trim().split('\n').filter(Boolean);
+    } catch (err) {
+      log.warn('Failed to list install-owned networks', { err });
+      return;
+    }
+    const removed: string[] = [];
+    for (const name of names) {
+      try {
+        this.#cli.run(['network', 'rm', validateRuntimeName(name, 'network')]);
+        removed.push(name);
+      } catch {
+        /* still in use by a live session, or already gone */
+      }
+    }
+    if (removed.length > 0) log.info('Removed orphaned networks', { count: removed.length, names: removed });
+  }
+
+  /**
+   * Name-existence alone cannot answer "is this MY session": the name is
+   * key-derived, but a foreign container can wear it — another install sharing
+   * this daemon whose truncated identity collides, or an operator's hand-made
+   * container. Adopting one by name would attach this session to a runtime it
+   * does not own, so the canonical labels are verified and a mismatch refuses
+   * loudly instead of aliasing.
+   */
+  #existingSession(name: string, key: SessionKey): boolean {
+    let out: string;
+    try {
+      out = this.#cli.run([
+        'inspect',
+        '--format',
+        `{{index .Config.Labels "${LABELS.install}"}}|{{index .Config.Labels "${LABELS.group}"}}|{{index .Config.Labels "${LABELS.session}"}}`,
+        name,
+      ]);
+    } catch {
+      return false;
+    }
+    const [install, group, session] = out.trim().split('|');
+    if (install === key.installSlug && group === key.agentGroupId && session === key.sessionId) return true;
+    log.warn('Container name collision: existing container is not this session', {
+      containerName: name,
+      wanted: key,
+      found: { install, group, session },
+    });
+    throw asFailureError({ kind: 'unknown', retryable: false, opaqueRef: `name-collision-${name}` });
+  }
+}
+
+class DockerHandle implements SessionHandle {
+  #proc: SupervisedProcess | null = null;
+  /** Log hygiene only — events are never intent-filtered here (that is the hub's job). */
+  #stopping = false;
+  /** Exit code the attach process observed; undefined until it exits. */
+  #attachExitCode: number | null | undefined;
+  readonly #stderrTail: string[] = [];
+
+  constructor(
+    readonly key: SessionKey,
+    readonly name: string,
+    private readonly cli: Cli,
+    /** Present only between prepare and start; null for an adopted handle. */
+    private readonly pendingSpec: SessionSpec | null,
+    private readonly emit: (event: SessionEvent) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.#proc) return; // idempotent
+    // `start --attach` is the supervision channel: it exits with the container's
+    // exit code and streams the stderr that explains a boot failure. A container
+    // that dies at boot (unknown provider, missing binary, bad config) explains
+    // itself only here, so keep a tail and surface it at warn on a non-zero exit.
+    const proc = this.cli.start(['start', '--attach', this.name]);
+    this.#proc = proc;
+    proc.onStderr((line) => {
+      log.debug(line, { container: this.name });
+      this.#stderrTail.push(line);
+      if (this.#stderrTail.length > 10) this.#stderrTail.shift();
+    });
+    proc.onExit((code) => {
+      this.#attachExitCode = code;
+      if (!this.#stopping && code !== 0 && code !== null && this.#stderrTail.length > 0) {
+        log.warn('Container exited non-zero', { containerName: this.name, code, stderrTail: this.#stderrTail });
+      }
+      // Every observed terminal transition rides the driver-level stream —
+      // even ends the host requested. Intent filtering is the hub's job.
+      this.emit({ key: this.key, kind: 'terminal' });
+    });
+  }
+
+  async status(): Promise<SessionStatus> {
+    let state: string;
+    try {
+      state = this.cli.run(['inspect', '--format', '{{.State.Status}}|{{.State.ExitCode}}', this.name]).trim();
+    } catch {
+      // `--rm` means an exited container has already been removed; the attach
+      // exit code is the only record of how it ended. A host-requested stop is
+      // not a failure, whatever code the runtime used to end the process.
+      if (!this.#stopping && typeof this.#attachExitCode === 'number' && this.#attachExitCode !== 0) {
+        return {
+          phase: 'failed',
+          failure: { kind: 'started-then-died', retryable: false, exitCode: this.#attachExitCode },
+        };
+      }
+      if (!this.#stopping && this.#proc && this.#attachExitCode === undefined) {
+        // The container is gone but the attach process has not exited yet —
+        // and that process holds the only record of HOW the session ended. The
+        // events stream can outrun it (a 'die' event lands before the attach
+        // exit), and concluding 'stopped' here would let the hub spend its
+        // at-most-once terminal delivery without the exit code. Report running:
+        // the attach exit always emits its own hint, so deferral converges
+        // within one process exit.
+        return { phase: 'running' };
+      }
+      return this.pendingSpec && !this.#proc ? { phase: 'ready' } : { phase: 'stopped' };
+    }
+    const [status, exit] = state.split('|');
+    if (status === 'running') return { phase: 'running' };
+    if (status === 'created') return { phase: 'ready' };
+    if (status === 'exited' && exit !== '0') {
+      return { phase: 'failed', failure: { kind: 'started-then-died', retryable: false, exitCode: Number(exit) } };
+    }
+    return { phase: 'stopped' };
+  }
+
+  /**
+   * Full teardown. That this blocks until the container is gone is an
+   * implementation behavior (it happens to serialize workspace single-writer
+   * during termination), not a contract guarantee — see `SessionHandle.stop`.
+   */
+  async stop(reason: string): Promise<void> {
+    this.#stopping = true;
+    log.info('Stopping session container', { containerName: this.name, reason });
+    const grace = String(this.pendingSpec?.stopGraceSeconds ?? 1);
+    try {
+      this.cli.run(['stop', '-t', grace, this.name]);
+    } catch {
+      // Already gone, or the daemon refused: fall back to killing the attach
+      // process so supervision never hangs waiting for an exit that cannot come.
+      this.#proc?.kill();
+    }
+    try {
+      this.cli.run(['rm', '--force', this.name]);
+    } catch {
+      /* `--rm` usually got there first */
+    }
+  }
+}
+
+/** Collision-proof key identity for driver-internal maps (NUL cannot appear in a key part). */
+function keyId(key: SessionKey): string {
+  return `${key.installSlug}\u0000${key.agentGroupId}\u0000${key.sessionId}`;
+}
+
+// ---------- realization helpers (absorbed from container-runtime.ts) ----------
+
+/**
+ * `docker ps` state → seam phase. 'created' is prepared-not-started — an
+ * adoption-adjacent incarnation, NOT a corpse; treating it as terminal would
+ * have adoption tear down freshly-prepared sessions.
+ */
+export function dockerStatePhase(state: string): SessionPhase {
+  if (state === 'running' || state === 'paused' || state === 'restarting') return 'running';
+  if (state === 'created') return 'starting';
+  // exited, dead, removing — self-ended corpses awaiting cleanup.
+  return 'terminal';
+}
+
+interface DockerEventDoc {
+  Action?: string;
+  Actor?: { Attributes?: Record<string, string> };
+}
+
+/**
+ * One `docker events` document → one best-effort hint, keyed from the labels
+ * the event carries (the adoption contract, again: labels are the identity).
+ * Unknown actions and label-less events are dropped — hints may drop.
+ */
+export function dockerEventToSessionEvent(doc: unknown, installSlug: string): SessionEvent | null {
+  const event = doc as DockerEventDoc;
+  const attrs = event.Actor?.Attributes ?? {};
+  const agentGroupId = attrs[LABELS.group];
+  const sessionId = attrs[LABELS.session];
+  if (!agentGroupId || !sessionId) return null;
+  const action = event.Action ?? '';
+  const kind =
+    action === 'die' || action === 'destroy'
+      ? ('terminal' as const)
+      : action === 'create' || action === 'start' || action === 'restart'
+        ? ('phase' as const)
+        : action === 'kill' || action === 'stop' || action === 'oom' || action === 'pause' || action === 'unpause'
+          ? ('hint' as const)
+          : null;
+  if (!kind) return null;
+  return { key: { installSlug, agentGroupId, sessionId }, kind };
+}
+
+/**
+ * Derived from the key, never from a timestamp.
+ *
+ * `prepare` is idempotent on key, and it cannot be if the name it allocates
+ * changes between calls. The install slug is part of the derivation because
+ * the daemon is a shared namespace: two peer installs holding the same session
+ * id must never alias one runtime object (`#existingSession` verifies labels
+ * as the backstop). Over-length identities truncate-then-hash over the FULL
+ * identity, so distinct keys that share a 39-byte prefix still get distinct
+ * names, deterministically. The human-readable, timestamped name the host used
+ * to generate survives as the `nanoclaw-container-name` lineage label.
+ */
+export function agentContainerName(spec: SessionSpec): string {
+  const raw = `${spec.key.installSlug}-${spec.key.sessionId}`.replaceAll(/[^a-zA-Z0-9_.-]/g, '-');
+  if (raw.length <= 48) return `ncl-${raw}`;
+  const hash = createHash('sha256').update(`${spec.key.installSlug} ${spec.key.sessionId}`).digest('hex').slice(0, 8);
+  return `ncl-${raw.slice(0, 39)}-${hash}`;
+}
+
+/**
+ * 'standard' posture, Docker dialect.
+ *
+ * cap-drop and no-new-privileges are inert while containers run under the
+ * `--user` mapping (the capability sets are already empty and the image carries
+ * no file capabilities) — they are depth against a root-in-container path.
+ * `--init` is not optional: overriding the entrypoint defeats the image's tini,
+ * leaving the runtime as PID 1 with no signal handler, and Linux discards
+ * default-action signals to PID 1. Without docker-init, SIGTERM is ignored and
+ * every stop ends in SIGKILL after the full grace period.
+ */
+export function hardeningArgs(spec: SessionSpec): string[] {
+  const args = ['--cap-drop=ALL', '--security-opt', 'no-new-privileges', '--init'];
+  // Test >0, not truthiness: cgroups v2 rejects `--pids-limit 0` with EINVAL.
+  const pids = spec.resources.pidsLimit;
+  if (typeof pids === 'number' && Number.isFinite(pids) && pids > 0) {
+    args.push('--pids-limit', String(Math.floor(pids)));
+  }
+  return args;
+}
+
+/**
+ * Per-container resource caps. Undefined stays unbounded — the operator opts
+ * in, and a default cap here would OOM-kill workloads that run fine today.
+ * Whether `--memory` is a hard cap depends on the host having no swap, which
+ * is a deployment concern and not managed from here.
+ */
+export function resourceArgs(spec: SessionSpec): string[] {
+  const args: string[] = [];
+  if (spec.resources.cpus) args.push('--cpus', spec.resources.cpus);
+  if (spec.resources.memoryMb) args.push('--memory', `${spec.resources.memoryMb}m`);
+  // Docker defaults /dev/shm to 64m, which silently short-writes past that size.
+  if (spec.resources.shmSizeMb) args.push(`--shm-size=${spec.resources.shmSizeMb}m`);
+  return args;
+}
+
+export function userArgs(spec: SessionSpec): string[] {
+  return spec.runAs ? ['--user', `${spec.runAs.uid}:${spec.runAs.gid}`] : [];
+}
+
+export function mountArgs(mounts: readonly MountSpec[]): string[] {
+  return mounts.flatMap((m) => [
+    '-v',
+    m.mode === 'ro' ? `${m.hostPath}:${m.containerPath}:ro` : `${m.hostPath}:${m.containerPath}`,
+  ]);
+}
+
+export function envArgs(env: Record<string, string>): string[] {
+  return Object.entries(env).flatMap(([k, v]) => ['-e', `${k}=${v}`]);
+}
+
+export function labelArgs(labels: Record<string, string>): string[] {
+  return Object.entries(labels).flatMap(([k, v]) => ['--label', `${k}=${v}`]);
+}
+
+export function normalizeDockerError(error: unknown): Error & SessionFailure {
+  const msg = error instanceof Error ? error.message : String(error);
+  const failure: SessionFailure = /manifest unknown|pull access denied|not found: manifest|No such image/i.test(msg)
+    ? { kind: 'image-unavailable', retryable: true }
+    : /Cannot connect to the Docker daemon|daemon is not running/i.test(msg)
+      ? { kind: 'runtime-unavailable', retryable: true }
+      : /no space left|cannot allocate memory/i.test(msg)
+        ? { kind: 'resources-exhausted', retryable: true }
+        : // Raw runtime errors never cross the seam.
+          { kind: 'unknown', retryable: false, opaqueRef: `docker-${Date.now()}` };
+  return asFailureError(failure);
+}
+
+/**
+ * Docker mounts a missing hostPath as a fresh empty directory, which silently
+ * turns a typo'd file mount into an empty dir inside the container. Composition
+ * already existsSync-gates these; the driver re-checks so a realization
+ * cannot silently invent a mount source that composition never saw.
+ */
+export function assertMountSourcesExist(mounts: readonly MountSpec[]): void {
+  for (const mount of mounts) {
+    if (!fs.existsSync(mount.hostPath)) {
+      throw asFailureError({
+        kind: 'spec-invalid',
+        retryable: false,
+        detail: `mount source missing: ${mount.hostPath}`,
+      });
+    }
+  }
+}
+
+/** Ensure the container runtime is reachable. Fatal at startup — agents cannot run without it. */
+export function ensureDockerRunning(cli: Cli = realCli('docker')): void {
+  try {
+    cli.run(['info'], { timeoutMs: 10_000 });
+    log.debug('Container runtime already running');
+  } catch (err) {
+    log.error('Failed to reach container runtime', { err });
+    console.error('\n╔════════════════════════════════════════════════════════════════╗');
+    console.error('║  FATAL: Container runtime failed to start                      ║');
+    console.error('║                                                                ║');
+    console.error('║  Agents cannot run without a container runtime. To fix:        ║');
+    console.error('║  1. Ensure Docker is installed and running                     ║');
+    console.error('║  2. Run: docker info                                           ║');
+    console.error('║  3. Restart NanoClaw                                           ║');
+    console.error('╚════════════════════════════════════════════════════════════════╝\n');
+    throw new Error('Container runtime is required but failed to start', { cause: err });
+  }
+}
+
+export type { ContainerSpec };

--- a/src/drivers/driver-registry.ts
+++ b/src/drivers/driver-registry.ts
@@ -1,0 +1,48 @@
+/**
+ * Session driver registry.
+ *
+ * Its own module, not part of `index.ts`, for the same reason
+ * `provider-container-registry.ts` is separate from the provider barrel: the
+ * file an overlay appends an import to must not be the file that owns the map.
+ * An appended `import './x.js';` is evaluated BEFORE the importing module's
+ * body, so a driver registering from inside `index.ts`'s own import graph would
+ * touch the map while it is still in its temporal dead zone — a
+ * `ReferenceError` at startup, on the one path nobody exercises until an
+ * overlay is installed.
+ */
+import type { MountPolicy, SessionDriver } from './types.js';
+
+/**
+ * Not a union. This tree ships one driver and must not enumerate kinds it
+ * cannot execute — a union here would list `vm` as a legitimate value on a
+ * host where selecting it can only throw, and would make every overlay's kind a
+ * change to this file.
+ */
+export type DriverKind = string;
+
+/** Built from the fully-resolved mount policy; the driver owns everything else. */
+export type SessionDriverFactory = (policy: MountPolicy) => SessionDriver;
+
+const registry = new Map<DriverKind, SessionDriverFactory>();
+
+/**
+ * Install a driver under a kind. Overlays call this at module scope from a file
+ * reached via `installed.ts`; a duplicate registration is a wiring bug (the
+ * import got added twice, or two overlays claim one kind) and throws rather
+ * than letting the last import silently win.
+ */
+export function registerSessionDriver(kind: DriverKind, factory: SessionDriverFactory): void {
+  if (registry.has(kind)) {
+    throw new Error(`Session driver already registered: ${kind}`);
+  }
+  registry.set(kind, factory);
+}
+
+export function getSessionDriverFactory(kind: DriverKind): SessionDriverFactory | undefined {
+  return registry.get(kind);
+}
+
+/** The kinds this build can actually run — what the failure message reports. */
+export function listSessionDriverKinds(): DriverKind[] {
+  return [...registry.keys()];
+}

--- a/src/drivers/driver-selection.test.ts
+++ b/src/drivers/driver-selection.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Driver selection, the registry it resolves through, and the settings it reads.
+ *
+ * The host service has no `EnvironmentFile=`; it parses `.env` in-process. A
+ * setting that consulted only `process.env` would be silently ignored in the
+ * file where every other NanoClaw setting lives — and for the driver selection,
+ * being ignored means silently running the wrong runtime.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import {
+  configuredDriverKind,
+  createSessionDriver,
+  getSessionDriver,
+  mountPolicy,
+  readSetting,
+  resetSessionDriver,
+} from './index.js';
+// Imported from the registry module, not the barrel that re-exports it: this is
+// the entry point an overlay reaches for, and it has to work without the
+// selection module having been evaluated first.
+import { listSessionDriverKinds, registerSessionDriver } from './driver-registry.js';
+import { log } from '../log.js';
+import type { MountPolicy, SessionDriver } from './types.js';
+
+let cwd: string;
+let previous: string;
+let uniqueKind = 0;
+
+function writeEnv(contents: string): void {
+  fs.writeFileSync(path.join(cwd, '.env'), contents);
+}
+
+/**
+ * Registration is permanent by design (a duplicate is a wiring bug, so there is
+ * no unregister to reach for). Each case therefore claims a kind of its own.
+ */
+function registerFake(seen: MountPolicy[] = []): { kind: string; seen: MountPolicy[] } {
+  const kind = `fake-${++uniqueKind}`;
+  registerSessionDriver(kind, (policy) => {
+    seen.push(policy);
+    return {
+      kind,
+      capabilities: () => ({
+        isolationTiers: ['container'],
+        admissionEnforced: false,
+        networkPolicy: 'topology',
+        encryptedVolumes: false,
+        unrealized: [],
+        sharedNetworkNamespace: false,
+        auxiliaryContainers: false,
+        imageBuild: false,
+      }),
+      prepare: () => Promise.reject(new Error('not under test')),
+      listSessions: () => Promise.resolve([]),
+      watchSessions: () => ({ stop: () => {} }),
+    } satisfies SessionDriver;
+  });
+  return { kind, seen };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  previous = process.cwd();
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-driver-env-'));
+  process.chdir(cwd);
+});
+
+afterEach(() => {
+  resetSessionDriver(null);
+  process.chdir(previous);
+});
+
+describe('configuredDriverKind', () => {
+  it('defaults to docker when nothing is set anywhere', () => {
+    expect(configuredDriverKind({})).toBe('docker');
+  });
+
+  it('reads the selection from .env, not only from the process environment', () => {
+    writeEnv('NANOCLAW_RUNTIME_DRIVER=vm\n');
+    expect(configuredDriverKind({})).toBe('vm');
+  });
+
+  it('lets the process environment win over .env', () => {
+    writeEnv('NANOCLAW_RUNTIME_DRIVER=vm\n');
+    expect(configuredDriverKind({ NANOCLAW_RUNTIME_DRIVER: 'docker' })).toBe('docker');
+  });
+
+  it('reports the configured value verbatim instead of correcting it', () => {
+    // Selection does not decide what is legitimate; the registry does. Anything
+    // that "corrects" a value here is a silent fallback wearing a hat.
+    expect(configuredDriverKind({ NANOCLAW_RUNTIME_DRIVER: 'firecracker' })).toBe('firecracker');
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSessionDriver', () => {
+  it('builds the docker driver by default, and it is pre-registered', () => {
+    expect(listSessionDriverKinds()).toContain('docker');
+    expect(createSessionDriver('docker').kind).toBe('docker');
+  });
+
+  it('refuses a kind no driver is registered for, naming the setting, the value and what is installed', () => {
+    // The message is the entire remediation an operator gets. Asserting its
+    // shape — not just that something threw — is what keeps it actionable. The
+    // `[^\n]*` anchoring is the point: all three facts must be in the FIRST
+    // line, because that is the line a log aggregator shows.
+    const selecting = (): unknown => createSessionDriver('vm');
+    expect(selecting).toThrow(/^[^\n]*NANOCLAW_RUNTIME_DRIVER[^\n]*'vm'[^\n]*installed: /);
+    // The list is what the registry actually holds, not a literal: an overlay
+    // adds kinds, and a test that hard-coded `docker` would fail on a tree
+    // where the message is doing its job.
+    expect(selecting).toThrow(`installed: ${listSessionDriverKinds().join(', ')}`);
+    expect(selecting).toThrow(/install the driver skill or unset the variable/);
+  });
+
+  it('refuses a typo exactly as it refuses an uninstalled driver', () => {
+    // `=dcoker` silently running docker is the same failure as `=vm` silently
+    // running docker: a host configured for one runtime running another.
+    const selecting = (): unknown => createSessionDriver('dcoker');
+    expect(selecting).toThrow(/^[^\n]*NANOCLAW_RUNTIME_DRIVER[^\n]*'dcoker'[^\n]*installed: /);
+    expect(selecting).toThrow(`installed: ${listSessionDriverKinds().join(', ')}`);
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('resolves a kind once a driver registers it, and hands it the resolved policy', () => {
+    const { kind, seen } = registerFake();
+    const driver = createSessionDriver(kind, { materialsRoot: '/srv/override' });
+    expect(driver.kind).toBe(kind);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.materialsRoot).toBe('/srv/override');
+    expect(seen[0]?.surfaceRoots).toHaveLength(3);
+  });
+
+  it('resolves a driver registered through the registry module alone', () => {
+    // What an overlay does: import the registry, register at module scope, and
+    // never touch selection. If that only worked when `index.js` had already
+    // been evaluated, the appended-import install shape would be a startup
+    // crash on the one path nobody exercises until an overlay exists.
+    const { kind } = registerFake();
+    expect(listSessionDriverKinds()).toContain(kind);
+    expect(createSessionDriver(kind).kind).toBe(kind);
+  });
+
+  it('refuses to let two registrations claim one kind', () => {
+    const { kind } = registerFake();
+    expect(() => registerSessionDriver(kind, () => createSessionDriver('docker'))).toThrow(/already registered/);
+  });
+
+  it('logs the boot marker an operator uses to tell a crash loop from a healthy start', () => {
+    // Under `Restart=always`, `systemctl is-active` says `active` all through a
+    // crash loop. Absent marker + active unit = selection is throwing.
+    createSessionDriver('docker');
+    expect(log.info).toHaveBeenCalledWith(
+      'Session runtime driver selected',
+      expect.objectContaining({ driver: 'docker' }),
+    );
+  });
+});
+
+describe('getSessionDriver', () => {
+  it('builds the configured kind through the registry and memoizes it', () => {
+    const { kind } = registerFake();
+    process.env.NANOCLAW_RUNTIME_DRIVER = kind;
+    try {
+      resetSessionDriver(null);
+      const first = getSessionDriver();
+      expect(first.kind).toBe(kind);
+      expect(getSessionDriver()).toBe(first);
+    } finally {
+      delete process.env.NANOCLAW_RUNTIME_DRIVER;
+    }
+  });
+
+  it('honours the reset seam so a suite can install its own driver', () => {
+    const { kind } = registerFake();
+    const standIn = createSessionDriver(kind);
+    resetSessionDriver(standIn);
+    expect(getSessionDriver()).toBe(standIn);
+    resetSessionDriver(null);
+    expect(getSessionDriver().kind).toBe('docker');
+  });
+});
+
+describe('mountPolicy', () => {
+  it('pins materialsRoot to the .env value the provisioner also reads', () => {
+    // The provisioner reads this key from .env. If the two resolve differently,
+    // every identity-material mount is denied by a policy naming a path that
+    // looks correct.
+    writeEnv('NANOCLAW_SESSION_MATERIAL_ROOT=/srv/materials\n');
+    expect(mountPolicy({}).materialsRoot).toBe('/srv/materials');
+  });
+
+  it('enumerates surface roots instead of trusting an install-root prefix', () => {
+    // The state roots nest inside the project root, so a prefix check would
+    // admit the central DB as a mountable "surface".
+    const policy = mountPolicy({});
+    expect(policy.surfaceRoots).toHaveLength(3);
+    expect(policy.surfaceRoots.every((root) => root.includes(`${path.sep}container${path.sep}`))).toBe(true);
+    expect(policy.surfaceRoots.some((root) => root === policy.dataRoot)).toBe(false);
+  });
+});
+
+describe('readSetting', () => {
+  it('trims and treats blank as unset', () => {
+    writeEnv('NANOCLAW_SESSION_MATERIAL_ROOT=   \n');
+    expect(readSetting('NANOCLAW_SESSION_MATERIAL_ROOT', {})).toBe('');
+  });
+});

--- a/src/drivers/fake-cli.ts
+++ b/src/drivers/fake-cli.ts
@@ -1,0 +1,84 @@
+/**
+ * A recording, scriptable stand-in for a runtime CLI (`docker`, or whatever
+ * an out-of-tree driver shells).
+ *
+ * This exists so driver tests can drive a real spec through real realization
+ * logic and assert on what the driver *did*, rather than on what its source
+ * text looks like.
+ */
+import type { Cli, SupervisedProcess } from './cli.js';
+
+export interface FakeCall {
+  args: string[];
+  input?: string;
+  /** Position in one sequence shared with `start()`, so ordering is assertable. */
+  seq: number;
+}
+
+export class FakeSupervisedProcess implements SupervisedProcess {
+  readonly exitCbs: Array<(code: number | null) => void> = [];
+  readonly stderrCbs: Array<(line: string) => void> = [];
+  readonly stdoutCbs: Array<(line: string) => void> = [];
+  killed = false;
+
+  onExit(cb: (code: number | null) => void): void {
+    this.exitCbs.push(cb);
+  }
+  onStderr(cb: (line: string) => void): void {
+    this.stderrCbs.push(cb);
+  }
+  onStdout(cb: (line: string) => void): void {
+    this.stdoutCbs.push(cb);
+  }
+  kill(): void {
+    this.killed = true;
+  }
+
+  emitStderr(line: string): void {
+    for (const cb of this.stderrCbs) cb(line);
+  }
+  emitStdout(chunk: string): void {
+    for (const cb of this.stdoutCbs) cb(chunk);
+  }
+  emitExit(code: number | null): void {
+    for (const cb of this.exitCbs) cb(code);
+  }
+}
+
+export class FakeCli implements Cli {
+  readonly calls: FakeCall[] = [];
+  readonly started: Array<{ args: string[]; proc: FakeSupervisedProcess; seq: number }> = [];
+  #seq = 0;
+  /** Matched in order against the joined argv; first hit wins. */
+  responses: Array<{ match: RegExp; output?: string; throws?: Error | string }> = [];
+
+  constructor(readonly bin = 'fake') {}
+
+  run(args: string[], opts?: { input?: string }): string {
+    this.calls.push({ args, input: opts?.input, seq: this.#seq++ });
+    const joined = args.join(' ');
+    for (const response of this.responses) {
+      if (!response.match.test(joined)) continue;
+      if (response.throws) {
+        throw response.throws instanceof Error ? response.throws : new Error(response.throws);
+      }
+      return response.output ?? '';
+    }
+    return '';
+  }
+
+  start(args: string[]): SupervisedProcess {
+    const proc = new FakeSupervisedProcess();
+    this.started.push({ args, proc, seq: this.#seq++ });
+    return proc;
+  }
+
+  /** Every argv this CLI was asked to run, joined — convenient for assertions. */
+  joined(): string[] {
+    return this.calls.map((c) => c.args.join(' '));
+  }
+
+  callMatching(pattern: RegExp): FakeCall | undefined {
+    return this.calls.find((c) => pattern.test(c.args.join(' ')));
+  }
+}

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -1,0 +1,162 @@
+/**
+ * Driver selection.
+ *
+ * `NANOCLAW_RUNTIME_DRIVER` is read once, at first use, and defaults to
+ * `docker` — so an install that never sets it behaves exactly as it did before
+ * the seam existed. Nothing above this module may branch on the driver's
+ * identity: features gate on `capabilities()`, never on `kind`.
+ *
+ * Selection is a registry, not a switch. Drivers self-register by kind; this
+ * module pre-registers `docker`, the only realization that ships here. An
+ * overlay adds its own with one `registerSessionDriver(...)` call and one
+ * appended import — the same shape as the provider container-config barrel
+ * (`src/providers/index.ts`) and the session-egress factory. Nothing outside
+ * this file has to be rewritten to install a driver, so an overlay never has to
+ * keep a patch of this file's internals in sync with it.
+ *
+ * A configured kind with no registered driver throws, uniformly. There is no
+ * "recognized but uninstalled" tier and no typo tolerance, because there is no
+ * difference worth encoding between the two: `=vm` on a host with no vm
+ * driver and `=dcoker` on any host are the same operator error — a host
+ * configured for one runtime that would otherwise silently run another. A
+ * fallback here surfaces later as anything but a configuration problem.
+ *
+ * CAVEAT for whoever debugs this at 3am: a startup throw under a service
+ * manager configured `Restart=always` is a crash loop, and `systemctl is-active`
+ * reports `active` throughout one — the loud failure is invisible in the status
+ * command an operator reaches for first. The discriminator is the boot-scoped
+ * `Session runtime driver selected` line below: a unit that reports active with
+ * no such line in the current boot is a host whose driver selection is
+ * throwing. That log.info is load-bearing for this reason; do not demote it to
+ * debug.
+ *
+ * Settings are read from `.env` with `process.env` taking precedence. That
+ * precedence is not decoration: the host service has no `EnvironmentFile=`,
+ * it parses `.env` in-process, so a setting that only consulted `process.env`
+ * would be silently ignored when written to the file where every other
+ * NanoClaw setting lives.
+ */
+import os from 'os';
+import path from 'path';
+
+import { DATA_DIR, GROUPS_DIR } from '../config.js';
+import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from '../egress-lockdown.js';
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+
+import { DockerSessionDriver, agentContainerName } from './docker-driver.js';
+import {
+  getSessionDriverFactory,
+  listSessionDriverKinds,
+  registerSessionDriver,
+  type DriverKind,
+} from './driver-registry.js';
+// Side-effect import: the barrel overlays append their driver's registration to.
+// Everything it pulls in registers before this module's body runs, which is the
+// whole reason the registry lives in its own module — see `driver-registry.ts`.
+import './installed.js';
+import { withSessionEvents, type SessionEventsDriver } from './session-events.js';
+import type { MountPolicy, SessionDriver, SessionSpec } from './types.js';
+
+const DEFAULT_DRIVER_KIND = 'docker';
+
+const SETTINGS = ['NANOCLAW_RUNTIME_DRIVER', 'NANOCLAW_SESSION_MATERIAL_ROOT'] as const;
+
+/** `process.env` wins, then `.env`, then the default. */
+export function readSetting(key: (typeof SETTINGS)[number], env: NodeJS.ProcessEnv = process.env): string {
+  return env[key]?.trim() || readEnvFile([...SETTINGS])[key]?.trim() || '';
+}
+
+/**
+ * Docker's network topology, decided at spawn: the egress-lockdown network
+ * when the flag is on (throws rather than spawning with open egress), else the
+ * host-gateway mapping Linux needs to reach host services. Injected at
+ * registration — the driver stays constructible without it in tests, and
+ * composition never sees an argv-shaped network selection: `spec.network`
+ * states the intent, this realizes it, and nothing rides between them.
+ */
+function dockerNetworkArgs(spec: SessionSpec): string[] {
+  if (ensureEgressNetwork()) {
+    log.info('Egress lockdown active', { containerName: agentContainerName(spec), network: EGRESS_NETWORK });
+    return egressNetworkArgs();
+  }
+  return os.platform() === 'linux' ? ['--add-host=host.docker.internal:host-gateway'] : [];
+}
+
+registerSessionDriver(
+  DEFAULT_DRIVER_KIND,
+  (policy) => new DockerSessionDriver({ ...policy, networkArgsFor: dockerNetworkArgs }),
+);
+
+export function configuredDriverKind(env: NodeJS.ProcessEnv = process.env): DriverKind {
+  return readSetting('NANOCLAW_RUNTIME_DRIVER', env).toLowerCase() || DEFAULT_DRIVER_KIND;
+}
+
+/**
+ * The mount policy every driver enforces. `surfaceRoots` is an enumerated list,
+ * never a bare install-root prefix: in this layout the state roots nest inside
+ * the project root, so a prefix check would admit the central DB as a
+ * mountable "surface".
+ */
+export function mountPolicy(env: NodeJS.ProcessEnv = process.env): MountPolicy {
+  // `config.ts` derives every root from `process.cwd()` (the unit's
+  // WorkingDirectory) and does not export it; `buildMounts` reads it the same
+  // way, so the two cannot disagree.
+  const projectRoot = process.cwd();
+  return {
+    groupsRoot: GROUPS_DIR,
+    dataRoot: DATA_DIR,
+    surfaceRoots: [
+      path.join(projectRoot, 'container', 'agent-runner', 'src'),
+      path.join(projectRoot, 'container', 'skills'),
+      path.join(projectRoot, 'container', 'CLAUDE.md'),
+    ],
+    // Must resolve to the same path an egress overlay's provisioner writes
+    // material to, and a provisioner reads this key from `.env`. Reading it
+    // from `process.env` alone would leave the two agreeing only by
+    // coincidence of their defaults: move it in `.env` and every
+    // identity-material mount is denied by a policy naming a path that looks
+    // correct.
+    materialsRoot: readSetting('NANOCLAW_SESSION_MATERIAL_ROOT', env) || path.join(DATA_DIR, 'session-materials'),
+  };
+}
+
+let installed: SessionEventsDriver | null = null;
+
+export function getSessionDriver(): SessionEventsDriver {
+  if (!installed) installed = createSessionDriver(configuredDriverKind());
+  return installed;
+}
+
+export function createSessionDriver(kind: DriverKind, overrides: Partial<MountPolicy> = {}): SessionEventsDriver {
+  const factory = getSessionDriverFactory(kind);
+  if (!factory) {
+    // Name the fix in the first line: the setting, the value it holds, and what
+    // this build can actually run. An operator reading only this line has to be
+    // able to act on it.
+    throw new Error(
+      `NANOCLAW_RUNTIME_DRIVER='${kind}' but no driver is registered for '${kind}'; ` +
+        `installed: ${listSessionDriverKinds().join(', ')}. ` +
+        'Other drivers arrive as overlays — install the driver skill or unset the variable.',
+    );
+  }
+  const policy = { ...mountPolicy(), ...overrides };
+  // The session-events hub wraps whatever the factory produced — overlays
+  // included — so `onTerminal`/stop-intent semantics are trunk-owned, never
+  // re-implemented per driver (see `session-events.ts`).
+  const driver: SessionEventsDriver = withSessionEvents(factory(policy));
+  // Boot-scoped marker; see the crash-loop caveat at the top of this file.
+  log.info('Session runtime driver selected', { driver: driver.kind, capabilities: driver.capabilities() });
+  return driver;
+}
+
+/** Test seam: drop the memoized driver so a suite can select another one. */
+export function resetSessionDriver(next: SessionDriver | null = null): void {
+  // Tests may inject raw fakes; the probe (isSessionEventsDriver) guards resync,
+  // and fake handles carry their own onTerminal where flows need it.
+  installed = next as SessionEventsDriver | null;
+}
+
+export * from './driver-registry.js';
+export * from './session-events.js';
+export * from './types.js';

--- a/src/drivers/installed.ts
+++ b/src/drivers/installed.ts
@@ -1,0 +1,8 @@
+// Out-of-tree session drivers self-register on import. Drivers that ship in
+// this tree (docker) register in `index.ts` and do not appear here.
+//
+// Skills add a driver by appending one import line below — the same shape as
+// the provider container-config barrel (`src/providers/index.ts`). Append-only
+// on purpose: an overlay that instead rewrote the construction expression in
+// `index.ts` would own a patch of this tree's internals, and every later edit
+// to selection would silently invalidate it.

--- a/src/drivers/json-stream.ts
+++ b/src/drivers/json-stream.ts
@@ -1,0 +1,51 @@
+/**
+ * Split a concatenated stream of pretty-printed JSON documents.
+ *
+ * Watch-style runtime CLIs emit one indented JSON object per event with no
+ * separator, so a line-based parser cannot find the boundaries. Brace-depth scanning can, provided it ignores braces inside
+ * strings — which is the entire subtlety here.
+ */
+export class JsonDocumentStream {
+  #buffer = '';
+  #depth = 0;
+  #inString = false;
+  #escaped = false;
+  #start = -1;
+
+  /** Feed a chunk; returns every document completed by it. */
+  push(chunk: string): unknown[] {
+    const docs: unknown[] = [];
+    this.#buffer += chunk;
+    for (let i = this.#buffer.length - chunk.length; i < this.#buffer.length; i++) {
+      const ch = this.#buffer[i];
+      if (this.#inString) {
+        if (this.#escaped) this.#escaped = false;
+        else if (ch === '\\') this.#escaped = true;
+        else if (ch === '"') this.#inString = false;
+        continue;
+      }
+      if (ch === '"') {
+        this.#inString = true;
+      } else if (ch === '{') {
+        if (this.#depth === 0) this.#start = i;
+        this.#depth++;
+      } else if (ch === '}') {
+        this.#depth--;
+        if (this.#depth === 0 && this.#start >= 0) {
+          const text = this.#buffer.slice(this.#start, i + 1);
+          try {
+            docs.push(JSON.parse(text));
+          } catch {
+            /* a truncated or non-JSON preamble is not worth killing supervision over */
+          }
+          this.#buffer = this.#buffer.slice(i + 1);
+          i = -1;
+          this.#start = -1;
+        }
+      }
+    }
+    // Never let an un-terminated document grow without bound.
+    if (this.#depth === 0 && this.#buffer.length > 1_000_000) this.#buffer = '';
+    return docs;
+  }
+}

--- a/src/drivers/session-events.test.ts
+++ b/src/drivers/session-events.test.ts
@@ -1,0 +1,368 @@
+/**
+ * The session-events hub — the ONE trunk layer behind `onTerminal`.
+ *
+ * These cases pin the hub's own obligations against a scripted driver, so
+ * they hold for every driver at once: hints are never acted on without a
+ * truth read, delivery is at-most-once per incarnation, stop-intent observed
+ * through any wrapped handle suppresses, pre-arming terminals are buffered,
+ * and resync reconciles what the stream dropped. The docker realization of
+ * the stream itself is covered in `docker-driver.test.ts`; the consumer-facing
+ * floor is in `conformance.test.ts`.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { isSessionEventsDriver, withSessionEvents, type SupervisedHandle } from './session-events.js';
+import { fixtureSpec } from './spec-fixture.js';
+import type {
+  DriverCapabilities,
+  SessionDriver,
+  SessionEvent,
+  SessionHandle,
+  SessionKey,
+  SessionSnapshot,
+  SessionSpec,
+  SessionStatus,
+} from './types.js';
+
+function makeKey(sessionId: string): SessionKey {
+  return { installSlug: 'spike', agentGroupId: 'g1', sessionId };
+}
+
+class FakeHandle implements SessionHandle {
+  /** What the next truth read reports — the hub must believe this, not the hint. */
+  statusValue: SessionStatus = { phase: 'running' };
+  /** When set, each status() blocks until the test settles it — an async truth read. */
+  manualStatus = false;
+  readonly pendingStatus: Array<{ resolve: (status: SessionStatus) => void; reject: (err: Error) => void }> = [];
+  readonly stops: string[] = [];
+
+  constructor(
+    readonly key: SessionKey,
+    readonly name = `ncl-${sessionIdOf(key)}`,
+  ) {}
+
+  async start(): Promise<void> {}
+  async status(): Promise<SessionStatus> {
+    if (this.manualStatus) {
+      return new Promise((resolve, reject) => this.pendingStatus.push({ resolve, reject }));
+    }
+    return this.statusValue;
+  }
+  async stop(reason: string): Promise<void> {
+    this.stops.push(reason);
+  }
+  onTerminal(): void {
+    throw new Error('raw handle onTerminal must never be reached');
+  }
+}
+
+function sessionIdOf(key: SessionKey): string {
+  return key.sessionId;
+}
+
+class FakeDriver implements SessionDriver {
+  readonly kind = 'fake';
+  nextPrepared: FakeHandle | null = null;
+  snapshots: SessionSnapshot[] = [];
+  listCalls = 0;
+  watchCalls = 0;
+  readonly subscribers = new Set<(event: SessionEvent) => void>();
+
+  capabilities(): DriverCapabilities {
+    return {
+      isolationTiers: ['container'],
+      admissionEnforced: false,
+      networkPolicy: 'topology',
+      encryptedVolumes: false,
+      unrealized: [],
+      sharedNetworkNamespace: false,
+      auxiliaryContainers: false,
+      imageBuild: false,
+    };
+  }
+  async prepare(_spec: SessionSpec): Promise<SessionHandle> {
+    return this.nextPrepared!;
+  }
+  async listSessions(): Promise<SessionSnapshot[]> {
+    this.listCalls += 1;
+    return this.snapshots;
+  }
+  watchSessions(_installSlug: string, onEvent: (event: SessionEvent) => void): { stop(): void } {
+    this.watchCalls += 1;
+    this.subscribers.add(onEvent);
+    return { stop: () => this.subscribers.delete(onEvent) };
+  }
+  emit(event: SessionEvent): void {
+    for (const subscriber of this.subscribers) subscriber(event);
+  }
+}
+
+async function settled(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function prepared(
+  driver: FakeDriver,
+  sessionId: string,
+): Promise<{ inner: FakeHandle; handle: SupervisedHandle; hub: ReturnType<typeof withSessionEvents> }> {
+  const hub = withSessionEvents(driver);
+  const inner = new FakeHandle(makeKey(sessionId));
+  driver.nextPrepared = inner;
+  const handle = await hub.prepare(fixtureSpec());
+  return { inner, handle, hub };
+}
+
+describe('hint discipline: events are re-read, never acted on', () => {
+  it('does not fire while the truth read still says running', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    // A replayed/spurious hint (watch transports re-send existing state on reconnect).
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    await settled();
+    expect(terminal).not.toHaveBeenCalled();
+
+    inner.statusValue = { phase: 'stopped' };
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    await settled();
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('delivers a confirmed failure at most once, however many hints arrive', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    const failure = { kind: 'started-then-died' as const, retryable: false as const, exitCode: 3 };
+    inner.statusValue = { phase: 'failed', failure };
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    await settled();
+
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(failure);
+  });
+
+  it('re-checks a hint that lands during an in-flight truth read instead of dropping it', async () => {
+    // On a driver whose status() is a remote round trip, a
+    // replayed hint's read can snapshot 'running' before the incarnation
+    // actually dies — and the real death hint then arrives mid-read. Dropping
+    // it would leave the session 'active' until the heartbeat sweep.
+    const driver = new FakeDriver();
+    const { inner, handle } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    inner.manualStatus = true;
+    driver.emit({ key: inner.key, kind: 'terminal' }); // replayed hint — read goes in flight
+    await settled();
+    driver.emit({ key: inner.key, kind: 'terminal' }); // the real death, mid-read
+    await settled();
+    expect(inner.pendingStatus).toHaveLength(1); // queued, not raced into a second read
+    inner.pendingStatus.shift()!.resolve({ phase: 'running' }); // pre-death truth
+    await settled();
+
+    expect(inner.pendingStatus).toHaveLength(1); // the queued hint re-read
+    inner.pendingStatus.shift()!.resolve({ phase: 'stopped' });
+    await settled();
+
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('a hint queued behind a failed truth read still re-reads', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    inner.manualStatus = true;
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    await settled();
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    inner.pendingStatus.shift()!.reject(new Error('apiserver hiccup'));
+    await settled();
+    inner.pendingStatus.shift()!.resolve({ phase: 'stopped' });
+    await settled();
+
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('ignores hints for keys it never handed out', async () => {
+    const driver = new FakeDriver();
+    const { handle } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    driver.emit({ key: makeKey('someone-else'), kind: 'terminal' });
+    await settled();
+
+    expect(terminal).not.toHaveBeenCalled();
+  });
+});
+
+describe('stop-intent suppression is hub-owned', () => {
+  it('suppresses the terminal for a stop requested through the wrapped handle', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    await handle.stop('host-shutdown');
+    inner.statusValue = { phase: 'stopped' };
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    await settled();
+
+    expect(inner.stops).toEqual(['host-shutdown']);
+    expect(terminal).not.toHaveBeenCalled();
+  });
+
+  it('sees stop() on adopted handles too — the wrapper rides the driver boundary', async () => {
+    const driver = new FakeDriver();
+    const hub = withSessionEvents(driver);
+    const inner = new FakeHandle(makeKey('s1'));
+    driver.snapshots = [{ handle: inner, phase: 'running' }];
+
+    const [{ handle }] = await hub.listSessions('spike');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+    await handle.stop('orphan-at-startup');
+    inner.statusValue = { phase: 'stopped' };
+    driver.emit({ key: inner.key, kind: 'terminal' });
+    await settled();
+
+    expect(inner.stops).toEqual(['orphan-at-startup']);
+    expect(terminal).not.toHaveBeenCalled();
+  });
+});
+
+describe('arming order', () => {
+  it('buffers a terminal confirmed before onTerminal is armed and delivers on arming', async () => {
+    const driver = new FakeDriver();
+    // Arming any key starts the install-wide subscription; the second key's
+    // end then lands before its own callback exists — the adoption gap.
+    const first = await prepared(driver, 's1');
+    first.handle.onTerminal(vi.fn());
+
+    const second = new FakeHandle(makeKey('s2'));
+    driver.nextPrepared = second;
+    const handle = await first.hub.prepare(fixtureSpec());
+    second.statusValue = { phase: 'stopped' };
+    driver.emit({ key: second.key, kind: 'terminal' });
+    await settled();
+
+    const late = vi.fn();
+    handle.onTerminal(late);
+    await settled();
+    expect(late).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('a fresh incarnation resets fired and stop-intent for its key', async () => {
+    const driver = new FakeDriver();
+    const first = await prepared(driver, 's1');
+    first.handle.onTerminal(vi.fn());
+    await first.handle.stop('host-shutdown'); // old incarnation, host-requested end
+
+    const secondInner = new FakeHandle(makeKey('s1'));
+    driver.nextPrepared = secondInner;
+    const handle = await first.hub.prepare(fixtureSpec());
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    secondInner.statusValue = { phase: 'stopped' };
+    driver.emit({ key: secondInner.key, kind: 'terminal' });
+    await settled();
+
+    // The old incarnation's stop-intent must not swallow the new one's end.
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+});
+
+describe('resync', () => {
+  it('delivers a terminal the stream dropped, once', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle, hub } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    const failure = { kind: 'started-then-died' as const, retryable: false as const, exitCode: 9 };
+    driver.snapshots = [{ handle: inner, phase: 'terminal', failure }];
+    await hub.resync('spike');
+    await hub.resync('spike');
+
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(failure);
+  });
+
+  it('confirms via the handle itself when the session is gone from the list', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle, hub } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    driver.snapshots = []; // reaped runtime object: absence is the hint
+    inner.statusValue = { phase: 'stopped' };
+    await hub.resync('spike');
+
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('never re-fires for sessions the host itself stopped', async () => {
+    const driver = new FakeDriver();
+    const { inner, handle, hub } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+    handle.onTerminal(terminal);
+
+    await handle.stop('orphan-at-startup');
+    driver.snapshots = [{ handle: inner, phase: 'terminal' }];
+    await hub.resync('spike');
+
+    expect(terminal).not.toHaveBeenCalled();
+  });
+
+  it('does not even re-list when nothing is armed — no periodic machinery to feed', async () => {
+    const driver = new FakeDriver();
+    const hub = withSessionEvents(driver);
+    await hub.resync('spike');
+    expect(driver.listCalls).toBe(0);
+  });
+});
+
+describe('wrapper shape', () => {
+  it('shares ONE watch subscription per install across every armed session', async () => {
+    const driver = new FakeDriver();
+    const first = await prepared(driver, 's1');
+    first.handle.onTerminal(vi.fn());
+    const secondInner = new FakeHandle(makeKey('s2'));
+    driver.nextPrepared = secondInner;
+    const handle = await first.hub.prepare(fixtureSpec());
+    handle.onTerminal(vi.fn());
+
+    expect(driver.watchCalls).toBe(1);
+  });
+
+  it('survives a minimal driver without watchSessions instead of crashing arming', async () => {
+    const driver = new FakeDriver();
+    (driver as { watchSessions?: unknown }).watchSessions = undefined;
+    const { handle } = await prepared(driver, 's1');
+    expect(() => handle.onTerminal(vi.fn())).not.toThrow();
+  });
+
+  it('is probe-detectable, and raw drivers are not', () => {
+    const driver = new FakeDriver();
+    expect(isSessionEventsDriver(driver)).toBe(false);
+    expect(isSessionEventsDriver(withSessionEvents(driver))).toBe(true);
+  });
+
+  it('only mirrors the optional surface the inner driver actually has', () => {
+    const driver = new FakeDriver();
+    const wrapped = withSessionEvents(driver);
+    // adoptRunningSessions gates on `driver.reapResidue?.` — a wrapper that
+    // invents the method would shell a cleanup the driver cannot do.
+    expect(wrapped.reapResidue).toBeUndefined();
+    expect(wrapped.ensureReady).toBeUndefined();
+    expect(wrapped.kind).toBe('fake');
+  });
+});

--- a/src/drivers/session-events.ts
+++ b/src/drivers/session-events.ts
@@ -1,0 +1,252 @@
+/**
+ * Session events hub — the ONE trunk layer that turns a driver's best-effort
+ * watch stream into the supervised handle's `onTerminal`.
+ *
+ * Drivers emit hints for ALL observed terminal transitions, with no intent
+ * filtering and no delivery guarantees (drop, duplicate, coalesce, unknown
+ * keys — see `SessionEvent`). Everything on top of that lives here, once, for
+ * every driver:
+ *
+ * - truth: an event is never acted on directly — the hub re-reads the
+ *   handle's `status()` and fires only on a confirmed end, which is what
+ *   keeps replayed watch events (watch transports re-send existing state on
+ *   reconnect; docker events can duplicate) from firing terminals for sessions that still run. A
+ *   hint landing while a read is in flight queues one re-check — the read may
+ *   have snapshotted a truth older than the hint;
+ * - at-most-once: one terminal delivery per incarnation, however many hints;
+ * - stop-intent: `onTerminal` fires only for ends the host did NOT request
+ *   via `stop()`. The hub observes `stop()` through the handles it wraps, so
+ *   the wrapper is applied at the driver boundary (`createSessionDriver`) —
+ *   every handle a consumer can reach, prepared or adopted, is a wrapped one;
+ * - arming order: a terminal confirmed before `onTerminal` is armed is
+ *   buffered per key and delivered on registration, so adoption cannot lose
+ *   an end that lands between `listSessions()` and arming.
+ */
+import type {
+  SessionDriver,
+  SessionEvent,
+  SessionFailure,
+  SessionHandle,
+  SessionKey,
+  SessionSnapshot,
+  SessionSpec,
+  SessionStatus,
+  SessionWatch,
+} from './types.js';
+
+/**
+ * What consumers hold after the hub wraps a driver: the raw contract plus
+ * `onTerminal` — at-most-once, verified-against-truth, stop-intent-suppressed.
+ * Drivers never implement this; it exists only on hub-wrapped handles.
+ */
+export interface SupervisedHandle extends SessionHandle {
+  /** Fires at most once, on any end the host did not request via stop(). */
+  onTerminal(cb: (failure?: SessionFailure) => void): void;
+}
+
+export interface SupervisedSnapshot extends Omit<SessionSnapshot, 'handle'> {
+  handle: SupervisedHandle;
+}
+
+export interface SessionEventsDriver extends SessionDriver {
+  prepare(spec: SessionSpec): Promise<SupervisedHandle>;
+  listSessions(installSlug: string): Promise<SupervisedSnapshot[]>;
+  /**
+   * Re-list and reconcile terminals the watch stream may have missed (r4).
+   * Deliberately not periodic machinery: wire it where a re-list is already
+   * cheap — the adoption path does. Sessions the host itself stopped are
+   * intent-suppressed like any other terminal.
+   */
+  resync(installSlug: string): Promise<void>;
+}
+
+/** Raw fakes installed via `resetSessionDriver` are not hubs; probe, never assume. */
+export function isSessionEventsDriver(driver: SessionDriver): driver is SessionEventsDriver {
+  return typeof (driver as Partial<SessionEventsDriver>).resync === 'function';
+}
+
+function idOf(key: SessionKey): string {
+  return `${key.installSlug}\u0000${key.agentGroupId}\u0000${key.sessionId}`;
+}
+
+interface KeyState {
+  /** Latest inner (unwrapped) handle for this key — the truth-read channel. */
+  handle: SessionHandle;
+  cb: ((failure?: SessionFailure) => void) | null;
+  stopIntent: boolean;
+  fired: boolean;
+  /** Terminal confirmed before a callback was armed; delivered on arming. */
+  pending?: { failure?: SessionFailure };
+  verifying: boolean;
+  /** A hint landed mid-verify; re-read truth once the in-flight read returns. */
+  recheck: boolean;
+}
+
+class SessionEventsHub {
+  readonly #states = new Map<string, KeyState>();
+  readonly #watches = new Map<string, SessionWatch>();
+
+  constructor(private readonly driver: SessionDriver) {}
+
+  /** A fresh incarnation resets the key: fired/stop-intent belong to the old one. */
+  trackPrepared(handle: SessionHandle): void {
+    this.#states.set(idOf(handle.key), {
+      handle,
+      cb: null,
+      stopIntent: false,
+      fired: false,
+      verifying: false,
+      recheck: false,
+    });
+  }
+
+  /** A listed handle refreshes the truth-read channel without resetting state. */
+  trackListed(handle: SessionHandle): void {
+    const state = this.#states.get(idOf(handle.key));
+    if (state) state.handle = handle;
+    else this.trackPrepared(handle);
+  }
+
+  arm(key: SessionKey, cb: (failure?: SessionFailure) => void): void {
+    const state = this.#states.get(idOf(key));
+    if (!state) return; // only handles this hub wrapped can register
+    state.cb = cb;
+    this.#ensureWatch(key.installSlug);
+    if (state.pending) {
+      const { failure } = state.pending;
+      state.pending = undefined;
+      queueMicrotask(() => cb(failure));
+    }
+  }
+
+  /** Intent first: events the teardown itself provokes must already be suppressed. */
+  markStopIntent(key: SessionKey): void {
+    const state = this.#states.get(idOf(key));
+    if (state) state.stopIntent = true;
+  }
+
+  async resync(installSlug: string): Promise<void> {
+    const armed = [...this.#states.values()].filter(
+      (s) => s.handle.key.installSlug === installSlug && s.cb && !s.fired && !s.stopIntent,
+    );
+    if (armed.length === 0) return;
+    const snapshots = await this.driver.listSessions(installSlug);
+    const byId = new Map(snapshots.map((s) => [idOf(s.handle.key), s]));
+    for (const state of armed) {
+      const snapshot = byId.get(idOf(state.handle.key));
+      if (snapshot && snapshot.phase !== 'terminal') continue; // still live — nothing was missed
+      if (snapshot) this.#deliver(state, snapshot.failure);
+      else await this.#verify(state); // gone from the list — confirm via the handle's own truth read
+    }
+  }
+
+  #ensureWatch(installSlug: string): void {
+    if (this.#watches.has(installSlug)) return;
+    // Minimal test fakes may lack watchSessions; the hub must not crash on them.
+    if (typeof this.driver.watchSessions !== 'function') return;
+    this.#watches.set(
+      installSlug,
+      this.driver.watchSessions(installSlug, (event) => this.#onEvent(event)),
+    );
+  }
+
+  #onEvent(event: SessionEvent): void {
+    if (event.kind !== 'terminal') return; // phase/hint carry nothing onTerminal acts on
+    const state = this.#states.get(idOf(event.key));
+    if (!state) return; // hints may reference keys we never handed out
+    void this.#verify(state);
+  }
+
+  /** The hint discipline: re-read truth, then (maybe) fire — never fire on the event alone. */
+  async #verify(state: KeyState): Promise<void> {
+    if (state.fired || state.stopIntent) return;
+    if (state.verifying) {
+      // Never drop a hint into an in-flight read: on a driver whose status()
+      // is a remote round trip, the read may have snapshotted
+      // 'running' before this hint's death happened. Queue one re-check; the
+      // loop below drains it.
+      state.recheck = true;
+      return;
+    }
+    state.verifying = true;
+    try {
+      do {
+        state.recheck = false;
+        try {
+          const status = await state.handle.status();
+          if (status.phase === 'stopped' || status.phase === 'failed') {
+            this.#deliver(state, status.phase === 'failed' ? status.failure : undefined);
+            return;
+          }
+          // spurious or replayed hint — unless a newer hint queued a re-check
+        } catch {
+          /* truth read failed; a queued hint re-reads, else the next hint or resync retries */
+        }
+      } while (state.recheck && !state.fired && !state.stopIntent);
+    } finally {
+      state.verifying = false;
+    }
+  }
+
+  #deliver(state: KeyState, failure?: SessionFailure): void {
+    if (state.fired || state.stopIntent) return;
+    state.fired = true;
+    if (state.cb) state.cb(failure);
+    else state.pending = { failure };
+  }
+}
+
+class HubHandle implements SupervisedHandle {
+  constructor(
+    private readonly inner: SessionHandle,
+    private readonly hub: SessionEventsHub,
+  ) {}
+
+  get key(): SessionKey {
+    return this.inner.key;
+  }
+  get name(): string {
+    return this.inner.name;
+  }
+  start(): Promise<void> {
+    return this.inner.start();
+  }
+  status(): Promise<SessionStatus> {
+    return this.inner.status();
+  }
+  stop(reason: string): Promise<void> {
+    this.hub.markStopIntent(this.inner.key);
+    return this.inner.stop(reason);
+  }
+  onTerminal(cb: (failure?: SessionFailure) => void): void {
+    this.hub.arm(this.inner.key, cb);
+  }
+}
+
+/**
+ * Wrap a driver so every handle it hands out routes `onTerminal` and stop
+ * intent through one shared hub. Applied by `createSessionDriver` to whatever
+ * the registry's factory produced — overlays get the hub for free.
+ */
+export function withSessionEvents(driver: SessionDriver): SessionEventsDriver {
+  const hub = new SessionEventsHub(driver);
+  const wrapped: SessionEventsDriver = {
+    kind: driver.kind,
+    capabilities: () => driver.capabilities(),
+    prepare: async (spec) => {
+      const handle = await driver.prepare(spec);
+      hub.trackPrepared(handle);
+      return new HubHandle(handle, hub);
+    },
+    listSessions: async (installSlug) =>
+      (await driver.listSessions(installSlug)).map((snapshot): SupervisedSnapshot => {
+        hub.trackListed(snapshot.handle);
+        return { ...snapshot, handle: new HubHandle(snapshot.handle, hub) };
+      }),
+    watchSessions: (installSlug, onEvent) => driver.watchSessions(installSlug, onEvent),
+    resync: (installSlug) => hub.resync(installSlug),
+  };
+  if (driver.ensureReady) wrapped.ensureReady = (): Promise<void> => driver.ensureReady!();
+  if (driver.reapResidue) wrapped.reapResidue = (installSlug): Promise<void> => driver.reapResidue!(installSlug);
+  return wrapped;
+}

--- a/src/drivers/spec-fixture.ts
+++ b/src/drivers/spec-fixture.ts
@@ -1,0 +1,116 @@
+/**
+ * The one session spec every driver test starts from.
+ *
+ * Shared so assertions about two drivers are demonstrably about the same
+ * input — which is what makes the conformance cases mean anything. Only the
+ * Docker driver ships in this tree; an out-of-tree driver plugs its harness
+ * into the same suite against this same fixture.
+ *
+ * `fixtureSpec()` is the agent-only session this tree's realization actually
+ * runs. `fixtureSpecWithAux()` adds an overlay-composed auxiliary container:
+ * it exercises the multi-container contract rules (identity-material custody,
+ * per-role mount checks) through `validateSpec`, and the refusal rule on
+ * drivers that do not manage auxiliary containers — a driver never realizes a
+ * subset of a spec.
+ */
+import type { ContainerSpec, MountPolicy, SessionSpec } from './types.js';
+
+export const FIXTURE_POLICY: MountPolicy = {
+  groupsRoot: '/install/groups',
+  dataRoot: '/install/data',
+  surfaceRoots: ['/install/container/agent-runner/src', '/install/container/skills', '/install/container/CLAUDE.md'],
+  materialsRoot: '/install/data/session-materials',
+};
+
+export function fixtureSpec(overrides: Partial<SessionSpec> = {}): SessionSpec {
+  const spec: SessionSpec = {
+    key: { installSlug: 'spike', agentGroupId: 'g1', sessionId: 's1' },
+    labels: {
+      'nanoclaw-container-name': 'nanoclaw-v2-agent-one-1700000000000',
+      // D9: composition stamps the group folder for admission to join on.
+      'nanoclaw-group-folder': 'agent-one',
+    },
+    containers: [
+      {
+        role: 'agent',
+        image: 'nanoclaw-agent:spike-p0',
+        env: { TZ: 'UTC', HTTPS_PROXY: 'http://127.0.0.1:15001' },
+        command: ['bash', '-c'],
+        args: ['exec bun run /app/src/index.ts'],
+        labels: { 'session-channel': 'channel-abc' },
+        mounts: [
+          {
+            class: 'group-state',
+            hostPath: '/install/data/v2-sessions/g1/s1',
+            containerPath: '/workspace',
+            mode: 'rw',
+            groupScope: 'g1',
+          },
+          {
+            class: 'install-surface',
+            hostPath: '/install/container/agent-runner/src',
+            containerPath: '/app/src',
+            mode: 'ro',
+            groupScope: 'g1',
+          },
+          {
+            class: 'install-surface',
+            hostPath: '/install/container/CLAUDE.md',
+            containerPath: '/app/CLAUDE.md',
+            mode: 'ro',
+            groupScope: 'g1',
+          },
+        ],
+      },
+    ],
+    network: 'shared-private',
+    hardening: 'standard',
+    resources: { shmSizeMb: 1024, pidsLimit: 2048 },
+    runtimeTier: 'container',
+    runAs: { uid: 501, gid: 1000 },
+    stopGraceSeconds: 1,
+    ...overrides,
+  };
+  return spec;
+}
+
+/**
+ * An overlay-composed auxiliary container: exercises every multi-container
+ * rule (identity-material custody, per-role mount checks) without this tree
+ * shipping such a composer itself.
+ */
+export function fixtureAuxContainer(): ContainerSpec {
+  return {
+    role: 'egress-proxy',
+    image: 'example-egress-proxy:test',
+    env: { PROXY_LISTEN_ADDR: '0.0.0.0:15001' },
+    mounts: [
+      {
+        class: 'identity-material',
+        hostPath: '/install/data/session-materials/channel-abc-XXXX/session-key.pem',
+        containerPath: '/run/session/session-key.pem',
+        mode: 'ro',
+        groupScope: 'g1',
+      },
+      {
+        // A deployment CA from outside the material root — NOT the material
+        // root. A fixture where every auxiliary mount shared one root could
+        // not distinguish a correct classification from a uniform one, and a
+        // uniform one shipped: it denied every spawn on the node while this
+        // suite stayed green.
+        class: 'allowlisted-extra',
+        hostPath: '/pki/upstream-ca.pem',
+        containerPath: '/run/session/upstream-ca.pem',
+        mode: 'ro',
+        groupScope: 'g1',
+      },
+    ],
+  };
+}
+
+/** The two-container session an overlay composes; see the module comment. */
+export function fixtureSpecWithAux(overrides: Partial<SessionSpec> = {}): SessionSpec {
+  const spec = fixtureSpec(overrides);
+  spec.containers = [...spec.containers, fixtureAuxContainer()];
+  return spec;
+}

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -1,0 +1,605 @@
+/**
+ * Session driver seam — shared contract types.
+ *
+ * The host composes a fully-resolved `SessionSpec`; a driver realizes it and
+ * reports. Drivers never compute, look up, or decide: if a driver needs to
+ * figure something out, the spec is underspecified.
+ *
+ * Mounts live on ContainerSpec, not the session: an auxiliary container needs its material
+ * mounts and the agent needs its workspace mounts, and neither may see the
+ * other's.
+ */
+
+export interface SessionKey {
+  installSlug: string;
+  agentGroupId: string;
+  sessionId: string;
+}
+
+/**
+ * Not a union, for the same reason `DriverKind` is not: this tree composes
+ * `['agent']` and must not enumerate roles it does not ship. An overlay that
+ * composes auxiliary containers (a per-session proxy, say) brings its own role
+ * names; the seam's rules key only on 'agent' — the one required role.
+ */
+export type ContainerRole = string;
+
+export type MountClass = 'group-state' | 'install-surface' | 'identity-material' | 'allowlisted-extra';
+
+export interface MountSpec {
+  /**
+   * Class = which pinning rule applies (and, later, what the sealed tier encrypts).
+   * - 'group-state': state pinned to this group's subtrees (session channel, group
+   *   folder, provider state — the path carries provider specifics; the seam is
+   *   provider-agnostic). Usually rw; read-only views over group paths (composed
+   *   instructions, per-group config) use this class with mode 'ro'.
+   * - 'install-surface': shipped runtime surfaces from the release (runner source,
+   *   skills, shared instructions). Pinned to an enumerated surfaceRoots allowlist —
+   *   never a bare install-root prefix, since state roots may nest inside it; mode
+   *   MUST be 'ro'.
+   * - 'identity-material': provisioner-emitted certs and keys for an auxiliary
+   *   container's leased identity. Pinned to the deployment's materialsRoot; mode
+   *   MUST be 'ro'; NEVER mountable into the 'agent' role — this makes the
+   *   no-credentials-in-agents invariant an admission-checkable rule.
+   * - 'allowlisted-extra': arbitrary host paths vetted upstream by the mount allowlist.
+   */
+  class: MountClass;
+  hostPath: string;
+  containerPath: string;
+  mode: 'rw' | 'ro';
+  /** Lets a realization — by admission or by in-code checks — pin group-state to the group subtree. */
+  groupScope: string;
+}
+
+export interface ContainerSpec {
+  role: ContainerRole;
+  /**
+   * Decision 3: drivers never build and never resolve tags. Named `image`
+   * rather than `imageDigest` because the spike pins by imported-tag identity
+   * (k3s containerd has no registry to digest against); the *rule* the seam
+   * enforces is unchanged — resolution happens before composition, never here.
+   */
+  image: string;
+  /** Non-secret by contract; conformance asserts absence of secret-shaped keys. */
+  env: Record<string, string>;
+  /**
+   * Env contributed by a registry-sourced lane (a model provider's container
+   * config, the install's gateway) rather than composed literals. Same bytes
+   * on the wire — the separation exists because provenance is what the secret
+   * rules key on: these lanes are the sanctioned channel for credential-NAMED
+   * configuration (a bearer placeholder the proxy overwrites, a stub the vault
+   * swaps at egress), so `validateSpec` exempts the key-name check here — and
+   * still refuses credential VALUES, from anyone. A typed field rather than a
+   * marker value because a marker is claimable by any composer; a lane is
+   * filled only by its call sites. Realizations emit `env` first, then this,
+   * and on a key collision this lane wins — the ordering the old raw-argv
+   * append guaranteed by Docker's last-wins rule, now stated as contract.
+   */
+  contributedEnv?: Record<string, string>;
+  /**
+   * PID 1 and its arguments. Split because not every runtime can express a
+   * single argv the way `docker --entrypoint X image -c Y` can: `command`
+   * maps to the container entrypoint, `args` to what follows it.
+   */
+  command?: string[];
+  args?: string[];
+  mounts: MountSpec[];
+  /** Stamped onto the realized object in addition to the canonical key labels. */
+  labels?: Record<string, string>;
+  // No raw runtime flags here, ever: network topology is driver-private (the
+  // Docker realization's `networkArgsFor`), and everything a gateway used to
+  // append as raw `-e`/`-v` rides the typed lanes above, where admission can
+  // see it. No raw security flags either. Rootfs policy (auxiliary roles: read-only; agent:
+  // writable ephemeral scratch) is part of the named hardening posture, mapped per role by
+  // each driver. Changing it means a new posture version, not a per-session knob.
+}
+
+export interface SessionResources {
+  /**
+   * Deliberately optional: today's Docker path sets no `--memory` unless the
+   * operator opted in, so a required number here would silently introduce a
+   * cap that OOM-kills workloads that run fine now. Undefined means unbounded
+   * on both drivers.
+   */
+  memoryMb?: number;
+  /** Docker `--cpus`, or the realization's cpu limit. Undefined means unbounded. */
+  cpus?: string;
+  /**
+   * Docker `--pids-limit`. A realization with no per-session equivalent
+   * reports this as a hardening reduction rather than faking it. See
+   * `DriverCapabilities.unrealized`.
+   */
+  pidsLimit?: number;
+  /** Docker `--shm-size`, or the realization's /dev/shm sizing. */
+  shmSizeMb?: number;
+}
+
+export interface SessionSpec {
+  key: SessionKey;
+  /** Lineage labels (channel id, container instance id, ...). Drivers stamp these onto every runtime object. */
+  labels: Record<string, string>;
+  /** One session, one or more containers: ['agent'] in this tree; an overlay may compose auxiliary containers beside it. */
+  containers: ContainerSpec[];
+  /**
+   * 'shared-private': the containers of this session reach the gateway and nothing
+   * else. On Docker that is the egress-lockdown network machinery; other
+   * realizations enforce it declaratively. `capabilities.networkPolicy` tells
+   * the overlay which enforcement it got.
+   */
+  network: 'shared-private' | 'none';
+  /** Named, versioned posture. Drivers map it; raw flags never cross the seam. */
+  hardening: 'standard';
+  resources: SessionResources;
+  runtimeTier: 'container' | 'vm';
+  /**
+   * uid:gid the containers run as. Docker papers over an image/host uid mismatch
+   * with `--user`; not every realization has such a default, so the identity
+   * that must read 0600 material has to be explicit in the spec rather than
+   * inherited from the image.
+   */
+  runAs?: { uid: number; gid: number };
+  /** Grace before SIGKILL. Docker `stop -t`, or the realization's termination grace. */
+  stopGraceSeconds: number;
+}
+
+export type SessionFailure =
+  | { kind: 'spec-invalid'; retryable: false; detail: string }
+  | { kind: 'denied-by-policy'; retryable: false; detail: string }
+  | { kind: 'image-unavailable'; retryable: true }
+  | { kind: 'runtime-unavailable'; retryable: true }
+  | { kind: 'resources-exhausted'; retryable: true }
+  | { kind: 'started-then-died'; retryable: false; exitCode?: number }
+  | { kind: 'unknown'; retryable: false; opaqueRef: string };
+
+export type SessionStatus =
+  | { phase: 'preparing' }
+  | { phase: 'ready' } // prepared, not started
+  | { phase: 'running' }
+  | { phase: 'stopped' }
+  | { phase: 'failed'; failure: SessionFailure };
+
+/**
+ * Coarse liveness for discovery, deliberately distinct from `SessionStatus`:
+ * that is the per-handle truth read; this is the one-shot classification a
+ * list can vouch for without a per-handle round trip. 'starting' covers
+ * prepared-not-started incarnations (a created container is not a corpse);
+ * 'terminal' covers self-exited runtimes awaiting cleanup.
+ */
+export type SessionPhase = 'starting' | 'running' | 'terminal';
+
+/**
+ * One discovered session: the handle rebuilt from labels, plus the phase the
+ * listing itself observed. `failure` rides along when the runtime recorded
+ * one (a non-zero exit the list could still see).
+ */
+export interface SessionSnapshot {
+  handle: SessionHandle;
+  phase: SessionPhase;
+  failure?: SessionFailure;
+}
+
+/**
+ * Best-effort change notification from a driver's watch stream.
+ *
+ * Events are HINTS, never truth: they may drop, duplicate, coalesce, arrive
+ * late, or reference keys the consumer has never seen. A consumer must treat
+ * an event as "re-read truth via listSessions()/status() for this key" —
+ * never as a state transition to act on directly. `kind` grades the hint:
+ * 'terminal' (the driver observed an end), 'phase' (a liveness change),
+ * 'hint' (something happened; go look).
+ */
+export interface SessionEvent {
+  key: SessionKey;
+  kind: 'terminal' | 'phase' | 'hint';
+}
+
+/** Subscription returned by `SessionDriver.watchSessions`. */
+export interface SessionWatch {
+  stop(): void;
+}
+
+export interface SessionHandle {
+  key: SessionKey;
+  /** Stable runtime name for logs and operator commands. */
+  readonly name: string;
+  start(): Promise<void>;
+  status(): Promise<SessionStatus>;
+  /**
+   * Full teardown of everything this key allocated. The contract is that the
+   * session ENDS and its resources get cleaned up; that today's
+   * implementations block until the runtime object is actually gone is an
+   * implementation behavior (it happens to serialize workspace single-writer
+   * during termination), NOT a contract guarantee — callers must not rely on
+   * blocking-until-gone.
+   */
+  stop(reason: string): Promise<void>;
+}
+
+export interface DriverCapabilities {
+  isolationTiers: ('container' | 'vm')[];
+  admissionEnforced: boolean;
+  networkPolicy: 'topology' | 'declarative';
+  encryptedVolumes: boolean;
+  /**
+   * Spec fields this driver cannot realize, named honestly rather than faked.
+   * A driver with no per-session pids cap lists 'pidsLimit' here.
+   * Features gate on capabilities, never on driver identity.
+   */
+  unrealized: readonly (keyof SessionResources)[];
+  /**
+   * Whether the containers of a session share one network namespace. An egress
+   * overlay reads this to decide the proxy URL it puts in the agent's env:
+   * localhost when true, a resolvable name when the proxy is a separate host.
+   */
+  sharedNetworkNamespace: boolean;
+  /**
+   * Whether this driver realizes containers beside the agent. A driver that
+   * does not MUST refuse specs carrying them — never validate-then-ignore:
+   * silently dropping a composed container is semantic loss on a public
+   * contract, not a degradation. Composition gates gateway-contributed
+   * containers on this flag before such a spec is ever built, so the refusal
+   * is a backstop, not the UX.
+   */
+  auxiliaryContainers: boolean;
+  /**
+   * Whether this runtime can rebuild per-group agent images in place
+   * (`buildAgentGroupImage` shells `docker build` against the local daemon).
+   * A driver whose node has no build daemon — images arrive pre-imported —
+   * declares false, and BOTH call sites gate on this: `ncl groups restart
+   * --rebuild` refuses in its payload, and the self-mod guard DENIES
+   * install_packages at request time, so an admin is never asked to approve
+   * a rebuild that cannot happen.
+   */
+  imageBuild: boolean;
+}
+
+export interface SessionDriver {
+  /**
+   * Identity, for logs and diagnostics only — never a branch. Deliberately not
+   * a union: this tree ships one driver and enumerating kinds it cannot execute
+   * would make every overlay's kind a change to this file. Selection resolves
+   * kinds through the registry in `index.ts`.
+   */
+  readonly kind: string;
+  capabilities(): DriverCapabilities;
+  /** Fatal-at-startup reachability check. Agents cannot run without a runtime. */
+  ensureReady?(): Promise<void>;
+  /** Allocate everything, start nothing. Idempotent on key: an existing live session returns its handle. */
+  prepare(spec: SessionSpec): Promise<SessionHandle>;
+  /**
+   * Discovery for adoption and reaping. Handles are reconstructed from
+   * runtime-visible labels only. Each snapshot carries the phase the listing
+   * observed, so a caller can tell adoptable sessions from corpses WITHOUT a
+   * per-handle status() read: a self-exited runtime (an exited container with
+   * no teardown in flight) is either excluded or returned with phase
+   * 'terminal' — never dressed up as live.
+   */
+  listSessions(installSlug: string): Promise<SessionSnapshot[]>;
+  /**
+   * ONE driver-level subscription to session lifecycle changes for this
+   * install — never a per-session watch process. Started lazily on the first
+   * call; the driver owns reconnection with bounded backoff and never gives
+   * up, because an unrecovered drop ends supervision for every session at
+   * once. Events are best-effort hints (see `SessionEvent`). Drivers emit for
+   * ALL observed terminal transitions with no intent filtering: stop-intent
+   * suppression belongs to the session-events hub, not to drivers.
+   */
+  watchSessions(installSlug: string, onEvent: (event: SessionEvent) => void): SessionWatch;
+  /**
+   * Residue a stopped session could not clean up itself (a host that died
+   * between stop and teardown). `stop()` remains full teardown for a live one.
+   */
+  reapResidue?(installSlug: string): Promise<void>;
+}
+
+/** Canonical label keys — the adoption contract. A handle must be rebuildable from these alone. */
+export const LABELS = {
+  install: 'nanoclaw-install',
+  group: 'nanoclaw-group',
+  session: 'nanoclaw-session',
+  role: 'nanoclaw-role',
+} as const;
+
+/**
+ * The group-folder label (D9). Deliberately NOT part of `LABELS`: adoption
+ * rebuilds handles from the four canonical keys alone and must keep working
+ * against sessions that predate this label. It exists for admission: the
+ * `groups/<folder>` mount subtree is named by the folder, the folder is not
+ * derivable from the group id (the mapping lives in the central DB, which
+ * neither the in-code check nor a CEL policy can read), so the composer
+ * carries it on the session for the policy to join `hostPath` prefixes
+ * against. Composition stamps it into `SessionSpec.labels`; drivers realize
+ * it VERBATIM or refuse — never projected, truncated or case-folded.
+ */
+export const GROUP_FOLDER_LABEL = 'nanoclaw-group-folder';
+
+/**
+ * A label VALUE every driver can realize VERBATIM: <=63 bytes of
+ * `[A-Za-z0-9._-]`, alphanumeric at both ends (empty is legal). This is the
+ * strictest label grammar any driver realizes values onto, adopted as the
+ * seam-wide bound so a spec composed on one driver is not quietly
+ * unrealizable on another. The charset is ASCII-only,
+ * so for any value that passes, `length` counts bytes.
+ *
+ * Used to decide when a value may NOT be projected: `GROUP_FOLDER_LABEL` is
+ * an admission join key and must be refused at composition, not capped by a
+ * driver, when it fails this (see `composeSessionSpec`).
+ */
+export function labelValueLegal(value: string): boolean {
+  return value.length <= 63 && /^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$/.test(value);
+}
+
+export function labelsForKey(
+  key: SessionKey,
+  role: ContainerRole,
+  extra: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    [LABELS.install]: key.installSlug,
+    [LABELS.group]: key.agentGroupId,
+    [LABELS.session]: key.sessionId,
+    [LABELS.role]: role,
+    ...extra,
+  };
+}
+
+// ---------- failure constructors, shared by both drivers ----------
+
+export type SessionFailureError = Error & SessionFailure;
+
+export function specInvalid(detail: string): SessionFailureError {
+  return Object.assign(new Error(`spec-invalid: ${detail}`), {
+    kind: 'spec-invalid' as const,
+    retryable: false as const,
+    detail,
+  });
+}
+
+export function deniedByPolicy(detail: string): SessionFailureError {
+  return Object.assign(new Error(`denied-by-policy: ${detail}`), {
+    kind: 'denied-by-policy' as const,
+    retryable: false as const,
+    detail,
+  });
+}
+
+export function asFailureError(failure: SessionFailure): SessionFailureError {
+  return Object.assign(new Error(`session realization failed: ${failure.kind}`), failure);
+}
+
+/**
+ * Mount rules shared by every driver. A realization may ALSO enforce them
+ * out-of-process (`capabilities.admissionEnforced`), but running them
+ * host-side keeps external enforcement from being the only thing standing
+ * between an agent and a private key.
+ */
+export interface MountPolicy {
+  groupsRoot: string;
+  dataRoot: string;
+  surfaceRoots: string[];
+  materialsRoot: string;
+}
+
+export function validateSpec(spec: SessionSpec, policy: MountPolicy): void {
+  if (spec.runtimeTier !== 'container') {
+    throw specInvalid(`runtimeTier '${spec.runtimeTier}' not in capabilities`);
+  }
+  if (spec.containers.filter((c) => c.role === 'agent').length !== 1) {
+    // Exactly one, not at-least-one: the agent is the session's one required
+    // role, and a second container claiming it would make every 'agent'-keyed
+    // rule (identity-material exclusion, the realization's supervision) apply
+    // to an ambiguous target.
+    throw specInvalid('spec must carry exactly one agent container');
+  }
+  const pluginsRoot = stampedPluginsRoot(spec, policy);
+  for (const container of spec.containers) {
+    const seenTargets = new Set<string>();
+    for (const mount of container.mounts) {
+      if (!hostPathCanonical(mount.hostPath)) {
+        // Every class rule below is a prefix check against a trusted root, and
+        // a prefix check reads `materialsRoot/../outside` as inside — the
+        // runtime then normalizes it OUTSIDE the root it was judged against.
+        // Requiring the canonical absolute form makes the string these rules
+        // judge the same path the runtime mounts. (A relative source would not
+        // even be a bind: Docker reads it as a named volume.) Symlinks remain
+        // beyond a lexical check — that is what `admissionEnforced`
+        // realizations are for.
+        throw deniedByPolicy(
+          `mount ${mount.hostPath} must be a canonical absolute path (no '..', '.', '//', or trailing '/')`,
+        );
+      }
+      if (seenTargets.has(mount.containerPath)) {
+        // Two sources for one target would make the realized mount an ordering
+        // artifact. Composition resolves collisions (contributed mounts win),
+        // so a spec reaching a driver has exactly one source per target.
+        throw specInvalid(`duplicate containerPath ${mount.containerPath} on ${container.role}`);
+      }
+      seenTargets.add(mount.containerPath);
+      const required =
+        classRequiredByPath(mount.hostPath, policy) ??
+        (pluginsRoot && underRoot(mount.hostPath, pluginsRoot) ? 'install-surface' : null);
+      if (required && mount.class !== required) {
+        // Where a file lives decides what it IS, so the class is not the
+        // composer's to choose for these roots. Without this the taxonomy is
+        // only as strong as whoever assigns the class, and two of the four
+        // classes carry safety properties that a demotion silently drops:
+        // `allowlisted-extra` is permitted unconditionally, so relabelling a
+        // session private key as one mounts it INTO THE AGENT — defeating the
+        // no-credentials invariant outright — and relabelling the runner source
+        // as one escapes the read-only rule on the code the agent executes.
+        // Neither is exotic: both are a single word in a mount literal.
+        throw deniedByPolicy(`mount ${mount.hostPath} must be classed ${required}, not ${mount.class}`);
+      }
+      if (mount.class === 'install-surface' && mount.mode !== 'ro') {
+        throw deniedByPolicy(`install-surface mount ${mount.hostPath} must be ro`);
+      }
+      if (mount.class === 'identity-material' && (mount.mode !== 'ro' || container.role === 'agent')) {
+        // The no-credentials invariant, as a checkable rule: identity materials
+        // are ro-only and never enter the agent container.
+        throw deniedByPolicy(`identity-material mount ${mount.hostPath} invalid on role ${container.role}`);
+      }
+      if (!mountAllowed(mount, spec, policy)) {
+        throw deniedByPolicy(`mount ${mount.hostPath} violates class ${mount.class} scope ${mount.groupScope}`);
+      }
+    }
+    for (const [key, value] of Object.entries(container.env)) {
+      if (isSecretShaped(key, value)) {
+        throw deniedByPolicy(`secret-shaped env '${key}' on ${container.role}`);
+      }
+    }
+    for (const [key, value] of Object.entries(container.contributedEnv ?? {})) {
+      // The sanctioned lane: credential-shaped NAMES are its purpose — a
+      // provider registering `ANTHROPIC_AUTH_TOKEN=placeholder` for the proxy
+      // to overwrite is the pattern working as intended, and the name check
+      // alone denies every such install. Credential VALUES have no sanctioned
+      // channel, from anyone: real material rides mounts by reference.
+      if (looksLikeCredential(value)) {
+        throw deniedByPolicy(`credential value in contributed env '${key}' on ${container.role}`);
+      }
+    }
+  }
+}
+
+/**
+ * The canonical absolute form the mount rules require: rooted, and free of
+ * empty, '.' and '..' segments — so the string a prefix rule judges is the
+ * path the runtime mounts, and a trusted root cannot be escaped lexically.
+ */
+function hostPathCanonical(hostPath: string): boolean {
+  if (!hostPath.startsWith('/')) return false;
+  const segments = hostPath.split('/').slice(1);
+  return segments.every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+/**
+ * The invariant is that no credential VALUE rides in the environment — not that
+ * no key is ever named after one. So the rule measures both sides: a
+ * credential-named key carrying a non-exempt value, OR a value that IS a
+ * credential whatever its key is called. The name check alone measures the
+ * wrong thing wherever the name is chosen by whoever is leaking:
+ * `ANTHROPIC_API_KEY` is caught while the identical credential in
+ * `ANTHROPIC_AUTH`, `GW_CRED` or `SESSION_BEARER` passes straight through.
+ *
+ * Two exemptions, neither able to admit a credential's bytes:
+ *
+ * - An absolute path. The mount classes pass material by reference: mount the
+ *   file read-only, put its path in an env var.
+ *   `PROXY_CLIENT_KEY=/run/session/session-key.pem` is that pattern
+ *   working exactly as intended, and a key-name check alone rejects it —
+ *   denying every session whose auxiliary containers need their own client
+ *   key. A path is a pointer; the thing it points at is governed by
+ *   the mount classes, where it is actually checkable.
+ */
+export function isSecretShaped(key: string, value: string): boolean {
+  // A path is a pointer, never a credential, whatever the key is called.
+  if (/^\/[^\s]*$/.test(value)) return false;
+  return /(_KEY|_TOKEN|_SECRET|PASSWORD)$/i.test(key) || looksLikeCredential(value);
+}
+
+/**
+ * Credential VALUES, recognised by issuer-assigned prefixes.
+ *
+ * Deliberately prefix-matching rather than entropy-scoring. Entropy
+ * false-positives on legitimate opaque config — a base64 fingerprint, an image
+ * digest, a UUID-ish id — and a false positive here does not warn, it denies
+ * every session at once, fail-closed. These prefixes are issuer-assigned and
+ * cannot plausibly appear in ordinary configuration. The list is a floor, not
+ * a guarantee: it catches the credentials people actually paste, and the
+ * key-name check above still covers well-named keys carrying anything else.
+ */
+export function looksLikeCredential(value: string): boolean {
+  return (
+    /^sk-[A-Za-z0-9_-]{20,}$/.test(value) || // Anthropic / OpenAI
+    /^(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}$/.test(value) || // GitHub
+    /^github_pat_[A-Za-z0-9_]{20,}$/.test(value) ||
+    /^xox[baprs]-[A-Za-z0-9-]{10,}$/.test(value) || // Slack
+    /^AKIA[0-9A-Z]{16}$/.test(value) || // AWS access key id
+    /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value) || // JWT
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(value) // a key pasted inline
+  );
+}
+
+/**
+ * The class a path is not allowed to disagree with.
+ *
+ * Only the two roots whose classes carry a safety property are pinned this way.
+ * `group-state` and `allowlisted-extra` stay a composition choice, because
+ * `allowlisted-extra` legitimately covers operator-configured read-write mounts
+ * and forcing those read-only would break the mount-allowlist feature. The rule
+ * is not "everything is derived" — it is "a class that grants something cannot
+ * be claimed by a path that has not earned it".
+ */
+export function classRequiredByPath(hostPath: string, policy: MountPolicy): MountClass | null {
+  if (underRoot(hostPath, policy.materialsRoot)) return 'identity-material';
+  if (policy.surfaceRoots.some((root) => underRoot(hostPath, root))) return 'install-surface';
+  return null;
+}
+
+/**
+ * `groups/<folder>/plugins` — the one install surface that does not live under
+ * an install root.
+ *
+ * Whole-plugin stamping copies a validated plugin's whole tree into the group
+ * folder and mounts it read-only, because what lands there is code the agent
+ * EXECUTES (skills, stdio MCP servers) and the plugin contract sends writes to
+ * `plugin-data/` instead. That is the `install-surface` property exactly — and
+ * `install-surface` is the only class whose read-only rule is enforced rather
+ * than chosen, which is the point: classed `allowlisted-extra` it would be
+ * permitted unconditionally, and the read-only pin on executed code would be
+ * one word in a mount literal away from gone.
+ *
+ * It cannot be a `surfaceRoots` entry, though, and the reason is structural
+ * rather than incidental: every surfaceRoot is also a REQUIRED class
+ * (`classRequiredByPath`), and every root that contains this path also contains
+ * the group's read-write state mounts — the group folder itself, container.json,
+ * the composed instructions. Listing `groupsRoot` would force all of those to
+ * `install-surface` too and deny every session. Listing the exact per-group path
+ * is impossible: a `MountPolicy` is install-wide and knows no group.
+ *
+ * So it is pinned here instead, joined through `GROUP_FOLDER_LABEL` — the same
+ * verbatim label admission uses to pin `groups/<folder>` hostPath prefixes,
+ * doing precisely the job it was added for. A spec that carries no folder label
+ * gets no plugins root, and a `groups/<folder>/plugins` mount on it is judged by
+ * the ordinary class rules.
+ */
+export function stampedPluginsRoot(spec: SessionSpec, policy: MountPolicy): string | null {
+  const folder = spec.labels[GROUP_FOLDER_LABEL];
+  if (!folder || !labelValueLegal(folder)) return null;
+  return `${policy.groupsRoot}/${folder}/plugins`;
+}
+
+function mountAllowed(mount: MountSpec, spec: SessionSpec, policy: MountPolicy): boolean {
+  switch (mount.class) {
+    case 'allowlisted-extra':
+      // Vetted upstream by the mount-allowlist feature.
+      return true;
+    case 'install-surface': {
+      if (policy.surfaceRoots.some((root) => underRoot(mount.hostPath, root))) return true;
+      const pluginsRoot = stampedPluginsRoot(spec, policy);
+      return pluginsRoot !== null && underRoot(mount.hostPath, pluginsRoot);
+    }
+    case 'identity-material':
+      return underRoot(mount.hostPath, policy.materialsRoot);
+    case 'group-state': {
+      if (mount.groupScope !== spec.key.agentGroupId) return false;
+      if (underRoot(mount.hostPath, `${policy.dataRoot}/v2-sessions/${mount.groupScope}`)) return true;
+      if (underRoot(mount.hostPath, policy.groupsRoot)) {
+        // The groups root holds EVERY group's folder, so "under groupsRoot"
+        // alone would grant a session any group's state — `groupScope` cannot
+        // arbitrate, being stamped by the same composer whose mounts are being
+        // judged. The folder label can: it is admission's join key, carried
+        // verbatim, and it pins this session to its own subtree.
+        const folder = spec.labels[GROUP_FOLDER_LABEL];
+        if (!folder || !labelValueLegal(folder)) return false;
+        return underRoot(mount.hostPath, `${policy.groupsRoot}/${folder}`);
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
+function underRoot(hostPath: string, root: string): boolean {
+  return hostPath === root || hostPath.startsWith(`${root}/`);
+}


### PR DESCRIPTION
Adds `src/drivers/` — a seam between "what a session is" and "how it runs", with Docker as the built-in realization. **Purely additive: no call site changes, nothing in the host loads differently after this PR** (the whole suite is green at this commit alone — 128 files / 1672 tests).

## What's in the module

- **`SessionSpec` vocabulary** — a substrate-neutral description of a session: containers with roles, env, command/args split, mounts, labels, resources, `runAs`, stop grace.
- **A mount-class taxonomy + `validateSpec`** — where a file lives decides what it *is*: `install-surface` (read-only, enforced), `identity-material` (never mounted into the agent container), `group-state` (pinned to the group subtree), `allowlisted-extra`. Required classes are computed from paths, so a mount can't be relabelled into a weaker class. Paths must be canonical and absolute (no `..` escapes past a prefix check), one source per container path, and `group-state` mounts under the groups root are pinned to the session's own folder via the group-folder label — the composer's `groupScope` claim alone cannot reach another group's state.
- **A contributed-env lane** (`ContainerSpec.contributedEnv`) — registry-sourced env (a model provider's container config, the install's gateway) rides a typed lane distinct from composed literals. Provenance is what the secret rules key on: the lane exempts the credential-NAME check (a bearer placeholder the proxy overwrites is the pattern working as intended) and still refuses credential VALUES, from anyone. Realizations emit composed env first, contributed env second; the contributed lane wins a key collision by contract.
- **A driver registry with an overlay barrel** — out-of-tree drivers register a kind; selection is dormant in this PR (nothing reads it yet).
- **The Docker driver** — `prepare` (allocate everything, start nothing; idempotent per session; refuses container roles it does not manage rather than validating-then-ignoring them — `capabilities().auxiliaryContainers` is the gate), `start`, snapshot-honest `listSessions` (an exited runtime is reported `terminal`, never dressed up as live), `watchSessions` (one driver-level `docker events` subscription with reconnect + gap reconciliation), `stop`. Container names are scoped by install and verified against the canonical labels, so peer installs sharing a daemon can never alias one runtime object. The supervision channel is spawned detached: a service manager restarting the host signals the host's process group, and `docker start --attach` forwards signals — undetached, every host restart would ride into every `--rm` container and erase the sessions adoption exists to preserve.
- **A session-events hub** — `onTerminal` becomes at-most-once sugar over the driver's event stream: every hint is verified against `status()` before firing, replayed/duplicate events can't fire terminals for live sessions, and stop-intent suppression lives in one place instead of per driver. `status()` never concludes while the attach channel is alive and unresolved, so a fast `die` event cannot spend the one terminal delivery before the exit code lands.
- **A conformance suite** — the executable contract every driver must pass, driven through a scriptable CLI fake so tests assert what a driver *did*, not what its source looks like.

## Why

Motivations, in order: (1) an extension point — alternative container runtimes (Podman, microVMs, remote runtimes) become one driver + a green conformance run instead of a fork of the host; (2) testability — session realization becomes drivable end-to-end against a fake CLI; (3) supervision robustness — the hub closes real gaps in terminal detection (events that arrive during a status read are re-checked, not dropped; watch reconnects reconcile the gap instead of going blind).

Part 1 of 3. Part 2 routes the host through the seam (dormant selection, Docker default); part 3 is a small behavioral fix in group-folder handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
