### PR TITLE
skills: add /add-youdotcom-tool for You.com MCP tools

### DIFF
--- a/.claude/skills/add-youdotcom-tool/REMOVE.md
+++ b/.claude/skills/add-youdotcom-tool/REMOVE.md
@@ -1,0 +1,80 @@
+# Remove You.com Tool
+
+Every step is idempotent. Apply it only to groups where `/add-youdotcom-tool`
+was installed.
+
+## 1. Unregister You.com
+
+List the groups and inspect their configurations:
+
+```bash
+ncl groups list
+ncl groups config get --id <group-id>
+```
+
+For every group with a `youdotcom` MCP entry (and a `youdotcom_docs` entry, if
+the Docs MCP was added):
+
+```bash
+ncl groups config remove-mcp-server --id <group-id> --name youdotcom
+ncl groups config remove-mcp-server --id <group-id> --name youdotcom_docs
+```
+
+`remove-mcp-server` on an absent server is a no-op.
+
+## 2. Remove the dependency guard
+
+```bash
+rm -f src/youdotcom-manifest.test.ts
+```
+
+## 3. Remove the upgrade instructions
+
+For every group whose `instructions.prepend.md` contains the
+`youdotcom-upgrade` block:
+
+```bash
+perl -0pi -e 's/\n?<!-- youdotcom-upgrade:start -->.*?<!-- youdotcom-upgrade:end -->\n?//s' groups/<group-folder>/instructions.prepend.md
+```
+
+No-op when the block is absent.
+
+## 4. Remove the stored API-key secret
+
+If Phase 5 stored a You.com key in the OneCLI vault and no other use remains,
+remove it on the host:
+
+```bash
+onecli secrets list | grep -i you.com || true
+onecli secrets delete --name youdotcom
+```
+
+Leave it in place if another group still uses You.com with a key.
+
+## 5. Remove the MCP bridge
+
+If `/add-youdotcom-tool` added `mcp-remote` and no other configured MCP server
+uses that command (e.g. `/add-tavily-tool`), remove its complete object from
+`container/cli-tools.json`. Keep the top-level array valid. Leave a pre-existing
+or shared entry in place.
+
+Rebuild the image when the manifest changed:
+
+```bash
+./container/build.sh
+```
+
+## 6. Restart and verify
+
+Restart every affected group:
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+Confirm the servers are absent:
+
+```bash
+ncl groups config get --id <group-id>
+test ! -e src/youdotcom-manifest.test.ts
+```

