### PR TITLE
chore(lint): enforce async promise handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,15 @@ import noCatchAll from 'eslint-plugin-no-catch-all'
 export default [
   { ignores: ['node_modules/', 'dist/', 'container/', 'groups/'] },
   { files: ['src/**/*.{js,ts}'] },
-  { languageOptions: { globals: globals.node } },
+  {
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   {
@@ -27,6 +35,9 @@ export default [
       ],
       'no-catch-all/no-catch-all': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
     },
   },
 ]

--- a/src/channels/chat-sdk-bridge-agent-mode.test.ts
+++ b/src/channels/chat-sdk-bridge-agent-mode.test.ts
@@ -41,7 +41,11 @@ const hostConfig = {
 /** Drive a Chat process* dispatcher and await its internal task. */
 async function dispatch(fire: (options: { waitUntil: (p: Promise<unknown>) => void }) => void): Promise<void> {
   let task: Promise<unknown> | undefined;
-  fire({ waitUntil: (p) => (task = p) });
+  fire({
+    waitUntil: (p) => {
+      task = p;
+    },
+  });
   await task;
 }
 

--- a/src/channels/chat-sdk-bridge-membership.test.ts
+++ b/src/channels/chat-sdk-bridge-membership.test.ts
@@ -41,7 +41,11 @@ function lastRegisteredChat(): Chat {
 /** Drive a Chat process* dispatcher and await its internal task. */
 async function dispatch(fire: (options: { waitUntil: (p: Promise<unknown>) => void }) => void): Promise<void> {
   let task: Promise<unknown> | undefined;
-  fire({ waitUntil: (p) => (task = p) });
+  fire({
+    waitUntil: (p) => {
+      task = p;
+    },
+  });
   await task;
 }
 

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -700,7 +700,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           const startedAt = Date.now();
           // Capture the long-running listener promise via waitUntil
           let listenerPromise: Promise<unknown> | undefined;
-          gatewayAdapter.startGatewayListener!(
+          void gatewayAdapter.startGatewayListener!(
             {
               waitUntil: (p: Promise<unknown>) => {
                 listenerPromise = p;
@@ -709,34 +709,38 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
             24 * 60 * 60 * 1000,
             gatewayAbort!.signal,
             webhookUrl,
-          ).then(() => {
-            // startGatewayListener resolves immediately with a Response;
-            // the actual work is in the listenerPromise passed to waitUntil
-            if (!listenerPromise) return;
-            const reschedule = (err?: unknown) => {
-              if (gatewayAbort?.signal.aborted) return;
-              const ranForMs = Date.now() - startedAt;
-              if (ranForMs > 5 * 60 * 1000) consecutiveFailures = 0;
-              else consecutiveFailures++;
-              const delayMs = Math.min(60 * 60 * 1000, 2 ** consecutiveFailures * 1000);
-              if (err) {
-                log.error('Gateway listener error, retrying', {
-                  adapter: adapter.name,
-                  err,
-                  consecutiveFailures,
-                  delayMs,
-                });
-              } else {
-                log.info('Gateway listener expired, restarting', {
-                  adapter: adapter.name,
-                  consecutiveFailures,
-                  delayMs,
-                });
-              }
-              setTimeout(startGateway, delayMs);
-            };
-            listenerPromise.then(() => reschedule()).catch(reschedule);
-          });
+          )
+            .then(() => {
+              // startGatewayListener resolves immediately with a Response;
+              // the actual work is in the listenerPromise passed to waitUntil
+              if (!listenerPromise) return;
+              const reschedule = (err?: unknown) => {
+                if (gatewayAbort?.signal.aborted) return;
+                const ranForMs = Date.now() - startedAt;
+                if (ranForMs > 5 * 60 * 1000) consecutiveFailures = 0;
+                else consecutiveFailures++;
+                const delayMs = Math.min(60 * 60 * 1000, 2 ** consecutiveFailures * 1000);
+                if (err) {
+                  log.error('Gateway listener error, retrying', {
+                    adapter: adapter.name,
+                    err,
+                    consecutiveFailures,
+                    delayMs,
+                  });
+                } else {
+                  log.info('Gateway listener expired, restarting', {
+                    adapter: adapter.name,
+                    consecutiveFailures,
+                    delayMs,
+                  });
+                }
+                setTimeout(startGateway, delayMs);
+              };
+              void listenerPromise.then(() => reschedule()).catch(reschedule);
+            })
+            .catch((err) => {
+              log.error('Gateway listener failed to start', { adapter: adapter.name, err });
+            });
         };
         startGateway();
         log.info('Gateway listener started', { adapter: adapter.name });

--- a/src/channels/cli.ts
+++ b/src/channels/cli.ts
@@ -208,7 +208,7 @@ function createAdapter(): ChannelAdapter {
     };
     try {
       payload = JSON.parse(line);
-    } catch (err) {
+    } catch (_err) {
       log.warn('CLI: ignoring non-JSON line from client', { line });
       return;
     }

--- a/src/circuit-breaker.test.ts
+++ b/src/circuit-breaker.test.ts
@@ -6,19 +6,13 @@
  * before initDb, so it has to create the dir itself).
  */
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // vi.mock factories are hoisted above imports, so they can't close over local
 // consts. vi.hoisted is hoisted alongside the mock and runs before any
-// `import` — so it can only use globals (no path/os modules). Use require()
-// inside the callback to compute the test dir.
-const { TEST_DIR } = vi.hoisted(() => {
-  const nodePath = require('path') as typeof import('path');
-  const nodeOs = require('os') as typeof import('os');
-  return { TEST_DIR: nodePath.join(nodeOs.tmpdir(), 'nanoclaw-cb-test') };
-});
+// `import` — so it can only use globals (no path/os modules).
+const { TEST_DIR } = vi.hoisted(() => ({ TEST_DIR: '/tmp/nanoclaw-cb-test' }));
 const CB_PATH = path.join(TEST_DIR, 'circuit-breaker.json');
 
 vi.mock('./config.js', async () => {

--- a/src/circuit-breaker.ts
+++ b/src/circuit-breaker.ts
@@ -40,7 +40,9 @@ export function resetCircuitBreaker(): void {
   try {
     fs.unlinkSync(CB_PATH);
     log.info('Circuit breaker reset on clean shutdown');
-  } catch {}
+  } catch {
+    // Missing/stale breaker state is already the reset state.
+  }
 }
 
 export async function enforceStartupBackoff(): Promise<void> {

--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -398,8 +398,8 @@ export function validateArgs(
         if (typeof v === 'string') {
           try {
             out[def.name] = JSON.parse(v);
-          } catch {
-            throw new Error(`${flag} must be valid JSON`);
+          } catch (err) {
+            throw new Error(`${flag} must be valid JSON`, { cause: err });
           }
         }
         break;
@@ -504,7 +504,7 @@ export function registerResource(def: ResourceDef): void {
               } catch (e) {
                 const usage = renderVerbHelp(def, verb);
                 const msg = e instanceof Error ? e.message : String(e);
-                throw new Error(usage ? `${msg}\n\n${usage}` : msg);
+                throw new Error(usage ? `${msg}\n\n${usage}` : msg, { cause: e });
               }
             }
           : (raw) => normalizeArgs(raw),

--- a/src/cli/delivery-action.ts
+++ b/src/cli/delivery-action.ts
@@ -5,15 +5,12 @@
  * the delivery poll picks it up and calls this handler. We dispatch
  * the command and write the response back to inbound.db.
  */
-import type Database from 'better-sqlite3';
-
 import { registerDeliveryAction } from '../delivery.js';
 import { unguarded } from '../guard/index.js';
 import { insertMessage } from '../db/session-db.js';
 import { log } from '../log.js';
 import { dispatch } from './dispatch.js';
 import type { RequestFrame } from './frame.js';
-import type { Session } from '../types.js';
 
 registerDeliveryAction(
   'cli_request',

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -308,7 +308,7 @@ registerResource({
             message
               ? () => {
                   const s = getSession(ctx.sessionId);
-                  if (s) wakeContainer(s);
+                  if (s) void wakeContainer(s);
                 }
               : undefined,
           );

--- a/src/container-restart.ts
+++ b/src/container-restart.ts
@@ -52,7 +52,7 @@ export function restartAgentGroupContainers(agentGroupId: string, reason: string
       wakeMessage || hasPending
         ? () => {
             const s = getSession(session.id);
-            if (s) wakeContainer(s);
+            if (s) void wakeContainer(s);
           }
         : undefined,
     );

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -26,14 +26,7 @@ vi.mock('./config.js', async () => {
 
 const TEST_DIR = '/tmp/nanoclaw-test-delivery';
 
-import {
-  initTestDb,
-  closeDb,
-  runMigrations,
-  createAgentGroup,
-  createMessagingGroup,
-  createMessagingGroupAgent,
-} from './db/index.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createMessagingGroup } from './db/index.js';
 import { getDeliveredIds } from './db/session-db.js';
 import { resolveSession, resolveTaskSession, outboundDbPath, openInboundDb } from './session-manager.js';
 import {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -133,14 +133,14 @@ export function setDeliveryAdapter(adapter: ChannelDeliveryAdapter): void {
 export function startActiveDeliveryPoll(): void {
   if (activePolling) return;
   activePolling = true;
-  pollActive();
+  void pollActive();
 }
 
 /** Start the sweep poll loop (~60s). */
 export function startSweepDeliveryPoll(): void {
   if (sweepPolling) return;
   sweepPolling = true;
-  pollSweep();
+  void pollSweep();
 }
 
 async function pollActive(): Promise<void> {
@@ -155,7 +155,7 @@ async function pollActive(): Promise<void> {
     log.error('Active delivery poll error', { err });
   }
 
-  setTimeout(pollActive, ACTIVE_POLL_MS);
+  setTimeout(() => void pollActive(), ACTIVE_POLL_MS);
 }
 
 async function pollSweep(): Promise<void> {
@@ -170,7 +170,7 @@ async function pollSweep(): Promise<void> {
     log.error('Sweep delivery poll error', { err });
   }
 
-  setTimeout(pollSweep, SWEEP_POLL_MS);
+  setTimeout(() => void pollSweep(), SWEEP_POLL_MS);
 }
 
 export async function deliverSessionMessages(session: Session): Promise<void> {

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -138,7 +138,7 @@ let running = false;
 export function startHostSweep(): void {
   if (running) return;
   running = true;
-  sweep();
+  void sweep();
 }
 
 export function stopHostSweep(): void {
@@ -179,7 +179,7 @@ async function sweep(): Promise<void> {
   }
   // MODULE-HOOK:approvals-reason-sweep:end
 
-  setTimeout(sweep, SWEEP_INTERVAL_MS);
+  setTimeout(() => void sweep(), SWEEP_INTERVAL_MS);
 }
 
 /** A per-task session with no live tasks and no running container is spent → close it. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,8 +186,8 @@ async function shutdown(signal: string): Promise<void> {
   }
 }
 
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));
 
 main().catch((err) => {
   log.fatal('Startup failed', { err });

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -78,7 +78,7 @@ export async function applyInstallPackages(payload: Record<string, unknown>, ses
     });
     killContainer(session.id, 'rebuild applied', () => {
       const s = getSession(session.id);
-      if (s) wakeContainer(s);
+      if (s) void wakeContainer(s);
     });
     log.info('Container rebuild completed (bundled with install)', { agentGroupId: session.agent_group_id });
   } catch (e) {
@@ -152,7 +152,7 @@ export async function applyAddMcpServer(payload: Record<string, unknown>, sessio
   });
   killContainer(session.id, 'mcp server added', () => {
     const s = getSession(session.id);
-    if (s) wakeContainer(s);
+    if (s) void wakeContainer(s);
   });
   log.info('MCP server add approved', { agentGroupId: session.agent_group_id });
 }

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -112,51 +112,53 @@ function ensureServer(): void {
 
   const port = parseInt(process.env.WEBHOOK_PORT || String(DEFAULT_PORT), 10);
 
-  server = http.createServer(async (req, res) => {
-    const url = req.url || '/';
+  server = http.createServer((req, res) => {
+    void (async () => {
+      const url = req.url || '/';
 
-    // Route: /webhook/{adapterName}
-    const match = url.match(/^\/webhook\/([^/?]+)/);
-    if (!match) {
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end('Not found');
-      return;
-    }
-
-    const adapterName = match[1];
-
-    try {
-      // Raw routes take priority — the handler writes the response itself.
-      const rawHandler = rawRoutes.get(adapterName);
-      if (rawHandler) {
-        await rawHandler(req, res);
-        return;
-      }
-
-      const entry = routes.get(adapterName);
-      if (!entry) {
+      // Route: /webhook/{adapterName}
+      const match = url.match(/^\/webhook\/([^/?]+)/);
+      if (!match) {
         res.writeHead(404, { 'Content-Type': 'text/plain' });
-        res.end(`Unknown adapter: ${adapterName}`);
+        res.end('Not found');
         return;
       }
 
-      const webReq = await toWebRequest(req);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const webhooks = entry.chat.webhooks as Record<string, (r: Request, opts?: any) => Promise<Response>>;
-      const handler = webhooks[entry.adapterName];
-      const webRes = await handler(webReq, {
-        waitUntil: (p: Promise<unknown>) => {
-          p.catch(() => {});
-        },
-      });
-      await fromWebResponse(webRes, res);
-    } catch (err) {
-      log.error('Webhook handler error', { adapter: adapterName, url: req.url, err });
-      if (!res.headersSent) {
-        res.writeHead(500, { 'Content-Type': 'text/plain' });
-        res.end('Internal Server Error');
+      const adapterName = match[1];
+
+      try {
+        // Raw routes take priority — the handler writes the response itself.
+        const rawHandler = rawRoutes.get(adapterName);
+        if (rawHandler) {
+          await rawHandler(req, res);
+          return;
+        }
+
+        const entry = routes.get(adapterName);
+        if (!entry) {
+          res.writeHead(404, { 'Content-Type': 'text/plain' });
+          res.end(`Unknown adapter: ${adapterName}`);
+          return;
+        }
+
+        const webReq = await toWebRequest(req);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const webhooks = entry.chat.webhooks as Record<string, (r: Request, opts?: any) => Promise<Response>>;
+        const handler = webhooks[entry.adapterName];
+        const webRes = await handler(webReq, {
+          waitUntil: (p: Promise<unknown>) => {
+            void p.catch(() => {});
+          },
+        });
+        await fromWebResponse(webRes, res);
+      } catch (err) {
+        log.error('Webhook handler error', { adapter: adapterName, url: req.url, err });
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+          res.end('Internal Server Error');
+        }
       }
-    }
+    })();
   });
 
   server.listen(port, '0.0.0.0', () => {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Enable typed ESLint promise rules and fix the existing findings.

### Why

Promise misuse needs to fail lint before the central database API can safely become asynchronous.

### How it works

Enables project-service type information plus no-floating-promises, no-misused-promises, and await-thenable. Existing call sites are adjusted without behavior changes.

### How it was tested

pnpm run lint; pnpm run typecheck; pnpm run build; full SQLite Vitest suite excluding the unchanged macOS /var vs /private/var upstream transaction fixture. 1,614 SQLite tests passed.

Stack 1/7.