### PR TITLE
setup: optional automatic Slack app provisioning behind an opt-in flag

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -25,6 +25,21 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
+# ─── --slack-agents: opt-in flag → env passthrough ─────────────────────
+# Consumed here rather than forwarded: setup:auto reads the env var
+# (NANOCLAW_SLACK_AGENTS=1, checked in setup/channels/slack-auto-register.ts).
+# Without the flag, nothing changes.
+_filtered_args=()
+for arg in "$@"; do
+  if [ "$arg" = "--slack-agents" ]; then
+    export NANOCLAW_SLACK_AGENTS=1
+  else
+    _filtered_args+=("$arg")
+  fi
+done
+set -- ${_filtered_args[@]+"${_filtered_args[@]}"}
+unset _filtered_args
+
 # ─── --help: show usage without bootstrapping ──────────────────────────
 for arg in "$@"; do
   if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then

--- a/setup/channels/companions.ts
+++ b/setup/channels/companions.ts
@@ -24,6 +24,8 @@
  * adapter barrel) — trunk ships none.
  */
 
+import { registerSlackAutoProvision } from './slack-auto-register.js';
+
 /**
  * A channel's auto-provision pre-step. `agentName` is the operator's resolved
  * assistant name. Resolves to the skill inputs to pre-bind, or undefined for
@@ -56,3 +58,9 @@ export function getCompanionSkills(channel: string): readonly string[] {
 }
 
 // ── Feature self-registration imports (appended by channel install skills) ──
+
+// Env-gated registrations shipped with trunk. Each shim checks its opt-in
+// flag and returns without touching the registries when it is off; the
+// register function is passed in (rather than the shim importing it) so the
+// shim stays cycle-free and evaluates nothing beyond the flag check.
+registerSlackAutoProvision(registerChannelPreStep);

--- a/setup/channels/slack-auto-register.test.ts
+++ b/setup/channels/slack-auto-register.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The NANOCLAW_SLACK_AGENTS opt-in gate.
+ *
+ * Flag off (the default) must leave the wizard exactly as shipped: no
+ * pre-step registered for slack, no companion skills declared, and the
+ * provisioning flow never evaluated. Flag on registers the pre-step, which
+ * lazy-loads the flow only when the wizard actually invokes it.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { registerSlackAutoProvision } from './slack-auto-register.js';
+
+afterEach(() => {
+  delete process.env.NANOCLAW_SLACK_AGENTS;
+  vi.doUnmock('./slack-auto.js');
+  vi.resetModules();
+});
+
+describe('registerSlackAutoProvision', () => {
+  it('flag unset: registers nothing', () => {
+    const register = vi.fn();
+    registerSlackAutoProvision(register, {});
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('only "1" enables — other values register nothing', () => {
+    const register = vi.fn();
+    for (const value of ['', '0', 'false', 'yes', 'true']) {
+      registerSlackAutoProvision(register, { NANOCLAW_SLACK_AGENTS: value });
+    }
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('flag "1": registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
+    const register = vi.fn();
+    registerSlackAutoProvision(register, { NANOCLAW_SLACK_AGENTS: '1' });
+
+    expect(register).toHaveBeenCalledTimes(1);
+    const [channel, step] = register.mock.calls[0];
+    expect(channel).toBe('slack');
+
+    // The flow module is only reached through the pre-step's dynamic import.
+    const maybeAutoProvisionSlack = vi.fn(async (name: string) => ({ bot_token: `xoxb-for-${name}` }));
+    vi.doMock('./slack-auto.js', () => ({ maybeAutoProvisionSlack }));
+    await expect(step('Nano')).resolves.toEqual({ bot_token: 'xoxb-for-Nano' });
+    expect(maybeAutoProvisionSlack).toHaveBeenCalledExactlyOnceWith('Nano');
+  });
+});
+
+describe('companions registry wiring', () => {
+  it('flag unset: a fresh companions module has no slack hooks at all', async () => {
+    delete process.env.NANOCLAW_SLACK_AGENTS;
+    vi.resetModules();
+    const companions = await import('./companions.js');
+    expect(companions.getChannelPreStep('slack')).toBeUndefined();
+    expect(companions.getCompanionSkills('slack')).toEqual([]);
+  });
+
+  it('flag "1": a fresh companions module carries the slack pre-step', async () => {
+    process.env.NANOCLAW_SLACK_AGENTS = '1';
+    vi.resetModules();
+    const companions = await import('./companions.js');
+    expect(companions.getChannelPreStep('slack')).toBeTypeOf('function');
+    // Companion skills stay undeclared either way — the add-slack skill
+    // payload owns those; an absent declaration just means none run.
+    expect(companions.getCompanionSkills('slack')).toEqual([]);
+  });
+});

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -1,0 +1,33 @@
+/**
+ * Opt-in registration for automatic Slack app provisioning.
+ *
+ * This shim is the only piece of the feature on the default wizard path.
+ * It checks the NANOCLAW_SLACK_AGENTS env flag ("1" enables it — set the
+ * var directly or pass `--slack-agents` to nanoclaw.sh) and returns without
+ * registering anything when the flag is off, leaving the wizard identical
+ * to a build without the feature. The flow itself (slack-auto.ts plus the
+ * provisioning core it bootstraps from the channels branch — the module's
+ * permanent home is the add-slack channel payload, at
+ * src/provisioning/slack-app.ts on an installed tree) loads via dynamic
+ * import only after the flag check passes AND the wizard actually invokes
+ * the Slack pre-step. No fetch, no import, nothing runs while the flag is
+ * off.
+ *
+ * The register function is injected by the caller (companions.ts passes
+ * `registerChannelPreStep`) so this module has zero runtime imports — no
+ * import cycle with the registry, nothing evaluated beyond the env check.
+ */
+import type { ChannelPreStep } from './companions.js';
+
+export const SLACK_AGENTS_FLAG = 'NANOCLAW_SLACK_AGENTS';
+
+export function registerSlackAutoProvision(
+  register: (channel: string, step: ChannelPreStep) => void,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env[SLACK_AGENTS_FLAG] !== '1') return;
+  register('slack', async (agentName) => {
+    const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
+    return maybeAutoProvisionSlack(agentName);
+  });
+}

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -1,0 +1,230 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  account: undefined as { api?: string; token: string } | undefined,
+  installToken: undefined as string | undefined,
+  notes: [] as Array<{ message: string; title: string }>,
+  warns: [] as string[],
+  runInheritScript: vi.fn(async () => 0),
+  brokerListWorkspaces: vi.fn(async () => [
+    { team_id: 'T0TEAM123', team_name: 'NanoCo', status: 'active', connected_as: 'U0OWNER12' },
+  ]),
+  brokerProvision: vi.fn(async () => ({
+    appId: 'A0APP123',
+    appToken: 'xapp-test',
+    botToken: 'xoxb-test',
+    installUrl: '',
+  })),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  note: vi.fn((message: string, title: string) => state.notes.push({ message, title })),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: { warn: vi.fn((message: string) => state.warns.push(message)) },
+}));
+
+vi.mock('../logs.js', () => ({ userInput: vi.fn(), step: vi.fn() }));
+vi.mock('../lib/bright-select.js', () => ({ brightSelect: vi.fn(async () => 'auto') }));
+vi.mock('../lib/browser.js', () => ({ confirmThenOpen: vi.fn() }));
+vi.mock('../lib/inherit-script.js', () => ({ runInheritScript: state.runInheritScript }));
+vi.mock('../lib/registry-state.js', () => ({
+  REGISTRY_LOGIN_SCRIPT: 'setup/registry-login.sh',
+  imageSourceDecided: vi.fn(() => false),
+  loginScriptAvailable: vi.fn(() => true),
+  readImageSource: vi.fn(() => 'local'),
+  readRegistryAccount: vi.fn(() => state.account),
+  writeImageSource: vi.fn(),
+}));
+vi.mock('../lib/runner.js', () => ({ ensureAnswer: <T>(answer: T): T => answer }));
+vi.mock('../lib/theme.js', () => ({ wrapForGutter: (message: string): string => message }));
+
+import {
+  PROVISIONING_MODULE,
+  loadProvisioningCore,
+  maybeAutoProvisionSlack,
+  type ProvisioningCore,
+} from './slack-auto.js';
+
+/**
+ * The provisioning core is NOT in this tree (it ships in the add-slack
+ * channel payload), so the tests never import the real module: the fake
+ * below stands in via the injectable importModule seam, and the bootstrap's
+ * git commands go through the injectable exec — no fetch ever leaves a test.
+ */
+class FakeBrokerHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly path: string,
+  ) {
+    super(`HTTP ${status}`);
+  }
+}
+
+function fakeCore(): ProvisioningCore {
+  return {
+    BrokerHttpError: FakeBrokerHttpError,
+    brokerListWorkspaces: state.brokerListWorkspaces,
+    brokerOauthUrl: vi.fn(async () => ({ url: 'https://example.invalid/oauth' })),
+    brokerProvision: state.brokerProvision,
+    provisionManagedApp: vi.fn(async () => {
+      throw new Error('unexpected direct provisioning');
+    }),
+    readInstallToken: vi.fn(() => state.installToken),
+    readManagerToken: vi.fn(() => undefined),
+  };
+}
+
+/** A root where the module already sits at its installed-tree path. */
+function rootWithModule(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-auto-'));
+  const modulePath = path.join(root, PROVISIONING_MODULE);
+  fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+  fs.writeFileSync(modulePath, '// stand-in — tests inject importModule\n');
+  return root;
+}
+
+const roots: string[] = [];
+function track(root: string): string {
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('provisioning-core bootstrap', () => {
+  beforeEach(() => {
+    state.warns.length = 0;
+  });
+
+  it('module present in the tree: imports it, never touches git', async () => {
+    const root = track(rootWithModule());
+    const exec = vi.fn<(command: string) => string>();
+    const core = fakeCore();
+    const importModule = vi.fn(async () => core);
+
+    await expect(loadProvisioningCore({ root, exec, importModule })).resolves.toBe(core);
+    expect(exec).not.toHaveBeenCalled();
+    expect(importModule).toHaveBeenCalledExactlyOnceWith(pathToFileURL(path.join(root, PROVISIONING_MODULE)).href);
+  });
+
+  it('module absent: fetches the channels branch and materializes the one file, engine-style', async () => {
+    const root = track(fs.mkdtempSync(path.join(os.tmpdir(), 'slack-auto-')));
+    const exec = vi.fn((command: string): string => {
+      if (command === 'git remote') return 'upstream\norigin\n';
+      if (command.startsWith('git ls-remote')) return 'abc123\trefs/heads/channels\n';
+      return '';
+    });
+    const core = fakeCore();
+    const importModule = vi.fn(async () => core);
+
+    await expect(loadProvisioningCore({ root, exec, importModule })).resolves.toBe(core);
+    // origin wins remote resolution even when listed after another remote
+    expect(exec.mock.calls.map(([c]) => c)).toEqual([
+      'git remote',
+      'git ls-remote --heads origin channels',
+      'git fetch origin channels',
+      `git show origin/channels:${PROVISIONING_MODULE} > ${PROVISIONING_MODULE}`,
+    ]);
+    // the parent directory exists before the git show redirect runs
+    expect(fs.existsSync(path.join(root, 'src/provisioning'))).toBe(true);
+    expect(importModule).toHaveBeenCalledExactlyOnceWith(pathToFileURL(path.join(root, PROVISIONING_MODULE)).href);
+  });
+
+  it('module absent and the fetch fails (offline / no branch): resolves undefined, never imports', async () => {
+    const root = track(fs.mkdtempSync(path.join(os.tmpdir(), 'slack-auto-')));
+    const exec = vi.fn((): string => {
+      throw new Error('could not read from remote repository');
+    });
+    const importModule = vi.fn(async () => fakeCore());
+
+    await expect(loadProvisioningCore({ root, exec, importModule })).resolves.toBeUndefined();
+    expect(importModule).not.toHaveBeenCalled();
+  });
+
+  it('bootstrap failure degrades the pre-step to the manual path with one warning line', async () => {
+    const root = track(fs.mkdtempSync(path.join(os.tmpdir(), 'slack-auto-')));
+    const exec = vi.fn((): string => {
+      throw new Error('could not read from remote repository');
+    });
+
+    await expect(maybeAutoProvisionSlack('Trusty', { root, exec })).resolves.toBeUndefined();
+    expect(state.warns).toEqual([
+      "Couldn't load the Slack provisioning module — walking through manual app creation instead.",
+    ]);
+  });
+
+  it('runtime probe: tsx imports a fetched .ts module file directly', () => {
+    const root = track(rootWithModule());
+    const modulePath = path.join(root, PROVISIONING_MODULE);
+    fs.writeFileSync(
+      modulePath,
+      [
+        '// TypeScript-only syntax on purpose: a plain-JS loader would reject this file.',
+        'export interface Probe { value: string }',
+        'export function readManagerToken(): string {',
+        "  const probe: Probe = { value: 'loaded-ts' };",
+        '  return probe.value;',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    const probePath = path.join(root, 'probe.ts');
+    fs.writeFileSync(
+      probePath,
+      `import(${JSON.stringify(pathToFileURL(modulePath).href)}).then((m) => process.stdout.write(m.readManagerToken()));\n`,
+    );
+    const tsxBin = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const result = spawnSync(tsxBin, [probePath], { encoding: 'utf-8' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('loaded-ts');
+  });
+});
+
+describe('Slack managed-app sign-in', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.notes.length = 0;
+    state.warns.length = 0;
+    state.installToken = 'nct-saved';
+    state.account = {
+      token: 'nct-saved',
+      api: 'https://user:password@registry.sandbox.nanoclaw.dev/private?token=secret',
+    };
+  });
+
+  it('validates a saved credential before using it and shows only its service origin', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    const result = await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    expect(state.runInheritScript).toHaveBeenCalledOnce();
+    expect(state.runInheritScript).toHaveBeenCalledWith('bash', ['setup/registry-login.sh']);
+    expect(state.brokerListWorkspaces).toHaveBeenCalledWith('nct-saved');
+    expect(result).toMatchObject({
+      connection: 'provisioned',
+      bot_token: 'xoxb-test',
+      app_token: 'xapp-test',
+      owner_handle: 'U0OWNER12',
+    });
+
+    expect(state.notes).toEqual([
+      {
+        title: 'NanoClaw sign-in',
+        message: [
+          'Found saved NanoClaw credentials.',
+          'Service: https://registry.sandbox.nanoclaw.dev',
+          'Checking whether they are valid for this setup…',
+        ].join('\n'),
+      },
+    ]);
+    expect(state.notes[0].message).not.toContain('password');
+    expect(state.notes[0].message).not.toContain('secret');
+  });
+});

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -1,0 +1,459 @@
+/**
+ * Automatic Slack app provisioning — the wizard's Slack channel pre-step.
+ *
+ * The add-slack SKILL.md owns the channel procedure (adapter install,
+ * credential prompts, auth.test, DM resolution, wire). This module runs
+ * BEFORE it and, when the operator opts in, provisions the agent's Slack app
+ * programmatically — through the managed-Slack broker (slack.nanoclaw.dev,
+ * authenticated with the registry install token; sign-in offered on demand)
+ * or directly with a SLACK_MANAGER_TOKEN. The provisioned tokens are handed
+ * to the skill as pre-bound `inputs`, so its nc:prompt directives skip and
+ * the rest of the flow (build, auth.test, wire, welcome) runs unchanged.
+ *
+ * This module is the wizard UX only — prompts, flow control, spinner copy.
+ * The provisioning core (manifest, scope sets, broker + direct-Slack
+ * transports) is NOT part of this tree: it ships in the add-slack channel
+ * payload and lives at src/provisioning/slack-app.ts on an installed tree.
+ * Before offering provisioning, this pre-step ensures the module is present —
+ * already installed means a plain dynamic import; otherwise it bootstraps that
+ * one file from the channels branch the same way the skill engine fetches
+ * payloads (git fetch + git show, remote resolution included). Setup runs
+ * under tsx, so importing the fetched .ts file directly works.
+ *
+ * Loaded ONLY behind the NANOCLAW_SLACK_AGENTS opt-in: slack-auto-register.ts
+ * dynamic-imports this module when the flag is set, so the default wizard
+ * never evaluates this file or its strings.
+ *
+ * Returns undefined to mean "walk the manual path" — never throws for
+ * expected declines (not signed in, provisioning refused, cancel) or for
+ * expected bootstrap failures (offline, branch missing, file missing).
+ */
+import * as p from '@clack/prompts';
+import k from 'kleur';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+import * as setupLog from '../logs.js';
+import { brightSelect } from '../lib/bright-select.js';
+import { confirmThenOpen } from '../lib/browser.js';
+import { runInheritScript } from '../lib/inherit-script.js';
+import {
+  REGISTRY_LOGIN_SCRIPT,
+  imageSourceDecided,
+  loginScriptAvailable,
+  readImageSource,
+  readRegistryAccount,
+  writeImageSource,
+} from '../lib/registry-state.js';
+import { ensureAnswer } from '../lib/runner.js';
+import { wrapForGutter } from '../lib/theme.js';
+
+const OAUTH_POLL_INTERVAL_MS = 5_000;
+const OAUTH_POLL_TIMEOUT_MS = 5 * 60_000;
+
+/** The provisioning core's home in an installed tree (the add-slack payload ships it). */
+export const PROVISIONING_MODULE = 'src/provisioning/slack-app.ts';
+const CHANNELS_BRANCH = 'channels';
+
+// Structural mirrors of the provisioning core's exported types. Deliberately
+// local: the module is not part of this tree, so nothing here may import its
+// types statically — the build must pass without src/provisioning present.
+export interface BrokerWorkspace {
+  team_id: string;
+  team_name: string;
+  status: string;
+  connected_as?: string;
+  connected_at?: string;
+}
+
+export interface ProvisionedApp {
+  appId: string;
+  /** xapp-… app-level token for Socket Mode. */
+  appToken: string;
+  /** xoxb-… bot token — absent when auto-install was refused. */
+  botToken?: string;
+  /** Manual install URL — the fallback when auto-install was refused. */
+  installUrl: string;
+  teamDomain?: string;
+  installError?: string;
+}
+
+/** The slice of src/provisioning/slack-app.ts this flow calls. */
+export interface ProvisioningCore {
+  BrokerHttpError: new (status: number, path: string, detail?: string) => Error & { status: number; path: string };
+  brokerListWorkspaces(token: string): Promise<BrokerWorkspace[]>;
+  brokerOauthUrl(token: string): Promise<{ url: string }>;
+  brokerProvision(token: string, spec: { team_id: string; name: string }): Promise<ProvisionedApp>;
+  provisionManagedApp(managerToken: string, spec: { name: string }): Promise<ProvisionedApp>;
+  readInstallToken(): string | undefined;
+  readManagerToken(): string | undefined;
+}
+
+/** Injection seam for tests — the bootstrap never touches git or the loader in a unit test. */
+export interface BootstrapDeps {
+  root?: string;
+  /** Run a shell command at root; returns stdout, throws on failure. */
+  exec?: (command: string) => string;
+  importModule?: (fileUrl: string) => Promise<ProvisioningCore>;
+}
+
+/**
+ * Mirror of the skill engine's remote resolution (defaultResolveRemote in
+ * scripts/skill-apply.ts): NANOCLAW_CHANNELS_REMOTE override first, else the
+ * first remote (origin preferred) that has the channels branch, else origin.
+ */
+function resolveChannelsRemote(exec: (command: string) => string): string {
+  const override = process.env.NANOCLAW_CHANNELS_REMOTE;
+  if (override) return override;
+  const cap = (command: string): string => {
+    try {
+      return exec(command);
+    } catch {
+      return '';
+    }
+  };
+  const remotes = cap('git remote')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const ordered = remotes.includes('origin') ? ['origin', ...remotes.filter((r) => r !== 'origin')] : remotes;
+  for (const r of ordered) if (cap(`git ls-remote --heads ${r} ${CHANNELS_BRANCH}`).trim()) return r;
+  return 'origin';
+}
+
+/**
+ * Ensure the provisioning core is present in the tree, then import it.
+ * Already installed (the add-slack payload carries it) → plain import, no
+ * fetch. Absent → materialize that one file from the channels branch exactly
+ * the way the skill engine copies payloads. Any failure resolves undefined —
+ * the caller logs one line and walks the manual path.
+ */
+export async function loadProvisioningCore(deps: BootstrapDeps = {}): Promise<ProvisioningCore | undefined> {
+  const root = deps.root ?? process.cwd();
+  const exec =
+    deps.exec ?? ((command: string) => execSync(command, { cwd: root, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
+  const importModule = deps.importModule ?? ((fileUrl: string) => import(fileUrl) as Promise<ProvisioningCore>);
+  const modulePath = path.join(root, PROVISIONING_MODULE);
+  const start = Date.now();
+  try {
+    if (!fs.existsSync(modulePath)) {
+      const remote = resolveChannelsRemote(exec);
+      exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
+      fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+      exec(`git show ${remote}/${CHANNELS_BRANCH}:${PROVISIONING_MODULE} > ${PROVISIONING_MODULE}`);
+      setupLog.step('slack-provision-bootstrap', 'success', Date.now() - start, { REMOTE: remote });
+    }
+    return await importModule(pathToFileURL(modulePath).href);
+  } catch (err) {
+    setupLog.step('slack-provision-bootstrap', 'failed', Date.now() - start, {
+      ERROR: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Offer to create the agent's Slack app programmatically. Resolves to the
+ * skill `inputs` to pre-bind (tokens + connection mode), or undefined for
+ * the manual walkthrough. `agentName` doubles as the Slack app name.
+ */
+export async function maybeAutoProvisionSlack(
+  agentName: string,
+  deps: BootstrapDeps = {},
+): Promise<Record<string, string> | undefined> {
+  const core = await loadProvisioningCore(deps);
+  if (!core) {
+    p.log.warn("Couldn't load the Slack provisioning module — walking through manual app creation instead.");
+    return undefined;
+  }
+  const managerToken = core.readManagerToken();
+  const installToken = managerToken ? undefined : core.readInstallToken();
+  // Offered even when not enrolled yet — signing in is a step of the flow,
+  // not a precondition for seeing it. Hidden only when this copy has no way
+  // to auto-provision at all.
+  if (!managerToken && !installToken && !loginScriptAvailable()) return undefined;
+
+  const needsSignIn = !managerToken && !installToken;
+  // Automatic provisioning leads as the default; supplying your own bot
+  // token stays available as the explicit, advanced alternative.
+  const mode = ensureAnswer(
+    await brightSelect<'auto' | 'manual'>({
+      message: 'How do you want to create the Slack app?',
+      initialValue: 'auto',
+      options: [
+        {
+          value: 'auto',
+          label: 'Create it for me',
+          hint: needsSignIn
+            ? 'sign in with your NanoClaw account, then app + install in one step'
+            : 'app + install in one step, no token pasting',
+        },
+        {
+          value: 'manual',
+          label: 'I will supply my own bot token',
+          hint: 'advanced — walk through api.slack.com/apps by hand',
+        },
+      ],
+    }),
+  );
+  setupLog.userInput('slack_provision_mode', mode);
+  if (mode === 'manual') return undefined;
+
+  if (managerToken) return provisionDirect(core, managerToken, agentName);
+
+  // The login driver is idempotent: it validates a matching saved credential
+  // without opening a browser, and re-authenticates when its issuer or token
+  // is stale. Always pass through it rather than treating "a token exists" as
+  // proof that the token belongs to this setup's registry environment.
+  const validatedToken = await signInForBroker(core);
+  if (!validatedToken) {
+    p.log.warn('Not signed in — walking through manual app creation instead.');
+    return undefined;
+  }
+  return provisionViaBroker(core, validatedToken, agentName);
+}
+
+/**
+ * Sign in with the NanoClaw account so the broker can act for this install.
+ * Reuses the registry login driver (device flow / enrollment code) — one
+ * account, one sign-in, shared by the image pull and the Slack broker.
+ *
+ * The login driver flips the install's image source to 'hardened' as a side
+ * effect (it exists to enable the pull). Signing in for Slack must not
+ * override a deliberate local-build choice, so a decided source is restored.
+ */
+async function signInForBroker(core: ProvisioningCore): Promise<string | undefined> {
+  const savedAccount = readRegistryAccount();
+  const savedService = displayServiceOrigin(savedAccount?.api);
+  p.note(
+    wrapForGutter(
+      savedAccount
+        ? [
+            'Found saved NanoClaw credentials.',
+            `Service: ${savedService ?? 'unknown'}`,
+            'Checking whether they are valid for this setup…',
+          ].join('\n')
+        : [
+            'Creating the app for you runs through your NanoClaw account.',
+            'A code appears below — finish the sign-in in your browser,',
+            'then come back here.',
+          ].join('\n'),
+      6,
+    ),
+    'NanoClaw sign-in',
+  );
+  const priorSource = imageSourceDecided() ? readImageSource() : undefined;
+  const start = Date.now();
+  const code = await runInheritScript('bash', [REGISTRY_LOGIN_SCRIPT]);
+  if (priorSource === 'local') writeImageSource('local');
+  const token = code === 0 ? core.readInstallToken() : undefined;
+  setupLog.step('slack-broker-login', token ? 'success' : code === 2 ? 'skipped' : 'failed', Date.now() - start, {
+    EXIT_CODE: String(code),
+  });
+  return token;
+}
+
+/** Display credential provenance without echoing paths, query strings, or userinfo. */
+function displayServiceOrigin(api: string | undefined): string | undefined {
+  if (!api) return undefined;
+  try {
+    const url = new URL(api);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.origin : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function provisionDirect(
+  core: ProvisioningCore,
+  managerToken: string,
+  name: string,
+): Promise<Record<string, string> | undefined> {
+  const s = p.spinner();
+  const start = Date.now();
+  s.start(`Creating ${name} in Slack… (~30s — generating its avatar first)`);
+  try {
+    const app = await core.provisionManagedApp(managerToken, { name });
+    return finishProvisioned(app, name, s, start, 'slack-provision');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    s.stop("Couldn't create the Slack app.", 1);
+    setupLog.step('slack-provision', 'failed', Date.now() - start, { ERROR: message });
+    p.log.warn(`Slack said: ${message}. Walking through manual app creation instead.`);
+    return undefined;
+  }
+}
+
+async function provisionViaBroker(
+  core: ProvisioningCore,
+  installToken: string,
+  name: string,
+): Promise<Record<string, string> | undefined> {
+  let workspaces: BrokerWorkspace[];
+  const s = p.spinner();
+  let start = Date.now();
+  s.start('Checking your connected Slack workspaces…');
+  try {
+    workspaces = (await core.brokerListWorkspaces(installToken)).filter((w) => w.status === 'active');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    s.stop("Couldn't reach the Slack service.", 1);
+    setupLog.step('slack-broker-workspaces', 'failed', Date.now() - start, { ERROR: message });
+    p.log.warn(`The service said: ${message}. Walking through manual app creation instead.`);
+    return undefined;
+  }
+  if (workspaces.length > 0) {
+    s.stop(
+      workspaces.length === 1
+        ? `Found your workspace: ${workspaces[0].team_name}.`
+        : `Found ${workspaces.length} connected workspaces.`,
+    );
+  } else {
+    s.stop('No Slack workspace is connected yet.');
+    workspaces = await connectWorkspace(core, installToken);
+    if (workspaces.length === 0) return undefined;
+  }
+
+  const workspace = await pickWorkspace(workspaces);
+  const s2 = p.spinner();
+  start = Date.now();
+  s2.start(`Creating ${name} in ${workspace.team_name}… (~30s — generating its avatar first)`);
+  try {
+    const app = await core.brokerProvision(installToken, { team_id: workspace.team_id, name });
+    const inputs = finishProvisioned(app, name, s2, start, 'slack-broker-provision');
+    // The broker knows who connected the workspace — pre-fill the member-ID
+    // prompt too (only when it matches the skill's validator; Enterprise Grid
+    // W-ids fall back to the prompt like before).
+    if (workspace.connected_as && /^U[A-Z0-9]{8,}$/.test(workspace.connected_as)) {
+      inputs.owner_handle = workspace.connected_as;
+    }
+    return inputs;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    s2.stop("Couldn't create the Slack app.", 1);
+    setupLog.step('slack-broker-provision', 'failed', Date.now() - start, { ERROR: message });
+    p.log.warn(`The service said: ${message}. Walking through manual app creation instead.`);
+    return undefined;
+  }
+}
+
+/**
+ * Map a provisioned app onto the skill's inputs. A refused auto-install
+ * (admin-approval policy) still returns the app token and lets the skill's
+ * own bot_token prompt collect the xoxb after the manual install.
+ */
+function finishProvisioned(
+  app: ProvisionedApp,
+  name: string,
+  s: ReturnType<typeof p.spinner>,
+  start: number,
+  step: string,
+): Record<string, string> {
+  if (app.botToken) {
+    s.stop(`Created and installed ${name}. ${k.dim(`(${Math.round((Date.now() - start) / 1000)}s)`)}`);
+    setupLog.step(step, 'success', Date.now() - start, { APP_ID: app.appId, AUTO_INSTALL: 'true' });
+    return { connection: 'provisioned', bot_token: app.botToken, app_token: app.appToken };
+  }
+  s.stop(`Created ${name}, but Slack wouldn't auto-install it (${app.installError}).`, 1);
+  setupLog.step(step, 'success', Date.now() - start, {
+    APP_ID: app.appId,
+    AUTO_INSTALL: 'false',
+    INSTALL_ERROR: app.installError ?? '',
+  });
+  p.note(
+    wrapForGutter(
+      [
+        'Your workspace requires a manual install (usually an admin-approval',
+        'policy). Install the app in the browser, then paste the "Bot User',
+        'OAuth Token" (xoxb-…) from its OAuth & Permissions page at the next',
+        'prompt.',
+        '',
+        k.dim(app.installUrl || 'https://api.slack.com/apps'),
+      ].join('\n'),
+      6,
+    ),
+    'Finish installing in Slack',
+  );
+  return { connection: 'provisioned', app_token: app.appToken };
+}
+
+async function connectWorkspace(core: ProvisioningCore, installToken: string): Promise<BrokerWorkspace[]> {
+  let url: string;
+  try {
+    ({ url } = await core.brokerOauthUrl(installToken));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    setupLog.step('slack-broker-oauth', 'failed', 0, { ERROR: message });
+    p.log.warn(`Couldn't start the workspace connection (${message}).`);
+    return [];
+  }
+  p.note(
+    wrapForGutter(
+      [
+        "You'll connect your Slack workspace so NanoClaw can create the",
+        "agent's app in it. Slack will ask you to pick a workspace and",
+        'approve the connection — then come back here.',
+      ].join('\n'),
+      6,
+    ),
+    'Connect your Slack workspace',
+  );
+  await confirmThenOpen(url, 'Press Enter to open Slack and connect your workspace');
+
+  const s = p.spinner();
+  const start = Date.now();
+  s.start('Waiting for Slack to confirm the connection…');
+  const deadline = start + OAUTH_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(OAUTH_POLL_INTERVAL_MS);
+    let found: BrokerWorkspace[];
+    try {
+      found = (await core.brokerListWorkspaces(installToken)).filter((w) => w.status === 'active');
+    } catch (err) {
+      // An auth failure is not transient — the install token is dead and no
+      // amount of polling fixes it. Everything else: keep polling.
+      if (err instanceof core.BrokerHttpError && (err.status === 401 || err.status === 403)) {
+        s.stop("The Slack service rejected this install's credentials.", 1);
+        setupLog.step('slack-broker-oauth', 'failed', Date.now() - start, { ERROR: err.message });
+        p.log.warn(`${err.message}. Re-run nanoclaw login, then retry.`);
+        return [];
+      }
+      continue;
+    }
+    if (found.length > 0) {
+      const elapsedS = Math.round((Date.now() - start) / 1000);
+      s.stop(`Connected to ${found[0].team_name}. ${k.dim(`(${elapsedS}s)`)}`);
+      setupLog.step('slack-broker-oauth', 'success', Date.now() - start, {
+        TEAM_ID: found[0].team_id,
+        TEAM_NAME: found[0].team_name,
+      });
+      return found;
+    }
+  }
+  s.stop("Slack didn't confirm the connection in time.", 1);
+  setupLog.step('slack-broker-oauth', 'failed', Date.now() - start, { ERROR: 'timeout' });
+  p.log.warn('Finish approving the connection in the browser, then retry.');
+  return [];
+}
+
+async function pickWorkspace(workspaces: BrokerWorkspace[]): Promise<BrokerWorkspace> {
+  if (workspaces.length === 1) {
+    setupLog.userInput('slack_broker_workspace', workspaces[0].team_id);
+    return workspaces[0];
+  }
+  const choice = ensureAnswer(
+    await brightSelect<BrokerWorkspace>({
+      message: 'Which workspace should the agent live in?',
+      options: workspaces.map((w) => ({
+        value: w,
+        label: w.team_name,
+        hint: w.connected_as ? `connected as ${w.connected_as}` : w.team_id,
+      })),
+    }),
+  );
+  setupLog.userInput('slack_broker_workspace', choice.team_id);
+  return choice;
+}


### PR DESCRIPTION
## What

An optional pre-step for the setup wizard's Slack channel flow: hosts that hold a Slack manager token (`SLACK_MANAGER_TOKEN`, with `app_configurations:write` + `managed_apps:install`) or are enrolled with the registry service can have the agent's Slack app created and installed programmatically — `apps.manifest.create` (socket-mode manifest, `generate_app_token=true`) followed by `apps.managedInstall` — instead of walking through api.slack.com/apps and pasting tokens by hand. Experimental and opt-in; the default wizard is unchanged.

The pre-step registers through the existing per-channel extension seam (`registerChannelPreStep` in `setup/channels/companions.ts`, consulted by `runChannelSkillWithPreStep`). The provisioned tokens are handed to the add-slack skill as pre-bound `inputs`, so its prompts skip and the rest of the flow (build, auth.test, wire, welcome) runs unchanged. Every decline or failure falls back to the manual walkthrough — the pre-step never throws for expected declines.

Layout: the provisioning core — app manifest template, scope/event set constants, the broker (registry service) client (oauth URL, workspaces, provision, avatar request/poll), and the direct manager-token transport — is **not part of this PR**. Its permanent home is the add-slack channel payload on the `channels` branch; an installed Slack channel already carries it at `src/provisioning/slack-app.ts`. `setup/channels/slack-auto.ts` keeps only the wizard UX (clack prompts, flow control) and, before offering provisioning, ensures the module is present:

- **Already installed** (the file exists in the tree): plain dynamic import, no fetch.
- **Absent** (the wizard's own first run, before the channel payload lands): bootstrap that one file the way the skill engine fetches payloads — the same remote resolution as `scripts/skill-apply.ts` (`NANOCLAW_CHANNELS_REMOTE` override, else the first remote carrying the branch, origin preferred), `git fetch <remote> channels`, `git show <remote>/channels:src/provisioning/slack-app.ts` materialized into the tree — then dynamic import. Setup runs under tsx, so importing the fetched `.ts` file directly works (pinned by a runtime probe test).
- **Any bootstrap failure** (offline, no channels branch, file not on the branch): one logged line, then the manual walkthrough. The pre-step never throws for expected failures.

`slack-auto.ts` declares a local structural `ProvisioningCore` interface for the slice of the module it calls, so the branch builds and typechecks with no `src/provisioning/` present.

## Why

Manual Slack app creation is the longest and most error-prone part of channel onboarding (manifest fields, two token pastes, scope mistakes). Hosts enrolled with the registry service can get an identical app in one step; the broker holds the Slack manager credential server-side and the host only ever sees the derived per-app tokens. A direct path via a locally held manager token is supported for installs that have one. Keeping the core in the channel payload keeps one copy of the Slack-app manifest and transports, installed alongside the adapter it provisions for.

## Flag semantics

- `NANOCLAW_SLACK_AGENTS=1` enables the registration; any other value (including unset) disables it.
- `bash nanoclaw.sh --slack-agents` sets the env var; the flag is consumed in nanoclaw.sh and not forwarded to setup:auto's flag parser.
- Flag on: the Slack flow leads with automatic provisioning as the default select option ("Create it for me", `initialValue: 'auto'`); supplying your own bot token remains available as the explicit advanced alternative.
- Flag off: the only always-loaded code is `setup/channels/slack-auto-register.ts`, a shim with zero runtime imports whose exported function returns before registering anything. The flow module (`setup/channels/slack-auto.ts`, strings included) is reachable only through a dynamic import inside the registered pre-step callback — and the provisioning core only through the bootstrap inside that flow, so with the flag off nothing loads and no fetch ever runs.

## Flag-off proof

Static: the only non-comment reference to `slack-auto.js` outside its own files is the dynamic import inside the shim's registered callback, which is only created after the env gate passes; the provisioning module path appears in `slack-auto.ts` only as the bootstrap's path constant (nothing on the host runtime path touches it, and no static import of `src/provisioning/` exists anywhere):

```
$ grep -rn "slack-auto\|slack-app\|provisioning/slack" setup/ src/ scripts/ nanoclaw.sh --include='*.ts' --include='*.sh' | grep -v '.test.ts' | grep -v '^\S*:[0-9]*: \*'
setup/channels/slack-auto-register.ts:30:    const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
setup/channels/slack-auto.ts:58:export const PROVISIONING_MODULE = 'src/provisioning/slack-app.ts';
setup/channels/slack-auto.ts:84:/** The slice of src/provisioning/slack-app.ts this flow calls. */
setup/channels/companions.ts:27:import { registerSlackAutoProvision } from './slack-auto-register.js';
nanoclaw.sh:30:# (NANOCLAW_SLACK_AGENTS=1, checked in setup/channels/slack-auto-register.ts).
```

Runtime:

```
$ tsx: delete process.env.NANOCLAW_SLACK_AGENTS; import('./setup/channels/companions.js')
flag off → getChannelPreStep('slack'): undefined
$ NANOCLAW_SLACK_AGENTS=1 tsx: import('./setup/channels/companions.js')
flag on → getChannelPreStep('slack'): function
```

Test: `setup/channels/slack-auto-register.test.ts` pins both directions (unset and non-"1" values register nothing; "1" registers a slack pre-step that lazy-loads and delegates to the flow) plus the companions-registry wiring in a fresh module graph.

## Notes

- The bootstrap seam is injectable (`root`, `exec`, `importModule`), so the unit tests drive the decision path without any git or loader involvement: module present → import with no fetch; absent → engine-style fetch + materialize; absent with the fetch failing → `undefined`, one warning line, manual flow. No test executes a real fetch.
- No companion-skill declaration in this PR: channel companions arrive with the add-slack skill payload, and a missing declaration degrades gracefully — none run, and the channel install itself is unaffected.
- On workspaces where auto-install is refused (admin-approval policy), the pre-step still returns the app-level token plus the manual install URL; the skill's own bot_token prompt collects the xoxb after the browser install.

## Verification

- `pnpm install --frozen-lockfile` — ok
- `pnpm run build` — ok, with no `src/provisioning/` in the tree
- `pnpm exec vitest run setup/channels/` — 6 files, 41 tests passed (includes the tsx runtime probe importing a fetched `.ts` file)
- `pnpm test` — 126 files, 1566 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
