### PR TITLE
Fix Telegram skill copy list

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -6,8 +6,8 @@ description: Add Telegram channel integration via Chat SDK.
 # Add Telegram Channel
 
 Adds Telegram bot support via the Chat SDK bridge. NanoClaw doesn't ship
-channels in trunk — this skill copies the Telegram adapter, its
-formatting/pairing helpers, and their tests in from the `channels` branch. The
+channels in trunk — this skill copies the Telegram adapter, its pairing helper,
+and their tests in from the `channels` branch. The
 `pair-telegram` setup step is maintained in trunk, so it is not copied here.
 
 The mechanical steps under **Apply** carry `nc:` directive fences: an agent
@@ -19,16 +19,14 @@ safe to re-run; anything a parser can't apply falls back to the prose beside it.
 
 ### 1. Copy the adapter, helpers, and tests
 
-Fetch the `channels` branch and copy the Telegram adapter, its pairing and
-markdown-sanitize helpers (with their tests), and the registration test into
-place (overwrite — the branch is canonical):
+Fetch the `channels` branch and copy the Telegram adapter, its pairing helper
+(with its test), and the registration test into place (overwrite — the branch
+is canonical):
 
 ```nc:copy from-branch:channels
 src/channels/telegram.ts
 src/channels/telegram-pairing.ts
 src/channels/telegram-pairing.test.ts
-src/channels/telegram-markdown-sanitize.ts
-src/channels/telegram-markdown-sanitize.test.ts
 src/channels/telegram-registration.test.ts
 ```
 


### PR DESCRIPTION
## What

Remove the obsolete Telegram markdown-sanitizer files from the add-telegram skill's canonical copy list and update the surrounding description.

## Why

Those files no longer exist on the `channels` branch. The deterministic setup engine therefore stopped at the copy step before installing the registration test, causing Telegram setup to fall back to an agent and fail validation.

## Impact

Telegram setup can copy the current canonical adapter files and proceed to build, registration validation, and pairing without an unnecessary agent fallback.

## Testing

- `pnpm exec tsx scripts/skill-directives.ts .claude/skills/add-telegram/SKILL.md`
- Verified the resulting directive list reports zero problems and zero warnings.
