### PR TITLE
slack: defaults factory, membership, onboarding, a2a guard (wave B — per-thread everywhere)

### DIFF
--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -14,6 +14,9 @@ import './discord.js';
 
 // slack
 // import './slack.js';
+// slack bot-authored inbound guard (registers the bridge inbound policy for
+// the 'slack' channel type — installs alongside the slack adapter)
+import './slack-a2a-guard.js';
 
 // telegram
 import './telegram.js';

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -13,7 +13,7 @@ import './cli.js';
 import './discord.js';
 
 // slack
-// import './slack.js';
+import './slack.js';
 // slack bot-authored inbound guard (registers the bridge inbound policy for
 // the 'slack' channel type — installs alongside the slack adapter)
 import './slack-a2a-guard.js';

--- a/src/channels/slack-a2a-guard.test.ts
+++ b/src/channels/slack-a2a-guard.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for the Slack bot-authored inbound guard.
+ *
+ * The wrap is unit-tested directly (ChannelSetup in → ChannelSetup out, driven
+ * with bridge-shaped inbound fixtures): human pass-through is byte-identical,
+ * bot-authored inbound is dropped by default, and the admission-policy seam's
+ * mechanics (admit / drop / re-attribution / accept-after-downstream) hold.
+ * Allowlist, hop-limit, and attribution *semantics* belong to the
+ * slack-a2a-rooms feature policy and are tested with it, not here.
+ *
+ * Registration note: this branch's bridge predates the inbound-policy seam
+ * (`registerBridgeInboundPolicy`, trunk PR refa-b5-bridge-inbound-policy), so
+ * the module's self-registration is a feature-detected no-op here and the
+ * composed path (SDK dispatch → bridge → policy → host) cannot be driven on
+ * this branch. `registerSlackBotGuard` is pinned against an injected registrar
+ * instead: the guard registers for the `slack` channel type only, which is
+ * what keeps non-Slack adapters untouched. The composed path is covered by
+ * trunk's chat-sdk-bridge-inbound-policy.test.ts and activates automatically
+ * once the seam forward-merges into this branch.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { log } from '../log.js';
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import {
+  botAuthorOf,
+  registerSlackBotGuard,
+  setBotInboundPolicy,
+  wrapSlackBotGuard,
+  type SlackBotInboundContext,
+  type SlackBotInboundDecision,
+} from './slack-a2a-guard.js';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+let nextMessageId = 0;
+
+/** Bridge-shaped inbound fixture (see chat-sdk-bridge.ts messageToInbound). */
+function makeInbound(author: Record<string, unknown>, text = 'hello'): InboundMessage {
+  const id = `msg-${++nextMessageId}`;
+  return {
+    id,
+    kind: 'chat-sdk',
+    content: {
+      id,
+      text,
+      author,
+      senderId: author.userId,
+      sender: author.userName,
+      senderName: author.userName,
+    },
+    timestamp: '2026-01-01T00:00:00.000Z',
+    isMention: false,
+    isGroup: true,
+  };
+}
+
+function humanMessage(text = 'hello'): InboundMessage {
+  return makeInbound({ userId: 'U123', userName: 'human', isBot: false, isMe: false }, text);
+}
+
+function botMessage(botId = 'B0AGENT', text = 'beep'): InboundMessage {
+  return makeInbound({ userId: botId, userName: 'sibling-agent', isBot: true, isMe: false }, text);
+}
+
+interface InboundCall {
+  platformId: string;
+  threadId: string | null;
+  message: InboundMessage;
+}
+
+function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const setup: ChannelSetup = {
+    onInbound:
+      onInbound ??
+      ((platformId, threadId, message) => {
+        calls.push({ platformId, threadId, message });
+      }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { setup, calls };
+}
+
+afterEach(() => {
+  setBotInboundPolicy(null);
+  vi.clearAllMocks();
+});
+
+describe('botAuthorOf', () => {
+  it('returns the bot id for a bot-authored message', () => {
+    expect(botAuthorOf(botMessage('B0FOREIGN'))).toEqual({ botId: 'B0FOREIGN' });
+  });
+
+  it('returns null for a human-authored message', () => {
+    expect(botAuthorOf(humanMessage())).toBeNull();
+  });
+
+  it('returns null when isBot is true but the bot is unattributable (no userId)', () => {
+    expect(botAuthorOf(makeInbound({ isBot: true, userName: 'ghost' }))).toBeNull();
+  });
+
+  it('returns null when content has no author or is not an object', () => {
+    const noAuthor: InboundMessage = { ...humanMessage(), content: { text: 'x' } };
+    expect(botAuthorOf(noAuthor)).toBeNull();
+    const stringContent: InboundMessage = { ...humanMessage(), content: 'just text' };
+    expect(botAuthorOf(stringContent)).toBeNull();
+  });
+});
+
+describe('wrapSlackBotGuard — default (no admission policy)', () => {
+  it('passes human-authored inbound through byte-identical', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const message = humanMessage('untouched');
+    const snapshot = JSON.parse(JSON.stringify(message));
+
+    await wrapped.onInbound('slack:C1', 'slack:C1:T1', message);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].platformId).toBe('slack:C1');
+    expect(calls[0].threadId).toBe('slack:C1:T1');
+    expect(calls[0].message).toBe(message); // same object, not a copy
+    expect(calls[0].message).toEqual(snapshot); // and no field was mutated
+  });
+
+  it('drops bot-authored inbound with a debug log — never reaches the host', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:C1', 'slack:C1:T1', botMessage('B0FOREIGN'));
+
+    expect(calls).toHaveLength(0);
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining('bot-authored inbound dropped'),
+      expect.objectContaining({ botId: 'B0FOREIGN', platformId: 'slack:C1', instanceKey: 'slack' }),
+    );
+  });
+
+  it('leaves the other ChannelSetup members untouched (pass-through references)', () => {
+    const { setup } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    expect(wrapped).not.toBe(setup);
+    expect(wrapped.onInbound).not.toBe(setup.onInbound);
+    expect(wrapped.onInboundEvent).toBe(setup.onInboundEvent);
+    expect(wrapped.onMetadata).toBe(setup.onMetadata);
+    expect(wrapped.onAction).toBe(setup.onAction);
+  });
+});
+
+describe('wrapSlackBotGuard — admission-policy seam', () => {
+  it('consults the policy with full context and admits when it says admit', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack-tester');
+    const seen: SlackBotInboundContext[] = [];
+    setBotInboundPolicy({
+      decideBotInbound(ctx) {
+        seen.push(ctx);
+        return { action: 'admit' };
+      },
+    });
+    const message = botMessage('B0SIBLING');
+
+    await wrapped.onInbound('slack:G7', 'slack:G7:T1', message);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      instanceKey: 'slack-tester',
+      platformId: 'slack:G7',
+      threadId: 'slack:G7:T1',
+      botId: 'B0SIBLING',
+    });
+    expect(seen[0].message).toBe(message);
+    expect(calls).toHaveLength(1);
+    // No senderId in the decision — content is not re-attributed.
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('B0SIBLING');
+  });
+
+  it('re-attributes content.senderId before the host sees the message', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: (ctx) => ({ action: 'admit', senderId: `slack:bot:${ctx.botId}` }),
+    });
+
+    await wrapped.onInbound('slack:G7', null, botMessage('B0SIBLING'));
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('slack:bot:B0SIBLING');
+  });
+
+  it('calls onAccepted only after downstream accepted (resolved without throwing)', async () => {
+    const order: string[] = [];
+    const { setup } = makeSetup(async () => {
+      order.push('downstream');
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'admit', onAccepted: () => order.push('accepted') }),
+    });
+
+    await wrapped.onInbound('slack:G7', null, botMessage());
+
+    expect(order).toEqual(['downstream', 'accepted']);
+  });
+
+  it('does not call onAccepted when downstream throws — the error propagates', async () => {
+    const onAccepted = vi.fn();
+    const { setup } = makeSetup(async () => {
+      throw new Error('router exploded');
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'admit', onAccepted }),
+    });
+
+    await expect(wrapped.onInbound('slack:G7', null, botMessage())).rejects.toThrow('router exploded');
+    expect(onAccepted).not.toHaveBeenCalled();
+  });
+
+  it('drops when the policy says drop', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'drop', reason: 'room not allowlisted' }),
+    });
+
+    await wrapped.onInbound('slack:C1', null, botMessage());
+
+    expect(calls).toHaveLength(0);
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining('dropped by policy'),
+      expect.objectContaining({ reason: 'room not allowlisted' }),
+    );
+  });
+
+  it('fails closed when the policy throws: bot message dropped, warning logged', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => {
+        throw new Error('policy bug');
+      },
+    });
+
+    await expect(wrapped.onInbound('slack:C1', null, botMessage())).resolves.toBeUndefined();
+    expect(calls).toHaveLength(0);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('dropping bot-authored inbound'), expect.anything());
+  });
+
+  it('never consults decideBotInbound for human messages; onHumanInbound observes them', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const decideBotInbound = vi.fn<() => SlackBotInboundDecision>(() => ({ action: 'drop' }));
+    const onHumanInbound = vi.fn();
+    setBotInboundPolicy({ decideBotInbound, onHumanInbound });
+    const message = humanMessage();
+
+    await wrapped.onInbound('slack:C1', 'slack:C1:T1', message);
+
+    expect(decideBotInbound).not.toHaveBeenCalled();
+    expect(onHumanInbound).toHaveBeenCalledWith({
+      instanceKey: 'slack',
+      platformId: 'slack:C1',
+      threadId: 'slack:C1:T1',
+      message,
+    });
+    expect(calls).toHaveLength(1); // observe-only — the human message still passes
+  });
+
+  it('passes human messages through even when the onHumanInbound observer throws', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'drop' }),
+      onHumanInbound: () => {
+        throw new Error('observer bug');
+      },
+    });
+
+    await wrapped.onInbound('slack:C1', null, humanMessage());
+
+    expect(calls).toHaveLength(1);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('human message unaffected'), expect.anything());
+  });
+
+  it('clearing the policy (null) restores the default drop', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({ decideBotInbound: () => ({ action: 'admit' }) });
+    setBotInboundPolicy(null);
+
+    await wrapped.onInbound('slack:C1', null, botMessage());
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('overwriting an installed policy warns (single-provider discipline)', () => {
+    setBotInboundPolicy({ decideBotInbound: () => ({ action: 'drop' }) });
+    expect(log.warn).not.toHaveBeenCalled();
+    setBotInboundPolicy({ decideBotInbound: () => ({ action: 'drop' }) });
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('policy overwritten'));
+  });
+});
+
+describe('registerSlackBotGuard', () => {
+  it("registers the wrap for the 'slack' channel type only — non-Slack bridges stay untouched", () => {
+    const registered: Array<[string, unknown]> = [];
+    registerSlackBotGuard((channelType, wrap) => {
+      registered.push([channelType, wrap]);
+    });
+    expect(registered).toEqual([['slack', wrapSlackBotGuard]]);
+  });
+});

--- a/src/channels/slack-a2a-guard.ts
+++ b/src/channels/slack-a2a-guard.ts
@@ -228,12 +228,6 @@ export function registerSlackBotGuard(register: BridgeInboundPolicyRegistrar): v
   register('slack', wrapSlackBotGuard);
 }
 
-// The bridge's registration seam (`registerBridgeInboundPolicy`, trunk PR
-// refa-b5-bridge-inbound-policy) has not been forward-merged into this branch
-// yet. Feature-detect it so this module loads (and the wrap stays
-// unit-testable) on a pre-B5 tree; the registration below activates
-// automatically, with no further edit, once the hook merges.
-const registerBridgeInboundPolicy = (
-  chatSdkBridge as unknown as { registerBridgeInboundPolicy?: BridgeInboundPolicyRegistrar }
-).registerBridgeInboundPolicy;
-if (registerBridgeInboundPolicy) registerSlackBotGuard(registerBridgeInboundPolicy);
+// Registers on import through the bridge's inbound-policy seam (on this
+// branch since the main sync).
+registerSlackBotGuard(chatSdkBridge.registerBridgeInboundPolicy);

