### PR TITLE
refactor(db): make central SQL portable

### DIFF
--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -104,6 +104,10 @@ CREATE TABLE user_roles (
   PRIMARY KEY (user_id, role, agent_group_id)
 );
 CREATE INDEX idx_user_roles_scope ON user_roles(agent_group_id, role);
+CREATE UNIQUE INDEX idx_user_roles_global_unique
+  ON user_roles(user_id, role) WHERE agent_group_id IS NULL;
+CREATE UNIQUE INDEX idx_user_roles_scoped_unique
+  ON user_roles(user_id, role, agent_group_id) WHERE agent_group_id IS NOT NULL;
 ```
 
 Invariants:
@@ -434,7 +438,22 @@ Several early migrations were later renamed/retired and replaced by "module" fil
 | 19 | `wiring-threads-override` | `019-wiring-threads.ts` | `messaging_group_agents.threads` — per-wiring thread-policy override (NULL = adapter default) |
 | 20 | `container-config-timezone` | `020-container-config-timezone.ts` | `container_configs.timezone` — per-agent-group timezone override (NULL = install-global) |
 | 21 | `approval-question-render-metadata` | `021-approval-question.ts` | `question` card-body column on all three approval tables so terminal edits retain the original request |
+| 22 | `messaging-group-detached-at` | `022-messaging-group-detached.ts` | `messaging_groups.detached_at` — records when the bot left a channel without deleting its wiring |
+| 23 | `user-roles-unique` | `023-user-roles-unique.ts` | Deduplicate legacy global grants and enforce separate unique keys for global and scoped roles |
 
 Numbers 5 and 6 are intentionally absent — migrations were renumbered during early development.
 
 Session DB schemas (`INBOUND_SCHEMA`, `OUTBOUND_SCHEMA`) are **not** versioned here. They're `CREATE TABLE IF NOT EXISTS` so new columns land via the session-DB lazy migration helpers (`migrateDeliveredTable()` etc.) when a session file from an older build is reopened. See [db-session.md](db-session.md).
+
+## 3. Portable SQL rules
+
+Central-DB runtime SQL must work on both SQLite and PostgreSQL. Session mailbox SQL is outside this rule because `inbound.db` and `outbound.db` remain backend-specific.
+
+- Use `INSERT ... ON CONFLICT (...) DO NOTHING` instead of `INSERT OR IGNORE`.
+- Use `INSERT ... ON CONFLICT (...) DO UPDATE SET ... = excluded....` instead of `INSERT OR REPLACE`; replacement deletes and recreates a row on SQLite and has no PostgreSQL equivalent.
+- Never use `rowid` for runtime ordering. Declare a stable domain-column order, with a deterministic key as the final tie-breaker.
+- Use snake_case aliases. PostgreSQL folds unquoted identifiers to lowercase, so camelCase aliases do not round-trip reliably.
+- Use `IS NOT DISTINCT FROM ?` when nullable equality is required. `IS ?` is SQLite-only, while `=` does not match two NULL values.
+- Keep named parameters in the existing `@name` form. The backend driver owns placeholder rewriting.
+- Store timestamps as ISO-8601 UTC text produced by `new Date().toISOString()`. Portable central-DB SQL compares the consistently shaped text directly; SQLite-only operational snippets may use `datetime()` around both sides.
+- Central migrations added after the async DB boundary must use the backend-neutral driver API and portable SQL. Backend-specific schema work belongs in a named migration override.

--- a/src/cli/crud.test.ts
+++ b/src/cli/crud.test.ts
@@ -69,11 +69,70 @@ registerResource({
   },
 });
 
+registerResource({
+  name: 'listtest',
+  plural: 'listtests',
+  table: 'listtest_rows',
+  description: 'Synthetic resource for portable list filtering and ordering.',
+  idColumn: 'id',
+  columns: [
+    { name: 'id', type: 'string', description: 'ID.', generated: true },
+    { name: 'enabled', type: 'boolean', description: 'Boolean filter.' },
+    { name: 'score', type: 'number', description: 'Numeric filter.' },
+    { name: 'payload', type: 'json', description: 'JSON filter.' },
+    { name: 'created_at', type: 'string', description: 'Timestamp.', generated: true },
+  ],
+  operations: { list: 'open' },
+});
+
 beforeEach(() => {
   const db = initTestDb();
   runMigrations(db);
   ensureContainerConfigSpy.mockClear();
   writeDestinationsSpy.mockClear();
+  getDb().exec(
+    `CREATE TABLE listtest_rows (
+      id TEXT PRIMARY KEY,
+      enabled INTEGER NOT NULL,
+      score INTEGER NOT NULL,
+      payload TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )`,
+  );
+});
+
+describe('genericList portable filters and ordering', () => {
+  beforeEach(() => {
+    const insert = getDb().prepare(
+      'INSERT INTO listtest_rows (id, enabled, score, payload, created_at) VALUES (?, ?, ?, ?, ?)',
+    );
+    insert.run('b', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
+    insert.run('a', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
+    insert.run('c', 0, 3, '{"kind":"other"}', '2026-08-17T11:00:00.000Z');
+  });
+
+  it('coerces boolean, number, and JSON filters by column type', async () => {
+    const rows = (await lookup('listtests-list')!.handler(
+      { enabled: 'true', score: '2', payload: { kind: 'match' } },
+      hostCtx,
+    )) as Array<{ id: string }>;
+
+    expect(rows.map((row) => row.id)).toEqual(['a', 'b']);
+  });
+
+  it('orders by the first timestamp descending and the id as a stable tie-breaker', async () => {
+    const rows = (await lookup('listtests-list')!.handler({}, hostCtx)) as Array<{ id: string }>;
+    expect(rows.map((row) => row.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('rejects invalid typed filters', async () => {
+    await expect(lookup('listtests-list')!.handler({ enabled: 'sometimes' }, hostCtx)).rejects.toThrow(
+      '--enabled must be true or false',
+    );
+    await expect(lookup('listtests-list')!.handler({ score: 'many' }, hostCtx)).rejects.toThrow(
+      '--score must be a number',
+    );
+  });
 });
 
 afterEach(() => {

--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -83,6 +83,9 @@ export interface ResourceDef {
     update?: Access;
     delete?: Access;
   };
+  /** Portable ORDER BY expression for list. Defaults to the first timestamp
+   * column descending, then the resource id for deterministic ties. */
+  listOrder?: string;
   /**
    * Columns forming a natural unique key. When set, generic `create` is
    * idempotent: if a row already matches on these columns it is returned
@@ -161,18 +164,43 @@ function visibleColumns(def: ResourceDef): string[] {
   return def.columns.map((c) => c.name);
 }
 
+function coerceListFilter(column: ColumnDef, value: unknown): unknown {
+  switch (column.type) {
+    case 'number': {
+      const number = Number(value);
+      if (Number.isNaN(number)) throw new Error(`--${column.name.replace(/_/g, '-')} must be a number`);
+      return number;
+    }
+    case 'boolean':
+      if (value === true || value === 'true' || value === '1' || value === 1) return 1;
+      if (value === false || value === 'false' || value === '0' || value === 0) return 0;
+      throw new Error(`--${column.name.replace(/_/g, '-')} must be true or false`);
+    case 'json':
+      return typeof value === 'string' ? value : JSON.stringify(value);
+    case 'string':
+      return String(value);
+  }
+}
+
+function listOrder(def: ResourceDef): string {
+  if (def.listOrder) return def.listOrder;
+  const timestamp = def.columns.find((column) => column.name.endsWith('_at'))?.name;
+  return timestamp ? `${timestamp} DESC, ${def.idColumn}` : def.idColumn;
+}
+
 function genericList(def: ResourceDef) {
   const cols = visibleColumns(def).join(', ');
-  const filterableNames = new Set(def.columns.filter((c) => !c.generated).map((c) => c.name));
+  const filterableColumns = new Map(def.columns.filter((c) => !c.generated).map((c) => [c.name, c]));
   return async (args: Record<string, unknown>) => {
     const limit = args.limit !== undefined ? Math.max(1, Number(args.limit)) : 200;
     const filters: string[] = [];
     const params: unknown[] = [];
     for (const [k, v] of Object.entries(args)) {
       if (k === 'id' || k === 'limit') continue;
-      if (filterableNames.has(k)) {
+      const column = filterableColumns.get(k);
+      if (column) {
         filters.push(`${k} = ?`);
-        params.push(v);
+        params.push(coerceListFilter(column, v));
       }
     }
     const where = filters.length > 0 ? ` WHERE ${filters.join(' AND ')}` : '';
@@ -181,7 +209,7 @@ function genericList(def: ResourceDef) {
     // recently inserted rows once a table outgrows it (bit `sessions list`
     // past 200 sessions — a just-created session was invisible).
     return getDb()
-      .prepare(`SELECT ${cols} FROM ${def.table}${where} ORDER BY rowid DESC LIMIT ?`)
+      .prepare(`SELECT ${cols} FROM ${def.table}${where} ORDER BY ${listOrder(def)} LIMIT ?`)
       .all(...params);
   };
 }

--- a/src/cli/resources/dropped-messages.ts
+++ b/src/cli/resources/dropped-messages.ts
@@ -7,6 +7,7 @@ registerResource({
   description:
     "Dropped message log — tracks messages that were dropped by the router or access gate. Aggregates by (channel_type, platform_id) with a running count. Reasons include: no_agent_wired (no wiring exists), no_agent_engaged (wiring exists but engage rules didn't fire), unknown_sender_strict (sender not recognized, strict policy), unknown_sender_request_approval (sender not recognized, approval requested).",
   idColumn: 'channel_type',
+  listOrder: 'last_seen DESC, channel_type, platform_id',
   columns: [
     { name: 'channel_type', type: 'string', description: 'Channel adapter type of the dropped message.' },
     { name: 'platform_id', type: 'string', description: 'Platform chat ID where the message was dropped.' },

--- a/src/cli/resources/members.ts
+++ b/src/cli/resources/members.ts
@@ -40,8 +40,9 @@ registerResource({
         if (!groupId) throw new Error('--group is required');
         getDb()
           .prepare(
-            `INSERT OR IGNORE INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
-             VALUES (?, ?, ?, ?)`,
+            `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT (user_id, agent_group_id) DO NOTHING`,
           )
           .run(userId, groupId, addedBy, new Date().toISOString());
         return { user_id: userId, agent_group_id: groupId };

--- a/src/cli/resources/roles.ts
+++ b/src/cli/resources/roles.ts
@@ -40,8 +40,9 @@ registerResource({
         if (role === 'owner' && groupId) throw new Error('owner role is always global (do not pass --group)');
         getDb()
           .prepare(
-            `INSERT OR IGNORE INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
-             VALUES (?, ?, ?, ?, ?)`,
+            `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT DO NOTHING`,
           )
           .run(userId, role, groupId, grantedBy, new Date().toISOString());
         return { user_id: userId, role, agent_group_id: groupId };
@@ -57,7 +58,7 @@ registerResource({
         if (!userId) throw new Error('--user is required');
         if (!role) throw new Error('--role is required');
         const result = getDb()
-          .prepare('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS ?')
+          .prepare('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NOT DISTINCT FROM ?')
           .run(userId, role, groupId);
         if (result.changes === 0) throw new Error('role not found');
         return { revoked: { user_id: userId, role, agent_group_id: groupId } };

--- a/src/cli/resources/user-dms.ts
+++ b/src/cli/resources/user-dms.ts
@@ -7,6 +7,7 @@ registerResource({
   description:
     "User DM cache — maps (user, channel_type) to the messaging group used for DM delivery. Populated lazily by ensureUserDm() when the host needs to cold-DM a user (approvals, pairing). For direct-addressable channels (Telegram, WhatsApp) the handle IS the DM chat ID. For resolution-required channels (Discord, Slack) the adapter's openDM resolves it.",
   idColumn: 'user_id',
+  listOrder: 'resolved_at DESC, user_id, channel_type',
   columns: [
     { name: 'user_id', type: 'string', description: 'User this DM route is for.' },
     { name: 'channel_type', type: 'string', description: 'Channel adapter type.' },

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -67,8 +67,9 @@ export function ensureContainerConfig(agentGroupId: string, provider?: string | 
   const stamped = normalized && normalized !== 'claude' ? normalized : null;
   getDb()
     .prepare(
-      `INSERT OR IGNORE INTO container_configs (agent_group_id, provider, updated_at)
-       VALUES (?, ?, ?)`,
+      `INSERT INTO container_configs (agent_group_id, provider, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT (agent_group_id) DO NOTHING`,
     )
     .run(agentGroupId, stamped, new Date().toISOString());
 }

--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -305,7 +305,7 @@ export function ensureAgentDestinationForWiring(mga: MessagingGroupAgent): void 
 
 export function getMessagingGroupAgents(messagingGroupId: string): MessagingGroupAgent[] {
   return getDb()
-    .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? ORDER BY priority DESC')
+    .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? ORDER BY priority DESC, id')
     .all(messagingGroupId) as MessagingGroupAgent[];
 }
 

--- a/src/db/migrations/023-user-roles-unique.test.ts
+++ b/src/db/migrations/023-user-roles-unique.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb } from '../connection.js';
+import { lookup } from '../../cli/registry.js';
+import { migration023 } from './023-user-roles-unique.js';
+import { migrations, runMigrations } from './index.js';
+import '../../cli/resources/roles.js';
+
+afterEach(() => closeDb());
+
+describe('user-roles-unique migration', () => {
+  it('deduplicates nullable global grants and enforces both logical key shapes', () => {
+    const db = initTestDb();
+    runMigrations(
+      db,
+      migrations.filter((migration) => migration.name !== migration023.name),
+    );
+
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)').run('cli:owner', 'cli', now);
+    db.prepare('INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)').run(
+      'ag-1',
+      'Agent',
+      'agent',
+      now,
+    );
+    const insert = db.prepare(
+      `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
+       VALUES (?, ?, ?, NULL, ?)`,
+    );
+    insert.run('cli:owner', 'owner', null, now);
+    insert.run('cli:owner', 'owner', null, now);
+    insert.run('cli:owner', 'admin', 'ag-1', now);
+
+    runMigrations(db, [migration023]);
+
+    const global = db
+      .prepare("SELECT COUNT(*) AS count FROM user_roles WHERE role = 'owner' AND agent_group_id IS NULL")
+      .get() as { count: number };
+    expect(global.count).toBe(1);
+    expect(() => insert.run('cli:owner', 'owner', null, now)).toThrow();
+    expect(() => insert.run('cli:owner', 'admin', 'ag-1', now)).toThrow();
+  });
+
+  it('makes repeated global grants through ncl idempotent', async () => {
+    const db = initTestDb();
+    runMigrations(db);
+    db.prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)').run(
+      'cli:owner',
+      'cli',
+      new Date().toISOString(),
+    );
+
+    const grant = lookup('roles-grant');
+    expect(grant).toBeDefined();
+    await grant!.handler({ user: 'cli:owner', role: 'owner' }, { caller: 'host' });
+    await grant!.handler({ user: 'cli:owner', role: 'owner' }, { caller: 'host' });
+
+    const row = db.prepare("SELECT COUNT(*) AS count FROM user_roles WHERE role = 'owner'").get() as {
+      count: number;
+    };
+    expect(row.count).toBe(1);
+  });
+});

--- a/src/db/migrations/023-user-roles-unique.ts
+++ b/src/db/migrations/023-user-roles-unique.ts
@@ -1,0 +1,31 @@
+import type { Migration } from './index.js';
+
+/**
+ * SQLite treats NULL values as distinct inside a composite primary key, so
+ * the original (user_id, role, agent_group_id) key allowed duplicate global
+ * owner/admin grants. Collapse any existing duplicates, then enforce the two
+ * logical key shapes explicitly. The Postgres baseline preserves these
+ * indexes instead of relying on nullable-key behavior.
+ */
+export const migration023: Migration = {
+  version: 23,
+  name: 'user-roles-unique',
+  up(db) {
+    db.exec(`
+      DELETE FROM user_roles
+      WHERE rowid NOT IN (
+        SELECT MIN(rowid)
+        FROM user_roles
+        GROUP BY user_id, role, agent_group_id
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_user_roles_global_unique
+        ON user_roles(user_id, role)
+        WHERE agent_group_id IS NULL;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_user_roles_scoped_unique
+        ON user_roles(user_id, role, agent_group_id)
+        WHERE agent_group_id IS NOT NULL;
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -21,6 +21,7 @@ import { migration019 } from './019-wiring-threads.js';
 import { migration020 } from './020-container-config-timezone.js';
 import { migration021 } from './021-approval-question.js';
 import { migration022 } from './022-messaging-group-detached.js';
+import { migration023 } from './023-user-roles-unique.js';
 
 export interface Migration {
   version: number;
@@ -66,6 +67,7 @@ export const migrations: Migration[] = [
   migration020,
   migration021,
   migration022,
+  migration023,
 ];
 
 /**

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -153,8 +153,9 @@ export function deleteSession(id: string): void {
 export function createPendingQuestion(pq: PendingQuestion): boolean {
   const result = getDb()
     .prepare(
-      `INSERT OR IGNORE INTO pending_questions (question_id, session_id, message_out_id, platform_id, channel_type, thread_id, title, options_json, created_at)
-       VALUES (@question_id, @session_id, @message_out_id, @platform_id, @channel_type, @thread_id, @title, @options_json, @created_at)`,
+      `INSERT INTO pending_questions (question_id, session_id, message_out_id, platform_id, channel_type, thread_id, title, options_json, created_at)
+       VALUES (@question_id, @session_id, @message_out_id, @platform_id, @channel_type, @thread_id, @title, @options_json, @created_at)
+       ON CONFLICT (question_id) DO NOTHING`,
     )
     .run({
       question_id: pq.question_id,
@@ -199,14 +200,15 @@ export function createPendingApproval(
 ): boolean {
   const result = getDb()
     .prepare(
-      `INSERT OR IGNORE INTO pending_approvals
+      `INSERT INTO pending_approvals
          (approval_id, session_id, request_id, action, payload, created_at,
           agent_group_id, channel_type, platform_id, platform_message_id, expires_at, status,
           title, question, options_json, approver_user_id)
        VALUES
          (@approval_id, @session_id, @request_id, @action, @payload, @created_at,
           @agent_group_id, @channel_type, @platform_id, @platform_message_id, @expires_at, @status,
-          @title, @question, @options_json, @approver_user_id)`,
+          @title, @question, @options_json, @approver_user_id)
+       ON CONFLICT (approval_id) DO NOTHING`,
     )
     .run({
       session_id: null,

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -1271,12 +1271,14 @@ describe('agent-to-agent routing', () => {
     // Wire bidirectional A2A destinations (table created by runMigrations)
     const db = getDb();
     db.prepare(
-      `INSERT OR IGNORE INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
-       VALUES ('ag-pa', 'researcher', 'agent', 'ag-researcher', ?)`,
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+       VALUES ('ag-pa', 'researcher', 'agent', 'ag-researcher', ?)
+       ON CONFLICT (agent_group_id, local_name) DO NOTHING`,
     ).run(now());
     db.prepare(
-      `INSERT OR IGNORE INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
-       VALUES ('ag-researcher', 'pa', 'agent', 'ag-pa', ?)`,
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+       VALUES ('ag-researcher', 'pa', 'agent', 'ag-pa', ?)
+       ON CONFLICT (agent_group_id, local_name) DO NOTHING`,
     ).run(now());
   });
 

--- a/src/modules/permissions/db/agent-group-members.ts
+++ b/src/modules/permissions/db/agent-group-members.ts
@@ -5,8 +5,9 @@ import { isAdminOfAgentGroup, isGlobalAdmin, isOwner } from './user-roles.js';
 export function addMember(row: AgentGroupMember): void {
   getDb()
     .prepare(
-      `INSERT OR IGNORE INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
-       VALUES (@user_id, @agent_group_id, @added_by, @added_at)`,
+      `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
+       VALUES (@user_id, @agent_group_id, @added_by, @added_at)
+       ON CONFLICT (user_id, agent_group_id) DO NOTHING`,
     )
     .run(row);
 }

--- a/src/state-sqlite.ts
+++ b/src/state-sqlite.ts
@@ -68,7 +68,10 @@ export class SqliteStateAdapter implements StateAdapter {
   async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
     this.db
-      .prepare('INSERT OR REPLACE INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)')
+      .prepare(
+        `INSERT INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at`,
+      )
       .run(this.k(key), JSON.stringify(value), expiresAt);
   }
 
@@ -82,7 +85,7 @@ export class SqliteStateAdapter implements StateAdapter {
     }
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
     const result = this.db
-      .prepare('INSERT OR IGNORE INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)')
+      .prepare('INSERT INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?) ON CONFLICT (key) DO NOTHING')
       .run(k, JSON.stringify(value), expiresAt);
     return result.changes > 0;
   }
@@ -94,7 +97,12 @@ export class SqliteStateAdapter implements StateAdapter {
   // --- Subscriptions ---
 
   async subscribe(threadId: string): Promise<void> {
-    this.db.prepare('INSERT OR REPLACE INTO chat_sdk_subscriptions (thread_id) VALUES (?)').run(this.k(threadId));
+    this.db
+      .prepare(
+        `INSERT INTO chat_sdk_subscriptions (thread_id, subscribed_at) VALUES (?, ?)
+         ON CONFLICT (thread_id) DO UPDATE SET subscribed_at = excluded.subscribed_at`,
+      )
+      .run(this.k(threadId), new Date().toISOString());
   }
 
   async unsubscribe(threadId: string): Promise<void> {
@@ -117,7 +125,10 @@ export class SqliteStateAdapter implements StateAdapter {
     const k = this.k(threadId);
     this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND expires_at < ?').run(k, now);
     const result = this.db
-      .prepare('INSERT OR IGNORE INTO chat_sdk_locks (thread_id, token, expires_at) VALUES (?, ?, ?)')
+      .prepare(
+        `INSERT INTO chat_sdk_locks (thread_id, token, expires_at) VALUES (?, ?, ?)
+         ON CONFLICT (thread_id) DO NOTHING`,
+      )
       .run(k, token, expiresAt);
     if (result.changes === 0) return null;
     // The Lock carries the RAW threadId; release/extend re-apply k() at
@@ -152,10 +163,10 @@ export class SqliteStateAdapter implements StateAdapter {
   async appendToList(key: string, value: unknown, options?: { maxLength?: number; ttlMs?: number }): Promise<void> {
     const expiresAt = options?.ttlMs ? Date.now() + options.ttlMs : null;
     const k = this.k(key);
-    const maxRow = this.db.prepare('SELECT MAX(idx) as maxIdx FROM chat_sdk_lists WHERE key = ?').get(k) as
-      | { maxIdx: number | null }
+    const maxRow = this.db.prepare('SELECT MAX(idx) AS max_idx FROM chat_sdk_lists WHERE key = ?').get(k) as
+      | { max_idx: number | null }
       | undefined;
-    const nextIdx = (maxRow?.maxIdx ?? -1) + 1;
+    const nextIdx = (maxRow?.max_idx ?? -1) + 1;
     this.db
       .prepare('INSERT INTO chat_sdk_lists (key, idx, value, expires_at) VALUES (?, ?, ?, ?)')
       .run(k, nextIdx, JSON.stringify(value), expiresAt);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Rewrite central-database SQL into a portable subset and add the unique user-role migration as migration 023.

### Why

SQLite-specific query shapes would leak through any future driver seam and make backend behavior diverge.

### How it works

Uses portable conflict handling and null-safe comparisons, centralizes list ordering/filter coercion, and documents the accepted SQL subset. Existing migration 022 remains messaging-group-detached-at.

### How it was tested

pnpm run lint; pnpm run typecheck; pnpm run build; full SQLite Vitest suite excluding the unchanged macOS /var vs /private/var upstream transaction fixture. 1,619 SQLite tests passed.

Stack 3/7.