### PR TITLE
fix(channels): await central database operations

### DIFF
--- a/src/channels/deltachat.ts
+++ b/src/channels/deltachat.ts
@@ -21,6 +21,7 @@ import { basename, join, resolve } from 'path';
 import { getDb, hasTable } from '../db/connection.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
+import { isGlobalAdmin, isOwner } from '../modules/permissions/db/user-roles.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
@@ -39,21 +40,11 @@ const OPTIONAL_ENV = ['DC_IMAP_SECURITY', 'DC_SMTP_SECURITY'] as const;
 
 type DcEnv = { [K in (typeof REQUIRED_ENV)[number]]: string } & { [K in (typeof OPTIONAL_ENV)[number]]?: string };
 
-function isDcAdmin(userId: string): boolean {
+async function isDcAdmin(userId: string): Promise<boolean> {
   try {
     const db = getDb();
-    if (!hasTable(db, 'user_roles')) return true;
-    return (
-      db
-        .prepare(
-          `SELECT 1 FROM user_roles
-       WHERE user_id = ?
-         AND (role = 'owner' OR role = 'admin')
-         AND agent_group_id IS NULL
-       LIMIT 1`,
-        )
-        .get(userId) != null
-    );
+    if (!(await hasTable(db, 'user_roles'))) return true;
+    return (await isOwner(userId)) || (await isGlobalAdmin(userId));
   } catch {
     return false;
   }
@@ -146,7 +137,7 @@ function createAdapter(env: DcEnv): ChannelAdapter {
           if (/^\/set-avatar$/i.test((msg.text || '').trim()) && msg.file) {
             const userId = `deltachat:${contact.address}`;
             try {
-              if (isDcAdmin(userId)) {
+              if (await isDcAdmin(userId)) {
                 const absPath = resolve(msg.file as string);
                 await dc.rpc.setConfig(accountId, 'selfavatar', absPath);
                 await dc.rpc.sendMsg(accountId, event.chatId, { text: 'Avatar updated.' });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -152,13 +152,13 @@ function createPairingInterceptor(
       // code-bearing message never reaches an agent. Privilege is now a
       // property of the paired user, not the chat: upsert the user, and if
       // this instance has no owner yet, promote them to owner.
-      const existing = getMessagingGroupByPlatform('telegram', platformId);
+      const existing = await getMessagingGroupByPlatform('telegram', platformId);
       if (existing) {
-        updateMessagingGroup(existing.id, {
+        await updateMessagingGroup(existing.id, {
           is_group: consumed.consumed!.isGroup ? 1 : 0,
         });
       } else {
-        createMessagingGroup({
+        await createMessagingGroup({
           id: `mg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           channel_type: 'telegram',
           platform_id: platformId,
@@ -173,7 +173,7 @@ function createPairingInterceptor(
       }
 
       const pairedUserId = `telegram:${consumed.consumed!.adminUserId}`;
-      upsertUser({
+      await upsertUser({
         id: pairedUserId,
         kind: 'telegram',
         display_name: null,
@@ -181,8 +181,8 @@ function createPairingInterceptor(
       });
 
       let promotedToOwner = false;
-      if (!hasAnyOwner()) {
-        grantRole({
+      if (!(await hasAnyOwner())) {
+        await grantRole({
           user_id: pairedUserId,
           role: 'owner',
           agent_group_id: null,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Await Telegram pairing database mutations and make the DeltaChat admin lookup async.

### Why

The central database API is becoming asynchronous. These awaits are also compatible with the current synchronous API, so channel payloads can be updated before the breaking trunk migration without a broken install window.

### How it works

Telegram awaits the existing messaging-group, user, and role helpers. DeltaChat reuses the existing owner/global-admin helpers and awaits their results instead of querying the concrete SQLite handle.

### How it was tested

`pnpm exec eslint src/channels/telegram.ts src/channels/deltachat.ts` passes with zero errors. The diff is two adapter files and uses only await-compatible existing APIs.