--- a/src/channels/slack-a2a-guard.ts
+++ b/src/channels/slack-a2a-guard.ts
@@ -1,0 +1,239 @@
+/**
+ * Slack bot-authored inbound guard — default drop at the bridge boundary.
+ *
+ * Where bot-authored messages die upstream: neither `@chat-adapter/slack` nor
+ * the Chat SDK core drops a *sibling* bot's messages — the only bot filter in
+ * that stack is `author.isMe` (chat core `handleIncomingMessage`, fed by the
+ * Slack adapter's `isMessageFromSelf`, keyed on this app's own
+ * `bot_id`/`botUserId`). A sibling or foreign bot's message arrives with
+ * `bot_id` set, `isMe: false`, `isBot: true`, flows through the bridge into
+ * the router, and only then dies at the permissions access gate: its sender
+ * resolves to `slack:<bot_id>`, which is never a member, so the messaging
+ * group's `unknown_sender_policy` drops it (and, on the default
+ * `request_approval` policy, spams an approval card). Two bots wired into the
+ * same room can also feed each other into a loop.
+ *
+ * This guard replaces that implicit downstream drop with an explicit one at
+ * the bridge boundary: bot-authored inbound is DROPPED by default, with a
+ * debug log — the safe default every Slack install wants. Human-authored
+ * messages are never touched.
+ *
+ * Extension seam: an optional admission policy (`setBotInboundPolicy`) can
+ * selectively admit bot traffic under its own rules — e.g. the
+ * slack-a2a-rooms skill's allowlist + hop-limit + `slack:bot:<bot_id>`
+ * re-attribution. The policy decides *which* bot messages pass and how they
+ * are attributed; the guard owns the mechanics (default drop, human
+ * pass-through, senderId rewrite, accept accounting). Without a policy,
+ * everything bot-authored is dropped.
+ *
+ * Registration: the guard registers itself for the `slack` channel type via
+ * the bridge's inbound-policy seam (`registerBridgeInboundPolicy`) on barrel
+ * import, so it applies to every Slack bridge instance — and only to Slack.
+ */
+import { log } from '../log.js';
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import * as chatSdkBridge from './chat-sdk-bridge.js';
+
+// ---------------------------------------------------------------------------
+// Bot-author detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the bot author of a bridge-serialized message, or null for human
+ * (or unattributable) messages. Keyed on the Slack event's `bot_id` presence,
+ * which the adapter projects to `author.isBot` / `author.userId` — sibling-bot
+ * messages arrive as plain `message` events with `bot_id` set and subtype
+ * null, so this is the only reliable bot marker.
+ */
+export function botAuthorOf(message: InboundMessage): { botId: string } | null {
+  const content =
+    typeof message.content === 'object' && message.content !== null
+      ? (message.content as Record<string, unknown>)
+      : undefined;
+  const author =
+    content && typeof content.author === 'object' && content.author !== null
+      ? (content.author as Record<string, unknown>)
+      : undefined;
+  if (author?.isBot !== true) return null;
+  const botId = typeof author.userId === 'string' ? author.userId : undefined;
+  return botId ? { botId } : null;
+}
+
+// ---------------------------------------------------------------------------
+// Admission-policy seam (feature-side extension point)
+// ---------------------------------------------------------------------------
+
+/** Inbound context handed to the admission policy. */
+export interface SlackInboundContext {
+  /**
+   * The bridge's registry key (`config.instance ?? 'slack'`). The wrap runs
+   * once per bridge instance, so per-bot-identity policy state keys off this.
+   */
+  instanceKey: string;
+  /** Adapter channel id as the bridge reports it (`slack:C0…`). */
+  platformId: string;
+  threadId: string | null;
+  message: InboundMessage;
+}
+
+/** Bot-authored inbound context — adds the authoring bot's id. */
+export interface SlackBotInboundContext extends SlackInboundContext {
+  /** Slack `bot_id` of the authoring bot (adapter's `author.userId`). */
+  botId: string;
+}
+
+/** Admission decision for one bot-authored inbound message. */
+export type SlackBotInboundDecision =
+  | { action: 'drop'; reason?: string }
+  | {
+      action: 'admit';
+      /**
+       * When set, replaces `content.senderId` before routing (e.g.
+       * `slack:bot:<bot_id>`). The permissions module uses a senderId that
+       * already contains a `:` verbatim (see extractAndUpsertUser), so the
+       * users row becomes distinguishable from human `slack:U…` ids.
+       */
+      senderId?: string;
+      /**
+       * Called only after downstream accepted the message (the host's
+       * onInbound resolved without throwing). Use for accept accounting —
+       * e.g. a hop budget must not be consumed by a message that never
+       * reached a session.
+       */
+      onAccepted?: () => void;
+    };
+
+/**
+ * The narrow surface a feature module (e.g. slack-a2a-rooms) implements to
+ * selectively admit bot traffic. Humans are structurally outside the policy's
+ * power: `onHumanInbound` is observe-only (e.g. to reset hop counters) and
+ * cannot drop or mutate — human pass-through is guaranteed by the guard,
+ * not by policy good behavior.
+ */
+export interface SlackBotInboundPolicy {
+  /** Decide one bot-authored inbound message. A throw is treated as drop. */
+  decideBotInbound(ctx: SlackBotInboundContext): SlackBotInboundDecision;
+  /** Observe a human-authored inbound message. Cannot affect delivery. */
+  onHumanInbound?(ctx: SlackInboundContext): void;
+}
+
+let botInboundPolicy: SlackBotInboundPolicy | null = null;
+
+/**
+ * Install THE admission policy for bot-authored Slack inbound (single
+ * provider — a second installation overwrites with a warning, mirroring the
+ * bridge registry's hook discipline). Pass null to clear and restore the
+ * default drop-everything behavior.
+ */
+export function setBotInboundPolicy(policy: SlackBotInboundPolicy | null): void {
+  if (policy && botInboundPolicy) {
+    log.warn('slack-a2a-guard: bot inbound policy overwritten');
+  }
+  botInboundPolicy = policy;
+}
+
+// ---------------------------------------------------------------------------
+// The ChannelSetup wrap
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a Slack bridge's ChannelSetup so its onInbound applies the bot guard:
+ * human-authored messages pass through byte-identical; bot-authored messages
+ * are dropped unless the installed admission policy admits them. Shaped as a
+ * `BridgeInboundPolicy` — applied once per bridge instance at bridge setup.
+ */
+export function wrapSlackBotGuard(setup: ChannelSetup, instanceKey: string): ChannelSetup {
+  return {
+    ...setup,
+    async onInbound(platformId: string, threadId: string | null, message: InboundMessage) {
+      const bot = botAuthorOf(message);
+
+      if (!bot) {
+        // Human message — pass through untouched. The policy may observe it
+        // (hop-counter resets), but can neither drop nor mutate it.
+        if (botInboundPolicy?.onHumanInbound) {
+          try {
+            botInboundPolicy.onHumanInbound({ instanceKey, platformId, threadId, message });
+          } catch (err) {
+            log.warn('slack-a2a-guard: onHumanInbound observer threw — human message unaffected', {
+              instanceKey,
+              platformId,
+              err,
+            });
+          }
+        }
+        return setup.onInbound(platformId, threadId, message);
+      }
+
+      if (!botInboundPolicy) {
+        log.debug('slack-a2a-guard: bot-authored inbound dropped — no admission policy installed', {
+          instanceKey,
+          platformId,
+          botId: bot.botId,
+        });
+        return;
+      }
+
+      let decision: SlackBotInboundDecision;
+      try {
+        decision = botInboundPolicy.decideBotInbound({ instanceKey, platformId, threadId, message, botId: bot.botId });
+      } catch (err) {
+        // Fail closed: a buggy policy must not fail open into approval spam.
+        log.warn('slack-a2a-guard: admission policy threw — dropping bot-authored inbound', {
+          instanceKey,
+          platformId,
+          botId: bot.botId,
+          err,
+        });
+        return;
+      }
+
+      if (decision.action !== 'admit') {
+        log.debug('slack-a2a-guard: bot-authored inbound dropped by policy', {
+          instanceKey,
+          platformId,
+          botId: bot.botId,
+          reason: decision.reason,
+        });
+        return;
+      }
+
+      if (decision.senderId) {
+        (message.content as Record<string, unknown>).senderId = decision.senderId;
+      }
+      // Report acceptance only after downstream accepted it — a throw in the
+      // host's onInbound must not count a message that never reached a session.
+      const result = await setup.onInbound(platformId, threadId, message);
+      decision.onAccepted?.();
+      return result;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Self-registration (barrel-import side effect)
+// ---------------------------------------------------------------------------
+
+type BridgeInboundPolicyRegistrar = (
+  channelType: string,
+  wrap: (setup: ChannelSetup, instanceKey: string) => ChannelSetup,
+) => void;
+
+/**
+ * Register the guard as THE bridge inbound policy for the `slack` channel
+ * type. Non-Slack bridges are untouched — the bridge applies a policy only to
+ * the channel type it was registered for.
+ */
+export function registerSlackBotGuard(register: BridgeInboundPolicyRegistrar): void {
+  register('slack', wrapSlackBotGuard);
+}
+
+// The bridge's registration seam (`registerBridgeInboundPolicy`, trunk PR
+// refa-b5-bridge-inbound-policy) has not been forward-merged into this branch
+// yet. Feature-detect it so this module loads (and the wrap stays
+// unit-testable) on a pre-B5 tree; the registration below activates
+// automatically, with no further edit, once the hook merges.
+const registerBridgeInboundPolicy = (
+  chatSdkBridge as unknown as { registerBridgeInboundPolicy?: BridgeInboundPolicyRegistrar }
+).registerBridgeInboundPolicy;
+if (registerBridgeInboundPolicy) registerSlackBotGuard(registerBridgeInboundPolicy);

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -4,13 +4,39 @@
  *
  * Socket Mode opt-in: set SLACK_APP_TOKEN (xapp-…) to receive events over an
  * outbound WebSocket instead of an inbound HTTPS webhook.
+ *
+ * Additional bot identities in the same workspace reuse createSlackBridge
+ * with suffixed env keys and an instance key (see the slack-multi-instance
+ * skill) — same construction path as the default app, no mirrored factory.
  */
 import { createSlackAdapter } from '@chat-adapter/slack';
 
 import { readEnvFile } from '../env.js';
-import type { ChannelDefaults } from './adapter.js';
+import type { ChannelAdapter, ChannelContextDefaults, ChannelDefaults } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
+
+/**
+ * TYPE-COMPAT SHIM — collapses into plain ChannelDefaults once trunk `main`
+ * is synced into this branch. Two trunk PRs extend the declaration surface:
+ * pr-series/stan-decline-notify adds 'decline_notify' to the
+ * unknownSenderPolicy union, and pr-series/refa-b7-channel-dm-defaults adds
+ * the optional sessionMode field to ChannelContextDefaults (the wiring's
+ * threads=1 stamp is derived from sessionMode 'per-thread' by
+ * resolveWiringDefaults, not declared). This branch's copy of the types
+ * predates both, so the aliases below widen them locally — field-for-field
+ * the trunk shape, nothing trunk doesn't declare. When the sync lands:
+ * delete both aliases and the one assertion at SLACK_DEFAULTS_DECL, and type
+ * SLACK_DEFAULTS as ChannelDefaults directly.
+ */
+type SlackContextDefaults = Omit<ChannelContextDefaults, 'unknownSenderPolicy'> & {
+  unknownSenderPolicy: ChannelContextDefaults['unknownSenderPolicy'] | 'decline_notify';
+  sessionMode?: 'shared' | 'per-thread';
+};
+type SlackChannelDefaults = Omit<ChannelDefaults, 'dm' | 'group'> & {
+  dm: SlackContextDefaults;
+  group: SlackContextDefaults;
+};
 
 /**
  * Dedicated bot app on a threaded platform. group threads:true keeps
@@ -21,42 +47,105 @@ import { registerChannelAdapter } from './channel-registry.js';
  * This declaration owns that judgment (it used to be hardcoded router
  * behavior); operators who want in-thread DM replies override per wiring
  * with `--threads true`.
+ *
+ * Agent-DM anchors (the settled Slack DM shape) — creation-time stamps, so
+ * they apply to wirings/rows created from this declaration onward and never
+ * flip existing installs:
+ * - dm.sessionMode 'per-thread': Slack's agent-mode DM surface materializes
+ *   a thread per conversation, so a new DM wiring roots a session per thread.
+ *   resolveWiringDefaults derives the threads=1 stamp from this at creation
+ *   (per-thread sessions structurally require honored thread ids — no
+ *   separate field to declare). The live inherit value dm.threads stays
+ *   false, so wirings created earlier (threads column NULL) keep collapsing
+ *   DM sub-threads into the one DM session.
+ * - dm.unknownSenderPolicy 'decline_notify': an unknown DM sender gets a
+ *   polite decline and the owner a one-line FYI — no approval card; access
+ *   grants stay explicit (`ncl members add`). A deliberate, reviewed default
+ *   change for Slack DM rows auto-created after this lands.
  */
-const SLACK_DEFAULTS: ChannelDefaults = {
-  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+export const SLACK_DEFAULTS: SlackChannelDefaults = {
+  dm: {
+    engageMode: 'pattern',
+    engagePattern: '.',
+    threads: false,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'decline_notify',
+  },
   group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
   mentions: 'platform',
 };
 
+// One assertion, shared by the bridge config and the registry declaration.
+// Sound because the trunk ChannelDefaults is a strict widening of this
+// branch's (see the type-compat shim above); dies with the shim on sync.
+const SLACK_DEFAULTS_DECL = SLACK_DEFAULTS as ChannelDefaults;
+
+/** Construction knobs for one Slack bot identity. */
+export interface SlackBridgeOptions {
+  /**
+   * Uppercased/underscored instance suffix appended to each token env key
+   * after an underscore — 'ALPHA' reads SLACK_BOT_TOKEN_ALPHA /
+   * SLACK_SIGNING_SECRET_ALPHA / SLACK_APP_TOKEN_ALPHA. Omit (or pass '')
+   * for the default app's unsuffixed keys.
+   */
+  envKeySuffix?: string;
+  /**
+   * Registry/bridge instance key (e.g. 'slack-alpha'). Omit for the default
+   * instance, keyed by channelType. channelType stays 'slack' either way —
+   * instance is a host-side routing key only, so user ids, formatting,
+   * container config, and the wiring-defaults declaration are shared with
+   * the default Slack app.
+   */
+  instanceKey?: string;
+}
+
+/**
+ * Build one Slack bot identity's bridge from its token set. The default app
+ * is the zero-suffix call (used by the registration below); named instances
+ * pass a suffix + instance key and get the exact same construction — Socket
+ * Mode opt-in, channel-name resolution, SLACK_DEFAULTS declaration. Returns
+ * null when the bot token is missing so the registry surfaces its normal
+ * "credentials missing, skipping" warning.
+ */
+export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdapter | null {
+  const suffix = options.envKeySuffix ? `_${options.envKeySuffix}` : '';
+  const keys = {
+    botToken: `SLACK_BOT_TOKEN${suffix}`,
+    signingSecret: `SLACK_SIGNING_SECRET${suffix}`,
+    appToken: `SLACK_APP_TOKEN${suffix}`,
+  };
+  const env = readEnvFile([keys.botToken, keys.signingSecret, keys.appToken]);
+  const botToken = env[keys.botToken];
+  if (!botToken) return null;
+  // An xapp-… token enables Socket Mode: events arrive over an outbound
+  // WebSocket, so no public HTTPS endpoint is required. When set, the
+  // signing secret is optional (Slack signs socket frames separately).
+  const appToken = env[keys.appToken];
+  const slackAdapter = createSlackAdapter({
+    botToken,
+    signingSecret: env[keys.signingSecret],
+    appToken,
+    mode: appToken ? 'socket' : 'webhook',
+  });
+  const bridge = createChatSdkBridge({
+    adapter: slackAdapter,
+    instance: options.instanceKey, // undefined ⇒ default instance (keyed by channelType)
+    concurrency: 'concurrent',
+    supportsThreads: true,
+    defaults: SLACK_DEFAULTS_DECL,
+  });
+  bridge.resolveChannelName = async (platformId: string) => {
+    try {
+      const info = await slackAdapter.fetchThread(platformId);
+      return (info as { channelName?: string }).channelName ?? null;
+    } catch {
+      return null;
+    }
+  };
+  return bridge;
+}
+
 registerChannelAdapter('slack', {
-  factory: () => {
-    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_APP_TOKEN']);
-    if (!env.SLACK_BOT_TOKEN) return null;
-    // SLACK_APP_TOKEN (xapp-…) enables Socket Mode: events arrive over an
-    // outbound WebSocket, so no public HTTPS endpoint is required. When set,
-    // the signing secret is optional (Slack signs socket frames separately).
-    const useSocketMode = Boolean(env.SLACK_APP_TOKEN);
-    const slackAdapter = createSlackAdapter({
-      botToken: env.SLACK_BOT_TOKEN,
-      signingSecret: env.SLACK_SIGNING_SECRET,
-      appToken: env.SLACK_APP_TOKEN,
-      mode: useSocketMode ? 'socket' : 'webhook',
-    });
-    const bridge = createChatSdkBridge({
-      adapter: slackAdapter,
-      concurrency: 'concurrent',
-      supportsThreads: true,
-      defaults: SLACK_DEFAULTS,
-    });
-    bridge.resolveChannelName = async (platformId: string) => {
-      try {
-        const info = await slackAdapter.fetchThread(platformId);
-        return (info as { channelName?: string }).channelName ?? null;
-      } catch {
-        return null;
-      }
-    };
-    return bridge;
-  },
-  defaults: SLACK_DEFAULTS,
+  factory: () => createSlackBridge(),
+  defaults: SLACK_DEFAULTS_DECL,
 });

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -17,28 +17,6 @@ import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
 /**
- * TYPE-COMPAT SHIM — collapses into plain ChannelDefaults once trunk `main`
- * is synced into this branch. Two trunk PRs extend the declaration surface:
- * pr-series/stan-decline-notify adds 'decline_notify' to the
- * unknownSenderPolicy union, and pr-series/refa-b7-channel-dm-defaults adds
- * the optional sessionMode field to ChannelContextDefaults (the wiring's
- * threads=1 stamp is derived from sessionMode 'per-thread' by
- * resolveWiringDefaults, not declared). This branch's copy of the types
- * predates both, so the aliases below widen them locally — field-for-field
- * the trunk shape, nothing trunk doesn't declare. When the sync lands:
- * delete both aliases and the one assertion at SLACK_DEFAULTS_DECL, and type
- * SLACK_DEFAULTS as ChannelDefaults directly.
- */
-type SlackContextDefaults = Omit<ChannelContextDefaults, 'unknownSenderPolicy'> & {
-  unknownSenderPolicy: ChannelContextDefaults['unknownSenderPolicy'] | 'decline_notify';
-  sessionMode?: 'shared' | 'per-thread';
-};
-type SlackChannelDefaults = Omit<ChannelDefaults, 'dm' | 'group'> & {
-  dm: SlackContextDefaults;
-  group: SlackContextDefaults;
-};
-
-/**
  * Dedicated bot app on a threaded platform. group threads:true keeps
  * mention-sticky bounded — engagement sticks per-thread, not forever.
  * dm.threads:false is a deliberate policy choice, not a capability limit:
@@ -63,7 +41,7 @@ type SlackChannelDefaults = Omit<ChannelDefaults, 'dm' | 'group'> & {
  *   grants stay explicit (`ncl members add`). A deliberate, reviewed default
  *   change for Slack DM rows auto-created after this lands.
  */
-export const SLACK_DEFAULTS: SlackChannelDefaults = {
+export const SLACK_DEFAULTS: ChannelDefaults = {
   dm: {
     engageMode: 'pattern',
     engagePattern: '.',
@@ -71,14 +49,20 @@ export const SLACK_DEFAULTS: SlackChannelDefaults = {
     sessionMode: 'per-thread',
     unknownSenderPolicy: 'decline_notify',
   },
-  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  group: {
+    engageMode: 'mention-sticky',
+    threads: true,
+    // D29: group conversations are per-thread too — Slack channels
+    // materialize a thread per top-level message, and ambient context
+    // (same-mg fan + channel-timeline backfill) is the continuity layer.
+    // Creation-time stamp like dm.sessionMode; existing wirings never flip.
+    // Canvas-comment shadow channels deliberately stay shared (wired
+    // explicitly in room-canvas, the documented D29 exception).
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'request_approval',
+  },
   mentions: 'platform',
 };
-
-// One assertion, shared by the bridge config and the registry declaration.
-// Sound because the trunk ChannelDefaults is a strict widening of this
-// branch's (see the type-compat shim above); dies with the shim on sync.
-const SLACK_DEFAULTS_DECL = SLACK_DEFAULTS as ChannelDefaults;
 
 /** Construction knobs for one Slack bot identity. */
 export interface SlackBridgeOptions {
@@ -132,7 +116,7 @@ export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdap
     instance: options.instanceKey, // undefined ⇒ default instance (keyed by channelType)
     concurrency: 'concurrent',
     supportsThreads: true,
-    defaults: SLACK_DEFAULTS_DECL,
+    defaults: SLACK_DEFAULTS,
   });
   bridge.resolveChannelName = async (platformId: string) => {
     try {
@@ -147,5 +131,5 @@ export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdap
 
 registerChannelAdapter('slack', {
   factory: () => createSlackBridge(),
-  defaults: SLACK_DEFAULTS_DECL,
+  defaults: SLACK_DEFAULTS,
 });

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -28,3 +28,11 @@ import './self-mod/index.js';
 // registry (src/guard/, 3-arg registerDeliveryAction), on this branch since
 // the main sync underneath this commit.
 import './canvas-actions/index.js';
+
+// slack room membership (adopt-on-invite, detach/re-attach, owner-presence).
+// Active per this branch's fully-loaded convention; /add-slack appends the
+// same import on user installs.
+import './slack-room-membership/index.js';
+
+// slack DM onboarding + thread titles (welcome prompts, auto-title).
+import './slack-onboarding/index.js';

--- a/src/modules/slack-onboarding/index.ts
+++ b/src/modules/slack-onboarding/index.ts
@@ -1,0 +1,160 @@
+/**
+ * Slack DM onboarding + thread auto-title (agent-view DM surface).
+ *
+ * Channel-layer module owning the platform knowledge that used to sit inline
+ * in trunk's delivery.ts/router.ts. Registers exclusively through generic
+ * trunk hooks — trunk carries no Slack literals for any of this:
+ *
+ *   - `registerPostDeliveryHook` (delivery): the FIRST delivery of an
+ *     empty-thread DM session (the welcome) pins the get-started suggested
+ *     prompts at the top of the Messages tab.
+ *   - `setAgentDmOpenedHandler` (Chat SDK bridge): (re)asserts or retires
+ *     the prompts when the user opens the agent DM.
+ *   - `registerSessionCreatedHook` (router): a brand-new per-thread DM
+ *     session names its thread after the first user message (D15) and
+ *     retires the onboarding prompts.
+ *
+ * Everything here is decoration: fire-and-forget, capability-gated inside
+ * the registry passthroughs (adapters without the APIs no-op), and never
+ * allowed to affect delivery or routing.
+ *
+ * Installed with the Slack channel payload; registered via a barrel-appended
+ * import at install time.
+ */
+import { setSuggestedPrompts, setThreadTitle } from '../../channels/channel-registry.js';
+import { setAgentDmOpenedHandler } from '../../channels/chat-sdk-bridge.js';
+import { getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
+import type { OutboundMessage } from '../../db/session-db.js';
+import { getActiveSessions } from '../../db/sessions.js';
+import { registerPostDeliveryHook } from '../../delivery.js';
+import { log } from '../../log.js';
+import { registerSessionCreatedHook } from '../../router.js';
+
+/**
+ * Auto-title timing. The initial delay lets the first typing
+ * assistant.threads.setStatus materialize the assistant thread before the
+ * title lands (Slack rejects titles on not-yet-assistant threads with
+ * channel_not_found). Mutable as a test seam only.
+ */
+export const titleDelays = { initialMs: 3000, retryMs: 7000 };
+export function setTitleDelaysForTest(initialMs: number, retryMs: number): void {
+  titleDelays.initialMs = initialMs;
+  titleDelays.retryMs = retryMs;
+}
+
+/**
+ * Welcome-notification follow-through (agent-view DMs). The welcome is a
+ * NOTIFICATION — informational, never a question the user replies to
+ * (product decision after the focus-hack dead end: no Slack API can navigate
+ * a user into a thread; conversations are user-rooted by design). The tour
+ * offer lives in SUGGESTED PROMPTS pinned at the top of the Messages tab:
+ * clicking one sends that text as the user's own message, rooting a
+ * conversation thread whose opener carries the intent by itself.
+ * Fire-and-forget; silent no-op on non-agent-view channels via the
+ * capability gates. Scoped by the post-delivery hook's firstDelivery flag
+ * to the FIRST delivery of an empty-thread DM session — i.e. the welcome.
+ */
+const WELCOME_PROMPTS: Array<{ title: string; message: string }> = [
+  { title: 'Give me the tour', message: 'Give me a quick tour of what you can do.' },
+  {
+    title: 'What should I try first?',
+    message: 'What should I try first? Suggest something useful we could do right now.',
+  },
+  { title: 'Help me with something', message: 'I have something specific I want help with.' },
+];
+
+/** True when this DM already has a real conversation (a per-thread session
+ *  with a ts segment) — the get-started prompts are then stale. */
+function dmHasConversation(mgId: string): boolean {
+  return getActiveSessions().some((s) => {
+    if (s.messaging_group_id !== mgId || !s.thread_id) return false;
+    const parts = s.thread_id.split(':');
+    return parts.length >= 3 && parts[parts.length - 1] !== '';
+  });
+}
+
+/** Clear the onboarding prompts once the first conversation starts. Fired
+ *  where the auto-title trigger runs (session-created consumer below). */
+export function clearWelcomePrompts(instanceKey: string, platformId: string): void {
+  void setSuggestedPrompts(instanceKey, platformId, [])
+    .then(() => log.info('Welcome prompts cleared', { platformId }))
+    .catch(() => {});
+}
+
+// (Re)assert or retire the onboarding prompts when the user OPENS the agent
+// DM — prompt sets made before the DM was ever opened may not render
+// (live-hit), and stale get-started buttons should retire once a real
+// conversation exists.
+setAgentDmOpenedHandler(({ channelId }) => {
+  const platformId = `slack:${channelId}`;
+  const mg = getMessagingGroupByPlatform('slack', platformId);
+  if (!mg || mg.is_group !== 0) return;
+  if (dmHasConversation(mg.id)) {
+    clearWelcomePrompts(mg.instance ?? mg.channel_type, platformId);
+    return;
+  }
+  void setSuggestedPrompts(mg.instance ?? mg.channel_type, platformId, WELCOME_PROMPTS, 'Get started')
+    .then(() => log.info('Welcome prompts re-asserted on DM open', { platformId }))
+    .catch(() => {});
+});
+
+function offerWelcomePrompts(msg: OutboundMessage): void {
+  try {
+    const channelType = msg.channel_type;
+    const platformId = msg.platform_id;
+    if (!channelType || !platformId) return;
+    const tidParts = (msg.thread_id ?? '').split(':');
+    if (tidParts.length >= 3 && tidParts[tidParts.length - 1] !== '') return; // threaded → not the welcome
+    const mg = getMessagingGroupByPlatform(channelType, platformId);
+    if (!mg || mg.is_group !== 0) return;
+    void setSuggestedPrompts(mg.instance ?? channelType, platformId, WELCOME_PROMPTS, 'Get started')
+      .then(() => log.info('Welcome prompts set', { platformId }))
+      .catch((err) => log.warn('Welcome prompts failed', { platformId, err }));
+  } catch {
+    // Decoration only — never let it affect delivery.
+  }
+}
+
+// Welcome notification follow-through: the FIRST delivery of an empty-thread
+// DM session (the welcome) pins the get-started suggested prompts. The hook
+// already scopes to user-facing rows (non-system, non-agent, non-task_log).
+registerPostDeliveryHook((msg, _session, { firstDelivery }) => {
+  if (firstDelivery) offerWelcomePrompts(msg);
+});
+
+function safeParseContent(raw: string): { text?: string; sender?: string; senderId?: string } {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { text: raw };
+  }
+}
+
+registerSessionCreatedHook(({ session, mg, platformId, threadId, sessionMode, message }) => {
+  if (mg.is_group !== 0 || sessionMode !== 'per-thread' || threadId === null) return;
+  // Agent-mode auto-title (D15): a brand-new per-thread DM session names
+  // its thread after the first user message. Fire-and-forget, capability-
+  // gated inside setThreadTitle (adapters without the API no-op) — zero
+  // behavior change for non-Slack and for shared-session DM wirings.
+  //
+  // Timing: the assistant thread only materializes once the first
+  // assistant.threads.setStatus (the typing fire) lands on it — a
+  // title set before that fails with channel_not_found. Delay past the
+  // initial typing fire and retry once for slow paths.
+  const title = (safeParseContent(message.content).text ?? '').trim().slice(0, 45);
+  if (title) {
+    const trySetTitle = (attempt: number): void => {
+      void setThreadTitle(mg.instance ?? mg.channel_type, platformId, threadId, title).catch((err) => {
+        if (attempt < 1) {
+          setTimeout(() => trySetTitle(attempt + 1), titleDelays.retryMs);
+        } else {
+          log.warn('setThreadTitle failed', { sessionId: session.id, threadId, err });
+        }
+      });
+    };
+    setTimeout(() => trySetTitle(0), titleDelays.initialMs);
+  }
+  // The first real conversation retires the get-started prompts (they
+  // point at starting a conversation, which just happened).
+  clearWelcomePrompts(mg.instance ?? mg.channel_type, platformId);
+});

--- a/src/modules/slack-onboarding/onboarding.test.ts
+++ b/src/modules/slack-onboarding/onboarding.test.ts
@@ -1,0 +1,314 @@
+/**
+ * DM onboarding welcome prompts — NET-NEW coverage (the release branch had
+ * none): the get-started suggested prompts are pinned on the FIRST delivery
+ * of an empty-thread DM session (the welcome), (re)asserted or retired when
+ * the user opens the agent DM depending on whether a real conversation
+ * exists, and retired by the session-created consumer (pinned in
+ * thread-title.test.ts).
+ *
+ * Drives the module through the post-delivery hook (registerPostDeliveryHook)
+ * and the bridge's agent-DM-opened handler (setAgentDmOpenedHandler); the
+ * hook surfaces are mocked at the import seam. The hook itself guarantees
+ * user-facing-rows-only (non-system, non-agent, non-task_log) and the
+ * firstDelivery flag — pinned by refa-b2's delivery test, not here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../delivery.js', () => {
+  const hooks: Array<(msg: unknown, session: unknown, info: { firstDelivery: boolean }) => void> = [];
+  return {
+    registerPostDeliveryHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __postDeliveryHooks: hooks,
+  };
+});
+
+vi.mock('../../router.js', () => {
+  const hooks: Array<(event: never) => void | Promise<void>> = [];
+  return {
+    registerSessionCreatedHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __sessionCreatedHooks: hooks,
+  };
+});
+
+vi.mock('../../channels/chat-sdk-bridge.js', () => {
+  const ref: { handler: ((e: { instance: string; channelId: string }) => void | Promise<void>) | null } = {
+    handler: null,
+  };
+  return {
+    setAgentDmOpenedHandler: (fn: NonNullable<typeof ref.handler>) => {
+      ref.handler = fn;
+    },
+    __dmOpened: ref,
+  };
+});
+
+vi.mock('../../channels/channel-registry.js', () => ({
+  setThreadTitle: vi.fn(async () => {}),
+  setSuggestedPrompts: vi.fn(async () => {}),
+}));
+
+vi.mock('../../db/messaging-groups.js', () => ({ getMessagingGroupByPlatform: vi.fn(() => undefined) }));
+vi.mock('../../db/sessions.js', () => ({ getActiveSessions: vi.fn(() => []) }));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Release-branch prompt copy, pinned verbatim (behavior-preservation gate). */
+const EXPECTED_PROMPTS = [
+  { title: 'Give me the tour', message: 'Give me a quick tour of what you can do.' },
+  {
+    title: 'What should I try first?',
+    message: 'What should I try first? Suggest something useful we could do right now.',
+  },
+  { title: 'Help me with something', message: 'I have something specific I want help with.' },
+];
+
+interface TestMsg {
+  id: string;
+  kind: string;
+  platform_id: string | null;
+  channel_type: string | null;
+  thread_id: string | null;
+  content: string;
+}
+
+function welcomeMsg(overrides: Partial<TestMsg> = {}): TestMsg {
+  return {
+    id: 'out-1',
+    kind: 'chat',
+    platform_id: 'slack:D1',
+    channel_type: 'slack',
+    thread_id: 'slack:D1:',
+    content: JSON.stringify({ text: 'Welcome!' }),
+    ...overrides,
+  };
+}
+
+const dmMg = (overrides: Record<string, unknown> = {}) => ({
+  id: 'mg-dm',
+  channel_type: 'slack',
+  platform_id: 'slack:D1',
+  instance: 'slack',
+  is_group: 0,
+  ...overrides,
+});
+
+/** The module registers its hooks at import time (module singleton), so it
+ *  is loaded once; per-test isolation is mock state — vi.resetAllMocks
+ *  restores the original vi.fn implementations between tests. */
+type Loaded = Awaited<ReturnType<typeof doLoad>>;
+let cached: Loaded | null = null;
+
+async function loadModule(): Promise<Loaded> {
+  if (cached) return cached;
+  cached = await doLoad();
+  return cached;
+}
+
+async function doLoad() {
+  await import('./index.js');
+  const delivery = (await import('../../delivery.js')) as unknown as {
+    __postDeliveryHooks: Array<(msg: TestMsg, session: unknown, info: { firstDelivery: boolean }) => void>;
+  };
+  const bridge = (await import('../../channels/chat-sdk-bridge.js')) as unknown as {
+    __dmOpened: { handler: ((e: { instance: string; channelId: string }) => void | Promise<void>) | null };
+  };
+  const registry = (await import('../../channels/channel-registry.js')) as unknown as {
+    setThreadTitle: ReturnType<typeof vi.fn>;
+    setSuggestedPrompts: ReturnType<typeof vi.fn>;
+  };
+  const { getMessagingGroupByPlatform } = (await import('../../db/messaging-groups.js')) as unknown as {
+    getMessagingGroupByPlatform: ReturnType<typeof vi.fn>;
+  };
+  const { getActiveSessions } = (await import('../../db/sessions.js')) as unknown as {
+    getActiveSessions: ReturnType<typeof vi.fn>;
+  };
+  const { log } = (await import('../../log.js')) as unknown as { log: { warn: ReturnType<typeof vi.fn> } };
+  expect(delivery.__postDeliveryHooks).toHaveLength(1);
+  expect(bridge.__dmOpened.handler).not.toBeNull();
+  return {
+    postDelivery: delivery.__postDeliveryHooks[0],
+    dmOpened: bridge.__dmOpened.handler!,
+    registry,
+    getMessagingGroupByPlatform,
+    getActiveSessions,
+    log,
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(async () => {
+  await loadModule();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('welcome prompts on first delivery (post-delivery hook)', () => {
+  it('pins the get-started prompts on the FIRST delivery of an empty-thread DM', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(getMessagingGroupByPlatform).toHaveBeenCalledWith('slack', 'slack:D1');
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
+  });
+
+  it('a threadless welcome row (thread_id null) also counts as the welcome', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg({ thread_id: null }), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledTimes(1);
+  });
+
+  it('never on later deliveries', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: false });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never for a threaded delivery (a conversation reply is not the welcome)', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg({ thread_id: 'slack:D1:171' }), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never for group conversations or unknown messaging groups', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ id: 'mg-room', is_group: 1 }));
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    getMessagingGroupByPlatform.mockReturnValue(undefined);
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('no-op when the row has no channel/platform address', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+
+    postDelivery(welcomeMsg({ channel_type: null }), { id: 'sess-1' }, { firstDelivery: true });
+    postDelivery(welcomeMsg({ platform_id: null }), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(getMessagingGroupByPlatform).not.toHaveBeenCalled();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('keys the prompt set by the mg’s own instance (never a sibling bot)', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ instance: 'slack-teamster' }));
+
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith(
+      'slack-teamster',
+      'slack:D1',
+      EXPECTED_PROMPTS,
+      'Get started',
+    );
+  });
+
+  it('prompt failure is decoration: logged, never thrown into delivery', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform, log } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    registry.setSuggestedPrompts.mockRejectedValueOnce(new Error('not_allowed'));
+
+    expect(() => postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true })).not.toThrow();
+
+    await flush();
+    expect(log.warn).toHaveBeenCalledWith(
+      'Welcome prompts failed',
+      expect.objectContaining({ platformId: 'slack:D1' }),
+    );
+  });
+});
+
+describe('agent-DM opened (bridge handler)', () => {
+  it('re-asserts the prompts when the DM is opened before any conversation exists', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    getActiveSessions.mockReturnValue([]);
+
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    await flush();
+    expect(getMessagingGroupByPlatform).toHaveBeenCalledWith('slack', 'slack:D1');
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
+  });
+
+  it('retires the prompts when a real conversation already exists', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    getActiveSessions.mockReturnValue([{ messaging_group_id: 'mg-dm', thread_id: 'slack:D1:171' }]);
+
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', []]]);
+  });
+
+  it('sessions without a ts segment do not count as conversations', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    getActiveSessions.mockReturnValue([
+      { messaging_group_id: 'mg-dm', thread_id: 'slack:D1:' }, // empty ts → the welcome thread, not a conversation
+      { messaging_group_id: 'mg-dm', thread_id: null }, // threadless session
+      { messaging_group_id: 'mg-other', thread_id: 'slack:D2:999' }, // someone else's conversation
+    ]);
+
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
+  });
+
+  it('no-op for unknown or group messaging groups', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform } = await loadModule();
+
+    getMessagingGroupByPlatform.mockReturnValue(undefined);
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ id: 'mg-room', is_group: 1 }));
+    await dmOpened({ instance: 'slack', channelId: 'C9' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('re-assert keys by the mg’s own instance', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ instance: 'slack-teamster' }));
+    getActiveSessions.mockReturnValue([]);
+
+    await dmOpened({ instance: 'slack-teamster', channelId: 'D1' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith(
+      'slack-teamster',
+      'slack:D1',
+      EXPECTED_PROMPTS,
+      'Get started',
+    );
+  });
+});

