### PR TITLE
groups: refuse to create a group over a folder that already exists undisposed

### DIFF
--- a/src/cli/resources/groups-create-folder-reuse.test.ts
+++ b/src/cli/resources/groups-create-folder-reuse.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A4 — folder-reuse refusal (plan-review security finding "immutable
+ * identity").
+ *
+ * `ncl groups delete` never removes `groups/<folder>/` (declared contract of
+ * the delete handler), so a folder on disk with no claiming DB row is
+ * deleted-group residue or an operator-placed dir. Minting a NEW agent-group
+ * id over it would silently adopt the old group's data (memory, skills,
+ * CLAUDE.md) under a new identity. The fresh-create branch of
+ * `ncl groups create` must refuse; idempotent reuse of a LIVE folder's group
+ * (DB row exists) is untouched.
+ *
+ * Separate file from groups.test.ts on purpose: this suite must mock
+ * GROUPS_DIR (groups.test.ts mocks only DATA_DIR — create-path tests added
+ * there would write into the real repo groups/ during test runs).
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-groups-create-folder-reuse/data',
+    GROUPS_DIR: '/tmp/nanoclaw-test-groups-create-folder-reuse/groups',
+  };
+});
+
+const TEST_ROOT = '/tmp/nanoclaw-test-groups-create-folder-reuse';
+const GROUPS_DIR = path.join(TEST_ROOT, 'groups');
+
+import { initTestDb, closeDb, runMigrations, getDb } from '../../db/index.js';
+import { dispatch } from '../dispatch.js';
+// Side-effect import: registers the `groups-*` commands (including create).
+import './groups.js';
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(GROUPS_DIR, { recursive: true });
+  runMigrations(initTestDb());
+});
+
+afterEach(() => {
+  closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+async function create(folder: string) {
+  return dispatch(
+    {
+      id: `req-create-${folder}-${Math.random().toString(36).slice(2, 8)}`,
+      command: 'groups-create',
+      args: { folder },
+    },
+    { caller: 'host' },
+  );
+}
+
+describe('groups-create — folder-reuse refusal (A4)', () => {
+  it('refuses to mint a new group over undisposed on-disk residue', async () => {
+    // Deleted-group residue: the folder is on disk, no DB row claims it.
+    fs.mkdirSync(path.join(GROUPS_DIR, 'recycled'));
+    fs.writeFileSync(path.join(GROUPS_DIR, 'recycled', 'memory.md'), 'old group memory\n');
+
+    const resp = await create('recycled');
+
+    expect(resp.ok).toBe(false);
+    const error = (resp as { ok: false; error: { message: string } }).error;
+    expect(error.message).toContain('already exists on disk');
+    expect(error.message).toContain('recycled');
+    // No row minted, residue untouched.
+    expect(getDb().prepare('SELECT * FROM agent_groups WHERE folder = ?').get('recycled')).toBeUndefined();
+    expect(fs.readFileSync(path.join(GROUPS_DIR, 'recycled', 'memory.md'), 'utf8')).toBe('old group memory\n');
+  });
+
+  it('refuses when the residue is a dangling symlink at groups/<folder>', async () => {
+    // Residue can be a symlink whose target is gone (e.g. an operator linked
+    // the folder elsewhere and the target was removed). It still occupies the
+    // name — mkdir would EEXIST — so the fresh-create branch must refuse it
+    // like any other on-disk presence.
+    fs.symlinkSync(path.join(TEST_ROOT, 'no-such-target'), path.join(GROUPS_DIR, 'linked'));
+
+    const resp = await create('linked');
+
+    expect(resp.ok).toBe(false);
+    const error = (resp as { ok: false; error: { message: string } }).error;
+    expect(error.message).toContain('already exists on disk');
+    expect(getDb().prepare('SELECT * FROM agent_groups WHERE folder = ?').get('linked')).toBeUndefined();
+  });
+
+  it('allows creation when the folder is absent (scaffolds folder + config row)', async () => {
+    const resp = await create('fresh');
+
+    expect(resp.ok).toBe(true);
+    const row = getDb().prepare('SELECT * FROM agent_groups WHERE folder = ?').get('fresh') as { id: string };
+    expect(row).toBeDefined();
+    expect(fs.existsSync(path.join(GROUPS_DIR, 'fresh'))).toBe(true);
+    expect(getDb().prepare('SELECT * FROM container_configs WHERE agent_group_id = ?').get(row.id)).toBeDefined();
+  });
+
+  it('returns the SAME group when the folder is live — idempotency on --folder pinned', async () => {
+    const first = await create('steady');
+    expect(first.ok).toBe(true);
+    const firstId = (first as { ok: true; data: { id: string } }).data.id;
+
+    // The folder now exists on disk AND a DB row claims it. The refusal must
+    // sit on the fresh-create branch only — a second create with the same
+    // --folder returns the existing group, exactly as documented
+    // ("Idempotent on --folder").
+    const second = await create('steady');
+    expect(second.ok).toBe(true);
+    expect((second as { ok: true; data: { id: string } }).data.id).toBe(firstId);
+  });
+});

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -19,7 +19,7 @@ import {
   updateContainerConfigJson,
 } from '../../db/container-configs.js';
 import { getSessionDriver } from '../../drivers/index.js';
-import { assertValidGroupFolder } from '../../group-folder.js';
+import { assertValidGroupFolder, groupFolderExistsOnDisk } from '../../group-folder.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { createAgentFromTemplate } from '../../templates/create-agent.js';
 import {
@@ -167,6 +167,17 @@ registerResource({
           initGroupFilesystem(existing); // ensure a reused group is fully configured too (idempotent; also repairs a missing workspace folder)
           return existing;
         }
+        // Fresh-create branch only: a folder on disk with no claiming DB row
+        // is deleted-group residue (delete never removes groups/<folder>/) or
+        // an operator-placed dir — minting a new id over it would silently
+        // re-scope the old group's data under a new identity.
+        if (groupFolderExistsOnDisk(folder)) {
+          throw new Error(
+            `group folder 'groups/${folder}' already exists on disk but no agent group claims it — ` +
+              `deleting a group never removes its folder, and creating a new group over it would silently ` +
+              `adopt the old group's data under a new identity. Move or remove the folder, or pick a different --folder.`,
+          );
+        }
         const id = `ag-${randomUUID()}`;
         const group: AgentGroup = { id, name, folder, agent_provider: null, created_at: new Date().toISOString() };
         createAgentGroup(group);
@@ -196,7 +207,8 @@ registerResource({
       description:
         'Delete an agent group and its dependent rows (sessions, destinations, approvals, role grants, ' +
         'memberships, channel wirings). FK-ordered cascade in a single transaction. ' +
-        'Use --id <group-id>. Out of scope: killing running containers, on-disk cleanup of groups/<folder>/ and data/v2-sessions/<group-id>/.',
+        'Use --id <group-id>. Out of scope: killing running containers, on-disk cleanup of groups/<folder>/ and data/v2-sessions/<group-id>/. ' +
+        'The leftover groups/<folder>/ blocks re-creating a group under the same folder name until it is moved or removed.',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');

--- a/src/group-folder.test.ts
+++ b/src/group-folder.test.ts
@@ -1,8 +1,20 @@
+import fs from 'fs';
 import path from 'path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isValidGroupFolder, resolveGroupFolderPath } from './group-folder.js';
+// groupFolderExistsOnDisk reads GROUPS_DIR — point it at a temp root so the
+// polarity tests control what is on disk. resolveGroupFolderPath assertions
+// below only check the `groups/<folder>` suffix, so they hold either way.
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, GROUPS_DIR: '/tmp/nanoclaw-test-group-folder/groups' };
+});
+
+import { groupFolderExistsOnDisk, isValidGroupFolder, resolveGroupFolderPath } from './group-folder.js';
+
+const TEST_ROOT = '/tmp/nanoclaw-test-group-folder';
+const GROUPS_DIR = path.join(TEST_ROOT, 'groups');
 
 describe('group folder validation', () => {
   it('accepts normal group folder names', () => {
@@ -25,5 +37,42 @@ describe('group folder validation', () => {
 
   it('throws for unsafe folder names', () => {
     expect(() => resolveGroupFolderPath('../../etc')).toThrow();
+  });
+});
+
+describe('groupFolderExistsOnDisk', () => {
+  beforeEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+    fs.mkdirSync(GROUPS_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it('is true when groups/<folder> is present in any form', () => {
+    fs.mkdirSync(path.join(GROUPS_DIR, 'residue-dir'));
+    expect(groupFolderExistsOnDisk('residue-dir')).toBe(true);
+    // A plain file counts too — presence, not shape, is the rule.
+    fs.writeFileSync(path.join(GROUPS_DIR, 'residue-file'), '');
+    expect(groupFolderExistsOnDisk('residue-file')).toBe(true);
+  });
+
+  it('is true for a dangling symlink — the probe must not follow links', () => {
+    // A symlink whose target is gone still occupies groups/<folder> (mkdir
+    // would EEXIST) and still resolves reads through whatever reappears at
+    // the target. existsSync follows the link and reports absent; the
+    // docstring's "any form" requires lstat semantics.
+    fs.symlinkSync(path.join(TEST_ROOT, 'no-such-target'), path.join(GROUPS_DIR, 'residue-link'));
+    expect(fs.existsSync(path.join(GROUPS_DIR, 'residue-link'))).toBe(false); // precondition: link is dangling
+    expect(groupFolderExistsOnDisk('residue-link')).toBe(true);
+  });
+
+  it('is false when the folder is absent', () => {
+    expect(groupFolderExistsOnDisk('never-created')).toBe(false);
+  });
+
+  it('throws when the name escapes the groups dir', () => {
+    expect(() => groupFolderExistsOnDisk('../../etc')).toThrow(/escapes/);
   });
 });

--- a/src/group-folder.ts
+++ b/src/group-folder.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
@@ -44,4 +45,30 @@ export function resolveGroupFolderPath(folder: string): string {
   const groupPath = path.resolve(GROUPS_DIR, folder);
   ensureWithinBase(GROUPS_DIR, groupPath);
   return groupPath;
+}
+
+/**
+ * True when `groups/<folder>` is present on disk in any form — directory,
+ * file, or symlink, empty or not. Every creation path writes the DB row
+ * before mkdir, so presence with no claiming row is exactly deleted-group
+ * residue (delete never removes the folder) or an operator-placed dir.
+ *
+ * Confinement-only on purpose: this deliberately does NOT go through
+ * resolveGroupFolderPath/assertValidGroupFolder. Occupancy must be probed for
+ * names the current grammar refuses too — a legacy folder minted before the
+ * grammar tightened still occupies its name, and refusing to LOOK would let a
+ * create mint a new identity over its data.
+ */
+export function groupFolderExistsOnDisk(folder: string): boolean {
+  const groupPath = path.resolve(GROUPS_DIR, folder);
+  ensureWithinBase(GROUPS_DIR, groupPath);
+  // lstat, not existsSync: existsSync follows symlinks, so a dangling symlink
+  // at groups/<folder> would read as absent even though it occupies the name
+  // (mkdir would fail on it). lstat probes the entry itself.
+  try {
+    fs.lstatSync(groupPath);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/modules/agent-to-agent/create-agent.test.ts
+++ b/src/modules/agent-to-agent/create-agent.test.ts
@@ -9,9 +9,20 @@
  * delivery action (the only reachable path) and the approve continuation's
  * grant-carrying re-entry.
  */
+import fs from 'fs';
+import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PendingApproval, Session } from '../../types.js';
+
+// The folder-dedupe loop is disk-aware (A4): point GROUPS_DIR at a temp root
+// so the residue-skip test controls what is on disk. Absent for every other
+// test, so their behavior is unchanged.
+const A2A_TEST_ROOT = '/tmp/nanoclaw-test-a2a-create-agent';
+vi.mock('../../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../config.js')>()),
+  GROUPS_DIR: '/tmp/nanoclaw-test-a2a-create-agent/groups',
+}));
 
 // Mocks for the collaborators the branch decides between / depends on.
 // vi.hoisted: the module barrel import below runs before this file's const
@@ -207,6 +218,23 @@ describe('create_agent — guard-based authorization (wrapped delivery action)',
 
     expect(mockRequestApproval).not.toHaveBeenCalled();
     expect(mockCreateAgentGroup).not.toHaveBeenCalled();
+  });
+
+  it('skips deleted-group residue on disk when minting the folder (A4)', async () => {
+    // groups/scout exists on disk but no DB row claims it (the mocked
+    // getAgentGroupByFolder always returns undefined) — exactly the state
+    // `ncl groups delete` leaves behind. The dedupe loop must treat disk
+    // presence as taken and mint scout-2, never adopt the residue.
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'global' });
+    fs.mkdirSync(path.join(A2A_TEST_ROOT, 'groups', 'scout'), { recursive: true });
+    try {
+      await runCreateAgent({ name: 'Scout', instructions: 'help' });
+
+      expect(mockCreateAgentGroup).toHaveBeenCalledTimes(1);
+      expect(mockCreateAgentGroup.mock.calls[0][0]).toMatchObject({ folder: 'scout-2' });
+    } finally {
+      fs.rmSync(A2A_TEST_ROOT, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -21,6 +21,7 @@ import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db
 import { getContainerConfig } from '../../db/container-configs.js';
 import { getSession } from '../../db/sessions.js';
 import { wakeContainer } from '../../container-runner.js';
+import { groupFolderExistsOnDisk } from '../../group-folder.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
@@ -126,10 +127,14 @@ async function performCreateAgent(
     return;
   }
 
-  // Derive a safe folder name, deduplicated globally across agent_groups.folder
+  // Derive a safe folder name, deduplicated globally across
+  // agent_groups.folder AND the on-disk groups/ dir: a folder present on disk
+  // with no claiming DB row is deleted-group residue, and adopting it would
+  // silently re-scope the old group's data under the new agent's identity —
+  // skip to the next suffix instead (templates/create-agent.ts precedent).
   let folder = localName;
   let suffix = 2;
-  while (getAgentGroupByFolder(folder)) {
+  while (getAgentGroupByFolder(folder) || groupFolderExistsOnDisk(folder)) {
     folder = `${localName}-${suffix}`;
     suffix++;
   }

--- a/src/modules/permissions/channel-approval.test.ts
+++ b/src/modules/permissions/channel-approval.test.ts
@@ -14,10 +14,12 @@
  *  - No agent groups configured: no card, no row
  */
 import fs from 'fs';
+import path from 'path';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
+import { createNewAgentGroup } from './channel-approval.js';
 import { createMessagingGroup, getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
 import { registerChannelAdapter } from '../../channels/channel-registry.js';
 import type { ChannelDefaults } from '../../channels/adapter.js';
@@ -722,5 +724,23 @@ describe('no-owner / no-agent failure modes', () => {
     expect(deliverMock).not.toHaveBeenCalled();
     const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
     expect(count).toBe(0);
+  });
+});
+
+describe('createNewAgentGroup — disk-aware folder dedupe (A4)', () => {
+  it('skips deleted-group residue on disk and mints the next suffix', () => {
+    // groups/my-agent exists on disk but no DB row claims it — exactly the
+    // state `ncl groups delete` leaves behind. The dedupe loop must treat
+    // disk presence as taken (matching templates/create-agent.ts) and mint
+    // my-agent-2, never adopt the residue.
+    const residue = path.join(TEST_DIR, 'groups', 'my-agent');
+    fs.mkdirSync(residue, { recursive: true });
+    fs.writeFileSync(path.join(residue, 'memory.md'), 'old group memory\n');
+
+    const ag = createNewAgentGroup('My Agent');
+
+    expect(ag.folder).toBe('my-agent-2');
+    // Residue untouched.
+    expect(fs.readFileSync(path.join(residue, 'memory.md'), 'utf8')).toBe('old group memory\n');
   });
 });

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -50,6 +50,7 @@ import { createAgentGroup, getAgentGroup, getAgentGroupByFolder, getAllAgentGrou
 import { getChannelAdapter } from '../../channels/channel-registry.js';
 import { getMessagingGroup, updateMessagingGroup } from '../../db/messaging-groups.js';
 import { getDeliveryAdapter } from '../../delivery.js';
+import { groupFolderExistsOnDisk } from '../../group-folder.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { log } from '../../log.js';
 import type { InboundEvent } from '../../channels/adapter.js';
@@ -360,7 +361,11 @@ export function createNewAgentGroup(name: string): AgentGroup {
   let folder = toFolder(name);
   const baseFolder = folder;
   let suffix = 2;
-  while (getAgentGroupByFolder(folder)) {
+  // Disk-aware dedupe (A4): a folder present on disk with no claiming DB row
+  // is deleted-group residue — adopting it would silently re-scope the old
+  // group's data under the new agent's identity. Skip to the next suffix
+  // instead (templates/create-agent.ts precedent).
+  while (getAgentGroupByFolder(folder) || groupFolderExistsOnDisk(folder)) {
     folder = `${baseFolder}-${suffix}`;
     suffix++;
   }


### PR DESCRIPTION
Stacked on #3306 and the consumption PR. Two small refusals that close a data-loss shape:

- **Creating a new agent group over an existing folder is refused.** A leftover folder is either deleted-group residue or an operator-placed directory; silently minting a new group id over it would adopt files the new agent never created (and expose them to it). The error names the folder and the way out.
- **A folder name the session labels cannot carry verbatim is refused at creation time**, instead of failing later at spawn where the error loses its context.

Covers group creation via the CLI, agent-to-agent creation, and channel-approval provisioning, each with tests (including symlink residue whose target is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)