### PR TITLE
Slack channel: adapter-level conversation resolution, native SLACK_INSTANCES, and the full install-skill payload

### DIFF
--- a/.claude/skills/add-slack/REMOVE.md
+++ b/.claude/skills/add-slack/REMOVE.md
@@ -2,33 +2,59 @@
 
 Every step is idempotent — safe to re-run.
 
-## 1. Remove the adapter
+## 1. Remove the registrations
 
-Delete the self-registration import from `src/channels/index.ts` (skip if already gone):
+Delete the appended lines (skip any already gone):
 
-```typescript
-import './slack.js';
-```
+- `src/channels/index.ts`: `import './slack.js';` and `import './slack-a2a-guard.js';`
+- `src/modules/index.ts`: `import './slack-room-membership/index.js';`,
+  `import './canvas-actions/index.js';`, `import './slack-onboarding/index.js';`
+- `container/agent-runner/src/mcp-tools/index.ts`: `import './canvas.js';`
+- `setup/channels/companions.ts`: `import { SLACK_COMPANION_SKILLS } from './slack-companions.js';`
+  and `registerCompanionSkills('slack', SLACK_COMPANION_SKILLS);`
 
-Then delete the copied adapter, its registration test, and the `slack-formatting`
-container skill (part of the channel payload — trunk doesn't ship it):
+## 2. Remove the payload files
 
 ```bash
-rm -f src/channels/slack.ts src/channels/slack-registration.test.ts container/skills/slack-formatting/SKILL.md
+rm -f src/channels/slack.ts src/channels/slack-lib.ts src/channels/slack-lib.test.ts \
+  src/channels/slack-a2a-guard.ts src/channels/slack-a2a-guard.test.ts \
+  src/channels/slack-registration.test.ts \
+  src/channels/slack-instances-registration.test.ts \
+  src/env-file.ts src/env-file.test.ts \
+  container/agent-runner/src/mcp-tools/canvas.ts \
+  container/agent-runner/src/mcp-tools/canvas.instructions.md \
+  container/agent-runner/src/mcp-tools/canvas.test.ts \
+  container/skills/slack-formatting/SKILL.md \
+  container/skills/welcome/addenda/slack.md \
+  setup/channels/slack-companions.ts
+rm -rf src/modules/slack-room-membership src/modules/canvas-actions \
+  src/modules/slack-onboarding container/skills/canvas-work \
+  container/skills/slack-construct
 ```
 
-## 2. Remove credentials
+Caution: `src/env-file.ts` is shared plumbing — leave it in place if another
+installed skill (e.g. the agent-provisioning flow) still imports it.
+
+## 3. Remove credentials
 
 Remove `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_SIGNING_SECRET` from
-`.env` (each is present only if its delivery mode was configured).
+`.env` (each is present only if its delivery mode was configured). If named
+instances were configured, also remove `SLACK_INSTANCES` and every suffixed
+`SLACK_BOT_TOKEN_<NAME>` / `SLACK_APP_TOKEN_<NAME>` /
+`SLACK_SIGNING_SECRET_<NAME>` line.
 
-## 3. Remove the package
+## 4. Remove the package
 
 ```bash
 pnpm uninstall @chat-adapter/slack
 ```
 
-## 4. Rebuild and restart
+## 5. Companion skills
+
+If the companion skill was applied, remove it too (its own REMOVE.md):
+`slack-a2a-rooms`.
+
+## 6. Rebuild and restart
 
 ```bash
 pnpm run build

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -5,88 +5,126 @@ description: Add Slack channel integration via Chat SDK.
 
 # Add Slack Channel
 
-Adds Slack support via the Chat SDK bridge. NanoClaw doesn't ship channels in
-trunk — this skill copies the Slack adapter in from the `channels` branch.
-
-The mechanical steps under **Apply** carry `nc:` directive fences: an agent
-reads the prose and applies them, and a parser can apply them deterministically
-from the same document. Every directive is idempotent, so the whole skill is
-safe to re-run; anything a parser can't apply falls back to the prose beside it.
+Adds Slack support via the Chat SDK bridge. Trunk ships no channels — this skill
+copies the Slack channel layer (adapter, host modules, container tool, container
+skills) in from the `channels` branch. The **Apply** steps carry `nc:` directive
+fences (an agent applies the prose, a parser the directives); all idempotent.
 
 ## Apply
 
-### 1. Copy the adapter, registration test, and formatting skill
+### 1. Copy the channel payload
 
-Fetch the `channels` branch and copy the Slack adapter, its registration test,
-and the formatting container skill into place (overwrite — the branch is
-canonical):
-
+Fetch the `channels` branch and copy the payload into place (overwrite — the branch is canonical):
 ```nc:copy from-branch:channels
 src/channels/slack.ts
+src/channels/slack-lib.ts
+src/channels/slack-lib.test.ts
+src/channels/slack-a2a-guard.ts
+src/channels/slack-a2a-guard.test.ts
 src/channels/slack-registration.test.ts
+src/channels/slack-instances-registration.test.ts
+src/env-file.ts
+src/env-file.test.ts
+src/provisioning/slack-app.ts
+src/provisioning/slack-app.test.ts
+src/modules/slack-room-membership/index.ts
+src/modules/slack-room-membership/membership.ts
+src/modules/slack-room-membership/membership.test.ts
+src/modules/slack-room-membership/env-file.ts
+src/modules/slack-room-membership/env-file.test.ts
+src/modules/canvas-actions/index.ts
+src/modules/canvas-actions/handlers.ts
+src/modules/canvas-actions/canvas-api.ts
+src/modules/canvas-actions/canvas-actions.test.ts
+src/modules/slack-onboarding/index.ts
+src/modules/slack-onboarding/onboarding.test.ts
+src/modules/slack-onboarding/thread-title.test.ts
+container/agent-runner/src/mcp-tools/canvas.ts
+container/agent-runner/src/mcp-tools/canvas.instructions.md
+container/agent-runner/src/mcp-tools/canvas.test.ts
+container/skills/slack-construct/SKILL.md
+container/skills/slack-construct/instructions.md
+container/skills/canvas-work/SKILL.md
 container/skills/slack-formatting/SKILL.md
+container/skills/welcome/addenda/slack.md
+setup/channels/slack-companions.ts
 ```
 
-The `slack-formatting` container skill is part of the channel payload: it
-reaches agents via `~/.claude/skills` (synced at spawn) and teaches Slack's
-mrkdwn syntax. Trunk does not ship it — without this copy step agents send
-Slack messages with generic markdown that renders literally.
+- **Adapter + shared lib** (`slack.ts`, `slack-lib.ts`): bridge registration, wiring defaults, conversation resolver, the native `SLACK_INSTANCES` loop — pinned by the two registration tests.
+- **Bot-inbound guard** (`slack-a2a-guard.ts`): drops bot-authored inbound at the bridge by default; feature skills register a narrower admission policy on its seam.
+- **Host modules**: `slack-room-membership/` (invite-to-room adoption, group-DM fork carry-over, detach on removal, owner-presence access rule), `canvas-actions/` + the container `canvas` tool + `canvas-work` (section-scoped canvas edits/reads via the session's own bot identity), `slack-onboarding/` (get-started prompts, per-thread DM titles); the `env-file.ts` copies are their dotenv plumbing.
+- **Provisioning core** (`src/provisioning/slack-app.ts`): manifest template, scope/event constants, and the broker + manager-token transports for creating a Slack app programmatically. Nothing on the adapter path imports it — the setup wizard's auto-provision pre-step and feature skills do.
+- **Container skills**: `slack-construct/` (standing room/canvas/access/DM-history rules — its `instructions.md` composes into each group's CLAUDE.md at spawn), `slack-formatting/` (mrkdwn syntax; synced to `~/.claude/skills`), `welcome/addenda/slack.md` (channel-matched welcome addendum — inert on hosts predating the mechanism).
+- **Companion declaration** (`slack-companions.ts`): the companion skills (`slack-a2a-rooms`) the channel install flow applies after this one.
 
-### 2. Register the adapter
+### 2. Register the payload
 
-Append the self-registration import to the channel barrel (skipped if the line
-is already present). This one line is the skill's only reach-in into core:
-
+Append the self-registration imports (each append is skipped if its first
+line is already present). The adapter and the guard, in the channel barrel:
 ```nc:append to:src/channels/index.ts
 import './slack.js';
+```
+```nc:append to:src/channels/index.ts
+import './slack-a2a-guard.js';
+```
+
+The three host modules, in the modules barrel:
+```nc:append to:src/modules/index.ts
+import './slack-room-membership/index.js';
+import './canvas-actions/index.js';
+import './slack-onboarding/index.js';
+```
+
+The canvas tool, in the container tool barrel (mounted read-only — a host
+restart is enough, no image rebuild):
+```nc:append to:container/agent-runner/src/mcp-tools/index.ts
+import './canvas.js';
+```
+
+The companion declaration goes directly into the registry file (an import
+there would evaluate before the registry's own maps initialize):
+```nc:append to:setup/channels/companions.ts
+import { SLACK_COMPANION_SKILLS } from './slack-companions.js';
+registerCompanionSkills('slack', SLACK_COMPANION_SKILLS);
 ```
 
 ### 3. Install the adapter package
 
-Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
-
+Pinned exactly — the supply-chain policy rejects ranges and `latest`:
 ```nc:dep
 @chat-adapter/slack@4.29.0
 ```
 
 ### 4. Build and validate
 
-Build first: it guards the typed `createChatSdkBridge(...)` core call and proves
-the dependency is installed. Then run the one integration test.
-
+The build guards the typed `createChatSdkBridge(...)` call and proves the dependency
+installed; the tests pin registration (barrel import, dependency, the `SLACK_INSTANCES`
+loop) and the payload modules' behavior. The container canvas test is `bun:test`-only
+(`cd container/agent-runner && bun test src/mcp-tools/canvas.test.ts`) — optional here.
 ```nc:run effect:build
 pnpm run build
 ```
 ```nc:run effect:test
-pnpm exec vitest run src/channels/slack-registration.test.ts
+pnpm exec vitest run src/channels/slack-registration.test.ts src/channels/slack-instances-registration.test.ts src/channels/slack-lib.test.ts src/channels/slack-a2a-guard.test.ts src/modules/slack-room-membership src/modules/canvas-actions src/modules/slack-onboarding src/provisioning/slack-app.test.ts src/env-file.test.ts
 ```
-
-`slack-registration.test.ts` imports the real channel barrel and asserts the
-registry contains `slack`. It goes red if the import line is deleted or drifts,
-if the barrel fails to evaluate, or if `@chat-adapter/slack` isn't installed (the
-import throws) — so it also covers the dependency from step 3. End-to-end
-delivery against a real workspace is verified manually once the service runs.
 
 ## Credentials
 
-Slack can deliver events two ways. Socket Mode holds an outbound WebSocket open
-— no public URL, so it works on a laptop or behind NAT — and is the right
-default. Webhook delivery needs a public HTTPS Request URL but avoids the
-long-lived socket. The adapter picks Socket Mode automatically whenever
-`SLACK_APP_TOKEN` is set; otherwise it serves the webhook.
-
-```nc:prompt connection validate:^(socket|webhook)$
+Socket Mode (an outbound WebSocket — no public URL, the right default behind NAT)
+vs webhook delivery (needs a public HTTPS Request URL); the adapter picks Socket
+Mode automatically whenever `SLACK_APP_TOKEN` is set.
+```nc:prompt connection validate:^(socket|webhook|provisioned)$
 How should Slack deliver events? `socket` (Socket Mode — no public URL, recommended for local or behind-NAT installs) or `webhook` (needs a public HTTPS Request URL).
 ```
 
-Walk the operator through creating the Slack app, then collect the secrets it
-hands back. The adapter is already installed and registered — it just can't
-receive a message until this is done. For Socket Mode, tell the user:
+`provisioned` is never offered interactively — it arrives only via pre-bound `inputs`
+(a programmatically created app) and behaves like Socket Mode minus the walkthrough below.
 
+For Socket Mode, tell the user:
 ```nc:operator when:connection=socket
 Create the Slack app (Socket Mode):
 1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
-2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, users:read, reactions:write, files:read, files:write.
+2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Basic Information → App-Level Tokens → "Generate Token and Scopes" → add the connections:write scope → copy the token (starts with xapp-).
 5. Socket Mode → toggle "Enable Socket Mode" on.
@@ -95,25 +133,24 @@ Create the Slack app (Socket Mode):
 ```
 
 For webhook delivery, tell the user:
-
 ```nc:operator when:connection=webhook
 Create the Slack app (webhook delivery):
 1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
-2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, users:read, reactions:write, files:read, files:write.
+2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Install to Workspace, then copy the Bot User OAuth Token (starts with xoxb-).
 5. Basic Information → copy the Signing Secret.
 ```
 
-Collect the secrets and store them (the bridge reads them from `.env`; the
-app-level token doubles as the Socket Mode switch, the signing secret
-authenticates webhook requests — each mode needs only its own):
-
+Store the secrets in `.env` (the app-level token doubles as the Socket Mode switch, the signing secret authenticates webhook requests):
 ```nc:prompt bot_token secret validate:^xoxb-
 Paste the Bot User OAuth Token — OAuth & Permissions, starts with `xoxb-`.
 ```
 ```nc:prompt app_token secret validate:^xapp- reuse:SLACK_APP_TOKEN when:connection=socket
 Paste the App-Level Token — Basic Information → App-Level Tokens, starts with `xapp-`.
+```
+```nc:prompt app_token secret validate:^xapp- when:connection=provisioned
+Paste the App-Level Token of the provisioned app (starts with `xapp-`).
 ```
 ```nc:prompt signing_secret secret validate:^[a-fA-F0-9]{16,}$ when:connection=webhook
 Paste the Signing Secret — Basic Information.
@@ -124,16 +161,19 @@ SLACK_BOT_TOKEN={{bot_token}}
 ```nc:env-set when:connection=socket
 SLACK_APP_TOKEN={{app_token}}
 ```
+```nc:env-set when:connection=provisioned
+SLACK_APP_TOKEN={{app_token}}
+```
 ```nc:env-set when:connection=webhook
 SLACK_SIGNING_SECRET={{signing_secret}}
 ```
 
-With webhook delivery, the bridge serves port 3000 at `/webhook/slack`
-automatically; to receive replies, that port must be reachable from the internet
-and registered with Slack as the Request URL (Socket Mode needs no public URL —
-with the bot events subscribed above, events arrive over the socket as soon as
-the service restarts). Tell the user:
+**Additional bot identities (optional).** The adapter natively reads
+`SLACK_INSTANCES=<name>[,…]` from `.env`, registering one `slack-<name>` instance per
+name from suffixed keys (`SLACK_BOT_TOKEN_<NAME>` etc.) — see `/slack-multi-instance`.
 
+With webhook delivery, the bridge serves port 3000 at `/webhook/slack`; that
+URL must be publicly reachable and registered with Slack. Tell the user:
 ```nc:operator when:connection=webhook
 Set up event delivery (needs a public HTTPS URL for port 3000 — ngrok, a Cloudflare Tunnel, or a reverse proxy on a VPS):
 1. Event Subscriptions → Enable Events. Set the Request URL to https://<your-public-host>/webhook/slack and wait for the challenge to pass.
@@ -143,50 +183,35 @@ Set up event delivery (needs a public HTTPS URL for port 3000 — ngrok, a Cloud
 
 ## Resolve your DM channel
 
-The agent talks to you in your direct-message channel with the bot. Resolve its
-address so the owner-wiring step can target it. Validating the token here, before
-the restart, fast-fails a bad credential while it's still cheap to fix. You'll
-need your Slack member ID: open your profile (your avatar, bottom-left), then
-**⋮** → **Copy member ID** — it starts with `U`.
-
+Resolve the owner DM address the owner-wiring step needs; validating the token here, before the restart, fast-fails a bad credential.
 ```nc:prompt owner_handle validate:^U[A-Z0-9]{8,}$
 Your Slack member ID (Profile → ⋮ → "Copy member ID"; starts with U).
 ```
 
-Confirm the bot token works and capture the bot identity — `auth.test` returns the
-bot user and workspace, and fails here if the token is bad:
-
+`auth.test` confirms the bot token works and captures the bot identity:
 ```nc:run capture:connected_as effect:fetch
 curl -sf -X POST https://slack.com/api/auth.test -H "Authorization: Bearer {{bot_token}}" | jq -er '"@" + .user + " in " + .team'
 ```
 
-Open the DM with `conversations.open` and take the channel id it returns as the
-conversation address `slack:<channelId>` (if Slack returns no channel, the bot is
-missing the `im:write` scope — add it and reinstall):
-
+`conversations.open` yields the DM address `slack:<channelId>` (no channel back = the `im:write` scope is missing — add it and reinstall):
 ```nc:run capture:platform_id effect:fetch
 curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer {{bot_token}}" -H "Content-Type: application/json" -d '{"users":"{{owner_handle}}"}' | jq -er '"slack:" + .channel.id'
 ```
 
-`owner_handle` and `platform_id` are what the owner-wiring step needs. The
-greeting goes out over `chat.postMessage`, which works right away. Receiving
-replies needs the event path live: with Socket Mode that happens as soon as the
-service restarts below; with webhook delivery, finish the Event Subscriptions
-and Interactivity steps above first.
+`owner_handle` and `platform_id` feed the owner-wiring step. Sending works immediately;
+receiving needs the event path (Socket Mode: live after the restart below; webhook: the steps above first).
 
 ## Restart
 
-With the credential validated, restart the service so it loads the Slack adapter
-and the secrets you just stored, and wait for its CLI socket before wiring:
-
+Restart so the service loads the adapter and secrets; wait for its CLI socket before wiring:
 ```nc:run effect:restart
 bash setup/lib/restart.sh
 ```
 
 ## Next Steps
 
-If you're in the middle of `/setup`, return to the setup flow now. Otherwise wire
-this channel with `/init-first-agent` (or `/manage-channels`).
+Mid-`/setup`: return to the setup flow. Otherwise wire the channel with `/init-first-agent`
+(or `/manage-channels`) and apply the companion skill (`/slack-a2a-rooms`).
 
 ## Channel Info
 
@@ -200,10 +225,8 @@ this channel with `/init-first-agent` (or `/manage-channels`).
 
 ## Troubleshooting
 
-**A token paste is rejected.** Each secret has a fixed shape: the Bot User OAuth Token starts `xoxb-` (OAuth & Permissions, after Install to Workspace), the App-Level Token starts `xapp-` (Basic Information → App-Level Tokens), and the Signing Secret is a hex string (Basic Information). The classic mix-up is pasting a user token (`xoxp-`) instead of the bot token, or the app's Client Secret instead of the Signing Secret.
-
-**`auth.test` fails, or `conversations.open` returns no channel.** A failing `auth.test` means the bot token is wrong or the app was never installed to the workspace. `conversations.open` coming back empty means the `im:write` scope is missing — add it under OAuth & Permissions and **reinstall the app**; scope changes only take effect after reinstall, which also mints a new `xoxb-` token to store.
-
-**The greeting arrives but your replies vanish.** Sending works with just the bot token; *receiving* needs the event path. Socket Mode: the toggle on, `SLACK_APP_TOKEN` set with `connections:write`, and the bot events (`message.im`, `message.channels`, `message.groups`, `app_mention`) subscribed. Webhook: the Request URL must have passed Slack's challenge and the same events subscribed. Either way, App Home's Messages Tab must be enabled or Slack refuses DMs to the app.
-
-**Adapter registered but Slack never connects.** Run `pnpm exec vitest run src/channels/slack-registration.test.ts` — red means the barrel import or the `@chat-adapter/slack` install drifted, so re-run the Apply steps. If green, restart the service (`bash setup/lib/restart.sh`) so it picks up the adapter and tokens, then check `logs/nanoclaw.error.log`.
+- **A token paste is rejected.** Each secret has a fixed shape: the Bot User OAuth Token starts `xoxb-` (OAuth & Permissions, after Install to Workspace), the App-Level Token starts `xapp-` (Basic Information → App-Level Tokens), and the Signing Secret is a hex string (Basic Information). The classic mix-up is pasting a user token (`xoxp-`) instead of the bot token, or the app's Client Secret instead of the Signing Secret.
+- **`auth.test` fails, or `conversations.open` returns no channel.** A failing `auth.test` means the bot token is wrong or the app was never installed to the workspace. An empty `conversations.open` means the `im:write` scope is missing — add it and **reinstall the app**; scope changes only take effect after reinstall, which also mints a new `xoxb-` token to store.
+- **The greeting arrives but your replies vanish.** Sending works with just the bot token; *receiving* needs the event path. Socket Mode: the toggle on, `SLACK_APP_TOKEN` set with `connections:write`, and the bot events (`message.im`, `message.channels`, `message.groups`, `app_mention`) subscribed. Webhook: the Request URL must have passed Slack's challenge and the same events subscribed. Either way, App Home's Messages Tab must be enabled or Slack refuses DMs to the app.
+- **Adapter registered but Slack never connects.** Run `pnpm exec vitest run src/channels/slack-registration.test.ts` — red means the barrel import or the `@chat-adapter/slack` install drifted, so re-run the Apply steps. If green, restart the service (`bash setup/lib/restart.sh`) and check `logs/nanoclaw.error.log`.
+- **Rooms, canvases, or DM onboarding behave like a bare install.** Those live in the payload modules, not the adapter. Check that `src/modules/index.ts` carries the three Slack module imports and `container/agent-runner/src/mcp-tools/index.ts` imports `./canvas.js`, then restart — the Apply steps are idempotent, so re-running them is always safe. Standing instructions and the welcome addendum only reach sessions started after the restart.

--- a/.claude/skills/add-slack/apply-fixtures.json
+++ b/.claude/skills/add-slack/apply-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — shaped fake values only, never real credentials. Two scenarios cover both when:connection= legs; the auth.test stub answers the connected_as capture and conversations.open answers platform_id.",
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — shaped fake values only, never real credentials. Three scenarios cover all when:connection= legs (socket, webhook, provisioned); the auth.test stub answers the connected_as capture and conversations.open answers platform_id. The payload copy/append/dep/build/test steps need no stubs — they run through the stubbed exec.",
   "scenarios": [
     {
       "name": "socket",
@@ -10,8 +10,14 @@
         "owner_handle": "U12345678"
       },
       "exec": [
-        { "match": "auth.test", "stdout": "@nano in Acme" },
-        { "match": "conversations.open", "stdout": "slack:D0FAKE" }
+        {
+          "match": "auth.test",
+          "stdout": "@nano in Acme"
+        },
+        {
+          "match": "conversations.open",
+          "stdout": "slack:D0FAKE"
+        }
       ]
     },
     {
@@ -23,8 +29,33 @@
         "owner_handle": "U12345678"
       },
       "exec": [
-        { "match": "auth.test", "stdout": "@nano in Acme" },
-        { "match": "conversations.open", "stdout": "slack:D0FAKE" }
+        {
+          "match": "auth.test",
+          "stdout": "@nano in Acme"
+        },
+        {
+          "match": "conversations.open",
+          "stdout": "slack:D0FAKE"
+        }
+      ]
+    },
+    {
+      "name": "provisioned",
+      "inputs": {
+        "connection": "provisioned",
+        "bot_token": "xoxb-fake-bot-token",
+        "app_token": "xapp-fake-app-token",
+        "owner_handle": "U12345678"
+      },
+      "exec": [
+        {
+          "match": "auth.test",
+          "stdout": "@nano in Acme"
+        },
+        {
+          "match": "conversations.open",
+          "stdout": "slack:D0FAKE"
+        }
       ]
     }
   ]