--- a/src/modules/slack-onboarding/thread-title.test.ts
+++ b/src/modules/slack-onboarding/thread-title.test.ts
@@ -1,0 +1,288 @@
+/**
+ * DM thread auto-title (plan 02, D15) — moved from src/router-thread-title.test.ts
+ * with the auto-title body's extraction into this module: when a brand-new
+ * per-thread DM session is created, the module fire-and-forgets a thread
+ * title — the first user message truncated to 45 chars — through the
+ * registry's setThreadTitle passthrough, on the platform's thread-
+ * materialization timing (delayed initial fire, one retry).
+ *
+ * The tests drive the module through the router's session-created hook
+ * (registerSessionCreatedHook) instead of router internals; the hook
+ * surfaces are mocked at the import seam. What the router itself guarantees
+ * — the hook fires once per CREATED session, never on reuse and never for
+ * the accumulate branch — is pinned by refa-b3's router-session-created
+ * test, not here. Capability gating (adapters without setThreadTitle
+ * no-op) lives in the registry passthrough (stan-adapter-capabilities).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../delivery.js', () => {
+  const hooks: Array<(msg: unknown, session: unknown, info: { firstDelivery: boolean }) => void> = [];
+  return {
+    registerPostDeliveryHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __postDeliveryHooks: hooks,
+  };
+});
+
+vi.mock('../../router.js', () => {
+  const hooks: Array<(event: never) => void | Promise<void>> = [];
+  return {
+    registerSessionCreatedHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __sessionCreatedHooks: hooks,
+  };
+});
+
+vi.mock('../../channels/chat-sdk-bridge.js', () => {
+  const ref: { handler: ((e: { instance: string; channelId: string }) => void | Promise<void>) | null } = {
+    handler: null,
+  };
+  return {
+    setAgentDmOpenedHandler: (fn: NonNullable<typeof ref.handler>) => {
+      ref.handler = fn;
+    },
+    __dmOpened: ref,
+  };
+});
+
+vi.mock('../../channels/channel-registry.js', () => ({
+  setThreadTitle: vi.fn(async () => {}),
+  setSuggestedPrompts: vi.fn(async () => {}),
+}));
+
+vi.mock('../../db/messaging-groups.js', () => ({ getMessagingGroupByPlatform: vi.fn(() => undefined) }));
+vi.mock('../../db/sessions.js', () => ({ getActiveSessions: vi.fn(() => []) }));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function now() {
+  return new Date().toISOString();
+}
+
+interface TestEvent {
+  session: { id: string };
+  mg: { id: string; channel_type: string; platform_id: string; instance?: string; is_group: number };
+  platformId: string;
+  threadId: string | null;
+  sessionMode: 'shared' | 'per-thread' | 'agent-shared';
+  message: { id: string; kind: string; content: string; timestamp: string };
+}
+
+function dmEvent(text: string, overrides: Partial<TestEvent> = {}): TestEvent {
+  return {
+    session: { id: 'sess-1' },
+    mg: { id: 'mg-dm', channel_type: 'slack', platform_id: 'slack:D1', instance: 'slack', is_group: 0 },
+    platformId: 'slack:D1',
+    threadId: 'slack:D1:171',
+    sessionMode: 'per-thread',
+    message: {
+      id: 'm1',
+      kind: 'chat-sdk',
+      content: JSON.stringify({ sender: 'Gavriel', senderId: 'U1', text }),
+      timestamp: now(),
+    },
+    ...overrides,
+  };
+}
+
+/** The module registers its hooks at import time (module singleton), so it
+ *  is loaded once; per-test isolation is mock state (vi.resetAllMocks
+ *  restores the original vi.fn implementations) + the delays seam. The
+ *  default titleDelays are snapshotted at first load, before any test
+ *  touches setTitleDelaysForTest. */
+type Loaded = {
+  mod: typeof import('./index.js');
+  sessionCreated: (event: TestEvent) => void | Promise<void>;
+  registry: { setThreadTitle: ReturnType<typeof vi.fn>; setSuggestedPrompts: ReturnType<typeof vi.fn> };
+  log: { warn: ReturnType<typeof vi.fn> };
+};
+let cached: Loaded | null = null;
+let defaultDelays: { initialMs: number; retryMs: number } | null = null;
+
+async function loadModule(): Promise<Loaded> {
+  if (cached) return cached;
+  const mod = await import('./index.js');
+  const router = (await import('../../router.js')) as unknown as {
+    __sessionCreatedHooks: Array<(event: TestEvent) => void | Promise<void>>;
+  };
+  const registry = (await import('../../channels/channel-registry.js')) as unknown as {
+    setThreadTitle: ReturnType<typeof vi.fn>;
+    setSuggestedPrompts: ReturnType<typeof vi.fn>;
+  };
+  const { log } = (await import('../../log.js')) as unknown as { log: { warn: ReturnType<typeof vi.fn> } };
+  expect(router.__sessionCreatedHooks).toHaveLength(1);
+  defaultDelays = { ...mod.titleDelays };
+  cached = { mod, sessionCreated: router.__sessionCreatedHooks[0], registry, log };
+  return cached;
+}
+
+/** Title fires on a delayed timer (assistant-thread materialization); the
+ *  tests zero the delays and flush the macrotask queue before asserting. */
+async function flushTitles(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 15));
+}
+
+beforeEach(async () => {
+  await loadModule();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetAllMocks();
+});
+
+describe('DM thread auto-title (session-created hook)', () => {
+  it('preserves the release timing constants: 3s initial, 7s retry', () => {
+    expect(defaultDelays).toEqual({ initialMs: 3000, retryMs: 7000 });
+  });
+
+  it('titles a NEW per-thread DM session with the first message, truncated to 45 chars', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    const longText = 'Can you help me put together the quarterly report for the design review?';
+    sessionCreated(dmEvent(longText));
+
+    await flushTitles();
+    expect(registry.setThreadTitle.mock.calls).toEqual([['slack', 'slack:D1', 'slack:D1:171', longText.slice(0, 45)]]);
+    expect((registry.setThreadTitle.mock.calls[0][3] as string).length).toBe(45);
+  });
+
+  it('titles each created conversation independently (once-per-session is the hook contract)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('first conversation'));
+    sessionCreated(dmEvent('second conversation', { session: { id: 'sess-2' }, threadId: 'slack:D1:999' }));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(2);
+    expect(registry.setThreadTitle).toHaveBeenLastCalledWith(
+      'slack',
+      'slack:D1',
+      'slack:D1:999',
+      'second conversation',
+    );
+  });
+
+  it('never fires for shared-session DM wirings (plain-variant bots keep today’s behavior)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('hello there', { sessionMode: 'shared', threadId: null }));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+    // The whole block is gated: prompt retirement never fires either.
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never fires for group conversations', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(
+      dmEvent('hello there', {
+        mg: { id: 'mg-room', channel_type: 'slack', platform_id: 'slack:C9', instance: 'slack', is_group: 1 },
+        platformId: 'slack:C9',
+      }),
+    );
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never fires without a resolved thread id', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('hello there', { threadId: null }));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+  });
+
+  it('dispatches through the mg’s own instance key (never a sibling bot)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(
+      dmEvent('hi', {
+        mg: { id: 'mg-dm', channel_type: 'slack', platform_id: 'slack:D1', instance: 'slack-teamster', is_group: 0 },
+      }),
+    );
+
+    await flushTitles();
+    expect(registry.setThreadTitle).toHaveBeenCalledWith('slack-teamster', 'slack:D1', 'slack:D1:171', 'hi');
+  });
+
+  it('treats unparseable content as raw text (safeParseContent fallback)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(
+      dmEvent('ignored', { message: { id: 'm1', kind: 'chat', content: 'plain text hello', timestamp: now() } }),
+    );
+
+    await flushTitles();
+    expect(registry.setThreadTitle).toHaveBeenCalledWith('slack', 'slack:D1', 'slack:D1:171', 'plain text hello');
+  });
+
+  it('empty first message: no title, but the get-started prompts still retire', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('   '));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith('slack', 'slack:D1', []);
+  });
+
+  it('retires the get-started prompts on the first created conversation', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('let’s go'));
+
+    await flushTitles();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith('slack', 'slack:D1', []);
+  });
+
+  it('delays the title past assistant-thread materialization and retries once on failure', async () => {
+    vi.useFakeTimers();
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(10, 20);
+    registry.setThreadTitle.mockRejectedValueOnce(new Error('channel_not_found'));
+
+    sessionCreated(dmEvent('needs a retry'));
+    expect(registry.setThreadTitle).not.toHaveBeenCalled(); // nothing before the initial delay
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(1); // initial fire (fails)
+
+    await vi.advanceTimersByTimeAsync(19);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(1); // retry waits the full retryMs
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(2); // single retry succeeds
+    expect(registry.setThreadTitle).toHaveBeenLastCalledWith('slack', 'slack:D1', 'slack:D1:171', 'needs a retry');
+  });
+
+  it('gives up after one retry and logs a warning', async () => {
+    vi.useFakeTimers();
+    const { mod, sessionCreated, registry, log } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+    registry.setThreadTitle.mockRejectedValue(new Error('channel_not_found'));
+
+    sessionCreated(dmEvent('never lands'));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(2); // initial + one retry, never a third
+    expect(log.warn).toHaveBeenCalledWith(
+      'setThreadTitle failed',
+      expect.objectContaining({ sessionId: 'sess-1', threadId: 'slack:D1:171' }),
+    );
+  });
+});

