### PR TITLE
[BREAKING] refactor(db): adopt async central database seam

### DIFF
--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts
@@ -46,10 +46,16 @@ function startFakeDashboard(): Promise<{ port: number; posts: CapturedPost[]; cl
   const posts: CapturedPost[] = [];
   const server = http.createServer((req, res) => {
     let raw = '';
-    req.on('data', (c) => { raw += c; });
+    req.on('data', (c) => {
+      raw += c;
+    });
     req.on('end', () => {
       let body: Record<string, unknown> = {};
-      try { body = JSON.parse(raw); } catch { /* leave empty */ }
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        /* leave empty */
+      }
       posts.push({ path: req.url || '', auth: req.headers.authorization, body });
       res.writeHead(200);
       res.end('ok');
@@ -72,22 +78,28 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
 }
 
 describe('add-dashboard integration point (startDashboard)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     stopDashboardPusher();
-    closeDb();
+    await closeDb();
     delete process.env.DASHBOARD_SECRET;
     delete process.env.DASHBOARD_PORT;
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
   it('posts a snapshot of the seeded state when DASHBOARD_SECRET is set', async () => {
-    createAgentGroup({ id: 'ag-1', name: 'Test Agent', folder: 'test-agent', agent_provider: null, created_at: now() });
+    await createAgentGroup({
+      id: 'ag-1',
+      name: 'Test Agent',
+      folder: 'test-agent',
+      agent_provider: null,
+      created_at: now(),
+    });
 
     const dash = await startFakeDashboard();
     process.env.DASHBOARD_SECRET = 'test-secret';
@@ -104,7 +116,16 @@ describe('add-dashboard integration point (startDashboard)', () => {
     const groups = ingest.body.agent_groups as Array<{ id: string }>;
     expect(groups.map((g) => g.id)).toContain('ag-1');
 
-    for (const key of ['timestamp', 'sessions', 'channels', 'users', 'tokens', 'context_windows', 'activity', 'messages']) {
+    for (const key of [
+      'timestamp',
+      'sessions',
+      'channels',
+      'users',
+      'tokens',
+      'context_windows',
+      'activity',
+      'messages',
+    ]) {
       expect(ingest.body).toHaveProperty(key);
     }
 

--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
@@ -105,108 +105,135 @@ function startLogTail(config: PusherConfig): void {
 
   // Send last 200 lines as backfill
   try {
-    const allLines = fs.readFileSync(logFile, 'utf-8').split('\n').filter((l) => l.trim());
+    const allLines = fs
+      .readFileSync(logFile, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
     logOffset = fs.statSync(logFile).size;
     const tail = allLines.slice(-200).map((l) => l.replace(ANSI_RE, ''));
     if (tail.length > 0) postJson(config, '/api/logs/push', { lines: tail });
-  } catch { return; }
+  } catch {
+    return;
+  }
 
   // Poll every 2s for new lines
   logTimer = setInterval(() => {
     try {
       const stat = fs.statSync(logFile);
-      if (stat.size <= logOffset) { logOffset = stat.size; return; }
+      if (stat.size <= logOffset) {
+        logOffset = stat.size;
+        return;
+      }
       const buf = Buffer.alloc(stat.size - logOffset);
       const fd = fs.openSync(logFile, 'r');
       fs.readSync(fd, buf, 0, buf.length, logOffset);
       fs.closeSync(fd);
       logOffset = stat.size;
-      const lines = buf.toString().split('\n').filter((l) => l.trim()).map((l) => l.replace(ANSI_RE, ''));
+      const lines = buf
+        .toString()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => l.replace(ANSI_RE, ''));
       if (lines.length > 0) postJson(config, '/api/logs/push', { lines });
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }, 2000);
 }
 
 async function push(config: PusherConfig): Promise<void> {
-  const snapshot = collectSnapshot();
+  const snapshot = await collectSnapshot();
   postJson(config, '/api/ingest', snapshot);
   log.debug('Dashboard snapshot pushed');
 }
 
-function collectSnapshot(): Record<string, unknown> {
+async function collectSnapshot(): Promise<Record<string, unknown>> {
+  const [agentGroups, sessions, channels, users, tokens, contextWindows] = await Promise.all([
+    collectAgentGroups(),
+    collectSessions(),
+    collectChannels(),
+    collectUsers(),
+    collectTokens(),
+    collectContextWindows(),
+  ]);
   return {
     timestamp: new Date().toISOString(),
     assistant_name: ASSISTANT_NAME,
     uptime: Math.floor(process.uptime()),
-    agent_groups: collectAgentGroups(),
-    sessions: collectSessions(),
-    channels: collectChannels(),
-    users: collectUsers(),
-    tokens: collectTokens(),
-    context_windows: collectContextWindows(),
+    agent_groups: agentGroups,
+    sessions,
+    channels,
+    users,
+    tokens,
+    context_windows: contextWindows,
     activity: collectActivity(),
     messages: collectMessages(),
   };
 }
 
-function collectAgentGroups() {
-  return getAllAgentGroups().map((g) => {
-    const sessions = getSessionsByAgentGroup(g.id);
-    const running = sessions.filter((s) => s.container_status === 'running' || s.container_status === 'idle');
-    const destinations = getDestinations(g.id);
-    const members = getMembers(g.id).map((m) => {
-      const user = getUser(m.user_id);
-      return { ...m, display_name: user?.display_name ?? null };
-    });
-    const admins = getAdminsOfAgentGroup(g.id).map((a) => {
-      const user = getUser(a.user_id);
-      return { ...a, display_name: user?.display_name ?? null };
-    });
-
-    // Wirings
-    const db = getDb();
-    const wirings = db
-      .prepare(
-        `SELECT mga.*, mg.channel_type, mg.platform_id, mg.name as mg_name, mg.is_group, mg.unknown_sender_policy
+async function collectAgentGroups() {
+  const groups = await getAllAgentGroups();
+  return Promise.all(
+    groups.map(async (g) => {
+      const [sessions, destinations, rawMembers, rawAdmins, containerConfig, wirings] = await Promise.all([
+        getSessionsByAgentGroup(g.id),
+        getDestinations(g.id),
+        getMembers(g.id),
+        getAdminsOfAgentGroup(g.id),
+        getContainerConfig(g.id),
+        getDb().all<Record<string, unknown>>(
+          `SELECT mga.*, mg.channel_type, mg.platform_id, mg.name as mg_name, mg.is_group, mg.unknown_sender_policy
          FROM messaging_group_agents mga
          JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
          WHERE mga.agent_group_id = ?`,
-      )
-      .all(g.id) as Array<Record<string, unknown>>;
+          g.id,
+        ),
+      ]);
+      const running = sessions.filter((s) => s.container_status === 'running' || s.container_status === 'idle');
+      const members = await Promise.all(
+        rawMembers.map(async (m) => {
+          const user = await getUser(m.user_id);
+          return { ...m, display_name: user?.display_name ?? null };
+        }),
+      );
+      const admins = await Promise.all(
+        rawAdmins.map(async (a) => {
+          const user = await getUser(a.user_id);
+          return { ...a, display_name: user?.display_name ?? null };
+        }),
+      );
 
-    return {
-      id: g.id,
-      name: g.name,
-      folder: g.folder,
-      agent_provider: g.agent_provider,
-      container_config: getContainerConfig(g.id) ?? null,
-      sessionCount: sessions.length,
-      runningSessions: running.length,
-      wirings,
-      destinations,
-      members,
-      admins,
-      created_at: g.created_at,
-    };
-  });
+      return {
+        id: g.id,
+        name: g.name,
+        folder: g.folder,
+        agent_provider: g.agent_provider,
+        container_config: containerConfig ?? null,
+        sessionCount: sessions.length,
+        runningSessions: running.length,
+        wirings,
+        destinations,
+        members,
+        admins,
+        created_at: g.created_at,
+      };
+    }),
+  );
 }
 
-function collectSessions() {
-  const db = getDb();
-  return db
-    .prepare(
-      `SELECT s.*, ag.name as agent_group_name, ag.folder as agent_group_folder,
+async function collectSessions() {
+  return getDb().all<Record<string, unknown>>(
+    `SELECT s.*, ag.name as agent_group_name, ag.folder as agent_group_folder,
               mg.channel_type, mg.platform_id, mg.name as messaging_group_name
        FROM sessions s
        LEFT JOIN agent_groups ag ON ag.id = s.agent_group_id
        LEFT JOIN messaging_groups mg ON mg.id = s.messaging_group_id
        ORDER BY s.last_active DESC NULLS LAST`,
-    )
-    .all() as Array<Record<string, unknown>>;
+  );
 }
 
-function collectChannels() {
-  const messagingGroups = getAllMessagingGroups();
+async function collectChannels() {
+  const messagingGroups = await getAllMessagingGroups();
   const liveAdapters = getActiveAdapters().map((a) => a.channelType);
   const registeredChannels = getRegisteredChannelNames();
 
@@ -222,10 +249,13 @@ function collectChannels() {
       };
     }
 
-    const agents = getMessagingGroupAgents(mg.id).map((a) => {
-      const group = getAgentGroup(a.agent_group_id);
-      return { agent_group_id: a.agent_group_id, agent_group_name: group?.name ?? null, priority: a.priority };
-    });
+    const wiringAgents = await getMessagingGroupAgents(mg.id);
+    const agents = await Promise.all(
+      wiringAgents.map(async (a) => {
+        const group = await getAgentGroup(a.agent_group_id);
+        return { agent_group_id: a.agent_group_id, agent_group_name: group?.name ?? null, priority: a.priority };
+      }),
+    );
 
     byType[mg.channel_type].groups.push({
       messagingGroup: {
@@ -249,44 +279,53 @@ function collectChannels() {
   return Object.values(byType).sort((a, b) => a.channelType.localeCompare(b.channelType));
 }
 
-function collectUsers() {
-  return getAllUsers().map((u) => {
-    const roles = getUserRoles(u.id);
-    const dms = getUserDmsForUser(u.id);
-
-    const db = getDb();
-    const memberships = db
-      .prepare(
-        `SELECT agm.agent_group_id, ag.name as agent_group_name
+async function collectUsers() {
+  const users = await getAllUsers();
+  return Promise.all(
+    users.map(async (u) => {
+      const [roles, dms, memberships] = await Promise.all([
+        getUserRoles(u.id),
+        getUserDmsForUser(u.id),
+        getDb().all<Record<string, unknown>>(
+          `SELECT agm.agent_group_id, ag.name as agent_group_name
          FROM agent_group_members agm
          JOIN agent_groups ag ON ag.id = agm.agent_group_id
          WHERE agm.user_id = ?`,
-      )
-      .all(u.id) as Array<Record<string, unknown>>;
+          u.id,
+        ),
+      ]);
 
-    let privilege = 'none';
-    if (roles.some((r) => r.role === 'owner')) privilege = 'owner';
-    else if (roles.some((r) => r.role === 'admin' && !r.agent_group_id)) privilege = 'global_admin';
-    else if (roles.some((r) => r.role === 'admin')) privilege = 'admin';
-    else if (memberships.length > 0) privilege = 'member';
+      let privilege = 'none';
+      if (roles.some((r) => r.role === 'owner')) privilege = 'owner';
+      else if (roles.some((r) => r.role === 'admin' && !r.agent_group_id)) privilege = 'global_admin';
+      else if (roles.some((r) => r.role === 'admin')) privilege = 'admin';
+      else if (memberships.length > 0) privilege = 'member';
 
-    return {
-      id: u.id,
-      kind: u.kind,
-      display_name: u.display_name,
-      privilege,
-      roles,
-      memberships,
-      dmChannels: dms.map((d) => ({ channel_type: d.channel_type })),
-      created_at: u.created_at,
-    };
-  });
+      return {
+        id: u.id,
+        kind: u.kind,
+        display_name: u.display_name,
+        privilege,
+        roles,
+        memberships,
+        dmChannels: dms.map((d) => ({ channel_type: d.channel_type })),
+        created_at: u.created_at,
+      };
+    }),
+  );
 }
 
-function collectTokens() {
+async function collectTokens() {
   const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
-  const allEntries: Array<{ model: string; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number; agentGroupId: string }> = [];
-  const agentGroups = getAllAgentGroups();
+  const allEntries: Array<{
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    agentGroupId: string;
+  }> = [];
+  const agentGroups = await getAllAgentGroups();
   const nameMap = new Map(agentGroups.map((g) => [g.id, g.name]));
 
   if (fs.existsSync(sessionsDir)) {
@@ -296,19 +335,47 @@ function collectTokens() {
     }
   }
 
-  const byModel: Record<string, { requests: number; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number }> = {};
-  const byGroup: Record<string, { requests: number; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number; name: string }> = {};
+  const byModel: Record<
+    string,
+    {
+      requests: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+    }
+  > = {};
+  const byGroup: Record<
+    string,
+    {
+      requests: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+      name: string;
+    }
+  > = {};
   const totals = { requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
 
   for (const e of allEntries) {
-    if (!byModel[e.model]) byModel[e.model] = { requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    if (!byModel[e.model])
+      byModel[e.model] = { requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
     byModel[e.model].requests++;
     byModel[e.model].inputTokens += e.inputTokens;
     byModel[e.model].outputTokens += e.outputTokens;
     byModel[e.model].cacheReadTokens += e.cacheReadTokens;
     byModel[e.model].cacheCreationTokens += e.cacheCreationTokens;
 
-    if (!byGroup[e.agentGroupId]) byGroup[e.agentGroupId] = { requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, name: nameMap.get(e.agentGroupId) || e.agentGroupId };
+    if (!byGroup[e.agentGroupId])
+      byGroup[e.agentGroupId] = {
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        name: nameMap.get(e.agentGroupId) || e.agentGroupId,
+      };
     byGroup[e.agentGroupId].requests++;
     byGroup[e.agentGroupId].inputTokens += e.inputTokens;
     byGroup[e.agentGroupId].outputTokens += e.outputTokens;
@@ -329,7 +396,13 @@ function scanJsonlTokens(agentDir: string) {
   const claudeDir = path.join(agentDir, '.claude-shared', 'projects');
   if (!fs.existsSync(claudeDir)) return [];
 
-  const entries: Array<{ model: string; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number }> = [];
+  const entries: Array<{
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  }> = [];
 
   const walk = (dir: string): void => {
     try {
@@ -352,23 +425,29 @@ function scanJsonlTokens(agentDir: string) {
                     cacheCreationTokens: u.cache_creation_input_tokens || 0,
                   });
                 }
-              } catch { /* skip line */ }
+              } catch {
+                /* skip line */
+              }
             }
-          } catch { /* skip file */ }
+          } catch {
+            /* skip file */
+          }
         }
       }
-    } catch { /* skip dir */ }
+    } catch {
+      /* skip dir */
+    }
   };
   walk(claudeDir);
   return entries;
 }
 
-function collectContextWindows() {
+async function collectContextWindows() {
   const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
   if (!fs.existsSync(sessionsDir)) return [];
 
   const results: unknown[] = [];
-  const agentGroups = getAllAgentGroups();
+  const agentGroups = await getAllAgentGroups();
   const nameMap = new Map(agentGroups.map((g) => [g.id, g.name]));
 
   for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
@@ -384,13 +463,19 @@ function collectContextWindows() {
           if (entry.isDirectory()) walk(full);
           else if (entry.name.endsWith('.jsonl')) jsonlFiles.push(full);
         }
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     };
     walk(claudeDir);
     if (jsonlFiles.length === 0) continue;
 
     jsonlFiles.sort((a, b) => {
-      try { return fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs; } catch { return 0; }
+      try {
+        return fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs;
+      } catch {
+        return 0;
+      }
     });
 
     // Read last assistant turn from newest file
@@ -420,7 +505,9 @@ function collectContextWindows() {
           });
           break;
         }
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     }
   }
 
@@ -453,23 +540,32 @@ function collectActivity() {
     for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
       const agPath = path.join(sessionsDir, agDir);
       for (const sessDir of fs.readdirSync(agPath).filter((d) => d.startsWith('sess-'))) {
-        for (const [dbName, direction] of [['outbound.db', 'outbound'], ['inbound.db', 'inbound']] as const) {
+        for (const [dbName, direction] of [
+          ['outbound.db', 'outbound'],
+          ['inbound.db', 'inbound'],
+        ] as const) {
           const dbPath = path.join(agPath, sessDir, dbName);
           if (!fs.existsSync(dbPath)) continue;
           try {
             const db = new Database(dbPath, { readonly: true });
             const table = direction === 'outbound' ? 'messages_out' : 'messages_in';
-            const rows = db.prepare(`SELECT timestamp FROM ${table} WHERE timestamp > ?`).all(cutoff) as { timestamp: string }[];
+            const rows = db.prepare(`SELECT timestamp FROM ${table} WHERE timestamp > ?`).all(cutoff) as {
+              timestamp: string;
+            }[];
             for (const row of rows) {
               const key = localHourKey(new Date(row.timestamp));
               if (buckets[key]) buckets[key][direction]++;
             }
             db.close();
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
       }
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
   return toBucketArray(buckets);
 }
@@ -501,7 +597,9 @@ function collectMessages() {
             const rows = db.prepare('SELECT * FROM messages_in ORDER BY seq DESC LIMIT ?').all(limit);
             inbound.push(...(rows as unknown[]).reverse());
             db.close();
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
 
         const outDbPath = path.join(agPath, sessDir, 'outbound.db');
@@ -511,7 +609,9 @@ function collectMessages() {
             const rows = db.prepare('SELECT * FROM messages_out ORDER BY seq DESC LIMIT ?').all(limit);
             outbound.push(...(rows as unknown[]).reverse());
             db.close();
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
 
         if (inbound.length > 0 || outbound.length > 0) {
@@ -519,7 +619,9 @@ function collectMessages() {
         }
       }
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
   return results;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to NanoClaw will be documented in this file.
 ## [Unreleased]
 
 - **New NanoClaw installs now use OneCLI gateway 1.41.0.** Existing 1.36.0 gateways remain compatible because NanoClaw does not depend on any 1.41-only behavior. See [the OneCLI upgrade guide](docs/onecli-upgrades.md) to upgrade an existing gateway.
+- [BREAKING] **Central database access is now asynchronous behind `DbDriver`.** SQLite remains the default and existing `data/v2.db` files are unchanged, but custom source and installed channel/provider extensions must await central reads and writes and adopt the retyped host seams. **Migration:** follow [the central database async migration guide](docs/central-db-async-migration.md) to find affected calls, preserve transaction boundaries, update extensions, verify SQLite behavior, or roll back.
 
 ## [2.2.0] - 2026-08-13
 

--- a/scripts/delete-cli-agent.ts
+++ b/scripts/delete-cli-agent.ts
@@ -36,29 +36,27 @@ function parseArgs(): Args {
 
 const args = parseArgs();
 
-const db = initDb(CENTRAL_DB_PATH);
-runMigrations(db);
+const db = await initDb(CENTRAL_DB_PATH);
+await runMigrations(db);
 
-const ag = getAgentGroupByFolder(args.folder);
+const ag = await getAgentGroupByFolder(args.folder);
 if (!ag) {
   console.log(`No agent group with folder "${args.folder}" — nothing to delete.`);
   process.exit(0);
 }
 
-const cleanup = db.transaction(() => {
-  const tables = db
-    .prepare(
-      `SELECT DISTINCT m.name FROM sqlite_master m
-       JOIN pragma_table_info(m.name) p ON p.name = 'agent_group_id'
-       WHERE m.type = 'table' AND m.name != 'agent_groups'`,
-    )
-    .all() as { name: string }[];
+await db.transaction(async () => {
+  const tables = await db.all<{ name: string }>(
+    `SELECT DISTINCT m.name FROM sqlite_master m
+     JOIN pragma_table_info(m.name) p ON p.name = 'agent_group_id'
+     WHERE m.type = 'table' AND m.name != 'agent_groups'`,
+  );
   for (const { name } of tables) {
-    db.prepare(`DELETE FROM ${name} WHERE agent_group_id = ?`).run(ag.id);
+    const quotedName = `"${name.replaceAll('"', '""')}"`;
+    await db.run(`DELETE FROM ${quotedName} WHERE agent_group_id = ?`, ag.id);
   }
-  deleteAgentGroup(ag.id);
+  await deleteAgentGroup(ag.id);
 });
-cleanup();
 
 // Remove the groups/<folder>/ directory.
 const groupDir = path.join(process.cwd(), 'groups', args.folder);

--- a/scripts/init-cli-agent.ts
+++ b/scripts/init-cli-agent.ts
@@ -86,13 +86,13 @@ function generateId(prefix: string): string {
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
-  const db = initDb(CENTRAL_DB_PATH);
-  runMigrations(db);
+  const db = await initDb(CENTRAL_DB_PATH);
+  await runMigrations(db);
 
   const now = new Date().toISOString();
 
   // 1. Synthetic CLI user + owner grant if none exists.
-  upsertUser({
+  await upsertUser({
     id: CLI_SYNTHETIC_USER_ID,
     kind: CLI_CHANNEL,
     display_name: args.displayName,
@@ -106,22 +106,22 @@ async function main(): Promise<void> {
   // 2. Agent group + filesystem.
   const folder = args.folder || `cli-with-${normalizeName(args.displayName)}`;
   const pickedProvider = process.env.NANOCLAW_PICKED_PROVIDER?.trim().toLowerCase();
-  let ag: AgentGroup | undefined = getAgentGroupByFolder(folder);
+  let ag: AgentGroup | undefined = await getAgentGroupByFolder(folder);
   if (!ag) {
     const agId = generateId('ag');
-    createAgentGroup({
+    await createAgentGroup({
       id: agId,
       name: args.agentName,
       folder,
       agent_provider: null,
       created_at: now,
     });
-    ag = getAgentGroupByFolder(folder)!;
+    ag = (await getAgentGroupByFolder(folder))!;
     console.log(`Created agent group: ${ag.id} (${folder})`);
   } else {
     console.log(`Reusing agent group: ${ag.id} (${folder})`);
   }
-  initGroupFilesystem(ag, {
+  await initGroupFilesystem(ag, {
     instructions:
       `# ${args.agentName}\n\n` +
       `You are ${args.agentName}, a personal NanoClaw agent for ${args.displayName}. ` +
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
   });
 
   // 3. CLI messaging group + wiring.
-  let cliMg: MessagingGroup | undefined = getMessagingGroupByPlatform(CLI_CHANNEL, CLI_PLATFORM_ID);
+  let cliMg: MessagingGroup | undefined = await getMessagingGroupByPlatform(CLI_CHANNEL, CLI_PLATFORM_ID);
   if (!cliMg) {
     cliMg = {
       id: generateId('mg'),
@@ -146,16 +146,16 @@ async function main(): Promise<void> {
       unknown_sender_policy: resolveUnknownSenderPolicy(CLI_CHANNEL, false),
       created_at: now,
     };
-    createMessagingGroup(cliMg);
+    await createMessagingGroup(cliMg);
     console.log(`Created CLI messaging group: ${cliMg.id}`);
   }
 
-  const existing = getMessagingGroupAgentByPair(cliMg.id, ag.id);
+  const existing = await getMessagingGroupAgentByPair(cliMg.id, ag.id);
   if (!existing) {
     // cli declares pattern '.' for DMs — every line the operator types is
     // for the agent. Identical to the pre-declaration hardcodes.
     const engage = resolveWiringDefaults(CLI_CHANNEL, false, ag.name);
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: generateId('mga'),
       messaging_group_id: cliMg.id,
       agent_group_id: ag.id,

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -180,8 +180,14 @@ function generateId(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function wireIfMissing(mg: MessagingGroup, ag: AgentGroup, now: string, label: string, engagePattern?: string): void {
-  const existing = getMessagingGroupAgentByPair(mg.id, ag.id);
+async function wireIfMissing(
+  mg: MessagingGroup,
+  ag: AgentGroup,
+  now: string,
+  label: string,
+  engagePattern?: string,
+): Promise<void> {
+  const existing = await getMessagingGroupAgentByPair(mg.id, ag.id);
   if (existing) {
     console.log(`Wiring already exists: ${existing.id} (${label})`);
     return;
@@ -209,7 +215,7 @@ function wireIfMissing(mg: MessagingGroup, ag: AgentGroup, now: string, label: s
       (isGroup
         ? { engage_mode: 'mention' as const, engage_pattern: null }
         : { engage_mode: 'pattern' as const, engage_pattern: '.' }));
-  createMessagingGroupAgent({
+  await createMessagingGroupAgent({
     id: generateId('mga'),
     messaging_group_id: mg.id,
     agent_group_id: ag.id,
@@ -231,14 +237,14 @@ function wireIfMissing(mg: MessagingGroup, ag: AgentGroup, now: string, label: s
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
-  const db = initDb(CENTRAL_DB_PATH);
-  runMigrations(db); // idempotent
+  const db = await initDb(CENTRAL_DB_PATH);
+  await runMigrations(db); // idempotent
 
   const now = new Date().toISOString();
 
   // 1. User + (conditional) owner grant.
   const userId = namespacedUserId(args.channel, args.userId);
-  upsertUser({
+  await upsertUser({
     id: userId,
     kind: args.channel,
     display_name: args.displayName,
@@ -254,31 +260,31 @@ async function main(): Promise<void> {
   let ag: AgentGroup;
   let folder: string;
   if (args.agentGroupId) {
-    const existing = getAgentGroup(args.agentGroupId);
+    const existing = await getAgentGroup(args.agentGroupId);
     if (!existing) throw new Error(`Agent group not found: ${args.agentGroupId}`);
     ag = existing;
     folder = existing.folder;
     console.log(`Using agent group: ${ag.id} (${folder})`);
   } else {
     folder = `dm-with-${normalizeName(args.displayName)}`;
-    const existing = getAgentGroupByFolder(folder);
+    const existing = await getAgentGroupByFolder(folder);
     if (existing) {
       ag = existing;
       console.log(`Reusing agent group: ${ag.id} (${folder})`);
     } else {
       const agId = generateId('ag');
-      createAgentGroup({
+      await createAgentGroup({
         id: agId,
         name: args.agentName,
         folder,
         agent_provider: null,
         created_at: now,
       });
-      ag = getAgentGroupByFolder(folder)!;
+      ag = (await getAgentGroupByFolder(folder))!;
       console.log(`Created agent group: ${ag.id} (${folder})`);
     }
     // A reused group keeps its provider because this insert is idempotent.
-    ensureContainerConfig(ag.id, pickedProvider);
+    await ensureContainerConfig(ag.id, pickedProvider);
     stageGroupPersona(
       path.resolve(GROUPS_DIR, folder),
       `# ${args.agentName}\n\n` +
@@ -294,11 +300,11 @@ async function main(): Promise<void> {
   //  - member: no role grant, just the membership row below.
   // grantRole inserts a new row per call — idempotence check against
   // getUserRoles prevents duplicates on re-runs.
-  const existingRoles = getUserRoles(userId);
+  const existingRoles = await getUserRoles(userId);
   if (args.role === 'owner') {
     const alreadyOwner = existingRoles.some((r) => r.role === 'owner' && r.agent_group_id === null);
     if (!alreadyOwner) {
-      grantRole({
+      await grantRole({
         user_id: userId,
         role: 'owner',
         agent_group_id: null,
@@ -307,11 +313,11 @@ async function main(): Promise<void> {
       });
     }
     // Owner's agent group gets global CLI access
-    updateContainerConfigScalars(ag.id, { cli_scope: 'global' });
+    await updateContainerConfigScalars(ag.id, { cli_scope: 'global' });
   } else if (args.role === 'admin') {
     const alreadyAdmin = existingRoles.some((r) => r.role === 'admin' && r.agent_group_id === ag.id);
     if (!alreadyAdmin) {
-      grantRole({
+      await grantRole({
         user_id: userId,
         role: 'admin',
         agent_group_id: ag.id,
@@ -325,7 +331,7 @@ async function main(): Promise<void> {
   // yes/no even for users without a role grant. INSERT OR IGNORE, so this
   // is a no-op when the row already exists (e.g. re-runs, owners whose
   // access already passes via role).
-  addMember({
+  await addMember({
     user_id: userId,
     agent_group_id: ag.id,
     added_by: null,
@@ -334,7 +340,7 @@ async function main(): Promise<void> {
 
   // 3. DM messaging group.
   const platformId = namespacedPlatformId(args.channel, args.platformId);
-  let dmMg = getMessagingGroupByPlatform(args.channel, platformId);
+  let dmMg = await getMessagingGroupByPlatform(args.channel, platformId);
   if (!dmMg) {
     const mgId = generateId('mg');
     // Policy from the channel declaration (DM context); legacy 'strict' for
@@ -342,7 +348,7 @@ async function main(): Promise<void> {
     const unknownSenderPolicy = hasDeclaredChannelDefaults(args.channel)
       ? resolveUnknownSenderPolicy(args.channel, false)
       : 'strict';
-    createMessagingGroup({
+    await createMessagingGroup({
       id: mgId,
       channel_type: args.channel,
       platform_id: platformId,
@@ -351,14 +357,14 @@ async function main(): Promise<void> {
       unknown_sender_policy: unknownSenderPolicy,
       created_at: now,
     });
-    dmMg = getMessagingGroupByPlatform(args.channel, platformId)!;
+    dmMg = (await getMessagingGroupByPlatform(args.channel, platformId))!;
     console.log(`Created messaging group: ${dmMg.id} (${platformId})`);
   } else {
     console.log(`Reusing messaging group: ${dmMg.id} (${platformId})`);
   }
 
   // 4. Wire DM messaging group to the agent.
-  wireIfMissing(dmMg, ag, now, 'dm', args.engagePattern);
+  await wireIfMissing(dmMg, ag, now, 'dm', args.engagePattern);
 
   // 5. Welcome delivery over the CLI socket. Router picks up the line,
   // writes the message into the DM session's inbound.db, and wakes the

--- a/scripts/photon-setup.test.ts
+++ b/scripts/photon-setup.test.ts
@@ -126,7 +126,11 @@ describe('userOptedIn / waitForOptedInUser', () => {
       calls += 1;
       if (calls <= 2) throw new Error('ECONNRESET');
       return new Response(
-        JSON.stringify({ users: [{ id: 'u1', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: { opt_in: true } }] }),
+        JSON.stringify({
+          users: [
+            { id: 'u1', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: { opt_in: true } },
+          ],
+        }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     }) as typeof fetch;
@@ -163,7 +167,10 @@ describe('userOptedIn / waitForOptedInUser', () => {
 
   it('times out with a re-run hint when the opt-in never lands', async () => {
     const fetchFn = (async () =>
-      new Response(JSON.stringify({ users: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as typeof fetch;
+      new Response(JSON.stringify({ users: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch;
     await expect(
       waitForOptedInUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '+15551234567', {
         sleepFn: async () => {},
@@ -175,7 +182,10 @@ describe('userOptedIn / waitForOptedInUser', () => {
 
   it('names the assigned line in the timeout message when it is known', async () => {
     const fetchFn = (async () =>
-      new Response(JSON.stringify({ users: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as typeof fetch;
+      new Response(JSON.stringify({ users: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch;
     await expect(
       waitForOptedInUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '+15551234567', {
         sleepFn: async () => {},
@@ -206,7 +216,9 @@ describe('createUser / ensureUser', () => {
     const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
       body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
       return new Response(
-        JSON.stringify({ user: { id: 'u-new', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} } }),
+        JSON.stringify({
+          user: { id: 'u-new', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} },
+        }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     }) as typeof fetch;
@@ -234,7 +246,9 @@ describe('createUser / ensureUser', () => {
       called = true;
       return new Response('{}', { status: 200 });
     }) as typeof fetch;
-    await expect(createUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '5551234567')).rejects.toThrow(/E\.164/);
+    await expect(createUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '5551234567')).rejects.toThrow(
+      /E\.164/,
+    );
     expect(called).toBe(false);
   });
 
@@ -243,7 +257,9 @@ describe('createUser / ensureUser', () => {
     const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
       if ((init?.method || 'GET').toUpperCase() === 'POST') posts += 1;
       return new Response(
-        JSON.stringify({ users: [{ id: 'u-existing', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} }] }),
+        JSON.stringify({
+          users: [{ id: 'u-existing', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} }],
+        }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     }) as typeof fetch;
@@ -446,7 +462,11 @@ describe('photon setup flow (mocked API)', () => {
     // The row flips to opted in on the third list poll, as if the operator
     // texted the assigned line while the wizard waited.
     const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 2 });
-    const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
+    const code = await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      fetchFn,
+      noSleep,
+    );
     expect(code).toBe(0);
 
     const env = fs.readFileSync(path.join(tempDir, '.env'), 'utf-8');
@@ -478,7 +498,11 @@ describe('photon setup flow (mocked API)', () => {
 
   it('a registered-but-not-opted-in row is not success — it keeps polling until opt_in lands', async () => {
     const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 2, pendingUser: true });
-    const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
+    const code = await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      fetchFn,
+      noSleep,
+    );
     expect(code).toBe(0);
     expect(calls.filter((c) => c.method === 'GET' && /\/users\/$/.test(c.pathname)).length).toBe(3);
     // An existing row is reused, never duplicated by a second create.
@@ -494,7 +518,9 @@ describe('photon setup flow (mocked API)', () => {
       return true;
     }) as typeof process.stdout.write;
     try {
-      expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+      expect(
+        await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep),
+      ).toBe(0);
     } finally {
       process.stdout.write = realWrite;
     }
@@ -504,21 +530,31 @@ describe('photon setup flow (mocked API)', () => {
 
   it('does not create a second row when a completed setup is re-run', async () => {
     const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 1 });
-    expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
-    expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+    expect(
+      await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep),
+    ).toBe(0);
+    expect(
+      await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep),
+    ).toBe(0);
     expect(calls.filter((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname)).length).toBe(1);
   });
 
   it('short-circuits an already-opted-in row without waiting', async () => {
     const { fetchFn, calls } = makeMockFetch({ existingUser: true });
-    expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+    expect(
+      await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep),
+    ).toBe(0);
     // One lookup, no poll loop.
     expect(calls.filter((c) => c.method === 'GET' && /\/users\/$/.test(c.pathname)).length).toBe(1);
   });
 
   it('fails (exit 1) when the opt-in never lands, and never claims success', async () => {
     const { fetchFn, calls } = makeMockFetch();
-    const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
+    const code = await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      fetchFn,
+      noSleep,
+    );
     expect(code).toBe(1);
     // The row is created once; a never-opted-in row is still not success.
     expect(calls.filter((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname)).length).toBe(1);
@@ -531,7 +567,11 @@ describe('photon setup flow (mocked API)', () => {
 
   it('reuses an existing project + user and skips creation', async () => {
     const { fetchFn, calls } = makeMockFetch({ existingProject: true, existingUser: true });
-    const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
+    const code = await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      fetchFn,
+      noSleep,
+    );
     expect(code).toBe(0);
 
     const env = fs.readFileSync(path.join(tempDir, '.env'), 'utf-8');
@@ -547,11 +587,19 @@ describe('photon setup flow (mocked API)', () => {
 
   it('reuses a stored device token on a second run (no re-login)', async () => {
     // First run stores the token.
-    await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], makeMockFetch({ existingUser: true }).fetchFn, noSleep);
+    await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      makeMockFetch({ existingUser: true }).fetchFn,
+      noSleep,
+    );
 
     // Second run: token is validated + reused, device-code is never requested.
     const { fetchFn, calls } = makeMockFetch({ existingUser: true });
-    const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
+    const code = await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      fetchFn,
+      noSleep,
+    );
     expect(code).toBe(0);
     expect(calls.some((c) => c.pathname === '/api/auth/device/code')).toBe(false);
     expect(calls.some((c) => c.pathname === '/api/auth/get-session')).toBe(true);
@@ -559,7 +607,11 @@ describe('photon setup flow (mocked API)', () => {
 
   it('a no-phone re-run preserves the stored phone_number and routing stays green', async () => {
     // First run: full success, phone_number + assigned number stored.
-    await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], makeMockFetch({ existingUser: true }).fetchFn, noSleep);
+    await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      makeMockFetch({ existingUser: true }).fetchFn,
+      noSleep,
+    );
 
     // Re-run without --phone: step 4 is skipped, and the merge must not erase
     // what the first run learned.
@@ -575,13 +627,21 @@ describe('photon setup flow (mocked API)', () => {
   it('status probes the API: a stale phone_number with an un-opted-in row is not ready', async () => {
     // Simulate an install configured by the old wizard: local state says
     // "registered", but the live row never got the dashboard opt-in.
-    await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], makeMockFetch({ existingUser: true }).fetchFn, noSleep);
+    await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      makeMockFetch({ existingUser: true }).fetchFn,
+      noSleep,
+    );
     const { fetchFn } = makeMockFetch({ optInAfterListPolls: Number.MAX_SAFE_INTEGER, pendingUser: true });
     expect(await main(['status'], fetchFn)).toBe(1);
   });
 
   it('status returns 1 when the routing probe cannot reach the API', async () => {
-    await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], makeMockFetch({ existingUser: true }).fetchFn, noSleep);
+    await main(
+      ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'],
+      makeMockFetch({ existingUser: true }).fetchFn,
+      noSleep,
+    );
     const failFetch = (async () => {
       throw new Error('network down');
     }) as typeof fetch;

--- a/scripts/photon-setup.ts
+++ b/scripts/photon-setup.ts
@@ -191,7 +191,12 @@ export interface PollOptions {
 }
 
 /** Poll the device-token endpoint until the user approves (RFC 8628 §3.4-3.5). */
-export async function pollForToken(fetchFn: FetchFn, dashboardHost: string, code: DeviceCode, opts: PollOptions = {}): Promise<string> {
+export async function pollForToken(
+  fetchFn: FetchFn,
+  dashboardHost: string,
+  code: DeviceCode,
+  opts: PollOptions = {},
+): Promise<string> {
   const clientId = opts.clientId ?? DEFAULT_CLIENT_ID;
   const sleepFn = opts.sleepFn ?? sleep;
   const now = opts.now ?? Date.now;
@@ -249,10 +254,12 @@ export async function pollForToken(fetchFn: FetchFn, dashboardHost: string, code
 /** Confirm a token works for the project APIs (not just session lookup). */
 export async function validateToken(fetchFn: FetchFn, dashboardHost: string, token: string): Promise<void> {
   const session = await fetchFn(`${dashboardHost}/api/auth/get-session`, { headers: bearer(token) });
-  if (session.status === 401 || session.status === 403) throw new Error('Photon rejected the device token (session lookup)');
+  if (session.status === 401 || session.status === 403)
+    throw new Error('Photon rejected the device token (session lookup)');
   if (!session.ok) throw new Error(`Photon session lookup failed: ${await errorDetail(session)}`);
   const projects = await fetchFn(`${dashboardHost}/api/projects/`, { headers: bearer(token) });
-  if (projects.status === 401 || projects.status === 403) throw new Error('Photon device token rejected by the project API');
+  if (projects.status === 401 || projects.status === 403)
+    throw new Error('Photon device token rejected by the project API');
   if (!projects.ok) throw new Error(`Photon project API check failed: ${await errorDetail(projects)}`);
 }
 
@@ -277,15 +284,27 @@ export function unwrapList(data: unknown): Array<Record<string, unknown>> {
   return [];
 }
 
-export async function listProjects(fetchFn: FetchFn, dashboardHost: string, token: string): Promise<Array<Record<string, unknown>>> {
+export async function listProjects(
+  fetchFn: FetchFn,
+  dashboardHost: string,
+  token: string,
+): Promise<Array<Record<string, unknown>>> {
   const resp = await fetchFn(`${dashboardHost}/api/projects`, { headers: bearer(token) });
   if (!resp.ok) throw new Error(`Photon list-projects failed: ${await errorDetail(resp)}`);
   return unwrapList(await resp.json().catch(() => []));
 }
 
-export function findProjectByName(projects: Array<Record<string, unknown>>, name: string): Record<string, unknown> | undefined {
+export function findProjectByName(
+  projects: Array<Record<string, unknown>>,
+  name: string,
+): Record<string, unknown> | undefined {
   const target = (name || '').trim().toLowerCase();
-  return projects.find((proj) => String(proj.name ?? '').trim().toLowerCase() === target);
+  return projects.find(
+    (proj) =>
+      String(proj.name ?? '')
+        .trim()
+        .toLowerCase() === target,
+  );
 }
 
 /**
@@ -353,7 +372,10 @@ export async function listUsers(
   return unwrapList(await resp.json().catch(() => []));
 }
 
-export function findUserByPhone(users: Array<Record<string, unknown>>, phone: string): Record<string, unknown> | undefined {
+export function findUserByPhone(
+  users: Array<Record<string, unknown>>,
+  phone: string,
+): Record<string, unknown> | undefined {
   const target = normalizePhone(phone);
   return users.find((u) => normalizePhone(String(u.phoneNumber ?? '')) === target);
 }
@@ -420,7 +442,10 @@ export function userOptedIn(user: Record<string, unknown> | undefined): boolean 
  * number, an opted-in row wins over whichever happens to list first — opt-in is
  * scoped to one user-number/assigned-line pair, so only that row routes.
  */
-export function findRoutableUser(users: Array<Record<string, unknown>>, phone: string): Record<string, unknown> | undefined {
+export function findRoutableUser(
+  users: Array<Record<string, unknown>>,
+  phone: string,
+): Record<string, unknown> | undefined {
   const target = normalizePhone(phone);
   const matches = users.filter((u) => normalizePhone(String(u.phoneNumber ?? '')) === target);
   return matches.find(userOptedIn) ?? matches[0];
@@ -495,7 +520,9 @@ export async function waitForOptedInUser(
     opts.onWaiting?.(attempt);
     if (attempt < maxAttempts) await sleepFn(intervalS * 1000);
   }
-  const lastErrorNote = lastError ? ` Last API error: ${lastError instanceof Error ? lastError.message : String(lastError)}.` : '';
+  const lastErrorNote = lastError
+    ? ` Last API error: ${lastError instanceof Error ? lastError.message : String(lastError)}.`
+    : '';
   const target = opts.assignedLine ? `to ${opts.assignedLine}` : 'to the line Photon assigned to it';
   throw new Error(
     `${phone} was not opted in after ${timeoutS}s.${lastErrorNote} Send one message from ${phone} ${target}, then re-run setup — it resumes where it left off.`,
@@ -767,11 +794,15 @@ async function runStatus(args: Args, fetchFn: FetchFn = fetch): Promise<number> 
     return 1;
   }
   if (routing === 'unverified') {
-    p.outro('Could not verify routing. Check connectivity and that the stored project secret is still valid, then try again.');
+    p.outro(
+      'Could not verify routing. Check connectivity and that the stored project secret is still valid, then try again.',
+    );
     return 1;
   }
   if (credentialsReady) {
-    p.outro('Photon credentials are saved, but phone routing is not ready. Re-run setup with --phone to register and opt in your number.');
+    p.outro(
+      'Photon credentials are saved, but phone routing is not ready. Re-run setup with --phone to register and opt in your number.',
+    );
     return 1;
   }
   p.outro('Run setup to finish onboarding.');
@@ -882,7 +913,9 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
     try {
       const { user, created } = await ensureUser(fetchFn, args.spectrumHost, projectId, secret, phone);
       const line = userAssignedLine(user);
-      p.log.info(created ? `Created your Photon user (assigned line ${line ?? 'pending'})` : 'Found your existing Photon user');
+      p.log.info(
+        created ? `Created your Photon user (assigned line ${line ?? 'pending'})` : 'Found your existing Photon user',
+      );
       if (userOptedIn(user)) {
         p.log.info('Phone already opted in');
         assigned = line;

--- a/scripts/q.test.ts
+++ b/scripts/q.test.ts
@@ -77,15 +77,15 @@ describe('scripts/q.ts', () => {
     expect(r.status).toBe(0);
 
     const db = new Database(dbPath, { readonly: true });
-    const ids = (db.prepare('SELECT id FROM t ORDER BY id').all() as { id: number }[]).map(
-      (r) => r.id,
-    );
+    const ids = (db.prepare('SELECT id FROM t ORDER BY id').all() as { id: number }[]).map((r) => r.id);
     db.close();
     expect(ids).toEqual([2, 9]);
   });
 
   it('WITH...DELETE is treated as a mutation, not a query', () => {
-    const r = run("WITH stale AS (SELECT id FROM t WHERE name = 'alice') DELETE FROM t WHERE id IN (SELECT id FROM stale)");
+    const r = run(
+      "WITH stale AS (SELECT id FROM t WHERE name = 'alice') DELETE FROM t WHERE id IN (SELECT id FROM stale)",
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toBe('');
 

--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -33,9 +33,7 @@ const toVersion = process.argv[3];
 const newCorePath = process.argv[4];
 
 if (!fromVersion || !toVersion || !newCorePath) {
-  console.error(
-    'Usage: tsx scripts/run-migrations.ts <from-version> <to-version> <new-core-path>',
-  );
+  console.error('Usage: tsx scripts/run-migrations.ts <from-version> <to-version> <new-core-path>');
   process.exit(1);
 }
 
@@ -60,10 +58,7 @@ const entries = fs.readdirSync(migrationsDir, { withFileTypes: true });
 const migrationVersions = entries
   .filter((e) => e.isDirectory() && /^\d+\.\d+\.\d+$/.test(e.name))
   .map((e) => e.name)
-  .filter(
-    (v) =>
-      compareSemver(v, fromVersion) > 0 && compareSemver(v, toVersion) <= 0,
-  )
+  .filter((v) => compareSemver(v, fromVersion) > 0 && compareSemver(v, toVersion) <= 0)
   .sort(compareSemver);
 
 const projectRoot = process.cwd();
@@ -80,9 +75,7 @@ for (const version of migrationVersions) {
   }
 
   try {
-    const tsxArgs = tsxBin.endsWith('npx')
-      ? ['tsx', migrationIndex, projectRoot]
-      : [migrationIndex, projectRoot];
+    const tsxArgs = tsxBin.endsWith('npx') ? ['tsx', migrationIndex, projectRoot] : [migrationIndex, projectRoot];
     execFileSync(tsxBin, tsxArgs, {
       stdio: 'pipe',
       cwd: projectRoot,
@@ -95,9 +88,7 @@ for (const version of migrationVersions) {
   }
 }
 
-console.log(
-  JSON.stringify({ migrationsRun: results.length, results }, null, 2),
-);
+console.log(JSON.stringify({ migrationsRun: results.length, results }, null, 2));
 
 // Exit with error if any migration failed
 if (results.some((r) => !r.success)) {

--- a/scripts/sanity-live-poll.ts
+++ b/scripts/sanity-live-poll.ts
@@ -25,37 +25,44 @@
  * Requires: Docker Desktop running, nanoclaw-agent:latest image built.
  */
 
-import { spawn, spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { mkdirSync, rmSync } from "node:fs";
-import Database from "better-sqlite3";
+import { spawn, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import Database from 'better-sqlite3';
 
-const dbDir = join("/tmp", `nanoclaw-live-${Date.now()}`);
+const dbDir = join('/tmp', `nanoclaw-live-${Date.now()}`);
 mkdirSync(dbDir, { recursive: true });
-spawnSync("chmod", ["777", dbDir]);
-const dbPath = join(dbDir, "live.db");
+spawnSync('chmod', ['777', dbDir]);
+const dbPath = join(dbDir, 'live.db');
 
-for (const journalMode of ["DELETE", "WAL"]) {
+for (const journalMode of ['DELETE', 'WAL']) {
   console.log(`\n=== ${journalMode} ===`);
   rmSync(dbPath, { force: true });
-  rmSync(dbPath + "-wal", { force: true });
-  rmSync(dbPath + "-shm", { force: true });
-  rmSync(dbPath + "-journal", { force: true });
+  rmSync(dbPath + '-wal', { force: true });
+  rmSync(dbPath + '-shm', { force: true });
+  rmSync(dbPath + '-journal', { force: true });
 
   const db = new Database(dbPath);
   db.pragma(`journal_mode = ${journalMode}`);
-  db.pragma("synchronous = FULL");
-  db.exec("CREATE TABLE msgs (seq INTEGER PRIMARY KEY, content TEXT)");
+  db.pragma('synchronous = FULL');
+  db.exec('CREATE TABLE msgs (seq INTEGER PRIMARY KEY, content TEXT)');
   db.close();
 
   // Start container poller in background
-  const contProc = spawn("docker", [
-    "run", "--rm", "-w", "/app",
-    "-v", `${dbDir}:/workspace`,
-    "--entrypoint", "node",
-    "nanoclaw-agent:latest",
-    "-e",
-    `const Database = require('better-sqlite3');
+  const contProc = spawn(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '-w',
+      '/app',
+      '-v',
+      `${dbDir}:/workspace`,
+      '--entrypoint',
+      'node',
+      'nanoclaw-agent:latest',
+      '-e',
+      `const Database = require('better-sqlite3');
      const db = new Database('/workspace/live.db', { readonly: true });
      db.pragma('busy_timeout = 2000');
      const stmt = db.prepare('SELECT COUNT(*) as n, MAX(seq) as hi FROM msgs');
@@ -65,10 +72,12 @@ for (const journalMode of ["DELETE", "WAL"]) {
        console.log('poll t=' + (Date.now() % 100000) + ' count=' + r.n + ' max=' + r.hi);
        if (++count >= 10) { clearInterval(timer); db.close(); }
      }, 1000);`,
-  ], { stdio: ["ignore", "pipe", "pipe"] });
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  );
 
-  contProc.stdout.on("data", (d) => process.stdout.write(`  [cont] ${d}`));
-  contProc.stderr.on("data", (d) => process.stderr.write(`  [cont-err] ${d}`));
+  contProc.stdout.on('data', (d) => process.stdout.write(`  [cont] ${d}`));
+  contProc.stderr.on('data', (d) => process.stderr.write(`  [cont-err] ${d}`));
 
   // Give container a moment to start
   const waitUntil = Date.now() + 2000;
@@ -78,8 +87,8 @@ for (const journalMode of ["DELETE", "WAL"]) {
   for (let i = 1; i <= 8; i++) {
     const h = new Database(dbPath);
     h.pragma(`journal_mode = ${journalMode}`);
-    h.pragma("synchronous = FULL");
-    h.prepare("INSERT INTO msgs (seq, content) VALUES (?, ?)").run(i, `msg-${i}`);
+    h.pragma('synchronous = FULL');
+    h.prepare('INSERT INTO msgs (seq, content) VALUES (?, ?)').run(i, `msg-${i}`);
     h.close();
     console.log(`  [host] wrote+closed seq=${i} t=${Date.now() % 100000}`);
     const sleepUntil = Date.now() + 1000;
@@ -87,7 +96,7 @@ for (const journalMode of ["DELETE", "WAL"]) {
   }
 
   // Wait for container to finish
-  await new Promise<void>((res) => contProc.once("exit", () => res()));
+  await new Promise<void>((res) => contProc.once('exit', () => res()));
 }
 
 rmSync(dbDir, { recursive: true, force: true });

--- a/scripts/seed-discord.ts
+++ b/scripts/seed-discord.ts
@@ -7,22 +7,18 @@ import { CENTRAL_DB_PATH } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup, getAgentGroup } from '../src/db/agent-groups.js';
-import {
-  createMessagingGroup,
-  createMessagingGroupAgent,
-  getMessagingGroup,
-} from '../src/db/messaging-groups.js';
+import { createMessagingGroup, createMessagingGroupAgent, getMessagingGroup } from '../src/db/messaging-groups.js';
 
-const db = initDb(CENTRAL_DB_PATH);
-runMigrations(db);
+const db = await initDb(CENTRAL_DB_PATH);
+await runMigrations(db);
 
 const AGENT_GROUP_ID = 'ag-main';
 const MESSAGING_GROUP_ID = 'mg-discord';
 const CHANNEL_ID = 'discord:1470188214710046894:1491569326447132673';
 
 // Agent group
-if (!getAgentGroup(AGENT_GROUP_ID)) {
-  createAgentGroup({
+if (!(await getAgentGroup(AGENT_GROUP_ID))) {
+  await createAgentGroup({
     id: AGENT_GROUP_ID,
     name: 'Main',
     folder: 'main',
@@ -35,8 +31,8 @@ if (!getAgentGroup(AGENT_GROUP_ID)) {
 }
 
 // Messaging group
-if (!getMessagingGroup(MESSAGING_GROUP_ID)) {
-  createMessagingGroup({
+if (!(await getMessagingGroup(MESSAGING_GROUP_ID))) {
+  await createMessagingGroup({
     id: MESSAGING_GROUP_ID,
     channel_type: 'discord',
     platform_id: CHANNEL_ID,
@@ -52,7 +48,7 @@ if (!getMessagingGroup(MESSAGING_GROUP_ID)) {
 
 // Link
 try {
-  createMessagingGroupAgent({
+  await createMessagingGroupAgent({
     id: 'mga-discord',
     messaging_group_id: MESSAGING_GROUP_ID,
     agent_group_id: AGENT_GROUP_ID,

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -50,7 +50,15 @@ export interface InputMeta {
 // its own.
 export type ApplyEvent =
   | { type: 'step-start'; kind: string; line: number; label: string | null }
-  | { type: 'step-end'; kind: string; line: number; label: string | null; ok: boolean; durationMs: number; error?: string }
+  | {
+      type: 'step-end';
+      kind: string;
+      line: number;
+      label: string | null;
+      ok: boolean;
+      durationMs: number;
+      error?: string;
+    }
   | { type: 'operator'; line: number; text: string };
 // operator: text = the rendered, {{var}}-substituted block body;
 //           line = the directive's opening-fence line (keys driver policy maps)
@@ -103,14 +111,21 @@ function envKeySet(root: string, key: string): boolean {
 function jsonArrayHasKey(root: string, rel: string, key: string, value: unknown): boolean {
   try {
     const arr = JSON.parse(read(join(root, rel)) || '[]');
-    return Array.isArray(arr) && arr.some((el) => el !== null && typeof el === 'object' && (el as Record<string, unknown>)[key] === value);
+    return (
+      Array.isArray(arr) &&
+      arr.some((el) => el !== null && typeof el === 'object' && (el as Record<string, unknown>)[key] === value)
+    );
   } catch {
     return false;
   }
 }
 
 // Per-directive idempotency check + "what it would do". Read-only.
-function selfStatus(d: Directive, root: string, mode: 'install' | 'refresh' = 'install'): { status: StepStatus; detail: string } {
+function selfStatus(
+  d: Directive,
+  root: string,
+  mode: 'install' | 'refresh' = 'install',
+): { status: StepStatus; detail: string } {
   switch (d.kind) {
     case 'copy': {
       const dests = d.body.map(destOf);
@@ -156,7 +171,10 @@ function selfStatus(d: Directive, root: string, mode: 'install' | 'refresh' = 'i
       try {
         value = (JSON.parse(d.body.join('\n')) as Record<string, unknown>)[key];
       } catch {
-        return { status: 'agent', detail: `nc:json-merge body is not parseable JSON — an agent applies it from the prose` };
+        return {
+          status: 'agent',
+          detail: `nc:json-merge body is not parseable JSON — an agent applies it from the prose`,
+        };
       }
       if (mode === 'refresh') {
         return { status: 'apply', detail: `refresh ${key}=${JSON.stringify(value)} in ${into}` };
@@ -170,17 +188,24 @@ function selfStatus(d: Directive, root: string, mode: 'install' | 'refresh' = 'i
     case 'operator':
       return { status: 'apply', detail: `show operator: ${(d.body[0] ?? '').slice(0, 50)}…` };
     default:
-      return { status: 'agent', detail: `no deterministic handler for nc:${d.kind} — an agent applies it from the prose` };
+      return {
+        status: 'agent',
+        detail: `no deterministic handler for nc:${d.kind} — an agent applies it from the prose`,
+      };
   }
 }
 
-export function planSkill(skillDir: string, root: string): { steps: PlanStep[]; needsInput: string[]; agentSteps: number } {
+export function planSkill(
+  skillDir: string,
+  root: string,
+): { steps: PlanStep[]; needsInput: string[]; agentSteps: number } {
   const directives = parseDirectives(read(join(skillDir, 'SKILL.md')));
   const self = directives.map((d) => ({ d, ...selfStatus(d, root) }));
 
   const consumers = new Map<string, number[]>();
   self.forEach(({ d }, i) => {
-    for (const line of d.body) for (const m of line.matchAll(VAR_REF)) (consumers.get(m[1]) ?? consumers.set(m[1], []).get(m[1])!).push(i);
+    for (const line of d.body)
+      for (const m of line.matchAll(VAR_REF)) (consumers.get(m[1]) ?? consumers.set(m[1], []).get(m[1])!).push(i);
   });
 
   const steps: PlanStep[] = self.map(({ d, status, detail }, i) => {
@@ -316,7 +341,10 @@ export function firstFailureHint(res: ApplyResult): { headline: string; hint: st
   const hint = first.prose.trim();
   // The concise headline: the nearest `#`-heading the prose carries, stripped of
   // its markers; failing that, the first prose line; failing that, the reason.
-  const lines = first.prose.split('\n').map((l) => l.trim()).filter(Boolean);
+  const lines = first.prose
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
   const heading = lines.find((l) => l.startsWith('#'));
   const headline = heading ? heading.replace(/^#+\s*/, '').trim() : (lines[0] ?? first.reason);
   return { headline, hint };
@@ -360,7 +388,10 @@ export function referenceProse(md: string): string {
       }
       continue;
     }
-    if (fence !== null) { keep(line); continue; } // fence body
+    if (fence !== null) {
+      keep(line);
+      continue;
+    } // fence body
     const h = line.match(/^(#{1,6})\s+(.*)$/);
     if (h) {
       const level = h[1].length;
@@ -369,7 +400,10 @@ export function referenceProse(md: string): string {
         if (cur) sections.push(cur.join('\n').trim());
         cur = [line]; // open a new reference section
       } else if (level <= 2) {
-        if (cur) { sections.push(cur.join('\n').trim()); cur = null; } // a non-reference h1/h2 closes the slice
+        if (cur) {
+          sections.push(cur.join('\n').trim());
+          cur = null;
+        } // a non-reference h1/h2 closes the slice
       } else if (cur) {
         cur.push(line); // a subsection (### …) inside a captured reference section
       }
@@ -394,7 +428,10 @@ function defaultResolveRemote(branch: string, root: string): string {
       return '';
     }
   };
-  const remotes = cap('git remote').split('\n').map((s) => s.trim()).filter(Boolean);
+  const remotes = cap('git remote')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
   const ordered = remotes.includes('origin') ? ['origin', ...remotes.filter((r) => r !== 'origin')] : remotes;
   for (const r of ordered) if (cap(`git ls-remote --heads ${r} ${branch}`).trim()) return r;
   return 'origin';
@@ -409,7 +446,11 @@ function proseFor(md: string, fenceLine1: number): string {
   const para: string[] = [];
   while (i >= 0 && lines[i].trim() !== '' && !lines[i].startsWith('#')) para.unshift(lines[i--]);
   let heading = '';
-  for (let h = i; h >= 0; h--) if (lines[h].startsWith('#')) { heading = lines[h]; break; }
+  for (let h = i; h >= 0; h--)
+    if (lines[h].startsWith('#')) {
+      heading = lines[h];
+      break;
+    }
   return [heading, ...para].filter(Boolean).join('\n').trim();
 }
 
@@ -427,7 +468,10 @@ function headingAbove(md: string, fenceLine1: number): string {
       // sequence restarts the count mid-run — so the operator sees
       // "1, 3, 4, 4, Restart, 2, 4". The engine's own (i/n) suffix
       // (labelOrdinals) already disambiguates repeats, and it stays correct.
-      return lines[h].replace(/^#+\s*/, '').replace(/^\d+[.)]\s+/, '').trim();
+      return lines[h]
+        .replace(/^#+\s*/, '')
+        .replace(/^\d+[.)]\s+/, '')
+        .trim();
     }
   }
   return '';
@@ -461,8 +505,12 @@ export function stepLabel(d: Directive, md: string): string | null {
   if (d.kind === 'dep') return 'Installing dependencies';
   if (d.kind === 'copy') return 'Fetching files';
   const byEffect: Record<string, string> = {
-    build: 'Building', test: 'Testing', fetch: 'Fetching',
-    wire: 'Wiring', restart: 'Restarting', external: 'Running',
+    build: 'Building',
+    test: 'Testing',
+    fetch: 'Fetching',
+    wire: 'Wiring',
+    restart: 'Restarting',
+    external: 'Running',
   };
   return (effect && byEffect[effect]) || 'Running';
 }
@@ -578,7 +626,17 @@ function bindCapture(
 // is derivable. Throws on failure → caught and bounced to an agent.
 async function applyOne(
   d: Directive,
-  ctx: { root: string; skillDir: string; exec: (c: string) => string | void | Promise<string | void>; execStream?: (c: string) => Promise<StepOutcome>; resolveRemote: (b: string) => string; resolveDependencyCommand?: (request: DependencyCommandRequest) => string; vars: Map<string, { value: string; secret: boolean }>; journal: JournalEntry[]; mode: 'install' | 'refresh' },
+  ctx: {
+    root: string;
+    skillDir: string;
+    exec: (c: string) => string | void | Promise<string | void>;
+    execStream?: (c: string) => Promise<StepOutcome>;
+    resolveRemote: (b: string) => string;
+    resolveDependencyCommand?: (request: DependencyCommandRequest) => string;
+    vars: Map<string, { value: string; secret: boolean }>;
+    journal: JournalEntry[];
+    mode: 'install' | 'refresh';
+  },
 ): Promise<void> {
   const { root, skillDir, exec, vars, journal } = ctx;
   switch (d.kind) {
@@ -675,14 +733,18 @@ async function applyOne(
       // multi-valued twin of stdout capture. No streaming exec ⇒ throw → an agent
       // runs the step from the prose (degrade, not crash).
       if (d.attrs.effect === 'step') {
-        if (!ctx.execStream) throw new Error('effect:step needs a streaming exec — an agent runs the step from the prose');
+        if (!ctx.execStream)
+          throw new Error('effect:step needs a streaming exec — an agent runs the step from the prose');
         const { ok, fields } = await ctx.execStream(substitute(d.body.join('\n'), vars));
         if (!ok) throw new Error('the step did not complete');
         if (capture) {
           for (const pair of capture.split(',')) {
             const eq = pair.indexOf('=');
             if (eq < 1) continue;
-            vars.set(pair.slice(0, eq).trim(), { value: (fields[pair.slice(eq + 1).trim()] ?? '').trim(), secret: false });
+            vars.set(pair.slice(0, eq).trim(), {
+              value: (fields[pair.slice(eq + 1).trim()] ?? '').trim(),
+              secret: false,
+            });
           }
         }
         journal.push({ op: 'ran', cmd: d.body.join('\n') });
@@ -713,7 +775,10 @@ async function applyOne(
         const key = entry.slice(0, eq).trim();
         const value = substitute(entry.slice(eq + 1).trim(), vars); // throws if a {{var}} is unresolved
         if (!envKeySet(root, key)) {
-          appendFileSync(envPath, (read(envPath).endsWith('\n') || read(envPath) === '' ? '' : '\n') + `${key}=${value}\n`);
+          appendFileSync(
+            envPath,
+            (read(envPath).endsWith('\n') || read(envPath) === '' ? '' : '\n') + `${key}=${value}\n`,
+          );
           journal.push({ op: 'set-env', key });
         }
       }
@@ -753,10 +818,23 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
   // caught, or one newer than this engine) bounces to an agent, never blocks.
   const md = read(join(skillDir, 'SKILL.md'));
   const directives = parseDirectives(md);
-  const exec = opts.exec ?? (() => { throw new Error('no exec provided'); });
+  const exec =
+    opts.exec ??
+    (() => {
+      throw new Error('no exec provided');
+    });
   const resolveRemote = opts.resolveRemote ?? ((b: string) => defaultResolveRemote(b, root));
   const vars = new Map<string, { value: string; secret: boolean }>();
-  const res: ApplyResult = { applied: [], skipped: [], deferred: [], agentTasks: [], operatorMessages: [], vars: {}, journal: [], referenceProse: referenceProse(md) };
+  const res: ApplyResult = {
+    applied: [],
+    skipped: [],
+    deferred: [],
+    agentTasks: [],
+    operatorMessages: [],
+    vars: {},
+    journal: [],
+    referenceProse: referenceProse(md),
+  };
   // A run-health gate: once ANY directive bounces to an agent, the skill is no
   // longer in a known-good state, so the dangerous side effects below must not
   // fire on their own — a live restart, an interactive pairing/QR step, or a wire
@@ -812,7 +890,10 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
         // via `resolveInput`; still undefined ⇒ defer (headless, no answer).
         let val = opts.inputs?.[v];
         if (val === undefined) val = await opts.resolveInput?.(v, inputMetaOf(d, secret, validate));
-        if (val === undefined) { res.deferred.push(v); continue; }
+        if (val === undefined) {
+          res.deferred.push(v);
+          continue;
+        }
         // normalize:<how> binds DETERMINISTICALLY for both inputs and answers, so
         // an `inputs` value and a typed one land identically (a trailing slash
         // stripped, whitespace trimmed) — see normalizeValue.
@@ -876,8 +957,14 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
         continue;
       }
       const st = selfStatus(d, root, opts.mode);
-      if (st.status === 'agent') { bounce(d, 'no deterministic handler'); continue; }
-      if (st.status === 'skip') { res.skipped.push(`${d.kind}: ${st.detail}`); continue; }
+      if (st.status === 'agent') {
+        bounce(d, 'no deterministic handler');
+        continue;
+      }
+      if (st.status === 'skip') {
+        res.skipped.push(`${d.kind}: ${st.detail}`);
+        continue;
+      }
       // Bracket the real mutation with step events so a consumer can render
       // progress. `label` null is a step-cost/interactivity declaration (see
       // `stepLabel`). `inFlight` is set only after step-start fires; the ok:true
@@ -886,10 +973,21 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
       const label = stepLabel(d, md);
       if (opts.onEvent) await opts.onEvent({ type: 'step-start', kind: d.kind, line: d.line, label });
       inFlight = { label, at: Date.now() };
-      await applyOne(d, { root, skillDir, exec, execStream: opts.execStream, resolveRemote, resolveDependencyCommand: opts.resolveDependencyCommand, vars, journal: res.journal, mode: opts.mode ?? 'install' });
+      await applyOne(d, {
+        root,
+        skillDir,
+        exec,
+        execStream: opts.execStream,
+        resolveRemote,
+        resolveDependencyCommand: opts.resolveDependencyCommand,
+        vars,
+        journal: res.journal,
+        mode: opts.mode ?? 'install',
+      });
       const durationMs = Date.now() - inFlight.at;
       inFlight = null;
-      if (opts.onEvent) await opts.onEvent({ type: 'step-end', kind: d.kind, line: d.line, label, ok: true, durationMs });
+      if (opts.onEvent)
+        await opts.onEvent({ type: 'step-end', kind: d.kind, line: d.line, label, ok: true, durationMs });
       res.applied.push(`${d.kind}: ${st.detail}`);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -899,10 +997,22 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
       // best-effort: a consumer that also throws here can't change the outcome —
       // we're already on the failure path.
       if (inFlight && opts.onEvent) {
-        const end = { kind: d.kind, line: d.line, label: inFlight.label, ok: false, durationMs: Date.now() - inFlight.at, error: msg };
-        try { await opts.onEvent({ type: 'step-end', ...end }); } catch { /* already failing — the close is best-effort */ }
+        const end = {
+          kind: d.kind,
+          line: d.line,
+          label: inFlight.label,
+          ok: false,
+          durationMs: Date.now() - inFlight.at,
+          error: msg,
+        };
+        try {
+          await opts.onEvent({ type: 'step-end', ...end });
+        } catch {
+          /* already failing — the close is best-effort */
+        }
       }
-      if (/unresolved \{\{/.test(msg)) res.deferred.push(msg); // blocked on a prompt input
+      if (/unresolved \{\{/.test(msg))
+        res.deferred.push(msg); // blocked on a prompt input
       else bounce(d, `engine could not apply (${msg}) — an agent applies it from the prose`);
     }
   }
@@ -912,15 +1022,31 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
 }
 
 // Remove is the journal played backwards — no hand-written REMOVE.md.
-export async function removeSkill(root: string, journal: JournalEntry[], exec?: (c: string) => void | Promise<void>): Promise<void> {
+export async function removeSkill(
+  root: string,
+  journal: JournalEntry[],
+  exec?: (c: string) => void | Promise<void>,
+): Promise<void> {
   for (const e of [...journal].reverse()) {
     if (e.op === 'wrote') rmSync(join(root, e.path), { force: true });
     else if (e.op === 'appended') {
       const p = join(root, e.path);
-      writeFileSync(p, read(p).split('\n').filter((l) => l.trim() !== e.line.trim()).join('\n'));
+      writeFileSync(
+        p,
+        read(p)
+          .split('\n')
+          .filter((l) => l.trim() !== e.line.trim())
+          .join('\n'),
+      );
     } else if (e.op === 'set-env') {
       const p = join(root, '.env');
-      writeFileSync(p, read(p).split('\n').filter((l) => !l.startsWith(`${e.key}=`)).join('\n'));
+      writeFileSync(
+        p,
+        read(p)
+          .split('\n')
+          .filter((l) => !l.startsWith(`${e.key}=`))
+          .join('\n'),
+      );
     } else if (e.op === 'json-merge') {
       const p = join(root, e.path);
       const arr = JSON.parse(read(p) || '[]') as unknown[];
@@ -948,7 +1074,13 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
   const root = process.cwd();
   const { steps, needsInput, agentSteps } = planSkill(skillDir, root);
   console.log(`PLAN ${skillDir}   project: ${root}\n`);
-  const icon: Record<StepStatus, string> = { skip: '✓ skip', apply: '→ apply', 'needs-input': '? human', agent: '↳ agent' };
-  for (const s of steps) console.log(`${String(s.n).padStart(2)}. ${icon[s.status].padEnd(8)} ${s.kind.padEnd(9)} ${s.detail}`);
+  const icon: Record<StepStatus, string> = {
+    skip: '✓ skip',
+    apply: '→ apply',
+    'needs-input': '? human',
+    agent: '↳ agent',
+  };
+  for (const s of steps)
+    console.log(`${String(s.n).padStart(2)}. ${icon[s.status].padEnd(8)} ${s.kind.padEnd(9)} ${s.detail}`);
   console.log(`\nneeds human input: ${needsInput.join(', ') || '(none)'}    →agent: ${agentSteps}`);
 }

--- a/scripts/skill-conformance.test.ts
+++ b/scripts/skill-conformance.test.ts
@@ -194,7 +194,10 @@ describe.each(SKILLS)('%s', (name) => {
   const directives = parseDirectives(md);
   const byLine = new Map(directives.map((d) => [d.line, d]));
   const promptVars = new Set(
-    directives.filter((d) => d.kind === 'prompt').map((d) => promptVar(d)).filter(isString),
+    directives
+      .filter((d) => d.kind === 'prompt')
+      .map((d) => promptVar(d))
+      .filter(isString),
   );
   const guards = [...new Set(directives.map((d) => d.attrs.when).filter(isString))];
   const fixture = loadFixture(name);
@@ -220,7 +223,10 @@ describe.each(SKILLS)('%s', (name) => {
       .filter(isString);
     for (const sc of fixture?.scenarios ?? []) {
       for (const k of Object.keys(sc.inputs ?? {})) {
-        expect(promptVars.has(k), `scenario "${sc.name}" supplies input "${k}" which is not a prompt var of ${name} — stale fixture?`).toBe(true);
+        expect(
+          promptVars.has(k),
+          `scenario "${sc.name}" supplies input "${k}" which is not a prompt var of ${name} — stale fixture?`,
+        ).toBe(true);
       }
       for (const v of unguarded) {
         expect(
@@ -250,7 +256,10 @@ describe.each(SKILLS)('%s', (name) => {
     // exec/stepFields fixture entry is missing (bindCapture binds '' when the
     // stub returned nothing and no validate: catches it).
     for (const [k, v] of Object.entries(res.vars)) {
-      expect(v, `resolved {{${k}}} is empty in scenario "${sc.name}" — add/fix the exec or stepFields fixture entry answering that capture`).not.toBe('');
+      expect(
+        v,
+        `resolved {{${k}}} is empty in scenario "${sc.name}" — add/fix the exec or stepFields fixture entry answering that capture`,
+      ).not.toBe('');
     }
   });
 
@@ -283,7 +292,9 @@ describe.each(SKILLS)('%s', (name) => {
     if (firstBuild >= 0) {
       directives.forEach((d, i) => {
         if (['copy', 'append', 'dep', 'json-merge'].includes(d.kind)) {
-          expect(i, `${d.kind} at line ${d.line} lands after the build — the build would not see it`).toBeLessThan(firstBuild);
+          expect(i, `${d.kind} at line ${d.line} lands after the build — the build would not see it`).toBeLessThan(
+            firstBuild,
+          );
         }
       });
     }

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { parseDirectives, validate, promptVar, resolveChatCoreVersion, lintReferenceFloor, lintGateAmbiguity } from './skill-directives.js';
+import {
+  parseDirectives,
+  validate,
+  promptVar,
+  resolveChatCoreVersion,
+  lintReferenceFloor,
+  lintGateAmbiguity,
+} from './skill-directives.js';
 
 // Guards the structured-directive format against the converted add-slack skill:
 // red if the conversion drifts (a directive dropped/renamed) or the parser breaks.
@@ -157,7 +164,11 @@ describe('validation catches malformed directives', () => {
 });
 
 describe('json-merge directive', () => {
-  const codex = ['```nc:json-merge into:container/cli-tools.json key:name', '{ "name": "@openai/codex", "version": "0.138.0" }', '```'].join('\n');
+  const codex = [
+    '```nc:json-merge into:container/cli-tools.json key:name',
+    '{ "name": "@openai/codex", "version": "0.138.0" }',
+    '```',
+  ].join('\n');
 
   it('parses into/key attrs and the JSON object body', () => {
     const [d] = parseDirectives(codex);
@@ -199,7 +210,11 @@ describe('json-merge directive', () => {
 
 describe('append at:<marker> attribute', () => {
   it('parses an optional at:<marker> alongside to:', () => {
-    const md = ['```nc:append to:setup/index.ts at:nanoclaw:setup-steps', "  codex: () => import('./codex.js'),", '```'].join('\n');
+    const md = [
+      '```nc:append to:setup/index.ts at:nanoclaw:setup-steps',
+      "  codex: () => import('./codex.js'),",
+      '```',
+    ].join('\n');
     const [d] = parseDirectives(md);
     expect(d.kind).toBe('append');
     expect(d.attrs.to).toBe('setup/index.ts');
@@ -207,7 +222,11 @@ describe('append at:<marker> attribute', () => {
   });
 
   it('still validates an append that carries at: (to + a line are all it needs)', () => {
-    const md = ['```nc:append to:setup/index.ts at:nanoclaw:setup-steps', "  codex: () => import('./codex.js'),", '```'].join('\n');
+    const md = [
+      '```nc:append to:setup/index.ts at:nanoclaw:setup-steps',
+      "  codex: () => import('./codex.js'),",
+      '```',
+    ].join('\n');
     expect(validate(parseDirectives(md))).toEqual([]);
   });
 });
@@ -223,7 +242,14 @@ describe('retired directives', () => {
 
 describe('when: guard + multi-field capture', () => {
   it('parses when: into attrs and lints a guard whose var an earlier prompt defined', () => {
-    const md = ['```nc:prompt mode', 'local or remote', '```', '```nc:prompt server_url when:mode=remote', 'url', '```'].join('\n');
+    const md = [
+      '```nc:prompt mode',
+      'local or remote',
+      '```',
+      '```nc:prompt server_url when:mode=remote',
+      'url',
+      '```',
+    ].join('\n');
     const ds = parseDirectives(md);
     expect(ds[1].attrs.when).toBe('mode=remote');
     expect(validate(ds)).toEqual([]);
@@ -305,7 +331,9 @@ describe('prompt attrs (flags/normalize/reuse)', () => {
 
   it('flags a reuse: that is not a valid ENV_KEY', () => {
     const md = ['```nc:prompt u reuse:not-an-env-key', 'q', '```'].join('\n');
-    expect(validate(parseDirectives(md)).some((p) => /reuse:not-an-env-key must be a valid ENV_KEY/.test(p.message))).toBe(true);
+    expect(
+      validate(parseDirectives(md)).some((p) => /reuse:not-an-env-key must be a valid ENV_KEY/.test(p.message)),
+    ).toBe(true);
   });
 
   it('flags illegal regex flags:', () => {
@@ -333,7 +361,9 @@ describe('lintReferenceFloor (warn-only reference floor)', () => {
   });
 
   it('is silent once a ## Troubleshooting section is present', () => {
-    const md = ['```nc:prompt token secret', 'Paste it.', '```', '', '## Troubleshooting', 'Check the logs.'].join('\n');
+    const md = ['```nc:prompt token secret', 'Paste it.', '```', '', '## Troubleshooting', 'Check the logs.'].join(
+      '\n',
+    );
     expect(lintReferenceFloor(md)).toEqual([]);
   });
 
@@ -356,7 +386,11 @@ describe('lintReferenceFloor (warn-only reference floor)', () => {
 // document structure, the preceding heading, the surrounding prose).
 describe('removed presentation attrs are lint errors', () => {
   it('rejects operator open: — the URL belongs in the body prose', () => {
-    const md = ['```nc:operator open:https://portal.azure.com', 'Visit https://portal.azure.com and click through.', '```'].join('\n');
+    const md = [
+      '```nc:operator open:https://portal.azure.com',
+      'Visit https://portal.azure.com and click through.',
+      '```',
+    ].join('\n');
     const probs = validate(parseDirectives(md));
     expect(probs.some((p) => /operator open: was removed — put the URL in the body prose/.test(p.message))).toBe(true);
   });
@@ -364,7 +398,11 @@ describe('removed presentation attrs are lint errors', () => {
   it('rejects the bare operator gate flag — the barrier is structure-derived', () => {
     const md = ['```nc:operator gate', 'Finish the UI steps.', '```'].join('\n');
     const probs = validate(parseDirectives(md));
-    expect(probs.some((p) => /operator gate was removed — the human barrier is derived from document structure/.test(p.message))).toBe(true);
+    expect(
+      probs.some((p) =>
+        /operator gate was removed — the human barrier is derived from document structure/.test(p.message),
+      ),
+    ).toBe(true);
   });
 
   it('rejects prompt min: — length is regex-encoded now', () => {
@@ -376,23 +414,33 @@ describe('removed presentation attrs are lint errors', () => {
   it('rejects prompt error: — the miss message derives from the question prose', () => {
     const md = ['```nc:prompt token error:bad-token', 'Paste the token.', '```'].join('\n');
     const probs = validate(parseDirectives(md));
-    expect(probs.some((p) => /prompt error: was removed — the validation-miss message derives from the question prose/.test(p.message))).toBe(true);
+    expect(
+      probs.some((p) =>
+        /prompt error: was removed — the validation-miss message derives from the question prose/.test(p.message),
+      ),
+    ).toBe(true);
   });
 
   it('rejects label: on any directive — labels are heading-derived only', () => {
     const md = ['```nc:run effect:build label:build', 'pnpm run build', '```'].join('\n');
     const probs = validate(parseDirectives(md));
-    expect(probs.some((p) => /label: was removed — step labels derive from the preceding heading/.test(p.message))).toBe(true);
+    expect(
+      probs.some((p) => /label: was removed — step labels derive from the preceding heading/.test(p.message)),
+    ).toBe(true);
   });
 
   it('rejects on-fail: on any directive — the hint is always the surrounding prose', () => {
     const md = ['```nc:run effect:test on-fail:rerun', 'pnpm test', '```'].join('\n');
     const probs = validate(parseDirectives(md));
-    expect(probs.some((p) => /on-fail: was removed — the failure hint is always the surrounding prose/.test(p.message))).toBe(true);
+    expect(
+      probs.some((p) => /on-fail: was removed — the failure hint is always the surrounding prose/.test(p.message)),
+    ).toBe(true);
   });
 
   it('still accepts a plain operator block (body-only, no attrs)', () => {
-    const md = ['```nc:prompt bot', 'Bot?', '```', '```nc:operator', 'Open @{{bot}} and press Start.', '```'].join('\n');
+    const md = ['```nc:prompt bot', 'Bot?', '```', '```nc:operator', 'Open @{{bot}} and press Start.', '```'].join(
+      '\n',
+    );
     expect(validate(parseDirectives(md))).toEqual([]);
   });
 });
@@ -403,10 +451,18 @@ describe('removed presentation attrs are lint errors', () => {
 // be runtime-skipped — the static policy cannot know which branch runs.
 describe('lintGateAmbiguity (warn-only unguarded-operator/multi-branch)', () => {
   const branchy = [
-    '```nc:prompt mode', 'local or remote?', '```',
-    '```nc:operator', 'Get ready.', '```',
-    '```nc:prompt server_url when:mode=remote', 'URL?', '```',
-    '```nc:run effect:external when:mode=local', './configure.sh', '```',
+    '```nc:prompt mode',
+    'local or remote?',
+    '```',
+    '```nc:operator',
+    'Get ready.',
+    '```',
+    '```nc:prompt server_url when:mode=remote',
+    'URL?',
+    '```',
+    '```nc:run effect:external when:mode=local',
+    './configure.sh',
+    '```',
   ].join('\n');
 
   it('warns on an unguarded operator followed by guards spanning two branch values', () => {
@@ -424,37 +480,71 @@ describe('lintGateAmbiguity (warn-only unguarded-operator/multi-branch)', () => 
 
   it('is silent when the operator itself is guarded (mutually-exclusive branches gate on their own next action)', () => {
     const md = [
-      '```nc:prompt mode', 'local or remote?', '```',
-      '```nc:operator when:mode=local', 'Get ready.', '```',
-      '```nc:prompt server_url when:mode=remote', 'URL?', '```',
-      '```nc:run effect:external when:mode=local', './configure.sh', '```',
+      '```nc:prompt mode',
+      'local or remote?',
+      '```',
+      '```nc:operator when:mode=local',
+      'Get ready.',
+      '```',
+      '```nc:prompt server_url when:mode=remote',
+      'URL?',
+      '```',
+      '```nc:run effect:external when:mode=local',
+      './configure.sh',
+      '```',
     ].join('\n');
     expect(lintGateAmbiguity(parseDirectives(md))).toEqual([]);
   });
 
   it('is silent when the following guards all share one branch value', () => {
     const md = [
-      '```nc:prompt mode', 'local or remote?', '```',
-      '```nc:operator', 'Get ready.', '```',
-      '```nc:prompt server_url when:mode=remote', 'URL?', '```',
-      '```nc:prompt api_key when:mode=remote', 'Key?', '```',
+      '```nc:prompt mode',
+      'local or remote?',
+      '```',
+      '```nc:operator',
+      'Get ready.',
+      '```',
+      '```nc:prompt server_url when:mode=remote',
+      'URL?',
+      '```',
+      '```nc:prompt api_key when:mode=remote',
+      'Key?',
+      '```',
     ].join('\n');
     expect(lintGateAmbiguity(parseDirectives(md))).toEqual([]);
   });
 
   it('stops scanning at the first unguarded directive (it always runs — no ambiguity past it)', () => {
     const md = [
-      '```nc:prompt mode', 'local or remote?', '```',
-      '```nc:operator', 'Get ready.', '```',
-      '```nc:run effect:build', 'pnpm run build', '```',
-      '```nc:prompt server_url when:mode=remote', 'URL?', '```',
-      '```nc:run effect:external when:mode=local', './configure.sh', '```',
+      '```nc:prompt mode',
+      'local or remote?',
+      '```',
+      '```nc:operator',
+      'Get ready.',
+      '```',
+      '```nc:run effect:build',
+      'pnpm run build',
+      '```',
+      '```nc:prompt server_url when:mode=remote',
+      'URL?',
+      '```',
+      '```nc:run effect:external when:mode=local',
+      './configure.sh',
+      '```',
     ].join('\n');
     expect(lintGateAmbiguity(parseDirectives(md))).toEqual([]);
   });
 
   it('never warns on the in-tree channel skills (none author the pattern)', () => {
-    for (const ch of ['add-slack', 'add-discord', 'add-telegram', 'add-teams', 'add-whatsapp', 'add-signal', 'add-imessage']) {
+    for (const ch of [
+      'add-slack',
+      'add-discord',
+      'add-telegram',
+      'add-teams',
+      'add-whatsapp',
+      'add-signal',
+      'add-imessage',
+    ]) {
       const md = readFileSync(`.claude/skills/${ch}/SKILL.md`, 'utf8');
       expect(lintGateAmbiguity(parseDirectives(md))).toEqual([]);
     }

--- a/scripts/skill-directives.ts
+++ b/scripts/skill-directives.ts
@@ -117,7 +117,8 @@ const KNOWN = new Set(['copy', 'append', 'dep', 'run', 'prompt', 'operator', 'en
 // Retired directives get a targeted lint error (not just "unknown") so an
 // author knows the removal was deliberate and what to do instead.
 const RETIRED: Record<string, string> = {
-  'env-sync': 'nc:env-sync was retired — nothing reads the data/env/env mirror (and it copied live tokens); delete the fence, the adapter reads .env directly',
+  'env-sync':
+    'nc:env-sync was retired — nothing reads the data/env/env mirror (and it copied live tokens); delete the fence, the adapter reads .env directly',
 };
 const PROMPT_FLAGS = new Set(['secret']);
 
@@ -221,7 +222,10 @@ export function validate(directives: Directive[], ctx?: { chatVersion?: string }
           // lockfile — the family moves together. This catches pin drift (the
           // 4.27.0-vs-chat@4.26.0 mismatch) at lint time.
           if (ctx?.chatVersion && name.startsWith('@chat-adapter/') && version !== ctx.chatVersion) {
-            flag(d, `${name} pinned ${version} but our chat core is ${ctx.chatVersion} — a @chat-adapter/* adapter must match the chat package`);
+            flag(
+              d,
+              `${name} pinned ${version} but our chat core is ${ctx.chatVersion} — a @chat-adapter/* adapter must match the chat package`,
+            );
           }
         }
         break;
@@ -317,7 +321,8 @@ export function validate(directives: Directive[], ctx?: { chatVersion?: string }
         flag(d, `when:${d.attrs.when} must be <var>=<value>`);
       } else {
         const wvar = d.attrs.when.slice(0, eq).trim();
-        if (!defined.has(wvar)) flag(d, `when:${d.attrs.when} references {{${wvar}}} but no earlier nc:prompt or nc:run capture defined it`);
+        if (!defined.has(wvar))
+          flag(d, `when:${d.attrs.when} references {{${wvar}}} but no earlier nc:prompt or nc:run capture defined it`);
       }
     }
     if (d.kind === 'prompt') {
@@ -358,11 +363,14 @@ export function lintReferenceFloor(markdown: string): Problem[] {
   if (!anchor) return []; // no credential / interactive step ⇒ no floor expected
   const hasTroubleshooting = markdown.split('\n').some((l) => /^##\s+Troubleshooting\s*$/.test(l.trim()));
   if (hasTroubleshooting) return [];
-  return [{
-    line: anchor.line,
-    kind: 'reference-floor',
-    message: 'a credentialed/interactive skill should carry a ## Troubleshooting section (the human floor when a live step misbehaves)',
-  }];
+  return [
+    {
+      line: anchor.line,
+      kind: 'reference-floor',
+      message:
+        'a credentialed/interactive skill should carry a ## Troubleshooting section (the human floor when a live step misbehaves)',
+    },
+  ];
 }
 
 /**

--- a/scripts/skill-inputs.test.ts
+++ b/scripts/skill-inputs.test.ts
@@ -26,14 +26,7 @@ describe('inputsFromEnv (docs/skill-engine-seam.md §6)', () => {
   });
 
   it('errors on an uppercase collision instead of silently merging', () => {
-    const md = [
-      '```nc:prompt bot_token',
-      'Token?',
-      '```',
-      '```nc:prompt Bot_Token',
-      'Token again?',
-      '```',
-    ].join('\n');
+    const md = ['```nc:prompt bot_token', 'Token?', '```', '```nc:prompt Bot_Token', 'Token again?', '```'].join('\n');
     expect(() => inputsFromEnv(md, {})).toThrow(/NC_INPUT_BOT_TOKEN/);
   });
 

--- a/scripts/skill-inputs.ts
+++ b/scripts/skill-inputs.ts
@@ -12,7 +12,10 @@
 
 import { parseDirectives, promptVar } from './skill-directives.js';
 
-export function inputsFromEnv(md: string, env: Record<string, string | undefined> = process.env): Record<string, string> {
+export function inputsFromEnv(
+  md: string,
+  env: Record<string, string | undefined> = process.env,
+): Record<string, string> {
   const inputs: Record<string, string> = {};
   const byKey = new Map<string, string>(); // NC_INPUT_<VAR> → the prompt var that claimed it
   for (const d of parseDirectives(md)) {
@@ -22,7 +25,9 @@ export function inputsFromEnv(md: string, env: Record<string, string | undefined
     const key = `NC_INPUT_${v.toUpperCase()}`;
     const prior = byKey.get(key);
     if (prior !== undefined && prior !== v) {
-      throw new Error(`inputsFromEnv: prompt vars "${prior}" and "${v}" both map to ${key} — rename one (var names must be case-insensitively unique)`);
+      throw new Error(
+        `inputsFromEnv: prompt vars "${prior}" and "${v}" both map to ${key} — rename one (var names must be case-insensitively unique)`,
+      );
     }
     byKey.set(key, v);
     const val = env[key];

--- a/scripts/test-v2-agent.ts
+++ b/scripts/test-v2-agent.ts
@@ -33,9 +33,7 @@ db.exec(`
 `);
 
 // Insert test message
-db.prepare(
-  `INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES (?, 'chat', ?, 'pending', ?)`,
-).run(
+db.prepare(`INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES (?, 'chat', ?, 'pending', ?)`).run(
   'test-1',
   new Date().toISOString(),
   JSON.stringify({ sender: 'Gavriel', text: 'Say "Hello from v2!" and nothing else. Do not use any tools.' }),

--- a/scripts/test-v2-channel-e2e.ts
+++ b/scripts/test-v2-channel-e2e.ts
@@ -22,8 +22,8 @@ import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup } from '../src/db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../src/db/messaging-groups.js';
 
-const centralDb = initDb(path.join(TEST_DIR, 'v2.db'));
-runMigrations(centralDb);
+const centralDb = await initDb(path.join(TEST_DIR, 'v2.db'));
+await runMigrations(centralDb);
 
 // Create groups dir for agent folder mount
 const groupsDir = path.resolve(process.cwd(), 'groups');
@@ -31,7 +31,7 @@ const testGroupDir = path.join(groupsDir, 'test-channel-e2e');
 fs.mkdirSync(testGroupDir, { recursive: true });
 fs.writeFileSync(path.join(testGroupDir, 'CLAUDE.md'), '# Test Agent\nYou are a test agent. Be brief.\n');
 
-createAgentGroup({
+await createAgentGroup({
   id: 'ag-chan',
   name: 'Channel E2E Agent',
   folder: 'test-channel-e2e',
@@ -39,7 +39,7 @@ createAgentGroup({
   created_at: new Date().toISOString(),
 });
 
-createMessagingGroup({
+await createMessagingGroup({
   id: 'mg-chan',
   channel_type: 'mock',
   platform_id: 'mock-channel-1',
@@ -49,7 +49,7 @@ createMessagingGroup({
   created_at: new Date().toISOString(),
 });
 
-createMessagingGroupAgent({
+await createMessagingGroupAgent({
   id: 'mga-chan',
   messaging_group_id: 'mg-chan',
   agent_group_id: 'ag-chan',
@@ -169,7 +169,7 @@ await routeInbound({
   },
 });
 
-const session = findSession('mg-chan', null);
+const session = await findSession('mg-chan', null);
 if (!session) {
   console.log('✗ No session created!');
   cleanup();

--- a/scripts/test-v2-host.ts
+++ b/scripts/test-v2-host.ts
@@ -24,8 +24,8 @@ import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup } from '../src/db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../src/db/messaging-groups.js';
 
-const centralDb = initDb(path.join(TEST_DIR, 'v2.db'));
-runMigrations(centralDb);
+const centralDb = await initDb(path.join(TEST_DIR, 'v2.db'));
+await runMigrations(centralDb);
 
 // Create groups dir for agent folder mount
 const groupsDir = path.resolve(process.cwd(), 'groups');
@@ -33,7 +33,7 @@ const testGroupDir = path.join(groupsDir, 'test-agent-e2e');
 fs.mkdirSync(testGroupDir, { recursive: true });
 fs.writeFileSync(path.join(testGroupDir, 'CLAUDE.md'), '# Test Agent\nYou are a test agent. Be brief.\n');
 
-createAgentGroup({
+await createAgentGroup({
   id: 'ag-e2e',
   name: 'E2E Test Agent',
   folder: 'test-agent-e2e',
@@ -41,7 +41,7 @@ createAgentGroup({
   created_at: new Date().toISOString(),
 });
 
-createMessagingGroup({
+await createMessagingGroup({
   id: 'mg-e2e',
   channel_type: 'test',
   platform_id: 'e2e-channel',
@@ -51,7 +51,7 @@ createMessagingGroup({
   created_at: new Date().toISOString(),
 });
 
-createMessagingGroupAgent({
+await createMessagingGroupAgent({
   id: 'mga-e2e',
   messaging_group_id: 'mg-e2e',
   agent_group_id: 'ag-e2e',
@@ -88,7 +88,7 @@ await routeInbound({
   },
 });
 
-const session = findSession('mg-e2e', null);
+const session = await findSession('mg-e2e', null);
 if (!session) {
   console.log('✗ No session created!');
   process.exit(1);

--- a/scripts/update-skills.test.ts
+++ b/scripts/update-skills.test.ts
@@ -62,12 +62,7 @@ describe('registry refresh end to end', () => {
     write(
       root,
       '.claude/skills/add-opencode/SKILL.md',
-      [
-        '# Apply',
-        '```nc:dep manager:bun cwd:container/agent-runner',
-        'example-provider@1.2.3',
-        '```',
-      ].join('\n'),
+      ['# Apply', '```nc:dep manager:bun cwd:container/agent-runner', 'example-provider@1.2.3', '```'].join('\n'),
     );
     const commands: string[] = [];
 

--- a/scripts/update-skills.ts
+++ b/scripts/update-skills.ts
@@ -61,9 +61,7 @@ function pinnedBunVersion(root: string): string {
 export function portableDependencyCommand(root: string, bunOnHost: boolean, request: DependencyCommandRequest): string {
   const prefix = request.cwd ? `cd ${request.cwd} && ` : '';
   const manager =
-    request.manager === 'bun' && !bunOnHost
-      ? `pnpm --package=bun@${pinnedBunVersion(root)} dlx bun`
-      : request.manager;
+    request.manager === 'bun' && !bunOnHost ? `pnpm --package=bun@${pinnedBunVersion(root)} dlx bun` : request.manager;
   return `${prefix}${manager} ${request.action} ${request.packages.join(' ')}`;
 }
 

--- a/scripts/update/transaction.ts
+++ b/scripts/update/transaction.ts
@@ -603,8 +603,7 @@ export function pruneTransactions(
       continue;
     }
     const valid =
-      state.schema === 'nanoclaw-update/v1' &&
-      hasSafeStatePaths(state, resolvedProjectRoot, transactionRoot, id);
+      state.schema === 'nanoclaw-update/v1' && hasSafeStatePaths(state, resolvedProjectRoot, transactionRoot, id);
     const olderThanKeep = Date.parse(state.createdAt) < Date.parse(keep.createdAt);
     if (!valid || id === keepId || !terminal.has(state.phase) || !olderThanKeep) {
       retained.push(id);

--- a/setup/auth.ts
+++ b/setup/auth.ts
@@ -161,7 +161,7 @@ export async function run(args: string[]): Promise<void> {
     createAnthropicSecret(value!);
   } catch (err) {
     const e = err as { stderr?: string | Buffer; status?: number };
-    const stderr = typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString('utf-8') ?? '';
+    const stderr = typeof e.stderr === 'string' ? e.stderr : (e.stderr?.toString('utf-8') ?? '');
     log.error('onecli secrets create failed', { status: e.status, stderr });
     emitStatus('AUTH', {
       STATUS: 'failed',

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -59,12 +59,7 @@ import {
   type ImageSource,
 } from './lib/registry-state.js';
 import { upsertEnvVar } from './set-env.js';
-import {
-  applyToEnv,
-  parseFlags,
-  printHelp,
-  readFromEnv,
-} from './lib/setup-config-parse.js';
+import { applyToEnv, parseFlags, printHelp, readFromEnv } from './lib/setup-config-parse.js';
 import { runAdvancedScreen } from './lib/setup-config-screen.js';
 import { runWindowedStep } from './lib/windowed-runner.js';
 import { runUninstallFlow } from './uninstall/flow.js';
@@ -76,7 +71,17 @@ import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-clau
 import * as setupLog from './logs.js';
 import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
 import { emit as phEmit } from './lib/diagnostics.js';
-import { accentGreen, brandBody, brandBold, brandChip, dimWrap, fitToWidth, fmtDuration, note, wrapForGutter } from './lib/theme.js';
+import {
+  accentGreen,
+  brandBody,
+  brandBold,
+  brandChip,
+  dimWrap,
+  fitToWidth,
+  fmtDuration,
+  note,
+  wrapForGutter,
+} from './lib/theme.js';
 import { isValidTimezone } from '../src/timezone.js';
 import { DEFAULT_AGENT_PROVIDER, TEMPLATES_DIR } from '../src/config.js';
 import { SocketTransport } from '../src/cli/socket-client.js';
@@ -231,15 +236,14 @@ async function main(): Promise<void> {
   }
   // Existing installs do not get an unsolicited first-agent picker, but an
   // explicit --template-path is always honoured.
-  if (
-    !isResume &&
-    (process.env.NANOCLAW_TEMPLATE_PATH?.trim() || !detectRegisteredGroups(process.cwd()))
-  ) {
+  if (!isResume && (process.env.NANOCLAW_TEMPLATE_PATH?.trim() || !detectRegisteredGroups(process.cwd()))) {
     await runTemplateSetup(savedPickBridged);
   }
 
   if (!skip.has('container')) {
-    p.log.message(brandBody(dimWrap('Your assistant lives in its own sandbox. It can only see what you explicitly share.', 4)));
+    p.log.message(
+      brandBody(dimWrap('Your assistant lives in its own sandbox. It can only see what you explicitly share.', 4)),
+    );
     // Asked before the step runs, because the step is what acts on the answer.
     await chooseImageSource();
     p.log.message(
@@ -375,9 +379,7 @@ async function main(): Promise<void> {
       const res = await runQuietStep(
         'onecli',
         {
-          running: reuse
-            ? 'Hooking up to your existing OneCLI…'
-            : "Setting up OneCLI, your agent's vault…",
+          running: reuse ? 'Hooking up to your existing OneCLI…' : "Setting up OneCLI, your agent's vault…",
           done: 'OneCLI vault ready.',
         },
         reuse ? ['--reuse'] : [],
@@ -456,20 +458,12 @@ async function main(): Promise<void> {
       } catch (err) {
         s.stop(`Couldn't install ${agentProvider}.`, 1);
         const message = err instanceof Error ? err.message : String(err);
-        await fail(
-          `add-${agentProvider}`,
-          `Couldn't install ${agentProvider}.`,
-          message,
-        );
+        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, message);
         return; // unreachable — fail() exits — but narrows blockers for TS
       }
       if (blockers.length) {
         s.stop(`Couldn't install ${agentProvider}.`, 1);
-        await fail(
-          `add-${agentProvider}`,
-          `Couldn't install ${agentProvider}.`,
-          blockers.join('; '),
-        );
+        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, blockers.join('; '));
       }
       s.stop(`${agentProvider} installed.`);
       p.log.info(brandBody('Rebuilding the container image with the new provider…'));
@@ -621,7 +615,15 @@ async function main(): Promise<void> {
           const createRes = await runQuietChild(
             'create-terminal-agent',
             'pnpm',
-            ['exec', 'tsx', 'scripts/init-cli-agent.ts', '--display-name', displayName!, '--agent-name', terminalAgentName],
+            [
+              'exec',
+              'tsx',
+              'scripts/init-cli-agent.ts',
+              '--display-name',
+              displayName!,
+              '--agent-name',
+              terminalAgentName,
+            ],
             { running: `Creating ${terminalAgentName}…`, done: `${terminalAgentName} is ready.` },
           );
           if (!createRes.ok) {
@@ -1290,11 +1292,7 @@ async function chooseImageSource(): Promise<void> {
   if (choice === 'local') return;
 
   if (!loginScriptAvailable()) {
-    p.log.warn(
-      brandBody(
-        `This copy of NanoClaw has no ${REGISTRY_LOGIN_SCRIPT} — building the sandbox here instead.`,
-      ),
-    );
+    p.log.warn(brandBody(`This copy of NanoClaw has no ${REGISTRY_LOGIN_SCRIPT} — building the sandbox here instead.`));
     writeImageSource('local');
     return;
   }
@@ -1368,9 +1366,7 @@ async function askAgentProviderChoice(): Promise<string> {
   // pre-select the current default — a re-run Enter-through then preserves it
   // instead of silently resetting it to claude. Fall back to claude if the
   // persisted default isn't an offered option (e.g. its provider was removed).
-  const currentDefault = options.some((o) => o.value === DEFAULT_AGENT_PROVIDER)
-    ? DEFAULT_AGENT_PROVIDER
-    : 'claude';
+  const currentDefault = options.some((o) => o.value === DEFAULT_AGENT_PROVIDER) ? DEFAULT_AGENT_PROVIDER : 'claude';
   const choice = ensureAnswer(
     await brightSelect<string>({
       message: 'Which agent runtime should power your assistant?',
@@ -1443,11 +1439,7 @@ async function runAuthStep(): Promise<void> {
       return runAuthStep();
     }
     setupLog.step('auth', 'skipped', 0, { REASON: 'user-skipped' });
-    p.log.warn(
-      brandBody(
-        'Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.',
-      ),
-    );
+    p.log.warn(brandBody('Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.'));
     return;
   }
 
@@ -1548,19 +1540,12 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
  * Authorization header on the wire — the container only ever sees
  * ANTHROPIC_BASE_URL + a placeholder bearer.
  */
-async function runCustomEndpointAuth(
-  baseUrl: string,
-  token: string,
-): Promise<void> {
+async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<void> {
   let host: string;
   try {
     host = new URL(baseUrl).hostname;
   } catch {
-    await fail(
-      'auth',
-      `Invalid Anthropic base URL: ${baseUrl}`,
-      'Check --anthropic-base-url and retry.',
-    );
+    await fail('auth', `Invalid Anthropic base URL: ${baseUrl}`, 'Check --anthropic-base-url and retry.');
     return;
   }
 
@@ -1826,7 +1811,10 @@ async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELE
       placeholder: 'e.g. matrix, github, linear, webex',
     }),
   );
-  const name = (answer as string).trim().toLowerCase().replace(/^\/?(add-)?/, '');
+  const name = (answer as string)
+    .trim()
+    .toLowerCase()
+    .replace(/^\/?(add-)?/, '');
   setupLog.userInput('other_channel', name);
   phEmit('channel_other_named', { channel: name });
   p.log.info(
@@ -1919,7 +1907,10 @@ function maybeReexecUnderSg(): void {
   if (spawnSync('which', ['sg'], { stdio: 'ignore' }).status !== 0) return;
 
   p.log.warn(brandBody('Docker socket not accessible in current group. Re-executing under `sg docker`.'));
-  const existingSkip = (process.env.NANOCLAW_SKIP ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  const existingSkip = (process.env.NANOCLAW_SKIP ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
   const skipList = [...new Set([...existingSkip, ...setupLog.completedStepNames()])].join(',');
   const res = spawnSync('sg', ['docker', '-c', 'pnpm run setup:auto'], {
     stdio: 'inherit',

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -55,7 +55,12 @@ describe('runChannelSkill adapter (Option A)', () => {
       // the secrets + handle a human would supply; the skill resolves platform_id.
       // Values are valid-shaped for the prompts' validate: regexes — validate-at-bind
       // now enforces them on `inputs` too (they used to bypass validation).
-      inputs: { connection: 'webhook', bot_token: 'xoxb-x', signing_secret: '0123456789abcdef', owner_handle: 'U12345678' },
+      inputs: {
+        connection: 'webhook',
+        bot_token: 'xoxb-x',
+        signing_secret: '0123456789abcdef',
+        owner_handle: 'U12345678',
+      },
       wire: (a) => {
         wired.push(a);
         return true;
@@ -155,9 +160,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   // from the document so the test can't drift from what ships.
   it('Teams have_creds probe: either credential key present answers yes', () => {
     const md = readFileSync(join(process.cwd(), '.claude/skills/add-teams/SKILL.md'), 'utf8');
-    const probe = parseDirectives(md).find(
-      (d) => d.kind === 'run' && d.attrs.capture === 'have_creds',
-    );
+    const probe = parseDirectives(md).find((d) => d.kind === 'run' && d.attrs.capture === 'have_creds');
     expect(probe).toBeDefined();
     const cmd = probe!.body.join('\n');
 
@@ -190,8 +193,7 @@ describe('runChannelSkill adapter (Option A)', () => {
     writeFileSync(join(root, '.env'), '');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
 
-    const INSTALL_LINK =
-      'https://teams.microsoft.com/l/app/tapp-123?installAppPackage=true&appTenantId=tenant-1';
+    const INSTALL_LINK = 'https://teams.microsoft.com/l/app/tapp-123?installAppPackage=true&appTenantId=tenant-1';
     const log: string[] = [];
     const opened: string[] = [];
     const steps: string[] = [];
@@ -222,7 +224,12 @@ describe('runChannelSkill adapter (Option A)', () => {
         }
         // owner identity from the CLI session (status --json fence, plain exec)
         if (c.includes('status --json')) {
-          return JSON.stringify({ loggedIn: true, username: 'dan@acme.example', tenantId: 'tenant-1', userObjectId: 'aad-owner-1' });
+          return JSON.stringify({
+            loggedIn: true,
+            username: 'dan@acme.example',
+            tenantId: 'tenant-1',
+            userObjectId: 'aad-owner-1',
+          });
         }
         if (c.includes('login.microsoftonline.com')) return 'eyJfake.bot.token';
         // /members is a sub-path of /v3/conversations — match it FIRST
@@ -411,7 +418,6 @@ describe('runChannelSkill adapter (Option A)', () => {
     expect(fullyApplied(res)).toBe(true);
   });
 
-
   // The resolved leg of wireIfResolved, driven with a minimal fixture skill
   // (the real teams document needs a streaming exec runChannelSkill doesn't
   // expose): when the skill binds owner_handle + platform_id, the adapter asks
@@ -564,7 +570,12 @@ describe('backGate (first-prompt back-to-channel-selection)', () => {
       resolveRemote: () => 'origin',
       agentName: 'Nano',
       role: 'owner',
-      inputs: { connection: 'webhook', bot_token: 'xoxb-x', signing_secret: '0123456789abcdef', owner_handle: 'U12345678' },
+      inputs: {
+        connection: 'webhook',
+        bot_token: 'xoxb-x',
+        signing_secret: '0123456789abcdef',
+        owner_handle: 'U12345678',
+      },
       wire: (a) => {
         wired.push(a);
         return true;

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -123,13 +123,21 @@ async function initFirstAgent(args: WireArgs): Promise<boolean> {
     'init-first-agent',
     'pnpm',
     [
-      'exec', 'tsx', 'scripts/init-first-agent.ts',
-      '--channel', args.channel,
-      '--user-id', args.userId,
-      '--platform-id', args.platformId,
-      '--display-name', args.displayName,
-      '--agent-name', args.agentName,
-      '--role', args.role,
+      'exec',
+      'tsx',
+      'scripts/init-first-agent.ts',
+      '--channel',
+      args.channel,
+      '--user-id',
+      args.userId,
+      '--platform-id',
+      args.platformId,
+      '--display-name',
+      args.displayName,
+      '--agent-name',
+      args.agentName,
+      '--role',
+      args.role,
       ...(args.agentGroupId ? ['--agent-group-id', args.agentGroupId] : []),
       ...(args.engagePattern ? ['--engage-pattern', args.engagePattern] : []),
     ],
@@ -193,8 +201,8 @@ export async function runChannelSkill(
   // prompts past the skill run (only a fresh create resolves the wire inputs;
   // a drop-through re-run asks nothing).
   const askLater = overrides.wireIfResolved;
-  let agentName = askLater ? '' : overrides.agentName ?? (await resolveAgentName());
-  let role = askLater ? undefined : overrides.role ?? (await askOperatorRole(channel));
+  let agentName = askLater ? '' : (overrides.agentName ?? (await resolveAgentName()));
+  let role = askLater ? undefined : (overrides.role ?? (await askOperatorRole(channel)));
 
   // Channel-specific: install adapter, collect credentials, resolve the wire
   // inputs. The whole channel-specific procedure lives in the SKILL.md.
@@ -235,7 +243,10 @@ export async function runChannelSkill(
       writeFileSync(rawLog, res.agentTasks.map((t) => `## ${t.kind} (line ${t.line})\n${t.reason}\n`).join('\n'));
     }
     for (const t of res.agentTasks) {
-      const lines = t.reason.split('\n').map((l) => l.trim()).filter(Boolean);
+      const lines = t.reason
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
       const more = lines.length > 1 ? ` (+${lines.length - 1} more lines in ${rawLog})` : '';
       p.log.warn(`Needs an agent (${t.kind}): ${lines[0] ?? t.reason}${more}`);
     }
@@ -298,7 +309,11 @@ export async function runChannelSkill(
     engagePattern: res.vars.engage_pattern || undefined,
   });
   if (!ok) {
-    await failWith('init-first-agent', `Couldn't finish connecting ${agentName}.`, 'You can retry later with `/init-first-agent`.');
+    await failWith(
+      'init-first-agent',
+      `Couldn't finish connecting ${agentName}.`,
+      'You can retry later with `/init-first-agent`.',
+    );
   }
   // This wire is the seam that consumes the template pick: only now has the
   // pick done its job. Clearing earlier (at stamp time) orphans the agent on

--- a/setup/channels/teams-manifest-build.ts
+++ b/setup/channels/teams-manifest-build.ts
@@ -31,9 +31,7 @@ const rsc = process.argv.includes('--rsc');
 const shortName = process.env.NANOCLAW_AGENT_NAME?.trim() || 'NanoClaw';
 
 if (!appId || !url) {
-  console.error(
-    'usage: teams-manifest-build.ts --app-id <azure-app-id> --url <https-url> [--out <dir>] [--rsc]',
-  );
+  console.error('usage: teams-manifest-build.ts --app-id <azure-app-id> --url <https-url> [--out <dir>] [--rsc]');
   process.exit(2);
 }
 

--- a/setup/channels/whatsapp.test.ts
+++ b/setup/channels/whatsapp.test.ts
@@ -25,13 +25,11 @@ function runFence(pred: (d: Directive) => boolean): Directive {
 
 // Substitute {{vars}} the way the engine does, then run through bash -c in cwd.
 function bash(body: string[], vars: Record<string, string>, cwd: string): string {
-  const cmd = body
-    .join('\n')
-    .replace(/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g, (_, name) => {
-      const v = vars[name];
-      if (v === undefined) throw new Error(`unresolved {{${name}}}`);
-      return v;
-    });
+  const cmd = body.join('\n').replace(/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g, (_, name) => {
+    const v = vars[name];
+    if (v === undefined) throw new Error(`unresolved {{${name}}}`);
+    return v;
+  });
   return execFileSync('bash', ['-c', cmd], { cwd, encoding: 'utf-8' });
 }
 
@@ -91,7 +89,9 @@ describe('.env write fences (replace, not append)', () => {
   it('a mode-switching re-run replaces the flag — no stale true left behind', () => {
     bash(dedicated.body, {}, dir);
     bash(shared.body, {}, dir);
-    const lines = env().split('\n').filter((l) => l.startsWith('ASSISTANT_HAS_OWN_NUMBER='));
+    const lines = env()
+      .split('\n')
+      .filter((l) => l.startsWith('ASSISTANT_HAS_OWN_NUMBER='));
     expect(lines).toEqual(['ASSISTANT_HAS_OWN_NUMBER=false']);
     expect(env()).not.toContain('=true');
   });

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -236,17 +236,15 @@ export async function run(args: string[]): Promise<void> {
       }
 
       log.info('Re-executing container step under `sg docker`');
-      const res = spawnSync(
-        'sg',
-        ['docker', '-c', 'pnpm exec tsx setup/index.ts --step container'],
-        { cwd: projectRoot, stdio: 'inherit' },
-      );
+      const res = spawnSync('sg', ['docker', '-c', 'pnpm exec tsx setup/index.ts --step container'], {
+        cwd: projectRoot,
+        stdio: 'inherit',
+      });
       process.exit(res.status ?? 1);
     }
 
     if (status !== 'ok') {
-      const error =
-        status === 'no-permission' ? 'docker_group_not_active' : 'runtime_not_available';
+      const error = status === 'no-permission' ? 'docker_group_not_active' : 'runtime_not_available';
       emitStatus('SETUP_CONTAINER', {
         RUNTIME: runtime,
         IMAGE: image,
@@ -271,7 +269,10 @@ export async function run(args: string[]): Promise<void> {
     const envPath = path.join(projectRoot, '.env');
     if (fs.existsSync(envPath)) {
       const match = fs.readFileSync(envPath, 'utf-8').match(/^INSTALL_CJK_FONTS=(.+)$/m);
-      const val = match?.[1].trim().replace(/^["']|["']$/g, '').toLowerCase();
+      const val = match?.[1]
+        .trim()
+        .replace(/^["']|["']$/g, '')
+        .toLowerCase();
       if (val === 'true') buildArgs.push('--build-arg INSTALL_CJK_FONTS=true');
     }
   } catch {
@@ -282,10 +283,7 @@ export async function run(args: string[]): Promise<void> {
   // `image`, so everything past this point is identical either way. The other
   // rebuild paths refuse when this is set, because `docker build -t <slug>:latest`
   // would replace the pinned image in place with nothing downstream able to tell.
-  const source =
-    readSetting(projectRoot, 'NANOCLAW_HARDENED_IMAGE')?.toLowerCase() === 'true'
-      ? 'pull'
-      : 'build';
+  const source = readSetting(projectRoot, 'NANOCLAW_HARDENED_IMAGE')?.toLowerCase() === 'true' ? 'pull' : 'build';
 
   // Build — stdio inherit so the parent setup runner can tail docker's
   // per-step output and render it in a rolling window. Previously we used
@@ -306,7 +304,10 @@ export async function run(args: string[]): Promise<void> {
       // The pinned ref names the repository we pulled from; pass it so the
       // reported digest is that repository's and not some other one the same
       // bytes also live in.
-      digest = imageDigest(image, readSetting(projectRoot, 'NANOCLAW_AGENT_IMAGE_REF')?.split('@')[0] ?? pinnedRepo(projectRoot));
+      digest = imageDigest(
+        image,
+        readSetting(projectRoot, 'NANOCLAW_AGENT_IMAGE_REF')?.split('@')[0] ?? pinnedRepo(projectRoot),
+      );
       log.info('Container image acquired', { image, digest });
 
       // Retagging the slug tag does nothing for an agent group pinned to its
@@ -340,13 +341,7 @@ export async function run(args: string[]): Promise<void> {
     log.info('Building container', { runtime, buildArgs });
     const buildRes = spawnSync(
       buildCmd.split(' ')[0],
-      [
-        ...buildCmd.split(' ').slice(1),
-        ...buildArgs.flatMap((a) => a.split(' ')),
-        '-t',
-        image,
-        '.',
-      ],
+      [...buildCmd.split(' ').slice(1), ...buildArgs.flatMap((a) => a.split(' ')), '-t', image, '.'],
       {
         cwd: path.join(projectRoot, 'container'),
         stdio: 'inherit',

--- a/setup/environment.test.ts
+++ b/setup/environment.test.ts
@@ -70,9 +70,11 @@ describe('detectRegisteredGroups', () => {
       );
     `);
     db.prepare('INSERT INTO agent_groups (id) VALUES (?)').run('ag-1');
-    db.prepare(
-      'INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id) VALUES (?, ?, ?)',
-    ).run('mga-1', 'mg-1', 'ag-1');
+    db.prepare('INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id) VALUES (?, ?, ?)').run(
+      'mga-1',
+      'mg-1',
+      'ag-1',
+    );
     db.close();
 
     expect(detectRegisteredGroups(tempDir)).toBe(true);
@@ -81,31 +83,34 @@ describe('detectRegisteredGroups', () => {
 
 describe('credentials detection', () => {
   it('detects ANTHROPIC_API_KEY in env content', () => {
-    const content =
-      'SOME_KEY=value\nANTHROPIC_API_KEY=sk-ant-test123\nOTHER=foo';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
+    const content = 'SOME_KEY=value\nANTHROPIC_API_KEY=sk-ant-test123\nOTHER=foo';
+    const hasCredentials = /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(
+      content,
+    );
     expect(hasCredentials).toBe(true);
   });
 
   it('detects CLAUDE_CODE_OAUTH_TOKEN in env content', () => {
     const content = 'CLAUDE_CODE_OAUTH_TOKEN=token123';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
+    const hasCredentials = /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(
+      content,
+    );
     expect(hasCredentials).toBe(true);
   });
 
   it('detects ANTHROPIC_AUTH_TOKEN in env content', () => {
     const content = 'ANTHROPIC_AUTH_TOKEN=token123\nANTHROPIC_BASE_URL=http://localhost:8080';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
+    const hasCredentials = /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(
+      content,
+    );
     expect(hasCredentials).toBe(true);
   });
 
   it('returns false when no credentials', () => {
     const content = 'ASSISTANT_NAME="Andy"\nOTHER=foo';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
+    const hasCredentials = /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(
+      content,
+    );
     expect(hasCredentials).toBe(false);
   });
 });
@@ -132,4 +137,3 @@ describe('channel auth detection', () => {
     expect(hasAuth('/tmp/nonexistent_auth_dir_xyz')).toBe(false);
   });
 });
-

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -65,9 +65,9 @@ export function detectExistingDisplayName(projectRoot: string): string | null {
   let db: Database.Database | null = null;
   try {
     db = new Database(dbPath, { readonly: true });
-    const row = db
-      .prepare(`SELECT display_name FROM users WHERE id = 'cli:local'`)
-      .get() as { display_name: string } | undefined;
+    const row = db.prepare(`SELECT display_name FROM users WHERE id = 'cli:local'`).get() as
+      | { display_name: string }
+      | undefined;
     return row?.display_name?.trim() || null;
   } catch {
     return null;
@@ -132,23 +132,21 @@ export async function run(_args: string[]): Promise<void> {
 
   // Check for existing OpenClaw installation
   const homedir = (await import('os')).homedir();
-  const openClawPath =
-    fs.existsSync(path.join(homedir, '.openclaw')) ? path.join(homedir, '.openclaw') :
-    fs.existsSync(path.join(homedir, '.clawdbot')) ? path.join(homedir, '.clawdbot') :
-    null;
+  const openClawPath = fs.existsSync(path.join(homedir, '.openclaw'))
+    ? path.join(homedir, '.openclaw')
+    : fs.existsSync(path.join(homedir, '.clawdbot'))
+      ? path.join(homedir, '.clawdbot')
+      : null;
 
-  log.info(
-    'Environment check complete',
-    {
-      platform,
-      wsl,
-      docker,
-      hasEnv,
-      hasAuth,
-      hasRegisteredGroups,
-      openClawPath,
-    },
-  );
+  log.info('Environment check complete', {
+    platform,
+    wsl,
+    docker,
+    hasEnv,
+    hasAuth,
+    hasRegisteredGroups,
+    openClawPath,
+  });
 
   emitStatus('CHECK_ENVIRONMENT', {
     PLATFORM: platform,

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -5,10 +5,7 @@
 import { log } from '../src/log.js';
 import { emitStatus } from './status.js';
 
-const STEPS: Record<
-  string,
-  () => Promise<{ run: (args: string[]) => Promise<void> }>
-> = {
+const STEPS: Record<string, () => Promise<{ run: (args: string[]) => Promise<void> }>> = {
   timezone: () => import('./timezone.js'),
   'set-env': () => import('./set-env.js'),
   environment: () => import('./environment.js'),
@@ -36,16 +33,12 @@ async function main(): Promise<void> {
   const stepIdx = args.indexOf('--step');
 
   if (stepIdx === -1 || !args[stepIdx + 1]) {
-    console.error(
-      `Usage: pnpm exec tsx setup/index.ts --step <${Object.keys(STEPS).join('|')}> [args...]`,
-    );
+    console.error(`Usage: pnpm exec tsx setup/index.ts --step <${Object.keys(STEPS).join('|')}> [args...]`);
     process.exit(1);
   }
 
   const stepName = args[stepIdx + 1];
-  const stepArgs = args.filter(
-    (a, i) => i !== stepIdx && i !== stepIdx + 1 && a !== '--',
-  );
+  const stepArgs = args.filter((a, i) => i !== stepIdx && i !== stepIdx + 1 && a !== '--');
 
   const loader = STEPS[stepName];
   if (!loader) {

--- a/setup/lib/agent-ping.test.ts
+++ b/setup/lib/agent-ping.test.ts
@@ -21,12 +21,8 @@ describe('classifyPingResult', () => {
   });
 
   it('detects Claude Code login banners printed as a chat reply', () => {
-    expect(
-      classifyPingResult(0, 'Invalid API key · Please run /login'),
-    ).toBe('auth_error');
-    expect(
-      classifyPingResult(0, 'Not logged in · Please run /login'),
-    ).toBe('auth_error');
+    expect(classifyPingResult(0, 'Invalid API key · Please run /login')).toBe('auth_error');
+    expect(classifyPingResult(0, 'Not logged in · Please run /login')).toBe('auth_error');
   });
 
   it('preserves socket errors', () => {

--- a/setup/lib/back-nav.ts
+++ b/setup/lib/back-nav.ts
@@ -28,9 +28,7 @@ export type ChannelFlowResult = void | typeof BACK_TO_CHANNEL_SELECTION;
  * otherwise. Esc / Ctrl-C unwinds through `ensureAnswer` (exit 0), the same as
  * every other setup prompt.
  */
-export async function backGate(
-  label: string,
-): Promise<'continue' | typeof BACK_TO_CHANNEL_SELECTION> {
+export async function backGate(label: string): Promise<'continue' | typeof BACK_TO_CHANNEL_SELECTION> {
   const choice = ensureAnswer(
     await brightSelect<'continue' | 'back'>({
       message: `Connect ${label}?`,

--- a/setup/lib/bright-select.ts
+++ b/setup/lib/bright-select.ts
@@ -97,9 +97,7 @@ export function flushStdin(windowMs = 50): Promise<void> {
  * the result through `ensureAnswer(...)` the same way they do for
  * `p.select`.
  */
-export async function brightSelect<T>(
-  opts: BrightSelectOptions<T>,
-): Promise<T | symbol> {
+export async function brightSelect<T>(opts: BrightSelectOptions<T>): Promise<T | symbol> {
   const { message, options, initialValue } = opts;
 
   await flushStdin();
@@ -117,13 +115,9 @@ export async function brightSelect<T>(
       lines.push(`${headerIcon(st)}  ${message}`);
 
       if (st === 'submit' || st === 'cancel') {
-        const selected =
-          options.find((o) => o.value === this.value)?.label ??
-          String(this.value ?? '');
+        const selected = options.find((o) => o.value === this.value)?.label ?? String(this.value ?? '');
         const shown =
-          st === 'cancel'
-            ? styleText(['strikethrough', 'dim'], selected)
-            : styleText('dim', brandBody(selected));
+          st === 'cancel' ? styleText(['strikethrough', 'dim'], selected) : styleText('dim', brandBody(selected));
         lines.push(`${grayBar}  ${shown}`);
         return lines.join('\n');
       }
@@ -133,9 +127,7 @@ export async function brightSelect<T>(
         const label = opt.label ?? String(opt.value);
         const hint = opt.hint ? ` ${styleText('dim', `(${opt.hint})`)}` : '';
         const isActive = idx === cursor;
-        const marker = isActive
-          ? styleText('green', BULLET_ACTIVE)
-          : styleText('dim', BULLET_INACTIVE);
+        const marker = isActive ? styleText('green', BULLET_ACTIVE) : styleText('dim', BULLET_INACTIVE);
         const shownLabel = isActive ? brandBody(label) : label;
         lines.push(`${bar}  ${marker} ${shownLabel}${hint}`);
       });

--- a/setup/lib/browser.ts
+++ b/setup/lib/browser.ts
@@ -67,10 +67,7 @@ export function formatNoteLink(url: string): string | null {
  * <url>" in dim) so the user has a copy-paste path right next to the
  * action button without needing to scroll back up to the card.
  */
-export async function confirmThenOpen(
-  url: string,
-  message = 'Press Enter to open your browser',
-): Promise<void> {
+export async function confirmThenOpen(url: string, message = 'Press Enter to open your browser'): Promise<void> {
   if (isHeadless()) {
     // No browser to open here — ALWAYS surface the URL itself, and print it
     // RAW on stdout: clack notes wrap long lines and inject gutter pipes and

--- a/setup/lib/claude-assist.ts
+++ b/setup/lib/claude-assist.ts
@@ -47,17 +47,9 @@ export interface AssistContext {
 export const STEP_FILES: Record<string, string[]> = {
   bootstrap: ['setup.sh', 'setup/install-node.sh', 'nanoclaw.sh'],
   environment: ['setup/environment.ts'],
-  container: [
-    'setup/container.ts',
-    'setup/install-docker.sh',
-    'container/Dockerfile',
-  ],
+  container: ['setup/container.ts', 'setup/install-docker.sh', 'container/Dockerfile'],
   onecli: ['setup/onecli.ts'],
-  auth: [
-    'setup/auth.ts',
-    'setup/register-claude-token.sh',
-    'setup/install-claude.sh',
-  ],
+  auth: ['setup/auth.ts', 'setup/register-claude-token.sh', 'setup/install-claude.sh'],
   mounts: ['setup/mounts.ts'],
   service: ['setup/service.ts'],
   'cli-agent': ['setup/cli-agent.ts', 'scripts/init-cli-agent.ts'],
@@ -72,14 +64,14 @@ export const STEP_FILES: Record<string, string[]> = {
   'slack-install': ['.claude/skills/add-slack/SKILL.md', 'scripts/skill-apply.ts', 'setup/channels/slack.ts'],
   'slack-validate': ['setup/channels/slack.ts'],
   'imessage-install': ['.claude/skills/add-imessage/SKILL.md', 'scripts/skill-apply.ts', 'scripts/photon-setup.ts'],
-  'imessage': ['setup/channels/run-channel-skill.ts', 'scripts/photon-setup.ts'],
-  'teams-install': ['.claude/skills/add-teams/SKILL.md', 'scripts/skill-apply.ts', 'setup/channels/run-channel-skill.ts'],
-  'teams-manifest': ['setup/lib/teams-manifest.ts', 'setup/channels/teams-manifest-build.ts'],
-  'init-first-agent': [
-    'scripts/init-first-agent.ts',
-    'setup/channels/telegram.ts',
-    'setup/channels/discord.ts',
+  imessage: ['setup/channels/run-channel-skill.ts', 'scripts/photon-setup.ts'],
+  'teams-install': [
+    '.claude/skills/add-teams/SKILL.md',
+    'scripts/skill-apply.ts',
+    'setup/channels/run-channel-skill.ts',
   ],
+  'teams-manifest': ['setup/lib/teams-manifest.ts', 'setup/channels/teams-manifest-build.ts'],
+  'init-first-agent': ['scripts/init-first-agent.ts', 'setup/channels/telegram.ts', 'setup/channels/discord.ts'],
 };
 
 export const BIG_PICTURE_FILES = ['README.md', 'setup/auto.ts'];
@@ -90,10 +82,7 @@ export const BIG_PICTURE_FILES = ['README.md', 'setup/auto.ts'];
  * Returns `false` for every other outcome (skipped, declined, no command,
  * Claude unreachable, user chose not to run).
  */
-export async function offerClaudeAssist(
-  ctx: AssistContext,
-  projectRoot: string = process.cwd(),
-): Promise<boolean> {
+export async function offerClaudeAssist(ctx: AssistContext, projectRoot: string = process.cwd()): Promise<boolean> {
   if (process.env.NANOCLAW_SKIP_CLAUDE_ASSIST === '1') return false;
   if (!(await ensureClaudeReady(projectRoot))) return false;
 
@@ -116,10 +105,7 @@ export async function offerClaudeAssist(
     return false;
   }
 
-  note(
-    `${parsed.reason}\n\n${k.cyan('$')} ${parsed.command}`,
-    "Claude's suggestion",
-  );
+  note(`${parsed.reason}\n\n${k.cyan('$')} ${parsed.command}`, "Claude's suggestion");
 
   const run = ensureAnswer(
     await p.confirm({
@@ -164,8 +150,7 @@ export async function ensureClaudeReady(projectRoot: string): Promise<boolean> {
   if (!isClaudeInstalled()) {
     const install = ensureAnswer(
       await p.confirm({
-        message:
-          'Claude CLI is needed to diagnose this. Install it now?',
+        message: 'Claude CLI is needed to diagnose this. Install it now?',
         initialValue: true,
       }),
     );
@@ -185,8 +170,7 @@ export async function ensureClaudeReady(projectRoot: string): Promise<boolean> {
   if (!isClaudeAuthenticated()) {
     const auth = ensureAnswer(
       await p.confirm({
-        message:
-          "Claude CLI isn't signed in. Sign in now? (a browser will open)",
+        message: "Claude CLI isn't signed in. Sign in now? (a browser will open)",
         initialValue: true,
       }),
     );
@@ -205,7 +189,9 @@ export async function ensureClaudeReady(projectRoot: string): Promise<boolean> {
       const isUtilLinux = (() => {
         try {
           return execSync('script --version 2>&1', { encoding: 'utf-8' }).includes('util-linux');
-        } catch { return false; }
+        } catch {
+          return false;
+        }
       })();
       const scriptArgs = isUtilLinux
         ? ['-q', '-c', 'claude setup-token', tmpfile]
@@ -222,7 +208,9 @@ export async function ensureClaudeReady(projectRoot: string): Promise<boolean> {
       }
     } finally {
       // eslint-disable-next-line no-empty -- best-effort temp cleanup
-      try { fs.unlinkSync(tmpfile); } catch {}
+      try {
+        fs.unlinkSync(tmpfile);
+      } catch {}
     }
 
     if (!isClaudeAuthenticated()) {
@@ -241,9 +229,7 @@ function buildPrompt(ctx: AssistContext, projectRoot: string): string {
     ...BIG_PICTURE_FILES,
     ...stepRefs,
     'logs/setup.log',
-    ctx.rawLogPath
-      ? path.relative(projectRoot, ctx.rawLogPath)
-      : 'logs/setup-steps/',
+    ctx.rawLogPath ? path.relative(projectRoot, ctx.rawLogPath) : 'logs/setup-steps/',
   ].filter((v, i, a) => a.indexOf(v) === i);
 
   const hintLine = ctx.hint ? `Hint shown to the user: ${ctx.hint}\n` : '';
@@ -287,10 +273,7 @@ const SPINNER_FRAMES = ['◒', '◐', '◓', '◑'];
 const HIDE_CURSOR = '\x1b[?25l';
 const SHOW_CURSOR = '\x1b[?25h';
 
-async function queryClaudeUnderSpinner(
-  prompt: string,
-  projectRoot: string,
-): Promise<string | null> {
+async function queryClaudeUnderSpinner(prompt: string, projectRoot: string): Promise<string | null> {
   const out = process.stdout;
   const start = Date.now();
   const actions: string[] = [];
@@ -351,10 +334,7 @@ async function queryClaudeUnderSpinner(
     let stderr = '';
     let settled = false;
 
-    const finish = (
-      kind: 'ok' | 'error',
-      payload: string | null,
-    ): void => {
+    const finish = (kind: 'ok' | 'error', payload: string | null): void => {
       clearInterval(frameTick);
       clearBlock();
       out.write(SHOW_CURSOR);
@@ -364,9 +344,7 @@ async function queryClaudeUnderSpinner(
         p.log.success(`${brandBody(fitToWidth('Claude replied.', suffix))}${k.dim(suffix)}`);
         resolve(payload);
       } else {
-        p.log.error(
-          `${fitToWidth("Claude couldn't help here.", suffix)}${k.dim(suffix)}`,
-        );
+        p.log.error(`${fitToWidth("Claude couldn't help here.", suffix)}${k.dim(suffix)}`);
         const tail = stderr.trim().split('\n').slice(-3).join('\n');
         if (tail) p.log.message(k.dim(tail));
         resolve(null);
@@ -379,14 +357,7 @@ async function queryClaudeUnderSpinner(
     //
     // Resume the same session on repeat invocations so Claude carries
     // context across failures in one setup run.
-    const claudeArgs = [
-      '-p',
-      '--output-format',
-      'stream-json',
-      '--verbose',
-      '--permission-mode',
-      'bypassPermissions',
-    ];
+    const claudeArgs = ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
     if (claudeSessionId) {
       claudeArgs.push('--resume', claudeSessionId);
     }
@@ -458,8 +429,7 @@ interface StreamEvent {
   session_id?: string;
   message?: {
     content?: Array<
-      | { type: 'text'; text: string }
-      | { type: 'tool_use'; name: string; input: Record<string, unknown> }
+      { type: 'text'; text: string } | { type: 'tool_use'; name: string; input: Record<string, unknown> }
     >;
   };
 }
@@ -485,14 +455,15 @@ function handleStreamEvent(
 }
 
 function formatToolUse(name: string, input: Record<string, unknown>): string {
-  const truncate = (v: string, n: number): string =>
-    v.length > n ? v.slice(0, n) + '…' : v;
+  const truncate = (v: string, n: number): string => (v.length > n ? v.slice(0, n) + '…' : v);
   if (name === 'Read') {
     const f = String(input.file_path ?? '');
     return `Reading ${shortenPath(f)}`;
   }
   if (name === 'Bash') {
-    const cmd = String(input.command ?? '').replace(/\s+/g, ' ').trim();
+    const cmd = String(input.command ?? '')
+      .replace(/\s+/g, ' ')
+      .trim();
     return `Running ${truncate(cmd, 60)}`;
   }
   if (name === 'Grep') return `Searching for "${truncate(String(input.pattern ?? ''), 40)}"`;
@@ -505,9 +476,7 @@ function shortenPath(abs: string): string {
   return abs.startsWith(`${root}/`) ? abs.slice(root.length + 1) : abs;
 }
 
-function parseResponse(
-  raw: string,
-): { reason: string; command: string } | null {
+function parseResponse(raw: string): { reason: string; command: string } | null {
   // Accept the fields anywhere in the output — Claude sometimes wraps the
   // answer in a trailing explanation we can safely ignore.
   const reasonMatch = raw.match(/^\s*REASON:\s*(.+?)\s*$/m);

--- a/setup/lib/claude-handoff.ts
+++ b/setup/lib/claude-handoff.ts
@@ -84,17 +84,15 @@ export interface HandoffContext {
  */
 export async function offerClaudeHandoff(ctx: HandoffContext): Promise<boolean> {
   if (!isClaudeUsable()) {
-    p.log.warn(
-      brandBody("Claude isn't installed yet — can't hand you off here. Finish setup first, then retry."),
-    );
+    p.log.warn(brandBody("Claude isn't installed yet — can't hand you off here. Finish setup first, then retry."));
     return false;
   }
 
   note(
     [
       "I'm handing you off to Claude in interactive mode.",
-      "It has the context of where you are in setup.",
-      "",
+      'It has the context of where you are in setup.',
+      '',
       k.dim("Type /exit (or press Ctrl-D) when you're ready to come back to setup."),
     ].join('\n'),
     'Handing off to Claude',
@@ -117,20 +115,9 @@ let handoffSessionStarted = false;
  * the setup driver.
  */
 function spawnInteractiveClaude(prompt: string): Promise<boolean> {
-  const sessionArgs = handoffSessionStarted
-    ? ['--resume', handoffSessionId]
-    : ['--session-id', handoffSessionId];
+  const sessionArgs = handoffSessionStarted ? ['--resume', handoffSessionId] : ['--session-id', handoffSessionId];
   return new Promise<boolean>((resolve) => {
-    const child = spawn(
-      'claude',
-      [
-        prompt,
-        '--permission-mode',
-        'auto',
-        ...sessionArgs,
-      ],
-      { stdio: 'inherit' },
-    );
+    const child = spawn('claude', [prompt, '--permission-mode', 'auto', ...sessionArgs], { stdio: 'inherit' });
     child.on('close', () => {
       handoffSessionStarted = true;
       p.log.success(brandBody("Back from Claude. Let's continue."));
@@ -251,10 +238,7 @@ function buildHandoffPrompt(ctx: HandoffContext): string {
  *
  * Drop-in replacement for `offerClaudeAssist` at failure call sites.
  */
-export async function offerClaudeOnFailure(
-  ctx: AssistContext,
-  projectRoot: string = process.cwd(),
-): Promise<boolean> {
+export async function offerClaudeOnFailure(ctx: AssistContext, projectRoot: string = process.cwd()): Promise<boolean> {
   if (process.env.NANOCLAW_SKIP_CLAUDE_ASSIST === '1') return false;
 
   const provider = getPickedProvider();
@@ -291,10 +275,7 @@ export async function offerClaudeOnFailure(
  * Returns `true` if Claude was launched (the user may have fixed
  * things during the session), `false` if skipped/declined/unavailable.
  */
-async function offerFailureHandoff(
-  ctx: AssistContext,
-  projectRoot: string,
-): Promise<boolean> {
+async function offerFailureHandoff(ctx: AssistContext, projectRoot: string): Promise<boolean> {
   if (process.env.NANOCLAW_SKIP_CLAUDE_ASSIST === '1') return false;
   if (!(await ensureClaudeReady(projectRoot))) return false;
 
@@ -308,9 +289,9 @@ async function offerFailureHandoff(
 
   note(
     [
-      "Launching Claude to help debug this failure.",
-      "It has the context of what went wrong.",
-      "",
+      'Launching Claude to help debug this failure.',
+      'It has the context of what went wrong.',
+      '',
       k.dim("Type /exit (or press Ctrl-D) when you're ready to come back to setup."),
     ].join('\n'),
     'Handing off to Claude',
@@ -325,9 +306,7 @@ function buildFailurePrompt(ctx: AssistContext, projectRoot: string): string {
     ...BIG_PICTURE_FILES,
     ...stepRefs,
     'logs/setup.log',
-    ctx.rawLogPath
-      ? path.relative(projectRoot, ctx.rawLogPath)
-      : 'logs/setup-steps/',
+    ctx.rawLogPath ? path.relative(projectRoot, ctx.rawLogPath) : 'logs/setup-steps/',
   ].filter((v, i, a) => a.indexOf(v) === i);
 
   const lines: string[] = [

--- a/setup/lib/registry-state.test.ts
+++ b/setup/lib/registry-state.test.ts
@@ -53,9 +53,7 @@ describe('resolvePinForPlatform', () => {
   });
 
   it('trims, so a stray newline in a hand-edited pin still resolves', () => {
-    expect(resolvePinForPlatform({ 'linux/arm64': ' repo@sha256:dddd\n' }, 'linux/arm64')).toBe(
-      'repo@sha256:dddd',
-    );
+    expect(resolvePinForPlatform({ 'linux/arm64': ' repo@sha256:dddd\n' }, 'linux/arm64')).toBe('repo@sha256:dddd');
   });
 });
 
@@ -70,9 +68,7 @@ describe('pinnedPlatforms', () => {
   });
 
   it('omits entries that are not usable references', () => {
-    expect(pinnedPlatforms({ 'linux/amd64': 'repo@sha256:aaaa', 'linux/arm64': '' })).toEqual([
-      'linux/amd64',
-    ]);
+    expect(pinnedPlatforms({ 'linux/amd64': 'repo@sha256:aaaa', 'linux/arm64': '' })).toEqual(['linux/amd64']);
   });
 });
 

--- a/setup/lib/registry-state.ts
+++ b/setup/lib/registry-state.ts
@@ -215,9 +215,7 @@ export function readRegistryHost(): string | undefined {
   const ref = readAgentImagePin();
   if (!ref || !ref.includes('/')) return undefined;
   const first = ref.slice(0, ref.indexOf('/'));
-  return first.includes('.') || first.includes(':') || first === 'localhost'
-    ? first
-    : undefined;
+  return first.includes('.') || first.includes(':') || first === 'localhost' ? first : undefined;
 }
 
 export interface AgentImageInspection {
@@ -284,10 +282,7 @@ interface DockerInspectEntry {
  * leaves it empty, a registry populates it. Only a fallback because a
  * `docker save`/`load` sneakernet image has none and would read as local.
  */
-function resolveActualSource(
-  labels: Record<string, string>,
-  registryDigest: string | undefined,
-): ActualImageSource {
+function resolveActualSource(labels: Record<string, string>, registryDigest: string | undefined): ActualImageSource {
   const declared = labels[IMAGE_SOURCE_LABEL];
   // `derived` is a per-group image built on top of one of the other two. It has
   // to be its own answer: it inherits the base's RepoDigest-derived provenance

--- a/setup/lib/role-prompt.ts
+++ b/setup/lib/role-prompt.ts
@@ -13,9 +13,7 @@ import { ensureAnswer } from './runner.js';
 
 export type OperatorRole = 'owner' | 'admin' | 'member';
 
-export async function askOperatorRole(
-  channelLabel: string,
-): Promise<OperatorRole> {
+export async function askOperatorRole(channelLabel: string): Promise<OperatorRole> {
   const choice = ensureAnswer(
     await brightSelect<OperatorRole>({
       message: `How should this ${channelLabel} account be registered?`,

--- a/setup/lib/runner.ts
+++ b/setup/lib/runner.ts
@@ -157,8 +157,7 @@ export function spawnStep(
 
     child.on('close', (code) => {
       raw.end();
-      const terminal =
-        [...stream.blocks].reverse().find((b) => b.fields.STATUS) ?? null;
+      const terminal = [...stream.blocks].reverse().find((b) => b.fields.STATUS) ?? null;
       const status = terminal?.fields.STATUS;
       const ok = code === 0 && (status === 'success' || status === 'skipped');
       resolve({
@@ -200,8 +199,7 @@ export function spawnQuiet(
     });
     child.on('close', (code) => {
       raw.end();
-      const terminal =
-        [...blocks].reverse().find((b) => b.fields.STATUS) ?? null;
+      const terminal = [...blocks].reverse().find((b) => b.fields.STATUS) ?? null;
       resolve({ ok: code === 0, exitCode: code ?? 1, transcript, terminal, blocks });
     });
   });
@@ -216,9 +214,7 @@ export async function runQuietStep(
   const rawLog = setupLog.stepRawLog(stepName);
   const start = Date.now();
   phEmit('step_started', { step: stepName });
-  const result = await runUnderSpinner(labels, () =>
-    spawnStep(stepName, extra, () => {}, rawLog),
-  );
+  const result = await runUnderSpinner(labels, () => spawnStep(stepName, extra, () => {}, rawLog));
   const durationMs = Date.now() - start;
   writeStepEntry(stepName, result, durationMs, rawLog);
   phEmit('step_completed', {
@@ -245,9 +241,7 @@ export async function runQuietChild(
   const rawLog = setupLog.stepRawLog(logName);
   const start = Date.now();
   phEmit('step_started', { step: logName });
-  const result = await runUnderSpinner(labels, () =>
-    spawnQuiet(cmd, args, rawLog, opts?.env),
-  );
+  const result = await runUnderSpinner(labels, () => spawnQuiet(cmd, args, rawLog, opts?.env));
   const durationMs = Date.now() - start;
 
   const blockFields = summariseTerminalFields(result.terminal);
@@ -271,12 +265,7 @@ function outcomeStatus(result: StepResult): 'success' | 'skipped' | 'failed' {
 }
 
 /** Turn a step's terminal-block fields into a concise progression-log entry. */
-export function writeStepEntry(
-  stepName: string,
-  result: StepResult,
-  durationMs: number,
-  rawLog: string,
-): void {
+export function writeStepEntry(stepName: string, result: StepResult, durationMs: number, rawLog: string): void {
   const rawStatus = result.terminal?.fields.STATUS;
   const logStatus: 'success' | 'skipped' | 'failed' = !result.ok
     ? 'failed'
@@ -339,9 +328,7 @@ export function startSpinner(labels: SpinnerLabels): {
   };
 }
 
-async function runUnderSpinner<
-  T extends { ok: boolean; transcript: string; terminal?: Block | null },
->(
+async function runUnderSpinner<T extends { ok: boolean; transcript: string; terminal?: Block | null }>(
   labels: SpinnerLabels,
   work: () => Promise<T>,
 ): Promise<T> {
@@ -379,12 +366,7 @@ export function dumpTranscriptOnFailure(transcript: string): void {
  * process.exit. The return type is `Promise<never>`; control-flow
  * narrowing still works after `await`.
  */
-export async function fail(
-  stepName: string,
-  msg: string,
-  hint?: string,
-  rawLogPath?: string,
-): Promise<never> {
+export async function fail(stepName: string, msg: string, hint?: string, rawLogPath?: string): Promise<never> {
   setupLog.abort(stepName, msg);
   phEmit('setup_aborted', { step: stepName, reason: msg });
   p.log.error(msg);
@@ -409,9 +391,7 @@ export async function fail(
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean);
-      const skipList = [
-        ...new Set([...existingSkip, ...setupLog.completedStepNames()]),
-      ].join(',');
+      const skipList = [...new Set([...existingSkip, ...setupLog.completedStepNames()])].join(',');
       p.log.step(brandBody(`Retrying from ${stepName}…`));
       const result = spawnSync('pnpm', ['--silent', 'run', 'setup:auto'], {
         stdio: 'inherit',

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -13,13 +13,7 @@
  *   --key            booleans only (sets true)
  *   --no-key         booleans only (sets false)
  */
-import {
-  CONFIG,
-  envVarFor,
-  flagFor,
-  findByFlag,
-  type Entry,
-} from './setup-config.js';
+import { CONFIG, envVarFor, flagFor, findByFlag, type Entry } from './setup-config.js';
 
 export type ConfigValues = Record<string, string | boolean | number>;
 
@@ -132,15 +126,11 @@ export function parseFlags(argv: string[]): FlagParseResult {
   return { values, rest, help, errors };
 }
 
-export function applyToEnv(
-  values: ConfigValues,
-  env: NodeJS.ProcessEnv = process.env,
-): void {
+export function applyToEnv(values: ConfigValues, env: NodeJS.ProcessEnv = process.env): void {
   for (const e of CONFIG) {
     if (!(e.key in values)) continue;
     const v = values[e.key];
-    env[envVarFor(e)] =
-      typeof v === 'boolean' ? (v ? 'true' : 'false') : String(v);
+    env[envVarFor(e)] = typeof v === 'boolean' ? (v ? 'true' : 'false') : String(v);
   }
 }
 

--- a/setup/lib/setup-config-screen.ts
+++ b/setup/lib/setup-config-screen.ts
@@ -21,9 +21,7 @@ const SKIP_SENTINEL = '__leave_unchanged__';
 const DONE_SENTINEL = '__done__';
 const MASK = '••••••••';
 
-export async function runAdvancedScreen(
-  initial: ConfigValues,
-): Promise<ConfigValues> {
+export async function runAdvancedScreen(initial: ConfigValues): Promise<ConfigValues> {
   const result: ConfigValues = { ...initial };
   const visible = CONFIG.filter((e) => e.surface === 'flag+ui');
 
@@ -60,13 +58,8 @@ function hintFor(e: Entry, values: ConfigValues): string {
 
 async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
   if (e.type === 'boolean') {
-    const init =
-      typeof values[e.key] === 'boolean'
-        ? (values[e.key] as boolean)
-        : (e.default ?? false);
-    const ans = ensureAnswer(
-      await p.confirm({ message: e.label, initialValue: init }),
-    );
+    const init = typeof values[e.key] === 'boolean' ? (values[e.key] as boolean) : (e.default ?? false);
+    const ans = ensureAnswer(await p.confirm({ message: e.label, initialValue: init }));
     values[e.key] = ans as boolean;
     return;
   }
@@ -75,10 +68,7 @@ async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
     const ans = ensureAnswer(
       await brightSelect<string>({
         message: e.label,
-        options: [
-          { value: SKIP_SENTINEL, label: 'Leave unchanged' },
-          ...e.options,
-        ],
+        options: [{ value: SKIP_SENTINEL, label: 'Leave unchanged' }, ...e.options],
         initialValue: SKIP_SENTINEL,
       }),
     );

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -59,8 +59,7 @@ interface IntEntry extends BaseEntry {
 
 export type Entry = StringEntry | EnumEntry | BoolEntry | IntEntry;
 
-const httpUrl = (v: string): string | undefined =>
-  /^https?:\/\/\S+/.test(v) ? undefined : 'Must be http(s)://…';
+const httpUrl = (v: string): string | undefined => (/^https?:\/\/\S+/.test(v) ? undefined : 'Must be http(s)://…');
 
 export const CONFIG: Entry[] = [
   {

--- a/setup/lib/skill-driver.test.ts
+++ b/setup/lib/skill-driver.test.ts
@@ -3,7 +3,16 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from '
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { runSkill, hostExec, hostExecStream, labelOrdinals, literalChoices, promptValidator, clackResolveInput, type RunSkillOptions } from './skill-driver.js';
+import {
+  runSkill,
+  hostExec,
+  hostExecStream,
+  labelOrdinals,
+  literalChoices,
+  promptValidator,
+  clackResolveInput,
+  type RunSkillOptions,
+} from './skill-driver.js';
 import { fullyApplied, type ApplyEvent } from '../../scripts/skill-apply.js';
 
 // Shared test state for the clack + claude-handoff mocks (hoisted so the vi.mock
@@ -98,7 +107,11 @@ describe('thin skill driver', () => {
   it('runs fully from inputs — resolveInput never touched', async () => {
     const { root, skill } = scratch();
     const ran: string[] = [];
-    const res = await runSkill(skill, { projectRoot: root, inputs: { token: 'FROM-INPUTS' }, exec: (c) => void ran.push(c) });
+    const res = await runSkill(skill, {
+      projectRoot: root,
+      inputs: { token: 'FROM-INPUTS' },
+      exec: (c) => void ran.push(c),
+    });
     expect(fullyApplied(res)).toBe(true);
     expect(ran).toContain('ncl wire --token FROM-INPUTS');
   });

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -92,7 +92,9 @@ export interface PrompterContext {
  * against the prompt's declared `validate:`/`flags:` (the engine's
  * validate-at-bind is the programmatic backstop, not the UX).
  */
-export function clackResolveInput(ctx: PrompterContext = {}): (name: string, meta: InputMeta) => Promise<string | undefined> {
+export function clackResolveInput(
+  ctx: PrompterContext = {},
+): (name: string, meta: InputMeta) => Promise<string | undefined> {
   // The `?` help-escape is only meaningful at a real terminal: it hands the
   // operator off to an interactive Claude session (stdio inherited). In a
   // headless / non-TTY run nobody can type `?` into a clack prompt anyway, and
@@ -234,7 +236,8 @@ async function reuseFromEnv(
     // stale credential that no longer matches the declared shape is never
     // offered — prompting fresh beats a loud validate-at-bind dead-end.
     const shape = promptShape.get(v);
-    if (shape?.validate && !new RegExp(shape.validate, shape.flags).test(normalizeValue(existing, shape.normalize))) continue;
+    if (shape?.validate && !new RegExp(shape.validate, shape.flags).test(normalizeValue(existing, shape.normalize)))
+      continue;
     if (await confirm(`Found an existing ${key} (${maskValue(existing)}). Use it?`)) reuse[v] = existing;
   }
   return reuse;
@@ -274,14 +277,22 @@ export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) =>
       });
       let out = '';
       let err = '';
-      child.stdout.on('data', (c: Buffer) => { out += c.toString('utf8'); });
-      child.stderr.on('data', (c: Buffer) => { err += c.toString('utf8'); });
+      child.stdout.on('data', (c: Buffer) => {
+        out += c.toString('utf8');
+      });
+      child.stderr.on('data', (c: Buffer) => {
+        err += c.toString('utf8');
+      });
       child.on('error', reject);
       child.on('close', (code) => {
         tee(cmd, out, err);
         if (code === 0) return resolve(out);
         const stderr = err.trim();
-        const head = stderr.split('\n').map((l) => l.trim()).find(Boolean) ?? 'command failed';
+        const head =
+          stderr
+            .split('\n')
+            .map((l) => l.trim())
+            .find(Boolean) ?? 'command failed';
         reject(new Error(`exit ${code ?? '?'}: ${head}${stderr ? `\n${stderr}` : ''}`));
       });
     });
@@ -325,8 +336,15 @@ export function hostExecStream(projectRoot: string): (cmd: string) => Promise<St
         while ((idx = buf.indexOf('\n')) !== -1) {
           const line = buf.slice(0, idx);
           buf = buf.slice(idx + 1);
-          if (/^=== NANOCLAW SETUP: \S+ ===/.test(line)) { current = { fields: {} }; continue; }
-          if (line.startsWith('=== END ===')) { if (current) blocks.push(current); current = null; continue; }
+          if (/^=== NANOCLAW SETUP: \S+ ===/.test(line)) {
+            current = { fields: {} };
+            continue;
+          }
+          if (line.startsWith('=== END ===')) {
+            if (current) blocks.push(current);
+            current = null;
+            continue;
+          }
           if (current) {
             const c = line.indexOf(':');
             if (c > 0) current.fields[line.slice(0, c).trim()] = line.slice(c + 1).trim();

--- a/setup/lib/theme.ts
+++ b/setup/lib/theme.ts
@@ -15,9 +15,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 const USE_ANSI = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
-const TRUECOLOR =
-  USE_ANSI &&
-  (process.env.COLORTERM === 'truecolor' || process.env.COLORTERM === '24bit');
+const TRUECOLOR = USE_ANSI && (process.env.COLORTERM === 'truecolor' || process.env.COLORTERM === '24bit');
 
 export function brand(s: string): string {
   if (!USE_ANSI) return s;

--- a/setup/lib/tz-from-claude.ts
+++ b/setup/lib/tz-from-claude.ts
@@ -34,9 +34,7 @@ export function claudeCliAvailable(): boolean {
  * resolved zone string on success, or null if the CLI is missing, Claude
  * errored, or the reply wasn't a valid IANA zone.
  */
-export async function resolveTimezoneViaClaude(
-  input: string,
-): Promise<string | null> {
+export async function resolveTimezoneViaClaude(input: string): Promise<string | null> {
   if (!claudeCliAvailable()) return null;
 
   const prompt = buildPrompt(input);
@@ -57,23 +55,16 @@ export async function resolveTimezoneViaClaude(
 
   const resolved = reply ? extractTimezone(reply) : null;
   if (resolved) {
-    s.stop(
-      `${fitToWidth(`Interpreted as ${resolved}.`, suffix)}${k.dim(suffix)}`,
-    );
+    s.stop(`${fitToWidth(`Interpreted as ${resolved}.`, suffix)}${k.dim(suffix)}`);
     return resolved;
   }
-  s.stop(
-    `${fitToWidth("Couldn't interpret that as a timezone.", suffix)}${k.dim(
-      suffix,
-    )}`,
-    1,
-  );
+  s.stop(`${fitToWidth("Couldn't interpret that as a timezone.", suffix)}${k.dim(suffix)}`, 1);
   return null;
 }
 
 function buildPrompt(input: string): string {
   return [
-    'Convert the user\'s description of where they are into a single IANA',
+    "Convert the user's description of where they are into a single IANA",
     'timezone identifier (e.g. "America/New_York", "Europe/London",',
     '"Asia/Jerusalem"). Respond with ONLY the IANA string on a single line,',
     'nothing else — no prose, no quotes, no punctuation. If you cannot',

--- a/setup/lib/version-pins.ts
+++ b/setup/lib/version-pins.ts
@@ -9,12 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const VERSIONS_FILE = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '..',
-  '..',
-  'versions.json',
-);
+const VERSIONS_FILE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'versions.json');
 
 /**
  * Returns the pinned version for a component, e.g.

--- a/setup/lib/windowed-runner.ts
+++ b/setup/lib/windowed-runner.ts
@@ -182,9 +182,7 @@ async function handleStall(
   render: { pauseRender: () => void; resumeRender: () => void },
 ): Promise<void> {
   render.pauseRender();
-  p.log.warn(
-    brandBody(`This looks stuck — no output from the ${stepName} step for the last 60 seconds.`),
-  );
+  p.log.warn(brandBody(`This looks stuck — no output from the ${stepName} step for the last 60 seconds.`));
   phEmit('step_stalled', { step: stepName });
 
   const { ensureAnswer } = await import('./runner.js');
@@ -192,12 +190,12 @@ async function handleStall(
 
   const choice = ensureAnswer(
     await brightSelect<'wait' | 'help'>({
-      message: "What now?",
+      message: 'What now?',
       options: [
         {
           value: 'wait',
-          label: "Keep waiting",
-          hint: "large images can take 5–10 minutes",
+          label: 'Keep waiting',
+          hint: 'large images can take 5–10 minutes',
         },
         {
           value: 'help',

--- a/setup/logs.ts
+++ b/setup/logs.ts
@@ -91,28 +91,19 @@ export function step(
 export function userInput(key: string, value: string): void {
   fs.mkdirSync(LOGS_DIR, { recursive: true });
   const ts = new Date().toISOString();
-  fs.appendFileSync(
-    PROGRESS_LOG,
-    `=== [${ts}] user-input → ${key} ===\n  value: ${value}\n\n`,
-  );
+  fs.appendFileSync(PROGRESS_LOG, `=== [${ts}] user-input → ${key} ===\n  value: ${value}\n\n`);
 }
 
 /** Append the success footer. */
 export function complete(totalMs: number): void {
   const ts = new Date().toISOString();
-  fs.appendFileSync(
-    PROGRESS_LOG,
-    `## ${ts} · completed (total ${formatDurationTotal(totalMs)})\n`,
-  );
+  fs.appendFileSync(PROGRESS_LOG, `## ${ts} · completed (total ${formatDurationTotal(totalMs)})\n`);
 }
 
 /** Append the failure footer. Keep error short — full context lives in the failing step's raw log. */
 export function abort(stepName: string, error: string): void {
   const ts = new Date().toISOString();
-  fs.appendFileSync(
-    PROGRESS_LOG,
-    `## ${ts} · aborted at ${stepName} (${error})\n`,
-  );
+  fs.appendFileSync(PROGRESS_LOG, `## ${ts} · aborted at ${stepName} (${error})\n`);
 }
 
 /**
@@ -123,9 +114,7 @@ export function abort(stepName: string, error: string): void {
  */
 export function stepRawLog(name: string): string {
   fs.mkdirSync(STEPS_DIR, { recursive: true });
-  const existing = fs
-    .readdirSync(STEPS_DIR)
-    .filter((n) => /^\d+-.+\.log$/.test(n));
+  const existing = fs.readdirSync(STEPS_DIR).filter((n) => /^\d+-.+\.log$/.test(n));
   const nextIdx = existing.length + 1;
   const num = String(nextIdx).padStart(2, '0');
   const safeName = name.replace(/[^a-z0-9-]/gi, '-').toLowerCase();

--- a/setup/migrate-v2/db.ts
+++ b/setup/migrate-v2/db.ts
@@ -29,13 +29,7 @@ import {
 import { runMigrations } from '../../src/db/migrations/index.js';
 import { readEnvFile } from '../../src/env.js';
 import { buildDiscordResolver, type DiscordResolver } from './discord-resolver.js';
-import {
-  generateId,
-  inferIsGroup,
-  parseJid,
-  triggerToEngage,
-  v2PlatformId,
-} from './shared.js';
+import { generateId, inferIsGroup, parseJid, triggerToEngage, v2PlatformId } from './shared.js';
 
 interface V1Group {
   jid: string;
@@ -75,8 +69,8 @@ async function main(): Promise<void> {
 
   // Init v2 DB
   fs.mkdirSync(path.join(process.cwd(), 'data'), { recursive: true });
-  const v2Db = initDb(CENTRAL_DB_PATH);
-  runMigrations(v2Db);
+  const v2Db = await initDb(CENTRAL_DB_PATH);
+  await runMigrations(v2Db);
 
   let created = 0;
   let reused = 0;
@@ -136,16 +130,16 @@ async function main(): Promise<void> {
 
     try {
       // agent_group — one per folder
-      let ag = getAgentGroupByFolder(g.folder);
+      let ag = await getAgentGroupByFolder(g.folder);
       if (!ag) {
-        createAgentGroup({
+        await createAgentGroup({
           id: generateId('ag'),
           name: g.name || g.folder,
           folder: g.folder,
           agent_provider: null,
           created_at: createdAt,
         });
-        ag = getAgentGroupByFolder(g.folder)!;
+        ag = (await getAgentGroupByFolder(g.folder))!;
       }
 
       // messaging_group — one per (channel_type, platform_id).
@@ -157,9 +151,9 @@ async function main(): Promise<void> {
       // migration would have set if it had created the row first. Once
       // any wiring exists, the user has had a chance to tighten the
       // policy via the skill — leave it alone.
-      let mg = getMessagingGroupByPlatform(channelType, platformId);
+      let mg = await getMessagingGroupByPlatform(channelType, platformId);
       if (!mg) {
-        createMessagingGroup({
+        await createMessagingGroup({
           id: generateId('mg'),
           channel_type: channelType,
           platform_id: platformId,
@@ -168,23 +162,20 @@ async function main(): Promise<void> {
           unknown_sender_policy: 'public',
           created_at: createdAt,
         });
-        mg = getMessagingGroupByPlatform(channelType, platformId)!;
-      } else if (
-        mg.unknown_sender_policy !== 'public' &&
-        getMessagingGroupAgents(mg.id).length === 0
-      ) {
-        updateMessagingGroup(mg.id, { unknown_sender_policy: 'public' });
-        mg = getMessagingGroupByPlatform(channelType, platformId)!;
+        mg = (await getMessagingGroupByPlatform(channelType, platformId))!;
+      } else if (mg.unknown_sender_policy !== 'public' && (await getMessagingGroupAgents(mg.id)).length === 0) {
+        await updateMessagingGroup(mg.id, { unknown_sender_policy: 'public' });
+        mg = (await getMessagingGroupByPlatform(channelType, platformId))!;
       }
 
       // messaging_group_agents — wire them
-      const existing = getMessagingGroupAgentByPair(mg.id, ag.id);
+      const existing = await getMessagingGroupAgentByPair(mg.id, ag.id);
       if (!existing) {
         const engage = triggerToEngage({
           trigger_pattern: g.trigger_pattern,
           requires_trigger: g.requires_trigger,
         });
-        createMessagingGroupAgent({
+        await createMessagingGroupAgent({
           id: generateId('mga'),
           messaging_group_id: mg.id,
           agent_group_id: ag.id,
@@ -206,7 +197,7 @@ async function main(): Promise<void> {
     }
   }
 
-  v2Db.close();
+  await v2Db.close();
 
   // If every group was skipped, the migration didn't actually do anything.
   // Treat that as failure so the wrapper script surfaces it instead of

--- a/setup/migrate-v2/discord-resolver.test.ts
+++ b/setup/migrate-v2/discord-resolver.test.ts
@@ -31,13 +31,8 @@ describe('buildDiscordResolver', () => {
         { id: 'g1', name: 'Guild 1' },
         { id: 'g2', name: 'Guild 2' },
       ],
-      'https://discord.com/api/v10/guilds/g1/channels': [
-        { id: 'c1' },
-        { id: 'c2' },
-      ],
-      'https://discord.com/api/v10/guilds/g2/channels': [
-        { id: 'c3' },
-      ],
+      'https://discord.com/api/v10/guilds/g1/channels': [{ id: 'c1' }, { id: 'c2' }],
+      'https://discord.com/api/v10/guilds/g2/channels': [{ id: 'c3' }],
     });
 
     const r = await buildDiscordResolver('valid-token', [], fetchImpl);
@@ -123,11 +118,7 @@ describe('buildDiscordResolver', () => {
       'https://discord.com/api/v10/channels/groupDmId': { id: 'groupDmId', type: 3 },
     });
 
-    const r = await buildDiscordResolver(
-      'valid-token',
-      ['guild-chan', 'dmId', 'groupDmId'],
-      fetchImpl,
-    );
+    const r = await buildDiscordResolver('valid-token', ['guild-chan', 'dmId', 'groupDmId'], fetchImpl);
 
     expect(r.stats()).toEqual({ guilds: 1, channels: 1, dms: 2 });
     expect(r.resolve('guild-chan')).toBe('discord:g1:guild-chan');
@@ -152,11 +143,7 @@ describe('buildDiscordResolver', () => {
       },
     });
 
-    const r = await buildDiscordResolver(
-      'valid-token',
-      ['orphanId', 'leftoverGuildChan'],
-      fetchImpl,
-    );
+    const r = await buildDiscordResolver('valid-token', ['orphanId', 'leftoverGuildChan'], fetchImpl);
 
     expect(r.stats()).toEqual({ guilds: 0, channels: 0, dms: 0 });
     expect(r.resolve('orphanId')).toBeNull();
@@ -182,11 +169,7 @@ describe('buildDiscordResolver', () => {
 
     // 'guild-chan' is in the guild map (skip classify); 'dmId' appears twice
     // in the input (classify exactly once).
-    const r = await buildDiscordResolver(
-      'valid-token',
-      ['guild-chan', 'dmId', 'dmId'],
-      fetchImpl,
-    );
+    const r = await buildDiscordResolver('valid-token', ['guild-chan', 'dmId', 'dmId'], fetchImpl);
 
     expect(dmCallCount).toBe(1);
     expect(r.resolve('guild-chan')).toBe('discord:g1:guild-chan');

--- a/setup/migrate-v2/discord-resolver.ts
+++ b/setup/migrate-v2/discord-resolver.ts
@@ -117,11 +117,7 @@ export async function buildDiscordResolver(
   const channelToGuild = new Map<string, string>();
   for (const guild of guilds) {
     try {
-      const channels = await getJson<Channel[]>(
-        `${DISCORD_API}/guilds/${guild.id}/channels`,
-        token,
-        fetchImpl,
-      );
+      const channels = await getJson<Channel[]>(`${DISCORD_API}/guilds/${guild.id}/channels`, token, fetchImpl);
       for (const ch of channels) {
         channelToGuild.set(ch.id, guild.id);
       }
@@ -147,11 +143,7 @@ export async function buildDiscordResolver(
     if (seen.has(channelId)) continue;
     seen.add(channelId);
     try {
-      const ch = await getJson<ChannelInfo>(
-        `${DISCORD_API}/channels/${channelId}`,
-        token,
-        fetchImpl,
-      );
+      const ch = await getJson<ChannelInfo>(`${DISCORD_API}/channels/${channelId}`, token, fetchImpl);
       if (ch.type === CHANNEL_TYPE_DM || ch.type === CHANNEL_TYPE_GROUP_DM) {
         dmChannels.add(channelId);
       }

--- a/setup/migrate-v2/groups.ts
+++ b/setup/migrate-v2/groups.ts
@@ -73,9 +73,10 @@ function main(): void {
   const registeredFolders = new Set<string>();
   if (fs.existsSync(v1DbPath)) {
     const v1Db = new Database(v1DbPath, { readonly: true, fileMustExist: true });
-    const rows = v1Db
-      .prepare('SELECT folder, container_config FROM registered_groups')
-      .all() as Array<{ folder: string; container_config: string | null }>;
+    const rows = v1Db.prepare('SELECT folder, container_config FROM registered_groups').all() as Array<{
+      folder: string;
+      container_config: string | null;
+    }>;
     const containerConfigs = new Map<string, string | null>();
     for (const r of rows) {
       registeredFolders.add(r.folder);

--- a/setup/migrate-v2/select-channels.ts
+++ b/setup/migrate-v2/select-channels.ts
@@ -15,18 +15,18 @@ import * as p from '@clack/prompts';
 import { styleText } from 'node:util';
 
 const CHANNELS = [
-  { value: 'telegram',       label: 'Telegram' },
-  { value: 'discord',        label: 'Discord' },
-  { value: 'slack',          label: 'Slack' },
-  { value: 'whatsapp',       label: 'WhatsApp' },
-  { value: 'teams',          label: 'Microsoft Teams' },
-  { value: 'matrix',         label: 'Matrix' },
-  { value: 'imessage',       label: 'iMessage' },
-  { value: 'webex',          label: 'Webex' },
-  { value: 'gchat',          label: 'Google Chat' },
-  { value: 'resend',         label: 'Resend (email)' },
-  { value: 'github',         label: 'GitHub' },
-  { value: 'linear',         label: 'Linear' },
+  { value: 'telegram', label: 'Telegram' },
+  { value: 'discord', label: 'Discord' },
+  { value: 'slack', label: 'Slack' },
+  { value: 'whatsapp', label: 'WhatsApp' },
+  { value: 'teams', label: 'Microsoft Teams' },
+  { value: 'matrix', label: 'Matrix' },
+  { value: 'imessage', label: 'iMessage' },
+  { value: 'webex', label: 'Webex' },
+  { value: 'gchat', label: 'Google Chat' },
+  { value: 'resend', label: 'Resend (email)' },
+  { value: 'github', label: 'GitHub' },
+  { value: 'linear', label: 'Linear' },
   { value: 'whatsapp-cloud', label: 'WhatsApp Cloud API' },
 ];
 
@@ -42,7 +42,10 @@ async function main(): Promise<void> {
   // Non-interactive: NANOCLAW_CHANNELS="telegram,discord"
   const envChannels = process.env.NANOCLAW_CHANNELS?.trim();
   if (envChannels) {
-    const names = envChannels.split(',').map((s) => s.trim()).filter((s) => VALID_NAMES.has(s));
+    const names = envChannels
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => VALID_NAMES.has(s));
     fs.writeFileSync(outFile, names.join('\n') + '\n');
     return;
   }

--- a/setup/migrate-v2/sessions.ts
+++ b/setup/migrate-v2/sessions.ts
@@ -27,11 +27,7 @@ import { initDb, closeDb } from '../../src/db/connection.js';
 import { getAllAgentGroups } from '../../src/db/agent-groups.js';
 import { getMessagingGroupsByAgentGroup } from '../../src/db/messaging-groups.js';
 import { runMigrations } from '../../src/db/migrations/index.js';
-import {
-  resolveSession,
-  writeSessionRouting,
-  outboundDbPath,
-} from '../../src/session-manager.js';
+import { resolveSession, writeSessionRouting, outboundDbPath } from '../../src/session-manager.js';
 
 const SKIP_NAMES = new Set(['.DS_Store']);
 
@@ -79,10 +75,10 @@ function main(): void {
     process.exit(1);
   }
 
-  const v2Db = initDb(v2DbPath);
-  runMigrations(v2Db);
+  const v2Db = await initDb(v2DbPath);
+  await runMigrations(v2Db);
 
-  const agentGroups = getAllAgentGroups();
+  const agentGroups = await getAllAgentGroups();
   const folderToAg = new Map<string, { id: string; folder: string }>();
   for (const ag of agentGroups) {
     folderToAg.set(ag.folder, ag);
@@ -104,7 +100,7 @@ function main(): void {
     }
 
     // Find the messaging groups wired to this agent group
-    const messagingGroups = getMessagingGroupsByAgentGroup(ag.id);
+    const messagingGroups = await getMessagingGroupsByAgentGroup(ag.id);
     if (messagingGroups.length === 0) {
       sessionsSkipped++;
       continue;
@@ -113,7 +109,7 @@ function main(): void {
     // Create a session for each messaging group (v1 had one session per
     // folder, v2 has one per agent_group + messaging_group pair)
     for (const mg of messagingGroups) {
-      const { session, created } = resolveSession(ag.id, mg.id, null, 'shared');
+      const { session, created } = await resolveSession(ag.id, mg.id, null, 'shared');
 
       if (created) {
         // Write routing so the container knows where to reply
@@ -158,9 +154,9 @@ function main(): void {
             .sort((a, b) => b.mtime - a.mtime)[0].name;
 
           // Write into each v2 session's outbound.db for this agent group
-          const sessions = getMessagingGroupsByAgentGroup(ag.id);
+          const sessions = await getMessagingGroupsByAgentGroup(ag.id);
           for (const mg of sessions) {
-            const { session } = resolveSession(ag.id, mg.id, null, 'shared');
+            const { session } = await resolveSession(ag.id, mg.id, null, 'shared');
             const obPath = outboundDbPath(ag.id, session.id);
             if (fs.existsSync(obPath)) {
               const ob = new Database(obPath);
@@ -175,7 +171,7 @@ function main(): void {
     }
   }
 
-  closeDb();
+  await closeDb();
 
   console.log(`OK:created=${sessionsCreated},reused=${sessionsReused},skipped=${sessionsSkipped},files=${filesCopied}`);
 }

--- a/setup/migrate-v2/shared.ts
+++ b/setup/migrate-v2/shared.ts
@@ -103,10 +103,7 @@ export function inferIsGroup(channelType: string, platformId: string): number {
  * Key rule: requires_trigger=0 means "respond to everything" regardless
  * of the pattern value. The pattern was for mention highlighting, not gating.
  */
-export function triggerToEngage(input: {
-  trigger_pattern: string | null;
-  requires_trigger: number | null;
-}): {
+export function triggerToEngage(input: { trigger_pattern: string | null; requires_trigger: number | null }): {
   engage_mode: 'pattern' | 'mention' | 'mention-sticky';
   engage_pattern: string | null;
 } {
@@ -153,9 +150,7 @@ export const CHANNEL_AUTH_REGISTRY: Record<string, ChannelAuthSpec> = {
   },
   telegram: {
     v1EnvKeys: ['TELEGRAM_BOT_TOKEN', 'TELEGRAM_API_ID', 'TELEGRAM_API_HASH'],
-    requiredV2Keys: [
-      { key: 'TELEGRAM_BOT_TOKEN', where: 'BotFather on Telegram → /mybots → Bot → API Token' },
-    ],
+    requiredV2Keys: [{ key: 'TELEGRAM_BOT_TOKEN', where: 'BotFather on Telegram → /mybots → Bot → API Token' }],
     candidatePaths: ['data/sessions/telegram', 'store/telegram-session'],
   },
   whatsapp: {

--- a/setup/migrate-v2/tasks.ts
+++ b/setup/migrate-v2/tasks.ts
@@ -99,8 +99,8 @@ async function main(): Promise<void> {
     console.error('v2.db not found — run db step first');
     process.exit(1);
   }
-  const v2Db = initDb(v2DbPath);
-  runMigrations(v2Db);
+  const v2Db = await initDb(v2DbPath);
+  await runMigrations(v2Db);
 
   let migrated = 0;
   let skipped = 0;
@@ -116,34 +116,52 @@ async function main(): Promise<void> {
 
   for (const t of activeTasks) {
     try {
-      const ag = getAgentGroupByFolder(t.group_folder);
-      if (!ag) { skipped++; continue; }
+      const ag = await getAgentGroupByFolder(t.group_folder);
+      if (!ag) {
+        skipped++;
+        continue;
+      }
 
       const parsed = parseJid(t.chat_jid);
-      if (!parsed) { skipped++; continue; }
+      if (!parsed) {
+        skipped++;
+        continue;
+      }
 
       let platformId: string;
       if (parsed.channel_type === 'discord') {
         const resolved = discordResolver?.resolve(parsed.id) ?? null;
-        if (!resolved) { skipped++; continue; }
+        if (!resolved) {
+          skipped++;
+          continue;
+        }
         platformId = resolved;
       } else {
         platformId = v2PlatformId(parsed.channel_type, t.chat_jid);
       }
-      const mg = getMessagingGroupByPlatform(parsed.channel_type, platformId);
-      if (!mg) { skipped++; continue; }
+      const mg = await getMessagingGroupByPlatform(parsed.channel_type, platformId);
+      if (!mg) {
+        skipped++;
+        continue;
+      }
 
       const scheduling = toCron(t);
-      if (!scheduling) { skipped++; continue; }
+      if (!scheduling) {
+        skipped++;
+        continue;
+      }
 
-      const { session } = resolveSession(ag.id, mg.id, null, 'shared');
+      const { session } = await resolveSession(ag.id, mg.id, null, 'shared');
       const inboxDb = openInboundDb(ag.id, session.id);
       try {
         // Idempotence check
-        const existing = inboxDb
-          .prepare("SELECT id FROM messages_in WHERE id = ? AND kind = 'task'")
-          .get(t.id) as { id: string } | undefined;
-        if (existing) { skipped++; continue; }
+        const existing = inboxDb.prepare("SELECT id FROM messages_in WHERE id = ? AND kind = 'task'").get(t.id) as
+          | { id: string }
+          | undefined;
+        if (existing) {
+          skipped++;
+          continue;
+        }
 
         insertTask(inboxDb, {
           id: t.id,
@@ -168,7 +186,7 @@ async function main(): Promise<void> {
     }
   }
 
-  closeDb();
+  await closeDb();
   console.log(`OK:active=${activeTasks.length},migrated=${migrated},skipped=${skipped},failed=${failed}`);
 }
 

--- a/setup/mounts.ts
+++ b/setup/mounts.ts
@@ -32,18 +32,13 @@ export async function run(args: string[]): Promise<void> {
   const configFile = path.join(configDir, 'mount-allowlist.json');
 
   if (isRoot()) {
-    log.warn(
-      'Running as root — mount allowlist will be written to root home directory',
-    );
+    log.warn('Running as root — mount allowlist will be written to root home directory');
   }
 
   fs.mkdirSync(configDir, { recursive: true });
 
   if (fs.existsSync(configFile) && !force) {
-    log.info(
-      'Mount allowlist already exists — skipping (use --force to overwrite)',
-      { configFile },
-    );
+    log.info('Mount allowlist already exists — skipping (use --force to overwrite)', { configFile });
     emitStatus('CONFIGURE_MOUNTS', {
       PATH: configFile,
       ALLOWED_ROOTS: 0,
@@ -85,9 +80,7 @@ export async function run(args: string[]): Promise<void> {
     }
 
     fs.writeFileSync(configFile, JSON.stringify(parsed, null, 2) + '\n');
-    allowedRoots = Array.isArray(parsed.allowedRoots)
-      ? parsed.allowedRoots.length
-      : 0;
+    allowedRoots = Array.isArray(parsed.allowedRoots) ? parsed.allowedRoots.length : 0;
     nonMainReadOnly = parsed.nonMainReadOnly === false ? 'false' : 'true';
   } else {
     // Read from stdin
@@ -111,16 +104,11 @@ export async function run(args: string[]): Promise<void> {
     }
 
     fs.writeFileSync(configFile, JSON.stringify(parsed, null, 2) + '\n');
-    allowedRoots = Array.isArray(parsed.allowedRoots)
-      ? parsed.allowedRoots.length
-      : 0;
+    allowedRoots = Array.isArray(parsed.allowedRoots) ? parsed.allowedRoots.length : 0;
     nonMainReadOnly = parsed.nonMainReadOnly === false ? 'false' : 'true';
   }
 
-  log.info(
-    'Allowlist configured',
-    { configFile, allowedRoots, nonMainReadOnly },
-  );
+  log.info('Allowlist configured', { configFile, allowedRoots, nonMainReadOnly });
 
   emitStatus('CONFIGURE_MOUNTS', {
     PATH: configFile,

--- a/setup/pair-telegram.ts
+++ b/setup/pair-telegram.ts
@@ -20,11 +20,7 @@
  */
 import * as p from '@clack/prompts';
 
-import {
-  createPairing,
-  waitForPairing,
-  type PairingIntent,
-} from '../src/channels/telegram-pairing.js';
+import { createPairing, waitForPairing, type PairingIntent } from '../src/channels/telegram-pairing.js';
 import { CENTRAL_DB_PATH } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
@@ -85,8 +81,8 @@ export async function run(args: string[]): Promise<void> {
   // pairing primitive itself, but the inbound interceptor running inside the
   // live service needs migrations applied. Touch it here so a fresh install
   // doesn't fail on the first code match.
-  const db = initDb(CENTRAL_DB_PATH);
-  runMigrations(db);
+  const db = await initDb(CENTRAL_DB_PATH);
+  await runMigrations(db);
 
   const MAX_REGENERATIONS = 5;
   let record = await createPairing(intent);
@@ -119,9 +115,7 @@ export async function run(args: string[]): Promise<void> {
         // — byte-identical to the legacy PAIRED_USER_ID below. PAIRED_USER_ID
         // stays for the agent-driven callers that read it directly.
         ADMIN_USER_ID: consumed.consumed!.adminUserId ?? '',
-        PAIRED_USER_ID: consumed.consumed!.adminUserId
-          ? `telegram:${consumed.consumed!.adminUserId}`
-          : '',
+        PAIRED_USER_ID: consumed.consumed!.adminUserId ? `telegram:${consumed.consumed!.adminUserId}` : '',
       });
       return;
     } catch (err) {

--- a/setup/peer-cleanup.ts
+++ b/setup/peer-cleanup.ts
@@ -268,8 +268,7 @@ function probeSystemdPeer(unit: string): PeerStatus | null {
     const restartsStr = /^NRestarts=(\d+)/m.exec(output)?.[1];
     const runs = restartsStr ? parseInt(restartsStr, 10) : 0;
 
-    const unhealthy =
-      activeState === 'failed' || (activeState !== 'active' && runs > UNHEALTHY_RUNS_THRESHOLD);
+    const unhealthy = activeState === 'failed' || (activeState !== 'active' && runs > UNHEALTHY_RUNS_THRESHOLD);
     return { label: unit, configPath: unitPath, state: activeState, runs, unhealthy };
   } catch {
     return null;

--- a/setup/providers/install.ts
+++ b/setup/providers/install.ts
@@ -53,10 +53,7 @@ export interface ProviderInstallResult {
   blockers: string[];
 }
 
-export async function applyProviderSkill(
-  skillDir: string,
-  projectRoot: string,
-): Promise<ProviderInstallResult> {
+export async function applyProviderSkill(skillDir: string, projectRoot: string): Promise<ProviderInstallResult> {
   // A provider SKILL.md has no prompt directives (vault-only auth runs
   // separately). No resolveInput is passed: absent ⇒ any prompt defers, which
   // is exactly the old defer-all stub's semantics with no stub to maintain.

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -120,9 +120,7 @@ function parseArgs(args: string[]): RegisterArgs {
       case '--unknown-sender-policy': {
         const raw = (args[++i] || '').toLowerCase() as RegisterArgs['unknownSenderPolicy'];
         if (!raw || !SENDER_POLICIES.includes(raw)) {
-          throw new Error(
-            `--unknown-sender-policy must be one of ${SENDER_POLICIES.join('|')}, got "${raw}"`,
-          );
+          throw new Error(`--unknown-sender-policy must be one of ${SENDER_POLICIES.join('|')}, got "${raw}"`);
         }
         result.unknownSenderPolicy = raw;
         break;
@@ -181,8 +179,8 @@ export async function run(args: string[]): Promise<void> {
 
   // Init v2 central DB
   fs.mkdirSync(path.join(projectRoot, 'data'), { recursive: true });
-  const db = initDb(CENTRAL_DB_PATH);
-  runMigrations(db);
+  const db = await initDb(CENTRAL_DB_PATH);
+  await runMigrations(db);
 
   // 1. Create or find agent group. The workspace is scaffolded at the first
   // spawn (group-init), where the DB-resolved provider is known; here we only
@@ -190,23 +188,23 @@ export async function run(args: string[]): Promise<void> {
   // channel group is created on the operator's chosen provider (per-group
   // `ncl groups config update --provider` still overrides). A reused group
   // keeps its existing provider (INSERT OR IGNORE).
-  let agentGroup = getAgentGroupByFolder(parsed.folder);
+  let agentGroup = await getAgentGroupByFolder(parsed.folder);
   if (!agentGroup) {
     const agId = generateId('ag');
-    createAgentGroup({
+    await createAgentGroup({
       id: agId,
       name: parsed.assistantName,
       folder: parsed.folder,
       agent_provider: null,
       created_at: new Date().toISOString(),
     });
-    agentGroup = getAgentGroupByFolder(parsed.folder)!;
+    agentGroup = (await getAgentGroupByFolder(parsed.folder))!;
     log.info('Created agent group', { id: agId, folder: parsed.folder });
   }
-  ensureContainerConfig(agentGroup.id);
+  await ensureContainerConfig(agentGroup.id);
 
   // 2. Create or find messaging group
-  let messagingGroup = getMessagingGroupByPlatform(parsed.channel, parsed.platformId);
+  let messagingGroup = await getMessagingGroupByPlatform(parsed.channel, parsed.platformId);
   if (!messagingGroup) {
     const mgId = generateId('mg');
     // Policy: explicit flag → channel declaration → legacy 'strict' (stale
@@ -216,7 +214,7 @@ export async function run(args: string[]): Promise<void> {
       (hasDeclaredChannelDefaults(parsed.channel)
         ? resolveUnknownSenderPolicy(parsed.channel, parsed.isGroup)
         : 'strict');
-    createMessagingGroup({
+    await createMessagingGroup({
       id: mgId,
       channel_type: parsed.channel,
       platform_id: parsed.platformId,
@@ -225,14 +223,14 @@ export async function run(args: string[]): Promise<void> {
       unknown_sender_policy: unknownSenderPolicy,
       created_at: new Date().toISOString(),
     });
-    messagingGroup = getMessagingGroupByPlatform(parsed.channel, parsed.platformId)!;
+    messagingGroup = (await getMessagingGroupByPlatform(parsed.channel, parsed.platformId))!;
     log.info('Created messaging group', { id: mgId, channel: parsed.channel, platformId: parsed.platformId });
   }
 
   // 3. Wire agent to messaging group — createMessagingGroupAgent auto-creates
   // the companion agent_destinations row so delivery's ACL admits this target.
   let newlyWired = false;
-  const existing = getMessagingGroupAgentByPair(messagingGroup.id, agentGroup.id);
+  const existing = await getMessagingGroupAgentByPair(messagingGroup.id, agentGroup.id);
   if (!existing) {
     newlyWired = true;
     const mgaId = generateId('mga');
@@ -265,7 +263,7 @@ export async function run(args: string[]): Promise<void> {
     // channels declaring mentions:'never'; coerces mention-sticky→mention
     // when the channel context has no thread ids.
     validateEngageAgainstChannel(engage, messagingGroup);
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: mgaId,
       messaging_group_id: messagingGroup.id,
       agent_group_id: agentGroup.id,
@@ -286,7 +284,7 @@ export async function run(args: string[]): Promise<void> {
 
   // 4. Send onboarding message — only on first wiring, not re-registration
   if (newlyWired) {
-    const { session } = resolveSession(
+    const { session } = await resolveSession(
       agentGroup.id,
       messagingGroup.id,
       null,

--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -348,7 +348,10 @@ function readAccountCredential(): AccountCredential | undefined {
  */
 function resolveRegistryHost(fromBroker: string | undefined): string | undefined {
   if (fromBroker) {
-    return fromBroker.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').split('/')[0].toLowerCase();
+    return fromBroker
+      .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+      .split('/')[0]
+      .toLowerCase();
   }
   const first = readAgentImagePin()?.split('/')[0];
   return first && (first.includes('.') || first.includes(':')) ? first.toLowerCase() : undefined;
@@ -619,10 +622,7 @@ interface IdpConfig {
  * and answers 404 from the marketing site, so "unreachable" is not a safe proxy
  * for "misconfigured" either.
  */
-type BrokerProbe =
-  | { kind: 'idp'; config: IdpConfig }
-  | { kind: 'no-idp' }
-  | { kind: 'not-a-broker'; detail: string };
+type BrokerProbe = { kind: 'idp'; config: IdpConfig } | { kind: 'no-idp' } | { kind: 'not-a-broker'; detail: string };
 
 async function probeBroker(api: string): Promise<BrokerProbe> {
   const fromEnv = str(process.env[ENV.clientId]);
@@ -639,7 +639,11 @@ async function probeBroker(api: string): Promise<BrokerProbe> {
 
   let res;
   try {
-    res = await http(`${api}/v1/auth-config`, { method: 'GET', headers: { accept: 'application/json' } }, PROBE_TIMEOUT_MS);
+    res = await http(
+      `${api}/v1/auth-config`,
+      { method: 'GET', headers: { accept: 'application/json' } },
+      PROBE_TIMEOUT_MS,
+    );
   } catch (err) {
     return { kind: 'not-a-broker', detail: message(err) };
   }
@@ -779,10 +783,7 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
 
   for (;;) {
     if (Date.now() >= deadline) {
-      throw new LoginError(
-        'Timed out waiting for the sign-in to be approved.',
-        'Re-run setup to get a fresh code.',
-      );
+      throw new LoginError('Timed out waiting for the sign-in to be approved.', 'Re-run setup to get a fresh code.');
     }
     await sleep(intervalMs);
 
@@ -816,15 +817,9 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
         intervalMs += SLOW_DOWN_STEP_MS;
         continue;
       case 'expired_token':
-        throw new LoginError(
-          'That sign-in code expired before it was approved.',
-          'Re-run setup to get a fresh code.',
-        );
+        throw new LoginError('That sign-in code expired before it was approved.', 'Re-run setup to get a fresh code.');
       case 'access_denied':
-        throw new LoginError(
-          'The sign-in was declined in the browser.',
-          'Re-run setup if that was a mistake.',
-        );
+        throw new LoginError('The sign-in was declined in the browser.', 'Re-run setup if that was a mistake.');
       case 'invalid_client':
       case 'unauthorized_client':
         throw misconfiguredClient();
@@ -963,11 +958,7 @@ const CONSENT_TEXT = CONSENT_LINES.join(' ');
  * withdrawal path a one-shot terminal prompt cannot offer; until it exists the
  * unsubscribe link in every email is that path.
  */
-async function maybeAskEmailConsent(
-  api: string,
-  cred: AccountCredential,
-  current: boolean | null,
-): Promise<void> {
+async function maybeAskEmailConsent(api: string, cred: AccountCredential, current: boolean | null): Promise<void> {
   if (current !== null) return;
 
   // clack rather than this file's own readline, so the question looks like the
@@ -1155,9 +1146,7 @@ export async function run(argv: string[]): Promise<void> {
   // Bare newline rather than a lead-in sentence: the prompt below says what
   // pressing Enter does, and the spacing keeps it off whatever printed last.
   console.log('');
-  const typed = await askLine(
-    '   Press Enter to open your browser and authenticate, or paste an enrollment code: ',
-  );
+  const typed = await askLine('   Press Enter to open your browser and authenticate, or paste an enrollment code: ');
   if (typed === undefined) {
     reportSkipped('declined');
     return;

--- a/setup/registry-reconcile.ts
+++ b/setup/registry-reconcile.ts
@@ -18,12 +18,11 @@
 import fs from 'fs';
 import { spawnSync } from 'child_process';
 
-import type DatabaseType from 'better-sqlite3';
-
 import { CENTRAL_DB_PATH, CONTAINER_IMAGE_BASE } from '../src/config.js';
 import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
 import { getAllContainerConfigs, updateContainerConfigScalars } from '../src/db/container-configs.js';
 import { getDb, hasTable, initDb } from '../src/db/connection.js';
+import type { DbDriver } from '../src/db/driver.js';
 import { log } from '../src/log.js';
 import { readImageSource } from './lib/registry-state.js';
 import { emitStatus } from './status.js';
@@ -59,7 +58,7 @@ const SAFE_IMAGE_REF = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*:[a-zA-Z0-9][a-zA-Z0-9_.-]*
  * there a derived image is a working feature, not residue. The `run()` entry
  * point below carries that guard; a direct caller has to carry it itself.
  */
-export function reconcileDerivedImages(): ReconcileResult {
+export async function reconcileDerivedImages(): Promise<ReconcileResult> {
   const result = emptyResult();
 
   const dbPath = CENTRAL_DB_PATH;
@@ -73,20 +72,20 @@ export function reconcileDerivedImages(): ReconcileResult {
   // The step runs standalone (`--step registry-reconcile`) or is called from
   // the container step, which has no DB open. Reuse an existing handle rather
   // than opening a second writer onto the same file.
-  let db: DatabaseType.Database;
+  let db: DbDriver;
   try {
     db = getDb();
   } catch {
-    db = initDb(dbPath);
+    db = await initDb(dbPath);
   }
 
-  if (!hasTable(db, 'container_configs')) {
+  if (!(await hasTable(db, 'container_configs'))) {
     // Migrations haven't run yet. Nothing can be pinned before the table exists.
     log.info('container_configs not present — nothing to reconcile');
     return result;
   }
 
-  for (const row of getAllContainerConfigs()) {
+  for (const row of await getAllContainerConfigs()) {
     if (!row.image_tag) continue;
 
     const derivedTag = `${CONTAINER_IMAGE_BASE}:${row.agent_group_id}`;
@@ -108,7 +107,7 @@ export function reconcileDerivedImages(): ReconcileResult {
     // regardless of what the `docker rmi` below does. Doing it the other way
     // round would open a window where the row points at an image that no
     // longer exists, and the group would fail to spawn instead of downgrading.
-    updateContainerConfigScalars(row.agent_group_id, { image_tag: null });
+    await updateContainerConfigScalars(row.agent_group_id, { image_tag: null });
     result.cleared.push(row.agent_group_id);
     log.info('Cleared derived image pin', { agentGroupId: row.agent_group_id, imageTag: derivedTag });
 
@@ -162,7 +161,7 @@ export async function run(args: string[]): Promise<void> {
     return;
   }
 
-  const result = reconcileDerivedImages();
+  const result = await reconcileDerivedImages();
 
   log.info('Reconcile complete', {
     cleared: result.cleared.length,

--- a/setup/registry.ts
+++ b/setup/registry.ts
@@ -54,8 +54,7 @@ const MODE_FLAGS: Record<string, Mode> = {
 
 // One line: the step's own failures are rendered through setup/index.ts's
 // catch, which puts the message in an ERROR field of a line-oriented block.
-const USAGE =
-  'Usage: --step registry -- [--status | --refresh | --opt-out | --logout] [--non-interactive]';
+const USAGE = 'Usage: --step registry -- [--status | --refresh | --opt-out | --logout] [--non-interactive]';
 
 /**
  * The block name has to be `stepName.toUpperCase()`: on a thrown error
@@ -121,10 +120,7 @@ async function status(say: (line?: string) => void): Promise<void> {
   // `unknown` covers three different states — unpinned, not a digest ref, and
   // docker unreachable — and none of them is a mismatch. Only claim drift when
   // both sides answered.
-  const pinMatch =
-    !pinnedDigest || !image.registryDigest
-      ? 'unknown'
-      : String(pinnedDigest === image.registryDigest);
+  const pinMatch = !pinnedDigest || !image.registryDigest ? 'unknown' : String(pinnedDigest === image.registryDigest);
 
   const row = (label: string, value: string): void => say(`${(label + ':').padEnd(18)}${value}`);
   row('Image source', source === 'hardened' ? 'pull a pinned image' : 'build here');
@@ -286,7 +282,7 @@ async function refresh(say: (line?: string) => void): Promise<void> {
   let foreign = 0;
   try {
     const { reconcileDerivedImages } = await import('./registry-reconcile.js');
-    const result = reconcileDerivedImages();
+    const result = await reconcileDerivedImages();
     cleared = result.cleared.length;
     removed = result.removed.length;
     foreign = result.foreign.length;

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -11,11 +11,7 @@ import { getLaunchdLabel } from '../src/install-slug.js';
  */
 
 // Helper: generate a plist string the same way service.ts does
-function generatePlist(
-  nodePath: string,
-  projectRoot: string,
-  homeDir: string,
-): string {
+function generatePlist(nodePath: string, projectRoot: string, homeDir: string): string {
   const label = getLaunchdLabel(projectRoot);
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -49,12 +45,7 @@ function generatePlist(
 </plist>`;
 }
 
-function generateSystemdUnit(
-  nodePath: string,
-  projectRoot: string,
-  homeDir: string,
-  isSystem: boolean,
-): string {
+function generateSystemdUnit(nodePath: string, projectRoot: string, homeDir: string, isSystem: boolean): string {
   return `[Unit]
 Description=NanoClaw Personal Assistant
 After=network.target
@@ -84,29 +75,17 @@ describe('plist generation', () => {
   });
 
   it('uses the correct node path', () => {
-    const plist = generatePlist(
-      '/opt/node/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-    );
+    const plist = generatePlist('/opt/node/bin/node', '/home/user/nanoclaw', '/home/user');
     expect(plist).toContain('<string>/opt/node/bin/node</string>');
   });
 
   it('points to dist/index.js', () => {
-    const plist = generatePlist(
-      '/usr/local/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-    );
+    const plist = generatePlist('/usr/local/bin/node', '/home/user/nanoclaw', '/home/user');
     expect(plist).toContain('/home/user/nanoclaw/dist/index.js');
   });
 
   it('sets log paths', () => {
-    const plist = generatePlist(
-      '/usr/local/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-    );
+    const plist = generatePlist('/usr/local/bin/node', '/home/user/nanoclaw', '/home/user');
     expect(plist).toContain('nanoclaw.log');
     expect(plist).toContain('nanoclaw.error.log');
   });
@@ -114,56 +93,29 @@ describe('plist generation', () => {
 
 describe('systemd unit generation', () => {
   it('user unit uses default.target', () => {
-    const unit = generateSystemdUnit(
-      '/usr/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-      false,
-    );
+    const unit = generateSystemdUnit('/usr/bin/node', '/home/user/nanoclaw', '/home/user', false);
     expect(unit).toContain('WantedBy=default.target');
   });
 
   it('system unit uses multi-user.target', () => {
-    const unit = generateSystemdUnit(
-      '/usr/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-      true,
-    );
+    const unit = generateSystemdUnit('/usr/bin/node', '/home/user/nanoclaw', '/home/user', true);
     expect(unit).toContain('WantedBy=multi-user.target');
   });
 
   it('contains restart policy', () => {
-    const unit = generateSystemdUnit(
-      '/usr/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-      false,
-    );
+    const unit = generateSystemdUnit('/usr/bin/node', '/home/user/nanoclaw', '/home/user', false);
     expect(unit).toContain('Restart=always');
     expect(unit).toContain('RestartSec=5');
   });
 
   it('uses KillMode=process to preserve detached children', () => {
-    const unit = generateSystemdUnit(
-      '/usr/bin/node',
-      '/home/user/nanoclaw',
-      '/home/user',
-      false,
-    );
+    const unit = generateSystemdUnit('/usr/bin/node', '/home/user/nanoclaw', '/home/user', false);
     expect(unit).toContain('KillMode=process');
   });
 
   it('sets correct ExecStart', () => {
-    const unit = generateSystemdUnit(
-      '/usr/bin/node',
-      '/srv/nanoclaw',
-      '/home/user',
-      false,
-    );
-    expect(unit).toContain(
-      'ExecStart=/usr/bin/node /srv/nanoclaw/dist/index.js',
-    );
+    const unit = generateSystemdUnit('/usr/bin/node', '/srv/nanoclaw', '/home/user', false);
+    expect(unit).toContain('ExecStart=/usr/bin/node /srv/nanoclaw/dist/index.js');
   });
 });
 

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -13,15 +13,7 @@ import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { writeUpgradeState } from '../src/upgrade-state.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
-import {
-  commandExists,
-  getPlatform,
-  getNodePath,
-  getServiceManager,
-  hasSystemd,
-  isRoot,
-  isWSL,
-} from './platform.js';
+import { commandExists, getPlatform, getNodePath, getServiceManager, hasSystemd, isRoot, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -131,20 +123,11 @@ function installCliSymlink(projectRoot: string, homeDir: string): void {
   }
 }
 
-function setupLaunchd(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupLaunchd(projectRoot: string, nodePath: string, homeDir: string): void {
   // Per-checkout service label so multiple NanoClaw installs can coexist
   // without clobbering each other's plist.
   const label = getLaunchdLabel(projectRoot);
-  const plistPath = path.join(
-    homeDir,
-    'Library',
-    'LaunchAgents',
-    `${label}.plist`,
-  );
+  const plistPath = path.join(homeDir, 'Library', 'LaunchAgents', `${label}.plist`);
   fs.mkdirSync(path.dirname(plistPath), { recursive: true });
 
   const plist = `<?xml version="1.0" encoding="UTF-8"?>
@@ -238,11 +221,7 @@ function setupLaunchd(
   });
 }
 
-function setupLinux(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupLinux(projectRoot: string, nodePath: string, homeDir: string): void {
   const serviceManager = getServiceManager();
 
   if (serviceManager === 'systemd') {
@@ -295,11 +274,7 @@ function checkDockerGroupStale(): boolean {
   }
 }
 
-function setupSystemd(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupSystemd(projectRoot: string, nodePath: string, homeDir: string): void {
   const runningAsRoot = isRoot();
   const unitName = getSystemdUnit(projectRoot);
   const unitFileName = `${unitName}.service`;
@@ -317,9 +292,7 @@ function setupSystemd(
     try {
       execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
     } catch {
-      log.warn(
-        'systemd user session not available — falling back to nohup wrapper',
-      );
+      log.warn('systemd user session not available — falling back to nohup wrapper');
       setupNohupFallback(projectRoot, nodePath, homeDir);
       return;
     }
@@ -360,18 +333,14 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   // normal group perms apply again).
   let dockerGroupStale = !runningAsRoot && checkDockerGroupStale();
   if (dockerGroupStale) {
-    log.warn(
-      'Docker group not active in systemd session — user was likely added to docker group mid-session',
-    );
+    log.warn('Docker group not active in systemd session — user was likely added to docker group mid-session');
     if (commandExists('setfacl')) {
       const user = execSync('whoami', { encoding: 'utf-8' }).trim();
       try {
         execSync(`sudo setfacl -m u:${user}:rw /var/run/docker.sock`, {
           stdio: 'inherit',
         });
-        log.info(
-          'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
-        );
+        log.info('Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)');
         dockerGroupStale = false;
       } catch (err) {
         log.warn('Failed to apply setfacl workaround', { err });
@@ -391,10 +360,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
       execSync('loginctl enable-linger', { stdio: 'ignore' });
       log.info('Enabled loginctl linger for current user');
     } catch (err) {
-      log.warn(
-        'loginctl enable-linger failed — service may stop on SSH logout',
-        { err },
-      );
+      log.warn('loginctl enable-linger failed — service may stop on SSH logout', { err });
     }
   }
 
@@ -445,11 +411,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   });
 }
 
-function setupNohupFallback(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupNohupFallback(projectRoot: string, nodePath: string, homeDir: string): void {
   log.warn('No systemd detected — generating nohup wrapper script');
 
   const wrapperPath = path.join(projectRoot, 'start-nanoclaw.sh');

--- a/setup/signal-auth.ts
+++ b/setup/signal-auth.ts
@@ -82,8 +82,7 @@ function listAccounts(): string[] {
  * but be defensive) fall back to the URL alone for an external renderer.
  */
 async function renderQr(url: string): Promise<string[]> {
-  const scanHint =
-    'Signal → Settings → Linked Devices → Link New Device → scan this code.';
+  const scanHint = 'Signal → Settings → Linked Devices → Link New Device → scan this code.';
   const urlHint = 'Or open this link on the phone running Signal:';
   try {
     const QRCode = await import('qrcode');
@@ -196,10 +195,7 @@ export async function run(_args: string[]): Promise<void> {
       if (code === 0) {
         const post = listAccounts();
         if (post.length === 0) {
-          finish(
-            { STATUS: 'failed', ERROR: 'link exited 0 but no account registered' },
-            1,
-          );
+          finish({ STATUS: 'failed', ERROR: 'link exited 0 but no account registered' }, 1);
           return;
         }
         finish({ STATUS: 'success', ACCOUNT: post[0] }, 0);

--- a/setup/status.ts
+++ b/setup/status.ts
@@ -3,10 +3,7 @@
  * Each step emits a block that the SKILL.md LLM can parse.
  */
 
-export function emitStatus(
-  step: string,
-  fields: Record<string, string | number | boolean>,
-): void {
+export function emitStatus(step: string, fields: Record<string, string | number | boolean>): void {
   const lines = [`=== NANOCLAW SETUP: ${step} ===`];
   for (const [key, value] of Object.entries(fields)) {
     lines.push(`${key}: ${value}`);

--- a/setup/templates.test.ts
+++ b/setup/templates.test.ts
@@ -50,7 +50,7 @@ import {
 describe('setup template library', () => {
   let root: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-templates-'));
   });
 
@@ -241,7 +241,7 @@ describe('template pick persistence', () => {
 });
 
 describe('setup templates ncl contract (real dispatch)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     fs.rmSync(CONTRACT_ROOT, { recursive: true, force: true });
     const tpl = path.join(CONTRACT_ROOT, 'templates', 'sales', 'sdr');
     fs.mkdirSync(path.join(tpl, NANOCLAW_EXTENSION_NS, 'context'), { recursive: true });
@@ -254,11 +254,11 @@ describe('setup templates ncl contract (real dispatch)', () => {
         mcpServers: { docs: { type: 'streamable-http', url: 'https://mcp.example.com/mcp' } },
       }),
     );
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     fs.rmSync(CONTRACT_ROOT, { recursive: true, force: true });
   });
 

--- a/setup/templates.ts
+++ b/setup/templates.ts
@@ -95,9 +95,7 @@ export function cloneRegistry(): ClonedRegistry {
 export function listTemplatesFromDir(dir: string): TemplateEntry[] {
   if (!fs.existsSync(dir)) return [];
   const rootName = path.basename(path.resolve(dir));
-  const rels = (fs.readdirSync(dir, { recursive: true }) as string[]).map((entry) =>
-    entry.split(path.sep).join('/'),
-  );
+  const rels = (fs.readdirSync(dir, { recursive: true }) as string[]).map((entry) => entry.split(path.sep).join('/'));
 
   const refs = new Set<string>();
   for (const rel of rels) {

--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -23,11 +23,7 @@ import k from 'kleur';
 import { emit as phEmit } from '../lib/diagnostics.js';
 import { note } from '../lib/theme.js';
 import * as setupLog from '../logs.js';
-import {
-  resolveOnecliDeletions,
-  type RunCommand,
-  type VaultAgent,
-} from './onecli-agents.js';
+import { resolveOnecliDeletions, type RunCommand, type VaultAgent } from './onecli-agents.js';
 import { buildRemovalPlan, type Decisions } from './plan.js';
 import { executePlan, type ExecDeps } from './remove.js';
 import { scanInstall, tilde, type Inventory } from './scan.js';
@@ -96,11 +92,7 @@ export async function runUninstallFlow(opts: {
   const dataRows = [...inv.data, ...inv.runtime].map(({ what, where }) => ({ what, where }));
   const userRows = inv.user.map(({ what, where }) => ({ what, where }));
   const totalFound =
-    svcRows.length +
-    dataRows.length +
-    userRows.length +
-    inv.onecli.mine.length +
-    inv.onecli.orphans.length;
+    svcRows.length + dataRows.length + userRows.length + inv.onecli.mine.length + inv.onecli.orphans.length;
 
   if (totalFound === 0) {
     p.outro(
@@ -111,9 +103,7 @@ export async function runUninstallFlow(opts: {
   }
 
   if (dryRun) {
-    p.log.message(
-      k.cyan('PREVIEW ONLY — this shows what would be deleted and changes nothing.'),
-    );
+    p.log.message(k.cyan('PREVIEW ONLY — this shows what would be deleted and changes nothing.'));
     if (svcRows.length > 0) note(groupBody(GROUPS.service.desc, svcRows), GROUPS.service.title);
     if (dataRows.length > 0) note(groupBody(GROUPS.data.desc, dataRows), GROUPS.data.title);
     if (userRows.length > 0) note(groupBody(GROUPS.user.desc, userRows), GROUPS.user.title);
@@ -257,11 +247,7 @@ async function confirmGroup(prompt: string, yes: boolean): Promise<boolean> {
  * (enforced in resolveOnecliDeletions); anything kept is reported with
  * the exact manual delete command (by vault uuid).
  */
-async function decideOnecli(
-  inv: Inventory,
-  yes: boolean,
-  keptNotes: string[],
-): Promise<VaultAgent[]> {
+async function decideOnecli(inv: Inventory, yes: boolean, keptNotes: string[]): Promise<VaultAgent[]> {
   const { mine, orphans } = inv.onecli;
   if (mine.length === 0 && orphans.length === 0) return [];
 
@@ -292,14 +278,10 @@ async function decideOnecli(
       p.log.warn(
         `Found ${orphans.length} other NanoClaw-style agent(s) in the vault not linked to this copy —\nthey may belong to ANOTHER NanoClaw copy on this machine.`,
       );
-      deleteOrphans = answered(
-        await p.confirm({ message: 'Delete them too?', initialValue: false }),
-      );
+      deleteOrphans = answered(await p.confirm({ message: 'Delete them too?', initialValue: false }));
     }
     if (yes || !deleteOrphans) {
-      keptNotes.push(
-        `OneCLI orphan agents (${orphans.length}): left in place — remove manually if they're yours:`,
-      );
+      keptNotes.push(`OneCLI orphan agents (${orphans.length}): left in place — remove manually if they're yours:`);
       for (const a of orphans) {
         keptNotes.push(`  onecli agents delete --id ${a.uuid}   # ${a.name} — ${a.identifier}`);
       }
@@ -337,12 +319,7 @@ function groupBody(desc: string, rows: { what: string; where: string }[]): strin
   return lines.join('\n');
 }
 
-function emptyGroupTitles(
-  svcCount: number,
-  dataCount: number,
-  userCount: number,
-  inv: Inventory,
-): string[] {
+function emptyGroupTitles(svcCount: number, dataCount: number, userCount: number, inv: Inventory): string[] {
   const empty: string[] = [];
   if (svcCount === 0) empty.push(GROUPS.service.title);
   if (dataCount === 0) empty.push(GROUPS.data.title);

--- a/setup/uninstall/onecli-agents.test.ts
+++ b/setup/uninstall/onecli-agents.test.ts
@@ -92,11 +92,7 @@ describe('readAgentGroupIds', () => {
 
 describe('splitVaultAgents', () => {
   it('splits mine vs ag-* orphans and ignores foreign identifiers', () => {
-    const agents = [
-      agent('u-1', 'ag-mine'),
-      agent('u-2', 'ag-other'),
-      agent('u-3', 'some-tool'),
-    ];
+    const agents = [agent('u-1', 'ag-mine'), agent('u-2', 'ag-other'), agent('u-3', 'some-tool')];
     const { mine, orphans } = splitVaultAgents(agents, new Set(['ag-mine']), true);
     expect(mine).toEqual([agent('u-1', 'ag-mine')]);
     expect(orphans).toEqual([agent('u-2', 'ag-other')]);

--- a/setup/uninstall/onecli-agents.ts
+++ b/setup/uninstall/onecli-agents.ts
@@ -19,10 +19,7 @@ export interface VaultAgent {
   name: string;
 }
 
-export type RunCommand = (
-  cmd: string,
-  args: string[],
-) => { status: number | null; stdout: string };
+export type RunCommand = (cmd: string, args: string[]) => { status: number | null; stdout: string };
 
 /**
  * List non-default vault agents via `onecli agents list`. `available: false`
@@ -49,9 +46,7 @@ export function listVaultAgents(run: RunCommand): {
   }
 
   const data =
-    parsed !== null && typeof parsed === 'object' && 'data' in parsed
-      ? (parsed as { data: unknown }).data
-      : null;
+    parsed !== null && typeof parsed === 'object' && 'data' in parsed ? (parsed as { data: unknown }).data : null;
   if (!Array.isArray(data)) return { available: false, agents: [] };
 
   const agents: VaultAgent[] = [];

--- a/setup/uninstall/plan.test.ts
+++ b/setup/uninstall/plan.test.ts
@@ -54,9 +54,7 @@ describe('buildRemovalPlan ordering invariants', () => {
   it('removes .env only via the atomic backup action, never a bare delete', () => {
     const actions = buildRemovalPlan(inventory(), allYes());
     expect(actions.filter((a) => a.kind === 'backup-env')).toHaveLength(1);
-    expect(
-      actions.some((a) => a.kind === 'delete-path' && a.item.path === '/proj/.env'),
-    ).toBe(false);
+    expect(actions.some((a) => a.kind === 'delete-path' && a.item.path === '/proj/.env')).toBe(false);
   });
 
   it('puts the runtime tail strictly last, with node_modules final', () => {
@@ -69,17 +67,13 @@ describe('buildRemovalPlan ordering invariants', () => {
     ]);
     // No non-tail action after the first runtime delete.
     const firstTailIdx = actions.findIndex((a) => a.kind === 'delete-runtime-path');
-    expect(
-      actions.slice(firstTailIdx).every((a) => a.kind === 'delete-runtime-path'),
-    ).toBe(true);
+    expect(actions.slice(firstTailIdx).every((a) => a.kind === 'delete-runtime-path')).toBe(true);
   });
 
   it('deletes OneCLI agents before the data group (which removes data/v2.db)', () => {
     const actions = buildRemovalPlan(inventory(), allYes([agent('u-1', 'ag-mine')]));
     const onecliIdx = actions.findIndex((a) => a.kind === 'delete-onecli-agent');
-    const dataIdx = actions.findIndex(
-      (a) => a.kind === 'delete-path' && a.item.path === '/proj/data',
-    );
+    const dataIdx = actions.findIndex((a) => a.kind === 'delete-path' && a.item.path === '/proj/data');
     expect(onecliIdx).toBeGreaterThanOrEqual(0);
     expect(dataIdx).toBeGreaterThan(onecliIdx);
   });
@@ -104,9 +98,7 @@ describe('buildRemovalPlan declined groups', () => {
     });
     expect(kinds(actions)).not.toContain('backup-env');
     expect(kinds(actions)).not.toContain('delete-runtime-path');
-    expect(
-      actions.some((a) => a.kind === 'delete-path' && a.item.path.startsWith('/proj/data')),
-    ).toBe(false);
+    expect(actions.some((a) => a.kind === 'delete-path' && a.item.path.startsWith('/proj/data'))).toBe(false);
   });
 
   it('all declined yields an empty plan', () => {
@@ -149,8 +141,6 @@ describe('buildRemovalPlan conditional actions', () => {
     // scan never saw. Removal re-lists by install label, not scan-time ids.
     expect(actionKinds).toContain('pkill-host');
     const rm = actions.find((a) => a.kind === 'rm-containers');
-    expect(rm && rm.kind === 'rm-containers' ? rm.labelFilter : '').toBe(
-      'nanoclaw-install=abcd1234',
-    );
+    expect(rm && rm.kind === 'rm-containers' ? rm.labelFilter : '').toBe('nanoclaw-install=abcd1234');
   });
 });

--- a/setup/uninstall/plan.ts
+++ b/setup/uninstall/plan.ts
@@ -119,9 +119,7 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
 
   if (d.data) {
     const tail = [...inv.runtime].sort(
-      (a, b) =>
-        Number(path.basename(a.path) === 'node_modules') -
-        Number(path.basename(b.path) === 'node_modules'),
+      (a, b) => Number(path.basename(a.path) === 'node_modules') - Number(path.basename(b.path) === 'node_modules'),
     );
     for (const item of tail) actions.push({ kind: 'delete-runtime-path', item });
   }

--- a/setup/uninstall/remove.test.ts
+++ b/setup/uninstall/remove.test.ts
@@ -57,10 +57,7 @@ describe('executePlan', () => {
     fs.mkdirSync(path.join(dir, 'nested'), { recursive: true });
     fs.writeFileSync(path.join(dir, 'nested', 'f.txt'), 'x');
 
-    const { notes } = executePlan(
-      [{ kind: 'delete-path', item: { what: 'Data', where: dir, path: dir } }],
-      deps(),
-    );
+    const { notes } = executePlan([{ kind: 'delete-path', item: { what: 'Data', where: dir, path: dir } }], deps());
 
     expect(fs.existsSync(dir)).toBe(false);
     expect(notes).toEqual([]);

--- a/setup/uninstall/remove.ts
+++ b/setup/uninstall/remove.ts
@@ -20,19 +20,14 @@ export interface ExecDeps {
   isRoot: boolean;
 }
 
-export function executePlan(
-  actions: RemovalAction[],
-  deps: ExecDeps,
-): { notes: string[] } {
+export function executePlan(actions: RemovalAction[], deps: ExecDeps): { notes: string[] } {
   const notes: string[] = [];
   for (const action of actions) {
     try {
       runAction(action, deps, notes);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      notes.push(
-        `${action.kind}: failed (${msg}) — re-run the uninstaller to retry.`,
-      );
+      notes.push(`${action.kind}: failed (${msg}) — re-run the uninstaller to retry.`);
     }
   }
   return { notes };
@@ -70,12 +65,7 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
           log('✓ background service removed');
           break;
         case 'systemd-user':
-          runCommand('systemctl', [
-            '--user',
-            'disable',
-            '--now',
-            `${action.unitName}.service`,
-          ]);
+          runCommand('systemctl', ['--user', 'disable', '--now', `${action.unitName}.service`]);
           fs.rmSync(action.unitPath, { force: true });
           runCommand('systemctl', ['--user', 'daemon-reload']);
           log('✓ background service removed');
@@ -83,9 +73,7 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
         case 'systemd-system':
           if (!deps.isRoot) {
             log('! system service needs root — left in place');
-            notes.push(
-              `System service ${action.unitPath} — re-run with sudo to remove.`,
-            );
+            notes.push(`System service ${action.unitPath} — re-run with sudo to remove.`);
             break;
           }
           runCommand('systemctl', ['disable', '--now', `${action.unitName}.service`]);
@@ -119,12 +107,7 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
     case 'rm-containers': {
       // Re-list at removal time: the host was alive during the confirm
       // phase and may have spawned containers the scan never saw.
-      const ps = runCommand(action.runtime, [
-        'ps',
-        '-aq',
-        '--filter',
-        `label=${action.labelFilter}`,
-      ]);
+      const ps = runCommand(action.runtime, ['ps', '-aq', '--filter', `label=${action.labelFilter}`]);
       if (ps.status !== 0) {
         notes.push(
           `Containers: '${action.runtime}' unavailable — remove later with: ` +
@@ -147,9 +130,7 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
         log('✓ removed container image');
       } else {
         log('! could not remove image (in use?)');
-        notes.push(
-          `Image ${action.image}: not removed — retry with: ${action.runtime} rmi ${action.image}`,
-        );
+        notes.push(`Image ${action.image}: not removed — retry with: ${action.runtime} rmi ${action.image}`);
       }
       break;
     }
@@ -158,12 +139,7 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
       log('✓ removed ncl command');
       break;
     case 'delete-onecli-agent': {
-      const res = runCommand('onecli', [
-        'agents',
-        'delete',
-        '--id',
-        action.agent.uuid,
-      ]);
+      const res = runCommand('onecli', ['agents', 'delete', '--id', action.agent.uuid]);
       if (res.status === 0) {
         log(`✓ deleted OneCLI agent ${action.agent.name} (${action.agent.identifier})`);
       } else if (res.status === null) {

--- a/setup/uninstall/scan.test.ts
+++ b/setup/uninstall/scan.test.ts
@@ -23,9 +23,7 @@ afterEach(() => {
 });
 
 /** Fake runCommand: unhandled commands fail (binary missing / daemon down). */
-function fakeRun(
-  handlers: Record<string, (args: string[]) => { status: number | null; stdout: string }>,
-): RunCommand {
+function fakeRun(handlers: Record<string, (args: string[]) => { status: number | null; stdout: string }>): RunCommand {
   return (cmd, args) => (handlers[cmd] ?? (() => ({ status: 1, stdout: '' })))(args);
 }
 
@@ -69,10 +67,7 @@ describe('scanInstall path groups', () => {
     ]);
     expect(inv.data.at(-1)).toMatchObject({ what: 'Update rollback snapshots', path: updates });
     fs.rmSync(updates, { recursive: true, force: true });
-    expect(inv.runtime.map((i) => path.basename(i.path))).toEqual([
-      'dist',
-      'node_modules',
-    ]);
+    expect(inv.runtime.map((i) => path.basename(i.path))).toEqual(['dist', 'node_modules']);
     expect(inv.user.map((i) => path.basename(i.path))).toEqual(['groups', 'store']);
   });
 
@@ -88,12 +83,7 @@ describe('scanInstall path groups', () => {
 
 describe('scanInstall service artifacts', () => {
   it('detects the launchd plist on macOS', () => {
-    const plist = path.join(
-      home,
-      'Library',
-      'LaunchAgents',
-      `${getLaunchdLabel(root)}.plist`,
-    );
+    const plist = path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(root)}.plist`);
     fs.mkdirSync(path.dirname(plist), { recursive: true });
     fs.writeFileSync(plist, '<plist/>');
 
@@ -103,13 +93,7 @@ describe('scanInstall service artifacts', () => {
   });
 
   it('detects systemd user unit and pidfile on Linux', () => {
-    const unit = path.join(
-      home,
-      '.config',
-      'systemd',
-      'user',
-      `${getSystemdUnit(root)}.service`,
-    );
+    const unit = path.join(home, '.config', 'systemd', 'user', `${getSystemdUnit(root)}.service`);
     fs.mkdirSync(path.dirname(unit), { recursive: true });
     fs.writeFileSync(unit, '[Unit]');
     fs.writeFileSync(path.join(root, 'nanoclaw.pid'), '12345');

--- a/setup/uninstall/scan.ts
+++ b/setup/uninstall/scan.ts
@@ -18,12 +18,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import {
-  getContainerImageBase,
-  getInstallSlug,
-  getLaunchdLabel,
-  getSystemdUnit,
-} from '../../src/install-slug.js';
+import { getContainerImageBase, getInstallSlug, getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
 import {
   listVaultAgents,
   readAgentGroupIds,
@@ -144,9 +139,7 @@ export function detectExistingInstall(projectRoot: string): boolean {
   if (fs.existsSync(path.join(projectRoot, 'data', 'v2.db'))) return true;
   const home = os.homedir();
   if (process.platform === 'darwin') {
-    return fs.existsSync(
-      path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(projectRoot)}.plist`),
-    );
+    return fs.existsSync(path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(projectRoot)}.plist`));
   }
   if (process.platform === 'linux') {
     const unit = getSystemdUnit(projectRoot);
@@ -158,22 +151,12 @@ export function detectExistingInstall(projectRoot: string): boolean {
   return false;
 }
 
-function scanService(
-  deps: ScanDeps,
-  slug: string,
-  containerRuntime: string,
-  notes: string[],
-): ServiceInventory {
+function scanService(deps: ScanDeps, slug: string, containerRuntime: string, notes: string[]): ServiceInventory {
   const { projectRoot, home, platform, runCommand } = deps;
   const service: ServiceInventory = { containerIds: [] };
 
   if (platform === 'darwin') {
-    const plist = path.join(
-      home,
-      'Library',
-      'LaunchAgents',
-      `${getLaunchdLabel(projectRoot)}.plist`,
-    );
+    const plist = path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(projectRoot)}.plist`);
     if (fs.existsSync(plist)) service.launchdPlist = plist;
   } else if (platform === 'linux') {
     const unit = getSystemdUnit(projectRoot);
@@ -190,12 +173,7 @@ function scanService(
   const image = `${getContainerImageBase(projectRoot)}:latest`;
   let runtimeOk = true;
   try {
-    const ps = runCommand(containerRuntime, [
-      'ps',
-      '-aq',
-      '--filter',
-      `label=${installLabel}`,
-    ]);
+    const ps = runCommand(containerRuntime, ['ps', '-aq', '--filter', `label=${installLabel}`]);
     if (ps.status === 0) {
       service.containerIds = ps.stdout
         .split('\n')
@@ -238,20 +216,14 @@ function scanService(
     if (path.resolve(target) === path.join(projectRoot, 'bin', 'ncl')) {
       service.nclSymlink = link;
     } else {
-      notes.push(
-        `ncl command ${tilde(link, home)} points to another NanoClaw copy; left untouched.`,
-      );
+      notes.push(`ncl command ${tilde(link, home)} points to another NanoClaw copy; left untouched.`);
     }
   }
 
   return service;
 }
 
-function scanOnecli(
-  projectRoot: string,
-  runCommand: RunCommand,
-  notes: string[],
-): OnecliInventory {
+function scanOnecli(projectRoot: string, runCommand: RunCommand, notes: string[]): OnecliInventory {
   const vault = listVaultAgents(runCommand);
   if (!vault.available || vault.agents.length === 0) {
     return { mine: [], orphans: [], idsKnown: false };

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -16,12 +16,7 @@ import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { inspectAgentImage, readImageSource } from './lib/registry-state.js';
-import {
-  getPlatform,
-  getServiceManager,
-  hasSystemd,
-  isRoot,
-} from './platform.js';
+import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -39,11 +34,7 @@ export async function run(_args: string[]): Promise<void> {
   // developers with multiple clones), nothing in this checkout is actually
   // wired up. Surface the mismatch directly so the user knows to point the
   // service at the right folder.
-  let service:
-    | 'not_found'
-    | 'stopped'
-    | 'running'
-    | 'running_other_checkout' = 'not_found';
+  let service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' = 'not_found';
   let runningFromPath: string | null = null;
   const mgr = getServiceManager();
 
@@ -75,10 +66,7 @@ export async function run(_args: string[]): Promise<void> {
       execSync(`${prefix} is-active ${systemdUnit}`, { stdio: 'ignore' });
       service = 'running';
       try {
-        const pidStr = execSync(
-          `${prefix} show ${systemdUnit} -p MainPID --value`,
-          { encoding: 'utf-8' },
-        ).trim();
+        const pidStr = execSync(`${prefix} show ${systemdUnit} -p MainPID --value`, { encoding: 'utf-8' }).trim();
         const pid = Number(pidStr);
         if (Number.isInteger(pid) && pid > 0) {
           runningFromPath = resolveBinaryScript(pid);
@@ -116,11 +104,7 @@ export async function run(_args: string[]): Promise<void> {
     }
   }
 
-  if (
-    service === 'running' &&
-    runningFromPath &&
-    !isPathInside(runningFromPath, projectRoot)
-  ) {
+  if (service === 'running' && runningFromPath && !isPathInside(runningFromPath, projectRoot)) {
     service = 'running_other_checkout';
   }
 
@@ -223,11 +207,9 @@ export async function run(_args: string[]): Promise<void> {
         // Table might not exist (DB not migrated yet)
       }
       try {
-        const row = db
-          .prepare(
-            'SELECT COUNT(*) as count FROM container_configs WHERE image_tag IS NOT NULL',
-          )
-          .get() as { count: number };
+        const row = db.prepare('SELECT COUNT(*) as count FROM container_configs WHERE image_tag IS NOT NULL').get() as {
+          count: number;
+        };
         derivedGroups = row.count;
       } catch {
         // Same: container_configs arrives with the migrations
@@ -238,11 +220,7 @@ export async function run(_args: string[]): Promise<void> {
 
   // 6. Check mount allowlist
   let mountAllowlist = 'missing';
-  if (
-    fs.existsSync(
-      path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'),
-    )
-  ) {
+  if (fs.existsSync(path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'))) {
     mountAllowlist = 'configured';
   }
 

--- a/setup/whatsapp-auth.ts
+++ b/setup/whatsapp-auth.ts
@@ -55,14 +55,10 @@ const _require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const { proto } = _require('@whiskeysockets/baileys') as { proto: any };
 try {
-  const _generics = _require(
-    '@whiskeysockets/baileys/lib/Utils/generics',
-  ) as Record<string, unknown>;
+  const _generics = _require('@whiskeysockets/baileys/lib/Utils/generics') as Record<string, unknown>;
   _generics.getPlatformId = (browser: string): string => {
     const platformType =
-      proto.DeviceProps.PlatformType[
-        browser.toUpperCase() as keyof typeof proto.DeviceProps.PlatformType
-      ];
+      proto.DeviceProps.PlatformType[browser.toUpperCase() as keyof typeof proto.DeviceProps.PlatformType];
     return platformType ? platformType.toString() : '1';
   };
 } catch {
@@ -215,12 +211,7 @@ export async function run(args: string[]): Promise<void> {
       });
 
       // Request pairing code only on first connect (not reconnect after 515).
-      if (
-        !isReconnect &&
-        method === 'pairing-code' &&
-        phone &&
-        !state.creds.registered
-      ) {
+      if (!isReconnect && method === 'pairing-code' && phone && !state.creds.registered) {
         setTimeout(async () => {
           try {
             const code = await sock.requestPairingCode(phone);
@@ -256,9 +247,7 @@ export async function run(args: string[]): Promise<void> {
         }
 
         if (connection === 'close') {
-          const reason = (
-            lastDisconnect?.error as { output?: { statusCode?: number } }
-          )?.output?.statusCode;
+          const reason = (lastDisconnect?.error as { output?: { statusCode?: number } })?.output?.statusCode;
           if (reason === DisconnectReason.loggedOut) {
             clearTimeout(timeout);
             emitStatus('WHATSAPP_AUTH', {

--- a/src/backfill-container-configs.ts
+++ b/src/backfill-container-configs.ts
@@ -26,13 +26,13 @@ interface LegacyContainerJson {
   maxMessagesPerPrompt?: number;
 }
 
-export function backfillContainerConfigs(): void {
-  const groups = getAllAgentGroups();
+export async function backfillContainerConfigs(): Promise<void> {
+  const groups = await getAllAgentGroups();
   let backfilled = 0;
 
   for (const group of groups) {
     // Skip if already has a config row
-    if (getContainerConfig(group.id)) continue;
+    if (await getContainerConfig(group.id)) continue;
 
     // Read legacy container.json from disk
     const filePath = path.join(GROUPS_DIR, group.folder, 'container.json');
@@ -69,7 +69,7 @@ export function backfillContainerConfigs(): void {
       updated_at: new Date().toISOString(),
     };
 
-    createContainerConfig(row);
+    await createContainerConfig(row);
     backfilled++;
   }
 

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -247,17 +247,17 @@ describe('channel + router integration', () => {
 
     const { initTestDb, runMigrations, createAgentGroup, createMessagingGroup, createMessagingGroupAgent } =
       await import('../db/index.js');
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
 
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Test Agent',
       folder: 'test-agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'mock',
       platform_id: 'chan-100',
@@ -266,7 +266,7 @@ describe('channel + router integration', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-1',
       messaging_group_id: 'mg-1',
       agent_group_id: 'ag-1',
@@ -282,7 +282,7 @@ describe('channel + router integration', () => {
 
   afterEach(async () => {
     const { closeDb } = await import('../db/index.js');
-    closeDb();
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -307,7 +307,7 @@ describe('channel + router integration', () => {
     });
 
     // Verify session was created and message written
-    const session = findSession('mg-1', null);
+    const session = await findSession('mg-1', null);
     expect(session).toBeDefined();
 
     const dbPath = inboundDbPath('ag-1', session!.id);

--- a/src/channels/channel-session-defaults.test.ts
+++ b/src/channels/channel-session-defaults.test.ts
@@ -92,7 +92,7 @@ afterEach(async () => {
   await teardownChannelAdapters();
   const { closeDb } = await import('../db/index.js');
   try {
-    closeDb();
+    await closeDb();
   } catch {
     // Test didn't open a DB.
   }
@@ -188,14 +188,14 @@ describe('wiring creation — resolved defaults persist onto the row', () => {
   /** In-memory central DB + one agent group and messaging group. */
   async function seedDb(channelType: string, isGroup = false) {
     const { initTestDb, runMigrations } = await import('../db/index.js');
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
 
     const { createAgentGroup } = await import('../db/agent-groups.js');
     const { createMessagingGroup } = await import('../db/messaging-groups.js');
     const now = new Date().toISOString();
     const ag: AgentGroup = { id: 'ag-1', name: 'Nano', folder: 'nano', agent_provider: null, created_at: now };
-    createAgentGroup(ag);
+    await createAgentGroup(ag);
     const mg: MessagingGroup = {
       id: 'mg-1',
       channel_type: channelType,
@@ -205,7 +205,7 @@ describe('wiring creation — resolved defaults persist onto the row', () => {
       unknown_sender_policy: 'strict',
       created_at: now,
     };
-    createMessagingGroup(mg);
+    await createMessagingGroup(mg);
     return { db, ag, mg, now };
   }
 
@@ -224,7 +224,7 @@ describe('wiring creation — resolved defaults persist onto the row', () => {
     },
   ): Promise<MessagingGroupAgent> {
     const { createMessagingGroupAgent, getMessagingGroupAgent } = await import('../db/messaging-groups.js');
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-1',
       messaging_group_id: mg.id,
       agent_group_id: ag.id,
@@ -237,7 +237,7 @@ describe('wiring creation — resolved defaults persist onto the row', () => {
       priority: 0,
       created_at: now,
     });
-    return getMessagingGroupAgent('mga-1')!;
+    return (await getMessagingGroupAgent('mga-1'))!;
   }
 
   it('declared per-thread DM defaults flow into the created wiring', async () => {
@@ -283,7 +283,7 @@ describe('wiring creation — resolved defaults persist onto the row', () => {
     await wire(mg, ag, now, resolved);
 
     const { updateMessagingGroupAgent, getMessagingGroupAgent } = await import('../db/messaging-groups.js');
-    updateMessagingGroupAgent('mga-1', { threads: 0 });
-    expect(getMessagingGroupAgent('mga-1')!.threads).toBe(0);
+    await updateMessagingGroupAgent('mga-1', { threads: 0 });
+    expect((await getMessagingGroupAgent('mga-1'))!.threads).toBe(0);
   });
 });

--- a/src/channels/chat-sdk-bridge-agent-mode.test.ts
+++ b/src/channels/chat-sdk-bridge-agent-mode.test.ts
@@ -55,12 +55,12 @@ const chatOf = (bridge: unknown): Chat => (bridge as any)._chat as Chat;
 beforeEach(async () => {
   const { initTestDb } = await import('../db/connection.js');
   const { runMigrations } = await import('../db/migrations/index.js');
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
 afterEach(async () => {
   const { closeDb } = await import('../db/connection.js');
-  closeDb();
+  await closeDb();
   // Module-level singleton: leave no handler behind for the next test file.
   setAgentDmOpenedHandler(() => {});
 });

--- a/src/channels/chat-sdk-bridge-byline.test.ts
+++ b/src/channels/chat-sdk-bridge-byline.test.ts
@@ -86,11 +86,11 @@ async function fireAction(
   return { edits, actions };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   captured.chat = null;
-  const db = initTestDb();
-  runMigrations(db);
-  createPendingApproval({
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createPendingApproval({
     approval_id: 'q-1',
     session_id: null,
     request_id: 'q-1',
@@ -106,8 +106,8 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 describe('chat-sdk-bridge approval-card terminal state', () => {

--- a/src/channels/chat-sdk-bridge-inbound-policy.test.ts
+++ b/src/channels/chat-sdk-bridge-inbound-policy.test.ts
@@ -97,12 +97,12 @@ function makeHostConfig(): { hostConfig: ChannelSetup; calls: InboundCall[] } {
 beforeEach(async () => {
   const { initTestDb } = await import('../db/connection.js');
   const { runMigrations } = await import('../db/migrations/index.js');
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
 afterEach(async () => {
   const { closeDb } = await import('../db/connection.js');
-  closeDb();
+  await closeDb();
 });
 
 // One policy for the whole file (module-level registry, one per channelType):

--- a/src/channels/chat-sdk-bridge-membership.test.ts
+++ b/src/channels/chat-sdk-bridge-membership.test.ts
@@ -52,12 +52,12 @@ async function dispatch(fire: (options: { waitUntil: (p: Promise<unknown>) => vo
 beforeEach(async () => {
   const { initTestDb } = await import('../db/connection.js');
   const { runMigrations } = await import('../db/migrations/index.js');
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
 afterEach(async () => {
   const { closeDb } = await import('../db/connection.js');
-  closeDb();
+  await closeDb();
   vi.restoreAllMocks();
 });
 

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
 import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { sqliteRaw } from '../db/drivers/sqlite.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -155,14 +156,14 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
   beforeEach(async () => {
     const { initTestDb } = await import('../db/connection.js');
     const { runMigrations } = await import('../db/migrations/index.js');
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
     const { registerWebhookAdapter } = await import('../webhook-server.js');
     vi.mocked(registerWebhookAdapter).mockClear();
   });
 
   afterEach(async () => {
     const { closeDb } = await import('../db/connection.js');
-    closeDb();
+    await closeDb();
   });
 
   const hostConfig = {
@@ -212,7 +213,9 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
     await def.setup(hostConfig);
     await def.subscribe!('slack:C1', 'slack:T1');
 
-    const rows = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions ORDER BY thread_id').all() as Array<{
+    const rows = sqliteRaw(getDb())
+      .prepare('SELECT thread_id FROM chat_sdk_subscriptions ORDER BY thread_id')
+      .all() as Array<{
       thread_id: string;
     }>;
     expect(rows.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1', 'slack:T1']);
@@ -230,7 +233,7 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
     });
     await bridge.setup(hostConfig);
     await bridge.subscribe!('slack:C1', 'slack:T9');
-    const rows = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
+    const rows = sqliteRaw(getDb()).prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
       thread_id: string;
     }>;
     expect(rows.map((r) => r.thread_id)).toEqual(['slack:T9']);

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -287,7 +287,7 @@ function dispatchMembership(event: MembershipEvent): void {
  * captured in the returned closure is naturally per-instance (= per bot
  * identity when several bridges share one platform).
  */
-export type BridgeInboundPolicy = (setup: ChannelSetup, instanceKey: string) => ChannelSetup;
+export type BridgeInboundPolicy = (setup: ChannelSetup, instanceKey: string) => ChannelSetup | Promise<ChannelSetup>;
 
 const bridgeInboundPolicies = new Map<string, BridgeInboundPolicy>();
 
@@ -521,7 +521,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // through — means one policy covers onSubscribedMessage, onNewMention,
       // onDirectMessage and onNewMessage alike.
       const inboundPolicy = bridgeInboundPolicies.get(adapter.name);
-      setupConfig = inboundPolicy ? inboundPolicy(hostConfig, instanceKey) : hostConfig;
+      setupConfig = inboundPolicy ? await inboundPolicy(hostConfig, instanceKey) : hostConfig;
 
       // State namespace: ONLY for a named non-default instance. A skill
       // that explicitly names the primary instance after the platform
@@ -646,7 +646,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         const userId = event.user?.userId || '';
 
         // Resolve render metadata BEFORE dispatching onAction (which deletes the row).
-        const render = resolveQuestionRender(questionId);
+        const render = await resolveQuestionRender(questionId);
         // New format: button id/value is an integer index into options (kept
         // short to fit Telegram's 64-byte callback_data cap). Old format:
         // the full value is embedded in actionId/value directly.
@@ -1036,7 +1036,7 @@ async function handleForwardedEvent(
       const originalEmbeds =
         ((interaction.message as Record<string, unknown>)?.embeds as Array<Record<string, unknown>>) || [];
       const originalDescription = (originalEmbeds[0]?.description as string) || '';
-      const render = questionId ? resolveQuestionRender(questionId) : undefined;
+      const render = questionId ? await resolveQuestionRender(questionId) : undefined;
       // Discord custom_id mirrors the new index-based encoding (see Button
       // construction). Decode back to the real option value for downstream.
       const selectedOption = resolveSelectedOption(render, tail, tail);

--- a/src/channels/question-render-registry.test.ts
+++ b/src/channels/question-render-registry.test.ts
@@ -6,18 +6,18 @@ import { createPendingApproval } from '../db/sessions.js';
 import { log } from '../log.js';
 import { registerQuestionRenderResolver, resolveQuestionRender } from './question-render-registry.js';
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   vi.restoreAllMocks();
 });
 
 describe('question render resolver registry', () => {
-  it('runs module resolvers in registration order and stops on the first result', () => {
+  it('runs module resolvers in registration order and stops on the first result', async () => {
     const order: string[] = [];
     const later = vi.fn(() => undefined);
     const expected = {
@@ -41,12 +41,12 @@ describe('question render resolver registry', () => {
       return undefined;
     });
 
-    expect(resolveQuestionRender('module-order-question')).toBe(expected);
+    expect(await resolveQuestionRender('module-order-question')).toBe(expected);
     expect(order).toEqual(['first', 'second']);
     expect(later).not.toHaveBeenCalled();
   });
 
-  it('resolves over a snapshot when a resolver registers another resolver', () => {
+  it('resolves over a snapshot when a resolver registers another resolver', async () => {
     const expected = {
       title: 'Registered during resolution',
       options: [{ label: 'Continue', selectedLabel: 'Continued', value: 'continue' }],
@@ -60,21 +60,21 @@ describe('question render resolver registry', () => {
       return undefined;
     });
 
-    expect(resolveQuestionRender('snapshot-question')).toBeUndefined();
+    expect(await resolveQuestionRender('snapshot-question')).toBeUndefined();
     expect(registeredDuringResolution).not.toHaveBeenCalled();
 
-    expect(resolveQuestionRender('snapshot-question')).toBe(expected);
+    expect(await resolveQuestionRender('snapshot-question')).toBe(expected);
     expect(registeredDuringResolution).toHaveBeenCalledOnce();
   });
 
-  it('logs an optional resolver failure and continues to the built-in fallback', () => {
+  it('logs an optional resolver failure and continues to the built-in fallback', async () => {
     const failure = new Error('resolver failure');
     const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => undefined);
     registerQuestionRenderResolver((questionId) => {
       if (questionId === 'resolver-failure-question') throw failure;
       return undefined;
     });
-    createPendingApproval({
+    await createPendingApproval({
       approval_id: 'resolver-failure-question',
       request_id: 'request-resolver-failure',
       action: 'test-action',
@@ -84,7 +84,7 @@ describe('question render resolver registry', () => {
       options_json: JSON.stringify([{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }]),
     });
 
-    expect(resolveQuestionRender('resolver-failure-question')).toEqual({
+    expect(await resolveQuestionRender('resolver-failure-question')).toEqual({
       title: 'Built-in fallback after failure',
       question: '',
       options: [{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }],
@@ -92,8 +92,8 @@ describe('question render resolver registry', () => {
     expect(errorSpy).toHaveBeenCalledWith('Question render resolver threw', { err: failure });
   });
 
-  it('uses the existing database lookup as the final built-in fallback', () => {
-    createPendingApproval({
+  it('uses the existing database lookup as the final built-in fallback', async () => {
+    await createPendingApproval({
       approval_id: 'built-in-render-question',
       request_id: 'request-1',
       action: 'test-action',
@@ -103,14 +103,14 @@ describe('question render resolver registry', () => {
       options_json: JSON.stringify([{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }]),
     });
 
-    expect(resolveQuestionRender('built-in-render-question')).toEqual({
+    expect(await resolveQuestionRender('built-in-render-question')).toEqual({
       title: 'Built-in approval',
       question: '',
       options: [{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }],
     });
   });
 
-  it('returns undefined when neither a module nor the built-in fallback owns the id', () => {
-    expect(resolveQuestionRender('unowned-render-question')).toBeUndefined();
+  it('returns undefined when neither a module nor the built-in fallback owns the id', async () => {
+    expect(await resolveQuestionRender('unowned-render-question')).toBeUndefined();
   });
 });

--- a/src/channels/question-render-registry.ts
+++ b/src/channels/question-render-registry.ts
@@ -15,7 +15,9 @@ export interface QuestionRender {
   options: NormalizedOption[];
 }
 
-export type QuestionRenderResolver = (questionId: string) => QuestionRender | undefined;
+export type QuestionRenderResolver = (
+  questionId: string,
+) => QuestionRender | undefined | Promise<QuestionRender | undefined>;
 
 const resolvers: QuestionRenderResolver[] = [];
 
@@ -23,11 +25,11 @@ export function registerQuestionRenderResolver(resolver: QuestionRenderResolver)
   resolvers.push(resolver);
 }
 
-export function resolveQuestionRender(questionId: string): QuestionRender | undefined {
+export async function resolveQuestionRender(questionId: string): Promise<QuestionRender | undefined> {
   for (const resolver of [...resolvers]) {
     /* eslint-disable no-catch-all/no-catch-all -- one optional resolver must not block later resolvers or the built-in fallback */
     try {
-      const render = resolver(questionId);
+      const render = await resolver(questionId);
       if (render) return render;
     } catch (err) {
       log.error('Question render resolver threw', { err });

--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -24,9 +24,9 @@ function group(id: string, folder: string): AgentGroup {
   return { id, name: folder, folder, agent_provider: null, created_at: new Date().toISOString() } as AgentGroup;
 }
 
-function seed(ag: AgentGroup): void {
-  createAgentGroup(ag);
-  ensureContainerConfig(ag.id);
+async function seed(ag: AgentGroup): Promise<void> {
+  await createAgentGroup(ag);
+  await ensureContainerConfig(ag.id);
 }
 
 function writePersona(folder: string, text: string): void {
@@ -40,24 +40,24 @@ function importsOf(folder: string): string[] {
   return md.split('\n').filter((line) => line.startsWith('@'));
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   fs.mkdirSync(TEST_ROOT, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
 describe('composeGroupClaudeMd persona prepend', () => {
-  it('imports the persona fragment FIRST, before the shared base', () => {
+  it('imports the persona fragment FIRST, before the shared base', async () => {
     const ag = group('ag-persona', 'persona-group');
-    seed(ag);
+    await seed(ag);
     writePersona(ag.folder, 'You are an SDR agent.\n');
 
-    composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
 
     const imports = importsOf(ag.folder);
     expect(imports[0]).toBe('@./.claude-fragments/persona.md');
@@ -67,23 +67,23 @@ describe('composeGroupClaudeMd persona prepend', () => {
     );
   });
 
-  it('keeps the persona across a second compose (not pruned)', () => {
+  it('keeps the persona across a second compose (not pruned)', async () => {
     const ag = group('ag-persona-2', 'persona-group-2');
-    seed(ag);
+    await seed(ag);
     writePersona(ag.folder, 'persona body');
 
-    composeGroupClaudeMd(ag);
-    composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
 
     expect(fs.existsSync(path.join(GROUPS_DIR, ag.folder, '.claude-fragments', 'persona.md'))).toBe(true);
     expect(importsOf(ag.folder)[0]).toBe('@./.claude-fragments/persona.md');
   });
 
-  it('is inert when no persona file is present (non-template groups)', () => {
+  it('is inert when no persona file is present (non-template groups)', async () => {
     const ag = group('ag-no-persona', 'no-persona-group');
-    seed(ag);
+    await seed(ag);
 
-    composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
 
     const imports = importsOf(ag.folder);
     expect(imports[0]).toBe('@./.claude-shared.md');
@@ -95,21 +95,21 @@ describe('composeGroupClaudeMd persona prepend', () => {
 describe('composeGroupClaudeMd scheduling instructions (ncl tasks reach-in)', () => {
   // Red-on-delete guard for the `scheduling`/`cli` exclusion at the
   // module-fragment loop: the agent is taught `ncl tasks` iff it has ncl.
-  it('imports module-scheduling.md at the default cli_scope', () => {
+  it('imports module-scheduling.md at the default cli_scope', async () => {
     const ag = group('ag-sched', 'sched-group');
-    seed(ag);
+    await seed(ag);
 
-    composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
 
     expect(importsOf(ag.folder)).toContain('@./.claude-fragments/module-scheduling.md');
   });
 
-  it('excludes module-scheduling.md (and module-cli.md) when cli_scope is disabled', () => {
+  it('excludes module-scheduling.md (and module-cli.md) when cli_scope is disabled', async () => {
     const ag = group('ag-sched-off', 'sched-group-off');
-    seed(ag);
-    updateContainerConfigScalars(ag.id, { cli_scope: 'disabled' });
+    await seed(ag);
+    await updateContainerConfigScalars(ag.id, { cli_scope: 'disabled' });
 
-    composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
 
     const imports = importsOf(ag.folder);
     expect(imports).not.toContain('@./.claude-fragments/module-scheduling.md');

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -43,7 +43,7 @@ const COMPOSED_HEADER =
  * Regenerate `groups/<folder>/CLAUDE.md` from the shared base, enabled skill
  * fragments, and MCP server fragments declared in `container.json`.
  */
-export function composeGroupClaudeMd(group: AgentGroup): void {
+export async function composeGroupClaudeMd(group: AgentGroup): Promise<void> {
   const groupDir = path.resolve(GROUPS_DIR, group.folder);
   if (!fs.existsSync(groupDir)) {
     fs.mkdirSync(groupDir, { recursive: true });
@@ -58,7 +58,7 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
   }
 
   // Desired fragment set.
-  const configRow = getContainerConfig(group.id);
+  const configRow = await getContainerConfig(group.id);
   const mcpServers: Record<string, McpServerConfig> = configRow
     ? (JSON.parse(configRow.mcp_servers) as Record<string, McpServerConfig>)
     : {};

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -10,9 +10,9 @@ import { renderVerbHelp, summaryLine } from '../help-render.js';
 import type { CallerContext } from '../frame.js';
 import { GROUP_SCOPE_RESOURCES, listCommands, register } from '../registry.js';
 
-function getCliScope(ctx: CallerContext): string | undefined {
+async function getCliScope(ctx: CallerContext): Promise<string | undefined> {
   if (ctx.caller !== 'agent') return undefined;
-  return getContainerConfig(ctx.agentGroupId)?.cli_scope ?? 'group';
+  return (await getContainerConfig(ctx.agentGroupId))?.cli_scope ?? 'group';
 }
 
 register({
@@ -21,7 +21,7 @@ register({
   access: 'open',
   parseArgs: () => ({}),
   handler: async (_args, ctx) => {
-    const cliScope = getCliScope(ctx);
+    const cliScope = await getCliScope(ctx);
     let resources = getResources();
     if (cliScope === 'group') {
       resources = resources.filter((r) => GROUP_SCOPE_RESOURCES.has(r.plural));
@@ -80,7 +80,7 @@ export function registerResourceHelpCommands(): void {
         resource: res.plural,
         parseArgs: (raw) => raw,
         handler: async (args, ctx) => {
-          const cliScope = getCliScope(ctx);
+          const cliScope = await getCliScope(ctx);
           const lines: string[] = [];
 
           // `ncl <resource> help <verb>` arrives via the dispatcher's

--- a/src/cli/crud.test.ts
+++ b/src/cli/crud.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { sqliteRaw } from '../db/drivers/sqlite.js';
 
 // `groups.ts`'s postCreate calls `initGroupFilesystem`, which touches the
 // real filesystem (groups/<folder>, data/v2-sessions/<id>/.claude-shared).
@@ -9,9 +10,9 @@ const ensureContainerConfigSpy = vi.fn();
 vi.mock('../group-init.js', async () => {
   const { ensureContainerConfig } = await import('../db/container-configs.js');
   return {
-    initGroupFilesystem: vi.fn((group: { id: string }) => {
+    initGroupFilesystem: vi.fn(async (group: { id: string }) => {
       ensureContainerConfigSpy(group.id);
-      ensureContainerConfig(group.id);
+      await ensureContainerConfig(group.id);
     }),
   };
 });
@@ -85,12 +86,12 @@ registerResource({
   operations: { list: 'open' },
 });
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
   ensureContainerConfigSpy.mockClear();
   writeDestinationsSpy.mockClear();
-  getDb().exec(
+  await getDb().exec(
     `CREATE TABLE listtest_rows (
       id TEXT PRIMARY KEY,
       enabled INTEGER NOT NULL,
@@ -103,7 +104,7 @@ beforeEach(() => {
 
 describe('genericList portable filters and ordering', () => {
   beforeEach(() => {
-    const insert = getDb().prepare(
+    const insert = sqliteRaw(getDb()).prepare(
       'INSERT INTO listtest_rows (id, enabled, score, payload, created_at) VALUES (?, ?, ?, ?, ?)',
     );
     insert.run('b', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
@@ -135,8 +136,8 @@ describe('genericList portable filters and ordering', () => {
   });
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 describe('genericCreate postCreate hook', () => {
@@ -152,21 +153,21 @@ describe('genericCreate postCreate hook', () => {
     // Visible side effect: container_configs row exists for the new group.
     // Without postCreate, this was empty and the first spawn threw
     // "Container config not found" — issue #2415.
-    const config = getContainerConfig(result.id);
+    const config = await getContainerConfig(result.id);
     expect(config).toBeDefined();
     expect(config!.agent_group_id).toBe(result.id);
   });
 
   it('wirings-create writes the companion agent_destinations row', async () => {
     // Seed the FKs that the wiring references.
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent One',
       folder: 'agent-one',
       agent_provider: null,
       created_at: new Date().toISOString(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'channel-123',
@@ -185,7 +186,7 @@ describe('genericCreate postCreate hook', () => {
     // address this chat as a delivery target. Without postCreate, this was
     // empty and the agent's replies were silently dropped by the delivery
     // ACL — issue #2389.
-    const destinations = getDestinations('ag-1');
+    const destinations = await getDestinations('ag-1');
     expect(destinations).toHaveLength(1);
     expect(destinations[0].target_type).toBe('channel');
     expect(destinations[0].target_id).toBe('mg-1');
@@ -194,14 +195,14 @@ describe('genericCreate postCreate hook', () => {
 
 describe('genericCreate postCommit hook', () => {
   it('wirings-create projects the new destination into live sessions', async () => {
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent One',
       folder: 'agent-one',
       agent_provider: null,
       created_at: new Date().toISOString(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'channel-123',
@@ -212,7 +213,7 @@ describe('genericCreate postCommit hook', () => {
     });
     // A container is already running for this agent — its session inbound.db
     // holds a stale destination projection.
-    createSession({
+    await createSession({
       id: 'sess-1',
       agent_group_id: 'ag-1',
       messaging_group_id: null,
@@ -234,14 +235,14 @@ describe('genericCreate postCommit hook', () => {
   });
 
   it('wirings-create projection is a no-op when no sessions are running', async () => {
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-2',
       name: 'Agent Two',
       folder: 'agent-two',
       agent_provider: null,
       created_at: new Date().toISOString(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-2',
       channel_type: 'discord',
       platform_id: 'channel-456',
@@ -261,8 +262,8 @@ describe('genericCreate postCommit hook', () => {
 });
 
 describe('genericCreate resolveDefaults hook (two-pass create)', () => {
-  beforeEach(() => {
-    getDb().exec(
+  beforeEach(async () => {
+    await getDb().exec(
       `CREATE TABLE hooktest_rows (id TEXT PRIMARY KEY, kind TEXT NOT NULL, mode TEXT, created_at TEXT NOT NULL)`,
     );
     hookCalls.length = 0;
@@ -291,7 +292,7 @@ describe('genericCreate resolveDefaults hook (two-pass create)', () => {
 
   it('a hook throw rejects the create and nothing is inserted', async () => {
     await expect(lookup('hooktests-create')!.handler({ kind: 'boom' }, hostCtx)).rejects.toThrow('hook rejected');
-    const count = getDb().prepare('SELECT COUNT(*) AS n FROM hooktest_rows').get() as { n: number };
+    const count = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS n FROM hooktest_rows').get() as { n: number };
     expect(count.n).toBe(0);
   });
 });

--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -114,7 +114,7 @@ export interface ResourceDef {
    * whose column combinations need cross-checks — a partial update must not
    * be able to produce a combination `create` would have rejected.
    */
-  preUpdate?: (updates: Record<string, unknown>, current: Record<string, unknown>) => void;
+  preUpdate?: (updates: Record<string, unknown>, current: Record<string, unknown>) => void | Promise<void>;
   /**
    * Runs after a successful `create` INSERT, with the row that was just
    * written. Used to wire in side effects that the central row alone
@@ -123,7 +123,7 @@ export interface ResourceDef {
    * wiring is added. The hook receives the same `values` object that was
    * inserted, so generated fields like `id` and `created_at` are populated.
    */
-  postCreate?: (row: Record<string, unknown>) => void;
+  postCreate?: (row: Record<string, unknown>) => void | Promise<void>;
   /**
    * Runs AFTER the create transaction has committed, with the row that was
    * written. Use this — not `postCreate` — for side effects that live
@@ -208,9 +208,7 @@ function genericList(def: ResourceDef) {
     // Newest first: without an ORDER BY the LIMIT silently hides the most
     // recently inserted rows once a table outgrows it (bit `sessions list`
     // past 200 sessions — a just-created session was invisible).
-    return getDb()
-      .prepare(`SELECT ${cols} FROM ${def.table}${where} ORDER BY ${listOrder(def)} LIMIT ?`)
-      .all(...params);
+    return getDb().all(`SELECT ${cols} FROM ${def.table}${where} ORDER BY ${listOrder(def)} LIMIT ?`, ...params);
   };
 }
 
@@ -219,7 +217,7 @@ function genericGet(def: ResourceDef) {
   return async (args: Record<string, unknown>) => {
     const id = args.id as string;
     if (!id) throw new Error(`${def.name} id is required`);
-    const row = getDb().prepare(`SELECT ${cols} FROM ${def.table} WHERE ${def.idColumn} = ?`).get(id);
+    const row = await getDb().get(`SELECT ${cols} FROM ${def.table} WHERE ${def.idColumn} = ?`, id);
     if (!row) throw new Error(`${def.name} not found: ${id}`);
     return row;
   };
@@ -275,9 +273,10 @@ function genericCreate(def: ResourceDef) {
     if (def.naturalKey && def.naturalKey.length > 0) {
       const where = def.naturalKey.map((c) => `${c} = ?`).join(' AND ');
       const params = def.naturalKey.map((c) => values[c]);
-      const existing = getDb()
-        .prepare(`SELECT ${visibleColumns(def).join(', ')} FROM ${def.table} WHERE ${where}`)
-        .get(...params);
+      const existing = await getDb().get(
+        `SELECT ${visibleColumns(def).join(', ')} FROM ${def.table} WHERE ${where}`,
+        ...params,
+      );
       if (existing) return existing;
     }
 
@@ -285,15 +284,14 @@ function genericCreate(def: ResourceDef) {
     const placeholders = colNames.map((c) => `@${c}`);
     // Single transaction so a postCreate throw rolls back the parent INSERT —
     // closes the partial-state class this PR exists to fix (#2415, #2389).
-    // better-sqlite3 .transaction() is sync, so `postCreate` is sync too and
-    // must only touch the central DB (it's the atomic companion-row write).
-    // Anything async or outside the central DB — filesystem, session-DB
-    // projection — belongs in `postCommit`, which runs after commit below.
+    // `postCreate` may await central-DB work only. Anything outside the
+    // central DB — filesystem, mailbox projection, adapters, containers, or
+    // network — belongs in `postCommit`, which runs after commit below.
     const db = getDb();
-    db.transaction(() => {
-      db.prepare(`INSERT INTO ${def.table} (${colNames.join(', ')}) VALUES (${placeholders.join(', ')})`).run(values);
-      if (def.postCreate) def.postCreate(values);
-    })();
+    await db.transaction(async () => {
+      await db.run(`INSERT INTO ${def.table} (${colNames.join(', ')}) VALUES (${placeholders.join(', ')})`, values);
+      if (def.postCreate) await def.postCreate(values);
+    });
     if (def.postCommit) await def.postCommit(values);
     return values;
   };
@@ -323,22 +321,24 @@ function genericUpdate(def: ResourceDef) {
     }
 
     if (def.preUpdate) {
-      const current = getDb().prepare(`SELECT ${cols} FROM ${def.table} WHERE ${def.idColumn} = ?`).get(id) as
-        | Record<string, unknown>
-        | undefined;
+      const current = await getDb().get<Record<string, unknown>>(
+        `SELECT ${cols} FROM ${def.table} WHERE ${def.idColumn} = ?`,
+        id,
+      );
       if (!current) throw new Error(`${def.name} not found: ${id}`);
-      def.preUpdate(updates, current);
+      await def.preUpdate(updates, current);
     }
 
     const setClause = Object.keys(updates)
       .map((k) => `${k} = @${k}`)
       .join(', ');
-    const result = getDb()
-      .prepare(`UPDATE ${def.table} SET ${setClause} WHERE ${def.idColumn} = @_id`)
-      .run({ ...updates, _id: id });
+    const result = await getDb().run(`UPDATE ${def.table} SET ${setClause} WHERE ${def.idColumn} = @_id`, {
+      ...updates,
+      _id: id,
+    });
     if (result.changes === 0) throw new Error(`${def.name} not found: ${id}`);
 
-    return getDb().prepare(`SELECT ${cols} FROM ${def.table} WHERE ${def.idColumn} = ?`).get(id);
+    return getDb().get(`SELECT ${cols} FROM ${def.table} WHERE ${def.idColumn} = ?`, id);
   };
 }
 
@@ -346,7 +346,7 @@ function genericDelete(def: ResourceDef) {
   return async (args: Record<string, unknown>) => {
     const id = args.id as string;
     if (!id) throw new Error(`${def.name} id is required`);
-    const result = getDb().prepare(`DELETE FROM ${def.table} WHERE ${def.idColumn} = ?`).run(id);
+    const result = await getDb().run(`DELETE FROM ${def.table} WHERE ${def.idColumn} = ?`, id);
     if (result.changes === 0) throw new Error(`${def.name} not found: ${id}`);
     return { deleted: id };
   };

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -73,7 +73,7 @@ export async function dispatch(
   // Group-scope mechanics for agent callers (visibility, not policy — the
   // allow/hold/deny decisions live in the guard decision, cli/guard.ts).
   if (ctx.caller === 'agent') {
-    const configRow = getContainerConfig(ctx.agentGroupId);
+    const configRow = await getContainerConfig(ctx.agentGroupId);
     const cliScope = configRow?.cli_scope ?? 'group';
 
     if (cliScope === 'group') {
@@ -92,7 +92,7 @@ export async function dispatch(
       // Group-scoped agents may only inspect or update the wiring for the
       // conversation they are currently serving. Never trust a caller ID.
       if (req.args.help !== true && (req.command === 'wirings-get' || req.command === 'wirings-update')) {
-        const wiring = getMessagingGroupAgentByPair(ctx.messagingGroupId, ctx.agentGroupId);
+        const wiring = await getMessagingGroupAgentByPair(ctx.messagingGroupId, ctx.agentGroupId);
         if (!wiring) return err(req.id, 'forbidden', 'Wiring not found for this conversation.');
         fill.id = wiring.id;
       }
@@ -107,7 +107,7 @@ export async function dispatch(
         (req.command === 'sessions-get' || req.command === 'sessions-history') &&
         req.args.id
       ) {
-        const s = getSession(req.args.id as string);
+        const s = await getSession(req.args.id as string);
         if (!s || s.agent_group_id !== ctx.agentGroupId) {
           return err(req.id, 'handler-error', `session not found: ${req.args.id}`);
         }
@@ -115,7 +115,7 @@ export async function dispatch(
     }
   }
 
-  const decision = guard(commandGuard(cmd.name), {
+  const decision = await guard(commandGuard(cmd.name), {
     actor: actorFor(ctx),
     payload: req.args,
     grant: opts.grant ?? null,
@@ -142,11 +142,11 @@ export async function dispatch(
       // fail closed rather than card a ghost.
       return err(req.id, 'forbidden', decision.reason);
     }
-    const session = getSession(ctx.sessionId);
+    const session = await getSession(ctx.sessionId);
     if (!session) {
       return err(req.id, 'handler-error', 'Session not found.');
     }
-    const agentGroup = getAgentGroup(ctx.agentGroupId);
+    const agentGroup = await getAgentGroup(ctx.agentGroupId);
     const agentName = agentGroup?.name ?? ctx.agentGroupId;
 
     const argSummary = Object.entries(req.args)
@@ -188,7 +188,7 @@ export async function dispatch(
     // pre-handler `--id` auto-fill (groups/destinations) or gated behind approval,
     // so they can't reach another group's data anyway.
     if (ctx.caller === 'agent' && cmd.resource && cmd.generic) {
-      const configRow = getContainerConfig(ctx.agentGroupId);
+      const configRow = await getContainerConfig(ctx.agentGroupId);
       if ((configRow?.cli_scope ?? 'group') === 'group') {
         const def = getResource(cmd.resource);
         const groupField = def?.scopeField;
@@ -237,9 +237,9 @@ registerApprovalHandler('cli_command', async ({ payload, approval, notify }) => 
   if (response.ok) {
     const localized = localizeIsoTimestamps(response.data);
     const data = typeof localized === 'string' ? localized : JSON.stringify(localized, null, 2);
-    notify(`Your \`ncl ${frame.command}\` request was approved and executed.\n\n${data}`);
+    await notify(`Your \`ncl ${frame.command}\` request was approved and executed.\n\n${data}`);
   } else {
-    notify(`Your \`ncl ${frame.command}\` request was approved but failed: ${response.error.message}`);
+    await notify(`Your \`ncl ${frame.command}\` request was approved but failed: ${response.error.message}`);
   }
 });
 

--- a/src/cli/guard.ts
+++ b/src/cli/guard.ts
@@ -45,7 +45,7 @@ export function commandGuardSpec(cmd: CommandDef): GuardedActionSpec {
   };
 }
 
-function commandDecide(cmd: CommandDef, input: GuardInput) {
+async function commandDecide(cmd: CommandDef, input: GuardInput) {
   const { actor } = input;
   if (actor.kind === 'host') return ALLOW('host caller (trusted socket)');
   if (actor.kind !== 'agent') return DENY('CLI commands accept host or agent callers only.');
@@ -59,7 +59,7 @@ function commandDecide(cmd: CommandDef, input: GuardInput) {
   }
 
   const args = input.payload;
-  const cliScope = getContainerConfig(actor.agentGroupId)?.cli_scope ?? 'group';
+  const cliScope = (await getContainerConfig(actor.agentGroupId))?.cli_scope ?? 'group';
 
   if (cliScope === 'disabled') {
     return DENY('CLI access is disabled for this agent group.');

--- a/src/cli/resources/destinations.test.ts
+++ b/src/cli/resources/destinations.test.ts
@@ -53,21 +53,21 @@ describe('destinations CLI custom ops project to inbound.db (#2465)', () => {
   const SESSION_A = 'sess-source-1';
   const SESSION_B = 'sess-source-2';
 
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
 
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
 
-    createAgentGroup({ id: SOURCE, name: 'source', folder: 'source', agent_provider: null, created_at: now() });
-    createAgentGroup({ id: TARGET, name: 'target', folder: 'target', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: SOURCE, name: 'source', folder: 'source', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: TARGET, name: 'target', folder: 'target', agent_provider: null, created_at: now() });
 
     // Two active sessions for the source agent — both must receive the
     // projected destination row. Fixing only the "newest" session is a
     // common regression shape, so the second session catches that.
     for (const sid of [SESSION_A, SESSION_B]) {
-      createSession({
+      await createSession({
         id: sid,
         agent_group_id: SOURCE,
         messaging_group_id: null,
@@ -82,8 +82,8 @@ describe('destinations CLI custom ops project to inbound.db (#2465)', () => {
     }
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 

--- a/src/cli/resources/destinations.ts
+++ b/src/cli/resources/destinations.ts
@@ -18,11 +18,11 @@ import { registerResource } from '../crud.js';
  * src/modules/agent-to-agent/db/agent-destinations.ts.
  */
 export async function projectDestinationsToSessions(agentGroupId: string): Promise<void> {
-  if (!hasTable(getDb(), 'agent_destinations')) return;
+  if (!(await hasTable(getDb(), 'agent_destinations'))) return;
   const { writeDestinations } = await import('../../modules/agent-to-agent/write-destinations.js');
-  for (const session of getSessionsByAgentGroup(agentGroupId)) {
+  for (const session of await getSessionsByAgentGroup(agentGroupId)) {
     try {
-      writeDestinations(agentGroupId, session.id);
+      await writeDestinations(agentGroupId, session.id);
     } catch (err) {
       log.warn('Failed to project destinations to session inbound.db', { agentGroupId, sessionId: session.id, err });
     }
@@ -74,9 +74,8 @@ registerResource({
         const params: unknown[] = [];
         const where = agentGroupId ? 'WHERE ad.agent_group_id = ?' : '';
         if (agentGroupId) params.push(agentGroupId);
-        return getDb()
-          .prepare(
-            `SELECT
+        return getDb().all(
+          `SELECT
                ad.agent_group_id,
                ad.local_name,
                ad.target_type,
@@ -89,8 +88,8 @@ registerResource({
              LEFT JOIN agent_groups ag ON ad.target_type = 'agent' AND ad.target_id = ag.id
              ${where}
              ORDER BY ad.agent_group_id, ad.local_name`,
-          )
-          .all(...params);
+          ...params,
+        );
       },
     },
     add: {
@@ -107,12 +106,15 @@ registerResource({
           throw new Error('--target-type must be channel or agent');
         }
         if (!targetId) throw new Error('--target-id is required');
-        getDb()
-          .prepare(
-            `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
-             VALUES (?, ?, ?, ?, ?)`,
-          )
-          .run(agentGroupId, localName, targetType, targetId, new Date().toISOString());
+        await getDb().run(
+          `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+          agentGroupId,
+          localName,
+          targetType,
+          targetId,
+          new Date().toISOString(),
+        );
         await projectDestinationsToSessions(agentGroupId);
         return { agent_group_id: agentGroupId, local_name: localName, target_type: targetType, target_id: targetId };
       },
@@ -125,9 +127,11 @@ registerResource({
         const localName = args.local_name as string;
         if (!agentGroupId) throw new Error('--agent-group-id is required');
         if (!localName) throw new Error('--local-name is required');
-        const result = getDb()
-          .prepare('DELETE FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?')
-          .run(agentGroupId, localName);
+        const result = await getDb().run(
+          'DELETE FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?',
+          agentGroupId,
+          localName,
+        );
         if (result.changes === 0) throw new Error('destination not found');
         await projectDestinationsToSessions(agentGroupId);
         return { removed: { agent_group_id: agentGroupId, local_name: localName } };

--- a/src/cli/resources/groups-plugin-guard.test.ts
+++ b/src/cli/resources/groups-plugin-guard.test.ts
@@ -59,16 +59,16 @@ async function run(command: string, args: Record<string, unknown>) {
 
 let groupId: string;
 
-beforeEach(() => {
+beforeEach(async () => {
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   fs.mkdirSync(TEST_ROOT, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
   writeTemplate();
-  groupId = createAgentFromTemplate('sdr', { name: 'SDR' }).group.id;
+  groupId = (await createAgentFromTemplate('sdr', { name: 'SDR' })).group.id;
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
@@ -81,14 +81,14 @@ describe('plugin-owned MCP server guard (ncl groups config)', () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.message).toMatch(/owned by plugin "sdr".*restamp/);
-    expect(JSON.parse(getContainerConfig(groupId)!.mcp_servers).docs.url).toBe('https://mcp.example.com/mcp');
+    expect(JSON.parse((await getContainerConfig(groupId))!.mcp_servers).docs.url).toBe('https://mcp.example.com/mcp');
   });
 
   it('refuses to remove a plugin-owned server', async () => {
     const res = await run('groups-config-remove-mcp-server', { id: groupId, name: 'docs' });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.message).toMatch(/owned by plugin "sdr"/);
-    expect(JSON.parse(getContainerConfig(groupId)!.mcp_servers).docs).toBeDefined();
+    expect(JSON.parse((await getContainerConfig(groupId))!.mcp_servers).docs).toBeDefined();
   });
 
   it('leaves unmarked servers fully editable', async () => {
@@ -100,7 +100,7 @@ describe('plugin-owned MCP server guard (ncl groups config)', () => {
     expect(added.ok).toBe(true);
     const removed = await run('groups-config-remove-mcp-server', { id: groupId, name: 'mine' });
     expect(removed.ok).toBe(true);
-    expect(JSON.parse(getContainerConfig(groupId)!.mcp_servers).mine).toBeUndefined();
+    expect(JSON.parse((await getContainerConfig(groupId))!.mcp_servers).mine).toBeUndefined();
   });
 });
 

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -13,6 +13,7 @@
  */
 import fs from 'fs';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 
 vi.mock('../../container-runner.js', () => ({
   wakeContainer: vi.fn().mockResolvedValue(undefined),
@@ -42,23 +43,23 @@ function now(): string {
 
 function count(sql: string, ...params: unknown[]): number {
   return (
-    getDb()
+    sqliteRaw(getDb())
       .prepare(sql)
       .get(...params) as { c: number }
   ).c;
 }
 
 describe('groups CLI delete cascades dependent rows (#2525)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
 
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -68,8 +69,8 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     const MGID = 'mg-1';
     const UID = 'tg:42';
 
-    createAgentGroup({ id: GID, name: 'victim', folder: 'victim', agent_provider: null, created_at: now() });
-    createSession({
+    await createAgentGroup({ id: GID, name: 'victim', folder: 'victim', agent_provider: null, created_at: now() });
+    await createSession({
       id: SID,
       agent_group_id: GID,
       messaging_group_id: null,
@@ -86,60 +87,77 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     // Direct inserts for the dependent tables. Keeps the fixture minimal —
     // we only need rows that establish FK relationships, not full domain
     // entities.
-    db.prepare(`INSERT INTO users (id, kind, display_name, created_at) VALUES (?, 'telegram', 'someone', ?)`).run(
-      UID,
-      now(),
-    );
-    db.prepare(
-      `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+    sqliteRaw(db)
+      .prepare(`INSERT INTO users (id, kind, display_name, created_at) VALUES (?, 'telegram', 'someone', ?)`)
+      .run(UID, now());
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
        VALUES (?, 'telegram', 'tg-1', 'telegram', 'chat', 1, 'strict', ?)`,
-    ).run(MGID, now());
+      )
+      .run(MGID, now());
 
-    db.prepare(
-      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES (?, 'chan', 'channel', ?, ?)`,
-    ).run(GID, MGID, now());
+      )
+      .run(GID, MGID, now());
 
-    db.prepare(
-      `INSERT INTO pending_questions (question_id, session_id, message_out_id, title, options_json, created_at)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO pending_questions (question_id, session_id, message_out_id, title, options_json, created_at)
        VALUES (?, ?, 'mout-1', 'q', '[]', ?)`,
-    ).run('q-1', SID, now());
+      )
+      .run('q-1', SID, now());
 
-    db.prepare(
-      `INSERT INTO pending_approvals (approval_id, session_id, request_id, action, payload, created_at, agent_group_id, status, title, options_json)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO pending_approvals (approval_id, session_id, request_id, action, payload, created_at, agent_group_id, status, title, options_json)
        VALUES (?, ?, 'req-1', 'cli_command', '{}', ?, ?, 'pending', '', '[]')`,
-    ).run('pa-1', SID, now(), GID);
+      )
+      .run('pa-1', SID, now(), GID);
 
-    db.prepare(
-      `INSERT INTO pending_sender_approvals (id, messaging_group_id, agent_group_id, sender_identity, sender_name, original_message, approver_user_id, created_at)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO pending_sender_approvals (id, messaging_group_id, agent_group_id, sender_identity, sender_name, original_message, approver_user_id, created_at)
        VALUES ('psa-1', ?, ?, 'tg:99', 'them', '{}', ?, ?)`,
-    ).run(MGID, GID, UID, now());
+      )
+      .run(MGID, GID, UID, now());
 
-    db.prepare(
-      `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at)
        VALUES (?, ?, '{}', ?, ?)`,
-    ).run(MGID, GID, UID, now());
+      )
+      .run(MGID, GID, UID, now());
 
-    db.prepare(
-      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, session_mode, priority, created_at)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, session_mode, priority, created_at)
        VALUES ('mga-1', ?, ?, 'mention', 'all', 'drop', 'shared', 0, ?)`,
-    ).run(MGID, GID, now());
+      )
+      .run(MGID, GID, now());
 
-    db.prepare(
-      `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at) VALUES (?, ?, NULL, ?)`,
-    ).run(UID, GID, now());
+    sqliteRaw(db)
+      .prepare(`INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at) VALUES (?, ?, NULL, ?)`)
+      .run(UID, GID, now());
 
-    db.prepare(
-      `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at) VALUES (?, 'admin', ?, NULL, ?)`,
-    ).run(UID, GID, now());
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at) VALUES (?, 'admin', ?, NULL, ?)`,
+      )
+      .run(UID, GID, now());
 
     // Container config row exercises the ON DELETE CASCADE on container_configs.
-    db.prepare(
-      `INSERT INTO container_configs
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO container_configs
          (agent_group_id, provider, model, effort, image_tag, assistant_name, max_messages_per_prompt,
           skills, mcp_servers, packages_apt, packages_npm, additional_mounts, cli_scope, updated_at)
        VALUES (?, NULL, NULL, NULL, NULL, NULL, NULL, '"all"', '{}', '[]', '[]', '[]', 'group', ?)`,
-    ).run(GID, now());
+      )
+      .run(GID, now());
 
     const resp = await dispatch({ id: 'req-del', command: 'groups-delete', args: { id: GID } }, { caller: 'host' });
 
@@ -183,18 +201,20 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
   it('removes polymorphic agent_destinations that point at the deleted group', async () => {
     const A = 'ag-a';
     const B = 'ag-b';
-    createAgentGroup({ id: A, name: 'a', folder: 'a', agent_provider: null, created_at: now() });
-    createAgentGroup({ id: B, name: 'b', folder: 'b', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: A, name: 'a', folder: 'a', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: B, name: 'b', folder: 'b', agent_provider: null, created_at: now() });
 
     const db = getDb();
 
     // B has a destination pointing at A. target_id is polymorphic — no FK
     // constraint enforces it, so without explicit cleanup the row would
     // dangle after A is deleted.
-    db.prepare(
-      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES (?, 'sibling', 'agent', ?, ?)`,
-    ).run(B, A, now());
+      )
+      .run(B, A, now());
 
     const resp = await dispatch({ id: 'req-del-a', command: 'groups-delete', args: { id: A } }, { caller: 'host' });
 
@@ -221,31 +241,31 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
 });
 
 describe('groups config add-mount / remove-mount (host-only)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
   });
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
   it('adds a mount idempotently and removes it (host caller)', async () => {
     const GID = 'ag-mount';
-    createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
-    ensureContainerConfig(GID);
+    await createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
     const args = { id: GID, host: '/data/.gmail-mcp', container: '/home/node/.gmail-mcp', ro: true };
 
     const add = await dispatch({ id: 'r1', command: 'groups-config-add-mount', args }, { caller: 'host' });
     expect(add.ok).toBe(true);
-    expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toEqual([
+    expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([
       { hostPath: '/data/.gmail-mcp', containerPath: '/home/node/.gmail-mcp', readonly: true },
     ]);
 
     // idempotent: a second add does not duplicate
     await dispatch({ id: 'r2', command: 'groups-config-add-mount', args }, { caller: 'host' });
-    expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toHaveLength(1);
+    expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toHaveLength(1);
 
     const rm = await dispatch(
       {
@@ -256,27 +276,27 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
       { caller: 'host' },
     );
     expect(rm.ok).toBe(true);
-    expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toEqual([]);
+    expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
   });
 });
 
 describe('groups CLI MCP config', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    runMigrations(initTestDb());
-    createAgentGroup({
+    await runMigrations(await initTestDb());
+    await createAgentGroup({
       id: 'ag-mcp',
       name: 'mcp',
       folder: 'mcp',
       agent_provider: null,
       created_at: now(),
     });
-    ensureContainerConfig('ag-mcp');
+    await ensureContainerConfig('ag-mcp');
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -300,7 +320,7 @@ describe('groups CLI MCP config', () => {
 
     expect(local.ok).toBe(true);
     expect(remote.ok).toBe(true);
-    expect(JSON.parse(getContainerConfig('ag-mcp')!.mcp_servers)).toEqual({
+    expect(JSON.parse((await getContainerConfig('ag-mcp'))!.mcp_servers)).toEqual({
       local: { command: 'pnpm', args: ['dlx', 'server'], env: {} },
       remote: { type: 'http', url: 'https://mcp.example.com/mcp' },
     });
@@ -342,6 +362,6 @@ describe('groups CLI MCP config', () => {
 
     expect(badName.ok).toBe(false);
     expect(badName.ok ? '' : badName.error.message).toMatch(/1-64 characters/);
-    expect(JSON.parse(getContainerConfig('ag-mcp')!.mcp_servers)).toEqual({});
+    expect(JSON.parse((await getContainerConfig('ag-mcp'))!.mcp_servers)).toEqual({});
   });
 });

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -131,7 +131,7 @@ registerResource({
           // --yes), never a duplicate agent. --new opts out; agent callers
           // have --id auto-filled, so they always target their own group.
           if (args.new !== true) {
-            const carriers = args.id ? [] : groupsCarryingPlugin(ref);
+            const carriers = args.id ? [] : await groupsCarryingPlugin(ref);
             if (carriers.length > 1) {
               throw new Error(
                 `${carriers.length} groups already carry this plugin: ` +
@@ -141,13 +141,13 @@ registerResource({
             }
             const targetId = args.id ? String(args.id) : carriers[0]?.id;
             if (targetId) {
-              const result = restampAgentFromTemplate(ref, targetId, { apply: args.yes === true });
+              const result = await restampAgentFromTemplate(ref, targetId, { apply: args.yes === true });
               return result.applied
                 ? result
                 : { ...result, note: `${result.note} Pass --new to stamp a separate agent instead.` };
             }
           }
-          const { group, report } = createAgentFromTemplate(ref, {
+          const { group, report } = await createAgentFromTemplate(ref, {
             name: args.name ? String(args.name) : undefined,
             timezone,
           });
@@ -156,14 +156,14 @@ registerResource({
         const folder = args.folder as string;
         if (!folder) throw new Error('--folder is required');
         const name = (args.name as string) ?? folder;
-        const existing = getAgentGroupByFolder(folder);
+        const existing = await getAgentGroupByFolder(folder);
         if (existing) {
-          initGroupFilesystem(existing); // ensure a reused group is fully configured too (idempotent; also repairs a missing workspace folder)
+          await initGroupFilesystem(existing); // ensure a reused group is fully configured too (idempotent; also repairs a missing workspace folder)
           return existing;
         }
         const id = `ag-${randomUUID()}`;
         const group: AgentGroup = { id, name, folder, agent_provider: null, created_at: new Date().toISOString() };
-        createAgentGroup(group);
+        await createAgentGroup(group);
         // Provision the workspace folder and the `container_configs` row that
         // `getContainerConfig` and the spawn path require. Without this, a
         // group created via `ncl groups create` would throw "Container config
@@ -174,8 +174,8 @@ registerResource({
         // group via the setup flow. The config row is stamped with the
         // instance default provider (`ensureContainerConfig` inside) — per-group
         // `groups config update --provider` still wins.
-        initGroupFilesystem(group);
-        if (timezone) updateContainerConfigScalars(id, { timezone });
+        await initGroupFilesystem(group);
+        if (timezone) await updateContainerConfigScalars(id, { timezone });
         return getAgentGroupByFolder(folder);
       },
       // The restamp path returns a plan that wants the aligned-lines view;
@@ -198,18 +198,18 @@ registerResource({
 
         // Verify the group exists before doing anything — preserves the
         // genericDelete behaviour of throwing "not found" for unknown IDs.
-        const exists = db.prepare('SELECT 1 FROM agent_groups WHERE id = ? LIMIT 1').get(id);
+        const exists = await db.get('SELECT 1 FROM agent_groups WHERE id = ? LIMIT 1', id);
         if (!exists) throw new Error(`group not found: ${id}`);
 
-        const hasAgentDestinations = hasTable(db, 'agent_destinations');
-        const hasPendingApprovals = hasTable(db, 'pending_approvals');
+        const hasAgentDestinations = await hasTable(db, 'agent_destinations');
+        const hasPendingApprovals = await hasTable(db, 'pending_approvals');
 
-        // FK-ordered cascade. Single sync transaction — better-sqlite3 rolls
+        // FK-ordered cascade. The async driver transaction rolls
         // back the whole thing if any statement throws (e.g. an FK constraint
         // we missed), so the central DB stays consistent. The `removed` counts
         // are sourced from each DELETE's `changes` so they describe exactly
         // what the transaction did, not a separate pre-flight snapshot.
-        const cascade = db.transaction((groupId: string) => {
+        const removed = await db.transaction(async () => {
           const counts = {
             sessions: 0,
             pending_questions: 0,
@@ -225,48 +225,50 @@ registerResource({
           };
 
           if (hasAgentDestinations) {
-            counts.agent_destinations_owned = db
-              .prepare('DELETE FROM agent_destinations WHERE agent_group_id = ?')
-              .run(groupId).changes;
-            counts.agent_destinations_pointing = db
-              .prepare('DELETE FROM agent_destinations WHERE target_type = ? AND target_id = ?')
-              .run('agent', groupId).changes;
+            counts.agent_destinations_owned = (
+              await db.run('DELETE FROM agent_destinations WHERE agent_group_id = ?', id)
+            ).changes;
+            counts.agent_destinations_pointing = (
+              await db.run('DELETE FROM agent_destinations WHERE target_type = ? AND target_id = ?', 'agent', id)
+            ).changes;
           }
-          counts.pending_questions = db
-            .prepare(
+          counts.pending_questions = (
+            await db.run(
               'DELETE FROM pending_questions WHERE session_id IN (SELECT id FROM sessions WHERE agent_group_id = ?)',
+              id,
             )
-            .run(groupId).changes;
+          ).changes;
           if (hasPendingApprovals) {
-            counts.pending_approvals = db
-              .prepare(
+            counts.pending_approvals = (
+              await db.run(
                 'DELETE FROM pending_approvals WHERE agent_group_id = ? OR session_id IN (SELECT id FROM sessions WHERE agent_group_id = ?)',
+                id,
+                id,
               )
-              .run(groupId, groupId).changes;
+            ).changes;
           }
-          counts.sessions = db.prepare('DELETE FROM sessions WHERE agent_group_id = ?').run(groupId).changes;
-          counts.pending_sender_approvals = db
-            .prepare('DELETE FROM pending_sender_approvals WHERE agent_group_id = ?')
-            .run(groupId).changes;
-          counts.pending_channel_approvals = db
-            .prepare('DELETE FROM pending_channel_approvals WHERE agent_group_id = ?')
-            .run(groupId).changes;
-          counts.messaging_group_agents = db
-            .prepare('DELETE FROM messaging_group_agents WHERE agent_group_id = ?')
-            .run(groupId).changes;
-          counts.agent_group_members = db
-            .prepare('DELETE FROM agent_group_members WHERE agent_group_id = ?')
-            .run(groupId).changes;
-          counts.user_roles = db.prepare('DELETE FROM user_roles WHERE agent_group_id = ?').run(groupId).changes;
+          counts.sessions = (await db.run('DELETE FROM sessions WHERE agent_group_id = ?', id)).changes;
+          counts.pending_sender_approvals = (
+            await db.run('DELETE FROM pending_sender_approvals WHERE agent_group_id = ?', id)
+          ).changes;
+          counts.pending_channel_approvals = (
+            await db.run('DELETE FROM pending_channel_approvals WHERE agent_group_id = ?', id)
+          ).changes;
+          counts.messaging_group_agents = (
+            await db.run('DELETE FROM messaging_group_agents WHERE agent_group_id = ?', id)
+          ).changes;
+          counts.agent_group_members = (
+            await db.run('DELETE FROM agent_group_members WHERE agent_group_id = ?', id)
+          ).changes;
+          counts.user_roles = (await db.run('DELETE FROM user_roles WHERE agent_group_id = ?', id)).changes;
           // migration-014 has ON DELETE CASCADE on container_configs.agent_group_id;
           // the explicit delete here mirrors the other tables and surfaces the count.
-          counts.container_configs = db
-            .prepare('DELETE FROM container_configs WHERE agent_group_id = ?')
-            .run(groupId).changes;
-          db.prepare('DELETE FROM agent_groups WHERE id = ?').run(groupId);
+          counts.container_configs = (
+            await db.run('DELETE FROM container_configs WHERE agent_group_id = ?', id)
+          ).changes;
+          await db.run('DELETE FROM agent_groups WHERE id = ?', id);
           return counts;
         });
-        const removed = cascade(id);
 
         return { deleted: id, removed };
       },
@@ -291,7 +293,7 @@ registerResource({
         // From an agent: scope to the calling session only
         if (ctx.caller === 'agent') {
           if (message) {
-            writeSessionMessage(id, ctx.sessionId, {
+            await writeSessionMessage(id, ctx.sessionId, {
               id: `restart-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
               kind: 'chat',
               timestamp: new Date().toISOString(),
@@ -307,8 +309,10 @@ registerResource({
             'restarted via ncl',
             message
               ? () => {
-                  const s = getSession(ctx.sessionId);
-                  if (s) void wakeContainer(s);
+                  void (async () => {
+                    const s = await getSession(ctx.sessionId);
+                    if (s) await wakeContainer(s);
+                  })();
                 }
               : undefined,
           );
@@ -326,7 +330,7 @@ registerResource({
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
         return presentConfig(row);
       },
@@ -340,7 +344,7 @@ registerResource({
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const updates: Partial<
@@ -379,9 +383,9 @@ registerResource({
           );
         }
 
-        updateContainerConfigScalars(id, updates);
+        await updateContainerConfigScalars(id, updates);
 
-        const updated = getContainerConfig(id)!;
+        const updated = (await getContainerConfig(id))!;
         return presentConfig(updated);
       },
     },
@@ -398,7 +402,7 @@ registerResource({
         if (!name) throw new Error('--name is required');
         validateMcpServerName(name);
 
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const servers = JSON.parse(row.mcp_servers) as Record<string, McpServerConfig>;
@@ -416,7 +420,7 @@ registerResource({
           env: args.env === undefined ? undefined : JSON.parse(String(args.env)),
           headers: args.headers === undefined ? undefined : JSON.parse(String(args.headers)),
         });
-        updateContainerConfigJson(id, 'mcp_servers', servers);
+        await updateContainerConfigJson(id, 'mcp_servers', servers);
 
         return { added: name, servers };
       },
@@ -431,7 +435,7 @@ registerResource({
         const name = args.name as string;
         if (!name) throw new Error('--name is required');
 
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const servers = JSON.parse(row.mcp_servers) as Record<string, McpServerConfig>;
@@ -444,7 +448,7 @@ registerResource({
           );
         }
         delete servers[name];
-        updateContainerConfigJson(id, 'mcp_servers', servers);
+        await updateContainerConfigJson(id, 'mcp_servers', servers);
 
         return { removed: name };
       },
@@ -457,7 +461,7 @@ registerResource({
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
 
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const apt = args.apt as string | undefined;
@@ -468,14 +472,14 @@ registerResource({
           const existing = JSON.parse(row.packages_apt) as string[];
           if (!existing.includes(apt)) {
             existing.push(apt);
-            updateContainerConfigJson(id, 'packages_apt', existing);
+            await updateContainerConfigJson(id, 'packages_apt', existing);
           }
         }
         if (npm) {
           const existing = JSON.parse(row.packages_npm) as string[];
           if (!existing.includes(npm)) {
             existing.push(npm);
-            updateContainerConfigJson(id, 'packages_npm', existing);
+            await updateContainerConfigJson(id, 'packages_npm', existing);
           }
         }
 
@@ -493,7 +497,7 @@ registerResource({
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
 
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const apt = args.apt as string | undefined;
@@ -503,12 +507,12 @@ registerResource({
         if (apt) {
           const existing = JSON.parse(row.packages_apt) as string[];
           const filtered = existing.filter((p) => p !== apt);
-          updateContainerConfigJson(id, 'packages_apt', filtered);
+          await updateContainerConfigJson(id, 'packages_apt', filtered);
         }
         if (npm) {
           const existing = JSON.parse(row.packages_npm) as string[];
           const filtered = existing.filter((p) => p !== npm);
-          updateContainerConfigJson(id, 'packages_npm', filtered);
+          await updateContainerConfigJson(id, 'packages_npm', filtered);
         }
 
         return {
@@ -531,7 +535,7 @@ registerResource({
         const containerPath = (args.container ?? args['container-path']) as string | undefined;
         if (!hostPath || !containerPath) throw new Error('Provide --host <host-path> and --container <container-path>');
 
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const mount: AdditionalMountConfig = {
@@ -542,7 +546,7 @@ registerResource({
         const existing = JSON.parse(row.additional_mounts) as AdditionalMountConfig[];
         if (!existing.some((m) => m.hostPath === hostPath && m.containerPath === containerPath)) {
           existing.push(mount);
-          updateContainerConfigJson(id, 'additional_mounts', existing);
+          await updateContainerConfigJson(id, 'additional_mounts', existing);
         }
         return { added: mount, note: `Run \`ncl groups restart --id ${id}\` for the mount to take effect.` };
       },
@@ -560,12 +564,12 @@ registerResource({
         const containerPath = (args.container ?? args['container-path']) as string | undefined;
         if (!hostPath || !containerPath) throw new Error('Provide --host <host-path> and --container <container-path>');
 
-        const row = getContainerConfig(id);
+        const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const existing = JSON.parse(row.additional_mounts) as AdditionalMountConfig[];
         const filtered = existing.filter((m) => !(m.hostPath === hostPath && m.containerPath === containerPath));
-        updateContainerConfigJson(id, 'additional_mounts', filtered);
+        await updateContainerConfigJson(id, 'additional_mounts', filtered);
         return { removed: { hostPath, containerPath }, note: `Run \`ncl groups restart --id ${id}\` to apply.` };
       },
     },

--- a/src/cli/resources/members.ts
+++ b/src/cli/resources/members.ts
@@ -38,13 +38,15 @@ registerResource({
         const addedBy = (args.added_by as string) ?? null;
         if (!userId) throw new Error('--user is required');
         if (!groupId) throw new Error('--group is required');
-        getDb()
-          .prepare(
-            `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
+        await getDb().run(
+          `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
              VALUES (?, ?, ?, ?)
              ON CONFLICT (user_id, agent_group_id) DO NOTHING`,
-          )
-          .run(userId, groupId, addedBy, new Date().toISOString());
+          userId,
+          groupId,
+          addedBy,
+          new Date().toISOString(),
+        );
         return { user_id: userId, agent_group_id: groupId };
       },
     },
@@ -56,9 +58,11 @@ registerResource({
         const groupId = args.group as string;
         if (!userId) throw new Error('--user is required');
         if (!groupId) throw new Error('--group is required');
-        const result = getDb()
-          .prepare('DELETE FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
-          .run(userId, groupId);
+        const result = await getDb().run(
+          'DELETE FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+          userId,
+          groupId,
+        );
         if (result.changes === 0) throw new Error('member not found');
         return { removed: { user_id: userId, agent_group_id: groupId } };
       },

--- a/src/cli/resources/messaging-groups.test.ts
+++ b/src/cli/resources/messaging-groups.test.ts
@@ -42,14 +42,14 @@ const declared: ChannelDefaults = {
 registerChannelAdapter('declchan-mg', { factory: () => null, defaults: declared });
 
 describe('messaging-groups CLI create defaults instance to channel_type', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -65,7 +65,7 @@ describe('messaging-groups CLI create defaults instance to channel_type', () => 
     );
 
     expect(resp.ok).toBe(true);
-    const row = getMessagingGroupByPlatform('telegram', '12345');
+    const row = await getMessagingGroupByPlatform('telegram', '12345');
     expect(row).toBeDefined();
     expect(row?.instance).toBe('telegram');
   });
@@ -81,19 +81,19 @@ describe('messaging-groups CLI create defaults instance to channel_type', () => 
     );
 
     expect(resp.ok).toBe(true);
-    expect(getMessagingGroupByPlatform('telegram', '67890', 'work')?.instance).toBe('work');
+    expect((await getMessagingGroupByPlatform('telegram', '67890', 'work'))?.instance).toBe('work');
   });
 });
 
 describe('messaging-groups CLI create resolves unknown_sender_policy from the channel declaration', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -103,13 +103,13 @@ describe('messaging-groups CLI create resolves unknown_sender_policy from the ch
   it('DM context takes the declared dm policy', async () => {
     const resp = await create({ channel_type: 'declchan-mg', platform_id: 'dm-1' }, 'req-d1');
     expect(resp.ok).toBe(true);
-    expect(getMessagingGroupByPlatform('declchan-mg', 'dm-1')?.unknown_sender_policy).toBe('public');
+    expect((await getMessagingGroupByPlatform('declchan-mg', 'dm-1'))?.unknown_sender_policy).toBe('public');
   });
 
   it('group context takes the declared group policy', async () => {
     const resp = await create({ channel_type: 'declchan-mg', platform_id: 'g-1', is_group: '1' }, 'req-d2');
     expect(resp.ok).toBe(true);
-    expect(getMessagingGroupByPlatform('declchan-mg', 'g-1')?.unknown_sender_policy).toBe('request_approval');
+    expect((await getMessagingGroupByPlatform('declchan-mg', 'g-1'))?.unknown_sender_policy).toBe('request_approval');
   });
 
   it('explicit --unknown-sender-policy wins over the declaration', async () => {
@@ -118,12 +118,12 @@ describe('messaging-groups CLI create resolves unknown_sender_policy from the ch
       'req-d3',
     );
     expect(resp.ok).toBe(true);
-    expect(getMessagingGroupByPlatform('declchan-mg', 'dm-2')?.unknown_sender_policy).toBe('strict');
+    expect((await getMessagingGroupByPlatform('declchan-mg', 'dm-2'))?.unknown_sender_policy).toBe('strict');
   });
 
   it("undeclared channels keep the legacy static 'strict' default (back-compat)", async () => {
     const resp = await create({ channel_type: 'stalechan-mg', platform_id: 's-1' }, 'req-d4');
     expect(resp.ok).toBe(true);
-    expect(getMessagingGroupByPlatform('stalechan-mg', 's-1')?.unknown_sender_policy).toBe('strict');
+    expect((await getMessagingGroupByPlatform('stalechan-mg', 's-1'))?.unknown_sender_policy).toBe('strict');
   });
 });

--- a/src/cli/resources/messaging-groups.ts
+++ b/src/cli/resources/messaging-groups.ts
@@ -102,7 +102,7 @@ registerResource({
           throw new Error('--channel-type, --platform-id and --text are required');
         }
         const instance = (args.instance as string) ?? channelType;
-        const mg = getMessagingGroupByPlatform(channelType, platformId, instance);
+        const mg = await getMessagingGroupByPlatform(channelType, platformId, instance);
         if (!mg) {
           throw new Error(`no messaging group for ${channelType} ${platformId} — create + wire it first`);
         }

--- a/src/cli/resources/policies.ts
+++ b/src/cli/resources/policies.ts
@@ -33,10 +33,10 @@ registerResource({
         if (!to) throw new Error('--to is required');
         if (!approver) throw new Error('--approver is required');
         if (from === to) throw new Error('--from and --to must differ (self-messages are never gated)');
-        if (!getAgentGroup(from)) throw new Error(`source agent group not found: ${from}`);
-        if (!getAgentGroup(to)) throw new Error(`target agent group not found: ${to}`);
+        if (!(await getAgentGroup(from))) throw new Error(`source agent group not found: ${from}`);
+        if (!(await getAgentGroup(to))) throw new Error(`target agent group not found: ${to}`);
 
-        setMessagePolicy(from, to, approver, new Date().toISOString());
+        await setMessagePolicy(from, to, approver, new Date().toISOString());
         return { from_agent_group_id: from, to_agent_group_id: to, approver };
       },
     },
@@ -48,7 +48,7 @@ registerResource({
         const to = args.to as string;
         if (!from) throw new Error('--from is required');
         if (!to) throw new Error('--to is required');
-        if (!removeMessagePolicy(from, to)) throw new Error('policy not found');
+        if (!(await removeMessagePolicy(from, to))) throw new Error('policy not found');
         return { removed: { from_agent_group_id: from, to_agent_group_id: to } };
       },
     },

--- a/src/cli/resources/programmatic-wiring.test.ts
+++ b/src/cli/resources/programmatic-wiring.test.ts
@@ -20,6 +20,7 @@
 import fs from 'fs';
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 
 vi.mock('../../container-runner.js', () => ({
   wakeContainer: vi.fn().mockResolvedValue(undefined),
@@ -40,8 +41,8 @@ vi.mock('../../config.js', async () => {
 vi.mock('../../group-init.js', async () => {
   const { ensureContainerConfig } = await import('../../db/container-configs.js');
   return {
-    initGroupFilesystem: vi.fn((group: { id: string }) => {
-      ensureContainerConfig(group.id);
+    initGroupFilesystem: vi.fn(async (group: { id: string }) => {
+      await ensureContainerConfig(group.id);
     }),
   };
 });
@@ -69,21 +70,21 @@ function send(command: string, args: Record<string, unknown>) {
 }
 function count(sql: string, ...params: unknown[]): number {
   return (
-    getDb()
+    sqliteRaw(getDb())
       .prepare(sql)
       .get(...params) as { c: number }
   ).c;
 }
 
 describe('programmatic wiring verbs', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    runMigrations(initTestDb());
-    createAgentGroup({ id: 'ag-1', name: 'Nano', folder: 'nano', agent_provider: null, created_at: now() });
+    await runMigrations(await initTestDb());
+    await createAgentGroup({ id: 'ag-1', name: 'Nano', folder: 'nano', agent_provider: null, created_at: now() });
   });
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 

--- a/src/cli/resources/roles.ts
+++ b/src/cli/resources/roles.ts
@@ -38,13 +38,16 @@ registerResource({
         if (!userId) throw new Error('--user is required');
         if (!role || !['owner', 'admin'].includes(role)) throw new Error('--role must be owner or admin');
         if (role === 'owner' && groupId) throw new Error('owner role is always global (do not pass --group)');
-        getDb()
-          .prepare(
-            `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
+        await getDb().run(
+          `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
              VALUES (?, ?, ?, ?, ?)
              ON CONFLICT DO NOTHING`,
-          )
-          .run(userId, role, groupId, grantedBy, new Date().toISOString());
+          userId,
+          role,
+          groupId,
+          grantedBy,
+          new Date().toISOString(),
+        );
         return { user_id: userId, role, agent_group_id: groupId };
       },
     },
@@ -57,9 +60,12 @@ registerResource({
         const groupId = (args.group as string) ?? null;
         if (!userId) throw new Error('--user is required');
         if (!role) throw new Error('--role is required');
-        const result = getDb()
-          .prepare('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NOT DISTINCT FROM ?')
-          .run(userId, role, groupId);
+        const result = await getDb().run(
+          'DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NOT DISTINCT FROM ?',
+          userId,
+          role,
+          groupId,
+        );
         if (result.changes === 0) throw new Error('role not found');
         return { revoked: { user_id: userId, role, agent_group_id: groupId } };
       },

--- a/src/cli/resources/tasks.test.ts
+++ b/src/cli/resources/tasks.test.ts
@@ -35,12 +35,12 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function createGroup(id: string): void {
-  createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: now() });
+async function createGroup(id: string): Promise<void> {
+  await createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: now() });
 }
 
-function createChatSession(group: string, id: string): void {
-  createSession({
+async function createChatSession(group: string, id: string): Promise<void> {
+  await createSession({
     id,
     agent_group_id: group,
     messaging_group_id: null,
@@ -59,19 +59,19 @@ function agentCtx(group = 'ag-1', session = 'chat-1'): CallerContext {
 }
 
 describe('tasks CLI resource', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    const db = initTestDb();
-    runMigrations(db);
-    createGroup('ag-1');
-    createGroup('ag-2');
-    createChatSession('ag-1', 'chat-1');
-    createChatSession('ag-2', 'chat-2');
+    const db = await initTestDb();
+    await runMigrations(db);
+    await createGroup('ag-1');
+    await createGroup('ag-2');
+    await createChatSession('ag-1', 'chat-1');
+    await createChatSession('ag-2', 'chat-2');
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -92,7 +92,7 @@ describe('tasks CLI resource', () => {
     expect(created.session_id).not.toBe('chat-1');
 
     // The task lands in its own isolated per-series session, not the chat session.
-    const sessions = getSessionsByAgentGroup('ag-1');
+    const sessions = await getSessionsByAgentGroup('ag-1');
     const taskSession = sessions.find((s) => s.id === created.session_id);
     expect(taskSession?.thread_id).toBe(taskThreadId(created.series_id));
 
@@ -233,7 +233,7 @@ describe('tasks CLI resource', () => {
       agentCtx(),
     );
 
-    expect(findSessionByAgentGroup('ag-1')?.id).toBe('chat-1');
+    expect((await findSessionByAgentGroup('ag-1'))?.id).toBe('chat-1');
   });
 
   it('group-scoped agents cannot list tasks from another group session', async () => {

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -79,8 +79,8 @@ function groupArg(args: Record<string, unknown>, ctx: CallerContext): string | u
   return str(args.group) ?? str(args.agent_group_id);
 }
 
-function ownSession(sessionId: string, ctx: CallerContext): ScopedSession {
-  const session = getSession(sessionId);
+async function ownSession(sessionId: string, ctx: CallerContext): Promise<ScopedSession> {
+  const session = await getSession(sessionId);
   if (!session) throw new Error(`session not found: ${sessionId}`);
   if (ctx.caller === 'agent' && session.agent_group_id !== ctx.agentGroupId) {
     throw new Error(`session not found: ${sessionId}`);
@@ -88,18 +88,18 @@ function ownSession(sessionId: string, ctx: CallerContext): ScopedSession {
   return { id: session.id, agent_group_id: session.agent_group_id };
 }
 
-function selectedSessions(args: Record<string, unknown>, ctx: CallerContext): ScopedSession[] {
+async function selectedSessions(args: Record<string, unknown>, ctx: CallerContext): Promise<ScopedSession[]> {
   const sessionId = str(args.session);
-  if (sessionId) return [ownSession(sessionId, ctx)];
+  if (sessionId) return [await ownSession(sessionId, ctx)];
 
   const group = groupArg(args, ctx);
   if (group) {
     // One session per live task series — the loops below already fan out across them.
-    return findTaskSessions(group).map((s) => ({ id: s.id, agent_group_id: s.agent_group_id }));
+    return (await findTaskSessions(group)).map((s) => ({ id: s.id, agent_group_id: s.agent_group_id }));
   }
 
   if (ctx.caller === 'agent') return [];
-  return getActiveSessions().map((s) => ({ id: s.id, agent_group_id: s.agent_group_id }));
+  return (await getActiveSessions()).map((s) => ({ id: s.id, agent_group_id: s.agent_group_id }));
 }
 
 function withInbound<T>(session: ScopedSession, fn: (db: Database.Database) => T): T | undefined {
@@ -158,7 +158,7 @@ function taskId(args: Record<string, unknown>): string {
   return id;
 }
 
-function createTask(args: Record<string, unknown>, ctx: CallerContext) {
+async function createTask(args: Record<string, unknown>, ctx: CallerContext) {
   const group = groupArg(args, ctx);
   if (!group) throw new Error('--group is required');
   const prompt = str(args.prompt);
@@ -172,9 +172,9 @@ function createTask(args: Record<string, unknown>, ctx: CallerContext) {
     processAfter: str(args.process_after),
     script,
     dangerouslyOverrideRecurrenceLimit: bool(args.dangerously_override_recurrence_limit),
-    timezone: resolveGroupTimezone(group),
+    timezone: await resolveGroupTimezone(group),
   });
-  const { session, row } = createScheduledTask(group, prepared, {
+  const { session, row } = await createScheduledTask(group, prepared, {
     originSessionId: ctx.caller === 'agent' ? ctx.sessionId : null,
   });
   return toOutput(session, row);
@@ -187,17 +187,17 @@ function createTask(args: Record<string, unknown>, ctx: CallerContext) {
  * can see when and why each run happened. Inside a task run the series is derived from
  * the caller's own task session, so the agent supplies only --msg.
  */
-function appendTaskLog(
+async function appendTaskLog(
   args: Record<string, unknown>,
   ctx: CallerContext,
-): { series: string; timestamp: string; path: string; ok: true } {
+): Promise<{ series: string; timestamp: string; path: string; ok: true }> {
   const msg = str(args.msg);
   if (!msg) throw new Error('--msg is required');
 
   let series = str(args.id);
   let group = groupArg(args, ctx);
   if (!series && ctx.caller === 'agent' && ctx.sessionId) {
-    const sess = getSession(ctx.sessionId);
+    const sess = await getSession(ctx.sessionId);
     if (sess && sess.thread_id && isTaskThread(sess.thread_id)) {
       series = sess.thread_id.slice(`${TASKS_SYSTEM_THREAD_ID}:`.length);
       group ??= sess.agent_group_id;
@@ -209,7 +209,7 @@ function appendTaskLog(
   // Group scope is enforced by groupArg (a cli_scope=group caller can only
   // ever resolve its own folder), so a foreign id at worst writes a stray log
   // under the caller's OWN folder — no leak. appendRunLog guards the charset.
-  return { ...appendRunLog(group, series, msg), ok: true };
+  return { ...(await appendRunLog(group, series, msg)), ok: true };
 }
 
 /**
@@ -235,8 +235,8 @@ function seriesStats(
 }
 
 /** Last ~10 lines of a series' run log (`tasks/<series>.md`), newest last. */
-function tailRunLog(agentGroupId: string, seriesKey: string, lines = 10): string[] {
-  const ag = getAgentGroup(agentGroupId);
+async function tailRunLog(agentGroupId: string, seriesKey: string, lines = 10): Promise<string[]> {
+  const ag = await getAgentGroup(agentGroupId);
   if (!ag) return [];
   const file = `${GROUPS_DIR}/${ag.folder}/tasks/${seriesKey}.md`;
   if (!fs.existsSync(file)) return [];
@@ -264,10 +264,10 @@ function enrichListRow(db: Database.Database, base: ReturnType<typeof toOutput>)
   };
 }
 
-function listTasks(args: Record<string, unknown>, ctx: CallerContext) {
+async function listTasks(args: Record<string, unknown>, ctx: CallerContext) {
   const status = statusFilter(args);
   const rows = [];
-  for (const session of selectedSessions(args, ctx)) {
+  for (const session of await selectedSessions(args, ctx)) {
     const sessionRows = withInbound(session, (db) =>
       selectLiveTasks(db, status).map((row) => enrichListRow(db, toOutput(session, row))),
     );
@@ -276,9 +276,9 @@ function listTasks(args: Record<string, unknown>, ctx: CallerContext) {
   return rows;
 }
 
-function getTask(args: Record<string, unknown>, ctx: CallerContext) {
+async function getTask(args: Record<string, unknown>, ctx: CallerContext) {
   const id = taskId(args);
-  for (const session of selectedSessions(args, ctx)) {
+  for (const session of await selectedSessions(args, ctx)) {
     const found = withInbound(session, (db) => {
       const row = selectTask(db, id);
       if (!row) return undefined;
@@ -292,29 +292,32 @@ function getTask(args: Record<string, unknown>, ctx: CallerContext) {
         origin_session_id: content.originSessionId,
         completed_runs: stats.runs,
         failed_runs: stats.failed_runs,
-        recent_log: tailRunLog(session.agent_group_id, seriesKey),
+        series_key: seriesKey,
       };
     });
-    if (found) return found;
+    if (found) {
+      const { series_key, ...output } = found;
+      return { ...output, recent_log: await tailRunLog(session.agent_group_id, series_key) };
+    }
   }
   throw new Error(`task not found: ${id}`);
 }
 
-function mutateTask(
+async function mutateTask(
   args: Record<string, unknown>,
   ctx: CallerContext,
   fn: (db: Database.Database, id: string) => number,
 ) {
   const id = taskId(args);
   let touched = 0;
-  for (const session of selectedSessions(args, ctx)) {
+  for (const session of await selectedSessions(args, ctx)) {
     touched += withInbound(session, (db) => fn(db, id)) ?? 0;
   }
   if (touched === 0) throw new Error(`no live task matched: ${id}`);
   return { series_id: id, touched };
 }
 
-function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
+async function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   const id = taskId(args);
   const update: TaskUpdate = {};
   if (typeof args.prompt === 'string') update.prompt = args.prompt;
@@ -328,7 +331,7 @@ function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   let ownerGroup: string | undefined;
   let currentScript: string | null = null;
   if (args.process_after !== undefined || recurrence !== undefined) {
-    for (const session of selectedSessions(args, ctx)) {
+    for (const session of await selectedSessions(args, ctx)) {
       const row = withInbound(session, (db) => selectTask(db, id));
       if (row) {
         ownerGroup = session.agent_group_id;
@@ -337,7 +340,7 @@ function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
       }
     }
   }
-  const tz = ownerGroup ? resolveGroupTimezone(ownerGroup) : TIMEZONE;
+  const tz = ownerGroup ? await resolveGroupTimezone(ownerGroup) : TIMEZONE;
 
   if (args.process_after !== undefined) update.processAfter = parseProcessAfter(args.process_after, tz);
   if (recurrence !== undefined) {
@@ -353,20 +356,20 @@ function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   if (fields.length === 0) throw new Error('nothing to update');
 
   let touched = 0;
-  for (const session of selectedSessions(args, ctx)) {
+  for (const session of await selectedSessions(args, ctx)) {
     touched += withInbound(session, (db) => updateTask(db, id, update)) ?? 0;
   }
   if (touched === 0) throw new Error(`no live task matched: ${id}`);
   return { series_id: id, touched, fields };
 }
 
-function cancelTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
+async function cancelTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   if (!bool(args.all)) {
-    return mutateTask(args, ctx, cancelTask);
+    return await mutateTask(args, ctx, cancelTask);
   }
 
   let touched = 0;
-  for (const session of selectedSessions(args, ctx)) {
+  for (const session of await selectedSessions(args, ctx)) {
     touched += withInbound(session, cancelAllTasks) ?? 0;
   }
   return { cancelled: touched };
@@ -379,9 +382,9 @@ function cancelTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
  * `update --process-after now`, it neither consumes a one-shot nor force-advances
  * a recurring series' armed occurrence, so it is safe for testing a task.
  */
-function runTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
+async function runTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   const id = taskId(args);
-  for (const session of selectedSessions(args, ctx)) {
+  for (const session of await selectedSessions(args, ctx)) {
     const fired = withInbound(session, (db) => {
       const row = selectTask(db, id);
       if (!row) return undefined;

--- a/src/cli/resources/wirings.test.ts
+++ b/src/cli/resources/wirings.test.ts
@@ -45,8 +45,8 @@ const neverDeclared: ChannelDefaults = {
 };
 registerChannelAdapter('neverchan', { factory: () => null, defaults: neverDeclared });
 
-function mg(id: string, channelType: string, isGroup: number) {
-  createMessagingGroup({
+async function mg(id: string, channelType: string, isGroup: number): Promise<void> {
+  await createMessagingGroup({
     id,
     channel_type: channelType,
     platform_id: `pid-${id}`,
@@ -65,23 +65,23 @@ async function update(args: Record<string, unknown>) {
   return (await lookup('wirings-update')!.handler(args, hostCtx)) as Record<string, unknown>;
 }
 
-beforeEach(() => {
-  runMigrations(initTestDb());
-  createAgentGroup({
+beforeEach(async () => {
+  await runMigrations(await initTestDb());
+  await createAgentGroup({
     id: 'ag-1',
     name: 'Helper Bot',
     folder: 'helper-bot',
     agent_provider: null,
     created_at: now(),
   });
-  mg('mg-dm', 'declchan', 0);
-  mg('mg-group', 'declchan', 1);
-  mg('mg-never', 'neverchan', 1);
-  mg('mg-stale', 'stalechan', 1); // no declaration anywhere
+  await mg('mg-dm', 'declchan', 0);
+  await mg('mg-group', 'declchan', 1);
+  await mg('mg-never', 'neverchan', 1);
+  await mg('mg-stale', 'stalechan', 1); // no declaration anywhere
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 it('declares its agent-group scope field', () => {
@@ -98,7 +98,7 @@ describe('wirings-create — declaration-derived defaults', () => {
   it('fills group defaults from the declaration', async () => {
     const row = await create({ messaging_group_id: 'mg-group', agent_group_id: 'ag-1' });
     expect(row.engage_mode).toBe('mention-sticky');
-    const persisted = getMessagingGroupAgent(row.id as string);
+    const persisted = await getMessagingGroupAgent(row.id as string);
     expect(persisted!.engage_pattern).toBeNull();
   });
 
@@ -152,14 +152,14 @@ describe('wirings-create — validation', () => {
 describe('wirings — threads and priority columns', () => {
   it('omitted --threads stores NULL (inherit declaration)', async () => {
     const row = await create({ messaging_group_id: 'mg-group', agent_group_id: 'ag-1' });
-    expect(getMessagingGroupAgent(row.id as string)!.threads).toBeNull();
+    expect((await getMessagingGroupAgent(row.id as string))!.threads).toBeNull();
   });
 
   it('--threads true/false stores 1/0', async () => {
     const on = await create({ messaging_group_id: 'mg-group', agent_group_id: 'ag-1', threads: 'true' });
-    expect(getMessagingGroupAgent(on.id as string)!.threads).toBe(1);
+    expect((await getMessagingGroupAgent(on.id as string))!.threads).toBe(1);
     const off = await create({ messaging_group_id: 'mg-dm', agent_group_id: 'ag-1', threads: 'false' });
-    expect(getMessagingGroupAgent(off.id as string)!.threads).toBe(0);
+    expect((await getMessagingGroupAgent(off.id as string))!.threads).toBe(0);
   });
 
   it('rejects a non-boolean --threads value', async () => {
@@ -212,7 +212,7 @@ describe('wirings-update — same validation as create', () => {
   it('allows unrelated updates to a legacy pattern row with NULL engage_pattern', async () => {
     // Rows created on main before engage_pattern defaults existed: pattern
     // mode + NULL pattern, which the router evaluates as match-all.
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-legacy',
       messaging_group_id: 'mg-stale',
       agent_group_id: 'ag-1',
@@ -228,7 +228,7 @@ describe('wirings-update — same validation as create', () => {
     const updated = (await update({ id: 'mga-legacy', priority: '5' })) as { priority: number };
     expect(updated.priority).toBe(5);
     // The pattern fields stay untouched — no silent backfill.
-    expect(getMessagingGroupAgent('mga-legacy')!.engage_pattern).toBeNull();
+    expect((await getMessagingGroupAgent('mga-legacy'))!.engage_pattern).toBeNull();
 
     // But actually changing the pattern fields to an invalid combination
     // still rejects.

--- a/src/cli/resources/wirings.ts
+++ b/src/cli/resources/wirings.ts
@@ -31,8 +31,8 @@ const CREATE_ENUMS: Record<string, string[]> = {
   session_mode: ['shared', 'per-thread', 'agent-shared'],
 };
 
-function requireMessagingGroup(id: unknown): MessagingGroup {
-  const mg = getMessagingGroup(String(id));
+async function requireMessagingGroup(id: unknown): Promise<MessagingGroup> {
+  const mg = await getMessagingGroup(String(id));
   if (!mg) throw new Error(`messaging group not found: ${id}`);
   return mg;
 }
@@ -134,8 +134,8 @@ registerResource({
   // handler (declaration-aware defaults, companion destination row, live
   // session projection) — keep them in sync with genericCreate's semantics.
   operations: { list: 'open', get: 'open', update: 'approval', delete: 'approval' },
-  preUpdate: (updates, current) => {
-    const mg = requireMessagingGroup(current.messaging_group_id);
+  preUpdate: async (updates, current) => {
+    const mg = await requireMessagingGroup(current.messaging_group_id);
     if (updates.threads !== undefined) updates.threads = normalizeThreads(updates.threads);
 
     const merged: EngageValues = { ...current, ...updates };
@@ -177,7 +177,11 @@ registerResource({
           if (!channelType || !platformId) {
             throw new Error('provide --messaging-group-id, or --channel-type and --platform-id to resolve it');
           }
-          const mg = getMessagingGroupByPlatform(channelType, platformId, (args.instance as string) ?? channelType);
+          const mg = await getMessagingGroupByPlatform(
+            channelType,
+            platformId,
+            (args.instance as string) ?? channelType,
+          );
           if (!mg) throw new Error(`no messaging group for ${channelType} ${platformId} — create it first`);
           mgId = mg.id;
         }
@@ -187,14 +191,14 @@ registerResource({
         if (!agId) {
           const ref = args.agent_group as string;
           if (!ref) throw new Error('provide --agent-group-id or --agent-group <folder>');
-          const ag = getAgentGroup(ref) ?? getAgentGroupByFolder(ref);
+          const ag = (await getAgentGroup(ref)) ?? (await getAgentGroupByFolder(ref));
           if (!ag) throw new Error(`no agent group "${ref}" (by id or folder)`);
           agId = ag.id;
         }
 
         // Idempotent: a wiring for this pair already exists → return it
         // (defaults/validation/side-effects are skipped — nothing new is written).
-        const existing = getMessagingGroupAgentByPair(mgId, agId);
+        const existing = await getMessagingGroupAgentByPair(mgId, agId);
         if (existing) return existing;
 
         // Pass-1 parity: only defined keys enter `values` (an unset
@@ -218,7 +222,7 @@ registerResource({
         if (args.priority !== undefined) values.priority = Number(args.priority);
 
         // Pass-2 parity: context-aware defaults + cross-column validation.
-        const mg = requireMessagingGroup(values.messaging_group_id);
+        const mg = await requireMessagingGroup(values.messaging_group_id);
         if (values.threads !== undefined) values.threads = normalizeThreads(values.threads);
 
         const channelKey = mg.instance ?? mg.channel_type;
@@ -227,7 +231,7 @@ registerResource({
         // change ncl's creation defaults for adapters without a declaration.
         if (values.engage_mode === undefined) {
           if (hasDeclaredChannelDefaults(channelKey, mg.channel_type)) {
-            const ag = getAgentGroup(String(values.agent_group_id));
+            const ag = await getAgentGroup(String(values.agent_group_id));
             if (!ag) throw new Error(`agent group not found: ${values.agent_group_id}`);
             const resolved = resolveWiringDefaults(channelKey, mg.is_group === 1, ag.name, mg.channel_type);
             values.engage_mode = resolved.engage_mode;
@@ -264,12 +268,13 @@ registerResource({
         const colNames = Object.keys(values);
         const placeholders = colNames.map((c) => `@${c}`);
         const db = getDb();
-        db.transaction(() => {
-          db.prepare(
+        await db.transaction(async () => {
+          await db.run(
             `INSERT INTO messaging_group_agents (${colNames.join(', ')}) VALUES (${placeholders.join(', ')})`,
-          ).run(values);
-          ensureAgentDestinationForWiring(values as unknown as MessagingGroupAgent);
-        })();
+            values,
+          );
+          await ensureAgentDestinationForWiring(values as unknown as MessagingGroupAgent);
+        });
 
         // postCommit parity — live-refresh with `ncl destinations add`: the
         // transaction above only wrote the central `agent_destinations` row.

--- a/src/command-gate.test.ts
+++ b/src/command-gate.test.ts
@@ -14,70 +14,76 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function seedAgentGroup(id: string): void {
-  createAgentGroup({ id, name: id.toUpperCase(), folder: id, agent_provider: null, created_at: now() });
+async function seedAgentGroup(id: string): Promise<void> {
+  await createAgentGroup({ id, name: id.toUpperCase(), folder: id, agent_provider: null, created_at: now() });
 }
 
-function seedUser(id: string): void {
-  createUser({ id, kind: 'telegram', display_name: null, created_at: now() });
+async function seedUser(id: string): Promise<void> {
+  await createUser({ id, kind: 'telegram', display_name: null, created_at: now() });
 }
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
-  seedAgentGroup('ag-1');
-  seedAgentGroup('ag-2');
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
+  await seedAgentGroup('ag-1');
+  await seedAgentGroup('ag-2');
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 describe('filtered commands', () => {
-  it('drops /start before it reaches the container', () => {
-    expect(gateCommand('/start', 'telegram:1', 'ag-1')).toEqual({ action: 'filter' });
+  it('drops /start before it reaches the container', async () => {
+    expect(await gateCommand('/start', 'telegram:1', 'ag-1')).toEqual({ action: 'filter' });
   });
 
-  it('drops /start regardless of sender', () => {
-    expect(gateCommand('/start', null, 'ag-1')).toEqual({ action: 'filter' });
+  it('drops /start regardless of sender', async () => {
+    expect(await gateCommand('/start', null, 'ag-1')).toEqual({ action: 'filter' });
   });
 });
 
 describe('admin gating goes through roles', () => {
-  it('denies an admin command from a non-admin user', () => {
-    expect(gateCommand('/clear', 'telegram:nobody', 'ag-1')).toEqual({ action: 'deny', command: '/clear' });
+  it('denies an admin command from a non-admin user', async () => {
+    expect(await gateCommand('/clear', 'telegram:nobody', 'ag-1')).toEqual({ action: 'deny', command: '/clear' });
   });
 
-  it('denies an admin command with no sender', () => {
-    expect(gateCommand('/clear', null, 'ag-1')).toEqual({ action: 'deny', command: '/clear' });
+  it('denies an admin command with no sender', async () => {
+    expect(await gateCommand('/clear', null, 'ag-1')).toEqual({ action: 'deny', command: '/clear' });
   });
 
-  it('allows an admin command from an owner', () => {
-    seedUser('telegram:owner');
-    grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-    expect(gateCommand('/clear', 'telegram:owner', 'ag-1')).toEqual({ action: 'pass' });
+  it('allows an admin command from an owner', async () => {
+    await seedUser('telegram:owner');
+    await grantRole({
+      user_id: 'telegram:owner',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
+    expect(await gateCommand('/clear', 'telegram:owner', 'ag-1')).toEqual({ action: 'pass' });
   });
 
-  it('allows an admin command from a scoped admin of the group', () => {
-    seedUser('telegram:admin');
-    grantRole({
+  it('allows an admin command from a scoped admin of the group', async () => {
+    await seedUser('telegram:admin');
+    await grantRole({
       user_id: 'telegram:admin',
       role: 'admin',
       agent_group_id: 'ag-1',
       granted_by: null,
       granted_at: now(),
     });
-    expect(gateCommand('/clear', 'telegram:admin', 'ag-1')).toEqual({ action: 'pass' });
-    expect(gateCommand('/clear', 'telegram:admin', 'ag-2')).toEqual({ action: 'deny', command: '/clear' });
+    expect(await gateCommand('/clear', 'telegram:admin', 'ag-1')).toEqual({ action: 'pass' });
+    expect(await gateCommand('/clear', 'telegram:admin', 'ag-2')).toEqual({ action: 'deny', command: '/clear' });
   });
 });
 
 describe('normal messages pass through', () => {
-  it('passes a plain message', () => {
-    expect(gateCommand('hello there', 'telegram:1', 'ag-1')).toEqual({ action: 'pass' });
+  it('passes a plain message', async () => {
+    expect(await gateCommand('hello there', 'telegram:1', 'ag-1')).toEqual({ action: 'pass' });
   });
 
-  it('passes an unknown slash command', () => {
-    expect(gateCommand('/whatever', 'telegram:1', 'ag-1')).toEqual({ action: 'pass' });
+  it('passes an unknown slash command', async () => {
+    expect(await gateCommand('/whatever', 'telegram:1', 'ag-1')).toEqual({ action: 'pass' });
   });
 });

--- a/src/command-gate.ts
+++ b/src/command-gate.ts
@@ -20,7 +20,7 @@ const ADMIN_COMMANDS = new Set(['/clear', '/compact', '/context', '/cost', '/fil
  * 'filter' for silently-dropped commands, 'deny' for unauthorized
  * admin commands.
  */
-export function gateCommand(content: string, userId: string | null, agentGroupId: string): GateResult {
+export async function gateCommand(content: string, userId: string | null, agentGroupId: string): Promise<GateResult> {
   let text: string;
   try {
     const parsed = JSON.parse(content);
@@ -36,7 +36,7 @@ export function gateCommand(content: string, userId: string | null, agentGroupId
   if (FILTERED_COMMANDS.has(command)) return { action: 'filter' };
 
   if (ADMIN_COMMANDS.has(command)) {
-    if (isAdmin(userId, agentGroupId)) {
+    if (await isAdmin(userId, agentGroupId)) {
       return { action: 'pass' };
     }
     return { action: 'deny', command };
@@ -46,7 +46,7 @@ export function gateCommand(content: string, userId: string | null, agentGroupId
   return { action: 'pass' };
 }
 
-function isAdmin(userId: string | null, agentGroupId: string): boolean {
+async function isAdmin(userId: string | null, agentGroupId: string): Promise<boolean> {
   if (!userId) return false;
   return hasAdminPrivilege(userId, agentGroupId);
 }

--- a/src/container-config.test.ts
+++ b/src/container-config.test.ts
@@ -34,34 +34,34 @@ const GROUP: AgentGroup = {
 };
 
 describe('resolveGroupTimezone', () => {
-  beforeEach(() => {
-    runMigrations(initTestDb());
-    createAgentGroup(GROUP);
-    ensureContainerConfig(GROUP.id);
+  beforeEach(async () => {
+    await runMigrations(await initTestDb());
+    await createAgentGroup(GROUP);
+    await ensureContainerConfig(GROUP.id);
   });
-  afterEach(() => {
-    closeDb();
-  });
-
-  it('returns the install-global timezone when no override is set', () => {
-    expect(resolveGroupTimezone(GROUP.id)).toBe(TIMEZONE);
-    expect(resolveGroupTimezone('ag-no-such-group')).toBe(TIMEZONE);
+  afterEach(async () => {
+    await closeDb();
   });
 
-  it('returns a valid override, and falls back to global on an invalid stored value', () => {
-    updateContainerConfigScalars(GROUP.id, { timezone: 'Asia/Tokyo' });
-    expect(resolveGroupTimezone(GROUP.id)).toBe('Asia/Tokyo');
-
-    updateContainerConfigScalars(GROUP.id, { timezone: 'Not/AZone' });
-    expect(resolveGroupTimezone(GROUP.id)).toBe(TIMEZONE);
+  it('returns the install-global timezone when no override is set', async () => {
+    expect(await resolveGroupTimezone(GROUP.id)).toBe(TIMEZONE);
+    expect(await resolveGroupTimezone('ag-no-such-group')).toBe(TIMEZONE);
   });
 
-  it('configFromDb ships a valid timezone to the container and drops an invalid one', () => {
-    updateContainerConfigScalars(GROUP.id, { timezone: 'Asia/Tokyo' });
-    expect(configFromDb(getContainerConfig(GROUP.id)!, GROUP).timezone).toBe('Asia/Tokyo');
+  it('returns a valid override, and falls back to global on an invalid stored value', async () => {
+    await updateContainerConfigScalars(GROUP.id, { timezone: 'Asia/Tokyo' });
+    expect(await resolveGroupTimezone(GROUP.id)).toBe('Asia/Tokyo');
 
-    updateContainerConfigScalars(GROUP.id, { timezone: 'Not/AZone' });
-    expect(configFromDb(getContainerConfig(GROUP.id)!, GROUP).timezone).toBeUndefined();
+    await updateContainerConfigScalars(GROUP.id, { timezone: 'Not/AZone' });
+    expect(await resolveGroupTimezone(GROUP.id)).toBe(TIMEZONE);
+  });
+
+  it('configFromDb ships a valid timezone to the container and drops an invalid one', async () => {
+    await updateContainerConfigScalars(GROUP.id, { timezone: 'Asia/Tokyo' });
+    expect(configFromDb((await getContainerConfig(GROUP.id))!, GROUP).timezone).toBe('Asia/Tokyo');
+
+    await updateContainerConfigScalars(GROUP.id, { timezone: 'Not/AZone' });
+    expect(configFromDb((await getContainerConfig(GROUP.id))!, GROUP).timezone).toBeUndefined();
   });
 });
 

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -258,8 +258,8 @@ export interface ContainerConfig {
  * flip scheduling to UTC — an invalid override falls back to the global tz,
  * same as no override.
  */
-export function resolveGroupTimezone(agentGroupId: string): string {
-  const tz = getContainerConfig(agentGroupId)?.timezone;
+export async function resolveGroupTimezone(agentGroupId: string): Promise<string> {
+  const tz = (await getContainerConfig(agentGroupId))?.timezone;
   return tz && isValidTimezone(tz) ? tz : TIMEZONE;
 }
 
@@ -338,11 +338,11 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
  * container always sees fresh config. Returns the `ContainerConfig` for
  * use by the caller (buildMounts, buildContainerArgs, etc.).
  */
-export function materializeContainerJson(agentGroupId: string): ContainerConfig {
-  const group = getAgentGroup(agentGroupId);
+export async function materializeContainerJson(agentGroupId: string): Promise<ContainerConfig> {
+  const group = await getAgentGroup(agentGroupId);
   if (!group) throw new Error(`Agent group not found: ${agentGroupId}`);
 
-  const row = getContainerConfig(agentGroupId);
+  const row = await getContainerConfig(agentGroupId);
   if (!row) throw new Error(`Container config not found for agent group: ${agentGroupId}`);
 
   const config = configFromDb(row, group);

--- a/src/container-restart.test.ts
+++ b/src/container-restart.test.ts
@@ -49,53 +49,53 @@ function makeSession(id: string, agentGroupId: string, status = 'active') {
 // --- Tests ---
 
 describe('restartAgentGroupContainers', () => {
-  it('skips sessions without a running container', () => {
+  it('skips sessions without a running container', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1'), makeSession('s2', 'g1')]);
     mockIsContainerRunning.mockReturnValue(false);
 
-    const count = restartAgentGroupContainers('g1', 'test');
+    const count = await restartAgentGroupContainers('g1', 'test');
 
     expect(count).toBe(0);
     expect(mockKillContainer).not.toHaveBeenCalled();
     expect(mockWriteSessionMessage).not.toHaveBeenCalled();
   });
 
-  it('skips non-active sessions', () => {
+  it('skips non-active sessions', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1', 'closed')]);
     mockIsContainerRunning.mockReturnValue(true);
 
-    const count = restartAgentGroupContainers('g1', 'test');
+    const count = await restartAgentGroupContainers('g1', 'test');
 
     expect(count).toBe(0);
     expect(mockKillContainer).not.toHaveBeenCalled();
   });
 
-  it('kills running containers and returns count', () => {
+  it('kills running containers and returns count', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1'), makeSession('s2', 'g1')]);
     mockIsContainerRunning.mockImplementation((id) => id === 's1');
 
-    const count = restartAgentGroupContainers('g1', 'test');
+    const count = await restartAgentGroupContainers('g1', 'test');
 
     expect(count).toBe(1);
     expect(mockKillContainer).toHaveBeenCalledTimes(1);
     expect(mockKillContainer).toHaveBeenCalledWith('s1', 'test', undefined);
   });
 
-  it('does not write wake message when wakeMessage is omitted', () => {
+  it('does not write wake message when wakeMessage is omitted', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1')]);
     mockIsContainerRunning.mockReturnValue(true);
 
-    restartAgentGroupContainers('g1', 'test');
+    await restartAgentGroupContainers('g1', 'test');
 
     expect(mockWriteSessionMessage).not.toHaveBeenCalled();
     expect(mockKillContainer).toHaveBeenCalledWith('s1', 'test', undefined);
   });
 
-  it('writes on_wake message and passes onExit callback when wakeMessage is provided', () => {
+  it('writes on_wake message and passes onExit callback when wakeMessage is provided', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1')]);
     mockIsContainerRunning.mockReturnValue(true);
 
-    restartAgentGroupContainers('g1', 'test', 'Resuming.');
+    await restartAgentGroupContainers('g1', 'test', 'Resuming.');
 
     // Should write an on-wake message
     expect(mockWriteSessionMessage).toHaveBeenCalledTimes(1);
@@ -111,28 +111,28 @@ describe('restartAgentGroupContainers', () => {
     expect(typeof onExit).toBe('function');
   });
 
-  it('onExit callback calls wakeContainer with refreshed session', () => {
+  it('onExit callback calls wakeContainer with refreshed session', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1')]);
     mockIsContainerRunning.mockReturnValue(true);
     const freshSession = makeSession('s1', 'g1');
     mockGetSession.mockReturnValue(freshSession);
 
-    restartAgentGroupContainers('g1', 'test', 'Resuming.');
+    await restartAgentGroupContainers('g1', 'test', 'Resuming.');
 
     // Simulate container exit by calling the onExit callback
     const onExit = mockKillContainer.mock.calls[0][2] as () => void;
     onExit();
 
     expect(mockGetSession).toHaveBeenCalledWith('s1');
-    expect(mockWakeContainer).toHaveBeenCalledWith(freshSession);
+    await vi.waitFor(() => expect(mockWakeContainer).toHaveBeenCalledWith(freshSession));
   });
 
-  it('onExit callback does not wake if session no longer exists', () => {
+  it('onExit callback does not wake if session no longer exists', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1')]);
     mockIsContainerRunning.mockReturnValue(true);
     mockGetSession.mockReturnValue(undefined);
 
-    restartAgentGroupContainers('g1', 'test', 'Resuming.');
+    await restartAgentGroupContainers('g1', 'test', 'Resuming.');
 
     const onExit = mockKillContainer.mock.calls[0][2] as () => void;
     onExit();
@@ -140,11 +140,11 @@ describe('restartAgentGroupContainers', () => {
     expect(mockWakeContainer).not.toHaveBeenCalled();
   });
 
-  it('handles multiple running sessions with wake message', () => {
+  it('handles multiple running sessions with wake message', async () => {
     mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'g1'), makeSession('s2', 'g1')]);
     mockIsContainerRunning.mockReturnValue(true);
 
-    const count = restartAgentGroupContainers('g1', 'test', 'Config updated.');
+    const count = await restartAgentGroupContainers('g1', 'test', 'Config updated.');
 
     expect(count).toBe(2);
     expect(mockKillContainer).toHaveBeenCalledTimes(2);
@@ -155,7 +155,7 @@ describe('restartAgentGroupContainers', () => {
     expect(mockWriteSessionMessage.mock.calls[1][1]).toBe('s2');
   });
 
-  it('wakes even without a wake message when in-flight messages are pending', () => {
+  it('wakes even without a wake message when in-flight messages are pending', async () => {
     // A provider switch mid-conversation kills a container holding claimed
     // messages — without an immediate respawn those messages stay dark until
     // the next inbound or a slow sweep backoff.
@@ -163,12 +163,12 @@ describe('restartAgentGroupContainers', () => {
     mockIsContainerRunning.mockReturnValue(true);
     mockCountDueMessages.mockReturnValue(2);
 
-    restartAgentGroupContainers('ag1', 'provider switch');
+    await restartAgentGroupContainers('ag1', 'provider switch');
 
     const onExit = mockKillContainer.mock.calls[0][2] as () => void;
     expect(typeof onExit).toBe('function');
     mockGetSession.mockReturnValue(makeSession('s1', 'ag1'));
     onExit();
-    expect(mockWakeContainer).toHaveBeenCalled();
+    await vi.waitFor(() => expect(mockWakeContainer).toHaveBeenCalled());
   });
 });

--- a/src/container-restart.ts
+++ b/src/container-restart.ts
@@ -19,14 +19,18 @@ import { openInboundDb, writeSessionMessage } from './session-manager.js';
  * wakeContainer call on exit. Without it, containers are killed and
  * only come back on the next real user message.
  */
-export function restartAgentGroupContainers(agentGroupId: string, reason: string, wakeMessage?: string): number {
-  const sessions = getSessionsByAgentGroup(agentGroupId).filter(
+export async function restartAgentGroupContainers(
+  agentGroupId: string,
+  reason: string,
+  wakeMessage?: string,
+): Promise<number> {
+  const sessions = (await getSessionsByAgentGroup(agentGroupId)).filter(
     (s) => s.status === 'active' && isContainerRunning(s.id),
   );
 
   for (const session of sessions) {
     if (wakeMessage) {
-      writeSessionMessage(agentGroupId, session.id, {
+      await writeSessionMessage(agentGroupId, session.id, {
         id: `restart-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         kind: 'chat',
         timestamp: new Date().toISOString(),
@@ -51,8 +55,10 @@ export function restartAgentGroupContainers(agentGroupId: string, reason: string
       reason,
       wakeMessage || hasPending
         ? () => {
-            const s = getSession(session.id);
-            if (s) void wakeContainer(s);
+            void (async () => {
+              const s = await getSession(session.id);
+              if (s) await wakeContainer(s);
+            })();
           }
         : undefined,
     );

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -116,7 +116,7 @@ export function wakeContainer(session: Session): Promise<boolean> {
 }
 
 async function spawnContainer(session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) {
     log.error('Agent group not found', { agentGroupId: session.agent_group_id });
     return;
@@ -125,33 +125,33 @@ async function spawnContainer(session: Session): Promise<void> {
   // Refresh the destination map and current-thread routing so any admin
   // changes take effect on wake. Destinations come from the agent-to-agent
   // module — skip when the module isn't installed (table absent).
-  if (hasTable(getDb(), 'agent_destinations')) {
+  if (await hasTable(getDb(), 'agent_destinations')) {
     const { writeDestinations } = await import('./modules/agent-to-agent/write-destinations.js');
-    writeDestinations(agentGroup.id, session.id);
+    await writeDestinations(agentGroup.id, session.id);
   }
-  writeSessionRouting(agentGroup.id, session.id);
+  await writeSessionRouting(agentGroup.id, session.id);
 
   // Materialize container.json from DB — writes fresh file and returns
   // the config object, threaded through provider resolution, buildMounts,
   // and buildContainerArgs so we don't re-read.
-  const containerConfig = materializeContainerJson(agentGroup.id);
+  const containerConfig = await materializeContainerJson(agentGroup.id);
 
   // Per-group filesystem state lives forever after first creation. Init is
   // idempotent: it only writes paths that don't already exist, so this call
   // is a no-op for groups that have spawned before. Runs before the provider
   // contribution so a surfaces-providing provider finds the group dir ready.
   const providerName = resolveProviderName(session.agent_provider, containerConfig.provider);
-  initGroupFilesystem(agentGroup, { provider: providerName });
+  await initGroupFilesystem(agentGroup, { provider: providerName });
 
   // Resolve the effective provider + any host-side contribution it declares
   // (extra mounts, env passthrough). Computed once and threaded through both
   // buildMounts and buildContainerArgs so side effects (mkdir, etc.) fire once.
-  const { provider, contribution } = resolveProviderContribution(session, agentGroup, containerConfig);
+  const { provider, contribution } = await resolveProviderContribution(session, agentGroup, containerConfig);
 
-  const mounts = buildMounts(agentGroup, session, containerConfig, provider, contribution);
+  const mounts = await buildMounts(agentGroup, session, containerConfig, provider, contribution);
   const containerName = `nanoclaw-v2-${agentGroup.folder}-${Date.now()}`;
   // OneCLI agent identifier is always the agent group id — stable across
-  // sessions and reversible via getAgentGroup() for approval routing.
+  // sessions and reversible via await getAgentGroup() for approval routing.
   const agentIdentifier = agentGroup.id;
   const args = await buildContainerArgs(
     mounts,
@@ -174,7 +174,7 @@ async function spawnContainer(session: Session): Promise<void> {
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
   activeContainers.set(session.id, { process: container, containerName, startedAtMs: Date.now() });
-  markContainerRunning(session.id);
+  await markContainerRunning(session.id);
 
   // Log stderr. A container that dies at boot (unknown provider, missing
   // binary, bad config) explains itself only here — and debug is below the
@@ -199,7 +199,7 @@ async function spawnContainer(session: Session): Promise<void> {
 
   container.on('close', (code) => {
     activeContainers.delete(session.id);
-    markContainerStopped(session.id);
+    void markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     // code null = killed by signal (normal shutdown path), not a boot failure.
     if (code !== 0 && code !== null && stderrTail.length > 0) {
@@ -211,7 +211,7 @@ async function spawnContainer(session: Session): Promise<void> {
 
   container.on('error', (err) => {
     activeContainers.delete(session.id);
-    markContainerStopped(session.id);
+    void markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     log.error('Container spawn error', { sessionId: session.id, err });
   });
@@ -273,15 +273,15 @@ export function hardeningArgs(pidsLimit: string): string[] {
   return args;
 }
 
-function resolveProviderContribution(
+async function resolveProviderContribution(
   session: Session,
   agentGroup: AgentGroup,
   containerConfig: import('./container-config.js').ContainerConfig,
-): { provider: string; contribution: ProviderContainerContribution } {
+): Promise<{ provider: string; contribution: ProviderContainerContribution }> {
   const provider = resolveProviderName(session.agent_provider, containerConfig.provider);
   const fn = getProviderContainerConfig(provider);
   const contribution = fn
-    ? fn({
+    ? await fn({
         sessionDir: sessionDir(agentGroup.id, session.id),
         agentGroupId: agentGroup.id,
         groupDir: path.resolve(GROUPS_DIR, agentGroup.folder),
@@ -292,13 +292,13 @@ function resolveProviderContribution(
   return { provider, contribution };
 }
 
-export function buildMounts(
+export async function buildMounts(
   agentGroup: AgentGroup,
   session: Session,
   containerConfig: import('./container-config.js').ContainerConfig,
   provider: string,
   providerContribution: ProviderContainerContribution,
-): VolumeMount[] {
+): Promise<VolumeMount[]> {
   const projectRoot = process.cwd();
 
   // Default agent surfaces (composed project doc, skill links, provider state
@@ -313,7 +313,7 @@ export function buildMounts(
 
     // Compose CLAUDE.md fresh every spawn from the shared base, enabled skill
     // fragments, and MCP server instructions. See `claude-md-compose.ts`.
-    composeGroupClaudeMd(agentGroup);
+    await composeGroupClaudeMd(agentGroup);
   }
 
   const mounts: VolumeMount[] = [];
@@ -561,10 +561,10 @@ const execAsync = promisify(exec);
 
 /** Build a per-agent-group Docker image with custom packages. */
 export async function buildAgentGroupImage(agentGroupId: string): Promise<void> {
-  const agentGroup = getAgentGroup(agentGroupId);
+  const agentGroup = await getAgentGroup(agentGroupId);
   if (!agentGroup) throw new Error('Agent group not found');
 
-  const configRow = getContainerConfig(agentGroup.id);
+  const configRow = await getContainerConfig(agentGroup.id);
   if (!configRow) throw new Error('Container config not found');
   const aptPackages = JSON.parse(configRow.packages_apt) as string[];
   const npmPackages = JSON.parse(configRow.packages_npm) as string[];
@@ -630,7 +630,7 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
   }
 
   // Store the image tag in the DB
-  updateContainerConfigScalars(agentGroup.id, { image_tag: imageTag });
+  await updateContainerConfigScalars(agentGroup.id, { image_tag: imageTag });
 
   log.info('Per-agent-group image built', { agentGroupId, imageTag });
 }

--- a/src/db/agent-groups.ts
+++ b/src/db/agent-groups.ts
@@ -1,28 +1,30 @@
 import type { AgentGroup } from '../types.js';
 import { getDb } from './connection.js';
 
-export function createAgentGroup(group: AgentGroup): void {
-  getDb()
-    .prepare(
-      `INSERT INTO agent_groups (id, name, folder, agent_provider, created_at)
-       VALUES (@id, @name, @folder, @agent_provider, @created_at)`,
-    )
-    .run(group);
+export async function createAgentGroup(group: AgentGroup): Promise<void> {
+  await getDb().run(
+    `INSERT INTO agent_groups (id, name, folder, agent_provider, created_at)
+     VALUES (@id, @name, @folder, @agent_provider, @created_at)`,
+    group,
+  );
 }
 
-export function getAgentGroup(id: string): AgentGroup | undefined {
-  return getDb().prepare('SELECT * FROM agent_groups WHERE id = ?').get(id) as AgentGroup | undefined;
+export async function getAgentGroup(id: string): Promise<AgentGroup | undefined> {
+  return getDb().get<AgentGroup>('SELECT * FROM agent_groups WHERE id = ?', id);
 }
 
-export function getAgentGroupByFolder(folder: string): AgentGroup | undefined {
-  return getDb().prepare('SELECT * FROM agent_groups WHERE folder = ?').get(folder) as AgentGroup | undefined;
+export async function getAgentGroupByFolder(folder: string): Promise<AgentGroup | undefined> {
+  return getDb().get<AgentGroup>('SELECT * FROM agent_groups WHERE folder = ?', folder);
 }
 
-export function getAllAgentGroups(): AgentGroup[] {
-  return getDb().prepare('SELECT * FROM agent_groups ORDER BY name').all() as AgentGroup[];
+export async function getAllAgentGroups(): Promise<AgentGroup[]> {
+  return getDb().all<AgentGroup>('SELECT * FROM agent_groups ORDER BY name');
 }
 
-export function updateAgentGroup(id: string, updates: Partial<Pick<AgentGroup, 'name' | 'agent_provider'>>): void {
+export async function updateAgentGroup(
+  id: string,
+  updates: Partial<Pick<AgentGroup, 'name' | 'agent_provider'>>,
+): Promise<void> {
   const fields: string[] = [];
   const values: Record<string, unknown> = { id };
 
@@ -34,11 +36,9 @@ export function updateAgentGroup(id: string, updates: Partial<Pick<AgentGroup, '
   }
   if (fields.length === 0) return;
 
-  getDb()
-    .prepare(`UPDATE agent_groups SET ${fields.join(', ')} WHERE id = @id`)
-    .run(values);
+  await getDb().run(`UPDATE agent_groups SET ${fields.join(', ')} WHERE id = @id`, values);
 }
 
-export function deleteAgentGroup(id: string): void {
-  getDb().prepare('DELETE FROM agent_groups WHERE id = ?').run(id);
+export async function deleteAgentGroup(id: string): Promise<void> {
+  await getDb().run('DELETE FROM agent_groups WHERE id = ?', id);
 }

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -3,32 +3,36 @@ import fs from 'fs';
 import path from 'path';
 
 import { log } from '../log.js';
+import type { DbDriver } from './driver.js';
+import { SqliteDriver } from './drivers/sqlite.js';
 
-let _db: Database.Database | null = null;
+let _db: DbDriver | null = null;
 
-export function getDb(): Database.Database {
+export function getDb(): DbDriver {
   if (!_db) throw new Error('Database not initialized. Call initDb() first.');
   return _db;
 }
 
-export function initDb(dbPath: string): Database.Database {
+export async function initDb(dbPath: string): Promise<DbDriver> {
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-  _db = new Database(dbPath);
-  _db.pragma('journal_mode = WAL');
-  _db.pragma('foreign_keys = ON');
+  const raw = new Database(dbPath);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  _db = new SqliteDriver(raw);
   log.info('Central DB initialized', { path: dbPath });
   return _db;
 }
 
 /** For tests only — creates an in-memory DB and runs migrations. */
-export function initTestDb(): Database.Database {
-  _db = new Database(':memory:');
-  _db.pragma('foreign_keys = ON');
+export async function initTestDb(): Promise<DbDriver> {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  _db = new SqliteDriver(raw);
   return _db;
 }
 
-export function closeDb(): void {
-  _db?.close();
+export async function closeDb(): Promise<void> {
+  await _db?.close();
   _db = null;
 }
 
@@ -40,9 +44,6 @@ export function closeDb(): void {
  * table at runtime (next service start), and callers may run before
  * or after that boundary.
  */
-export function hasTable(db: Database.Database, name: string): boolean {
-  const row = db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1`).get(name) as
-    | { '1': number }
-    | undefined;
-  return row !== undefined;
+export async function hasTable(db: DbDriver, name: string): Promise<boolean> {
+  return db.hasTable(name);
 }

--- a/src/db/container-configs.test.ts
+++ b/src/db/container-configs.test.ts
@@ -14,59 +14,59 @@ import { runMigrations } from './migrations/index.js';
 import { createAgentGroup } from './agent-groups.js';
 import { ensureContainerConfig, getContainerConfig, updateContainerConfigScalars } from './container-configs.js';
 
-function makeGroup(id: string): void {
-  createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: new Date().toISOString() });
+async function makeGroup(id: string): Promise<void> {
+  await createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: new Date().toISOString() });
 }
 
 describe('ensureContainerConfig provider stamping', () => {
-  beforeEach(() => {
-    const db = initTestDb();
-    runMigrations(db);
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
   });
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
   });
 
-  it('stamps a non-default provider on a fresh row; claude is stored as NULL', () => {
-    makeGroup('ag-codex');
-    ensureContainerConfig('ag-codex', 'codex');
-    expect(getContainerConfig('ag-codex')?.provider).toBe('codex');
+  it('stamps a non-default provider on a fresh row; claude is stored as NULL', async () => {
+    await makeGroup('ag-codex');
+    await ensureContainerConfig('ag-codex', 'codex');
+    expect((await getContainerConfig('ag-codex'))?.provider).toBe('codex');
 
-    makeGroup('ag-claude');
-    ensureContainerConfig('ag-claude', 'claude');
-    expect(getContainerConfig('ag-claude')?.provider).toBeNull();
+    await makeGroup('ag-claude');
+    await ensureContainerConfig('ag-claude', 'claude');
+    expect((await getContainerConfig('ag-claude'))?.provider).toBeNull();
 
     // Casing is normalized to match what resolution lowercases to.
-    makeGroup('ag-cased');
-    ensureContainerConfig('ag-cased', 'Codex');
-    expect(getContainerConfig('ag-cased')?.provider).toBe('codex');
+    await makeGroup('ag-cased');
+    await ensureContainerConfig('ag-cased', 'Codex');
+    expect((await getContainerConfig('ag-cased'))?.provider).toBe('codex');
 
-    makeGroup('ag-cased-claude');
-    ensureContainerConfig('ag-cased-claude', 'Claude');
-    expect(getContainerConfig('ag-cased-claude')?.provider).toBeNull();
+    await makeGroup('ag-cased-claude');
+    await ensureContainerConfig('ag-cased-claude', 'Claude');
+    expect((await getContainerConfig('ag-cased-claude'))?.provider).toBeNull();
   });
 
-  it('never overwrites an existing row — existing groups are not flipped', () => {
-    makeGroup('ag-existing');
-    ensureContainerConfig('ag-existing', 'codex'); // existing group already on codex
-    expect(getContainerConfig('ag-existing')?.provider).toBe('codex');
+  it('never overwrites an existing row — existing groups are not flipped', async () => {
+    await makeGroup('ag-existing');
+    await ensureContainerConfig('ag-existing', 'codex'); // existing group already on codex
+    expect((await getContainerConfig('ag-existing'))?.provider).toBe('codex');
 
     // A later bare ensure (defensive re-init, or a changed instance default)
     // must NOT change it — INSERT OR IGNORE keeps the row frozen.
-    ensureContainerConfig('ag-existing');
-    expect(getContainerConfig('ag-existing')?.provider).toBe('codex');
+    await ensureContainerConfig('ag-existing');
+    expect((await getContainerConfig('ag-existing'))?.provider).toBe('codex');
   });
 
-  it('sets and clears the timezone override (NULL = follow the install default)', () => {
-    makeGroup('ag-tz');
-    ensureContainerConfig('ag-tz');
-    expect(getContainerConfig('ag-tz')?.timezone).toBeNull();
+  it('sets and clears the timezone override (NULL = follow the install default)', async () => {
+    await makeGroup('ag-tz');
+    await ensureContainerConfig('ag-tz');
+    expect((await getContainerConfig('ag-tz'))?.timezone).toBeNull();
 
-    updateContainerConfigScalars('ag-tz', { timezone: 'Asia/Tokyo' });
-    expect(getContainerConfig('ag-tz')?.timezone).toBe('Asia/Tokyo');
+    await updateContainerConfigScalars('ag-tz', { timezone: 'Asia/Tokyo' });
+    expect((await getContainerConfig('ag-tz'))?.timezone).toBe('Asia/Tokyo');
 
     // `ncl groups config update --timezone ""` maps to null — the clear path.
-    updateContainerConfigScalars('ag-tz', { timezone: null });
-    expect(getContainerConfig('ag-tz')?.timezone).toBeNull();
+    await updateContainerConfigScalars('ag-tz', { timezone: null });
+    expect((await getContainerConfig('ag-tz'))?.timezone).toBeNull();
   });
 });

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -14,21 +14,18 @@ const SCALAR_COLUMNS = new Set([
 ]);
 const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts']);
 
-export function getContainerConfig(agentGroupId: string): ContainerConfigRow | undefined {
-  return getDb().prepare('SELECT * FROM container_configs WHERE agent_group_id = ?').get(agentGroupId) as
-    | ContainerConfigRow
-    | undefined;
+export async function getContainerConfig(agentGroupId: string): Promise<ContainerConfigRow | undefined> {
+  return getDb().get<ContainerConfigRow>('SELECT * FROM container_configs WHERE agent_group_id = ?', agentGroupId);
 }
 
-export function getAllContainerConfigs(): ContainerConfigRow[] {
-  return getDb().prepare('SELECT * FROM container_configs').all() as ContainerConfigRow[];
+export async function getAllContainerConfigs(): Promise<ContainerConfigRow[]> {
+  return getDb().all<ContainerConfigRow>('SELECT * FROM container_configs');
 }
 
 /** Insert a new config row. Caller must supply all JSON fields (use defaults for empty). */
-export function createContainerConfig(config: ContainerConfigRow): void {
-  getDb()
-    .prepare(
-      `INSERT INTO container_configs (
+export async function createContainerConfig(config: ContainerConfigRow): Promise<void> {
+  await getDb().run(
+    `INSERT INTO container_configs (
         agent_group_id, provider, model, effort, image_tag, assistant_name,
         max_messages_per_prompt, skills, mcp_servers, packages_apt, packages_npm,
         additional_mounts, cli_scope, timezone, updated_at
@@ -37,8 +34,8 @@ export function createContainerConfig(config: ContainerConfigRow): void {
         @max_messages_per_prompt, @skills, @mcp_servers, @packages_apt, @packages_npm,
         @additional_mounts, @cli_scope, @timezone, @updated_at
       )`,
-    )
-    .run(config);
+    config,
+  );
 }
 
 /**
@@ -51,7 +48,7 @@ export function createContainerConfig(config: ContainerConfigRow): void {
  * `claude` and an absent value that resolves to claude are stored as NULL — the
  * column means "follows the built-in default", matching pre-feature rows.
  */
-export function ensureContainerConfig(agentGroupId: string, provider?: string | null): void {
+export async function ensureContainerConfig(agentGroupId: string, provider?: string | null): Promise<void> {
   // Single chokepoint for the instance default: a fresh row with no explicit
   // provider is stamped with DEFAULT_AGENT_PROVIDER, so every new-group creation
   // path inherits it without each having to remember. INSERT OR IGNORE keeps an
@@ -65,17 +62,18 @@ export function ensureContainerConfig(agentGroupId: string, provider?: string | 
   // column matches what resolution lowercases to.
   const normalized = (provider ?? DEFAULT_AGENT_PROVIDER).toLowerCase();
   const stamped = normalized && normalized !== 'claude' ? normalized : null;
-  getDb()
-    .prepare(
-      `INSERT INTO container_configs (agent_group_id, provider, updated_at)
+  await getDb().run(
+    `INSERT INTO container_configs (agent_group_id, provider, updated_at)
        VALUES (?, ?, ?)
        ON CONFLICT (agent_group_id) DO NOTHING`,
-    )
-    .run(agentGroupId, stamped, new Date().toISOString());
+    agentGroupId,
+    stamped,
+    new Date().toISOString(),
+  );
 }
 
 /** Update scalar fields on a config row. Only touches fields present in `updates`. */
-export function updateContainerConfigScalars(
+export async function updateContainerConfigScalars(
   agentGroupId: string,
   updates: Partial<
     Pick<
@@ -90,7 +88,7 @@ export function updateContainerConfigScalars(
       | 'timezone'
     >
   >,
-): void {
+): Promise<void> {
   const fields: string[] = [];
   const values: Record<string, unknown> = { agent_group_id: agentGroupId };
 
@@ -106,24 +104,25 @@ export function updateContainerConfigScalars(
   fields.push('updated_at = @updated_at');
   values.updated_at = new Date().toISOString();
 
-  getDb()
-    .prepare(`UPDATE container_configs SET ${fields.join(', ')} WHERE agent_group_id = @agent_group_id`)
-    .run(values);
+  await getDb().run(`UPDATE container_configs SET ${fields.join(', ')} WHERE agent_group_id = @agent_group_id`, values);
 }
 
 /** Overwrite a JSON column wholesale. Used for skills, mcp_servers, packages_*, additional_mounts. */
-export function updateContainerConfigJson(
+export async function updateContainerConfigJson(
   agentGroupId: string,
   column: 'skills' | 'mcp_servers' | 'packages_apt' | 'packages_npm' | 'additional_mounts',
   value: unknown,
-): void {
+): Promise<void> {
   if (!JSON_COLUMNS.has(column)) throw new Error(`Invalid JSON column: ${column}`);
   const now = new Date().toISOString();
-  getDb()
-    .prepare(`UPDATE container_configs SET ${column} = ?, updated_at = ? WHERE agent_group_id = ?`)
-    .run(JSON.stringify(value), now, agentGroupId);
+  await getDb().run(
+    `UPDATE container_configs SET ${column} = ?, updated_at = ? WHERE agent_group_id = ?`,
+    JSON.stringify(value),
+    now,
+    agentGroupId,
+  );
 }
 
-export function deleteContainerConfig(agentGroupId: string): void {
-  getDb().prepare('DELETE FROM container_configs WHERE agent_group_id = ?').run(agentGroupId);
+export async function deleteContainerConfig(agentGroupId: string): Promise<void> {
+  await getDb().run('DELETE FROM container_configs WHERE agent_group_id = ?', agentGroupId);
 }

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sqliteRaw } from './drivers/sqlite.js';
 
 import {
   initTestDb,
@@ -39,29 +40,29 @@ function now() {
   return new Date().toISOString();
 }
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 // ── Migrations ──
 
 describe('migrations', () => {
-  it('should be idempotent', () => {
-    const db = initTestDb();
-    runMigrations(db);
+  it('should be idempotent', async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
     // Running again should not throw
-    runMigrations(db);
+    await runMigrations(db);
   });
 
-  it('adds messaging_group_agents.threads as a nullable, default-free override column (019)', () => {
-    const db = initTestDb();
-    runMigrations(db);
-    const col = db
+  it('adds messaging_group_agents.threads as a nullable, default-free override column (019)', async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    const col = sqliteRaw(db)
       .prepare(
         `SELECT type, "notnull", dflt_value FROM pragma_table_info('messaging_group_agents') WHERE name = 'threads'`,
       )
@@ -74,11 +75,11 @@ describe('migrations', () => {
     expect(col!.dflt_value).toBeNull();
   });
 
-  it('persists approval card bodies for terminal rendering (021)', () => {
-    const db = initTestDb();
-    runMigrations(db);
+  it('persists approval card bodies for terminal rendering (021)', async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
     for (const table of ['pending_approvals', 'pending_channel_approvals', 'pending_sender_approvals']) {
-      const col = db
+      const col = sqliteRaw(db)
         .prepare(`SELECT type, "notnull", dflt_value FROM pragma_table_info(?) WHERE name = 'question'`)
         .get(table) as { type: string; notnull: number; dflt_value: string } | undefined;
       expect(col, table).toEqual({ type: 'TEXT', notnull: 1, dflt_value: "''" });
@@ -97,42 +98,42 @@ describe('agent groups', () => {
     created_at: now(),
   });
 
-  it('should create and retrieve', () => {
-    createAgentGroup(ag());
-    const result = getAgentGroup('ag-1');
+  it('should create and retrieve', async () => {
+    await createAgentGroup(ag());
+    const result = await getAgentGroup('ag-1');
     expect(result).toBeDefined();
     expect(result!.name).toBe('Test Agent');
     expect(result!.folder).toBe('test-agent');
   });
 
-  it('should find by folder', () => {
-    createAgentGroup(ag());
-    const result = getAgentGroupByFolder('test-agent');
+  it('should find by folder', async () => {
+    await createAgentGroup(ag());
+    const result = await getAgentGroupByFolder('test-agent');
     expect(result).toBeDefined();
     expect(result!.id).toBe('ag-1');
   });
 
-  it('should list all', () => {
-    createAgentGroup(ag());
-    createAgentGroup({ ...ag(), id: 'ag-2', name: 'Another', folder: 'another' });
-    expect(getAllAgentGroups()).toHaveLength(2);
+  it('should list all', async () => {
+    await createAgentGroup(ag());
+    await createAgentGroup({ ...ag(), id: 'ag-2', name: 'Another', folder: 'another' });
+    expect(await getAllAgentGroups()).toHaveLength(2);
   });
 
-  it('should update', () => {
-    createAgentGroup(ag());
-    updateAgentGroup('ag-1', { name: 'Updated' });
-    expect(getAgentGroup('ag-1')!.name).toBe('Updated');
+  it('should update', async () => {
+    await createAgentGroup(ag());
+    await updateAgentGroup('ag-1', { name: 'Updated' });
+    expect((await getAgentGroup('ag-1'))!.name).toBe('Updated');
   });
 
-  it('should delete', () => {
-    createAgentGroup(ag());
-    deleteAgentGroup('ag-1');
-    expect(getAgentGroup('ag-1')).toBeUndefined();
+  it('should delete', async () => {
+    await createAgentGroup(ag());
+    await deleteAgentGroup('ag-1');
+    expect(await getAgentGroup('ag-1')).toBeUndefined();
   });
 
-  it('should enforce unique folder', () => {
-    createAgentGroup(ag());
-    expect(() => createAgentGroup({ ...ag(), id: 'ag-dup' })).toThrow();
+  it('should enforce unique folder', async () => {
+    await createAgentGroup(ag());
+    await expect(createAgentGroup({ ...ag(), id: 'ag-dup' })).rejects.toThrow();
   });
 });
 
@@ -149,50 +150,50 @@ describe('messaging groups', () => {
     created_at: now(),
   });
 
-  it('should create and retrieve', () => {
-    createMessagingGroup(mg());
-    const result = getMessagingGroup('mg-1');
+  it('should create and retrieve', async () => {
+    await createMessagingGroup(mg());
+    const result = await getMessagingGroup('mg-1');
     expect(result).toBeDefined();
     expect(result!.channel_type).toBe('discord');
   });
 
-  it('should find by platform', () => {
-    createMessagingGroup(mg());
-    const result = getMessagingGroupByPlatform('discord', 'chan-123');
+  it('should find by platform', async () => {
+    await createMessagingGroup(mg());
+    const result = await getMessagingGroupByPlatform('discord', 'chan-123');
     expect(result).toBeDefined();
     expect(result!.id).toBe('mg-1');
   });
 
-  it('should enforce unique channel_type + platform_id', () => {
-    createMessagingGroup(mg());
-    expect(() => createMessagingGroup({ ...mg(), id: 'mg-dup' })).toThrow();
+  it('should enforce unique channel_type + platform_id', async () => {
+    await createMessagingGroup(mg());
+    await expect(createMessagingGroup({ ...mg(), id: 'mg-dup' })).rejects.toThrow();
   });
 
-  it('should update', () => {
-    createMessagingGroup(mg());
-    updateMessagingGroup('mg-1', { name: 'Updated' });
-    expect(getMessagingGroup('mg-1')!.name).toBe('Updated');
+  it('should update', async () => {
+    await createMessagingGroup(mg());
+    await updateMessagingGroup('mg-1', { name: 'Updated' });
+    expect((await getMessagingGroup('mg-1'))!.name).toBe('Updated');
   });
 
-  it('should delete', () => {
-    createMessagingGroup(mg());
-    deleteMessagingGroup('mg-1');
-    expect(getMessagingGroup('mg-1')).toBeUndefined();
+  it('should delete', async () => {
+    await createMessagingGroup(mg());
+    await deleteMessagingGroup('mg-1');
+    expect(await getMessagingGroup('mg-1')).toBeUndefined();
   });
 });
 
 // ── Messaging Group Agents ──
 
 describe('messaging group agents', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'chan-1',
@@ -216,77 +217,77 @@ describe('messaging group agents', () => {
     created_at: now(),
   });
 
-  it('should create and list by messaging group', () => {
-    createMessagingGroupAgent(mga());
-    const results = getMessagingGroupAgents('mg-1');
+  it('should create and list by messaging group', async () => {
+    await createMessagingGroupAgent(mga());
+    const results = await getMessagingGroupAgents('mg-1');
     expect(results).toHaveLength(1);
     expect(results[0].agent_group_id).toBe('ag-1');
   });
 
-  it('should order by priority descending', () => {
-    createMessagingGroupAgent(mga());
-    createAgentGroup({
+  it('should order by priority descending', async () => {
+    await createMessagingGroupAgent(mga());
+    await createAgentGroup({
       id: 'ag-2',
       name: 'Agent2',
       folder: 'agent2',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroupAgent({ ...mga(), id: 'mga-2', agent_group_id: 'ag-2', priority: 10 });
-    const results = getMessagingGroupAgents('mg-1');
+    await createMessagingGroupAgent({ ...mga(), id: 'mga-2', agent_group_id: 'ag-2', priority: 10 });
+    const results = await getMessagingGroupAgents('mg-1');
     expect(results[0].agent_group_id).toBe('ag-2');
     expect(results[1].agent_group_id).toBe('ag-1');
   });
 
-  it('should enforce unique messaging_group + agent_group', () => {
-    createMessagingGroupAgent(mga());
-    expect(() => createMessagingGroupAgent({ ...mga(), id: 'mga-dup' })).toThrow();
+  it('should enforce unique messaging_group + agent_group', async () => {
+    await createMessagingGroupAgent(mga());
+    await expect(createMessagingGroupAgent({ ...mga(), id: 'mga-dup' })).rejects.toThrow();
   });
 
-  it('should update', () => {
-    createMessagingGroupAgent(mga());
-    updateMessagingGroupAgent('mga-1', { priority: 5 });
-    expect(getMessagingGroupAgent('mga-1')!.priority).toBe(5);
+  it('should update', async () => {
+    await createMessagingGroupAgent(mga());
+    await updateMessagingGroupAgent('mga-1', { priority: 5 });
+    expect((await getMessagingGroupAgent('mga-1'))!.priority).toBe(5);
   });
 
-  it('should delete', () => {
-    createMessagingGroupAgent(mga());
-    deleteMessagingGroupAgent('mga-1');
-    expect(getMessagingGroupAgents('mg-1')).toHaveLength(0);
+  it('should delete', async () => {
+    await createMessagingGroupAgent(mga());
+    await deleteMessagingGroupAgent('mga-1');
+    expect(await getMessagingGroupAgents('mg-1')).toHaveLength(0);
   });
 
-  it('should enforce foreign key on agent_group_id', () => {
-    expect(() => createMessagingGroupAgent({ ...mga(), agent_group_id: 'nonexistent' })).toThrow();
+  it('should enforce foreign key on agent_group_id', async () => {
+    await expect(createMessagingGroupAgent({ ...mga(), agent_group_id: 'nonexistent' })).rejects.toThrow();
   });
 
   it('auto-creates an agent_destinations row for the wiring', async () => {
     const { getDestinationByTarget, getDestinations } =
       await import('../modules/agent-to-agent/db/agent-destinations.js');
-    createMessagingGroupAgent(mga());
+    await createMessagingGroupAgent(mga());
 
-    const dest = getDestinationByTarget('ag-1', 'channel', 'mg-1');
+    const dest = await getDestinationByTarget('ag-1', 'channel', 'mg-1');
     expect(dest).toBeDefined();
     expect(dest!.local_name).toBe('gen'); // normalized from mg.name='Gen'
-    expect(getDestinations('ag-1')).toHaveLength(1);
+    expect(await getDestinations('ag-1')).toHaveLength(1);
   });
 
   it('does not duplicate destination row on re-wiring', async () => {
     const { getDestinations } = await import('../modules/agent-to-agent/db/agent-destinations.js');
-    createMessagingGroupAgent(mga());
+    await createMessagingGroupAgent(mga());
     // Re-create the same wiring throws (PK unique), but even if we got the
     // row in some other way (e.g. via createDestination directly followed
     // by createMessagingGroupAgent), we should not end up with two rows.
-    deleteMessagingGroupAgent('mga-1');
-    createMessagingGroupAgent(mga());
-    expect(getDestinations('ag-1')).toHaveLength(1);
+    await deleteMessagingGroupAgent('mga-1');
+    await createMessagingGroupAgent(mga());
+    expect(await getDestinations('ag-1')).toHaveLength(1);
   });
 
   it('breaks local_name collisions within an agent group', async () => {
     const { getDestinations } = await import('../modules/agent-to-agent/db/agent-destinations.js');
     // Two messaging groups with the same `name` wired to the same agent
     // should get distinct local_names (gen, gen-2).
-    createMessagingGroupAgent(mga());
-    createMessagingGroup({
+    await createMessagingGroupAgent(mga());
+    await createMessagingGroup({
       id: 'mg-2',
       channel_type: 'discord',
       platform_id: 'chan-2',
@@ -295,11 +296,9 @@ describe('messaging group agents', () => {
       unknown_sender_policy: 'strict',
       created_at: now(),
     });
-    createMessagingGroupAgent({ ...mga(), id: 'mga-2', messaging_group_id: 'mg-2' });
+    await createMessagingGroupAgent({ ...mga(), id: 'mga-2', messaging_group_id: 'mg-2' });
 
-    const dests = getDestinations('ag-1')
-      .map((d) => d.local_name)
-      .sort();
+    const dests = (await getDestinations('ag-1')).map((d) => d.local_name).sort();
     expect(dests).toEqual(['gen', 'gen-2']);
   });
 });
@@ -307,15 +306,15 @@ describe('messaging group agents', () => {
 // ── Sessions ──
 
 describe('sessions', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'chan-1',
@@ -338,78 +337,78 @@ describe('sessions', () => {
     created_at: now(),
   });
 
-  it('should create and retrieve', () => {
-    createSession(sess());
-    const result = getSession('sess-1');
+  it('should create and retrieve', async () => {
+    await createSession(sess());
+    const result = await getSession('sess-1');
     expect(result).toBeDefined();
     expect(result!.agent_group_id).toBe('ag-1');
   });
 
-  it('should find by messaging group (shared, no thread)', () => {
-    createSession(sess());
-    const result = findSession('mg-1', null);
+  it('should find by messaging group (shared, no thread)', async () => {
+    await createSession(sess());
+    const result = await findSession('mg-1', null);
     expect(result).toBeDefined();
     expect(result!.id).toBe('sess-1');
   });
 
-  it('should find by messaging group + thread', () => {
-    createSession({ ...sess(), thread_id: 'thread-1' });
-    expect(findSession('mg-1', 'thread-1')).toBeDefined();
-    expect(findSession('mg-1', 'thread-2')).toBeUndefined();
-    expect(findSession('mg-1', null)).toBeUndefined();
+  it('should find by messaging group + thread', async () => {
+    await createSession({ ...sess(), thread_id: 'thread-1' });
+    expect(await findSession('mg-1', 'thread-1')).toBeDefined();
+    expect(await findSession('mg-1', 'thread-2')).toBeUndefined();
+    expect(await findSession('mg-1', null)).toBeUndefined();
   });
 
-  it('should only find active sessions', () => {
-    createSession({ ...sess(), status: 'closed' });
-    expect(findSession('mg-1', null)).toBeUndefined();
+  it('should only find active sessions', async () => {
+    await createSession({ ...sess(), status: 'closed' });
+    expect(await findSession('mg-1', null)).toBeUndefined();
   });
 
-  it('should list by agent group', () => {
-    createSession(sess());
-    createSession({ ...sess(), id: 'sess-2', thread_id: 'thread-1' });
-    expect(getSessionsByAgentGroup('ag-1')).toHaveLength(2);
+  it('should list by agent group', async () => {
+    await createSession(sess());
+    await createSession({ ...sess(), id: 'sess-2', thread_id: 'thread-1' });
+    expect(await getSessionsByAgentGroup('ag-1')).toHaveLength(2);
   });
 
-  it('should list active sessions', () => {
-    createSession(sess());
-    createSession({ ...sess(), id: 'sess-closed', status: 'closed', thread_id: 'thread-x' });
-    expect(getActiveSessions()).toHaveLength(1);
+  it('should list active sessions', async () => {
+    await createSession(sess());
+    await createSession({ ...sess(), id: 'sess-closed', status: 'closed', thread_id: 'thread-x' });
+    expect(await getActiveSessions()).toHaveLength(1);
   });
 
-  it('should list running sessions', () => {
-    createSession({ ...sess(), container_status: 'running' });
-    createSession({ ...sess(), id: 'sess-idle', container_status: 'idle', thread_id: 'thread-1' });
-    createSession({ ...sess(), id: 'sess-stopped', container_status: 'stopped', thread_id: 'thread-2' });
-    expect(getRunningSessions()).toHaveLength(2);
+  it('should list running sessions', async () => {
+    await createSession({ ...sess(), container_status: 'running' });
+    await createSession({ ...sess(), id: 'sess-idle', container_status: 'idle', thread_id: 'thread-1' });
+    await createSession({ ...sess(), id: 'sess-stopped', container_status: 'stopped', thread_id: 'thread-2' });
+    expect(await getRunningSessions()).toHaveLength(2);
   });
 
-  it('should update', () => {
-    createSession(sess());
-    updateSession('sess-1', { container_status: 'running', last_active: now() });
-    const result = getSession('sess-1')!;
+  it('should update', async () => {
+    await createSession(sess());
+    await updateSession('sess-1', { container_status: 'running', last_active: now() });
+    const result = (await getSession('sess-1'))!;
     expect(result.container_status).toBe('running');
     expect(result.last_active).not.toBeNull();
   });
 
-  it('should delete', () => {
-    createSession(sess());
-    deleteSession('sess-1');
-    expect(getSession('sess-1')).toBeUndefined();
+  it('should delete', async () => {
+    await createSession(sess());
+    await deleteSession('sess-1');
+    expect(await getSession('sess-1')).toBeUndefined();
   });
 });
 
 // ── Pending Questions ──
 
 describe('pending questions', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
       agent_provider: null,
       created_at: now(),
     });
-    createSession({
+    await createSession({
       id: 'sess-1',
       agent_group_id: 'ag-1',
       messaging_group_id: null,
@@ -422,8 +421,8 @@ describe('pending questions', () => {
     });
   });
 
-  it('should create and retrieve', () => {
-    createPendingQuestion({
+  it('should create and retrieve', async () => {
+    await createPendingQuestion({
       question_id: 'q-1',
       session_id: 'sess-1',
       message_out_id: 'msg-out-1',
@@ -434,15 +433,15 @@ describe('pending questions', () => {
       options: [{ label: 'Yes', selectedLabel: 'Yes', value: 'yes' }],
       created_at: now(),
     });
-    const result = getPendingQuestion('q-1');
+    const result = await getPendingQuestion('q-1');
     expect(result).toBeDefined();
     expect(result!.session_id).toBe('sess-1');
     expect(result!.title).toBe('Test');
     expect(result!.options[0].value).toBe('yes');
   });
 
-  it('should delete', () => {
-    createPendingQuestion({
+  it('should delete', async () => {
+    await createPendingQuestion({
       question_id: 'q-1',
       session_id: 'sess-1',
       message_out_id: 'msg-out-1',
@@ -453,17 +452,17 @@ describe('pending questions', () => {
       options: [{ label: 'Yes', selectedLabel: 'Yes', value: 'yes' }],
       created_at: now(),
     });
-    deletePendingQuestion('q-1');
-    expect(getPendingQuestion('q-1')).toBeUndefined();
+    await deletePendingQuestion('q-1');
+    expect(await getPendingQuestion('q-1')).toBeUndefined();
   });
 });
 
 // ── Container Configs ──
 
 describe('container configs', () => {
-  it('createContainerConfig persists cli_scope', () => {
-    createAgentGroup({ id: 'ag-full', name: 'Full', folder: 'full', agent_provider: null, created_at: now() });
-    createContainerConfig({
+  it('createContainerConfig persists cli_scope', async () => {
+    await createAgentGroup({ id: 'ag-full', name: 'Full', folder: 'full', agent_provider: null, created_at: now() });
+    await createContainerConfig({
       agent_group_id: 'ag-full',
       provider: null,
       model: null,
@@ -480,7 +479,7 @@ describe('container configs', () => {
       timezone: null,
       updated_at: now(),
     });
-    const row = getContainerConfig('ag-full');
+    const row = await getContainerConfig('ag-full');
     expect(row).toBeDefined();
     expect(row!.cli_scope).toBe('global');
   });

--- a/src/db/dropped-messages.ts
+++ b/src/db/dropped-messages.ts
@@ -13,7 +13,7 @@ export interface UnregisteredSender {
   last_seen: string;
 }
 
-export function recordDroppedMessage(msg: {
+export async function recordDroppedMessage(msg: {
   channel_type: string;
   platform_id: string;
   user_id: string | null;
@@ -21,11 +21,10 @@ export function recordDroppedMessage(msg: {
   reason: string;
   messaging_group_id: string | null;
   agent_group_id: string | null;
-}): void {
+}): Promise<void> {
   const now = new Date().toISOString();
-  getDb()
-    .prepare(
-      `INSERT INTO unregistered_senders (channel_type, platform_id, user_id, sender_name, reason, messaging_group_id, agent_group_id, message_count, first_seen, last_seen)
+  await getDb().run(
+    `INSERT INTO unregistered_senders (channel_type, platform_id, user_id, sender_name, reason, messaging_group_id, agent_group_id, message_count, first_seen, last_seen)
        VALUES (@channel_type, @platform_id, @user_id, @sender_name, @reason, @messaging_group_id, @agent_group_id, 1, @now, @now)
        ON CONFLICT (channel_type, platform_id) DO UPDATE SET
          user_id = COALESCE(excluded.user_id, unregistered_senders.user_id),
@@ -33,12 +32,10 @@ export function recordDroppedMessage(msg: {
          reason = excluded.reason,
          message_count = unregistered_senders.message_count + 1,
          last_seen = excluded.last_seen`,
-    )
-    .run({ ...msg, now });
+    { ...msg, now },
+  );
 }
 
-export function getUnregisteredSenders(limit = 50): UnregisteredSender[] {
-  return getDb()
-    .prepare('SELECT * FROM unregistered_senders ORDER BY last_seen DESC LIMIT ?')
-    .all(limit) as UnregisteredSender[];
+export async function getUnregisteredSenders(limit = 50): Promise<UnregisteredSender[]> {
+  return getDb().all<UnregisteredSender>('SELECT * FROM unregistered_senders ORDER BY last_seen DESC LIMIT ?', limit);
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 export { initDb, initTestDb, getDb, closeDb } from './connection.js';
+export type { DbDriver, DbDialect, RunResult } from './driver.js';
 export { runMigrations } from './migrations/index.js';
 export {
   createAgentGroup,

--- a/src/db/messaging-groups-instance.test.ts
+++ b/src/db/messaging-groups-instance.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { initTestDb, closeDb, getDb } from './connection.js';
+import { sqliteRaw } from './drivers/sqlite.js';
 import { runMigrations, migrations, type Migration } from './migrations/index.js';
 import {
   createMessagingGroup,
@@ -42,18 +43,18 @@ function mg(overrides: Partial<MessagingGroup> & { id: string }): MessagingGroup
   };
 }
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 describe('migration 016 — fresh DB', () => {
-  beforeEach(() => {
-    const db = initTestDb();
-    runMigrations(db);
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
   });
 
   it('adds a NOT NULL instance column', () => {
-    const cols = getDb().prepare("PRAGMA table_info('messaging_groups')").all() as Array<{
+    const cols = sqliteRaw(getDb()).prepare("PRAGMA table_info('messaging_groups')").all() as Array<{
       name: string;
       notnull: number;
     }>;
@@ -62,82 +63,94 @@ describe('migration 016 — fresh DB', () => {
     expect(instance!.notnull).toBe(1);
   });
 
-  it('createMessagingGroup without instance stamps instance = channel_type', () => {
-    createMessagingGroup(mg({ id: 'mg-default' }));
-    const row = getDb().prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-default'").get() as {
+  it('createMessagingGroup without instance stamps instance = channel_type', async () => {
+    await createMessagingGroup(mg({ id: 'mg-default' }));
+    const row = sqliteRaw(getDb()).prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-default'").get() as {
       instance: string;
     };
     expect(row.instance).toBe('slack');
   });
 
-  it('allows sibling instances on the same (channel_type, platform_id)', () => {
-    createMessagingGroup(mg({ id: 'mg-default' }));
-    createMessagingGroup(mg({ id: 'mg-tester', instance: 'slack-tester' }));
-    const count = getDb().prepare('SELECT COUNT(*) AS c FROM messaging_groups').get() as { c: number };
+  it('allows sibling instances on the same (channel_type, platform_id)', async () => {
+    await createMessagingGroup(mg({ id: 'mg-default' }));
+    await createMessagingGroup(mg({ id: 'mg-tester', instance: 'slack-tester' }));
+    const count = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM messaging_groups').get() as { c: number };
     expect(count.c).toBe(2);
   });
 
-  it('rejects a duplicate (channel_type, platform_id, instance) triple', () => {
-    createMessagingGroup(mg({ id: 'mg-a', instance: 'slack-tester' }));
-    expect(() => createMessagingGroup(mg({ id: 'mg-b', instance: 'slack-tester' }))).toThrow();
+  it('rejects a duplicate (channel_type, platform_id, instance) triple', async () => {
+    await createMessagingGroup(mg({ id: 'mg-a', instance: 'slack-tester' }));
+    await expect(createMessagingGroup(mg({ id: 'mg-b', instance: 'slack-tester' }))).rejects.toThrow();
   });
 
-  it('rejects a duplicate default pair (single-bot uniqueness preserved)', () => {
-    createMessagingGroup(mg({ id: 'mg-a' }));
-    expect(() => createMessagingGroup(mg({ id: 'mg-b' }))).toThrow();
+  it('rejects a duplicate default pair (single-bot uniqueness preserved)', async () => {
+    await createMessagingGroup(mg({ id: 'mg-a' }));
+    await expect(createMessagingGroup(mg({ id: 'mg-b' }))).rejects.toThrow();
   });
 });
 
 describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () => {
-  it('recreates messaging_groups under FK children without violations and backfills instance', () => {
-    const db = initTestDb();
+  it('recreates messaging_groups under FK children without violations and backfills instance', async () => {
+    const db = await initTestDb();
     // Bring the DB to the pre-016 schema.
-    runMigrations(
+    await runMigrations(
       db,
       migrations.filter((m) => m.name !== 'messaging-group-instance'),
     );
-    const preCols = db.prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
+    const preCols = sqliteRaw(db).prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
     expect(preCols.some((c) => c.name === 'instance')).toBe(false);
 
     // Seed a wired install: messaging_groups with live FK children
     // (messaging_group_agents + sessions reference messaging_groups.id).
     // Raw SQL — the new createMessagingGroup expects the instance column.
-    db.prepare("INSERT INTO agent_groups (id, name, folder, created_at) VALUES ('ag-1', 'A', 'a', ?)").run(now());
-    db.prepare(
-      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
+    sqliteRaw(db)
+      .prepare("INSERT INTO agent_groups (id, name, folder, created_at) VALUES ('ag-1', 'A', 'a', ?)")
+      .run(now());
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
        VALUES ('mg-1', 'telegram', 'telegram:123', 'Chat', 0, 'public', ?)`,
-    ).run(now());
-    db.prepare(
-      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, created_at)
+      )
+      .run(now());
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, created_at)
        VALUES ('mga-1', 'mg-1', 'ag-1', 'pattern', 'all', 'drop', ?)`,
-    ).run(now());
-    db.prepare(
-      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, created_at)
+      )
+      .run(now());
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO sessions (id, agent_group_id, messaging_group_id, created_at)
        VALUES ('sess-1', 'ag-1', 'mg-1', ?)`,
-    ).run(now());
+      )
+      .run(now());
 
     // Upgrade: only 016 is pending now. Without disableForeignKeys this
     // throws 'FOREIGN KEY constraint failed' at DROP TABLE.
-    expect(() => runMigrations(db)).not.toThrow();
+    await expect(runMigrations(db)).resolves.toBeUndefined();
 
     // Backfill: existing row got instance = channel_type.
-    const row = db.prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-1'").get() as { instance: string };
+    const row = sqliteRaw(db).prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-1'").get() as {
+      instance: string;
+    };
     expect(row.instance).toBe('telegram');
 
     // Children intact and pointing at the recreated parent.
     expect(
-      db.prepare("SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = 'mg-1'").get(),
+      sqliteRaw(db).prepare("SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = 'mg-1'").get(),
     ).toEqual({ c: 1 });
-    expect(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE messaging_group_id = 'mg-1'").get()).toEqual({ c: 1 });
+    expect(sqliteRaw(db).prepare("SELECT COUNT(*) AS c FROM sessions WHERE messaging_group_id = 'mg-1'").get()).toEqual(
+      { c: 1 },
+    );
 
     // Full-DB FK integrity (FK enforcement was restored by the runner).
-    expect(db.pragma('foreign_key_check')).toEqual([]);
-    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    expect(sqliteRaw(db).pragma('foreign_key_check')).toEqual([]);
+    expect(sqliteRaw(db).pragma('foreign_keys', { simple: true })).toBe(1);
   });
 
-  it('tolerates pre-existing FK orphans: the migration still applies (no boot crash-loop)', () => {
-    const db = initTestDb();
-    runMigrations(
+  it('tolerates pre-existing FK orphans: the migration still applies (no boot crash-loop)', async () => {
+    const db = await initTestDb();
+    await runMigrations(
       db,
       migrations.filter((m) => m.name !== 'messaging-group-instance'),
     );
@@ -147,33 +160,36 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
     // messaging_group was deleted through a FK-OFF connection — the
     // sqlite3 CLI ships with foreign_keys OFF, and operators are told to
     // poke v2.db when troubleshooting.
-    db.prepare("INSERT INTO users (id, kind, created_at) VALUES ('slack:U1', 'slack', ?)").run(now());
-    db.pragma('foreign_keys = OFF');
-    db.prepare(
-      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+    sqliteRaw(db).prepare("INSERT INTO users (id, kind, created_at) VALUES ('slack:U1', 'slack', ?)").run(now());
+    sqliteRaw(db).pragma('foreign_keys = OFF');
+    sqliteRaw(db)
+      .prepare(
+        `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES ('slack:U1', 'slack', 'mg-deleted-via-cli', ?)`,
-    ).run(now());
-    db.pragma('foreign_keys = ON');
-    expect(db.pragma('foreign_key_check')).toHaveLength(1);
+      )
+      .run(now());
+    sqliteRaw(db).pragma('foreign_keys = ON');
+    expect(sqliteRaw(db).pragma('foreign_key_check')).toHaveLength(1);
 
     // 016 did not create this violation — it must still apply (the runner
     // diffs post-up violations against a pre-up snapshot and only throws
     // on NEW ones; pre-existing ones are warned about and carried through).
-    expect(() => runMigrations(db)).not.toThrow();
-    const cols = db.prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
+    await expect(runMigrations(db)).resolves.toBeUndefined();
+    const cols = sqliteRaw(db).prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
     expect(cols.some((c) => c.name === 'instance')).toBe(true);
 
     // The orphan is untouched: still present, still the only violation.
-    expect(db.pragma('foreign_key_check')).toHaveLength(1);
+    expect(sqliteRaw(db).pragma('foreign_key_check')).toHaveLength(1);
   });
 
-  it('still rejects a migration that ITSELF introduces FK violations', () => {
-    const db = initTestDb();
-    runMigrations(db);
+  it('still rejects a migration that ITSELF introduces FK violations', async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
 
     const rogue: Migration = {
       version: 999,
       name: 'test-rogue-fk-violation',
+      sqliteOnly: true,
       disableForeignKeys: true,
       up: (d) => {
         d.prepare("INSERT INTO users (id, kind, created_at) VALUES ('slack:U-rogue', 'slack', datetime('now'))").run();
@@ -184,19 +200,21 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
       },
     };
 
-    expect(() => runMigrations(db, [...migrations, rogue])).toThrow(/left FK violations/);
+    await expect(runMigrations(db, [...migrations, rogue])).rejects.toThrow(/left FK violations/);
 
     // Rolled back atomically: not recorded as applied, nothing committed.
-    expect(db.prepare("SELECT 1 FROM schema_version WHERE name = 'test-rogue-fk-violation'").get()).toBeUndefined();
-    expect(db.pragma('foreign_key_check')).toEqual([]);
+    expect(
+      sqliteRaw(db).prepare("SELECT 1 FROM schema_version WHERE name = 'test-rogue-fk-violation'").get(),
+    ).toBeUndefined();
+    expect(sqliteRaw(db).pragma('foreign_key_check')).toEqual([]);
   });
 
-  it('is idempotent — re-running the full barrel is a no-op', () => {
-    const db = initTestDb();
-    runMigrations(db);
-    createMessagingGroup(mg({ id: 'mg-keep', instance: 'slack-tester' }));
-    expect(() => runMigrations(db)).not.toThrow();
-    const row = db.prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-keep'").get() as {
+  it('is idempotent — re-running the full barrel is a no-op', async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    await createMessagingGroup(mg({ id: 'mg-keep', instance: 'slack-tester' }));
+    await expect(runMigrations(db)).resolves.toBeUndefined();
+    const row = sqliteRaw(db).prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-keep'").get() as {
       instance: string;
     };
     expect(row.instance).toBe('slack-tester');
@@ -204,51 +222,51 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
 });
 
 describe('lookup asymmetry — inbound exact-only vs outbound default-first', () => {
-  beforeEach(() => {
-    const db = initTestDb();
-    runMigrations(db);
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
     // The named instance ('alpha-tester') sorts lexically BEFORE the
     // channel type ('slack') and is inserted first — so both rowid order
     // and the triple-autoindex order put it ahead of the default row.
     // A query missing the `(instance = channel_type) DESC` ORDER BY would
     // return it; only the deterministic default-first ordering picks
     // mg-default.
-    createMessagingGroup(mg({ id: 'mg-tester', instance: 'alpha-tester' }));
-    createMessagingGroup(mg({ id: 'mg-default' }));
+    await createMessagingGroup(mg({ id: 'mg-tester', instance: 'alpha-tester' }));
+    await createMessagingGroup(mg({ id: 'mg-default' }));
   });
 
-  it('getMessagingGroupWithAgentCount without instance resolves the default-instance row', () => {
-    const found = getMessagingGroupWithAgentCount('slack', 'slack:C1');
+  it('getMessagingGroupWithAgentCount without instance resolves the default-instance row', async () => {
+    const found = await getMessagingGroupWithAgentCount('slack', 'slack:C1');
     expect(found).not.toBeNull();
     expect(found!.mg.id).toBe('mg-default');
   });
 
-  it('getMessagingGroupWithAgentCount with a named instance resolves exactly that row', () => {
-    const found = getMessagingGroupWithAgentCount('slack', 'slack:C1', 'alpha-tester');
+  it('getMessagingGroupWithAgentCount with a named instance resolves exactly that row', async () => {
+    const found = await getMessagingGroupWithAgentCount('slack', 'slack:C1', 'alpha-tester');
     expect(found).not.toBeNull();
     expect(found!.mg.id).toBe('mg-tester');
   });
 
-  it('getMessagingGroupWithAgentCount with an unknown instance returns null (no-hijack rule)', () => {
-    expect(getMessagingGroupWithAgentCount('slack', 'slack:C1', 'slack-unknown')).toBeNull();
+  it('getMessagingGroupWithAgentCount with an unknown instance returns null (no-hijack rule)', async () => {
+    expect(await getMessagingGroupWithAgentCount('slack', 'slack:C1', 'slack-unknown')).toBeNull();
   });
 
-  it('getMessagingGroupByPlatform without instance prefers the default-instance row', () => {
-    const found = getMessagingGroupByPlatform('slack', 'slack:C1');
+  it('getMessagingGroupByPlatform without instance prefers the default-instance row', async () => {
+    const found = await getMessagingGroupByPlatform('slack', 'slack:C1');
     expect(found).toBeDefined();
     expect(found!.id).toBe('mg-default');
   });
 
-  it('getMessagingGroupByPlatform with explicit instance is exact', () => {
-    expect(getMessagingGroupByPlatform('slack', 'slack:C1', 'alpha-tester')!.id).toBe('mg-tester');
-    expect(getMessagingGroupByPlatform('slack', 'slack:C1', 'slack-unknown')).toBeUndefined();
+  it('getMessagingGroupByPlatform with explicit instance is exact', async () => {
+    expect((await getMessagingGroupByPlatform('slack', 'slack:C1', 'alpha-tester'))!.id).toBe('mg-tester');
+    expect(await getMessagingGroupByPlatform('slack', 'slack:C1', 'slack-unknown')).toBeUndefined();
   });
 
-  it('getMessagingGroupByPlatform falls back deterministically when only named instances exist', () => {
+  it('getMessagingGroupByPlatform falls back deterministically when only named instances exist', async () => {
     const db = getDb();
-    db.prepare("DELETE FROM messaging_groups WHERE id = 'mg-default'").run();
-    createMessagingGroup(mg({ id: 'mg-zeta', instance: 'zeta' }));
-    const found = getMessagingGroupByPlatform('slack', 'slack:C1');
+    sqliteRaw(db).prepare("DELETE FROM messaging_groups WHERE id = 'mg-default'").run();
+    await createMessagingGroup(mg({ id: 'mg-zeta', instance: 'zeta' }));
+    const found = await getMessagingGroupByPlatform('slack', 'slack:C1');
     // Lexically-first named instance: 'alpha-tester' < 'zeta'.
     expect(found!.id).toBe('mg-tester');
   });

--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -18,17 +18,16 @@ import { getDb, hasTable } from './connection.js';
 
 // ── Messaging Groups ──
 
-export function createMessagingGroup(group: MessagingGroup): void {
-  getDb()
-    .prepare(
-      `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+export async function createMessagingGroup(group: MessagingGroup): Promise<void> {
+  await getDb().run(
+    `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
        VALUES (@id, @channel_type, @platform_id, @instance, @name, @is_group, @unknown_sender_policy, @created_at)`,
-    )
-    .run({ ...group, instance: group.instance ?? group.channel_type });
+    { ...group, instance: group.instance ?? group.channel_type },
+  );
 }
 
-export function getMessagingGroup(id: string): MessagingGroup | undefined {
-  return getDb().prepare('SELECT * FROM messaging_groups WHERE id = ?').get(id) as MessagingGroup | undefined;
+export async function getMessagingGroup(id: string): Promise<MessagingGroup | undefined> {
+  return getDb().get<MessagingGroup>('SELECT * FROM messaging_groups WHERE id = ?', id);
 }
 
 /**
@@ -41,24 +40,27 @@ export function getMessagingGroup(id: string): MessagingGroup | undefined {
  * falling back deterministically to the lexically-first named instance.
  * A set `instance` is exact-only — unknown instance returns undefined.
  */
-export function getMessagingGroupByPlatform(
+export async function getMessagingGroupByPlatform(
   channelType: string,
   platformId: string,
   instance?: string,
-): MessagingGroup | undefined {
+): Promise<MessagingGroup | undefined> {
   if (instance !== undefined) {
-    return getDb()
-      .prepare('SELECT * FROM messaging_groups WHERE channel_type = ? AND platform_id = ? AND instance = ?')
-      .get(channelType, platformId, instance) as MessagingGroup | undefined;
+    return getDb().get<MessagingGroup>(
+      'SELECT * FROM messaging_groups WHERE channel_type = ? AND platform_id = ? AND instance = ?',
+      channelType,
+      platformId,
+      instance,
+    );
   }
-  return getDb()
-    .prepare(
-      `SELECT * FROM messaging_groups
+  return getDb().get<MessagingGroup>(
+    `SELECT * FROM messaging_groups
         WHERE channel_type = ? AND platform_id = ?
      ORDER BY (instance = channel_type) DESC, instance ASC
         LIMIT 1`,
-    )
-    .get(channelType, platformId) as MessagingGroup | undefined;
+    channelType,
+    platformId,
+  );
 }
 
 /**
@@ -79,22 +81,23 @@ export function getMessagingGroupByPlatform(
  * platform-only lookup, falling back to it only when the sender has no
  * matching destination (e.g. the agent-to-agent module isn't installed).
  */
-export function getMessagingGroupForOwnDestination(
+export async function getMessagingGroupForOwnDestination(
   agentGroupId: string,
   channelType: string,
   platformId: string,
-): MessagingGroup | undefined {
-  if (!hasTable(getDb(), 'agent_destinations')) return undefined;
-  return getDb()
-    .prepare(
-      `SELECT mg.* FROM agent_destinations ad
+): Promise<MessagingGroup | undefined> {
+  if (!(await hasTable(getDb(), 'agent_destinations'))) return undefined;
+  return getDb().get<MessagingGroup>(
+    `SELECT mg.* FROM agent_destinations ad
          JOIN messaging_groups mg ON mg.id = ad.target_id
         WHERE ad.agent_group_id = ? AND ad.target_type = 'channel'
           AND mg.channel_type = ? AND mg.platform_id = ?
      ORDER BY ad.created_at ASC
         LIMIT 1`,
-    )
-    .get(agentGroupId, channelType, platformId) as MessagingGroup | undefined;
+    agentGroupId,
+    channelType,
+    platformId,
+  );
 }
 
 /**
@@ -117,27 +120,28 @@ export function getMessagingGroupForOwnDestination(
  * default param (= channelType) keeps instance-less callers resolving the
  * default instance, identical to pre-instance behavior.
  */
-export function getMessagingGroupWithAgentCount(
+export async function getMessagingGroupWithAgentCount(
   channelType: string,
   platformId: string,
   instance: string = channelType,
-): { mg: MessagingGroup; agentCount: number } | null {
-  const row = getDb()
-    .prepare(
-      `SELECT mg.*, COUNT(mga.id) AS agent_count
+): Promise<{ mg: MessagingGroup; agentCount: number } | null> {
+  const row = await getDb().get<MessagingGroup & { agent_count: number }>(
+    `SELECT mg.*, COUNT(mga.id) AS agent_count
          FROM messaging_groups mg
     LEFT JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
         WHERE mg.channel_type = ? AND mg.platform_id = ? AND mg.instance = ?
      GROUP BY mg.id`,
-    )
-    .get(channelType, platformId, instance) as (MessagingGroup & { agent_count: number }) | undefined;
+    channelType,
+    platformId,
+    instance,
+  );
   if (!row) return null;
   const { agent_count, ...mg } = row;
   return { mg: mg as MessagingGroup, agentCount: agent_count };
 }
 
-export function getAllMessagingGroups(): MessagingGroup[] {
-  return getDb().prepare('SELECT * FROM messaging_groups ORDER BY name').all() as MessagingGroup[];
+export async function getAllMessagingGroups(): Promise<MessagingGroup[]> {
+  return getDb().all<MessagingGroup>('SELECT * FROM messaging_groups ORDER BY name');
 }
 
 /**
@@ -146,14 +150,14 @@ export function getAllMessagingGroups(): MessagingGroup[] {
  * stays the semantic platform key. No live caller today; if a caller needs
  * a single instance's rows, filter on `mg.instance`.
  */
-export function getMessagingGroupsByChannel(channelType: string): MessagingGroup[] {
-  return getDb().prepare('SELECT * FROM messaging_groups WHERE channel_type = ?').all(channelType) as MessagingGroup[];
+export async function getMessagingGroupsByChannel(channelType: string): Promise<MessagingGroup[]> {
+  return getDb().all<MessagingGroup>('SELECT * FROM messaging_groups WHERE channel_type = ?', channelType);
 }
 
-export function updateMessagingGroup(
+export async function updateMessagingGroup(
   id: string,
   updates: Partial<Pick<MessagingGroup, 'name' | 'is_group' | 'unknown_sender_policy'>>,
-): void {
+): Promise<void> {
   const fields: string[] = [];
   const values: Record<string, unknown> = { id };
 
@@ -165,13 +169,11 @@ export function updateMessagingGroup(
   }
   if (fields.length === 0) return;
 
-  getDb()
-    .prepare(`UPDATE messaging_groups SET ${fields.join(', ')} WHERE id = @id`)
-    .run(values);
+  await getDb().run(`UPDATE messaging_groups SET ${fields.join(', ')} WHERE id = @id`, values);
 }
 
-export function deleteMessagingGroup(id: string): void {
-  getDb().prepare('DELETE FROM messaging_groups WHERE id = ?').run(id);
+export async function deleteMessagingGroup(id: string): Promise<void> {
+  await getDb().run('DELETE FROM messaging_groups WHERE id = ?', id);
 }
 
 /**
@@ -184,8 +186,8 @@ export function deleteMessagingGroup(id: string): void {
  * Passing null unsets the flag (used by tests or a future "unblock channel"
  * admin command).
  */
-export function setMessagingGroupDeniedAt(id: string, deniedAt: string | null): void {
-  getDb().prepare('UPDATE messaging_groups SET denied_at = ? WHERE id = ?').run(deniedAt, id);
+export async function setMessagingGroupDeniedAt(id: string, deniedAt: string | null): Promise<void> {
+  await getDb().run('UPDATE messaging_groups SET denied_at = ? WHERE id = ?', deniedAt, id);
 }
 
 /**
@@ -195,16 +197,17 @@ export function setMessagingGroupDeniedAt(id: string, deniedAt: string | null): 
  * delivery/typing should skip the row until the bot rejoins. Passing null
  * clears the flag (rejoin), restoring the room with zero re-setup.
  */
-export function setMessagingGroupDetachedAt(id: string, detachedAt: string | null): void {
-  getDb().prepare('UPDATE messaging_groups SET detached_at = ? WHERE id = ?').run(detachedAt, id);
+export async function setMessagingGroupDetachedAt(id: string, detachedAt: string | null): Promise<void> {
+  await getDb().run('UPDATE messaging_groups SET detached_at = ? WHERE id = ?', detachedAt, id);
 }
 
 /** True when the bot has left this conversation (detached_at set). The check
  *  delivery-side callers should consult before attempting a send. */
-export function isMessagingGroupDetached(id: string): boolean {
-  const row = getDb().prepare('SELECT detached_at FROM messaging_groups WHERE id = ?').get(id) as
-    | { detached_at: string | null }
-    | undefined;
+export async function isMessagingGroupDetached(id: string): Promise<boolean> {
+  const row = await getDb().get<{ detached_at: string | null }>(
+    'SELECT detached_at FROM messaging_groups WHERE id = ?',
+    id,
+  );
   return typeof row?.detached_at === 'string' && row.detached_at.length > 0;
 }
 
@@ -223,10 +226,9 @@ export function isMessagingGroupDetached(id: string): boolean {
  * a numeric suffix to break collisions within the agent's namespace. This
  * mirrors the backfill logic in migration 004.
  */
-export function createMessagingGroupAgent(mga: MessagingGroupAgent): void {
-  getDb()
-    .prepare(
-      `INSERT INTO messaging_group_agents (
+export async function createMessagingGroupAgent(mga: MessagingGroupAgent): Promise<void> {
+  await getDb().run(
+    `INSERT INTO messaging_group_agents (
          id, messaging_group_id, agent_group_id,
          engage_mode, engage_pattern, sender_scope, ignored_message_policy,
          session_mode, priority, created_at
@@ -236,18 +238,18 @@ export function createMessagingGroupAgent(mga: MessagingGroupAgent): void {
          @engage_mode, @engage_pattern, @sender_scope, @ignored_message_policy,
          @session_mode, @priority, @created_at
        )`,
-    )
-    .run(mga);
+    mga,
+  );
 
   // `threads` (migration 019) is written separately so existing callers that
   // omit it keep passing named-param sets that match the INSERT exactly
   // (better-sqlite3 rejects missing named params). Omitted/NULL = column
   // stays NULL = inherit the channel declaration at fanout time.
   if (mga.threads !== undefined && mga.threads !== null) {
-    getDb().prepare('UPDATE messaging_group_agents SET threads = ? WHERE id = ?').run(mga.threads, mga.id);
+    await getDb().run('UPDATE messaging_group_agents SET threads = ? WHERE id = ?', mga.threads, mga.id);
   }
 
-  ensureAgentDestinationForWiring(mga);
+  await ensureAgentDestinationForWiring(mga);
 }
 
 /**
@@ -274,27 +276,27 @@ export function createMessagingGroupAgent(mga: MessagingGroupAgent): void {
  * process and need the refresh to happen immediately, explicitly call the
  * module's `writeDestinations(mga.agent_group_id, <sessionId>)` afterwards.
  */
-export function ensureAgentDestinationForWiring(mga: MessagingGroupAgent): void {
+export async function ensureAgentDestinationForWiring(mga: MessagingGroupAgent): Promise<void> {
   // Guarded: when the agent-to-agent module isn't installed the table
   // doesn't exist — skip silently. Without the module, the ACL check in
   // delivery is also skipped (same guard), so channel sends still work.
-  if (!hasTable(getDb(), 'agent_destinations')) return;
+  if (!(await hasTable(getDb(), 'agent_destinations'))) return;
 
-  const existing = getDestinationByTarget(mga.agent_group_id, 'channel', mga.messaging_group_id);
+  const existing = await getDestinationByTarget(mga.agent_group_id, 'channel', mga.messaging_group_id);
   if (existing) return;
 
-  const mg = getMessagingGroup(mga.messaging_group_id);
+  const mg = await getMessagingGroup(mga.messaging_group_id);
   if (!mg) return;
 
   const base = normalizeName(mg.name || `${mg.channel_type}-${mga.messaging_group_id.slice(0, 8)}`);
   let localName = base;
   let suffix = 2;
-  while (getDestinationByName(mga.agent_group_id, localName)) {
+  while (await getDestinationByName(mga.agent_group_id, localName)) {
     localName = `${base}-${suffix}`;
     suffix++;
   }
 
-  createDestination({
+  await createDestination({
     agent_group_id: mga.agent_group_id,
     local_name: localName,
     target_type: 'channel',
@@ -303,28 +305,29 @@ export function ensureAgentDestinationForWiring(mga: MessagingGroupAgent): void 
   });
 }
 
-export function getMessagingGroupAgents(messagingGroupId: string): MessagingGroupAgent[] {
-  return getDb()
-    .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? ORDER BY priority DESC, id')
-    .all(messagingGroupId) as MessagingGroupAgent[];
+export async function getMessagingGroupAgents(messagingGroupId: string): Promise<MessagingGroupAgent[]> {
+  return getDb().all<MessagingGroupAgent>(
+    'SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? ORDER BY priority DESC, id',
+    messagingGroupId,
+  );
 }
 
-export function getMessagingGroupAgentByPair(
+export async function getMessagingGroupAgentByPair(
   messagingGroupId: string,
   agentGroupId: string,
-): MessagingGroupAgent | undefined {
-  return getDb()
-    .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?')
-    .get(messagingGroupId, agentGroupId) as MessagingGroupAgent | undefined;
+): Promise<MessagingGroupAgent | undefined> {
+  return getDb().get<MessagingGroupAgent>(
+    'SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?',
+    messagingGroupId,
+    agentGroupId,
+  );
 }
 
-export function getMessagingGroupAgent(id: string): MessagingGroupAgent | undefined {
-  return getDb().prepare('SELECT * FROM messaging_group_agents WHERE id = ?').get(id) as
-    | MessagingGroupAgent
-    | undefined;
+export async function getMessagingGroupAgent(id: string): Promise<MessagingGroupAgent | undefined> {
+  return getDb().get<MessagingGroupAgent>('SELECT * FROM messaging_group_agents WHERE id = ?', id);
 }
 
-export function updateMessagingGroupAgent(
+export async function updateMessagingGroupAgent(
   id: string,
   updates: Partial<
     Pick<
@@ -338,7 +341,7 @@ export function updateMessagingGroupAgent(
       | 'threads'
     >
   >,
-): void {
+): Promise<void> {
   const fields: string[] = [];
   const values: Record<string, unknown> = { id };
 
@@ -350,22 +353,19 @@ export function updateMessagingGroupAgent(
   }
   if (fields.length === 0) return;
 
-  getDb()
-    .prepare(`UPDATE messaging_group_agents SET ${fields.join(', ')} WHERE id = @id`)
-    .run(values);
+  await getDb().run(`UPDATE messaging_group_agents SET ${fields.join(', ')} WHERE id = @id`, values);
 }
 
-export function deleteMessagingGroupAgent(id: string): void {
-  getDb().prepare('DELETE FROM messaging_group_agents WHERE id = ?').run(id);
+export async function deleteMessagingGroupAgent(id: string): Promise<void> {
+  await getDb().run('DELETE FROM messaging_group_agents WHERE id = ?', id);
 }
 
 /** Get all messaging groups wired to an agent group (reverse lookup). */
-export function getMessagingGroupsByAgentGroup(agentGroupId: string): MessagingGroup[] {
-  return getDb()
-    .prepare(
-      `SELECT mg.* FROM messaging_groups mg
+export async function getMessagingGroupsByAgentGroup(agentGroupId: string): Promise<MessagingGroup[]> {
+  return getDb().all<MessagingGroup>(
+    `SELECT mg.* FROM messaging_groups mg
        JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
        WHERE mga.agent_group_id = ?`,
-    )
-    .all(agentGroupId) as MessagingGroup[];
+    agentGroupId,
+  );
 }

--- a/src/db/migrations/001-initial.ts
+++ b/src/db/migrations/001-initial.ts
@@ -5,6 +5,7 @@ import type { Migration } from './index.js';
 export const migration001: Migration = {
   version: 1,
   name: 'initial-v2-schema',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`
       CREATE TABLE agent_groups (

--- a/src/db/migrations/002-chat-sdk-state.ts
+++ b/src/db/migrations/002-chat-sdk-state.ts
@@ -5,6 +5,7 @@ import type { Migration } from './index.js';
 export const migration002: Migration = {
   version: 2,
   name: 'chat-sdk-state',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`
       CREATE TABLE chat_sdk_kv (

--- a/src/db/migrations/008-dropped-messages.ts
+++ b/src/db/migrations/008-dropped-messages.ts
@@ -4,6 +4,7 @@ import type { Migration } from './index.js';
 export const migration008: Migration = {
   version: 8,
   name: 'dropped-messages',
+  sqliteOnly: true,
   up: (db: Database.Database) => {
     db.exec(`
       CREATE TABLE IF NOT EXISTS unregistered_senders (

--- a/src/db/migrations/009-drop-pending-credentials.ts
+++ b/src/db/migrations/009-drop-pending-credentials.ts
@@ -4,6 +4,7 @@ import type { Migration } from './index.js';
 export const migration009: Migration = {
   version: 9,
   name: 'drop-pending-credentials',
+  sqliteOnly: true,
   up: (db: Database.Database) => {
     db.exec(`
       DROP INDEX IF EXISTS idx_pending_credentials_status;

--- a/src/db/migrations/010-engage-modes.ts
+++ b/src/db/migrations/010-engage-modes.ts
@@ -64,6 +64,7 @@ function backfill(row: LegacyRow): {
 export const migration010: Migration = {
   version: 10,
   name: 'engage-modes',
+  sqliteOnly: true,
   up: (db: Database.Database) => {
     // Add the four new columns alongside the existing two. SQLite ALTER ADD
     // is cheap and non-rewriting.

--- a/src/db/migrations/011-pending-sender-approvals.ts
+++ b/src/db/migrations/011-pending-sender-approvals.ts
@@ -20,6 +20,7 @@ import type { Migration } from './index.js';
 export const migration011: Migration = {
   version: 11,
   name: 'pending-sender-approvals',
+  sqliteOnly: true,
   up: (db: Database.Database) => {
     db.exec(`
       CREATE TABLE IF NOT EXISTS pending_sender_approvals (

--- a/src/db/migrations/012-channel-registration.ts
+++ b/src/db/migrations/012-channel-registration.ts
@@ -23,6 +23,7 @@ import type { Migration } from './index.js';
 export const migration012: Migration = {
   version: 12,
   name: 'channel-registration',
+  sqliteOnly: true,
   up: (db: Database.Database) => {
     // 1. Add denied_at to messaging_groups. Idempotent guard in case the
     //    column was added by some other path before this migration ran.

--- a/src/db/migrations/013-approval-render-metadata.ts
+++ b/src/db/migrations/013-approval-render-metadata.ts
@@ -18,6 +18,7 @@ import type { Migration } from './index.js';
 export const migration013: Migration = {
   version: 13,
   name: 'approval-render-metadata',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`ALTER TABLE pending_channel_approvals ADD COLUMN title TEXT NOT NULL DEFAULT ''`);
     db.exec(`ALTER TABLE pending_channel_approvals ADD COLUMN options_json TEXT NOT NULL DEFAULT '[]'`);

--- a/src/db/migrations/014-container-configs.ts
+++ b/src/db/migrations/014-container-configs.ts
@@ -4,6 +4,7 @@ import type { Migration } from './index.js';
 export const migration014: Migration = {
   version: 14,
   name: 'container-configs',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`
       CREATE TABLE container_configs (

--- a/src/db/migrations/015-cli-scope.ts
+++ b/src/db/migrations/015-cli-scope.ts
@@ -4,6 +4,7 @@ import type { Migration } from './index.js';
 export const migration015: Migration = {
   version: 15,
   name: 'cli-scope',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.prepare("ALTER TABLE container_configs ADD COLUMN cli_scope TEXT NOT NULL DEFAULT 'group'").run();
   },

--- a/src/db/migrations/016-messaging-group-instance.ts
+++ b/src/db/migrations/016-messaging-group-instance.ts
@@ -31,6 +31,7 @@ import type { Migration } from './index.js';
 export const migration016: Migration = {
   version: 16,
   name: 'messaging-group-instance',
+  sqliteOnly: true,
   disableForeignKeys: true,
   up: (db: Database.Database) => {
     // Idempotency guard per the 012 pattern.

--- a/src/db/migrations/017-agent-message-policies.ts
+++ b/src/db/migrations/017-agent-message-policies.ts
@@ -6,6 +6,7 @@ import type { Migration } from './index.js';
 export const migration017: Migration = {
   version: 17,
   name: 'agent-message-policies',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`
       CREATE TABLE agent_message_policies (

--- a/src/db/migrations/018-approvals-approver-user-id.ts
+++ b/src/db/migrations/018-approvals-approver-user-id.ts
@@ -8,6 +8,7 @@ import type { Migration } from './index.js';
 export const migration018: Migration = {
   version: 18,
   name: 'approvals-approver-user-id',
+  sqliteOnly: true,
   up(db) {
     db.exec(`ALTER TABLE pending_approvals ADD COLUMN approver_user_id TEXT;`);
   },

--- a/src/db/migrations/019-wiring-threads.ts
+++ b/src/db/migrations/019-wiring-threads.ts
@@ -14,6 +14,7 @@ import type { Migration } from './index.js';
 export const migration019: Migration = {
   version: 19,
   name: 'wiring-threads-override',
+  sqliteOnly: true,
   up(db) {
     db.exec(`ALTER TABLE messaging_group_agents ADD COLUMN threads INTEGER;`);
   },

--- a/src/db/migrations/020-container-config-timezone.ts
+++ b/src/db/migrations/020-container-config-timezone.ts
@@ -12,6 +12,7 @@ import type { Migration } from './index.js';
 export const migration020: Migration = {
   version: 20,
   name: 'container-config-timezone',
+  sqliteOnly: true,
   up(db) {
     db.exec(`ALTER TABLE container_configs ADD COLUMN timezone TEXT;`);
   },

--- a/src/db/migrations/021-approval-question.ts
+++ b/src/db/migrations/021-approval-question.ts
@@ -11,6 +11,7 @@ import type { Migration } from './index.js';
 export const migration021: Migration = {
   version: 21,
   name: 'approval-question-render-metadata',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`ALTER TABLE pending_approvals ADD COLUMN question TEXT NOT NULL DEFAULT ''`);
     db.exec(`ALTER TABLE pending_channel_approvals ADD COLUMN question TEXT NOT NULL DEFAULT ''`);

--- a/src/db/migrations/022-messaging-group-detached.ts
+++ b/src/db/migrations/022-messaging-group-detached.ts
@@ -16,7 +16,7 @@ import type { Migration } from './index.js';
 export const migration022: Migration = {
   version: 22,
   name: 'messaging-group-detached-at',
-  up(db) {
-    db.exec(`ALTER TABLE messaging_groups ADD COLUMN detached_at TEXT;`);
+  async up(db) {
+    await db.exec(`ALTER TABLE messaging_groups ADD COLUMN detached_at TEXT;`);
   },
 };

--- a/src/db/migrations/023-user-roles-unique.test.ts
+++ b/src/db/migrations/023-user-roles-unique.test.ts
@@ -1,30 +1,28 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { closeDb, initTestDb } from '../connection.js';
+import { sqliteRaw } from '../drivers/sqlite.js';
 import { lookup } from '../../cli/registry.js';
 import { migration023 } from './023-user-roles-unique.js';
 import { migrations, runMigrations } from './index.js';
 import '../../cli/resources/roles.js';
 
-afterEach(() => closeDb());
+afterEach(async () => await closeDb());
 
 describe('user-roles-unique migration', () => {
-  it('deduplicates nullable global grants and enforces both logical key shapes', () => {
-    const db = initTestDb();
-    runMigrations(
+  it('deduplicates nullable global grants and enforces both logical key shapes', async () => {
+    const db = await initTestDb();
+    await runMigrations(
       db,
       migrations.filter((migration) => migration.name !== migration023.name),
     );
 
     const now = new Date().toISOString();
-    db.prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)').run('cli:owner', 'cli', now);
-    db.prepare('INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)').run(
-      'ag-1',
-      'Agent',
-      'agent',
-      now,
-    );
-    const insert = db.prepare(
+    sqliteRaw(db).prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)').run('cli:owner', 'cli', now);
+    sqliteRaw(db)
+      .prepare('INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)')
+      .run('ag-1', 'Agent', 'agent', now);
+    const insert = sqliteRaw(db).prepare(
       `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
        VALUES (?, ?, ?, NULL, ?)`,
     );
@@ -32,9 +30,9 @@ describe('user-roles-unique migration', () => {
     insert.run('cli:owner', 'owner', null, now);
     insert.run('cli:owner', 'admin', 'ag-1', now);
 
-    runMigrations(db, [migration023]);
+    await runMigrations(db, [migration023]);
 
-    const global = db
+    const global = sqliteRaw(db)
       .prepare("SELECT COUNT(*) AS count FROM user_roles WHERE role = 'owner' AND agent_group_id IS NULL")
       .get() as { count: number };
     expect(global.count).toBe(1);
@@ -43,20 +41,18 @@ describe('user-roles-unique migration', () => {
   });
 
   it('makes repeated global grants through ncl idempotent', async () => {
-    const db = initTestDb();
-    runMigrations(db);
-    db.prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)').run(
-      'cli:owner',
-      'cli',
-      new Date().toISOString(),
-    );
+    const db = await initTestDb();
+    await runMigrations(db);
+    sqliteRaw(db)
+      .prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)')
+      .run('cli:owner', 'cli', new Date().toISOString());
 
     const grant = lookup('roles-grant');
     expect(grant).toBeDefined();
     await grant!.handler({ user: 'cli:owner', role: 'owner' }, { caller: 'host' });
     await grant!.handler({ user: 'cli:owner', role: 'owner' }, { caller: 'host' });
 
-    const row = db.prepare("SELECT COUNT(*) AS count FROM user_roles WHERE role = 'owner'").get() as {
+    const row = sqliteRaw(db).prepare("SELECT COUNT(*) AS count FROM user_roles WHERE role = 'owner'").get() as {
       count: number;
     };
     expect(row.count).toBe(1);

--- a/src/db/migrations/023-user-roles-unique.ts
+++ b/src/db/migrations/023-user-roles-unique.ts
@@ -10,6 +10,7 @@ import type { Migration } from './index.js';
 export const migration023: Migration = {
   version: 23,
   name: 'user-roles-unique',
+  sqliteOnly: true,
   up(db) {
     db.exec(`
       DELETE FROM user_roles

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -1,6 +1,8 @@
 import type Database from 'better-sqlite3';
 
 import { log } from '../../log.js';
+import type { DbDriver } from '../driver.js';
+import { sqliteRaw } from '../drivers/sqlite.js';
 import { migration001 } from './001-initial.js';
 import { migration002 } from './002-chat-sdk-state.js';
 import { moduleAgentToAgentDestinations } from './module-agent-to-agent-destinations.js';
@@ -23,11 +25,10 @@ import { migration021 } from './021-approval-question.js';
 import { migration022 } from './022-messaging-group-detached.js';
 import { migration023 } from './023-user-roles-unique.js';
 
-export interface Migration {
+interface MigrationBase {
   version: number;
   /** Permanent applied identity. Never rename a migration after release. */
   name: string;
-  up: (db: Database.Database) => void;
   /**
    * Run with foreign_keys=OFF. Required for table recreates (SQLite can't
    * drop a table-level UNIQUE without DROP+RENAME, and DROP fails FK
@@ -39,12 +40,26 @@ export interface Migration {
   disableForeignKeys?: boolean;
 }
 
+export interface PortableMigration extends MigrationBase {
+  sqliteOnly?: false;
+  up: (db: DbDriver) => void | Promise<void>;
+}
+
+export interface SqliteOnlyMigration extends MigrationBase {
+  sqliteOnly: true;
+  up: (db: Database.Database) => void | Promise<void>;
+}
+
+export type Migration = PortableMigration | SqliteOnlyMigration;
+
 /**
  * Public module migrations use a core-reserved, owner-qualified identity so
  * independent modules may reuse local migration names without colliding.
  */
 export type ModuleMigrationName = `module:${string}:${string}`;
-export type ModuleMigration = Omit<Migration, 'name'> & { name: ModuleMigrationName };
+export type ModuleMigration = (Omit<PortableMigration, 'name'> | Omit<SqliteOnlyMigration, 'name'>) & {
+  name: ModuleMigrationName;
+};
 
 export const migrations: Migration[] = [
   migration001,
@@ -110,8 +125,11 @@ interface FkViolation {
 const fkIdentity = (v: FkViolation): string =>
   JSON.stringify({ table: v.table, rowid: v.rowid, parent: v.parent, fkid: v.fkid });
 
-export function runMigrations(db: Database.Database, list: readonly Migration[] = getRegisteredMigrations()): void {
-  db.exec(`
+export async function runMigrations(
+  db: DbDriver,
+  list: readonly Migration[] = getRegisteredMigrations(),
+): Promise<void> {
+  await db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY,
       name    TEXT NOT NULL,
@@ -127,7 +145,7 @@ export function runMigrations(db: Database.Database, list: readonly Migration[] 
   // the stored `version` column is auto-assigned at insert time as an
   // applied-order number.
   const applied = new Set<string>(
-    (db.prepare('SELECT name FROM schema_version').all() as { name: string }[]).map((r) => r.name),
+    (await db.all<{ name: string }>('SELECT name FROM schema_version')).map((r) => r.name),
   );
   const pending = list.filter((m) => !applied.has(m.name));
   if (pending.length === 0) return;
@@ -135,13 +153,14 @@ export function runMigrations(db: Database.Database, list: readonly Migration[] 
   log.info('Running migrations', { count: pending.length });
 
   for (const m of pending) {
+    const raw = m.sqliteOnly || m.disableForeignKeys ? sqliteRaw(db) : null;
     // Table recreates need FK enforcement off for the DROP+RENAME window.
     // The pragma must be toggled OUTSIDE the transaction (it's a silent
     // no-op inside one); foreign_key_check runs INSIDE so a violating
     // recreate rolls back atomically with nothing committed.
-    if (m.disableForeignKeys) db.pragma('foreign_keys = OFF');
+    if (m.disableForeignKeys) raw!.pragma('foreign_keys = OFF');
     try {
-      db.transaction(() => {
+      await db.transaction(async () => {
         // Snapshot violations BEFORE up() runs: live DBs can carry latent
         // FK orphans (e.g. parents deleted through a FK-OFF sqlite3 CLI
         // session — ensureUserDm tolerates exactly this at runtime). The
@@ -149,11 +168,12 @@ export function runMigrations(db: Database.Database, list: readonly Migration[] 
         // on pre-existing ones would crash-loop the host at every boot
         // (runMigrations runs on startup) until manual DB surgery.
         const preexisting = m.disableForeignKeys
-          ? new Set((db.pragma('foreign_key_check') as FkViolation[]).map(fkIdentity))
+          ? new Set((raw!.pragma('foreign_key_check') as FkViolation[]).map(fkIdentity))
           : null;
-        m.up(db);
+        if (m.sqliteOnly) await m.up(raw!);
+        else await m.up(db);
         if (m.disableForeignKeys && preexisting) {
-          const violations = db.pragma('foreign_key_check') as FkViolation[];
+          const violations = raw!.pragma('foreign_key_check') as FkViolation[];
           const introduced = violations.filter((v) => !preexisting.has(fkIdentity(v)));
           const carried = violations.length - introduced.length;
           if (carried > 0) {
@@ -166,17 +186,16 @@ export function runMigrations(db: Database.Database, list: readonly Migration[] 
             throw new Error(`migration ${m.name} left FK violations: ${JSON.stringify(introduced.slice(0, 5))}`);
           }
         }
-        const next = (
-          db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as { v: number }
-        ).v;
-        db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)').run(
+        const next = (await db.get<{ v: number }>('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version'))!.v;
+        await db.run(
+          'INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)',
           next,
           m.name,
           new Date().toISOString(),
         );
-      })();
+      });
     } finally {
-      if (m.disableForeignKeys) db.pragma('foreign_keys = ON');
+      if (m.disableForeignKeys) raw!.pragma('foreign_keys = ON');
     }
     log.info('Migration applied', { name: m.name });
   }

--- a/src/db/migrations/module-agent-to-agent-destinations.ts
+++ b/src/db/migrations/module-agent-to-agent-destinations.ts
@@ -21,6 +21,7 @@ import type { Migration } from './index.js';
 export const moduleAgentToAgentDestinations: Migration = {
   version: 4,
   name: 'agent-destinations',
+  sqliteOnly: true,
   up(db: Database.Database) {
     db.exec(`
       CREATE TABLE agent_destinations (

--- a/src/db/migrations/module-approvals-pending-approvals.ts
+++ b/src/db/migrations/module-approvals-pending-approvals.ts
@@ -18,6 +18,7 @@ import type { Migration } from './index.js';
 export const moduleApprovalsPendingApprovals: Migration = {
   version: 3,
   name: 'pending-approvals',
+  sqliteOnly: true,
   up(db) {
     db.exec(`
       CREATE TABLE pending_approvals (

--- a/src/db/migrations/module-approvals-title-options.ts
+++ b/src/db/migrations/module-approvals-title-options.ts
@@ -18,6 +18,7 @@ import type { Migration } from './index.js';
 export const moduleApprovalsTitleOptions: Migration = {
   version: 7,
   name: 'pending-approvals-title-options',
+  sqliteOnly: true,
   up(db) {
     const addIfMissing = (col: string, sql: string): void => {
       try {

--- a/src/db/migrations/registry.test.ts
+++ b/src/db/migrations/registry.test.ts
@@ -2,10 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Migration, ModuleMigration, ModuleMigrationName } from './index.js';
 
-let closeCurrentDb: (() => void) | undefined;
+let closeCurrentDb: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  closeCurrentDb?.();
+afterEach(async () => {
+  await closeCurrentDb?.();
   closeCurrentDb = undefined;
 });
 
@@ -13,8 +13,8 @@ function testMigration(name: string, table = name.replace(/[^a-zA-Z0-9_]/g, '_')
   return {
     version,
     name,
-    up(db) {
-      db.exec(`CREATE TABLE ${table} (id TEXT PRIMARY KEY)`);
+    async up(db) {
+      await db.exec(`CREATE TABLE ${table} (id TEXT PRIMARY KEY)`);
     },
   };
 }
@@ -30,7 +30,7 @@ async function freshRegistry() {
 
 async function freshTestDb() {
   const connection = await import('../connection.js');
-  const db = connection.initTestDb();
+  const db = await connection.initTestDb();
   closeCurrentDb = connection.closeDb;
   return db;
 }
@@ -76,13 +76,13 @@ describe('module migration registry', () => {
     const db = await freshTestDb();
     registry.registerMigration(testModuleMigration('module:test-owner:applied', 'test_module_applied'));
 
-    registry.runMigrations(db);
+    await registry.runMigrations(db);
 
-    expect(db.prepare("SELECT name FROM schema_version WHERE name = 'module:test-owner:applied'").get()).toEqual({
+    expect(await db.get("SELECT name FROM schema_version WHERE name = 'module:test-owner:applied'")).toEqual({
       name: 'module:test-owner:applied',
     });
     expect(
-      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_applied'").get(),
+      await db.get("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_applied'"),
     ).toEqual({ name: 'test_module_applied' });
   });
 
@@ -92,13 +92,11 @@ describe('module migration registry', () => {
     const explicit = testMigration('test-explicit-only');
     registry.registerMigration(testModuleMigration('module:test-owner:not-selected', 'test_module_not_selected'));
 
-    registry.runMigrations(db, [explicit]);
+    await registry.runMigrations(db, [explicit]);
 
-    expect(db.prepare('SELECT name FROM schema_version ORDER BY version').all()).toEqual([
-      { name: 'test-explicit-only' },
-    ]);
+    expect(await db.all('SELECT name FROM schema_version ORDER BY version')).toEqual([{ name: 'test-explicit-only' }]);
     expect(
-      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_not_selected'").get(),
+      await db.get("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_not_selected'"),
     ).toBeUndefined();
   });
 });

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -5,28 +5,32 @@ import { getDb, hasTable } from './connection.js';
 
 export const TASKS_SYSTEM_THREAD_ID = 'system:tasks';
 
-export function createSession(session: Session): void {
-  getDb()
-    .prepare(
-      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
+export async function createSession(session: Session): Promise<void> {
+  await getDb().run(
+    `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
        VALUES (@id, @agent_group_id, @messaging_group_id, @thread_id, @agent_provider, @status, @container_status, @last_active, @created_at)`,
-    )
-    .run(session);
+    session,
+  );
 }
 
-export function getSession(id: string): Session | undefined {
-  return getDb().prepare('SELECT * FROM sessions WHERE id = ?').get(id) as Session | undefined;
+export async function getSession(id: string): Promise<Session | undefined> {
+  return getDb().get<Session>('SELECT * FROM sessions WHERE id = ?', id);
 }
 
-export function findSession(messagingGroupId: string, threadId: string | null): Session | undefined {
+export async function findSession(messagingGroupId: string, threadId: string | null): Promise<Session | undefined> {
   if (threadId) {
-    return getDb()
-      .prepare('SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id = ? AND status = ?')
-      .get(messagingGroupId, threadId, 'active') as Session | undefined;
+    return getDb().get<Session>(
+      'SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id = ? AND status = ?',
+      messagingGroupId,
+      threadId,
+      'active',
+    );
   }
-  return getDb()
-    .prepare('SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id IS NULL AND status = ?')
-    .get(messagingGroupId, 'active') as Session | undefined;
+  return getDb().get<Session>(
+    'SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id IS NULL AND status = ?',
+    messagingGroupId,
+    'active',
+  );
 }
 
 /**
@@ -35,55 +39,55 @@ export function findSession(messagingGroupId: string, threadId: string | null): 
  * plain `findSession` would return whichever agent's session happened to
  * be first and route to the wrong container.
  */
-export function findSessionForAgent(
+export async function findSessionForAgent(
   agentGroupId: string,
   messagingGroupId: string,
   threadId: string | null,
-): Session | undefined {
+): Promise<Session | undefined> {
   if (threadId) {
-    return getDb()
-      .prepare(
-        "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id = ? AND status = 'active'",
-      )
-      .get(agentGroupId, messagingGroupId, threadId) as Session | undefined;
+    return getDb().get<Session>(
+      "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id = ? AND status = 'active'",
+      agentGroupId,
+      messagingGroupId,
+      threadId,
+    );
   }
-  return getDb()
-    .prepare(
-      "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id IS NULL AND status = 'active'",
-    )
-    .get(agentGroupId, messagingGroupId) as Session | undefined;
+  return getDb().get<Session>(
+    "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id IS NULL AND status = 'active'",
+    agentGroupId,
+    messagingGroupId,
+  );
 }
 
 /** Find an active session scoped to an agent group (ignoring messaging group). */
-export function findSessionByAgentGroup(agentGroupId: string): Session | undefined {
-  return getDb()
-    .prepare(
-      `SELECT * FROM sessions
+export async function findSessionByAgentGroup(agentGroupId: string): Promise<Session | undefined> {
+  return getDb().get<Session>(
+    `SELECT * FROM sessions
        WHERE agent_group_id = ?
          AND status = 'active'
          AND NOT (messaging_group_id IS NULL AND thread_id IS NOT NULL AND thread_id LIKE 'system:%')
        ORDER BY created_at DESC
        LIMIT 1`,
-    )
-    .get(agentGroupId) as Session | undefined;
+    agentGroupId,
+  );
 }
 
-export function getSessionsByAgentGroup(agentGroupId: string): Session[] {
-  return getDb().prepare('SELECT * FROM sessions WHERE agent_group_id = ?').all(agentGroupId) as Session[];
+export async function getSessionsByAgentGroup(agentGroupId: string): Promise<Session[]> {
+  return getDb().all<Session>('SELECT * FROM sessions WHERE agent_group_id = ?', agentGroupId);
 }
 
-export function findSystemSession(agentGroupId: string, threadId: string): Session | undefined {
-  return getDb()
-    .prepare(
-      `SELECT * FROM sessions
+export async function findSystemSession(agentGroupId: string, threadId: string): Promise<Session | undefined> {
+  return getDb().get<Session>(
+    `SELECT * FROM sessions
        WHERE agent_group_id = ?
          AND messaging_group_id IS NULL
          AND thread_id = ?
          AND status = 'active'
        ORDER BY created_at DESC
        LIMIT 1`,
-    )
-    .get(agentGroupId, threadId) as Session | undefined;
+    agentGroupId,
+    threadId,
+  );
 }
 
 /** Per-task session thread id for a scheduled task series. */
@@ -97,31 +101,32 @@ export function isTaskThread(threadId: string | null): boolean {
 }
 
 /** All active task sessions for a group — one per live series, plus any legacy shared one. */
-export function findTaskSessions(agentGroupId: string): Session[] {
-  return getDb()
-    .prepare(
-      `SELECT * FROM sessions
+export async function findTaskSessions(agentGroupId: string): Promise<Session[]> {
+  return getDb().all<Session>(
+    `SELECT * FROM sessions
        WHERE agent_group_id = ?
          AND messaging_group_id IS NULL
          AND status = 'active'
          AND (thread_id = ? OR thread_id LIKE ?)
        ORDER BY created_at DESC`,
-    )
-    .all(agentGroupId, TASKS_SYSTEM_THREAD_ID, `${TASKS_SYSTEM_THREAD_ID}:%`) as Session[];
+    agentGroupId,
+    TASKS_SYSTEM_THREAD_ID,
+    `${TASKS_SYSTEM_THREAD_ID}:%`,
+  );
 }
 
-export function getActiveSessions(): Session[] {
-  return getDb().prepare("SELECT * FROM sessions WHERE status = 'active'").all() as Session[];
+export async function getActiveSessions(): Promise<Session[]> {
+  return getDb().all<Session>("SELECT * FROM sessions WHERE status = 'active'");
 }
 
-export function getRunningSessions(): Session[] {
-  return getDb().prepare("SELECT * FROM sessions WHERE container_status IN ('running', 'idle')").all() as Session[];
+export async function getRunningSessions(): Promise<Session[]> {
+  return getDb().all<Session>("SELECT * FROM sessions WHERE container_status IN ('running', 'idle')");
 }
 
-export function updateSession(
+export async function updateSession(
   id: string,
   updates: Partial<Pick<Session, 'status' | 'container_status' | 'last_active' | 'agent_provider'>>,
-): void {
+): Promise<void> {
   const fields: string[] = [];
   const values: Record<string, unknown> = { id };
 
@@ -133,13 +138,11 @@ export function updateSession(
   }
   if (fields.length === 0) return;
 
-  getDb()
-    .prepare(`UPDATE sessions SET ${fields.join(', ')} WHERE id = @id`)
-    .run(values);
+  await getDb().run(`UPDATE sessions SET ${fields.join(', ')} WHERE id = @id`, values);
 }
 
-export function deleteSession(id: string): void {
-  getDb().prepare('DELETE FROM sessions WHERE id = ?').run(id);
+export async function deleteSession(id: string): Promise<void> {
+  await getDb().run('DELETE FROM sessions WHERE id = ?', id);
 }
 
 // ── Pending Questions ──
@@ -150,14 +153,12 @@ export function deleteSession(id: string): void {
  * IGNORE` that would throw UNIQUE and prevent the retry from reaching the
  * actual send step. Returns true if a new row was inserted.
  */
-export function createPendingQuestion(pq: PendingQuestion): boolean {
-  const result = getDb()
-    .prepare(
-      `INSERT INTO pending_questions (question_id, session_id, message_out_id, platform_id, channel_type, thread_id, title, options_json, created_at)
+export async function createPendingQuestion(pq: PendingQuestion): Promise<boolean> {
+  const result = await getDb().run(
+    `INSERT INTO pending_questions (question_id, session_id, message_out_id, platform_id, channel_type, thread_id, title, options_json, created_at)
        VALUES (@question_id, @session_id, @message_out_id, @platform_id, @channel_type, @thread_id, @title, @options_json, @created_at)
        ON CONFLICT (question_id) DO NOTHING`,
-    )
-    .run({
+    {
       question_id: pq.question_id,
       session_id: pq.session_id,
       message_out_id: pq.message_out_id,
@@ -167,21 +168,23 @@ export function createPendingQuestion(pq: PendingQuestion): boolean {
       title: pq.title,
       options_json: JSON.stringify(pq.options),
       created_at: pq.created_at,
-    });
+    },
+  );
   return result.changes > 0;
 }
 
-export function getPendingQuestion(questionId: string): PendingQuestion | undefined {
-  const row = getDb().prepare('SELECT * FROM pending_questions WHERE question_id = ?').get(questionId) as
-    | (Omit<PendingQuestion, 'options'> & { options_json: string })
-    | undefined;
+export async function getPendingQuestion(questionId: string): Promise<PendingQuestion | undefined> {
+  const row = await getDb().get<Omit<PendingQuestion, 'options'> & { options_json: string }>(
+    'SELECT * FROM pending_questions WHERE question_id = ?',
+    questionId,
+  );
   if (!row) return undefined;
   const { options_json, ...rest } = row;
   return { ...rest, options: JSON.parse(options_json) };
 }
 
-export function deletePendingQuestion(questionId: string): void {
-  getDb().prepare('DELETE FROM pending_questions WHERE question_id = ?').run(questionId);
+export async function deletePendingQuestion(questionId: string): Promise<void> {
+  await getDb().run('DELETE FROM pending_questions WHERE question_id = ?', questionId);
 }
 
 // ── Pending Approvals ──
@@ -191,16 +194,15 @@ export function deletePendingQuestion(questionId: string): void {
  * createPendingQuestion: delivery retries with the same approval_id must not
  * fail on UNIQUE before the send step gets a chance to succeed.
  */
-export function createPendingApproval(
+export async function createPendingApproval(
   pa: Partial<PendingApproval> &
     Pick<
       PendingApproval,
       'approval_id' | 'request_id' | 'action' | 'payload' | 'created_at' | 'title' | 'options_json'
     >,
-): boolean {
-  const result = getDb()
-    .prepare(
-      `INSERT INTO pending_approvals
+): Promise<boolean> {
+  const result = await getDb().run(
+    `INSERT INTO pending_approvals
          (approval_id, session_id, request_id, action, payload, created_at,
           agent_group_id, channel_type, platform_id, platform_message_id, expires_at, status,
           title, question, options_json, approver_user_id)
@@ -209,8 +211,7 @@ export function createPendingApproval(
           @agent_group_id, @channel_type, @platform_id, @platform_message_id, @expires_at, @status,
           @title, @question, @options_json, @approver_user_id)
        ON CONFLICT (approval_id) DO NOTHING`,
-    )
-    .run({
+    {
       session_id: null,
       agent_group_id: null,
       channel_type: null,
@@ -221,18 +222,20 @@ export function createPendingApproval(
       question: '',
       approver_user_id: null,
       ...pa,
-    });
+    },
+  );
   return result.changes > 0;
 }
 
-export function getPendingApproval(approvalId: string): PendingApproval | undefined {
-  return getDb().prepare('SELECT * FROM pending_approvals WHERE approval_id = ?').get(approvalId) as
-    | PendingApproval
-    | undefined;
+export async function getPendingApproval(approvalId: string): Promise<PendingApproval | undefined> {
+  return getDb().get<PendingApproval>('SELECT * FROM pending_approvals WHERE approval_id = ?', approvalId);
 }
 
-export function updatePendingApprovalStatus(approvalId: string, status: PendingApproval['status']): void {
-  getDb().prepare('UPDATE pending_approvals SET status = ? WHERE approval_id = ?').run(status, approvalId);
+export async function updatePendingApprovalStatus(
+  approvalId: string,
+  status: PendingApproval['status'],
+): Promise<void> {
+  await getDb().run('UPDATE pending_approvals SET status = ? WHERE approval_id = ?', status, approvalId);
 }
 
 /**
@@ -242,27 +245,28 @@ export function updatePendingApprovalStatus(approvalId: string, status: PendingA
  * ghosted hold never strands the requesting agent). Reuses the otherwise-unused
  * `expires_at` column on module-initiated rows.
  */
-export function markApprovalAwaitingReason(approvalId: string, expiresAt: string): void {
-  getDb()
-    .prepare("UPDATE pending_approvals SET status = 'awaiting_reason', expires_at = ? WHERE approval_id = ?")
-    .run(expiresAt, approvalId);
+export async function markApprovalAwaitingReason(approvalId: string, expiresAt: string): Promise<void> {
+  await getDb().run(
+    "UPDATE pending_approvals SET status = 'awaiting_reason', expires_at = ? WHERE approval_id = ?",
+    expiresAt,
+    approvalId,
+  );
 }
 
 /** Awaiting-reason approvals whose reply window has elapsed — the sweep's ghost set. */
-export function getExpiredAwaitingReasonApprovals(nowIso: string): PendingApproval[] {
-  return getDb()
-    .prepare(
-      "SELECT * FROM pending_approvals WHERE status = 'awaiting_reason' AND expires_at IS NOT NULL AND expires_at <= ?",
-    )
-    .all(nowIso) as PendingApproval[];
+export async function getExpiredAwaitingReasonApprovals(nowIso: string): Promise<PendingApproval[]> {
+  return getDb().all<PendingApproval>(
+    "SELECT * FROM pending_approvals WHERE status = 'awaiting_reason' AND expires_at IS NOT NULL AND expires_at <= ?",
+    nowIso,
+  );
 }
 
-export function deletePendingApproval(approvalId: string): void {
-  getDb().prepare('DELETE FROM pending_approvals WHERE approval_id = ?').run(approvalId);
+export async function deletePendingApproval(approvalId: string): Promise<void> {
+  await getDb().run('DELETE FROM pending_approvals WHERE approval_id = ?', approvalId);
 }
 
-export function getPendingApprovalsByAction(action: string): PendingApproval[] {
-  return getDb().prepare('SELECT * FROM pending_approvals WHERE action = ?').all(action) as PendingApproval[];
+export async function getPendingApprovalsByAction(action: string): Promise<PendingApproval[]> {
+  return getDb().all<PendingApproval>('SELECT * FROM pending_approvals WHERE action = ?', action);
 }
 
 /**
@@ -271,33 +275,37 @@ export function getPendingApprovalsByAction(action: string): PendingApproval[] {
  * card resolves; generic pending_questions intentionally keep their existing
  * title + options shape.
  */
-export function getAskQuestionRender(id: string):
+export async function getAskQuestionRender(id: string): Promise<
   | {
       title: string;
       question?: string;
       options: import('../channels/ask-question.js').NormalizedOption[];
     }
-  | undefined {
-  const q = getPendingQuestion(id);
+  | undefined
+> {
+  const q = await getPendingQuestion(id);
   if (q) return { title: q.title, options: q.options };
-  const a = getDb()
-    .prepare('SELECT title, question, options_json FROM pending_approvals WHERE approval_id = ?')
-    .get(id) as { title: string; question: string; options_json: string } | undefined;
+  const a = await getDb().get<{ title: string; question: string; options_json: string }>(
+    'SELECT title, question, options_json FROM pending_approvals WHERE approval_id = ?',
+    id,
+  );
   if (a?.title) return { title: a.title, question: a.question, options: JSON.parse(a.options_json) };
 
   // Channel-registration + unknown-sender approvals persist the same render
   // metadata as pending_approvals — just SELECT and return.
-  if (hasTable(getDb(), 'pending_channel_approvals')) {
-    const c = getDb()
-      .prepare('SELECT title, question, options_json FROM pending_channel_approvals WHERE messaging_group_id = ?')
-      .get(id) as { title: string; question: string; options_json: string } | undefined;
+  if (await hasTable(getDb(), 'pending_channel_approvals')) {
+    const c = await getDb().get<{ title: string; question: string; options_json: string }>(
+      'SELECT title, question, options_json FROM pending_channel_approvals WHERE messaging_group_id = ?',
+      id,
+    );
     if (c?.title) return { title: c.title, question: c.question, options: JSON.parse(c.options_json) };
   }
 
-  if (hasTable(getDb(), 'pending_sender_approvals')) {
-    const s = getDb()
-      .prepare('SELECT title, question, options_json FROM pending_sender_approvals WHERE id = ?')
-      .get(id) as { title: string; question: string; options_json: string } | undefined;
+  if (await hasTable(getDb(), 'pending_sender_approvals')) {
+    const s = await getDb().get<{ title: string; question: string; options_json: string }>(
+      'SELECT title, question, options_json FROM pending_sender_approvals WHERE id = ?',
+      id,
+    );
     if (s?.title) return { title: s.title, question: s.question, options: JSON.parse(s.options_json) };
   }
 

--- a/src/delivery-guard.ts
+++ b/src/delivery-guard.ts
@@ -24,7 +24,7 @@ export interface DeliveryGuardSpec {
   /** Create the hold (the domain's requestApproval call — card text lives with the domain). */
   requestHold: (content: Record<string, unknown>, session: Session) => Promise<void>;
   /** Tell the requester about a deny. */
-  onDeny?: (content: Record<string, unknown>, session: Session, reason: string) => void;
+  onDeny?: (content: Record<string, unknown>, session: Session, reason: string) => void | Promise<void>;
 }
 
 /**
@@ -44,7 +44,7 @@ export async function runGuarded(
 ): Promise<void> {
   if (spec.precheck && !(await spec.precheck(content, session))) return;
 
-  const decision = guard(spec.guardAction, {
+  const decision = await guard(spec.guardAction, {
     actor: { kind: 'agent', agentGroupId: session.agent_group_id, sessionId: session.id },
     payload: content,
     grant,
@@ -52,7 +52,7 @@ export async function runGuarded(
 
   if (decision.effect === 'deny') {
     log.warn('Delivery action denied by guard', { action, reason: decision.reason });
-    spec.onDeny?.(content, session, decision.reason);
+    await spec.onDeny?.(content, session, decision.reason);
     return;
   }
   if (decision.effect === 'hold') {

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -42,15 +42,15 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function seedAgentAndChannel(): void {
-  createAgentGroup({
+async function seedAgentAndChannel(): Promise<void> {
+  await createAgentGroup({
     id: 'ag-1',
     name: 'Test Agent',
     folder: 'test-agent',
     agent_provider: null,
     created_at: now(),
   });
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-1',
     channel_type: 'telegram',
     platform_id: 'telegram:123',
@@ -70,22 +70,22 @@ function insertOutbound(agentGroupId: string, sessionId: string, msgId: string):
   db.close();
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
 describe('deliverSessionMessages — concurrent invocations', () => {
   it('delivers a message exactly once when active and sweep polls overlap', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-1');
 
     const calls: string[] = [];
@@ -107,8 +107,8 @@ describe('deliverSessionMessages — concurrent invocations', () => {
   });
 
   it('still delivers on a subsequent call after the first finishes', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-first');
 
     const calls: string[] = [];
@@ -134,8 +134,8 @@ describe('deliverSessionMessages — concurrent invocations', () => {
     // still landed on the user's screen — the catch path must not trigger
     // a re-send. We simulate by having the adapter succeed on the first
     // call and recording how many times it's invoked across two attempts.
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-once');
 
     let callCount = 0;
@@ -157,8 +157,8 @@ describe('deliverSessionMessages — concurrent invocations', () => {
 
 describe('deliverSessionMessages — retry and permanent failure', () => {
   it('retries on adapter failure and marks failed after MAX_DELIVERY_ATTEMPTS (3)', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-flaky');
 
     let callCount = 0;
@@ -199,8 +199,8 @@ describe('deliverSessionMessages — retry and permanent failure', () => {
     // throw so the row takes the normal retry → failed path. Uses the REAL
     // createChannelDeliveryAdapter with an empty registry — the state after
     // an adapter factory returns null (missing credentials) at startup.
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-offline');
 
     setDeliveryAdapter(createChannelDeliveryAdapter());
@@ -227,8 +227,8 @@ describe('deliverSessionMessages — retry and permanent failure', () => {
   });
 
   it('clears attempt counter on successful delivery', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-retry-ok');
 
     let callCount = 0;
@@ -256,7 +256,7 @@ describe('deliverSessionMessages — retry and permanent failure', () => {
 
 describe('deliverSessionMessages — instance resolution', () => {
   it('delivers via the origin session instance when sibling rows share (channel_type, platform_id)', async () => {
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Test Agent',
       folder: 'test-agent',
@@ -266,7 +266,7 @@ describe('deliverSessionMessages — instance resolution', () => {
     // Two instances own the same chat address. The named row sorts before
     // 'slack', so a plain by-platform lookup (default-instance-first) would
     // pick mg-default — only origin-session preference selects mg-tester.
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-default',
       channel_type: 'slack',
       platform_id: 'slack:C1',
@@ -275,7 +275,7 @@ describe('deliverSessionMessages — instance resolution', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-tester',
       channel_type: 'slack',
       platform_id: 'slack:C1',
@@ -286,7 +286,7 @@ describe('deliverSessionMessages — instance resolution', () => {
       created_at: now(),
     });
 
-    const { session } = resolveSession('ag-1', 'mg-tester', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-tester', null, 'shared');
     const db = new Database(outboundDbPath('ag-1', session.id));
     db.prepare(
       `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
@@ -307,8 +307,8 @@ describe('deliverSessionMessages — instance resolution', () => {
   });
 
   it('default session passes the backfilled default instance (= channel_type)', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'out-default-inst');
 
     const instances: Array<string | undefined> = [];
@@ -326,10 +326,10 @@ describe('deliverSessionMessages — instance resolution', () => {
 
 describe('deliverSessionMessages — permission check', () => {
   it('rejects delivery to an unauthorized channel destination', async () => {
-    seedAgentAndChannel();
+    await seedAgentAndChannel();
 
     // Create a second messaging group that the agent is NOT wired to
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-2',
       channel_type: 'discord',
       platform_id: 'discord:456',
@@ -340,7 +340,7 @@ describe('deliverSessionMessages — permission check', () => {
     });
 
     // Session is on mg-1 (telegram)
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
     // Insert an outbound message targeting mg-2 (discord) — not the origin chat
     const outDb = new Database(outboundDbPath('ag-1', session.id));
@@ -376,14 +376,14 @@ describe('deliverSessionMessages — permission check', () => {
   });
 
   it("authorizes and delivers via the sender's own instance when sibling instances share a platform address", async () => {
-    seedAgentAndChannel();
+    await seedAgentAndChannel();
 
     // Two sibling messaging groups share one physical channel address but
     // belong to different adapter instances (e.g. two bot identities in the
     // same multi-bot room). "alpha" sorts before "zulu" lexically, so a
     // plain by-platform lookup with no instance hint would pick "alpha" —
     // the wrong sibling for this sender.
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-sib-alpha',
       channel_type: 'discord',
       platform_id: 'discord:999',
@@ -393,7 +393,7 @@ describe('deliverSessionMessages — permission check', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-sib-zulu',
       channel_type: 'discord',
       platform_id: 'discord:999',
@@ -405,7 +405,7 @@ describe('deliverSessionMessages — permission check', () => {
     });
 
     // The sender is only authorized against its own ("zulu") sibling.
-    createDestination({
+    await createDestination({
       agent_group_id: 'ag-1',
       local_name: 'room',
       target_type: 'channel',
@@ -415,7 +415,7 @@ describe('deliverSessionMessages — permission check', () => {
 
     // Session origin is mg-1 (telegram) — not the shared room, so the
     // origin-session shortcut doesn't apply here.
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
     const outDb = new Database(outboundDbPath('ag-1', session.id));
     outDb
@@ -448,12 +448,12 @@ describe('deliverSessionMessages — permission check', () => {
   });
 
   it('still authorizes and delivers an ordinary single-instance non-origin channel destination', async () => {
-    seedAgentAndChannel();
+    await seedAgentAndChannel();
 
     // A second, single-instance channel the agent is legitimately wired to
     // (the common case: broadcasting from a DM session to a wired channel —
     // no sibling instances, no ambiguity, exactly one row for this address).
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-broadcast',
       channel_type: 'discord',
       platform_id: 'discord:789',
@@ -462,7 +462,7 @@ describe('deliverSessionMessages — permission check', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createDestination({
+    await createDestination({
       agent_group_id: 'ag-1',
       local_name: 'team-channel',
       target_type: 'channel',
@@ -471,7 +471,7 @@ describe('deliverSessionMessages — permission check', () => {
     });
 
     // Session is on mg-1 (telegram) — not the origin of the broadcast target.
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
     const outDb = new Database(outboundDbPath('ag-1', session.id));
     outDb
@@ -507,8 +507,8 @@ describe('deliverSessionMessages — permission check', () => {
 
 describe('deliverSessionMessages — task_log rows (one-door task delivery)', () => {
   it('appends to the series run log and never calls the adapter', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveTaskSession('ag-1', 'daily-digest-a1b2');
+    await seedAgentAndChannel();
+    const { session } = await resolveTaskSession('ag-1', 'daily-digest-a1b2');
 
     const db = new Database(outboundDbPath('ag-1', session.id));
     db.prepare(
@@ -539,8 +539,8 @@ describe('deliverSessionMessages — task_log rows (one-door task delivery)', ()
 
 describe('deliverSessionMessages — batch preview hooks', () => {
   it('hooks see the whole undelivered batch before row processing; a throwing hook never breaks delivery', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutbound('ag-1', session.id, 'bp-1');
     insertOutbound('ag-1', session.id, 'bp-2');
 
@@ -595,8 +595,8 @@ describe('deliverSessionMessages — post-delivery hooks', () => {
   }
 
   it('fires only for user-facing kinds — system and task_log rows are skipped', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     // Unknown system action: handled internally, marked delivered, no hook.
     insertOutboundRow('ag-1', session.id, 'pd-sys', 'system', '2026-01-01T00:00:01.000Z', { action: 'nope' });
     // task_log outside a task session: ignored + marked delivered, no hook.
@@ -620,8 +620,8 @@ describe('deliverSessionMessages — post-delivery hooks', () => {
   });
 
   it('firstDelivery is true exactly on the first delivered row of a fresh session', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutboundRow('ag-1', session.id, 'fd-1', 'chat', '2026-01-01T00:00:01.000Z');
     insertOutboundRow('ag-1', session.id, 'fd-2', 'chat', '2026-01-01T00:00:02.000Z');
 
@@ -644,8 +644,8 @@ describe('deliverSessionMessages — post-delivery hooks', () => {
   });
 
   it('a throwing hook never breaks delivery or markDelivered', async () => {
-    seedAgentAndChannel();
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     insertOutboundRow('ag-1', session.id, 'th-1', 'chat', '2026-01-01T00:00:01.000Z');
     insertOutboundRow('ag-1', session.id, 'th-2', 'chat', '2026-01-01T00:00:02.000Z');
 

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -147,7 +147,7 @@ async function pollActive(): Promise<void> {
   if (!activePolling) return;
 
   try {
-    const sessions = getRunningSessions();
+    const sessions = await getRunningSessions();
     for (const session of sessions) {
       await deliverSessionMessages(session);
     }
@@ -162,7 +162,7 @@ async function pollSweep(): Promise<void> {
   if (!sweepPolling) return;
 
   try {
-    const sessions = getActiveSessions();
+    const sessions = await getActiveSessions();
     for (const session of sessions) {
       await deliverSessionMessages(session);
     }
@@ -187,7 +187,7 @@ export async function deliverSessionMessages(session: Session): Promise<void> {
 }
 
 async function drainSession(session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) return;
 
   let outDb: Database.Database;
@@ -220,7 +220,7 @@ async function drainSession(session: Session): Promise<void> {
     // delivery.
     for (const hook of batchPreviewHooks) {
       try {
-        hook(
+        await hook(
           undelivered.map((m) => ({ kind: m.kind, content: m.content })),
           session,
         );
@@ -254,13 +254,13 @@ async function drainSession(session: Session): Promise<void> {
           // user-facing — excluded. Runs after markDelivered so a delivery
           // retry never double-fans.
           if (msg.kind !== 'task_log') {
-            fanOutboundMessage(msg, session, agentGroup);
+            await fanOutboundMessage(msg, session, agentGroup);
             // Post-delivery hooks: user-facing rows only, same exclusions
             // as the fan above. Hooks are decoration: failures log and can
             // never affect delivery or retries.
             for (const hook of postDeliveryHooks) {
               try {
-                hook(msg, session, { firstDelivery });
+                await hook(msg, session, { firstDelivery });
               } catch (err) {
                 log.warn('Post-delivery hook failed', { messageId: msg.id, sessionId: session.id, err });
               }
@@ -330,7 +330,7 @@ async function deliverMessage(
     if (session.messaging_group_id === null && isTaskThread(session.thread_id) && session.thread_id) {
       const series = session.thread_id.slice(`${TASKS_SYSTEM_THREAD_ID}:`.length);
       try {
-        appendRunLog(session.agent_group_id, series, typeof content.text === 'string' ? content.text : '');
+        await appendRunLog(session.agent_group_id, series, typeof content.text === 'string' ? content.text : '');
       } catch (err) {
         log.warn('Failed to append task run log', { id: msg.id, sessionId: session.id, err });
       }
@@ -345,7 +345,7 @@ async function deliverMessage(
   // `agent_destinations` table won't exist and `routeAgentMessage`'s permission
   // check will throw, which falls into the normal retry → mark-failed path.
   if (msg.channel_type === 'agent') {
-    if (!hasTable(getDb(), 'agent_destinations')) {
+    if (!(await hasTable(getDb(), 'agent_destinations'))) {
       throw new Error(`agent-to-agent module not installed — cannot route message ${msg.id}`);
     }
     const { routeAgentMessage } = await import('./modules/agent-to-agent/agent-route.js');
@@ -379,12 +379,12 @@ async function deliverMessage(
     // sibling instances share the same channel address), falling back to the
     // by-platform lookup (default-instance-first) when the sender has no
     // matching destination.
-    const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+    const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
     const mg =
       originMg && originMg.channel_type === msg.channel_type && originMg.platform_id === msg.platform_id
         ? originMg
-        : (getMessagingGroupForOwnDestination(session.agent_group_id, msg.channel_type, msg.platform_id) ??
-          getMessagingGroupByPlatform(msg.channel_type, msg.platform_id));
+        : ((await getMessagingGroupForOwnDestination(session.agent_group_id, msg.channel_type, msg.platform_id)) ??
+          (await getMessagingGroupByPlatform(msg.channel_type, msg.platform_id)));
     if (!mg) {
       throw new Error(`unknown messaging group for ${msg.channel_type}/${msg.platform_id} (message ${msg.id})`);
     }
@@ -402,12 +402,13 @@ async function deliverMessage(
     // doesn't exist and we permit all non-origin channel sends (the
     // origin-chat case is always allowed regardless). Inlined SQL instead
     // of importing `hasDestination` so core doesn't depend on the module.
-    if (!isOriginChat && hasTable(getDb(), 'agent_destinations')) {
-      const row = getDb()
-        .prepare(
-          'SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ? LIMIT 1',
-        )
-        .get(session.agent_group_id, 'channel', mg.id);
+    if (!isOriginChat && (await hasTable(getDb(), 'agent_destinations'))) {
+      const row = await getDb().get(
+        'SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ? LIMIT 1',
+        session.agent_group_id,
+        'channel',
+        mg.id,
+      );
       if (!row) {
         throw new Error(
           `unauthorized channel destination: ${session.agent_group_id} cannot send to ${mg.channel_type}/${mg.platform_id}`,
@@ -421,7 +422,7 @@ async function deliverMessage(
   // Guarded: without the interactive module, `pending_questions` doesn't
   // exist and we skip persistence — the card still delivers to the user,
   // but the response path has nowhere to land and will log unclaimed.
-  if (content.type === 'ask_question' && content.questionId && hasTable(getDb(), 'pending_questions')) {
+  if (content.type === 'ask_question' && content.questionId && (await hasTable(getDb(), 'pending_questions'))) {
     const title = content.title as string | undefined;
     const rawOptions = content.options as unknown;
     if (!title || !Array.isArray(rawOptions)) {
@@ -429,7 +430,7 @@ async function deliverMessage(
         questionId: content.questionId,
       });
     } else {
-      const inserted = createPendingQuestion({
+      const inserted = await createPendingQuestion({
         question_id: content.questionId,
         session_id: session.id,
         message_out_id: msg.id,
@@ -505,7 +506,7 @@ export interface PostDeliveryInfo {
   firstDelivery: boolean;
 }
 
-export type PostDeliveryHook = (msg: OutboundMessage, session: Session, info: PostDeliveryInfo) => void;
+export type PostDeliveryHook = (msg: OutboundMessage, session: Session, info: PostDeliveryInfo) => void | Promise<void>;
 
 const postDeliveryHooks: PostDeliveryHook[] = [];
 
@@ -548,7 +549,10 @@ function isUnguardedEntry(entry: DeliveryEntry): entry is Extract<DeliveryEntry,
 }
 
 /** See the batch-preview invocation in the delivery poll for semantics. */
-type DeliveryBatchPreviewHook = (batch: Array<{ kind: string; content: string }>, session: Session) => void;
+type DeliveryBatchPreviewHook = (
+  batch: Array<{ kind: string; content: string }>,
+  session: Session,
+) => void | Promise<void>;
 const batchPreviewHooks: DeliveryBatchPreviewHook[] = [];
 export function registerDeliveryBatchPreview(hook: DeliveryBatchPreviewHook): void {
   batchPreviewHooks.push(hook);

--- a/src/group-init.settings.test.ts
+++ b/src/group-init.settings.test.ts
@@ -18,35 +18,35 @@ import { closeDb, createAgentGroup, initTestDb, runMigrations } from './db/index
 import { initGroupFilesystem } from './group-init.js';
 import type { AgentGroup } from './types.js';
 
-function makeGroup(id: string): AgentGroup {
+async function makeGroup(id: string): Promise<AgentGroup> {
   const ag = { id, name: id, folder: id, agent_provider: null, created_at: new Date().toISOString() } as AgentGroup;
-  createAgentGroup(ag);
+  await createAgentGroup(ag);
   return ag;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   fs.mkdirSync(TEST_ROOT, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
 describe('group filesystem scaffold', () => {
-  it('creates plugins/ so the read-only plugins mount is unconditional', () => {
-    const ag = makeGroup('ag-plugins');
-    initGroupFilesystem(ag, {});
+  it('creates plugins/ so the read-only plugins mount is unconditional', async () => {
+    const ag = await makeGroup('ag-plugins');
+    await initGroupFilesystem(ag, {});
     expect(fs.statSync(path.join(TEST_ROOT, 'groups', ag.folder, 'plugins')).isDirectory()).toBe(true);
   });
 });
 
 describe('default settings.json for new groups', () => {
-  it('is lean: no agent-teams env key, unmanaged keys intact', () => {
-    const ag = makeGroup('ag-lean');
-    initGroupFilesystem(ag, {});
+  it('is lean: no agent-teams env key, unmanaged keys intact', async () => {
+    const ag = await makeGroup('ag-lean');
+    await initGroupFilesystem(ag, {});
 
     const file = path.join(TEST_ROOT, 'data', 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
     const settings = JSON.parse(fs.readFileSync(file, 'utf-8'));
@@ -56,9 +56,9 @@ describe('default settings.json for new groups', () => {
     expect(JSON.stringify(settings.hooks.PreCompact)).toContain('compact-instructions');
   });
 
-  it('never rewrites an existing settings.json — a hand-edited re-enable sticks', () => {
-    const ag = makeGroup('ag-reenable');
-    initGroupFilesystem(ag, {});
+  it('never rewrites an existing settings.json — a hand-edited re-enable sticks', async () => {
+    const ag = await makeGroup('ag-reenable');
+    await initGroupFilesystem(ag, {});
     const file = path.join(TEST_ROOT, 'data', 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
 
     // Operator re-enables both features by editing the file (the documented path).
@@ -67,7 +67,7 @@ describe('default settings.json for new groups', () => {
     edited.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
     fs.writeFileSync(file, JSON.stringify(edited, null, 2) + '\n');
 
-    initGroupFilesystem(ag, {}); // next spawn
+    await initGroupFilesystem(ag, {}); // next spawn
 
     const after = JSON.parse(fs.readFileSync(file, 'utf-8'));
     expect(after.disableWorkflows).toBeUndefined();

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -48,10 +48,10 @@ const DEFAULT_SETTINGS_JSON =
  * The provider project document is regenerated on every spawn. Initial
  * standing instructions are staged once in the provider-neutral prepend file.
  */
-export function initGroupFilesystem(
+export async function initGroupFilesystem(
   group: AgentGroup,
   opts?: { instructions?: string; provider?: string | null },
-): void {
+): Promise<void> {
   const initialized: string[] = [];
 
   // `opts.provider` absent means "caller has no provider opinion" — for a
@@ -90,7 +90,7 @@ export function initGroupFilesystem(
   // the row already exists (e.g. created by backfill or group creation). On a
   // fresh row, stamp the resolved provider hint so a new group is created on
   // the instance default (or the caller's explicit pick).
-  ensureContainerConfig(group.id, providerHint);
+  await ensureContainerConfig(group.id, providerHint);
   initialized.push('container_configs');
 
   // 2. data/v2-sessions/<id>/.claude-shared/ — Claude state + per-group skills

--- a/src/guard/conformance.test.ts
+++ b/src/guard/conformance.test.ts
@@ -2,7 +2,7 @@
  * Guard conformance — checked with the real registries.
  *
  * The old registry walk is gone: an unmapped consult or an undeclared
- * unguarded registration is now unconstructible — guard() takes the defined
+ * unguarded registration is now unconstructible — await guard() takes the defined
  * GuardedAction value (a dropped module-edge import or typo'd name is a
  * compile error), and the keyed registries require a guard spec or an
  * explicit unguarded(<reason>) declaration. What's left to verify is the

--- a/src/guard/guard-actions.ts
+++ b/src/guard/guard-actions.ts
@@ -24,7 +24,7 @@ export interface GuardedActionSpec {
    * allow. Runs on every consult, including approved replays (a grant
    * satisfies a hold, never a deny).
    */
-  decide: (input: GuardInput) => GuardDecision;
+  decide: (input: GuardInput) => GuardDecision | Promise<GuardDecision>;
   /**
    * The pending_approvals.action its holds resolve through — a grant is only
    * accepted when its row carries this action. Omit for actions that can

--- a/src/guard/guard.test.ts
+++ b/src/guard/guard.test.ts
@@ -36,14 +36,14 @@ afterEach(() => {
 });
 
 describe('decide is the decision', () => {
-  it('decide allow → allow', () => {
+  it('decide allow → allow', async () => {
     const action = defineGuardedAction({ action: 't.allow1', decide: () => ALLOW('ok') });
-    expect(guard(action, input()).effect).toBe('allow');
+    expect((await guard(action, input())).effect).toBe('allow');
   });
 
-  it('decide hold → hold, default approver chain', () => {
+  it('decide hold → hold, default approver chain', async () => {
     const action = defineGuardedAction({ action: 't.hold1', decide: () => HOLD('needs approval') });
-    const d = guard(action, input());
+    const d = await guard(action, input());
     expect(d.effect).toBe('hold');
     if (d.effect === 'hold') {
       expect(d.reason).toBe('needs approval');
@@ -51,23 +51,23 @@ describe('decide is the decision', () => {
     }
   });
 
-  it('decide hold → hold, carrying a named approver', () => {
+  it('decide hold → hold, carrying a named approver', async () => {
     const action = defineGuardedAction({ action: 't.hold2', decide: () => HOLD('policy row', 'telegram:dana') });
-    const d = guard(action, input());
+    const d = await guard(action, input());
     expect(d.effect).toBe('hold');
     if (d.effect === 'hold') expect(d.approverUserId).toBe('telegram:dana');
   });
 
-  it('decide deny → deny, carrying the reason', () => {
+  it('decide deny → deny, carrying the reason', async () => {
     const action = defineGuardedAction({ action: 't.deny1', decide: () => DENY('structurally unauthorized') });
-    const d = guard(action, input());
+    const d = await guard(action, input());
     expect(d.effect).toBe('deny');
     if (d.effect === 'deny') expect(d.reason).toBe('structurally unauthorized');
   });
 
-  it('a forged action value (not from defineGuardedAction) is denied', () => {
+  it('a forged action value (not from defineGuardedAction) is denied', async () => {
     const forged = { action: 't.forged', decide: () => ALLOW('never vetted') } as unknown as GuardedAction;
-    const d = guard(forged, input());
+    const d = await guard(forged, input());
     expect(d.effect).toBe('deny');
     if (d.effect === 'deny') expect(d.reason).toContain('undefined action');
   });
@@ -77,7 +77,7 @@ describe('grants', () => {
   const grantRow = (action: string) =>
     ({ approval_id: 'appr-1', action, payload: '{}' }) as unknown as NonNullable<GuardInput['grant']>;
 
-  it('a valid live grant satisfies a hold', () => {
+  it('a valid live grant satisfies a hold', async () => {
     const action = defineGuardedAction({
       action: 't.g1',
       grantActionName: 'g1_approved',
@@ -85,10 +85,10 @@ describe('grants', () => {
     });
     const grant = grantRow('g1_approved');
     mockGetPendingApproval.mockReturnValue(grant);
-    expect(guard(action, input({ grant })).effect).toBe('allow');
+    expect((await guard(action, input({ grant }))).effect).toBe('allow');
   });
 
-  it('a grant never satisfies a deny — the checks re-run live', () => {
+  it('a grant never satisfies a deny — the checks re-run live', async () => {
     const action = defineGuardedAction({
       action: 't.g2',
       grantActionName: 'g2_approved',
@@ -96,23 +96,23 @@ describe('grants', () => {
     });
     const grant = grantRow('g2_approved');
     mockGetPendingApproval.mockReturnValue(grant);
-    const d = guard(action, input({ grant }));
+    const d = await guard(action, input({ grant }));
     expect(d.effect).toBe('deny');
     if (d.effect === 'deny') expect(d.reason).toBe('revoked since');
   });
 
-  it('a dead grant (row deleted) refuses instead of re-holding', () => {
+  it('a dead grant (row deleted) refuses instead of re-holding', async () => {
     const action = defineGuardedAction({
       action: 't.g3',
       grantActionName: 'g3_approved',
       decide: () => HOLD('b'),
     });
     mockGetPendingApproval.mockReturnValue(undefined);
-    const d = guard(action, input({ grant: grantRow('g3_approved') }));
+    const d = await guard(action, input({ grant: grantRow('g3_approved') }));
     expect(d.effect).toBe('deny');
   });
 
-  it("a grant for a different action doesn't transfer", () => {
+  it("a grant for a different action doesn't transfer", async () => {
     const action = defineGuardedAction({
       action: 't.g4',
       grantActionName: 'g4_approved',
@@ -120,10 +120,10 @@ describe('grants', () => {
     });
     const grant = grantRow('other_action');
     mockGetPendingApproval.mockReturnValue(grant);
-    expect(guard(action, input({ grant })).effect).toBe('deny');
+    expect((await guard(action, input({ grant }))).effect).toBe('deny');
   });
 
-  it('a domain grantCoversRequest binding can refuse a payload mismatch', () => {
+  it('a domain grantCoversRequest binding can refuse a payload mismatch', async () => {
     const action = defineGuardedAction({
       action: 't.g5',
       grantActionName: 'g5_approved',
@@ -132,10 +132,10 @@ describe('grants', () => {
     });
     const grant = grantRow('g5_approved');
     mockGetPendingApproval.mockReturnValue(grant);
-    expect(guard(action, input({ grant })).effect).toBe('deny');
+    expect((await guard(action, input({ grant }))).effect).toBe('deny');
   });
 
-  it('a grant on an already-allowed action is a no-op', () => {
+  it('a grant on an already-allowed action is a no-op', async () => {
     const action = defineGuardedAction({
       action: 't.g6',
       grantActionName: 'g6_approved',
@@ -143,18 +143,18 @@ describe('grants', () => {
     });
     const grant = grantRow('g6_approved');
     mockGetPendingApproval.mockReturnValue(grant);
-    expect(guard(action, input({ grant })).effect).toBe('allow');
+    expect((await guard(action, input({ grant }))).effect).toBe('allow');
   });
 });
 
 describe('fail-closed posture', () => {
-  it('a throwing decide denies', () => {
+  it('a throwing decide denies', async () => {
     const action = defineGuardedAction({
       action: 't.f1',
       decide: () => {
         throw new Error('boom');
       },
     });
-    expect(guard(action, input()).effect).toBe('deny');
+    expect((await guard(action, input())).effect).toBe('deny');
   });
 });

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -26,7 +26,7 @@ import { log } from '../log.js';
 import { isGuardedAction, type GuardedAction } from './guard-actions.js';
 import { ALLOW, DENY, type GuardDecision, type GuardInput } from './types.js';
 
-export function guard(action: GuardedAction, input: GuardInput): GuardDecision {
+export async function guard(action: GuardedAction, input: GuardInput): Promise<GuardDecision> {
   if (!isGuardedAction(action)) {
     // JS-level backstop — the branded type already forbids this. A
     // hand-rolled object must not carry a decide fn never vetted at
@@ -39,7 +39,7 @@ export function guard(action: GuardedAction, input: GuardInput): GuardDecision {
 
   let decision: GuardDecision;
   try {
-    decision = action.decide(input);
+    decision = await action.decide(input);
   } catch (err) {
     log.error('Guard evaluation threw — failing closed', { action: action.action, err });
     return DENY('guard failure (failing closed)');
@@ -53,19 +53,19 @@ export function guard(action: GuardedAction, input: GuardInput): GuardDecision {
 
   // An invalid grant on a replay is a refusal, not a fresh hold — approved
   // replays must execute exactly once.
-  if (grantSatisfies(action, input)) {
+  if (await grantSatisfies(action, input)) {
     return ALLOW(`hold satisfied by approval ${input.grant.approval_id}`);
   }
   return DENY('replay carried an invalid or mismatched grant');
 }
 
-function grantSatisfies(action: GuardedAction, input: GuardInput): boolean {
+async function grantSatisfies(action: GuardedAction, input: GuardInput): Promise<boolean> {
   const grant = input.grant;
   if (!grant || !action.grantActionName) return false;
   if (grant.action !== action.grantActionName) return false;
   // The row must still be live — resolution deletes it, so a grant can only
   // execute once and a fabricated row object doesn't pass.
-  const live = getPendingApproval(grant.approval_id);
+  const live = await getPendingApproval(grant.approval_id);
   if (!live || live.action !== action.grantActionName) return false;
   if (action.grantCoversRequest && !action.grantCoversRequest(grant, input)) return false;
   return true;

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -29,6 +29,7 @@ import {
   clearOutbox,
 } from './session-manager.js';
 import { getSession, findSession } from './db/sessions.js';
+import { sqliteRaw } from './db/drivers/sqlite.js';
 import type { InboundEvent } from './channels/adapter.js';
 
 // Mock container runner to prevent actual Docker spawning
@@ -51,30 +52,30 @@ function now() {
 
 const TEST_DIR = '/tmp/nanoclaw-test-host';
 
-beforeEach(() => {
+beforeEach(async () => {
   // Clean test directory
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
 
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
 describe('session manager', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Test Agent',
       folder: 'test-agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'chan-123',
@@ -85,7 +86,7 @@ describe('session manager', () => {
     });
   });
 
-  it('should create session folder and both DBs', () => {
+  it('should create session folder and both DBs', async () => {
     initSessionFolder('ag-1', 'sess-test');
     const dir = sessionDir('ag-1', 'sess-test');
     expect(fs.existsSync(dir)).toBe(true);
@@ -112,7 +113,7 @@ describe('session manager', () => {
     outDb.close();
   });
 
-  it('should reject outbound attachment filenames that escape the message outbox', () => {
+  it('should reject outbound attachment filenames that escape the message outbox', async () => {
     initSessionFolder('ag-1', 'sess-test');
     const dir = sessionDir('ag-1', 'sess-test');
     const msgOutbox = path.join(dir, 'outbox', 'msg-1');
@@ -124,7 +125,7 @@ describe('session manager', () => {
     expect(readOutboxFiles('ag-1', 'sess-test', 'msg-1', ['../../../../../outside.txt'])).toBeUndefined();
   });
 
-  it('should reject outbound attachment symlinks that escape the message outbox', () => {
+  it('should reject outbound attachment symlinks that escape the message outbox', async () => {
     initSessionFolder('ag-1', 'sess-test');
     const dir = sessionDir('ag-1', 'sess-test');
     const msgOutbox = path.join(dir, 'outbox', 'msg-1');
@@ -137,7 +138,7 @@ describe('session manager', () => {
     expect(readOutboxFiles('ag-1', 'sess-test', 'msg-1', ['safe-name.txt'])).toBeUndefined();
   });
 
-  it('should not recursively delete outside the outbox for unsafe message ids', () => {
+  it('should not recursively delete outside the outbox for unsafe message ids', async () => {
     initSessionFolder('ag-1', 'sess-test');
     const victimDir = path.join(TEST_DIR, 'victim-dir');
     fs.mkdirSync(victimDir, { recursive: true });
@@ -148,7 +149,7 @@ describe('session manager', () => {
     expect(fs.existsSync(path.join(victimDir, 'keep.txt'))).toBe(true);
   });
 
-  it('should still read and clear normal basename outbox files', () => {
+  it('should still read and clear normal basename outbox files', async () => {
     initSessionFolder('ag-1', 'sess-test');
     const dir = sessionDir('ag-1', 'sess-test');
     const msgOutbox = path.join(dir, 'outbox', 'msg-1');
@@ -164,9 +165,9 @@ describe('session manager', () => {
     expect(fs.existsSync(msgOutbox)).toBe(false);
   });
 
-  it('should reject inbound attachment writes through a pre-placed symlinked inbox dir', () => {
+  it('should reject inbound attachment writes through a pre-placed symlinked inbox dir', async () => {
     initSessionFolder('ag-1', 'sess-test');
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
     // The container has /workspace write access, so it can pre create
     // inbox/<msgId> as a symlink to escape.
@@ -176,7 +177,7 @@ describe('session manager', () => {
     fs.mkdirSync(evilTarget, { recursive: true });
     fs.symlinkSync(evilTarget, path.join(inboxRoot, 'msg-evil'));
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: 'msg-evil',
       kind: 'chat',
       timestamp: now(),
@@ -189,9 +190,9 @@ describe('session manager', () => {
     expect(fs.existsSync(path.join(evilTarget, 'photo.png'))).toBe(false);
   });
 
-  it('should refuse to follow a pre-existing symlink at the inbound attachment path', () => {
+  it('should refuse to follow a pre-existing symlink at the inbound attachment path', async () => {
     initSessionFolder('ag-1', 'sess-test');
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
     // The container pre creates inbox/<msgId>/photo.png as a symlink to a
     // host file. Without the wx flag, writeFileSync would follow it.
@@ -201,7 +202,7 @@ describe('session manager', () => {
     fs.writeFileSync(outside, 'ORIGINAL');
     fs.symlinkSync(outside, path.join(inboxDir, 'photo.png'));
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: 'msg-sym',
       kind: 'chat',
       timestamp: now(),
@@ -214,11 +215,11 @@ describe('session manager', () => {
     expect(fs.readFileSync(outside, 'utf-8')).toBe('ORIGINAL');
   });
 
-  it('should reject inbound attachments when messageId is unsafe', () => {
+  it('should reject inbound attachments when messageId is unsafe', async () => {
     initSessionFolder('ag-1', 'sess-test');
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: '../../escape',
       kind: 'chat',
       timestamp: now(),
@@ -234,11 +235,11 @@ describe('session manager', () => {
     }
   });
 
-  it('should still save inbound attachments with safe basenames', () => {
+  it('should still save inbound attachments with safe basenames', async () => {
     initSessionFolder('ag-1', 'sess-test');
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: 'msg-ok',
       kind: 'chat',
       timestamp: now(),
@@ -253,32 +254,32 @@ describe('session manager', () => {
     expect(fs.readFileSync(expected, 'utf-8')).toBe('PNGBYTES');
   });
 
-  it('should resolve to existing session (shared mode)', () => {
-    const { session: s1, created: c1 } = resolveSession('ag-1', 'mg-1', null, 'shared');
+  it('should resolve to existing session (shared mode)', async () => {
+    const { session: s1, created: c1 } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     expect(c1).toBe(true);
 
-    const { session: s2, created: c2 } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session: s2, created: c2 } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     expect(c2).toBe(false);
     expect(s2.id).toBe(s1.id);
   });
 
-  it('should create separate sessions per thread (per-thread mode)', () => {
-    const { session: s1 } = resolveSession('ag-1', 'mg-1', 'thread-1', 'per-thread');
-    const { session: s2 } = resolveSession('ag-1', 'mg-1', 'thread-2', 'per-thread');
+  it('should create separate sessions per thread (per-thread mode)', async () => {
+    const { session: s1 } = await resolveSession('ag-1', 'mg-1', 'thread-1', 'per-thread');
+    const { session: s2 } = await resolveSession('ag-1', 'mg-1', 'thread-2', 'per-thread');
     expect(s1.id).not.toBe(s2.id);
   });
 
-  it('should reuse session for same thread', () => {
-    const { session: s1 } = resolveSession('ag-1', 'mg-1', 'thread-1', 'per-thread');
-    const { session: s2, created } = resolveSession('ag-1', 'mg-1', 'thread-1', 'per-thread');
+  it('should reuse session for same thread', async () => {
+    const { session: s1 } = await resolveSession('ag-1', 'mg-1', 'thread-1', 'per-thread');
+    const { session: s2, created } = await resolveSession('ag-1', 'mg-1', 'thread-1', 'per-thread');
     expect(created).toBe(false);
     expect(s2.id).toBe(s1.id);
   });
 
-  it('should write message to inbound DB', () => {
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+  it('should write message to inbound DB', async () => {
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: 'msg-1',
       kind: 'chat',
       timestamp: now(),
@@ -305,31 +306,31 @@ describe('session manager', () => {
     expect(JSON.parse(rows[0].content).text).toBe('Hello');
   });
 
-  it('should update last_active on message write', () => {
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
-    expect(getSession(session.id)!.last_active).toBeNull();
+  it('should update last_active on message write', async () => {
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    expect((await getSession(session.id))!.last_active).toBeNull();
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: 'msg-1',
       kind: 'chat',
       timestamp: now(),
       content: JSON.stringify({ text: 'hi' }),
     });
 
-    expect(getSession(session.id)!.last_active).not.toBeNull();
+    expect((await getSession(session.id))!.last_active).not.toBeNull();
   });
 
-  it('should refuse path-traversal in attachment filenames', () => {
+  it('should refuse path-traversal in attachment filenames', async () => {
     // Regression: attachment.name comes from untrusted senders (E2EE-protected
     // chat platforms can't sanitize it server-side). Without the guard, a
     // `../../../tmp/pwned` filename escapes the inbox dir and writes anywhere
     // the host process can reach.
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
     const inboxBase = path.join(sessionDir('ag-1', session.id), 'inbox');
     const escapeTarget = path.join('/tmp', 'nanoclaw-traversal-canary');
     if (fs.existsSync(escapeTarget)) fs.rmSync(escapeTarget);
 
-    writeSessionMessage('ag-1', session.id, {
+    await writeSessionMessage('ag-1', session.id, {
       id: 'msg-attack',
       kind: 'chat',
       timestamp: now(),
@@ -358,8 +359,8 @@ describe('session manager', () => {
 });
 
 describe('router', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Test Agent',
       folder: 'test-agent',
@@ -368,7 +369,7 @@ describe('router', () => {
     });
     // Use 'public' policy so the router tests exercise routing, not the
     // access gate. Dedicated access-gate tests live with the access module.
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'chan-123',
@@ -377,7 +378,7 @@ describe('router', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-1',
       messaging_group_id: 'mg-1',
       agent_group_id: 'ag-1',
@@ -410,7 +411,7 @@ describe('router', () => {
     await routeInbound(event);
 
     // Verify session was created
-    const session = findSession('mg-1', null);
+    const session = await findSession('mg-1', null);
     expect(session).toBeDefined();
 
     // Verify message was written to inbound DB
@@ -446,7 +447,7 @@ describe('router', () => {
         timestamp: now(),
       },
     });
-    expect(getMessagingGroupByPlatform('slack', 'C-PLAIN')).toBeUndefined();
+    expect(await getMessagingGroupByPlatform('slack', 'C-PLAIN')).toBeUndefined();
 
     // Mention on unknown channel — SHOULD auto-create (next step: channel-registration flow).
     await routeInbound({
@@ -461,7 +462,7 @@ describe('router', () => {
         isMention: true,
       },
     });
-    expect(getMessagingGroupByPlatform('slack', 'C-MENTIONED')).toBeDefined();
+    expect(await getMessagingGroupByPlatform('slack', 'C-MENTIONED')).toBeDefined();
   });
 
   it('should route multiple messages to the same session', async () => {
@@ -487,7 +488,7 @@ describe('router', () => {
     });
 
     // Both should be in the same session
-    const session = findSession('mg-1', null);
+    const session = await findSession('mg-1', null);
     const dbPath = inboundDbPath('ag-1', session!.id);
     const db = new Database(dbPath);
     const rows = db.prepare('SELECT * FROM messages_in ORDER BY timestamp').all();
@@ -502,14 +503,14 @@ describe('router', () => {
     (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
 
     // Wire a second agent to the same messaging group.
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-2',
       name: 'Secondary Agent',
       folder: 'secondary-agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-2',
       messaging_group_id: 'mg-1',
       agent_group_id: 'ag-2',
@@ -533,8 +534,8 @@ describe('router', () => {
     expect(wakeContainer).toHaveBeenCalledTimes(2);
 
     const { getSessionsByAgentGroup } = await import('./db/sessions.js');
-    expect(getSessionsByAgentGroup('ag-1')).toHaveLength(1);
-    expect(getSessionsByAgentGroup('ag-2')).toHaveLength(1);
+    expect(await getSessionsByAgentGroup('ag-1')).toHaveLength(1);
+    expect(await getSessionsByAgentGroup('ag-2')).toHaveLength(1);
   });
 
   it('accumulates without waking when engage fails + ignored_message_policy=accumulate', async () => {
@@ -545,7 +546,7 @@ describe('router', () => {
     // Replace the seed row with a mention-only wiring whose accumulate
     // policy should store context even when the message doesn't mention us.
     const { updateMessagingGroupAgent } = await import('./db/messaging-groups.js');
-    updateMessagingGroupAgent('mga-1', {
+    await updateMessagingGroupAgent('mga-1', {
       engage_mode: 'mention',
       ignored_message_policy: 'accumulate',
     });
@@ -564,7 +565,7 @@ describe('router', () => {
 
     expect(wakeContainer).not.toHaveBeenCalled();
 
-    const session = findSession('mg-1', null);
+    const session = await findSession('mg-1', null);
     expect(session).toBeDefined();
     const db = new Database(inboundDbPath('ag-1', session!.id));
     const rows = db.prepare('SELECT id, trigger FROM messages_in').all() as Array<{
@@ -582,7 +583,7 @@ describe('router', () => {
     (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
 
     const { updateMessagingGroupAgent } = await import('./db/messaging-groups.js');
-    updateMessagingGroupAgent('mga-1', { engage_mode: 'mention' }); // drop is the default
+    await updateMessagingGroupAgent('mga-1', { engage_mode: 'mention' }); // drop is the default
 
     await routeInbound({
       channelType: 'discord',
@@ -593,20 +594,20 @@ describe('router', () => {
 
     expect(wakeContainer).not.toHaveBeenCalled();
     // No session should have been created for this agent.
-    expect(findSession('mg-1', null)).toBeUndefined();
+    expect(await findSession('mg-1', null)).toBeUndefined();
   });
 });
 
 describe('router — channel instances', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Default Bot',
       folder: 'default-bot',
       agent_provider: null,
       created_at: now(),
     });
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-2',
       name: 'Tester Bot',
       folder: 'tester-bot',
@@ -615,7 +616,7 @@ describe('router — channel instances', () => {
     });
     // Two messaging groups on the SAME (channel_type, platform_id), owned
     // by different adapter instances and wired to different agents.
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-default',
       channel_type: 'slack',
       platform_id: 'slack:C1',
@@ -624,7 +625,7 @@ describe('router — channel instances', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-tester',
       channel_type: 'slack',
       platform_id: 'slack:C1',
@@ -638,7 +639,7 @@ describe('router — channel instances', () => {
       ['mga-default', 'mg-default', 'ag-1'],
       ['mga-tester', 'mg-tester', 'ag-2'],
     ] as const) {
-      createMessagingGroupAgent({
+      await createMessagingGroupAgent({
         id: mgaId,
         messaging_group_id: mgId,
         agent_group_id: agId,
@@ -700,10 +701,10 @@ describe('router — channel instances', () => {
         },
       });
 
-      const testerSessions = getSessionsByAgentGroup('ag-2');
+      const testerSessions = await getSessionsByAgentGroup('ag-2');
       expect(testerSessions).toHaveLength(1);
       expect(testerSessions[0].messaging_group_id).toBe('mg-tester');
-      expect(getSessionsByAgentGroup('ag-1')).toHaveLength(0);
+      expect(await getSessionsByAgentGroup('ag-1')).toHaveLength(0);
 
       const tDb = new Database(inboundDbPath('ag-2', testerSessions[0].id));
       const tRow = tDb.prepare('SELECT thread_id, content FROM messages_in').get() as {
@@ -729,7 +730,7 @@ describe('router — channel instances', () => {
         },
       });
 
-      const defaultSessions = getSessionsByAgentGroup('ag-1');
+      const defaultSessions = await getSessionsByAgentGroup('ag-1');
       expect(defaultSessions).toHaveLength(1);
       expect(defaultSessions[0].messaging_group_id).toBe('mg-default');
       const dDb = new Database(inboundDbPath('ag-1', defaultSessions[0].id));
@@ -747,7 +748,7 @@ describe('router — channel instances', () => {
 
     // No row exists for this address on ANY instance yet; create an
     // unwired default row to prove the named event doesn't reuse it.
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-plain',
       channel_type: 'slack',
       platform_id: 'slack:C-NEW',
@@ -771,12 +772,12 @@ describe('router — channel instances', () => {
       },
     });
 
-    const created = getMessagingGroupByPlatform('slack', 'slack:C-NEW', 'slack-tester');
+    const created = await getMessagingGroupByPlatform('slack', 'slack:C-NEW', 'slack-tester');
     expect(created).toBeDefined();
     expect(created!.instance).toBe('slack-tester');
     expect(created!.id).not.toBe('mg-plain');
     // The default row is untouched.
-    expect(getMessagingGroupByPlatform('slack', 'slack:C-NEW', 'slack')!.id).toBe('mg-plain');
+    expect((await getMessagingGroupByPlatform('slack', 'slack:C-NEW', 'slack'))!.id).toBe('mg-plain');
   });
 });
 
@@ -795,15 +796,15 @@ describe('router — per-wiring thread policy', () => {
     },
   });
 
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-tp',
       name: 'Thread Agent',
       folder: 'thread-agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-tp',
       channel_type: 'tp-slack',
       platform_id: 'tp:C1',
@@ -812,7 +813,7 @@ describe('router — per-wiring thread policy', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-tp',
       messaging_group_id: 'mg-tp',
       agent_group_id: 'ag-tp',
@@ -866,7 +867,7 @@ describe('router — per-wiring thread policy', () => {
       // threads=NULL inherits the (fallback) declaration → supportsThreads →
       // per-thread session with the platform thread id, message addressed
       // in-thread. Identical to pre-declaration routing.
-      const sessions = getSessionsByAgentGroup('ag-tp');
+      const sessions = await getSessionsByAgentGroup('ag-tp');
       expect(sessions).toHaveLength(1);
       expect(sessions[0].thread_id).toBe('thread-42');
 
@@ -878,7 +879,7 @@ describe('router — per-wiring thread policy', () => {
   });
 
   it('wiring threads=0 nulls the event-derived thread for session and delivery', async () => {
-    getDb().prepare("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'").run();
+    sqliteRaw(getDb()).prepare("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'").run();
 
     await withThreadedAdapter(async () => {
       const { routeInbound } = await import('./router.js');
@@ -888,7 +889,7 @@ describe('router — per-wiring thread policy', () => {
 
       // Session collapses (no per-thread force, thread id stripped) and the
       // reply address is top-level.
-      const sessions = getSessionsByAgentGroup('ag-tp');
+      const sessions = await getSessionsByAgentGroup('ag-tp');
       expect(sessions).toHaveLength(1);
       expect(sessions[0].thread_id).toBeNull();
 
@@ -900,7 +901,7 @@ describe('router — per-wiring thread policy', () => {
   });
 
   it('wiring threads=0 never strips replyTo (operator intent)', async () => {
-    getDb().prepare("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'").run();
+    sqliteRaw(getDb()).prepare("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'").run();
 
     await withThreadedAdapter(async () => {
       const { routeInbound } = await import('./router.js');
@@ -911,7 +912,7 @@ describe('router — per-wiring thread policy', () => {
         replyTo: { channelType: 'cli', platformId: 'cli:operator', threadId: 'term-1' },
       });
 
-      const sessions = getSessionsByAgentGroup('ag-tp');
+      const sessions = await getSessionsByAgentGroup('ag-tp');
       expect(sessions).toHaveLength(1);
       const db = new Database(inboundDbPath('ag-tp', sessions[0].id));
       const row = db.prepare('SELECT channel_type, thread_id FROM messages_in').get() as {
@@ -957,29 +958,31 @@ describe('router — per-wiring thread policy', () => {
 
     // Declared adapter: group context reads the group declaration...
     await routeInbound(mention('tp-declared', 'tp:G1', true));
-    expect(getMessagingGroupByPlatform('tp-declared', 'tp:G1')!.unknown_sender_policy).toBe('public');
+    expect((await getMessagingGroupByPlatform('tp-declared', 'tp:G1'))!.unknown_sender_policy).toBe('public');
 
     // ...and DM context reads the dm declaration.
     await routeInbound(mention('tp-declared', 'tp:D1', false));
-    expect(getMessagingGroupByPlatform('tp-declared', 'tp:D1')!.unknown_sender_policy).toBe('strict');
+    expect((await getMessagingGroupByPlatform('tp-declared', 'tp:D1'))!.unknown_sender_policy).toBe('strict');
 
     // Undeclared channel: the behavior-faithful fallback reproduces the
     // historical hardcoded 'request_approval'.
     await routeInbound(mention('tp-undeclared', 'tp:U1', true));
-    expect(getMessagingGroupByPlatform('tp-undeclared', 'tp:U1')!.unknown_sender_policy).toBe('request_approval');
+    expect((await getMessagingGroupByPlatform('tp-undeclared', 'tp:U1'))!.unknown_sender_policy).toBe(
+      'request_approval',
+    );
   });
 });
 
 describe('routing metadata preservation', () => {
   beforeEach(async () => {
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Test Agent',
       folder: 'test-agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'chan-123',
@@ -988,7 +991,7 @@ describe('routing metadata preservation', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-1',
       messaging_group_id: 'mg-1',
       agent_group_id: 'ag-1',
@@ -1041,7 +1044,7 @@ describe('routing metadata preservation', () => {
     });
 
     // Threaded adapter in a group chat forces a per-thread session.
-    const session = findSession('mg-1', 'thread-42');
+    const session = await findSession('mg-1', 'thread-42');
     const db = new Database(inboundDbPath('ag-1', session!.id));
     const row = db
       .prepare('SELECT platform_id, channel_type, thread_id FROM messages_in WHERE id LIKE ?')
@@ -1060,14 +1063,14 @@ describe('routing metadata preservation', () => {
   it('fan-out gives each agent its own routing, not leaked from sibling', async () => {
     const { routeInbound } = await import('./router.js');
 
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-2',
       name: 'Agent Two',
       folder: 'agent-two',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-2',
       messaging_group_id: 'mg-1',
       agent_group_id: 'ag-2',
@@ -1090,7 +1093,7 @@ describe('routing metadata preservation', () => {
     // Both agents should have the message with correct routing
     const { getSessionsByAgentGroup } = await import('./db/sessions.js');
     for (const agId of ['ag-1', 'ag-2']) {
-      const sessions = getSessionsByAgentGroup(agId);
+      const sessions = await getSessionsByAgentGroup(agId);
       expect(sessions).toHaveLength(1);
       const db = new Database(inboundDbPath(agId, sessions[0].id));
       const row = db.prepare('SELECT platform_id, channel_type, thread_id FROM messages_in LIMIT 1').get() as {
@@ -1107,15 +1110,15 @@ describe('routing metadata preservation', () => {
 });
 
 describe('writeSessionRouting', () => {
-  it('populates session_routing from the messaging group', () => {
-    createAgentGroup({
+  it('populates session_routing from the messaging group', async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'telegram',
       platform_id: 'tg:12345',
@@ -1125,8 +1128,8 @@ describe('writeSessionRouting', () => {
       created_at: now(),
     });
 
-    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
-    writeSessionRouting('ag-1', session.id);
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    await writeSessionRouting('ag-1', session.id);
 
     const db = new Database(inboundDbPath('ag-1', session.id));
     const row = db.prepare('SELECT channel_type, platform_id, thread_id FROM session_routing WHERE id = 1').get() as
@@ -1144,8 +1147,8 @@ describe('writeSessionRouting', () => {
     expect(row!.thread_id).toBeNull();
   });
 
-  it('writes null routing for agent-shared session (no messaging group)', () => {
-    createAgentGroup({
+  it('writes null routing for agent-shared session (no messaging group)', async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
@@ -1153,8 +1156,8 @@ describe('writeSessionRouting', () => {
       created_at: now(),
     });
 
-    const { session } = resolveSession('ag-1', null, null, 'agent-shared');
-    writeSessionRouting('ag-1', session.id);
+    const { session } = await resolveSession('ag-1', null, null, 'agent-shared');
+    await writeSessionRouting('ag-1', session.id);
 
     const db = new Database(inboundDbPath('ag-1', session.id));
     const row = db.prepare('SELECT channel_type, platform_id, thread_id FROM session_routing WHERE id = 1').get() as
@@ -1172,15 +1175,15 @@ describe('writeSessionRouting', () => {
     expect(row!.thread_id).toBeNull();
   });
 
-  it('includes thread_id from per-thread session', () => {
-    createAgentGroup({
+  it('includes thread_id from per-thread session', async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-1',
       channel_type: 'discord',
       platform_id: 'chan-123',
@@ -1190,8 +1193,8 @@ describe('writeSessionRouting', () => {
       created_at: now(),
     });
 
-    const { session } = resolveSession('ag-1', 'mg-1', 'thread-77', 'per-thread');
-    writeSessionRouting('ag-1', session.id);
+    const { session } = await resolveSession('ag-1', 'mg-1', 'thread-77', 'per-thread');
+    await writeSessionRouting('ag-1', session.id);
 
     const db = new Database(inboundDbPath('ag-1', session.id));
     const row = db.prepare('SELECT channel_type, platform_id, thread_id FROM session_routing WHERE id = 1').get() as
@@ -1211,8 +1214,8 @@ describe('writeSessionRouting', () => {
 });
 
 describe('agent-shared session resolution', () => {
-  it('resolves to the same session on repeated calls', () => {
-    createAgentGroup({
+  it('resolves to the same session on repeated calls', async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
@@ -1220,16 +1223,16 @@ describe('agent-shared session resolution', () => {
       created_at: now(),
     });
 
-    const { session: s1, created: c1 } = resolveSession('ag-1', null, null, 'agent-shared');
-    const { session: s2, created: c2 } = resolveSession('ag-1', null, null, 'agent-shared');
+    const { session: s1, created: c1 } = await resolveSession('ag-1', null, null, 'agent-shared');
+    const { session: s2, created: c2 } = await resolveSession('ag-1', null, null, 'agent-shared');
 
     expect(c1).toBe(true);
     expect(c2).toBe(false);
     expect(s1.id).toBe(s2.id);
   });
 
-  it('agent-shared session has null messaging_group_id', () => {
-    createAgentGroup({
+  it('agent-shared session has null messaging_group_id', async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
@@ -1237,21 +1240,21 @@ describe('agent-shared session resolution', () => {
       created_at: now(),
     });
 
-    const { session } = resolveSession('ag-1', null, null, 'agent-shared');
+    const { session } = await resolveSession('ag-1', null, null, 'agent-shared');
     expect(session.messaging_group_id).toBeNull();
   });
 });
 
 describe('agent-to-agent routing', () => {
-  beforeEach(() => {
-    createAgentGroup({
+  beforeEach(async () => {
+    await createAgentGroup({
       id: 'ag-pa',
       name: 'PA',
       folder: 'pa-agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-slack',
       channel_type: 'slack',
       platform_id: 'C-GENERAL',
@@ -1260,7 +1263,7 @@ describe('agent-to-agent routing', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    createAgentGroup({
+    await createAgentGroup({
       id: 'ag-researcher',
       name: 'Researcher',
       folder: 'researcher-agent',
@@ -1269,7 +1272,7 @@ describe('agent-to-agent routing', () => {
     });
 
     // Wire bidirectional A2A destinations (table created by runMigrations)
-    const db = getDb();
+    const db = sqliteRaw(getDb());
     db.prepare(
       `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES ('ag-pa', 'researcher', 'agent', 'ag-researcher', ?)
@@ -1285,7 +1288,7 @@ describe('agent-to-agent routing', () => {
   it('A2A outbound lands in a session for the target agent', async () => {
     const { routeAgentMessage } = await import('./modules/agent-to-agent/agent-route.js');
 
-    const { session: paSlackSession } = resolveSession('ag-pa', 'mg-slack', null, 'shared');
+    const { session: paSlackSession } = await resolveSession('ag-pa', 'mg-slack', null, 'shared');
 
     await routeAgentMessage(
       {
@@ -1298,7 +1301,7 @@ describe('agent-to-agent routing', () => {
     );
 
     const { getSessionsByAgentGroup } = await import('./db/sessions.js');
-    const researcherSessions = getSessionsByAgentGroup('ag-researcher');
+    const researcherSessions = await getSessionsByAgentGroup('ag-researcher');
     expect(researcherSessions.length).toBeGreaterThanOrEqual(1);
 
     const rDb = new Database(inboundDbPath('ag-researcher', researcherSessions[0].id));
@@ -1321,9 +1324,9 @@ describe('agent-to-agent routing', () => {
     // routes back to the Slack session (originator) not Discord (newest).
     const { routeAgentMessage } = await import('./modules/agent-to-agent/agent-route.js');
 
-    const { session: paSlackSession } = resolveSession('ag-pa', 'mg-slack', null, 'shared');
+    const { session: paSlackSession } = await resolveSession('ag-pa', 'mg-slack', null, 'shared');
 
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-discord',
       channel_type: 'discord',
       platform_id: 'chan-discord',
@@ -1332,7 +1335,7 @@ describe('agent-to-agent routing', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    const { session: paDiscordSession } = resolveSession('ag-pa', 'mg-discord', null, 'shared');
+    const { session: paDiscordSession } = await resolveSession('ag-pa', 'mg-discord', null, 'shared');
 
     // PA sends from Slack
     await routeAgentMessage(
@@ -1342,7 +1345,7 @@ describe('agent-to-agent routing', () => {
 
     // Researcher responds back to PA
     const { getSessionsByAgentGroup } = await import('./db/sessions.js');
-    const researcherSession = getSessionsByAgentGroup('ag-researcher')[0];
+    const researcherSession = (await getSessionsByAgentGroup('ag-researcher'))[0];
 
     await routeAgentMessage(
       { id: 'out-reply', platform_id: 'ag-pa', content: JSON.stringify({ text: 'found it' }), in_reply_to: null },
@@ -1367,17 +1370,17 @@ describe('agent-to-agent routing', () => {
     // writeSessionRouting writes nulls because messaging_group_id is null.
     const { routeAgentMessage } = await import('./modules/agent-to-agent/agent-route.js');
 
-    const { session: paSession } = resolveSession('ag-pa', 'mg-slack', null, 'shared');
+    const { session: paSession } = await resolveSession('ag-pa', 'mg-slack', null, 'shared');
     await routeAgentMessage(
       { id: 'out-1', platform_id: 'ag-researcher', content: JSON.stringify({ text: 'go' }), in_reply_to: null },
       paSession,
     );
 
     const { getSessionsByAgentGroup } = await import('./db/sessions.js');
-    const researcherSessions = getSessionsByAgentGroup('ag-researcher');
+    const researcherSessions = await getSessionsByAgentGroup('ag-researcher');
     expect(researcherSessions).toHaveLength(1);
 
-    writeSessionRouting('ag-researcher', researcherSessions[0].id);
+    await writeSessionRouting('ag-researcher', researcherSessions[0].id);
 
     const rDb = new Database(inboundDbPath('ag-researcher', researcherSessions[0].id));
     const routing = rDb.prepare('SELECT channel_type, platform_id FROM session_routing WHERE id = 1').get() as
@@ -1396,15 +1399,15 @@ describe('agent-to-agent routing', () => {
 });
 
 describe('delivery', () => {
-  it('should detect undelivered messages in outbound DB', () => {
-    createAgentGroup({
+  it('should detect undelivered messages in outbound DB', async () => {
+    await createAgentGroup({
       id: 'ag-1',
       name: 'Agent',
       folder: 'agent',
       agent_provider: null,
       created_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-test',
       channel_type: 'discord',
       platform_id: 'chan-test',
@@ -1414,7 +1417,7 @@ describe('delivery', () => {
       created_at: now(),
     });
 
-    const { session } = resolveSession('ag-1', 'mg-test', null, 'shared');
+    const { session } = await resolveSession('ag-1', 'mg-test', null, 'shared');
 
     // Write a response to the outbound DB (simulating what the agent-runner does)
     const dbPath = outboundDbPath('ag-1', session.id);

--- a/src/host-lifecycle.ts
+++ b/src/host-lifecycle.ts
@@ -5,12 +5,11 @@
  * inert: startup work begins only after the database and delivery adapter are
  * ready, and shutdown work begins only from the host's graceful-shutdown path.
  */
-import type Database from 'better-sqlite3';
-
+import type { DbDriver } from './db/driver.js';
 import { log } from './log.js';
 
 export interface HostStartContext {
-  db: Database.Database;
+  db: DbDriver;
   signal: AbortSignal;
 }
 

--- a/src/host-sweep-grace.test.ts
+++ b/src/host-sweep-grace.test.ts
@@ -82,7 +82,7 @@ async function runSweepTick(): Promise<void> {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.mocked(isContainerRunning).mockReset().mockReturnValue(false);
   vi.mocked(killContainer).mockReset();
   vi.mocked(wakeContainer)
@@ -105,10 +105,10 @@ beforeEach(() => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
 
-  const db = initTestDb();
-  runMigrations(db);
-  createAgentGroup({ id: AG, name: 'Test Agent', folder: 'test-agent', agent_provider: null, created_at: now() });
-  createSession({
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({ id: AG, name: 'Test Agent', folder: 'test-agent', agent_provider: null, created_at: now() });
+  await createSession({
     id: SESS,
     agent_group_id: AG,
     messaging_group_id: null,
@@ -123,14 +123,14 @@ beforeEach(() => {
 
   // A due message (wakes the container) + a stale claim from a previous crash
   // (would trip claim-stuck if the SLA check ran on the wake tick).
-  writeSessionMessage(AG, SESS, { id: 'm-1', kind: 'chat', timestamp: now(), content: '{"text":"hi"}' });
+  await writeSessionMessage(AG, SESS, { id: 'm-1', kind: 'chat', timestamp: now(), content: '{"text":"hi"}' });
   seedStaleClaim('m-1', 2 * 60 * 60 * 1000); // claimed 2h ago
 });
 
-afterEach(() => {
+afterEach(async () => {
   stopHostSweep();
   setTimeoutSpy.mockRestore();
-  closeDb();
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -159,7 +159,7 @@ async function sweep(): Promise<void> {
   }
 
   try {
-    const sessions = getActiveSessions();
+    const sessions = await getActiveSessions();
     for (const session of sessions) {
       await sweepSession(session);
     }
@@ -192,7 +192,7 @@ export function shouldCloseTaskSession(
 }
 
 async function sweepSession(session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) return;
 
   const inPath = inboundDbPath(agentGroup.id, session.id);
@@ -272,7 +272,7 @@ async function sweepSession(session: Session): Promise<void> {
           .get() as { c: number }
       ).c;
       if (shouldCloseTaskSession(session.thread_id, isContainerRunning(session.id), liveTasks)) {
-        updateSession(session.id, { status: 'closed' });
+        await updateSession(session.id, { status: 'closed' });
         log.info('Closed spent task session', { sessionId: session.id, threadId: session.thread_id });
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
 import { backfillContainerConfigs } from './backfill-container-configs.js';
 import { CENTRAL_DB_PATH } from './config.js';
 import { enforceStartupBackoff, resetCircuitBreaker } from './circuit-breaker.js';
-import { initDb } from './db/connection.js';
+import { closeDb, initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
 import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
@@ -69,13 +69,13 @@ async function main(): Promise<void> {
   enforceUpgradeTripwire();
 
   // 1. Init central DB
-  const db = initDb(CENTRAL_DB_PATH);
-  runMigrations(db);
+  const db = await initDb(CENTRAL_DB_PATH);
+  await runMigrations(db);
   log.info('Central DB ready', { path: CENTRAL_DB_PATH });
 
   // 1b. Backfill container_configs from legacy container.json files.
   // Idempotent — skips groups that already have a config row.
-  backfillContainerConfigs();
+  await backfillContainerConfigs();
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();
@@ -175,6 +175,7 @@ async function shutdown(signal: string): Promise<void> {
   try {
     await teardownChannelAdapters();
   } finally {
+    await closeDb();
     // Always reset on graceful shutdown — even if teardown threw, we got here
     // via SIGTERM/SIGINT, not a crash, so the next start shouldn't be counted
     // as one.

--- a/src/modules/agent-to-agent/agent-route.test.ts
+++ b/src/modules/agent-to-agent/agent-route.test.ts
@@ -94,15 +94,15 @@ describe('routeAgentMessage return-path', () => {
   let S2: Session;
   let SB: Session;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
 
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
 
-    createAgentGroup({ id: A, name: 'A', folder: 'a', agent_provider: null, created_at: now() });
-    createAgentGroup({ id: B, name: 'B', folder: 'b', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: A, name: 'A', folder: 'a', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: B, name: 'B', folder: 'b', agent_provider: null, created_at: now() });
 
     // S1 (older), S2 (newer) — both active sessions on A.
     S1 = {
@@ -138,21 +138,21 @@ describe('routeAgentMessage return-path', () => {
       last_active: null,
       created_at: '2026-01-15T00:00:00.000Z',
     };
-    createSession(S1);
-    createSession(S2);
-    createSession(SB);
+    await createSession(S1);
+    await createSession(S2);
+    await createSession(SB);
     initSessionFolder(A, S1.id);
     initSessionFolder(A, S2.id);
     initSessionFolder(B, SB.id);
 
-    createDestination({
+    await createDestination({
       agent_group_id: A,
       local_name: 'b',
       target_type: 'agent',
       target_id: B,
       created_at: now(),
     });
-    createDestination({
+    await createDestination({
       agent_group_id: B,
       local_name: 'a',
       target_type: 'agent',
@@ -161,8 +161,8 @@ describe('routeAgentMessage return-path', () => {
     });
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
@@ -286,7 +286,7 @@ describe('routeAgentMessage return-path', () => {
     const inboundId = bRows[0].id;
 
     // Close S1 — simulates session cleanup or channel disconnect.
-    updateSession(S1.id, { status: 'closed' });
+    await updateSession(S1.id, { status: 'closed' });
 
     // B replies. origin points to S1 (closed), should fall through to S2.
     await routeAgentMessage(
@@ -303,7 +303,7 @@ describe('routeAgentMessage return-path', () => {
   it('cross-agent-group guard: origin session belonging to wrong agent group is rejected', async () => {
     // Third agent group C sends to B, stamping source_session_id = SC on B's inbound.
     const C = 'ag-C';
-    createAgentGroup({ id: C, name: 'C', folder: 'c', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: C, name: 'C', folder: 'c', agent_provider: null, created_at: now() });
     const SC: Session = {
       id: 'sess-C',
       agent_group_id: C,
@@ -315,9 +315,15 @@ describe('routeAgentMessage return-path', () => {
       last_active: null,
       created_at: '2026-03-01T00:00:00.000Z',
     };
-    createSession(SC);
+    await createSession(SC);
     initSessionFolder(C, SC.id);
-    createDestination({ agent_group_id: C, local_name: 'b', target_type: 'agent', target_id: B, created_at: now() });
+    await createDestination({
+      agent_group_id: C,
+      local_name: 'b',
+      target_type: 'agent',
+      target_id: B,
+      created_at: now(),
+    });
 
     await routeAgentMessage(
       { id: 'msg-from-C', platform_id: B, content: JSON.stringify({ text: 'from C' }), in_reply_to: null },
@@ -346,7 +352,7 @@ describe('routeAgentMessage return-path', () => {
 
   it('in_reply_to referencing a non-a2a row falls through to newest session', async () => {
     // Write a channel message into B's inbound (no source_session_id).
-    writeSessionMessage(B, SB.id, {
+    await writeSessionMessage(B, SB.id, {
       id: 'channel-msg-1',
       kind: 'chat',
       timestamp: now(),

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -206,7 +206,11 @@ export interface RoutableAgentMessage {
  *    has been recorded with `source_session_id` (e.g. fresh installs,
  *    pre-migration data).
  */
-function resolveTargetSession(msg: RoutableAgentMessage, sourceSession: Session, targetAgentGroupId: string): Session {
+async function resolveTargetSession(
+  msg: RoutableAgentMessage,
+  sourceSession: Session,
+  targetAgentGroupId: string,
+): Promise<Session> {
   const srcDb = openInboundDb(sourceSession.agent_group_id, sourceSession.id);
   let originSessionId: string | null = null;
   try {
@@ -223,12 +227,12 @@ function resolveTargetSession(msg: RoutableAgentMessage, sourceSession: Session,
     srcDb.close();
   }
   if (originSessionId) {
-    const candidate = getSession(originSessionId);
+    const candidate = await getSession(originSessionId);
     if (candidate && candidate.agent_group_id === targetAgentGroupId && candidate.status === 'active') {
       return candidate;
     }
   }
-  return resolveSession(targetAgentGroupId, null, null, 'agent-shared').session;
+  return (await resolveSession(targetAgentGroupId, null, null, 'agent-shared')).session;
 }
 
 export async function routeAgentMessage(
@@ -247,7 +251,7 @@ export async function routeAgentMessage(
   // allow, agent_message_policies hold. An approved replay carries the
   // grant — the hold is satisfied but the structure is re-checked live, so
   // revoking a destination between hold and approve blocks delivery.
-  const decision = guard(a2aSend, {
+  const decision = await guard(a2aSend, {
     actor: { kind: 'agent', agentGroupId: sourceAgentGroupId, sessionId: session.id },
     resource: { from: sourceAgentGroupId, to: targetAgentGroupId },
     payload: { id: msg.id, platform_id: targetAgentGroupId, content: msg.content, in_reply_to: msg.in_reply_to },
@@ -262,8 +266,8 @@ export async function routeAgentMessage(
   // consumes the outbound row; `applyA2aMessageGate` re-enters here with the
   // grant on approve.
   if (decision.effect === 'hold') {
-    const sourceName = getAgentGroup(sourceAgentGroupId)?.name ?? sourceAgentGroupId;
-    const targetName = getAgentGroup(targetAgentGroupId)?.name ?? targetAgentGroupId;
+    const sourceName = (await getAgentGroup(sourceAgentGroupId))?.name ?? sourceAgentGroupId;
+    const targetName = (await getAgentGroup(targetAgentGroupId))?.name ?? targetAgentGroupId;
     await requestApproval({
       session,
       agentName: sourceName,
@@ -326,7 +330,7 @@ async function performAgentRoute(
   session: Session,
   targetAgentGroupId: string,
 ): Promise<void> {
-  const targetSession = resolveTargetSession(msg, session, targetAgentGroupId);
+  const targetSession = await resolveTargetSession(msg, session, targetAgentGroupId);
   const a2aMsgId = `a2a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
   // If the source message references files (via `send_file`), forward the
@@ -336,7 +340,7 @@ async function performAgentRoute(
   // read the bytes — they live in a session dir it doesn't mount.
   const forwardedContent = forwardFileAttachments(msg, a2aMsgId, session, targetAgentGroupId, targetSession.id);
 
-  writeSessionMessage(targetAgentGroupId, targetSession.id, {
+  await writeSessionMessage(targetAgentGroupId, targetSession.id, {
     id: a2aMsgId,
     kind: 'chat',
     timestamp: new Date().toISOString(),
@@ -353,7 +357,7 @@ async function performAgentRoute(
     a2aMsgId,
     forwardedFileCount: countForwardedFiles(forwardedContent),
   });
-  const fresh = getSession(targetSession.id);
+  const fresh = await getSession(targetSession.id);
   if (fresh) await wakeContainer(fresh);
 }
 

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -29,8 +29,8 @@ import { requestApproval } from '../approvals/index.js';
 import { createDestination, getDestinationByName, normalizeName } from './db/agent-destinations.js';
 import { writeDestinations } from './write-destinations.js';
 
-function notifyAgent(session: Session, text: string): void {
-  writeSessionMessage(session.agent_group_id, session.id, {
+async function notifyAgent(session: Session, text: string): Promise<void> {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `sys-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     kind: 'chat',
     timestamp: new Date().toISOString(),
@@ -39,21 +39,19 @@ function notifyAgent(session: Session, text: string): void {
     threadId: null,
     content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
   });
-  const fresh = getSession(session.id);
-  if (fresh) {
-    wakeContainer(fresh).catch((err) => log.error('Failed to wake container after notification', { err }));
-  }
+  const fresh = await getSession(session.id);
+  if (fresh) await wakeContainer(fresh);
 }
 
 /** Guard precheck: malformed requests are answered without ever creating a hold. */
-export function validateCreateAgent(content: Record<string, unknown>, session: Session): boolean {
+export async function validateCreateAgent(content: Record<string, unknown>, session: Session): Promise<boolean> {
   const name = typeof content.name === 'string' ? content.name : '';
   if (!name) {
-    notifyAgent(session, 'create_agent failed: name is required.');
+    await notifyAgent(session, 'create_agent failed: name is required.');
     return false;
   }
-  if (!getAgentGroup(session.agent_group_id)) {
-    notifyAgent(session, 'create_agent failed: source agent group not found.');
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'create_agent failed: source agent group not found.');
     log.warn('create_agent failed: missing source group', { sessionAgentGroup: session.agent_group_id, name });
     return false;
   }
@@ -64,7 +62,7 @@ export function validateCreateAgent(content: Record<string, unknown>, session: S
 export async function requestCreateAgentHold(content: Record<string, unknown>, session: Session): Promise<void> {
   const name = typeof content.name === 'string' ? content.name : '';
   const instructions = typeof content.instructions === 'string' ? content.instructions : null;
-  const sourceGroup = getAgentGroup(session.agent_group_id);
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
   if (!sourceGroup) return;
 
   await requestApproval({
@@ -96,7 +94,7 @@ export async function createAgent(
 ): Promise<void> {
   const name = typeof content.name === 'string' ? content.name : '';
   const instructions = typeof content.instructions === 'string' ? content.instructions : null;
-  const sourceGroup = getAgentGroup(session.agent_group_id);
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
   if (!name || !sourceGroup) return; // precheck already answered the requester
 
   await performCreateAgent(name, instructions, session, sourceGroup, (text) => notifyAgent(session, text), options);
@@ -115,21 +113,21 @@ async function performCreateAgent(
   instructions: string | null,
   session: Session,
   sourceGroup: AgentGroup,
-  notify: (text: string) => void,
+  notify: (text: string) => Promise<void>,
   options?: CreateAgentOptions,
 ): Promise<void> {
   const localName = normalizeName(name);
 
   // Collision in the creator's destination namespace
-  if (getDestinationByName(sourceGroup.id, localName)) {
-    notify(`Cannot create agent "${name}": you already have a destination named "${localName}".`);
+  if (await getDestinationByName(sourceGroup.id, localName)) {
+    await notify(`Cannot create agent "${name}": you already have a destination named "${localName}".`);
     return;
   }
 
   // Derive a safe folder name, deduplicated globally across agent_groups.folder
   let folder = localName;
   let suffix = 2;
-  while (getAgentGroupByFolder(folder)) {
+  while (await getAgentGroupByFolder(folder)) {
     folder = `${localName}-${suffix}`;
     suffix++;
   }
@@ -138,7 +136,7 @@ async function performCreateAgent(
   const resolvedPath = path.resolve(groupPath);
   const resolvedGroupsDir = path.resolve(GROUPS_DIR);
   if (!resolvedPath.startsWith(resolvedGroupsDir + path.sep)) {
-    notify(`Cannot create agent "${name}": invalid folder path.`);
+    await notify(`Cannot create agent "${name}": invalid folder path.`);
     log.error('create_agent path traversal attempt', { folder, resolvedPath });
     return;
   }
@@ -153,7 +151,7 @@ async function performCreateAgent(
     agent_provider: null,
     created_at: now,
   };
-  createAgentGroup(newGroup);
+  await createAgentGroup(newGroup);
   // Subagent path: a child inherits its creator's EFFECTIVE provider, NOT the
   // instance-wide default — so a child is never spawned on a runtime the parent
   // can't reach (e.g. a codex-only install where claude isn't authenticated).
@@ -161,12 +159,12 @@ async function performCreateAgent(
   // stamps its config row in one step (a NULL parent resolves to claude). The
   // operator can still flip a child later with `ncl groups config update
   // --provider`.
-  const parentProvider = getContainerConfig(sourceGroup.id)?.provider ?? 'claude';
-  initGroupFilesystem(newGroup, { instructions: instructions ?? undefined, provider: parentProvider });
+  const parentProvider = (await getContainerConfig(sourceGroup.id))?.provider ?? 'claude';
+  await initGroupFilesystem(newGroup, { instructions: instructions ?? undefined, provider: parentProvider });
 
   // Insert bidirectional destination rows (= ACL grants).
   // Creator refers to child by the name it chose; child refers to creator as "parent".
-  createDestination({
+  await createDestination({
     agent_group_id: sourceGroup.id,
     local_name: localName,
     target_type: 'agent',
@@ -177,11 +175,11 @@ async function performCreateAgent(
   // (shouldn't happen for a brand-new agent, but be safe).
   let parentName = 'parent';
   let parentSuffix = 2;
-  while (getDestinationByName(agentGroupId, parentName)) {
+  while (await getDestinationByName(agentGroupId, parentName)) {
     parentName = `parent-${parentSuffix}`;
     parentSuffix++;
   }
-  createDestination({
+  await createDestination({
     agent_group_id: agentGroupId,
     local_name: parentName,
     target_type: 'agent',
@@ -193,10 +191,12 @@ async function performCreateAgent(
   // inbound.db. See the top-of-file invariant in db/agent-destinations.ts
   // — forgetting this causes "dropped: unknown destination" when the parent
   // tries to send to the newly-created child.
-  writeDestinations(session.agent_group_id, session.id);
+  await writeDestinations(session.agent_group_id, session.id);
 
   if (!options?.suppressCreatedNotify) {
-    notify(`Agent "${localName}" created. You can now message it with send_message({ to: "${localName}", ... }).`);
+    await notify(
+      `Agent "${localName}" created. You can now message it with send_message({ to: "${localName}", ... }).`,
+    );
   }
   log.info('Agent group created', { agentGroupId, name, localName, folder, parent: sourceGroup.id });
 }

--- a/src/modules/agent-to-agent/db/agent-destinations.ts
+++ b/src/modules/agent-to-agent/db/agent-destinations.ts
@@ -44,43 +44,55 @@ import { deletePoliciesTouching, removeMessagePolicy } from './agent-message-pol
  * session of that agent group so the change propagates to the running
  * container's inbound.db. See the top-of-file invariant.
  */
-export function createDestination(row: AgentDestination): void {
-  getDb()
-    .prepare(
-      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
-       VALUES (@agent_group_id, @local_name, @target_type, @target_id, @created_at)`,
-    )
-    .run(row);
+export async function createDestination(row: AgentDestination): Promise<void> {
+  await getDb().run(
+    `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+     VALUES (@agent_group_id, @local_name, @target_type, @target_id, @created_at)`,
+    row,
+  );
 }
 
-export function getDestinations(agentGroupId: string): AgentDestination[] {
-  return getDb()
-    .prepare('SELECT * FROM agent_destinations WHERE agent_group_id = ?')
-    .all(agentGroupId) as AgentDestination[];
+export async function getDestinations(agentGroupId: string): Promise<AgentDestination[]> {
+  return getDb().all<AgentDestination>('SELECT * FROM agent_destinations WHERE agent_group_id = ?', agentGroupId);
 }
 
-export function getDestinationByName(agentGroupId: string, localName: string): AgentDestination | undefined {
-  return getDb()
-    .prepare('SELECT * FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?')
-    .get(agentGroupId, localName) as AgentDestination | undefined;
+export async function getDestinationByName(
+  agentGroupId: string,
+  localName: string,
+): Promise<AgentDestination | undefined> {
+  return getDb().get<AgentDestination>(
+    'SELECT * FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?',
+    agentGroupId,
+    localName,
+  );
 }
 
 /** Reverse lookup: what does this agent call the given target? */
-export function getDestinationByTarget(
+export async function getDestinationByTarget(
   agentGroupId: string,
   targetType: 'channel' | 'agent',
   targetId: string,
-): AgentDestination | undefined {
-  return getDb()
-    .prepare('SELECT * FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ?')
-    .get(agentGroupId, targetType, targetId) as AgentDestination | undefined;
+): Promise<AgentDestination | undefined> {
+  return getDb().get<AgentDestination>(
+    'SELECT * FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ?',
+    agentGroupId,
+    targetType,
+    targetId,
+  );
 }
 
 /** Permission check: can this agent send to this target? */
-export function hasDestination(agentGroupId: string, targetType: 'channel' | 'agent', targetId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ? LIMIT 1')
-    .get(agentGroupId, targetType, targetId);
+export async function hasDestination(
+  agentGroupId: string,
+  targetType: 'channel' | 'agent',
+  targetId: string,
+): Promise<boolean> {
+  const row = await getDb().get(
+    'SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ? LIMIT 1',
+    agentGroupId,
+    targetType,
+    targetId,
+  );
   return !!row;
 }
 
@@ -89,16 +101,20 @@ export function hasDestination(agentGroupId: string, targetType: 'channel' | 'ag
  * `writeDestinations(agentGroupId, <sessionId>)` for each active session
  * so the deletion propagates to the running container's inbound.db.
  */
-export function deleteDestination(agentGroupId: string, localName: string): void {
+export async function deleteDestination(agentGroupId: string, localName: string): Promise<void> {
   // Resolve the target first so we can drop a matching policy for this edge (no ghost gate on re-wire).
-  const row = getDb()
-    .prepare('SELECT target_type, target_id FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?')
-    .get(agentGroupId, localName) as { target_type: string; target_id: string } | undefined;
-  getDb()
-    .prepare('DELETE FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?')
-    .run(agentGroupId, localName);
+  const row = await getDb().get<{ target_type: string; target_id: string }>(
+    'SELECT target_type, target_id FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?',
+    agentGroupId,
+    localName,
+  );
+  await getDb().run(
+    'DELETE FROM agent_destinations WHERE agent_group_id = ? AND local_name = ?',
+    agentGroupId,
+    localName,
+  );
   if (row?.target_type === 'agent') {
-    removeMessagePolicy(agentGroupId, row.target_id);
+    await removeMessagePolicy(agentGroupId, row.target_id);
   }
 }
 
@@ -112,11 +128,14 @@ export function deleteDestination(agentGroupId: string, localName: string): void
  * `agentGroupId` as a destination target. Use `getDestinationReferencers`
  * below to find them BEFORE calling this (the rows are gone afterwards).
  */
-export function deleteAllDestinationsTouching(agentGroupId: string): void {
-  getDb()
-    .prepare('DELETE FROM agent_destinations WHERE agent_group_id = ? OR (target_type = ? AND target_id = ?)')
-    .run(agentGroupId, 'agent', agentGroupId);
-  deletePoliciesTouching(agentGroupId);
+export async function deleteAllDestinationsTouching(agentGroupId: string): Promise<void> {
+  await getDb().run(
+    'DELETE FROM agent_destinations WHERE agent_group_id = ? OR (target_type = ? AND target_id = ?)',
+    agentGroupId,
+    'agent',
+    agentGroupId,
+  );
+  await deletePoliciesTouching(agentGroupId);
 }
 
 /**
@@ -126,12 +145,12 @@ export function deleteAllDestinationsTouching(agentGroupId: string): void {
  * projections to refresh after the delete — the rows are gone once the
  * delete runs.
  */
-export function getDestinationReferencers(targetAgentGroupId: string): string[] {
-  const rows = getDb()
-    .prepare(
-      "SELECT DISTINCT agent_group_id FROM agent_destinations WHERE target_type = 'agent' AND target_id = ? AND agent_group_id != ?",
-    )
-    .all(targetAgentGroupId, targetAgentGroupId) as Array<{ agent_group_id: string }>;
+export async function getDestinationReferencers(targetAgentGroupId: string): Promise<string[]> {
+  const rows = await getDb().all<{ agent_group_id: string }>(
+    "SELECT DISTINCT agent_group_id FROM agent_destinations WHERE target_type = 'agent' AND target_id = ? AND agent_group_id != ?",
+    targetAgentGroupId,
+    targetAgentGroupId,
+  );
   return rows.map((r) => r.agent_group_id);
 }
 

--- a/src/modules/agent-to-agent/db/agent-message-policies.ts
+++ b/src/modules/agent-to-agent/db/agent-message-policies.ts
@@ -2,37 +2,45 @@
 import type { AgentMessagePolicy } from '../../../types.js';
 import { getDb } from '../../../db/connection.js';
 
-export function getMessagePolicy(fromAgentGroupId: string, toAgentGroupId: string): AgentMessagePolicy | undefined {
-  return getDb()
-    .prepare('SELECT * FROM agent_message_policies WHERE from_agent_group_id = ? AND to_agent_group_id = ?')
-    .get(fromAgentGroupId, toAgentGroupId) as AgentMessagePolicy | undefined;
+export async function getMessagePolicy(
+  fromAgentGroupId: string,
+  toAgentGroupId: string,
+): Promise<AgentMessagePolicy | undefined> {
+  return getDb().get<AgentMessagePolicy>(
+    'SELECT * FROM agent_message_policies WHERE from_agent_group_id = ? AND to_agent_group_id = ?',
+    fromAgentGroupId,
+    toAgentGroupId,
+  );
 }
 
-export function setMessagePolicy(
+export async function setMessagePolicy(
   fromAgentGroupId: string,
   toAgentGroupId: string,
   approver: string,
   createdAt: string,
-): void {
-  getDb()
-    .prepare(
-      `INSERT INTO agent_message_policies (from_agent_group_id, to_agent_group_id, approver, created_at)
+): Promise<void> {
+  await getDb().run(
+    `INSERT INTO agent_message_policies (from_agent_group_id, to_agent_group_id, approver, created_at)
        VALUES (@from_agent_group_id, @to_agent_group_id, @approver, @created_at)
        ON CONFLICT (from_agent_group_id, to_agent_group_id) DO UPDATE SET approver = excluded.approver`,
-    )
-    .run({ from_agent_group_id: fromAgentGroupId, to_agent_group_id: toAgentGroupId, approver, created_at: createdAt });
+    { from_agent_group_id: fromAgentGroupId, to_agent_group_id: toAgentGroupId, approver, created_at: createdAt },
+  );
 }
 
-export function removeMessagePolicy(fromAgentGroupId: string, toAgentGroupId: string): boolean {
-  const info = getDb()
-    .prepare('DELETE FROM agent_message_policies WHERE from_agent_group_id = ? AND to_agent_group_id = ?')
-    .run(fromAgentGroupId, toAgentGroupId);
+export async function removeMessagePolicy(fromAgentGroupId: string, toAgentGroupId: string): Promise<boolean> {
+  const info = await getDb().run(
+    'DELETE FROM agent_message_policies WHERE from_agent_group_id = ? AND to_agent_group_id = ?',
+    fromAgentGroupId,
+    toAgentGroupId,
+  );
   return info.changes > 0;
 }
 
 /** Delete every policy touching this agent group, so none outlives its connection. */
-export function deletePoliciesTouching(agentGroupId: string): void {
-  getDb()
-    .prepare('DELETE FROM agent_message_policies WHERE from_agent_group_id = ? OR to_agent_group_id = ?')
-    .run(agentGroupId, agentGroupId);
+export async function deletePoliciesTouching(agentGroupId: string): Promise<void> {
+  await getDb().run(
+    'DELETE FROM agent_message_policies WHERE from_agent_group_id = ? OR to_agent_group_id = ?',
+    agentGroupId,
+    agentGroupId,
+  );
 }

--- a/src/modules/agent-to-agent/guard.ts
+++ b/src/modules/agent-to-agent/guard.ts
@@ -41,9 +41,9 @@ export const agentsCreate = defineGuardedAction({
       return false;
     }
   },
-  decide: (input) => {
+  decide: async (input) => {
     if (input.actor.kind !== 'agent') return DENY('create_agent is a container-originated action.');
-    const cliScope = getContainerConfig(input.actor.agentGroupId)?.cli_scope ?? 'group';
+    const cliScope = (await getContainerConfig(input.actor.agentGroupId))?.cli_scope ?? 'group';
     if (cliScope === 'global') {
       // Trusted owner agent group — an approval tap on every sub-agent spawn
       // would be needless friction.
@@ -67,19 +67,19 @@ export const a2aSend = defineGuardedAction({
       return false;
     }
   },
-  decide: (input) => {
+  decide: async (input) => {
     if (input.actor.kind !== 'agent') return DENY('agent-to-agent send requires an agent actor');
     const from = input.actor.agentGroupId;
     const to = input.resource?.to ?? '';
     const isSelf = to === from;
-    if (!isSelf && !hasDestination(from, 'agent', to)) {
+    if (!isSelf && !(await hasDestination(from, 'agent', to))) {
       return DENY(`unauthorized agent-to-agent: ${from} has no destination for ${to}`);
     }
-    if (!getAgentGroup(to)) {
+    if (!(await getAgentGroup(to))) {
       return DENY(`target agent group ${to} not found for message ${String(input.payload.id)}`);
     }
     if (isSelf) return ALLOW('self-send');
-    const policy = getMessagePolicy(from, to);
+    const policy = await getMessagePolicy(from, to);
     if (policy) {
       return HOLD(`a2a message policy ${from}→${to} holds for ${policy.approver}`, policy.approver);
     }

--- a/src/modules/agent-to-agent/message-gate.test.ts
+++ b/src/modules/agent-to-agent/message-gate.test.ts
@@ -9,6 +9,7 @@ import { getMessagePolicy, removeMessagePolicy, setMessagePolicy } from './db/ag
 import { applyA2aMessageGate } from './message-gate.js';
 import { initTestDb, closeDb, runMigrations, createAgentGroup } from '../../db/index.js';
 import { getDb } from '../../db/connection.js';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createPendingApproval, createSession, deletePendingApproval, getPendingApproval } from '../../db/sessions.js';
 import { requestApproval } from '../approvals/index.js';
 import { initSessionFolder, inboundDbPath } from '../../session-manager.js';
@@ -40,7 +41,7 @@ function now(): string {
 }
 
 function policyCount(): number {
-  return (getDb().prepare('SELECT COUNT(*) AS n FROM agent_message_policies').get() as { n: number }).n;
+  return (sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS n FROM agent_message_policies').get() as { n: number }).n;
 }
 
 function readInbound(agentGroupId: string, sessionId: string) {
@@ -69,8 +70,8 @@ function makeSession(id: string, agentGroupId: string): Session {
 }
 
 /** Seed a live a2a hold row (what requestApproval writes) and return it as the grant. */
-function seedA2aHold(approvalId: string, payload: Record<string, unknown>): PendingApproval {
-  createPendingApproval({
+async function seedA2aHold(approvalId: string, payload: Record<string, unknown>): Promise<PendingApproval> {
+  await createPendingApproval({
     approval_id: approvalId,
     session_id: 'sess-A',
     request_id: approvalId,
@@ -82,44 +83,50 @@ function seedA2aHold(approvalId: string, payload: Record<string, unknown>): Pend
     options_json: '[]',
     approver_user_id: 'telegram:dana',
   });
-  return getPendingApproval(approvalId)!;
+  return (await getPendingApproval(approvalId))!;
 }
 
 describe('agent message policies', () => {
   let SA: Session;
   let SB: Session;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
     vi.mocked(requestApproval).mockClear();
 
-    createAgentGroup({ id: A, name: 'A', folder: 'a', agent_provider: null, created_at: now() });
-    createAgentGroup({ id: B, name: 'B', folder: 'b', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: A, name: 'A', folder: 'a', agent_provider: null, created_at: now() });
+    await createAgentGroup({ id: B, name: 'B', folder: 'b', agent_provider: null, created_at: now() });
     SA = makeSession('sess-A', A);
     SB = makeSession('sess-B', B);
-    createSession(SA);
-    createSession(SB);
+    await createSession(SA);
+    await createSession(SB);
     initSessionFolder(A, SA.id);
     initSessionFolder(B, SB.id);
     // A→B connection wired.
-    createDestination({ agent_group_id: A, local_name: 'b', target_type: 'agent', target_id: B, created_at: now() });
+    await createDestination({
+      agent_group_id: A,
+      local_name: 'b',
+      target_type: 'agent',
+      target_id: B,
+      created_at: now(),
+    });
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
   // ── policy table round-trip ──
 
-  it('set / get / remove round-trip, incl. approver', () => {
-    expect(getMessagePolicy(A, B)).toBeUndefined();
+  it('set / get / remove round-trip, incl. approver', async () => {
+    expect(await getMessagePolicy(A, B)).toBeUndefined();
 
-    setMessagePolicy(A, B, 'telegram:sam', now());
-    expect(getMessagePolicy(A, B)).toMatchObject({
+    await setMessagePolicy(A, B, 'telegram:sam', now());
+    expect(await getMessagePolicy(A, B)).toMatchObject({
       from_agent_group_id: A,
       to_agent_group_id: B,
       approver: 'telegram:sam',
@@ -127,13 +134,13 @@ describe('agent message policies', () => {
     expect(policyCount()).toBe(1);
 
     // Upsert updates the approver without inserting a duplicate row.
-    setMessagePolicy(A, B, 'telegram:dana', now());
-    expect(getMessagePolicy(A, B)!.approver).toBe('telegram:dana');
+    await setMessagePolicy(A, B, 'telegram:dana', now());
+    expect((await getMessagePolicy(A, B))!.approver).toBe('telegram:dana');
     expect(policyCount()).toBe(1);
 
-    expect(removeMessagePolicy(A, B)).toBe(true);
-    expect(getMessagePolicy(A, B)).toBeUndefined();
-    expect(removeMessagePolicy(A, B)).toBe(false);
+    expect(await removeMessagePolicy(A, B)).toBe(true);
+    expect(await getMessagePolicy(A, B)).toBeUndefined();
+    expect(await removeMessagePolicy(A, B)).toBe(false);
   });
 
   // ── gate behavior in routeAgentMessage ──
@@ -148,7 +155,7 @@ describe('agent message policies', () => {
   });
 
   it('policy present → holds the message and requests approval from the policy approver', async () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
+    await setMessagePolicy(A, B, 'telegram:dana', now());
 
     await routeAgentMessage(
       { id: 'm2', platform_id: B, content: JSON.stringify({ text: 'sensitive' }), in_reply_to: null },
@@ -167,7 +174,7 @@ describe('agent message policies', () => {
   });
 
   it('self-message is never gated even if a policy row somehow exists', async () => {
-    setMessagePolicy(A, A, 'telegram:dana', now()); // pathological, but must be ignored
+    await setMessagePolicy(A, A, 'telegram:dana', now()); // pathological, but must be ignored
     await routeAgentMessage(
       { id: 'self', platform_id: A, content: JSON.stringify({ text: 'note' }), in_reply_to: null },
       SA,
@@ -177,8 +184,8 @@ describe('agent message policies', () => {
   });
 
   it('ghost policy (policy row, no destination row) still denies — deny beats the policy hold', async () => {
-    deleteDestination(A, 'b'); // removes A→B — the destination ACL now denies
-    setMessagePolicy(A, B, 'telegram:dana', now()); // ...but a stale policy row remains
+    await deleteDestination(A, 'b'); // removes A→B — the destination ACL now denies
+    await setMessagePolicy(A, B, 'telegram:dana', now()); // ...but a stale policy row remains
 
     await expect(
       routeAgentMessage({ id: 'ghost', platform_id: B, content: JSON.stringify({ text: 'x' }), in_reply_to: null }, SA),
@@ -190,9 +197,9 @@ describe('agent message policies', () => {
   // ── approve handler re-enters the guarded route with the grant ──
 
   it('applyA2aMessageGate delivers the held message to the target (valid grant)', async () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
+    await setMessagePolicy(A, B, 'telegram:dana', now());
     const payload = { id: 'held-1', platform_id: B, content: JSON.stringify({ text: 'approved!' }), in_reply_to: null };
-    const approval = seedA2aHold('appr-a2a-1', payload);
+    const approval = await seedA2aHold('appr-a2a-1', payload);
 
     const notify = vi.fn();
     await applyA2aMessageGate({ session: SA, userId: 'telegram:dana', notify, payload, approval });
@@ -206,11 +213,11 @@ describe('agent message policies', () => {
   });
 
   it('destination revoked between hold and approve → refused cleanly, requester told, nothing delivered', async () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
+    await setMessagePolicy(A, B, 'telegram:dana', now());
     const payload = { id: 'held-2', platform_id: B, content: JSON.stringify({ text: 'stale' }), in_reply_to: null };
-    const approval = seedA2aHold('appr-a2a-2', payload);
+    const approval = await seedA2aHold('appr-a2a-2', payload);
 
-    deleteDestination(A, 'b'); // revoke A→B while the card is pending
+    await deleteDestination(A, 'b'); // revoke A→B while the card is pending
 
     const notify = vi.fn();
     // An expected policy refusal — resolves (no throw), so the response
@@ -222,9 +229,9 @@ describe('agent message policies', () => {
   });
 
   it('mismatched grant (held for another target) refuses the replay cleanly', async () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
+    await setMessagePolicy(A, B, 'telegram:dana', now());
     // Grant was approved for a message to A (different target than the replay).
-    const approval = seedA2aHold('appr-a2a-3', { id: 'other', platform_id: A, content: '{}', in_reply_to: null });
+    const approval = await seedA2aHold('appr-a2a-3', { id: 'other', platform_id: A, content: '{}', in_reply_to: null });
     const payload = { id: 'held-3', platform_id: B, content: JSON.stringify({ text: 'swap' }), in_reply_to: null };
 
     const notify = vi.fn();
@@ -235,11 +242,11 @@ describe('agent message policies', () => {
   });
 
   it('a grant only works while its row is live (executes once)', async () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
+    await setMessagePolicy(A, B, 'telegram:dana', now());
     const payload = { id: 'held-4', platform_id: B, content: JSON.stringify({ text: 'once' }), in_reply_to: null };
-    const approval = seedA2aHold('appr-a2a-4', payload);
+    const approval = await seedA2aHold('appr-a2a-4', payload);
 
-    deletePendingApproval(approval.approval_id); // resolution already consumed the row
+    await deletePendingApproval(approval.approval_id); // resolution already consumed the row
 
     const notify = vi.fn();
     await applyA2aMessageGate({ session: SA, userId: 'telegram:dana', notify, payload, approval });
@@ -250,17 +257,17 @@ describe('agent message policies', () => {
 
   // ── ghost-gate cleanup ──
 
-  it('deleting the connection drops its policy', () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
-    deleteDestination(A, 'b'); // removes the A→B agent destination
-    expect(getMessagePolicy(A, B)).toBeUndefined();
+  it('deleting the connection drops its policy', async () => {
+    await setMessagePolicy(A, B, 'telegram:dana', now());
+    await deleteDestination(A, 'b'); // removes the A→B agent destination
+    expect(await getMessagePolicy(A, B)).toBeUndefined();
   });
 
-  it('deleteAllDestinationsTouching drops policies on both sides', () => {
-    setMessagePolicy(A, B, 'telegram:dana', now());
-    setMessagePolicy(B, A, 'telegram:dana', now());
-    deleteAllDestinationsTouching(A);
-    expect(getMessagePolicy(A, B)).toBeUndefined();
-    expect(getMessagePolicy(B, A)).toBeUndefined();
+  it('deleteAllDestinationsTouching drops policies on both sides', async () => {
+    await setMessagePolicy(A, B, 'telegram:dana', now());
+    await setMessagePolicy(B, A, 'telegram:dana', now());
+    await deleteAllDestinationsTouching(A);
+    expect(await getMessagePolicy(A, B)).toBeUndefined();
+    expect(await getMessagePolicy(B, A)).toBeUndefined();
   });
 });

--- a/src/modules/agent-to-agent/message-gate.ts
+++ b/src/modules/agent-to-agent/message-gate.ts
@@ -7,7 +7,7 @@ import { routeAgentMessage, type RoutableAgentMessage } from './agent-route.js';
 export const applyA2aMessageGate: ApprovalHandler = async ({ session, payload, approval, notify }) => {
   const { id, platform_id, content, in_reply_to } = payload;
   if (typeof platform_id !== 'string' || !platform_id) {
-    notify('Message approved but the target agent group was missing from the request.');
+    await notify('Message approved but the target agent group was missing from the request.');
     log.warn('a2a_message_gate apply: missing target', { sessionId: session.id });
     return;
   }
@@ -35,7 +35,7 @@ export const applyA2aMessageGate: ApprovalHandler = async ({ session, payload, a
         msgId: msg.id,
         reason: err.message,
       });
-      notify(`Message approved, but not delivered — no longer authorized: ${err.message}`);
+      await notify(`Message approved, but not delivered — no longer authorized: ${err.message}`);
       return;
     }
     throw err;

--- a/src/modules/agent-to-agent/write-destinations.ts
+++ b/src/modules/agent-to-agent/write-destinations.ts
@@ -16,16 +16,16 @@ import { log } from '../../log.js';
 import { inboundDbPath, openInboundDb } from '../../session-manager.js';
 import { getDestinations } from './db/agent-destinations.js';
 
-export function writeDestinations(agentGroupId: string, sessionId: string): void {
+export async function writeDestinations(agentGroupId: string, sessionId: string): Promise<void> {
   const dbPath = inboundDbPath(agentGroupId, sessionId);
   if (!fs.existsSync(dbPath)) return;
 
-  const rows = getDestinations(agentGroupId);
+  const rows = await getDestinations(agentGroupId);
   const resolved: DestinationRow[] = [];
 
   for (const row of rows) {
     if (row.target_type === 'channel') {
-      const mg = getMessagingGroup(row.target_id);
+      const mg = await getMessagingGroup(row.target_id);
       if (!mg) continue;
       resolved.push({
         name: row.local_name,
@@ -36,7 +36,7 @@ export function writeDestinations(agentGroupId: string, sessionId: string): void
         agent_group_id: null,
       });
     } else if (row.target_type === 'agent') {
-      const ag = getAgentGroup(row.target_id);
+      const ag = await getAgentGroup(row.target_id);
       if (!ag) continue;
       resolved.push({
         name: row.local_name,

--- a/src/modules/approvals/approval-resolved.test.ts
+++ b/src/modules/approvals/approval-resolved.test.ts
@@ -35,8 +35,8 @@ function now() {
   return new Date().toISOString();
 }
 
-function seedApproval(approvalId: string, action: string): void {
-  createPendingApproval({
+async function seedApproval(approvalId: string, action: string): Promise<void> {
+  await createPendingApproval({
     approval_id: approvalId,
     session_id: 'sess-1',
     request_id: approvalId,
@@ -48,14 +48,14 @@ function seedApproval(approvalId: string, action: string): void {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
-  createSession({
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createSession({
     id: 'sess-1',
     agent_group_id: 'ag-1',
     messaging_group_id: null,
@@ -69,12 +69,18 @@ beforeEach(() => {
   initSessionFolder('ag-1', 'sess-1');
 
   // Resolution only happens for authorized clicks — seed the clicking admin.
-  upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
-  grantRole({ user_id: 'slack:admin-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+  await upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
+  await grantRole({
+    user_id: 'slack:admin-1',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now(),
+  });
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -85,7 +91,7 @@ describe('approval-resolved callbacks', () => {
       events.push(event);
     });
 
-    seedApproval('appr-reject-1', 'test_reject_action');
+    await seedApproval('appr-reject-1', 'test_reject_action');
     const claimed = await handleApprovalsResponse({
       questionId: 'appr-reject-1',
       value: 'reject',
@@ -113,7 +119,7 @@ describe('approval-resolved callbacks', () => {
       calls.push(`resolved:${outcome}`);
     });
 
-    seedApproval('appr-approve-1', 'test_approve_action');
+    await seedApproval('appr-approve-1', 'test_approve_action');
     await handleApprovalsResponse({
       questionId: 'appr-approve-1',
       value: 'approve',
@@ -136,7 +142,7 @@ describe('approval-resolved callbacks', () => {
       events.push('after');
     });
 
-    seedApproval('appr-reject-2', 'test_isolation_action');
+    await seedApproval('appr-reject-2', 'test_isolation_action');
     const claimed = await handleApprovalsResponse({
       questionId: 'appr-reject-2',
       value: 'reject',

--- a/src/modules/approvals/finalize.ts
+++ b/src/modules/approvals/finalize.ts
@@ -36,7 +36,7 @@ export async function finalizeReject(
     ? `Your ${approval.action} request was rejected by admin: "${reason}"`
     : `Your ${approval.action} request was rejected by admin.`;
 
-  writeSessionMessage(session.agent_group_id, session.id, {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `appr-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     kind: 'chat',
     timestamp: new Date().toISOString(),
@@ -53,7 +53,7 @@ export async function finalizeReject(
     withReason: reason !== undefined,
   });
 
-  deletePendingApproval(approval.approval_id);
+  await deletePendingApproval(approval.approval_id);
   await notifyApprovalResolved({ approval, session, outcome: 'reject', userId });
   await wakeContainer(session);
 }

--- a/src/modules/approvals/onecli-approvals.ts
+++ b/src/modules/approvals/onecli-approvals.ts
@@ -67,17 +67,17 @@ function shortApprovalId(): string {
 }
 
 /** Called from the approvals response handler when a card button is clicked. */
-export function resolveOneCLIApproval(approvalId: string, selectedOption: string): boolean {
+export async function resolveOneCLIApproval(approvalId: string, selectedOption: string): Promise<boolean> {
   const state = pending.get(approvalId);
   if (!state) return false;
   pending.delete(approvalId);
   clearTimeout(state.timer);
 
   const decision: Decision = selectedOption === 'approve' ? 'approve' : 'deny';
-  updatePendingApprovalStatus(approvalId, decision === 'approve' ? 'approved' : 'rejected');
+  await updatePendingApprovalStatus(approvalId, decision === 'approve' ? 'approved' : 'rejected');
   // Card is auto-edited to "✅ <option>" by chat-sdk-bridge's onAction handler,
   // so we don't need to deliver an edit here.
-  deletePendingApproval(approvalId);
+  await deletePendingApproval(approvalId);
 
   state.resolve(decision);
   log.info('OneCLI approval resolved', { approvalId, decision });
@@ -118,9 +118,9 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
   // Originating agent group is carried on the request via OneCLI's agent
   // identifier (set by container-runner.ts to agentGroup.id). Use it as
   // the scope for approver selection: admin @ group → global admin → owner.
-  const originGroup = request.agent.externalId ? getAgentGroup(request.agent.externalId) : undefined;
+  const originGroup = request.agent.externalId ? await getAgentGroup(request.agent.externalId) : undefined;
   const agentGroupId = originGroup?.id ?? null;
-  const approvers = pickApprover(agentGroupId);
+  const approvers = await pickApprover(agentGroupId);
   if (approvers.length === 0) {
     log.warn('OneCLI approval auto-denied: no eligible approver', {
       id: request.id,
@@ -172,7 +172,7 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
     return 'deny';
   }
 
-  createPendingApproval({
+  await createPendingApproval({
     approval_id: approvalId,
     session_id: null,
     request_id: request.id,
@@ -218,13 +218,13 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
 }
 
 async function expireApproval(approvalId: string, reason: ExpiryReason): Promise<void> {
-  const rows = getPendingApprovalsByAction(ONECLI_ACTION).filter((r) => r.approval_id === approvalId);
+  const rows = (await getPendingApprovalsByAction(ONECLI_ACTION)).filter((r) => r.approval_id === approvalId);
   const row = rows[0];
   if (!row) return;
 
-  updatePendingApprovalStatus(approvalId, 'expired');
+  await updatePendingApprovalStatus(approvalId, 'expired');
   await editCardExpired(row, reason);
-  deletePendingApproval(approvalId);
+  await deletePendingApproval(approvalId);
   log.info('OneCLI approval expired', { approvalId, reason });
 }
 
@@ -257,12 +257,12 @@ async function editCardExpired(row: PendingApproval, reason: ExpiryReason): Prom
 }
 
 async function sweepStaleApprovals(): Promise<void> {
-  const rows = getPendingApprovalsByAction(ONECLI_ACTION);
+  const rows = await getPendingApprovalsByAction(ONECLI_ACTION);
   if (rows.length === 0) return;
   log.info('Sweeping stale OneCLI approvals from previous process', { count: rows.length });
   for (const row of rows) {
     await editCardExpired(row, 'host restarted');
-    deletePendingApproval(row.approval_id);
+    await deletePendingApproval(row.approval_id);
   }
 }
 

--- a/src/modules/approvals/picks.test.ts
+++ b/src/modules/approvals/picks.test.ts
@@ -20,14 +20,14 @@ function now(): string {
   return new Date().toISOString();
 }
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
 afterEach(async () => {
   await teardownChannelAdapters();
-  closeDb();
+  await closeDb();
 });
 
 async function mountMockAdapter(
@@ -68,8 +68,8 @@ async function mountMockAdapter(
   return { delivered, openDMCalls };
 }
 
-function seedAgentGroup(id: string): void {
-  createAgentGroup({
+async function seedAgentGroup(id: string): Promise<void> {
+  await createAgentGroup({
     id,
     name: id.toUpperCase(),
     folder: id,
@@ -78,43 +78,43 @@ function seedAgentGroup(id: string): void {
   });
 }
 
-function seedUser(id: string, kind: string): void {
-  createUser({ id, kind, display_name: null, created_at: now() });
+async function seedUser(id: string, kind: string): Promise<void> {
+  await createUser({ id, kind, display_name: null, created_at: now() });
 }
 
 describe('pickApprover', () => {
-  beforeEach(() => {
-    seedAgentGroup('ag-1');
-    seedAgentGroup('ag-2');
+  beforeEach(async () => {
+    await seedAgentGroup('ag-1');
+    await seedAgentGroup('ag-2');
   });
 
-  it('prefers scoped admins, then globals, then owners — deduplicated', () => {
-    seedUser('u-owner', 'telegram');
-    seedUser('u-ga', 'telegram');
-    seedUser('u-sa', 'telegram');
-    grantRole({ user_id: 'u-owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-    grantRole({ user_id: 'u-ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: now() });
-    grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
+  it('prefers scoped admins, then globals, then owners — deduplicated', async () => {
+    await seedUser('u-owner', 'telegram');
+    await seedUser('u-ga', 'telegram');
+    await seedUser('u-sa', 'telegram');
+    await grantRole({ user_id: 'u-owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    await grantRole({ user_id: 'u-ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: now() });
+    await grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
 
-    expect(pickApprover('ag-1')).toEqual(['u-sa', 'u-ga', 'u-owner']);
-    expect(pickApprover('ag-2')).toEqual(['u-ga', 'u-owner']);
-    expect(pickApprover(null)).toEqual(['u-ga', 'u-owner']);
+    expect(await pickApprover('ag-1')).toEqual(['u-sa', 'u-ga', 'u-owner']);
+    expect(await pickApprover('ag-2')).toEqual(['u-ga', 'u-owner']);
+    expect(await pickApprover(null)).toEqual(['u-ga', 'u-owner']);
   });
 
-  it('returns empty list when nobody is privileged', () => {
-    expect(pickApprover('ag-1')).toEqual([]);
+  it('returns empty list when nobody is privileged', async () => {
+    expect(await pickApprover('ag-1')).toEqual([]);
   });
 });
 
 describe('pickApprovalDelivery', () => {
-  beforeEach(() => {
-    seedAgentGroup('ag-1');
+  beforeEach(async () => {
+    await seedAgentGroup('ag-1');
   });
 
   it('returns the first reachable approver', async () => {
     await mountMockAdapter('telegram');
-    seedUser('telegram:111', 'telegram');
-    seedUser('telegram:222', 'telegram');
+    await seedUser('telegram:111', 'telegram');
+    await seedUser('telegram:222', 'telegram');
 
     const result = await pickApprovalDelivery(['telegram:111', 'telegram:222'], 'telegram');
     expect(result?.userId).toBe('telegram:111');
@@ -124,8 +124,8 @@ describe('pickApprovalDelivery', () => {
   it('prefers same-channel-kind approver on tie-break', async () => {
     await mountMockAdapter('telegram');
     await mountMockAdapter('discord', async (h) => `dm-${h}`);
-    seedUser('telegram:111', 'telegram');
-    seedUser('discord:222', 'discord');
+    await seedUser('telegram:111', 'telegram');
+    await seedUser('discord:222', 'discord');
 
     const result = await pickApprovalDelivery(['telegram:111', 'discord:222'], 'discord');
     expect(result?.userId).toBe('discord:222');
@@ -133,14 +133,14 @@ describe('pickApprovalDelivery', () => {
 
   it('falls through to any reachable approver when none match origin', async () => {
     await mountMockAdapter('telegram');
-    seedUser('telegram:111', 'telegram');
+    await seedUser('telegram:111', 'telegram');
 
     const result = await pickApprovalDelivery(['telegram:111'], 'discord');
     expect(result?.userId).toBe('telegram:111');
   });
 
   it('returns null when nobody is reachable', async () => {
-    seedUser('telegram:111', 'telegram');
+    await seedUser('telegram:111', 'telegram');
     expect(await pickApprovalDelivery(['telegram:111'], 'telegram')).toBeNull();
   });
 });

--- a/src/modules/approvals/primitive.test.ts
+++ b/src/modules/approvals/primitive.test.ts
@@ -50,14 +50,14 @@ function now(): string {
 
 let session: Session;
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
   session = {
     id: 'sess-1',
     agent_group_id: 'ag-1',
@@ -69,13 +69,19 @@ beforeEach(() => {
     last_active: now(),
     created_at: now(),
   };
-  createSession(session);
+  await createSession(session);
 
   // Authorized approver + a cached DM so ensureUserDm resolves without a
   // platform openDM call.
-  upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
-  grantRole({ user_id: 'slack:admin-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-  createMessagingGroup({
+  await upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
+  await grantRole({
+    user_id: 'slack:admin-1',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now(),
+  });
+  await createMessagingGroup({
     id: 'mg-dm-1',
     channel_type: DM_CHANNEL,
     platform_id: DM_PLATFORM,
@@ -84,7 +90,7 @@ beforeEach(() => {
     unknown_sender_policy: 'strict',
     created_at: now(),
   });
-  upsertUserDm({
+  await upsertUserDm({
     user_id: 'slack:admin-1',
     channel_type: DM_CHANNEL,
     messaging_group_id: 'mg-dm-1',
@@ -92,8 +98,8 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -123,7 +129,7 @@ describe('requestApproval delivery failure', () => {
     });
 
     // No orphan: the row created before the delivery attempt is gone.
-    expect(getPendingApprovalsByAction('test_action')).toHaveLength(0);
+    expect(await getPendingApprovalsByAction('test_action')).toHaveLength(0);
     expect(lastNotifyText()).toMatch(/test_action failed: could not deliver/);
   });
 
@@ -144,7 +150,7 @@ describe('requestApproval delivery failure', () => {
       question: 'Approve the thing?',
     });
 
-    expect(getPendingApprovalsByAction('test_action')).toHaveLength(1);
+    expect(await getPendingApprovalsByAction('test_action')).toHaveLength(1);
     expect(vi.mocked(writeSessionMessage)).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -68,7 +68,7 @@ export interface ApprovalHandlerContext {
   /** User ID of the admin who approved. Empty string if unknown. */
   userId: string;
   /** Send a system chat message to the requesting agent's session. */
-  notify: (text: string) => void;
+  notify: (text: string) => Promise<void>;
 }
 
 export type ApprovalHandler = (ctx: ApprovalHandlerContext) => Promise<void>;
@@ -136,7 +136,7 @@ export async function notifyApprovalResolved(event: ApprovalResolvedEvent): Prom
  * Ordered list of user IDs eligible to approve an action for the given agent
  * group. Preference: admins @ that group → global admins → owners.
  */
-export function pickApprover(agentGroupId: string | null): string[] {
+export async function pickApprover(agentGroupId: string | null): Promise<string[]> {
   const approvers: string[] = [];
   const seen = new Set<string>();
   const add = (id: string): void => {
@@ -147,10 +147,10 @@ export function pickApprover(agentGroupId: string | null): string[] {
   };
 
   if (agentGroupId) {
-    for (const r of getAdminsOfAgentGroup(agentGroupId)) add(r.user_id);
+    for (const r of await getAdminsOfAgentGroup(agentGroupId)) add(r.user_id);
   }
-  for (const r of getGlobalAdmins()) add(r.user_id);
-  for (const r of getOwners()) add(r.user_id);
+  for (const r of await getGlobalAdmins()) add(r.user_id);
+  for (const r of await getOwners()) add(r.user_id);
 
   return approvers;
 }
@@ -189,8 +189,8 @@ function channelTypeOf(userId: string): string {
 // ── Request API ──
 
 /** Send a system chat to the agent's session. Used by callers and by the response handler. */
-export function notifyAgent(session: Session, text: string): void {
-  writeSessionMessage(session.agent_group_id, session.id, {
+export async function notifyAgent(session: Session, text: string): Promise<void> {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `sys-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     kind: 'chat',
     timestamp: new Date().toISOString(),
@@ -199,10 +199,8 @@ export function notifyAgent(session: Session, text: string): void {
     threadId: null,
     content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
   });
-  const fresh = getSession(session.id);
-  if (fresh) {
-    wakeContainer(fresh).catch((err) => log.error('Failed to wake container after notification', { err }));
-  }
+  const fresh = await getSession(session.id);
+  if (fresh) await wakeContainer(fresh);
 }
 
 export interface RequestApprovalOptions {
@@ -229,25 +227,25 @@ export interface RequestApprovalOptions {
 export async function requestApproval(opts: RequestApprovalOptions): Promise<void> {
   const { session, action, payload, title, question, agentName, approverUserId } = opts;
 
-  const approvers = approverUserId ? [approverUserId] : pickApprover(session.agent_group_id);
+  const approvers = approverUserId ? [approverUserId] : await pickApprover(session.agent_group_id);
   if (approvers.length === 0) {
-    notifyAgent(session, `${action} failed: no owner or admin configured to approve.`);
+    await notifyAgent(session, `${action} failed: no owner or admin configured to approve.`);
     return;
   }
 
   const originChannelType = session.messaging_group_id
-    ? (getMessagingGroup(session.messaging_group_id)?.channel_type ?? '')
+    ? ((await getMessagingGroup(session.messaging_group_id))?.channel_type ?? '')
     : '';
 
   const target = await pickApprovalDelivery(approvers, originChannelType);
   if (!target) {
-    notifyAgent(session, `${action} failed: no DM channel found for any eligible approver.`);
+    await notifyAgent(session, `${action} failed: no DM channel found for any eligible approver.`);
     return;
   }
 
   const approvalId = `appr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const normalizedOptions = normalizeOptions(APPROVAL_OPTIONS);
-  createPendingApproval({
+  await createPendingApproval({
     approval_id: approvalId,
     session_id: session.id,
     request_id: approvalId,
@@ -280,8 +278,8 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
       log.error('Failed to deliver approval card', { action, approvalId, err });
       // The single delivery target never saw the card — remove the row so it
       // can't linger as a pending approval nobody can act on.
-      deletePendingApproval(approvalId);
-      notifyAgent(session, `${action} failed: could not deliver approval request to ${target.userId}.`);
+      await deletePendingApproval(approvalId);
+      await notifyAgent(session, `${action} failed: could not deliver approval request to ${target.userId}.`);
       return;
     }
   }

--- a/src/modules/approvals/reason-capture.test.ts
+++ b/src/modules/approvals/reason-capture.test.ts
@@ -62,8 +62,8 @@ const fakeAdapter: ChannelDeliveryAdapter = {
   },
 };
 
-function seedApproval(approvalId: string, action = 'create_agent'): void {
-  createPendingApproval({
+async function seedApproval(approvalId: string, action = 'create_agent'): Promise<void> {
+  await createPendingApproval({
     approval_id: approvalId,
     session_id: 'sess-1',
     request_id: approvalId,
@@ -106,16 +106,16 @@ function lastRelayedText(): string | undefined {
   return (JSON.parse(call[2].content) as { text: string }).text;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
   delivered = [];
 
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
-  createSession({
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createSession({
     id: 'sess-1',
     agent_group_id: 'ag-1',
     messaging_group_id: null,
@@ -129,9 +129,15 @@ beforeEach(() => {
 
   // Authorized approver + a cached DM so ensureUserDm resolves without a
   // platform openDM call.
-  upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
-  grantRole({ user_id: 'slack:admin-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-  createMessagingGroup({
+  await upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
+  await grantRole({
+    user_id: 'slack:admin-1',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now(),
+  });
+  await createMessagingGroup({
     id: 'mg-dm-1',
     channel_type: DM_CHANNEL,
     platform_id: DM_PLATFORM,
@@ -140,7 +146,7 @@ beforeEach(() => {
     unknown_sender_policy: 'strict',
     created_at: now(),
   });
-  upsertUserDm({
+  await upsertUserDm({
     user_id: 'slack:admin-1',
     channel_type: DM_CHANNEL,
     messaging_group_id: 'mg-dm-1',
@@ -150,17 +156,17 @@ beforeEach(() => {
   setDeliveryAdapter(fakeAdapter);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 describe('reject with reason', () => {
   it('holds the row and prompts the admin instead of finalizing', async () => {
-    seedApproval('appr-1');
+    await seedApproval('appr-1');
     await clickRejectWithReason('appr-1');
 
-    const row = getPendingApproval('appr-1');
+    const row = await getPendingApproval('appr-1');
     expect(row?.status).toBe('awaiting_reason');
     expect(row?.expires_at).toBeTruthy();
 
@@ -176,19 +182,19 @@ describe('reject with reason', () => {
 
   it('relays the captured reason as one combined message and clears the row', async () => {
     const { captureReasonReply } = await import('./reason-capture.js');
-    seedApproval('appr-2', 'install_packages');
+    await seedApproval('appr-2', 'install_packages');
     await clickRejectWithReason('appr-2');
 
     const consumed = await captureReasonReply(dmReply('too risky for prod'));
 
     expect(consumed).toBe(true);
-    expect(getPendingApproval('appr-2')).toBeUndefined();
+    expect(await getPendingApproval('appr-2')).toBeUndefined();
     expect(lastRelayedText()).toBe('Your install_packages request was rejected by admin: "too risky for prod"');
   });
 
   it('truncates an over-long reason to 280 chars with an ellipsis', async () => {
     const { captureReasonReply } = await import('./reason-capture.js');
-    seedApproval('appr-3');
+    await seedApproval('appr-3');
     await clickRejectWithReason('appr-3');
 
     await captureReasonReply(dmReply('x'.repeat(400)));
@@ -200,22 +206,22 @@ describe('reject with reason', () => {
 
   it('finalizes a plain reject when the captured reply carries no text', async () => {
     const { captureReasonReply } = await import('./reason-capture.js');
-    seedApproval('appr-4');
+    await seedApproval('appr-4');
     await clickRejectWithReason('appr-4');
 
     const consumed = await captureReasonReply(dmReply(undefined));
 
     expect(consumed).toBe(true);
-    expect(getPendingApproval('appr-4')).toBeUndefined();
+    expect(await getPendingApproval('appr-4')).toBeUndefined();
     expect(lastRelayedText()).toBe('Your create_agent request was rejected by admin.');
   });
 
   it('does not swallow a later DM once the hold was already finalized', async () => {
     const { captureReasonReply } = await import('./reason-capture.js');
-    seedApproval('appr-5');
+    await seedApproval('appr-5');
     await clickRejectWithReason('appr-5');
     // Simulate the sweep (or any other path) finalizing first.
-    deletePendingApproval('appr-5');
+    await deletePendingApproval('appr-5');
 
     const consumed = await captureReasonReply(dmReply('late reason'));
 
@@ -237,23 +243,23 @@ describe('reject with reason', () => {
 describe('reject-with-reason host sweep', () => {
   it('finalizes a hold whose window elapsed as a plain reject', async () => {
     const { sweepAwaitingReasonRejects } = await import('./reason-capture.js');
-    seedApproval('appr-ghost', 'add_mcp_server');
-    markApprovalAwaitingReason('appr-ghost', new Date(Date.now() - 1000).toISOString());
+    await seedApproval('appr-ghost', 'add_mcp_server');
+    await markApprovalAwaitingReason('appr-ghost', new Date(Date.now() - 1000).toISOString());
 
     await sweepAwaitingReasonRejects();
 
-    expect(getPendingApproval('appr-ghost')).toBeUndefined();
+    expect(await getPendingApproval('appr-ghost')).toBeUndefined();
     expect(lastRelayedText()).toBe('Your add_mcp_server request was rejected by admin.');
   });
 
   it('leaves a still-open hold untouched', async () => {
     const { sweepAwaitingReasonRejects } = await import('./reason-capture.js');
-    seedApproval('appr-open');
-    markApprovalAwaitingReason('appr-open', new Date(Date.now() + 60_000).toISOString());
+    await seedApproval('appr-open');
+    await markApprovalAwaitingReason('appr-open', new Date(Date.now() + 60_000).toISOString());
 
     await sweepAwaitingReasonRejects();
 
-    expect(getPendingApproval('appr-open')?.status).toBe('awaiting_reason');
+    expect((await getPendingApproval('appr-open'))?.status).toBe('awaiting_reason');
     expect(vi.mocked(writeSessionMessage)).not.toHaveBeenCalled();
   });
 });
@@ -261,7 +267,7 @@ describe('reject-with-reason host sweep', () => {
 describe('plain reject (regression)', () => {
   it('finalizes immediately with no reason and no DM prompt', async () => {
     const { handleApprovalsResponse } = await import('./response-handler.js');
-    seedApproval('appr-plain', 'install_packages');
+    await seedApproval('appr-plain', 'install_packages');
 
     await handleApprovalsResponse({
       questionId: 'appr-plain',
@@ -272,7 +278,7 @@ describe('plain reject (regression)', () => {
       threadId: null,
     });
 
-    expect(getPendingApproval('appr-plain')).toBeUndefined();
+    expect(await getPendingApproval('appr-plain')).toBeUndefined();
     expect(delivered).toHaveLength(0);
     expect(lastRelayedText()).toBe('Your install_packages request was rejected by admin.');
   });

--- a/src/modules/approvals/reason-capture.ts
+++ b/src/modules/approvals/reason-capture.ts
@@ -110,7 +110,7 @@ export async function armReasonCapture(approval: PendingApproval, session: Sessi
   // Prompt is out — now hold the row and arm capture. Order matters: a reply
   // can't arrive before the prompt is read, so there's no lost-message window.
   const expiresAt = new Date(Date.now() + REASON_CAPTURE_WINDOW_MS).toISOString();
-  markApprovalAwaitingReason(approval.approval_id, expiresAt);
+  await markApprovalAwaitingReason(approval.approval_id, expiresAt);
   awaitingReason.set(dmKey(dm.channel_type, dm.platform_id), { approvalId: approval.approval_id, userId });
   log.info('reject-with-reason: awaiting reason reply', { approvalId: approval.approval_id, userId });
 }
@@ -129,16 +129,16 @@ export async function captureReasonReply(event: InboundEvent): Promise<boolean> 
   // This DM is an armed reason channel — disarm regardless of outcome.
   awaitingReason.delete(dmKey(event.channelType, event.platformId));
 
-  const approval = getPendingApproval(arming.approvalId);
+  const approval = await getPendingApproval(arming.approvalId);
   if (!approval || approval.status !== 'awaiting_reason') {
     // Already finalized (e.g. ghosted by the sweep). The reply is no longer a
     // reason — let it route normally instead of swallowing it.
     return false;
   }
 
-  const session = approval.session_id ? getSession(approval.session_id) : null;
+  const session = approval.session_id ? await getSession(approval.session_id) : null;
   if (!session) {
-    deletePendingApproval(approval.approval_id);
+    await deletePendingApproval(approval.approval_id);
     return true;
   }
 
@@ -160,11 +160,11 @@ registerMessageInterceptor(captureReasonReply);
  * requesting agent always gets its decision. Called once per sweep tick.
  */
 export async function sweepAwaitingReasonRejects(): Promise<void> {
-  const rows = getExpiredAwaitingReasonApprovals(new Date().toISOString());
+  const rows = await getExpiredAwaitingReasonApprovals(new Date().toISOString());
   for (const approval of rows) {
-    const session = approval.session_id ? getSession(approval.session_id) : null;
+    const session = approval.session_id ? await getSession(approval.session_id) : null;
     if (!session) {
-      deletePendingApproval(approval.approval_id);
+      await deletePendingApproval(approval.approval_id);
       continue;
     }
     // Plain reject, unknown resolver — the admin opted in but never typed.

--- a/src/modules/approvals/response-handler.test.ts
+++ b/src/modules/approvals/response-handler.test.ts
@@ -29,14 +29,14 @@ function now() {
   return new Date().toISOString();
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
-  createSession({
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createSession({
     id: 'sess-1',
     agent_group_id: 'ag-1',
     messaging_group_id: null,
@@ -49,8 +49,8 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -61,7 +61,7 @@ describe('approval response authorization', () => {
     const handler = vi.fn().mockResolvedValue(undefined);
     registerApprovalHandler('install_packages', handler);
 
-    createPendingApproval({
+    await createPendingApproval({
       approval_id: 'appr-1',
       session_id: 'sess-1',
       request_id: 'appr-1',
@@ -83,19 +83,25 @@ describe('approval response authorization', () => {
 
     expect(claimed).toBe(true);
     expect(handler).not.toHaveBeenCalled();
-    expect(getPendingApproval('appr-1')).toBeDefined();
+    expect(await getPendingApproval('appr-1')).toBeDefined();
   });
 
   it('allows an owner/admin click to dispatch the registered approval handler', async () => {
-    upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
-    grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+    await grantRole({
+      user_id: 'telegram:owner',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
 
     const { registerApprovalHandler } = await import('./primitive.js');
     const { handleApprovalsResponse } = await import('./response-handler.js');
     const handler = vi.fn().mockResolvedValue(undefined);
     registerApprovalHandler('install_packages_allowed', handler);
 
-    createPendingApproval({
+    await createPendingApproval({
       approval_id: 'appr-2',
       session_id: 'sess-1',
       request_id: 'appr-2',
@@ -118,12 +124,17 @@ describe('approval response authorization', () => {
     expect(claimed).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ userId: 'telegram:owner' }));
-    expect(getPendingApproval('appr-2')).toBeUndefined();
+    expect(await getPendingApproval('appr-2')).toBeUndefined();
   });
 
   it('allows global admins to resolve approvals without a session-scoped agent group', async () => {
-    upsertUser({ id: 'telegram:global-admin', kind: 'telegram', display_name: 'Global Admin', created_at: now() });
-    grantRole({
+    await upsertUser({
+      id: 'telegram:global-admin',
+      kind: 'telegram',
+      display_name: 'Global Admin',
+      created_at: now(),
+    });
+    await grantRole({
       user_id: 'telegram:global-admin',
       role: 'admin',
       agent_group_id: null,
@@ -136,7 +147,7 @@ describe('approval response authorization', () => {
     const handler = vi.fn().mockResolvedValue(undefined);
     registerApprovalHandler('global_admin_allowed', handler);
 
-    createPendingApproval({
+    await createPendingApproval({
       approval_id: 'appr-3',
       session_id: 'sess-1',
       agent_group_id: null,
@@ -159,7 +170,7 @@ describe('approval response authorization', () => {
 
     expect(claimed).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(getPendingApproval('appr-3')).toBeUndefined();
+    expect(await getPendingApproval('appr-3')).toBeUndefined();
   });
 
   it('an approval with approver_user_id is resolvable by that user, not a non-assignee', async () => {
@@ -168,7 +179,7 @@ describe('approval response authorization', () => {
     const handler = vi.fn().mockResolvedValue(undefined);
     registerApprovalHandler('assigned_approver_action', handler);
 
-    createPendingApproval({
+    await createPendingApproval({
       approval_id: 'appr-4',
       session_id: 'sess-1',
       request_id: 'appr-4',
@@ -190,7 +201,7 @@ describe('approval response authorization', () => {
       threadId: null,
     });
     expect(handler).not.toHaveBeenCalled();
-    expect(getPendingApproval('appr-4')).toBeDefined();
+    expect(await getPendingApproval('appr-4')).toBeDefined();
 
     // The named approver resolves it.
     await handleApprovalsResponse({
@@ -202,6 +213,6 @@ describe('approval response authorization', () => {
       threadId: null,
     });
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(getPendingApproval('appr-4')).toBeUndefined();
+    expect(await getPendingApproval('appr-4')).toBeUndefined();
   });
 });

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -28,10 +28,10 @@ import { getApprovalHandler, notifyApprovalResolved, REJECT_WITH_REASON_VALUE } 
 import { armReasonCapture } from './reason-capture.js';
 
 export async function handleApprovalsResponse(payload: ResponsePayload): Promise<boolean> {
-  const approval = getPendingApproval(payload.questionId);
+  const approval = await getPendingApproval(payload.questionId);
   if (!approval) return false;
 
-  if (!isAuthorizedApprovalClick(approval, payload)) {
+  if (!(await isAuthorizedApprovalClick(approval, payload))) {
     log.warn('Ignoring unauthorized approval response', {
       approvalId: approval.approval_id,
       action: approval.action,
@@ -42,12 +42,12 @@ export async function handleApprovalsResponse(payload: ResponsePayload): Promise
   }
 
   if (approval.action === ONECLI_ACTION) {
-    if (resolveOneCLIApproval(payload.questionId, payload.value)) {
+    if (await resolveOneCLIApproval(payload.questionId, payload.value)) {
       return true;
     }
     // Row exists but the in-memory resolver is gone (timer fired or the process
     // was in a weird state). Nothing to do — just drop the row.
-    deletePendingApproval(payload.questionId);
+    await deletePendingApproval(payload.questionId);
     return true;
   }
 
@@ -61,12 +61,12 @@ async function handleRegisteredApproval(
   userId: string,
 ): Promise<void> {
   if (!approval.session_id) {
-    deletePendingApproval(approval.approval_id);
+    await deletePendingApproval(approval.approval_id);
     return;
   }
-  const session = getSession(approval.session_id);
+  const session = await getSession(approval.session_id);
   if (!session) {
-    deletePendingApproval(approval.approval_id);
+    await deletePendingApproval(approval.approval_id);
     return;
   }
 
@@ -85,8 +85,8 @@ async function handleRegisteredApproval(
   }
 
   // Approved — dispatch to the module that registered for this action.
-  const notify = (text: string): void => {
-    writeSessionMessage(session.agent_group_id, session.id, {
+  const notify = async (text: string): Promise<void> => {
+    await writeSessionMessage(session.agent_group_id, session.id, {
       id: `appr-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       kind: 'chat',
       timestamp: new Date().toISOString(),
@@ -103,8 +103,8 @@ async function handleRegisteredApproval(
       approvalId: approval.approval_id,
       action: approval.action,
     });
-    notify(`Your ${approval.action} was approved, but no handler is installed to apply it.`);
-    deletePendingApproval(approval.approval_id);
+    await notify(`Your ${approval.action} was approved, but no handler is installed to apply it.`);
+    await deletePendingApproval(approval.approval_id);
     await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
     await wakeContainer(session);
     return;
@@ -116,12 +116,12 @@ async function handleRegisteredApproval(
     log.info('Approval handled', { approvalId: approval.approval_id, action: approval.action, userId });
   } catch (err) {
     log.error('Approval handler threw', { approvalId: approval.approval_id, action: approval.action, err });
-    notify(
+    await notify(
       `Your ${approval.action} was approved, but applying it failed: ${err instanceof Error ? err.message : String(err)}.`,
     );
   }
 
-  deletePendingApproval(approval.approval_id);
+  await deletePendingApproval(approval.approval_id);
   await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
   await wakeContainer(session);
 }
@@ -131,7 +131,7 @@ function namespacedUserId(payload: ResponsePayload): string | null {
   return payload.userId.includes(':') ? payload.userId : `${payload.channelType}:${payload.userId}`;
 }
 
-function isAuthorizedApprovalClick(approval: PendingApproval, payload: ResponsePayload): boolean {
+async function isAuthorizedApprovalClick(approval: PendingApproval, payload: ResponsePayload): Promise<boolean> {
   const userId = namespacedUserId(payload);
   if (!userId) return false;
 
@@ -141,10 +141,10 @@ function isAuthorizedApprovalClick(approval: PendingApproval, payload: ResponseP
   }
 
   const agentGroupId =
-    approval.agent_group_id ?? (approval.session_id ? getSession(approval.session_id)?.agent_group_id : null);
+    approval.agent_group_id ?? (approval.session_id ? (await getSession(approval.session_id))?.agent_group_id : null);
 
   if (!agentGroupId) {
-    return isOwner(userId) || isGlobalAdmin(userId);
+    return (await isOwner(userId)) || (await isGlobalAdmin(userId));
   }
 
   return hasAdminPrivilege(userId, agentGroupId);

--- a/src/modules/cross-session-context/backfill.test.ts
+++ b/src/modules/cross-session-context/backfill.test.ts
@@ -69,13 +69,13 @@ beforeEach(() => {
 });
 
 describe('backfillNewSession', () => {
-  it('seeds the new session with sibling roots + top-level agent posts, ordered by time', () => {
+  it('seeds the new session with sibling roots + top-level agent posts, ordered by time', async () => {
     outboundRows = [
       { timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'Hey Gavriel! I am Pete… tour?' }) },
     ];
     inboundRows = [{ timestamp: '2026-08-01T19:10:00Z', content: chat('hello there') }];
 
-    backfillNewSession(AG, NEW_SESSION, DM_MG);
+    await backfillNewSession(AG, NEW_SESSION, DM_MG);
 
     expect(written).toHaveLength(2);
     expect(written[0]).toMatchObject({
@@ -94,27 +94,27 @@ describe('backfillNewSession', () => {
     expect(first.self).toBeUndefined();
   });
 
-  it('queries only conversation roots inbound and top-level outbound (SQL shape)', () => {
-    backfillNewSession(AG, NEW_SESSION, DM_MG);
+  it('queries only conversation roots inbound and top-level outbound (SQL shape)', async () => {
+    await backfillNewSession(AG, NEW_SESSION, DM_MG);
     expect(inboundSql[0]).toContain('ORDER BY seq ASC LIMIT 1');
     expect(inboundSql[0]).toContain('trigger = 1');
     expect(outboundSql[0]).toContain("thread_id IS NULL OR thread_id = '' OR thread_id LIKE '%:'");
     expect(outboundSql[0]).toContain("kind NOT IN ('system','task_log')");
   });
 
-  it('skips task sessions and sessions without siblings', () => {
-    backfillNewSession(AG, { ...(NEW_SESSION as object), thread_id: 'system:tasks:t-1' } as never, DM_MG);
+  it('skips task sessions and sessions without siblings', async () => {
+    await backfillNewSession(AG, { ...(NEW_SESSION as object), thread_id: 'system:tasks:t-1' } as never, DM_MG);
     siblingSessions = [];
-    backfillNewSession(AG, NEW_SESSION, DM_MG);
+    await backfillNewSession(AG, NEW_SESSION, DM_MG);
     expect(written).toHaveLength(0);
   });
 
-  it('seeds group-surface sessions with the channel timeline: channel-timeline surface + channel label', () => {
+  it('seeds group-surface sessions with the channel timeline: channel-timeline surface + channel label', async () => {
     siblingSessions = [{ id: 'sess-room-t1', status: 'active', messaging_group_id: 'mg-room' }];
     inboundRows = [{ timestamp: '2026-08-01T19:10:00Z', content: chat('thread root msg') }];
     outboundRows = [{ timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'top-level agent post' }) }];
 
-    backfillNewSession(AG, NEW_SESSION, ROOM_MG);
+    await backfillNewSession(AG, NEW_SESSION, ROOM_MG);
 
     expect(written).toHaveLength(2);
     const first = JSON.parse(written[0]!.content as string) as Record<string, unknown>;
@@ -124,14 +124,14 @@ describe('backfillNewSession', () => {
     expect(second.self).toBe(true);
   });
 
-  it('ignores system-sender roots and caps at BACKFILL_LIMIT newest rows', () => {
+  it('ignores system-sender roots and caps at BACKFILL_LIMIT newest rows', async () => {
     inboundRows = [{ timestamp: '2026-08-01T18:00:00Z', content: chat('Introduce yourself', 'system', 'system') }];
     outboundRows = Array.from({ length: 20 }, (_, i) => ({
       timestamp: `2026-08-01T19:${String(10 + i).padStart(2, '0')}:00Z`,
       content: JSON.stringify({ text: `post ${i}` }),
     }));
 
-    backfillNewSession(AG, NEW_SESSION, DM_MG);
+    await backfillNewSession(AG, NEW_SESSION, DM_MG);
 
     expect(written).toHaveLength(BACKFILL_LIMIT);
     const texts = written.map((w) => (JSON.parse(w.content as string) as { text: string }).text);
@@ -139,9 +139,9 @@ describe('backfillNewSession', () => {
     expect(texts.at(-1)).toBe('post 19');
   });
 
-  it('only considers siblings of the same messaging group', () => {
+  it('only considers siblings of the same messaging group', async () => {
     siblingSessions = [{ id: 'sess-other-dm', status: 'active', messaging_group_id: 'mg-other' }];
-    backfillNewSession(AG, NEW_SESSION, DM_MG);
+    await backfillNewSession(AG, NEW_SESSION, DM_MG);
     expect(written).toHaveLength(0);
   });
 });

--- a/src/modules/cross-session-context/backfill.ts
+++ b/src/modules/cross-session-context/backfill.ts
@@ -119,11 +119,11 @@ function collectSiblingTopLevel(agentGroup: AgentGroup, sessionId: string, limit
  * means the same audience. Call BEFORE the triggering message is written.
  * Non-throwing; no-ops for task sessions and sessions with no siblings.
  */
-export function backfillNewSession(agentGroup: AgentGroup, session: Session, mg: MessagingGroup): void {
+export async function backfillNewSession(agentGroup: AgentGroup, session: Session, mg: MessagingGroup): Promise<void> {
   try {
     if (session.thread_id !== null && isTaskThread(session.thread_id)) return;
 
-    const siblings = getSessionsByAgentGroup(agentGroup.id).filter(
+    const siblings = (await getSessionsByAgentGroup(agentGroup.id)).filter(
       (s) => s.id !== session.id && s.status === 'active' && s.messaging_group_id === mg.id,
     );
     if (siblings.length === 0) return;
@@ -141,11 +141,11 @@ export function backfillNewSession(agentGroup: AgentGroup, session: Session, mg:
       ? 'this channel, just before this conversation'
       : 'this DM, just before this conversation';
     const surface = isGroupSurface ? ECHO_CHANNEL_TIMELINE_SURFACE : ECHO_TIMELINE_SURFACE;
-    newest.forEach((row, i) => {
+    for (const [i, row] of newest.entries()) {
       // The most recent entry is what a short opener ("sure") is usually
       // answering — deliver it whole; earlier entries get the normal cap.
       const isLast = i === newest.length - 1;
-      writeSessionMessage(agentGroup.id, session.id, {
+      await writeSessionMessage(agentGroup.id, session.id, {
         id: `${session.id}:backfill:${i}`,
         kind: 'chat',
         timestamp: row.timestamp,
@@ -159,7 +159,7 @@ export function backfillNewSession(agentGroup: AgentGroup, session: Session, mg:
         }),
         trigger: 0,
       });
-    });
+    }
     log.debug('Backfilled new session with conversation timeline', {
       sessionId: session.id,
       rows: newest.length,

--- a/src/modules/cross-session-context/fan.test.ts
+++ b/src/modules/cross-session-context/fan.test.ts
@@ -96,27 +96,27 @@ function chatContent(text: string): string {
   return JSON.stringify({ text, sender: 'Gavriel', senderId: 'slack:U1' });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
-  createAgentGroup({ id: AG, name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: NOW });
-  createAgentGroup({ id: 'ag-2', name: 'Other', folder: 'other', agent_provider: null, created_at: NOW });
-  for (const m of [ROOM_MG, DM_MG, ROOM2_MG, DM2_MG]) createMessagingGroup(m);
-  createSession(SRC_ROOM);
-  createSession(SRC_DM);
-  createSession(DM_SIBLING);
-  createSession(TASK_SESS);
-  createSession(session('s-room2', AG, 'mg-room2', null));
-  createSession(session('s-dm2', AG, 'mg-dm2', null));
-  createSession(session('s-dm-closed', AG, 'mg-dm', 'closed-thread', 'closed'));
-  createSession(session('s-a2a', AG, null, null));
-  createSession(session('s-other-group', 'ag-2', 'mg-dm', null));
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({ id: AG, name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: NOW });
+  await createAgentGroup({ id: 'ag-2', name: 'Other', folder: 'other', agent_provider: null, created_at: NOW });
+  for (const m of [ROOM_MG, DM_MG, ROOM2_MG, DM2_MG]) await createMessagingGroup(m);
+  await createSession(SRC_ROOM);
+  await createSession(SRC_DM);
+  await createSession(DM_SIBLING);
+  await createSession(TASK_SESS);
+  await createSession(session('s-room2', AG, 'mg-room2', null));
+  await createSession(session('s-dm2', AG, 'mg-dm2', null));
+  await createSession(session('s-dm-closed', AG, 'mg-dm', 'closed-thread', 'closed'));
+  await createSession(session('s-a2a', AG, null, null));
+  await createSession(session('s-other-group', 'ag-2', 'mg-dm', null));
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
@@ -133,24 +133,24 @@ describe('selectEchoTargets (same-conversation audience rule)', () => {
     { id: 's-closed', status: 'closed', messaging_group_id: 'mg-dm' },
   ];
 
-  it('targets ONLY active same-mg siblings: never other conversations, task/a2a sessions, closed, or the source', () => {
+  it('targets ONLY active same-mg siblings: never other conversations, task/a2a sessions, closed, or the source', async () => {
     const ids = selectEchoTargets(candidates, 's-dm', 'mg-dm').map((s) => s.id);
     expect(ids.sort()).toEqual(['s-dm-t2']);
   });
 
-  it('room thread siblings are same-mg and therefore targets', () => {
+  it('room thread siblings are same-mg and therefore targets', async () => {
     const ids = selectEchoTargets(candidates, 's-src', 'mg-room').map((s) => s.id);
     expect(ids.sort()).toEqual(['s-room-t2']);
   });
 
-  it('an unresolved source conversation fans nowhere', () => {
+  it('an unresolved source conversation fans nowhere', async () => {
     expect(selectEchoTargets(candidates, 's-dm', null)).toEqual([]);
   });
 });
 
 describe('fanInboundMessage', () => {
-  it('fans a DM trigger into same-mg sibling threads ONLY — never rooms, other DMs, or task sessions', () => {
-    const written = fanInboundMessage({
+  it('fans a DM trigger into same-mg sibling threads ONLY — never rooms, other DMs, or task sessions', async () => {
+    const written = await fanInboundMessage({
       session: SRC_DM,
       mg: DM_MG,
       messageId: 'msg-2:ag-1',
@@ -193,9 +193,9 @@ describe('fanInboundMessage', () => {
     expect(readEchoRows('s-dm')).toHaveLength(0);
   });
 
-  it('a room trigger reaches same-mg room thread siblings only — room→DM and room→task are retired', () => {
-    createSession(session('s-room-t2', AG, 'mg-room', 'room-thread-2'));
-    const written = fanInboundMessage({
+  it('a room trigger reaches same-mg room thread siblings only — room→DM and room→task are retired', async () => {
+    await createSession(session('s-room-t2', AG, 'mg-room', 'room-thread-2'));
+    const written = await fanInboundMessage({
       session: SRC_ROOM,
       mg: ROOM_MG,
       messageId: 'msg-1:ag-1',
@@ -218,8 +218,8 @@ describe('fanInboundMessage', () => {
     expect(readEchoRows('s-task')).toHaveLength(0);
   });
 
-  it('a DM sibling-thread source fans back to the original DM session (symmetric)', () => {
-    const written = fanInboundMessage({
+  it('a DM sibling-thread source fans back to the original DM session (symmetric)', async () => {
+    const written = await fanInboundMessage({
       session: DM_SIBLING,
       mg: DM_MG,
       messageId: 'msg-2b:ag-1',
@@ -237,9 +237,9 @@ describe('fanInboundMessage', () => {
     expect(readEchoRows('s-dm-t2')).toHaveLength(0);
   });
 
-  it('truncates text to 500 chars head with … appended', () => {
+  it('truncates text to 500 chars head with … appended', async () => {
     const long = 'x'.repeat(ECHO_TEXT_MAX_CHARS + 100);
-    fanInboundMessage({
+    await fanInboundMessage({
       session: SRC_DM,
       mg: DM_MG,
       messageId: 'msg-3:ag-1',
@@ -253,7 +253,7 @@ describe('fanInboundMessage', () => {
     expect(content.text.length).toBe(ECHO_TEXT_MAX_CHARS + 1);
   });
 
-  it('never fans echo rows, a2a rows, non-chat kinds, or empty text', () => {
+  it('never fans echo rows, a2a rows, non-chat kinds, or empty text', async () => {
     const base = {
       session: SRC_ROOM,
       mg: ROOM_MG,
@@ -261,19 +261,19 @@ describe('fanInboundMessage', () => {
       content: chatContent('hi'),
       timestamp: NOW,
     };
-    expect(fanInboundMessage({ ...base, kind: 'chat', channelType: ECHO_CHANNEL_TYPE })).toBe(0);
-    expect(fanInboundMessage({ ...base, kind: 'chat', channelType: 'agent' })).toBe(0);
-    expect(fanInboundMessage({ ...base, kind: 'task', channelType: 'slack' })).toBe(0);
-    expect(fanInboundMessage({ ...base, kind: 'system', channelType: 'slack' })).toBe(0);
+    expect(await fanInboundMessage({ ...base, kind: 'chat', channelType: ECHO_CHANNEL_TYPE })).toBe(0);
+    expect(await fanInboundMessage({ ...base, kind: 'chat', channelType: 'agent' })).toBe(0);
+    expect(await fanInboundMessage({ ...base, kind: 'task', channelType: 'slack' })).toBe(0);
+    expect(await fanInboundMessage({ ...base, kind: 'system', channelType: 'slack' })).toBe(0);
     expect(
-      fanInboundMessage({ ...base, kind: 'chat', channelType: 'slack', content: JSON.stringify({ text: '' }) }),
+      await fanInboundMessage({ ...base, kind: 'chat', channelType: 'slack', content: JSON.stringify({ text: '' }) }),
     ).toBe(0);
     expect(readEchoRows('s-dm')).toHaveLength(0);
     expect(readEchoRows('s-task')).toHaveLength(0);
   });
 
-  it('never fans from a task session (task sessions are not a source)', () => {
-    const written = fanInboundMessage({
+  it('never fans from a task session (task sessions are not a source)', async () => {
+    const written = await fanInboundMessage({
       session: TASK_SESS,
       mg: ROOM_MG,
       messageId: 'msg-5:ag-1',
@@ -290,8 +290,8 @@ describe('fanInboundMessage', () => {
 describe('fanOutboundMessage', () => {
   const agentGroup = { id: AG, name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: NOW };
 
-  it('fans a delivered DM reply into same-mg sibling threads ONLY, with the agent as sender', () => {
-    const written = fanOutboundMessage(
+  it('fans a delivered DM reply into same-mg sibling threads ONLY, with the agent as sender', async () => {
+    const written = await fanOutboundMessage(
       {
         id: 'out-2',
         kind: 'chat',
@@ -319,9 +319,9 @@ describe('fanOutboundMessage', () => {
     });
   });
 
-  it('a delivered room reply reaches same-mg room siblings only — never the group DMs or task sessions', () => {
-    createSession(session('s-room-t2', AG, 'mg-room', 'room-thread-2'));
-    const written = fanOutboundMessage(
+  it('a delivered room reply reaches same-mg room siblings only — never the group DMs or task sessions', async () => {
+    await createSession(session('s-room-t2', AG, 'mg-room', 'room-thread-2'));
+    const written = await fanOutboundMessage(
       {
         id: 'out-1',
         kind: 'chat',
@@ -339,7 +339,7 @@ describe('fanOutboundMessage', () => {
     expect(readEchoRows('s-task')).toHaveLength(0);
   });
 
-  it("resolves the sender's own instance, not a lexically-first sibling, when instances share a platform address", () => {
+  it("resolves the sender's own instance, not a lexically-first sibling, when instances share a platform address", async () => {
     // Two sibling messaging groups share one platform address (e.g. two bot
     // identities in the same multi-bot conversation) but belong to different
     // adapter instances. "alpha" sorts before "zulu", so a plain by-platform
@@ -347,12 +347,12 @@ describe('fanOutboundMessage', () => {
     // for this sender.
     const dmAlpha = { ...mg('mg-dm-alpha', 'D-multi', 0, 'Shared DM'), instance: 'alpha' };
     const dmZulu = { ...mg('mg-dm-zulu', 'D-multi', 0, 'Shared DM'), instance: 'zulu' };
-    createMessagingGroup(dmAlpha);
-    createMessagingGroup(dmZulu);
+    await createMessagingGroup(dmAlpha);
+    await createMessagingGroup(dmZulu);
 
     // The sender is only authorized against (and only reaches Slack through)
     // its "zulu" sibling.
-    createDestination({
+    await createDestination({
       agent_group_id: AG,
       local_name: 'shared-dm',
       target_type: 'channel',
@@ -362,12 +362,12 @@ describe('fanOutboundMessage', () => {
 
     // Two candidate sibling sessions, one per instance's row — only the one
     // on the sender's own ("zulu") row should count as "the same DM".
-    createSession(session('s-sib-zulu', AG, 'mg-dm-zulu', 'thread-zulu'));
-    createSession(session('s-sib-alpha', AG, 'mg-dm-alpha', 'thread-alpha'));
+    await createSession(session('s-sib-zulu', AG, 'mg-dm-zulu', 'thread-zulu'));
+    await createSession(session('s-sib-alpha', AG, 'mg-dm-alpha', 'thread-alpha'));
 
     // Source is a room session (not the origin of "D-multi"), so resolution
     // falls into the non-origin, sibling-collision-prone branch.
-    const written = fanOutboundMessage(
+    const written = await fanOutboundMessage(
       {
         id: 'out-shared-dm',
         kind: 'chat',
@@ -393,27 +393,27 @@ describe('fanOutboundMessage', () => {
     expect(written).toBe(1);
   });
 
-  it('skips system/task_log/agent/echo/unrouted messages', () => {
+  it('skips system/task_log/agent/echo/unrouted messages', async () => {
     const content = JSON.stringify({ text: 'x' });
     const base = { id: 'out-3', platform_id: 'C123', channel_type: 'slack', content };
-    expect(fanOutboundMessage({ ...base, kind: 'system' }, SRC_ROOM, agentGroup)).toBe(0);
-    expect(fanOutboundMessage({ ...base, kind: 'task_log' }, SRC_ROOM, agentGroup)).toBe(0);
-    expect(fanOutboundMessage({ ...base, kind: 'chat', channel_type: 'agent' }, SRC_ROOM, agentGroup)).toBe(0);
-    expect(fanOutboundMessage({ ...base, kind: 'chat', channel_type: ECHO_CHANNEL_TYPE }, SRC_ROOM, agentGroup)).toBe(
-      0,
-    );
-    expect(fanOutboundMessage({ ...base, kind: 'chat', platform_id: null }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(await fanOutboundMessage({ ...base, kind: 'system' }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(await fanOutboundMessage({ ...base, kind: 'task_log' }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(await fanOutboundMessage({ ...base, kind: 'chat', channel_type: 'agent' }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(
+      await fanOutboundMessage({ ...base, kind: 'chat', channel_type: ECHO_CHANNEL_TYPE }, SRC_ROOM, agentGroup),
+    ).toBe(0);
+    expect(await fanOutboundMessage({ ...base, kind: 'chat', platform_id: null }, SRC_ROOM, agentGroup)).toBe(0);
     // task_log from a task session (series bookkeeping) still never fans.
-    expect(fanOutboundMessage({ ...base, kind: 'task_log' }, TASK_SESS, agentGroup)).toBe(0);
+    expect(await fanOutboundMessage({ ...base, kind: 'task_log' }, TASK_SESS, agentGroup)).toBe(0);
     expect(readEchoRows('s-dm')).toHaveLength(0);
     expect(readEchoRows('s-task')).toHaveLength(0);
   });
 
-  it("a task-session DM send fans ONLY into that DM's sessions, with the task-delivery shape", () => {
+  it("a task-session DM send fans ONLY into that DM's sessions, with the task-delivery shape", async () => {
     // A second task session proves task sessions are excluded as targets for
     // task-delivery fans (the source itself is excluded by id).
-    createSession(session('s-task2', AG, null, 'system:tasks:weekly-1'));
-    const written = fanOutboundMessage(
+    await createSession(session('s-task2', AG, null, 'system:tasks:weekly-1'));
+    const written = await fanOutboundMessage(
       {
         id: 'out-task-dm',
         kind: 'chat',
@@ -446,8 +446,8 @@ describe('fanOutboundMessage', () => {
     expect(readEchoRows('s-task2')).toHaveLength(0);
   });
 
-  it("a task-session room send fans only into that room's sessions — never the DM fan the room rule would give", () => {
-    const written = fanOutboundMessage(
+  it("a task-session room send fans only into that room's sessions — never the DM fan the room rule would give", async () => {
+    const written = await fanOutboundMessage(
       {
         id: 'out-task-room',
         kind: 'chat',
@@ -472,14 +472,14 @@ describe('fanOutboundMessage', () => {
 });
 
 describe('label + truncation helpers', () => {
-  it('buildEchoLabel renders room and DM labels', () => {
+  it('buildEchoLabel renders room and DM labels', async () => {
     expect(buildEchoLabel({ name: 'pixel-room', platform_id: 'C1', is_group: 1 })).toBe('#pixel-room room');
     expect(buildEchoLabel({ name: null, platform_id: 'C1', is_group: 1 })).toBe('#C1 room');
     expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, 'Gavriel')).toBe('DM with Gavriel');
     expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, null)).toBe('DM (D1)');
   });
 
-  it('buildSiblingEchoLabel renders same-DM sibling labels with sensible fallbacks', () => {
+  it('buildSiblingEchoLabel renders same-DM sibling labels with sensible fallbacks', async () => {
     expect(buildSiblingEchoLabel({ name: 'Gavriel', platform_id: 'D1', is_group: 0 })).toBe(
       'another conversation with Gavriel',
     );
@@ -495,14 +495,14 @@ describe('label + truncation helpers', () => {
     );
   });
 
-  it("buildDeliveredEchoLabel names the delivered-to surface from the receiver's perspective", () => {
+  it("buildDeliveredEchoLabel names the delivered-to surface from the receiver's perspective", async () => {
     expect(buildDeliveredEchoLabel({ is_group: 0 }, true)).toBe('this DM, posted by your scheduled task');
     expect(buildDeliveredEchoLabel({ is_group: 1 }, true)).toBe('this room, posted by your scheduled task');
     expect(buildDeliveredEchoLabel({ is_group: 0 }, false)).toBe('this DM, posted by you from another conversation');
     expect(buildDeliveredEchoLabel({ is_group: 1 }, false)).toBe('this room, posted by you from another conversation');
   });
 
-  it('truncateEchoText leaves short text untouched', () => {
+  it('truncateEchoText leaves short text untouched', async () => {
     expect(truncateEchoText('short')).toBe('short');
   });
 });

--- a/src/modules/cross-session-context/fan.ts
+++ b/src/modules/cross-session-context/fan.ts
@@ -139,8 +139,8 @@ interface EchoFanInput {
   senderId: string | null;
 }
 
-function fanEcho(input: EchoFanInput): number {
-  const candidates = getSessionsByAgentGroup(input.agentGroupId);
+async function fanEcho(input: EchoFanInput): Promise<number> {
+  const candidates = await getSessionsByAgentGroup(input.agentGroupId);
   const targets = selectEchoTargets(candidates, input.sourceSessionId, input.sourceMessagingGroupId);
   if (targets.length === 0) return 0;
 
@@ -154,7 +154,7 @@ function fanEcho(input: EchoFanInput): number {
   let written = 0;
   for (const target of targets) {
     try {
-      writeSessionMessage(input.agentGroupId, target.id, {
+      await writeSessionMessage(input.agentGroupId, target.id, {
         id: echoRowId(input.origMessageId, target.id),
         kind: 'chat',
         timestamp: input.timestamp,
@@ -184,7 +184,7 @@ function fanEcho(input: EchoFanInput): number {
  * sessions. Call ONLY for the engaged (wake) branch — accumulate (trigger=0)
  * writes must never fan (D3). Never throws; returns rows written.
  */
-export function fanInboundMessage(args: {
+export async function fanInboundMessage(args: {
   /** Source session the trigger=1 row was written to. */
   session: Session;
   /** Messaging group the message arrived on (the source surface). */
@@ -196,7 +196,7 @@ export function fanInboundMessage(args: {
   channelType: string;
   content: string;
   timestamp: string;
-}): number {
+}): Promise<number> {
   try {
     const { session, mg } = args;
     if (!CHAT_KINDS.has(args.kind)) return 0;
@@ -208,7 +208,7 @@ export function fanInboundMessage(args: {
     if (!parsed.text) return 0;
     // Targets are always sibling threads of the conversation the message
     // arrived on, so every echo is sibling-flavored.
-    return fanEcho({
+    return await fanEcho({
       agentGroupId: session.agent_group_id,
       sourceSessionId: session.id,
       sourceMessagingGroupId: mg.id,
@@ -237,7 +237,7 @@ export function fanInboundMessage(args: {
  * needed so sibling-instance rows sharing one channel address resolve to the
  * sender's own row, not an arbitrary sibling's. Never throws.
  */
-export function fanOutboundMessage(
+export async function fanOutboundMessage(
   msg: {
     id: string;
     kind: string;
@@ -247,19 +247,19 @@ export function fanOutboundMessage(
   },
   session: Session,
   agentGroup: AgentGroup,
-): number {
+): Promise<number> {
   try {
     if (msg.kind === 'system' || msg.kind === 'task_log') return 0;
     if (!msg.channel_type || !msg.platform_id) return 0;
     if (msg.channel_type === 'agent' || msg.channel_type === ECHO_CHANNEL_TYPE) return 0;
     const isTaskSource = isTaskThread(session.thread_id);
 
-    const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+    const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
     const mg =
       originMg && originMg.channel_type === msg.channel_type && originMg.platform_id === msg.platform_id
         ? originMg
-        : (getMessagingGroupForOwnDestination(session.agent_group_id, msg.channel_type, msg.platform_id) ??
-          getMessagingGroupByPlatform(msg.channel_type, msg.platform_id));
+        : ((await getMessagingGroupForOwnDestination(session.agent_group_id, msg.channel_type, msg.platform_id)) ??
+          (await getMessagingGroupByPlatform(msg.channel_type, msg.platform_id)));
     if (!mg) return 0;
 
     const parsed = parseContent(msg.content);
@@ -269,7 +269,7 @@ export function fanOutboundMessage(
     // a message the agent posted INTO this conversation from elsewhere (a
     // task run, or a cross-conversation send) gets the delivered flavor.
     const isOriginSend = session.messaging_group_id === mg.id;
-    return fanEcho({
+    return await fanEcho({
       agentGroupId: session.agent_group_id,
       sourceSessionId: session.id,
       sourceMessagingGroupId: mg.id,

--- a/src/modules/cross-session-context/history.test.ts
+++ b/src/modules/cross-session-context/history.test.ts
@@ -30,8 +30,8 @@ const FOREIGN_AGENT: CallerContext = {
   messagingGroupId: 'mg-y',
 };
 
-function writeInbound(id: string, timestamp: string, text: string, sender = 'Gavriel'): void {
-  writeSessionMessage(AG, SESS, {
+async function writeInbound(id: string, timestamp: string, text: string, sender = 'Gavriel'): Promise<void> {
+  await writeSessionMessage(AG, SESS, {
     id,
     kind: 'chat',
     timestamp,
@@ -42,19 +42,19 @@ function writeInbound(id: string, timestamp: string, text: string, sender = 'Gav
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
-  createAgentGroup({
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({
     id: AG,
     name: 'Pixel',
     folder: 'pixel',
     agent_provider: null,
     created_at: '2026-08-01T00:00:00.000Z',
   });
-  createSession({
+  await createSession({
     id: SESS,
     agent_group_id: AG,
     messaging_group_id: null,
@@ -68,15 +68,15 @@ beforeEach(() => {
   initSessionFolder(AG, SESS);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
 describe('sessionHistory', () => {
-  it('merges inbound + outbound chronologically as structured rows (ISO timestamps)', () => {
-    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
-    writeInbound('in-2', '2026-08-01T10:02:00.000Z', 'second message');
+  it('merges inbound + outbound chronologically as structured rows (ISO timestamps)', async () => {
+    await writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
+    await writeInbound('in-2', '2026-08-01T10:02:00.000Z', 'second message');
     // writeOutboundDirect stamps now() — always sorts after the fixed 2026 stamps.
     writeOutboundDirect(AG, SESS, {
       id: 'out-1',
@@ -87,7 +87,7 @@ describe('sessionHistory', () => {
       content: JSON.stringify({ text: 'agent reply' }),
     });
 
-    const rows = sessionHistory({ id: SESS }, HOST);
+    const rows = await sessionHistory({ id: SESS }, HOST);
     expect(rows).toHaveLength(3);
     expect(rows[0]).toEqual({
       timestamp: '2026-08-01T10:00:00.000Z',
@@ -103,44 +103,44 @@ describe('sessionHistory', () => {
     expect(rows[2].text).toBe('agent reply');
   });
 
-  it('formatHistoryLines renders pipe lines with localized stamps and capped cells', () => {
-    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
-    const lines = formatHistoryLines(sessionHistory({ id: SESS }, HOST), 'UTC').split('\n');
+  it('formatHistoryLines renders pipe lines with localized stamps and capped cells', async () => {
+    await writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
+    const lines = formatHistoryLines(await sessionHistory({ id: SESS }, HOST), 'UTC').split('\n');
     expect(lines).toEqual(['2026-08-01 10:00|in|chat|Gavriel|hello there']);
     // A non-UTC install timezone shifts the human stamp; data stays ISO.
-    const berlin = formatHistoryLines(sessionHistory({ id: SESS }, HOST), 'Europe/Berlin');
+    const berlin = formatHistoryLines(await sessionHistory({ id: SESS }, HOST), 'Europe/Berlin');
     expect(berlin.startsWith('2026-08-01 12:00|')).toBe(true);
   });
 
-  it('applies --limit keeping the NEWEST rows', () => {
+  it('applies --limit keeping the NEWEST rows', async () => {
     for (let i = 0; i < 5; i++) {
-      writeInbound(`in-${i}`, `2026-08-01T10:0${i}:00.000Z`, `msg ${i}`);
+      await writeInbound(`in-${i}`, `2026-08-01T10:0${i}:00.000Z`, `msg ${i}`);
     }
-    const rows = sessionHistory({ id: SESS, limit: 2 }, HOST);
+    const rows = await sessionHistory({ id: SESS, limit: 2 }, HOST);
     expect(rows).toHaveLength(2);
     expect(rows[0].text).toBe('msg 3');
     expect(rows[1].text).toBe('msg 4');
   });
 
-  it('sanitizes newlines and pipes in the human rendering only — rows keep the raw text', () => {
-    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'line one\nline two | with pipe');
-    const rows = sessionHistory({ id: SESS }, HOST);
+  it('sanitizes newlines and pipes in the human rendering only — rows keep the raw text', async () => {
+    await writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'line one\nline two | with pipe');
+    const rows = await sessionHistory({ id: SESS }, HOST);
     expect(rows[0].text).toBe('line one\nline two | with pipe');
     const line = formatHistoryLines(rows, 'UTC');
     expect(line.split('\n')).toHaveLength(1);
     expect(line.endsWith('line one line two / with pipe')).toBe(true);
   });
 
-  it('self-scopes: a cross-group agent gets "session not found", same as a bogus id', () => {
-    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'private');
-    expect(() => sessionHistory({ id: SESS }, FOREIGN_AGENT)).toThrow(`session not found: ${SESS}`);
-    expect(() => sessionHistory({ id: 'sess-nope' }, FOREIGN_AGENT)).toThrow('session not found: sess-nope');
-    expect(() => sessionHistory({ id: 'sess-nope' }, HOST)).toThrow('session not found: sess-nope');
+  it('self-scopes: a cross-group agent gets "session not found", same as a bogus id', async () => {
+    await writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'private');
+    await expect(sessionHistory({ id: SESS }, FOREIGN_AGENT)).rejects.toThrow(`session not found: ${SESS}`);
+    await expect(sessionHistory({ id: 'sess-nope' }, FOREIGN_AGENT)).rejects.toThrow('session not found: sess-nope');
+    await expect(sessionHistory({ id: 'sess-nope' }, HOST)).rejects.toThrow('session not found: sess-nope');
   });
 
-  it('allows the owning agent group and the host', () => {
-    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'visible');
-    expect(sessionHistory({ id: SESS }, OWN_AGENT)[0].text).toBe('visible');
-    expect(sessionHistory({ id: SESS }, HOST)[0].text).toBe('visible');
+  it('allows the owning agent group and the host', async () => {
+    await writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'visible');
+    expect((await sessionHistory({ id: SESS }, OWN_AGENT))[0].text).toBe('visible');
+    expect((await sessionHistory({ id: SESS }, HOST))[0].text).toBe('visible');
   });
 });

--- a/src/modules/cross-session-context/history.ts
+++ b/src/modules/cross-session-context/history.ts
@@ -61,19 +61,19 @@ function parseText(raw: string): { text: string; sender: string | null } {
  * Human rendering (pipe lines, localized stamps, capped cells) lives in
  * `formatHistoryLines`, wired as the operation's `formatHuman`.
  */
-export function sessionHistory(args: Record<string, unknown>, ctx: CallerContext): HistoryRow[] {
+export async function sessionHistory(args: Record<string, unknown>, ctx: CallerContext): Promise<HistoryRow[]> {
   const sessionId = typeof args.id === 'string' && args.id.length > 0 ? args.id : undefined;
   if (!sessionId) throw new Error('session id is required');
   const limitRaw = Number(args.limit ?? HISTORY_DEFAULT_LIMIT);
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : HISTORY_DEFAULT_LIMIT;
 
-  const session = getSession(sessionId);
+  const session = await getSession(sessionId);
   // Self-scope (see header): cross-group agents get "not found", never "forbidden".
   if (!session || (ctx.caller === 'agent' && session.agent_group_id !== ctx.agentGroupId)) {
     throw new Error(`session not found: ${sessionId}`);
   }
 
-  const agentName = getAgentGroup(session.agent_group_id)?.name ?? 'agent';
+  const agentName = (await getAgentGroup(session.agent_group_id))?.name ?? 'agent';
   const rows: HistoryRow[] = [];
 
   if (fs.existsSync(inboundDbPath(session.agent_group_id, session.id))) {

--- a/src/modules/interactive/index.ts
+++ b/src/modules/interactive/index.ts
@@ -18,19 +18,19 @@ import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 
 async function handleInteractiveResponse(payload: ResponsePayload): Promise<boolean> {
-  if (!hasTable(getDb(), 'pending_questions')) return false;
+  if (!(await hasTable(getDb(), 'pending_questions'))) return false;
 
-  const pq = getPendingQuestion(payload.questionId);
+  const pq = await getPendingQuestion(payload.questionId);
   if (!pq) return false;
 
-  const session = getSession(pq.session_id);
+  const session = await getSession(pq.session_id);
   if (!session) {
     log.warn('Session not found for pending question', { questionId: payload.questionId, sessionId: pq.session_id });
-    deletePendingQuestion(payload.questionId);
+    await deletePendingQuestion(payload.questionId);
     return true; // claimed — we owned this questionId even though the session is gone
   }
 
-  writeSessionMessage(session.agent_group_id, session.id, {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `qr-${payload.questionId}-${Date.now()}`,
     kind: 'system',
     timestamp: new Date().toISOString(),
@@ -45,7 +45,7 @@ async function handleInteractiveResponse(payload: ResponsePayload): Promise<bool
     }),
   });
 
-  deletePendingQuestion(payload.questionId);
+  await deletePendingQuestion(payload.questionId);
   log.info('Question response routed', {
     questionId: payload.questionId,
     selectedOption: payload.value,

--- a/src/modules/permissions/access.ts
+++ b/src/modules/permissions/access.ts
@@ -18,11 +18,11 @@ export type AccessDecision =
   | { allowed: false; reason: 'unknown_user' | 'not_member' };
 
 /** Can this user interact with this agent group? */
-export function canAccessAgentGroup(userId: string, agentGroupId: string): AccessDecision {
-  if (!getUser(userId)) return { allowed: false, reason: 'unknown_user' };
-  if (isOwner(userId)) return { allowed: true, reason: 'owner' };
-  if (isGlobalAdmin(userId)) return { allowed: true, reason: 'global_admin' };
-  if (isAdminOfAgentGroup(userId, agentGroupId)) return { allowed: true, reason: 'admin_of_group' };
-  if (isMember(userId, agentGroupId)) return { allowed: true, reason: 'member' };
+export async function canAccessAgentGroup(userId: string, agentGroupId: string): Promise<AccessDecision> {
+  if (!(await getUser(userId))) return { allowed: false, reason: 'unknown_user' };
+  if (await isOwner(userId)) return { allowed: true, reason: 'owner' };
+  if (await isGlobalAdmin(userId)) return { allowed: true, reason: 'global_admin' };
+  if (await isAdminOfAgentGroup(userId, agentGroupId)) return { allowed: true, reason: 'admin_of_group' };
+  if (await isMember(userId, agentGroupId)) return { allowed: true, reason: 'member' };
   return { allowed: false, reason: 'not_member' };
 }

--- a/src/modules/permissions/channel-approval.test.ts
+++ b/src/modules/permissions/channel-approval.test.ts
@@ -17,6 +17,7 @@ import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
 import { registerChannelAdapter } from '../../channels/channel-registry.js';
@@ -55,7 +56,7 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const row = getDb()
+    const row = sqliteRaw(getDb())
       .prepare(
         `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
@@ -84,16 +85,16 @@ function now() {
 beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
   await import('./index.js'); // register hooks
 
   // Base fixtures: one agent group + owner with a DM on 'telegram'.
-  createAgentGroup({ id: 'ag-1', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-1', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
 
-  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
-  grantRole({
+  await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+  await grantRole({
     user_id: 'telegram:owner',
     role: 'owner',
     agent_group_id: null,
@@ -102,7 +103,7 @@ beforeEach(async () => {
   });
 
   // Pre-seed owner's DM messaging group + user_dms mapping.
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-dm-owner',
     channel_type: 'telegram',
     platform_id: 'dm-owner',
@@ -112,7 +113,7 @@ beforeEach(async () => {
     created_at: now(),
   });
   const { getDb } = await import('../../db/connection.js');
-  getDb()
+  sqliteRaw(getDb())
     .prepare(
       `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES (?, ?, ?, ?)`,
@@ -122,8 +123,8 @@ beforeEach(async () => {
   deliverMock.mockClear();
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
@@ -180,7 +181,7 @@ describe('unknown-channel registration flow', () => {
     expect(connectOption.label).toContain('Andy');
 
     const { getDb } = await import('../../db/connection.js');
-    const rows = getDb().prepare('SELECT * FROM pending_channel_approvals').all() as Array<{
+    const rows = sqliteRaw(getDb()).prepare('SELECT * FROM pending_channel_approvals').all() as Array<{
       messaging_group_id: string;
     }>;
     expect(rows).toHaveLength(1);
@@ -195,7 +196,9 @@ describe('unknown-channel registration flow', () => {
     const payload = JSON.parse(deliverMock.mock.calls[0][4] as string) as { question: string };
     expect(payload.question).toContain('will respond to all messages');
     const { getDb } = await import('../../db/connection.js');
-    const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+    const count = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(count).toBe(1);
   });
 
@@ -208,7 +211,9 @@ describe('unknown-channel registration flow', () => {
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
     const { getDb } = await import('../../db/connection.js');
-    const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+    const count = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(count).toBe(1);
   });
 
@@ -222,7 +227,7 @@ describe('unknown-channel registration flow', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
     expect(pending).toBeDefined();
@@ -241,7 +246,7 @@ describe('unknown-channel registration flow', () => {
     }
 
     // Wiring created with defaults.
-    const mga = getDb()
+    const mga = sqliteRaw(getDb())
       .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ?')
       .get(pending.messaging_group_id) as {
       engage_mode: string;
@@ -259,14 +264,15 @@ describe('unknown-channel registration flow', () => {
 
     // Triggering sender auto-admitted so sender_scope='known' doesn't
     // bounce the replay into sender-approval.
-    const member = getDb()
+    const member = sqliteRaw(getDb())
       .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
       .get('telegram:caller', 'ag-1');
     expect(member).toBeDefined();
 
     // Pending row cleared and container woken via replay.
-    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number })
-      .c;
+    const stillPending = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(stillPending).toBe(0);
     expect(wakeContainer).toHaveBeenCalled();
   });
@@ -279,7 +285,7 @@ describe('unknown-channel registration flow', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
 
@@ -295,7 +301,7 @@ describe('unknown-channel registration flow', () => {
       if (claimed) break;
     }
 
-    const mga = getDb()
+    const mga = sqliteRaw(getDb())
       .prepare('SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?')
       .get(pending.messaging_group_id) as { engage_mode: string; engage_pattern: string };
     expect(mga.engage_mode).toBe('pattern');
@@ -327,7 +333,7 @@ describe('unknown-channel registration flow', () => {
   async function approvePending(agentGroupId = 'ag-1') {
     const { getResponseHandlers } = await import('../../response-registry.js');
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
     expect(pending).toBeDefined();
@@ -353,7 +359,7 @@ describe('unknown-channel registration flow', () => {
     const mgId = await approvePending();
 
     const { getDb } = await import('../../db/connection.js');
-    const mga = getDb()
+    const mga = sqliteRaw(getDb())
       .prepare('SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?')
       .get(mgId) as { engage_mode: string; engage_pattern: string | null };
     // Faithful fallback group default is mention-sticky, but with no live
@@ -374,7 +380,7 @@ describe('unknown-channel registration flow', () => {
     const mgId = await approvePending();
 
     const { getDb } = await import('../../db/connection.js');
-    const mga = getDb()
+    const mga = sqliteRaw(getDb())
       .prepare('SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?')
       .get(mgId) as { engage_mode: string; engage_pattern: string | null };
     expect(mga.engage_mode).toBe('pattern');
@@ -394,7 +400,7 @@ describe('unknown-channel registration flow', () => {
     // Path 2: new agent via free-text name reply.
     await routeInbound(groupMention('chat-path-newagent'));
     await new Promise((r) => setTimeout(r, 10));
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
     for (const handler of getResponseHandlers()) {
@@ -425,8 +431,8 @@ describe('unknown-channel registration flow', () => {
     const select =
       'SELECT engage_mode, engage_pattern, sender_scope, ignored_message_policy, session_mode, priority ' +
       'FROM messaging_group_agents WHERE messaging_group_id = ?';
-    const viaConnect = getDb().prepare(select).get(mgIdConnect);
-    const viaNewAgent = getDb().prepare(select).get(pending.messaging_group_id);
+    const viaConnect = sqliteRaw(getDb()).prepare(select).get(mgIdConnect);
+    const viaNewAgent = sqliteRaw(getDb()).prepare(select).get(pending.messaging_group_id);
     expect(viaNewAgent).toBeDefined();
     expect(viaNewAgent).toEqual(viaConnect);
   });
@@ -438,7 +444,7 @@ describe('unknown-channel registration flow', () => {
     await routeInbound(groupMention('chat-deny'));
     await new Promise((r) => setTimeout(r, 10));
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
 
@@ -455,11 +461,11 @@ describe('unknown-channel registration flow', () => {
     }
 
     // denied_at set, pending row cleared, no wiring.
-    const mg = getMessagingGroupByPlatform('telegram', 'chat-deny');
+    const mg = await getMessagingGroupByPlatform('telegram', 'chat-deny');
     expect(mg?.denied_at).not.toBeNull();
     expect(mg?.denied_at).toBeTruthy();
     const mgaCount = (
-      getDb()
+      sqliteRaw(getDb())
         .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
         .get(pending.messaging_group_id) as { c: number }
     ).c;
@@ -470,8 +476,9 @@ describe('unknown-channel registration flow', () => {
     await routeInbound(groupMention('chat-deny', '@bot please'));
     await new Promise((r) => setTimeout(r, 10));
     expect(deliverMock).not.toHaveBeenCalled();
-    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number })
-      .c;
+    const stillPending = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(stillPending).toBe(0);
   });
 
@@ -482,7 +489,7 @@ describe('unknown-channel registration flow', () => {
     await routeInbound(groupMention('chat-unauth'));
     await new Promise((r) => setTimeout(r, 10));
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
 
@@ -500,13 +507,14 @@ describe('unknown-channel registration flow', () => {
 
     // No wiring created, pending row preserved so a real approver can act on it.
     const mgaCount = (
-      getDb()
+      sqliteRaw(getDb())
         .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
         .get(pending.messaging_group_id) as { c: number }
     ).c;
     expect(mgaCount).toBe(0);
-    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number })
-      .c;
+    const stillPending = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(stillPending).toBe(1);
   });
 
@@ -515,16 +523,21 @@ describe('unknown-channel registration flow', () => {
     const { getResponseHandlers } = await import('../../response-registry.js');
     const { getDb } = await import('../../db/connection.js');
 
-    createAgentGroup({ id: 'ag-2', name: 'Betty', folder: 'betty', agent_provider: null, created_at: now() });
-    upsertUser({ id: 'telegram:scoped-admin', kind: 'telegram', display_name: 'Scoped Admin', created_at: now() });
-    grantRole({
+    await createAgentGroup({ id: 'ag-2', name: 'Betty', folder: 'betty', agent_provider: null, created_at: now() });
+    await upsertUser({
+      id: 'telegram:scoped-admin',
+      kind: 'telegram',
+      display_name: 'Scoped Admin',
+      created_at: now(),
+    });
+    await grantRole({
       user_id: 'telegram:scoped-admin',
       role: 'admin',
       agent_group_id: 'ag-1',
       granted_by: 'telegram:owner',
       granted_at: now(),
     });
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-dm-scoped-admin',
       channel_type: 'telegram',
       platform_id: 'dm-scoped-admin',
@@ -533,7 +546,7 @@ describe('unknown-channel registration flow', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    getDb()
+    sqliteRaw(getDb())
       .prepare(
         `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES (?, ?, ?, ?)`,
@@ -543,7 +556,7 @@ describe('unknown-channel registration flow', () => {
     await routeInbound(groupMention('chat-scoped-cross-group'));
     await new Promise((r) => setTimeout(r, 10));
 
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
     expect(pending).toBeDefined();
@@ -581,13 +594,14 @@ describe('unknown-channel registration flow', () => {
     }
 
     const mgaCount = (
-      getDb()
+      sqliteRaw(getDb())
         .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
         .get(pending.messaging_group_id) as { c: number }
     ).c;
     expect(mgaCount).toBe(0);
-    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number })
-      .c;
+    const stillPending = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(stillPending).toBe(1);
   });
 
@@ -598,7 +612,7 @@ describe('unknown-channel registration flow', () => {
 
     await routeInbound(groupMention('chat-create-new'));
     await new Promise((r) => setTimeout(r, 10));
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
 
@@ -629,18 +643,19 @@ describe('unknown-channel registration flow', () => {
       },
     });
 
-    const created = getDb().prepare("SELECT id FROM agent_groups WHERE name = 'Newbie'").get() as
+    const created = sqliteRaw(getDb()).prepare("SELECT id FROM agent_groups WHERE name = 'Newbie'").get() as
       | { id: string }
       | undefined;
     expect(created).toBeDefined();
     const mgaCount = (
-      getDb()
+      sqliteRaw(getDb())
         .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?')
         .get(pending.messaging_group_id, created!.id) as { c: number }
     ).c;
     expect(mgaCount).toBe(1);
-    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number })
-      .c;
+    const stillPending = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(stillPending).toBe(0);
   });
 
@@ -651,7 +666,7 @@ describe('unknown-channel registration flow', () => {
 
     await routeInbound(groupMention('chat-vanished'));
     await new Promise((r) => setTimeout(r, 10));
-    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
       messaging_group_id: string;
     };
 
@@ -670,11 +685,13 @@ describe('unknown-channel registration flow', () => {
     // The registration disappears between the click and the reply (rejected
     // from another card, group delete cascade, …) — the interceptor no
     // longer finds a pending registration, so the reply must not create.
-    getDb()
+    sqliteRaw(getDb())
       .prepare('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?')
       .run(pending.messaging_group_id);
 
-    const agentGroupsBefore = (getDb().prepare('SELECT COUNT(*) AS c FROM agent_groups').get() as { c: number }).c;
+    const agentGroupsBefore = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM agent_groups').get() as { c: number }
+    ).c;
     await routeInbound({
       channelType: 'telegram',
       platformId: 'dm-owner',
@@ -687,9 +704,13 @@ describe('unknown-channel registration flow', () => {
       },
     });
 
-    const agentGroupsAfter = (getDb().prepare('SELECT COUNT(*) AS c FROM agent_groups').get() as { c: number }).c;
+    const agentGroupsAfter = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM agent_groups').get() as { c: number }
+    ).c;
     expect(agentGroupsAfter).toBe(agentGroupsBefore);
-    const mgaCount = (getDb().prepare('SELECT COUNT(*) AS c FROM messaging_group_agents').get() as { c: number }).c;
+    const mgaCount = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM messaging_group_agents').get() as { c: number }
+    ).c;
     expect(mgaCount).toBe(0);
   });
 });
@@ -698,29 +719,33 @@ describe('no-owner / no-agent failure modes', () => {
   it('no owner → no card, no pending row (fresh-install bootstrap path)', async () => {
     // Wipe the owner grant set up in the outer beforeEach.
     const { getDb } = await import('../../db/connection.js');
-    getDb().prepare('DELETE FROM user_roles').run();
+    sqliteRaw(getDb()).prepare('DELETE FROM user_roles').run();
 
     const { routeInbound } = await import('../../router.js');
     await routeInbound(groupMention('chat-noowner'));
     await new Promise((r) => setTimeout(r, 10));
 
     expect(deliverMock).not.toHaveBeenCalled();
-    const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+    const count = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(count).toBe(0);
   });
 
   it('no agent groups → no card, no pending row', async () => {
     const { getDb } = await import('../../db/connection.js');
     // Drop foreign-key-dependent rows first, then the agent group itself.
-    getDb().prepare('DELETE FROM user_roles').run();
-    getDb().prepare('DELETE FROM agent_groups').run();
+    sqliteRaw(getDb()).prepare('DELETE FROM user_roles').run();
+    sqliteRaw(getDb()).prepare('DELETE FROM agent_groups').run();
 
     const { routeInbound } = await import('../../router.js');
     await routeInbound(groupMention('chat-noagent'));
     await new Promise((r) => setTimeout(r, 10));
 
     expect(deliverMock).not.toHaveBeenCalled();
-    const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+    const count = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
+    ).c;
     expect(count).toBe(0);
   });
 });

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -101,16 +101,20 @@ function toFolder(name: string): string {
 
 // ── Card builders ──
 
-function visibleAgentGroupsForApprover(
+async function visibleAgentGroupsForApprover(
   agentGroups: AgentGroup[],
   approverUserId: string | null | undefined,
-): AgentGroup[] {
+): Promise<AgentGroup[]> {
   if (!approverUserId) return agentGroups;
-  return agentGroups.filter((agentGroup) => hasAdminPrivilege(approverUserId, agentGroup.id));
+  const visible: AgentGroup[] = [];
+  for (const agentGroup of agentGroups) {
+    if (await hasAdminPrivilege(approverUserId, agentGroup.id)) visible.push(agentGroup);
+  }
+  return visible;
 }
 
-function buildApprovalOptions(agentGroups: AgentGroup[], approverUserId?: string | null): RawOption[] {
-  const visibleAgentGroups = visibleAgentGroupsForApprover(agentGroups, approverUserId);
+async function buildApprovalOptions(agentGroups: AgentGroup[], approverUserId?: string | null): Promise<RawOption[]> {
+  const visibleAgentGroups = await visibleAgentGroupsForApprover(agentGroups, approverUserId);
   const options: RawOption[] = [];
   if (visibleAgentGroups.length === 1) {
     options.push({
@@ -190,12 +194,12 @@ export interface RequestChannelApprovalInput {
 export async function requestChannelApproval(input: RequestChannelApprovalInput): Promise<void> {
   const { messagingGroupId, event } = input;
 
-  if (hasInFlightChannelApproval(messagingGroupId)) {
+  if (await hasInFlightChannelApproval(messagingGroupId)) {
     log.debug('Channel registration already in flight — dropping retry', { messagingGroupId });
     return;
   }
 
-  const originMg = getMessagingGroup(messagingGroupId);
+  const originMg = await getMessagingGroup(messagingGroupId);
 
   // Channel-module interceptor: consulted before any card work so a module
   // can auto-wire / decline / suppress for its own channel type. Runs after
@@ -216,7 +220,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     }
   }
 
-  const agentGroups = getAllAgentGroups();
+  const agentGroups = await getAllAgentGroups();
   if (agentGroups.length === 0) {
     log.warn('Channel registration skipped — no agent groups configured. Run /init-first-agent.', {
       messagingGroupId,
@@ -227,7 +231,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
   // are returned regardless of which group we pass.
   const referenceGroup = agentGroups[0];
 
-  const approvers = pickApprover(referenceGroup.id);
+  const approvers = await pickApprover(referenceGroup.id);
   if (approvers.length === 0) {
     log.warn('Channel registration skipped — no owner or admin configured', {
       messagingGroupId,
@@ -246,7 +250,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
       try {
         const name = await channelAdapter.resolveChannelName(originMg.platform_id);
         if (name) {
-          updateMessagingGroup(originMg.id, { name });
+          await updateMessagingGroup(originMg.id, { name });
           originMg.name = name;
         }
       } catch {
@@ -286,9 +290,9 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     originChannelType,
   );
   const question = buildQuestionText(isGroup, senderName, channelName, originChannelType, ruleNote);
-  const options = normalizeOptions(buildApprovalOptions(agentGroups, delivery.userId));
+  const options = normalizeOptions(await buildApprovalOptions(agentGroups, delivery.userId));
 
-  createPendingChannelApproval({
+  await createPendingChannelApproval({
     messaging_group_id: messagingGroupId,
     agent_group_id: referenceGroup.id,
     original_message: JSON.stringify(event),
@@ -334,11 +338,11 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
 /**
  * Build normalized options for the agent-selection follow-up card.
  */
-export function buildAgentSelectionOptions(
+export async function buildAgentSelectionOptions(
   agentGroups: AgentGroup[],
   approverUserId?: string | null,
-): NormalizedOption[] {
-  const visibleAgentGroups = visibleAgentGroupsForApprover(agentGroups, approverUserId);
+): Promise<NormalizedOption[]> {
+  const visibleAgentGroups = await visibleAgentGroupsForApprover(agentGroups, approverUserId);
   const options: RawOption[] = visibleAgentGroups.map((ag) => ({
     label: ag.name,
     selectedLabel: `✅ Connected to ${ag.name}`,
@@ -356,17 +360,17 @@ export function buildAgentSelectionOptions(
  * Create a new agent group and initialize its filesystem. Handles
  * folder-name collisions with numeric suffixes.
  */
-export function createNewAgentGroup(name: string): AgentGroup {
+export async function createNewAgentGroup(name: string): Promise<AgentGroup> {
   let folder = toFolder(name);
   const baseFolder = folder;
   let suffix = 2;
-  while (getAgentGroupByFolder(folder)) {
+  while (await getAgentGroupByFolder(folder)) {
     folder = `${baseFolder}-${suffix}`;
     suffix++;
   }
 
   const agId = `ag-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  createAgentGroup({
+  await createAgentGroup({
     id: agId,
     name,
     folder,
@@ -374,11 +378,11 @@ export function createNewAgentGroup(name: string): AgentGroup {
     created_at: new Date().toISOString(),
   });
 
-  const ag = getAgentGroup(agId)!;
+  const ag = (await getAgentGroup(agId))!;
   // Channel-approved groups are created on the instance default provider
   // (DEFAULT_AGENT_PROVIDER, or claude when unset) — initGroupFilesystem stamps
   // it onto the fresh config row. The operator flips a group afterward with
   // `ncl groups config update --provider`.
-  initGroupFilesystem(ag);
+  await initGroupFilesystem(ag);
   return ag;
 }

--- a/src/modules/permissions/channel-card-interceptor.test.ts
+++ b/src/modules/permissions/channel-card-interceptor.test.ts
@@ -14,6 +14,7 @@ import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup } from '../../db/messaging-groups.js';
 import type { InboundEvent } from '../../channels/adapter.js';
@@ -39,7 +40,8 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const row = getDb()
+    const { sqliteRaw } = await import('../../db/drivers/sqlite.js');
+    const row = sqliteRaw(getDb())
       .prepare(
         `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
@@ -64,14 +66,20 @@ function now() {
 beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
-  createAgentGroup({ id: 'ag-1', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-1', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
 
-  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
-  grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-  createMessagingGroup({
+  await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+  await grantRole({
+    user_id: 'telegram:owner',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now(),
+  });
+  await createMessagingGroup({
     id: 'mg-dm-owner',
     channel_type: 'telegram',
     platform_id: 'dm-owner',
@@ -81,19 +89,19 @@ beforeEach(async () => {
     created_at: now(),
   });
   const { getDb } = await import('../../db/connection.js');
-  getDb()
+  sqliteRaw(getDb())
     .prepare(`INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at) VALUES (?, ?, ?, ?)`)
     .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
 
   deliverMock.mockClear();
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
-function unwiredChannel(id: string, channelType = 'telegram'): MessagingGroup {
+async function unwiredChannel(id: string, channelType = 'telegram'): Promise<MessagingGroup> {
   const mg: MessagingGroup = {
     id,
     channel_type: channelType,
@@ -104,7 +112,7 @@ function unwiredChannel(id: string, channelType = 'telegram'): MessagingGroup {
     unknown_sender_policy: 'request_approval',
     created_at: now(),
   };
-  createMessagingGroup(mg);
+  await createMessagingGroup(mg);
   return mg;
 }
 
@@ -126,7 +134,7 @@ function mention(mg: MessagingGroup): InboundEvent {
 
 async function pendingCount(): Promise<number> {
   const { getDb } = await import('../../db/connection.js');
-  return (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+  return (sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
 }
 
 describe('channel-card interceptor seam', () => {
@@ -135,7 +143,7 @@ describe('channel-card interceptor seam', () => {
     const interceptor = vi.fn().mockResolvedValue('handled');
     registerChannelCardInterceptor('telegram', interceptor);
 
-    const mg = unwiredChannel('mg-a');
+    const mg = await unwiredChannel('mg-a');
     const event = mention(mg);
     await requestChannelApproval({ messagingGroupId: mg.id, event });
 
@@ -149,7 +157,7 @@ describe('channel-card interceptor seam', () => {
     const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
     registerChannelCardInterceptor('telegram', vi.fn().mockResolvedValue('card'));
 
-    const mg = unwiredChannel('mg-b');
+    const mg = await unwiredChannel('mg-b');
     await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
@@ -162,7 +170,7 @@ describe('channel-card interceptor seam', () => {
     const { registerChannelCardInterceptor, requestChannelApproval } = await import('./channel-approval.js');
     registerChannelCardInterceptor('telegram', vi.fn().mockRejectedValue(new Error('boom')));
 
-    const mg = unwiredChannel('mg-c');
+    const mg = await unwiredChannel('mg-c');
     await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
@@ -174,7 +182,7 @@ describe('channel-card interceptor seam', () => {
     const interceptor = vi.fn().mockResolvedValue('handled');
     registerChannelCardInterceptor('slack', interceptor);
 
-    const mg = unwiredChannel('mg-d'); // telegram
+    const mg = await unwiredChannel('mg-d'); // telegram
     await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
 
     expect(interceptor).not.toHaveBeenCalled();
@@ -186,7 +194,7 @@ describe('channel-card interceptor seam', () => {
     const interceptor = vi.fn().mockResolvedValue('card');
     registerChannelCardInterceptor('telegram', interceptor);
 
-    const mg = unwiredChannel('mg-e');
+    const mg = await unwiredChannel('mg-e');
     await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
     await requestChannelApproval({ messagingGroupId: mg.id, event: mention(mg) });
 

--- a/src/modules/permissions/db/agent-group-members.ts
+++ b/src/modules/permissions/db/agent-group-members.ts
@@ -2,44 +2,48 @@ import type { AgentGroupMember } from '../../../types.js';
 import { getDb } from '../../../db/connection.js';
 import { isAdminOfAgentGroup, isGlobalAdmin, isOwner } from './user-roles.js';
 
-export function addMember(row: AgentGroupMember): void {
-  getDb()
-    .prepare(
-      `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
+export async function addMember(row: AgentGroupMember): Promise<void> {
+  await getDb().run(
+    `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at)
        VALUES (@user_id, @agent_group_id, @added_by, @added_at)
        ON CONFLICT (user_id, agent_group_id) DO NOTHING`,
-    )
-    .run(row);
+    row,
+  );
 }
 
-export function removeMember(userId: string, agentGroupId: string): void {
-  getDb().prepare('DELETE FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?').run(userId, agentGroupId);
+export async function removeMember(userId: string, agentGroupId: string): Promise<void> {
+  await getDb().run('DELETE FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?', userId, agentGroupId);
 }
 
-export function getMembers(agentGroupId: string): AgentGroupMember[] {
-  return getDb()
-    .prepare('SELECT * FROM agent_group_members WHERE agent_group_id = ? ORDER BY added_at')
-    .all(agentGroupId) as AgentGroupMember[];
+export async function getMembers(agentGroupId: string): Promise<AgentGroupMember[]> {
+  return getDb().all<AgentGroupMember>(
+    'SELECT * FROM agent_group_members WHERE agent_group_id = ? ORDER BY added_at',
+    agentGroupId,
+  );
 }
 
 /**
  * Is the user "known" in this agent group?
  * Owner, global admin, and scoped admin are implicitly members.
  */
-export function isMember(userId: string, agentGroupId: string): boolean {
-  if (isOwner(userId) || isGlobalAdmin(userId) || isAdminOfAgentGroup(userId, agentGroupId)) {
+export async function isMember(userId: string, agentGroupId: string): Promise<boolean> {
+  if ((await isOwner(userId)) || (await isGlobalAdmin(userId)) || (await isAdminOfAgentGroup(userId, agentGroupId))) {
     return true;
   }
-  const row = getDb()
-    .prepare('SELECT 1 FROM agent_group_members WHERE user_id = ? AND agent_group_id = ? LIMIT 1')
-    .get(userId, agentGroupId);
+  const row = await getDb().get(
+    'SELECT 1 FROM agent_group_members WHERE user_id = ? AND agent_group_id = ? LIMIT 1',
+    userId,
+    agentGroupId,
+  );
   return !!row;
 }
 
 /** Direct row lookup — does not honor the admin/owner implicit-membership rule. */
-export function hasMembershipRow(userId: string, agentGroupId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 FROM agent_group_members WHERE user_id = ? AND agent_group_id = ? LIMIT 1')
-    .get(userId, agentGroupId);
+export async function hasMembershipRow(userId: string, agentGroupId: string): Promise<boolean> {
+  const row = await getDb().get(
+    'SELECT 1 FROM agent_group_members WHERE user_id = ? AND agent_group_id = ? LIMIT 1',
+    userId,
+    agentGroupId,
+  );
   return !!row;
 }

--- a/src/modules/permissions/db/pending-channel-approvals.ts
+++ b/src/modules/permissions/db/pending-channel-approvals.ts
@@ -25,10 +25,9 @@ export interface PendingChannelApproval {
   options_json: string;
 }
 
-export function createPendingChannelApproval(row: PendingChannelApproval): void {
-  getDb()
-    .prepare(
-      `INSERT INTO pending_channel_approvals (
+export async function createPendingChannelApproval(row: PendingChannelApproval): Promise<void> {
+  await getDb().run(
+    `INSERT INTO pending_channel_approvals (
          messaging_group_id, agent_group_id, original_message,
          approver_user_id, created_at, title, question, options_json
        )
@@ -36,36 +35,40 @@ export function createPendingChannelApproval(row: PendingChannelApproval): void 
          @messaging_group_id, @agent_group_id, @original_message,
          @approver_user_id, @created_at, @title, @question, @options_json
        )`,
-    )
-    .run(row);
+    row,
+  );
 }
 
-export function getPendingChannelApproval(messagingGroupId: string): PendingChannelApproval | undefined {
-  return getDb()
-    .prepare('SELECT * FROM pending_channel_approvals WHERE messaging_group_id = ?')
-    .get(messagingGroupId) as PendingChannelApproval | undefined;
+export async function getPendingChannelApproval(messagingGroupId: string): Promise<PendingChannelApproval | undefined> {
+  return getDb().get<PendingChannelApproval>(
+    'SELECT * FROM pending_channel_approvals WHERE messaging_group_id = ?',
+    messagingGroupId,
+  );
 }
 
-export function hasInFlightChannelApproval(messagingGroupId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 AS x FROM pending_channel_approvals WHERE messaging_group_id = ?')
-    .get(messagingGroupId) as { x: number } | undefined;
+export async function hasInFlightChannelApproval(messagingGroupId: string): Promise<boolean> {
+  const row = await getDb().get<{ x: number }>(
+    'SELECT 1 AS x FROM pending_channel_approvals WHERE messaging_group_id = ?',
+    messagingGroupId,
+  );
   return row !== undefined;
 }
 
-export function updatePendingChannelApprovalCard(
+export async function updatePendingChannelApprovalCard(
   messagingGroupId: string,
   title: string,
   question: string,
   optionsJson: string,
-): void {
-  getDb()
-    .prepare(
-      'UPDATE pending_channel_approvals SET title = ?, question = ?, options_json = ? WHERE messaging_group_id = ?',
-    )
-    .run(title, question, optionsJson, messagingGroupId);
+): Promise<void> {
+  await getDb().run(
+    'UPDATE pending_channel_approvals SET title = ?, question = ?, options_json = ? WHERE messaging_group_id = ?',
+    title,
+    question,
+    optionsJson,
+    messagingGroupId,
+  );
 }
 
-export function deletePendingChannelApproval(messagingGroupId: string): void {
-  getDb().prepare('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?').run(messagingGroupId);
+export async function deletePendingChannelApproval(messagingGroupId: string): Promise<void> {
+  await getDb().run('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?', messagingGroupId);
 }

--- a/src/modules/permissions/db/pending-sender-approvals.ts
+++ b/src/modules/permissions/db/pending-sender-approvals.ts
@@ -27,10 +27,9 @@ export interface PendingSenderApproval {
   options_json: string;
 }
 
-export function createPendingSenderApproval(row: PendingSenderApproval): void {
-  getDb()
-    .prepare(
-      `INSERT INTO pending_sender_approvals (
+export async function createPendingSenderApproval(row: PendingSenderApproval): Promise<void> {
+  await getDb().run(
+    `INSERT INTO pending_sender_approvals (
          id, messaging_group_id, agent_group_id, sender_identity,
          sender_name, original_message, approver_user_id, created_at,
          title, question, options_json
@@ -40,25 +39,25 @@ export function createPendingSenderApproval(row: PendingSenderApproval): void {
          @sender_name, @original_message, @approver_user_id, @created_at,
          @title, @question, @options_json
        )`,
-    )
-    .run(row);
+    row,
+  );
 }
 
-export function getPendingSenderApproval(id: string): PendingSenderApproval | undefined {
-  return getDb().prepare('SELECT * FROM pending_sender_approvals WHERE id = ?').get(id) as
-    | PendingSenderApproval
-    | undefined;
+export async function getPendingSenderApproval(id: string): Promise<PendingSenderApproval | undefined> {
+  return getDb().get<PendingSenderApproval>('SELECT * FROM pending_sender_approvals WHERE id = ?', id);
 }
 
-export function hasInFlightSenderApproval(messagingGroupId: string, senderIdentity: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 AS x FROM pending_sender_approvals WHERE messaging_group_id = ? AND sender_identity = ?')
-    .get(messagingGroupId, senderIdentity) as { x: number } | undefined;
+export async function hasInFlightSenderApproval(messagingGroupId: string, senderIdentity: string): Promise<boolean> {
+  const row = await getDb().get<{ x: number }>(
+    'SELECT 1 AS x FROM pending_sender_approvals WHERE messaging_group_id = ? AND sender_identity = ?',
+    messagingGroupId,
+    senderIdentity,
+  );
   return row !== undefined;
 }
 
-export function deletePendingSenderApproval(id: string): void {
-  getDb().prepare('DELETE FROM pending_sender_approvals WHERE id = ?').run(id);
+export async function deletePendingSenderApproval(id: string): Promise<void> {
+  await getDb().run('DELETE FROM pending_sender_approvals WHERE id = ?', id);
 }
 
 // ── Decline stamps (decline_notify dedupe) ──
@@ -75,28 +74,27 @@ export function deletePendingSenderApproval(id: string): void {
 const DECLINE_STAMP_ID_PREFIX = 'decline:';
 
 /** ISO timestamp of the last decline for this pair, if any. */
-export function getDeclineStampAt(messagingGroupId: string, senderIdentity: string): string | undefined {
-  const row = getDb()
-    .prepare(
-      `SELECT created_at FROM pending_sender_approvals
-        WHERE messaging_group_id = ? AND sender_identity = ? AND id LIKE '${DECLINE_STAMP_ID_PREFIX}%'`,
-    )
-    .get(messagingGroupId, senderIdentity) as { created_at: string } | undefined;
+export async function getDeclineStampAt(messagingGroupId: string, senderIdentity: string): Promise<string | undefined> {
+  const row = await getDb().get<{ created_at: string }>(
+    `SELECT created_at FROM pending_sender_approvals
+      WHERE messaging_group_id = ? AND sender_identity = ? AND id LIKE '${DECLINE_STAMP_ID_PREFIX}%'`,
+    messagingGroupId,
+    senderIdentity,
+  );
   return row?.created_at;
 }
 
 /** Record (or refresh) the decline stamp. `agent_group_id` must reference a
  *  real agent group (FK). title/options_json keep their '' / '[]' defaults. */
-export function upsertDeclineStamp(stamp: {
+export async function upsertDeclineStamp(stamp: {
   messaging_group_id: string;
   agent_group_id: string;
   sender_identity: string;
   sender_name: string | null;
   original_message: string;
-}): void {
-  getDb()
-    .prepare(
-      `INSERT INTO pending_sender_approvals (
+}): Promise<void> {
+  await getDb().run(
+    `INSERT INTO pending_sender_approvals (
          id, messaging_group_id, agent_group_id, sender_identity,
          sender_name, original_message, approver_user_id, created_at
        )
@@ -112,20 +110,20 @@ export function upsertDeclineStamp(stamp: {
          approver_user_id = excluded.approver_user_id,
          title = excluded.title,
          options_json = excluded.options_json`,
-    )
-    .run({
+    {
       id: `${DECLINE_STAMP_ID_PREFIX}${stamp.messaging_group_id}:${stamp.sender_identity}`,
       ...stamp,
       created_at: new Date().toISOString(),
-    });
+    },
+  );
 }
 
 /** Remove any decline stamp for this pair — real card rows are untouched. */
-export function clearDeclineStamp(messagingGroupId: string, senderIdentity: string): void {
-  getDb()
-    .prepare(
-      `DELETE FROM pending_sender_approvals
-        WHERE messaging_group_id = ? AND sender_identity = ? AND id LIKE '${DECLINE_STAMP_ID_PREFIX}%'`,
-    )
-    .run(messagingGroupId, senderIdentity);
+export async function clearDeclineStamp(messagingGroupId: string, senderIdentity: string): Promise<void> {
+  await getDb().run(
+    `DELETE FROM pending_sender_approvals
+      WHERE messaging_group_id = ? AND sender_identity = ? AND id LIKE '${DECLINE_STAMP_ID_PREFIX}%'`,
+    messagingGroupId,
+    senderIdentity,
+  );
 }

--- a/src/modules/permissions/db/user-dms.ts
+++ b/src/modules/permissions/db/user-dms.ts
@@ -1,28 +1,25 @@
 import type { UserDm } from '../../../types.js';
 import { getDb } from '../../../db/connection.js';
 
-export function upsertUserDm(row: UserDm): void {
-  getDb()
-    .prepare(
-      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+export async function upsertUserDm(row: UserDm): Promise<void> {
+  await getDb().run(
+    `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES (@user_id, @channel_type, @messaging_group_id, @resolved_at)
        ON CONFLICT(user_id, channel_type) DO UPDATE SET
          messaging_group_id = excluded.messaging_group_id,
          resolved_at = excluded.resolved_at`,
-    )
-    .run(row);
+    row,
+  );
 }
 
-export function getUserDm(userId: string, channelType: string): UserDm | undefined {
-  return getDb().prepare('SELECT * FROM user_dms WHERE user_id = ? AND channel_type = ?').get(userId, channelType) as
-    | UserDm
-    | undefined;
+export async function getUserDm(userId: string, channelType: string): Promise<UserDm | undefined> {
+  return getDb().get<UserDm>('SELECT * FROM user_dms WHERE user_id = ? AND channel_type = ?', userId, channelType);
 }
 
-export function getUserDmsForUser(userId: string): UserDm[] {
-  return getDb().prepare('SELECT * FROM user_dms WHERE user_id = ?').all(userId) as UserDm[];
+export async function getUserDmsForUser(userId: string): Promise<UserDm[]> {
+  return getDb().all<UserDm>('SELECT * FROM user_dms WHERE user_id = ?', userId);
 }
 
-export function deleteUserDm(userId: string, channelType: string): void {
-  getDb().prepare('DELETE FROM user_dms WHERE user_id = ? AND channel_type = ?').run(userId, channelType);
+export async function deleteUserDm(userId: string, channelType: string): Promise<void> {
+  await getDb().run('DELETE FROM user_dms WHERE user_id = ? AND channel_type = ?', userId, channelType);
 }

--- a/src/modules/permissions/db/user-roles.ts
+++ b/src/modules/permissions/db/user-roles.ts
@@ -5,81 +5,90 @@ import { getDb } from '../../../db/connection.js';
  * Grant a role. Owner rows must have agent_group_id = null (enforced here,
  * not by schema, so callers get a clean error path).
  */
-export function grantRole(row: UserRole): void {
+export async function grantRole(row: UserRole): Promise<void> {
   if (row.role === 'owner' && row.agent_group_id !== null) {
     throw new Error('owner role must be global (agent_group_id = null)');
   }
-  getDb()
-    .prepare(
-      `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
-       VALUES (@user_id, @role, @agent_group_id, @granted_by, @granted_at)`,
-    )
-    .run(row);
+  await getDb().run(
+    `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
+     VALUES (@user_id, @role, @agent_group_id, @granted_by, @granted_at)`,
+    row,
+  );
 }
 
-export function revokeRole(userId: string, role: UserRoleKind, agentGroupId: string | null): void {
+export async function revokeRole(userId: string, role: UserRoleKind, agentGroupId: string | null): Promise<void> {
   if (agentGroupId === null) {
-    getDb()
-      .prepare('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NULL')
-      .run(userId, role);
+    await getDb().run('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NULL', userId, role);
   } else {
-    getDb()
-      .prepare('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id = ?')
-      .run(userId, role, agentGroupId);
+    await getDb().run(
+      'DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id = ?',
+      userId,
+      role,
+      agentGroupId,
+    );
   }
 }
 
-export function getUserRoles(userId: string): UserRole[] {
-  return getDb().prepare('SELECT * FROM user_roles WHERE user_id = ?').all(userId) as UserRole[];
+export async function getUserRoles(userId: string): Promise<UserRole[]> {
+  return getDb().all<UserRole>('SELECT * FROM user_roles WHERE user_id = ?', userId);
 }
 
-export function isOwner(userId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NULL LIMIT 1')
-    .get(userId, 'owner');
+export async function isOwner(userId: string): Promise<boolean> {
+  const row = await getDb().get(
+    'SELECT 1 FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NULL LIMIT 1',
+    userId,
+    'owner',
+  );
   return !!row;
 }
 
-export function isGlobalAdmin(userId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NULL LIMIT 1')
-    .get(userId, 'admin');
+export async function isGlobalAdmin(userId: string): Promise<boolean> {
+  const row = await getDb().get(
+    'SELECT 1 FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS NULL LIMIT 1',
+    userId,
+    'admin',
+  );
   return !!row;
 }
 
-export function isAdminOfAgentGroup(userId: string, agentGroupId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id = ? LIMIT 1')
-    .get(userId, 'admin', agentGroupId);
+export async function isAdminOfAgentGroup(userId: string, agentGroupId: string): Promise<boolean> {
+  const row = await getDb().get(
+    'SELECT 1 FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id = ? LIMIT 1',
+    userId,
+    'admin',
+    agentGroupId,
+  );
   return !!row;
 }
 
 /** Any admin privilege over this agent group: global admin OR scoped admin. */
-export function hasAdminPrivilege(userId: string, agentGroupId: string): boolean {
-  return isOwner(userId) || isGlobalAdmin(userId) || isAdminOfAgentGroup(userId, agentGroupId);
+export async function hasAdminPrivilege(userId: string, agentGroupId: string): Promise<boolean> {
+  return (await isOwner(userId)) || (await isGlobalAdmin(userId)) || (await isAdminOfAgentGroup(userId, agentGroupId));
 }
 
-export function getOwners(): UserRole[] {
-  return getDb()
-    .prepare('SELECT * FROM user_roles WHERE role = ? AND agent_group_id IS NULL ORDER BY granted_at')
-    .all('owner') as UserRole[];
+export async function getOwners(): Promise<UserRole[]> {
+  return getDb().all<UserRole>(
+    'SELECT * FROM user_roles WHERE role = ? AND agent_group_id IS NULL ORDER BY granted_at',
+    'owner',
+  );
 }
 
-export function hasAnyOwner(): boolean {
-  const row = getDb()
-    .prepare('SELECT 1 FROM user_roles WHERE role = ? AND agent_group_id IS NULL LIMIT 1')
-    .get('owner');
+export async function hasAnyOwner(): Promise<boolean> {
+  const row = await getDb().get('SELECT 1 FROM user_roles WHERE role = ? AND agent_group_id IS NULL LIMIT 1', 'owner');
   return !!row;
 }
 
-export function getGlobalAdmins(): UserRole[] {
-  return getDb()
-    .prepare('SELECT * FROM user_roles WHERE role = ? AND agent_group_id IS NULL ORDER BY granted_at')
-    .all('admin') as UserRole[];
+export async function getGlobalAdmins(): Promise<UserRole[]> {
+  return getDb().all<UserRole>(
+    'SELECT * FROM user_roles WHERE role = ? AND agent_group_id IS NULL ORDER BY granted_at',
+    'admin',
+  );
 }
 
-export function getAdminsOfAgentGroup(agentGroupId: string): UserRole[] {
-  return getDb()
-    .prepare('SELECT * FROM user_roles WHERE role = ? AND agent_group_id = ? ORDER BY granted_at')
-    .all('admin', agentGroupId) as UserRole[];
+export async function getAdminsOfAgentGroup(agentGroupId: string): Promise<UserRole[]> {
+  return getDb().all<UserRole>(
+    'SELECT * FROM user_roles WHERE role = ? AND agent_group_id = ? ORDER BY granted_at',
+    'admin',
+    agentGroupId,
+  );
 }

--- a/src/modules/permissions/db/users.ts
+++ b/src/modules/permissions/db/users.ts
@@ -1,38 +1,36 @@
 import type { User } from '../../../types.js';
 import { getDb } from '../../../db/connection.js';
 
-export function createUser(user: User): void {
-  getDb()
-    .prepare(
-      `INSERT INTO users (id, kind, display_name, created_at)
-       VALUES (@id, @kind, @display_name, @created_at)`,
-    )
-    .run(user);
+export async function createUser(user: User): Promise<void> {
+  await getDb().run(
+    `INSERT INTO users (id, kind, display_name, created_at)
+     VALUES (@id, @kind, @display_name, @created_at)`,
+    user,
+  );
 }
 
-export function upsertUser(user: User): void {
-  getDb()
-    .prepare(
-      `INSERT INTO users (id, kind, display_name, created_at)
+export async function upsertUser(user: User): Promise<void> {
+  await getDb().run(
+    `INSERT INTO users (id, kind, display_name, created_at)
        VALUES (@id, @kind, @display_name, @created_at)
        ON CONFLICT(id) DO UPDATE SET
          display_name = COALESCE(excluded.display_name, users.display_name)`,
-    )
-    .run(user);
+    user,
+  );
 }
 
-export function getUser(id: string): User | undefined {
-  return getDb().prepare('SELECT * FROM users WHERE id = ?').get(id) as User | undefined;
+export async function getUser(id: string): Promise<User | undefined> {
+  return getDb().get<User>('SELECT * FROM users WHERE id = ?', id);
 }
 
-export function getAllUsers(): User[] {
-  return getDb().prepare('SELECT * FROM users ORDER BY created_at').all() as User[];
+export async function getAllUsers(): Promise<User[]> {
+  return getDb().all<User>('SELECT * FROM users ORDER BY created_at');
 }
 
-export function updateDisplayName(id: string, displayName: string): void {
-  getDb().prepare('UPDATE users SET display_name = ? WHERE id = ?').run(displayName, id);
+export async function updateDisplayName(id: string, displayName: string): Promise<void> {
+  await getDb().run('UPDATE users SET display_name = ? WHERE id = ?', displayName, id);
 }
 
-export function deleteUser(id: string): void {
-  getDb().prepare('DELETE FROM users WHERE id = ?').run(id);
+export async function deleteUser(id: string): Promise<void> {
+  await getDb().run('DELETE FROM users WHERE id = ?', id);
 }

--- a/src/modules/permissions/guard.ts
+++ b/src/modules/permissions/guard.ts
@@ -27,7 +27,7 @@ import { hasAdminPrivilege } from './db/user-roles.js';
 
 export const sendersAdmit = defineGuardedAction({
   action: 'senders.admit',
-  decide: (input) => {
+  decide: async (input) => {
     const policy = input.payload.policy;
     if (policy === 'public') return ALLOW('public messaging group');
     if (policy === 'request_approval') {
@@ -46,14 +46,14 @@ export const sendersAdmit = defineGuardedAction({
 
 export const channelsRegister = defineGuardedAction({
   action: 'channels.register',
-  decide: (input) => {
+  decide: async (input) => {
     if (input.actor.kind !== 'human') return DENY('channel registration resolves via human clicks/replies');
     const questionId = typeof input.payload.questionId === 'string' ? input.payload.questionId : '';
-    const row = getPendingChannelApproval(questionId);
+    const row = await getPendingChannelApproval(questionId);
     if (!row) return DENY(`no pending channel registration for ${questionId || '(missing questionId)'}`);
     if (
       input.actor.userId &&
-      (input.actor.userId === row.approver_user_id || hasAdminPrivilege(input.actor.userId, row.agent_group_id))
+      (input.actor.userId === row.approver_user_id || (await hasAdminPrivilege(input.actor.userId, row.agent_group_id)))
     ) {
       return ALLOW('delivered approver or anchor-group admin');
     }

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -68,7 +68,7 @@ interface PendingNameInput {
 }
 const awaitingNameInput = new Map<string, PendingNameInput>();
 
-function extractAndUpsertUser(event: InboundEvent): string | null {
+async function extractAndUpsertUser(event: InboundEvent): Promise<string | null> {
   let content: Record<string, unknown>;
   try {
     content = JSON.parse(event.message.content) as Record<string, unknown>;
@@ -95,8 +95,8 @@ function extractAndUpsertUser(event: InboundEvent): string | null {
   if (!rawHandle) return null;
 
   const userId = rawHandle.includes(':') ? rawHandle : `${event.channelType}:${rawHandle}`;
-  if (!getUser(userId)) {
-    upsertUser({
+  if (!(await getUser(userId))) {
+    await upsertUser({
       id: userId,
       kind: event.channelType,
       display_name: senderName ?? null,
@@ -114,13 +114,13 @@ function safeParseContent(raw: string): { text?: string; sender?: string; sender
   }
 }
 
-function handleUnknownSender(
+async function handleUnknownSender(
   mg: MessagingGroup,
   userId: string | null,
   agentGroupId: string,
   accessReason: string,
   event: InboundEvent,
-): void {
+): Promise<void> {
   const parsed = safeParseContent(event.message.content);
   const senderName = parsed.sender ?? null;
   const dropRecord = {
@@ -137,7 +137,7 @@ function handleUnknownSender(
   // — unknown_sender_policy verbatim: strict → deny, request_approval → hold,
   // public → allow (short-circuited before the gate). Drop-recording and the
   // hold creation stay here.
-  const decision = guard(sendersAdmit, {
+  const decision = await guard(sendersAdmit, {
     actor: userId ? { kind: 'human', userId } : { kind: 'system' },
     payload: {
       messagingGroupId: mg.id,
@@ -164,7 +164,7 @@ function handleUnknownSender(
       accessReason,
     },
   );
-  recordDroppedMessage(dropRecord);
+  await recordDroppedMessage(dropRecord);
 
   // decline_notify: polite in-DM decline + one-line owner FYI, no
   // card. Fire-and-forget like the hold path — declineAndNotify dedupes
@@ -209,23 +209,23 @@ function handleUnknownSender(
 
 setSenderResolver(extractAndUpsertUser);
 
-setAccessGate((event, userId, mg, agentGroupId): AccessGateResult => {
+setAccessGate(async (event, userId, mg, agentGroupId): Promise<AccessGateResult> => {
   // Public channels skip the access check entirely.
   if (mg.unknown_sender_policy === 'public') {
     return { allowed: true };
   }
 
   if (!userId) {
-    handleUnknownSender(mg, null, agentGroupId, 'unknown_user', event);
+    await handleUnknownSender(mg, null, agentGroupId, 'unknown_user', event);
     return { allowed: false, reason: 'unknown_user' };
   }
 
-  const decision = canAccessAgentGroup(userId, agentGroupId);
+  const decision = await canAccessAgentGroup(userId, agentGroupId);
   if (decision.allowed) {
     return { allowed: true };
   }
 
-  handleUnknownSender(mg, userId, agentGroupId, decision.reason, event);
+  await handleUnknownSender(mg, userId, agentGroupId, decision.reason, event);
   return { allowed: false, reason: decision.reason };
 });
 
@@ -238,10 +238,15 @@ setAccessGate((event, userId, mg, agentGroupId): AccessGateResult => {
  * canAccessAgentGroup accepts (owner, admin, or group member).
  */
 setSenderScopeGate(
-  (_event: InboundEvent, userId: string | null, _mg: MessagingGroup, agent: MessagingGroupAgent): AccessGateResult => {
+  async (
+    _event: InboundEvent,
+    userId: string | null,
+    _mg: MessagingGroup,
+    agent: MessagingGroupAgent,
+  ): Promise<AccessGateResult> => {
     if (agent.sender_scope === 'all') return { allowed: true };
     if (!userId) return { allowed: false, reason: 'unknown_user_scope' };
-    const decision = canAccessAgentGroup(userId, agent.agent_group_id);
+    const decision = await canAccessAgentGroup(userId, agent.agent_group_id);
     if (decision.allowed) return { allowed: true };
     return { allowed: false, reason: `sender_scope_${decision.reason}` };
   },
@@ -262,7 +267,7 @@ setSenderScopeGate(
  * fresh card per ACTION-ITEMS item 5 "no denial persistence").
  */
 async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<boolean> {
-  const row = getPendingSenderApproval(payload.questionId);
+  const row = await getPendingSenderApproval(payload.questionId);
   if (!row) return false;
 
   // payload.userId is the raw platform userId (e.g. "6037840640"); namespace it
@@ -275,7 +280,8 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
       : `${payload.channelType}:${payload.userId}`
     : null;
   const isAuthorized =
-    clickerId !== null && (clickerId === row.approver_user_id || hasAdminPrivilege(clickerId, row.agent_group_id));
+    clickerId !== null &&
+    (clickerId === row.approver_user_id || (await hasAdminPrivilege(clickerId, row.agent_group_id)));
   if (!isAuthorized) {
     log.warn('Unknown-sender approval click rejected — unauthorized clicker', {
       approvalId: row.id,
@@ -288,7 +294,7 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
   const approved = payload.value === 'approve';
 
   if (approved) {
-    addMember({
+    await addMember({
       user_id: row.sender_identity,
       agent_group_id: row.agent_group_id,
       added_by: approverId,
@@ -303,7 +309,7 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
 
     // Clear the pending row BEFORE re-routing so the gate check on the
     // second attempt doesn't see the in-flight row and short-circuit.
-    deletePendingSenderApproval(row.id);
+    await deletePendingSenderApproval(row.id);
 
     try {
       const event = JSON.parse(row.original_message) as InboundEvent;
@@ -320,7 +326,7 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
     agentGroupId: row.agent_group_id,
     approverId,
   });
-  deletePendingSenderApproval(row.id);
+  await deletePendingSenderApproval(row.id);
   return true;
 }
 
@@ -356,13 +362,13 @@ async function wireApprovedChannel(
       messagingGroupId: row.messaging_group_id,
       err,
     });
-    deletePendingChannelApproval(row.messaging_group_id);
+    await deletePendingChannelApproval(row.messaging_group_id);
     return false;
   }
 
-  const mg = getMessagingGroup(row.messaging_group_id);
+  const mg = await getMessagingGroup(row.messaging_group_id);
   const isGroup = event.message.isGroup ?? mg?.is_group === 1;
-  const agentGroupName = getAgentGroup(agentGroupId)?.name ?? '';
+  const agentGroupName = (await getAgentGroup(agentGroupId))?.name ?? '';
 
   let engage: { engage_mode: MessagingGroupAgent['engage_mode']; engage_pattern: string | null };
   try {
@@ -379,12 +385,12 @@ async function wireApprovedChannel(
       messagingGroupId: row.messaging_group_id,
       err,
     });
-    deletePendingChannelApproval(row.messaging_group_id);
+    await deletePendingChannelApproval(row.messaging_group_id);
     return false;
   }
 
   const mgaId = `mga-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  createMessagingGroupAgent({
+  await createMessagingGroupAgent({
     id: mgaId,
     messaging_group_id: row.messaging_group_id,
     agent_group_id: agentGroupId,
@@ -407,9 +413,9 @@ async function wireApprovedChannel(
     approverId,
   });
 
-  const senderUserId = extractAndUpsertUser(event);
+  const senderUserId = await extractAndUpsertUser(event);
   if (senderUserId) {
-    addMember({
+    await addMember({
       user_id: senderUserId,
       agent_group_id: agentGroupId,
       added_by: approverId,
@@ -417,7 +423,7 @@ async function wireApprovedChannel(
     });
   }
 
-  deletePendingChannelApproval(row.messaging_group_id);
+  await deletePendingChannelApproval(row.messaging_group_id);
 
   try {
     await routeInbound(event);
@@ -445,7 +451,7 @@ async function wireApprovedChannel(
  *   reject          — set denied_at, delete pending row
  */
 async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<boolean> {
-  const row = getPendingChannelApproval(payload.questionId);
+  const row = await getPendingChannelApproval(payload.questionId);
   if (!row) return false;
 
   // Click authorization is the guard's channels.register decision (./guard.ts):
@@ -455,7 +461,7 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
       ? payload.userId
       : `${payload.channelType}:${payload.userId}`
     : null;
-  const decision = guard(channelsRegister, {
+  const decision = await guard(channelsRegister, {
     actor: { kind: 'human', userId: clickerId ?? '' },
     payload: { questionId: payload.questionId },
   });
@@ -472,8 +478,8 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
 
   // ── Reject / Cancel ──
   if (payload.value === REJECT_VALUE) {
-    setMessagingGroupDeniedAt(row.messaging_group_id, new Date().toISOString());
-    deletePendingChannelApproval(row.messaging_group_id);
+    await setMessagingGroupDeniedAt(row.messaging_group_id, new Date().toISOString());
+    await deletePendingChannelApproval(row.messaging_group_id);
     log.info('Channel registration denied', {
       messagingGroupId: row.messaging_group_id,
       approverId,
@@ -495,11 +501,11 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
     const adapter = getDeliveryAdapter();
     if (!adapter) return true;
 
-    const agentGroups = getAllAgentGroups();
-    const options = buildAgentSelectionOptions(agentGroups, approverId);
+    const agentGroups = await getAllAgentGroups();
+    const options = await buildAgentSelectionOptions(agentGroups, approverId);
     const title = '📋 Choose an agent';
     const question = 'Which agent should handle this channel?';
-    updatePendingChannelApprovalCard(row.messaging_group_id, title, question, JSON.stringify(options));
+    await updatePendingChannelApprovalCard(row.messaging_group_id, title, question, JSON.stringify(options));
 
     try {
       await adapter.deliver(
@@ -572,16 +578,16 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
 
   if (payload.value.startsWith(CONNECT_PREFIX)) {
     targetAgentGroupId = payload.value.slice(CONNECT_PREFIX.length);
-    const ag = getAgentGroup(targetAgentGroupId);
+    const ag = await getAgentGroup(targetAgentGroupId);
     if (!ag) {
       log.error('Channel registration: target agent group no longer exists', {
         messagingGroupId: row.messaging_group_id,
         targetAgentGroupId,
       });
-      deletePendingChannelApproval(row.messaging_group_id);
+      await deletePendingChannelApproval(row.messaging_group_id);
       return true;
     }
-    if (!hasAdminPrivilege(approverId, targetAgentGroupId)) {
+    if (!(await hasAdminPrivilege(approverId, targetAgentGroupId))) {
       log.warn('Channel registration: target agent group rejected for unauthorized approver', {
         messagingGroupId: row.messaging_group_id,
         targetAgentGroupId,
@@ -609,7 +615,7 @@ registerResponseHandler(handleChannelApprovalResponse);
 // creates the agent immediately, wires the channel, and replays.
 
 registerMessageInterceptor(async (event: InboundEvent): Promise<boolean> => {
-  const userId = extractAndUpsertUser(event);
+  const userId = await extractAndUpsertUser(event);
   if (!userId) return false;
 
   const pending = awaitingNameInput.get(userId);
@@ -631,10 +637,10 @@ registerMessageInterceptor(async (event: InboundEvent): Promise<boolean> => {
     return true;
   }
 
-  const row = getPendingChannelApproval(pending.channelMgId);
+  const row = await getPendingChannelApproval(pending.channelMgId);
   if (!row) return true;
 
-  const ag = createNewAgentGroup(text);
+  const ag = await createNewAgentGroup(text);
   log.info('Channel registration: new agent group created', {
     messagingGroupId: row.messaging_group_id,
     agentGroupId: ag.id,

--- a/src/modules/permissions/permissions.test.ts
+++ b/src/modules/permissions/permissions.test.ts
@@ -23,14 +23,14 @@ function now(): string {
   return new Date().toISOString();
 }
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
 afterEach(async () => {
   await teardownChannelAdapters();
-  closeDb();
+  await closeDb();
 });
 
 async function mountMockAdapter(
@@ -71,8 +71,8 @@ async function mountMockAdapter(
   return { delivered, openDMCalls };
 }
 
-function seedAgentGroup(id: string): void {
-  createAgentGroup({
+async function seedAgentGroup(id: string): Promise<void> {
+  await createAgentGroup({
     id,
     name: id.toUpperCase(),
     folder: id,
@@ -81,70 +81,70 @@ function seedAgentGroup(id: string): void {
   });
 }
 
-function seedUser(id: string, kind: string): void {
-  createUser({ id, kind, display_name: null, created_at: now() });
+async function seedUser(id: string, kind: string): Promise<void> {
+  await createUser({ id, kind, display_name: null, created_at: now() });
 }
 
 describe('canAccessAgentGroup', () => {
-  beforeEach(() => {
-    seedAgentGroup('ag-1');
-    seedAgentGroup('ag-2');
+  beforeEach(async () => {
+    await seedAgentGroup('ag-1');
+    await seedAgentGroup('ag-2');
   });
 
-  it('denies unknown users', () => {
-    const d = canAccessAgentGroup('ghost', 'ag-1');
+  it('denies unknown users', async () => {
+    const d = await canAccessAgentGroup('ghost', 'ag-1');
     expect(d.allowed).toBe(false);
     expect(d.allowed === false && d.reason).toBe('unknown_user');
   });
 
-  it('allows owners globally', () => {
-    seedUser('u-owner', 'telegram');
-    grantRole({ user_id: 'u-owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-    expect(canAccessAgentGroup('u-owner', 'ag-1').allowed).toBe(true);
-    expect(canAccessAgentGroup('u-owner', 'ag-2').allowed).toBe(true);
+  it('allows owners globally', async () => {
+    await seedUser('u-owner', 'telegram');
+    await grantRole({ user_id: 'u-owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    expect((await canAccessAgentGroup('u-owner', 'ag-1')).allowed).toBe(true);
+    expect((await canAccessAgentGroup('u-owner', 'ag-2')).allowed).toBe(true);
   });
 
-  it('allows global admins', () => {
-    seedUser('u-ga', 'telegram');
-    grantRole({ user_id: 'u-ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: now() });
-    expect(canAccessAgentGroup('u-ga', 'ag-1').allowed).toBe(true);
-    expect(canAccessAgentGroup('u-ga', 'ag-2').allowed).toBe(true);
+  it('allows global admins', async () => {
+    await seedUser('u-ga', 'telegram');
+    await grantRole({ user_id: 'u-ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: now() });
+    expect((await canAccessAgentGroup('u-ga', 'ag-1')).allowed).toBe(true);
+    expect((await canAccessAgentGroup('u-ga', 'ag-2')).allowed).toBe(true);
   });
 
-  it('scopes admins to their agent group', () => {
-    seedUser('u-sa', 'telegram');
-    grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
-    expect(canAccessAgentGroup('u-sa', 'ag-1').allowed).toBe(true);
-    const denied = canAccessAgentGroup('u-sa', 'ag-2');
+  it('scopes admins to their agent group', async () => {
+    await seedUser('u-sa', 'telegram');
+    await grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
+    expect((await canAccessAgentGroup('u-sa', 'ag-1')).allowed).toBe(true);
+    const denied = await canAccessAgentGroup('u-sa', 'ag-2');
     expect(denied.allowed).toBe(false);
     expect(denied.allowed === false && denied.reason).toBe('not_member');
   });
 
-  it('admin @ group is implicitly a member', () => {
-    seedUser('u-sa', 'telegram');
-    grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
-    expect(isMember('u-sa', 'ag-1')).toBe(true);
+  it('admin @ group is implicitly a member', async () => {
+    await seedUser('u-sa', 'telegram');
+    await grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
+    expect(await isMember('u-sa', 'ag-1')).toBe(true);
   });
 
-  it('allows members of the group', () => {
-    seedUser('u-m', 'telegram');
-    addMember({ user_id: 'u-m', agent_group_id: 'ag-1', added_by: null, added_at: now() });
-    expect(canAccessAgentGroup('u-m', 'ag-1').allowed).toBe(true);
-    expect(canAccessAgentGroup('u-m', 'ag-2').allowed).toBe(false);
+  it('allows members of the group', async () => {
+    await seedUser('u-m', 'telegram');
+    await addMember({ user_id: 'u-m', agent_group_id: 'ag-1', added_by: null, added_at: now() });
+    expect((await canAccessAgentGroup('u-m', 'ag-1')).allowed).toBe(true);
+    expect((await canAccessAgentGroup('u-m', 'ag-2')).allowed).toBe(false);
   });
 
-  it('denies known-but-not-member users', () => {
-    seedUser('u-known', 'telegram');
-    const d = canAccessAgentGroup('u-known', 'ag-1');
+  it('denies known-but-not-member users', async () => {
+    await seedUser('u-known', 'telegram');
+    const d = await canAccessAgentGroup('u-known', 'ag-1');
     expect(d.allowed).toBe(false);
     expect(d.allowed === false && d.reason).toBe('not_member');
   });
 });
 
 describe('role helpers', () => {
-  it('rejects owner rows with a scope', () => {
-    seedUser('u-1', 'telegram');
-    expect(() =>
+  it('rejects owner rows with a scope', async () => {
+    await seedUser('u-1', 'telegram');
+    await expect(
       grantRole({
         user_id: 'u-1',
         role: 'owner',
@@ -152,22 +152,22 @@ describe('role helpers', () => {
         granted_by: null,
         granted_at: now(),
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 
-  it('hasAnyOwner reflects owner grants', () => {
-    seedUser('u-1', 'telegram');
-    expect(hasAnyOwner()).toBe(false);
-    grantRole({ user_id: 'u-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-    expect(hasAnyOwner()).toBe(true);
-    expect(isOwner('u-1')).toBe(true);
+  it('hasAnyOwner reflects owner grants', async () => {
+    await seedUser('u-1', 'telegram');
+    expect(await hasAnyOwner()).toBe(false);
+    await grantRole({ user_id: 'u-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    expect(await hasAnyOwner()).toBe(true);
+    expect(await isOwner('u-1')).toBe(true);
   });
 });
 
 describe('ensureUserDm', () => {
   it('adapter without openDM: falls through to using the bare handle as platform_id', async () => {
     await mountMockAdapter('nodm');
-    seedUser('nodm:123', 'nodm');
+    await seedUser('nodm:123', 'nodm');
 
     const mg = await ensureUserDm('nodm:123');
     expect(mg).toBeDefined();
@@ -175,13 +175,13 @@ describe('ensureUserDm', () => {
     expect(mg!.platform_id).toBe('123');
     expect(mg!.is_group).toBe(0);
 
-    const cached = getUserDm('nodm:123', 'nodm');
+    const cached = await getUserDm('nodm:123', 'nodm');
     expect(cached?.messaging_group_id).toBe(mg!.id);
   });
 
   it('Telegram via chat-sdk-bridge: adapter.openDM returns prefixed platform_id', async () => {
     const mock = await mountMockAdapter('telegram', async (handle) => `telegram:${handle}`);
-    seedUser('telegram:6037840640', 'telegram');
+    await seedUser('telegram:6037840640', 'telegram');
 
     const mg = await ensureUserDm('telegram:6037840640');
     expect(mg).toBeDefined();
@@ -195,7 +195,7 @@ describe('ensureUserDm', () => {
 
   it('resolution-required channels: calls adapter.openDM, uses its result, caches', async () => {
     const mock = await mountMockAdapter('discord', async (handle) => `dm-channel-${handle}`);
-    seedUser('discord:user-1', 'discord');
+    await seedUser('discord:user-1', 'discord');
 
     const mg = await ensureUserDm('discord:user-1');
     expect(mg).toBeDefined();
@@ -208,7 +208,7 @@ describe('ensureUserDm', () => {
   });
 
   it('returns null when the adapter is not registered', async () => {
-    seedUser('missing:42', 'missing');
+    await seedUser('missing:42', 'missing');
     expect(await ensureUserDm('missing:42')).toBeNull();
   });
 
@@ -216,14 +216,14 @@ describe('ensureUserDm', () => {
     await mountMockAdapter('slack', async () => {
       throw new Error('openDM boom');
     });
-    seedUser('slack:u1', 'slack');
+    await seedUser('slack:u1', 'slack');
     expect(await ensureUserDm('slack:u1')).toBeNull();
-    expect(getUserDm('slack:u1', 'slack')).toBeUndefined();
+    expect(await getUserDm('slack:u1', 'slack')).toBeUndefined();
   });
 
   it('reuses an existing messaging_group row if one already matches', async () => {
     await mountMockAdapter('telegram');
-    seedUser('telegram:555', 'telegram');
+    await seedUser('telegram:555', 'telegram');
     const existing = {
       id: 'mg-preexisting',
       channel_type: 'telegram',
@@ -233,10 +233,10 @@ describe('ensureUserDm', () => {
       unknown_sender_policy: 'strict' as const,
       created_at: now(),
     };
-    createMessagingGroup(existing);
+    await createMessagingGroup(existing);
 
     const mg = await ensureUserDm('telegram:555');
     expect(mg?.id).toBe('mg-preexisting');
-    expect(getUserDm('telegram:555', 'telegram')?.messaging_group_id).toBe('mg-preexisting');
+    expect((await getUserDm('telegram:555', 'telegram'))?.messaging_group_id).toBe('mg-preexisting');
   });
 });

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -15,6 +15,7 @@ import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../../db/messaging-groups.js';
 import { upsertUser } from './db/users.js';
@@ -41,7 +42,7 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const row = getDb()
+    const row = sqliteRaw(getDb())
       .prepare(
         `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
@@ -66,8 +67,8 @@ function now() {
 beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
   // Side-effect imports: register hooks (permissions module) AFTER the
   // mocks are in place so the access gate / response handler pick up the
@@ -76,9 +77,9 @@ beforeEach(async () => {
 
   // Fixtures: agent group, messaging group with request_approval, wiring,
   // owner + DM messaging group for approver delivery.
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
 
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-chat',
     channel_type: 'telegram',
     platform_id: 'chat-123',
@@ -87,7 +88,7 @@ beforeEach(async () => {
     unknown_sender_policy: 'request_approval',
     created_at: now(),
   });
-  createMessagingGroupAgent({
+  await createMessagingGroupAgent({
     id: 'mga-1',
     messaging_group_id: 'mg-chat',
     agent_group_id: 'ag-1',
@@ -101,15 +102,15 @@ beforeEach(async () => {
   });
 
   // Owner user + their DM messaging group (pickApprover + ensureUserDm target).
-  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
-  grantRole({
+  await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+  await grantRole({
     user_id: 'telegram:owner',
     role: 'owner',
     agent_group_id: null,
     granted_by: null,
     granted_at: now(),
   });
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-dm-owner',
     channel_type: 'telegram',
     platform_id: 'dm-owner',
@@ -119,7 +120,7 @@ beforeEach(async () => {
     created_at: now(),
   });
   const { getDb } = await import('../../db/connection.js');
-  getDb()
+  sqliteRaw(getDb())
     .prepare(
       `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES (?, ?, ?, ?)`,
@@ -129,8 +130,8 @@ beforeEach(async () => {
   deliverMock.mockClear();
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
@@ -171,7 +172,7 @@ describe('unknown-sender request_approval flow', () => {
     expect(payload.questionId).toMatch(/^nsa-/);
 
     const { getDb } = await import('../../db/connection.js');
-    const rows = getDb().prepare('SELECT * FROM pending_sender_approvals').all();
+    const rows = sqliteRaw(getDb()).prepare('SELECT * FROM pending_sender_approvals').all();
     expect(rows).toHaveLength(1);
   });
 
@@ -184,7 +185,9 @@ describe('unknown-sender request_approval flow', () => {
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
     const { getDb } = await import('../../db/connection.js');
-    const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }).c;
+    const count = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }
+    ).c;
     expect(count).toBe(1);
   });
 
@@ -198,7 +201,7 @@ describe('unknown-sender request_approval flow', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
     expect(pending).toBeDefined();
 
     // Fire the approve click through the response-handler chain.
@@ -218,13 +221,15 @@ describe('unknown-sender request_approval flow', () => {
     }
 
     // Member row added for the stranger against the wired agent group.
-    const member = getDb()
+    const member = sqliteRaw(getDb())
       .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
       .get('tg:stranger', 'ag-1');
     expect(member).toBeDefined();
 
     // Pending row cleared.
-    const stillPending = getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number };
+    const stillPending = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as {
+      c: number;
+    };
     expect(stillPending.c).toBe(0);
 
     // Message replayed + container woken.
@@ -239,7 +244,7 @@ describe('unknown-sender request_approval flow', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
     expect(pending).toBeDefined();
 
     for (const handler of getResponseHandlers()) {
@@ -254,9 +259,11 @@ describe('unknown-sender request_approval flow', () => {
       if (claimed) break;
     }
 
-    const count = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }).c;
+    const count = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }
+    ).c;
     expect(count).toBe(0);
-    const member = getDb()
+    const member = sqliteRaw(getDb())
       .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
       .get('tg:stranger', 'ag-1');
     expect(member).toBeUndefined();
@@ -271,7 +278,7 @@ describe('unknown-sender request_approval flow', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
     expect(pending).toBeDefined();
 
     // A random user (not the stranger, not the owner, not an admin) tries to
@@ -290,21 +297,22 @@ describe('unknown-sender request_approval flow', () => {
     }
 
     // No member added for the stranger.
-    const member = getDb()
+    const member = sqliteRaw(getDb())
       .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
       .get('tg:stranger', 'ag-1');
     expect(member).toBeUndefined();
 
     // Pending row is still there — a legitimate approver can still act on it.
-    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number })
-      .c;
+    const stillPending = (
+      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }
+    ).c;
     expect(stillPending).toBe(1);
   });
 
   it('accepts a click from a global admin even if they are not the designated approver', async () => {
     // Pre-seed a separate admin user so we can click as them.
-    upsertUser({ id: 'telegram:admin-bob', kind: 'telegram', display_name: 'Bob', created_at: now() });
-    grantRole({
+    await upsertUser({ id: 'telegram:admin-bob', kind: 'telegram', display_name: 'Bob', created_at: now() });
+    await grantRole({
       user_id: 'telegram:admin-bob',
       role: 'admin',
       agent_group_id: null,
@@ -319,7 +327,7 @@ describe('unknown-sender request_approval flow', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
     expect(pending).toBeDefined();
 
     // Admin clicks approve (not the designated approver, which was owner).
@@ -336,7 +344,7 @@ describe('unknown-sender request_approval flow', () => {
     }
 
     // Stranger admitted thanks to the admin's authority.
-    const member = getDb()
+    const member = sqliteRaw(getDb())
       .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
       .get('tg:stranger', 'ag-1');
     expect(member).toBeDefined();

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -72,11 +72,11 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
   // request_approval) occupies the UNIQUE(messaging_group_id, sender_identity)
   // key this flow needs — clear it so the in-flight check and the row insert
   // see a clean slate.
-  clearDeclineStamp(messagingGroupId, senderIdentity);
+  await clearDeclineStamp(messagingGroupId, senderIdentity);
 
   // In-flight dedup: don't spam the admin if the same unknown sender
   // retries while a card is already pending.
-  if (hasInFlightSenderApproval(messagingGroupId, senderIdentity)) {
+  if (await hasInFlightSenderApproval(messagingGroupId, senderIdentity)) {
     log.debug('Unknown-sender approval already in flight — dropping retry', {
       messagingGroupId,
       senderIdentity,
@@ -84,7 +84,7 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
     return;
   }
 
-  const approvers = pickApprover(agentGroupId);
+  const approvers = await pickApprover(agentGroupId);
   if (approvers.length === 0) {
     log.warn('Unknown-sender approval skipped — no owner or admin configured', {
       messagingGroupId,
@@ -94,7 +94,7 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
     return;
   }
 
-  const originMg = getMessagingGroup(messagingGroupId);
+  const originMg = await getMessagingGroup(messagingGroupId);
   const originChannelType = originMg?.channel_type ?? '';
   const target = await pickApprovalDelivery(approvers, originChannelType);
   if (!target) {
@@ -114,7 +114,7 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
   const question = `${senderDisplay} wants to talk to your agent in ${originName}. Allow?`;
   const options = normalizeOptions(APPROVAL_OPTIONS);
 
-  createPendingSenderApproval({
+  await createPendingSenderApproval({
     id: approvalId,
     messaging_group_id: messagingGroupId,
     agent_group_id: agentGroupId,
@@ -185,9 +185,9 @@ export const DECLINE_NOTIFY_DEDUPE_MS = 24 * 60 * 60 * 1000;
 const UNKNOWN_SENDER_KEY = 'unknown';
 
 /** First owner with a display_name, for the decline copy. */
-function ownerDisplayName(): string | null {
-  for (const owner of getOwners()) {
-    const name = getUser(owner.user_id)?.display_name;
+async function ownerDisplayName(): Promise<string | null> {
+  for (const owner of await getOwners()) {
+    const name = (await getUser(owner.user_id))?.display_name;
     if (name && name.length > 0) return name;
   }
   return null;
@@ -215,7 +215,7 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
 
   // Dedupe: at most one decline + FYI per (sender, messaging group) per 24h.
   const senderKey = senderIdentity ?? UNKNOWN_SENDER_KEY;
-  const stampedAt = getDeclineStampAt(messagingGroupId, senderKey);
+  const stampedAt = await getDeclineStampAt(messagingGroupId, senderKey);
   if (stampedAt && Date.now() - new Date(stampedAt).getTime() < DECLINE_NOTIFY_DEDUPE_MS) {
     log.debug('decline_notify deduped — declined within the last 24h', { messagingGroupId, senderIdentity });
     return;
@@ -232,9 +232,9 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
   // fall back to the first one (same reference-group pattern as the channel
   // card flow); with zero agent groups the stamp is skipped (no dedupe, rare
   // bootstrap state) but the decline still goes out.
-  const stampAgentGroupId = agentGroupId ?? getAllAgentGroups()[0]?.id;
+  const stampAgentGroupId = agentGroupId ?? (await getAllAgentGroups())[0]?.id;
   if (stampAgentGroupId) {
-    upsertDeclineStamp({
+    await upsertDeclineStamp({
       messaging_group_id: messagingGroupId,
       agent_group_id: stampAgentGroupId,
       sender_identity: senderKey,
@@ -245,12 +245,12 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
     log.debug('decline_notify stamp skipped — no agent groups exist', { messagingGroupId });
   }
 
-  const originMg = getMessagingGroup(messagingGroupId);
+  const originMg = await getMessagingGroup(messagingGroupId);
 
   // (a) Polite decline in the sender's DM, as the bot. Instance-addressed so
   // a per-agent bot identity registered as its own adapter instance
   // answers as itself.
-  const owner = ownerDisplayName();
+  const owner = await ownerDisplayName();
   const declineText = `I'm ${owner ?? 'my owner'}'s personal agent — I can't help you directly.`;
   try {
     await adapter.deliver(
@@ -268,7 +268,7 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
 
   // (b) Owner FYI — informational one-liner through the same approver-DM
   // resolution the card flows use.
-  const approvers = pickApprover(agentGroupId);
+  const approvers = await pickApprover(agentGroupId);
   if (approvers.length === 0) {
     log.warn('decline_notify FYI skipped — no owner or admin configured', { messagingGroupId, senderIdentity });
     return;

--- a/src/modules/permissions/sender-decline-notify.test.ts
+++ b/src/modules/permissions/sender-decline-notify.test.ts
@@ -15,6 +15,7 @@ import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent, updateMessagingGroup } from '../../db/messaging-groups.js';
 import { upsertUser } from './db/users.js';
@@ -41,7 +42,8 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const row = getDb()
+    const { sqliteRaw } = await import('../../db/drivers/sqlite.js');
+    const row = sqliteRaw(getDb())
       .prepare(
         `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
@@ -66,8 +68,8 @@ function now() {
 beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
   // Side-effect imports: register hooks (permissions module) AFTER the
   // mocks are in place.
@@ -75,9 +77,9 @@ beforeEach(async () => {
 
   // Fixtures: agent group, a wired 1:1 DM messaging group with
   // decline_notify (a DM-shaped channel), owner + owner DM.
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
 
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-dm-stranger',
     channel_type: 'telegram',
     platform_id: 'dm-stranger',
@@ -86,7 +88,7 @@ beforeEach(async () => {
     unknown_sender_policy: 'decline_notify',
     created_at: now(),
   });
-  createMessagingGroupAgent({
+  await createMessagingGroupAgent({
     id: 'mga-1',
     messaging_group_id: 'mg-dm-stranger',
     agent_group_id: 'ag-1',
@@ -100,15 +102,15 @@ beforeEach(async () => {
   });
 
   // Owner user (with display name — feeds the decline copy) + their DM.
-  upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Gavriel', created_at: now() });
-  grantRole({
+  await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Gavriel', created_at: now() });
+  await grantRole({
     user_id: 'telegram:owner',
     role: 'owner',
     agent_group_id: null,
     granted_by: null,
     granted_at: now(),
   });
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-dm-owner',
     channel_type: 'telegram',
     platform_id: 'dm-owner',
@@ -118,7 +120,7 @@ beforeEach(async () => {
     created_at: now(),
   });
   const { getDb } = await import('../../db/connection.js');
-  getDb()
+  sqliteRaw(getDb())
     .prepare(
       `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES (?, ?, ?, ?)`,
@@ -128,8 +130,8 @@ beforeEach(async () => {
   deliverMock.mockClear();
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
@@ -192,16 +194,18 @@ describe('unknown-sender decline_notify flow', () => {
     // Drop recorded. (The gate writes reason 'unknown_sender_decline_notify';
     // core's structural no_agent_engaged record then upserts the same row —
     // pre-existing behavior shared with every refusal path.)
-    const drop = getDb()
+    const drop = sqliteRaw(getDb())
       .prepare('SELECT user_id FROM unregistered_senders WHERE platform_id = ?')
       .get('dm-stranger') as { user_id: string };
     expect(drop.user_id).toBe('tg:stranger');
 
     // No card rows anywhere — only the decline stamp.
-    const rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    const rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^decline:/);
-    const channelRows = getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number };
+    const channelRows = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as {
+      c: number;
+    };
     expect(channelRows.c).toBe(0);
   });
 
@@ -219,7 +223,7 @@ describe('unknown-sender decline_notify flow', () => {
     // no_agent_engaged record — pre-existing double-count on refusals).
     expect(deliverMock).toHaveBeenCalledTimes(2);
     const { getDb } = await import('../../db/connection.js');
-    const drop = getDb()
+    const drop = sqliteRaw(getDb())
       .prepare('SELECT message_count FROM unregistered_senders WHERE platform_id = ?')
       .get('dm-stranger') as { message_count: number };
     expect(drop.message_count).toBe(4);
@@ -234,13 +238,13 @@ describe('unknown-sender decline_notify flow', () => {
     // Age the stamp past the window.
     const { getDb } = await import('../../db/connection.js');
     const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
-    getDb().prepare(`UPDATE pending_sender_approvals SET created_at = ? WHERE id LIKE 'decline:%'`).run(old);
+    sqliteRaw(getDb()).prepare(`UPDATE pending_sender_approvals SET created_at = ? WHERE id LIKE 'decline:%'`).run(old);
 
     await routeInbound(strangerDm('hello again'));
     await settle();
 
     expect(deliverMock).toHaveBeenCalledTimes(4); // second decline + FYI pair
-    const stamp = getDb()
+    const stamp = sqliteRaw(getDb())
       .prepare(`SELECT created_at FROM pending_sender_approvals WHERE id LIKE 'decline:%'`)
       .get() as {
       created_at: string;
@@ -250,19 +254,19 @@ describe('unknown-sender decline_notify flow', () => {
 
   it('flip request_approval→decline_notify with a card pending: card row converts to a stamp, dedupe holds', async () => {
     // Start on request_approval — the stranger's first message cards.
-    updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
+    await updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hello'));
     await settle();
     expect(deliverMock).toHaveBeenCalledTimes(1); // the approval card
 
     const { getDb } = await import('../../db/connection.js');
-    let rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    let rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^nsa-/);
 
     // Operator flips the policy while the card is still pending.
-    updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'decline_notify' });
+    await updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'decline_notify' });
     deliverMock.mockClear();
 
     await routeInbound(strangerDm('are you there?'));
@@ -271,7 +275,7 @@ describe('unknown-sender decline_notify flow', () => {
     // Decline + FYI went out; the pending card row became the stamp (the
     // UNIQUE(messaging_group_id, sender_identity) collision converts it).
     expect(deliverMock).toHaveBeenCalledTimes(2);
-    rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^decline:/);
 
@@ -282,7 +286,7 @@ describe('unknown-sender decline_notify flow', () => {
   });
 
   it('decline_notify on a group messaging group: silent drop — no public decline, no FYI', async () => {
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'mg-team',
       channel_type: 'telegram',
       platform_id: 'group-team',
@@ -291,7 +295,7 @@ describe('unknown-sender decline_notify flow', () => {
       unknown_sender_policy: 'decline_notify',
       created_at: now(),
     });
-    createMessagingGroupAgent({
+    await createMessagingGroupAgent({
       id: 'mga-team',
       messaging_group_id: 'mg-team',
       agent_group_id: 'ag-1',
@@ -312,11 +316,13 @@ describe('unknown-sender decline_notify flow', () => {
     // posted publicly into the group channel; no stamp either.
     expect(deliverMock).not.toHaveBeenCalled();
     const { getDb } = await import('../../db/connection.js');
-    const drop = getDb()
+    const drop = sqliteRaw(getDb())
       .prepare('SELECT user_id FROM unregistered_senders WHERE platform_id = ?')
       .get('group-team') as { user_id: string };
     expect(drop.user_id).toBe('tg:stranger');
-    const stamps = getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number };
+    const stamps = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as {
+      c: number;
+    };
     expect(stamps.c).toBe(0);
   });
 
@@ -326,7 +332,7 @@ describe('unknown-sender decline_notify flow', () => {
     await settle();
     expect(deliverMock).toHaveBeenCalledTimes(2);
 
-    updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
+    await updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
     deliverMock.mockClear();
 
     await routeInbound(strangerDm('let me in'));
@@ -340,7 +346,7 @@ describe('unknown-sender decline_notify flow', () => {
     expect(payload.type).toBe('ask_question');
 
     const { getDb } = await import('../../db/connection.js');
-    const rows = getDb().prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    const rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^nsa-/); // real card row; stamp gone
   });

--- a/src/modules/permissions/user-dm.test.ts
+++ b/src/modules/permissions/user-dm.test.ts
@@ -17,6 +17,7 @@ import {
   teardownChannelAdapters,
 } from '../../channels/channel-registry.js';
 import { closeDb, getDb, initTestDb } from '../../db/connection.js';
+import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createMessagingGroup } from '../../db/messaging-groups.js';
 import { runMigrations } from '../../db/migrations/index.js';
 import { log } from '../../log.js';
@@ -28,8 +29,8 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function seedUser(id: string, kind: string): void {
-  createUser({ id, kind, display_name: null, created_at: now() });
+async function seedUser(id: string, kind: string): Promise<void> {
+  await createUser({ id, kind, display_name: null, created_at: now() });
 }
 
 function registerTestAdapter(channelType: string, openDM?: (handle: string) => Promise<string>): void {
@@ -58,15 +59,15 @@ async function startRegisteredAdapters(): Promise<void> {
   }));
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
 afterEach(async () => {
   await teardownChannelAdapters();
-  closeDb();
+  await closeDb();
 });
 
 describe('ensureUserDm privacy-safe logging', () => {
@@ -76,7 +77,7 @@ describe('ensureUserDm privacy-safe logging', () => {
       throw failure;
     });
     await startRegisteredAdapters();
-    seedUser('legacy-default:default-handle-sentinel', 'legacy-default');
+    await seedUser('legacy-default:default-handle-sentinel', 'legacy-default');
 
     await expect(ensureUserDm('legacy-default:default-handle-sentinel')).resolves.toBeNull();
 
@@ -94,11 +95,11 @@ describe('ensureUserDm privacy-safe logging', () => {
     registerTestAdapter('privacy-direct');
     await startRegisteredAdapters();
 
-    seedUser('privacy-error:private-handle-sentinel', 'privacy-error');
-    seedUser('privacy-direct:stale-handle-sentinel', 'privacy-direct');
-    seedUser('invalid-user-private-sentinel', 'invalid-kind');
+    await seedUser('privacy-error:private-handle-sentinel', 'privacy-error');
+    await seedUser('privacy-direct:stale-handle-sentinel', 'privacy-direct');
+    await seedUser('invalid-user-private-sentinel', 'invalid-kind');
 
-    createMessagingGroup({
+    await createMessagingGroup({
       id: 'messaging-group-private-sentinel',
       channel_type: 'privacy-direct',
       platform_id: 'old-platform-private-sentinel',
@@ -107,15 +108,16 @@ describe('ensureUserDm privacy-safe logging', () => {
       unknown_sender_policy: 'strict',
       created_at: now(),
     });
-    upsertUserDm({
+    await upsertUserDm({
       user_id: 'privacy-direct:stale-handle-sentinel',
       channel_type: 'privacy-direct',
       messaging_group_id: 'messaging-group-private-sentinel',
       resolved_at: now(),
     });
-    getDb().pragma('foreign_keys = OFF');
-    getDb().prepare("DELETE FROM messaging_groups WHERE id = 'messaging-group-private-sentinel'").run();
-    getDb().pragma('foreign_keys = ON');
+    const db = sqliteRaw(getDb());
+    db.pragma('foreign_keys = OFF');
+    db.prepare("DELETE FROM messaging_groups WHERE id = 'messaging-group-private-sentinel'").run();
+    db.pragma('foreign_keys = ON');
 
     const options = { privacySafeLogs: true };
     await expect(ensureUserDm('unknown-user-private-sentinel', options)).resolves.toBeNull();

--- a/src/modules/permissions/user-dm.ts
+++ b/src/modules/permissions/user-dm.ts
@@ -55,7 +55,7 @@ export async function ensureUserDm(
   userId: string,
   { privacySafeLogs = false }: { privacySafeLogs?: boolean } = {},
 ): Promise<MessagingGroup | null> {
-  const user = getUser(userId);
+  const user = await getUser(userId);
   if (!user) {
     log.warn('ensureUserDm: user not found', privacySafeLogs ? undefined : { userId });
     return null;
@@ -68,9 +68,9 @@ export async function ensureUserDm(
   }
 
   // Cache hit: existing user_dms row → load and return the messaging_group.
-  const cached = getUserDm(userId, channelType);
+  const cached = await getUserDm(userId, channelType);
   if (cached) {
-    const mg = getMessagingGroup(cached.messaging_group_id);
+    const mg = await getMessagingGroup(cached.messaging_group_id);
     if (mg) return mg;
     // Row points to a deleted messaging_group — fall through and re-resolve.
     log.warn(
@@ -86,7 +86,7 @@ export async function ensureUserDm(
   // Find-or-create the underlying messaging_group. A DM we received
   // earlier may already have a row matching (channel_type, platform_id).
   const now = new Date().toISOString();
-  let mg = getMessagingGroupByPlatform(channelType, dmPlatformId);
+  let mg = await getMessagingGroupByPlatform(channelType, dmPlatformId);
   if (!mg) {
     const mgId = `mg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     mg = {
@@ -102,14 +102,14 @@ export async function ensureUserDm(
       unknown_sender_policy: 'strict',
       created_at: now,
     };
-    createMessagingGroup(mg);
+    await createMessagingGroup(mg);
     log.info(
       'ensureUserDm: created DM messaging_group',
       privacySafeLogs ? { channelType } : { userId, channelType, messagingGroupId: mgId },
     );
   }
 
-  upsertUserDm({
+  await upsertUserDm({
     user_id: userId,
     channel_type: channelType,
     messaging_group_id: mg.id,

--- a/src/modules/scheduling/create.ts
+++ b/src/modules/scheduling/create.ts
@@ -141,13 +141,13 @@ export function prepareScheduledTask(input: {
 }
 
 /** Persist a prepared task through NanoClaw's single task/session representation. */
-export function createScheduledTask(
+export async function createScheduledTask(
   agentGroupId: string,
   task: PreparedScheduledTask,
   options?: { status?: 'pending' | 'paused'; originSessionId?: string | null },
-): { session: { id: string; agent_group_id: string }; row: ScheduledTaskRow } {
+): Promise<{ session: { id: string; agent_group_id: string }; row: ScheduledTaskRow }> {
   const id = makeTaskId(task.name);
-  const { session } = resolveTaskSession(agentGroupId, id);
+  const { session } = await resolveTaskSession(agentGroupId, id);
 
   if (!fs.existsSync(inboundDbPath(agentGroupId, session.id))) {
     throw new Error('task system session inbound.db not found');

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -39,9 +39,9 @@ export function scriptBackoffMinutes(fails: number): number {
  *  appendRunLog helper (one writer format); appendRunLog throws on a bad
  *  series charset or a missing agent group, and the sweep must not crash
  *  over a log line, so failures are logged and swallowed. */
-function appendHostTaskNote(agentGroupId: string, seriesId: string, note: string): void {
+async function appendHostTaskNote(agentGroupId: string, seriesId: string, note: string): Promise<void> {
   try {
-    appendRunLog(agentGroupId, seriesId, note);
+    await appendRunLog(agentGroupId, seriesId, note);
   } catch (err) {
     log.warn('Could not append host task note to run log', { agentGroupId, seriesId, err });
   }
@@ -52,7 +52,7 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
   // Resolved per call, not cached at module load: a group timezone change
   // (approved `groups config update --timezone`) must shift the series from
   // the very next re-arm.
-  const tz = resolveGroupTimezone(session.agent_group_id);
+  const tz = await resolveGroupTimezone(session.agent_group_id);
 
   for (const msg of recurring) {
     try {
@@ -71,7 +71,7 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
         // series in place; leave the why in the run log.
         insertRecurrence(inDb, msg, newId, cronNext.toISOString(), 'paused');
         clearRecurrence(inDb, msg.id);
-        appendHostTaskNote(
+        await appendHostTaskNote(
           session.agent_group_id,
           msg.series_id,
           `auto-paused after ${scriptFails} consecutive script failures (host); fix the script, then \`ncl tasks resume ${msg.series_id}\``,

--- a/src/modules/scheduling/run-log.ts
+++ b/src/modules/scheduling/run-log.ts
@@ -14,18 +14,18 @@ import { resolveGroupTimezone } from '../../container-config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { formatLocalStamp } from '../../timezone.js';
 
-export function appendRunLog(
+export async function appendRunLog(
   agentGroupId: string,
   series: string,
   msg: string,
-): { series: string; timestamp: string; path: string } {
+): Promise<{ series: string; timestamp: string; path: string }> {
   // Charset guard is the security boundary: blocks path traversal and keeps
   // the id safe as a filename. Callers resolve group scope before this.
   if (!/^[a-z0-9-]+$/.test(series)) throw new Error(`invalid task id: ${series}`);
-  const ag = getAgentGroup(agentGroupId);
+  const ag = await getAgentGroup(agentGroupId);
   if (!ag) throw new Error(`agent group not found: ${agentGroupId}`);
 
-  const timestamp = formatLocalStamp(new Date(), resolveGroupTimezone(agentGroupId));
+  const timestamp = formatLocalStamp(new Date(), await resolveGroupTimezone(agentGroupId));
   const dir = `${GROUPS_DIR}/${ag.folder}/tasks`;
   const file = `${dir}/${series}.md`;
   fs.mkdirSync(dir, { recursive: true });

--- a/src/modules/self-mod/apply.test.ts
+++ b/src/modules/self-mod/apply.test.ts
@@ -28,22 +28,22 @@ import { applyAddMcpServer } from './apply.js';
 const TEST_DIR = '/tmp/nanoclaw-test-self-mod-apply';
 const session = { id: 'session-1', agent_group_id: 'ag-1' } as Session;
 
-beforeEach(() => {
+beforeEach(async () => {
   fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  runMigrations(initTestDb());
-  createAgentGroup({
+  await runMigrations(await initTestDb());
+  await createAgentGroup({
     id: 'ag-1',
     name: 'Agent',
     folder: 'agent',
     agent_provider: null,
     created_at: new Date().toISOString(),
   });
-  ensureContainerConfig('ag-1');
+  await ensureContainerConfig('ag-1');
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -51,19 +51,19 @@ describe('applyAddMcpServer', () => {
   it('persists approved HTTPS MCP config', async () => {
     await applyAddMcpServer({ name: 'remote', type: 'http', url: 'https://mcp.example.com/mcp' }, session);
 
-    expect(JSON.parse(getContainerConfig('ag-1')!.mcp_servers)).toEqual({
+    expect(JSON.parse((await getContainerConfig('ag-1'))!.mcp_servers)).toEqual({
       remote: { type: 'http', url: 'https://mcp.example.com/mcp' },
     });
   });
 
   it('refuses to overwrite a plugin-owned server even after approval', async () => {
-    updateContainerConfigJson('ag-1', 'mcp_servers', {
+    await updateContainerConfigJson('ag-1', 'mcp_servers', {
       docs: { type: 'http', url: 'https://mcp.example.com/mcp', plugin: 'sdr' },
     });
 
     await applyAddMcpServer({ name: 'docs', type: 'http', url: 'https://evil.example.com/mcp' }, session);
 
-    expect(JSON.parse(getContainerConfig('ag-1')!.mcp_servers)).toEqual({
+    expect(JSON.parse((await getContainerConfig('ag-1'))!.mcp_servers)).toEqual({
       docs: { type: 'http', url: 'https://mcp.example.com/mcp', plugin: 'sdr' },
     });
   });

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -26,16 +26,21 @@ import { writeSessionMessage } from '../../session-manager.js';
 import type { Session } from '../../types.js';
 import { notifyAgent } from '../approvals/index.js';
 
+async function wakeSessionById(sessionId: string): Promise<void> {
+  const session = await getSession(sessionId);
+  if (session) await wakeContainer(session);
+}
+
 export async function applyInstallPackages(payload: Record<string, unknown>, session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) {
-    notifyAgent(session, 'install_packages approved but agent group missing.');
+    await notifyAgent(session, 'install_packages approved but agent group missing.');
     return;
   }
 
-  const configRow = getContainerConfig(agentGroup.id);
+  const configRow = await getContainerConfig(agentGroup.id);
   if (!configRow) {
-    notifyAgent(session, 'install_packages approved but container config missing.');
+    await notifyAgent(session, 'install_packages approved but container config missing.');
     return;
   }
 
@@ -45,14 +50,14 @@ export async function applyInstallPackages(payload: Record<string, unknown>, ses
     for (const pkg of payload.apt as string[]) {
       if (!existing.includes(pkg)) existing.push(pkg);
     }
-    updateContainerConfigJson(agentGroup.id, 'packages_apt', existing);
+    await updateContainerConfigJson(agentGroup.id, 'packages_apt', existing);
   }
   if (payload.npm) {
     const existing = JSON.parse(configRow.packages_npm) as string[];
     for (const pkg of payload.npm as string[]) {
       if (!existing.includes(pkg)) existing.push(pkg);
     }
-    updateContainerConfigJson(agentGroup.id, 'packages_npm', existing);
+    await updateContainerConfigJson(agentGroup.id, 'packages_npm', existing);
   }
 
   const pkgs = [
@@ -62,7 +67,7 @@ export async function applyInstallPackages(payload: Record<string, unknown>, ses
   log.info('Package install approved', { agentGroupId: session.agent_group_id });
   try {
     await buildAgentGroupImage(session.agent_group_id);
-    writeSessionMessage(session.agent_group_id, session.id, {
+    await writeSessionMessage(session.agent_group_id, session.id, {
       id: `appr-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       kind: 'chat',
       timestamp: new Date().toISOString(),
@@ -77,12 +82,11 @@ export async function applyInstallPackages(payload: Record<string, unknown>, ses
       onWake: 1,
     });
     killContainer(session.id, 'rebuild applied', () => {
-      const s = getSession(session.id);
-      if (s) void wakeContainer(s);
+      void wakeSessionById(session.id);
     });
     log.info('Container rebuild completed (bundled with install)', { agentGroupId: session.agent_group_id });
   } catch (e) {
-    notifyAgent(
+    await notifyAgent(
       session,
       `Packages added to config (${pkgs}) but rebuild failed: ${e instanceof Error ? e.message : String(e)}. Tell the user — an admin will need to retry the install_packages request or inspect the build logs.`,
     );
@@ -91,22 +95,22 @@ export async function applyInstallPackages(payload: Record<string, unknown>, ses
 }
 
 export async function applyAddMcpServer(payload: Record<string, unknown>, session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) {
-    notifyAgent(session, 'add_mcp_server approved but agent group missing.');
+    await notifyAgent(session, 'add_mcp_server approved but agent group missing.');
     return;
   }
 
-  const configRow = getContainerConfig(agentGroup.id);
+  const configRow = await getContainerConfig(agentGroup.id);
   if (!configRow) {
-    notifyAgent(session, 'add_mcp_server approved but container config missing.');
+    await notifyAgent(session, 'add_mcp_server approved but container config missing.');
     return;
   }
 
   // Add the new MCP server to the existing map in the DB
   const name = typeof payload.name === 'string' ? payload.name : '';
   if (!name) {
-    notifyAgent(session, 'add_mcp_server approved but server name is missing.');
+    await notifyAgent(session, 'add_mcp_server approved but server name is missing.');
     return;
   }
   let serverConfig: McpServerConfig;
@@ -115,7 +119,7 @@ export async function applyAddMcpServer(payload: Record<string, unknown>, sessio
     serverConfig = parseMcpServerConfig(payload);
     // eslint-disable-next-line no-catch-all/no-catch-all -- approval payload validation must fail closed
   } catch (err) {
-    notifyAgent(
+    await notifyAgent(
       session,
       `add_mcp_server approved but config is invalid: ${err instanceof Error ? err.message : String(err)}.`,
     );
@@ -126,7 +130,7 @@ export async function applyAddMcpServer(payload: Record<string, unknown>, sessio
   // that stamped a plugin server under this name after the card went out.
   const owner = mcpServerPluginOwner(servers[name]);
   if (owner) {
-    notifyAgent(
+    await notifyAgent(
       session,
       `add_mcp_server approved but server "${name}" is owned by plugin "${owner}" — ` +
         'plugin servers can only be changed by updating the plugin and re-stamping.',
@@ -134,9 +138,9 @@ export async function applyAddMcpServer(payload: Record<string, unknown>, sessio
     return;
   }
   servers[name] = serverConfig;
-  updateContainerConfigJson(agentGroup.id, 'mcp_servers', servers);
+  await updateContainerConfigJson(agentGroup.id, 'mcp_servers', servers);
 
-  writeSessionMessage(session.agent_group_id, session.id, {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `appr-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     kind: 'chat',
     timestamp: new Date().toISOString(),
@@ -151,8 +155,7 @@ export async function applyAddMcpServer(payload: Record<string, unknown>, sessio
     onWake: 1,
   });
   killContainer(session.id, 'mcp server added', () => {
-    const s = getSession(session.id);
-    if (s) void wakeContainer(s);
+    void wakeSessionById(session.id);
   });
   log.info('MCP server add approved', { agentGroupId: session.agent_group_id });
 }

--- a/src/modules/self-mod/request.test.ts
+++ b/src/modules/self-mod/request.test.ts
@@ -71,15 +71,15 @@ const fakeAdapter: ChannelDeliveryAdapter = {
 
 let session: Session;
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
   delivered = [];
 
-  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
   session = {
     id: 'sess-1',
     agent_group_id: 'ag-1',
@@ -91,13 +91,19 @@ beforeEach(() => {
     last_active: now(),
     created_at: now(),
   };
-  createSession(session);
+  await createSession(session);
 
   // Authorized approver + a cached DM so ensureUserDm resolves without a
   // platform openDM call.
-  upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
-  grantRole({ user_id: 'slack:admin-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
-  createMessagingGroup({
+  await upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
+  await grantRole({
+    user_id: 'slack:admin-1',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now(),
+  });
+  await createMessagingGroup({
     id: 'mg-dm-1',
     channel_type: DM_CHANNEL,
     platform_id: DM_PLATFORM,
@@ -106,7 +112,7 @@ beforeEach(() => {
     unknown_sender_policy: 'strict',
     created_at: now(),
   });
-  upsertUserDm({
+  await upsertUserDm({
     user_id: 'slack:admin-1',
     channel_type: DM_CHANNEL,
     messaging_group_id: 'mg-dm-1',
@@ -116,8 +122,8 @@ beforeEach(() => {
   setDeliveryAdapter(fakeAdapter);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -141,14 +147,14 @@ function lastNotifyText(): string {
  * is the production path for every case these tests cover.
  */
 async function submitAddMcpServer(content: Record<string, unknown>, s: Session): Promise<void> {
-  if (!validateAddMcpServer(content, s)) return;
+  if (!(await validateAddMcpServer(content, s))) return;
   await requestAddMcpServerHold(content, s);
 }
 
 /** Assert the handler rejected: no card delivered, no row, agent notified with a failure. */
-function expectRejected(): string {
+async function expectRejected(): Promise<string> {
   expect(delivered).toHaveLength(0);
-  expect(getPendingApprovalsByAction('add_mcp_server')).toHaveLength(0);
+  expect(await getPendingApprovalsByAction('add_mcp_server')).toHaveLength(0);
   expect(vi.mocked(writeSessionMessage)).toHaveBeenCalled();
   const text = lastNotifyText();
   expect(text).toMatch(/add_mcp_server failed/);
@@ -193,7 +199,7 @@ describe('add_mcp_server approval card', () => {
     const question = lastQuestion();
     expect(question).toContain('type: "http"');
     expect(question).toContain('url: "https://mcp.example.com/mcp"');
-    const rows = getPendingApprovalsByAction('add_mcp_server');
+    const rows = await getPendingApprovalsByAction('add_mcp_server');
     expect(JSON.parse(rows[0].payload)).toEqual({
       name: 'docs',
       type: 'http',
@@ -269,24 +275,24 @@ describe('add_mcp_server validation', () => {
   it('rejects a server name carrying config syntax before creating an approval', async () => {
     await submitAddMcpServer({ name: 'docs]\n[mcp_servers.evil]', url: 'https://mcp.example.com/mcp' }, session);
 
-    expect(expectRejected()).toMatch(/1-64 characters/);
+    expect(await expectRejected()).toMatch(/1-64 characters/);
   });
 
   it('rejects editing a plugin-owned server before creating an approval', async () => {
-    ensureContainerConfig('ag-1');
-    updateContainerConfigJson('ag-1', 'mcp_servers', {
+    await ensureContainerConfig('ag-1');
+    await updateContainerConfigJson('ag-1', 'mcp_servers', {
       docs: { type: 'http', url: 'https://mcp.example.com/mcp', plugin: 'sdr' },
     });
 
     await submitAddMcpServer({ name: 'docs', url: 'https://evil.example.com/mcp' }, session);
 
-    expect(expectRejected()).toMatch(/owned by plugin "sdr"/);
+    expect(await expectRejected()).toMatch(/owned by plugin "sdr"/);
   });
 
   it('rejects an env key that is not a valid environment variable name', async () => {
     await submitAddMcpServer({ name: 'ok', command: 'node', env: { 'BAD KEY': 'v' } }, session);
 
-    expect(expectRejected()).toMatch(/valid environment variable name/);
+    expect(await expectRejected()).toMatch(/valid environment variable name/);
   });
 
   it('rejects a cwd on a raw payload before creating an approval', async () => {
@@ -294,29 +300,29 @@ describe('add_mcp_server validation', () => {
     // against), so an approver must never be asked to sign it.
     await submitAddMcpServer({ name: 'ok', command: 'node', cwd: '${PLUGIN_DATA}/work' }, session);
 
-    expect(expectRejected()).toMatch(/only supported for plugin-shipped/);
+    expect(await expectRejected()).toMatch(/only supported for plugin-shipped/);
   });
 
   it('rejects a credential-bearing URL before creating an approval', async () => {
     await submitAddMcpServer({ name: 'bad', url: 'https://mcp.example.com/mcp?api_key=secret' }, session);
 
-    expect(expectRejected()).toMatch(/looks like a credential/);
+    expect(await expectRejected()).toMatch(/looks like a credential/);
   });
 
   it('rejects args and env for an HTTPS server before creating an approval', async () => {
     await submitAddMcpServer({ name: 'bad', url: 'https://mcp.example.com/mcp', env: { TOKEN: 'secret' } }, session);
 
-    expect(expectRejected()).toMatch(/only valid with command/);
+    expect(await expectRejected()).toMatch(/only valid with command/);
   });
 
   it('rejects a non-string element in args before creating an approval', async () => {
     await submitAddMcpServer({ name: 'bad', command: 'node', args: ['ok', 123] }, session);
-    expectRejected();
+    await expectRejected();
   });
 
   it('rejects a non-record env before creating an approval', async () => {
     await submitAddMcpServer({ name: 'bad', command: 'node', env: ['not', 'a', 'record'] }, session);
-    expectRejected();
+    await expectRejected();
   });
 
   it('accepts 32 args and rejects 33', async () => {
@@ -417,7 +423,7 @@ describe('add_mcp_server secret redaction', () => {
     expect(question).toContain('--token');
 
     // The approval payload carries the verbatim values — applied unchanged.
-    const rows = getPendingApprovalsByAction('add_mcp_server');
+    const rows = await getPendingApprovalsByAction('add_mcp_server');
     expect(rows).toHaveLength(1);
     const payload = JSON.parse(rows[0].payload) as {
       args: string[];
@@ -437,7 +443,7 @@ describe('add_mcp_server secret redaction', () => {
     expect(question).not.toContain(token);
     expect(question).toContain(redactedForm(token));
 
-    const rows = getPendingApprovalsByAction('add_mcp_server');
+    const rows = await getPendingApprovalsByAction('add_mcp_server');
     expect(JSON.parse(rows[0].payload)).toEqual({ name: 'zap', type: 'http', url });
   });
 

--- a/src/modules/self-mod/request.ts
+++ b/src/modules/self-mod/request.ts
@@ -21,10 +21,10 @@ import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { notifyAgent, requestApproval } from '../approvals/index.js';
 
-export function validateInstallPackages(content: Record<string, unknown>, session: Session): boolean {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+export async function validateInstallPackages(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) {
-    notifyAgent(session, 'install_packages failed: agent group not found.');
+    await notifyAgent(session, 'install_packages failed: agent group not found.');
     return false;
   }
 
@@ -35,22 +35,22 @@ export function validateInstallPackages(content: Record<string, unknown>, sessio
   const NPM_RE = /^(@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
   const MAX_PACKAGES = 20;
   if (apt.length + npm.length === 0) {
-    notifyAgent(session, 'install_packages failed: at least one apt or npm package is required.');
+    await notifyAgent(session, 'install_packages failed: at least one apt or npm package is required.');
     return false;
   }
   if (apt.length + npm.length > MAX_PACKAGES) {
-    notifyAgent(session, `install_packages failed: max ${MAX_PACKAGES} packages per request.`);
+    await notifyAgent(session, `install_packages failed: max ${MAX_PACKAGES} packages per request.`);
     return false;
   }
   const invalidApt = apt.find((p) => !APT_RE.test(p));
   if (invalidApt) {
-    notifyAgent(session, `install_packages failed: invalid apt package name "${invalidApt}".`);
+    await notifyAgent(session, `install_packages failed: invalid apt package name "${invalidApt}".`);
     log.warn('install_packages: invalid apt package rejected', { pkg: invalidApt });
     return false;
   }
   const invalidNpm = npm.find((p) => !NPM_RE.test(p));
   if (invalidNpm) {
-    notifyAgent(session, `install_packages failed: invalid npm package name "${invalidNpm}".`);
+    await notifyAgent(session, `install_packages failed: invalid npm package name "${invalidNpm}".`);
     log.warn('install_packages: invalid npm package rejected', { pkg: invalidNpm });
     return false;
   }
@@ -58,7 +58,7 @@ export function validateInstallPackages(content: Record<string, unknown>, sessio
 }
 
 export async function requestInstallPackagesHold(content: Record<string, unknown>, session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) return;
   const apt = (content.apt as string[]) || [];
   const npm = (content.npm as string[]) || [];
@@ -119,15 +119,15 @@ export function escapeInvisibles(s: string): string {
   });
 }
 
-export function validateAddMcpServer(content: Record<string, unknown>, session: Session): boolean {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+export async function validateAddMcpServer(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) {
-    notifyAgent(session, 'add_mcp_server failed: agent group not found.');
+    await notifyAgent(session, 'add_mcp_server failed: agent group not found.');
     return false;
   }
   const serverName = typeof content.name === 'string' ? content.name : '';
   if (!serverName) {
-    notifyAgent(session, 'add_mcp_server failed: name is required.');
+    await notifyAgent(session, 'add_mcp_server failed: name is required.');
     return false;
   }
   let serverConfig;
@@ -136,18 +136,18 @@ export function validateAddMcpServer(content: Record<string, unknown>, session: 
     serverConfig = parseMcpServerConfig(content);
     // eslint-disable-next-line no-catch-all/no-catch-all -- parse failures are expected user input errors
   } catch (err) {
-    notifyAgent(session, `add_mcp_server failed: ${err instanceof Error ? err.message : String(err)}.`);
+    await notifyAgent(session, `add_mcp_server failed: ${err instanceof Error ? err.message : String(err)}.`);
     return false;
   }
 
   // Plugin-owned servers are template content: reject before an approval round
   // is spent — the only sanctioned change path is updating the plugin and
   // re-stamping (apply.ts re-checks in case an approval races a restamp).
-  const configRow = getContainerConfig(agentGroup.id);
+  const configRow = await getContainerConfig(agentGroup.id);
   const existing = configRow ? (JSON.parse(configRow.mcp_servers) as Record<string, unknown>)[serverName] : undefined;
   const owner = mcpServerPluginOwner(existing);
   if (owner) {
-    notifyAgent(
+    await notifyAgent(
       session,
       `add_mcp_server failed: server "${serverName}" is owned by plugin "${owner}". ` +
         'Plugin servers can only be changed by updating the plugin and re-stamping (ncl groups create --template <ref> --yes).',
@@ -160,7 +160,7 @@ export function validateAddMcpServer(content: Record<string, unknown>, session: 
   // would be silently dropped). Rejecting keeps the card honest: an approver
   // must never sign a working directory that won't take effect.
   if (serverConfig.type !== 'http' && serverConfig.cwd !== undefined) {
-    notifyAgent(session, 'add_mcp_server failed: cwd is only supported for plugin-shipped servers.');
+    await notifyAgent(session, 'add_mcp_server failed: cwd is only supported for plugin-shipped servers.');
     return false;
   }
 
@@ -168,22 +168,22 @@ export function validateAddMcpServer(content: Record<string, unknown>, session: 
   const env = serverConfig.type === 'http' ? {} : (serverConfig.env ?? {});
 
   if (args.length > MAX_MCP_ARGS) {
-    notifyAgent(session, `add_mcp_server failed: max ${MAX_MCP_ARGS} args per server.`);
+    await notifyAgent(session, `add_mcp_server failed: max ${MAX_MCP_ARGS} args per server.`);
     return false;
   }
   if (Object.keys(env).length > MAX_MCP_ENV_VARS) {
-    notifyAgent(session, `add_mcp_server failed: max ${MAX_MCP_ENV_VARS} env vars per server.`);
+    await notifyAgent(session, `add_mcp_server failed: max ${MAX_MCP_ENV_VARS} env vars per server.`);
     return false;
   }
   if (Buffer.byteLength(JSON.stringify({ name: serverName, ...serverConfig }), 'utf8') > MCP_PAYLOAD_MAX_BYTES) {
-    notifyAgent(session, `add_mcp_server failed: payload exceeds ${MCP_PAYLOAD_MAX_BYTES} bytes.`);
+    await notifyAgent(session, `add_mcp_server failed: payload exceeds ${MCP_PAYLOAD_MAX_BYTES} bytes.`);
     return false;
   }
   return true;
 }
 
 export async function requestAddMcpServerHold(content: Record<string, unknown>, session: Session): Promise<void> {
-  const agentGroup = getAgentGroup(session.agent_group_id);
+  const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) return; // precheck already answered the requester
   const serverName = content.name as string;
   const serverConfig = parseMcpServerConfig(content);
@@ -248,7 +248,7 @@ export async function requestAddMcpServerHold(content: Record<string, unknown>, 
   const question =
     `Agent "${agentGroup.name}" is attempting to add a new MCP server:\n` + '```\n' + fields.join('\n') + '\n' + '```';
   if (Buffer.byteLength(question, 'utf8') > MCP_APPROVAL_CARD_MAX_BYTES) {
-    notifyAgent(
+    await notifyAgent(
       session,
       `add_mcp_server failed: rendered approval card exceeds ${MCP_APPROVAL_CARD_MAX_BYTES} bytes — trim the MCP configuration.`,
     );

--- a/src/provider-surfaces.test.ts
+++ b/src/provider-surfaces.test.ts
@@ -48,24 +48,24 @@ function containerConfig(): ContainerConfig {
   return { mcpServers: {}, packages: { apt: [], npm: [] }, additionalMounts: [], skills: [] };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   fs.mkdirSync(TEST_ROOT, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
 describe('initGroupFilesystem agent surfaces', () => {
-  it('stages provider-neutral instructions and default Claude support files', () => {
+  it('stages provider-neutral instructions and default Claude support files', async () => {
     const ag = group('ag-default', 'default-group');
-    createAgentGroup(ag);
+    await createAgentGroup(ag);
 
-    initGroupFilesystem(ag, { instructions: 'hello' });
+    await initGroupFilesystem(ag, { instructions: 'hello' });
 
     const groupDir = path.join(GROUPS_DIR, ag.folder);
     const claudeDir = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared');
@@ -80,10 +80,10 @@ describe('initGroupFilesystem agent surfaces', () => {
     expect(settings.hooks.SessionStart).toBeUndefined();
   });
 
-  it('disables native Claude memory in existing settings without clobbering other values', () => {
+  it('disables native Claude memory in existing settings without clobbering other values', async () => {
     const ag = group('ag-existing-claude', 'existing-claude-group');
-    createAgentGroup(ag);
-    initGroupFilesystem(ag);
+    await createAgentGroup(ag);
+    await initGroupFilesystem(ag);
 
     const settingsFile = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
     const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
@@ -96,7 +96,7 @@ describe('initGroupFilesystem agent surfaces', () => {
     ];
     fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + '\n');
 
-    initGroupFilesystem(ag);
+    await initGroupFilesystem(ag);
 
     const reconciled = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
     expect(reconciled.autoMemoryEnabled).toBe(false);
@@ -111,15 +111,15 @@ describe('initGroupFilesystem agent surfaces', () => {
   it.each([
     ['malformed JSON', '{"hooks":'],
     ['a non-object root', '[]\n'],
-  ])('warns and leaves existing settings unchanged for %s', (_label, content) => {
+  ])('warns and leaves existing settings unchanged for %s', async (_label, content) => {
     const ag = group('ag-invalid-claude', 'invalid-claude-group');
-    createAgentGroup(ag);
-    initGroupFilesystem(ag);
+    await createAgentGroup(ag);
+    await initGroupFilesystem(ag);
 
     const settingsFile = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
     fs.writeFileSync(settingsFile, content);
 
-    initGroupFilesystem(ag);
+    await initGroupFilesystem(ag);
 
     expect(fs.readFileSync(settingsFile, 'utf-8')).toBe(content);
     expect(log.warn).toHaveBeenCalledWith(
@@ -128,11 +128,11 @@ describe('initGroupFilesystem agent surfaces', () => {
     );
   });
 
-  it('stages the same provider-neutral instructions for a provider with its own surfaces', () => {
+  it('stages the same provider-neutral instructions for a provider with its own surfaces', async () => {
     const ag = group('ag-surfy', 'surfy-group');
-    createAgentGroup(ag);
+    await createAgentGroup(ag);
 
-    initGroupFilesystem(ag, { instructions: 'hello', provider: 'surfaces-test-provider' });
+    await initGroupFilesystem(ag, { instructions: 'hello', provider: 'surfaces-test-provider' });
 
     const groupDir = path.join(GROUPS_DIR, ag.folder);
     const sessionRoot = path.join(DATA_DIR, 'v2-sessions', ag.id);
@@ -143,11 +143,11 @@ describe('initGroupFilesystem agent surfaces', () => {
     expect(fs.existsSync(path.join(sessionRoot, '.claude-shared'))).toBe(false);
   });
 
-  it('writes nothing at all for a surfaces-owning provider without instructions', () => {
+  it('writes nothing at all for a surfaces-owning provider without instructions', async () => {
     const ag = group('ag-surfy-bare', 'surfy-bare-group');
-    createAgentGroup(ag);
+    await createAgentGroup(ag);
 
-    initGroupFilesystem(ag, { provider: 'surfaces-test-provider' });
+    await initGroupFilesystem(ag, { provider: 'surfaces-test-provider' });
 
     const groupDir = path.join(GROUPS_DIR, ag.folder);
     expect(fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))).toBe(false);
@@ -155,11 +155,11 @@ describe('initGroupFilesystem agent surfaces', () => {
     expect(fs.existsSync(path.join(groupDir, PERSONA_PREPEND_FILE))).toBe(false);
   });
 
-  it('treats an unregistered provider name as default support files without creating memory', () => {
+  it('treats an unregistered provider name as default support files without creating memory', async () => {
     const ag = group('ag-unknown', 'unknown-group');
-    createAgentGroup(ag);
+    await createAgentGroup(ag);
 
-    initGroupFilesystem(ag, { provider: 'not-registered' });
+    await initGroupFilesystem(ag, { provider: 'not-registered' });
 
     const groupDir = path.join(GROUPS_DIR, ag.folder);
     expect(fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))).toBe(false);
@@ -168,14 +168,14 @@ describe('initGroupFilesystem agent surfaces', () => {
 });
 
 describe('initGroupFilesystem legacy seed isolation', () => {
-  it('leaves .seed.md untouched for the manual migration workflow', () => {
+  it('leaves .seed.md untouched for the manual migration workflow', async () => {
     const ag = group('ag-seed', 'seed-group');
-    createAgentGroup(ag);
+    await createAgentGroup(ag);
     const groupDir = path.join(GROUPS_DIR, ag.folder);
     fs.mkdirSync(groupDir, { recursive: true });
     fs.writeFileSync(path.join(groupDir, '.seed.md'), 'seeded identity\n');
 
-    initGroupFilesystem(ag, {});
+    await initGroupFilesystem(ag, {});
 
     expect(fs.readFileSync(path.join(groupDir, '.seed.md'), 'utf-8')).toBe('seeded identity\n');
     expect(fs.existsSync(path.join(groupDir, PERSONA_PREPEND_FILE))).toBe(false);
@@ -185,13 +185,13 @@ describe('initGroupFilesystem legacy seed isolation', () => {
 });
 
 describe('buildMounts agent surfaces', () => {
-  it('mounts the default surfaces for an unregistered provider (today’s behavior)', () => {
+  it('mounts the default surfaces for an unregistered provider (today’s behavior)', async () => {
     const ag = group('ag-mounts-default', 'mounts-default');
-    createAgentGroup(ag);
-    ensureContainerConfig(ag.id);
-    initGroupFilesystem(ag, {});
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id);
+    await initGroupFilesystem(ag, {});
 
-    const mounts = buildMounts(ag, session('s1', ag.id), containerConfig(), 'claude', {});
+    const mounts = await buildMounts(ag, session('s1', ag.id), containerConfig(), 'claude', {});
 
     const byContainerPath = new Map(mounts.map((m) => [m.containerPath, m]));
     expect(byContainerPath.has('/home/node/.claude')).toBe(true);
@@ -201,11 +201,11 @@ describe('buildMounts agent surfaces', () => {
     expect(fs.existsSync(path.join(GROUPS_DIR, ag.folder, 'CLAUDE.md'))).toBe(true);
   });
 
-  it('suppresses the default surfaces and keeps contributed mounts for a surfaces-providing provider', () => {
+  it('suppresses the default surfaces and keeps contributed mounts for a surfaces-providing provider', async () => {
     const ag = group('ag-mounts-surfy', 'mounts-surfy');
-    createAgentGroup(ag);
-    ensureContainerConfig(ag.id);
-    initGroupFilesystem(ag, { provider: 'surfaces-test-provider' });
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id);
+    await initGroupFilesystem(ag, { provider: 'surfaces-test-provider' });
 
     const contributed = {
       mounts: [
@@ -216,7 +216,13 @@ describe('buildMounts agent surfaces', () => {
         },
       ],
     };
-    const mounts = buildMounts(ag, session('s2', ag.id), containerConfig(), 'surfaces-test-provider', contributed);
+    const mounts = await buildMounts(
+      ag,
+      session('s2', ag.id),
+      containerConfig(),
+      'surfaces-test-provider',
+      contributed,
+    );
 
     const containerPaths = mounts.map((m) => m.containerPath);
     expect(containerPaths).not.toContain('/home/node/.claude');

--- a/src/providers/provider-container-registry.ts
+++ b/src/providers/provider-container-registry.ts
@@ -69,7 +69,9 @@ export interface ProviderHostCapabilities {
   readonly providesAgentSurfaces?: boolean;
 }
 
-export type ProviderContainerConfigFn = (ctx: ProviderContainerContext) => ProviderContainerContribution;
+export type ProviderContainerConfigFn = (
+  ctx: ProviderContainerContext,
+) => ProviderContainerContribution | Promise<ProviderContainerContribution>;
 
 interface RegistryEntry {
   fn: ProviderContainerConfigFn;

--- a/src/router-session-created.test.ts
+++ b/src/router-session-created.test.ts
@@ -73,21 +73,21 @@ async function activate(): Promise<void> {
   }));
 }
 
-function seedWiring(options: {
+async function seedWiring(options: {
   isGroup?: 0 | 1;
   engageMode?: MessagingGroupAgent['engage_mode'];
   engagePattern?: string | null;
   sessionMode?: 'shared' | 'per-thread';
   ignoredMessagePolicy?: 'drop' | 'accumulate';
-}): void {
-  createAgentGroup({
+}): Promise<void> {
+  await createAgentGroup({
     id: 'ag-1',
     name: 'Test Agent',
     folder: 'test-agent',
     agent_provider: null,
     created_at: now(),
   });
-  createMessagingGroup({
+  await createMessagingGroup({
     id: 'mg-1',
     channel_type: 'testchat',
     platform_id: 'testchat:C1',
@@ -97,7 +97,7 @@ function seedWiring(options: {
     unknown_sender_policy: 'public',
     created_at: now(),
   });
-  createMessagingGroupAgent({
+  await createMessagingGroupAgent({
     id: 'mga-1',
     messaging_group_id: 'mg-1',
     agent_group_id: 'ag-1',
@@ -130,22 +130,22 @@ async function inbound(id: string, threadId: string | null, text: string, isMent
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
 });
 
 afterEach(async () => {
   await teardownChannelAdapters();
-  closeDb();
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
 describe('registerSessionCreatedHook', () => {
   it('fires once per created session with the resolved wiring context, not again on reuse', async () => {
     await activate();
-    seedWiring({ sessionMode: 'per-thread' });
+    await seedWiring({ sessionMode: 'per-thread' });
 
     const events: SessionCreatedEvent[] = [];
     registerSessionCreatedHook((event) => {
@@ -179,7 +179,7 @@ describe('registerSessionCreatedHook', () => {
     await activate();
     // A mention-mode wiring with accumulate policy: a non-mention message
     // takes the accumulate path (wake=false) and still creates the session.
-    seedWiring({ isGroup: 1, engageMode: 'mention', ignoredMessagePolicy: 'accumulate', sessionMode: 'shared' });
+    await seedWiring({ isGroup: 1, engageMode: 'mention', ignoredMessagePolicy: 'accumulate', sessionMode: 'shared' });
 
     const events: SessionCreatedEvent[] = [];
     registerSessionCreatedHook((event) => {
@@ -198,7 +198,7 @@ describe('registerSessionCreatedHook', () => {
     await activate();
     // Group chat + thread-enabled wiring: shared session_mode resolves to
     // per-thread at fanout — the hook must see the RESOLVED mode.
-    seedWiring({ isGroup: 1, engageMode: 'pattern', engagePattern: '.', sessionMode: 'shared' });
+    await seedWiring({ isGroup: 1, engageMode: 'pattern', engagePattern: '.', sessionMode: 'shared' });
 
     const events: SessionCreatedEvent[] = [];
     registerSessionCreatedHook((event) => {
@@ -213,7 +213,7 @@ describe('registerSessionCreatedHook', () => {
 
   it('a throwing hook (sync or async) never breaks routing', async () => {
     await activate();
-    seedWiring({ sessionMode: 'per-thread' });
+    await seedWiring({ sessionMode: 'per-thread' });
 
     registerSessionCreatedHook(() => {
       throw new Error('sync boom');

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,7 +49,7 @@ function generateId(): string {
  * carry enough info to identify a sender. Without the hook, every message
  * arrives at the gate with userId=null.
  */
-export type SenderResolverFn = (event: InboundEvent) => string | null;
+export type SenderResolverFn = (event: InboundEvent) => string | null | Promise<string | null>;
 
 let senderResolver: SenderResolverFn | null = null;
 
@@ -76,7 +76,7 @@ export type AccessGateFn = (
   userId: string | null,
   mg: MessagingGroup,
   agentGroupId: string,
-) => AccessGateResult;
+) => AccessGateResult | Promise<AccessGateResult>;
 
 let accessGate: AccessGateFn | null = null;
 
@@ -99,7 +99,7 @@ export type SenderScopeGateFn = (
   userId: string | null,
   mg: MessagingGroup,
   agent: MessagingGroupAgent,
-) => AccessGateResult;
+) => AccessGateResult | Promise<AccessGateResult>;
 
 let senderScopeGate: SenderScopeGateFn | null = null;
 
@@ -238,7 +238,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   //    resolution, no log spam. Exact-on-instance: an unknown named
   //    instance falls through to auto-create rather than hijacking a
   //    sibling instance's row.
-  const found = getMessagingGroupWithAgentCount(
+  const found = await getMessagingGroupWithAgentCount(
     event.channelType,
     event.platformId,
     event.instance ?? event.channelType,
@@ -273,7 +273,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
       denied_at: null,
       created_at: new Date().toISOString(),
     };
-    createMessagingGroup(mg);
+    await createMessagingGroup(mg);
     log.info('Auto-created messaging group', {
       id: mgId,
       channelType: event.channelType,
@@ -298,7 +298,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     }
 
     const parsed = safeParseContent(event.message.content);
-    recordDroppedMessage({
+    await recordDroppedMessage({
       channel_type: event.channelType,
       platform_id: event.platformId,
       user_id: null,
@@ -329,11 +329,11 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   // 2. Sender resolution (permissions module upserts the users row as a
   //    side effect so later role/access lookups find a real record).
   //    Without the module, userId is null — downstream tolerates it.
-  const userId: string | null = senderResolver ? senderResolver(event) : null;
+  const userId: string | null = senderResolver ? await senderResolver(event) : null;
 
   // 3. Fetch wired agents in full (we already know the count is > 0; now
   //    we need their actual rows for fan-out).
-  const agents = getMessagingGroupAgents(mg.id);
+  const agents = await getMessagingGroupAgents(mg.id);
 
   // 4. Fan-out: evaluate each wired agent independently against engage_mode,
   //    sender_scope, and access gate. An agent that engages gets its own
@@ -363,7 +363,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   let subscribed = false;
 
   for (const agent of agents) {
-    const agentGroup = getAgentGroup(agent.agent_group_id);
+    const agentGroup = await getAgentGroup(agent.agent_group_id);
     if (!agentGroup) continue;
 
     // Effective thread id for THIS wiring: the event-derived address is
@@ -381,10 +381,10 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     );
     const effectiveThreadId = threadsEnabled ? event.threadId : null;
 
-    const engages = evaluateEngage(agent, messageText, isMention, mg, effectiveThreadId);
+    const engages = await evaluateEngage(agent, messageText, isMention, mg, effectiveThreadId);
 
-    const accessOk = engages && (!accessGate || accessGate(event, userId, mg, agent.agent_group_id).allowed);
-    const scopeOk = engages && (!senderScopeGate || senderScopeGate(event, userId, mg, agent).allowed);
+    const accessOk = engages && (!accessGate || (await accessGate(event, userId, mg, agent.agent_group_id)).allowed);
+    const scopeOk = engages && (!senderScopeGate || (await senderScopeGate(event, userId, mg, agent)).allowed);
 
     if (engages && accessOk && scopeOk) {
       await deliverToAgent(agent, agentGroup, mg, event, userId, threadsEnabled, effectiveThreadId, true);
@@ -433,7 +433,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   }
 
   if (engagedCount + accumulatedCount === 0) {
-    recordDroppedMessage({
+    await recordDroppedMessage({
       channel_type: event.channelType,
       platform_id: event.platformId,
       user_id: userId,
@@ -465,13 +465,13 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
  *                      a thread has engaged us once, follow-ups arrive
  *                      with no mention and should still fire.
  */
-function evaluateEngage(
+async function evaluateEngage(
   agent: MessagingGroupAgent,
   text: string,
   isMention: boolean,
   mg: MessagingGroup,
   threadId: string | null,
-): boolean {
+): Promise<boolean> {
   switch (agent.engage_mode) {
     case 'pattern': {
       const pat = agent.engage_pattern ?? '.';
@@ -490,7 +490,7 @@ function evaluateEngage(
       // Sticky follow-up: session already exists for this (agent, mg, thread)
       // — the thread was activated before, keep firing.
       if (mg.is_group === 0) return false; // DMs never use mention-sticky sensibly
-      const existing = findSessionForAgent(agent.agent_group_id, mg.id, threadId);
+      const existing = await findSessionForAgent(agent.agent_group_id, mg.id, threadId);
       return existing !== undefined;
     }
     default:
@@ -519,7 +519,12 @@ async function deliverToAgent(
     effectiveSessionMode = 'per-thread';
   }
 
-  const { session, created } = resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
+  const { session, created } = await resolveSession(
+    agent.agent_group_id,
+    mg.id,
+    effectiveThreadId,
+    effectiveSessionMode,
+  );
 
   // The inbound row's (channel_type, platform_id, thread_id) is the address
   // the agent's reply will be delivered to. Normally it mirrors the source
@@ -537,7 +542,7 @@ async function deliverToAgent(
   // Filtered commands are dropped silently. Denied admin commands get a
   // permission-denied response written directly to messages_out.
   if (event.message.kind === 'chat' || event.message.kind === 'chat-sdk') {
-    const gate = gateCommand(event.message.content, userId, agent.agent_group_id);
+    const gate = await gateCommand(event.message.content, userId, agent.agent_group_id);
     if (gate.action === 'filter') {
       log.debug('Filtered command dropped by gate', { agentGroupId: agent.agent_group_id });
       return;
@@ -561,11 +566,11 @@ async function deliverToAgent(
     // seeded with its conversation's top-level timeline from sibling
     // sessions BEFORE the triggering message is written, so replying to
     // something said in another thread lands with that context in view.
-    backfillNewSession(agentGroup, session, mg);
+    await backfillNewSession(agentGroup, session, mg);
   }
 
   const messageId = messageIdForAgent(event.message.id, agent.agent_group_id);
-  writeSessionMessage(session.agent_group_id, session.id, {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: messageId,
     kind: event.message.kind,
     timestamp: event.message.timestamp,
@@ -581,7 +586,7 @@ async function deliverToAgent(
     // sessions of the SAME conversation as trigger=0 'session-echo' rows.
     // Only the engaged branch fans — the accumulate branch above (trigger=0)
     // never does, so ambient backlog is never copied twice. Never throws.
-    fanInboundMessage({
+    await fanInboundMessage({
       session,
       mg,
       messageId,
@@ -633,7 +638,7 @@ async function deliverToAgent(
       effectiveThreadId,
       mg.instance,
     );
-    const freshSession = getSession(session.id);
+    const freshSession = await getSession(session.id);
     if (freshSession) {
       const woke = await wakeContainer(freshSession);
       // wakeContainer never throws — it returns false on transient spawn

--- a/src/session-manager.attachments.test.ts
+++ b/src/session-manager.attachments.test.ts
@@ -40,14 +40,14 @@ function now(): string {
   return new Date().toISOString();
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
 
-  const db = initTestDb();
-  runMigrations(db);
+  const db = await initTestDb();
+  await runMigrations(db);
 
-  createAgentGroup({ id: AG, name: 'SaveAtt', folder: 'saveatt', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: AG, name: 'SaveAtt', folder: 'saveatt', agent_provider: null, created_at: now() });
   const sess: Session = {
     id: SESS,
     agent_group_id: AG,
@@ -59,17 +59,17 @@ beforeEach(() => {
     last_active: null,
     created_at: now(),
   };
-  createSession(sess);
+  await createSession(sess);
   initSessionFolder(AG, SESS);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
 describe('extractAttachmentFiles — inbox-root symlink containment (#2828 sibling)', () => {
-  it('does not write an attachment outside the session root via a symlinked inbox root', () => {
+  it('does not write an attachment outside the session root via a symlinked inbox root', async () => {
     // Attacker-controlled location outside the session sandbox.
     const canaryDir = path.join(TEST_DIR, 'canary-outside');
     fs.mkdirSync(canaryDir, { recursive: true });
@@ -84,7 +84,7 @@ describe('extractAttachmentFiles — inbox-root symlink containment (#2828 sibli
       attachments: [{ name: 'pwn.txt', data: Buffer.from('attacker-bytes').toString('base64') }],
     });
 
-    writeSessionMessage(AG, SESS, {
+    await writeSessionMessage(AG, SESS, {
       id: 'evil-inbox-root',
       kind: 'chat',
       timestamp: now(),

--- a/src/session-manager.test.ts
+++ b/src/session-manager.test.ts
@@ -117,10 +117,10 @@ describe('writeOutboundDirect', () => {
  * message is logged-and-dropped forever — the reset silently kills the chat.
  */
 describe('writeSessionMessage re-provisions a deleted session folder', () => {
-  beforeEach(() => {
-    const db = initTestDb();
-    runMigrations(db);
-    createAgentGroup({
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    await createAgentGroup({
       id: AG,
       name: 'Reset',
       folder: 'reset',
@@ -138,11 +138,11 @@ describe('writeSessionMessage re-provisions a deleted session folder', () => {
       last_active: null,
       created_at: new Date().toISOString(),
     };
-    createSession(sess);
+    await createSession(sess);
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
   });
 
   it('re-creates the folder + inbound.db and does not throw when the row still exists', () => {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -79,15 +79,15 @@ function generateId(): string {
  * - 'agent-shared': one session per agent group — all messaging groups
  *   wired with this mode share a single session (e.g. GitHub + Slack)
  */
-export function resolveSession(
+export async function resolveSession(
   agentGroupId: string,
   messagingGroupId: string | null,
   threadId: string | null,
   sessionMode: 'shared' | 'per-thread' | 'agent-shared',
-): { session: Session; created: boolean } {
+): Promise<{ session: Session; created: boolean }> {
   // agent-shared: single session per agent group, regardless of messaging group
   if (sessionMode === 'agent-shared') {
-    const existing = findSessionByAgentGroup(agentGroupId);
+    const existing = await findSessionByAgentGroup(agentGroupId);
     if (existing) {
       return { session: existing, created: false };
     }
@@ -95,7 +95,7 @@ export function resolveSession(
     const lookupThreadId = sessionMode === 'shared' ? null : threadId;
     // Scope lookup by agent_group_id so fan-out to multiple agents in the
     // same chat doesn't accidentally deliver to the wrong agent's session.
-    const existing = findSessionForAgent(agentGroupId, messagingGroupId, lookupThreadId);
+    const existing = await findSessionForAgent(agentGroupId, messagingGroupId, lookupThreadId);
     if (existing) {
       return { session: existing, created: false };
     }
@@ -115,7 +115,7 @@ export function resolveSession(
     created_at: new Date().toISOString(),
   };
 
-  createSession(session);
+  await createSession(session);
   initSessionFolder(agentGroupId, id);
   log.info('Session created', { id, agentGroupId, messagingGroupId, threadId: lookupThreadId, sessionMode });
 
@@ -124,9 +124,12 @@ export function resolveSession(
 
 /** Find or create the per-agent-group session used for scheduled tasks. */
 /** Find or create the isolated session for one task series (thread `system:tasks:<seriesId>`). */
-export function resolveTaskSession(agentGroupId: string, seriesId: string): { session: Session; created: boolean } {
+export async function resolveTaskSession(
+  agentGroupId: string,
+  seriesId: string,
+): Promise<{ session: Session; created: boolean }> {
   const threadId = taskThreadId(seriesId);
-  const existing = findSystemSession(agentGroupId, threadId);
+  const existing = await findSystemSession(agentGroupId, threadId);
   if (existing) return { session: existing, created: false };
 
   const id = generateId();
@@ -142,7 +145,7 @@ export function resolveTaskSession(agentGroupId: string, seriesId: string): { se
     created_at: new Date().toISOString(),
   };
 
-  createSession(session);
+  await createSession(session);
   initSessionFolder(agentGroupId, id);
   log.info('Task session created', { id, agentGroupId, seriesId });
 
@@ -170,17 +173,17 @@ export function initSessionFolder(agentGroupId: string, sessionId: string): void
  * writeDestinations() (when installed) so the latest routing is always in
  * place, including after admin rewiring.
  */
-export function writeSessionRouting(agentGroupId: string, sessionId: string): void {
+export async function writeSessionRouting(agentGroupId: string, sessionId: string): Promise<void> {
   const dbPath = inboundDbPath(agentGroupId, sessionId);
   if (!fs.existsSync(dbPath)) return;
 
-  const session = getSession(sessionId);
+  const session = await getSession(sessionId);
   if (!session) return;
 
   let channelType: string | null = null;
   let platformId: string | null = null;
   if (session.messaging_group_id) {
-    const mg = getMessagingGroup(session.messaging_group_id);
+    const mg = await getMessagingGroup(session.messaging_group_id);
     if (mg) {
       channelType = mg.channel_type;
       platformId = mg.platform_id;
@@ -207,7 +210,7 @@ export function writeSessionRouting(agentGroupId: string, sessionId: string): vo
  * long-lived connection — see the "Cross-mount visibility invariants" note
  * at the top of this file.
  */
-export function writeSessionMessage(
+export async function writeSessionMessage(
   agentGroupId: string,
   sessionId: string,
   message: {
@@ -239,7 +242,7 @@ export function writeSessionMessage(
      */
     onWake?: 0 | 1;
   },
-): void {
+): Promise<void> {
   // Documented reset: operators `rm -rf` a session folder to clear a stuck
   // session. The sessions row survives, so the next message takes the
   // existing-session path and lands here with a missing inbound.db — the open
@@ -273,7 +276,7 @@ export function writeSessionMessage(
     db.close();
   }
 
-  updateSession(sessionId, { last_active: new Date().toISOString() });
+  await updateSession(sessionId, { last_active: new Date().toISOString() });
 }
 
 /**
@@ -539,16 +542,16 @@ export function clearOutbox(agentGroupId: string, sessionId: string, messageId: 
 }
 
 /** Mark a container as running for a session. */
-export function markContainerRunning(sessionId: string): void {
-  updateSession(sessionId, { container_status: 'running', last_active: new Date().toISOString() });
+export async function markContainerRunning(sessionId: string): Promise<void> {
+  await updateSession(sessionId, { container_status: 'running', last_active: new Date().toISOString() });
 }
 
 /** Mark a container as idle for a session. */
-export function markContainerIdle(sessionId: string): void {
-  updateSession(sessionId, { container_status: 'idle' });
+export async function markContainerIdle(sessionId: string): Promise<void> {
+  await updateSession(sessionId, { container_status: 'idle' });
 }
 
 /** Mark a container as stopped for a session. */
-export function markContainerStopped(sessionId: string): void {
-  updateSession(sessionId, { container_status: 'stopped' });
+export async function markContainerStopped(sessionId: string): Promise<void> {
+  await updateSession(sessionId, { container_status: 'stopped' });
 }

--- a/src/state-sqlite.test.ts
+++ b/src/state-sqlite.test.ts
@@ -14,16 +14,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { initTestDb, closeDb, getDb } from './db/connection.js';
+import { sqliteRaw } from './db/drivers/sqlite.js';
 import { runMigrations } from './db/migrations/index.js';
 import { SqliteStateAdapter } from './state-sqlite.js';
 
-beforeEach(() => {
-  const db = initTestDb();
-  runMigrations(db);
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
 });
 
 async function makeAdapter(namespace?: string): Promise<SqliteStateAdapter> {
@@ -35,7 +36,7 @@ async function makeAdapter(namespace?: string): Promise<SqliteStateAdapter> {
 describe('default instance — legacy unprefixed keys (live-install regression arm)', () => {
   it('reads rows written before the namespace dimension existed', async () => {
     // A pre-existing install's subscription row: bare thread id.
-    getDb().prepare("INSERT INTO chat_sdk_subscriptions (thread_id) VALUES ('T-raw')").run();
+    sqliteRaw(getDb()).prepare("INSERT INTO chat_sdk_subscriptions (thread_id) VALUES ('T-raw')").run();
     const state = await makeAdapter();
     expect(await state.isSubscribed('T-raw')).toBe(true);
   });
@@ -46,13 +47,13 @@ describe('default instance — legacy unprefixed keys (live-install regression a
     await state.subscribe('slack:T1');
     await state.appendToList('l1', 'item');
 
-    const kv = getDb().prepare('SELECT key FROM chat_sdk_kv').all() as Array<{ key: string }>;
+    const kv = sqliteRaw(getDb()).prepare('SELECT key FROM chat_sdk_kv').all() as Array<{ key: string }>;
     expect(kv.map((r) => r.key)).toEqual(['k1']);
-    const subs = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
+    const subs = sqliteRaw(getDb()).prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
       thread_id: string;
     }>;
     expect(subs.map((r) => r.thread_id)).toEqual(['slack:T1']);
-    const lists = getDb().prepare('SELECT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
+    const lists = sqliteRaw(getDb()).prepare('SELECT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
     expect(lists.map((r) => r.key)).toEqual(['l1']);
   });
 });
@@ -63,7 +64,7 @@ describe('namespaced instance — round-trips and raw-key shape', () => {
     await state.set('k1', { v: 42 });
     expect(await state.get('k1')).toEqual({ v: 42 });
 
-    const raw = getDb().prepare('SELECT key FROM chat_sdk_kv').all() as Array<{ key: string }>;
+    const raw = sqliteRaw(getDb()).prepare('SELECT key FROM chat_sdk_kv').all() as Array<{ key: string }>;
     expect(raw.map((r) => r.key)).toEqual(['slack-tester:k1']);
 
     expect(await state.setIfNotExists('k1', 'other')).toBe(false);
@@ -78,7 +79,7 @@ describe('namespaced instance — round-trips and raw-key shape', () => {
     await state.subscribe('slack:T1');
     expect(await state.isSubscribed('slack:T1')).toBe(true);
 
-    const raw = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
+    const raw = sqliteRaw(getDb()).prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
       thread_id: string;
     }>;
     expect(raw.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1']);
@@ -92,7 +93,7 @@ describe('namespaced instance — round-trips and raw-key shape', () => {
     await state.appendToList('history', 'a');
     await state.appendToList('history', 'b');
     expect(await state.getList('history')).toEqual(['a', 'b']);
-    const raw = getDb().prepare('SELECT DISTINCT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
+    const raw = sqliteRaw(getDb()).prepare('SELECT DISTINCT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
     expect(raw.map((r) => r.key)).toEqual(['slack-tester:history']);
   });
 });
@@ -128,12 +129,14 @@ describe('locks under a namespace', () => {
     // own SQL sites. A prefixed id here would double-prefix on release.
     expect(lock!.threadId).toBe('slack:T1');
 
-    const raw = getDb().prepare('SELECT thread_id FROM chat_sdk_locks').all() as Array<{ thread_id: string }>;
+    const raw = sqliteRaw(getDb()).prepare('SELECT thread_id FROM chat_sdk_locks').all() as Array<{
+      thread_id: string;
+    }>;
     expect(raw.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1']);
 
     expect(await state.extendLock(lock!, 10_000)).toBe(true);
     await state.releaseLock(lock!);
-    expect(getDb().prepare('SELECT COUNT(*) AS c FROM chat_sdk_locks').get()).toEqual({ c: 0 });
+    expect(sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM chat_sdk_locks').get()).toEqual({ c: 0 });
   });
 
   it('same-thread locks in different namespaces do not contend', async () => {
@@ -152,7 +155,7 @@ describe('queue under a namespace', () => {
     const entry = { message: { id: 'm1' } } as never;
     expect(await state.enqueue('slack:T1', entry, 10)).toBe(1);
 
-    const raw = getDb().prepare('SELECT DISTINCT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
+    const raw = sqliteRaw(getDb()).prepare('SELECT DISTINCT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
     // Single prefix: enqueue must NOT apply k() itself (appendToList does);
     // a double prefix ('slack-tester:slack-tester:queue:…') never drains.
     expect(raw.map((r) => r.key)).toEqual(['slack-tester:queue:slack:T1']);

--- a/src/state-sqlite.ts
+++ b/src/state-sqlite.ts
@@ -6,10 +6,10 @@
  */
 import crypto from 'crypto';
 
-import type Database from 'better-sqlite3';
 import type { StateAdapter, QueueEntry } from 'chat';
 
 import { getDb } from './db/connection.js';
+import type { DbDriver } from './db/driver.js';
 
 interface Lock {
   threadId: string;
@@ -18,7 +18,7 @@ interface Lock {
 }
 
 export class SqliteStateAdapter implements StateAdapter {
-  private db!: Database.Database;
+  private db!: DbDriver;
 
   /**
    * namespace = adapter-instance name; undefined ⇒ legacy unprefixed keys.
@@ -44,7 +44,7 @@ export class SqliteStateAdapter implements StateAdapter {
 
   async connect(): Promise<void> {
     this.db = getDb();
-    this.cleanup();
+    await this.cleanup();
   }
 
   async disconnect(): Promise<void> {}
@@ -52,14 +52,15 @@ export class SqliteStateAdapter implements StateAdapter {
   // --- Key-value ---
 
   async get<T = unknown>(key: string): Promise<T | null> {
-    this.cleanup();
+    await this.cleanup();
     const k = this.k(key);
-    const row = this.db.prepare('SELECT value, expires_at FROM chat_sdk_kv WHERE key = ?').get(k) as
-      | { value: string; expires_at: number | null }
-      | undefined;
+    const row = await this.db.get<{ value: string; expires_at: number | null }>(
+      'SELECT value, expires_at FROM chat_sdk_kv WHERE key = ?',
+      k,
+    );
     if (!row) return null;
     if (row.expires_at && row.expires_at < Date.now()) {
-      this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(k);
+      await this.db.run('DELETE FROM chat_sdk_kv WHERE key = ?', k);
       return null;
     }
     return JSON.parse(row.value) as T;
@@ -67,52 +68,55 @@ export class SqliteStateAdapter implements StateAdapter {
 
   async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
-    this.db
-      .prepare(
-        `INSERT INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)
-         ON CONFLICT (key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at`,
-      )
-      .run(this.k(key), JSON.stringify(value), expiresAt);
+    await this.db.run(
+      `INSERT INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)
+       ON CONFLICT (key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at`,
+      this.k(key),
+      JSON.stringify(value),
+      expiresAt,
+    );
   }
 
   async setIfNotExists(key: string, value: unknown, ttlMs?: number): Promise<boolean> {
     const k = this.k(key);
-    const existing = this.db.prepare('SELECT expires_at FROM chat_sdk_kv WHERE key = ?').get(k) as
-      | { expires_at: number | null }
-      | undefined;
+    const existing = await this.db.get<{ expires_at: number | null }>(
+      'SELECT expires_at FROM chat_sdk_kv WHERE key = ?',
+      k,
+    );
     if (existing?.expires_at && existing.expires_at < Date.now()) {
-      this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(k);
+      await this.db.run('DELETE FROM chat_sdk_kv WHERE key = ?', k);
     }
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
-    const result = this.db
-      .prepare('INSERT INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?) ON CONFLICT (key) DO NOTHING')
-      .run(k, JSON.stringify(value), expiresAt);
+    const result = await this.db.run(
+      'INSERT INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?) ON CONFLICT (key) DO NOTHING',
+      k,
+      JSON.stringify(value),
+      expiresAt,
+    );
     return result.changes > 0;
   }
 
   async delete(key: string): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(this.k(key));
+    await this.db.run('DELETE FROM chat_sdk_kv WHERE key = ?', this.k(key));
   }
 
   // --- Subscriptions ---
 
   async subscribe(threadId: string): Promise<void> {
-    this.db
-      .prepare(
-        `INSERT INTO chat_sdk_subscriptions (thread_id, subscribed_at) VALUES (?, ?)
-         ON CONFLICT (thread_id) DO UPDATE SET subscribed_at = excluded.subscribed_at`,
-      )
-      .run(this.k(threadId), new Date().toISOString());
+    await this.db.run(
+      `INSERT INTO chat_sdk_subscriptions (thread_id, subscribed_at) VALUES (?, ?)
+       ON CONFLICT (thread_id) DO UPDATE SET subscribed_at = excluded.subscribed_at`,
+      this.k(threadId),
+      new Date().toISOString(),
+    );
   }
 
   async unsubscribe(threadId: string): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_subscriptions WHERE thread_id = ?').run(this.k(threadId));
+    await this.db.run('DELETE FROM chat_sdk_subscriptions WHERE thread_id = ?', this.k(threadId));
   }
 
   async isSubscribed(threadId: string): Promise<boolean> {
-    const row = this.db
-      .prepare('SELECT 1 FROM chat_sdk_subscriptions WHERE thread_id = ? LIMIT 1')
-      .get(this.k(threadId));
+    const row = await this.db.get('SELECT 1 FROM chat_sdk_subscriptions WHERE thread_id = ? LIMIT 1', this.k(threadId));
     return !!row;
   }
 
@@ -123,13 +127,14 @@ export class SqliteStateAdapter implements StateAdapter {
     const token = crypto.randomUUID();
     const expiresAt = now + ttlMs;
     const k = this.k(threadId);
-    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND expires_at < ?').run(k, now);
-    const result = this.db
-      .prepare(
-        `INSERT INTO chat_sdk_locks (thread_id, token, expires_at) VALUES (?, ?, ?)
-         ON CONFLICT (thread_id) DO NOTHING`,
-      )
-      .run(k, token, expiresAt);
+    await this.db.run('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND expires_at < ?', k, now);
+    const result = await this.db.run(
+      `INSERT INTO chat_sdk_locks (thread_id, token, expires_at) VALUES (?, ?, ?)
+       ON CONFLICT (thread_id) DO NOTHING`,
+      k,
+      token,
+      expiresAt,
+    );
     if (result.changes === 0) return null;
     // The Lock carries the RAW threadId; release/extend re-apply k() at
     // their own SQL sites. Uniform — no un/re-prefixing on the caller side.
@@ -137,16 +142,21 @@ export class SqliteStateAdapter implements StateAdapter {
   }
 
   async releaseLock(lock: Lock): Promise<void> {
-    this.db
-      .prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND token = ?')
-      .run(this.k(lock.threadId), lock.token);
+    await this.db.run(
+      'DELETE FROM chat_sdk_locks WHERE thread_id = ? AND token = ?',
+      this.k(lock.threadId),
+      lock.token,
+    );
   }
 
   async extendLock(lock: Lock, ttlMs: number): Promise<boolean> {
     const newExpiry = Date.now() + ttlMs;
-    const result = this.db
-      .prepare('UPDATE chat_sdk_locks SET expires_at = ? WHERE thread_id = ? AND token = ?')
-      .run(newExpiry, this.k(lock.threadId), lock.token);
+    const result = await this.db.run(
+      'UPDATE chat_sdk_locks SET expires_at = ? WHERE thread_id = ? AND token = ?',
+      newExpiry,
+      this.k(lock.threadId),
+      lock.token,
+    );
     if (result.changes > 0) {
       lock.expiresAt = newExpiry;
       return true;
@@ -155,7 +165,7 @@ export class SqliteStateAdapter implements StateAdapter {
   }
 
   async forceReleaseLock(threadId: string): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ?').run(this.k(threadId));
+    await this.db.run('DELETE FROM chat_sdk_locks WHERE thread_id = ?', this.k(threadId));
   }
 
   // --- Lists ---
@@ -163,28 +173,33 @@ export class SqliteStateAdapter implements StateAdapter {
   async appendToList(key: string, value: unknown, options?: { maxLength?: number; ttlMs?: number }): Promise<void> {
     const expiresAt = options?.ttlMs ? Date.now() + options.ttlMs : null;
     const k = this.k(key);
-    const maxRow = this.db.prepare('SELECT MAX(idx) AS max_idx FROM chat_sdk_lists WHERE key = ?').get(k) as
-      | { max_idx: number | null }
-      | undefined;
+    const maxRow = await this.db.get<{ max_idx: number | null }>(
+      'SELECT MAX(idx) AS max_idx FROM chat_sdk_lists WHERE key = ?',
+      k,
+    );
     const nextIdx = (maxRow?.max_idx ?? -1) + 1;
-    this.db
-      .prepare('INSERT INTO chat_sdk_lists (key, idx, value, expires_at) VALUES (?, ?, ?, ?)')
-      .run(k, nextIdx, JSON.stringify(value), expiresAt);
+    await this.db.run(
+      'INSERT INTO chat_sdk_lists (key, idx, value, expires_at) VALUES (?, ?, ?, ?)',
+      k,
+      nextIdx,
+      JSON.stringify(value),
+      expiresAt,
+    );
     if (options?.maxLength) {
       const cutoff = nextIdx - options.maxLength;
       if (cutoff >= 0) {
-        this.db.prepare('DELETE FROM chat_sdk_lists WHERE key = ? AND idx <= ?').run(k, cutoff);
+        await this.db.run('DELETE FROM chat_sdk_lists WHERE key = ? AND idx <= ?', k, cutoff);
       }
     }
   }
 
   async getList<T = unknown>(key: string): Promise<T[]> {
     const now = Date.now();
-    const rows = this.db
-      .prepare(
-        'SELECT value FROM chat_sdk_lists WHERE key = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY idx ASC',
-      )
-      .all(this.k(key), now) as { value: string }[];
+    const rows = await this.db.all<{ value: string }>(
+      'SELECT value FROM chat_sdk_lists WHERE key = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY idx ASC',
+      this.k(key),
+      now,
+    );
     return rows.map((r) => JSON.parse(r.value) as T);
   }
 
@@ -201,28 +216,28 @@ export class SqliteStateAdapter implements StateAdapter {
 
   async dequeue(threadId: string): Promise<QueueEntry | null> {
     const key = this.k(`queue:${threadId}`);
-    const row = this.db
-      .prepare('SELECT idx, value FROM chat_sdk_lists WHERE key = ? ORDER BY idx ASC LIMIT 1')
-      .get(key) as { idx: number; value: string } | undefined;
+    const row = await this.db.get<{ idx: number; value: string }>(
+      'SELECT idx, value FROM chat_sdk_lists WHERE key = ? ORDER BY idx ASC LIMIT 1',
+      key,
+    );
     if (!row) return null;
-    this.db.prepare('DELETE FROM chat_sdk_lists WHERE key = ? AND idx = ?').run(key, row.idx);
+    await this.db.run('DELETE FROM chat_sdk_lists WHERE key = ? AND idx = ?', key, row.idx);
     return JSON.parse(row.value) as QueueEntry;
   }
 
   async queueDepth(threadId: string): Promise<number> {
     const key = this.k(`queue:${threadId}`);
-    const row = this.db.prepare('SELECT COUNT(*) as count FROM chat_sdk_lists WHERE key = ?').get(key) as {
-      count: number;
-    };
+    const row = await this.db.get<{ count: number }>('SELECT COUNT(*) as count FROM chat_sdk_lists WHERE key = ?', key);
+    if (!row) return 0;
     return row.count;
   }
 
   // --- Cleanup ---
 
-  private cleanup(): void {
+  private async cleanup(): Promise<void> {
     const now = Date.now();
-    this.db.prepare('DELETE FROM chat_sdk_kv WHERE expires_at IS NOT NULL AND expires_at < ?').run(now);
-    this.db.prepare('DELETE FROM chat_sdk_locks WHERE expires_at < ?').run(now);
-    this.db.prepare('DELETE FROM chat_sdk_lists WHERE expires_at IS NOT NULL AND expires_at < ?').run(now);
+    await this.db.run('DELETE FROM chat_sdk_kv WHERE expires_at IS NOT NULL AND expires_at < ?', now);
+    await this.db.run('DELETE FROM chat_sdk_locks WHERE expires_at < ?', now);
+    await this.db.run('DELETE FROM chat_sdk_lists WHERE expires_at IS NOT NULL AND expires_at < ?', now);
   }
 }

--- a/src/templates/create-agent.test.ts
+++ b/src/templates/create-agent.test.ts
@@ -68,21 +68,21 @@ function writeTask(name: string, schedule: string, prompt: string, script?: stri
   fs.writeFileSync(path.join(dir, `${name}.md`), `---\nschedule: "${schedule}"\n${scriptBlock}---\n\n${prompt}\n`);
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   fs.mkdirSync(TEST_ROOT, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
   writeTemplate();
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
 describe('createAgentFromTemplate', () => {
-  it('writes the persona prepend verbatim — no injected context refs, no .seed.md', () => {
-    const { group: g, report } = createAgentFromTemplate('sales/sdr', { name: 'SDR Test' });
+  it('writes the persona prepend verbatim — no injected context refs, no .seed.md', async () => {
+    const { group: g, report } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Test' });
 
     const groupDir = path.join(GROUPS_DIR, g.folder);
     const prepend = fs.readFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'utf-8');
@@ -94,15 +94,15 @@ describe('createAgentFromTemplate', () => {
     expect(g.id).toMatch(/^ag-/);
   });
 
-  it('copies template skills into the group-private Claude-plane skills dir', () => {
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR Skills' });
+  it('copies template skills into the group-private Claude-plane skills dir', async () => {
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Skills' });
 
     const skill = path.join(DATA_DIR, 'v2-sessions', g.id, '.claude-shared', 'skills', 'widget', 'SKILL.md');
     expect(fs.existsSync(skill)).toBe(true);
   });
 
-  it('copies the whole plugin into plugins/<name> and provisions plugin-data/<name>', () => {
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR Plugin Copy' });
+  it('copies the whole plugin into plugins/<name> and provisions plugin-data/<name>', async () => {
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Plugin Copy' });
 
     const pluginDir = path.join(GROUPS_DIR, g.folder, 'plugins', 'sdr');
     // The whole-plugin copy fixes the broken-sibling-reference class of bugs:
@@ -117,10 +117,10 @@ describe('createAgentFromTemplate', () => {
     expect(fs.existsSync(path.join(GROUPS_DIR, g.folder, 'plugin-data', 'sdr', 'state'))).toBe(true);
   });
 
-  it('records the ownership marker on every server and pluginRoot on stdio only', () => {
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR Mcp' });
+  it('records the ownership marker on every server and pluginRoot on stdio only', async () => {
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Mcp' });
 
-    const servers = JSON.parse(getContainerConfig(g.id)!.mcp_servers);
+    const servers = JSON.parse((await getContainerConfig(g.id))!.mcp_servers);
     expect(servers.hubspot).toMatchObject({ command: 'npx', pluginRoot: '/workspace/agent/plugins/sdr' });
     expect(servers.docs).toEqual({ type: 'http', url: 'https://mcp.example.com/mcp', plugin: 'sdr' });
     // Declared cwd wins; an omitted one defaults to the plugin root (spec §7.2.1).
@@ -128,18 +128,18 @@ describe('createAgentFromTemplate', () => {
     expect(servers.search.cwd).toBe('${PLUGIN_ROOT}');
   });
 
-  it('refuses a template whose task names collide on the truncated id slug', () => {
+  it('refuses a template whose task names collide on the truncated id slug', async () => {
     // Both names slug to the same 24-char prefix; the collision must surface
     // at first stamp, not on the first later restamp.
     writeTask('a'.repeat(30), '0 9 * * *', 'First.');
     writeTask(`${'a'.repeat(30)}b`, '0 9 * * *', 'Second.');
 
-    expect(() => createAgentFromTemplate('sales/sdr', { name: 'SDR Collide' })).toThrow(/collide on id slug/);
-    expect(getAllAgentGroups()).toHaveLength(0);
+    await expect(createAgentFromTemplate('sales/sdr', { name: 'SDR Collide' })).rejects.toThrow(/collide on id slug/);
+    expect(await getAllAgentGroups()).toHaveLength(0);
   });
 
-  it('writes context extras at their template-relative paths', () => {
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR Extras' });
+  it('writes context extras at their template-relative paths', async () => {
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Extras' });
 
     const groupDir = path.join(GROUPS_DIR, g.folder);
     expect(fs.existsSync(path.join(groupDir, 'playbook.md'))).toBe(true);
@@ -147,30 +147,30 @@ describe('createAgentFromTemplate', () => {
     expect(fs.existsSync(path.join(groupDir, 'context'))).toBe(false);
   });
 
-  it('derives the display name: explicit option → extension agentName → folder leaf', () => {
+  it('derives the display name: explicit option → extension agentName → folder leaf', async () => {
     fs.rmSync(TPL, { recursive: true, force: true });
     writeTemplate({ extensions: { [NANOCLAW_EXTENSION_NS]: { agentName: 'Sales Development Rep' } } });
-    const { group: named } = createAgentFromTemplate('sales/sdr');
+    const { group: named } = await createAgentFromTemplate('sales/sdr');
     expect(named.name).toBe('Sales Development Rep');
 
     fs.rmSync(TPL, { recursive: true, force: true });
     writeTemplate();
-    const { group: fallback } = createAgentFromTemplate('sales/sdr');
+    const { group: fallback } = await createAgentFromTemplate('sales/sdr');
     expect(fallback.name).toBe('sdr');
 
     fs.rmSync(TPL, { recursive: true, force: true });
     writeTemplate({ extensions: { [NANOCLAW_EXTENSION_NS]: { agentName: 'Ignored' } } });
-    const { group: explicit } = createAgentFromTemplate('sales/sdr', { name: 'Chosen' });
+    const { group: explicit } = await createAgentFromTemplate('sales/sdr', { name: 'Chosen' });
     expect(explicit.name).toBe('Chosen');
   });
 
-  it('stamps a persona-less conformant plugin: no prepend file, group still complete', () => {
+  it('stamps a persona-less conformant plugin: no prepend file, group still complete', async () => {
     fs.rmSync(TPL, { recursive: true, force: true });
     fs.mkdirSync(path.join(TPL, 'skills', 'greet'), { recursive: true });
     fs.writeFileSync(path.join(TPL, 'plugin.json'), JSON.stringify({ $schema: PLUGIN_SCHEMA_URL, name: 'greeter' }));
     fs.writeFileSync(path.join(TPL, 'skills', 'greet', 'SKILL.md'), '---\nname: greet\ndescription: says hi\n---\n');
 
-    const { group: g, report } = createAgentFromTemplate('sales/sdr');
+    const { group: g, report } = await createAgentFromTemplate('sales/sdr');
 
     expect(g.name).toBe('sdr'); // folder leaf, not the manifest name
     expect(fs.existsSync(path.join(GROUPS_DIR, g.folder, PERSONA_PREPEND_FILE))).toBe(false);
@@ -181,27 +181,27 @@ describe('createAgentFromTemplate', () => {
     expect(report).toEqual([]);
   });
 
-  it('surfaces the reader report to the caller', () => {
+  it('surfaces the reader report to the caller', async () => {
     fs.writeFileSync(
       path.join(TPL, 'plugin.json'),
       JSON.stringify({ $schema: PLUGIN_SCHEMA_URL, name: 'sdr', publisher: 'acme' }),
     );
-    const { report } = createAgentFromTemplate('sales/sdr', { name: 'SDR Report' });
+    const { report } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Report' });
     expect(report).toEqual([expect.stringContaining('unknown field "publisher"')]);
   });
 
-  it('rejects a template containing a symlink before any group state is created', () => {
+  it('rejects a template containing a symlink before any group state is created', async () => {
     fs.symlinkSync('/etc/hosts', path.join(TPL, 'stolen'));
 
-    expect(() => createAgentFromTemplate('sales/sdr', { name: 'Evil' })).toThrow(/symlink/);
-    expect(getAllAgentGroups()).toEqual([]);
+    await expect(createAgentFromTemplate('sales/sdr', { name: 'Evil' })).rejects.toThrow(/symlink/);
+    expect(await getAllAgentGroups()).toEqual([]);
   });
 
-  it('creates template tasks paused through the normal isolated task-session path', () => {
+  it('creates template tasks paused through the normal isolated task-session path', async () => {
     writeTask('weekday-briefing', '0 9 * * 1-5', 'Send the weekday briefing.');
 
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR Tasks' });
-    const sessions = findTaskSessions(g.id);
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Tasks' });
+    const sessions = await findTaskSessions(g.id);
     expect(sessions).toHaveLength(1);
 
     const db = new Database(inboundDbPath(g.id, sessions[0].id), { readonly: true });
@@ -221,13 +221,13 @@ describe('createAgentFromTemplate', () => {
     expect(fs.existsSync(path.join(GROUPS_DIR, g.folder, 'tasks', 'weekday-briefing.md'))).toBe(false);
   });
 
-  it('stamps a valid timezone onto the config row and grounds template task first runs in it', () => {
+  it('stamps a valid timezone onto the config row and grounds template task first runs in it', async () => {
     writeTask('daily-digest', '0 9 * * *', 'Send the digest.');
 
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR TZ', timezone: 'Asia/Tokyo' });
-    expect(getContainerConfig(g.id)?.timezone).toBe('Asia/Tokyo');
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR TZ', timezone: 'Asia/Tokyo' });
+    expect((await getContainerConfig(g.id))?.timezone).toBe('Asia/Tokyo');
 
-    const sessions = findTaskSessions(g.id);
+    const sessions = await findTaskSessions(g.id);
     const db = new Database(inboundDbPath(g.id, sessions[0].id), { readonly: true });
     const row = db.prepare("SELECT process_after FROM messages_in WHERE kind = 'task'").get() as {
       process_after: string;
@@ -240,17 +240,17 @@ describe('createAgentFromTemplate', () => {
     expect(row.process_after).toMatch(/T00:00:00/);
   });
 
-  it('ignores an invalid timezone — the group follows the install default', () => {
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'SDR Bad TZ', timezone: 'Not/AZone' });
-    expect(getContainerConfig(g.id)?.timezone).toBeNull();
+  it('ignores an invalid timezone — the group follows the install default', async () => {
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'SDR Bad TZ', timezone: 'Not/AZone' });
+    expect((await getContainerConfig(g.id))?.timezone).toBeNull();
   });
 
-  it('forwards multiline scripts unchanged through the shared task creation path', () => {
+  it('forwards multiline scripts unchanged through the shared task creation path', async () => {
     const script = 'count=2\necho \'{"wakeAgent": true, "data": {"count": 2}}\'';
     writeTask('alert-watch', '*/15 * * * *', 'Investigate new alerts.', script);
 
-    const { group: g } = createAgentFromTemplate('sales/sdr', { name: 'Scripted Tasks' });
-    const sessions = findTaskSessions(g.id);
+    const { group: g } = await createAgentFromTemplate('sales/sdr', { name: 'Scripted Tasks' });
+    const sessions = await findTaskSessions(g.id);
     expect(sessions).toHaveLength(1);
 
     const db = new Database(inboundDbPath(g.id, sessions[0].id), { readonly: true });
@@ -272,11 +272,11 @@ describe('createAgentFromTemplate', () => {
   it.each([
     ['invalid cron', 'not a cron', /invalid --recurrence/],
     ['too-frequent cron', '* * * * *', /has not been scheduled/],
-  ])('rejects %s before creating the agent group', (_case, schedule, expected) => {
+  ])('rejects %s before creating the agent group', async (_case, schedule, expected) => {
     writeTask('broken', schedule, 'Never created.');
 
-    expect(() => createAgentFromTemplate('sales/sdr', { name: 'Broken Tasks' })).toThrow(expected);
-    expect(getAllAgentGroups()).toEqual([]);
+    await expect(createAgentFromTemplate('sales/sdr', { name: 'Broken Tasks' })).rejects.toThrow(expected);
+    expect(await getAllAgentGroups()).toEqual([]);
     expect(fs.existsSync(path.join(GROUPS_DIR, 'broken-tasks'))).toBe(false);
   });
 });

--- a/src/templates/create-agent.ts
+++ b/src/templates/create-agent.ts
@@ -86,7 +86,7 @@ export function markPluginServers(
  * Returns the created group + the reader's report; the caller wires the group
  * to a channel as usual.
  */
-export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions): CreateAgentResult {
+export async function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions): Promise<CreateAgentResult> {
   const dir = resolveLocalTemplate(ref);
   const tpl = parseTemplate(dir);
   // The group doesn't exist yet, so resolveGroupTimezone can't apply — the
@@ -105,9 +105,9 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
   if (fs.existsSync(resolveGroupFolderPath(folder))) folder = `${folder}-${randomUUID().slice(0, 8)}`;
 
   const group: AgentGroup = { id, name, folder, agent_provider: null, created_at: new Date().toISOString() };
-  createAgentGroup(group);
-  ensureContainerConfig(id);
-  if (timezone) updateContainerConfigScalars(id, { timezone });
+  await createAgentGroup(group);
+  await ensureContainerConfig(id);
+  if (timezone) await updateContainerConfigScalars(id, { timezone });
 
   // group-init.ts owns the mkdir at first spawn, but it isn't called here — so we
   // create the dir ourselves to land instructions.prepend.md + context/.
@@ -140,7 +140,7 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
     fs.mkdirSync(path.join(groupDir, 'plugin-data', tpl.name, sub), { recursive: true });
   }
 
-  updateContainerConfigJson(id, 'mcp_servers', markPluginServers(tpl.mcpServers, tpl.name));
+  await updateContainerConfigJson(id, 'mcp_servers', markPluginServers(tpl.mcpServers, tpl.name));
 
   // Per-group skills overlay — keyed by group id, never shared. Copied through
   // the hardened copier like everything else that leaves the plugin.
@@ -151,7 +151,7 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
 
   // Template tasks require explicit activation. The later welcome flow can
   // present these exact paused tasks and resume only the ones the user accepts.
-  for (const task of tasks.values()) createScheduledTask(id, task, { status: 'paused' });
+  for (const task of tasks.values()) await createScheduledTask(id, task, { status: 'paused' });
 
   for (const line of tpl.report) log.warn('Template reader notice', { ref, notice: line });
 

--- a/src/templates/restamp.test.ts
+++ b/src/templates/restamp.test.ts
@@ -96,13 +96,15 @@ function writeTask(name: string, schedule: string, prompt: string): void {
   fs.writeFileSync(path.join(dir, `${name}.md`), `---\nschedule: "${schedule}"\n---\n\n${prompt}\n`);
 }
 
-function servers(groupId: string): Record<string, McpServerConfig> {
-  return JSON.parse(getContainerConfig(groupId)!.mcp_servers) as Record<string, McpServerConfig>;
+async function servers(groupId: string): Promise<Record<string, McpServerConfig>> {
+  return JSON.parse((await getContainerConfig(groupId))!.mcp_servers) as Record<string, McpServerConfig>;
 }
 
-function liveTasks(groupId: string): Array<{ series_id: string; status: string; recurrence: string; prompt: string }> {
+async function liveTasks(
+  groupId: string,
+): Promise<Array<{ series_id: string; status: string; recurrence: string; prompt: string }>> {
   const rows: Array<{ series_id: string; status: string; recurrence: string; prompt: string }> = [];
-  for (const session of findTaskSessions(groupId)) {
+  for (const session of await findTaskSessions(groupId)) {
     const db = new Database(inboundDbPath(groupId, session.id), { readonly: true });
     for (const row of db
       .prepare(
@@ -117,9 +119,9 @@ function liveTasks(groupId: string): Array<{ series_id: string; status: string; 
 }
 
 /** Every task series id in the group, across all rows regardless of status. */
-function allTaskSeries(groupId: string): string[] {
+async function allTaskSeries(groupId: string): Promise<string[]> {
   const ids = new Set<string>();
-  for (const session of findTaskSessions(groupId)) {
+  for (const session of await findTaskSessions(groupId)) {
     const db = new Database(inboundDbPath(groupId, session.id), { readonly: true });
     for (const row of db.prepare("SELECT DISTINCT series_id FROM messages_in WHERE kind = 'task'").all() as Array<{
       series_id: string;
@@ -137,36 +139,36 @@ function change(changes: RestampChange[], surface: RestampChange['surface'], nam
   return found!;
 }
 
-function stamp(): AgentGroup {
-  return createAgentFromTemplate('sales/sdr', { name: 'SDR' }).group;
+async function stamp(): Promise<AgentGroup> {
+  return (await createAgentFromTemplate('sales/sdr', { name: 'SDR' })).group;
 }
 
 const overlaySkill = (groupId: string, skill: string): string =>
   path.join(DATA_DIR, 'v2-sessions', groupId, '.claude-shared', 'skills', skill, 'SKILL.md');
 
-beforeEach(() => {
+beforeEach(async () => {
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   fs.mkdirSync(TEST_ROOT, { recursive: true });
-  runMigrations(initTestDb());
+  await runMigrations(await initTestDb());
   writeTemplateV1();
 });
 
-afterEach(() => {
-  closeDb();
+afterEach(async () => {
+  await closeDb();
   fs.rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
 describe('plugin ownership marker', () => {
-  it('stamps the plugin marker on every server and pluginRoot on stdio only', () => {
-    const g = stamp();
-    const s = servers(g.id);
+  it('stamps the plugin marker on every server and pluginRoot on stdio only', async () => {
+    const g = await stamp();
+    const s = await servers(g.id);
     expect(s.hubspot).toMatchObject({ plugin: 'sdr', pluginRoot: '/workspace/agent/plugins/sdr' });
     expect(s.docs).toEqual({ type: 'http', url: 'https://mcp.example.com/mcp', plugin: 'sdr' });
   });
 
-  it('never ships the marker to the container config', () => {
-    const g = stamp();
-    const config = configFromDb(getContainerConfig(g.id)!, g);
+  it('never ships the marker to the container config', async () => {
+    const g = await stamp();
+    const config = configFromDb((await getContainerConfig(g.id))!, g);
     expect(config.mcpServers.hubspot).not.toHaveProperty('plugin');
     expect(config.mcpServers.hubspot).toHaveProperty('pluginRoot');
     expect(config.mcpServers.docs).toEqual({ type: 'http', url: 'https://mcp.example.com/mcp' });
@@ -174,7 +176,7 @@ describe('plugin ownership marker', () => {
 });
 
 describe('restampAgentFromTemplate', () => {
-  it('throws when the group does not carry the plugin', () => {
+  it('throws when the group does not carry the plugin', async () => {
     const g: AgentGroup = {
       id: 'ag-bare',
       name: 'Bare',
@@ -182,28 +184,30 @@ describe('restampAgentFromTemplate', () => {
       agent_provider: null,
       created_at: new Date().toISOString(),
     };
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
-    expect(() => restampAgentFromTemplate('sales/sdr', g.id, { apply: false })).toThrow(/does not carry plugin "sdr"/);
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
+    await expect(restampAgentFromTemplate('sales/sdr', g.id, { apply: false })).rejects.toThrow(
+      /does not carry plugin "sdr"/,
+    );
   });
 
-  it('reports all-unchanged when the template did not change', () => {
-    const g = stamp();
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+  it('reports all-unchanged when the template did not change', async () => {
+    const g = await stamp();
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
     expect(result.changes.every((c) => c.action === 'unchanged')).toBe(true);
     expect(result.note).toMatch(/Nothing to apply/);
   });
 
-  it('treats an exec-bit-only template change as an update', () => {
+  it('treats an exec-bit-only template change as an update', async () => {
     // The copier preserves the executable bit, so a chmod-only revision must
     // ship on restamp instead of comparing as byte-identical.
-    const g = stamp();
+    const g = await stamp();
     fs.chmodSync(path.join(TPL, 'plugin.json'), 0o755);
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
     expect(result.changes.find((c) => c.surface === 'plugin')?.action).toBe('update');
   });
 
-  it('recreates a missing ${PLUGIN_DATA} cwd dir even when plugin files are unchanged', () => {
+  it('recreates a missing ${PLUGIN_DATA} cwd dir even when plugin files are unchanged', async () => {
     // The adoption path: same template ref, but the dir is absent (an older
     // engine skipped cwd servers at stamp time, or the agent deleted it).
     // plugin-data scaffold must heal without a plugin-file diff.
@@ -214,22 +218,22 @@ describe('restampAgentFromTemplate', () => {
         mcpServers: { hubspot: { type: 'stdio', command: 'npx', cwd: '${PLUGIN_DATA}/state' } },
       }),
     );
-    const g = stamp();
+    const g = await stamp();
     const stateDir = path.join(GROUPS_DIR, g.folder, 'plugin-data', 'sdr', 'state');
     fs.rmSync(stateDir, { recursive: true });
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(result.changes.find((c) => c.surface === 'plugin')?.action).toBe('unchanged');
     expect(fs.existsSync(stateDir)).toBe(true);
   });
 
-  it('dry run reports every change but mutates nothing', () => {
-    const g = stamp();
+  it('dry run reports every change but mutates nothing', async () => {
+    const g = await stamp();
     const groupDir = path.join(GROUPS_DIR, g.folder);
     writeTemplateV2();
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
 
     expect(result.applied).toBe(false);
     expect(change(result.changes, 'persona', PERSONA_PREPEND_FILE).action).toBe('update');
@@ -248,32 +252,32 @@ describe('restampAgentFromTemplate', () => {
     expect(fs.readFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'utf-8')).toBe('You are an SDR agent.\n');
     expect(fs.existsSync(path.join(groupDir, 'additional_context', 'faq.md'))).toBe(true);
     expect(fs.existsSync(path.join(groupDir, 'guide.md'))).toBe(false);
-    expect(servers(g.id).docs).toBeDefined();
-    expect(servers(g.id).search).toBeUndefined();
-    expect(liveTasks(g.id)).toHaveLength(1);
+    expect((await servers(g.id)).docs).toBeDefined();
+    expect((await servers(g.id)).search).toBeUndefined();
+    expect(await liveTasks(g.id)).toHaveLength(1);
     expect(fs.readFileSync(path.join(groupDir, 'plugins', 'sdr', 'TROUBLESHOOTING.md'), 'utf-8')).toContain('v1');
   });
 
-  it('applies the full update across every plugin-owned surface', () => {
-    const g = stamp();
+  it('applies the full update across every plugin-owned surface', async () => {
+    const g = await stamp();
     const groupDir = path.join(GROUPS_DIR, g.folder);
     // Operator state that must survive: a user-added server, a workspace file,
     // an agent-authored overlay skill, plugin-data content, a resumed task.
-    updateContainerConfigJson(g.id, 'mcp_servers', {
-      ...servers(g.id),
+    await updateContainerConfigJson(g.id, 'mcp_servers', {
+      ...(await servers(g.id)),
       mine: { type: 'http', url: 'https://mine.example.com/mcp' },
     });
     fs.writeFileSync(path.join(groupDir, 'notes.md'), 'agent notes\n');
     fs.mkdirSync(path.dirname(overlaySkill(g.id, 'own')), { recursive: true });
     fs.writeFileSync(overlaySkill(g.id, 'own'), '---\nname: own\ndescription: agent made\n---\n');
     fs.writeFileSync(path.join(groupDir, 'plugin-data', 'sdr', 'state.json'), '{"seen": 3}\n');
-    const series = liveTasks(g.id)[0].series_id;
-    for (const session of findTaskSessions(g.id)) {
+    const series = (await liveTasks(g.id))[0].series_id;
+    for (const session of await findTaskSessions(g.id)) {
       withInboundDb(g.id, session.id, (db) => resumeTask(db, series));
     }
     writeTemplateV2();
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(result.applied).toBe(true);
     expect(result.note).toMatch(/groups restart/);
@@ -289,7 +293,7 @@ describe('restampAgentFromTemplate', () => {
     expect(fs.existsSync(overlaySkill(g.id, 'lookup'))).toBe(true);
     expect(fs.existsSync(overlaySkill(g.id, 'own'))).toBe(true);
     // MCP: plugin set swapped, user server untouched.
-    const s = servers(g.id);
+    const s = await servers(g.id);
     expect(s.hubspot).toMatchObject({ args: ['-y', '@hubspot/mcp-server@2'], plugin: 'sdr' });
     expect(s.docs).toBeUndefined();
     expect(s.search).toMatchObject({ type: 'http', plugin: 'sdr' });
@@ -298,7 +302,7 @@ describe('restampAgentFromTemplate', () => {
     expect(fs.readFileSync(path.join(groupDir, 'notes.md'), 'utf-8')).toBe('agent notes\n');
     expect(fs.readFileSync(path.join(groupDir, 'plugin-data', 'sdr', 'state.json'), 'utf-8')).toBe('{"seen": 3}\n');
     // Tasks: definition updated in place, resumed status kept; new task paused.
-    const tasks = liveTasks(g.id);
+    const tasks = await liveTasks(g.id);
     const briefing = tasks.find((t) => t.series_id === series)!;
     expect(briefing.status).toBe('pending');
     expect(briefing.recurrence).toBe('0 8 * * 1-5');
@@ -307,43 +311,43 @@ describe('restampAgentFromTemplate', () => {
     expect(report.status).toBe('paused');
   });
 
-  it('flags locally customized files and resets them on apply', () => {
-    const g = stamp();
+  it('flags locally customized files and resets them on apply', async () => {
+    const g = await stamp();
     const groupDir = path.join(GROUPS_DIR, g.folder);
     fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'My hand-tuned persona.\n');
     fs.writeFileSync(path.join(groupDir, 'playbook.md'), '# My playbook\n');
     fs.writeFileSync(overlaySkill(g.id, 'widget'), '---\nname: widget\ndescription: my tweak\n---\n');
     writeTemplateV2();
 
-    const plan = restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
+    const plan = await restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
     expect(change(plan.changes, 'persona', PERSONA_PREPEND_FILE).customized).toBe(true);
     expect(change(plan.changes, 'context', 'playbook.md').customized).toBe(true);
     expect(change(plan.changes, 'skill', 'widget').customized).toBe(true);
     // Unmodified surfaces are not flagged.
     expect(change(plan.changes, 'context', 'guide.md').customized).toBeUndefined();
 
-    restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
     expect(fs.readFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'utf-8')).toBe('You are an SDR agent v2.\n');
     expect(fs.readFileSync(path.join(groupDir, 'playbook.md'), 'utf-8')).toBe('# Playbook v2\n');
     expect(fs.readFileSync(overlaySkill(g.id, 'widget'), 'utf-8')).toContain('v2');
   });
 
-  it('never clobbers a user-added server whose name a new plugin server takes', () => {
-    const g = stamp();
-    updateContainerConfigJson(g.id, 'mcp_servers', {
-      ...servers(g.id),
+  it('never clobbers a user-added server whose name a new plugin server takes', async () => {
+    const g = await stamp();
+    await updateContainerConfigJson(g.id, 'mcp_servers', {
+      ...(await servers(g.id)),
       search: { type: 'http', url: 'https://mine.example.com/mcp' },
     });
     writeTemplateV2();
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(change(result.changes, 'mcp-server', 'search').action).toBe('skip');
-    expect(servers(g.id).search).toEqual({ type: 'http', url: 'https://mine.example.com/mcp' });
+    expect((await servers(g.id)).search).toEqual({ type: 'http', url: 'https://mine.example.com/mcp' });
   });
 
-  it('neutralizes planted file symlinks instead of writing through them', () => {
-    const g = stamp();
+  it('neutralizes planted file symlinks instead of writing through them', async () => {
+    const g = await stamp();
     const groupDir = path.join(GROUPS_DIR, g.folder);
     const victim = path.join(TEST_ROOT, 'victim.txt');
     fs.writeFileSync(victim, 'precious\n');
@@ -353,7 +357,7 @@ describe('restampAgentFromTemplate', () => {
     fs.symlinkSync(victim, path.join(groupDir, 'playbook.md'));
     writeTemplateV2();
 
-    restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(fs.readFileSync(victim, 'utf-8')).toBe('precious\n');
     expect(fs.lstatSync(path.join(groupDir, PERSONA_PREPEND_FILE)).isSymbolicLink()).toBe(false);
@@ -361,8 +365,8 @@ describe('restampAgentFromTemplate', () => {
     expect(fs.readFileSync(path.join(groupDir, 'playbook.md'), 'utf-8')).toBe('# Playbook v2\n');
   });
 
-  it('refuses to write context through a symlinked directory', () => {
-    const g = stamp();
+  it('refuses to write context through a symlinked directory', async () => {
+    const g = await stamp();
     const groupDir = path.join(GROUPS_DIR, g.folder);
     const outside = path.join(TEST_ROOT, 'outside');
     fs.mkdirSync(outside, { recursive: true });
@@ -374,12 +378,12 @@ describe('restampAgentFromTemplate', () => {
     fs.mkdirSync(extraDir, { recursive: true });
     fs.writeFileSync(path.join(extraDir, 'faq.md'), '# FAQ v2\n');
 
-    expect(() => restampAgentFromTemplate('sales/sdr', g.id, { apply: true })).toThrow(/resolves outside/);
+    await expect(restampAgentFromTemplate('sales/sdr', g.id, { apply: true })).rejects.toThrow(/resolves outside/);
     expect(fs.existsSync(path.join(outside, 'faq.md'))).toBe(false);
   });
 
-  it('refuses to write skills through a symlinked overlay root', () => {
-    const g = stamp();
+  it('refuses to write skills through a symlinked overlay root', async () => {
+    const g = await stamp();
     const outside = path.join(TEST_ROOT, 'outside-skills');
     fs.mkdirSync(outside, { recursive: true });
     const overlayRoot = path.join(DATA_DIR, 'v2-sessions', g.id, '.claude-shared', 'skills');
@@ -387,48 +391,48 @@ describe('restampAgentFromTemplate', () => {
     fs.symlinkSync(outside, overlayRoot);
     writeTemplateV2();
 
-    expect(() => restampAgentFromTemplate('sales/sdr', g.id, { apply: true })).toThrow(/resolves outside/);
+    await expect(restampAgentFromTemplate('sales/sdr', g.id, { apply: true })).rejects.toThrow(/resolves outside/);
     expect(fs.existsSync(path.join(outside, 'widget'))).toBe(false);
   });
 
-  it('plans over a dangling symlink in the overlay without crashing', () => {
-    const g = stamp();
+  it('plans over a dangling symlink in the overlay without crashing', async () => {
+    const g = await stamp();
     fs.symlinkSync(
       '/nonexistent-target',
       path.join(DATA_DIR, 'v2-sessions', g.id, '.claude-shared', 'skills', 'widget', 'ghost'),
     );
 
-    const plan = restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
+    const plan = await restampAgentFromTemplate('sales/sdr', g.id, { apply: false });
     expect(change(plan.changes, 'skill', 'widget').action).toBe('unchanged');
   });
 
-  it('skips instead of duplicating a series that is re-arming between runs', () => {
-    const g = stamp();
-    const series = liveTasks(g.id)[0].series_id;
+  it('skips instead of duplicating a series that is re-arming between runs', async () => {
+    const g = await stamp();
+    const series = (await liveTasks(g.id))[0].series_id;
     // Simulate the ≤60s window: the run completed, the sweep has not re-armed
     // the next occurrence yet (recurrence still set on the completed row).
-    for (const session of findTaskSessions(g.id)) {
+    for (const session of await findTaskSessions(g.id)) {
       withInboundDb(g.id, session.id, (db) =>
         db.prepare("UPDATE messages_in SET status = 'completed' WHERE series_id = ?").run(series),
       );
     }
     writeTemplateV2();
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     const row = change(result.changes, 'task', 'weekday-briefing');
     expect(row.action).toBe('skip');
     expect(row.note).toMatch(/re-arming/);
     // No duplicate series was created for the briefing; the new template task was.
-    const seriesIds = allTaskSeries(g.id).filter((id) => id.startsWith('weekday-briefing-'));
+    const seriesIds = (await allTaskSeries(g.id)).filter((id) => id.startsWith('weekday-briefing-'));
     expect(seriesIds).toEqual([series]);
-    expect(liveTasks(g.id).some((t) => t.series_id.startsWith('weekly-report-'))).toBe(true);
+    expect((await liveTasks(g.id)).some((t) => t.series_id.startsWith('weekly-report-'))).toBe(true);
   });
 
-  it('deletes a dropped series even while it is re-arming', () => {
-    const g = stamp();
-    const series = liveTasks(g.id)[0].series_id;
-    for (const session of findTaskSessions(g.id)) {
+  it('deletes a dropped series even while it is re-arming', async () => {
+    const g = await stamp();
+    const series = (await liveTasks(g.id))[0].series_id;
+    for (const session of await findTaskSessions(g.id)) {
       withInboundDb(g.id, session.id, (db) =>
         db.prepare("UPDATE messages_in SET status = 'completed' WHERE series_id = ?").run(series),
       );
@@ -436,68 +440,68 @@ describe('restampAgentFromTemplate', () => {
     writeTemplateV2();
     fs.rmSync(path.join(TPL, NANOCLAW_EXTENSION_NS, 'tasks'), { recursive: true });
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(change(result.changes, 'task', 'weekday-briefing').action).toBe('remove');
-    expect(allTaskSeries(g.id)).toEqual([]);
+    expect(await allTaskSeries(g.id)).toEqual([]);
   });
 
-  it('updates the stamped series, not a newer user task with the same name', () => {
-    const g = stamp();
-    const stamped = liveTasks(g.id)[0].series_id;
+  it('updates the stamped series, not a newer user task with the same name', async () => {
+    const g = await stamp();
+    const stamped = (await liveTasks(g.id))[0].series_id;
     const prepared = prepareScheduledTask({
       name: 'weekday-briefing',
       prompt: 'My own briefing.',
       recurrence: '0 12 * * 1-5',
       timezone: 'UTC',
     });
-    const mine = createScheduledTask(g.id, prepared, { status: 'pending' }).row.series_id!;
+    const mine = (await createScheduledTask(g.id, prepared, { status: 'pending' })).row.series_id!;
     writeTemplateV2();
 
-    restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
-    const tasks = liveTasks(g.id);
+    const tasks = await liveTasks(g.id);
     expect(tasks.find((t) => t.series_id === mine)!.prompt).toBe('My own briefing.');
     expect(tasks.find((t) => t.series_id === stamped)!.prompt).toBe('Send the improved weekday briefing.');
   });
 
-  it('treats a rename that preserves the slug as an update, never remove+create', () => {
-    const g = stamp();
-    const series = liveTasks(g.id)[0].series_id;
+  it('treats a rename that preserves the slug as an update, never remove+create', async () => {
+    const g = await stamp();
+    const series = (await liveTasks(g.id))[0].series_id;
     writeTemplateV2();
     fs.rmSync(path.join(TPL, NANOCLAW_EXTENSION_NS, 'tasks'), { recursive: true });
     // Same slug as v1's weekday-briefing, different name casing.
     writeTask('Weekday-Briefing', '0 8 * * 1-5', 'Renamed but same series.');
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(result.changes.filter((c) => c.surface === 'task' && c.action === 'remove')).toEqual([]);
-    const tasks = liveTasks(g.id);
+    const tasks = await liveTasks(g.id);
     expect(tasks).toHaveLength(1);
     expect(tasks[0].series_id).toBe(series);
     expect(tasks[0].prompt).toBe('Renamed but same series.');
   });
 
-  it('rejects a template whose task names collide on the truncated id slug', () => {
-    const g = stamp();
+  it('rejects a template whose task names collide on the truncated id slug', async () => {
+    const g = await stamp();
     writeTask('a'.repeat(30), '0 9 * * *', 'One.');
     writeTask('a'.repeat(31), '0 9 * * *', 'Two.');
 
-    expect(() => restampAgentFromTemplate('sales/sdr', g.id, { apply: false })).toThrow(/collide on id slug/);
+    await expect(restampAgentFromTemplate('sales/sdr', g.id, { apply: false })).rejects.toThrow(/collide on id slug/);
   });
 
-  it('removes a skill and deletes a task series the new template dropped', () => {
-    const g = stamp();
+  it('removes a skill and deletes a task series the new template dropped', async () => {
+    const g = await stamp();
     writeTemplateV2();
     // v3 = v2 without the widget skill and without any tasks.
     fs.rmSync(path.join(TPL, 'skills', 'widget'), { recursive: true });
     fs.rmSync(path.join(TPL, NANOCLAW_EXTENSION_NS, 'tasks'), { recursive: true });
 
-    const result = restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
+    const result = await restampAgentFromTemplate('sales/sdr', g.id, { apply: true });
 
     expect(change(result.changes, 'skill', 'widget').action).toBe('remove');
     expect(change(result.changes, 'task', 'weekday-briefing').action).toBe('remove');
     expect(fs.existsSync(overlaySkill(g.id, 'widget'))).toBe(false);
-    expect(liveTasks(g.id)).toHaveLength(0);
+    expect(await liveTasks(g.id)).toHaveLength(0);
   });
 });

--- a/src/templates/restamp.ts
+++ b/src/templates/restamp.ts
@@ -63,7 +63,7 @@ export interface RestampResult {
  * manifest (the full walk/caps/lint pass runs in the stamp it gates, not in
  * this probe).
  */
-export function groupsCarryingPlugin(ref: string): AgentGroup[] {
+export async function groupsCarryingPlugin(ref: string): Promise<AgentGroup[]> {
   const dir = resolveLocalTemplate(ref);
   const manifestPath = path.join(dir, PLUGIN_MANIFEST_FILE);
   // The fast path reads ONLY a regular manifest file. Anything else — absent
@@ -74,7 +74,7 @@ export function groupsCarryingPlugin(ref: string): AgentGroup[] {
     parseTemplate(dir);
   }
   const manifest = parsePluginManifest(JSON.parse(fs.readFileSync(manifestPath, 'utf-8')));
-  return getAllAgentGroups().filter((g) =>
+  return (await getAllAgentGroups()).filter((g) =>
     fs.existsSync(path.join(resolveGroupFolderPath(g.folder), 'plugins', manifest.name, PLUGIN_MANIFEST_FILE)),
   );
 }
@@ -84,10 +84,14 @@ export function groupsCarryingPlugin(ref: string): AgentGroup[] {
  * before any mutation when the group is missing, the group doesn't carry this
  * plugin, either plugin copy fails validation, or a template task is invalid.
  */
-export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts: { apply: boolean }): RestampResult {
-  const group = getAgentGroup(agentGroupId);
+export async function restampAgentFromTemplate(
+  ref: string,
+  agentGroupId: string,
+  opts: { apply: boolean },
+): Promise<RestampResult> {
+  const group = await getAgentGroup(agentGroupId);
   if (!group) throw new Error(`Agent group not found: ${agentGroupId}`);
-  const configRow = getContainerConfig(group.id);
+  const configRow = await getContainerConfig(group.id);
   if (!configRow) throw new Error(`No container config for group: ${group.id}`);
 
   const tpl = parseTemplate(resolveLocalTemplate(ref));
@@ -112,11 +116,11 @@ export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts
   // can half-apply over an invalid task file. NEW-side only: the old parsed
   // copy is tolerated as-is, so an already-stamped bad template stays
   // restampable to a fixed version.
-  const preparedTasks = prepareTemplateTasks(tpl.tasks, resolveGroupTimezone(group.id));
+  const preparedTasks = prepareTemplateTasks(tpl.tasks, await resolveGroupTimezone(group.id));
   const newTaskSlugs = new Set(tpl.tasks.map((task) => taskNameSlug(task.name)));
 
   const changes: RestampChange[] = [];
-  const ops: Array<() => void> = [];
+  const ops: Array<() => void | Promise<void>> = [];
 
   // --- plugin files: plugins/<name> replaced wholesale ---------------------
   if (dirsEqual(tpl.dir, oldPluginDir)) {
@@ -316,7 +320,7 @@ export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts
     delete next[name];
     mcpDirty = true;
   }
-  if (mcpDirty) ops.push(() => updateContainerConfigJson(group.id, 'mcp_servers', next));
+  if (mcpDirty) ops.push(async () => await updateContainerConfigJson(group.id, 'mcp_servers', next));
 
   // --- tasks (matched by name slug; pause/resume state is operator-owned) --
   // Old-side tasks are keyed by SLUG — the identity live series carry. A rename
@@ -325,7 +329,7 @@ export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts
   const oldTasks = new Map(old.tasks.map((t) => [taskNameSlug(t.name), t]));
   for (const task of tpl.tasks) {
     const prepared = preparedTasks.get(task.name)!;
-    const match = findTaskSeriesBySlug(group.id, taskNameSlug(task.name));
+    const match = await findTaskSeriesBySlug(group.id, taskNameSlug(task.name));
     const oldTask = oldTasks.get(taskNameSlug(task.name));
     // A dead series (no live row, nothing armed to re-arm) is history, not a
     // task — a fresh series is created alongside it.
@@ -338,7 +342,7 @@ export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts
           ? { customized: true, note: 'was removed locally; recreated paused' }
           : { note: 'created paused' }),
       });
-      ops.push(() => void createScheduledTask(group.id, prepared, { status: 'paused' }));
+      ops.push(async () => void (await createScheduledTask(group.id, prepared, { status: 'paused' })));
       continue;
     }
     if (!match.live) {
@@ -385,7 +389,7 @@ export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts
   }
   for (const [slug, oldTask] of oldTasks) {
     if (newTaskSlugs.has(slug)) continue;
-    const match = findTaskSeriesBySlug(group.id, slug);
+    const match = await findTaskSeriesBySlug(group.id, slug);
     // Nothing to remove when the series is already dead history.
     if (match === undefined || (!match.live && match.recurrence === null)) continue;
     changes.push({
@@ -406,7 +410,7 @@ export function restampAgentFromTemplate(ref: string, agentGroupId: string, opts
   if (opts.apply) {
     for (const [index, op] of ops.entries()) {
       try {
-        op();
+        await op();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(
@@ -518,10 +522,10 @@ interface TaskSeriesMatch {
  * match in ANY state — a recurring series between a run completing and the
  * sweep re-arming it (≤60s) has only completed rows but is still alive.
  */
-function findTaskSeriesBySlug(agentGroupId: string, slug: string): TaskSeriesMatch | undefined {
+async function findTaskSeriesBySlug(agentGroupId: string, slug: string): Promise<TaskSeriesMatch | undefined> {
   if (!slug) return undefined;
   const pattern = `${slug}-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]`;
-  for (const session of [...findTaskSessions(agentGroupId)].reverse()) {
+  for (const session of [...(await findTaskSessions(agentGroupId))].reverse()) {
     if (!fs.existsSync(inboundDbPath(agentGroupId, session.id))) continue;
     const row = withInboundDb(agentGroupId, session.id, (db) =>
       db


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Move central repositories and their callers from concrete synchronous SQLite operations to the asynchronous driver API.

### Why

This is the one coordinated breaking step required to make the central database implementation replaceable.

### How it works

The large diff is a mechanical await/retype pass across host, CLI, setup, scripts, tests, new trunk hooks, and the add-dashboard payload. Migrations now accept `DbDriver`; the 22 legacy migrations are explicitly SQLite-only. The changelog and migration guide document the one-time update for out-of-tree host modules.

Session `inbound.db` and `outbound.db` are unchanged and remain direct SQLite with `journal_mode=DELETE`.

### How it was tested

pnpm run lint; pnpm run typecheck; pnpm run build; full SQLite Vitest suite excluding the unchanged macOS /var vs /private/var upstream transaction fixture. 1,626 SQLite tests passed. Typed lint and typecheck are the migration oracle.

Stack 5/7; this is the only breaking PR in the stack.