### PR TITLE
Log a warning for unrecognized engage_mode instead of silent drop

### DIFF
--- a/src/router-unknown-engage-mode.test.ts
+++ b/src/router-unknown-engage-mode.test.ts
@@ -1,0 +1,163 @@
+/**
+ * evaluateEngage's default case: an engage_mode value that isn't one of the
+ * three the type system allows ('pattern' | 'mention' | 'mention-sticky').
+ * The column has no DB CHECK constraint, so a stale row from a past CLI
+ * version or a direct DB write can still carry an unrecognized value. That
+ * must fail closed (never engage) but leave a diagnostic trail instead of
+ * disappearing into `no_agent_engaged` with zero signal.
+ *
+ * Exercised through the REAL routeInbound path (adapter registry + seeded
+ * wiring), not by calling the dispatch directly.
+ */
+import fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./log.js', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock container runner to prevent actual Docker spawning
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(true),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+// Override DATA_DIR for tests
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-unknown-engage-mode' };
+});
+
+import {
+  initTestDb,
+  closeDb,
+  runMigrations,
+  createAgentGroup,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+} from './db/index.js';
+import { getUnregisteredSenders } from './db/dropped-messages.js';
+import { initChannelAdapters, registerChannelAdapter, teardownChannelAdapters } from './channels/channel-registry.js';
+import { routeInbound } from './router.js';
+import { log } from './log.js';
+import type { ChannelAdapter, ChannelDefaults } from './channels/adapter.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-unknown-engage-mode';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const channelDefaults: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'public' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+function makeAdapter(): ChannelAdapter {
+  return {
+    name: 'testchat',
+    channelType: 'testchat',
+    supportsThreads: true,
+    defaults: channelDefaults,
+    setup: async () => {},
+    teardown: async () => {},
+    isConnected: () => true,
+    deliver: async () => undefined,
+  };
+}
+
+async function activate(): Promise<void> {
+  registerChannelAdapter('testchat', { factory: () => makeAdapter(), defaults: channelDefaults });
+  await initChannelAdapters(() => ({
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+}
+
+// A wiring row can end up with an engage_mode value the type system doesn't
+// allow — the DB column has no CHECK constraint. Simulate that by bypassing
+// the type at the call site, exactly as a stale row or direct DB write would.
+function seedUnknownEngageModeWiring(): void {
+  createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  createMessagingGroup({
+    id: 'mg-1',
+    channel_type: 'testchat',
+    platform_id: 'testchat:C1',
+    instance: 'testchat',
+    name: 'Test Chat',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  createMessagingGroupAgent({
+    id: 'mga-1',
+    messaging_group_id: 'mg-1',
+    agent_group_id: 'ag-1',
+    engage_mode: 'always' as unknown as 'pattern',
+    engage_pattern: null,
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'per-thread',
+    priority: 0,
+    threads: 1,
+    created_at: now(),
+  });
+}
+
+async function inbound(id: string, text: string): Promise<void> {
+  await routeInbound({
+    channelType: 'testchat',
+    platformId: 'testchat:C1',
+    threadId: null,
+    message: {
+      id,
+      kind: 'chat-sdk',
+      content: JSON.stringify({ sender: 'Gavriel', senderId: 'U1', text }),
+      timestamp: now(),
+      isMention: true,
+      isGroup: false,
+    },
+  });
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  runMigrations(initTestDb());
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('evaluateEngage with an unrecognized engage_mode', () => {
+  it('fails closed (drops the message as no_agent_engaged) but logs a warning', async () => {
+    await activate();
+    seedUnknownEngageModeWiring();
+
+    await inbound('m1', 'hello there');
+
+    const dropped = getUnregisteredSenders();
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe('no_agent_engaged');
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown engage_mode'),
+      expect.objectContaining({ engage_mode: 'always', wiring_id: 'mga-1' }),
+    );
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -494,6 +494,13 @@ function evaluateEngage(
       return existing !== undefined;
     }
     default:
+      // Unrecognized engage_mode (e.g. stale data from a past CLI version,
+      // or a direct DB write — the column has no CHECK constraint). Fail
+      // closed but leave a trail so this doesn't look like a mystery drop.
+      log.warn('Unknown engage_mode — treating as no-engage. Check wiring configuration.', {
+        engage_mode: agent.engage_mode,
+        wiring_id: agent.id,
+      });
       return false;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2606.

The issue reports `engage_mode='always'` silently dropping every message. I traced `evaluateEngage()` in `src/router.ts` and confirmed the mechanism: its `switch` only has cases for `'pattern'`, `'mention'`, and `'mention-sticky'` — any other stored value falls to `default: return false`, which the caller records as `no_agent_engaged` with no other signal anywhere.

`'always'` itself isn't a real value in this codebase: `EngageMode` (`src/types.ts`) is `'pattern' | 'mention' | 'mention-sticky'`, and the CLI's create/update enum validation (`src/cli/resources/wirings.ts`) rejects anything else, as the issue itself notes. `'always'` engagement is already expressed as `engage_mode='pattern'` + `engage_pattern='.'`, which `evaluateEngage` already handles correctly (returns `true` immediately). So I did not add a `case 'always'` — that would special-case one arbitrary invalid string among many possible ones, and would contradict the documented three-value enum.

What I did fix is the actual bug: the `default` branch fails closed (correctly, since the value is unrecognized) but did so **silently**. Since the `engage_mode` column has no DB `CHECK` constraint, a row can end up with any string via a direct DB write or a stale value from a past CLI version, and today that produces a mystery `no_agent_engaged` drop with zero diagnostic trail. The fix logs a warning naming the wiring id and the offending value before returning `false`, so this is debuggable instead of a silent black hole.

## Changes

- `src/router.ts`: `evaluateEngage()`'s `default` case now calls `log.warn(...)` with `{ engage_mode, wiring_id }` before returning `false`.
- `src/router-unknown-engage-mode.test.ts` (new): exercises `routeInbound` end-to-end with a wiring seeded with an out-of-enum `engage_mode` value (bypassing the TS type the way a stale DB row would), asserting the message is recorded as `no_agent_engaged` in `unregistered_senders` **and** that `log.warn` fires with the wiring id and value.

## Test plan

- [x] `npx vitest run src/router-unknown-engage-mode.test.ts` — new test passes
- [x] `npx vitest run src/router-session-created.test.ts src/router-unknown-engage-mode.test.ts` — no regression in adjacent router tests
- [x] `npx tsc --noEmit` — clean