--- a/src/modules/slack-room-membership/env-file.test.ts
+++ b/src/modules/slack-room-membership/env-file.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the module's vendored .env helpers — the read/append pair only
+ * (the upsert writer is private, exercised through appendToEnvList).
+ * Semantics must stay identical to src/env.ts readEnvFile parsing.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue } from './env-file.js';
+
+describe('slack-room-membership env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'srm-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'SRM_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'SRM_PLAIN=value1',
+          '  SRM_INDENTED = spaced ',
+          'SRM_DQUOTED="double quoted"',
+          "SRM_SQUOTED='single quoted'",
+          'SRM_EMPTY=',
+          '# SRM_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'SRM_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'SRM_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'SRM_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'SRM_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'SRM_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'SRM_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('SRM_PREFERS=file-value\n');
+      vi.stubEnv('SRM_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'SRM_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('SRM_BLANK_ENV=file-value\n');
+      vi.stubEnv('SRM_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'SRM_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('SRM_DUP=first\nSRM_DUP=second\n');
+      expect(readEnvValue(rootDir, 'SRM_DUP')).toBe('second');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates .env and the key, reporting the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'alpha')).toBe(true);
+      expect(read()).toBe('SRM_LIST=alpha\n');
+      expect(readEnvValue(rootDir, 'SRM_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('SRM_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'SRM_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nSRM_LIST=alpha\nLAST=9\n');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'beta')).toBe(true);
+      expect(read()).toBe('# keep me\nFIRST=1\nSRM_LIST=alpha,beta\nLAST=9\n');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'alpha')).toBe(true);
+      expect(read()).toBe('EXISTING=x\nSRM_LIST=alpha\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('SRM_LIST=alpha\nSRM_LIST=beta\n');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'gamma')).toBe(true);
+      expect(read()).toBe('SRM_LIST=beta,gamma\nSRM_LIST=beta,gamma\n');
+      expect(readEnvValue(rootDir, 'SRM_LIST')).toBe('beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('SRM_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys parse .env only, so the union must be based on
+      // the file, not a stale process.env copy.
+      write('SRM_LIST=alpha\n');
+      vi.stubEnv('SRM_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('SRM_LIST=alpha,beta');
+    });
+  });
+});

--- a/src/modules/slack-room-membership/env-file.ts
+++ b/src/modules/slack-room-membership/env-file.ts
@@ -1,0 +1,99 @@
+/**
+ * Vendored .env read helpers for the slack-room-membership module — the two
+ * helpers this module actually uses (readEnvValue, appendToEnvList), nothing
+ * more. Interim home per the series disposition: the trunk env-file hoist was
+ * reversed (no second trunk consumer yet), and this channel-layer module must
+ * not import from a feature module, so it carries its own minimal copy until
+ * a shared trunk home exists. Semantics are verbatim from the original.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — everything written here is read back through
+ * that parser. Write conventions: replace the key's line in place, preserve
+ * every other line (comments and blanks included), append with a clean
+ * trailing newline.
+ *
+ * Values read here include live Slack tokens: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value. Private: this
+ * module only writes through appendToEnvList.
+ */
+function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/src/modules/slack-room-membership/index.ts
+++ b/src/modules/slack-room-membership/index.ts
@@ -1,0 +1,26 @@
+/**
+ * slack-room-membership module — registers THE bridge membership handler
+ * (generic membership seam: setMembershipHandler('slack', …) in
+ * src/channels/chat-sdk-bridge.ts) and THE Slack channel-card interceptor
+ * (permissions seam: registerChannelCardInterceptor). All behavior lives in
+ * ./membership.ts: join-time adopt via the existing channel-approval card,
+ * MPIM-fork carry-over, own-left detachment (migration 021), membership
+ * notes into wired room sessions, and — via the interceptor, consulted by
+ * requestChannelApproval on both the router mention path and the join-time
+ * adopt path — the B2/D24 owner-presence access rule (owner present →
+ * auto-wire, no card; stranger 1:1 DM → decline-and-notify; Slackbot shadow
+ * channels → silently ignored).
+ *
+ * Registered by a skill-appended barrel import at install time (the Slack
+ * channel skill appends this module to src/modules/index.ts).
+ *
+ * No guard registration: this module adds no ncl commands and no delivery
+ * actions — the only privileged surface it touches is the channel-approval
+ * card, whose click path is already guarded (channels.register).
+ */
+import { setMembershipHandler } from '../../channels/chat-sdk-bridge.js';
+import { registerChannelCardInterceptor } from '../permissions/channel-approval.js';
+import { handleSlackMembershipEvent, slackChannelCardInterceptor } from './membership.js';
+
+setMembershipHandler('slack', (event) => handleSlackMembershipEvent(event));
+registerChannelCardInterceptor('slack', (mg, event) => slackChannelCardInterceptor(mg, event));

