### PR TITLE
cross-session context: extend new-session backfill to group conversations

### DIFF
--- a/container/agent-runner/src/cross-session-echo.test.ts
+++ b/container/agent-runner/src/cross-session-echo.test.ts
@@ -95,6 +95,25 @@ describe('formatter rendering', () => {
     expect(result).not.toContain('<message');
   });
 
+  it('renders channel-timeline backfill rows as <channel-history> (group-surface prelude)', () => {
+    insertMessage(
+      'bf-ch-1',
+      'chat',
+      {
+        text: 'earlier in the channel',
+        sender: 'Gavriel',
+        senderId: 'slack:U1',
+        echo: { surface: 'channel-timeline', label: 'this channel, just before this conversation' },
+      },
+      { trigger: 0, channelType: 'session-echo' },
+    );
+
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain('<channel-history sender="Gavriel"');
+    expect(result).toContain('earlier in the channel</channel-history>');
+    expect(result).not.toContain('<message');
+  });
+
   it('XML-escapes label, sender, and text', () => {
     insertEcho('e1', { text: '<b>&"hi"</b>', sender: 'A & B', label: 'DM with <Gavriel>' });
 

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -223,13 +223,15 @@ function formatEchoMessage(msg: MessageInRow): string {
   const label = content.echo?.label || 'another conversation';
   const sender = content.sender || 'Unknown';
   const time = formatLocalStamp(new Date(msg.timestamp), TIMEZONE);
-  // dm-timeline rows are the DM's own preceding timeline — FIRST-CLASS
-  // conversation history this thread continues from (the agent's own posts
-  // render as sender="you"), unlike cross-session-context ambient echoes
-  // from other live surfaces which must never be acted on in-place.
-  if (content.echo?.surface === 'dm-timeline') {
+  // Timeline rows are the conversation's own preceding history — FIRST-CLASS
+  // context this thread continues from (the agent's own posts render as
+  // sender="you"), unlike cross-session-context ambient echoes from other
+  // live surfaces which must never be acted on in-place. dm-timeline = a DM's
+  // timeline; channel-timeline = a group conversation's (per-thread groups).
+  if (content.echo?.surface === 'dm-timeline' || content.echo?.surface === 'channel-timeline') {
     const who = (content as { self?: boolean }).self ? 'you' : sender;
-    return `<dm-history sender="${escapeXml(who)}" time="${escapeXml(time)}">${escapeXml(content.text || '')}</dm-history>`;
+    const tag = content.echo.surface === 'channel-timeline' ? 'channel-history' : 'dm-history';
+    return `<${tag} sender="${escapeXml(who)}" time="${escapeXml(time)}">${escapeXml(content.text || '')}</${tag}>`;
   }
   return `<cross-session-context from="${escapeXml(label)}" sender="${escapeXml(sender)}" time="${escapeXml(time)}">${escapeXml(content.text || '')}</cross-session-context>`;
 }

--- a/src/modules/cross-session-context/backfill.test.ts
+++ b/src/modules/cross-session-context/backfill.test.ts
@@ -1,10 +1,11 @@
 /**
  * New-session backfill (the pull half of cross-session context): a just-born
- * DM session is seeded with the DM's TOP-LEVEL timeline from sibling sessions
- * — each sibling's root user message + top-level agent posts (welcome-style),
- * never the interiors of other threads. Live-hit this guards against: the
- * user replies to the welcome tour offer, the reply roots a new thread, and
- * the fresh session knows nothing about the offer.
+ * session is seeded with its conversation's TOP-LEVEL timeline from sibling
+ * sessions — each sibling's root user message + top-level agent posts
+ * (welcome-style), never the interiors of other threads. DMs seed under the
+ * dm-timeline surface, group conversations under channel-timeline. Live-hit
+ * this guards against: the user replies to the welcome tour offer, the reply
+ * roots a new thread, and the fresh session knows nothing about the offer.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -42,7 +43,7 @@ vi.mock('../../db/sessions.js', () => ({
   isTaskThread: (t: string) => t.startsWith('system:tasks'),
 }));
 
-const { backfillNewDmSession, BACKFILL_LIMIT } = await import('./backfill.js');
+const { backfillNewSession, BACKFILL_LIMIT } = await import('./backfill.js');
 
 const AG = { id: 'ag-1', name: 'Pete', folder: 'pete', agent_provider: null, created_at: '' } as never;
 const DM_MG = { id: 'mg-dm', channel_type: 'slack', platform_id: 'slack:D1', is_group: 0 } as never;
@@ -67,14 +68,14 @@ beforeEach(() => {
   siblingSessions = [{ id: 'sess-old', status: 'active', messaging_group_id: 'mg-dm' }];
 });
 
-describe('backfillNewDmSession', () => {
+describe('backfillNewSession', () => {
   it('seeds the new session with sibling roots + top-level agent posts, ordered by time', () => {
     outboundRows = [
       { timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'Hey Gavriel! I am Pete… tour?' }) },
     ];
     inboundRows = [{ timestamp: '2026-08-01T19:10:00Z', content: chat('hello there') }];
 
-    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    backfillNewSession(AG, NEW_SESSION, DM_MG);
 
     expect(written).toHaveLength(2);
     expect(written[0]).toMatchObject({
@@ -94,19 +95,33 @@ describe('backfillNewDmSession', () => {
   });
 
   it('queries only conversation roots inbound and top-level outbound (SQL shape)', () => {
-    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    backfillNewSession(AG, NEW_SESSION, DM_MG);
     expect(inboundSql[0]).toContain('ORDER BY seq ASC LIMIT 1');
     expect(inboundSql[0]).toContain('trigger = 1');
     expect(outboundSql[0]).toContain("thread_id IS NULL OR thread_id = '' OR thread_id LIKE '%:'");
     expect(outboundSql[0]).toContain("kind NOT IN ('system','task_log')");
   });
 
-  it('skips rooms, task sessions, and sessions without siblings', () => {
-    backfillNewDmSession(AG, NEW_SESSION, ROOM_MG);
-    backfillNewDmSession(AG, { ...(NEW_SESSION as object), thread_id: 'system:tasks:t-1' } as never, DM_MG);
+  it('skips task sessions and sessions without siblings', () => {
+    backfillNewSession(AG, { ...(NEW_SESSION as object), thread_id: 'system:tasks:t-1' } as never, DM_MG);
     siblingSessions = [];
-    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    backfillNewSession(AG, NEW_SESSION, DM_MG);
     expect(written).toHaveLength(0);
+  });
+
+  it('seeds group-surface sessions with the channel timeline: channel-timeline surface + channel label', () => {
+    siblingSessions = [{ id: 'sess-room-t1', status: 'active', messaging_group_id: 'mg-room' }];
+    inboundRows = [{ timestamp: '2026-08-01T19:10:00Z', content: chat('thread root msg') }];
+    outboundRows = [{ timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'top-level agent post' }) }];
+
+    backfillNewSession(AG, NEW_SESSION, ROOM_MG);
+
+    expect(written).toHaveLength(2);
+    const first = JSON.parse(written[0]!.content as string) as Record<string, unknown>;
+    expect((first.echo as Record<string, unknown>).surface).toBe('channel-timeline');
+    expect((first.echo as Record<string, unknown>).label).toBe('this channel, just before this conversation');
+    const second = JSON.parse(written[1]!.content as string) as Record<string, unknown>;
+    expect(second.self).toBe(true);
   });
 
   it('ignores system-sender roots and caps at BACKFILL_LIMIT newest rows', () => {
@@ -116,7 +131,7 @@ describe('backfillNewDmSession', () => {
       content: JSON.stringify({ text: `post ${i}` }),
     }));
 
-    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    backfillNewSession(AG, NEW_SESSION, DM_MG);
 
     expect(written).toHaveLength(BACKFILL_LIMIT);
     const texts = written.map((w) => (JSON.parse(w.content as string) as { text: string }).text);
@@ -126,7 +141,7 @@ describe('backfillNewDmSession', () => {
 
   it('only considers siblings of the same messaging group', () => {
     siblingSessions = [{ id: 'sess-other-dm', status: 'active', messaging_group_id: 'mg-other' }];
-    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    backfillNewSession(AG, NEW_SESSION, DM_MG);
     expect(written).toHaveLength(0);
   });
 });

--- a/src/modules/cross-session-context/backfill.ts
+++ b/src/modules/cross-session-context/backfill.ts
@@ -2,12 +2,13 @@
  * New-session backfill — the pull half of cross-session context.
  *
  * The fan-out layer (fan.ts) pushes echoes only into sessions that EXIST at
- * delivery time, so a brand-new per-thread DM session is born blind: the user
- * replies to something the agent just said in another thread (live-hit: the
- * welcome message tour offer) and the fresh session has no idea. At session
- * birth we seed the new session with the most recent user-facing exchanges
- * from sibling sessions of the SAME messaging group — identical audience, so
- * the same privacy argument as the dm-thread fan applies.
+ * delivery time, so a brand-new per-thread session is born blind: the user
+ * replies to something said at the conversation's top level (live-hit: the
+ * welcome message tour offer in a DM) and the fresh session has no idea. At
+ * session birth we seed the new session with the most recent user-facing
+ * exchanges from sibling sessions of the SAME messaging group — identical
+ * audience, DM or group alike, so the same privacy argument as the sibling
+ * fan applies.
  *
  * Bounded: last BACKFILL_LIMIT rows across all siblings, echo truncation as
  * usual. Rows are trigger=0 session-echo rows written BEFORE the triggering
@@ -19,7 +20,7 @@ import { getSessionsByAgentGroup, isTaskThread } from '../../db/sessions.js';
 import { log } from '../../log.js';
 import { inboundDbPath, openOutboundDb, withInboundDb, writeSessionMessage } from '../../session-manager.js';
 import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
-import { ECHO_CHANNEL_TYPE, ECHO_TIMELINE_SURFACE } from './config.js';
+import { ECHO_CHANNEL_TIMELINE_SURFACE, ECHO_CHANNEL_TYPE, ECHO_TIMELINE_SURFACE } from './config.js';
 import { truncateEchoText } from './fan.js';
 
 export const BACKFILL_LIMIT = 12;
@@ -112,13 +113,14 @@ function collectSiblingTopLevel(agentGroup: AgentGroup, sessionId: string, limit
 }
 
 /**
- * Seed a just-created DM session with recent sibling-thread context. Call
- * BEFORE the triggering message is written. Non-throwing; no-ops for rooms,
- * task sessions, and sessions with no siblings.
+ * Seed a just-created session with recent sibling context from the SAME
+ * conversation. Group surfaces can be per-thread like DMs, so both get the
+ * conversation's top-level timeline at thread birth — same messaging group
+ * means the same audience. Call BEFORE the triggering message is written.
+ * Non-throwing; no-ops for task sessions and sessions with no siblings.
  */
-export function backfillNewDmSession(agentGroup: AgentGroup, session: Session, mg: MessagingGroup): void {
+export function backfillNewSession(agentGroup: AgentGroup, session: Session, mg: MessagingGroup): void {
   try {
-    if (mg.is_group !== 0) return;
     if (session.thread_id !== null && isTaskThread(session.thread_id)) return;
 
     const siblings = getSessionsByAgentGroup(agentGroup.id).filter(
@@ -134,7 +136,11 @@ export function backfillNewDmSession(agentGroup: AgentGroup, session: Session, m
     const newest = rows.slice(-BACKFILL_LIMIT);
     if (newest.length === 0) return;
 
-    const label = 'this DM, just before this conversation';
+    const isGroupSurface = mg.is_group === 1;
+    const label = isGroupSurface
+      ? 'this channel, just before this conversation'
+      : 'this DM, just before this conversation';
+    const surface = isGroupSurface ? ECHO_CHANNEL_TIMELINE_SURFACE : ECHO_TIMELINE_SURFACE;
     newest.forEach((row, i) => {
       // The most recent entry is what a short opener ("sure") is usually
       // answering — deliver it whole; earlier entries get the normal cap.
@@ -149,12 +155,12 @@ export function backfillNewDmSession(agentGroup: AgentGroup, session: Session, m
           sender: row.sender,
           senderId: row.senderId,
           ...(row.self ? { self: true } : {}),
-          echo: { surface: ECHO_TIMELINE_SURFACE, label },
+          echo: { surface, label },
         }),
         trigger: 0,
       });
     });
-    log.debug('Backfilled new DM session with sibling context', {
+    log.debug('Backfilled new session with conversation timeline', {
       sessionId: session.id,
       rows: newest.length,
       siblings: siblings.length,

--- a/src/modules/cross-session-context/config.ts
+++ b/src/modules/cross-session-context/config.ts
@@ -36,3 +36,8 @@ export const ECHO_MAX_AGE_DAYS = 7;
 /** Backfill prelude surface: THIS DM's preceding timeline (first-class
  *  conversation history), distinct from live cross-thread fan echoes. */
 export const ECHO_TIMELINE_SURFACE = 'dm-timeline';
+
+/** Backfill prelude surface for group conversations: group surfaces can be
+ *  per-thread too, so a new thread session is seeded with the channel's
+ *  top-level timeline — same messaging group means the same audience. */
+export const ECHO_CHANNEL_TIMELINE_SURFACE = 'channel-timeline';

--- a/src/modules/cross-session-context/index.ts
+++ b/src/modules/cross-session-context/index.ts
@@ -40,4 +40,4 @@ export {
   sessionHistory,
   type HistoryRow,
 } from './history.js';
-export { backfillNewDmSession, BACKFILL_LIMIT } from './backfill.js';
+export { backfillNewSession, BACKFILL_LIMIT } from './backfill.js';

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,7 +28,7 @@ import {
   getMessagingGroupWithAgentCount,
 } from './db/messaging-groups.js';
 import { findSessionForAgent } from './db/sessions.js';
-import { backfillNewDmSession, fanInboundMessage } from './modules/cross-session-context/index.js';
+import { backfillNewSession, fanInboundMessage } from './modules/cross-session-context/index.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
@@ -557,11 +557,11 @@ async function deliverToAgent(
   }
 
   if (wake && created) {
-    // New-session backfill (cross-session context): a just-born DM session is
-    // seeded with the DM's top-level timeline from sibling sessions BEFORE
-    // the triggering message is written, so replying to something said in
-    // another conversation thread lands with that context in view.
-    backfillNewDmSession(agentGroup, session, mg);
+    // New-session backfill (cross-session context): a just-born session is
+    // seeded with its conversation's top-level timeline from sibling
+    // sessions BEFORE the triggering message is written, so replying to
+    // something said in another thread lands with that context in view.
+    backfillNewSession(agentGroup, session, mg);
   }
 
   const messageId = messageIdForAgent(event.message.id, agent.agent_group_id);


### PR DESCRIPTION
## What

Extends the cross-session-context module's new-session backfill from DM-only to group conversations. `backfillNewDmSession` becomes `backfillNewSession`; a just-born session in a group conversation is seeded with the channel's top-level timeline under a new `channel-timeline` wire surface (DMs keep `dm-timeline` unchanged), and the container formatter renders it as `<channel-history>` alongside `<dm-history>`.

## Why

Adapter-declared session-mode context defaults (#3304) let a group wiring run per-thread sessions — the same shape DMs already use. A new thread session in a group conversation therefore starts exactly like a new DM thread, except the backfill was DM-only, so it was born with no view of the conversation it continues (e.g. a short threaded reply to something said at top level lands with no context).

The DM-only restriction was caution, not privacy: the module's audience rule is that the same messaging group means an identical audience, and that holds for group conversations exactly as for DMs. Everything the backfill seeds was already visible to every participant of that conversation.

## Mechanics

- `src/modules/cross-session-context/backfill.ts` — drop the `mg.is_group !== 0` early return; pick surface + label by `mg.is_group` (`channel-timeline` / "this channel, just before this conversation" for groups, existing `dm-timeline` / DM label otherwise). Task-session skip and all bounds (`BACKFILL_LIMIT`, roots-only inbound, top-level-only outbound, truncation, whole-delivery of the newest entry) unchanged.
- `src/modules/cross-session-context/config.ts` — new `ECHO_CHANNEL_TIMELINE_SURFACE = 'channel-timeline'`.
- `src/modules/cross-session-context/index.ts`, `src/router.ts` — rename `backfillNewDmSession` → `backfillNewSession` at the export and the single call site.
- `container/agent-runner/src/formatter.ts` — timeline rendering now matches both surfaces; `channel-timeline` rows emit `<channel-history>`, `dm-timeline` rows keep emitting `<dm-history>` byte-for-byte. Ambient `<cross-session-context>` echoes unchanged.
- Tests: `backfill.test.ts` replaces the "skips rooms" assertion with a group-surface seeding test (surface + label + `self` marking) and renames call sites; `cross-session-echo.test.ts` adds a `<channel-history>` rendering test.

No schema, config-surface, or behavior change for DMs; group conversations only gain the same thread-birth prelude DMs already had.

## Verification

- `pnpm run build` — clean.
- `pnpm exec vitest run src/modules/cross-session-context/` — 4 files, 35 tests passed.
- `pnpm test` — 124 files, 1556 tests passed.
- `cd container/agent-runner && bun test cross-session-echo formatter` — 44 pass, 0 fail.
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)