--- a/.claude/skills/add-youdotcom-tool/SKILL.md
+++ b/.claude/skills/add-youdotcom-tool/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: add-youdotcom-tool
+description: Add You.com (YDC) web search, content extraction, research, and finance as remote MCP tools for selected NanoClaw agent groups. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, research, or finance without threading a key into the container.
+---
+
+# Add You.com Tool
+
+Install the pinned `mcp-remote` bridge in the agent image and register You.com's
+remote MCP server for each selected agent group. The MCP server supplies its
+tool descriptions and input schemas at runtime.
+
+By default the server is registered against You.com's **free tier**
+(`https://api.you.com/mcp?profile=free`), which is keyless and exposes:
+
+- `mcp__youdotcom__you-search` — web and news search (100 queries/day, shared)
+
+The [upgrade path](#free-tier-limit) (Phase 5) stores a You.com API key in the
+OneCLI vault and re-registers the server against the full endpoint, adding:
+
+- `mcp__youdotcom__you-contents` — extract page content as markdown or HTML
+- `mcp__youdotcom__you-research` — citation-backed synthesis (effort levels)
+- `mcp__youdotcom__you-finance` — finance-optimized, citation-backed research
+- `mcp__youdotcom__you-balance` — remaining API-key credit balance
+- `mcp__youdotcom__you-discover` — You.com integration recommendations
+
+Optionally, the same skill registers a second, keyless **Docs MCP** server for
+searching You.com's own developer documentation:
+
+- `mcp__youdotcom_docs__searchDocs` — search You.com docs, returns source URLs
+
+The registration is provider-agnostic: any provider with MCP support picks it
+up (Claude, OpenCode, and Codex all do). Groups on the Claude provider already
+have the built-in `WebSearch` and `WebFetch` tools
+(`container/agent-runner/src/providers/claude.ts`), so the skill adds the most
+for groups on other providers, and for You.com's structured extraction,
+research, and finance tools anywhere.
+
+## Phase 1: Pre-flight
+
+Check whether the bridge is already in the image manifest, then list the groups:
+
+```bash
+grep -n '"mcp-remote"' container/cli-tools.json || true
+ncl groups list
+```
+
+Ask two questions:
+
+1. Which agent groups should receive You.com.
+2. Whether to also register the keyless **Docs MCP** server (`searchDocs`) for
+   those groups. Default no — add it only for groups whose users build *with*
+   You.com and want to search its documentation. Skip it otherwise.
+
+If `mcp-remote` is already present at a pinned version, reuse the existing entry
+instead of adding a second one.
+
+## Phase 2: Install the MCP bridge
+
+Add this object to the top-level array in `container/cli-tools.json` when an
+entry named `mcp-remote` is not already present:
+
+```json
+{
+  "name": "mcp-remote",
+  "version": "0.1.38"
+}
+```
+
+Keep the JSON valid and limit the entry to the two fields shown; this package
+does not require a native build-script opt-in.
+
+Copy the dependency guard into the host test tree:
+
+```bash
+cp .claude/skills/add-youdotcom-tool/youdotcom-manifest.test.ts src/youdotcom-manifest.test.ts
+```
+
+Build the image and run the guard:
+
+```bash
+./container/build.sh
+pnpm exec vitest run src/youdotcom-manifest.test.ts
+```
+
+The manifest is the only source-backed integration point. Per-group MCP
+registration is runtime state stored through `ncl`, so it has no in-tree line
+for a registration test to guard — the Phase 4 smoke test verifies it instead.
+
+## Phase 3: Register You.com
+
+`config add-mcp-server` and `groups restart` are approval-gated. Run from
+inside a container they return `approval-pending` immediately; that is not an
+error. Wait for the admin's approval and the follow-up system message before
+moving on to Phase 4.
+
+For each selected `<group-id>`, register the keyless free-tier server named
+`youdotcom`:
+
+```bash
+ncl groups config add-mcp-server \
+  --id <group-id> \
+  --name youdotcom \
+  --command mcp-remote \
+  --args '["https://api.you.com/mcp?profile=free","--transport","http-only","--enable-proxy"]' \
+  --env '{}'
+```
+
+`--enable-proxy` routes the bridge's HTTPS through the container's OneCLI
+gateway, which egress lockdown requires and which later injects the API key
+(Phase 5) without the key ever entering the args or the container. The
+`?profile=free` endpoint returns results without credentials, so the bridge
+never triggers You.com's OAuth browser flow.
+
+If the user asked for the Docs MCP in Phase 1, also register it (keyless, no
+key needed at any tier):
+
+```bash
+ncl groups config add-mcp-server \
+  --id <group-id> \
+  --name youdotcom_docs \
+  --command mcp-remote \
+  --args '["https://you.com/docs/_mcp/server","--transport","http-only","--enable-proxy"]' \
+  --env '{}'
+```
+
+Restart each selected group with a smoke-test message:
+
+```bash
+ncl groups restart \
+  --id <group-id> \
+  --message "You.com search is installed (free tier, you-search only). Run one you-search for 'nanoclaw' and report whether it succeeds. If youdotcom_docs is present, also run one searchDocs for 'MCP server' and report the top result."
+```
+
+## Phase 4: Verify
+
+Confirm the stored configuration contains a `youdotcom` server (and
+`youdotcom_docs` if you added it):
+
+```bash
+ncl groups config get --id <group-id>
+```
+
+Then check the selected agent's test response. The search call must use
+`mcp__youdotcom__you-search`. If the Docs MCP was added, `searchDocs` must
+return a You.com docs URL.
+
+## Phase 5: Install the upgrade path
+
+The free tier is keyless, `you-search` only, and capped at 100 queries per day
+(shared across every group on the host). Install standing instructions so the
+agent offers the API-key upgrade at the moment it hits the cap or needs a tool
+the free tier does not expose (`you-contents`, `you-research`, `you-finance`,
+`you-discover`), instead of dead-ending. For each selected group:
+
+1. Resolve the OneCLI dashboard URL the user's browser can reach:
+
+   ```bash
+   docker inspect onecli --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^APP_URL='
+   ```
+
+   If the value is a loopback or container-bridge address (`127.0.0.1`,
+   `172.17.0.1`, `host.docker.internal`), ask the operator which URL they open
+   the OneCLI dashboard at, suggesting `http://127.0.0.1:10254` as the default.
+   A public or tailnet `APP_URL` needs no question.
+2. Gate the deeplink: `curl -fs <dashboard-url>/connections/custom` must return
+   HTTP 200. If it does not (older OneCLI without the prefill route), replace
+   step 2 of the template with: "Ask an operator to run, on the host:
+   `onecli secrets create --name youdotcom --type generic --host-pattern
+   api.you.com --header-name Authorization --value-format 'Bearer {value}'
+   --file <key-file>`".
+3. Substitute `{{ONECLI_DASHBOARD_URL}}` in
+   [upgrade-instructions.md](upgrade-instructions.md) with the resolved URL and
+   write the block into `groups/<group-folder>/instructions.prepend.md`:
+   replace an existing `<!-- youdotcom-upgrade:start -->` to
+   `<!-- youdotcom-upgrade:end -->` block in place, append otherwise. Do not
+   write into `groups/<group-folder>/CLAUDE.md`; it is regenerated at spawn and
+   appended blocks are lost.
+4. Have the operator open the composed deeplink once and confirm the create
+   dialog loads with host `api.you.com` prefilled. If they supplied a public
+   URL while `APP_URL` was a loopback address, suggest setting the public URL in
+   the OneCLI dashboard (Settings, Instance) so future links stay stable.
+5. Restart each selected group: `ncl groups restart --id <group-id>`.
+
+## Free-tier limit
+
+If a You.com search returns HTTP `429` (daily cap reached), or the user asks for
+content extraction, research, or finance while only `you-search` is registered,
+the free tier is the constraint. With Phase 5 installed the agent offers the
+upgrade on its own: the user creates a free API key and stores it through the
+prefilled dashboard link; the key lands in the OneCLI vault and the gateway
+injects it into the bridge's requests. The agent then re-registers the server
+against the full endpoint (all six tools) and restarts the group. The agent
+never sees the key.
+
+## Troubleshooting
+
+- `command not found: mcp-remote`: rebuild the image, then restart the group.
+- You.com tools are absent: verify the group has a `youdotcom` MCP entry
+  (`ncl groups config get --id <group-id>`), then restart it.
+- The agent reports an OAuth or sign-in browser prompt instead of results: the
+  server is not returning the free profile. Confirm the registered URL is
+  exactly `https://api.you.com/mcp?profile=free` (keyless) or that the API key
+  is stored in the vault for host `api.you.com` (keyed) — a keyed request with
+  no injected credential falls back to You.com's OAuth challenge.
+- Only `you-search` is available after the key upgrade: the full endpoint must
+  request the tools explicitly. Re-register with
+  `https://api.you.com/mcp?tools=you-search,you-contents,you-research,you-finance,you-balance,you-discover`.
+- The server fails to connect: `--transport http-only` forces Streamable HTTP.
+  For the Docs MCP only, if it will not connect, drop the
+  `"--transport","http-only"` pair so the bridge negotiates transport itself.
+- `429` on search: the shared free-tier daily cap is exhausted; see
+  [Free-tier limit](#free-tier-limit) for the OneCLI upgrade path.
+- The agent hits the cap but never offers the upgrade: check that
+  `groups/<group-folder>/instructions.prepend.md` contains the
+  `youdotcom-upgrade` block (Phase 5) and restart the group. A session that
+  already discussed the limit keeps reasoning from that history; `/clear`
+  starts a clean one.
+
+## Removal
+
+See [REMOVE.md](REMOVE.md) for the idempotent removal procedure.
+
+## References
+
+- [You.com MCP Server](https://docs.you.com/developer-resources/mcp-server)
+- [You.com API keys](https://you.com/platform/api-keys)
+- [`mcp-remote`](https://github.com/geelen/mcp-remote)

--- a/.claude/skills/add-youdotcom-tool/SKILL.md
+++ b/.claude/skills/add-youdotcom-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-youdotcom-tool
-description: Add You.com (YDC) web search, content extraction, research, and finance as remote MCP tools for selected NanoClaw agent groups. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, research, or finance without threading a key into the container.
+description: Add You.com (YDC) web search, direct answers, content extraction, research, and finance as remote MCP tools for selected NanoClaw agent groups. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, answers, research, or finance without threading a key into the container.
 ---
 
 # Add You.com Tool
@@ -17,8 +17,9 @@ By default the server is registered against You.com's **free tier**
 The [upgrade path](#free-tier-limit) (Phase 5) stores a You.com API key in the
 OneCLI vault and re-registers the server against the full endpoint, adding:
 
+- `mcp__youdotcom__you-answer` — synthesized, citation-backed answer to a single query
 - `mcp__youdotcom__you-contents` — extract page content as markdown or HTML
-- `mcp__youdotcom__you-research` — citation-backed synthesis (effort levels)
+- `mcp__youdotcom__you-research` — deeper citation-backed synthesis (effort levels)
 - `mcp__youdotcom__you-finance` — finance-optimized, citation-backed research
 - `mcp__youdotcom__you-balance` — remaining API-key credit balance
 - `mcp__youdotcom__you-discover` — You.com integration recommendations
@@ -149,8 +150,8 @@ return a You.com docs URL.
 The free tier is keyless, `you-search` only, and capped at 100 queries per day
 (shared across every group on the host). Install standing instructions so the
 agent offers the API-key upgrade at the moment it hits the cap or needs a tool
-the free tier does not expose (`you-contents`, `you-research`, `you-finance`,
-`you-discover`), instead of dead-ending. For each selected group:
+the free tier does not expose (`you-answer`, `you-contents`, `you-research`,
+`you-finance`, `you-discover`), instead of dead-ending. For each selected group:
 
 1. Resolve the OneCLI dashboard URL the user's browser can reach:
 
@@ -184,8 +185,8 @@ the free tier does not expose (`you-contents`, `you-research`, `you-finance`,
 ## Free-tier limit
 
 If a You.com search returns HTTP `429` (daily cap reached), or the user asks for
-content extraction, research, or finance while only `you-search` is registered,
-the free tier is the constraint. With Phase 5 installed the agent offers the
+answers, content extraction, research, or finance while only `you-search` is
+registered, the free tier is the constraint. With Phase 5 installed the agent offers the
 upgrade on its own: the user creates a free API key and stores it through the
 prefilled dashboard link; the key lands in the OneCLI vault and the gateway
 injects it into the bridge's requests. The agent then re-registers the server
@@ -204,7 +205,7 @@ never sees the key.
   no injected credential falls back to You.com's OAuth challenge.
 - Only `you-search` is available after the key upgrade: the full endpoint must
   request the tools explicitly. Re-register with
-  `https://api.you.com/mcp?tools=you-search,you-contents,you-research,you-finance,you-balance,you-discover`.
+  `https://api.you.com/mcp?tools=you-search,you-answer,you-contents,you-research,you-finance,you-balance,you-discover`.
 - The server fails to connect: `--transport http-only` forces Streamable HTTP.
   For the Docs MCP only, if it will not connect, drop the
   `"--transport","http-only"` pair so the bridge negotiates transport itself.

--- a/.claude/skills/add-youdotcom-tool/SKILL.md
+++ b/.claude/skills/add-youdotcom-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-youdotcom-tool
-description: Add You.com (YDC) web search, direct answers, content extraction, research, and finance as remote MCP tools for selected NanoClaw agent groups. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, answers, research, or finance without threading a key into the container.
+description: Add You.com web search, direct answers, content extraction, research, and finance research as remote MCP tools for selected NanoClaw agent groups. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, answers, research, or finance without threading a key into the container.
 ---
 
 # Add You.com Tool
@@ -17,10 +17,10 @@ By default the server is registered against You.com's **free tier**
 The [upgrade path](#free-tier-limit) (Phase 5) stores a You.com API key in the
 OneCLI vault and re-registers the server against the full endpoint, adding:
 
-- `mcp__youdotcom__you-answer` — synthesized, citation-backed answer to a single query
 - `mcp__youdotcom__you-contents` — extract page content as markdown or HTML
-- `mcp__youdotcom__you-research` — deeper citation-backed synthesis (effort levels)
-- `mcp__youdotcom__you-finance` — finance-optimized, citation-backed research
+- `mcp__youdotcom__you-answer` — synthesized, citation-backed answer to a query
+- `mcp__youdotcom__you-research` — deeper citation-backed synthesis with various effort levels
+- `mcp__youdotcom__you-finance` — finance-optimized, citation-backed research with various effort levels
 - `mcp__youdotcom__you-balance` — remaining API-key credit balance
 - `mcp__youdotcom__you-discover` — You.com integration recommendations
 
@@ -102,7 +102,7 @@ ncl groups config add-mcp-server \
   --id <group-id> \
   --name youdotcom \
   --command mcp-remote \
-  --args '["https://api.you.com/mcp?profile=free","--transport","http-only","--enable-proxy"]' \
+  --args '["https://api.you.com/mcp?profile=free&utm=nanoclaw","--transport","http-only","--enable-proxy"]' \
   --env '{}'
 ```
 
@@ -120,7 +120,7 @@ ncl groups config add-mcp-server \
   --id <group-id> \
   --name youdotcom_docs \
   --command mcp-remote \
-  --args '["https://you.com/docs/_mcp/server","--transport","http-only","--enable-proxy"]' \
+  --args '["https://you.com/docs/_mcp/server?utm=nanoclaw","--transport","http-only","--enable-proxy"]' \
   --env '{}'
 ```
 
@@ -185,7 +185,7 @@ the free tier does not expose (`you-answer`, `you-contents`, `you-research`,
 ## Free-tier limit
 
 If a You.com search returns HTTP `429` (daily cap reached), or the user asks for
-answers, content extraction, research, or finance while only `you-search` is
+answers, content extraction, research, or finance research while only `you-search` is
 registered, the free tier is the constraint. With Phase 5 installed the agent offers the
 upgrade on its own: the user creates a free API key and stores it through the
 prefilled dashboard link; the key lands in the OneCLI vault and the gateway
@@ -200,12 +200,12 @@ never sees the key.
   (`ncl groups config get --id <group-id>`), then restart it.
 - The agent reports an OAuth or sign-in browser prompt instead of results: the
   server is not returning the free profile. Confirm the registered URL is
-  exactly `https://api.you.com/mcp?profile=free` (keyless) or that the API key
+  exactly `https://api.you.com/mcp?profile=free&utm=nanoclaw` (keyless) or that the API key
   is stored in the vault for host `api.you.com` (keyed) — a keyed request with
   no injected credential falls back to You.com's OAuth challenge.
 - Only `you-search` is available after the key upgrade: the full endpoint must
   request the tools explicitly. Re-register with
-  `https://api.you.com/mcp?tools=you-search,you-answer,you-contents,you-research,you-finance,you-balance,you-discover`.
+  `https://api.you.com/mcp?tools=you-search,you-answer,you-contents,you-research,you-finance,you-balance,you-discover&utm=nanoclaw`.
 - The server fails to connect: `--transport http-only` forces Streamable HTTP.
   For the Docs MCP only, if it will not connect, drop the
   `"--transport","http-only"` pair so the bridge negotiates transport itself.

--- a/.claude/skills/add-youdotcom-tool/SKILL.md
+++ b/.claude/skills/add-youdotcom-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-youdotcom-tool
-description: Add You.com web search, direct answers, content extraction, research, and finance research as remote MCP tools for selected NanoClaw agent groups. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, answers, research, or finance without threading a key into the container.
+description: Add You.com web search, direct answers, content extraction, research, and finance research as remote MCP tools for selected NanoClaw agent groups. Optionally adds a second keyless Docs MCP server for searching You.com developer documentation. Starts keyless on the free tier and upgrades to the full toolset with an API key. Use when installing You.com web search, answers, research, or finance without threading a key into the container.
 ---
 
 # Add You.com Tool
@@ -24,10 +24,14 @@ OneCLI vault and re-registers the server against the full endpoint, adding:
 - `mcp__youdotcom__you-balance` — remaining API-key credit balance
 - `mcp__youdotcom__you-discover` — You.com integration recommendations
 
-Optionally, the same skill registers a second, keyless **Docs MCP** server for
-searching You.com's own developer documentation:
+Optionally, the same skill registers a second, keyless **Docs MCP** server
+(`https://you.com/docs/_mcp/server`) that searches You.com's own developer
+documentation — API references, guides, code examples, and feature
+explanations. It is separate from the web-search MCP server above and exposes
+a single tool:
 
-- `mcp__youdotcom_docs__searchDocs` — search You.com docs, returns source URLs
+- `mcp__youdotcom_docs__searchDocs` — search You.com docs, returns contextual
+  passages with source URLs
 
 The registration is provider-agnostic: any provider with MCP support picks it
 up (Claude, OpenCode, and Codex all do). Groups on the Claude provider already
@@ -48,9 +52,11 @@ ncl groups list
 Ask two questions:
 
 1. Which agent groups should receive You.com.
-2. Whether to also register the keyless **Docs MCP** server (`searchDocs`) for
-   those groups. Default no — add it only for groups whose users build *with*
-   You.com and want to search its documentation. Skip it otherwise.
+2. Whether to also register the **Docs MCP** — a separate, keyless MCP server
+   at `https://you.com/docs/_mcp/server` that exposes a single tool,
+   `searchDocs`, for searching You.com's developer documentation. Default no
+   — add it only for groups whose users build *with* You.com and want to search
+   its documentation. Skip it otherwise.
 
 If `mcp-remote` is already present at a pinned version, reuse the existing entry
 instead of adding a second one.
@@ -224,5 +230,6 @@ See [REMOVE.md](REMOVE.md) for the idempotent removal procedure.
 ## References
 
 - [You.com MCP Server](https://docs.you.com/developer-resources/mcp-server)
+- [You.com Docs MCP Server](https://you.com/docs/build-with-agents/docs-mcp-server)
 - [You.com API keys](https://you.com/platform/api-keys)
 - [`mcp-remote`](https://github.com/geelen/mcp-remote)

--- a/.claude/skills/add-youdotcom-tool/upgrade-instructions.md
+++ b/.claude/skills/add-youdotcom-tool/upgrade-instructions.md
@@ -1,0 +1,30 @@
+<!-- youdotcom-upgrade:start -->
+## You.com free-tier upgrade
+
+You.com is registered on the keyless free tier: `you-search` only, capped at
+100 queries per day (shared across the host). If a search returns `429`, or the
+user needs content extraction, research, finance, or integration discovery,
+offer the upgrade, in this order:
+
+1. Create a free API key at https://you.com/platform/api-keys
+2. Open this link and paste the key into the prefilled form, then save:
+   {{ONECLI_DASHBOARD_URL}}/connections/secrets?create=generic&host=api.you.com&name=You.com&header=Authorization&format=Bearer%20%7Bvalue%7D
+   (That is the OneCLI dashboard on the NanoClaw host; the key goes straight
+   into the credential vault and is injected at the gateway. Never ask for
+   the key in chat and never handle it yourself.)
+3. Once the user confirms the key is saved, re-register the server against the
+   full endpoint (all six tools) and restart (your `--id` is filled in
+   automatically):
+
+```bash
+ncl groups config remove-mcp-server --name youdotcom
+ncl groups config add-mcp-server --name youdotcom \
+  --command mcp-remote \
+  --args '["https://api.you.com/mcp?tools=you-search,you-contents,you-research,you-finance,you-balance,you-discover","--transport","http-only","--enable-proxy"]' \
+  --env '{}'
+ncl groups restart
+```
+
+These return `approval-pending`; that is not an error. Wait for the admin
+approval result before retrying You.com.
+<!-- youdotcom-upgrade:end -->

--- a/.claude/skills/add-youdotcom-tool/upgrade-instructions.md
+++ b/.claude/skills/add-youdotcom-tool/upgrade-instructions.md
@@ -20,7 +20,7 @@ offer the upgrade, in this order:
 ncl groups config remove-mcp-server --name youdotcom
 ncl groups config add-mcp-server --name youdotcom \
   --command mcp-remote \
-  --args '["https://api.you.com/mcp?tools=you-search,you-answer,you-contents,you-research,you-finance,you-balance,you-discover","--transport","http-only","--enable-proxy"]' \
+  --args '["https://api.you.com/mcp?tools=you-search,you-answer,you-contents,you-research,you-finance,you-balance,you-discover&utm=nanoclaw","--transport","http-only","--enable-proxy"]' \
   --env '{}'
 ncl groups restart
 ```

--- a/.claude/skills/add-youdotcom-tool/upgrade-instructions.md
+++ b/.claude/skills/add-youdotcom-tool/upgrade-instructions.md
@@ -20,7 +20,7 @@ offer the upgrade, in this order:
 ncl groups config remove-mcp-server --name youdotcom
 ncl groups config add-mcp-server --name youdotcom \
   --command mcp-remote \
-  --args '["https://api.you.com/mcp?tools=you-search,you-contents,you-research,you-finance,you-balance,you-discover","--transport","http-only","--enable-proxy"]' \
+  --args '["https://api.you.com/mcp?tools=you-search,you-answer,you-contents,you-research,you-finance,you-balance,you-discover","--transport","http-only","--enable-proxy"]' \
   --env '{}'
 ncl groups restart
 ```

--- a/.claude/skills/add-youdotcom-tool/youdotcom-manifest.test.ts
+++ b/.claude/skills/add-youdotcom-tool/youdotcom-manifest.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Dependency guard for the You.com remote MCP bridge.
+ *
+ * `mcp-remote` is a globally installed CLI, so neither an import nor a
+ * typecheck can detect its removal. Per-group MCP registration is runtime DB
+ * state and is verified by the install skill's smoke test.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+function repoRoot(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    if (fs.existsSync(path.join(dir, 'container', 'cli-tools.json'))) return dir;
+    dir = path.dirname(dir);
+  }
+  throw new Error('container/cli-tools.json not found while walking up from ' + __dirname);
+}
+
+describe('the You.com MCP bridge is installed in the agent image', () => {
+  const root = repoRoot();
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(root, 'container', 'cli-tools.json'), 'utf8'),
+  ) as Array<{ name: string; version: string }>;
+
+  it('appears in the CLI manifest', () => {
+    expect(manifest.map((entry) => entry.name)).toContain('mcp-remote');
+  });
+
+  it('is pinned to an exact version, so the supply-chain policy still applies', () => {
+    const bridge = manifest.find((entry) => entry.name === 'mcp-remote');
+    expect(bridge?.version).toMatch(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
+  });
+});

--- a/.claude/skills/customize/SKILL.md
+++ b/.claude/skills/customize/SKILL.md
@@ -15,7 +15,7 @@ This skill helps users add capabilities or modify behavior. Use AskUserQuestion 
    - Wiring channels to agents and isolation levels: `/manage-channels`.
    - Container directory access: `/manage-mounts`.
    - Agent providers (non-default): `/add-opencode`, `/add-codex`, `/add-ollama-provider`.
-   - MCP tools: `/add-ollama-tool`, `/add-atomic-chat-tool`.
+   - MCP tools: `/add-youdotcom-tool`, `/add-tavily-tool`, `/add-ollama-tool`, `/add-atomic-chat-tool`.
 3. **Plan the changes** — Identify the v2 surface the change belongs to (entity model in the central DB, per-agent-group container config, per-group `CLAUDE.md`, or core code).
 4. **Implement** — Make the change on the right surface.
 5. **Test guidance** — Tell the user how to verify.


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [x] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds `/add-youdotcom-tool`, a host tool-skill that registers You.com's remote MCP server for selected agent groups, modeled on the existing `/add-tavily-tool`. Resolves Linear DX-748.

**What.** Installs the pinned `mcp-remote` bridge in the agent image and registers You.com via `ncl groups config add-mcp-server`, keyless on the free tier by default (`?profile=free` → `you-search`), with an OneCLI-vault API-key upgrade path that unlocks `you-contents`, `you-research`, `you-finance`, `you-balance`, and `you-discover`. Optionally registers You.com's keyless Docs MCP (`searchDocs`) as a second server. Also lists the skill under MCP tools in `/customize`.

**Why.** You.com hosts one MCP server exposing all tools, so a single install skill fits NanoClaw's single-responsibility model and lets the model pick the right tool at runtime. The `youdotcom-oss/agent-skills` `you-web`/`you-research`/`you-finance` split is coding-agent routing guidance and has no NanoClaw target today. Provider-agnostic (Claude/OpenCode/Codex).

**How it works.** Same credential-safe pattern as `/add-tavily-tool`: `--enable-proxy` routes the bridge's HTTPS through the OneCLI gateway (required by egress lockdown), which injects the API key on the wire — the key never enters the args or the container. The single in-tree integration point is the `mcp-remote` entry in `container/cli-tools.json`, guarded by `youdotcom-manifest.test.ts` (copied into `src/` on apply). Per-group MCP registration is runtime `ncl` state with no in-tree line, so there is nothing for a registration test to guard there; the Phase 4 smoke test verifies it instead (this is stated explicitly in the SKILL.md, per the guidelines).

**How it was tested.**
- Directive lint (`pnpm exec tsx scripts/skill-directives.ts`) on the SKILL.md: clean, no problems or warnings.
- Manifest guard verified both ways with vitest: red when `mcp-remote` is absent (2 failed), green when present and exact-pinned (2 passed). The temporary manifest edit and `src/` copy were reverted afterward.
- Test file typechecks.
- Not yet run end-to-end in this environment (no image build / live `ncl` registration) — static guards and lint only. Flagging for maintainer review.

**Usage.** `/add-youdotcom-tool` → pick the agent group(s) → optionally add the Docs MCP. The skill registers the server(s) and installs the free-tier upgrade instructions; `REMOVE.md` reverses every change.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
