### PR TITLE
skills: channel welcome addenda, matched host-side (zero cost when absent)

### DIFF
--- a/container/skills/welcome/SKILL.md
+++ b/container/skills/welcome/SKILL.md
@@ -7,6 +7,14 @@ description: Introduce yourself to a newly connected channel. Triggered automati
 
 You've just been connected to a new user. This your time to shine and make a strong first impression. Introduce yourself and guide the user through what you can do. you got this!
 
+## Channel addenda
+
+The instruction that triggered this welcome may name a channel addendum file
+(e.g. `/app/skills/welcome/addenda/slack.md`). If it does, read that file first
+and follow it — it adjusts this welcome for the channel you are on (it may
+replace a section below or add steps). If no addendum is named, run this skill
+exactly as written.
+
 ## What to do
 
 1. Send a short, warm greeting
@@ -95,7 +103,7 @@ After the tour, finish with an open invitation. Ask if they want help with somet
 
 ## Tone
 
-Warm, confident, inviting. Make the user feel like they just unlocked something powerful. Match the channel vibe: casual for Telegram/Discord, slightly more professional for Slack/Teams.
+Warm, confident, inviting. Make the user feel like they just unlocked something powerful. Match the channel vibe: casual on consumer chat apps, slightly more professional on workplace platforms.
 
 ## Important
 

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -32,6 +32,7 @@
  * For direct-addressable channels (telegram, whatsapp, etc.), --platform-id
  * is typically the same as the handle in --user-id, with the channel prefix.
  */
+import fs from 'fs';
 import net from 'net';
 import path from 'path';
 
@@ -77,6 +78,23 @@ interface Args {
 }
 
 const DEFAULT_WELCOME = 'System instruction: run /welcome to introduce yourself to the user on this new channel.';
+
+/**
+ * Channel-specific welcome addendum, matched HOST-SIDE: this composer knows
+ * the channel, so the welcome skill never scans for applicability — it just
+ * follows the pointer when one is present. Channel install skills drop
+ * `container/skills/welcome/addenda/<channel>.md`; with no file the default
+ * welcome is byte-identical to today's and the skill runs as written.
+ * An explicit --welcome override is always respected verbatim.
+ */
+function defaultWelcome(channel: string): string {
+  const hostPath = path.resolve(process.cwd(), 'container', 'skills', 'welcome', 'addenda', `${channel}.md`);
+  if (!fs.existsSync(hostPath)) return DEFAULT_WELCOME;
+  return (
+    `${DEFAULT_WELCOME} First read /app/skills/welcome/addenda/${channel}.md and follow it — ` +
+    'it adjusts the welcome for this channel.'
+  );
+}
 
 const DEFAULT_ROLE: Role = 'owner';
 
@@ -148,7 +166,7 @@ function parseArgs(argv: string[]): Args {
     displayName: out.displayName!,
     agentName: out.agentName?.trim() || out.displayName!,
     agentGroupId: out.agentGroupId?.trim() || undefined,
-    welcome: out.welcome?.trim() || DEFAULT_WELCOME,
+    welcome: out.welcome?.trim() || defaultWelcome(out.channel!),
     role: out.role ?? DEFAULT_ROLE,
     engagePattern: out.engagePattern?.trim() || undefined,
   };


### PR DESCRIPTION
## What

Channel install skills can now drop `container/skills/welcome/addenda/<channel>.md` to adjust the first-agent welcome for their channel. The welcome trigger composer (`scripts/init-first-agent.ts`), which already knows the channel, appends a pointer to `/app/skills/welcome/addenda/<channel>.md` to the default welcome instruction — only when that file exists on the host. The base welcome skill stays channel-neutral, with a short fallback: if the trigger names an addendum, read and follow it; otherwise run as written.

## Why

Previously a channel install that wanted a channel-flavored welcome had to edit the base welcome `SKILL.md` in place. That makes the base skill channel-flavored, couples it to whichever channels happen to be installed, and turns every base-skill update into a conflict against those in-place edits. A drop-in addendum file keeps the base skill a single shared artifact and gives each channel an isolated, additive extension point.

## Mechanics

- `defaultWelcome(channel)` in `scripts/init-first-agent.ts`: resolves `container/skills/welcome/addenda/<channel>.md` on the host; if absent, returns the unchanged default welcome (byte-identical to before); if present, appends one sentence pointing the agent at the container path of that exact file.
- Deterministic applicability matching lives host-side — the welcome skill never scans a directory or probes for files; it just follows the pointer when one is present. No addendum means no extra reads and no convention prose at welcome time.
- An explicit `--welcome` override is respected verbatim, bypassing the addendum logic entirely.
- `container/skills/welcome/SKILL.md` gains a short "Channel addenda" section (the fallback contract) and a genericized Tone line so the base text names no specific channels.

## Verification

- `pnpm run build` — clean.
- `pnpm exec vitest run scripts/ setup/ src/channels/channel-session-defaults.test.ts` — 35 files / 583 tests passed.
- `pnpm test` — 124 files / 1555 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)