### PR TITLE
fix: force baseline (non-AVX2) Bun binary in agent image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -63,11 +63,26 @@ ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # ---- Bun runtime -------------------------------------------------------------
-# Install via the official script (handles multi-arch detection), then move
-# the binary to /usr/local/bin so the non-root `node` user can execute it.
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
-    install -m 0755 /root/.bun/bin/bun /usr/local/bin/bun && \
-    rm -rf /root/.bun
+# Download the release zip directly instead of piping bun.sh/install through
+# bash: that script auto-selects the AVX2 build vs. the `-baseline` (SSE4.2
+# floor) build by probing the *build machine's* /proc/cpuinfo, not the
+# machine the image will actually run on. A multi-arch image built on a
+# modern build host (or emulated under buildx) then bakes in an AVX2 binary
+# that SIGILLs on any run host without AVX2 (older Atoms, some cloud/VM
+# SKUs, emulators) — see #3245. Force the amd64 baseline build unconditionally
+# so the shipped image is portable; there is no baseline variant for arm64
+# since AVX2 is an x86 feature.
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+        amd64) BUN_TARGET=linux-x64-baseline ;; \
+        arm64) BUN_TARGET=linux-aarch64 ;; \
+        *) echo "unsupported architecture for bun install" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/bun.zip \
+        "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${BUN_TARGET}.zip" && \
+    unzip -q /tmp/bun.zip -d /tmp/bun && \
+    install -m 0755 "/tmp/bun/bun-${BUN_TARGET}/bun" /usr/local/bin/bun && \
+    rm -rf /tmp/bun /tmp/bun.zip
 
 # ---- agent-runner deps -------------------------------------------------------
 # Deps are cached independently of CLI versions. Source is NOT baked in —


### PR DESCRIPTION
## Summary

- `container/Dockerfile` installed Bun by piping `bun.sh/install` through bash. That script auto-selects the AVX2 build vs. the `-baseline` (SSE4.2 floor) build by probing the *build machine's* `/proc/cpuinfo`, not the machine the image will actually run on.
- Since build hosts (CI runners, most dev machines) almost universally have AVX2, the standard (AVX2-requiring) Bun binary gets baked into the shipped multi-arch image. Any run host without AVX2 — older Atom CPUs (e.g. Celeron J6413/N5105/N6005, common on NAS/homelab hardware), some cloud/VM SKUs, some emulated environments — gets a silent SIGILL on every Bun invocation, which crash-loops every spawned agent container forever with no error surfaced anywhere (see #3245 for the full silent-failure writeup).
- Fix: download the release zip directly (bypassing the installer's CPU probe) and force the `linux-x64-baseline` variant unconditionally for amd64. arm64 keeps the standard `linux-aarch64` build — AVX2 is an x86 feature, there's no baseline variant for arm64.

## Root cause confirmation

- Verified `bun.sh/install`'s source: it greps `/proc/cpuinfo` for `avx2` on the *build* machine to decide `linux-x64` vs `linux-x64-baseline` — there is no way to force the baseline variant through the installer's own argument parsing.
- Verified both release assets exist for the pinned `BUN_VERSION` (1.3.12): `bun-linux-x64-baseline.zip` and `bun-linux-x64.zip` both resolve (HTTP 200) from `oven-sh/bun`'s GitHub releases.

## Test plan

- [x] Built just the changed Bun-install layer in isolation (`dpkg --print-architecture` → `linux-x64-baseline` → download → unzip → install) on this amd64 sandbox; confirmed `bun --version` reports `1.3.12` successfully from the baseline binary.
- [ ] Could not run the full `container/build.sh` (Chromium + full agent-runner + CLI toolchain) in this environment, and could not verify on real non-AVX2 hardware. The layer change is narrowly scoped and doesn't touch anything downstream of `/usr/local/bin/bun`, so the full-image build path should be unaffected — but a maintainer with access to non-AVX2 hardware (or the reporter in #3245) verifying the built image no longer SIGILLs would be valuable before merge.

Fixes #3245