--- a/.claude/skills/slack-a2a-rooms/SKILL.md
+++ b/.claude/skills/slack-a2a-rooms/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: slack-a2a-rooms
+description: Agent-to-agent Slack rooms — a group DM (MPIM) holding a human plus two or more NanoClaw sibling bots, where each bot hears the room over its own Socket Mode connection. Registers the admission policy on the Slack channel's bot-inbound guard so bot-authored inbound is admitted only for rooms allowlisted in SLACK_A2A_ROOMS (re-attributed as slack:bot:<bot_id>, hop-limited via SLACK_A2A_MAX_HOPS), plus scripts/open-a2a-room.ts to open a room and register it.
+---
+
+# Slack agent-to-agent rooms (SLACK_A2A_ROOMS)
+
+Lets two or more NanoClaw Slack bots talk to each other — and to a human — in
+a shared group DM (MPIM). Empirically established against live Slack:
+`conversations.open` with `users=[<human>, <other bot user id>…]` works from a
+bot token holding `mpim:write` and returns an `is_mpim` channel, and bots
+receive each other's messages over their own Socket Mode connections as plain
+`message` events with `channel_type: "mpim"`, `bot_id` set, and `subtype`
+null.
+
+**Where sibling-bot messages die today.** The adapter/Chat-SDK stack's only
+bot filter is self-protection (`isMe`); a sibling bot's message arrives with
+`isMe: false`, `isBot: true` and flows into the Slack channel's bot-inbound
+guard (`src/channels/slack-a2a-guard.ts`, installed with `/add-slack`), which
+drops all bot-authored inbound at the bridge boundary by default — before the
+router, before any sender-approval flow. The guard exposes a single admission
+seam, `setBotInboundPolicy`; this skill registers the policy that opens it up
+selectively:
+
+- Rooms listed in `SLACK_A2A_ROOMS`: bot-authored inbound passes, attributed
+  to the user id `slack:bot:<bot_id>`, under a consecutive-hop limit.
+- Everywhere else: bot-authored inbound stays dropped at the bridge, exactly
+  as the guard's default already does.
+
+**Loop safety.** After N consecutive bot-authored inbound messages in an A2A
+room without a human message (N = `SLACK_A2A_MAX_HOPS`, default 6), further
+bot messages are dropped with a log line until a human speaks. The counter is
+per bot identity and per room; any human message resets it.
+
+**Requires:**
+
+- The Slack channel installed (`/add-slack`), current enough to ship the
+  bot-inbound guard (`src/channels/slack-a2a-guard.ts` with the
+  `setBotInboundPolicy` seam). The default drop arrives with that payload;
+  this skill only adds the allowlisted-room admission on top.
+- At least two Slack bot identities on this host (or sibling bots on other
+  hosts sharing the workspace). Named identities are registered natively by
+  the adapter from `SLACK_INSTANCES` — see the `slack-multi-instance` skill
+  for the env-key format. `scripts/open-a2a-room.ts` reads tokens by that
+  convention (`SLACK_BOT_TOKEN_<NAME>`; `default` → `SLACK_BOT_TOKEN`).
+- Every participating app's manifest must carry the MPIM scopes and event:
+  `mpim:write` (open the room), `mpim:history` + `mpim:read` (see it), and
+  the `message.mpim` bot event (hear it). Apps provisioned through the
+  managed flow (`apps.manifest.create` + `apps.managedInstall`) already
+  include all of these.
+
+## Apply
+
+### 1. Verify the installed Slack channel ships the bot-inbound guard
+
+The policy module copied next imports `setBotInboundPolicy` from the installed
+`src/channels/slack-a2a-guard.ts`. On a Slack payload that predates the guard,
+that import takes down the channel barrel — and with it **every** adapter — so
+verify the seam first. If the check fails, **stop**: re-run `/add-slack` from a
+channels branch that ships the guard, then re-apply this skill.
+
+```nc:run effect:check
+grep -sq 'export function setBotInboundPolicy' src/channels/slack-a2a-guard.ts || { echo 'slack-a2a-rooms: src/channels/slack-a2a-guard.ts is missing or does not export setBotInboundPolicy. Installing anyway would break the channel barrel and take down every channel adapter. Update the installed Slack channel first (re-run /add-slack from a channels branch that ships the bot-inbound guard), then re-apply this skill.' >&2; exit 1; }
+```
+
+### 2. Copy the policy module, its guard test, and the room-opener script
+
+This skill ships three files alongside this document; copy them into the tree
+at the same relative paths (overwrite; the skill's copies are canonical):
+
+```nc:copy
+src/channels/slack-a2a.ts
+src/channels/slack-a2a.test.ts
+scripts/open-a2a-room.ts
+```
+
+- `slack-a2a.ts` — the admission policy: `SLACK_A2A_ROOMS` /
+  `SLACK_A2A_MAX_HOPS` parsing (re-read with a ~30s cache so a freshly opened
+  room needs no restart), the per-room, per-identity consecutive-hop counter
+  with human reset, and the `slack:bot:<bot_id>` re-attribution. The module
+  registers itself onto the guard's admission seam on import.
+- `slack-a2a.test.ts` — the guard: drives the real channel barrel and the
+  real bot-inbound guard end-to-end (see step 4 for what it pins).
+- `open-a2a-room.ts` — operator CLI to open a room (see Configuration).
+
+### 3. Register the policy module
+
+Append the self-registration import to the channel barrel (skipped if the
+line is already present). Appending at the end keeps it after the Slack
+channel's own imports:
+
+```nc:append to:src/channels/index.ts
+import './slack-a2a.js';
+```
+
+### 4. Build and validate
+
+Build first — it guards the typed `setBotInboundPolicy` call against guard
+drift. The test imports the real channel barrel (a deleted or broken barrel
+line goes red) and asserts the policy end-to-end: allowlisted-room admission
+with `slack:bot:<bot_id>` re-attribution, non-listed-room drop, the hop limit
+with human reset, per-room/per-identity budgets, and that a downstream throw
+consumes no hop budget:
+
+```nc:run effect:build
+pnpm run build
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/channels/slack-a2a.test.ts
+```
+
+## Configuration
+
+`.env` keys (both re-read with a ~30s cache — no restart needed after edits):
+
+- `SLACK_A2A_ROOMS` — comma-separated raw Slack channel ids (the MPIM ids the
+  opener script prints, e.g. `G0AAAAAAA` — note MPIM ids may start with `G`
+  or `C` depending on workspace vintage). Only these rooms admit bot-authored
+  inbound.
+- `SLACK_A2A_MAX_HOPS` — consecutive bot-authored inbound messages allowed in
+  an A2A room without a human message before further bot messages are dropped.
+  Default `6`.
+
+### Opening a room
+
+```bash
+pnpm exec tsx scripts/open-a2a-room.ts --instances dana,eli --user U0AAAAAAA
+```
+
+The first listed instance opens the conversation (via `conversations.open`
+with the human + the other bots' user ids, resolved through `auth.test` per
+token) and posts an intro message. The script prints the channel id and
+appends it to `SLACK_A2A_ROOMS` in `.env`. Without `--user` you get a
+bots-only room, which needs at least three instances (Slack collapses a
+two-party open into a 1:1 IM).
+
+### Letting bot senders through the access gate
+
+The room allowlist gets bot messages *to* the router; the permissions module
+still gates them like any sender. Bot senders arrive as user id
+`slack:bot:<bot_id>`, which starts unknown. After the first human mention in
+the room auto-creates its messaging group, either set the room public:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:<channel id>'"
+```
+
+or keep `request_approval` and approve each `slack:bot:<bot_id>` sender once
+(or add them as members of the agent group). A private A2A room with known
+humans is a reasonable place for `public`.
+
+## Engagement: A2A conversation is mention-driven
+
+An MPIM is a *group* context in NanoClaw's channel-defaults model (Slack DMs
+are only `D…` channels), so the Slack group defaults apply:
+`engage_mode: mention-sticky`, per-thread stickiness. That means a bot
+replies when it is @-mentioned (then stays engaged in that thread) — it does
+not answer every room message. Bot-to-bot conversation is therefore
+**mention-driven by design**: bot A's reply reaches bot B's agent when it
+@-mentions bot B, and the chain continues only as long as each reply
+mentions the next speaker. Slack does not emit `app_mention` for
+bot-authored messages, but mention detection still works: the Chat SDK's
+text-level detector matches the bot's own `<@U…>` token, which the adapter
+deliberately leaves unresolved in the text. This is the intended loop
+governor alongside the hop limit — prompt the agents (group CLAUDE.md /
+personality) to @-mention the sibling they want an answer from, and to stop
+mentioning anyone when the exchange has converged.
+
+## Remove
+
+1. Delete the three copied files: `src/channels/slack-a2a.ts`,
+   `src/channels/slack-a2a.test.ts`, `scripts/open-a2a-room.ts`.
+2. Delete the `import './slack-a2a.js';` line from `src/channels/index.ts`.
+3. Remove `SLACK_A2A_ROOMS` and `SLACK_A2A_MAX_HOPS` from `.env`.
+4. Optionally re-tighten any messaging groups you set to
+   `unknown_sender_policy='public'`, and archive/leave the MPIMs from Slack
+   (the rooms themselves are ordinary Slack conversations; NanoClaw holds no
+   other state for them beyond the usual messaging-group/session rows).
+5. Rebuild (`pnpm run build`).
+
+With the skill removed, the channel guard's default applies everywhere again:
+bot-authored inbound is dropped in every room.
+
+## Notes
+
+- **Bot senders outside A2A rooms**: the Slack channel's bot-inbound guard
+  drops bot-authored messages in rooms not listed in `SLACK_A2A_ROOMS` at the
+  bridge — before the router and before any sender-approval flow — with or
+  without this skill applied. If an install relies on a bot sender (another
+  workspace app posting into a channel the agent watches), add that room to
+  `SLACK_A2A_ROOMS`. Human messages are never affected.
+- **Access-gate story is manual.** The recipe deliberately leaves letting
+  `slack:bot:<bot_id>` senders through the gate as an operator step (public
+  policy or per-bot approval). Should `open-a2a-room.ts` instead pre-create
+  the messaging group + wirings + members via `ncl` so a room works with zero
+  extra steps? That needs the host running and a choice of agent group per
+  bot — deferred.
+- **Hop-counter scope.** The counter counts bot-authored *inbound* per bot
+  identity (bridge instance). A bot's own outbound is invisible to it (`isMe`
+  dropped upstream), so with two bots the effective conversation length is
+  roughly `2×maxHops` messages; with k bots each message increments k−1
+  counters. If per-room total (not per-identity) semantics are wanted, the
+  counter needs to live host-side (router/session), not in the channel layer.
+- **Cross-host rooms.** For sibling bots on *different* NanoClaw hosts, each
+  host needs this skill (its own allowlist entry). The opener script only
+  handles co-hosted tokens; opening a cross-host room means running it where
+  the first bot's token lives and adding the room id to the other host's
+  `.env` manually.
+- **`message_changed` / edited bot messages** are not admitted (the adapter
+  only forwards unfurl data for edits) — fine for v1.
+- **Attribution name.** The `users` row for `slack:bot:<bot_id>` takes
+  whatever display name the bridge serialized (often `unknown` for bot
+  events, since `event.username` is frequently absent and `event.user` is
+  unset). A nicety would be resolving the bot's profile name via
+  `bots.info` — deferred.
+- **MPIM id prefix.** Older workspaces mint MPIM ids starting with `G`,
+  newer ones with `C`. The allowlist matches exact ids so both work, but the
+  adapter's `getChannelVisibility` calls `C…` ids "workspace"-visible —
+  cosmetic only, nothing here branches on it.

--- a/.claude/skills/slack-a2a-rooms/scripts/open-a2a-room.ts
+++ b/.claude/skills/slack-a2a-rooms/scripts/open-a2a-room.ts
@@ -1,0 +1,203 @@
+/**
+ * scripts/open-a2a-room.ts — open a Slack agent-to-agent (A2A) room.
+ *
+ * Creates a group DM (MPIM) holding a human plus two or more NanoClaw sibling
+ * bots, posts an intro message from the first bot, prints the channel id, and
+ * appends it to SLACK_A2A_ROOMS in .env so the slack-a2a-rooms bridge filter
+ * starts admitting bot-authored messages there (picked up within ~30s — no
+ * service restart required).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]
+ *
+ * Instance names follow the slack-multi-instance convention: each name reads
+ * its bot token from SLACK_BOT_TOKEN_<NAME> (uppercased, dashes →
+ * underscores); the special name `default` reads SLACK_BOT_TOKEN. The first
+ * listed instance is the caller — it opens the conversation and posts the
+ * intro. Bot user ids are resolved via auth.test per token.
+ *
+ * Requires the `mpim:write` scope on every listed app (see the skill's
+ * prerequisites). Without --user the room holds bots only, which needs at
+ * least three instances (Slack turns a two-party open into a 1:1 IM).
+ *
+ * Token values are never printed.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from '../src/env.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+interface SlackAuth {
+  name: string;
+  envKey: string;
+  token: string;
+  userId: string; // U… bot user id (auth.test user_id)
+  botId: string | null; // B… bot id (auth.test bot_id)
+}
+
+function fail(msg: string): never {
+  console.error(`open-a2a-room: ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): { instances: string[]; user?: string } {
+  let instances: string[] = [];
+  let user: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--instances') {
+      instances = (argv[++i] ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (argv[i] === '--user') {
+      user = argv[++i];
+    } else {
+      fail(
+        `unknown argument: ${argv[i]}\nUsage: pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]`,
+      );
+    }
+  }
+  if (instances.length < 2) fail('--instances needs at least two comma-separated instance names');
+  if (!user && instances.length < 3) {
+    fail(
+      'without --user the room holds bots only, which needs at least three instances (a two-party open becomes a 1:1 IM)',
+    );
+  }
+  if (user && !/^[UW][A-Z0-9]+$/.test(user)) {
+    fail(`--user must be a Slack user id (U…/W…), got: ${user}`);
+  }
+  return { instances, user };
+}
+
+function tokenEnvKey(name: string): string {
+  if (name === 'default') return 'SLACK_BOT_TOKEN';
+  return `SLACK_BOT_TOKEN_${name.toUpperCase().replace(/-/g, '_')}`;
+}
+
+async function slackCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (json.ok !== true) {
+    throw new Error(`${method} failed: ${String(json.error ?? `HTTP ${res.status}`)}`);
+  }
+  return json;
+}
+
+async function resolveAuth(name: string): Promise<SlackAuth> {
+  const envKey = tokenEnvKey(name);
+  const env = readEnvFile([envKey]);
+  const token = env[envKey];
+  if (!token) fail(`missing ${envKey} in .env (slack-multi-instance token convention)`);
+  const auth = await slackCall(token, 'auth.test', {});
+  const userId = typeof auth.user_id === 'string' ? auth.user_id : null;
+  if (!userId) fail(`auth.test for instance "${name}" returned no user_id`);
+  return {
+    name,
+    envKey,
+    token,
+    userId,
+    botId: typeof auth.bot_id === 'string' ? auth.bot_id : null,
+  };
+}
+
+/** Append the room to SLACK_A2A_ROOMS in .env (create the key if absent,
+ * no-op if the id is already listed). */
+function appendRoomToEnv(roomId: string): 'appended' | 'already-present' | 'created' {
+  const envPath = path.join(process.cwd(), '.env');
+  let content = '';
+  try {
+    content = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    // no .env — create one with just this key
+  }
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.trim().startsWith('SLACK_A2A_ROOMS='));
+  if (idx === -1) {
+    const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+    fs.writeFileSync(envPath, `${content}${suffix}SLACK_A2A_ROOMS=${roomId}\n`);
+    return 'created';
+  }
+  const existing = lines[idx].slice(lines[idx].indexOf('=') + 1).trim();
+  const rooms = existing
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (rooms.includes(roomId)) return 'already-present';
+  rooms.push(roomId);
+  lines[idx] = `SLACK_A2A_ROOMS=${rooms.join(',')}`;
+  fs.writeFileSync(envPath, lines.join('\n'));
+  return 'appended';
+}
+
+async function main(): Promise<void> {
+  const { instances, user } = parseArgs(process.argv.slice(2));
+
+  console.log(`Resolving bot identities for: ${instances.join(', ')}`);
+  const auths: SlackAuth[] = [];
+  for (const name of instances) {
+    const auth = await resolveAuth(name);
+    console.log(`  ${name}: bot user ${auth.userId}${auth.botId ? ` (bot id ${auth.botId})` : ''}`);
+    auths.push(auth);
+  }
+
+  const caller = auths[0];
+  const otherBotUserIds = auths.slice(1).map((a) => a.userId);
+  const members = [...(user ? [user] : []), ...otherBotUserIds];
+
+  console.log(`Opening group DM as "${caller.name}" with: ${members.join(', ')}`);
+  const opened = await slackCall(caller.token, 'conversations.open', {
+    users: members.join(','),
+  });
+  const channel = opened.channel as Record<string, unknown> | undefined;
+  const channelId = typeof channel?.id === 'string' ? channel.id : null;
+  if (!channelId) fail('conversations.open returned no channel id');
+  if (channel?.is_mpim !== true) {
+    console.warn(
+      `warning: opened conversation ${channelId} is not an MPIM (is_mpim=${String(channel?.is_mpim)}) — with fewer than three members Slack returns a 1:1 IM`,
+    );
+  }
+
+  const botMentions = otherBotUserIds.map((id) => `<@${id}>`).join(' ');
+  const introText =
+    `:robot_face: Agent-to-agent room opened by "${caller.name}". ` +
+    `${botMentions}${user ? ` <@${user}>` : ''} — bots in this room can hear each other. ` +
+    `Conversation is mention-driven: @-mention a bot to get its reply, and it can @-mention the next one. ` +
+    `After too many consecutive bot messages the room pauses until a human speaks.`;
+  await slackCall(caller.token, 'chat.postMessage', {
+    channel: channelId,
+    text: introText,
+  });
+
+  const envResult = appendRoomToEnv(channelId);
+  console.log('');
+  console.log(`A2A room channel id: ${channelId}`);
+  console.log(
+    envResult === 'already-present'
+      ? 'SLACK_A2A_ROOMS already lists this room — .env unchanged.'
+      : `SLACK_A2A_ROOMS ${envResult === 'created' ? 'created' : 'updated'} in .env — the bridge filter picks it up within ~30s (no restart needed).`,
+  );
+  console.log('');
+  console.log('Next steps (once per room):');
+  console.log(`  - Mention a bot in the room once so the host auto-creates the messaging group,`);
+  console.log(`    then allow bot senders through the access gate, e.g.:`);
+  console.log(
+    `      pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:${channelId}'"`,
+  );
+  console.log(`    (or approve / add the slack:bot:<bot_id> users as members instead of going public).`);
+  console.log(`  - Wire the room to each bot's agent group (ncl messaging-groups / wirings) if not auto-wired.`);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.test.ts
+++ b/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Guard for the slack-a2a-rooms admission policy and its registration.
+ *
+ * The skill's one reach-in is the barrel line `import './slack-a2a.js';` in
+ * src/channels/index.ts: importing the module installs the A2A room policy on
+ * the Slack channel layer's bot-inbound guard (setBotInboundPolicy). This
+ * file drives that wiring end-to-end through the REAL guard: it imports the
+ * real channel barrel — never ./slack-a2a.js directly, see the note at the
+ * env-parsing describe — and sends bridge-shaped inbound through
+ * wrapSlackBotGuard, asserting the policy's semantics:
+ *
+ *   - allowlisted rooms admit bot messages re-attributed as slack:bot:<bot_id>
+ *   - non-listed rooms stay dropped; humans pass everywhere, untouched
+ *   - the consecutive-hop limit drops bot messages until a human speaks
+ *   - budgets are tracked per room and per bot identity (bridge instance)
+ *   - a downstream throw does not consume hop budget
+ *
+ * If the barrel line is deleted (or the barrel fails to evaluate), no policy
+ * is installed, the guard's default drop applies, and the admit test goes
+ * red — exactly the composed-install failure this file guards. The guard's
+ * own mechanics (default drop, human byte-identical pass-through, fail-closed
+ * policy errors, non-Slack adapters untouched) are pinned by the channel
+ * payload's slack-a2a-guard.test.ts, not here.
+ *
+ * Config is read from .env (SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS) at first
+ * decision, so the test chdirs into a temp dir carrying a crafted .env BEFORE
+ * importing the barrel. Vitest's per-file process isolation keeps the chdir
+ * and the module cache local to this file. No DB, no Slack.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import { wrapSlackBotGuard } from './slack-a2a-guard.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'slack-a2a-'));
+  writeFileSync(
+    join(dir, '.env'),
+    'SLACK_A2A_ROOMS=G0ALLOW,G0HOPS,G0ROOMA,G0ROOMB,G0INST,G0THROW\nSLACK_A2A_MAX_HOPS=2\n',
+  );
+  process.chdir(dir);
+  await import('./index.js'); // the real barrel — installs the policy via the skill's barrel line
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+interface InboundCall {
+  platformId: string;
+  message: InboundMessage;
+}
+
+function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const setup: ChannelSetup = {
+    onInbound:
+      onInbound ??
+      ((platformId, _threadId, message) => {
+        calls.push({ platformId, message });
+      }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { setup, calls };
+}
+
+let nextMessageId = 0;
+
+/** Bridge-shaped inbound fixture (see chat-sdk-bridge.ts messageToInbound). */
+function makeInbound(author: Record<string, unknown>, text: string): InboundMessage {
+  const id = `msg-${++nextMessageId}`;
+  return {
+    id,
+    kind: 'chat-sdk',
+    content: { id, text, author, senderId: author.userId },
+    timestamp: new Date().toISOString(),
+    isGroup: true,
+  };
+}
+
+function humanMsg(): InboundMessage {
+  return makeInbound({ userId: 'U111', isBot: false, isMe: false }, 'hello');
+}
+
+function botMsg(botId = 'B999'): InboundMessage {
+  return makeInbound({ userId: botId, isBot: true, isMe: false }, 'from a sibling bot');
+}
+
+describe('slack-a2a room policy (registered via the channel barrel)', () => {
+  it('admits allowlisted bot messages re-attributed as slack:bot:<bot_id>', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const msg = botMsg('B42');
+
+    await wrapped.onInbound('slack:G0ALLOW', 'slack:G0ALLOW:171.1', msg);
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('slack:bot:B42');
+  });
+
+  it('drops bot messages for rooms not in SLACK_A2A_ROOMS', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:C0OTHER', null, botMsg());
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes human messages through unchanged — allowlisted room or not', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    const inRoom = humanMsg();
+    await wrapped.onInbound('slack:G0ALLOW', null, inRoom);
+    const outsideRoom = humanMsg();
+    await wrapped.onInbound('slack:C0OTHER', null, outsideRoom);
+
+    expect(calls).toHaveLength(2);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('U111');
+    expect((calls[1].message.content as Record<string, unknown>).senderId).toBe('U111');
+  });
+
+  it('enforces the consecutive-hop limit (SLACK_A2A_MAX_HOPS) and resets on a human message', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0HOPS';
+
+    await wrapped.onInbound(pid, null, botMsg('b1'));
+    await wrapped.onInbound(pid, null, botMsg('b2'));
+    expect(calls).toHaveLength(2);
+
+    // Third consecutive bot message exceeds maxHops=2 — dropped.
+    await wrapped.onInbound(pid, null, botMsg('b3'));
+    expect(calls).toHaveLength(2);
+
+    // A human message passes and resets the counter…
+    await wrapped.onInbound(pid, null, humanMsg());
+    expect(calls).toHaveLength(3);
+
+    // …so bot messages flow again.
+    await wrapped.onInbound(pid, null, botMsg('b4'));
+    expect(calls).toHaveLength(4);
+  });
+
+  it('tracks the hop budget per room', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a1'));
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a2'));
+    expect(calls).toHaveLength(2); // G0ROOMA at its limit (maxHops=2)
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a3'));
+    expect(calls).toHaveLength(2);
+
+    // A different room has its own budget.
+    await wrapped.onInbound('slack:G0ROOMB', null, botMsg('b1'));
+    expect(calls).toHaveLength(3);
+  });
+
+  it('tracks the hop budget per bot identity (bridge instance)', async () => {
+    const a = makeSetup();
+    const b = makeSetup();
+    const wrappedA = wrapSlackBotGuard(a.setup, 'slack');
+    const wrappedB = wrapSlackBotGuard(b.setup, 'slack-dana');
+    const pid = 'slack:G0INST';
+
+    await wrappedA.onInbound(pid, null, botMsg('a1'));
+    await wrappedA.onInbound(pid, null, botMsg('a2'));
+    await wrappedA.onInbound(pid, null, botMsg('a3'));
+    expect(a.calls).toHaveLength(2); // identity A exhausted its budget
+
+    // Identity B in the same room still has a full budget.
+    await wrappedB.onInbound(pid, null, botMsg('b1'));
+    expect(b.calls).toHaveLength(1);
+  });
+
+  it('does not consume hop budget when downstream throws', async () => {
+    let failNext = true;
+    const calls: InboundCall[] = [];
+    const { setup } = makeSetup(async (platformId, _threadId, message) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('router exploded');
+      }
+      calls.push({ platformId, message });
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0THROW';
+
+    // Admitted, but downstream throws — the message never reached a session,
+    // so the budget (maxHops=2) must be untouched.
+    await expect(wrapped.onInbound(pid, null, botMsg('t1'))).rejects.toThrow('router exploded');
+
+    // The full budget of two is still available…
+    await wrapped.onInbound(pid, null, botMsg('t2'));
+    await wrapped.onInbound(pid, null, botMsg('t3'));
+    expect(calls).toHaveLength(2);
+
+    // …and accounting still works: the third accepted hop is over the limit.
+    await wrapped.onInbound(pid, null, botMsg('t4'));
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('env parsing', () => {
+  // Imported dynamically, and only in this describe, which runs AFTER the
+  // behavior tests above: a static (or earlier) import of ./slack-a2a.js
+  // would install the policy as a side effect of this test file itself and
+  // mask a deleted barrel line. Via the barrel the module is already in the
+  // cache, so this import is a no-op read.
+  it('parseRooms splits, trims, and drops empties', async () => {
+    const { parseRooms } = await import('./slack-a2a.js');
+    expect([...parseRooms(' G0A , C0B ,,')]).toEqual(['G0A', 'C0B']);
+    expect(parseRooms(undefined).size).toBe(0);
+  });
+
+  it('parseMaxHops falls back to the default on junk', async () => {
+    const { parseMaxHops, DEFAULT_MAX_HOPS } = await import('./slack-a2a.js');
+    expect(parseMaxHops('4')).toBe(4);
+    expect(parseMaxHops('0')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('-2')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('six')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops(undefined)).toBe(DEFAULT_MAX_HOPS);
+  });
+});

--- a/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.ts
+++ b/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.ts
@@ -1,0 +1,135 @@
+/**
+ * Slack agent-to-agent (A2A) rooms — the admission policy for bot-authored
+ * inbound: room allowlist + consecutive-hop limit + `slack:bot:<bot_id>`
+ * re-attribution.
+ *
+ * The Slack channel layer's bot-inbound guard (src/channels/slack-a2a-guard.ts,
+ * installed with the Slack channel) drops every bot-authored inbound message
+ * at the bridge boundary by default — sibling and foreign bots never reach the
+ * router, so they can neither spam unknown-sender approval cards nor feed each
+ * other into loops. The guard exposes a single admission seam
+ * (`setBotInboundPolicy`); this module is that policy:
+ *
+ *   - Rooms allowlisted in `SLACK_A2A_ROOMS` (comma-separated Slack channel
+ *     ids, e.g. the MPIM ids printed by scripts/open-a2a-room.ts): bot-authored
+ *     inbound is admitted, re-attributed with sender id `slack:bot:<bot_id>`,
+ *     under a consecutive-hop limit (`SLACK_A2A_MAX_HOPS`, default 6) that any
+ *     human message in the room resets.
+ *   - Every other room: bot-authored inbound stays dropped (the guard logs the
+ *     drop with this policy's reason).
+ *
+ * Human-authored messages are structurally outside this policy's power: the
+ * guard passes them through untouched and only lets the policy observe them
+ * (for the hop-counter reset).
+ */
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { setBotInboundPolicy, type SlackBotInboundPolicy } from './slack-a2a-guard.js';
+
+export const DEFAULT_MAX_HOPS = 6;
+
+/** How long a read of SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS is cached.
+ * Short enough that a room appended to .env by scripts/open-a2a-room.ts is
+ * picked up without a service restart. */
+const CONFIG_TTL_MS = 30_000;
+
+export interface A2aConfig {
+  /** Raw Slack channel ids (C…/G…) allowed to carry bot-authored inbound. */
+  rooms: Set<string>;
+  /** Consecutive bot-authored inbound messages allowed without a human one. */
+  maxHops: number;
+}
+
+export function parseRooms(raw: string | undefined): Set<string> {
+  return new Set(
+    (raw ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+export function parseMaxHops(raw: string | undefined): number {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_MAX_HOPS;
+}
+
+let cached: { at: number; config: A2aConfig } | null = null;
+
+function readA2aConfig(): A2aConfig {
+  const now = Date.now();
+  if (cached && now - cached.at < CONFIG_TTL_MS) return cached.config;
+  const env = readEnvFile(['SLACK_A2A_ROOMS', 'SLACK_A2A_MAX_HOPS']);
+  cached = {
+    at: now,
+    config: {
+      rooms: parseRooms(env.SLACK_A2A_ROOMS),
+      maxHops: parseMaxHops(env.SLACK_A2A_MAX_HOPS),
+    },
+  };
+  return cached.config;
+}
+
+/** The guard reports the adapter's channel id (`slack:C0…`); the allowlist
+ * holds raw Slack channel ids. */
+function roomFromPlatformId(platformId: string): string {
+  const idx = platformId.indexOf(':');
+  return idx === -1 ? platformId : platformId.slice(idx + 1);
+}
+
+/**
+ * Build the A2A room policy. The hop counter is per bot identity and per room
+ * — keyed on the guard's instanceKey, since each bridge instance is one bot
+ * identity, and a bot's own outbound never arrives here (the SDK drops `isMe`
+ * upstream). With two bots the effective conversation length is therefore
+ * roughly 2×maxHops messages. Any human message in a room resets that room's
+ * counter for the identity that heard it; every co-hosted identity hears the
+ * same human message over its own connection, so the budgets reset together.
+ *
+ * `getConfig` is injectable for tests; production reads .env with a short TTL
+ * cache.
+ */
+export function createA2aRoomPolicy(getConfig: () => A2aConfig = readA2aConfig): SlackBotInboundPolicy {
+  /** Consecutive accepted bot hops, keyed `<instanceKey>:<room>`. */
+  const hops = new Map<string, number>();
+
+  return {
+    decideBotInbound(ctx) {
+      const room = roomFromPlatformId(ctx.platformId);
+      const { rooms, maxHops } = getConfig();
+      if (!rooms.has(room)) {
+        return { action: 'drop', reason: 'room not in SLACK_A2A_ROOMS' };
+      }
+      const key = `${ctx.instanceKey}:${room}`;
+      const count = hops.get(key) ?? 0;
+      if (count >= maxHops) {
+        log.info('slack-a2a: hop limit reached — dropping bot messages until a human speaks', {
+          room,
+          botId: ctx.botId,
+          maxHops,
+        });
+        return { action: 'drop', reason: 'hop limit reached' };
+      }
+      return {
+        action: 'admit',
+        // The permissions module uses a senderId that already contains a ':'
+        // verbatim (see extractAndUpsertUser), so the users row becomes
+        // `slack:bot:<bot_id>` — distinguishable from human `slack:U…` ids.
+        senderId: `slack:bot:${ctx.botId}`,
+        // The guard fires this only after downstream accepted the message —
+        // a throw in the host's onInbound must not consume budget for a
+        // message that never reached a session.
+        onAccepted: () => hops.set(key, count + 1),
+      };
+    },
+    onHumanInbound(ctx) {
+      // Human message — reset this identity's hop counter for the room.
+      hops.delete(`${ctx.instanceKey}:${roomFromPlatformId(ctx.platformId)}`);
+    },
+  };
+}
+
+// Install the policy on the channel layer's guard (single provider — the
+// guard warns if another policy was already installed). Runs on barrel
+// import, like every channel module's self-registration.
+setBotInboundPolicy(createA2aRoomPolicy());

--- a/.claude/skills/slack-agent-flow/REMOVE.md
+++ b/.claude/skills/slack-agent-flow/REMOVE.md
@@ -1,0 +1,34 @@
+# Remove slack-agent-flow
+
+Reverses everything Apply added. Runtime data the flow created (agent groups,
+messaging groups, wirings, `.env` token/instance/room lines, provisioned Slack
+apps) is user data and is deliberately left alone — for per-agent teardown of
+a provisioned bot, follow the slack-managed-agents skill's teardown section.
+
+1. Delete the barrel registration lines (delete, don't comment out):
+   - `import './slack-agent-flow/index.js';` from `src/modules/index.ts`
+   - `import './rooms.js';` from `container/agent-runner/src/mcp-tools/index.ts`
+
+2. Delete the copied payload files:
+
+   ```bash
+   rm -rf src/modules/slack-agent-flow
+   rm -f scripts/slack-agent-flow-finish.ts
+   rm -f container/agent-runner/src/mcp-tools/rooms.ts \
+         container/agent-runner/src/mcp-tools/rooms.test.ts \
+         container/agent-runner/src/mcp-tools/rooms.instructions.md \
+         container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+   rm -rf container/skills/slack-construct-agents
+   rm -f container/skills/welcome/addenda/teams-tour.md
+   ```
+
+3. Rebuild and restart:
+
+   ```bash
+   pnpm run build
+   bash setup/lib/restart.sh
+   ```
+
+Composed group CLAUDE.md files regenerate on the next container spawn, so the
+dropped instructions fragment and welcome addendum disappear from agents
+without any manual cleanup.

--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: slack-agent-flow
+description: Let an existing Slack agent create new agents that arrive as their own Slack bots — provisioned app, operator DM, and a shared three-way room, hot-started without a host restart.
+---
+
+# Slack agent flow (create_agent → provisioned Slack bot)
+
+Composes the Slack extension skills into one conversational flow: a user tells
+an existing Slack-wired agent "create an agent called Research", and the new
+agent doesn't just exist as a `send_message` destination — it arrives in Slack
+as **its own bot**. The host provisions a Slack app for it (managed broker, or
+a workspace manager token), registers it as a `slack-<name>` instance,
+hot-starts the adapter in the running host, opens a DM between the new bot and
+the operator, opens a three-way MPIM (operator + originating bot + new bot)
+registered as an agent-to-agent room, and wires everything so both agents hear
+the room. The flow also adds two agent-facing room actions — `create_room`
+(one shared room with N agents at once, the team primitive) and `add_to_room`
+(grow a room by one agent) — and extends the base `create_agent` tool with the
+flow's `purpose` / `allow_guests` / `room` parameters. Non-Slack sessions are
+untouched: `create_agent` from any other channel behaves exactly as upstream.
+
+## Prerequisites
+
+All prose below assumes these are already in place, in this order:
+
+1. **`add-slack`** — the Slack channel install (`src/channels/slack.ts` and
+   the shared channel-layer lib `src/channels/slack-lib.ts` present, with
+   `slack.ts` exporting its `SLACK_DEFAULTS` declaration and the
+   multi-instance factory `slackInstanceBridgeFactory` — the adapter owns
+   `SLACK_INSTANCES` registration natively, and the flow writes each new
+   agent's tokens under that env-key scheme).
+2. **`slack-a2a-rooms`** — the bot-sender room policy
+   (`src/channels/slack-a2a.ts` present), so shared rooms admit the sibling
+   bots' posts.
+3. **A provisioning credential in `.env`** — `NANOCLAW_INSTALL_TOKEN` (managed
+   broker) or `SLACK_MANAGER_TOKEN` (direct workspace-level app creation).
+   Without one, agent creation still works but the Slack leg reports
+   `no-credentials` and points at the finish script.
+4. **At least one Slack owner/admin in `user_roles`** — the flow resolves "the
+   operator" from the approver chain (scoped admins → global admins → owners)
+   and needs a `slack:U…` identity there to open the DM and the room.
+
+## Apply
+
+### 1. Check the Slack payloads are installed
+
+The flow imports the skill-installed Slack channel modules; verify they are in
+the tree before copying anything. If `slack-lib.ts`, the `SLACK_DEFAULTS`
+export, or the `slackInstanceBridgeFactory` export is missing, the installed
+Slack channel payload predates this flow — re-apply the two skills above (or
+`/update-skills`) first:
+
+```nc:run effect:check
+test -f src/channels/slack.ts && test -f src/channels/slack-lib.ts && test -f src/channels/slack-a2a.ts && grep -q "export const SLACK_DEFAULTS" src/channels/slack.ts && grep -q "export function slackInstanceBridgeFactory" src/channels/slack.ts
+```
+
+### 2. Check the trunk extension seams
+
+Everything this flow plugs into is standard trunk API — the adapter hot-start
+entry, the delivery batch preview, the create-agent notify option, the
+container tool-extension hook, and the setup wizard's channel registries. This
+is a trunk **version requirement, not an edit**: if the check below fails, the
+NanoClaw trunk is too old for this skill — bring the install up to date
+(`/update-nanoclaw`) instead of patching any of these files by hand:
+
+```nc:run effect:check
+grep -q "export async function startChannelAdapter" src/channels/channel-registry.ts && grep -q "export function registerDeliveryBatchPreview" src/delivery.ts && grep -q "suppressCreatedNotify" src/modules/agent-to-agent/create-agent.ts && grep -q "export function extendTool" container/agent-runner/src/mcp-tools/server.ts && grep -q "export function registerChannelPreStep" setup/channels/companions.ts && grep -q "instructions.md" src/claude-md-compose.ts
+```
+
+### 3. Copy the flow payload
+
+This skill ships its payload alongside this document; copy the files into the
+tree at the same relative paths (overwrite; the skill's copies are canonical).
+The host module carries the wrapped `create_agent` handler and the room
+actions; the container files carry the room tools, the `create_agent`
+extension, the sibling-agent standing-context skill, and the welcome-tour
+addendum. The two `mcp-tools/*.instructions.md` fragments and the
+`slack-construct-agents` skill's `instructions.md` are picked up by the
+CLAUDE.md compose scan; the welcome addendum is consumed by the host's
+channel-matched addenda mechanism (inert on hosts that predate it) — so
+copying the files is the whole install:
+
+```nc:copy
+src/modules/slack-agent-flow/types.ts
+src/modules/slack-agent-flow/env-file.ts
+src/modules/slack-agent-flow/provision.ts
+src/modules/slack-agent-flow/slack-deps.ts
+src/modules/slack-agent-flow/orchestrate.ts
+src/modules/slack-agent-flow/guard.ts
+src/modules/slack-agent-flow/room-actions.ts
+src/modules/slack-agent-flow/room-canvas.ts
+src/modules/slack-agent-flow/index.ts
+src/modules/slack-agent-flow/env-file.test.ts
+src/modules/slack-agent-flow/provision.congruence.test.ts
+src/modules/slack-agent-flow/provision.prefetch.test.ts
+src/modules/slack-agent-flow/orchestrate.test.ts
+src/modules/slack-agent-flow/room-actions.test.ts
+src/modules/slack-agent-flow/room-canvas.test.ts
+scripts/slack-agent-flow-finish.ts
+container/agent-runner/src/mcp-tools/rooms.ts
+container/agent-runner/src/mcp-tools/rooms.test.ts
+container/agent-runner/src/mcp-tools/rooms.instructions.md
+container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+container/skills/slack-construct-agents/SKILL.md
+container/skills/slack-construct-agents/instructions.md
+container/skills/welcome/addenda/teams-tour.md
+```
+
+### 4. Register the host module
+
+Append the self-registration import to the module barrel (skipped if the line
+is already present). It must evaluate after the agent-to-agent module's own
+registration, which appending at the end guarantees — the flow's `create_agent`
+handler re-registers over upstream's:
+
+```nc:append to:src/modules/index.ts
+import './slack-agent-flow/index.js';
+```
+
+### 5. Register the container room tools
+
+Append the tool-module import to the container MCP-tools barrel (skipped if
+already present). The module registers `create_room` / `add_to_room` and
+extends the base `create_agent` tool, so it must evaluate after the base
+agents module — import order follows document order, and appending at the end
+guarantees it:
+
+```nc:append to:container/agent-runner/src/mcp-tools/index.ts
+import './rooms.js';
+```
+
+### 6. Build
+
+The build guards every typed call the flow makes into trunk (delivery
+registration, DB helpers, channel defaults, the shared Slack lib) against
+drift:
+
+```nc:run effect:build
+pnpm run build
+```
+
+### 7. Validate
+
+The flow's own tests plus the trunk hot-start seam's test (host side), then
+the container room-tools test, which also pins the `create_agent` extension:
+
+```nc:run effect:test
+pnpm exec vitest run src/modules/slack-agent-flow src/channels/adapter-hot-start.test.ts
+```
+
+```nc:run effect:test
+cd container/agent-runner && bun test src/mcp-tools/rooms.test.ts
+```
+
+### 8. Restart the host
+
+The flow module registers at boot, and container mounts are read-only at
+runtime — restart so the running host picks everything up (new sessions see
+the container-side files; no image rebuild):
+
+```nc:run effect:restart
+bash setup/lib/restart.sh
+```
+
+## How it behaves
+
+- **Guard/approval flow is upstream's.** The flow re-registers `create_agent`
+  with the same guard action and precheck as the agent-to-agent module; only
+  the hold question changes when the request originates from a Slack session
+  (it names the Slack provisioning side effects — new app, operator DM,
+  shared room). The room actions get the same trust split: `global` cli_scope
+  groups act directly, everything else holds for the admin chain, and
+  approved replays re-enter the wrapped handlers automatically.
+- **Expected boot warning.** Because the barrel imports the flow module after
+  the agent-to-agent module, every boot logs
+  `Delivery action handler overwritten` for `create_agent`. That warning is
+  the intended signal that the wrapper won the registry — its absence means
+  the barrel line is missing or ordered wrong.
+- **What a successful run does.** Provisions (or reuses) the app — agent-mode
+  by default; `allow_guests: true` selects the plain, guest-accessible
+  variant — writes `SLACK_BOT_TOKEN_<NAME>` / `SLACK_APP_TOKEN_<NAME>` and
+  unions the slug into `SLACK_INSTANCES`, hot-starts `slack-<name>`, opens
+  the operator DM and wires it to the new agent group (agent-mode DMs get
+  thread-per-conversation sessions straight from the channel declaration),
+  opens the three-way MPIM with the new bot's token, appends the room's
+  channel id to `SLACK_A2A_ROOMS`, creates one room messaging group per
+  instance (both mention-gated), creates the room's canvas-tab contract, then
+  posts the DM intro and nudges the originating agent to introduce the new
+  one in the room. The new bot typically answers within ~10 seconds; if it
+  stays silent for a minute, an operator can run `bash setup/lib/restart.sh`
+  as the fallback.
+- **Teams get one room.** `create_agent({ ..., room: 'none' })` skips the
+  shared room; the multi-agent pattern is N such creates followed by ONE
+  `create_room` naming all of them. When a batch of creates arrives together,
+  their avatar generations are prefetched in parallel, so N waits collapse to
+  roughly one.
+- **A2A cache staleness.** The a2a room allowlist is re-read from `.env` on a
+  ≤30s cache. The room id is appended before any intro is posted, but the
+  originating agent's own bridge may still miss ingesting the intro inside
+  that window — harmless; the intro is for the human, and the originating
+  session is told the room id and wirings directly in its success message.
+- **Failures are resumable.** Any Slack-leg failure leaves the agent group
+  fully working via `send_message`, reports the exact step that failed, and
+  names the retry command. The finish script re-runs the whole leg
+  idempotently (tokens are reused from `.env`, rows are get-before-create,
+  intro posts fire only for newly created rows):
+
+  ```bash
+  pnpm exec tsx scripts/slack-agent-flow-finish.ts --group <newAgentGroupId> --name <slug> --source-group <sourceGroupId> [--origin-instance <key>] [--room none] [--allow-guests] [--restart]
+  ```
+
+  It runs outside the host process, so it cannot hot-start the adapter:
+  `--restart` runs `bash setup/lib/restart.sh` for you, otherwise it prints
+  the restart instruction.
+- **Setup-wizard leg.** On a trunk new enough for step 2's check, the setup
+  wizard's Slack arm already consults the managed-provisioning pre-step and
+  companion-skill declarations (`setup/channels/slack-auto.ts`, registered
+  through `setup/channels/companions.ts`) — that leg ships with trunk, and
+  this skill does not touch it.
+
+Everything the flow creates at runtime is user data, not skill payload: agent
+groups, messaging groups, and wirings stay in the central DB; token lines,
+`SLACK_INSTANCES` entries, and `SLACK_A2A_ROOMS` entries stay in `.env`;
+provisioned Slack apps stay in the workspace. Removal (see REMOVE.md) never
+touches any of it — for per-agent teardown of a provisioned bot, follow the
+slack-managed-agents skill's teardown section.

--- a/.claude/skills/slack-agent-flow/apply-fixtures.json
+++ b/.claude/skills/slack-agent-flow/apply-fixtures.json
@@ -1,0 +1,9 @@
+{
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — this skill declares no prompts and captures nothing, so one default scenario with no inputs covers the whole document (the two effect:check gates and the build/test/restart runs are exec-stubbed).",
+  "scenarios": [
+    {
+      "name": "default",
+      "inputs": {}
+    }
+  ]
+}

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
@@ -1,0 +1,8 @@
+## create_agent on Slack: acknowledge in the same turn (creation takes ~1 minute)
+
+On this install, every agent you create also gets its own Slack bot. Creation is not instant: a unique avatar is generated and a dedicated Slack app is provisioned, which takes about a minute. From the user's side that is silence — so ALWAYS acknowledge in the SAME turn as the `create_agent` call (before or alongside it), set the expectation, and say what happens next. Example: "On it — creating Pixel now. It takes about a minute; it'll introduce itself in a DM and open a shared room for the three of us."
+
+- What the user will see: roughly a minute of quiet, then an intro DM from the new agent plus a shared three-way room (you, the user, the new agent) — unless you passed `room: 'none'`, which skips the room (the team pattern: several agents with `room:'none'`, then one `create_room` with all of them — see the rooms tools).
+- Give each create a short PUBLIC `purpose` line (under 80 chars) — it appears in the room intro and on the room canvas; never put private detail from the instructions there.
+- In rooms, keep the acknowledgment brief — one short line, no play-by-play.
+- You'll be notified when the agent is live (or get a failure notice with a fix-it command). Relay completion only when that arrives — never report "done" early.

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
@@ -1,0 +1,22 @@
+## Shared rooms (`create_room`, `add_to_room`)
+
+A room is one Slack group conversation shared by the user and N agents, with a canvas tab carrying the room contract (purpose, members). `mcp__nanoclaw__create_room({ name, purpose, agents, include_me? })` opens one; `mcp__nanoclaw__add_to_room({ room, agent })` grows one.
+
+### The team pattern — one room, not N
+
+When the user asks for a TEAM (several agents for one project), never let each `create_agent` open its own room — that yields N separate three-way rooms nobody wants:
+
+1. Create each agent with `room: 'none'` (they still get their operator DM).
+2. When all are live, call `create_room` ONCE with all their names and a short public `purpose`.
+
+For a SINGLE new agent, plain `create_agent` (default `room: 'own'`) is right — don't follow up with `create_room`.
+
+### How it works
+
+- `agents` takes the same names you use with `send_message` — agents you created or can already message. Unknown names come back as an error note, nothing half-created.
+- Both tools are fire-and-forget and may require admin approval; the outcome arrives as a system note. When the room is live, the note tells you the destination to post to and whom to tag — post a brief intro in your own voice (1-2 lines, no mechanics, no member lists).
+- In rooms, agents engage when @-mentioned; everything else accumulates as ambient context. Tag an agent to bring it in.
+
+### Growing a room
+
+`add_to_room` works, but Slack group conversations never grow in place — the room MOVES to a new conversation (everyone re-wired automatically; the old conversation keeps working). Prefer creating rooms complete: if you know the team needs four agents, create all four first, then one `create_room`.

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Room MCP tool tests: create_room / add_to_room arg validation and
+ * system-action row shape, plus the extendTool-based create_agent extension
+ * (schema/description growth + purpose/allow_guests/room payload
+ * passthrough) — all fire-and-forget writes to messages_out (authorization
+ * is host-side). Importing ./rooms.js applies the extension, so these tests
+ * exercise the same wiring the barrel produces.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../db/connection.js';
+import { createAgent } from './agents.js';
+import { addToRoom, createRoom } from './rooms.js';
+
+function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
+  return (
+    getOutboundDb().prepare('SELECT id, kind, content FROM messages_out ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, content: JSON.parse(r.content) }));
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+describe('create_room — arg validation', () => {
+  it('requires name', async () => {
+    const r = await createRoom.handler({ agents: ['Pixel'] });
+    expect(r.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('requires a non-empty agents list of names', async () => {
+    for (const agents of [undefined, [], ['  '], 'Pixel']) {
+      const r = await createRoom.handler({ name: 'Website Team', agents });
+      expect(r.isError).toBe(true);
+    }
+    expect(outboundActions()).toHaveLength(0);
+  });
+});
+
+describe('create_room — submission', () => {
+  it('writes a create_room system action with the full agent list', async () => {
+    const r = await createRoom.handler({
+      name: '  Website Team ',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toContain('Creating room "Website Team"');
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({
+      action: 'create_room',
+      name: 'Website Team',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+    // include_me travels only when explicitly false (host default is true).
+    expect(rows[0].content.include_me).toBeUndefined();
+  });
+
+  it('carries include_me:false only when explicitly set', async () => {
+    await createRoom.handler({ name: 'Duo', agents: ['Pixel'], include_me: false });
+    expect(outboundActions()[0].content).toMatchObject({ action: 'create_room', include_me: false });
+  });
+});
+
+describe('add_to_room', () => {
+  it('requires room and agent', async () => {
+    const r1 = await addToRoom.handler({ agent: 'Devin' });
+    expect(r1.isError).toBe(true);
+    const r2 = await addToRoom.handler({ room: 'Website Team' });
+    expect(r2.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('writes an add_to_room system action', async () => {
+    const r = await addToRoom.handler({ room: 'Website Team', agent: 'Devin' });
+    expect(r.isError).toBeUndefined();
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({ action: 'add_to_room', room: 'Website Team', agent: 'Devin' });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+});
+
+describe('create_agent — Slack extension (extendTool)', () => {
+  it('extends the base tool schema and description without editing agents.ts', () => {
+    const props = (createAgent.tool.inputSchema as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['name', 'instructions', 'purpose', 'allow_guests', 'room']),
+    );
+    expect(createAgent.tool.description).toContain('acknowledge the user in this SAME turn');
+  });
+
+  it('passes the registered keys through into the written system payload', async () => {
+    await createAgent.handler({ name: 'Pixel', room: 'none', purpose: 'design things' });
+    await createAgent.handler({ name: 'Solo' });
+    await createAgent.handler({ name: 'Own', room: 'own' });
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].content).toMatchObject({
+      action: 'create_agent',
+      name: 'Pixel',
+      room: 'none',
+      purpose: 'design things',
+    });
+    // No extension args → the payload stays byte-identical to the base tool's.
+    expect(rows[1].content.room).toBeUndefined();
+    expect(rows[1].content.purpose).toBeUndefined();
+    // The passthrough copies provided values verbatim; the host reads an
+    // explicit 'own' exactly as an absent room (both mean the default
+    // own-room policy), so nothing normalizes it away container-side.
+    expect(rows[2].content.room).toBe('own');
+  });
+});

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
@@ -1,0 +1,160 @@
+/**
+ * Room management MCP tools: create_room, add_to_room.
+ *
+ * A "room" is one Slack group conversation shared by the user and N agents.
+ * create_room is the team primitive — the multi-agent pattern is N
+ * create_agent calls with room:'none', then ONE create_room naming all of
+ * them. Both tools are fire-and-forget (create_agent pattern): they write an
+ * outbound system row and return; the host resolves names, opens the
+ * conversation, wires everyone, and reports back as a system note.
+ *
+ * Authorization is enforced host-side by the guard (same trust split as
+ * create_agent: trusted global-scope groups act directly, confined groups
+ * hold for admin approval) — the container is untrusted and cannot be relied
+ * on to gate itself.
+ *
+ * This module also extends the base `create_agent` tool (see the extendTool
+ * call at the bottom): the Slack flow adds `purpose` / `allow_guests` /
+ * `room` params and the acknowledge-now guidance without touching the base
+ * tool's source. The barrel imports this module after the base agents
+ * module, which is what makes the extension legal.
+ */
+import { writeMessageOut } from '../db/messages-out.js';
+import { extendTool, registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+export const createRoom: McpToolDefinition = {
+  tool: {
+    name: 'create_room',
+    description:
+      'Open ONE shared Slack room (group conversation) with the user and several agents at once — the team primitive. Use after creating the agents (create_agent with room:\'none\' for teams): one room with ALL of them, never one room per agent. May require admin approval. Fire-and-forget: the call returns immediately; you will get a system note when the room is live, telling you how to post the intro there.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string', description: 'Room name (also names the Slack conversation and its canvas)' },
+        purpose: {
+          type: 'string',
+          description:
+            'One short PUBLIC line (under 80 chars) saying what the room is for — shown on the room canvas. Never include private details.',
+        },
+        agents: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Agent names to include — the same names you use with send_message (agents you created or can already message).',
+        },
+        include_me: {
+          type: 'boolean',
+          description: 'Include yourself in the room. Default true — keep it unless the user explicitly excludes you.',
+        },
+      },
+      required: ['name', 'agents'],
+    },
+  },
+  async handler(args) {
+    const name = typeof args.name === 'string' ? args.name.trim() : '';
+    if (!name) return err('name is required');
+    const agents = Array.isArray(args.agents) ? args.agents.filter((a) => typeof a === 'string' && a.trim()) : [];
+    if (agents.length === 0) return err('agents must list at least one agent name');
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'create_room',
+        requestId,
+        name,
+        agents,
+        ...(typeof args.purpose === 'string' && args.purpose.trim() ? { purpose: (args.purpose as string).trim() } : {}),
+        ...(args.include_me === false ? { include_me: false } : {}),
+      }),
+    });
+
+    log(`create_room: ${requestId} → "${name}" (${agents.length} agents)`);
+    return ok(`Creating room "${name}". You will be notified when it is live.`);
+  },
+};
+
+export const addToRoom: McpToolDefinition = {
+  tool: {
+    name: 'add_to_room',
+    description:
+      'Add one agent to an existing shared room. Slack group conversations never grow in place — this moves the room to a NEW conversation containing everyone plus the new agent (the old one keeps working). For a planned team, prefer creating the room once, complete, via create_room. May require admin approval. Fire-and-forget: a system note reports the outcome.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        room: { type: 'string', description: 'Room name (as the room was created/named)' },
+        agent: { type: 'string', description: 'Agent name to add — the same name you use with send_message' },
+      },
+      required: ['room', 'agent'],
+    },
+  },
+  async handler(args) {
+    const room = typeof args.room === 'string' ? args.room.trim() : '';
+    const agent = typeof args.agent === 'string' ? args.agent.trim() : '';
+    if (!room) return err('room is required');
+    if (!agent) return err('agent is required');
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({ action: 'add_to_room', requestId, room, agent }),
+    });
+
+    log(`add_to_room: ${requestId} → "${agent}" into "${room}"`);
+    return ok(`Adding "${agent}" to room "${room}". You will be notified when it is done.`);
+  },
+};
+
+registerTools([createRoom, addToRoom]);
+
+// ── create_agent extension (Slack agent flow) ──
+//
+// Additive extension of the base create_agent tool: on a Slack-wired install
+// each created agent also gets a dedicated Slack bot, so the tool grows the
+// flow's three params and the acknowledge-now guidance. The registered
+// passthrough keys are copied verbatim into the system-action payload the
+// base handler writes — the host reads them exactly as it reads name and
+// instructions (room:'own' and allow_guests:false travel explicitly and read
+// as the defaults host-side).
+extendTool('create_agent', {
+  properties: {
+    purpose: {
+      type: 'string',
+      description:
+        'One short PUBLIC line (under 80 chars) saying what this agent is for — shown to everyone in the shared room intro and canvas. ALWAYS provide it. Never include private details from the instructions; without it the room states no purpose at all.',
+    },
+    allow_guests: {
+      type: 'boolean',
+      description:
+        'Set true ONLY if Slack workspace guests must be able to DM this agent — guests cannot access agent-mode bots, so this provisions a plain bot without the agent DM experience. Default false.',
+    },
+    room: {
+      type: 'string',
+      enum: ['own', 'none'],
+      description:
+        "Shared-room policy. 'own' (default) opens a room with you, the user, and the new agent — right for a single create. 'none' skips the room (the agent still gets its DM) — REQUIRED when creating several agents for one team: create each with room:'none', then call create_room ONCE with all of them. Never open per-agent rooms for a team.",
+    },
+  },
+  passthroughKeys: ['purpose', 'allow_guests', 'room'],
+  descriptionSuffix:
+    'The call returns immediately. Creation takes about a minute (a unique avatar is generated and a dedicated Slack bot is provisioned); when ready, the new agent introduces itself via DM and a shared room. You MUST acknowledge the user in this SAME turn, before or alongside this call — say you are on it, set the ~1-minute expectation, and mention the agent will introduce itself.',
+});

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/SKILL.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: slack-construct-agents
+description: Standing context for Slack sibling agents — one room per team, creator-posted introductions, bot-to-bot hop discipline. Ships as instructions.md composed into the group's CLAUDE.md at spawn; there is no workflow to invoke.
+---
+
+# Slack construct — sibling agents
+
+This skill is a carrier for standing context, not an on-demand workflow. Its
+payload is `instructions.md` in this directory: the rules an agent needs when
+it shares Slack with sibling agents it can create (`create_agent`) and room
+with (`create_room` / `add_to_room`) — team-room shape, who posts the
+introduction, and the bot-to-bot self-limit.
+
+The host composes every container skill's `instructions.md` into each group's
+CLAUDE.md at spawn (`src/claude-md-compose.ts`), so if you are reading this
+from inside a session, those rules are already part of your standing
+instructions. There is nothing further to load or run here.
+
+The room-and-canvas half of the Slack standing context (mention engagement,
+canvas discipline, access rules) ships separately with the Slack channel
+payload as the `slack-construct` skill; this fragment layers the
+sibling-agent rules on top and arrives with the slack-agent-flow skill.

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
@@ -1,0 +1,26 @@
+## Your Slack sibling agents
+
+You may be part of a construct of agents on Slack: sibling agents (each with its own bot,
+DM, and workspace) plus shared rooms where humans, you, and siblings talk. Standing rules
+for the sibling half:
+
+- **Teams get ONE room.** When the user asks for several agents for one project ("build me
+  a team"), create each agent with `create_agent({ ..., room: 'none' })` — they still get
+  their operator DM — then open a single shared room with
+  `create_room({ name, purpose, agents: [all of them] })`. Never let each create open its
+  own room: that yields N separate three-way rooms nobody wants. `add_to_room` works for
+  later growth, but Slack group DMs never grow in place — the room MOVES to a new
+  conversation (everyone is re-wired automatically; the old one keeps working), so prefer
+  creating rooms complete.
+- **You introduce agents you create.** When a shared room comes with an agent you created,
+  YOU post the introduction in the room — the host posts nothing there. You'll get a
+  system nudge telling you which destination to use. Keep it to 1-2 lines in your own
+  voice: say what the new agent is for and tag them with their `<@bot-user-id>` mention
+  (send it literally; it renders as a mention). No mechanics, no member lists — the room's
+  canvas tab already holds that.
+- **Bot-to-bot hop budget.** The platform may cap consecutive bot-to-bot messages (~6)
+  until a human speaks again, but do not rely on it — self-limit. Don't ping-pong with
+  siblings: do the work, converge, hand back to the human.
+- **Persist durable facts.** Conversations are per-session; rooms and DMs don't share
+  history. Anything worth keeping (decisions, preferences, ongoing state) goes in your
+  memory directory, not just the chat transcript.

--- a/.claude/skills/slack-agent-flow/container/skills/welcome/addenda/teams-tour.md
+++ b/.claude/skills/slack-agent-flow/container/skills/welcome/addenda/teams-tour.md
@@ -1,0 +1,17 @@
+---
+channel: slack
+---
+
+# Teams tour item (Slack agent flow)
+
+When the tour runs on Slack, also reveal this — same drip-feed rule as the base
+tour, one item at a time, 2-4 sentences:
+
+### Teams
+
+Want a whole team? Ask your agent to build one — e.g. "create a designer, a
+builder, and a reviewer for my new site, in one shared room." It will create
+the agents first and then open a single room with all of them (plus you). You
+can grow a room later by asking to add an agent, but Slack moves the
+conversation to a new group DM when members change — the old thread keeps
+working, and everything is rewired automatically.

--- a/.claude/skills/slack-agent-flow/scripts/slack-agent-flow-finish.ts
+++ b/.claude/skills/slack-agent-flow/scripts/slack-agent-flow-finish.ts
@@ -1,0 +1,167 @@
+/**
+ * Finish (or retry) the Slack leg of an agent created via create_agent.
+ *
+ * The in-host slack-agent-flow wrapper points here when the Slack leg fails
+ * partway: re-runs S1–S13 idempotently (provision reuses .env tokens, every
+ * DB row is get-before-create, conversations.open is idempotent on Slack's
+ * side, intro posts are gated on newly-created rows) EXCEPT the S5 hot-add —
+ * a separate process cannot start an adapter inside the live host, so the
+ * new instance comes online via a service restart instead (--restart runs it,
+ * otherwise the command is printed).
+ *
+ * Runs alongside the service the way scripts/init-first-agent.ts does
+ * (WAL-mode sqlite; no channel adapters are connected — the channels barrel
+ * import is registration-only, so declared defaults resolve here).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/slack-agent-flow-finish.ts \
+ *     --group <newAgentGroupId> \
+ *     --name <slug> \
+ *     --source-group <sourceAgentGroupId> \
+ *     [--origin-instance <key>] \   # default: slack
+ *     [--room none] \               # original create used room:'none' — skip the shared room
+ *     [--restart]
+ *
+ * Never prints token values — only key names and ids.
+ */
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+// Registration-only barrel import: channel modules call
+// registerChannelAdapter() at module scope (factories are NOT invoked, no
+// adapter connects), so declared channel defaults resolve here without live
+// adapters.
+import '../src/channels/index.js';
+import { SlackApiError } from '../src/channels/slack-lib.js';
+import { DATA_DIR } from '../src/config.js';
+import { getAgentGroup } from '../src/db/agent-groups.js';
+import { initDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { finishSlackAgentFlow } from '../src/modules/slack-agent-flow/orchestrate.js';
+import { SlackFlowError } from '../src/modules/slack-agent-flow/types.js';
+
+interface Args {
+  group: string;
+  name: string;
+  sourceGroup: string;
+  originInstance: string;
+  restart: boolean;
+  allowGuests: boolean;
+  room?: 'own' | 'none';
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Partial<Args> = {};
+  let restart = false;
+  let allowGuests = false;
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    switch (key) {
+      case '--group':
+        out.group = val;
+        i++;
+        break;
+      case '--name':
+        out.name = val;
+        i++;
+        break;
+      case '--source-group':
+        out.sourceGroup = val;
+        i++;
+        break;
+      case '--origin-instance':
+        out.originInstance = val;
+        i++;
+        break;
+      case '--room': {
+        if (val !== 'own' && val !== 'none') {
+          console.error(`--room must be 'own' or 'none', got "${val}"`);
+          process.exit(2);
+        }
+        out.room = val;
+        i++;
+        break;
+      }
+      case '--restart':
+        restart = true;
+        break;
+      case '--allow-guests':
+        allowGuests = true;
+        break;
+      default:
+        console.error(`Unknown flag: ${key}`);
+        process.exit(2);
+    }
+  }
+  const missing = (['group', 'name', 'sourceGroup'] as const).filter((k) => !out[k]);
+  if (missing.length) {
+    console.error(
+      `Missing required args: ${missing.map((k) => `--${k.replace(/([A-Z])/g, '-$1').toLowerCase()}`).join(', ')}`,
+    );
+    console.error('See scripts/slack-agent-flow-finish.ts header for usage.');
+    process.exit(2);
+  }
+  return {
+    group: out.group!,
+    name: out.name!,
+    sourceGroup: out.sourceGroup!,
+    originInstance: out.originInstance ?? 'slack',
+    restart,
+    allowGuests,
+    room: out.room,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const root = process.cwd();
+
+  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  runMigrations(db); // idempotent
+
+  const newGroup = getAgentGroup(args.group);
+  if (!newGroup) throw new Error(`agent group ${args.group} not found (--group)`);
+  if (!getAgentGroup(args.sourceGroup)) throw new Error(`agent group ${args.sourceGroup} not found (--source-group)`);
+
+  const result = await finishSlackAgentFlow({
+    slug: args.name,
+    sourceGroupId: args.sourceGroup,
+    newAgentGroupId: args.group,
+    originInstanceKey: args.originInstance,
+    rootDir: root,
+    allowGuests: args.allowGuests,
+    room: args.room,
+  });
+
+  console.log('');
+  console.log('Slack leg complete:');
+  console.log(`  agent     ${newGroup.name} [${args.group}]`);
+  console.log(`  instance  slack-${result.slug} (SLACK_INSTANCES + SLACK_*_TOKEN_${result.slug.toUpperCase().replace(/-/g, '_')})`);
+  console.log(`  bot       ${result.newBotUserId}`);
+  console.log(`  DM        ${result.dmChannelId} (operator ${result.operatorUserId})`);
+  console.log(
+    result.roomChannelId
+      ? `  room      ${result.roomChannelId} (SLACK_A2A_ROOMS)`
+      : `  room      (skipped — room:'none')`,
+  );
+  console.log('');
+
+  // S5 replacement: the new adapter instance connects on the next service
+  // start — this process cannot hot-add into the live host.
+  if (args.restart) {
+    console.log('Restarting the service so the new instance connects…');
+    execFileSync('bash', [path.join(root, 'setup', 'lib', 'restart.sh')], { cwd: root, stdio: 'inherit' });
+  } else {
+    console.log('Restart the service so the new instance connects: bash setup/lib/restart.sh');
+  }
+}
+
+main().catch((err: unknown) => {
+  if (err instanceof SlackFlowError || err instanceof SlackApiError) {
+    console.error(`slack-agent-flow-finish failed at step '${err.step}': ${err.message}`);
+  } else {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+  process.exit(1);
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.test.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+
+describe('slack-agent-flow env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'SAF_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'SAF_PLAIN=value1',
+          '  SAF_INDENTED = spaced ',
+          'SAF_DQUOTED="double quoted"',
+          "SAF_SQUOTED='single quoted'",
+          'SAF_EMPTY=',
+          '# SAF_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'SAF_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'SAF_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'SAF_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'SAF_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'SAF_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('SAF_PREFERS=file-value\n');
+      vi.stubEnv('SAF_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'SAF_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('SAF_BLANK_ENV=file-value\n');
+      vi.stubEnv('SAF_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'SAF_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('second');
+    });
+  });
+
+  describe('upsertEnvKey', () => {
+    it('creates .env when absent', () => {
+      upsertEnvKey(rootDir, 'SAF_NEW', 'v1');
+      expect(read()).toBe('SAF_NEW=v1\n');
+      expect(readEnvValue(rootDir, 'SAF_NEW')).toBe('v1');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      upsertEnvKey(rootDir, 'SAF_APPENDED', 'v2');
+      expect(read()).toBe('EXISTING=x\nSAF_APPENDED=v2\n');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nSAF_TARGET=old\nLAST=9\n');
+      upsertEnvKey(rootDir, 'SAF_TARGET', 'new');
+      expect(read()).toBe('# keep me\nFIRST=1\nSAF_TARGET=new\nLAST=9\n');
+    });
+
+    it('does not touch keys that merely share a prefix', () => {
+      write('SAF_KEY=keep\nSAF_KEY_LONGER=keep-too\n');
+      upsertEnvKey(rootDir, 'SAF_KEY', 'changed');
+      expect(read()).toBe('SAF_KEY=changed\nSAF_KEY_LONGER=keep-too\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      upsertEnvKey(rootDir, 'SAF_DUP', 'final');
+      expect(read()).toBe('SAF_DUP=final\nSAF_DUP=final\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('final');
+    });
+
+    it('replaces an indented assignment (readable lines are writable lines)', () => {
+      write('  SAF_INDENTED=old\n');
+      upsertEnvKey(rootDir, 'SAF_INDENTED', 'new');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('new');
+      expect(read()).not.toContain('old');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates the key and reports the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'alpha')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('SAF_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('SAF_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys (the adapter's SLACK_INSTANCES loop) parse .env
+      // only, so the union must be based on the file, not a stale
+      // process.env copy.
+      write('SAF_LIST=alpha\n');
+      vi.stubEnv('SAF_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('SAF_LIST=alpha,beta');
+    });
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.ts
@@ -1,0 +1,96 @@
+/**
+ * .env read/write helpers for the slack-agent-flow leg.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — the adapter's SLACK_INSTANCES loop
+ * (src/channels/slack.ts) reads back everything written here through that
+ * parser. Write conventions mirror upsertEnvLine /
+ * appendSlackInstance in .claude/skills/slack-managed-agents/scripts/
+ * slack-create-agent.ts: replace the key's line in place, preserve every
+ * other line (comments and blanks included), append with a clean trailing
+ * newline.
+ *
+ * Values written here include live Slack tokens: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value.
+ */
+export function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/guard.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/guard.ts
@@ -1,0 +1,60 @@
+/**
+ * Slack-agent-flow guard adapter — the module's catalog entries for the
+ * agent-facing room actions, composed at the module edge (imported
+ * by ./index.ts), mirroring agent-to-agent/guard.ts.
+ *
+ * rooms.create / rooms.add_agent — same trust split as agents.create:
+ * `global` cli_scope acts directly (room wiring is the intended primitive for
+ * trusted owner agent groups); anything else — the default `group` scope, and
+ * unknown/missing config, fail-closed — holds for the requesting group's
+ * admin chain. Both actions write central-DB state (messaging groups,
+ * wirings, a2a destinations) and open Slack conversations with the operator,
+ * so a confined container must never reach the handler unheld.
+ */
+import { getContainerConfig } from '../../db/container-configs.js';
+import { ALLOW, DENY, HOLD, defineGuardedAction, type GuardedAction } from '../../guard/index.js';
+import type { GuardDecision, GuardInput } from '../../guard/index.js';
+
+/** The agents.create trust split, reused verbatim for the room actions. */
+function decideByCliScope(input: GuardInput, action: string): GuardDecision {
+  if (input.actor.kind !== 'agent') return DENY(`${action} is a container-originated action.`);
+  const cliScope = getContainerConfig(input.actor.agentGroupId)?.cli_scope ?? 'group';
+  if (cliScope === 'global') {
+    // Trusted owner agent group — an approval tap on every room change would
+    // be needless friction.
+    return ALLOW('trusted global-scope agent group');
+  }
+  // The realistic prompt-injection victim (default `group` scope) — and any
+  // unknown config value, fail-closed — requires an admin before any
+  // central-DB write or MPIM open.
+  return HOLD(`agent-initiated ${action} requires admin approval`);
+}
+
+export const roomsCreate: GuardedAction = defineGuardedAction({
+  action: 'rooms.create',
+  grantActionName: 'create_room',
+  // Bind a create_room grant to the room name that was approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      return (JSON.parse(grant.payload) as { name?: string }).name === input.payload.name;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'create_room'),
+});
+
+export const roomsAddAgent: GuardedAction = defineGuardedAction({
+  action: 'rooms.add_agent',
+  grantActionName: 'add_to_room',
+  // Bind an add_to_room grant to the exact (room, agent) pair approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      const p = JSON.parse(grant.payload) as { room?: string; agent?: string };
+      return p.room === input.payload.room && p.agent === input.payload.agent;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'add_to_room'),
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -1,0 +1,238 @@
+/**
+ * slack-agent-flow module — guarded re-registration of `create_agent`.
+ *
+ * Re-registers the delivery action with the SAME guard pieces as upstream
+ * (agents.create decision, validateCreateAgent precheck) and a handler that
+ * first runs the upstream `createAgent()` (with its premature success notify
+ * suppressed on the Slack path — see slackAwareCreateAgent), then — only when
+ * the request originated from a Slack session — provisions a dedicated Slack
+ * bot for the new group (orchestrate.ts). The barrel imports this module AFTER
+ * agent-to-agent's registration, so this entry wins; the expected boot log is
+ * `Delivery action handler overwritten`. Approved replays re-enter this
+ * wrapper automatically — reenterGuardedDeliveryAction resolves the entry at
+ * call time, so no approval-handler re-registration is needed.
+ *
+ * Also registers the agent-facing room actions: `create_room` (one
+ * MPIM with N bots + the operator over ensureAgentRoom) and `add_to_room`
+ * (superset re-open — MPIM fork), each guard-wrapped with the same
+ * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
+ *
+ * The handler never touches inbound DBs (guarded handlers replay without
+ * one); all requester notifications go through the approvals module's
+ * notifyAgent. Token values never appear in notify texts or logs.
+ */
+import { SlackApiError } from '../../channels/slack-lib.js';
+import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
+import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
+import { agentsCreate } from '../agent-to-agent/guard.js';
+import { notifyAgent, registerApprovalHandler, requestApproval } from '../approvals/index.js';
+import { roomsAddAgent, roomsCreate } from './guard.js';
+import { dedupeSlug, deriveInstanceSlug, runSlackAgentFlow } from './orchestrate.js';
+import {
+  handleAddToRoom,
+  handleCreateRoom,
+  requestAddToRoomHold,
+  requestCreateRoomHold,
+  validateAddToRoom,
+  validateCreateRoom,
+} from './room-actions.js';
+import { prefetchAvatar, resolveProvisioningCredential } from './provision.js';
+import { SlackFlowError } from './types.js';
+
+/** The Slack gate: the request came in through a Slack-channel session. */
+function isSlackOriginSession(session: Session): boolean {
+  if (!session.messaging_group_id) return false;
+  return getMessagingGroup(session.messaging_group_id)?.channel_type === 'slack';
+}
+
+// Avatar prefetch for multi-agent creates ("build me a team"): the batch
+// preview sees every create_agent row in the session's outbound batch before
+// they are processed sequentially, and starts all their avatar generations in
+// parallel — each is an independent async Lambda on the broker, so N waits
+// collapse to ~one (~23s). Gated on ≥2 creates: a single create starts its
+// flow immediately anyway, and skipping the single case means a guard-HELD
+// lone request never generates an avatar it might not get approval for.
+// The (displayName, description) derivation MUST mirror runSlackAgentFlow /
+// orchestrate exactly — a mismatch is harmless (fresh request) but wastes the
+// prefetch.
+registerDeliveryBatchPreview((batch, session) => {
+  if (!isSlackOriginSession(session)) return;
+  const creates = batch
+    .filter((m) => m.kind === 'system')
+    .map((m) => {
+      try {
+        return JSON.parse(m.content) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (c): c is Record<string, unknown> =>
+        c !== null && c.action === 'create_agent' && typeof c.name === 'string' && c.name !== '',
+    );
+  if (creates.length < 2) return;
+  const credential = resolveProvisioningCredential(process.cwd());
+  if (credential?.mode !== 'broker') return;
+  for (const c of creates) {
+    prefetchAvatar(
+      credential.baseUrl,
+      credential.installToken,
+      c.name as string,
+      typeof c.instructions === 'string' ? c.instructions.slice(0, 300) : undefined,
+    );
+  }
+  log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
+});
+
+function successText(name: string, roomChannelId: string | undefined): string {
+  // room:'none': no shared room was opened — the multi-create
+  // pattern finishes with one create_room naming every agent.
+  if (roomChannelId === undefined) {
+    return (
+      `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
+      `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
+      `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh`
+    );
+  }
+  return (
+    `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
+    `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
+    `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh`
+  );
+}
+
+function failureText(
+  name: string,
+  localName: string,
+  step: string,
+  message: string,
+  newAgentGroupId: string,
+  slug: string,
+  sourceGroupId: string,
+  roomNone: boolean,
+): string {
+  // room:'none' must survive into the printed finish command too — omitting
+  // it would make the retry grow a room the multi-create pattern skipped.
+  return (
+    `Agent "${name}" was created and is reachable via send_message({ to: "${localName}", ... }), ` +
+    `but its Slack setup failed at step '${step}': ${message}. An operator can finish it with: ` +
+    `pnpm exec tsx scripts/slack-agent-flow-finish.ts --group ${newAgentGroupId} --name ${slug} ` +
+    `--source-group ${sourceGroupId}${roomNone ? ' --room none' : ''} [--origin-instance <key>] [--restart]`
+  );
+}
+
+async function slackAwareCreateAgent(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = typeof content.name === 'string' ? content.name : '';
+  const localName = normalizeName(name);
+  const before = getDestinationByName(session.agent_group_id, localName);
+  const slackOrigin = isSlackOriginSession(session);
+
+  // Upstream behavior byte-for-byte on non-Slack sessions. On the Slack path
+  // the upstream "created — you can now message it" success notify is
+  // suppressed: it fires BEFORE Slack provisioning, so relaying it would
+  // report "done" ~a minute early — this wrapper's successText/failureText
+  // is the only completion signal. Upstream error notifies (collision,
+  // invalid path) still fire either way.
+  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+
+  const after = getDestinationByName(session.agent_group_id, localName);
+  // Creation bailed or collided — upstream already answered the requester.
+  if (!after || after.target_type !== 'agent' || before) return;
+  // Non-Slack sessions (and task/a2a sessions with no messaging group) behave exactly as upstream.
+  if (!slackOrigin) return;
+
+  const slug = dedupeSlug(deriveInstanceSlug(name), after.target_id);
+  try {
+    const r = await runSlackAgentFlow({ content, session, newAgentGroupId: after.target_id, slug });
+    notifyAgent(session, successText(name, r.roomChannelId));
+  } catch (err) {
+    // SlackApiError carries the flow step id its call site passed to the
+    // shared Slack lib — surface it like a typed flow step.
+    const step = err instanceof SlackFlowError || err instanceof SlackApiError ? err.step : 'unknown';
+    const message = err instanceof Error ? err.message : String(err);
+    notifyAgent(
+      session,
+      failureText(
+        name,
+        localName,
+        step,
+        message,
+        after.target_id,
+        slug,
+        session.agent_group_id,
+        content.room === 'none',
+      ),
+    );
+    log.error('slack-agent-flow failed', { step });
+  }
+}
+
+/**
+ * Slack-aware hold: same payload shape as upstream ({ name, instructions })
+ * so the approved replay re-enters this wrapper unchanged; only the card text
+ * differs, telling the admin a Slack bot comes with the sub-agent.
+ */
+async function requestSlackCreateAgentHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  if (!isSlackOriginSession(session)) {
+    await requestCreateAgentHold(content, session);
+    return;
+  }
+  const name = typeof content.name === 'string' ? content.name : '';
+  const instructions = typeof content.instructions === 'string' ? content.instructions : null;
+  const sourceGroup = getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_agent',
+    // allow_guests must survive the hold: the approved replay re-enters the
+    // wrapper with this payload, and dropping it would silently upgrade a
+    // guest-accessible request to the agent-view variant.
+    payload: {
+      name,
+      instructions,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.allow_guests === true ? { allow_guests: true } : {}),
+      // room:'none' must survive the hold too — dropping it would grow a
+      // room the multi-create pattern deliberately skipped.
+      ...(content.room === 'none' ? { room: 'none' } : {}),
+    },
+    title: `Create agent: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
+  });
+}
+
+registerDeliveryAction('create_agent', slackAwareCreateAgent, {
+  guardAction: agentsCreate,
+  precheck: validateCreateAgent,
+  requestHold: requestSlackCreateAgentHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_agent denied: ${reason}`),
+});
+
+// Agent-facing room actions — guard-wrapped like create_agent:
+// global-scope groups act directly, everything else holds for the admin
+// chain, and the approval continuation re-enters the same wrapped entry with
+// the approval row as its grant.
+registerDeliveryAction('create_room', handleCreateRoom, {
+  guardAction: roomsCreate,
+  precheck: validateCreateRoom,
+  requestHold: requestCreateRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_room denied: ${reason}`),
+});
+registerApprovalHandler('create_room', reenterGuardedDeliveryAction('create_room'));
+
+registerDeliveryAction('add_to_room', handleAddToRoom, {
+  guardAction: roomsAddAgent,
+  precheck: validateAddToRoom,
+  requestHold: requestAddToRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `add_to_room denied: ${reason}`),
+});
+registerApprovalHandler('add_to_room', reenterGuardedDeliveryAction('add_to_room'));

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -1,0 +1,703 @@
+/**
+ * End-to-end tests for the slack-agent-flow wrapped create_agent action.
+ *
+ * Drives the REAL guard-wrapped delivery entry (getDeliveryAction) over a real
+ * in-memory central DB; Slack/broker traffic is a recorded fetch stub and the
+ * optional-module seam (slack-deps.js) is a recorded fake — no network, no
+ * skill-installed channel files. rootDir is process.cwd(), so each test runs
+ * chdir'd into its own tmpdir (vitest's default forks pool allows chdir).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ORIGIN_BOT_TOKEN = 'xoxb-origin-secret-token';
+const NEW_BOT_TOKEN = 'xoxb-new-bot-secret-token';
+const NEW_APP_TOKEN = 'xapp-new-app-secret-token';
+const REGISTRY_TOKEN = 'nct-registry-secret-token';
+
+// vi.hoisted: the module import below runs before this file's const
+// initializers, and the mock factories close over this state.
+const {
+  mockNotifyWrite,
+  mockRequestApproval,
+  mockInitGroupFilesystem,
+  mockWriteDestinations,
+  mockCreateRoomCanvas,
+  mockWireCanvasComments,
+  mockAssertSlackInstancesModuleInstalled,
+  fakeDeps,
+} = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+  mockInitGroupFilesystem: vi.fn(),
+  mockWriteDestinations: vi.fn(),
+  mockCreateRoomCanvas: vi.fn(),
+  mockWireCanvasComments: vi.fn(),
+  mockAssertSlackInstancesModuleInstalled: vi.fn().mockResolvedValue(undefined),
+  fakeDeps: {
+    slackInstanceBridgeFactory: vi.fn().mockReturnValue(null),
+    SLACK_DEFAULTS: undefined as unknown, // assigned in beforeEach (TEST_SLACK_DEFAULTS)
+    registerChannelAdapter: vi.fn(),
+    startChannelAdapter: vi.fn().mockResolvedValue('started'),
+  },
+}));
+
+// The optional-module seam — the only door to skill-installed channel files.
+vi.mock('./slack-deps.js', () => ({
+  loadSlackChannelDeps: async () => fakeDeps,
+  assertSlackInstancesModuleInstalled: (...a: unknown[]) => mockAssertSlackInstancesModuleInstalled(...a),
+}));
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+// wireCanvasComments (shadow-channel wiring) rides in the same module.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+// delivery.ts pulls more session-manager exports at import time.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({
+  initGroupFilesystem: (...a: unknown[]) => mockInitGroupFilesystem(...a),
+}));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// wrapper only needs these three. notifyAgent stays REAL (from primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the wrapped create_agent delivery action — the path under test.
+// Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
+import './index.js';
+import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
+import { SlackFlowError } from './types.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+// Mirrors the shape the Slack adapter declares (SLACK_DEFAULTS): the dm
+// context carries the B7 agent-DM declaration (sessionMode 'per-thread';
+// resolveWiringDefaults derives the threads=1 stamp from it) — S8 stamps
+// whatever the declaration resolves, so the per-thread/threads:1 pins below
+// exercise the declaration-driven path, not a hardcode.
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: {
+    engageMode: 'pattern',
+    engagePattern: '.',
+    threads: true,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'strict',
+  },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+/** .env content snapshotted at each chat.postMessage — proves S10 ran before S13. */
+let postMessageEnvSnapshots: string[] = [];
+let brokerStatus = 200;
+let tmpDir = '';
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const auth = String(init?.headers?.Authorization ?? '');
+  const token = auth.replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.endsWith('/v1/avatars')) {
+    // Pre-create avatar job: dispatched...
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'pending' }, 202));
+  }
+  if (url.includes('/v1/avatars/')) {
+    // ...and ready on the first poll, so the bot is born wearing its face.
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'ready' }));
+  }
+  if (url.endsWith('/v1/apps')) {
+    if (brokerStatus !== 200) return Promise.resolve(jsonResponse({ message: 'boom' }, brokerStatus));
+    return Promise.resolve(jsonResponse({ appId: 'A0TEST', appToken: NEW_APP_TOKEN, botToken: NEW_BOT_TOKEN }));
+  }
+  if (url.includes('/api/auth.test')) {
+    const userId = token === ORIGIN_BOT_TOKEN ? 'U0ORIGINBOT' : 'U0NEWBOT';
+    return Promise.resolve(
+      jsonResponse({
+        ok: true,
+        user_id: userId,
+        team_id: 'T0TEST',
+        team: 'NanoCo Test',
+        url: 'https://nanoco-test.slack.com/',
+      }),
+    );
+  }
+  if (url.includes('/api/conversations.open')) {
+    const users = String((JSON.parse(body) as { users?: string }).users ?? '');
+    return Promise.resolve(jsonResponse({ ok: true, channel: { id: users.includes(',') ? 'G0ROOM' : 'D0NEWDM' } }));
+  }
+  if (url.includes('/api/chat.postMessage')) {
+    const envPath = path.join(tmpDir, '.env');
+    postMessageEnvSnapshots.push(fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : '');
+    return Promise.resolve(jsonResponse({ ok: true }));
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+async function runCreateAgent(content: Record<string, unknown>, session: Session = SLACK_SESSION): Promise<void> {
+  const wrapped = getDeliveryAction('create_agent');
+  expect(wrapped).toBeDefined();
+  await wrapped!(content, session, undefined as never);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ORIGIN_BOT_TOKEN, NEW_BOT_TOKEN, NEW_APP_TOKEN, REGISTRY_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeDeps.SLACK_DEFAULTS = TEST_SLACK_DEFAULTS;
+  fakeDeps.startChannelAdapter.mockResolvedValue('started');
+  // Degraded default (free workspace / canvases off): C2 returns undefined —
+  // the flow must tolerate it (no canvas, no link line). Canvas tests opt in.
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  postMessageEnvSnapshots = [];
+  brokerStatus = 200;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-agent-flow-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ORIGIN_BOT_TOKEN}\n`);
+  process.env.NANOCLAW_REGISTRY_TOKEN = REGISTRY_TOKEN; // broker mode, no account.json / .env lookup
+
+  const db = initTestDb();
+  runMigrations(db);
+
+  const now = new Date().toISOString();
+  createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  ensureContainerConfig(SRC_GROUP);
+  updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  grantRole({ user_id: 'slack:U0OPERATOR', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now });
+  createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  createSession(SLACK_SESSION);
+  // Declared platform defaults so resolveWiringDefaults / validate see slack's
+  // real shape (group: mention-sticky + threads) for the dead named instance.
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  delete process.env.NANOCLAW_REGISTRY_TOKEN;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slack-aware create_agent — happy path (Slack-origin session)', () => {
+  it('creates the group, provisions the bot, wires DM + room, posts intros in order', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // Upstream leg: group + scaffold + bidirectional a2a destinations.
+    const newGroup = getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(mockInitGroupFilesystem).toHaveBeenCalledTimes(1);
+    const dest = getDestinationByName(SRC_GROUP, 'research');
+    expect(dest).toMatchObject({ target_type: 'agent', target_id: newGroup!.id });
+    expect(getDestinationByName(newGroup!.id, 'parent')).toMatchObject({ target_type: 'agent', target_id: SRC_GROUP });
+
+    // Env keys (values themselves never asserted into messages/logs).
+    const env = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    expect(env).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(env).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // Hot-add through the seam.
+    expect(fakeDeps.registerChannelAdapter).toHaveBeenCalledWith(
+      'slack-research',
+      expect.objectContaining({ defaults: TEST_SLACK_DEFAULTS }),
+    );
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+
+    // DM row + wiring on the NEW instance. Agent-view is the default variant
+    // so the DM gets thread-per-conversation sessions:
+    // session_mode 'per-thread' + explicit threads:1.
+    const dmMg = getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(dmMg).toMatchObject({ is_group: 0, unknown_sender_policy: 'strict', name: 'Research DM' });
+    expect(getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'per-thread',
+      threads: 1,
+      priority: 0,
+    });
+
+    // Room: one row PER instance, policy 'public', mention/accumulate wirings
+    // (D4 — flow-created rooms only; mention-sticky is gone from the flow).
+    const roomOrigin = getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack');
+    const roomNew = getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack-research');
+    expect(roomOrigin).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(roomNew).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(getMessagingGroupAgentByPair(roomOrigin!.id, SRC_GROUP)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+    expect(getMessagingGroupAgentByPair(roomNew!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+
+    // Projections pushed into the live source session.
+    expect(mockWriteDestinations).toHaveBeenCalledWith(SRC_GROUP, 'sess-1');
+
+    // No room-contract post: the only chat.postMessage is the DM intro,
+    // and SLACK_A2A_ROOMS was in .env before it.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(posts[0]!.token).toBe(NEW_BOT_TOKEN);
+    expect(postMessageEnvSnapshots).toHaveLength(1);
+    expect(postMessageEnvSnapshots[0]).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // The ORIGIN agent authors the room intro — exactly one
+    // instruction-shaped nudge written into the origin session, tagging the
+    // new bot and addressing the room by its projected destination name.
+    const nudges = notifyTexts().filter((t) => t.includes('introduction'));
+    expect(nudges).toHaveLength(1);
+    const nudgeCall = mockNotifyWrite.mock.calls.find((c) =>
+      String((c[2] as { content: string }).content).includes('introduction'),
+    )!;
+    expect(nudgeCall[0]).toBe(SRC_GROUP);
+    expect(nudgeCall[1]).toBe('sess-1');
+    // notifyAgent leaves `trigger` unset — writeSessionMessage defaults it
+    // to 1, so the nudge wakes the origin agent.
+    expect((nudgeCall[2] as { trigger?: number }).trigger).toBeUndefined();
+    expect(nudges[0]).toContain('<@U0NEWBOT>');
+    expect(nudges[0]).toContain('send_message({ to: "research-room"');
+    expect(nudges[0]).toContain('no mechanics, no member lists');
+    // No explicit purpose was provided — the creation prompt must NOT leak
+    // into the nudge (no fallback — creation prompts are private).
+    expect(nudges[0]).not.toContain('dig deep');
+    // No canvas id → no shadow channel to wire.
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+
+    // MPIM opened as the new bot with operator + origin bot.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(2);
+    expect(JSON.parse(opens[1]!.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT' });
+    expect(opens[1]!.token).toBe(NEW_BOT_TOKEN);
+
+    // Requester heard ONLY the Slack success notify — the upstream "created —
+    // you can now message it" text is suppressed on the Slack path (it fires
+    // before provisioning and would report "done" ~a minute early).
+    const texts = notifyTexts();
+    expect(texts.some((t) => t.includes('Agent "research" created'))).toBe(false);
+    expect(texts.at(-1)).toContain('is live on Slack');
+    expect(texts.at(-1)).toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+});
+
+describe('slack-aware create_agent — manifest variants', () => {
+  it('allow_guests: broker gets allow_guests:true, DM wiring keeps the plain defaults', async () => {
+    await runCreateAgent({ name: 'Guesty', instructions: 'help the guests', allow_guests: true });
+
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBe(true);
+
+    const newGroup = getAgentGroupByFolder('guesty');
+    const dmMg = getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-guesty');
+    const dmWiring = getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id)!;
+    expect(dmWiring).toMatchObject({ session_mode: 'shared' });
+    expect(dmWiring.threads ?? null).toBeNull();
+  });
+
+  it('default (agent-view): broker body carries no allow_guests flag', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBeUndefined();
+  });
+});
+
+describe("slack-aware create_agent — room:'none'", () => {
+  it('skips the room half entirely: DM only, no MPIM, no a2a entry, no canvas, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    expect(getAgentGroupByFolder('research')).toBeDefined();
+    // Only the operator-DM conversations.open — no MPIM.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(1);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR' });
+    // No room rows on any instance, no a2a allowlist, no canvas, no shadow wiring.
+    expect(getAllMessagingGroups().filter((m) => m.platform_id === 'slack:G0ROOM')).toHaveLength(0);
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).not.toContain('SLACK_A2A_ROOMS');
+    expect(mockCreateRoomCanvas).not.toHaveBeenCalled();
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+    // The DM intro still posts; the origin agent gets NO intro nudge.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(0);
+    // Success text is the no-room variant pointing at create_room.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain("room:'none'");
+    expect(success).toContain('create_room');
+    expect(success).not.toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+
+  it("hold payload carries room:'none' through to the approved replay (confined group)", async () => {
+    updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    // Held — nothing created yet; the replay payload must preserve room:'none'.
+    expect(getAgentGroupByFolder('research')).toBeUndefined();
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_agent');
+    expect(opts.payload).toMatchObject({ name: 'Research', room: 'none' });
+  });
+});
+
+describe('slack-aware create_agent — room canvas contract', () => {
+  it('canvas available: called with the contract data (plain agent names), all participants wired', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The canvas carries the room contract: purpose, creator, members. Agent
+    // members travel as PLAIN NAMES — never bot user ids (the de-mention rule).
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Research room',
+      purpose: 'Research room',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Research'],
+    });
+    // Shadow-channel wiring rides on canvas success: EVERY participant —
+    // creator identified separately from the full list.
+    const newGroup = getAgentGroupByFolder('research')!;
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledWith(
+      'F0CANVAS',
+      expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      [
+        expect.objectContaining({ instanceKey: 'slack', agentGroupId: SRC_GROUP }),
+        expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      ],
+      'Research room',
+    );
+    // Still no room post: the canvas tab IS the pinned surface — no link
+    // message either.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+  });
+});
+
+describe('ensureAgentRoom — N-bot rooms', () => {
+  it('opens the MPIM with every participating bot, wires each instance, and makes destinations pairwise', async () => {
+    const now = new Date().toISOString();
+    createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    createAgentGroup({ id: 'ag-third', name: 'Devin', folder: 'devin', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-devin', botUserId: 'U0THIRD', agentGroupId: 'ag-third', agentGroupName: 'Devin' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+
+    const result = await ensureAgentRoom({
+      creator: participants[2]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      rootDir: tmpDir,
+    });
+    expect(result).toMatchObject({ roomChannelId: 'G0ROOM', created: true });
+
+    // MPIM opened as the creator with operator + every OTHER participating bot.
+    const open = fetchCalls.find((c) => c.url.includes('conversations.open'))!;
+    expect(open.token).toBe(NEW_BOT_TOKEN);
+    expect(JSON.parse(open.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT,U0THIRD' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const p of participants) {
+      const mg = getMessagingGroupByPlatform('slack', 'slack:G0ROOM', p.instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+      expect(getMessagingGroupAgentByPair(mg!.id, p.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Destinations symmetry: every distinct agent-group pair, both directions.
+    expect(getDestinationByName(SRC_GROUP, 'devin')).toMatchObject({ target_type: 'agent', target_id: 'ag-third' });
+    expect(getDestinationByName(SRC_GROUP, 'pixel')).toMatchObject({ target_type: 'agent', target_id: 'ag-new' });
+    expect(getDestinationByName('ag-third', 'andy')).toMatchObject({ target_type: 'agent', target_id: SRC_GROUP });
+    expect(getDestinationByName('ag-third', 'pixel')).toMatchObject({ target_type: 'agent', target_id: 'ag-new' });
+    expect(getDestinationByName('ag-new', 'andy')).toMatchObject({ target_type: 'agent', target_id: SRC_GROUP });
+    expect(getDestinationByName('ag-new', 'devin')).toMatchObject({ target_type: 'agent', target_id: 'ag-third' });
+
+    // Allowlisted for a2a. No room-contract post: ensureAgentRoom
+    // itself posts nothing — the origin agent authors the intro, and
+    // the contract data lives on the canvas.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    // The canvas gets the contract data — every agent by plain name.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Devin', 'Pixel'],
+    });
+  });
+
+  it('is idempotent: a second call creates nothing new and grows no second canvas', async () => {
+    const now = new Date().toISOString();
+    createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+    const args = {
+      creator: participants[1]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      rootDir: tmpDir,
+    };
+
+    await ensureAgentRoom(args);
+    const mgCountAfterFirst = getAllMessagingGroups().length;
+
+    const second = await ensureAgentRoom(args);
+    expect(second).toMatchObject({ roomChannelId: 'G0ROOM', created: false });
+    expect(getAllMessagingGroups().length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-aware create_agent — non-Slack parity', () => {
+  it('non-slack session: behaves exactly as upstream, zero Slack side effects', async () => {
+    createMessagingGroup({
+      id: 'mg-tg',
+      channel_type: 'telegram',
+      platform_id: 'tg:123',
+      name: 'TG DM',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+    const tgSession: Session = { ...SLACK_SESSION, id: 'sess-tg', messaging_group_id: 'mg-tg' };
+    createSession(tgSession);
+    const envBefore = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    const mgCountBefore = getAllMessagingGroups().length;
+
+    await runCreateAgent({ name: 'Helper' }, tgSession);
+
+    expect(getAgentGroupByFolder('helper')).toBeDefined(); // upstream leg ran
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toBe(envBefore);
+    expect(getAllMessagingGroups().length).toBe(mgCountBefore);
+  });
+
+  it('null messaging_group_id (task/a2a session): skips the Slack leg', async () => {
+    const bareSession: Session = { ...SLACK_SESSION, id: 'sess-bare', messaging_group_id: null };
+    createSession(bareSession);
+
+    await runCreateAgent({ name: 'Helper' }, bareSession);
+
+    expect(getAgentGroupByFolder('helper')).toBeDefined();
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack-aware create_agent — failure and retry', () => {
+  it('broker failure: group still exists, failure notify carries the finish command', async () => {
+    brokerStatus = 500;
+
+    await runCreateAgent({ name: 'Research' });
+
+    const newGroup = getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('scripts/slack-agent-flow-finish.ts');
+    expect(failure).toContain(`--group ${newGroup!.id}`);
+    expect(failure).toContain('--name research');
+    expect(failure).toContain(`--source-group ${SRC_GROUP}`);
+    expect(failure).toContain('send_message({ to: "research", ... })');
+
+    assertNoTokenLeak();
+  });
+
+  it('double invocation: upstream collision short-circuits — no duplicate rows, apps, posts, or nudges', async () => {
+    await runCreateAgent({ name: 'Research' });
+    const fetchCountAfterFirst = fetchCalls.length;
+    const mgCountAfterFirst = getAllMessagingGroups().length;
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(fetchCalls.length).toBe(fetchCountAfterFirst);
+    expect(getAllMessagingGroups().length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(1);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+    expect(notifyTexts().at(-1)).toContain('already have a destination named "research"');
+  });
+
+  it('finish-path retry after success: rows exist, so no second canvas, no posts, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = getAgentGroupByFolder('research')!;
+    const postCountAfterFirst = fetchCalls.filter((c) => c.url.includes('chat.postMessage')).length;
+    const notifyCountAfterFirst = mockNotifyWrite.mock.calls.length;
+
+    // Operator re-runs the finish script — the S8/S11 created-gates hold.
+    await finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id });
+
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(postCountAfterFirst);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockNotifyWrite.mock.calls.length).toBe(notifyCountAfterFirst);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+  });
+
+  it('finish path aborts before wiring DB rows if the multi-instance module is missing', async () => {
+    // Group exists (S1-S4 already ran) but the Slack leg never completed —
+    // same starting state as the "broker failure" case above.
+    brokerStatus = 500;
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = getAgentGroupByFolder('research')!;
+    brokerStatus = 200; // retry succeeds at the broker step this time
+    const mgCountBefore = getAllMessagingGroups().length;
+
+    mockAssertSlackInstancesModuleInstalled.mockRejectedValueOnce(
+      new SlackFlowError(
+        'adapter-start',
+        'Slack channel payloads not installed — apply add-slack and slack-multi-instance first',
+      ),
+    );
+
+    await expect(
+      finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id }),
+    ).rejects.toThrow(/multi-instance/);
+
+    // S6-S8 must not have run: no DM messaging group got wired for an
+    // instance the runtime still can't start.
+    expect(getAllMessagingGroups().length).toBe(mgCountBefore);
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -1,0 +1,635 @@
+/**
+ * The Slack leg of create_agent — steps S1–S13 (one typed step id each).
+ *
+ * Ordering is load-bearing:
+ *  - S1/S2 are local/cheap prechecks — nothing external is created until the
+ *    operator identity and the origin bot token both resolve.
+ *  - S10 (SLACK_A2A_ROOMS append) runs strictly BEFORE the origin agent is
+ *    nudged to post the room intro, so every sibling instance's a2a
+ *    bridge admits the bot-authored intro instead of dropping it as a bot
+ *    sender.
+ *  - S13's DM intro and the origin intro nudge are gated on rows newly
+ *    created in S8/S11 — a retry (finish script) never double-posts or
+ *    double-nudges.
+ * Every step is idempotent: provision reuses .env tokens, messaging groups
+ * and wirings are get-before-create, conversations.open is idempotent on
+ * Slack's side.
+ *
+ * Slack HTTP plumbing comes from the shared channel-layer lib
+ * (src/channels/slack-lib.ts, installed with the Slack channel payload);
+ * access to the skill-installed adapter modules goes through
+ * loadSlackChannelDeps() so a partial install fails as a typed step error.
+ */
+import {
+  resolveUnknownSenderPolicy,
+  resolveWiringDefaults,
+  validateEngageAgainstChannel,
+} from '../../channels/channel-defaults.js';
+import {
+  SlackApiError,
+  botTokenKeyForInstance,
+  slackAuthTest,
+  slackConversationsOpen,
+  slackPostMessage,
+} from '../../channels/slack-lib.js';
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import type { MessagingGroup, MessagingGroupAgent, Session } from '../../types.js';
+import {
+  createDestination,
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { notifyAgent, pickApprover } from '../approvals/primitive.js';
+import { appendToEnvList, readEnvValue } from './env-file.js';
+import { provisionSlackApp } from './provision.js';
+import { createRoomCanvas, wireCanvasComments } from './room-canvas.js';
+import { assertSlackInstancesModuleInstalled, loadSlackChannelDeps } from './slack-deps.js';
+import { SlackFlowError, type OrchestrateSuccess, type SlackFlowStep } from './types.js';
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function envSuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/** Wrap a non-typed failure with the step it happened in. Never carries token
+ *  values. A SlackApiError keeps its own step — the shared Slack lib
+ *  (src/channels/slack-lib.ts) tags each call with the flow step id the call
+ *  site passed, which is more precise than the enclosing wrapper's step. */
+function asFlowError(err: unknown, step: SlackFlowStep): SlackFlowError {
+  if (err instanceof SlackFlowError) return err;
+  if (err instanceof SlackApiError) return new SlackFlowError(err.step as SlackFlowStep, err.message);
+  return new SlackFlowError(step, err instanceof Error ? err.message : String(err));
+}
+
+/** One canonical slugger — the same normalizeName the a2a destination namespace uses. */
+export function deriveInstanceSlug(name: string): string {
+  return normalizeName(name);
+}
+
+/**
+ * First approver with a Slack identity, 'slack:' prefix stripped. pickApprover
+ * order (scoped admins → global admins → owners) picks who gets the DM.
+ */
+export function resolveOperatorSlackUserId(sourceAgentGroupId: string): string | null {
+  const hit = pickApprover(sourceAgentGroupId).find((id) => /^slack:U/i.test(id));
+  return hit ? hit.slice('slack:'.length) : null;
+}
+
+/**
+ * A slug conflicts when its .env footprint is already claimed (token key set
+ * or slug listed in SLACK_INSTANCES) AND its `slack-<slug>` instance is wired
+ * to a DIFFERENT agent group. Claimed-but-wired-to-this-group (or to nothing)
+ * is the retry path — reuse.
+ */
+function slugConflicts(slug: string, newAgentGroupId: string, rootDir: string): boolean {
+  const tokenExists = readEnvValue(rootDir, `SLACK_BOT_TOKEN_${envSuffix(slug)}`) !== undefined;
+  const instances = (readEnvValue(rootDir, 'SLACK_INSTANCES') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!tokenExists && !instances.includes(slug)) return false;
+
+  const instanceKey = `slack-${slug}`;
+  for (const mg of getAllMessagingGroups()) {
+    if (mg.instance !== instanceKey) continue;
+    for (const wiring of getMessagingGroupAgents(mg.id)) {
+      if (wiring.agent_group_id !== newAgentGroupId) return true;
+    }
+  }
+  return false;
+}
+
+export function dedupeSlug(base: string, newAgentGroupId: string, rootDir: string = process.cwd()): string {
+  let slug = base;
+  for (let n = 2; slugConflicts(slug, newAgentGroupId, rootDir); n++) slug = `${base}-${n}`;
+  return slug;
+}
+
+function ensureMessagingGroupRow(spec: {
+  platformId: string;
+  instance: string;
+  name: string;
+  isGroup: boolean;
+  unknownSenderPolicy: MessagingGroup['unknown_sender_policy'];
+}): { mg: MessagingGroup; created: boolean } {
+  const existing = getMessagingGroupByPlatform('slack', spec.platformId, spec.instance);
+  if (existing) return { mg: existing, created: false };
+  const mg: MessagingGroup = {
+    id: generateId('mg'),
+    channel_type: 'slack',
+    platform_id: spec.platformId,
+    instance: spec.instance,
+    name: spec.name,
+    is_group: spec.isGroup ? 1 : 0,
+    unknown_sender_policy: spec.unknownSenderPolicy,
+    created_at: new Date().toISOString(),
+  };
+  createMessagingGroup(mg);
+  return { mg, created: true };
+}
+
+/** Flow-chosen deviations from the channel-declared wiring defaults. */
+interface WiringOverrides {
+  /** Set together with engage_pattern to bypass resolveWiringDefaults. */
+  engage_mode?: MessagingGroupAgent['engage_mode'];
+  engage_pattern?: string | null;
+  ignored_message_policy?: MessagingGroupAgent['ignored_message_policy'];
+  session_mode?: MessagingGroupAgent['session_mode'];
+  /** 1/0 explicit stamp; null = explicitly leave the column NULL (inherit the
+   *  channel declaration at fanout time); omitted = follow the derived
+   *  creation-time stamp (resolveWiringDefaults stamps threads=1 when the
+   *  declared sessionMode is 'per-thread', else null). */
+  threads?: number | null;
+}
+
+/** Get-before-create wiring with channel-declared defaults (engage fields,
+ *  plus the B7 session-mode/threads creation-time stamps) unless overridden.
+ *  True iff newly created. */
+function ensureWiring(
+  mg: MessagingGroup,
+  agentGroupId: string,
+  agentGroupName: string,
+  overrides: WiringOverrides = {},
+): boolean {
+  if (getMessagingGroupAgentByPair(mg.id, agentGroupId)) return false;
+  const channelKey = mg.instance ?? mg.channel_type;
+  // Overriding engage_mode bypasses the declaration entirely (flow-owned
+  // room semantics, D4); declaration-resolved wirings take the declared
+  // session_mode / threads stamps too (B7).
+  const resolved =
+    overrides.engage_mode !== undefined
+      ? undefined
+      : resolveWiringDefaults(channelKey, mg.is_group === 1, agentGroupName, mg.channel_type);
+  const engage = resolved ?? { engage_mode: overrides.engage_mode!, engage_pattern: overrides.engage_pattern ?? null };
+  const threads = overrides.threads !== undefined ? overrides.threads : (resolved?.threads ?? null);
+  const wiring: MessagingGroupAgent = {
+    id: generateId('mga'),
+    messaging_group_id: mg.id,
+    agent_group_id: agentGroupId,
+    engage_mode: engage.engage_mode,
+    engage_pattern: engage.engage_pattern,
+    sender_scope: 'all',
+    ignored_message_policy: overrides.ignored_message_policy ?? 'drop',
+    session_mode: overrides.session_mode ?? resolved?.session_mode ?? 'shared',
+    priority: 0,
+    ...(threads !== null ? { threads } : {}),
+    created_at: new Date().toISOString(),
+  };
+  validateEngageAgainstChannel(wiring, mg);
+  // createMessagingGroupAgent persists an explicit `threads` value itself
+  // (follow-up UPDATE in src/db/messaging-groups.ts) — the declared threads:1 stamp lands.
+  createMessagingGroupAgent(wiring);
+  return true;
+}
+
+/**
+ * Room-wiring semantics for flow-created rooms (D4): each bot speaks only
+ * when @-mentioned; everything else accumulates as ambient context delivered
+ * with the next mention. Deliberately NOT the channel group default —
+ * flow-created rooms only.
+ */
+const ROOM_WIRING_OVERRIDES: WiringOverrides = {
+  engage_mode: 'mention',
+  engage_pattern: null,
+  ignored_message_policy: 'accumulate',
+};
+
+/** One bot in a shared room: its adapter instance and the agent group behind it. */
+export interface RoomParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  botUserId: string;
+  agentGroupId: string;
+  agentGroupName: string;
+}
+
+/**
+ * Idempotent agent→agent destination (= ACL grant + local name). No-op when
+ * a destination for the target already exists under any name (upstream
+ * create_agent's parent/child rows count). Name collisions get a numeric
+ * suffix, mirroring ensureAgentDestinationForWiring.
+ */
+function ensureAgentDestination(fromGroupId: string, toGroupId: string, toName: string): void {
+  if (fromGroupId === toGroupId) return;
+  if (getDestinationByTarget(fromGroupId, 'agent', toGroupId)) return;
+  const base = normalizeName(toName) || toGroupId.slice(0, 8);
+  let localName = base;
+  let suffix = 2;
+  while (getDestinationByName(fromGroupId, localName)) {
+    localName = `${base}-${suffix}`;
+    suffix++;
+  }
+  createDestination({
+    agent_group_id: fromGroupId,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: toGroupId,
+    created_at: new Date().toISOString(),
+  });
+}
+
+/** Full pairwise a2a destination symmetry between every distinct agent group
+ *  in the room — "ask Devin" must be actionable from any participant. */
+function ensurePairwiseAgentDestinations(participants: RoomParticipant[]): void {
+  for (const a of participants) {
+    for (const b of participants) {
+      if (a.agentGroupId === b.agentGroupId) continue;
+      ensureAgentDestination(a.agentGroupId, b.agentGroupId, b.agentGroupName);
+    }
+  }
+}
+
+/**
+ * Public purpose: ONLY the explicitly provided line (capped 80). No fallback
+ * from the instructions — the creation prompt is the agent's private persona
+ * and never appears on shared surfaces. No purpose = the intro simply
+ * doesn't state one.
+ */
+export function publicPurpose(explicit: string | undefined): string | undefined {
+  const cleaned = explicit?.trim();
+  if (!cleaned) return undefined;
+  return cleaned.length <= 80 ? cleaned : `${cleaned.slice(0, 80)}…`;
+}
+
+/**
+ * The ORIGIN agent — not a host template — introduces the new agent
+ * in the shared room. This is the instruction the origin session wakes to;
+ * the intro itself stays in the agent's own voice, and the room-contract
+ * data (purpose, members, created date) lives on the canvas, not in chat.
+ */
+function roomIntroNudgeText(args: {
+  newAgentName: string;
+  newBotUserId: string;
+  roomName: string;
+  /** The origin agent's local destination name for the room. */
+  roomDestination: string;
+  purpose?: string;
+}): string {
+  return (
+    `A shared Slack room "${args.roomName}" was just opened with you, the operator, and your new agent ${args.newAgentName}` +
+    `${args.purpose ? ` (${args.purpose})` : ''}. ` +
+    `Post a brief introduction of ${args.newAgentName} there now via send_message({ to: "${args.roomDestination}", ... }): ` +
+    `1-2 lines in your own voice saying what they're for, tagging them with <@${args.newBotUserId}> ` +
+    `(include that literally — it renders as a mention). Just the intro — no mechanics, no member lists.`
+  );
+}
+
+/**
+ * N-bot-capable room step (S9–S13's room half): open the MPIM as `creator`
+ * with the operator + every participating bot, allowlist it for a2a, create
+ * one mg row + mention/accumulate wiring PER participating instance, ensure
+ * pairwise a2a destinations, then (only when rows were newly created) create
+ * the room canvas — the room's pinned contract surface (no contract
+ * message, no link post; the channel canvas is already the room's canvas
+ * tab) — and wire its comment shadow channel for every participant. The
+ * conversational create_agent flow calls this with the 3-way default; any
+ * caller may pass a larger participant list.
+ */
+export async function ensureAgentRoom(args: {
+  /** Bot that opens the MPIM and creates the canvas. Must be one of `participants`. */
+  creator: RoomParticipant;
+  creatorBotToken: string;
+  operatorUserId: string;
+  /** All bots in the room, creator included. */
+  participants: RoomParticipant[];
+  /** Additional member user ids beyond the operator + participating bots —
+   *  e.g. Slack-UI-added humans carried over when add_to_room forks a room.
+   *  Members only; they get no mg rows or wirings. */
+  extraMemberUserIds?: string[];
+  roomName: string;
+  /** Creation prompt (room purpose) — the canvas contract excerpt. */
+  purpose?: string;
+  rootDir: string;
+}): Promise<{ roomChannelId: string; created: boolean }> {
+  const { creator, creatorBotToken, operatorUserId, participants, rootDir } = args;
+
+  // S9 mpim-open — operator + carried extra members + every other
+  // participating bot, opened AS the creator.
+  const otherBotIds = participants.filter((p) => p.botUserId !== creator.botUserId).map((p) => p.botUserId);
+  const roomChannelId = await slackConversationsOpen(
+    creatorBotToken,
+    [operatorUserId, ...(args.extraMemberUserIds ?? []), ...otherBotIds],
+    'mpim-open',
+  );
+
+  // S10 a2a-env — strictly before the origin agent can be nudged to post its
+  // intro: every sibling instance's a2a bridge must already allow the room
+  // or it drops bot-authored posts.
+  try {
+    appendToEnvList(rootDir, 'SLACK_A2A_ROOMS', roomChannelId);
+  } catch (err) {
+    throw asFlowError(err, 'a2a-env');
+  }
+
+  // S11 room-wire — one row PER participating instance (router lookup is
+  // exact-on-instance). unknown_sender_policy 'public' explicitly: sibling
+  // bridges' access gates must never approval-spam admitted bot messages.
+  // Wirings are mention/accumulate (D4 — flow-created rooms only).
+  let created = false;
+  try {
+    for (const p of participants) {
+      const row = ensureMessagingGroupRow({
+        platformId: `slack:${roomChannelId}`,
+        instance: p.instanceKey,
+        name: args.roomName,
+        isGroup: true,
+        unknownSenderPolicy: 'public',
+      });
+      ensureWiring(row.mg, p.agentGroupId, p.agentGroupName, ROOM_WIRING_OVERRIDES);
+      created = row.created || created;
+    }
+    ensurePairwiseAgentDestinations(participants);
+  } catch (err) {
+    throw asFlowError(err, 'room-wire');
+  }
+
+  // S12 projections — in-host-process, so already-running containers see the
+  // auto-created destinations without waiting for the next spawn.
+  for (const groupId of new Set(participants.map((p) => p.agentGroupId))) {
+    await projectDestinationsToSessions(groupId);
+  }
+
+  // S13 room half — gated on newly created rows so a retry never grows a
+  // second canvas. No room-contract message: the canvas tab is the
+  // pinned surface and carries the contract data; the intro is authored by
+  // the ORIGIN agent (nudged by runFlow). Canvas failure is non-fatal
+  // (C2: createRoomCanvas never throws) — no canvas, no shadow channel.
+  if (created) {
+    const canvasId = await createRoomCanvas(creatorBotToken, roomChannelId, {
+      roomName: args.roomName,
+      purpose: args.purpose ?? args.roomName,
+      creatorUserId: operatorUserId,
+      agentNames: participants.map((p) => p.agentGroupName),
+    });
+    // Canvas comments arrive in a Slackbot-owned shadow channel (canvas id
+    // with F→C) — wire EVERY participating instance: creator as the
+    // pattern-engage default responder, siblings mention/accumulate.
+    // Non-throwing; no canvas id, nothing to wire.
+    if (canvasId) wireCanvasComments(canvasId, creator, participants, args.roomName);
+  }
+
+  return { roomChannelId, created };
+}
+
+interface FlowArgs {
+  slug: string;
+  displayName: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey: string;
+  rootDir: string;
+  /** false on the out-of-process finish path — S5 needs the live host's registry. */
+  hotStart: boolean;
+  /** Agent instructions excerpt — drives the broker-generated avatar. */
+  description?: string;
+  /** Short PUBLIC line for the room contract + canvas ("what this agent is
+   *  for"). Falls back to a first-sentence excerpt of the instructions —
+   *  never the full creation prompt (it may carry private detail). */
+  purpose?: string;
+  /** true → plain manifest variant (guest-visible); false/absent → agent_view. */
+  allowGuests?: boolean;
+  /** The session whose create_agent call started the flow — receives the
+   *  room-intro nudge. Absent on the out-of-process finish path. */
+  originSession?: Session;
+  /**
+   * Room policy: 'own' (default) opens the shared origin+operator
+   * room; 'none' skips the room half entirely — the multi-create pattern is
+   * N creates with room:'none' followed by one create_room with all of them.
+   */
+  room?: 'own' | 'none';
+}
+
+async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
+  const { slug, displayName, sourceGroupId, newAgentGroupId, originInstanceKey, rootDir } = args;
+  const instanceKey = `slack-${slug}`;
+
+  // S1 operator-identity
+  const operatorUserId = resolveOperatorSlackUserId(sourceGroupId);
+  if (!operatorUserId) {
+    throw new SlackFlowError(
+      'operator-identity',
+      'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+    );
+  }
+
+  // S2 origin-auth — prove the origin instance's token before provisioning anything.
+  const originTokenKey = botTokenKeyForInstance(originInstanceKey);
+  const originBotToken = readEnvValue(rootDir, originTokenKey);
+  if (!originBotToken) {
+    throw new SlackFlowError(
+      'origin-auth',
+      `missing ${originTokenKey} in .env for origin instance '${originInstanceKey}'`,
+    );
+  }
+  const originAuth = await slackAuthTest(originBotToken, 'origin-auth');
+  const originBotUserId = originAuth.userId;
+
+  // S3/S4 provision + .env persist (reuse path: tokens already in .env, no network).
+  const app = await provisionSlackApp({
+    slug,
+    displayName,
+    rootDir,
+    teamId: originAuth.teamId,
+    description: args.description,
+    allowGuests: args.allowGuests,
+  });
+
+  // S5 adapter-start. The multi-instance module must be installed regardless
+  // of hotStart: S6-S8 below wire DB rows to an instance name the runtime
+  // needs to be able to start after a restart, so the out-of-process finish
+  // path (hotStart: false) checks this too instead of silently skipping
+  // straight to DB writes for an instance nothing can ever connect.
+  await assertSlackInstancesModuleInstalled();
+  if (args.hotStart) {
+    // Hot-add the new instance into the live registry.
+    const deps = await loadSlackChannelDeps();
+    deps.registerChannelAdapter(instanceKey, {
+      factory: () => deps.slackInstanceBridgeFactory(slug),
+      defaults: deps.SLACK_DEFAULTS,
+    });
+    let started: 'started' | 'already-active' | 'no-credentials';
+    try {
+      started = await deps.startChannelAdapter(instanceKey);
+    } catch (err) {
+      throw asFlowError(err, 'adapter-start');
+    }
+    // 'already-active' is the retry path — the instance survived a previous attempt.
+    if (started === 'no-credentials') {
+      throw new SlackFlowError(
+        'adapter-start',
+        `adapter '${instanceKey}' found no credentials in .env (SLACK_BOT_TOKEN_${app.envSuffix} / SLACK_APP_TOKEN_${app.envSuffix})`,
+      );
+    }
+  }
+
+  // S6 new-bot identity (auth.test gates the DM open — same step id).
+  const newBotUserId = (await slackAuthTest(app.botToken, 'dm-open')).userId;
+
+  // S7 dm-open — the operator DM, opened AS the new bot.
+  const dmChannelId = await slackConversationsOpen(app.botToken, [operatorUserId], 'dm-open');
+
+  // S8 dm-wire. Agent-view apps (the default variant, allowGuests !== true)
+  // get thread-per-conversation DMs from the CHANNEL DECLARATION: the
+  // Slack adapter's SLACK_DEFAULTS declares dm.sessionMode 'per-thread',
+  // resolveWiringDefaults derives the threads=1 stamp from it (per-thread
+  // sessions structurally require honored thread ids), and ensureWiring
+  // stamps whatever it resolves — nothing is hardcoded here. The plain
+  // (allow_guests) variant has no agent-mode DM surface, so it pins
+  // session_mode 'shared' and leaves the threads column NULL explicitly.
+  let dmCreated = false;
+  try {
+    const dmRow = ensureMessagingGroupRow({
+      platformId: `slack:${dmChannelId}`,
+      instance: instanceKey,
+      name: `${displayName} DM`,
+      isGroup: false,
+      unknownSenderPolicy: resolveUnknownSenderPolicy(instanceKey, false, 'slack'),
+    });
+    dmCreated = dmRow.created;
+    const agentView = args.allowGuests !== true;
+    ensureWiring(dmRow.mg, newAgentGroupId, displayName, agentView ? {} : { session_mode: 'shared', threads: null });
+  } catch (err) {
+    throw asFlowError(err, 'dm-wire');
+  }
+
+  // S9–S13 room half: MPIM + allowlist + per-instance mention/accumulate
+  // wirings + pairwise destinations + canvas + room-contract intro. The
+  // conversational flow's 3-way default; ensureAgentRoom itself is N-capable.
+  // room:'none' skips the whole half — the DM is the entire surface
+  // and the caller composes a shared room later via create_room.
+  let roomChannelId: string | undefined;
+  if (args.room !== 'none') {
+    const sourceGroupName = getAgentGroup(sourceGroupId)?.name ?? sourceGroupId;
+    const newParticipant: RoomParticipant = {
+      instanceKey,
+      botUserId: newBotUserId,
+      agentGroupId: newAgentGroupId,
+      agentGroupName: displayName,
+    };
+    const roomName = `${displayName} room`;
+    const roomPurpose = publicPurpose(args.purpose);
+    const room = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: app.botToken,
+      operatorUserId,
+      participants: [
+        {
+          instanceKey: originInstanceKey,
+          botUserId: originBotUserId,
+          agentGroupId: sourceGroupId,
+          agentGroupName: sourceGroupName,
+        },
+        newParticipant,
+      ],
+      roomName,
+      purpose: roomPurpose,
+      rootDir,
+    });
+    roomChannelId = room.roomChannelId;
+
+    // The ORIGIN agent authors the room intro — an instruction-shaped
+    // system nudge (trigger=1 wake via notifyAgent) into the origin session,
+    // gated on the S13 created-gate so a flow retry never double-nudges. The
+    // wizard first-agent path never reaches here (it opens no room); the
+    // out-of-process finish path has no origin session to nudge. The room
+    // destination was projected into the live session in S12.
+    if (room.created && args.originSession) {
+      const roomMg = getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, originInstanceKey);
+      const roomDest = roomMg ? getDestinationByTarget(sourceGroupId, 'channel', roomMg.id) : undefined;
+      notifyAgent(
+        args.originSession,
+        roomIntroNudgeText({
+          newAgentName: displayName,
+          newBotUserId,
+          roomName,
+          roomDestination: roomDest?.local_name ?? normalizeName(roomName),
+          purpose: roomPurpose,
+        }),
+      );
+    }
+  }
+
+  // S13 DM half — gated on the row newly created in S8.
+  if (dmCreated) {
+    await slackPostMessage(
+      app.botToken,
+      dmChannelId,
+      `Hi <@${operatorUserId}> — I'm ${displayName}, your new agent. This DM is already wired up; just reply here to start.`,
+      'intro-post',
+    );
+  }
+
+  return { slug, newBotUserId, operatorUserId, dmChannelId, roomChannelId };
+}
+
+/** In-host entry — the wrapped create_agent handler's Slack leg (hot-add active). */
+export async function runSlackAgentFlow(args: {
+  content: Record<string, unknown>;
+  session: Session;
+  newAgentGroupId: string;
+  slug: string;
+}): Promise<OrchestrateSuccess> {
+  const { content, session, newAgentGroupId, slug } = args;
+  const displayName =
+    typeof content.name === 'string' && content.name ? content.name : (getAgentGroup(newAgentGroupId)?.name ?? slug);
+  const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+  return runFlow({
+    slug,
+    displayName,
+    sourceGroupId: session.agent_group_id,
+    newAgentGroupId,
+    originInstanceKey: originMg?.instance ?? 'slack',
+    rootDir: process.cwd(),
+    hotStart: true,
+    description: typeof content.instructions === 'string' ? content.instructions.slice(0, 300) : undefined,
+    purpose: typeof content.purpose === 'string' ? content.purpose : undefined,
+    allowGuests: content.allow_guests === true,
+    originSession: session,
+    room: content.room === 'none' ? 'none' : 'own',
+  });
+}
+
+/**
+ * Out-of-process finish/retry entry (scripts/slack-agent-flow-finish.ts):
+ * S1–S13 minus the S5 hot-add — a separate process cannot start an adapter
+ * inside the live host, so the script restarts the service (or says how).
+ */
+export async function finishSlackAgentFlow(args: {
+  slug: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey?: string;
+  rootDir?: string;
+  /** Pass true when the original create used allow_guests (plain variant) —
+   *  keeps the finish path's DM wiring congruent with the provisioned app. */
+  allowGuests?: boolean;
+  /** Pass 'none' when the original create used room:'none' — keeps the
+   *  finish path from growing a room the caller deliberately skipped. */
+  room?: 'own' | 'none';
+}): Promise<OrchestrateSuccess> {
+  return runFlow({
+    slug: args.slug,
+    displayName: getAgentGroup(args.newAgentGroupId)?.name ?? args.slug,
+    sourceGroupId: args.sourceGroupId,
+    newAgentGroupId: args.newAgentGroupId,
+    originInstanceKey: args.originInstanceKey ?? 'slack',
+    rootDir: args.rootDir ?? process.cwd(),
+    hotStart: false,
+    allowGuests: args.allowGuests,
+    room: args.room,
+  });
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Congruence pins for provision.ts, which deliberately duplicates its broker
+ * protocol and manifest out of the trunk provisioning module
+ * src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts.
+ *
+ * ALL transports carry the same
+ * template: BASE + canvas scopes, BASE + membership events, and the
+ * agent-mode (agent_view) variant pair — matching the broker's BOT_SCOPES /
+ * BOT_EVENTS / AGENT_BOT_* in nanocoai/infra: modules/nanoclaw-slack lambda
+ * service/index.mjs. The pins here hold the mirrors (read as source text —
+ * they are not importable from src/) equal to provision.ts's own sets, and
+ * provision.ts equal to the documented BASE + additions.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_BROKER_BASE,
+  MANAGED_AGENT_BOT_EVENTS,
+  MANAGED_AGENT_BOT_SCOPES,
+  MANAGED_APP_DESCRIPTION,
+  MANAGED_BOT_EVENTS,
+  MANAGED_BOT_SCOPES,
+  buildManagedAppManifest,
+  provisionSlackApp,
+  resolveProvisioningCredential,
+} from './provision.js';
+
+const CREATE_AGENT_SCRIPT = path.resolve(
+  process.cwd(),
+  '.claude/skills/slack-managed-agents/scripts/slack-create-agent.ts',
+);
+const SLACK_PROVISION = path.resolve(process.cwd(), 'src/provisioning/slack-app.ts');
+
+/**
+ * The base managed-app sets, before the additions below. Kept literal so
+ * drift in either direction is loud.
+ */
+const BASE_BOT_SCOPES = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+];
+const BASE_BOT_EVENTS = ['message.channels', 'message.groups', 'message.im', 'message.mpim', 'app_mention'];
+
+/** Additions over the base set (room canvas + read-back; membership events). */
+const CANVAS_SCOPES = ['canvases:read', 'canvases:write', 'files:read'];
+const MEMBERSHIP_EVENTS = ['member_joined_channel', 'member_left_channel'];
+
+/** send_file: files.upload needs files:write, distinct from the canvas read-back path. */
+const SEND_FILE_SCOPES = ['files:write'];
+
+/** All single-quoted strings inside `export const <name> = […]`, comments stripped. */
+function extractStringArray(src: string, name: string): string[] {
+  const m = src.match(new RegExp(`export const ${name}[^=]*= \\[([\\s\\S]*?)\\];`));
+  expect(m, `export const ${name} = […] not found in mirror source`).toBeTruthy();
+  const body = m![1].replace(/\/\/.*$/gm, '');
+  return [...body.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+// The slack-managed-agents skill is optional (its install leg is coupled to
+// the managed-app provisioning service) — the mirror pins run wherever its
+// skill directory is present and skip cleanly where it is not. When present
+// it MUST match; the path is pinned literally, so a moved script fails loudly.
+describe.skipIf(!fs.existsSync(CREATE_AGENT_SCRIPT))('provision.ts congruence with slack-create-agent.ts', () => {
+  it("the mirror's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(extractStringArray(src, 'MANAGED_BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the mirror's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+    expect(src).toContain('--allow-guests');
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts sets', () => {
+  it("the trunk provisioning module's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(extractStringArray(src, 'BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the trunk provisioning module's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+  });
+});
+
+describe('provision.ts manifest shape (broker-congruent, both variants)', () => {
+  it('MANAGED_BOT_SCOPES = base + canvas scopes + send_file scope, bot scopes only', () => {
+    expect([...MANAGED_BOT_SCOPES]).toEqual([...BASE_BOT_SCOPES, ...CANVAS_SCOPES, ...SEND_FILE_SCOPES]);
+  });
+
+  it('MANAGED_BOT_EVENTS = base + membership events', () => {
+    expect([...MANAGED_BOT_EVENTS]).toEqual([...BASE_BOT_EVENTS, ...MEMBERSHIP_EVENTS]);
+  });
+
+  it('agent-mode additions are exactly assistant:write + the two agent events', () => {
+    expect([...MANAGED_AGENT_BOT_SCOPES]).toEqual(['assistant:write']);
+    expect([...MANAGED_AGENT_BOT_EVENTS]).toEqual(['app_home_opened', 'app_context_changed']);
+  });
+
+  interface ManifestShape {
+    display_information: { name: string; description: string };
+    features: {
+      bot_user: { display_name: string; always_online: boolean };
+      agent_view?: { agent_description: string };
+    };
+    oauth_config: { scopes: { bot: string[]; user?: string[] } };
+    settings: {
+      event_subscriptions: { bot_events: string[] };
+      socket_mode_enabled: boolean;
+      interactivity: { is_enabled: boolean };
+    };
+  }
+
+  it('default variant is agent-mode: agent_view + assistant:write + agent events', () => {
+    const manifest = buildManagedAppManifest('Research') as unknown as ManifestShape;
+    expect(manifest.display_information.name).toBe('Research');
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+    expect(manifest.features.bot_user).toEqual({ display_name: 'Research', always_online: true });
+    // The agent_description doubles as the attribution line (≤300-char field).
+    expect(manifest.features.agent_view).toEqual({ agent_description: MANAGED_APP_DESCRIPTION });
+    expect(MANAGED_APP_DESCRIPTION.length).toBeLessThanOrEqual(300);
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES]);
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([
+      ...MANAGED_BOT_EVENTS,
+      ...MANAGED_AGENT_BOT_EVENTS,
+    ]);
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    expect(manifest.settings.interactivity.is_enabled).toBe(false);
+  });
+
+  it('plain variant (agentView:false) omits agent_view, assistant:write, and the agent events', () => {
+    const manifest = buildManagedAppManifest('Research', { agentView: false }) as unknown as ManifestShape;
+    expect(manifest.features.agent_view).toBeUndefined();
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write');
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([...MANAGED_BOT_EVENTS]);
+    for (const ev of MANAGED_AGENT_BOT_EVENTS) {
+      expect(manifest.settings.event_subscriptions.bot_events).not.toContain(ev);
+    }
+    // Both still carry the always-on additions.
+    for (const scope of CANVAS_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const scope of SEND_FILE_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const ev of MEMBERSHIP_EVENTS) expect(manifest.settings.event_subscriptions.bot_events).toContain(ev);
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+  });
+
+  it('both variants stay bot-scopes-only (apps.managedInstall eligibility)', () => {
+    for (const agentView of [true, false]) {
+      const manifest = buildManagedAppManifest('Research', { agentView }) as unknown as ManifestShape;
+      expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
+    }
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts', () => {
+  it('broker base + override key + endpoint match the trunk provisioning module', () => {
+    expect(fs.existsSync(SLACK_PROVISION), `${SLACK_PROVISION} not found — the trunk provisioning module moved?`).toBe(
+      true,
+    );
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    const base = src.match(/export const DEFAULT_SLACK_SERVICE_BASE = '([^']+)'/);
+    expect(base?.[1]).toBe(DEFAULT_BROKER_BASE);
+    expect(src).toContain("'SLACK_SERVICE_BASE'");
+    expect(src).toContain("'/v1/apps'");
+  });
+});
+
+describe('provisionSlackApp broker body (allow_guests threading)', () => {
+  let rootDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-broker-'));
+    fs.writeFileSync(path.join(rootDir, '.env'), 'NANOCLAW_INSTALL_TOKEN=install-token-1\n');
+    for (const key of ['NANOCLAW_REGISTRY_TOKEN', 'SLACK_MANAGER_TOKEN', 'SLACK_SERVICE_BASE']) {
+      vi.stubEnv(key, '');
+    }
+    fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith('/v1/avatars')) {
+        // Generation unavailable → no avatar poll loop, no avatar_id in the create body.
+        return new Response(JSON.stringify({ avatar_id: null, status: 'unavailable' }), { status: 200 });
+      }
+      if (u.endsWith('/v1/apps')) {
+        return new Response(JSON.stringify({ app_id: 'A123', app_token: 'xapp-test', bot_token: 'xoxb-test' }), {
+          status: 201,
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  const createBody = (): Record<string, unknown> => {
+    const call = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/v1/apps'));
+    expect(call, 'POST /v1/apps was never called').toBeTruthy();
+    return JSON.parse((call![1] as RequestInit).body as string) as Record<string, unknown>;
+  };
+
+  it('omits allow_guests by default (broker provisions the agent-mode variant)', async () => {
+    const result = await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1' });
+    expect(result.reused).toBe(false);
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel' });
+  });
+
+  it('threads allowGuests:true into the body as allow_guests (plain variant)', async () => {
+    await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1', allowGuests: true });
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel', allow_guests: true });
+  });
+});
+
+describe('resolveProvisioningCredential', () => {
+  let rootDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-root-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-home-'));
+    // Neutralize the real environment — every key this resolver consults.
+    for (const key of [
+      'NANOCLAW_REGISTRY_TOKEN',
+      'NANOCLAW_INSTALL_TOKEN',
+      'SLACK_MANAGER_TOKEN',
+      'SLACK_SERVICE_BASE',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const writeEnv = (lines: string[]): void => fs.writeFileSync(path.join(rootDir, '.env'), lines.join('\n') + '\n');
+  const writeAccount = (content: string): void => {
+    const dir = path.join(homeDir, '.config', 'nanoclaw');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'account.json'), content);
+  };
+  const resolve = (): ReturnType<typeof resolveProvisioningCredential> =>
+    resolveProvisioningCredential(rootDir, { homeDir });
+
+  it('returns null when no credential exists anywhere', () => {
+    expect(resolve()).toBeNull();
+  });
+
+  it('process.env NANOCLAW_REGISTRY_TOKEN wins over every other source', () => {
+    vi.stubEnv('NANOCLAW_REGISTRY_TOKEN', 'registry-token-from-env');
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'registry-token-from-env',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('.env NANOCLAW_INSTALL_TOKEN beats account.json and the manager token', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('falls back to ~/.config/nanoclaw/account.json before direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({ mode: 'broker', installToken: 'account-token', baseUrl: DEFAULT_BROKER_BASE });
+  });
+
+  it('malformed account.json reads as not-enrolled, not an error', () => {
+    writeAccount('{not json');
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('account.json without a usable token field reads as not-enrolled', () => {
+    writeAccount(JSON.stringify({ token: '   ' }));
+    expect(resolve()).toBeNull();
+  });
+
+  it('SLACK_MANAGER_TOKEN alone selects direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('SLACK_SERVICE_BASE overrides the broker base, trailing slashes stripped', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_SERVICE_BASE=https://broker.example.test///']);
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: 'https://broker.example.test',
+    });
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.prefetch.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.prefetch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Avatar prefetch (multi-agent creates): prefetchAvatar starts the broker job
+ * in the background; the flow's later requestAvatar with the same
+ * (displayName, description) consumes that in-flight job instead of starting
+ * a second generation. A key miss or an already-consumed entry falls back to
+ * a fresh request.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAvatarPrefetches, prefetchAvatar, requestAvatar } from './provision.js';
+
+const fetchMock = vi.fn();
+
+function avatarBrokerResponses(id: string): void {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.endsWith('/v1/avatars')) {
+      return Promise.resolve(new Response(JSON.stringify({ avatar_id: id }), { status: 200 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ status: 'ready' }), { status: 200 }));
+  });
+}
+
+function postCount(): number {
+  return fetchMock.mock.calls.filter((c) => (c as [string])[0].endsWith('/v1/avatars')).length;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  clearAvatarPrefetches();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearAvatarPrefetches();
+});
+
+describe('avatar prefetch', () => {
+  it('requestAvatar consumes a pending prefetch — exactly one generation job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBe('av-1');
+    expect(postCount()).toBe(1);
+  });
+
+  it('a prefetch is consumed once — the next same-key request goes fresh', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('different (name, description) keys never share a job', async () => {
+    avatarBrokerResponses('av-x');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'designer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('duplicate prefetches for one key start one job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(1);
+  });
+
+  it('a failed prefetch resolves undefined without throwing into the flow', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBeUndefined();
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
@@ -1,0 +1,524 @@
+/**
+ * Managed Slack app provisioning for the slack-agent-flow leg.
+ *
+ * CONGRUENCE — this file deliberately duplicates:
+ * - src/provisioning/slack-app.ts (trunk provisioning module) — broker
+ *   protocol (install token from
+ *   ~/.config/nanoclaw/account.json or NANOCLAW_REGISTRY_TOKEN, base
+ *   SLACK_SERVICE_BASE else https://slack.nanoclaw.dev, POST /v1/apps) and the
+ *   direct apps.manifest.create + apps.managedInstall pair.
+ * - .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts —
+ *   MANAGED_BOT_SCOPES / MANAGED_BOT_EVENTS / buildManagedAppManifest,
+ *   credential resolution order, and the crash-safe persist-before-return
+ *   .env write (its step 1/3).
+ * This file, both mirrors, and the broker's server template all carry the
+ * SAME sets: base + canvas scopes, membership events, and the agent_view
+ * variant pair.
+ * provision.congruence.test.ts pins the mirrors against this file's sets and
+ * this file against the broker contract.
+ *
+ * The manager/install token is read, used as a Bearer header, and forgotten.
+ * Only the derived per-app bot/app tokens persist (to .env). No token value
+ * is ever logged or embedded in an error message.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+import { SlackFlowError, type ProvisionInput, type ProvisionResult } from './types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** The deployed managed-Slack broker. Overridable via SLACK_SERVICE_BASE. */
+export const DEFAULT_BROKER_BASE = 'https://slack.nanoclaw.dev';
+
+/**
+ * The managed-apps bot scope set — bot scopes only, no user scopes (that is
+ * the apps.managedInstall eligibility rule). Superset of MANAGED_BOT_SCOPES
+ * in slack-create-agent.ts (the base set) plus the canvas scopes; must stay
+ * identical to the broker's server-side BOT_SCOPES — apps provisioned via
+ * either transport must be scope-identical (pinned by
+ * provision.congruence.test.ts). im:write is what lets the new bot open the
+ * operator DM; mpim:* is what lets it open the three-way room; canvases:* +
+ * files:read is the room-canvas surface (files:read is the read-back path —
+ * canvases are files, the HTML download carries section ids).
+ */
+export const MANAGED_BOT_SCOPES: readonly string[] = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+  'canvases:read',
+  'canvases:write',
+  'files:read',
+  // send_file: agents deliver files they produce (charts, documents,
+  // generated artifacts) via files upload — live-verified missing_scope
+  // failure without it (filesUploadV2 needs files:write).
+  'files:write',
+];
+
+// member_joined/left_channel ride on the channels/groups/mpim:read scopes
+// already present (join-time adopt flow + membership bookkeeping).
+export const MANAGED_BOT_EVENTS: readonly string[] = [
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'app_mention',
+  'member_joined_channel',
+  'member_left_channel',
+];
+
+/**
+ * Agent-mode (features.agent_view) additions — the default variant. Slack
+ * auto-adds assistant:write when agent_view is enabled; declared explicitly
+ * so the manifest states what the app holds. Guests are hard-blocked from
+ * agent-enabled apps, so allowGuests selects the plain variant instead.
+ */
+export const MANAGED_AGENT_BOT_SCOPES: readonly string[] = ['assistant:write'];
+
+export const MANAGED_AGENT_BOT_EVENTS: readonly string[] = ['app_home_opened', 'app_context_changed'];
+
+/**
+ * Fixed attribution line: admins see this, never the creation prompt. Also
+ * the agent_view.agent_description (≤300 chars) on the agent-mode variant.
+ */
+export const MANAGED_APP_DESCRIPTION =
+  'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
+
+/**
+ * Socket-Mode-only managed-app manifest (see the congruence note above).
+ * Two variants, chosen at provision time — agent_view is a one-way door:
+ * agent-mode (default; free workspaces degrade to a plain DM) and plain
+ * (agentView:false, for workspaces that need guest access).
+ */
+export function buildManagedAppManifest(
+  displayName: string,
+  opts: { agentView?: boolean } = {},
+): Record<string, unknown> {
+  const agentView = opts.agentView ?? true;
+  return {
+    display_information: {
+      name: displayName,
+      description: MANAGED_APP_DESCRIPTION,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: displayName,
+        always_online: true,
+      },
+      ...(agentView ? { agent_view: { agent_description: MANAGED_APP_DESCRIPTION } } : {}),
+    },
+    oauth_config: {
+      scopes: { bot: agentView ? [...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES] : [...MANAGED_BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: agentView ? [...MANAGED_BOT_EVENTS, ...MANAGED_AGENT_BOT_EVENTS] : [...MANAGED_BOT_EVENTS],
+      },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+/**
+ * Which provisioning credential this install holds, in the decisive order:
+ * process.env.NANOCLAW_REGISTRY_TOKEN → .env NANOCLAW_INSTALL_TOKEN →
+ * ~/.config/nanoclaw/account.json (broker mode; base = SLACK_SERVICE_BASE
+ * else DEFAULT_BROKER_BASE) → .env SLACK_MANAGER_TOKEN (direct mode) → null.
+ *
+ * `opts.homeDir` overrides os.homedir() for tests only — the account.json
+ * credential is deliberately per-user, not per-checkout.
+ */
+export function resolveProvisioningCredential(
+  rootDir: string,
+  opts: { homeDir?: string } = {},
+): { mode: 'broker'; installToken: string; baseUrl: string } | { mode: 'direct'; managerToken: string } | null {
+  const baseUrl = (readEnvValue(rootDir, 'SLACK_SERVICE_BASE') ?? DEFAULT_BROKER_BASE).replace(/\/+$/, '');
+
+  const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
+  if (fromEnv) return { mode: 'broker', installToken: fromEnv, baseUrl };
+
+  const installToken = readEnvValue(rootDir, 'NANOCLAW_INSTALL_TOKEN');
+  if (installToken) return { mode: 'broker', installToken, baseUrl };
+
+  // Enrollment persists the install token at ~/.config/nanoclaw/account.json
+  // ({ token: "…" }). Malformed or missing reads as "not enrolled".
+  try {
+    const accountPath = path.join(opts.homeDir ?? os.homedir(), '.config', 'nanoclaw', 'account.json');
+    const parsed: unknown = JSON.parse(fs.readFileSync(accountPath, 'utf-8'));
+    const token = (parsed as { token?: unknown } | null)?.token;
+    if (typeof token === 'string' && token.trim()) {
+      return { mode: 'broker', installToken: token.trim(), baseUrl };
+    }
+  } catch {
+    // fall through to direct mode
+  }
+
+  const managerToken = readEnvValue(rootDir, 'SLACK_MANAGER_TOKEN');
+  if (managerToken) return { mode: 'direct', managerToken };
+
+  return null;
+}
+
+interface RawProvisioned {
+  appId: string;
+  appToken: string;
+  botToken?: string;
+  installUrl?: string;
+  installError?: string;
+}
+
+/** Broker mode: POST /v1/apps with the install token; 60s budget. */
+/** Poll cap for the pre-create avatar job — beyond it the bot is born with the mascot. */
+const AVATAR_WAIT_MS = 75_000;
+// Generation measures ~20-23s at the broker's floor settings (quality 'low',
+// 1024px is the model's minimum) — a 2s poll wastes at most ~2s of that,
+// where the old 4s poll wasted up to 4.
+const AVATAR_POLL_MS = 2_000;
+
+// ── Avatar prefetch (multi-agent creates) ──
+//
+// Each generation is an independent async Lambda on the broker, so N avatars
+// CAN run concurrently — the serialization was ours: flows run one at a time,
+// each paying the full ~23s avatar wait. The delivery batch preview
+// (index.ts) starts a prefetch for every create_agent in the batch in
+// parallel; requestAvatar consumes the matching prefetch instead of starting
+// a fresh job, collapsing N waits to ~one. Keyed by the exact
+// (displayName, description) derivation the flow uses, so a miss just means
+// a normal fresh request.
+const avatarPrefetches = new Map<string, { promise: Promise<string | undefined>; at: number }>();
+const AVATAR_PREFETCH_TTL_MS = 10 * 60_000;
+
+function avatarKey(displayName: string, description: string | undefined): string {
+  return `${displayName}\u0000${description ?? ''}`;
+}
+
+/** Start an avatar generation in the background for a create that is about to
+ *  be processed. Fire-and-forget; never throws. Deduped per key. */
+export function prefetchAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): void {
+  const key = avatarKey(displayName, description);
+  const existing = avatarPrefetches.get(key);
+  if (existing && Date.now() - existing.at < AVATAR_PREFETCH_TTL_MS) return;
+  avatarPrefetches.set(key, {
+    promise: requestAvatarFresh(baseUrl, installToken, displayName, description).catch(() => undefined),
+    at: Date.now(),
+  });
+}
+
+/** Test seam: drop all pending prefetches. */
+export function clearAvatarPrefetches(): void {
+  avatarPrefetches.clear();
+}
+
+/**
+ * Ask the broker to generate the agent's avatar BEFORE the app exists, so the
+ * bot's very first workspace appearance wears its face — the mascot default
+ * never shows on the happy path. Consumes a matching prefetch when one is
+ * pending (multi-agent creates start them in parallel). Returns undefined
+ * when generation is unavailable, failed, or over the wait cap (degraded
+ * path: mascot).
+ */
+export async function requestAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  const key = avatarKey(displayName, description);
+  const hit = avatarPrefetches.get(key);
+  if (hit) {
+    avatarPrefetches.delete(key);
+    if (Date.now() - hit.at < AVATAR_PREFETCH_TTL_MS) return hit.promise;
+  }
+  return requestAvatarFresh(baseUrl, installToken, displayName, description);
+}
+
+async function requestAvatarFresh(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  let avatarId: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/v1/avatars`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${installToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: displayName, ...(description ? { description } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = (await res.json()) as { avatar_id?: string | null };
+    avatarId = data.avatar_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+  if (!avatarId) return undefined;
+  const deadline = Date.now() + AVATAR_WAIT_MS;
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) await new Promise((r) => setTimeout(r, AVATAR_POLL_MS));
+    try {
+      const res = await fetch(`${baseUrl}/v1/avatars/${avatarId}`, {
+        headers: { Authorization: `Bearer ${installToken}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'ready') return avatarId;
+      if (data.status && data.status !== 'pending') return undefined;
+    } catch {
+      // Transient — bounded by the deadline.
+    }
+  }
+  return undefined;
+}
+
+async function provisionViaBroker(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  teamId: string | undefined,
+  description: string | undefined,
+  allowGuests = false,
+): Promise<RawProvisioned> {
+  if (!teamId) {
+    throw new SlackFlowError(
+      'broker',
+      'broker mode needs the origin workspace team_id (origin auth.test returned none)',
+    );
+  }
+  const avatarId = await requestAvatar(baseUrl, installToken, displayName, description);
+  let res: Response;
+  let text: string;
+  try {
+    res = await fetch(`${baseUrl}/v1/apps`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${installToken}`,
+        'Content-Type': 'application/json',
+      },
+      // The deployed broker's contract (POST /v1/apps): it builds the manifest
+      // server-side (agent-mode variant unless allow_guests) and generates
+      // the per-agent avatar from the description.
+      body: JSON.stringify({
+        team_id: teamId,
+        name: displayName,
+        ...(avatarId ? { avatar_id: avatarId } : {}),
+        ...(allowGuests ? { allow_guests: true } : {}),
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    text = await res.text();
+  } catch (err) {
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let data: Record<string, unknown>;
+  try {
+    data = (text ? JSON.parse(text) : {}) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('broker', `broker POST /v1/apps failed: HTTP ${res.status}, non-JSON body`);
+  }
+  if (!res.ok) {
+    // message is the human sentence, error the machine code — show the human one.
+    const detail = (data as { message?: string; error?: string }).message ?? (data as { error?: string }).error;
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: HTTP ${res.status}${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+  // Contract shape is camelCase; the deployed broker speaks snake_case
+  // (BrokerAppResponse in src/provisioning/slack-app.ts) — accept both.
+  const pick = (a: unknown, b: unknown): string | undefined =>
+    typeof a === 'string' && a ? a : typeof b === 'string' && b ? b : undefined;
+  const appId = pick(data.appId, data.app_id);
+  const appToken = pick(data.appToken, data.app_token);
+  if (!appId || !appToken) {
+    throw new SlackFlowError('broker', 'broker POST /v1/apps failed: response missing app id or app token');
+  }
+  return {
+    appId,
+    appToken,
+    botToken: pick(data.botToken, data.bot_token),
+    installUrl: pick(data.installUrl, data.install_url),
+    installError: pick(data.installError, data.install_error),
+  };
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+async function slackApi<T extends SlackApiResponse>(
+  method: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API}/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(params).toString(),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new SlackFlowError('direct-create', `${method} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok && res.status !== 200) throw new SlackFlowError('direct-create', `${method}: HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+/** Direct mode: apps.manifest.create + apps.managedInstall with the manager token. */
+async function provisionDirect(
+  managerToken: string,
+  displayName: string,
+  allowGuests = false,
+): Promise<RawProvisioned> {
+  const created = await slackApi<
+    SlackApiResponse & { app_id?: string; app_token?: string; oauth_authorize_url?: string }
+  >('apps.manifest.create', managerToken, {
+    manifest: JSON.stringify(buildManagedAppManifest(displayName, { agentView: !allowGuests })),
+    generate_app_token: 'true',
+  });
+  if (!created.ok || !created.app_id) {
+    throw new SlackFlowError(
+      'direct-create',
+      `apps.manifest.create failed: ${created.error ?? 'no app_id in response'}`,
+    );
+  }
+  if (!created.app_token) {
+    throw new SlackFlowError(
+      'direct-create',
+      'apps.manifest.create returned no app-level token (generate_app_token unsupported?)',
+    );
+  }
+  const result: RawProvisioned = {
+    appId: created.app_id,
+    appToken: created.app_token,
+    installUrl: created.oauth_authorize_url ?? '',
+  };
+  const installed = await slackApi<SlackApiResponse & { api_access_tokens?: { bot_access_token?: string } }>(
+    'apps.managedInstall',
+    managerToken,
+    { app_id: created.app_id },
+  );
+  if (installed.ok && installed.api_access_tokens?.bot_access_token) {
+    result.botToken = installed.api_access_tokens.bot_access_token;
+  } else {
+    result.installError = installed.error ?? 'no bot token in response';
+  }
+  return result;
+}
+
+/**
+ * Provision (or reuse) the named instance's Slack app and persist its tokens.
+ *
+ * Reuse: both per-instance tokens already in .env → no network, reused:true.
+ * Fresh: resolve a credential (broker else direct), provision, then persist
+ * SLACK_APP_TOKEN_<S> / SLACK_BOT_TOKEN_<S> and union the slug into
+ * SLACK_INSTANCES IMMEDIATELY — .env is the resume state; a failure after
+ * this point never re-provisions a duplicate Slack app on retry.
+ */
+export async function provisionSlackApp(input: ProvisionInput): Promise<ProvisionResult> {
+  const { slug, displayName, rootDir } = input;
+  const envSuffix = slug.toUpperCase().replace(/-/g, '_');
+  const botKey = `SLACK_BOT_TOKEN_${envSuffix}`;
+  const appKey = `SLACK_APP_TOKEN_${envSuffix}`;
+
+  const existingBot = readEnvValue(rootDir, botKey);
+  const existingApp = readEnvValue(rootDir, appKey);
+  if (existingBot && existingApp) {
+    // appId is unknown on the reuse path — .env stores tokens only.
+    return { slug, envSuffix, botToken: existingBot, appToken: existingApp, appId: '', reused: true };
+  }
+  if (existingApp && !existingBot) {
+    throw new SlackFlowError(
+      'no-credentials',
+      `${appKey} is set but ${botKey} is missing — the app exists but was never installed. ` +
+        `Finish the install from the app's page in Slack, put the xoxb-… token in .env as ${botKey}, and retry.`,
+    );
+  }
+  if (existingBot && !existingApp) {
+    throw new SlackFlowError(
+      'no-credentials',
+      `${botKey} is set but ${appKey} is missing — add the app-level xapp-… token to .env as ${appKey} and retry.`,
+    );
+  }
+
+  const credential = resolveProvisioningCredential(rootDir);
+  if (!credential) {
+    throw new SlackFlowError(
+      'no-credentials',
+      'no Slack provisioning credential: set NANOCLAW_INSTALL_TOKEN (managed service) or ' +
+        'SLACK_MANAGER_TOKEN (direct) in .env, or enroll this install with the registry.',
+    );
+  }
+
+  const allowGuests = input.allowGuests ?? false;
+  const app =
+    credential.mode === 'broker'
+      ? await provisionViaBroker(
+          credential.baseUrl,
+          credential.installToken,
+          displayName,
+          input.teamId,
+          input.description,
+          allowGuests,
+        )
+      : await provisionDirect(credential.managerToken, displayName, allowGuests);
+
+  // Persist what we have before anything else can fail — .env is the resume
+  // state (mirrors slack-create-agent.ts). App token + instance slug land
+  // even when auto-install was refused so a manual install can finish it.
+  try {
+    upsertEnvKey(rootDir, appKey, app.appToken);
+    if (app.botToken) upsertEnvKey(rootDir, botKey, app.botToken);
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${appKey}/${botKey}/SLACK_INSTANCES to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!app.botToken) {
+    // Usually a workspace admin-approval policy refusing auto-install.
+    throw new SlackFlowError(
+      credential.mode === 'broker' ? 'broker' : 'direct-create',
+      `Slack refused to auto-install app ${app.appId} (${app.installError ?? 'unknown reason'}). ` +
+        `Install it by hand${app.installUrl ? ` from ${app.installUrl}` : " from the app's page at api.slack.com/apps"}, ` +
+        `put the xoxb-… token in .env as ${botKey}, and retry — the app token is already saved.`,
+    );
+  }
+
+  return { slug, envSuffix, botToken: app.botToken, appToken: app.appToken, appId: app.appId, reused: false };
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Tests for the agent-facing room actions: create_room and
+ * add_to_room, driven through the REAL guard-wrapped delivery entries
+ * (getDeliveryAction) over a real in-memory central DB. Slack traffic is a
+ * recorded fetch stub (auth.test + conversations.open only — room actions
+ * never provision apps); the canvas leg is mocked like orchestrate.test.ts.
+ * rootDir is process.cwd(), so each test runs chdir'd into its own tmpdir.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ANDY_BOT_TOKEN = 'xoxb-andy-secret-token';
+const PIXEL_BOT_TOKEN = 'xoxb-pixel-secret-token';
+const DEVIN_BOT_TOKEN = 'xoxb-devin-secret-token';
+
+const { mockNotifyWrite, mockRequestApproval, mockWriteDestinations, mockCreateRoomCanvas, mockWireCanvasComments } =
+  vi.hoisted(() => ({
+    mockNotifyWrite: vi.fn(),
+    mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+    mockWriteDestinations: vi.fn(),
+    mockCreateRoomCanvas: vi.fn(),
+    mockWireCanvasComments: vi.fn(),
+  }));
+
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({ initGroupFilesystem: vi.fn() }));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// room actions only need these three. notifyAgent stays REAL (primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the create_room / add_to_room delivery actions — the path under
+// test. Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays
+// unloaded.
+import './index.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { listGuardedActions } from '../../guard/index.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { createDestination, getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'strict' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+let tmpDir = '';
+// conversations.members response for the add_to_room source-room read.
+let sourceRoomMembers: string[] = [];
+let membersFail = false;
+
+const BOT_IDS: Record<string, string> = {
+  [ANDY_BOT_TOKEN]: 'U0ANDYBOT',
+  [PIXEL_BOT_TOKEN]: 'U0PIXELBOT',
+  [DEVIN_BOT_TOKEN]: 'U0DEVINBOT',
+};
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const token = String(init?.headers?.Authorization ?? '').replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.includes('/api/auth.test')) {
+    const userId = BOT_IDS[token];
+    if (!userId) return Promise.resolve(jsonResponse({ ok: false, error: 'invalid_auth' }));
+    return Promise.resolve(jsonResponse({ ok: true, user_id: userId, team_id: 'T0TEST' }));
+  }
+  if (url.includes('/api/conversations.members')) {
+    if (membersFail) return Promise.resolve(jsonResponse({ ok: false, error: 'fetch_members_failed' }));
+    return Promise.resolve(jsonResponse({ ok: true, members: sourceRoomMembers }));
+  }
+  if (url.includes('/api/conversations.open')) {
+    // add_to_room opens the superset AS the newly added agent (Devin in
+    // these tests) — that open forks; every other open is the original room.
+    return Promise.resolve(
+      jsonResponse({ ok: true, channel: { id: token === DEVIN_BOT_TOKEN ? 'G0FORK' : 'G0TEAM' } }),
+    );
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+function roomOpens(): RecordedFetch[] {
+  return fetchCalls.filter((c) => c.url.includes('conversations.open'));
+}
+
+async function runAction(
+  action: string,
+  content: Record<string, unknown>,
+  session: Session = SLACK_SESSION,
+): Promise<void> {
+  const wrapped = getDeliveryAction(action);
+  expect(wrapped).toBeDefined();
+  await wrapped!({ action, ...content }, session, undefined as never);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ANDY_BOT_TOKEN, PIXEL_BOT_TOKEN, DEVIN_BOT_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+/** A provisioned sub-agent: group + DM wiring on its own instance + the
+ *  caller's a2a destination for it (what create_agent leaves behind). */
+function seedSubAgent(name: string, groupId: string, instanceKey: string): void {
+  const now = new Date().toISOString();
+  const localName = name.toLowerCase();
+  createAgentGroup({ id: groupId, name, folder: localName, agent_provider: null, created_at: now });
+  const dmMgId = `mg-${localName}-dm`;
+  createMessagingGroup({
+    id: dmMgId,
+    channel_type: 'slack',
+    platform_id: `slack:D0${name.toUpperCase()}DM`,
+    instance: instanceKey,
+    name: `${name} DM`,
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  createMessagingGroupAgent({
+    id: `mga-${localName}-dm`,
+    messaging_group_id: dmMgId,
+    agent_group_id: groupId,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+  createDestination({
+    agent_group_id: SRC_GROUP,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: groupId,
+    created_at: now,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  // Faithful default: the source room holds exactly the operator + its bots.
+  sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT'];
+  membersFail = false;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-room-actions-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(
+    path.join(tmpDir, '.env'),
+    `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\nSLACK_BOT_TOKEN_PIXEL=${PIXEL_BOT_TOKEN}\nSLACK_BOT_TOKEN_DEVIN=${DEVIN_BOT_TOKEN}\n`,
+  );
+
+  const db = initTestDb();
+  runMigrations(db);
+
+  const now = new Date().toISOString();
+  createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  ensureContainerConfig(SRC_GROUP);
+  updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  grantRole({ user_id: 'slack:U0OPERATOR', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now });
+  createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  createSession(SLACK_SESSION);
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+
+  seedSubAgent('Pixel', 'ag-pixel', 'slack-pixel');
+  seedSubAgent('Devin', 'ag-devin', 'slack-devin');
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('guard wiring', () => {
+  it('both room actions are in the guard catalog and their entries are guard-wrapped', () => {
+    const actions = new Set(listGuardedActions().map((s) => s.action));
+    expect(actions.has('rooms.create')).toBe(true);
+    expect(actions.has('rooms.add_agent')).toBe(true);
+    expect(getDeliveryAction('create_room')).toBeDefined();
+    expect(getDeliveryAction('add_to_room')).toBeDefined();
+  });
+
+  it('confined (group-scope) caller: create_room holds for approval, nothing runs', async () => {
+    updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel', 'Devin'] });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_room');
+    expect(opts.payload).toMatchObject({ name: 'Website Team', agents: ['Pixel', 'Devin'] });
+  });
+
+  it('confined (group-scope) caller: add_to_room holds for approval with the (room, agent) payload', async () => {
+    updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('add_to_room');
+    expect(opts.payload).toEqual({ room: 'Website Team', agent: 'Devin' });
+  });
+});
+
+describe('create_room', () => {
+  it('resolves names and hands ensureAgentRoom the full participant list (caller included)', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runAction('create_room', { name: 'Website Team', purpose: 'ship the new site', agents: ['Pixel', 'Devin'] });
+
+    // MPIM opened AS the caller with the operator + every other bot.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(ANDY_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0PIXELBOT,U0DEVINBOT' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = getMessagingGroupByPlatform('slack', 'slack:G0TEAM', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Pairwise a2a destinations between the sub-agents (caller already had both).
+    expect(getDestinationByName('ag-pixel', 'devin')).toMatchObject({ target_type: 'agent', target_id: 'ag-devin' });
+    expect(getDestinationByName('ag-devin', 'pixel')).toMatchObject({ target_type: 'agent', target_id: 'ag-pixel' });
+
+    // Canvas gets the contract data — every agent by plain name, caller first.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(ANDY_BOT_TOKEN, 'G0TEAM', {
+      roomName: 'Website Team',
+      purpose: 'ship the new site',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Pixel', 'Devin'],
+    });
+
+    // Allowlisted for a2a; success notify tells the CALLER to author the
+    // intro via its projected room destination, tagging both bots.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0TEAM/m);
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Room "Website Team" is live (G0TEAM)');
+    expect(success).toContain('send_message({ to: "website-team"');
+    expect(success).toContain('<@U0PIXELBOT>');
+    expect(success).toContain('<@U0DEVINBOT>');
+    expect(success).not.toContain('<@U0ANDYBOT>');
+    expect(success).toContain('no mechanics, no member lists');
+
+    assertNoTokenLeak();
+  });
+
+  it('include_me:false — first listed agent becomes creator, caller stays out', async () => {
+    await runAction('create_room', { name: 'Duo', agents: ['Pixel', 'Devin'], include_me: false });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(PIXEL_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0DEVINBOT' });
+
+    // No caller-instance row, no caller wiring.
+    expect(getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeUndefined();
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('You are not a member');
+    expect(success).not.toContain('send_message');
+  });
+
+  it('unknown agent name surfaces as a failure notify before anything is opened', async () => {
+    await runAction('create_room', { name: 'Website Team', agents: ['Ghost'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(getAllMessagingGroups().filter((m) => m.platform_id === 'slack:G0TEAM')).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('create_room failed: unknown agent "Ghost"');
+  });
+
+  it('missing bot token surfaces as a failure notify naming the key, never the value', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\n`);
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain('create_room failed: no bot token in .env for agent "Pixel"');
+    expect(failure).toContain('SLACK_BOT_TOKEN_PIXEL');
+    assertNoTokenLeak();
+  });
+
+  it('malformed request (no agents) is answered by the precheck without a hold', async () => {
+    updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: [] });
+
+    expect(mockRequestApproval).not.toHaveBeenCalled();
+    expect(notifyTexts().at(-1)).toContain('agents must be a non-empty list');
+  });
+});
+
+describe('add_to_room', () => {
+  beforeEach(async () => {
+    // An existing room: Andy + Pixel (+ operator), created through the real
+    // primitive so the wiring shape matches production.
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+    mockNotifyWrite.mockClear();
+    fetchCalls = [];
+  });
+
+  it('opens the superset MPIM as the new agent and wires everyone onto the forked channel', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    // Superset open AS Devin: operator + both existing bots → fork id.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(DEVIN_BOT_TOKEN);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(3);
+    expect(users).toContain('U0OPERATOR');
+    expect(users).toContain('U0ANDYBOT');
+    expect(users).toContain('U0PIXELBOT');
+
+    // Every participant wired onto the NEW channel; the old room untouched.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = getMessagingGroupByPlatform('slack', 'slack:G0FORK', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        ignored_message_policy: 'accumulate',
+      });
+    }
+    expect(getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeDefined();
+    expect(getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack-devin')).toBeUndefined();
+
+    // The caller is a room member — the notify explains the fork and asks
+    // for an intro of the new agent in the NEW conversation.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Devin was added to room "Website Team"');
+    expect(success).toContain('moved to a new conversation (G0FORK)');
+    expect(success).toContain('<@U0DEVINBOT>');
+
+    assertNoTokenLeak();
+  });
+
+  it('carries Slack-UI-added humans from the source room into the forked superset', async () => {
+    // A colleague was added to the room via the Slack UI — they exist only
+    // in the platform member list, never in wiring rows.
+    sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT', 'U0COLLEAGUE'];
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(4);
+    expect(users).toContain('U0COLLEAGUE');
+    expect(notifyTexts().at(-1)).toContain('moved to a new conversation (G0FORK)');
+  });
+
+  it('source-room member read failure fails the action — never a fork that silently drops members', async () => {
+    membersFail = true;
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed');
+  });
+
+  it('agent already in the room: says so, opens nothing', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Pixel' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('already in room "Website Team"');
+  });
+
+  it('unknown room surfaces as a failure notify', async () => {
+    await runAction('add_to_room', { room: 'Nope', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed: no wired Slack room named "Nope"');
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
@@ -1,0 +1,456 @@
+/**
+ * Agent-facing room actions: `create_room` and `add_to_room`
+ * delivery-action bodies over the already-N-capable ensureAgentRoom.
+ *
+ * `create_room` is the "team room" primitive — the multi-agent pattern is N
+ * `create_agent` calls with room:'none' followed by ONE create_room naming
+ * all of them. Agent names resolve through the CALLER's a2a destination
+ * namespace (the same names send_message uses), so an agent can only room
+ * with agents it can already message. Each resolved agent group maps to its
+ * Slack adapter instance via its wired messaging groups; bot identities come
+ * from auth.test on the instance's .env token (botTokenKeyForInstance) —
+ * token values never appear in notify texts or logs.
+ *
+ * `add_to_room` grows an existing room by one agent. Slack platform fact:
+ * MPIMs NEVER grow in place — opening the superset member list FORKS a new
+ * conversation id. ensureAgentRoom wires every participant onto the new id
+ * directly, and the source room's actual member list is read first so
+ * Slack-UI-added humans carry into the fork; the slack-room-membership
+ * MPIM-fork carry-over (membership.ts) remains the path for Slack-UI adds
+ * and stays silent here because the rows
+ * already exist when its join-recheck fires. The old room is left untouched
+ * (both conversations stay alive). For planned teams, prefer one complete
+ * create_room over add_to_room chains.
+ *
+ * Failures surface to the requesting agent via notifyAgent — never silent.
+ */
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  getMessagingGroupsByAgentGroup,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { AgentGroup, Session } from '../../types.js';
+import {
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { botTokenKeyForInstance, slackAuthTest, slackConversationsMembers } from '../../channels/slack-lib.js';
+import { notifyAgent, requestApproval } from '../approvals/index.js';
+import { readEnvValue } from './env-file.js';
+import { ensureAgentRoom, publicPurpose, resolveOperatorSlackUserId, type RoomParticipant } from './orchestrate.js';
+
+/** Domain failure with an agent-presentable message (no token values, ever). */
+class RoomActionError extends Error {}
+
+/** A room participant plus the bot token that proves it — token stays local. */
+interface ResolvedParticipant extends RoomParticipant {
+  botToken: string;
+}
+
+// ── Participant resolution ──
+
+/**
+ * An agent name → its agent group, through the CALLER's destination
+ * namespace (normalizeName'd, same as send_message targets).
+ */
+function resolveAgentByName(callerGroupId: string, name: string): AgentGroup {
+  const localName = normalizeName(name);
+  const dest = getDestinationByName(callerGroupId, localName);
+  if (!dest || dest.target_type !== 'agent') {
+    throw new RoomActionError(
+      `unknown agent "${name}" — you have no agent destination named "${localName}". ` +
+        `Use the names your send_message destinations use.`,
+    );
+  }
+  const group = getAgentGroup(dest.target_id);
+  if (!group) throw new RoomActionError(`agent group behind destination "${localName}" no longer exists`);
+  return group;
+}
+
+/** Bot token + auth.test identity for one adapter instance. */
+async function identityForInstance(
+  instanceKey: string,
+  agentGroupName: string,
+  rootDir: string,
+): Promise<{ botToken: string; botUserId: string }> {
+  const tokenKey = botTokenKeyForInstance(instanceKey);
+  const botToken = readEnvValue(rootDir, tokenKey);
+  if (!botToken) {
+    throw new RoomActionError(`missing ${tokenKey} in .env for agent "${agentGroupName}" (instance '${instanceKey}')`);
+  }
+  const botUserId = (await slackAuthTest(botToken, 'room-resolve')).userId;
+  return { botToken, botUserId };
+}
+
+/** Build the participant for a known (group, instance) pair. */
+async function participantForInstance(
+  group: AgentGroup,
+  instanceKey: string,
+  rootDir: string,
+): Promise<ResolvedParticipant> {
+  const { botToken, botUserId } = await identityForInstance(instanceKey, group.name, rootDir);
+  return { instanceKey, botUserId, agentGroupId: group.id, agentGroupName: group.name, botToken };
+}
+
+/**
+ * Build the participant for an agent group by finding its Slack adapter
+ * instance among its wired messaging groups (a provisioned agent's DM and
+ * rooms all live on its dedicated `slack-<slug>` instance; the origin agent
+ * lives on its origin instance). Multiple distinct instances is a
+ * pathological state — the first (sorted) with a token in .env wins.
+ */
+async function participantForAgentGroup(group: AgentGroup, rootDir: string): Promise<ResolvedParticipant> {
+  const instances = [
+    ...new Set(
+      getMessagingGroupsByAgentGroup(group.id)
+        .filter((mg) => mg.channel_type === 'slack')
+        .map((mg) => mg.instance ?? 'slack'),
+    ),
+  ].sort();
+  if (instances.length === 0) {
+    throw new RoomActionError(
+      `agent "${group.name}" has no Slack presence (no Slack wiring found) — was its Slack bot provisioned?`,
+    );
+  }
+  const withToken = instances.find((key) => readEnvValue(rootDir, botTokenKeyForInstance(key)) !== undefined);
+  if (!withToken) {
+    throw new RoomActionError(
+      `no bot token in .env for agent "${group.name}" (looked for ${instances.map(botTokenKeyForInstance).join(', ')})`,
+    );
+  }
+  return participantForInstance(group, withToken, rootDir);
+}
+
+/**
+ * The CALLING agent as a participant — its instance is the session's origin
+ * instance when the request came in through Slack (mirrors runSlackAgentFlow),
+ * else resolved from its wired messaging groups (task/a2a sessions).
+ */
+async function callerParticipant(session: Session, rootDir: string): Promise<ResolvedParticipant> {
+  const group = getAgentGroup(session.agent_group_id);
+  if (!group) throw new RoomActionError('source agent group not found');
+  const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+  if (originMg?.channel_type === 'slack') {
+    return participantForInstance(group, originMg.instance ?? 'slack', rootDir);
+  }
+  return participantForAgentGroup(group, rootDir);
+}
+
+/** The caller's local destination name for a room channel on its instance. */
+function callerRoomDestination(
+  callerGroupId: string,
+  callerInstanceKey: string,
+  roomChannelId: string,
+  roomName: string,
+): string {
+  const roomMg = getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, callerInstanceKey);
+  const dest = roomMg ? getDestinationByTarget(callerGroupId, 'channel', roomMg.id) : undefined;
+  return dest?.local_name ?? normalizeName(roomName);
+}
+
+/** `<@U…>, <@U…>` mention tags for every participant except the caller. */
+function mentionTags(participants: RoomParticipant[], excludeGroupId: string): string {
+  return participants
+    .filter((p) => p.agentGroupId !== excludeGroupId)
+    .map((p) => `<@${p.botUserId}>`)
+    .join(', ');
+}
+
+// ── create_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export function validateCreateRoom(content: Record<string, unknown>, session: Session): boolean {
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  if (!name) {
+    notifyAgent(session, 'create_room failed: name is required.');
+    return false;
+  }
+  const agents = Array.isArray(content.agents) ? content.agents : [];
+  if (agents.length === 0 || !agents.every((a) => typeof a === 'string' && a.trim())) {
+    notifyAgent(session, 'create_room failed: agents must be a non-empty list of agent names.');
+    return false;
+  }
+  if (!getAgentGroup(session.agent_group_id)) {
+    notifyAgent(session, 'create_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestCreateRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  const agents = (Array.isArray(content.agents) ? content.agents : []).filter(
+    (a): a is string => typeof a === 'string',
+  );
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_room',
+    // Same payload shape as the tool call — the approved replay re-enters
+    // the wrapped action unchanged.
+    payload: {
+      name,
+      agents,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.include_me === false ? { include_me: false } : {}),
+    },
+    title: `Create room: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to open a shared Slack room "${name}" with you and ` +
+      `${agents.join(', ')}${content.include_me === false ? ' (without itself)' : ''}. Approve?`,
+  });
+}
+
+/**
+ * Guard allow body: resolve every named agent (+ the caller unless
+ * include_me:false), then hand the full participant list to ensureAgentRoom
+ * — one MPIM with ALL bots + the operator, one canvas, mention/accumulate
+ * wirings per instance, pairwise a2a destinations. The success notify tells
+ * the CALLER to author the room intro (no host-templated intro).
+ */
+export async function handleCreateRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = (content.name as string).trim();
+  const agentNames = (content.agents as string[]).map((a) => a.trim());
+  const includeMe = content.include_me !== false;
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    // Caller first when included — it becomes the creator (opens the MPIM,
+    // creates the canvas); otherwise the first listed agent does.
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    if (includeMe) {
+      const caller = await callerParticipant(session, rootDir);
+      seen.add(caller.agentGroupId);
+      participants.push(caller);
+    }
+    for (const agentName of agentNames) {
+      const group = resolveAgentByName(session.agent_group_id, agentName);
+      if (seen.has(group.id)) continue;
+      seen.add(group.id);
+      participants.push(await participantForAgentGroup(group, rootDir));
+    }
+    if (participants.length === 0) throw new RoomActionError('no agents resolved');
+    const creator = participants[0]!;
+
+    const { roomChannelId, created } = await ensureAgentRoom({
+      creator,
+      creatorBotToken: creator.botToken,
+      operatorUserId,
+      participants,
+      roomName: name,
+      purpose: publicPurpose(typeof content.purpose === 'string' ? content.purpose : undefined),
+      rootDir,
+    });
+
+    const memberNames = participants.map((p) => p.agentGroupName).join(', ');
+    if (!includeMe) {
+      notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with the operator and ${memberNames}. ` +
+          `You are not a member (include_me was false), so you cannot post there.`,
+      );
+    } else if (!created) {
+      notifyAgent(session, `Room "${name}" already existed (${roomChannelId}) — nothing new was created.`);
+    } else {
+      // The calling agent authors the intro, in its own voice.
+      const roomDest = callerRoomDestination(session.agent_group_id, creator.instanceKey, roomChannelId, name);
+      notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with you, the operator, and ${memberNames}. ` +
+          `Post a brief introduction there now via send_message({ to: "${roomDest}", ... }): ` +
+          `1-2 lines in your own voice on what this room is for, tagging each agent literally ` +
+          `(${mentionTags(participants, session.agent_group_id)}) — the tags render as mentions and are how you ` +
+          `engage them there. Just the intro — no mechanics, no member lists.`,
+      );
+    }
+    log.info('create_room completed', { roomChannelId, created, participantCount: participants.length });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    notifyAgent(session, `create_room failed: ${message}`);
+    log.error('create_room failed', { name, err: message });
+  }
+}
+
+// ── add_to_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export function validateAddToRoom(content: Record<string, unknown>, session: Session): boolean {
+  if (typeof content.room !== 'string' || !content.room.trim()) {
+    notifyAgent(session, 'add_to_room failed: room is required.');
+    return false;
+  }
+  if (typeof content.agent !== 'string' || !content.agent.trim()) {
+    notifyAgent(session, 'add_to_room failed: agent is required.');
+    return false;
+  }
+  if (!getAgentGroup(session.agent_group_id)) {
+    notifyAgent(session, 'add_to_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestAddToRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const room = typeof content.room === 'string' ? content.room.trim() : '';
+  const agent = typeof content.agent === 'string' ? content.agent.trim() : '';
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'add_to_room',
+    payload: { room, agent },
+    title: `Add ${agent} to room: ${room}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to add agent "${agent}" to the shared Slack room "${room}" ` +
+      `(this opens a new group conversation with everyone plus "${agent}"). Approve?`,
+  });
+}
+
+/**
+ * The room named by an add_to_room call: wired Slack group rooms whose
+ * messaging-group name matches (case-insensitive). Shadow channels never
+ * match — their names carry a "canvas comments" suffix. When several rooms
+ * share the name (e.g. earlier add_to_room forks keep the old room alive
+ * under the same name), the NEWEST family wins — "the room" means its latest
+ * incarnation.
+ */
+function resolveRoomFamily(roomName: string): { family: ReturnType<typeof getAllMessagingGroups>; name: string } {
+  const wanted = roomName.trim().toLowerCase();
+  const matches = getAllMessagingGroups().filter(
+    (m) =>
+      m.channel_type === 'slack' &&
+      m.is_group === 1 &&
+      !m.denied_at &&
+      m.platform_id.startsWith('slack:') &&
+      (m.name ?? '').trim().toLowerCase() === wanted &&
+      getMessagingGroupAgents(m.id).length > 0,
+  );
+  if (matches.length === 0) throw new RoomActionError(`no wired Slack room named "${roomName}" found`);
+  const newestFirst = [...new Set(matches.map((m) => m.platform_id))]
+    .map((pid) => ({
+      pid,
+      createdAt: matches
+        .filter((m) => m.platform_id === pid)
+        .map((m) => m.created_at)
+        .sort()[0]!,
+    }))
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  const family = matches.filter((m) => m.platform_id === newestFirst[0]!.pid);
+  return { family, name: family[0]!.name ?? roomName };
+}
+
+/**
+ * Guard allow body: resolve the room's current participants from its wiring
+ * rows, resolve the named agent, and re-run ensureAgentRoom with the
+ * superset. The conversations.open on the superset member list FORKS a new
+ * MPIM (Slack never grows one in place); ensureAgentRoom wires everyone onto
+ * the new id, and the old room stays untouched — same shape the
+ * slack-room-membership fork carry-over produces for Slack-UI adds.
+ */
+export async function handleAddToRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const roomArg = (content.room as string).trim();
+  const agentArg = (content.agent as string).trim();
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    const { family, name: roomName } = resolveRoomFamily(roomArg);
+
+    // Current participants — one per wired agent group, on the room row's
+    // own instance (router lookup is exact-on-instance, so the row is the
+    // authoritative instance mapping).
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    for (const mg of family) {
+      for (const wiring of getMessagingGroupAgents(mg.id)) {
+        if (seen.has(wiring.agent_group_id)) continue;
+        seen.add(wiring.agent_group_id);
+        const group = getAgentGroup(wiring.agent_group_id);
+        if (!group) continue;
+        participants.push(await participantForInstance(group, mg.instance ?? 'slack', rootDir));
+      }
+    }
+
+    const newGroup = resolveAgentByName(session.agent_group_id, agentArg);
+    if (seen.has(newGroup.id)) {
+      notifyAgent(session, `add_to_room: agent "${newGroup.name}" is already in room "${roomName}".`);
+      return;
+    }
+    const newParticipant = await participantForAgentGroup(newGroup, rootDir);
+
+    // Members added via the Slack UI (extra humans, foreign bots) exist only
+    // on the platform — wiring rows carry agents alone. Read the source
+    // room's actual member list so the forked superset carries them instead
+    // of silently dropping them (the membership fork carry-over preserves
+    // members for UI adds; this path must too). A failed read fails the
+    // action (outer catch) — never a fork that quietly excludes someone.
+    let extraMemberUserIds: string[] = [];
+    if (participants.length > 0) {
+      const sourceChannelId = family[0]!.platform_id.slice('slack:'.length);
+      const knownIds = new Set([operatorUserId, newParticipant.botUserId, ...participants.map((p) => p.botUserId)]);
+      const sourceMembers = await slackConversationsMembers(participants[0]!.botToken, sourceChannelId, 'room-resolve');
+      extraMemberUserIds = sourceMembers.filter((id) => !knownIds.has(id));
+    }
+
+    // The NEW agent opens the superset MPIM (mirrors the create flow, where
+    // the newly arriving bot is the opener/canvas creator).
+    const { roomChannelId } = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: newParticipant.botToken,
+      operatorUserId,
+      participants: [...participants, newParticipant],
+      extraMemberUserIds,
+      roomName,
+      rootDir,
+    });
+
+    const callerInRoom = seen.has(session.agent_group_id);
+    const callerMg = family.find((mg) =>
+      getMessagingGroupAgents(mg.id).some((w) => w.agent_group_id === session.agent_group_id),
+    );
+    const intro =
+      callerInRoom && callerMg
+        ? ` Post a brief introduction of ${newParticipant.agentGroupName} there now via send_message({ to: ` +
+          `"${callerRoomDestination(session.agent_group_id, callerMg.instance ?? 'slack', roomChannelId, roomName)}", ... }): ` +
+          `1-2 lines in your own voice, tagging them with <@${newParticipant.botUserId}> (include that literally — ` +
+          `it renders as a mention). Just the intro — no mechanics, no member lists.`
+        : '';
+    notifyAgent(
+      session,
+      `${newParticipant.agentGroupName} was added to room "${roomName}". Slack group DMs never grow in place, ` +
+        `so the room moved to a new conversation (${roomChannelId}) — everyone is wired there and the old ` +
+        `conversation keeps working.${intro}`,
+    );
+    log.info('add_to_room completed', { roomChannelId, agentGroupId: newGroup.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    notifyAgent(session, `add_to_room failed: ${message}`);
+    log.error('add_to_room failed', { room: roomArg, agent: agentArg, err: message });
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Room canvas creation tests (contract C2): template shape (the canvas IS the
+ * room contract; no bot mentions in the body), the
+ * conversations.canvases.create call, and the non-throwing failure paths.
+ * Plus the canvas-comments shadow-channel wiring (F→C derivation, one mg row
+ * + wiring per participating instance, idempotence, non-throwing).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TIMEZONE } from '../../config.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { formatLocalTime } from '../../timezone.js';
+import {
+  createRoomCanvas,
+  deriveCanvasShadowChannelId,
+  roomCanvasMarkdown,
+  wireCanvasComments,
+} from './room-canvas.js';
+
+const OPTS = {
+  roomName: 'Pixel room',
+  purpose: 'Design work between Gavriel, Pixel, and Mark.\nSecond purpose line.',
+  creatorUserId: 'U0CREATOR',
+  agentNames: ['Pixel', 'Mark', 'Pixel'],
+  createdAt: '2026-08-01T12:00:00.000Z',
+};
+
+describe('roomCanvasMarkdown', () => {
+  const md = roomCanvasMarkdown(OPTS);
+
+  it('leads with the blockquoted purpose — no body H1 (the create-call `title` param renders the document title; a body heading duplicated it, live-observed)', () => {
+    expect(md.startsWith('> Design work between Gavriel, Pixel, and Mark.')).toBe(true);
+    expect(md).not.toContain('# Pixel room');
+    expect(md).toContain('> Second purpose line.');
+  });
+
+  it('carries the room-contract data: creator card, created date, Members table', () => {
+    expect(md).toContain(`Created by ![](@U0CREATOR) on ${formatLocalTime(OPTS.createdAt, TIMEZONE)}.`);
+    expect(md).toContain('## Members');
+    expect(md).toContain('| ![](@U0CREATOR) | creator |');
+  });
+
+  it('lists agents by PLAIN NAME, deduped — never as user cards', () => {
+    expect(md).toContain('| Pixel | agent |');
+    expect(md).toContain('| Mark | agent |');
+    expect(md.match(/\| Pixel \| agent \|/g)).toHaveLength(1);
+  });
+
+  it('never @-mentions a bot: the only user card is the human creator', () => {
+    const cards = md.match(/!\[\]\(@\w+\)/g) ?? [];
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) expect(card).toBe('![](@U0CREATOR)');
+    expect(md).not.toContain('<@');
+  });
+
+  it('carries the Tasks checklist and the Decisions / Notes sections', () => {
+    expect(md).toContain('## Tasks');
+    expect(md).toContain('- [ ] ');
+    expect(md).toContain('## Decisions');
+    expect(md).toContain('## Notes');
+  });
+});
+
+describe('createRoomCanvas', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the template to conversations.canvases.create and returns the canvas id', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true, canvas_id: 'F0CANVAS1' }), { status: 200 }),
+    );
+
+    const id = await createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS);
+
+    expect(id).toBe('F0CANVAS1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/conversations.canvases.create');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-test-token');
+    const body = JSON.parse(init.body as string);
+    expect(body.channel_id).toBe('C0ROOM');
+    expect(body.document_content).toEqual({ type: 'markdown', markdown: roomCanvasMarkdown(OPTS) });
+  });
+
+  it('returns undefined on a Slack error instead of throwing', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, error: 'free_team_not_allowed' }), { status: 200 }),
+    );
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when fetch itself rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when ok:true carries no canvas_id', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+});
+
+describe('deriveCanvasShadowChannelId', () => {
+  it('swaps the leading F for C on a canvas-shaped id', () => {
+    expect(deriveCanvasShadowChannelId('F0BME4DL401')).toBe('C0BME4DL401');
+    expect(deriveCanvasShadowChannelId('F1')).toBe('C1');
+  });
+
+  it('returns undefined for anything not canvas-id shaped', () => {
+    for (const bad of ['C0BME4DL401', 'F', '', 'F0bme4dl401', 'F0BME-4DL401', 'X0BME4DL401', ' F0BME4DL401']) {
+      expect(deriveCanvasShadowChannelId(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe('wireCanvasComments', () => {
+  const CREATOR = { instanceKey: 'slack-pixel', agentGroupId: 'ag-pixel' };
+  // Creator deliberately ALSO present in the list — must not double-wire.
+  const PARTICIPANTS = [
+    { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+    { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    CREATOR,
+  ];
+
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db);
+    const now = new Date().toISOString();
+    for (const [id, name, folder] of [
+      ['ag-pixel', 'Pixel', 'pixel'],
+      ['ag-andy', 'Andy', 'andy'],
+      ['ag-mark', 'Mark', 'mark'],
+    ] as const) {
+      createAgentGroup({ id, name, folder, agent_provider: null, created_at: now });
+    }
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('wires EVERY participating instance: creator pattern-engage, siblings mention/accumulate', () => {
+    const shadowId = wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(shadowId).toBe('C0CANVAS1');
+    // One mg row PER instance (router lookup is exact-on-instance), all public.
+    const all = getAllMessagingGroups().filter((m) => m.platform_id === 'slack:C0CANVAS1');
+    expect(all).toHaveLength(3);
+    for (const p of PARTICIPANTS) {
+      const mg = getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', p.instanceKey);
+      expect(mg).toMatchObject({
+        channel_type: 'slack',
+        instance: p.instanceKey,
+        name: 'Pixel room canvas comments (canvas F0CANVAS1)',
+        is_group: 1,
+        unknown_sender_policy: 'public',
+      });
+      expect(getMessagingGroupAgents(mg!.id)).toHaveLength(1);
+    }
+    // Creator = default responder for anchored comments.
+    const creatorMg = getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel')!;
+    expect(getMessagingGroupAgentByPair(creatorMg.id, 'ag-pixel')).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+    });
+    // Siblings = room semantics: mention to trigger, everything else context.
+    for (const sibling of [
+      { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+      { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    ]) {
+      const mg = getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', sibling.instanceKey)!;
+      expect(getMessagingGroupAgentByPair(mg.id, sibling.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        sender_scope: 'all',
+        ignored_message_policy: 'accumulate',
+        session_mode: 'shared',
+        priority: 0,
+      });
+    }
+  });
+
+  it('is idempotent: a second call creates no new rows', () => {
+    wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+    const mgCount = getAllMessagingGroups().length;
+    const mg = getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel')!;
+    const wiringId = getMessagingGroupAgentByPair(mg.id, 'ag-pixel')!.id;
+
+    const second = wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(second).toBe('C0CANVAS1');
+    expect(getAllMessagingGroups().length).toBe(mgCount);
+    expect(getMessagingGroupAgents(mg.id)).toHaveLength(1);
+    expect(getMessagingGroupAgentByPair(mg.id, 'ag-pixel')!.id).toBe(wiringId);
+  });
+
+  it('returns undefined and writes nothing on an invalid canvas id shape', () => {
+    const before = getAllMessagingGroups().length;
+    expect(wireCanvasComments('not-a-canvas', CREATOR, PARTICIPANTS, 'Pixel room')).toBeUndefined();
+    expect(getAllMessagingGroups().length).toBe(before);
+  });
+
+  it('never throws: a DB failure (unknown agent group breaks the FK) returns undefined', () => {
+    expect(
+      wireCanvasComments('F0CANVAS2', { instanceKey: 'slack', agentGroupId: 'ag-missing' }, [], 'X'),
+    ).toBeUndefined();
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.ts
@@ -1,0 +1,274 @@
+/**
+ * Room canvas creation — the room-contract template, written to the room's
+ * channel-tab canvas at room-creation time.
+ *
+ * Contract C2: `createRoomCanvas` is NON-THROWING — any failure (network,
+ * Slack error, malformed response) logs a warning and returns undefined. Room
+ * creation must never fail because the canvas leg did; the caller tolerates
+ * undefined and simply ships a room without a canvas.
+ *
+ * The Slack call is implemented locally (plain fetch, the shared slack-lib
+ * JSON-body conventions) — this file deliberately does not go through the
+ * lib's throwing helpers: canvas creation is contractually NON-THROWING (C2).
+ * Tokens travel only in the Authorization header and are never interpolated
+ * into messages or logs.
+ *
+ * Live-validated facts this leans on: `conversations.canvases.create`
+ * works on MPIMs and DMs (undocumented but confirmed); every markdown
+ * element in the template — checkboxes, tables with user cards, blockquote —
+ * is accepted; section headings are the later edit-addressing scheme
+ * (`canvases.sections.lookup` by contains_text), so heading text is part of
+ * the template's contract with the canvas-actions module.
+ */
+import { TIMEZONE } from '../../config.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import { formatLocalTime } from '../../timezone.js';
+import type { MessagingGroup } from '../../types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export interface RoomCanvasOpts {
+  roomName: string;
+  purpose: string;
+  /** The human operator who created the room — the ONLY member the template
+   *  may reference by user card. Bot user cards render as @-mentions, and a
+   *  creation-time mention is what triggered every sibling instance and
+   *  generated the approval-card spam. */
+  creatorUserId: string;
+  /** Agent members by display name — rendered as PLAIN TEXT, never mentioned. */
+  agentNames: string[];
+  /** ISO creation timestamp; defaults to now. Rendered install-local. */
+  createdAt?: string;
+}
+
+/** `![](@U…)` — Slack renders this image syntax as an inline user card.
+ *  Humans only: a bot's user card delivers a mention to that bot's instance. */
+function userCard(userId: string): string {
+  return `![](@${userId})`;
+}
+
+/** Blockquote-prefix every line so a multi-line purpose stays one quote block. */
+function asBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+/**
+ * The room-contract template (modeled on a live-verified room-canvas
+ * example). With the room-contract MESSAGE retired, this canvas IS the room
+ * contract: purpose, creator, member list, created date — the canvas tab is
+ * the room's pinned surface. Heading texts ("Tasks", "Decisions", "Notes")
+ * are load-bearing: agents address sections by contains_text lookup, and the
+ * canvas instructions reference them by name.
+ *
+ * The body must never @-mention a BOT — agent members appear by plain
+ * name. Only the (human) creator gets a user card.
+ */
+export function roomCanvasMarkdown(opts: RoomCanvasOpts): string {
+  const memberRows = [
+    `| ${userCard(opts.creatorUserId)} | creator |`,
+    ...opts.agentNames.filter((name, i, arr) => arr.indexOf(name) === i).map((name) => `| ${name} | agent |`),
+  ];
+
+  // No `# <roomName>` heading here: the `title` param on
+  // conversations.canvases.create already renders the canvas title as the
+  // document's H1 — a body heading would duplicate it (live-observed).
+  return [
+    asBlockquote(opts.purpose),
+    '',
+    `Created by ${userCard(opts.creatorUserId)} on ${formatLocalTime(opts.createdAt ?? new Date().toISOString(), TIMEZONE)}.`,
+    '',
+    '## Members',
+    '',
+    '| Who | Role |',
+    '|---|---|',
+    ...memberRows,
+    '',
+    '## Tasks',
+    '',
+    '- [ ] Add the room’s first task',
+    '',
+    '## Decisions',
+    '',
+    '_No decisions recorded yet — quote them here as they land._',
+    '',
+    '## Notes',
+    '',
+    '_Working notes and links — anything worth keeping that isn’t a task or a decision._',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Create the room's channel-tab canvas from the room-contract template.
+ * Returns the canvas id, or undefined on ANY failure (never throws).
+ */
+export async function createRoomCanvas(
+  botToken: string,
+  channelId: string,
+  opts: RoomCanvasOpts,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${SLACK_API}/conversations.canvases.create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        channel_id: channelId,
+        // Undocumented but live-verified: conversations.canvases.create
+        // accepts `title` (otherwise the canvas lists as "Untitled").
+        title: opts.roomName,
+        document_content: { type: 'markdown', markdown: roomCanvasMarkdown(opts) },
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (json.ok !== true) {
+      log.warn('Room canvas create failed', {
+        channelId,
+        error: String(json.error ?? `HTTP ${res.status}`),
+      });
+      return undefined;
+    }
+    const canvasId = typeof json.canvas_id === 'string' ? json.canvas_id : undefined;
+    if (!canvasId) {
+      log.warn('Room canvas create returned no canvas_id', { channelId });
+      return undefined;
+    }
+    log.info('Room canvas created', { channelId, canvasId });
+    return canvasId;
+  } catch (err) {
+    log.warn('Room canvas create failed', {
+      channelId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+// ── Canvas comments (shadow channel) ──
+
+/** Canvas ids are `F` + the base-36-ish Slack id body. */
+const CANVAS_ID_RE = /^F[A-Z0-9]+$/;
+
+/**
+ * Live-probed platform fact: creating ANY canvas makes Slack materialize
+ * a hidden private "shadow channel" owned by USLACKBOT whose id is the canvas
+ * id with the leading `F` swapped for `C` (canvas F0BME4DL401 → channel
+ * C0BME4DL401). Canvas comments live there as threads; members of the canvas
+ * are members of the shadow channel and bots receive its messages as ordinary
+ * message.groups events. Returns undefined for anything not canvas-id shaped.
+ */
+export function deriveCanvasShadowChannelId(canvasId: string): string | undefined {
+  return CANVAS_ID_RE.test(canvasId) ? `C${canvasId.slice(1)}` : undefined;
+}
+
+/** One room bot's instance/group pair, for shadow-channel wiring. The flow's
+ *  RoomParticipant satisfies this structurally. */
+export interface CanvasCommentsParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  agentGroupId: string;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Wire the canvas's shadow channel for EVERY participating instance — the
+ * shadow channel is the room's comment stream, so it gets room semantics for
+ * all room agents, not creator-only. Creator-only wiring is what turned
+ * every sibling's canvas events into unknown-channel approval-card spam.
+ *
+ * Per participant: one messaging-group row on ITS instance (router lookup is
+ * exact-on-instance) plus one wiring to its agent group. The CREATOR is the
+ * default responder — pattern `'.'` (always engage): a comment on the shared
+ * canvas is always addressed to the room's agents, unlike ambient room chat.
+ * Every SIBLING gets mention/accumulate — comments flow to all room agents
+ * as context, and tagging an agent in a comment actually triggers it with
+ * the anchor context. `unknown_sender_policy: 'public'` keeps access gates
+ * from approval-spamming on commenters.
+ *
+ * Idempotent (get-before-create on every row) and NON-THROWING — like
+ * createRoomCanvas, a failure here must never fail room creation. Returns the
+ * shadow channel id, or undefined on invalid canvas-id shape or any error.
+ */
+export function wireCanvasComments(
+  canvasId: string,
+  creator: CanvasCommentsParticipant,
+  participants: CanvasCommentsParticipant[],
+  roomName: string,
+): string | undefined {
+  try {
+    const shadowChannelId = deriveCanvasShadowChannelId(canvasId);
+    if (!shadowChannelId) {
+      log.warn('Canvas comments: unexpected canvas id shape — shadow channel not wired', { canvasId });
+      return undefined;
+    }
+    const platformId = `slack:${shadowChannelId}`;
+
+    // Creator first (its wiring must win even if it also appears in the list).
+    const isCreator = (p: CanvasCommentsParticipant): boolean =>
+      p.instanceKey === creator.instanceKey && p.agentGroupId === creator.agentGroupId;
+    const everyone = [creator, ...participants.filter((p) => !isCreator(p))];
+
+    for (const p of everyone) {
+      let mg = getMessagingGroupByPlatform('slack', platformId, p.instanceKey);
+      if (!mg) {
+        const row: MessagingGroup = {
+          id: generateId('mg'),
+          channel_type: 'slack',
+          platform_id: platformId,
+          instance: p.instanceKey,
+          name: `${roomName} canvas comments (canvas ${canvasId})`,
+          is_group: 1,
+          unknown_sender_policy: 'public',
+          created_at: new Date().toISOString(),
+        };
+        createMessagingGroup(row);
+        mg = row;
+      }
+
+      if (!getMessagingGroupAgentByPair(mg.id, p.agentGroupId)) {
+        const creatorRow = isCreator(p);
+        createMessagingGroupAgent({
+          id: generateId('mga'),
+          messaging_group_id: mg.id,
+          agent_group_id: p.agentGroupId,
+          engage_mode: creatorRow ? 'pattern' : 'mention',
+          engage_pattern: creatorRow ? '.' : null,
+          sender_scope: 'all',
+          ignored_message_policy: creatorRow ? 'drop' : 'accumulate',
+          session_mode: 'shared',
+          priority: 0,
+          created_at: new Date().toISOString(),
+        });
+      }
+    }
+
+    log.info('Canvas comments shadow channel wired', {
+      canvasId,
+      shadowChannelId,
+      creatorInstance: creator.instanceKey,
+      participantCount: everyone.length,
+    });
+    return shadowChannelId;
+  } catch (err) {
+    log.warn('Canvas comments shadow-channel wiring failed', {
+      canvasId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/slack-deps.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/slack-deps.ts
@@ -1,0 +1,70 @@
+/**
+ * Optional-module seam — the ONLY file in the slack-agent-flow payload that
+ * touches the skill-installed Slack channel module (src/channels/slack.ts
+ * arrives via the add-slack skill) dynamically. The computed-specifier import
+ * keeps tsc from resolving a file that may not be in the tree, so a missing
+ * or outdated channel payload surfaces at runtime as a typed, actionable
+ * SlackFlowError instead of a crash. The hot-start entry
+ * (startChannelAdapter) is trunk registry API and is imported statically like
+ * registerChannelAdapter.
+ */
+import type { ChannelAdapter, ChannelDefaults } from '../../channels/adapter.js';
+import { registerChannelAdapter, startChannelAdapter } from '../../channels/channel-registry.js';
+import { SlackFlowError } from './types.js';
+
+export interface SlackChannelDeps {
+  slackInstanceBridgeFactory: (name: string) => ChannelAdapter | null;
+  SLACK_DEFAULTS: ChannelDefaults;
+  registerChannelAdapter: (
+    name: string,
+    registration: { factory: () => ChannelAdapter | null; defaults?: ChannelDefaults },
+  ) => void;
+  startChannelAdapter: (key: string) => Promise<'started' | 'already-active' | 'no-credentials'>;
+}
+
+const NOT_INSTALLED =
+  'Slack channel payload not installed or too old — apply add-slack first (multi-instance registration ships with the adapter)';
+
+/**
+ * Fails fast if the installed Slack adapter doesn't carry the multi-instance
+ * factory — checked regardless of hotStart. The adapter owns SLACK_INSTANCES
+ * natively (slackInstanceBridgeFactory + the import-time registration loop
+ * live in slack.ts); an older installed copy without that export would let
+ * S6-S8 wire DB rows to an instance name the runtime could never start, even
+ * after a restart. The out-of-process finish path (hotStart: false) needs
+ * this check just as much as the hot-add branch below.
+ */
+export async function assertSlackInstancesModuleInstalled(): Promise<void> {
+  try {
+    const slackSpec = '../../channels/slack.js';
+    const slackMod = (await import(slackSpec)) as Record<string, unknown>;
+    if (typeof slackMod.slackInstanceBridgeFactory !== 'function' || !slackMod.SLACK_DEFAULTS) {
+      throw new Error('missing exports');
+    }
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+}
+
+export async function loadSlackChannelDeps(): Promise<SlackChannelDeps> {
+  let slackMod: Record<string, unknown>;
+  try {
+    const slackSpec = '../../channels/slack.js';
+    slackMod = (await import(slackSpec)) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  const slackInstanceBridgeFactory = slackMod.slackInstanceBridgeFactory;
+  const SLACK_DEFAULTS = slackMod.SLACK_DEFAULTS;
+  if (typeof slackInstanceBridgeFactory !== 'function' || !SLACK_DEFAULTS) {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  return {
+    slackInstanceBridgeFactory: slackInstanceBridgeFactory as (name: string) => ChannelAdapter | null,
+    SLACK_DEFAULTS: SLACK_DEFAULTS as ChannelDefaults,
+    registerChannelAdapter,
+    startChannelAdapter,
+  };
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
@@ -1,0 +1,77 @@
+/**
+ * slack-agent-flow shared types.
+ * Congruence: env-key shapes mirror the adapter's native SLACK_INSTANCES
+ * conventions (src/channels/slack.ts, instanceEnvKeySuffix);
+ * broker protocol mirrors src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts. Pinned by
+ * provision.congruence.test.ts.
+ */
+
+export type SlackFlowStep =
+  | 'operator-identity'
+  | 'origin-auth'
+  | 'no-credentials'
+  | 'broker'
+  | 'direct-create'
+  | 'env-write'
+  | 'adapter-start'
+  | 'dm-open'
+  | 'dm-wire'
+  | 'mpim-open'
+  | 'a2a-env'
+  | 'room-wire'
+  | 'intro-post'
+  /** room-actions module — create_room / add_to_room participant resolution. */
+  | 'room-resolve'
+  /** slack-room-membership module — join/left handling, not a create_agent flow step. */
+  | 'membership';
+
+/** Typed failure for the Slack leg. `message` MUST never contain a token value. */
+export class SlackFlowError extends Error {
+  constructor(
+    readonly step: SlackFlowStep,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SlackFlowError';
+  }
+}
+
+export interface ProvisionInput {
+  /** Instance slug: output of normalizeName(), post-dedupe. */
+  slug: string;
+  /** Display name for the Slack app/bot (the raw agent name). */
+  displayName: string;
+  /** Repo root; .env lives at `${rootDir}/.env`. */
+  rootDir: string;
+  /** Slack workspace the app is provisioned into (broker mode requires it). */
+  teamId?: string;
+  /** Agent description/instructions — drives the broker's generated avatar. */
+  description?: string;
+  /**
+   * true → plain manifest variant (no agent_view): workspace guests are
+   * hard-blocked from agent-enabled apps. Default false → agent mode, the
+   * default variant — a one-way door decided at provision time.
+   */
+  allowGuests?: boolean;
+}
+
+export interface ProvisionResult {
+  slug: string;
+  /** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix. */
+  envSuffix: string;
+  botToken: string; // xoxb-… NEVER log
+  appToken: string; // xapp-… NEVER log
+  appId: string;
+  /** True when tokens were already in .env and no provisioning call was made. */
+  reused: boolean;
+}
+
+export interface OrchestrateSuccess {
+  slug: string;
+  newBotUserId: string;
+  operatorUserId: string;
+  dmChannelId: string;
+  /** Absent when the create ran with room:'none' — no shared room. */
+  roomChannelId?: string;
+}

--- a/.claude/skills/slack-multi-instance/SKILL.md
+++ b/.claude/skills/slack-multi-instance/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: slack-multi-instance
+description: Run N Slack bot identities in one workspace via SLACK_INSTANCES — each name gets its own slack-<name> adapter instance built from a per-instance token set, sharing channelType, formatting, and wiring defaults with the default Slack app. Documentation only — the registration is native to the installed Slack adapter.
+---
+
+# Slack multi-instance (SLACK_INSTANCES)
+
+One NanoClaw host can run **several Slack apps in one workspace**, each with
+its own bot identity. There is nothing to install: the Slack adapter
+(`src/channels/slack.ts`, installed by `/add-slack`) reads
+`SLACK_INSTANCES=<name>[,<name>…]` from `.env` at load and registers one
+additional bridge per listed name under the `slack-<name>` instance key,
+built from that name's own token set through the same factory as the default
+app. `channelType` stays `slack` — instance is a routing key; user ids,
+formatting, container config, and the wiring-defaults declaration are shared
+with the default Slack app. This document only records the conventions.
+
+## Configuration
+
+Per named instance `<name>` (listed in `SLACK_INSTANCES`), create a separate
+Slack app in the same workspace — same scopes, events, and App Home settings
+as the default app (the `/add-slack` walkthrough lists them) — and store its
+tokens in `.env` under the suffixed keys. `<NAME>` is the name uppercased
+with dashes as underscores (`gh-bot` → `GH_BOT`):
+
+```
+SLACK_INSTANCES=dana
+SLACK_BOT_TOKEN_DANA=xoxb-…
+SLACK_APP_TOKEN_DANA=xapp-…        # Socket Mode (omit for webhook delivery)
+SLACK_SIGNING_SECRET_DANA=…        # webhook delivery only
+```
+
+Registration is unconditional for every listed name, so a missing token set
+surfaces as the registry's "credentials missing, skipping" warning at boot
+rather than a silently absent bot.
+
+Wire messaging groups to a named instance by setting the messaging group's
+`instance` to `slack-<name>`.
+
+## Restart vs hot start
+
+`SLACK_INSTANCES` is read once, at adapter load — after editing `.env` by
+hand, restart the service (`bash setup/lib/restart.sh`) so the new instance
+registers and connects. The exception is programmatic provisioning: flows
+that create agents in-process (the `slack-agent-flow` skill) append the
+instance and its tokens to `.env` and then hot-start the new adapter through
+the registry's `startChannelAdapter` entry, so those instances come up
+without a restart.
+
+## Validation
+
+The channel payload ships the guard for all of this:
+`src/channels/slack-instances-registration.test.ts` (installed by
+`/add-slack` alongside the adapter) drives the registration loop against a
+crafted `.env` and pins the shared wiring-defaults declaration and the
+env-key suffix mapping:
+
+```bash
+pnpm exec vitest run src/channels/slack-instances-registration.test.ts
+```
+
+## Remove
+
+Remove `SLACK_INSTANCES` and any `SLACK_*_<NAME>` token lines from `.env`,
+then restart the service. Messaging groups wired to a removed `slack-<name>`
+instance stop resolving an adapter until rewired or deleted. (Adapter code is
+untouched — the registration loop simply finds no names.)

--- a/container/skills/slack-construct/SKILL.md
+++ b/container/skills/slack-construct/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: slack-construct
+description: Standing context for Slack rooms — mention-driven engagement, room canvases, owner-presence access, and DM history. Ships as instructions.md composed into the group's CLAUDE.md at spawn; there is no workflow to invoke.
+---
+
+# Slack construct — standing context
+
+A carrier for standing context, not an on-demand workflow. The payload is
+`instructions.md` in this directory: the Slack room, canvas, access, and
+DM-history rules an agent needs the moment it wakes in a Slack conversation.
+The host composes every container skill's `instructions.md` into each group's
+CLAUDE.md at spawn (`src/claude-md-compose.ts`), so from inside a session
+those rules are already standing instructions — nothing to load or run here.
+
+Two scope notes for maintainers:
+
+- Skill fragments compose into **every** group, regardless of the group's
+  `cli_scope`. The content therefore never names host-CLI (`ncl`) commands —
+  groups with CLI access get that guidance from the CLI module's own
+  instructions fragment, which the host includes only where `ncl` is enabled.
+- Detailed canvas *editing* discipline lives in the `canvas-work` skill; the
+  fragment here only carries the always-on rules (read-before-edit, section
+  ops, comment behavior) at summary level.

--- a/container/skills/slack-construct/instructions.md
+++ b/container/skills/slack-construct/instructions.md
@@ -1,0 +1,56 @@
+## Slack rooms: mentions, canvas, ambient context
+
+On Slack you may share rooms (channels and group DMs) with humans and other
+agents, each with its own canvas. Standing rules:
+
+- **Rooms engage only on @-mention.** In a room you act ONLY when @-mentioned; every other
+  room message reaches you later as ambient context, not as a prompt. Caution: in a wake
+  batch, that backlog renders exactly like the message that prompted you — there is no
+  structural marker. The messages that @-mention you are your prompts (answer each of
+  them; there may be more than one); treat the rest as context. Comments channels differ —
+  see the canvas rules.
+- **The room canvas IS the room's contract.** A room may have a canvas pinned as its
+  canvas tab: purpose, creator, member list, created date, plus
+  Tasks / Decisions / Notes sections you keep current. There is no pinned contract
+  message. Never @-mention a bot (user card or `<@id>`) in a canvas BODY — canvas-body
+  mentions fire a mention event at every tagged agent's instance; use plain agent names in
+  canvas content. Deliberate @-mentions in canvas COMMENTS are fine and are how you summon
+  a specific agent into a comment thread.
+- **Canvas comments reach every room agent.** If you created the canvas you are its
+  default responder and every comment engages you — even USLACKBOT anchor posts and
+  "was mentioned in a canvas" notices, which can arrive as the very message that wakes
+  you: never answer those, only human comments (your prompt there is the newest human
+  comment; if there is none, ending the turn with no message is correct). Otherwise
+  comments accumulate as ambient context and you engage when @-mentioned in one (you'll
+  see the anchored section text as the thread root). A comment tagging another agent wakes
+  both that agent AND the creator — creator: when a comment tags someone else, let
+  them answer. Reply in the comment thread.
+- **Canvas edits follow the `canvas-work` skill.** `canvas_read` first, every time —
+  human edits generate no events, so the canvas may have changed since you last saw it;
+  `replace_section` to update existing sections; insert ops only for genuinely new
+  content — never a heading the canvas already has. A failed edit wakes you with a
+  system note saying why; verify structural changes with a re-read.
+- **Chat stays short; large output goes to the canvas.** Keep messages to a few lines —
+  coordination, answers, pointers. Any prose or code deliverable over ~a dozen lines
+  (plan, report, spec, analysis, long diff) goes into the room canvas (the right
+  section, or a new one) and the chat message becomes a 1-3 line summary pointing at
+  it. Binary artifacts (charts, PDFs, generated images) still go via `send_file`. In a
+  DM with no canvas, long content may stay in chat, but prefer canvas structure
+  wherever one exists.
+- **One reply per prompt.** Send your answer once and end the turn — never follow it
+  with a second message recapping what you just did ("Replied to X: …", "Done — I
+  posted…"). The reply IS the report.
+- **Access follows owner presence.** Rooms, group DMs, and channels where your owner is a
+  member are open — anyone present there may task you directly, with no approval step. If
+  you are added to a conversation your owner is NOT in, the host asks your owner before
+  you engage; until then you stay silent there. Unknown people who DM you 1:1 never reach
+  you at all — the host declines them politely on your behalf and sends your owner a
+  one-line FYI, so you will not see those messages and should never mention them. Once
+  your owner grants someone access, their DMs reach you normally.
+- **Persist durable facts.** Conversations are per-session; rooms and DMs don't share
+  history. Anything worth keeping (decisions, preferences, ongoing state) goes in your
+  memory directory, not just the chat transcript.
+- **`<dm-history>` lines are THIS DM's timeline just before this conversation** — they are
+  first-class history you continue from (entries with sender="you" are your own earlier
+  posts). A short opener ("sure", "yes", "the first one") is answering the most recent
+  `<dm-history>` entry — continue in flow from it. Never re-introduce yourself or restart.

--- a/container/skills/welcome/addenda/slack.md
+++ b/container/skills/welcome/addenda/slack.md
@@ -1,0 +1,50 @@
+---
+channel: slack
+---
+
+# Slack welcome adjustments
+
+Two adjustments when the welcome runs on Slack: agent DMs get a
+notification-shaped welcome instead of a question, and the tour gains
+Slack-specific items — one of which replaces the base Access Control point.
+
+## Agent DMs: the welcome is a NOTIFICATION
+
+If this DM is a Slack agent conversation (threads shown as a timeline above the
+composer), the welcome is a notification, NOT a question — do not end it with an
+offer that expects a reply ("want a tour?"). Suggested prompts pinned at the top of
+this DM already offer the tour and starting points; the user's click (or any new
+message) starts the first conversation.
+
+HARD LENGTH RULE: the whole welcome is AT MOST ~250 characters — 2-3 SHORT
+sentences total. No bullet lists, no headers, no capability catalog, no
+threading explanation (the tour covers all of that). It reads like a text
+message, not a broadcast post.
+
+Shape (adapt the words, keep the size):
+
+> Hey <name> — I'm <agent>, your personal agent. The buttons above are the
+> fastest way to start, or just tell me what you need.
+
+Everything else — capabilities, the threading model, memory — belongs in the
+tour conversation, not here. When the user takes the tour, weave the threading
+tip in there ("each conversation lives in its own thread; a new message in the
+main box starts a fresh one — I keep context either way").
+
+## Tour additions: rooms and access
+
+When the tour runs on Slack, also reveal these — same drip-feed rule, one at a
+time, 2-4 sentences each:
+
+### Shared rooms
+In shared rooms, @-mention an agent to engage it — unmentioned messages are
+context it only sees later. The room's canvas tab (top of the conversation)
+holds the room's purpose, member list, and running Tasks/Decisions — the
+agents keep it current.
+
+### Access (replaces the generic Access Control point on Slack)
+Anyone in a room or channel with both you and your agent can task it directly —
+no approval cards. If the agent gets added somewhere you're not a member,
+you'll be asked first. Strangers who DM your agent 1:1 get a polite automatic
+decline and you get a one-line heads-up (at most one per person per day);
+allow someone any time by asking your agent to add them.

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -10,8 +10,12 @@ const directives = parseDirectives(slack);
 describe('skill-directives parser, on the converted add-slack', () => {
   it('extracts every directive in document order — install, credentials, resolve, restart', () => {
     expect(directives.map((d) => d.kind)).toEqual([
-      'copy', // step 1: adapter + test from the channels branch
-      'append', // step 2: barrel registration
+      'copy', // step 1: the full channel payload from the channels branch
+      'append', // step 2: channel barrel — adapter registration
+      'append', // step 2: channel barrel — bot-inbound guard
+      'append', // step 2: modules barrel — membership, canvas, onboarding
+      'append', // step 2: container tool barrel — canvas tool
+      'append', // step 2: companion-skill declaration (registerCompanionSkills)
       'dep', // step 3: pinned package
       'run', // step 4: build
       'run', // step 4: test
@@ -20,9 +24,11 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'operator', // credentials: create-app walkthrough, webhook variant
       'prompt', // credentials: capture bot token
       'prompt', // credentials: capture app-level token (socket only)
+      'prompt', // credentials: app-level token twin (provisioned mode — binds from inputs)
       'prompt', // credentials: capture signing secret (webhook only)
       'env-set', // credentials: bot token (both modes)
       'env-set', // credentials: app token — doubles as the Socket Mode switch
+      'env-set', // credentials: app token, provisioned-mode twin
       'env-set', // credentials: signing secret (webhook only)
       'operator', // credentials: event-delivery walkthrough (webhook only)
       'prompt', // resolve: owner member id (owner_handle)
@@ -54,15 +60,67 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(copy.attrs['from-branch']).toBe('channels');
     expect(copy.body).toEqual([
       'src/channels/slack.ts',
+      'src/channels/slack-lib.ts',
+      'src/channels/slack-lib.test.ts',
+      'src/channels/slack-a2a-guard.ts',
+      'src/channels/slack-a2a-guard.test.ts',
       'src/channels/slack-registration.test.ts',
+      'src/channels/slack-instances-registration.test.ts',
+      'src/env-file.ts',
+      'src/env-file.test.ts',
+      'src/provisioning/slack-app.ts',
+      'src/provisioning/slack-app.test.ts',
+      'src/modules/slack-room-membership/index.ts',
+      'src/modules/slack-room-membership/membership.ts',
+      'src/modules/slack-room-membership/membership.test.ts',
+      'src/modules/slack-room-membership/env-file.ts',
+      'src/modules/slack-room-membership/env-file.test.ts',
+      'src/modules/canvas-actions/index.ts',
+      'src/modules/canvas-actions/handlers.ts',
+      'src/modules/canvas-actions/canvas-api.ts',
+      'src/modules/canvas-actions/canvas-actions.test.ts',
+      'src/modules/slack-onboarding/index.ts',
+      'src/modules/slack-onboarding/onboarding.test.ts',
+      'src/modules/slack-onboarding/thread-title.test.ts',
+      'container/agent-runner/src/mcp-tools/canvas.ts',
+      'container/agent-runner/src/mcp-tools/canvas.instructions.md',
+      'container/agent-runner/src/mcp-tools/canvas.test.ts',
+      'container/skills/slack-construct/SKILL.md',
+      'container/skills/slack-construct/instructions.md',
+      'container/skills/canvas-work/SKILL.md',
       'container/skills/slack-formatting/SKILL.md',
+      'container/skills/welcome/addenda/slack.md',
+      'setup/channels/slack-companions.ts',
     ]);
   });
 
-  it('reads the barrel append target and line', () => {
-    const append = directives.find((d) => d.kind === 'append')!;
-    expect(append.attrs.to).toBe('src/channels/index.ts');
-    expect(append.body).toEqual(["import './slack.js';"]);
+  it('reads the barrel appends: adapter, guard, modules, container tool, companions', () => {
+    const appends = directives.filter((d) => d.kind === 'append');
+    expect(appends.map((d) => d.attrs.to)).toEqual([
+      'src/channels/index.ts',
+      'src/channels/index.ts',
+      'src/modules/index.ts',
+      'container/agent-runner/src/mcp-tools/index.ts',
+      'setup/channels/companions.ts',
+    ]);
+    // The adapter and the guard are SEPARATE fences (idempotency is keyed on a
+    // fence's first line): an install that already has `import './slack.js';`
+    // from the pre-payload skill still gains the guard on a re-run.
+    expect(appends[0].body).toEqual(["import './slack.js';"]);
+    expect(appends[1].body).toEqual(["import './slack-a2a-guard.js';"]);
+    expect(appends[2].body).toEqual([
+      "import './slack-room-membership/index.js';",
+      "import './canvas-actions/index.js';",
+      "import './slack-onboarding/index.js';",
+    ]);
+    expect(appends[3].body).toEqual(["import './canvas.js';"]);
+    // The companion declaration is a direct registration call into the registry
+    // (an appended self-registration IMPORT would evaluate before the registry's
+    // own maps initialize), importing the payload's data module for the list.
+    expect(appends[4].body).toEqual([
+      "import { SLACK_COMPANION_SKILLS } from './slack-companions.js';",
+      "registerCompanionSkills('slack', SLACK_COMPANION_SKILLS);",
+    ]);
   });
 
   it('reads the dependency pinned exactly', () => {
@@ -82,15 +140,17 @@ describe('skill-directives parser, on the converted add-slack', () => {
 
   it('captures prompts into named vars — credentials secret, the mode and handle not', () => {
     const prompts = directives.filter((d) => d.kind === 'prompt');
-    expect(prompts.map(promptVar)).toEqual(['connection', 'bot_token', 'app_token', 'signing_secret', 'owner_handle']);
+    expect(prompts.map(promptVar)).toEqual(['connection', 'bot_token', 'app_token', 'app_token', 'signing_secret', 'owner_handle']);
     expect(prompts[0].args).not.toContain('secret'); // connection — a mode choice, not a secret
     expect(prompts[1].args).toContain('secret'); // bot_token
-    expect(prompts[2].args).toContain('secret'); // app_token
-    expect(prompts[3].args).toContain('secret'); // signing_secret
-    expect(prompts[4].args).not.toContain('secret'); // owner_handle — a plain id, not a secret
+    expect(prompts[2].args).toContain('secret'); // app_token (socket)
+    expect(prompts[3].args).toContain('secret'); // app_token (provisioned twin)
+    expect(prompts[4].args).toContain('secret'); // signing_secret
+    expect(prompts[5].args).not.toContain('secret'); // owner_handle — a plain id, not a secret
     // Each mode's credential is guard-scoped to its branch.
     expect(prompts[2].attrs.when).toBe('connection=socket');
-    expect(prompts[3].attrs.when).toBe('connection=webhook');
+    expect(prompts[3].attrs.when).toBe('connection=provisioned');
+    expect(prompts[4].attrs.when).toBe('connection=webhook');
     // The prompt body is the question; it does not mention env at all.
     expect(prompts[1].body.join(' ')).toMatch(/Bot User OAuth Token/);
   });
@@ -108,10 +168,12 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(envSets.map((d) => d.body)).toEqual([
       ['SLACK_BOT_TOKEN={{bot_token}}'],
       ['SLACK_APP_TOKEN={{app_token}}'],
+      ['SLACK_APP_TOKEN={{app_token}}'],
       ['SLACK_SIGNING_SECRET={{signing_secret}}'],
     ]);
     expect(envSets[1].attrs.when).toBe('connection=socket');
-    expect(envSets[2].attrs.when).toBe('connection=webhook');
+    expect(envSets[2].attrs.when).toBe('connection=provisioned');
+    expect(envSets[3].attrs.when).toBe('connection=webhook');
   });
 
   it('passes validation (well-formed, pinned, every {{var}} captured first)', () => {

--- a/setup/channels/slack-companions.ts
+++ b/setup/channels/slack-companions.ts
@@ -1,0 +1,24 @@
+/**
+ * Slack's companion-skill declaration — the rest of the Slack channel payload
+ * beyond /add-slack itself. The channel install flow's companion registry
+ * (setup/channels/companions.ts) applies these right after the main install
+ * skill, with one deferred service restart after all of them; the install
+ * skill appends the `registerCompanionSkills('slack', …)` call into that
+ * registry, importing this list. Kept as a plain data module (no import of
+ * the registry) so the appended registration can't create an import cycle
+ * back into the registry's own initialization.
+ *
+ * Why the companion is part of the payload:
+ *  - slack-a2a-rooms → src/channels/slack-a2a.ts. The room admission policy
+ *    (SLACK_A2A_ROOMS allowlist, hop limits, slack:bot:<id> re-attribution)
+ *    registered onto the channel guard's seam. Without it, shared rooms open
+ *    but bot-authored inbound stays dropped by the guard's default policy,
+ *    so sibling bots never hear each other.
+ *
+ * Deliberately NOT listed: slack-multi-instance. The SLACK_INSTANCES
+ * registration loop is native to the adapter (src/channels/slack.ts reads
+ * SLACK_INSTANCES at import and registers a `slack-<name>` instance per
+ * entry), so that skill is documentation-only — the env-key format for
+ * per-instance tokens — with no directives for the companion flow to apply.
+ */
+export const SLACK_COMPANION_SKILLS = ['slack-a2a-rooms'] as const;

--- a/src/channels/slack-instances-registration.test.ts
+++ b/src/channels/slack-instances-registration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guard for the native SLACK_INSTANCES registrations (slack.ts).
+ *
+ * Integration points under guard:
+ *  1. The barrel reach-in — `import './slack.js';` in src/channels/index.ts.
+ *     Importing the real barrel must run slack.ts's top-level SLACK_INSTANCES
+ *     loop; if the import line is deleted, or the barrel fails to evaluate
+ *     (e.g. @chat-adapter/slack uninstalled), the instance keys are absent
+ *     and this goes red.
+ *  2. The shared declaration — every `slack-<name>` registration must carry
+ *     the same SLACK_DEFAULTS declaration as the default Slack app (declared
+ *     defaults, not the core fallback). hasDeclaredChannelDefaults()
+ *     distinguishes a declared entry from fallbackChannelDefaults(), and
+ *     `group.threads === true` is the field where the two differ with no
+ *     live adapter (fallback resolves threads to false).
+ *  3. The shared factory — the per-name factory delegates to
+ *     createSlackBridge, whose credential path is driven for real here: with
+ *     no SLACK_BOT_TOKEN_<NAME> in .env the factory returns null (the
+ *     registry's "credentials missing, skipping" path). The non-null leg —
+ *     the typed createSlackBridge({envKeySuffix, instanceKey}) call — is
+ *     guarded by the build, which fails if the factory export or its options
+ *     shape drifts.
+ *
+ * SLACK_INSTANCES is read from `.env` at module import (readEnvFile reads
+ * process.cwd()/.env, never process.env), so the test chdirs into a temp dir
+ * carrying a crafted .env BEFORE dynamically importing the barrel. Vitest's
+ * per-file process isolation keeps the chdir and the module cache local to
+ * this file.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { getChannelDefaults, getRegisteredChannelNames, hasDeclaredChannelDefaults } from './channel-registry.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'slack-instances-'));
+  writeFileSync(join(dir, '.env'), 'SLACK_INSTANCES=alpha,gh-bot\n');
+  process.chdir(dir);
+  await import('./index.js'); // the real barrel — triggers every channel's self-registration
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+describe('slack multi-instance registration', () => {
+  it('registers a slack-<name> adapter per SLACK_INSTANCES entry via the channel barrel', () => {
+    const names = getRegisteredChannelNames();
+    expect(names).toContain('slack-alpha');
+    expect(names).toContain('slack-gh-bot');
+    // The default app's registration is untouched.
+    expect(names).toContain('slack');
+  });
+
+  it("every instance registration declares the default app's SLACK_DEFAULTS (not the core fallback)", () => {
+    for (const key of ['slack-alpha', 'slack-gh-bot']) {
+      expect(hasDeclaredChannelDefaults(key)).toBe(true);
+      const defaults = getChannelDefaults(key);
+      // One declaration, shared with the default app — a drifting private
+      // copy of the defaults would fail this even with equal-looking fields
+      // elsewhere.
+      expect(defaults).toEqual(getChannelDefaults('slack'));
+      // group.threads true is SLACK_DEFAULTS; the no-live-adapter fallback
+      // would resolve threads:false. Engagement fields ride along.
+      expect(defaults.group.threads).toBe(true);
+      expect(defaults.group.engageMode).toBe('mention-sticky');
+      expect(defaults.dm).toMatchObject({ engageMode: 'pattern', engagePattern: '.', threads: false });
+      expect(defaults.mentions).toBe('platform');
+    }
+  });
+});
+
+describe('instance factory (via the shared createSlackBridge)', () => {
+  // Imported dynamically, and only in this describe, which runs AFTER the
+  // registration tests above: a static import of ./slack.js would run the
+  // registration loop as a side effect of this test file itself (with the
+  // original cwd's .env) and mask a deleted barrel line. Via the barrel the
+  // module is already in the cache, so this import is a no-op read.
+  it('returns null when the instance token set is absent — the registry "credentials missing" path', async () => {
+    const { slackInstanceBridgeFactory } = await import('./slack.js');
+    // No SLACK_BOT_TOKEN_ALPHA in the temp .env: the shared factory must
+    // report missing credentials rather than construct a token-less bridge.
+    expect(slackInstanceBridgeFactory('alpha')).toBeNull();
+  });
+
+  it('maps an instance name to its env-key suffix (uppercased, dashes → underscores)', async () => {
+    const { instanceEnvKeySuffix } = await import('./slack.js');
+    expect(instanceEnvKeySuffix('gh-bot')).toBe('GH_BOT');
+    expect(instanceEnvKeySuffix('dana')).toBe('DANA');
+  });
+});

--- a/src/channels/slack-registration.test.ts
+++ b/src/channels/slack-registration.test.ts
@@ -21,14 +21,139 @@
  * (`pnpm run build`) guards it against upstream drift, not this test. Every Chat SDK
  * channel (discord, telegram, teams, gchat, webex, …) follows this same shape:
  * swap the channel name below and the adapter package in the build.
+ *
+ * This file also covers resolveSlackConversation — the adapter-level
+ * conversation classifier (direct / group_dm / channel) that consumers like
+ * approval cards render from. It is a pure function over an injected
+ * SlackAdapter, so it is driven here with mocks; no live API is touched.
  */
-import { describe, it, expect } from 'vitest';
+import type { SlackAdapter } from '@chat-adapter/slack';
+import { describe, it, expect, vi } from 'vitest';
 
 import { getRegisteredChannelNames } from './channel-registry.js';
+import { resolveSlackConversation } from './slack.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration
 
 describe('slack channel registration', () => {
   it('registers slack via the channel barrel', () => {
     expect(getRegisteredChannelNames()).toContain('slack');
+  });
+});
+
+describe('resolveSlackConversation', () => {
+  it('preserves direct messages, channel names, and the API-failure fallback', async () => {
+    const fetchThread = vi
+      .fn()
+      .mockResolvedValueOnce({ channelName: 'general', metadata: { channel: {} } })
+      .mockRejectedValueOnce(new Error('slack unavailable'));
+    const adapter = { fetchThread } as unknown as SlackAdapter;
+
+    await expect(resolveSlackConversation(adapter, 'slack:D123')).resolves.toEqual({
+      type: 'direct',
+      name: null,
+    });
+    expect(fetchThread).not.toHaveBeenCalled();
+    await expect(resolveSlackConversation(adapter, 'C123')).resolves.toEqual({
+      type: 'channel',
+      name: 'general',
+    });
+    expect(fetchThread).toHaveBeenLastCalledWith('slack:C123');
+    // API failure resolves null so the caller falls through to its generic rendering.
+    await expect(resolveSlackConversation(adapter, 'slack:C456')).resolves.toBeNull();
+  });
+
+  it('carries no participant arrays on direct and channel results', async () => {
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({ channelName: 'general', metadata: { channel: {} } }),
+    } as unknown as SlackAdapter;
+
+    const direct = await resolveSlackConversation(adapter, 'slack:D123');
+    expect(direct).not.toHaveProperty('participantNames');
+    expect(direct).not.toHaveProperty('participantIds');
+    const channel = await resolveSlackConversation(adapter, 'slack:C123');
+    expect(channel).not.toHaveProperty('participantNames');
+    expect(channel).not.toHaveProperty('participantIds');
+  });
+
+  it('resolves MPDM human participants and keeps the type when member lookup fails', async () => {
+    const members = vi
+      .fn()
+      .mockResolvedValueOnce({ members: ['U1', 'U2', 'UBOT'] })
+      .mockRejectedValueOnce(new Error('missing scope'));
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({
+        channelName: 'mpdm-avital--omri--avi-1',
+        metadata: { channel: { is_mpim: true } },
+      }),
+      webClient: { conversations: { members } },
+      getUser: vi.fn(async (id: string) => ({
+        userName: id === 'U1' ? 'Avital' : id === 'U2' ? 'Omri' : 'Avi',
+        fullName: id,
+        isBot: id === 'UBOT',
+        userId: id,
+      })),
+    } as unknown as SlackAdapter;
+
+    await expect(resolveSlackConversation(adapter, 'slack:G123')).resolves.toEqual({
+      type: 'group_dm',
+      name: null,
+      participantNames: ['Avital', 'Omri'],
+      participantIds: ['U1', 'U2'],
+    });
+    expect(members).toHaveBeenCalledWith({ channel: 'G123', limit: 100 });
+    await expect(resolveSlackConversation(adapter, 'G123')).resolves.toEqual({
+      type: 'group_dm',
+      name: null,
+    });
+  });
+
+  // participantIds must be raw Slack ids ("U…"), same length and same order
+  // as participantNames, with bots removed from BOTH arrays. A consumer
+  // pairing the arrays positionally (e.g. excluding one participant by id)
+  // breaks silently on a one-sided filter, so the invariant is pinned here.
+  it('keeps participantIds parallel to participantNames when bots are filtered', async () => {
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({ metadata: { channel: { is_mpim: true } } }),
+      webClient: {
+        conversations: {
+          members: vi.fn().mockResolvedValue({ members: ['UBOT1', 'U1', 'UBOT2', 'U2', 'U3'] }),
+        },
+      },
+      getUser: vi.fn(async (id: string) => ({
+        userName: `name-${id}`,
+        fullName: id,
+        isBot: id.startsWith('UBOT'),
+        userId: id,
+      })),
+    } as unknown as SlackAdapter;
+
+    const resolved = await resolveSlackConversation(adapter, 'slack:G777');
+    expect(resolved?.type).toBe('group_dm');
+    expect(resolved?.participantNames).toEqual(['name-U1', 'name-U2', 'name-U3']);
+    expect(resolved?.participantIds).toEqual(['U1', 'U2', 'U3']);
+    expect(resolved?.participantIds).toHaveLength(resolved?.participantNames?.length ?? -1);
+  });
+
+  it('drops a participant whose profile lookup fails from BOTH arrays', async () => {
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({ metadata: { channel: { is_mpim: true } } }),
+      webClient: {
+        conversations: { members: vi.fn().mockResolvedValue({ members: ['U1', 'UGONE', 'U3'] }) },
+      },
+      // UGONE's profile lookup fails (deactivated user / users:read gap) —
+      // getUser resolves null. The member must vanish from names AND ids
+      // together, never from just one array.
+      getUser: vi.fn(async (id: string) =>
+        id === 'UGONE' ? null : { userName: `name-${id}`, fullName: id, isBot: false, userId: id },
+      ),
+    } as unknown as SlackAdapter;
+
+    const resolved = await resolveSlackConversation(adapter, 'slack:G888');
+    expect(resolved).toEqual({
+      type: 'group_dm',
+      name: null,
+      participantNames: ['name-U1', 'name-U3'],
+      participantIds: ['U1', 'U3'],
+    });
   });
 });

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -9,7 +9,7 @@
  * with suffixed env keys and an instance key (see the slack-multi-instance
  * skill) — same construction path as the default app, no mirrored factory.
  */
-import { createSlackAdapter } from '@chat-adapter/slack';
+import { createSlackAdapter, type SlackAdapter } from '@chat-adapter/slack';
 
 import { readEnvFile } from '../env.js';
 import type { ChannelAdapter, ChannelContextDefaults, ChannelDefaults } from './adapter.js';
@@ -63,6 +63,63 @@ export const SLACK_DEFAULTS: ChannelDefaults = {
   },
   mentions: 'platform',
 };
+
+/**
+ * Classify a Slack conversation for consumers that render it to a human
+ * (e.g. approval cards): a 1:1 DM, a group DM (MPDM), or a channel. Channels
+ * resolve their name; MPDMs resolve their human participants through the
+ * calling bot's own authenticated client. Returns null when the Slack API
+ * can't classify the conversation (network failure, missing scope) so the
+ * caller falls through to its generic rendering.
+ */
+export async function resolveSlackConversation(
+  slackAdapter: SlackAdapter,
+  platformId: string,
+): Promise<{
+  type: 'direct' | 'group_dm' | 'channel';
+  name: string | null;
+  participantNames?: string[];
+  participantIds?: string[];
+} | null> {
+  const channelId = platformId.replace(/^slack:/, '').split(':')[0];
+  if (channelId.startsWith('D')) return { type: 'direct', name: null };
+
+  try {
+    const info = await slackAdapter.fetchThread(`slack:${channelId}`);
+    const channel = (info.metadata as { channel?: { is_mpim?: boolean } }).channel;
+    if (!channel?.is_mpim) return { type: 'channel', name: info.channelName ?? null };
+
+    try {
+      const { members = [] } = await slackAdapter.webClient.conversations.members({
+        channel: channelId,
+        limit: 100,
+      });
+      const users = await Promise.all(members.map((id) => slackAdapter.getUser(id)));
+      // participantIds (raw Slack "U…" ids) MUST stay parallel to
+      // participantNames — same length, same order. A consumer pairing the
+      // two arrays positionally (e.g. to exclude one participant by id)
+      // breaks silently if a member is filtered from only ONE array (bot,
+      // failed profile lookup). Both arrays are therefore projected from a
+      // single filtered list: bots and members whose profile lookup failed
+      // drop from BOTH.
+      const humans = members
+        .map((id, i) => ({ id, user: users[i] }))
+        .filter((entry): entry is { id: string; user: NonNullable<(typeof users)[number]> } =>
+          Boolean(entry.user && !entry.user.isBot),
+        );
+      return {
+        type: 'group_dm',
+        name: null,
+        participantNames: humans.map(({ user }) => user.userName || user.fullName),
+        participantIds: humans.map(({ id }) => id),
+      };
+    } catch {
+      return { type: 'group_dm', name: null };
+    }
+  } catch {
+    return null;
+  }
+}
 
 /** Construction knobs for one Slack bot identity. */
 export interface SlackBridgeOptions {
@@ -126,7 +183,13 @@ export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdap
       return null;
     }
   };
-  return bridge;
+  // Conversation classification closes over THIS identity's adapter, so
+  // every instance (default or named) resolves through its own token.
+  // ChannelAdapter does not declare resolveConversation yet — the extension
+  // rides on the returned object until the core seam lands.
+  return Object.assign(bridge, {
+    resolveConversation: (platformId: string) => resolveSlackConversation(slackAdapter, platformId),
+  });
 }
 
 registerChannelAdapter('slack', {

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -5,9 +5,14 @@
  * Socket Mode opt-in: set SLACK_APP_TOKEN (xapp-…) to receive events over an
  * outbound WebSocket instead of an inbound HTTPS webhook.
  *
- * Additional bot identities in the same workspace reuse createSlackBridge
- * with suffixed env keys and an instance key (see the slack-multi-instance
- * skill) — same construction path as the default app, no mirrored factory.
+ * Additional bot identities in the same workspace: set
+ * SLACK_INSTANCES=<name>[,<name>…] plus a per-instance token set
+ * (SLACK_BOT_TOKEN_<NAME> / SLACK_APP_TOKEN_<NAME> /
+ * SLACK_SIGNING_SECRET_<NAME>; name uppercased, dashes → underscores). Each
+ * name registers under the `slack-<name>` instance key through the same
+ * createSlackBridge factory as the default app — no mirrored construction.
+ * channelType stays 'slack' either way, so user ids, formatting, container
+ * config, and the wiring-defaults declaration are shared across instances.
  */
 import { createSlackAdapter, type SlackAdapter } from '@chat-adapter/slack';
 
@@ -192,7 +197,40 @@ export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdap
   });
 }
 
+/** Env-key suffix for a named instance: uppercased, dashes → underscores. */
+export function instanceEnvKeySuffix(name: string): string {
+  return name.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * Build one named instance's bridge from its per-instance token set, through
+ * the shared factory. Returns null when the bot token is missing so the
+ * registry surfaces its normal "credentials missing, skipping" warning.
+ *
+ * Exported so a test can drive the real factory against a token set.
+ */
+export function slackInstanceBridgeFactory(name: string): ChannelAdapter | null {
+  return createSlackBridge({
+    envKeySuffix: instanceEnvKeySuffix(name),
+    instanceKey: `slack-${name}`,
+  });
+}
+
 registerChannelAdapter('slack', {
   factory: () => createSlackBridge(),
   defaults: SLACK_DEFAULTS,
 });
+
+// Named instances — registration is unconditional for every listed name so a
+// missing token set surfaces as the registry's "credentials missing, skipping"
+// warning at boot rather than a silently absent bot. Every registration carries
+// the same SLACK_DEFAULTS declaration as the default app, so offline creation
+// paths (setup, ncl) resolve declared wiring defaults for named instances too.
+for (const raw of (readEnvFile(['SLACK_INSTANCES']).SLACK_INSTANCES ?? '').split(',')) {
+  const name = raw.trim();
+  if (!name) continue;
+  registerChannelAdapter(`slack-${name}`, {
+    factory: () => slackInstanceBridgeFactory(name),
+    defaults: SLACK_DEFAULTS,
+  });
+}

--- a/src/provisioning/slack-app.test.ts
+++ b/src/provisioning/slack-app.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  AGENT_BOT_EVENTS,
+  AGENT_BOT_SCOPES,
+  BOT_EVENTS,
+  BOT_SCOPES,
+  DEFAULT_SLACK_SERVICE_BASE,
+  MANAGED_APP_DESCRIPTION,
+  buildManagedAppManifest,
+  mapBrokerApp,
+  readInstallToken,
+  readManagerToken,
+  readServiceBase,
+} from './slack-app.js';
+
+interface ManifestShape {
+  display_information: { name: string; description: string };
+  features: {
+    bot_user: { display_name: string };
+    app_home: { messages_tab_enabled: boolean };
+    agent_view?: { agent_description: string };
+  };
+  oauth_config: { scopes: { bot: string[] } };
+  settings: {
+    socket_mode_enabled: boolean;
+    token_rotation_enabled: boolean;
+    event_subscriptions: { bot_events: string[] };
+  };
+}
+
+describe('buildManagedAppManifest', () => {
+  it('builds a socket-mode manifest; the default variant is agent-mode', () => {
+    const manifest = buildManagedAppManifest({ name: 'Trusty' }) as ManifestShape;
+
+    expect(manifest.display_information.name).toBe('Trusty');
+    expect(manifest.features.bot_user.display_name).toBe('Trusty');
+    expect(manifest.features.app_home.messages_tab_enabled).toBe(true);
+    // agent_view default: installs never fail; free workspaces degrade to a
+    // plain DM. The agent_description is the fixed attribution line.
+    expect(manifest.features.agent_view).toEqual({ agent_description: MANAGED_APP_DESCRIPTION });
+    expect(manifest.oauth_config.scopes.bot).toEqual([...BOT_SCOPES, ...AGENT_BOT_SCOPES]);
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([...BOT_EVENTS, ...AGENT_BOT_EVENTS]);
+    // Socket Mode is load-bearing: self-hosted installs have no public URL,
+    // and the adapter selects socket mode from SLACK_APP_TOKEN's presence.
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    // The adapter has no refresh-token handling; rotation must stay off.
+    expect(manifest.settings.token_rotation_enabled).toBe(false);
+  });
+
+  it('agentView:false selects the plain variant (guest-accessible bots)', () => {
+    const manifest = buildManagedAppManifest({ name: 'Trusty', agentView: false }) as ManifestShape;
+    expect(manifest.features.agent_view).toBeUndefined();
+    expect(manifest.oauth_config.scopes.bot).toEqual(BOT_SCOPES);
+    expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write');
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual(BOT_EVENTS);
+  });
+
+  it('never requests user scopes — bot-scopes-only is what makes auto-install eligible', () => {
+    for (const agentView of [true, false]) {
+      const manifest = buildManagedAppManifest({ name: 'x', agentView }) as {
+        oauth_config: { scopes: Record<string, unknown> };
+      };
+      expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
+    }
+  });
+});
+
+describe('readManagerToken', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    delete process.env.SLACK_MANAGER_TOKEN;
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it('prefers process env over .env', () => {
+    process.env.SLACK_MANAGER_TOKEN = 'xoxp-from-env';
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'SLACK_MANAGER_TOKEN=xoxp-from-file\n');
+    expect(readManagerToken(dir)).toBe('xoxp-from-env');
+  });
+
+  it('reads from .env, stripping quotes', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'OTHER=1\nSLACK_MANAGER_TOKEN="xoxp-from-file"\n');
+    expect(readManagerToken(dir)).toBe('xoxp-from-file');
+  });
+
+  it('returns undefined when absent', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'OTHER=1\n');
+    expect(readManagerToken(dir)).toBeUndefined();
+  });
+});
+
+describe('readServiceBase', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it('defaults to the deployed service', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    expect(readServiceBase(dir)).toBe(DEFAULT_SLACK_SERVICE_BASE);
+  });
+
+  it('prefers process env and strips trailing slashes', () => {
+    process.env.SLACK_SERVICE_BASE = 'https://slack-sandbox.example.dev/';
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    expect(readServiceBase(dir)).toBe('https://slack-sandbox.example.dev');
+  });
+
+  it('reads from .env, stripping quotes', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'SLACK_SERVICE_BASE="https://broker.example.test"\n');
+    expect(readServiceBase(dir)).toBe('https://broker.example.test');
+  });
+});
+
+describe('readInstallToken', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    delete process.env.NANOCLAW_REGISTRY_TOKEN;
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  const writeAccount = (configDir: string, content: string): void => {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'account.json'), content);
+  };
+
+  it('reads the token from account.json (the enrollment convention)', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    writeAccount(
+      dir,
+      JSON.stringify({ version: 1, api: 'https://registry.example', account_id: 'acct_1', token: 'nct_abc123' }),
+    );
+    expect(readInstallToken(process.cwd(), dir)).toBe('nct_abc123');
+  });
+
+  it('prefers NANOCLAW_REGISTRY_TOKEN from the process env', () => {
+    process.env.NANOCLAW_REGISTRY_TOKEN = 'nct_from_env';
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    writeAccount(dir, JSON.stringify({ token: 'nct_from_file' }));
+    expect(readInstallToken(process.cwd(), dir)).toBe('nct_from_env');
+  });
+
+  it('returns undefined when no account file exists', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+  });
+
+  it('reads malformed or token-less files as "not enrolled" rather than throwing', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    writeAccount(dir, 'not json{');
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+    writeAccount(dir, JSON.stringify({ version: 1, token: '' }));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+    writeAccount(dir, JSON.stringify({ version: 1 }));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+    writeAccount(dir, JSON.stringify(['token']));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+  });
+});
+
+describe('mapBrokerApp', () => {
+  it('maps a fully auto-installed app into the ProvisionedApp shape', () => {
+    const app = mapBrokerApp({
+      app_id: 'A0TEST123',
+      team_id: 'T0TEAM456',
+      name: 'Trusty',
+      app_token: 'xapp-1-A0TEST123-x',
+      bot_token: 'xoxb-000-bot',
+      install_url: 'https://slack.com/oauth/install/A0TEST123',
+      install_error: null,
+    });
+    expect(app).toEqual({
+      appId: 'A0TEST123',
+      appToken: 'xapp-1-A0TEST123-x',
+      botToken: 'xoxb-000-bot',
+      installUrl: 'https://slack.com/oauth/install/A0TEST123',
+      installError: undefined,
+    });
+  });
+
+  it('maps a refused auto-install: null bot_token → undefined, install_error carried', () => {
+    const app = mapBrokerApp({
+      app_id: 'A0TEST123',
+      app_token: 'xapp-1-A0TEST123-x',
+      bot_token: null,
+      install_url: 'https://slack.com/oauth/install/A0TEST123',
+      install_error: 'app_approval_request_eligible',
+    });
+    expect(app.botToken).toBeUndefined();
+    expect(app.installError).toBe('app_approval_request_eligible');
+    expect(app.installUrl).toBe('https://slack.com/oauth/install/A0TEST123');
+  });
+
+  it('tolerates absent optional fields — installUrl falls back to empty string', () => {
+    const app = mapBrokerApp({ app_id: 'A1', app_token: 'xapp-1' });
+    expect(app).toEqual({
+      appId: 'A1',
+      appToken: 'xapp-1',
+      botToken: undefined,
+      installUrl: '',
+      installError: undefined,
+    });
+  });
+});

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -1,0 +1,483 @@
+/**
+ * Managed Slack app provisioning.
+ *
+ * When the operator holds a manager-app user token (xoxp-… with
+ * app_configurations:write + managed_apps:install), we can create the
+ * bot's Slack app programmatically instead of walking the operator through
+ * api.slack.com/apps by hand:
+ *
+ *   1. apps.manifest.create — socket-mode manifest, generate_app_token=true
+ *      so the response carries the xapp-… app-level token (no public URL
+ *      needed, exactly matching the adapter's Socket Mode path)
+ *   2. apps.managedInstall — bot-scopes-only apps auto-install and return
+ *      the xoxb-… bot token directly
+ *
+ * Auto-install does not bypass Admin Approved Apps: on workspaces where the
+ * admin rules reject it, managedInstall errors and the caller falls back to
+ * the manual install URL (oauth_authorize_url from step 1).
+ *
+ * The manager token is read from SLACK_MANAGER_TOKEN (process env or .env).
+ * It never persists into the container or session env — only the derived
+ * bot + app tokens are handed to the add-slack skill.
+ *
+ * Broker transport ("hosts are always the initiator"): when this install is
+ * enrolled with the NanoClaw registry, the same install token that gates the
+ * hardened agent image also authenticates against the managed-Slack broker
+ * (slack.nanoclaw.dev). The broker holds the Slack manager credential
+ * server-side; the host only ever sees the derived per-app tokens. The
+ * broker client lives here next to the direct-Slack path so callers can
+ * pick whichever the install is set up for.
+ *
+ * This is the provisioning CORE — transport + manifest only, no prompts and
+ * no wizard state. It lives under src/ (main build + test pass) rather than
+ * setup/ because provisioning serves every agent's app creation, not just
+ * first-time setup; the setup wizard is just one caller. Wizard UX stays in
+ * setup/channels/slack-auto.ts.
+ *
+ * Nothing in this module loads on the default wizard path — it is reached
+ * only through the NANOCLAW_SLACK_AGENTS-gated dynamic import chain rooted
+ * in setup/channels/slack-auto-register.ts.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** The deployed managed-Slack broker. Overridable via SLACK_SERVICE_BASE. */
+export const DEFAULT_SLACK_SERVICE_BASE = 'https://slack.nanoclaw.dev';
+
+/**
+ * Superset of the add-slack skill's manual walkthrough: managed apps
+ * additionally carry the mpim + im:write scopes for multi-bot rooms and the
+ * post-provision welcome DM. Baked in at provision time deliberately —
+ * adding scopes to a live app later needs a manifest update AND a reinstall,
+ * a fleet migration we avoid by shipping the full template from day one.
+ * Must match the broker service's server-side template — the two transports
+ * must produce identical apps.
+ */
+export const BOT_SCOPES = [
+  // Required by the app_mention event subscription; the Slack UI adds it
+  // implicitly, so the manual walkthrough never lists it.
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  // users:read.email is deliberately ABSENT: it is outside the approved
+  // scope set for provisioned apps. Scope additions must be approved for
+  // that set BEFORE landing in any transport, or the manual-install
+  // fallback breaks on the unapproved scope.
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+  // Room-canvas surface: create/edit conversation canvases; files:read is
+  // the read-back path (canvases are files, HTML download carries section ids).
+  'canvases:read',
+  'canvases:write',
+  'files:read',
+  // send_file: agents deliver files they produce (charts, documents,
+  // generated artifacts) via files upload — live-verified missing_scope
+  // failure without it (filesUploadV2 needs files:write).
+  'files:write',
+];
+
+// member_joined/left_channel ride on the channels/groups/mpim:read scopes
+// already present above (join-time adopt flow + membership bookkeeping).
+export const BOT_EVENTS = [
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'app_mention',
+  'member_joined_channel',
+  'member_left_channel',
+];
+
+/**
+ * Agent-mode (features.agent_view) additions — the default variant. Slack
+ * auto-adds assistant:write when agent_view is enabled; declared explicitly
+ * so the manifest states what the app holds. Guests are hard-blocked from
+ * agent-enabled apps, so agentView:false selects the plain variant instead.
+ */
+export const AGENT_BOT_SCOPES = ['assistant:write'];
+
+export const AGENT_BOT_EVENTS = ['app_home_opened', 'app_context_changed'];
+
+/**
+ * Fixed attribution: admins see this line, never a caller-supplied text.
+ * Also the agent_view.agent_description (≤300 chars) on the agent-mode variant.
+ */
+export const MANAGED_APP_DESCRIPTION =
+  'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
+
+export interface ManagedAppSpec {
+  name: string;
+  description?: string;
+  /**
+   * agent_view is a one-way door decided at provision time (default true):
+   * installs never fail on free plans (chrome degrades to a plain DM), but
+   * agent apps are unusable by workspace guests — pass false for workspaces
+   * that need guest access.
+   */
+  agentView?: boolean;
+}
+
+export function buildManagedAppManifest(spec: ManagedAppSpec): object {
+  const agentView = spec.agentView ?? true;
+  return {
+    display_information: {
+      name: spec.name,
+      description: MANAGED_APP_DESCRIPTION,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: spec.name,
+        always_online: true,
+      },
+      ...(agentView ? { agent_view: { agent_description: MANAGED_APP_DESCRIPTION } } : {}),
+    },
+    oauth_config: {
+      // Copies, not the module constants — callers extend these per app.
+      scopes: { bot: agentView ? [...BOT_SCOPES, ...AGENT_BOT_SCOPES] : [...BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: { bot_events: agentView ? [...BOT_EVENTS, ...AGENT_BOT_EVENTS] : [...BOT_EVENTS] },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+export interface ProvisionedApp {
+  appId: string;
+  /** xapp-… app-level token for Socket Mode. */
+  appToken: string;
+  /** xoxb-… bot token — absent when auto-install was refused. */
+  botToken?: string;
+  /** Manual install URL — the fallback when auto-install was refused. */
+  installUrl: string;
+  teamDomain?: string;
+  /** managedInstall error when auto-install was refused (e.g. app_approval_request_eligible). */
+  installError?: string;
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+}
+
+async function slackApi<T extends SlackApiResponse>(
+  method: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<T> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams(params).toString(),
+  });
+  if (!res.ok && res.status !== 200) {
+    throw new Error(`${method}: HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Create and (attempt to) install a managed Slack app. Throws on creation
+ * failure; a refused auto-install is not an error — the result carries the
+ * manual install URL and `installError` instead of `botToken`.
+ */
+export async function provisionManagedApp(managerToken: string, spec: ManagedAppSpec): Promise<ProvisionedApp> {
+  const manifest = buildManagedAppManifest(spec);
+  const created = await slackApi<
+    SlackApiResponse & {
+      app_id?: string;
+      app_token?: string;
+      oauth_authorize_url?: string;
+      team_domain?: string;
+    }
+  >('apps.manifest.create', managerToken, {
+    manifest: JSON.stringify(manifest),
+    generate_app_token: 'true',
+  });
+  if (!created.ok || !created.app_id) {
+    throw new Error(`apps.manifest.create failed: ${created.error ?? 'no app_id in response'}`);
+  }
+  if (!created.app_token) {
+    throw new Error('apps.manifest.create returned no app-level token (generate_app_token unsupported?)');
+  }
+
+  const result: ProvisionedApp = {
+    appId: created.app_id,
+    appToken: created.app_token,
+    installUrl: created.oauth_authorize_url ?? '',
+    teamDomain: created.team_domain,
+  };
+
+  const installed = await slackApi<
+    SlackApiResponse & {
+      api_access_tokens?: { bot_access_token?: string };
+    }
+  >('apps.managedInstall', managerToken, { app_id: created.app_id });
+  if (installed.ok && installed.api_access_tokens?.bot_access_token) {
+    result.botToken = installed.api_access_tokens.bot_access_token;
+  } else {
+    result.installError = installed.error ?? 'no bot token in response';
+  }
+  return result;
+}
+
+/** Process env first, then the install's .env — the same order everywhere. */
+function readEnvSetting(key: string, projectRoot: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const envFile = fs.readFileSync(path.join(projectRoot, '.env'), 'utf-8');
+    const match = envFile.match(new RegExp(`^${key}=(.+)$`, 'm'));
+    const value = match?.[1]?.trim().replace(/^["']|["']$/g, '');
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Manager token from process env or the install's .env. Presence of the
+ * token is what unlocks the auto-provision option in the setup flow.
+ */
+export function readManagerToken(projectRoot = process.cwd()): string | undefined {
+  return readEnvSetting('SLACK_MANAGER_TOKEN', projectRoot);
+}
+
+// ---------------------------------------------------------------------------
+// Broker transport — the managed-Slack service at slack.nanoclaw.dev.
+
+/** Broker base URL: SLACK_SERVICE_BASE (process env or .env), else the default. */
+export function readServiceBase(projectRoot = process.cwd()): string {
+  const value = readEnvSetting('SLACK_SERVICE_BASE', projectRoot) ?? DEFAULT_SLACK_SERVICE_BASE;
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * The registry install token, exactly where enrollment persists it:
+ * `~/.config/nanoclaw/account.json` (per-user, not per-checkout — see
+ * `readRegistryAccount` in setup/lib/registry-state.ts; `{ token: "…" }` is
+ * the only required field). A malformed or missing file reads as "not
+ * enrolled" rather than throwing — the next move (fall back to the
+ * manager-token or manual path) is the same either way.
+ *
+ * `NANOCLAW_REGISTRY_TOKEN` in the process env wins, matching the login
+ * driver's CI path. `projectRoot` is accepted for signature parity with
+ * `readManagerToken` but the credential is deliberately per-user;
+ * `configDir` is overridable for tests only.
+ */
+export function readInstallToken(
+  _projectRoot = process.cwd(),
+  configDir = path.join(os.homedir(), '.config', 'nanoclaw'),
+): string | undefined {
+  const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(configDir, 'account.json'), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const token = (parsed as { token?: unknown }).token;
+  return typeof token === 'string' && token.trim() ? token : undefined;
+}
+
+/** Broker failure with enough context to say what broke, never the token. */
+export class BrokerHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly path: string,
+    detail?: string,
+  ) {
+    super(`Slack service ${path}: HTTP ${status}${detail ? ` — ${detail}` : ''}`);
+    this.name = 'BrokerHttpError';
+  }
+}
+
+/**
+ * One authenticated round-trip to the broker. Throws `BrokerHttpError` on any
+ * non-2xx (with the body's `error`/`message` when it has one) and on a 2xx
+ * body that isn't JSON — callers never have to inspect a Response.
+ */
+export async function brokerRequest<T>(
+  method: 'GET' | 'POST' | 'DELETE',
+  apiPath: string,
+  token: string,
+  body?: object,
+  base = readServiceBase(),
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${base}${apiPath}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    throw new BrokerHttpError(0, apiPath, err instanceof Error ? err.message : String(err));
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    let detail: string | undefined;
+    try {
+      const parsed = JSON.parse(text) as { error?: string; message?: string };
+      // message is the human sentence ("Install token expired. Re-run
+      // nanoclaw login."); error is the machine code. Show the human one.
+      detail = parsed.message ?? parsed.error;
+    } catch {
+      detail = text.trim().slice(0, 200) || undefined;
+    }
+    throw new BrokerHttpError(res.status, apiPath, detail);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new BrokerHttpError(res.status, apiPath, 'response was not JSON');
+  }
+}
+
+/** A workspace the operator has connected to the broker via OAuth. */
+export interface BrokerWorkspace {
+  team_id: string;
+  team_name: string;
+  status: string;
+  connected_as?: string;
+  connected_at?: string;
+}
+
+/** OAuth URL the operator opens to connect a workspace to the broker. */
+export async function brokerOauthUrl(token: string): Promise<{ url: string }> {
+  const res = await brokerRequest<{ url?: string }>('POST', '/v1/slack/oauth/url', token, {});
+  if (!res.url) throw new BrokerHttpError(200, '/v1/slack/oauth/url', 'no url in response');
+  return { url: res.url };
+}
+
+export async function brokerListWorkspaces(token: string): Promise<BrokerWorkspace[]> {
+  const res = await brokerRequest<{ workspaces?: BrokerWorkspace[] }>('GET', '/v1/workspaces', token);
+  return res.workspaces ?? [];
+}
+
+// ── Avatar generation (broker-side) ──
+
+/** Poll cap for the pre-create avatar job — beyond it the bot keeps the default icon. */
+const AVATAR_WAIT_MS = 75_000;
+// Generation measures ~20-23s at the broker's floor settings — a 2s poll
+// wastes at most ~2s of that.
+const AVATAR_POLL_MS = 2_000;
+
+/**
+ * Ask the broker to generate the agent's avatar BEFORE the app exists, so
+ * the bot's first workspace appearance already carries it. Returns undefined
+ * when generation is unavailable, failed, or over the wait cap — the
+ * degraded path is the default icon, never an error.
+ */
+export async function requestAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  let avatarId: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/v1/avatars`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${installToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: displayName, ...(description ? { description } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = (await res.json()) as { avatar_id?: string | null };
+    avatarId = data.avatar_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+  if (!avatarId) return undefined;
+  const deadline = Date.now() + AVATAR_WAIT_MS;
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) await new Promise((r) => setTimeout(r, AVATAR_POLL_MS));
+    try {
+      const res = await fetch(`${baseUrl}/v1/avatars/${avatarId}`, {
+        headers: { Authorization: `Bearer ${installToken}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'ready') return avatarId;
+      if (data.status && data.status !== 'pending') return undefined;
+    } catch {
+      // Transient — bounded by the deadline.
+    }
+  }
+  return undefined;
+}
+
+/** The broker's POST /v1/apps response shape. */
+export interface BrokerAppResponse {
+  app_id: string;
+  team_id?: string;
+  name?: string;
+  /** xapp-… app-level token for Socket Mode. */
+  app_token: string;
+  /** xoxb-… bot token — null when auto-install was refused. */
+  bot_token?: string | null;
+  install_url?: string | null;
+  install_error?: string | null;
+}
+
+/**
+ * Broker response → the same `ProvisionedApp` shape the direct-Slack path
+ * produces, so everything downstream of provisioning is transport-agnostic.
+ */
+export function mapBrokerApp(res: BrokerAppResponse): ProvisionedApp {
+  return {
+    appId: res.app_id,
+    appToken: res.app_token,
+    botToken: res.bot_token ?? undefined,
+    installUrl: res.install_url ?? '',
+    installError: res.install_error ?? undefined,
+  };
+}
+
+/**
+ * Create (and attempt to install) a managed app via the broker. Mirrors
+ * `provisionManagedApp`'s contract: throws on creation failure; a refused
+ * auto-install comes back as `installError` + `installUrl`, not an error.
+ */
+export async function brokerProvision(
+  token: string,
+  spec: { team_id: string; name: string; description?: string; icon_url?: string; allow_guests?: boolean },
+): Promise<ProvisionedApp> {
+  // Avatar-first: generate the avatar BEFORE the app exists so the bot's
+  // first appearance already wears it — undefined degrades to the default icon.
+  const avatarId = await requestAvatar(readServiceBase(), token, spec.name, spec.description);
+  const res = await brokerRequest<Partial<BrokerAppResponse>>('POST', '/v1/apps', token, {
+    ...spec,
+    ...(avatarId ? { avatar_id: avatarId } : {}),
+  });
+  if (!res.app_id || !res.app_token) {
+    throw new BrokerHttpError(200, '/v1/apps', 'response missing app_id or app_token');
+  }
+  return mapBrokerApp(res as BrokerAppResponse);
+}


### PR DESCRIPTION
Two adapter-layer changes to the Slack channel adapter plus the skill payload that installs the channel layer, targeting the `channels` branch.

## Adapter (`src/channels/slack.ts` + tests)

**Conversation resolution.** `resolveSlackConversation` classifies a conversation for consumers that render it to a human (approval cards and similar): `D…` ids are `direct` with no API call; channels resolve their name via `fetchThread`; MPDMs resolve their human participants through the calling identity's own authenticated `webClient`. Bots and members whose profile lookup failed drop from `participantNames` AND `participantIds` together, keeping the arrays parallel for positional consumers; a member-lookup failure keeps type `group_dm` without arrays; a `fetchThread` failure returns `null` so the caller falls back to its generic rendering. Each bridge attaches `resolveConversation` via a closure over that identity's own adapter, so every named instance resolves through its own token. `ChannelAdapter` does not declare `resolveConversation` yet — the method rides on the returned object (typechecks) until the core seam lands.

**Native `SLACK_INSTANCES` registration.** `slack.ts` now owns multi-bot registration: `SLACK_INSTANCES=<name>[,<name>…]` registers one `slack-<name>` instance per listed name through the shared `createSlackBridge` factory, reading per-instance tokens under suffixed keys (`instanceEnvKeySuffix`: uppercased, dashes to underscores). Registration is unconditional per listed name so a missing token set surfaces as the registry's "credentials missing, skipping" boot warning rather than a silently absent bot, and every registration carries the same `SLACK_DEFAULTS` declaration as the default app so offline creation paths resolve declared defaults for named instances too. `slack-instances-registration.test.ts` drives the loop against a crafted `.env` through the real barrel.

## Skill payload

**Canonical `add-slack`.** The install skill widens from a 3-file adapter copy to the full channel layer on this branch: adapter + shared lib, the bot-inbound guard, the room-membership / canvas-actions / onboarding modules, the provisioning core, the container canvas tool, the formatting and canvas-work container skills, and the `.env` helper interim copies — with the matching barrel appends, pinned-dep install, and payload test steps. The connection prompt gains the input-only `provisioned` leg (app created programmatically via `apps.manifest.create` + `apps.managedInstall`; tokens arrive via pre-bound inputs, never typed into chat), with its app-token twin prompt/env-set and a third conformance fixture scenario. Multi-instance support being native, the skill copies the instances registration test alongside the adapter and documents `SLACK_INSTANCES` + the suffixed token keys in the credentials step — no instances module, no adapter edit. The manual app-creation walkthroughs also list `mpim:read`, which `conversations.members` needs for group-DM participant resolution (documentation only; no provisioning scope array changes anywhere).

**Provisioning core in the payload.** `src/provisioning/slack-app.ts` (+ its test) ships as part of the channel payload: the Slack-app manifest template, the scope/event set constants, the broker client (oauth URL, workspaces, provision, avatar request/poll), and the direct manager-token transport (`apps.manifest.create` + `apps.managedInstall`). The copy step installs it with the rest of the layer, so every installed tree carries it; nothing on the adapter path imports it — the setup wizard's flag-gated auto-provision pre-step and feature skills do. The wizard bootstraps this one file from this branch when it runs before the channel is installed; its permanent home is here.

**Install-skill behavior.** The interactive flow offers only `socket` or `webhook` — the connection prompt never presents `provisioned`; that leg activates solely via pre-bound `inputs` (programmatic apply). A standard interactive install is therefore unchanged manual app creation.

**Standing context as container skills.** The Slack room/canvas/access/DM-history rules ship as `container/skills/slack-construct/` (`instructions.md` + a minimal SKILL.md): the host composes every container skill's `instructions.md` into each group's CLAUDE.md at spawn (`src/claude-md-compose.ts`). Skill fragments compose for every group regardless of `cli_scope`, so the content names no host-CLI commands — CLI guidance stays with the cli module fragment, which the compose path already withholds from `cli_scope=disabled` groups. The welcome addendum (`container/skills/welcome/addenda/slack.md`) is consumed by the host's channel-matched addenda mechanism; the base welcome skill is never edited, and the file sits inert on hosts that predate the mechanism.

**`slack-agent-flow`.** `create_agent` from a Slack session provisions a Slack app for the new agent (managed broker or workspace manager token), registers and hot-starts it as a `slack-<name>` instance, opens the operator DM and a shared three-way room, and adds the `create_room` / `add_to_room` agent tools. Aligned to this branch: `slack-deps.ts` probes `slack.ts` for `slackInstanceBridgeFactory` (there is no instances module to probe), the precondition checks match, and the sibling-agent standing context ships as `container/skills/slack-construct-agents/`.

The payload's congruence mirror reads `src/provisioning/slack-app.ts` from the installed tree — satisfied by construction now that the add-slack copy step installs that module (slack-agent-flow layers on an installed Slack channel). No ordering caveat remains.

**`slack-a2a-rooms`.** The multi-bot shared-room skill as a pure guard-seam policy: it registers the `SLACK_A2A_ROOMS` allowlist, hop limit, and `slack:bot:<bot_id>` re-attribution onto the channel guard's `setBotInboundPolicy` seam. Installing it is a precondition check, a three-file copy, and one barrel append — no bridge or adapter source edits.

**`slack-multi-instance`.** Shrinks to instructions-only: the env format, the per-instance token keys, the restart-vs-hot-start distinction, and the validation command. Its former code payload is superseded by the native registration, and it leaves the companion-skill list (`setup/channels/slack-companions.ts` now declares `slack-a2a-rooms` only).

**Test pair.** `scripts/skill-directives.test.ts` expectations updated to parse the canonical skill: the provisioned leg, the full copy list (including the instances test, the `slack-construct` pair, and the provisioning module + test), and the five barrel appends with their idempotency-keyed separate fences.

## Verification

Adapter pass:
- `pnpm exec vitest run src/channels/slack-registration.test.ts src/channels/slack-instances-registration.test.ts src/channels/slack-lib.test.ts` — green
- `pnpm run build` — only the branch's one pre-existing error (deltachat TS2307)
- full `pnpm test` — failing files are exactly the pre-existing barrel-commented channel registrations

Skill-payload pass:
- `pnpm exec vitest run scripts/skill-directives.test.ts scripts/skill-apply.test.ts scripts/skill-conformance.test.ts scripts/skill-policy.test.ts scripts/skill-inputs.test.ts setup/channels/run-channel-skill.test.ts` — 295 passed; conformance auto-discovers and programmatically applies all three fence-carrying Slack skills
- `pnpm exec vitest run src/channels/ src/provisioning/` — 431 passed | 4 skipped; same 10 pre-existing failures only
- `pnpm exec vitest run src/provisioning/` — 16 passed (the module compiles and its suite runs in this tree directly)
- full `pnpm test` — 2009 passed | 10 failed | 4 skipped, failing set identical to base (the same 10 barrel-commented channel registrations)
- directive lint on the updated add-slack SKILL.md — 25 directives, 0 problems
- agent-flow payload trial-copied into its real tree location on this branch: full module suite green — 6 files, 81 passed | 2 skipped (the 2 skips are the `skipIf`-guarded mirror for a script that isn't in this tree). The trunk-provisioning congruence pins that previously failed loudly on a tree without `src/provisioning/slack-app.ts` now run against the in-tree module and pass — the mirror path is satisfied by construction

## End-to-end application (verified offline)

Both install paths were executed for real against this branch's content via the skill engine (`scripts/skill-apply.ts`), with prompts deferred so no credential or network step runs:

- **Existing installs (current trunk skill, narrower copy list):** applies cleanly against this branch — the adapter imports only trunk modules, so the older 3-file copy leaves no dangling import; build + registration test green; idempotent on re-run. Existing installs simply get the updated adapter without the new modules until they update the skill.
- **Canonical skill on a trunk checkout:** all 32 copy paths resolve, 5 barrel appends land exactly once, host build + container typecheck green, the skill's declared test command passes (166 tests) plus the full container suite (320 pass), and a second engine run is a clean no-op.

**Sync rule for later:** whenever the canonical `SKILL.md` is copied to `main`, `scripts/skill-directives.test.ts` must land in the same commit — it pins the skill's directive shape as a golden fixture (this branch carries the matched pair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)