--- a/src/modules/slack-room-membership/membership.test.ts
+++ b/src/modules/slack-room-membership/membership.test.ts
@@ -1,0 +1,831 @@
+/**
+ * Unit tests for the slack-room-membership handler (generic membership-seam
+ * consumer).
+ *
+ * Every collaborator is mocked at its import seam: the slack-lib Web API
+ * client, the vendored env-file reader, channel-approval / sender-approval /
+ * router / session-manager / destination projection, and — because this
+ * channels-based branch predates the trunk hooks this module composes with
+ * (instance-aware messaging-group lookup, migration 021 detached_at
+ * accessors, decline_notify, the card interceptor) — the central-DB accessor
+ * modules themselves, replaced by in-memory fakes that mirror the composed
+ * trunk accessors' semantics. The release-branch suite ran the same cases
+ * against a real in-memory DB; that composed run is re-established once the
+ * trunk hooks forward-merge into this branch. Every test drives
+ * handleSlackMembershipEvent with joinRecheckDelayMs: 0.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockApi,
+  mockEnv,
+  mockRequestChannelApproval,
+  mockWriteSessionMessage,
+  mockProject,
+  mockRouteInbound,
+  mockDeclineAndNotify,
+  mockRecordDropped,
+  fakeDb,
+} = vi.hoisted(() => {
+  const mockApi = {
+    slackAuthTest: vi.fn(),
+    slackConversationsInfo: vi.fn(),
+    slackConversationsMembers: vi.fn(),
+    slackPostMessage: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockEnv = {
+    readEnvValue: vi.fn(),
+    appendToEnvList: vi.fn().mockReturnValue(true),
+  };
+
+  // ── In-memory central-DB fake ──
+  // Semantics mirror the composed trunk accessors: createMessagingGroup
+  // defaults `instance` to channel_type; the three-arg
+  // getMessagingGroupByPlatform is exact-only on a set instance and resolves
+  // default-instance-first (then lexically-first named instance) when unset;
+  // detached_at is a nullable stamp with set/is accessors (migration 021).
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const state = {
+    messagingGroups: [] as any[],
+    wirings: [] as any[],
+    agentGroups: [] as any[],
+    sessions: [] as any[],
+    roles: [] as any[],
+  };
+  const fakeDb = {
+    reset(): void {
+      state.messagingGroups = [];
+      state.wirings = [];
+      state.agentGroups = [];
+      state.sessions = [];
+      state.roles = [];
+    },
+    // messaging-groups
+    createMessagingGroup(group: any): void {
+      state.messagingGroups.push({
+        denied_at: null,
+        detached_at: null,
+        ...group,
+        instance: group.instance ?? group.channel_type,
+      });
+    },
+    getMessagingGroup(id: string): any {
+      return state.messagingGroups.find((m) => m.id === id);
+    },
+    getMessagingGroupByPlatform(channelType: string, platformId: string, instance?: string): any {
+      const hits = state.messagingGroups.filter((m) => m.channel_type === channelType && m.platform_id === platformId);
+      if (instance !== undefined) return hits.find((m) => m.instance === instance);
+      return hits.sort(
+        (a, b) =>
+          Number(b.instance === b.channel_type) - Number(a.instance === a.channel_type) ||
+          String(a.instance).localeCompare(String(b.instance)),
+      )[0];
+    },
+    getAllMessagingGroups(): any[] {
+      return [...state.messagingGroups];
+    },
+    updateMessagingGroup(id: string, patch: Record<string, unknown>): void {
+      const row = state.messagingGroups.find((m) => m.id === id);
+      if (row) Object.assign(row, patch);
+    },
+    setMessagingGroupDeniedAt(id: string, deniedAt: string | null): void {
+      const row = state.messagingGroups.find((m) => m.id === id);
+      if (row) row.denied_at = deniedAt;
+    },
+    setMessagingGroupDetachedAt(id: string, detachedAt: string | null): void {
+      const row = state.messagingGroups.find((m) => m.id === id);
+      if (row) row.detached_at = detachedAt;
+    },
+    isMessagingGroupDetached(id: string): boolean {
+      return state.messagingGroups.find((m) => m.id === id)?.detached_at != null;
+    },
+    createMessagingGroupAgent(mga: any): void {
+      state.wirings.push({ threads: mga.threads ?? null, ...mga });
+    },
+    getMessagingGroupAgents(messagingGroupId: string): any[] {
+      return state.wirings.filter((w) => w.messaging_group_id === messagingGroupId);
+    },
+    getMessagingGroupAgentByPair(messagingGroupId: string, agentGroupId: string): any {
+      return state.wirings.find((w) => w.messaging_group_id === messagingGroupId && w.agent_group_id === agentGroupId);
+    },
+    // agent-groups
+    createAgentGroup(group: any): void {
+      state.agentGroups.push(group);
+    },
+    getAgentGroup(id: string): any {
+      return state.agentGroups.find((g) => g.id === id);
+    },
+    // sessions
+    createSession(session: any): void {
+      state.sessions.push(session);
+    },
+    getSessionsByAgentGroup(agentGroupId: string): any[] {
+      return state.sessions.filter((s) => s.agent_group_id === agentGroupId);
+    },
+    // user-roles (+ the access fake reads the same rows)
+    grantRole(row: any): void {
+      state.roles.push(row);
+    },
+    getOwners(): any[] {
+      return state.roles.filter((r) => r.role === 'owner');
+    },
+    hasRole(userId: string): boolean {
+      return state.roles.some((r) => r.user_id === userId);
+    },
+  };
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return {
+    mockApi,
+    mockEnv,
+    mockRequestChannelApproval: vi.fn().mockResolvedValue(undefined),
+    mockWriteSessionMessage: vi.fn(),
+    mockProject: vi.fn().mockResolvedValue(undefined),
+    mockRouteInbound: vi.fn().mockResolvedValue(undefined),
+    mockDeclineAndNotify: vi.fn().mockResolvedValue(undefined),
+    mockRecordDropped: vi.fn(),
+    fakeDb,
+  };
+});
+
+vi.mock('../../channels/slack-lib.js', async (importOriginal) => ({
+  // botTokenKeyForInstance (and SlackApiError) stay real — only the four
+  // network-touching calls are mocked. Tests never hit the Slack API.
+  ...(await importOriginal<Record<string, unknown>>()),
+  ...mockApi,
+}));
+vi.mock('./env-file.js', () => mockEnv);
+vi.mock('../permissions/channel-approval.js', () => ({
+  requestChannelApproval: (...a: unknown[]) => mockRequestChannelApproval(...a),
+}));
+vi.mock('../permissions/sender-approval.js', () => ({
+  declineAndNotify: (...a: unknown[]) => mockDeclineAndNotify(...a),
+}));
+vi.mock('../../router.js', () => ({
+  routeInbound: (...a: unknown[]) => mockRouteInbound(...a),
+}));
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockWriteSessionMessage(...a),
+}));
+vi.mock('../../cli/resources/destinations.js', () => ({
+  projectDestinationsToSessions: (...a: unknown[]) => mockProject(...a),
+}));
+// Mirrors the release suite's registered TEST_SLACK_DEFAULTS declaration
+// (group: request_approval, dm: strict) without the channel registry.
+vi.mock('../../channels/channel-defaults.js', () => ({
+  resolveUnknownSenderPolicy: (_instance: string, isGroup: boolean) => (isGroup ? 'request_approval' : 'strict'),
+}));
+vi.mock('../permissions/access.js', () => ({
+  canAccessAgentGroup: (userId: string) => ({ allowed: fakeDb.hasRole(userId) }),
+}));
+vi.mock('../../db/dropped-messages.js', () => ({
+  recordDroppedMessage: (...a: unknown[]) => mockRecordDropped(...a),
+}));
+vi.mock('../../db/messaging-groups.js', () => ({
+  createMessagingGroup: fakeDb.createMessagingGroup,
+  getMessagingGroup: fakeDb.getMessagingGroup,
+  getMessagingGroupByPlatform: fakeDb.getMessagingGroupByPlatform,
+  getAllMessagingGroups: fakeDb.getAllMessagingGroups,
+  updateMessagingGroup: fakeDb.updateMessagingGroup,
+  setMessagingGroupDeniedAt: fakeDb.setMessagingGroupDeniedAt,
+  setMessagingGroupDetachedAt: fakeDb.setMessagingGroupDetachedAt,
+  isMessagingGroupDetached: fakeDb.isMessagingGroupDetached,
+  createMessagingGroupAgent: fakeDb.createMessagingGroupAgent,
+  getMessagingGroupAgents: fakeDb.getMessagingGroupAgents,
+  getMessagingGroupAgentByPair: fakeDb.getMessagingGroupAgentByPair,
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  createAgentGroup: fakeDb.createAgentGroup,
+  getAgentGroup: fakeDb.getAgentGroup,
+}));
+vi.mock('../../db/sessions.js', () => ({
+  createSession: fakeDb.createSession,
+  getSessionsByAgentGroup: fakeDb.getSessionsByAgentGroup,
+}));
+vi.mock('../permissions/db/user-roles.js', () => ({
+  grantRole: fakeDb.grantRole,
+  getOwners: fakeDb.getOwners,
+}));
+
+import { createAgentGroup } from '../../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  isMessagingGroupDetached,
+  setMessagingGroupDeniedAt,
+  setMessagingGroupDetachedAt,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import type { InboundEvent } from '../../channels/adapter.js';
+import type { MessagingGroup, MessagingGroupAgent, Session } from '../../types.js';
+import {
+  clearOwnBotIdCache,
+  handleSlackMembershipEvent,
+  slackChannelCardInterceptor,
+  type MembershipEvent,
+} from './membership.js';
+
+const OWN_BOT = 'U0OWNBOT';
+const PIXEL_BOT = 'U0PIXELBOT';
+const OPERATOR = 'U0OPERATOR';
+
+const now = () => new Date().toISOString();
+
+function mg(partial: Partial<MessagingGroup> & Pick<MessagingGroup, 'id' | 'platform_id'>): MessagingGroup {
+  const row: MessagingGroup = {
+    channel_type: 'slack',
+    instance: 'slack',
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+    ...partial,
+  };
+  createMessagingGroup(row);
+  return row;
+}
+
+function wire(mgId: string, agentGroupId: string, partial: Partial<MessagingGroupAgent> = {}): MessagingGroupAgent {
+  const row: MessagingGroupAgent = {
+    id: `mga-${mgId}-${agentGroupId}`,
+    messaging_group_id: mgId,
+    agent_group_id: agentGroupId,
+    engage_mode: 'mention',
+    engage_pattern: null,
+    sender_scope: 'all',
+    ignored_message_policy: 'accumulate',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now(),
+    ...partial,
+  };
+  createMessagingGroupAgent(row);
+  return row;
+}
+
+function session(id: string, agentGroupId: string, messagingGroupId: string | null): Session {
+  const s: Session = {
+    id,
+    agent_group_id: agentGroupId,
+    messaging_group_id: messagingGroupId,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: now(),
+  };
+  createSession(s);
+  return s;
+}
+
+function joinEvent(partial: Partial<MembershipEvent> = {}): MembershipEvent {
+  return {
+    instance: 'slack',
+    channelType: 'slack',
+    channelId: 'C0NEW',
+    userId: OWN_BOT,
+    ...partial,
+  };
+}
+
+async function handle(event: MembershipEvent): Promise<void> {
+  await handleSlackMembershipEvent(event, { joinRecheckDelayMs: 0, rootDir: '/fake-root' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearOwnBotIdCache();
+  fakeDb.reset();
+  createAgentGroup({ id: 'ag-andy', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
+  createAgentGroup({ id: 'ag-pixel', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now() });
+
+  // Token table: default instance + pixel sibling. auth.test maps token → bot id.
+  mockEnv.readEnvValue.mockImplementation((_root: string, key: string) => {
+    if (key === 'SLACK_BOT_TOKEN') return 'xoxb-own';
+    if (key === 'SLACK_BOT_TOKEN_PIXEL') return 'xoxb-pixel';
+    if (key === 'SLACK_A2A_ROOMS') return '';
+    return undefined;
+  });
+  mockApi.slackAuthTest.mockImplementation(async (token: string) => ({
+    userId: token === 'xoxb-own' ? OWN_BOT : PIXEL_BOT,
+  }));
+  mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false });
+  mockApi.slackConversationsMembers.mockResolvedValue([]);
+});
+
+describe('own-bot join — adopt flow (case 1)', () => {
+  it('unknown channel: creates the mg row (router shape) and fires the approval card with a synthesized greeting', async () => {
+    await handle(joinEvent({ inviterId: OPERATOR }));
+
+    const created = getMessagingGroupByPlatform('slack', 'slack:C0NEW', 'slack');
+    expect(created).toMatchObject({
+      channel_type: 'slack',
+      is_group: 1,
+      unknown_sender_policy: 'request_approval', // group context of the declared defaults
+      name: null,
+    });
+
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    const input = mockRequestChannelApproval.mock.calls[0]![0] as {
+      messagingGroupId: string;
+      event: {
+        channelType: string;
+        instance: string;
+        platformId: string;
+        message: { isMention?: boolean; isGroup?: boolean; kind: string; content: string };
+      };
+    };
+    expect(input.messagingGroupId).toBe(created!.id);
+    expect(input.event).toMatchObject({ channelType: 'slack', instance: 'slack', platformId: 'slack:C0NEW' });
+    // Replayable greeting: routes like a mention, carries invited-by context.
+    expect(input.event.message.isMention).toBe(true);
+    expect(input.event.message.isGroup).toBe(true);
+    const content = JSON.parse(input.event.message.content) as Record<string, unknown>;
+    expect(content.text).toContain(`<@${OPERATOR}> invited the bot`);
+    expect(content.senderId).toBe(OPERATOR);
+  });
+
+  it.each([
+    ['slack:C0NEW:', 'C0NEW'],
+    ['slack:G0NEW:', 'G0NEW'],
+    ['slack:C0NEW:1724264405.531769', 'C0NEW'],
+  ])('normalizes encoded channel id %s and reuses the router-created messaging group', async (encoded, raw) => {
+    const existing = mg({
+      id: `mg-router-${raw}`,
+      platform_id: `slack:${raw}`,
+      unknown_sender_policy: 'request_approval',
+    });
+
+    await handle(joinEvent({ channelId: encoded, inviterId: OPERATOR }));
+
+    expect(getAllMessagingGroups()).toHaveLength(1);
+    expect(mockApi.slackConversationsInfo).toHaveBeenCalledWith('xoxb-own', raw, 'membership');
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    expect(mockRequestChannelApproval).toHaveBeenCalledWith({
+      messagingGroupId: existing.id,
+      event: expect.objectContaining({ platformId: `slack:${raw}`, threadId: null }),
+    });
+  });
+
+  it('SAF-004 regression: encoded channel id with NO pre-existing row creates exactly one canonical row', async () => {
+    // The literal launch-blocking shape: bot invited before any message ever
+    // routed, so no router-created row exists. The encoded id must collapse
+    // to the raw channel id BEFORE the row is created — the pre-fix code
+    // persisted a malformed `slack:slack:C0NEW:` row here.
+    await handle(joinEvent({ channelId: 'slack:C0NEW:', inviterId: OPERATOR }));
+
+    const all = getAllMessagingGroups();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ channel_type: 'slack', platform_id: 'slack:C0NEW', instance: 'slack' });
+    expect(getMessagingGroupByPlatform('slack', 'slack:slack:C0NEW:', 'slack')).toBeUndefined();
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    expect(mockRequestChannelApproval).toHaveBeenCalledWith({
+      messagingGroupId: all[0]!.id,
+      event: expect.objectContaining({ platformId: 'slack:C0NEW' }),
+    });
+  });
+
+  it('rejects a double-prefixed channel id instead of persisting dead wiring', async () => {
+    await handle(joinEvent({ channelId: 'slack:slack:C0NEW:' }));
+
+    expect(getAllMessagingGroups()).toHaveLength(0);
+    expect(mockApi.slackAuthTest).not.toHaveBeenCalled();
+    expect(mockApi.slackConversationsInfo).not.toHaveBeenCalled();
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+  });
+
+  it('Slackbot-created shadow channel (canvas container): ignored — no mg row, no card', async () => {
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, name: 'Untitled', creator: 'USLACKBOT' });
+
+    await handle(joinEvent({}));
+
+    expect(getMessagingGroupByPlatform('slack', 'slack:C0NEW', 'slack')).toBeUndefined();
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+  });
+
+  it('denied tombstone holds: no card, no new rows', async () => {
+    const denied = mg({ id: 'mg-denied', platform_id: 'slack:C0NEW', unknown_sender_policy: 'request_approval' });
+    setMessagingGroupDeniedAt(denied.id, now());
+
+    await handle(joinEvent({ inviterId: OPERATOR }));
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(getAllMessagingGroups()).toHaveLength(1);
+  });
+
+  it('already-wired channel: silent, and a rejoin clears detached_at', async () => {
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    wire(room.id, 'ag-andy');
+    setMessagingGroupDetachedAt(room.id, now());
+
+    await handle(joinEvent());
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(isMessagingGroupDetached(room.id)).toBe(false);
+  });
+
+  it('no bot token for the instance: treated as a foreign member, no adopt', async () => {
+    mockEnv.readEnvValue.mockReturnValue(undefined);
+
+    await handle(joinEvent());
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(getAllMessagingGroups()).toHaveLength(0);
+  });
+});
+
+describe('own-bot join — MPIM-fork carry-over (case 2)', () => {
+  function seedOldRoom(): { oldDefault: MessagingGroup; oldPixel: MessagingGroup } {
+    // Old wired room G0OLD, two instances (default + pixel sibling).
+    const oldDefault = mg({ id: 'mg-old-slack', platform_id: 'slack:G0OLD', name: 'Pixel room' });
+    const oldPixel = mg({
+      id: 'mg-old-pixel',
+      platform_id: 'slack:G0OLD',
+      instance: 'slack-pixel',
+      name: 'Pixel room',
+    });
+    wire(oldDefault.id, 'ag-andy', { engage_mode: 'mention', ignored_message_policy: 'accumulate', threads: 1 });
+    wire(oldPixel.id, 'ag-pixel', { engage_mode: 'mention', ignored_message_policy: 'accumulate' });
+    return { oldDefault, oldPixel };
+  }
+
+  beforeEach(() => {
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: true });
+    mockApi.slackConversationsMembers.mockImplementation(async (_token: string, channelId: string) => {
+      if (channelId === 'G0OLD') return [OPERATOR, OWN_BOT, PIXEL_BOT];
+      if (channelId === 'G0NEW') return [OPERATOR, OWN_BOT, PIXEL_BOT, 'U0NEWHUMAN'];
+      return [];
+    });
+  });
+
+  it('superset MPIM: mirrors every instance row + wiring, carries the allowlist, posts the moved note, no card', async () => {
+    seedOldRoom();
+    mockEnv.readEnvValue.mockImplementation((_root: string, key: string) => {
+      if (key === 'SLACK_BOT_TOKEN') return 'xoxb-own';
+      if (key === 'SLACK_BOT_TOKEN_PIXEL') return 'xoxb-pixel';
+      if (key === 'SLACK_A2A_ROOMS') return 'G0OLD';
+      return undefined;
+    });
+
+    await handle(joinEvent({ channelId: 'G0NEW' }));
+
+    // No approval card — carry-over replaced it.
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+
+    // Mirrored rows for BOTH instances, same agent groups, same engage values.
+    const newDefault = getMessagingGroupByPlatform('slack', 'slack:G0NEW', 'slack');
+    const newPixel = getMessagingGroupByPlatform('slack', 'slack:G0NEW', 'slack-pixel');
+    expect(newDefault).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+    expect(newPixel).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+    expect(getMessagingGroupAgentByPair(newDefault!.id, 'ag-andy')).toMatchObject({
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+      threads: 1,
+    });
+    expect(getMessagingGroupAgentByPair(newPixel!.id, 'ag-pixel')).toMatchObject({
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+    });
+
+    // Old room untouched.
+    expect(getMessagingGroupAgents('mg-old-slack')).toHaveLength(1);
+    expect(getMessagingGroup('mg-old-slack')!.denied_at ?? null).toBeNull();
+
+    // Allowlist carried, destinations projected, note posted as the bot.
+    expect(mockEnv.appendToEnvList).toHaveBeenCalledWith('/fake-root', 'SLACK_A2A_ROOMS', 'G0NEW');
+    expect(mockProject).toHaveBeenCalledWith('ag-andy');
+    expect(mockProject).toHaveBeenCalledWith('ag-pixel');
+    expect(mockApi.slackPostMessage).toHaveBeenCalledWith('xoxb-own', 'G0NEW', expect.stringContaining('Room moved'));
+  });
+
+  it('old room not allowlisted: wiring carries over but SLACK_A2A_ROOMS is untouched', async () => {
+    seedOldRoom();
+
+    await handle(joinEvent({ channelId: 'G0NEW' }));
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(mockEnv.appendToEnvList).not.toHaveBeenCalled();
+  });
+
+  it('non-superset member set: falls through to the adopt card', async () => {
+    seedOldRoom();
+    mockApi.slackConversationsMembers.mockImplementation(async (_token: string, channelId: string) => {
+      if (channelId === 'G0OLD') return [OPERATOR, OWN_BOT, PIXEL_BOT];
+      if (channelId === 'G0NEW') return [OPERATOR, OWN_BOT, 'U0STRANGER']; // pixel bot missing
+      return [];
+    });
+
+    await handle(joinEvent({ channelId: 'G0NEW' }));
+
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    expect(getMessagingGroupByPlatform('slack', 'slack:G0NEW', 'slack-pixel')).toBeUndefined();
+  });
+
+  it('non-MPIM channel: no fork check, straight to the adopt card', async () => {
+    seedOldRoom();
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false });
+
+    await handle(joinEvent({ channelId: 'C0CHANNEL' }));
+
+    expect(mockApi.slackConversationsMembers).not.toHaveBeenCalled();
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('own-bot left (case 3)', () => {
+  it('wired channel: marks the mg detached', async () => {
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    wire(room.id, 'ag-andy');
+
+    await handle(joinEvent({ left: true }));
+
+    expect(isMessagingGroupDetached(room.id)).toBe(true);
+  });
+
+  it('unknown channel: no-op', async () => {
+    await handle(joinEvent({ left: true }));
+    expect(getAllMessagingGroups()).toHaveLength(0);
+  });
+});
+
+describe('non-bot membership change in a wired room (case 4)', () => {
+  it('human joined: system-sender note (trigger 0, channel_type agent) into every wired room session', async () => {
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    const elsewhere = mg({ id: 'mg-elsewhere', platform_id: 'slack:D0DM', is_group: 0 });
+    wire(room.id, 'ag-andy');
+    wire(room.id, 'ag-pixel');
+    session('sess-andy-room', 'ag-andy', room.id);
+    session('sess-andy-dm', 'ag-andy', elsewhere.id); // different mg — no note
+    session('sess-pixel-room', 'ag-pixel', room.id);
+
+    await handle(joinEvent({ userId: 'U0NEWHUMAN', inviterId: OPERATOR }));
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(mockWriteSessionMessage).toHaveBeenCalledTimes(2);
+    const targets = mockWriteSessionMessage.mock.calls.map((c) => [c[0], c[1]]);
+    expect(targets).toContainEqual(['ag-andy', 'sess-andy-room']);
+    expect(targets).toContainEqual(['ag-pixel', 'sess-pixel-room']);
+    const msg = mockWriteSessionMessage.mock.calls[0]![2] as {
+      kind: string;
+      channelType: string;
+      trigger: number;
+      content: string;
+    };
+    // kind 'chat' + sender 'system' (container-restart's system-note shape):
+    // the container poll loop filters kind 'system' rows out of agent batches.
+    expect(msg).toMatchObject({ kind: 'chat', channelType: 'agent', trigger: 0 });
+    const content = JSON.parse(msg.content) as { text: string; sender: string };
+    expect(content.sender).toBe('system');
+    expect(content.text).toContain('<@U0NEWHUMAN> joined this room');
+    expect(content.text).toContain(`invited by <@${OPERATOR}>`);
+  });
+
+  it('foreign bot left: note says left, no inviter clause', async () => {
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    wire(room.id, 'ag-andy');
+    session('sess-andy-room', 'ag-andy', room.id);
+
+    await handle(joinEvent({ userId: PIXEL_BOT, left: true }));
+
+    expect(mockWriteSessionMessage).toHaveBeenCalledTimes(1);
+    const content = JSON.parse((mockWriteSessionMessage.mock.calls[0]![2] as { content: string }).content) as {
+      text: string;
+    };
+    expect(content.text).toContain(`<@${PIXEL_BOT}> left this room`);
+    expect(content.text).not.toContain('invited by');
+  });
+
+  it('unwired or unknown channel: no notes', async () => {
+    await handle(joinEvent({ userId: 'U0NEWHUMAN' }));
+    expect(mockWriteSessionMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack channel-card interceptor — owner-presence rule (B2/D24)', () => {
+  function mentionEvent(
+    platformId: string,
+    partial: { isGroup?: boolean; senderId?: string; senderName?: string } = {},
+  ): InboundEvent {
+    return {
+      channelType: 'slack',
+      instance: 'slack',
+      platformId,
+      threadId: null,
+      message: {
+        id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+        kind: 'chat',
+        timestamp: now(),
+        isMention: true,
+        isGroup: partial.isGroup ?? true,
+        content: JSON.stringify({
+          text: '@bot hello',
+          senderId: partial.senderId ?? 'U0SOMEONE',
+          senderName: partial.senderName ?? 'Someone',
+        }),
+      },
+    };
+  }
+
+  /** Owner identity + the instance's DM wiring (what every per-agent
+   *  instance has) — the two facts the interceptor resolves against. */
+  function seedOwnerAndInstanceDm(): void {
+    grantRole({
+      user_id: `slack:${OPERATOR}`,
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
+    const dm = mg({ id: 'mg-dm-andy', platform_id: 'slack:D0ANDY', is_group: 0 });
+    wire(dm.id, 'ag-andy');
+  }
+
+  async function intercept(row: MessagingGroup, event: InboundEvent): Promise<'card' | 'handled'> {
+    return slackChannelCardInterceptor(row, event, { rootDir: '/fake-root' });
+  }
+
+  it('owner present in the channel: auto-wires mention/accumulate, flips mg to public, replays — no card', async () => {
+    seedOwnerAndInstanceDm();
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: true, creator: OPERATOR });
+    mockApi.slackConversationsMembers.mockResolvedValue([OPERATOR, OWN_BOT, 'U0STRANGER']);
+
+    const event = mentionEvent('slack:C0ROOM');
+    expect(await intercept(room, event)).toBe('handled');
+
+    expect(getMessagingGroup(room.id)).toMatchObject({ unknown_sender_policy: 'public' });
+    expect(getMessagingGroupAgentByPair(room.id, 'ag-andy')).toMatchObject({
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+      sender_scope: 'all',
+    });
+    expect(mockProject).toHaveBeenCalledWith('ag-andy');
+    expect(mockRouteInbound).toHaveBeenCalledTimes(1);
+    expect(mockRouteInbound).toHaveBeenCalledWith(event);
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('owner absent: falls back to the card, no wiring', async () => {
+    seedOwnerAndInstanceDm();
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsMembers.mockResolvedValue([OWN_BOT, 'U0STRANGER']);
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+
+    expect(getMessagingGroupAgents(room.id)).toHaveLength(0);
+    expect(getMessagingGroup(room.id)).toMatchObject({ unknown_sender_policy: 'request_approval' });
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+  });
+
+  it('owner present but instance→agent-group resolution ambiguous: card', async () => {
+    seedOwnerAndInstanceDm();
+    // A second DM wiring on the same instance to a different agent group.
+    const dm2 = mg({ id: 'mg-dm-pixel', platform_id: 'slack:D0PIXEL', is_group: 0 });
+    wire(dm2.id, 'ag-pixel');
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsMembers.mockResolvedValue([OPERATOR, OWN_BOT]);
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(getMessagingGroupAgents(room.id)).toHaveLength(0);
+  });
+
+  it('no owner with a Slack identity: card (no members probe)', async () => {
+    const dm = mg({ id: 'mg-dm-andy', platform_id: 'slack:D0ANDY', is_group: 0 });
+    wire(dm.id, 'ag-andy');
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(mockApi.slackConversationsMembers).not.toHaveBeenCalled();
+  });
+
+  it('USLACKBOT-created shadow channel: silently handled — no wiring, no decline, no replay', async () => {
+    seedOwnerAndInstanceDm();
+    const shadow = mg({ id: 'mg-shadow', platform_id: 'slack:C0SHADOW', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, name: 'Untitled', creator: 'USLACKBOT' });
+
+    expect(await intercept(shadow, mentionEvent('slack:C0SHADOW'))).toBe('handled');
+
+    expect(getMessagingGroupAgents(shadow.id)).toHaveLength(0);
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+    expect(mockApi.slackConversationsMembers).not.toHaveBeenCalled();
+  });
+
+  it('stranger 1:1 DM with decline_notify policy: declines and notifies, no card', async () => {
+    seedOwnerAndInstanceDm();
+    const dm = mg({
+      id: 'mg-dm-stranger',
+      platform_id: 'slack:D0STRANGER',
+      is_group: 0,
+      unknown_sender_policy: 'decline_notify',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+
+    const event = mentionEvent('slack:D0STRANGER', { isGroup: false, senderId: 'U0STRANGER', senderName: 'Stranger' });
+    expect(await intercept(dm, event)).toBe('handled');
+
+    expect(mockDeclineAndNotify).toHaveBeenCalledTimes(1);
+    expect(mockDeclineAndNotify).toHaveBeenCalledWith({
+      messagingGroupId: dm.id,
+      agentGroupId: 'ag-andy',
+      senderIdentity: 'slack:U0STRANGER',
+      senderName: 'Stranger',
+      event,
+    });
+    expect(mockRecordDropped).toHaveBeenCalledTimes(1);
+    expect(getMessagingGroupAgents(dm.id)).toHaveLength(0);
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+  });
+
+  it('owner DM with decline_notify policy: never declined — card fallback', async () => {
+    seedOwnerAndInstanceDm();
+    const dm = mg({
+      id: 'mg-dm-owner',
+      platform_id: 'slack:D0OWNER',
+      is_group: 0,
+      unknown_sender_policy: 'decline_notify',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: OPERATOR });
+
+    const event = mentionEvent('slack:D0OWNER', { isGroup: false, senderId: OPERATOR, senderName: 'Gavriel' });
+    expect(await intercept(dm, event)).toBe('card');
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('stranger 1:1 DM with the stale request_approval default: declines and stamps the row decline_notify', async () => {
+    seedOwnerAndInstanceDm();
+    const dm = mg({
+      id: 'mg-dm-x',
+      platform_id: 'slack:D0X',
+      is_group: 0,
+      unknown_sender_policy: 'request_approval',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+
+    const event = mentionEvent('slack:D0X', { isGroup: false, senderId: 'U0STRANGER', senderName: 'Stranger' });
+    expect(await intercept(dm, event)).toBe('handled');
+
+    expect(mockDeclineAndNotify).toHaveBeenCalledTimes(1);
+    expect(mockDeclineAndNotify).toHaveBeenCalledWith({
+      messagingGroupId: dm.id,
+      agentGroupId: 'ag-andy',
+      senderIdentity: 'slack:U0STRANGER',
+      senderName: 'Stranger',
+      event,
+    });
+    // The D24 flip is stamped onto the row so the DB matches the behavior.
+    expect(getMessagingGroup(dm.id)).toMatchObject({ unknown_sender_policy: 'decline_notify' });
+  });
+
+  it("1:1 DM with an operator-set 'strict' or 'public' policy keeps today's card", async () => {
+    seedOwnerAndInstanceDm();
+    for (const policy of ['strict', 'public'] as const) {
+      const dm = mg({
+        id: `mg-dm-${policy}`,
+        platform_id: `slack:D0${policy.toUpperCase()}`,
+        is_group: 0,
+        unknown_sender_policy: policy,
+      });
+      mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+      expect(await intercept(dm, mentionEvent(dm.platform_id, { isGroup: false, senderId: 'U0STRANGER' }))).toBe(
+        'card',
+      );
+      expect(getMessagingGroup(dm.id)).toMatchObject({ unknown_sender_policy: policy });
+    }
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('stranger 1:1 DM with ambiguous instance→agent-group resolution: card, no decline', async () => {
+    seedOwnerAndInstanceDm();
+    // A second DM wiring on the same instance to a different agent group —
+    // privileged senders can't be recognized, so nobody may be declined.
+    const dm2 = mg({ id: 'mg-dm-pixel', platform_id: 'slack:D0PIXEL', is_group: 0 });
+    wire(dm2.id, 'ag-pixel');
+    const dm = mg({
+      id: 'mg-dm-ambig',
+      platform_id: 'slack:D0AMBIG',
+      is_group: 0,
+      unknown_sender_policy: 'decline_notify',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+
+    expect(await intercept(dm, mentionEvent('slack:D0AMBIG', { isGroup: false, senderId: 'U0STRANGER' }))).toBe('card');
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('conversations.members failure: card fallback (never silent loss)', async () => {
+    seedOwnerAndInstanceDm();
+    const room = mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsMembers.mockRejectedValue(new Error('ratelimited'));
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(getMessagingGroupAgents(room.id)).toHaveLength(0);
+  });
+});

--- a/src/modules/slack-room-membership/membership.ts
+++ b/src/modules/slack-room-membership/membership.ts
@@ -1,0 +1,732 @@
+/**
+ * Slack room-membership handling (plan 04 §Slack-UI membership changes, D17).
+ *
+ * Reacts to member_joined_channel / member_left_channel events forwarded by
+ * the Chat SDK bridge (generic membership seam: setMembershipHandler('slack',
+ * …) — registration lives in ./index.ts). Four cases:
+ *
+ *  1. OWN bot joined an unknown channel/MPIM → the adopt flow: auto-create
+ *     the messaging-group row (mirroring the router's auto-create shape) and
+ *     fire the EXISTING channel-approval card with a synthesized greeting
+ *     event — the card's dedupe (pending-row PK) rides along for free; the
+ *     `denied_at` tombstone is checked here (the router only checks it on its
+ *     own path). On approve the greeting replays through routeInbound, so the
+ *     agent introduces itself. Since B2/D24 the card is the FALLBACK only:
+ *     requestChannelApproval consults slackChannelCardInterceptor (below)
+ *     first — owner present in the room → auto-wire 'public' +
+ *     mention/accumulate, no card; stranger 1:1 DMs → decline-and-notify.
+ *  2. MPIM-fork carry-over: Slack NEVER adds members to a group DM in place —
+ *     it forks a NEW conversation. Before firing the card in case 1, if the
+ *     joined channel is an MPIM whose member set is a superset of an existing
+ *     wired room's members (checked on this instance), mirror that room's mg
+ *     rows + wirings — for EVERY instance wired to the old room, same engage
+ *     values — onto the new channel id, carry the SLACK_A2A_ROOMS allowlist
+ *     entry when the old room had one, and post a brief "room moved" note
+ *     instead of asking for approval. The old room is left untouched.
+ *  3. OWN bot left a wired channel → mark the mg detached (migration 021,
+ *     `messaging_groups.detached_at`); a rejoin clears the flag. Routing goes
+ *     quiet on its own (no more inbound events); delivery-side callers should
+ *     consult `isMessagingGroupDetached` before sends.
+ *  4. Anyone else (human or foreign bot) joined/left a WIRED room → concise
+ *     system note into the room sessions of every wired agent group so agents
+ *     know the membership changed. No approval, no gating (D17: a2a stays
+ *     unrestricted for these rooms).
+ *
+ * The own-bot join path waits JOIN_RECHECK_DELAY_MS before deciding: when an
+ * agent-provisioning flow itself opens an MPIM, the join event can beat the
+ * flow's own room-wire writes — the recheck sees the flow's rows and stays
+ * silent instead of approval-spamming the operator.
+ */
+import { resolveUnknownSenderPolicy } from '../../channels/channel-defaults.js';
+import type { InboundEvent } from '../../channels/adapter.js';
+import {
+  botTokenKeyForInstance,
+  slackAuthTest,
+  slackConversationsInfo,
+  slackConversationsMembers,
+  slackPostMessage,
+} from '../../channels/slack-lib.js';
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { recordDroppedMessage } from '../../db/dropped-messages.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  setMessagingGroupDetachedAt,
+  updateMessagingGroup,
+} from '../../db/messaging-groups.js';
+import { getSessionsByAgentGroup } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { routeInbound } from '../../router.js';
+import { writeSessionMessage } from '../../session-manager.js';
+import type { MessagingGroup } from '../../types.js';
+import { canAccessAgentGroup } from '../permissions/access.js';
+import { requestChannelApproval } from '../permissions/channel-approval.js';
+import { getOwners } from '../permissions/db/user-roles.js';
+import { declineAndNotify } from '../permissions/sender-approval.js';
+import { appendToEnvList, readEnvValue } from './env-file.js';
+
+/** Structural mirror of the bridge's MembershipEvent (generic membership
+ *  seam) — declared locally so this file (and its tests) has no bridge
+ *  import. */
+export interface MembershipEvent {
+  instance: string;
+  channelType: string;
+  channelId: string;
+  userId: string;
+  inviterId?: string;
+  left?: boolean;
+}
+
+/** Test/config seam for handleSlackMembershipEvent. */
+export interface MembershipOpts {
+  /** Override the own-join recheck delay (tests pass 0). */
+  joinRecheckDelayMs?: number;
+  /** Repo root for .env reads; defaults to process.cwd(). */
+  rootDir?: string;
+}
+
+/** Own-join settle window — covers the provisioning flow's open→wire gap. */
+export const JOIN_RECHECK_DELAY_MS = 3000;
+
+/**
+ * Chat SDK 4.29 encodes member_joined_channel channel ids as Slack thread
+ * ids (`slack:C…:`), while direct/test callers may still supply raw `C…` or
+ * `G…` ids. Collapse both shapes before any DB lookup or Slack API call.
+ *
+ * The `slack` prefix allowlist deliberately covers named instances too:
+ * multi-instance registration (slack-instances.ts, skill-installed) passes
+ * `slack-<name>` only to the BRIDGE as a host-side routing key — the SDK
+ * adapter underneath is always createSlackAdapter, whose encoded ids stay
+ * `slack:C…:`-shaped, and the bridge forwards event.channelId verbatim. So
+ * `slack-<name>:C…`-shaped ids do not occur. Revisit this helper if that
+ * ever changes (e.g. an instance-named SDK adapter).
+ */
+function normalizeSlackMembershipChannelId(value: string): string | null {
+  const parts = value.split(':');
+  const raw =
+    parts.length === 1
+      ? parts[0]
+      : (parts.length === 2 || parts.length === 3) && parts[0] === 'slack'
+        ? parts[1]
+        : undefined;
+  return raw && /^[CG][A-Z0-9]+$/.test(raw) ? raw : null;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+// ── Own-bot identity ──
+
+/** auth.test result per instance — bot user ids are stable for a token's lifetime. */
+const ownBotIdCache = new Map<string, string>();
+
+/** Test seam: forget cached bot identities (tokens rotate between tests). */
+export function clearOwnBotIdCache(): void {
+  ownBotIdCache.clear();
+}
+
+async function resolveOwnBotUserId(instance: string, rootDir: string): Promise<string | undefined> {
+  const cached = ownBotIdCache.get(instance);
+  if (cached) return cached;
+  const token = readEnvValue(rootDir, botTokenKeyForInstance(instance));
+  if (!token) {
+    log.debug('slack-room-membership: no bot token for instance — cannot resolve own identity', { instance });
+    return undefined;
+  }
+  try {
+    const auth = await slackAuthTest(token, 'membership');
+    ownBotIdCache.set(instance, auth.userId);
+    return auth.userId;
+  } catch (err) {
+    log.warn('slack-room-membership: auth.test failed resolving own bot identity', { instance, err });
+    return undefined;
+  }
+}
+
+// ── Case 1: adopt flow ──
+
+/** Mirror of the router's auto-create shape (router.ts routeInbound step 1). */
+function createAdoptedMessagingGroup(instance: string, platformId: string): MessagingGroup {
+  const mg: MessagingGroup = {
+    id: generateId('mg'),
+    channel_type: 'slack',
+    platform_id: platformId,
+    instance,
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: resolveUnknownSenderPolicy(instance, true, 'slack'),
+    denied_at: null,
+    created_at: new Date().toISOString(),
+  };
+  createMessagingGroup(mg);
+  log.info('Auto-created messaging group (bot invited via Slack UI)', {
+    id: mg.id,
+    platformId,
+    instance,
+  });
+  return mg;
+}
+
+/**
+ * The replayable greeting standing in for the "original message" the
+ * mention-triggered flow would have stored: on approve it routes like a
+ * mention (isMention) and instructs the agent to introduce itself. The
+ * inviter rides as sender/senderId, so the card shows invited-by context and
+ * the approve path auto-admits the inviter as a member.
+ */
+function synthesizeJoinEvent(event: MembershipEvent, platformId: string): InboundEvent {
+  const inviter = event.inviterId;
+  return {
+    channelType: 'slack',
+    instance: event.instance,
+    platformId,
+    threadId: null,
+    message: {
+      id: `slack-join-${event.channelId}-${Date.now()}`,
+      kind: 'chat',
+      timestamp: new Date().toISOString(),
+      isMention: true,
+      isGroup: true,
+      content: JSON.stringify({
+        text: inviter
+          ? `<@${inviter}> invited the bot to this channel. Introduce yourself briefly and say what you can help with.`
+          : 'The bot was added to this channel. Introduce yourself briefly and say what you can help with.',
+        sender: inviter ? `<@${inviter}>` : 'system',
+        ...(inviter ? { senderId: inviter, senderName: `<@${inviter}> (invited the bot)` } : {}),
+      }),
+    },
+  };
+}
+
+// ── Case 2: MPIM-fork carry-over ──
+
+async function tryMpimForkCarryOver(args: {
+  instance: string;
+  channelId: string;
+  platformId: string;
+  token: string;
+  rootDir: string;
+}): Promise<boolean> {
+  let isMpim: boolean;
+  try {
+    isMpim = (await slackConversationsInfo(args.token, args.channelId, 'membership')).isMpim;
+  } catch (err) {
+    log.warn('slack-room-membership: conversations.info failed — skipping fork check', {
+      channelId: args.channelId,
+      err,
+    });
+    return false;
+  }
+  if (!isMpim) return false;
+
+  let newMembers: Set<string>;
+  try {
+    newMembers = new Set(await slackConversationsMembers(args.token, args.channelId, 'membership'));
+  } catch (err) {
+    log.warn('slack-room-membership: conversations.members failed — skipping fork check', {
+      channelId: args.channelId,
+      err,
+    });
+    return false;
+  }
+  if (newMembers.size === 0) return false;
+
+  const all = getAllMessagingGroups();
+  // Candidate old rooms: wired slack group rooms visible to THIS instance —
+  // the superset check needs our bot in both channels for members reads.
+  const candidates = all.filter(
+    (m) =>
+      m.channel_type === 'slack' &&
+      m.is_group === 1 &&
+      (m.instance ?? m.channel_type) === args.instance &&
+      m.platform_id.startsWith('slack:') &&
+      m.platform_id !== args.platformId &&
+      !m.denied_at,
+  );
+
+  for (const candidate of candidates) {
+    if (getMessagingGroupAgents(candidate.id).length === 0) continue;
+    const oldChannelId = candidate.platform_id.slice('slack:'.length);
+    let oldMembers: string[];
+    try {
+      oldMembers = await slackConversationsMembers(args.token, oldChannelId, 'membership');
+    } catch {
+      continue; // bot no longer in the old room (or API hiccup) — not a fork source we can prove
+    }
+    if (oldMembers.length === 0 || !oldMembers.every((m) => newMembers.has(m))) continue;
+
+    // Fork detected — mirror EVERY instance's row for the old room, same
+    // agent groups, same engage values. The old room stays untouched (it
+    // still works; Slack keeps both conversations alive).
+    const now = new Date().toISOString();
+    const family = all.filter((m) => m.channel_type === 'slack' && m.platform_id === candidate.platform_id);
+    const carriedAgentGroups = new Set<string>();
+    for (const oldMg of family) {
+      const oldWirings = getMessagingGroupAgents(oldMg.id);
+      if (oldWirings.length === 0) continue;
+      let newMg = getMessagingGroupByPlatform('slack', args.platformId, oldMg.instance ?? 'slack');
+      if (!newMg) {
+        newMg = {
+          id: generateId('mg'),
+          channel_type: 'slack',
+          platform_id: args.platformId,
+          instance: oldMg.instance ?? 'slack',
+          name: oldMg.name,
+          is_group: 1,
+          unknown_sender_policy: oldMg.unknown_sender_policy,
+          denied_at: null,
+          created_at: now,
+        };
+        createMessagingGroup(newMg);
+      }
+      for (const oldWiring of oldWirings) {
+        if (getMessagingGroupAgentByPair(newMg.id, oldWiring.agent_group_id)) continue;
+        createMessagingGroupAgent({
+          id: generateId('mga'),
+          messaging_group_id: newMg.id,
+          agent_group_id: oldWiring.agent_group_id,
+          engage_mode: oldWiring.engage_mode,
+          engage_pattern: oldWiring.engage_pattern,
+          sender_scope: oldWiring.sender_scope,
+          ignored_message_policy: oldWiring.ignored_message_policy,
+          session_mode: oldWiring.session_mode,
+          priority: oldWiring.priority,
+          ...(oldWiring.threads !== undefined && oldWiring.threads !== null ? { threads: oldWiring.threads } : {}),
+          created_at: now,
+        });
+        carriedAgentGroups.add(oldWiring.agent_group_id);
+      }
+    }
+    for (const agentGroupId of carriedAgentGroups) {
+      await projectDestinationsToSessions(agentGroupId);
+    }
+
+    // Carry the a2a allowlist entry when the old room had one.
+    const allowlisted = (readEnvValue(args.rootDir, 'SLACK_A2A_ROOMS') ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .includes(oldChannelId);
+    if (allowlisted) {
+      try {
+        appendToEnvList(args.rootDir, 'SLACK_A2A_ROOMS', args.channelId);
+      } catch (err) {
+        log.warn('slack-room-membership: SLACK_A2A_ROOMS carry-over write failed', {
+          channelId: args.channelId,
+          err,
+        });
+      }
+    }
+
+    try {
+      await slackPostMessage(
+        args.token,
+        args.channelId,
+        "Room moved — I carried the previous room's wiring over. Same agents, same behavior; the old room keeps working too.",
+      );
+    } catch (err) {
+      log.warn('slack-room-membership: room-moved note failed', { channelId: args.channelId, err });
+    }
+
+    log.info('MPIM fork carry-over applied', {
+      fromChannelId: oldChannelId,
+      toChannelId: args.channelId,
+      instance: args.instance,
+      agentGroups: [...carriedAgentGroups],
+      a2aCarried: allowlisted,
+    });
+    return true;
+  }
+  return false;
+}
+
+// ── Case handlers ──
+
+async function handleOwnJoin(event: MembershipEvent, platformId: string, opts: MembershipOpts): Promise<void> {
+  // Settle window: a provisioning flow's own room rows land moments after
+  // the join event when the flow itself opened the MPIM.
+  await sleep(opts.joinRecheckDelayMs ?? JOIN_RECHECK_DELAY_MS);
+
+  const rootDir = opts.rootDir ?? process.cwd();
+  let mg = getMessagingGroupByPlatform('slack', platformId, event.instance);
+  if (mg && getMessagingGroupAgents(mg.id).length > 0) {
+    // Already wired (flow-created or previously adopted). A rejoin re-attaches.
+    if (mg.detached_at) {
+      setMessagingGroupDetachedAt(mg.id, null);
+      log.info('Messaging group re-attached — bot rejoined', { messagingGroupId: mg.id, platformId });
+    }
+    return;
+  }
+  if (mg?.denied_at) {
+    log.debug('Bot invited to a denied channel — tombstone holds, no approval card', {
+      messagingGroupId: mg.id,
+      platformId,
+    });
+    return;
+  }
+  if (mg?.detached_at) setMessagingGroupDetachedAt(mg.id, null);
+
+  const token = readEnvValue(rootDir, botTokenKeyForInstance(event.instance));
+
+  // Canvas shadow channels: creating a canvas on an MPIM makes Slack
+  // materialize a hidden Slackbot-owned private channel as the canvas's
+  // access container and add the room's members to it (observed live:
+  // canvas F0… spawns channel C0… with the same id suffix). It fires real
+  // member_joined events but is never a conversation to adopt — no mg row,
+  // no approval card. Slackbot never creates adoptable channels, so the
+  // creator check covers this class wholesale.
+  if (token) {
+    try {
+      const info = await slackConversationsInfo(token, event.channelId, 'membership');
+      if (info.creator === 'USLACKBOT') {
+        log.debug('Ignoring Slackbot-created shadow channel', { channelId: event.channelId });
+        return;
+      }
+    } catch (err) {
+      log.warn('slack-room-membership: conversations.info failed — continuing without shadow check', {
+        channelId: event.channelId,
+        err,
+      });
+    }
+  }
+
+  if (
+    token &&
+    (await tryMpimForkCarryOver({
+      instance: event.instance,
+      channelId: event.channelId,
+      platformId,
+      token,
+      rootDir,
+    }))
+  ) {
+    return;
+  }
+
+  if (!mg) mg = createAdoptedMessagingGroup(event.instance, platformId);
+  // Dedupe of a second join/mention while pending is requestChannelApproval's
+  // own in-flight check (pending_channel_approvals PK on messaging_group_id).
+  // The owner-presence rule (D24) rides along for free: requestChannelApproval
+  // consults slackChannelCardInterceptor below, so an owner-containing room
+  // auto-wires (agent introduces itself via the synthesized greeting) and only
+  // owner-absent rooms actually card.
+  await requestChannelApproval({ messagingGroupId: mg.id, event: synthesizeJoinEvent(event, platformId) });
+}
+
+function handleOwnLeft(event: MembershipEvent, platformId: string): void {
+  const mg = getMessagingGroupByPlatform('slack', platformId, event.instance);
+  if (!mg) return;
+  setMessagingGroupDetachedAt(mg.id, new Date().toISOString());
+  log.info('Messaging group detached — bot left the channel', { messagingGroupId: mg.id, platformId });
+}
+
+/** Case 4: membership bookkeeping for wired rooms — a trigger=0 system note
+ *  into every wired agent group's room sessions (D17: no approval, no gating). */
+function handleMemberChange(event: MembershipEvent, platformId: string): void {
+  const mg = getMessagingGroupByPlatform('slack', platformId, event.instance);
+  if (!mg || mg.is_group !== 1) return;
+  const wirings = getMessagingGroupAgents(mg.id);
+  if (wirings.length === 0) return;
+
+  const action = event.left ? 'left' : 'joined';
+  const inviter = !event.left && event.inviterId ? ` (invited by <@${event.inviterId}>)` : '';
+  const text = `Room membership changed: <@${event.userId}> ${action} this room${inviter}.`;
+  const timestamp = new Date().toISOString();
+
+  for (const wiring of wirings) {
+    const sessions = getSessionsByAgentGroup(wiring.agent_group_id).filter(
+      (s) => s.messaging_group_id === mg.id && s.status === 'active',
+    );
+    for (const session of sessions) {
+      try {
+        // kind 'chat' + sender 'system' + channelType 'agent' mirrors the
+        // container-restart system-note shape. NOT kind 'system': those rows
+        // are reserved for MCP tool responses and the container poll loop
+        // filters them out of agent batches (poll-loop.ts) — a 'system'-kind
+        // note would sit pending forever and never reach the agent.
+        writeSessionMessage(wiring.agent_group_id, session.id, {
+          id: generateId(`member-${event.channelId}`),
+          kind: 'chat',
+          timestamp,
+          platformId,
+          channelType: 'agent',
+          threadId: null,
+          content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
+          trigger: 0,
+        });
+      } catch (err) {
+        log.warn('slack-room-membership: membership note write failed', {
+          sessionId: session.id,
+          messagingGroupId: mg.id,
+          err,
+        });
+      }
+    }
+  }
+  log.info('Room membership note written', { messagingGroupId: mg.id, userId: event.userId, action });
+}
+
+// ── Owner-presence access rule + channel-card interception (B2/D24) ──
+
+/** Owner Slack user ids (raw U… form) from user_roles — the presence probe key. */
+function resolveOwnerSlackUserIds(): string[] {
+  return getOwners()
+    .map((r) => r.user_id)
+    .filter((id) => id.startsWith('slack:'))
+    .map((id) => id.slice('slack:'.length));
+}
+
+/**
+ * The agent group a Slack instance "is": the distinct agent group across the
+ * instance's existing wirings, DM wirings first (every per-agent instance has
+ * one). Exactly one distinct hit wins; ambiguous or empty → undefined and the
+ * caller falls back to the approval card.
+ */
+function resolveInstanceAgentGroup(instance: string): { id: string; name: string } | undefined {
+  const rows = getAllMessagingGroups().filter(
+    (m) => m.channel_type === 'slack' && (m.instance ?? m.channel_type) === instance,
+  );
+  for (const dmOnly of [true, false]) {
+    const ids = new Set<string>();
+    for (const m of rows) {
+      if (dmOnly && m.is_group !== 0) continue;
+      for (const wiring of getMessagingGroupAgents(m.id)) ids.add(wiring.agent_group_id);
+    }
+    if (ids.size === 1) {
+      const id = [...ids][0]!;
+      const ag = getAgentGroup(id);
+      if (ag) return { id, name: ag.name };
+    }
+  }
+  return undefined;
+}
+
+/** Sender identity off an inbound payload — top-level senderId/sender (v1,
+ *  synthesized events) or the chat-sdk bridge's nested author.userId. */
+function senderFromEvent(event: InboundEvent): { userId: string | null; name: string | null } {
+  try {
+    const parsed = JSON.parse(event.message.content) as Record<string, unknown>;
+    const author =
+      typeof parsed.author === 'object' && parsed.author !== null
+        ? (parsed.author as Record<string, unknown>)
+        : undefined;
+    const raw =
+      (typeof parsed.senderId === 'string' ? parsed.senderId : undefined) ??
+      (typeof parsed.sender === 'string' ? parsed.sender : undefined) ??
+      (typeof author?.userId === 'string' ? (author.userId as string) : undefined);
+    const name =
+      (typeof parsed.senderName === 'string' ? parsed.senderName : undefined) ??
+      (typeof author?.fullName === 'string' ? (author.fullName as string) : undefined) ??
+      null;
+    if (!raw) return { userId: null, name };
+    return { userId: raw.includes(':') ? raw : `slack:${raw}`, name };
+  } catch {
+    return { userId: null, name: null };
+  }
+}
+
+/**
+ * THE Slack channel-card interceptor (registered via
+ * registerChannelCardInterceptor in ./index.ts) — consulted by
+ * requestChannelApproval before any card goes out, which means BOTH
+ * escalation paths funnel here: the router's mention path (step 1b) and this
+ * module's own join-time adopt (handleOwnJoin calls requestChannelApproval).
+ * Decides per D24's owner-presence rule:
+ *
+ *   - Slackbot-created shadow channel (canvas comment container) → silent
+ *     'handled' — mirrors handleOwnJoin's guard for events that arrive via
+ *     the mention path (canvases created outside our flow).
+ *   - 1:1 DM, unknown sender → polite decline + owner FYI ('handled').
+ *     Keyed on D24 itself, not on a pre-set policy value: the Slack
+ *     adapter's declared DM default is still the pre-B2 'request_approval'
+ *     (the declaration lives on the channels branch), so rows carrying that
+ *     stale default decline exactly like 'decline_notify' ones and get
+ *     stamped 'decline_notify' so the row matches the behavior. Deliberate
+ *     operator overrides ('strict', 'public') and known/privileged senders
+ *     keep the card.
+ *   - Group/MPIM with the OWNER in the member list → auto-wire: mg flips to
+ *     'public', the instance's agent group gets a mention/accumulate wiring
+ *     (room semantics), the triggering event replays ('handled', no card).
+ *   - Anything else (owner absent, no token, ambiguous instance→agent-group
+ *     resolution, API failure) → 'card', today's notify-and-ask flow.
+ */
+export async function slackChannelCardInterceptor(
+  mg: MessagingGroup,
+  event: InboundEvent,
+  opts: MembershipOpts = {},
+): Promise<'card' | 'handled'> {
+  const rootDir = opts.rootDir ?? process.cwd();
+  const instance = mg.instance ?? 'slack';
+  const token = readEnvValue(rootDir, botTokenKeyForInstance(instance));
+  const channelId = mg.platform_id.startsWith('slack:') ? mg.platform_id.slice('slack:'.length) : mg.platform_id;
+
+  // USLACKBOT backstop: shadow channels are never conversations to card.
+  if (token) {
+    try {
+      const info = await slackConversationsInfo(token, channelId, 'membership');
+      if (info.creator === 'USLACKBOT') {
+        log.debug('Ignoring Slackbot-created shadow channel (card path)', { channelId });
+        return 'handled';
+      }
+    } catch (err) {
+      log.warn('slack-room-membership: conversations.info failed — continuing without shadow check', {
+        channelId,
+        err,
+      });
+    }
+  }
+
+  const isGroup = event.message.isGroup ?? mg.is_group === 1;
+  const agentGroup = resolveInstanceAgentGroup(instance);
+
+  if (!isGroup) {
+    // 1:1 DM — the owner is never "present" (D24 table): unknown senders are
+    // declined-and-notified. Keyed on the D24 rule itself, not on a pre-set
+    // policy value: router-auto-created DM rows still carry the adapter's
+    // stale declared default 'request_approval' (the flip lives on the
+    // channels branch), so both shapes decline; deliberate operator
+    // overrides ('strict', 'public') keep today's card.
+    if (mg.unknown_sender_policy !== 'decline_notify' && mg.unknown_sender_policy !== 'request_approval') {
+      return 'card';
+    }
+    if (!agentGroup) {
+      // Ambiguous instance→agent-group resolution (e.g. a shared instance
+      // wired to two agent groups): privileged senders can't be recognized,
+      // so mirror the group branch — card, never a misdirected decline.
+      log.warn('slack-room-membership: DM instance→agent-group resolution is ambiguous — card, no decline', {
+        instance,
+        channelId,
+      });
+      return 'card';
+    }
+    const sender = senderFromEvent(event);
+    // Known/privileged senders are never declined — their DM still cards.
+    if (sender.userId && canAccessAgentGroup(sender.userId, agentGroup.id).allowed) return 'card';
+    // Stamp the D24 default onto rows still carrying the stale declared
+    // policy, so the row reflects the behavior (ncl dumps, access gate).
+    if (mg.unknown_sender_policy !== 'decline_notify') {
+      updateMessagingGroup(mg.id, { unknown_sender_policy: 'decline_notify' });
+    }
+    recordDroppedMessage({
+      channel_type: 'slack',
+      platform_id: event.platformId,
+      user_id: sender.userId,
+      sender_name: sender.name,
+      reason: 'unknown_sender_decline_notify',
+      messaging_group_id: mg.id,
+      agent_group_id: agentGroup.id,
+    });
+    await declineAndNotify({
+      messagingGroupId: mg.id,
+      agentGroupId: agentGroup.id,
+      senderIdentity: sender.userId,
+      senderName: sender.name,
+      event,
+    });
+    return 'handled';
+  }
+
+  // Group / MPIM / channel — the owner-presence rule proper.
+  if (!token) return 'card';
+  const ownerIds = resolveOwnerSlackUserIds();
+  if (ownerIds.length === 0) return 'card';
+  let members: string[];
+  try {
+    members = await slackConversationsMembers(token, channelId, 'membership');
+  } catch (err) {
+    log.warn('slack-room-membership: conversations.members failed — falling back to the card', { channelId, err });
+    return 'card';
+  }
+  if (!ownerIds.some((id) => members.includes(id))) return 'card'; // owner absent → notify-and-ask
+
+  if (!agentGroup) {
+    log.warn('slack-room-membership: owner present but instance→agent-group resolution is ambiguous — card', {
+      instance,
+      channelId,
+    });
+    return 'card';
+  }
+
+  // Owner present → open: 'public' mg + mention/accumulate wiring (room
+  // semantics — anyone there can task the agent; unmentioned chatter
+  // accumulates as context). No card, no notification.
+  updateMessagingGroup(mg.id, { unknown_sender_policy: 'public' });
+  if (!getMessagingGroupAgentByPair(mg.id, agentGroup.id)) {
+    createMessagingGroupAgent({
+      id: generateId('mga'),
+      messaging_group_id: mg.id,
+      agent_group_id: agentGroup.id,
+      engage_mode: 'mention',
+      engage_pattern: null,
+      sender_scope: 'all',
+      ignored_message_policy: 'accumulate',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: new Date().toISOString(),
+    });
+  }
+  await projectDestinationsToSessions(agentGroup.id);
+  log.info('Owner present — channel auto-wired, no card', {
+    messagingGroupId: mg.id,
+    channelId,
+    instance,
+    agentGroupId: agentGroup.id,
+  });
+
+  // Replay the triggering event through normal routing so the agent answers
+  // the mention (or introduces itself, on the join path's synthesized event).
+  try {
+    await routeInbound(event);
+  } catch (err) {
+    log.error('slack-room-membership: replay after auto-wire failed', { messagingGroupId: mg.id, err });
+  }
+  return 'handled';
+}
+
+// ── Entry ──
+
+/**
+ * THE membership handler (registered via setMembershipHandler('slack', …) in
+ * ./index.ts). Never throws — the bridge fire-and-forgets, and a failure here
+ * must never affect SDK dispatch or sibling events.
+ */
+export async function handleSlackMembershipEvent(event: MembershipEvent, opts: MembershipOpts = {}): Promise<void> {
+  try {
+    const channelId = normalizeSlackMembershipChannelId(event.channelId);
+    if (!channelId) {
+      log.warn('slack-room-membership: invalid channel id — ignoring membership event', {
+        channelId: event.channelId,
+        userId: event.userId,
+      });
+      return;
+    }
+
+    const normalizedEvent = channelId === event.channelId ? event : { ...event, channelId };
+    const platformId = `slack:${channelId}`;
+    const ownBotUserId = await resolveOwnBotUserId(normalizedEvent.instance, opts.rootDir ?? process.cwd());
+    const isOwnBot = ownBotUserId !== undefined && normalizedEvent.userId === ownBotUserId;
+
+    if (isOwnBot) {
+      if (normalizedEvent.left) handleOwnLeft(normalizedEvent, platformId);
+      else await handleOwnJoin(normalizedEvent, platformId, opts);
+      return;
+    }
+    handleMemberChange(normalizedEvent, platformId);
+  } catch (err) {
+    log.error('slack-room-membership: event handling failed', {
+      channelId: event.channelId,
+      userId: event.userId,
+      err,
+    });
+  }
+}


### PR DESCRIPTION
Lands the rest of the channel layer, every trunk gate now merged:

- **Defaults factory**: slack.ts exports SLACK_DEFAULTS + the parameterized bridge factory. sessionMode 'per-thread' is declared for BOTH contexts — Slack is per-thread everywhere, no DM/room split. Creation-time stamps only: existing wirings never flip. The type-compat shim is deleted (the session-mode contract and decline_notify arrived with the sync underneath).
- **Room membership**: adopt-on-invite, MPIM-fork carry-over, detach/re-attach, owner-presence policy — registering through the bridge membership hook and the channel-card interceptor.
- **DM onboarding + thread titles**: welcome prompts and auto-title, evicted from trunk delivery/router into the channel layer via the post-delivery, session-created, and dm-opened hooks.
- **A2A bot-authored inbound guard**: registers directly through the bridge inbound-policy seam (its feature-detect fallback removed — the seam is real here now).
- Barrels activated per the branch's fully-loaded convention: './slack.js', membership, onboarding. slack-registration now passes.

Verification: targeted suites 154/154 (session-defaults, slack-lib, a2a-guard, membership, onboarding, canvas, guard conformance); full run strictly better than the branch baseline (11 → 10 pre-existing failures, slack-registration flipped to passing, zero new); tsc adds zero errors beyond the pre-existing deltachat baseline.

With this merged, new Slack installs get per-thread sessions in channels as well as DMs, with ambient context (same-mg fan + channel-timeline backfill) as the continuity layer. Canvas-comment shadow channels stay shared — the documented exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
