### PR TITLE
refactor(db): centralize the central database path

### DIFF
--- a/scripts/delete-cli-agent.ts
+++ b/scripts/delete-cli-agent.ts
@@ -12,7 +12,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH, DATA_DIR } from '../src/config.js';
 import { getAgentGroupByFolder, deleteAgentGroup } from '../src/db/agent-groups.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
@@ -36,7 +36,7 @@ function parseArgs(): Args {
 
 const args = parseArgs();
 
-const db = initDb(path.join(DATA_DIR, 'v2.db'));
+const db = initDb(CENTRAL_DB_PATH);
 runMigrations(db);
 
 const ag = getAgentGroupByFolder(args.folder);

--- a/scripts/init-cli-agent.ts
+++ b/scripts/init-cli-agent.ts
@@ -18,13 +18,11 @@
  *     --display-name "Gavriel" \
  *     [--agent-name "Andy"]
  */
-import path from 'path';
-
 // Registration-only: makes the in-tree cli adapter's declared defaults
 // (pattern '.', no threads, 'public') resolvable below.
 import '../src/channels/index.js';
 import { resolveUnknownSenderPolicy, resolveWiringDefaults } from '../src/channels/channel-defaults.js';
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH } from '../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { initDb } from '../src/db/connection.js';
 import {
@@ -88,7 +86,7 @@ function generateId(prefix: string): string {
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
-  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db);
 
   const now = new Date().toISOString();

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -43,7 +43,7 @@ import path from 'path';
 import '../src/channels/index.js';
 import { resolveUnknownSenderPolicy, resolveWiringDefaults } from '../src/channels/channel-defaults.js';
 import { hasDeclaredChannelDefaults } from '../src/channels/channel-registry.js';
-import { DATA_DIR, GROUPS_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH, DATA_DIR, GROUPS_DIR } from '../src/config.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { initDb } from '../src/db/connection.js';
 import {
@@ -231,7 +231,7 @@ function wireIfMissing(mg: MessagingGroup, ag: AgentGroup, now: string, label: s
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
-  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db); // idempotent
 
   const now = new Date().toISOString();

--- a/scripts/seed-discord.ts
+++ b/scripts/seed-discord.ts
@@ -3,9 +3,7 @@
  *
  * Usage: pnpm exec tsx scripts/seed-discord.ts
  */
-import path from 'path';
-
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup, getAgentGroup } from '../src/db/agent-groups.js';
@@ -15,7 +13,7 @@ import {
   getMessagingGroup,
 } from '../src/db/messaging-groups.js';
 
-const db = initDb(path.join(DATA_DIR, 'v2.db'));
+const db = initDb(CENTRAL_DB_PATH);
 runMigrations(db);
 
 const AGENT_GROUP_ID = 'ag-main';

--- a/setup/migrate-v2/db.ts
+++ b/setup/migrate-v2/db.ts
@@ -15,7 +15,7 @@ import path from 'path';
 
 import Database from 'better-sqlite3';
 
-import { DATA_DIR } from '../../src/config.js';
+import { CENTRAL_DB_PATH } from '../../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../../src/db/agent-groups.js';
 import { initDb } from '../../src/db/connection.js';
 import {
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
 
   // Init v2 DB
   fs.mkdirSync(path.join(process.cwd(), 'data'), { recursive: true });
-  const v2Db = initDb(path.join(DATA_DIR, 'v2.db'));
+  const v2Db = initDb(CENTRAL_DB_PATH);
   runMigrations(v2Db);
 
   let created = 0;

--- a/setup/migrate-v2/sessions.ts
+++ b/setup/migrate-v2/sessions.ts
@@ -22,7 +22,7 @@ import path from 'path';
 
 import Database from 'better-sqlite3';
 
-import { DATA_DIR } from '../../src/config.js';
+import { CENTRAL_DB_PATH, DATA_DIR } from '../../src/config.js';
 import { initDb, closeDb } from '../../src/db/connection.js';
 import { getAllAgentGroups } from '../../src/db/agent-groups.js';
 import { getMessagingGroupsByAgentGroup } from '../../src/db/messaging-groups.js';
@@ -73,7 +73,7 @@ function main(): void {
   }
 
   // Init v2 central DB
-  const v2DbPath = path.join(DATA_DIR, 'v2.db');
+  const v2DbPath = CENTRAL_DB_PATH;
   if (!fs.existsSync(v2DbPath)) {
     console.error('v2.db not found — run db step first');
     process.exit(1);

--- a/setup/migrate-v2/tasks.ts
+++ b/setup/migrate-v2/tasks.ts
@@ -15,7 +15,7 @@ import path from 'path';
 
 import Database from 'better-sqlite3';
 
-import { DATA_DIR } from '../../src/config.js';
+import { CENTRAL_DB_PATH, DATA_DIR } from '../../src/config.js';
 import { initDb, closeDb } from '../../src/db/connection.js';
 import { getAgentGroupByFolder } from '../../src/db/agent-groups.js';
 import { getMessagingGroupByPlatform } from '../../src/db/messaging-groups.js';
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
   }
 
   // Init v2 central DB
-  const v2DbPath = path.join(DATA_DIR, 'v2.db');
+  const v2DbPath = CENTRAL_DB_PATH;
   if (!fs.existsSync(v2DbPath)) {
     console.error('v2.db not found — run db step first');
     process.exit(1);

--- a/setup/pair-telegram.ts
+++ b/setup/pair-telegram.ts
@@ -18,8 +18,6 @@
  * excluded from the host tsconfig, so this file's import resolves only at
  * runtime — tsc won't complain on branches that haven't run add-telegram yet.
  */
-import path from 'path';
-
 import * as p from '@clack/prompts';
 
 import {
@@ -27,7 +25,7 @@ import {
   waitForPairing,
   type PairingIntent,
 } from '../src/channels/telegram-pairing.js';
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 
@@ -87,7 +85,7 @@ export async function run(args: string[]): Promise<void> {
   // pairing primitive itself, but the inbound interceptor running inside the
   // live service needs migrations applied. Touch it here so a fresh install
   // doesn't fail on the first code match.
-  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db);
 
   const MAX_REGENERATIONS = 5;

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -17,7 +17,7 @@ import {
   validateEngageAgainstChannel,
 } from '../src/channels/channel-defaults.js';
 import { hasDeclaredChannelDefaults } from '../src/channels/channel-registry.js';
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
@@ -181,8 +181,7 @@ export async function run(args: string[]): Promise<void> {
 
   // Init v2 central DB
   fs.mkdirSync(path.join(projectRoot, 'data'), { recursive: true });
-  const dbPath = path.join(DATA_DIR, 'v2.db');
-  const db = initDb(dbPath);
+  const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db);
 
   // 1. Create or find agent group. The workspace is scaffolded at the first

--- a/setup/registry-reconcile.ts
+++ b/setup/registry-reconcile.ts
@@ -16,12 +16,11 @@
  * Idempotent — a second run finds nothing pinned and nothing to remove.
  */
 import fs from 'fs';
-import path from 'path';
 import { spawnSync } from 'child_process';
 
 import type DatabaseType from 'better-sqlite3';
 
-import { CONTAINER_IMAGE_BASE, DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH, CONTAINER_IMAGE_BASE } from '../src/config.js';
 import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
 import { getAllContainerConfigs, updateContainerConfigScalars } from '../src/db/container-configs.js';
 import { getDb, hasTable, initDb } from '../src/db/connection.js';
@@ -63,7 +62,7 @@ const SAFE_IMAGE_REF = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*:[a-zA-Z0-9][a-zA-Z0-9_.-]*
 export function reconcileDerivedImages(): ReconcileResult {
   const result = emptyResult();
 
-  const dbPath = path.join(DATA_DIR, 'v2.db');
+  const dbPath = CENTRAL_DB_PATH;
   if (!fs.existsSync(dbPath)) {
     // First install: no central DB, so no group has ever built a derived
     // image. Bail before initDb, which would create an empty file here.

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import Database from 'better-sqlite3';
 
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH } from '../src/config.js';
 import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
@@ -200,7 +200,7 @@ export async function run(_args: string[]): Promise<void> {
   //    partially migrated DB must not hide one behind the other's failure.
   let registeredGroups = 0;
   let derivedGroups = 0;
-  const dbPath = path.join(DATA_DIR, 'v2.db');
+  const dbPath = CENTRAL_DB_PATH;
   if (fs.existsSync(dbPath)) {
     let db: Database.Database | null = null;
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,7 @@ export const SENDER_ALLOWLIST_PATH = path.join(HOME_DIR, '.config', 'nanoclaw', 
 export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+export const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
 // Local agent-template library. Committed but ships empty (+ README). Resolved
 // once at load. Override to another LOCAL path via NANOCLAW_TEMPLATES_DIR; never
 // a remote URL, never an ncl flag, never runtime-mutable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,8 @@
  * Thin orchestrator: init DB, run migrations, start channel adapters,
  * start delivery polls, start sweep, handle shutdown.
  */
-import path from 'path';
-
 import { backfillContainerConfigs } from './backfill-container-configs.js';
-import { DATA_DIR } from './config.js';
+import { CENTRAL_DB_PATH } from './config.js';
 import { enforceStartupBackoff, resetCircuitBreaker } from './circuit-breaker.js';
 import { initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
@@ -71,10 +69,9 @@ async function main(): Promise<void> {
   enforceUpgradeTripwire();
 
   // 1. Init central DB
-  const dbPath = path.join(DATA_DIR, 'v2.db');
-  const db = initDb(dbPath);
+  const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db);
-  log.info('Central DB ready', { path: dbPath });
+  log.info('Central DB ready', { path: CENTRAL_DB_PATH });
 
   // 1b. Backfill container_configs from legacy container.json files.
   // Idempotent — skips groups that already have a config row.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Add `CENTRAL_DB_PATH` and replace duplicated `data/v2.db` path construction.

### Why

A single neutral path constant gives central-database tooling one stable target without introducing any remote-backend configuration.

### How it works

Host, setup, and scripts import the same path constant. No PostgreSQL environment variables or behavior changes are introduced.

### How it was tested

pnpm run lint; pnpm run typecheck; pnpm run build; full SQLite Vitest suite excluding the unchanged macOS /var vs /private/var upstream transaction fixture. 1,614 SQLite tests passed.

Stack 2/7; depends on the preceding lint PR.