### PR TITLE
refactor(db): add backend composition and migration modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to NanoClaw will be documented in this file.
 
 - **New NanoClaw installs now use OneCLI gateway 1.41.0.** Existing 1.36.0 gateways remain compatible because NanoClaw does not depend on any 1.41-only behavior. See [the OneCLI upgrade guide](docs/onecli-upgrades.md) to upgrade an existing gateway.
 - [BREAKING] **Central database access is now asynchronous behind `DbDriver`.** SQLite remains the default and existing `data/v2.db` files are unchanged, but custom source and installed channel/provider extensions must await central reads and writes and adopt the retyped host seams. **Migration:** follow [the central database async migration guide](docs/central-db-async-migration.md) to find affected calls, preserve transaction boundaries, update extensions, verify SQLite behavior, or roll back.
+- **Central DB composition and migrations are backend-ready.** A one-slot driver registry keeps backend selection in `src/db/compose.ts`; `pnpm run migrate` is the explicit schema-change path, host validation can fail closed without DDL, and a shared conformance suite pins transaction, parameter, ordering, and timestamp behavior. SQLite remains the installed default.
 
 ## [2.2.0] - 2026-08-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,9 @@ Exactly one writer per file — no cross-mount lock contention. Heartbeat is a f
 
 ## Central DB
 
-`data/v2.db` holds everything that isn't per-session: users, user_roles, agent_groups, messaging_groups, wiring, pending_approvals, user_dms, chat_sdk_* (for the Chat SDK bridge), schema_version. Migrations live at `src/db/migrations/`.
+The central database holds everything that isn't per-session: users, user_roles, agent_groups, messaging_groups, wiring, pending_approvals, user_dms, chat_sdk_* (for the Chat SDK bridge), schema_version. SQLite at `data/v2.db` is the default; host code uses the async `DbDriver` boundary. Migrations live at `src/db/migrations/`.
 
-For ad-hoc queries from skills or scripts, use the in-tree wrapper rather than the `sqlite3` CLI: `pnpm exec tsx scripts/q.ts <db> "<sql>"`. The host setup intentionally avoids depending on the `sqlite3` binary (`setup/verify.ts:5`); the wrapper goes through the `better-sqlite3` dep that setup already installs and verifies. Default-output format matches `sqlite3 -list` (pipe-separated, no header) so existing skill text reads identically.
+For ad-hoc central queries from skills or scripts, use the in-tree wrapper rather than the `sqlite3` CLI: `pnpm exec tsx scripts/q.ts data/v2.db "<sql>"`. The canonical central path routes through the installed composition; explicit session paths remain direct SQLite. Default output matches `sqlite3 -list` (pipe-separated, no header).
 
 ## Key Files
 
@@ -264,7 +264,7 @@ Note: container logs are lost after the container exits (`--rm` flag). If the ag
 
 Two rules, no exceptions:
 
-- **Storage**: every timestamp written from JS is `new Date().toISOString()` (ISO-8601 UTC with `Z`). Never `datetime('now')` — its naive `YYYY-MM-DD HH:MM:SS` shape is misparsed as local time by `new Date()` and breaks string comparisons against ISO values. In pure-SQL contexts (skill snippets) use `strftime('%Y-%m-%dT%H:%M:%fZ','now')`. SQL-side *comparisons* wrap both sides in `datetime()`.
+- **Storage**: every timestamp written from JS is `new Date().toISOString()` (ISO-8601 UTC with `Z`). Central SQL receives that timestamp as a parameter; never use `datetime('now')` or `strftime(...)` there because they are SQLite-specific and the naive shape is misparsed as local time by `new Date()`. SQLite-only mailbox SQL may use `strftime('%Y-%m-%dT%H:%M:%fZ','now')`. SQLite-only comparisons wrap both sides in `datetime()`.
 - **Display**: anything shown to an agent or a user renders in the install timezone — `formatLocalTime` (prose) or `formatLocalStamp` (log lines) from `src/timezone.ts` / `container/agent-runner/src/timezone.ts`. `--json` output, DB values, and operator logs stay ISO.
 
 An agent group can override the install timezone (`ncl groups config update --timezone <IANA>`, `""` clears; approval-gated for agent callers). The override grounds that group's scheduling (cron interpretation, `--process-after`, run-log stamps — effective immediately) and the container's `TZ` env (effective on respawn). Host-side operator display (`ncl` human output) stays in the install timezone. Resolution: `resolveGroupTimezone` in `src/container-config.ts` — group override → install global.

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -1,5 +1,10 @@
 # NanoClaw — Central DB Schema
 
+The central store is accessed through the asynchronous `DbDriver` contract in
+`src/db/driver.ts`. `src/db/compose.ts` performs the one backend choice and
+registers it through `src/db/driver-registry.ts`; callers never import a backend
+directly. SQLite at `data/v2.db` remains the default composition.
+
 Complete reference for `data/v2.db`, the host-owned admin-plane database. Start with [db.md](db.md) for the three-DB overview, the map, and the cross-mount rules.
 
 Access layer: `src/db/`. `src/db/schema.ts`'s `SCHEMA` constant is a *reference copy* of the core tables for orientation — it is not exhaustive: several tables (`agent_destinations`, `pending_approvals`, `container_configs`, `agent_message_policies`, `pending_channel_approvals`, and others) exist only in their migration files under `src/db/migrations/`, which remain the actual source of truth for what's created at runtime.
@@ -440,6 +445,7 @@ Several early migrations were later renamed/retired and replaced by "module" fil
 | 21 | `approval-question-render-metadata` | `021-approval-question.ts` | `question` card-body column on all three approval tables so terminal edits retain the original request |
 | 22 | `messaging-group-detached-at` | `022-messaging-group-detached.ts` | `messaging_groups.detached_at` — records when the bot left a channel without deleting its wiring |
 | 23 | `user-roles-unique` | `023-user-roles-unique.ts` | Deduplicate legacy global grants and enforce separate unique keys for global and scoped roles |
+| 24 | `session-routing-unique` | `024-session-routing-unique.ts` | Enforce one active row per normalized `(agent_group_id, messaging_group_id, thread_id)` route |
 
 Numbers 5 and 6 are intentionally absent — migrations were renumbered during early development.
 
@@ -447,13 +453,32 @@ Session DB schemas (`INBOUND_SCHEMA`, `OUTBOUND_SCHEMA`) are **not** versioned h
 
 ## 3. Portable SQL rules
 
-Central-DB runtime SQL must work on both SQLite and PostgreSQL. Session mailbox SQL is outside this rule because `inbound.db` and `outbound.db` remain backend-specific.
+Central-DB runtime SQL must work on SQLite and installed remote backends. Session mailbox SQL is outside this rule because `inbound.db` and `outbound.db` remain direct SQLite.
 
 - Use `INSERT ... ON CONFLICT (...) DO NOTHING` instead of `INSERT OR IGNORE`.
-- Use `INSERT ... ON CONFLICT (...) DO UPDATE SET ... = excluded....` instead of `INSERT OR REPLACE`; replacement deletes and recreates a row on SQLite and has no PostgreSQL equivalent.
+- Use `INSERT ... ON CONFLICT (...) DO UPDATE SET ... = excluded....` instead of `INSERT OR REPLACE`; replacement deletes and recreates a row and is not portable.
 - Never use `rowid` for runtime ordering. Declare a stable domain-column order, with a deterministic key as the final tie-breaker.
-- Use snake_case aliases. PostgreSQL folds unquoted identifiers to lowercase, so camelCase aliases do not round-trip reliably.
+- Use snake_case aliases because remote SQL engines may fold unquoted identifiers to lowercase.
 - Use `IS NOT DISTINCT FROM ?` when nullable equality is required. `IS ?` is SQLite-only, while `=` does not match two NULL values.
 - Keep named parameters in the existing `@name` form. The backend driver owns placeholder rewriting.
 - Store timestamps as ISO-8601 UTC text produced by `new Date().toISOString()`. Portable central-DB SQL compares the consistently shaped text directly; SQLite-only operational snippets may use `datetime()` around both sides.
 - Central migrations added after the async DB boundary must use the backend-neutral driver API and portable SQL. Backend-specific schema work belongs in a named migration override.
+
+## 4. Migration execution
+
+`runMigrations()` has three modes:
+
+- `auto` migrates SQLite and validates non-SQLite backends.
+- `validate` performs no DDL and refuses startup when the ledger is missing or pending.
+- `migrate` applies migrations and is used by `pnpm run migrate` under the migration-owner role.
+
+Backends may provide three narrow hooks: baseline bootstrap, name-keyed
+migration overrides, and a lock around the complete migration run. Legacy
+SQLite-only migrations are frozen by name; a non-SQLite backend must cover
+them in its baseline or provide an override. Foreign-key PRAGMA handling is
+never attempted outside SQLite.
+
+Host startup uses `auto`; production schema changes are a separate operator
+step. `scripts/q.ts` sends only the canonical `data/v2.db` path through the
+installed composition. Explicit `inbound.db` and `outbound.db` paths always
+remain local SQLite files and retain their journal mode.

--- a/docs/db.md
+++ b/docs/db.md
@@ -2,7 +2,7 @@
 
 Orientation for the data model: the three databases, how they fit together, and the invariants that hold across them. For table-level schemas, follow the links below.
 
-- **[db-central.md](db-central.md)** — every table in `data/v2.db` (identity, wiring, approvals, Chat SDK state) plus the migration system.
+- **[db-central.md](db-central.md)** — every central table (identity, wiring, approvals, Chat SDK state), the driver boundary, and the migration system.
 - **[db-session.md](db-session.md)** — the per-session `inbound.db` + `outbound.db` pair, seq parity, and session folder layout.
 
 Related: [architecture.md](architecture.md) for the high-level design; [api-details.md](api-details.md) for inbound/outbound message content shapes; [isolation-model.md](isolation-model.md) for channel-to-agent wiring modes.
@@ -11,15 +11,15 @@ Related: [architecture.md](architecture.md) for the high-level design; [api-deta
 
 ## 1. The three databases
 
-NanoClaw uses **three kinds of SQLite database**, all on the host filesystem:
+NanoClaw uses one backend-neutral central database and two SQLite session mailboxes:
 
 | DB | Location | Writer | Readers | Purpose |
 |----|----------|--------|---------|---------|
-| **Central** | `data/v2.db` | host | host | Identity, permissions, routing, wiring — the admin plane |
+| **Central** | `data/v2.db` by default; configured backend otherwise | host | host | Identity, permissions, routing, wiring — the admin plane |
 | **Session inbound** | `data/v2-sessions/<agent_group_id>/<session_id>/inbound.db` | host | host (sync), container (read-only) | Host → container messages + routing projections |
 | **Session outbound** | `data/v2-sessions/<agent_group_id>/<session_id>/outbound.db` | container | host (poll), container | Container → host messages + processing status |
 
-**Single-writer rule.** Every SQLite file has exactly one writer. Host writes the central DB and every `inbound.db`; container writes only its own `outbound.db`. This eliminates write contention across the Docker/Apple Container mount boundary — SQLite locking across that boundary is unreliable.
+**Single-writer mailbox rule.** Every session SQLite file has exactly one writer. Host writes every `inbound.db`; container writes only its own `outbound.db`. The default SQLite central DB is host-only, while alternate central backends provide their own concurrency controls.
 
 **Everything is a message.** There is no IPC, stdin piping, or file watcher between host and container. The two session DBs are the sole IO surface. Heartbeat is a file `touch(2)` on `.heartbeat`, not a DB write.
 
@@ -31,7 +31,7 @@ NanoClaw uses **three kinds of SQLite database**, all on the host filesystem:
 
 ```
 data/
-  v2.db                                   ← CENTRAL (host ↔ host)
+  v2.db                                   ← default central backend
   v2-sessions/
     <agent_group_id>/
       .claude-shared/                     ← shared Claude state for the agent group
@@ -88,6 +88,7 @@ These rules are enforced by convention in `src/session-manager.ts` and `containe
 5. **Heartbeat out of band.** File `touch` on `.heartbeat`, not a DB write, so liveness doesn't serialize behind other writers.
 6. **Lazy session-DB migrations.** Central DB uses numbered migrations; per-session DBs use `IF NOT EXISTS` + ad-hoc `ALTER TABLE` helpers for older session folders.
 7. **ACL = row existence.** `agent_destinations` membership is itself the permission — no separate `permissions` table.
+8. **Async central boundary.** Host code reaches central state only through `DbDriver`; backend composition is registered once by `src/db/compose.ts`. Session mailbox access remains a separate seam.
 
 ---
 

--- a/docs/migration-dev.md
+++ b/docs/migration-dev.md
@@ -76,21 +76,21 @@ Each prints `OK:<details>`, `SKIPPED:<reason>`, or errors to stdout. Exit 0 on s
 
 ```bash
 # Agent groups
-sqlite3 data/v2.db "SELECT * FROM agent_groups"
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT * FROM agent_groups"
 
 # Messaging groups + wiring
-sqlite3 data/v2.db "SELECT mg.id, mg.channel_type, mg.platform_id, mg.unknown_sender_policy, mga.engage_mode, mga.engage_pattern FROM messaging_groups mg JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id"
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.id, mg.channel_type, mg.platform_id, mg.unknown_sender_policy, mga.engage_mode, mga.engage_pattern FROM messaging_groups mg JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id"
 
 # Sessions
-sqlite3 data/v2.db "SELECT * FROM sessions"
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT * FROM sessions"
 
 # Users and roles
-sqlite3 data/v2.db "SELECT * FROM users"
-sqlite3 data/v2.db "SELECT * FROM user_roles"
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT * FROM users"
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT * FROM user_roles"
 
 # Session continuation (which Claude Code session will be resumed)
-AG_ID=$(sqlite3 data/v2.db "SELECT id FROM agent_groups LIMIT 1")
-SESS_ID=$(sqlite3 data/v2.db "SELECT id FROM sessions LIMIT 1")
+AG_ID=$(pnpm exec tsx scripts/q.ts data/v2.db "SELECT id FROM agent_groups LIMIT 1")
+SESS_ID=$(pnpm exec tsx scripts/q.ts data/v2.db "SELECT id FROM sessions LIMIT 1")
 sqlite3 data/v2-sessions/$AG_ID/$SESS_ID/outbound.db "SELECT * FROM session_state"
 
 # Scheduled tasks
@@ -108,8 +108,8 @@ python3 -m json.tool logs/setup-migration/handoff.json
 **Bot doesn't respond after switchover:**
 1. Check both services aren't running: `systemctl --user list-units 'nanoclaw*'`
 2. Check error log: `tail logs/nanoclaw.error.log`
-3. Check sender policy: `sqlite3 data/v2.db "SELECT unknown_sender_policy FROM messaging_groups"` — must be `public` before owner is seeded
-4. Check engage pattern: `sqlite3 data/v2.db "SELECT engage_mode, engage_pattern FROM messaging_group_agents"` — should be `pattern` / `.` for respond-to-everything
+3. Check sender policy: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT unknown_sender_policy FROM messaging_groups"` — must be `public` before owner is seeded
+4. Check engage pattern: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT engage_mode, engage_pattern FROM messaging_group_agents"` — should be `pattern` / `.` for respond-to-everything
 
 **Session not continuing from v1:**
 1. Check continuation is set: see "Session continuation" query above

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "setup": "tsx setup/index.ts",
     "setup:auto": "tsx setup/auto.ts",
     "ncl": "tsx src/cli/client.ts",
+    "migrate": "tsx scripts/migrate.ts",
     "chat": "tsx scripts/chat.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/scripts/delete-cli-agent.ts
+++ b/scripts/delete-cli-agent.ts
@@ -14,8 +14,9 @@ import path from 'path';
 
 import { CENTRAL_DB_PATH, DATA_DIR } from '../src/config.js';
 import { getAgentGroupByFolder, deleteAgentGroup } from '../src/db/agent-groups.js';
-import { initDb } from '../src/db/connection.js';
+import { closeDb, initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
+import type { AgentGroup } from '../src/types.js';
 
 interface Args {
   folder: string;
@@ -37,26 +38,30 @@ function parseArgs(): Args {
 const args = parseArgs();
 
 const db = await initDb(CENTRAL_DB_PATH);
-await runMigrations(db);
+let ag: AgentGroup | undefined;
+try {
+  await runMigrations(db);
+  ag = await getAgentGroupByFolder(args.folder);
+  if (ag) {
+    if (!db.columnOwners) throw new Error(`Central DB driver "${db.dialect}" does not support column discovery`);
+    const group = ag;
+    await db.transaction(async () => {
+      const tables = (await db.columnOwners!('agent_group_id')).filter((name) => name !== 'agent_groups');
+      for (const name of tables) {
+        const quotedName = `"${name.replaceAll('"', '""')}"`;
+        await db.run(`DELETE FROM ${quotedName} WHERE agent_group_id = ?`, group.id);
+      }
+      await deleteAgentGroup(group.id);
+    });
+  }
+} finally {
+  await closeDb();
+}
 
-const ag = await getAgentGroupByFolder(args.folder);
 if (!ag) {
   console.log(`No agent group with folder "${args.folder}" — nothing to delete.`);
   process.exit(0);
 }
-
-await db.transaction(async () => {
-  const tables = await db.all<{ name: string }>(
-    `SELECT DISTINCT m.name FROM sqlite_master m
-     JOIN pragma_table_info(m.name) p ON p.name = 'agent_group_id'
-     WHERE m.type = 'table' AND m.name != 'agent_groups'`,
-  );
-  for (const { name } of tables) {
-    const quotedName = `"${name.replaceAll('"', '""')}"`;
-    await db.run(`DELETE FROM ${quotedName} WHERE agent_group_id = ?`, ag.id);
-  }
-  await deleteAgentGroup(ag.id);
-});
 
 // Remove the groups/<folder>/ directory.
 const groupDir = path.join(process.cwd(), 'groups', args.folder);

--- a/scripts/migrate.test.ts
+++ b/scripts/migrate.test.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+const MIGRATE = path.resolve(import.meta.dirname, 'migrate.ts');
+const TSX_LOADER = path.resolve(import.meta.dirname, '../node_modules/tsx/dist/loader.mjs');
+
+describe('scripts/migrate.ts', () => {
+  it('migrates the composed SQLite central database', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-migrate-script-'));
+    try {
+      const result = spawnSync(process.execPath, ['--import', TSX_LOADER, MIGRATE], {
+        cwd,
+        encoding: 'utf8',
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('Central DB migrations are current.');
+      const dbPath = path.join(cwd, 'data', 'v2.db');
+      const db = new Database(dbPath, { readonly: true });
+      const row = db.prepare('SELECT COUNT(*) AS count FROM schema_version').get() as { count: number };
+      db.close();
+      expect(row.count).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,12 @@
+import { CENTRAL_DB_PATH } from '../src/config.js';
+import { closeDb, initDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+
+const db = await initDb(CENTRAL_DB_PATH, { role: 'migration' });
+
+try {
+  await runMigrations(db, undefined, { mode: 'migrate' });
+  console.log('Central DB migrations are current.');
+} finally {
+  await closeDb();
+}

--- a/scripts/q.test.ts
+++ b/scripts/q.test.ts
@@ -43,6 +43,19 @@ describe('scripts/q.ts', () => {
     return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
   }
 
+  it('preserves DELETE journaling for explicit session-style paths', () => {
+    const before = new Database(dbPath);
+    expect(before.pragma('journal_mode = DELETE', { simple: true })).toBe('delete');
+    before.close();
+
+    const result = run('SELECT COUNT(*) FROM t');
+    expect(result.status, result.stderr).toBe(0);
+
+    const after = new Database(dbPath, { readonly: true });
+    expect(after.pragma('journal_mode', { simple: true })).toBe('delete');
+    after.close();
+  });
+
   it('SELECT prints pipe-separated rows in default order', () => {
     const r = run('SELECT id, name FROM t ORDER BY id');
     expect(r.status).toBe(0);

--- a/scripts/q.ts
+++ b/scripts/q.ts
@@ -1,24 +1,32 @@
 /**
- * scripts/q.ts — sqlite3 CLI replacement for skill SQL invocations.
+ * scripts/q.ts — central DB query wrapper for skill SQL invocations.
  *
  * Usage:
  *   pnpm exec tsx scripts/q.ts <db-path> "<sql>"
  *
- * Uses better-sqlite3's stmt.reader property to distinguish queries
- * (SELECT / WITH...SELECT) from mutations. Queries print rows in
+ * Routes only the canonical central DB path through the configured driver.
+ * Explicit session paths remain local SQLite files and retain their journal
+ * mode. Queries print rows in
  * sqlite3 CLI default ("list") format — pipe-separated, no header —
- * so existing skill text reads identically. Mutations run via
- * stmt.run() (single statement) or db.exec() (compound).
+ * so existing skill text reads identically. Mutations use the driver's
+ * parameterless `exec()` operation, including compound statements.
  *
  * Why this exists: setup/verify.ts:5 codifies that NanoClaw avoids
  * depending on the sqlite3 CLI binary; setup never installs or probes
  * for it. Skills that shell out to `sqlite3` therefore fail on hosts
  * where it isn't preinstalled (common on fresh Ubuntu — see #2191).
- * This wrapper preserves the skill-text shape (path then SQL string)
- * while routing through the better-sqlite3 dep that setup already
- * installs and verifies.
+ * This wrapper preserves the skill-text shape (path then SQL string). A
+ * remote composition may redirect the canonical data/v2.db path, but never
+ * an explicit inbound.db or outbound.db path.
  */
+import path from 'node:path';
+
 import Database from 'better-sqlite3';
+
+import { CENTRAL_DB_PATH } from '../src/config.js';
+import { closeDb, initDb } from '../src/db/connection.js';
+import type { DbDriver } from '../src/db/driver.js';
+import { SqliteDriver } from '../src/db/drivers/sqlite.js';
 
 const [, , dbPath, sql] = process.argv;
 
@@ -27,32 +35,36 @@ if (!dbPath || sql === undefined) {
   process.exit(2);
 }
 
-const db = new Database(dbPath);
+function isQuery(statement: string): boolean {
+  const normalized = statement
+    .trim()
+    .replace(/^(?:--[^\n]*\n|\/\*[\s\S]*?\*\/\s*)*/g, '')
+    .toUpperCase();
+  if (normalized.startsWith('SELECT')) return true;
+  if (!normalized.startsWith('WITH')) return false;
+  return !/\b(?:INSERT|UPDATE|DELETE)\b/.test(normalized);
+}
+
+let db: DbDriver;
+let close: () => Promise<void>;
+if (path.resolve(dbPath) === path.resolve(CENTRAL_DB_PATH)) {
+  db = await initDb(CENTRAL_DB_PATH, { role: 'tool' });
+  close = closeDb;
+} else {
+  db = new SqliteDriver(new Database(dbPath));
+  close = () => db.close();
+}
 try {
-  try {
-    const stmt = db.prepare(sql);
-    if (stmt.reader) {
-      const rows = stmt.all() as Record<string, unknown>[];
-      for (const row of rows) {
-        console.log(
-          Object.values(row)
-            .map((v) => (v === null ? '' : String(v)))
-            .join('|'),
-        );
-      }
-    } else {
-      stmt.run();
+  if (isQuery(sql)) {
+    const rows = await db.all<Record<string, unknown>>(sql);
+    for (const row of rows) {
+      console.log(
+        Object.values(row)
+          .map((value) => (value === null ? '' : String(value)))
+          .join('|'),
+      );
     }
-  } catch (e: unknown) {
-    // better-sqlite3 throws on compound statements ("contains more than
-    // one statement"). Compound SQL in skills is always mutations
-    // (e.g. "DELETE ...; INSERT ...;"), so fall back to db.exec().
-    if (e instanceof Error && /more than one statement/i.test(e.message)) {
-      db.exec(sql);
-    } else {
-      throw e;
-    }
-  }
+  } else await db.exec(sql);
 } finally {
-  db.close();
+  await close();
 }

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -236,7 +236,7 @@ async function main(): Promise<void> {
   }
   // Existing installs do not get an unsolicited first-agent picker, but an
   // explicit --template-path is always honoured.
-  if (!isResume && (process.env.NANOCLAW_TEMPLATE_PATH?.trim() || !detectRegisteredGroups(process.cwd()))) {
+  if (!isResume && (process.env.NANOCLAW_TEMPLATE_PATH?.trim() || !(await detectRegisteredGroups(process.cwd())))) {
     await runTemplateSetup(savedPickBridged);
   }
 
@@ -532,13 +532,13 @@ async function main(): Promise<void> {
   async function resolveDisplayName(): Promise<string> {
     if (displayName) return displayName;
     const preset = process.env.NANOCLAW_DISPLAY_NAME?.trim();
-    const existing = detectExistingDisplayName(process.cwd());
+    const existing = await detectExistingDisplayName(process.cwd());
     const fallback = process.env.USER?.trim() || 'Operator';
     displayName = preset || existing || (await askDisplayName(fallback));
     return displayName;
   }
 
-  if (!skip.has('cli-agent') && detectRegisteredGroups(process.cwd())) {
+  if (!skip.has('cli-agent') && (await detectRegisteredGroups(process.cwd()))) {
     skip.add('cli-agent');
     skip.add('first-chat');
   }

--- a/setup/central-db-compatibility.test.ts
+++ b/setup/central-db-compatibility.test.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('standalone central DB composition', () => {
+  it('initializes the SQLite composition in a fresh process', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-db-compose-'));
+    const dbPath = path.join(tempDir, 'central.db');
+    const source = `
+      const { initDb, closeDb } = await import('./src/db/connection.ts');
+      const db = await initDb(process.argv[1], { role: 'tool' });
+      await db.exec('CREATE TABLE probe (id TEXT PRIMARY KEY)');
+      await db.run('INSERT INTO probe (id) VALUES (?)', 'ok');
+      const row = await db.get('SELECT COUNT(*) AS n FROM probe');
+      console.log(db.dialect + '|' + row.n);
+      await closeDb();
+    `;
+
+    try {
+      const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', source, dbPath], {
+        cwd: path.resolve(import.meta.dirname, '..'),
+        encoding: 'utf8',
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('sqlite|1');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/central-db-inspection.test.ts
+++ b/setup/central-db-inspection.test.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeDb } from '../src/db/connection.js';
+import { inspectCentralDb } from './central-db-inspection.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await closeDb();
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function tempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-setup-inspection-'));
+  tempDirs.push(root);
+  return root;
+}
+
+describe('setup central-DB inspection', () => {
+  it('returns empty state without creating a missing SQLite database', async () => {
+    const projectRoot = tempRoot();
+    await expect(inspectCentralDb(projectRoot)).resolves.toEqual({
+      displayName: null,
+      registeredGroups: 0,
+      derivedGroups: 0,
+    });
+    expect(fs.existsSync(path.join(projectRoot, 'data', 'v2.db'))).toBe(false);
+  });
+
+  it('reads setup state without changing the SQLite journal mode', async () => {
+    const projectRoot = tempRoot();
+    fs.mkdirSync(path.join(projectRoot, 'data'));
+    const dbPath = path.join(projectRoot, 'data', 'v2.db');
+    const raw = new Database(dbPath);
+    raw.pragma('journal_mode = DELETE');
+    raw.exec(`
+      CREATE TABLE users (id TEXT PRIMARY KEY, display_name TEXT);
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE messaging_group_agents (id TEXT PRIMARY KEY, agent_group_id TEXT NOT NULL);
+      CREATE TABLE container_configs (agent_group_id TEXT PRIMARY KEY, image_tag TEXT);
+      INSERT INTO users (id, display_name) VALUES ('cli:local', 'Operator');
+      INSERT INTO agent_groups (id) VALUES ('ag-1');
+      INSERT INTO messaging_group_agents (id, agent_group_id) VALUES ('mga-1', 'ag-1');
+      INSERT INTO container_configs (agent_group_id, image_tag) VALUES ('ag-1', 'derived:test');
+    `);
+    raw.close();
+
+    await expect(inspectCentralDb(projectRoot)).resolves.toEqual({
+      displayName: 'Operator',
+      registeredGroups: 1,
+      derivedGroups: 1,
+    });
+
+    const inspected = new Database(dbPath, { readonly: true });
+    expect(inspected.pragma('journal_mode', { simple: true })).toBe('delete');
+    inspected.close();
+  });
+});

--- a/setup/central-db-inspection.ts
+++ b/setup/central-db-inspection.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+
+import { closeDb, initDb } from '../src/db/connection.js';
+import type { DbDriver } from '../src/db/driver.js';
+
+export interface CentralDbInspection {
+  displayName: string | null;
+  registeredGroups: number;
+  derivedGroups: number;
+}
+
+function isMissingSqliteFile(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'SQLITE_CANTOPEN'
+  );
+}
+
+/** Read-only setup inspection through the installed central-DB composition. */
+export async function inspectCentralDb(projectRoot: string): Promise<CentralDbInspection> {
+  const result: CentralDbInspection = { displayName: null, registeredGroups: 0, derivedGroups: 0 };
+  const dbPath = path.join(projectRoot, 'data', 'v2.db');
+
+  let db: DbDriver;
+  try {
+    db = await initDb(dbPath, { role: 'tool', readonly: true });
+  } catch (error) {
+    if (isMissingSqliteFile(error)) return result;
+    throw error;
+  }
+
+  try {
+    if (await db.hasTable('users')) {
+      const row = await db.get<{ display_name: string }>(`SELECT display_name FROM users WHERE id = 'cli:local'`);
+      result.displayName = row?.display_name?.trim() || null;
+    }
+    if ((await db.hasTable('agent_groups')) && (await db.hasTable('messaging_group_agents'))) {
+      const row = await db.get<{ count: number }>(
+        `SELECT COUNT(DISTINCT ag.id) AS count FROM agent_groups ag
+         JOIN messaging_group_agents mga ON mga.agent_group_id = ag.id`,
+      );
+      result.registeredGroups = row?.count ?? 0;
+    }
+    if (await db.hasTable('container_configs')) {
+      const row = await db.get<{ count: number }>(
+        'SELECT COUNT(*) AS count FROM container_configs WHERE image_tag IS NOT NULL',
+      );
+      result.derivedGroups = row?.count ?? 0;
+    }
+    return result;
+  } finally {
+    await closeDb();
+  }
+}

--- a/setup/environment.test.ts
+++ b/setup/environment.test.ts
@@ -33,13 +33,13 @@ describe('detectRegisteredGroups', () => {
 
   it('returns false when no registration state exists', async () => {
     const { detectRegisteredGroups } = await import('./environment.js');
-    expect(detectRegisteredGroups(tempDir)).toBe(false);
+    expect(await detectRegisteredGroups(tempDir)).toBe(false);
   });
 
   it('detects pre-migration registered_groups.json', async () => {
     const { detectRegisteredGroups } = await import('./environment.js');
     fs.writeFileSync(path.join(tempDir, 'data', 'registered_groups.json'), '[]');
-    expect(detectRegisteredGroups(tempDir)).toBe(true);
+    expect(await detectRegisteredGroups(tempDir)).toBe(true);
   });
 
   it('returns false for an empty v2 central DB', async () => {
@@ -55,7 +55,7 @@ describe('detectRegisteredGroups', () => {
     `);
     db.close();
 
-    expect(detectRegisteredGroups(tempDir)).toBe(false);
+    expect(await detectRegisteredGroups(tempDir)).toBe(false);
   });
 
   it('detects wired agent groups in the v2 central DB', async () => {
@@ -77,7 +77,7 @@ describe('detectRegisteredGroups', () => {
     );
     db.close();
 
-    expect(detectRegisteredGroups(tempDir)).toBe(true);
+    expect(await detectRegisteredGroups(tempDir)).toBe(true);
   });
 });
 

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -5,9 +5,8 @@
 import fs from 'fs';
 import path from 'path';
 
-import Database from 'better-sqlite3';
-
 import { log } from '../src/log.js';
+import { inspectCentralDb } from './central-db-inspection.js';
 import { commandExists, getPlatform, isHeadless, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
@@ -58,47 +57,16 @@ export function upsertEnvKey(key: string, value: string, projectRoot?: string): 
   fs.writeFileSync(envPath, lines.join('\n') + '\n');
 }
 
-export function detectExistingDisplayName(projectRoot: string): string | null {
-  const dbPath = path.join(projectRoot, 'data', 'v2.db');
-  if (!fs.existsSync(dbPath)) return null;
-
-  let db: Database.Database | null = null;
-  try {
-    db = new Database(dbPath, { readonly: true });
-    const row = db.prepare(`SELECT display_name FROM users WHERE id = 'cli:local'`).get() as
-      | { display_name: string }
-      | undefined;
-    return row?.display_name?.trim() || null;
-  } catch {
-    return null;
-  } finally {
-    db?.close();
-  }
+export async function detectExistingDisplayName(projectRoot: string): Promise<string | null> {
+  return (await inspectCentralDb(projectRoot)).displayName;
 }
 
-export function detectRegisteredGroups(projectRoot: string): boolean {
+export async function detectRegisteredGroups(projectRoot: string): Promise<boolean> {
   if (fs.existsSync(path.join(projectRoot, 'data', 'registered_groups.json'))) {
     return true;
   }
 
-  const dbPath = path.join(projectRoot, 'data', 'v2.db');
-  if (!fs.existsSync(dbPath)) return false;
-
-  let db: Database.Database | null = null;
-  try {
-    db = new Database(dbPath, { readonly: true });
-    const row = db
-      .prepare(
-        `SELECT COUNT(DISTINCT ag.id) as count FROM agent_groups ag
-         JOIN messaging_group_agents mga ON mga.agent_group_id = ag.id`,
-      )
-      .get() as { count: number };
-    return row.count > 0;
-  } catch {
-    return false;
-  } finally {
-    db?.close();
-  }
+  return (await inspectCentralDb(projectRoot)).registeredGroups > 0;
 }
 
 export async function run(_args: string[]): Promise<void> {
@@ -128,7 +96,7 @@ export async function run(_args: string[]): Promise<void> {
   const authDir = path.join(projectRoot, 'store', 'auth');
   const hasAuth = fs.existsSync(authDir) && fs.readdirSync(authDir).length > 0;
 
-  const hasRegisteredGroups = detectRegisteredGroups(projectRoot);
+  const hasRegisteredGroups = await detectRegisteredGroups(projectRoot);
 
   // Check for existing OpenClaw installation
   const homedir = (await import('os')).homedir();

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -2,19 +2,17 @@
  * Step: verify — End-to-end health check of the full installation.
  * Replaces 09-verify.sh
  *
- * Uses better-sqlite3 directly (no sqlite3 CLI), platform-aware service checks.
+ * Uses the configured central-DB driver and platform-aware service checks.
  */
 import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import Database from 'better-sqlite3';
-
-import { CENTRAL_DB_PATH } from '../src/config.js';
 import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { inspectCentralDb } from './central-db-inspection.js';
 import { inspectAgentImage, readImageSource } from './lib/registry-state.js';
 import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
 import { emitStatus } from './status.js';
@@ -182,41 +180,7 @@ export async function run(_args: string[]): Promise<void> {
   //    plus how many agent groups pin an image of their own (reported in step 7).
   //    The two counts get their own try/catch: they read different tables, and a
   //    partially migrated DB must not hide one behind the other's failure.
-  let registeredGroups = 0;
-  let derivedGroups = 0;
-  const dbPath = CENTRAL_DB_PATH;
-  if (fs.existsSync(dbPath)) {
-    let db: Database.Database | null = null;
-    try {
-      db = new Database(dbPath, { readonly: true });
-    } catch {
-      // Unreadable (permissions, or mid-migration) — leave both counts at 0
-      // rather than failing the health check on a transient condition.
-    }
-    if (db) {
-      try {
-        // Count agent groups that have at least one messaging group wired
-        const row = db
-          .prepare(
-            `SELECT COUNT(DISTINCT ag.id) as count FROM agent_groups ag
-             JOIN messaging_group_agents mga ON mga.agent_group_id = ag.id`,
-          )
-          .get() as { count: number };
-        registeredGroups = row.count;
-      } catch {
-        // Table might not exist (DB not migrated yet)
-      }
-      try {
-        const row = db.prepare('SELECT COUNT(*) as count FROM container_configs WHERE image_tag IS NOT NULL').get() as {
-          count: number;
-        };
-        derivedGroups = row.count;
-      } catch {
-        // Same: container_configs arrives with the migrations
-      }
-      db.close();
-    }
-  }
+  const { registeredGroups, derivedGroups } = await inspectCentralDb(projectRoot);
 
   // 6. Check mount allowlist
   let mountAllowlist = 'missing';

--- a/src/db/compose.ts
+++ b/src/db/compose.ts
@@ -1,0 +1,21 @@
+/** Open-source SQLite composition. A remote-backend skill replaces this file. */
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+import { registerDbDriver } from './driver-registry.js';
+import { SqliteDriver } from './drivers/sqlite.js';
+
+registerDbDriver((config, options) => {
+  if (config.url) {
+    throw new Error('A remote central-DB target was provided, but no remote backend is installed');
+  }
+  if (options.readonly && !fs.existsSync(config.path)) {
+    throw Object.assign(new Error(`SQLite central DB does not exist: ${config.path}`), { code: 'SQLITE_CANTOPEN' });
+  }
+  if (!options.readonly) fs.mkdirSync(path.dirname(config.path), { recursive: true });
+  const raw = new Database(config.path, options.readonly ? { readonly: true, fileMustExist: true } : undefined);
+  if (!options.readonly) raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  return new SqliteDriver(raw);
+});

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,10 +1,9 @@
-import Database from 'better-sqlite3';
-import fs from 'fs';
-import path from 'path';
-
+import { CENTRAL_DB_PATH } from '../config.js';
 import { log } from '../log.js';
-import type { DbDriver } from './driver.js';
-import { SqliteDriver } from './drivers/sqlite.js';
+import type { DbConfig, DbDriver, DbInitOptions } from './driver.js';
+import { createDbDriver } from './driver-registry.js';
+
+import './compose.js';
 
 let _db: DbDriver | null = null;
 
@@ -13,36 +12,50 @@ export function getDb(): DbDriver {
   return _db;
 }
 
-export async function initDb(dbPath: string): Promise<DbDriver> {
-  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-  const raw = new Database(dbPath);
-  raw.pragma('journal_mode = WAL');
-  raw.pragma('foreign_keys = ON');
-  _db = new SqliteDriver(raw);
-  log.info('Central DB initialized', { path: dbPath });
+function defaultConfig(): DbConfig {
+  return { path: CENTRAL_DB_PATH };
+}
+
+export async function initDb(
+  target: string | Partial<DbConfig> = CENTRAL_DB_PATH,
+  options: DbInitOptions = { role: 'runtime' },
+): Promise<DbDriver> {
+  if (_db) throw new Error('Central DB is already initialized');
+  const config = { ...defaultConfig(), ...(typeof target === 'string' ? { path: target } : target) };
+  _db = await createDbDriver(config, options);
+  if (options.role !== 'tool') {
+    log.info('Central DB initialized', {
+      dialect: _db.dialect,
+      target: config.url ? 'configured remote target' : config.path,
+      role: options.role,
+    });
+  }
   return _db;
 }
 
-/** For tests only — creates an in-memory DB and runs migrations. */
-export async function initTestDb(): Promise<DbDriver> {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  _db = new SqliteDriver(raw);
-  return _db;
+export interface InitTestDbOptions {
+  fresh?: boolean;
+}
+
+/** For tests only — the installed composition owns backend selection/reset. */
+export async function initTestDb(options: InitTestDbOptions = {}): Promise<DbDriver> {
+  await closeDb();
+  const db = await initDb(':memory:', { role: 'test' });
+  await db.prepareTestSchema?.(options);
+  return db;
 }
 
 export async function closeDb(): Promise<void> {
-  await _db?.close();
+  const current = _db;
   _db = null;
+  await current?.close();
 }
 
 /**
  * Check whether a table exists. Used by core code that touches
- * module-owned tables so that an uninstalled module degrades silently
- * instead of raising SQLite errors. Cheap: a single indexed lookup on
- * sqlite_master. Results are not cached — a module install adds the
- * table at runtime (next service start), and callers may run before
- * or after that boundary.
+ * module-owned tables so that an uninstalled module degrades silently.
+ * Each driver owns the dialect-specific lookup and a positive-only cache;
+ * creating a fresh test driver or closing the current driver resets it.
  */
 export async function hasTable(db: DbDriver, name: string): Promise<boolean> {
   return db.hasTable(name);

--- a/src/db/driver-registry.test.ts
+++ b/src/db/driver-registry.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { DbConfig, DbDriver } from './driver.js';
+import { createDbDriver, registerDbDriver, resetDbDriverRegistryForTesting } from './driver-registry.js';
+
+const config: DbConfig = {
+  path: ':memory:',
+};
+
+const driver = { dialect: 'sqlite' } as DbDriver;
+
+beforeEach(() => resetDbDriverRegistryForTesting());
+
+describe('central DB driver registry', () => {
+  it('fails closed when composition did not register a driver', async () => {
+    await expect(createDbDriver(config, { role: 'runtime' })).rejects.toThrow('No central DB driver registered');
+  });
+
+  it('creates the registered driver and forwards role/config', async () => {
+    let received: unknown;
+    registerDbDriver((nextConfig, options) => {
+      received = { nextConfig, options };
+      return driver;
+    });
+
+    await expect(createDbDriver(config, { role: 'host' })).resolves.toBe(driver);
+    expect(received).toEqual({ nextConfig: config, options: { role: 'host' } });
+  });
+
+  it('rejects duplicate registration', () => {
+    registerDbDriver(() => driver);
+    expect(() => registerDbDriver(() => driver)).toThrow('Central DB driver already registered');
+  });
+
+  it('rejects late registration after the first resolution attempt', async () => {
+    await expect(createDbDriver(config, { role: 'runtime' })).rejects.toThrow('No central DB driver registered');
+    expect(() => registerDbDriver(() => driver)).toThrow('Central DB driver registration is closed');
+  });
+});

--- a/src/db/driver-registry.ts
+++ b/src/db/driver-registry.ts
@@ -1,0 +1,23 @@
+import type { DbConfig, DbDriver, DbInitOptions } from './driver.js';
+
+export type DbDriverFactory = (config: DbConfig, options: DbInitOptions) => DbDriver | Promise<DbDriver>;
+
+let factory: DbDriverFactory | undefined;
+let sealed = false;
+
+export function registerDbDriver(next: DbDriverFactory): void {
+  if (sealed) throw new Error('Central DB driver registration is closed');
+  if (factory) throw new Error('Central DB driver already registered');
+  factory = next;
+}
+
+export async function createDbDriver(config: DbConfig, options: DbInitOptions): Promise<DbDriver> {
+  sealed = true;
+  if (!factory) throw new Error('No central DB driver registered');
+  return factory(config, options);
+}
+
+export function resetDbDriverRegistryForTesting(): void {
+  factory = undefined;
+  sealed = false;
+}

--- a/src/db/driver.ts
+++ b/src/db/driver.ts
@@ -1,7 +1,40 @@
-export type DbDialect = 'sqlite' | 'postgres';
+export type DbDialect = 'sqlite' | (string & {});
 
 export interface RunResult {
   changes: number;
+}
+
+export type DbRole = 'host' | 'runtime' | 'migration' | 'tool' | 'test';
+
+export interface DbConfig {
+  path: string;
+  /** Optional remote target supplied by an installed composition. */
+  url?: string;
+}
+
+export interface DbInitOptions {
+  role: DbRole;
+  /** Open without mutating the local database or its journal mode. */
+  readonly?: boolean;
+}
+
+export interface PrepareTestSchemaOptions {
+  fresh?: boolean;
+}
+
+/** Structurally compatible with a portable migration without importing it. */
+export interface DriverMigrationOverride {
+  name: string;
+  up: (db: DbDriver) => void | Promise<void>;
+}
+
+export interface DbMigrationHooks {
+  /** Create a backend-native baseline and seed its covered migration names. */
+  bootstrapSchema?: (db: DbDriver) => Promise<void>;
+  /** Replace a migration whose trunk implementation is backend-specific. */
+  migrationOverrides?: ReadonlyMap<string, DriverMigrationOverride>;
+  /** Serialize the complete migration run outside transaction watchdogs. */
+  withMigrationLock?: <T>(run: () => Promise<T>) => Promise<T>;
 }
 
 /**
@@ -14,6 +47,11 @@ export interface RunResult {
  */
 export interface DbDriver {
   readonly dialect: DbDialect;
+  readonly migrationHooks?: DbMigrationHooks;
+  /** Backend-owned test isolation/reset hook. */
+  prepareTestSchema?(options: PrepareTestSchemaOptions): Promise<void>;
+  /** Tables containing a named column, used by backend-neutral maintenance. */
+  columnOwners?(column: string): Promise<string[]>;
   get<T = unknown>(sql: string, ...params: unknown[]): Promise<T | undefined>;
   all<T = unknown>(sql: string, ...params: unknown[]): Promise<T[]>;
   run(sql: string, ...params: unknown[]): Promise<RunResult>;

--- a/src/db/drivers/sqlite.conformance.test.ts
+++ b/src/db/drivers/sqlite.conformance.test.ts
@@ -1,0 +1,12 @@
+import Database from 'better-sqlite3';
+
+import { defineDriverConformance } from '../testing/driver-conformance.js';
+import { SqliteDriver } from './sqlite.js';
+
+defineDriverConformance('SQLite', {
+  create(options) {
+    const raw = new Database(':memory:');
+    raw.pragma('foreign_keys = ON');
+    return new SqliteDriver(raw, options?.watchdogMs);
+  },
+});

--- a/src/db/drivers/sqlite.test.ts
+++ b/src/db/drivers/sqlite.test.ts
@@ -147,4 +147,9 @@ describe('SqliteDriver transactions', () => {
     await driver.close();
     await expect(driver.get('SELECT 1')).rejects.toThrow('driver is closed');
   });
+
+  it('discovers tables that own a column', async () => {
+    await driver.exec('CREATE TABLE other (id TEXT PRIMARY KEY, value TEXT NOT NULL)');
+    await expect(driver.columnOwners('value')).resolves.toEqual(['items', 'other']);
+  });
 });

--- a/src/db/drivers/sqlite.ts
+++ b/src/db/drivers/sqlite.ts
@@ -141,6 +141,18 @@ export class SqliteDriver implements DbDriver {
     return row !== undefined;
   }
 
+  async columnOwners(column: string): Promise<string[]> {
+    const rows = await this.all<{ name: string }>(
+      `SELECT DISTINCT m.name
+         FROM sqlite_master m
+         JOIN pragma_table_info(m.name) p ON p.name = ?
+        WHERE m.type = 'table'
+        ORDER BY m.name`,
+      column,
+    );
+    return rows.map(({ name }) => name);
+  }
+
   async close(): Promise<void> {
     if (this.closed) return;
     if (this.activeTransaction) await this.activeTransaction;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 export { initDb, initTestDb, getDb, closeDb } from './connection.js';
-export type { DbDriver, DbDialect, RunResult } from './driver.js';
+export type { DbConfig, DbDriver, DbDialect, DbInitOptions, DbRole, RunResult } from './driver.js';
 export { runMigrations } from './migrations/index.js';
+export type { MigrationMode, MigrationRunOptions } from './migrations/index.js';
 export {
   createAgentGroup,
   getAgentGroup,

--- a/src/db/migrations/023-user-roles-unique.ts
+++ b/src/db/migrations/023-user-roles-unique.ts
@@ -4,7 +4,7 @@ import type { Migration } from './index.js';
  * SQLite treats NULL values as distinct inside a composite primary key, so
  * the original (user_id, role, agent_group_id) key allowed duplicate global
  * owner/admin grants. Collapse any existing duplicates, then enforce the two
- * logical key shapes explicitly. The Postgres baseline preserves these
+ * logical key shapes explicitly. A remote baseline must preserve these
  * indexes instead of relying on nullable-key behavior.
  */
 export const migration023: Migration = {

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -53,6 +53,12 @@ export interface SqliteOnlyMigration extends MigrationBase {
 
 export type Migration = PortableMigration | SqliteOnlyMigration;
 
+export type MigrationMode = 'auto' | 'validate' | 'migrate';
+
+export interface MigrationRunOptions {
+  mode?: MigrationMode;
+}
+
 /**
  * Public module migrations use a core-reserved, owner-qualified identity so
  * independent modules may reuse local migration names without colliding.
@@ -130,75 +136,106 @@ const fkIdentity = (v: FkViolation): string =>
 export async function runMigrations(
   db: DbDriver,
   list: readonly Migration[] = getRegisteredMigrations(),
+  options: MigrationRunOptions = {},
 ): Promise<void> {
-  await db.exec(`
-    CREATE TABLE IF NOT EXISTS schema_version (
-      version INTEGER PRIMARY KEY,
-      name    TEXT NOT NULL,
-      applied TEXT NOT NULL
-    );
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_schema_version_name ON schema_version(name);
-  `);
+  const mode =
+    options.mode === undefined || options.mode === 'auto'
+      ? db.dialect === 'sqlite'
+        ? 'migrate'
+        : 'validate'
+      : options.mode;
 
-  // Uniqueness is keyed on `name`, not `version`. This lets module
-  // migrations (added later by install skills) pick arbitrary version
-  // numbers without coordinating across modules. `version` stays on
-  // the Migration object as an ordering hint within the barrel array;
-  // the stored `version` column is auto-assigned at insert time as an
-  // applied-order number.
-  const applied = new Set<string>(
-    (await db.all<{ name: string }>('SELECT name FROM schema_version')).map((r) => r.name),
-  );
-  const pending = list.filter((m) => !applied.has(m.name));
-  if (pending.length === 0) return;
-
-  log.info('Running migrations', { count: pending.length });
-
-  for (const m of pending) {
-    const raw = m.sqliteOnly || m.disableForeignKeys ? sqliteRaw(db) : null;
-    // Table recreates need FK enforcement off for the DROP+RENAME window.
-    // The pragma must be toggled OUTSIDE the transaction (it's a silent
-    // no-op inside one); foreign_key_check runs INSIDE so a violating
-    // recreate rolls back atomically with nothing committed.
-    if (m.disableForeignKeys) raw!.pragma('foreign_keys = OFF');
-    try {
-      await db.transaction(async () => {
-        // Snapshot violations BEFORE up() runs: live DBs can carry latent
-        // FK orphans (e.g. parents deleted through a FK-OFF sqlite3 CLI
-        // session — ensureUserDm tolerates exactly this at runtime). The
-        // migration must only fail for violations it INTRODUCED; throwing
-        // on pre-existing ones would crash-loop the host at every boot
-        // (runMigrations runs on startup) until manual DB surgery.
-        const preexisting = m.disableForeignKeys
-          ? new Set((raw!.pragma('foreign_key_check') as FkViolation[]).map(fkIdentity))
-          : null;
-        if (m.sqliteOnly) await m.up(raw!);
-        else await m.up(db);
-        if (m.disableForeignKeys && preexisting) {
-          const violations = raw!.pragma('foreign_key_check') as FkViolation[];
-          const introduced = violations.filter((v) => !preexisting.has(fkIdentity(v)));
-          const carried = violations.length - introduced.length;
-          if (carried > 0) {
-            log.warn('Pre-existing FK violations carried through migration (not introduced by it)', {
-              migration: m.name,
-              count: carried,
-            });
-          }
-          if (introduced.length > 0) {
-            throw new Error(`migration ${m.name} left FK violations: ${JSON.stringify(introduced.slice(0, 5))}`);
-          }
-        }
-        const next = (await db.get<{ v: number }>('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version'))!.v;
-        await db.run(
-          'INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)',
-          next,
-          m.name,
-          new Date().toISOString(),
-        );
-      });
-    } finally {
-      if (m.disableForeignKeys) raw!.pragma('foreign_keys = ON');
+  if (mode === 'validate') {
+    if (!(await db.hasTable('schema_version'))) {
+      throw new Error('Central DB schema is not initialized; run `pnpm run migrate` with the migration role');
     }
-    log.info('Migration applied', { name: m.name });
+    const applied = new Set((await db.all<{ name: string }>('SELECT name FROM schema_version')).map((row) => row.name));
+    const pending = list.filter((migration) => !applied.has(migration.name));
+    if (pending.length > 0) {
+      throw new Error(
+        `Central DB has pending migrations (${pending.map((migration) => migration.name).join(', ')}); run \`pnpm run migrate\``,
+      );
+    }
+    return;
   }
+
+  const migrate = async (): Promise<void> => {
+    await db.migrationHooks?.bootstrapSchema?.(db);
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY,
+        name    TEXT NOT NULL,
+        applied TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_schema_version_name ON schema_version(name);
+    `);
+
+    // Uniqueness is keyed on `name`, not `version`. This lets module
+    // migrations (added later by install skills) pick arbitrary version
+    // numbers without coordinating across modules. `version` stays on
+    // the Migration object as an ordering hint within the barrel array;
+    // the stored `version` column is auto-assigned at insert time as an
+    // applied-order number.
+    const applied = new Set((await db.all<{ name: string }>('SELECT name FROM schema_version')).map((row) => row.name));
+    const pending = list.filter((migration) => !applied.has(migration.name));
+    if (pending.length === 0) return;
+
+    log.info('Running migrations', { count: pending.length });
+    for (const migration of pending) await applyMigration(db, migration);
+  };
+
+  if (db.migrationHooks?.withMigrationLock) await db.migrationHooks.withMigrationLock(migrate);
+  else await migrate();
+}
+
+async function applyMigration(db: DbDriver, migration: Migration): Promise<void> {
+  const override = db.migrationHooks?.migrationOverrides?.get(migration.name);
+  const sqliteOnly = override ? false : migration.sqliteOnly === true;
+  const disableForeignKeys = override ? false : migration.disableForeignKeys === true;
+  if ((sqliteOnly || disableForeignKeys) && db.dialect !== 'sqlite') {
+    throw new Error(`Migration "${migration.name}" is SQLite-only; port it or provide a backend migration override`);
+  }
+
+  const raw = sqliteOnly || disableForeignKeys ? sqliteRaw(db) : null;
+  // Table recreates need FK enforcement off for the DROP+RENAME window.
+  // The pragma must be toggled OUTSIDE the transaction (it's a silent
+  // no-op inside one); foreign_key_check runs INSIDE so a violating
+  // recreate rolls back atomically with nothing committed.
+  if (disableForeignKeys) raw!.pragma('foreign_keys = OFF');
+  try {
+    await db.transaction(async () => {
+      // Snapshot violations BEFORE up() runs: live DBs can carry latent
+      // FK orphans. A migration must fail only for violations it introduces.
+      const preexisting = disableForeignKeys
+        ? new Set((raw!.pragma('foreign_key_check') as FkViolation[]).map(fkIdentity))
+        : null;
+      if (override) await override.up(db);
+      else if (migration.sqliteOnly) await migration.up(raw!);
+      else await migration.up(db);
+      if (disableForeignKeys && preexisting) {
+        const violations = raw!.pragma('foreign_key_check') as FkViolation[];
+        const introduced = violations.filter((violation) => !preexisting.has(fkIdentity(violation)));
+        const carried = violations.length - introduced.length;
+        if (carried > 0) {
+          log.warn('Pre-existing FK violations carried through migration (not introduced by it)', {
+            migration: migration.name,
+            count: carried,
+          });
+        }
+        if (introduced.length > 0) {
+          throw new Error(`migration ${migration.name} left FK violations: ${JSON.stringify(introduced.slice(0, 5))}`);
+        }
+      }
+      const next = (await db.get<{ v: number }>('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version'))!.v;
+      await db.run(
+        'INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)',
+        next,
+        migration.name,
+        new Date().toISOString(),
+      );
+    });
+  } finally {
+    if (disableForeignKeys) raw!.pragma('foreign_keys = ON');
+  }
+  log.info('Migration applied', { name: migration.name });
 }

--- a/src/db/migrations/portability.test.ts
+++ b/src/db/migrations/portability.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { migrations } from './index.js';
+
+const FROZEN_SQLITE_ONLY = new Set([
+  'initial-v2-schema',
+  'chat-sdk-state',
+  'pending-approvals',
+  'agent-destinations',
+  'agent-message-policies',
+  'pending-approvals-title-options',
+  'approvals-approver-user-id',
+  'dropped-messages',
+  'drop-pending-credentials',
+  'engage-modes',
+  'pending-sender-approvals',
+  'channel-registration',
+  'approval-render-metadata',
+  'container-configs',
+  'cli-scope',
+  'messaging-group-instance',
+  'wiring-threads-override',
+  'container-config-timezone',
+  'approval-question-render-metadata',
+  'user-roles-unique',
+]);
+
+const BANNED_PORTABLE_SQL = [
+  /\bPRAGMA\b/i,
+  /\bsqlite_master\b/i,
+  /\bINSERT\s+OR\b/i,
+  /\browid\b/i,
+  /\bdatetime\s*\(/i,
+  /\bstrftime\s*\(/i,
+  /\bIS\s+\?/i,
+];
+
+describe('central migration portability policy', () => {
+  it('freezes SQLite-only status to the pre-boundary migration set', () => {
+    const actual = migrations.filter((migration) => migration.sqliteOnly).map((migration) => migration.name);
+    expect(new Set(actual)).toEqual(FROZEN_SQLITE_ONLY);
+  });
+
+  it('requires every post-boundary migration to be async and portable', () => {
+    for (const migration of migrations.filter((candidate) => !candidate.sqliteOnly)) {
+      expect(migration.up.constructor.name, migration.name).toBe('AsyncFunction');
+      const source = String(migration.up);
+      for (const banned of BANNED_PORTABLE_SQL) expect(source, `${migration.name}: ${banned}`).not.toMatch(banned);
+    }
+  });
+
+  it('preserves the skill-edit migration anchors byte-for-byte', () => {
+    const source = fs.readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+    expect(source).toContain("import { migration019 } from './019-wiring-threads.js';");
+    expect(source).toContain('\n  migration019,\n');
+  });
+});

--- a/src/db/migrations/registry.test.ts
+++ b/src/db/migrations/registry.test.ts
@@ -100,3 +100,94 @@ describe('module migration registry', () => {
     ).toBeUndefined();
   });
 });
+
+describe('migration runner modes and hooks', () => {
+  it('validate mode performs no bootstrap DDL on an empty database', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+
+    await expect(registry.runMigrations(db, [], { mode: 'validate' })).rejects.toThrow('pnpm run migrate');
+    expect(await db.hasTable('schema_version')).toBe(false);
+  });
+
+  it('validate mode reports pending names and accepts a current ledger', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    const first = testMigration('test-mode-first');
+    const second = testMigration('test-mode-second');
+
+    await registry.runMigrations(db, [first], { mode: 'migrate' });
+    await expect(registry.runMigrations(db, [first, second], { mode: 'validate' })).rejects.toThrow('test-mode-second');
+    await expect(registry.runMigrations(db, [first], { mode: 'validate' })).resolves.toBeUndefined();
+  });
+
+  it('runs bootstrap, overrides, and the migration lock hook', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    const calls: string[] = [];
+    Object.defineProperty(db, 'migrationHooks', {
+      value: {
+        bootstrapSchema: async () => {
+          calls.push('bootstrap');
+        },
+        migrationOverrides: new Map([
+          [
+            'sqlite-original',
+            {
+              name: 'sqlite-original',
+              async up(driver: typeof db) {
+                calls.push('override');
+                await driver.exec('CREATE TABLE override_won (id TEXT PRIMARY KEY)');
+              },
+            },
+          ],
+        ]),
+        withMigrationLock: async (run: () => Promise<void>) => {
+          calls.push('lock-enter');
+          await run();
+          calls.push('lock-exit');
+        },
+      },
+    });
+    const original: Migration = {
+      version: 999,
+      name: 'sqlite-original',
+      sqliteOnly: true,
+      up() {
+        throw new Error('original migration must not run');
+      },
+    };
+
+    await registry.runMigrations(db, [original], { mode: 'migrate' });
+
+    expect(calls).toEqual(['lock-enter', 'bootstrap', 'override', 'lock-exit']);
+    expect(await db.hasTable('override_won')).toBe(true);
+  });
+
+  it('defaults non-SQLite auto mode to validation without DDL', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    Object.defineProperty(db, 'dialect', { value: 'remote' });
+
+    await expect(registry.runMigrations(db, [], { mode: 'auto' })).rejects.toThrow('pnpm run migrate');
+    expect(await db.hasTable('schema_version')).toBe(false);
+  });
+
+  it('refuses SQLite-only migrations on another dialect before running them', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    Object.defineProperty(db, 'dialect', { value: 'remote' });
+    const sqliteOnly: Migration = {
+      version: 999,
+      name: 'sqlite-refused',
+      sqliteOnly: true,
+      up() {
+        throw new Error('must not run');
+      },
+    };
+
+    await expect(registry.runMigrations(db, [sqliteOnly], { mode: 'migrate' })).rejects.toThrow(
+      'port it or provide a backend migration override',
+    );
+  });
+});

--- a/src/db/testing/driver-conformance.ts
+++ b/src/db/testing/driver-conformance.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { DbDriver } from '../driver.js';
+
+export interface DriverConformanceFactory {
+  create(options?: { watchdogMs?: number }): Promise<DbDriver> | DbDriver;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+/** Shared contract that every central DB backend must pass. */
+export function defineDriverConformance(name: string, factory: DriverConformanceFactory): void {
+  describe(`${name} central DB driver conformance`, () => {
+    let db: DbDriver;
+
+    beforeEach(async () => {
+      db = await factory.create();
+      await db.exec('CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT, n INTEGER NOT NULL)');
+    });
+
+    afterEach(async () => {
+      await db.close();
+    });
+
+    it('supports positional and named parameters', async () => {
+      await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'positional', 'first', 1);
+      await db.run('INSERT INTO items (id, value, n) VALUES (@id, @value, @n)', {
+        id: 'named',
+        value: 'second',
+        n: 2,
+        unused: 'ignored',
+      });
+
+      expect(await db.all('SELECT id, value, n FROM items ORDER BY n')).toEqual([
+        { id: 'positional', value: 'first', n: 1 },
+        { id: 'named', value: 'second', n: 2 },
+      ]);
+    });
+
+    it('reports changed rows', async () => {
+      expect((await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'one', null, 1)).changes).toBe(1);
+      expect((await db.run('UPDATE items SET value = ? WHERE id = ?', 'set', 'one')).changes).toBe(1);
+      expect((await db.run('DELETE FROM items WHERE id = ?', 'missing')).changes).toBe(0);
+    });
+
+    it('commits, rolls back, and uses nested savepoints', async () => {
+      await db.transaction(async () => {
+        await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'outer', null, 1);
+        await expect(
+          db.transaction(async () => {
+            await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'inner-rollback', null, 2);
+            throw new Error('inner failure');
+          }),
+        ).rejects.toThrow('inner failure');
+        await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'after-savepoint', null, 3);
+      });
+      await expect(
+        db.transaction(async () => {
+          await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'outer-rollback', null, 4);
+          throw new Error('outer failure');
+        }),
+      ).rejects.toThrow('outer failure');
+
+      expect(await db.all<{ id: string }>('SELECT id FROM items ORDER BY n')).toEqual([
+        { id: 'outer' },
+        { id: 'after-savepoint' },
+      ]);
+    });
+
+    it('executes compound SQL and reports table existence', async () => {
+      expect(await db.hasTable('extra')).toBe(false);
+      await db.exec("CREATE TABLE extra (id TEXT PRIMARY KEY); INSERT INTO extra (id) VALUES ('x');");
+      expect(await db.hasTable('extra')).toBe(true);
+      expect(await db.get('SELECT id FROM extra')).toEqual({ id: 'x' });
+    });
+
+    it('returns numeric aggregates and deterministic C-style ordering', async () => {
+      for (const [id, value, n] of [
+        ['null', null, 1],
+        ['upper', 'B', 2],
+        ['lower', 'a', 3],
+      ] as const) {
+        await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', id, value, n);
+      }
+      expect(await db.get('SELECT COUNT(*) AS n FROM items')).toEqual({ n: 3 });
+      expect(await db.all<{ value: string | null }>('SELECT value FROM items ORDER BY (value IS NULL), value')).toEqual(
+        [{ value: 'B' }, { value: 'a' }, { value: null }],
+      );
+    });
+
+    it('compares ISO timestamps lexically and returns truthy SELECT 1 rows', async () => {
+      await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'earlier', '2026-01-01T00:00:00.000Z', 1);
+      await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'later', '2026-01-02T00:00:00.000Z', 2);
+      expect(
+        await db.all<{ id: string }>('SELECT id FROM items WHERE value > ? ORDER BY value', '2026-01-01T12:00:00.000Z'),
+      ).toEqual([{ id: 'later' }]);
+      expect(await db.get('SELECT 1 AS present')).toEqual({ present: 1 });
+    });
+
+    it('rejects continuations that escape their transaction callback', async () => {
+      const resume = deferred();
+      let escaped!: Promise<unknown>;
+      await db.transaction(async () => {
+        escaped = resume.promise.then(() => db.get('SELECT 1 AS present'));
+      });
+      resume.resolve();
+      await expect(escaped).rejects.toThrow('transaction scope is closed');
+    });
+
+    it('watchdog rolls back and releases an outside waiter', async () => {
+      await db.close();
+      db = await factory.create({ watchdogMs: 25 });
+      await db.exec('CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT, n INTEGER NOT NULL)');
+      const release = deferred();
+      const timedOut = db.transaction(async () => {
+        await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'timed-out', null, 1);
+        await release.promise;
+      });
+      const waiting = db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'after', null, 2);
+
+      await expect(timedOut).rejects.toThrow('watchdog');
+      await waiting;
+      release.resolve();
+      expect(await db.all<{ id: string }>('SELECT id FROM items')).toEqual([{ id: 'after' }]);
+    });
+
+    it('cannot let a timed-out nested continuation roll back the next transaction', async () => {
+      await db.close();
+      db = await factory.create({ watchdogMs: 25 });
+      await db.exec('CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT, n INTEGER NOT NULL)');
+      const releaseStale = deferred();
+      const staleFinished = deferred();
+      const currentSavepointReady = deferred();
+      const finishCurrent = deferred();
+
+      const timedOut = db.transaction(async () => {
+        try {
+          await db.transaction(async () => {
+            await releaseStale.promise;
+          });
+        } finally {
+          staleFinished.resolve();
+        }
+      });
+      await expect(timedOut).rejects.toThrow('watchdog');
+
+      const current = db.transaction(async () => {
+        await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'current-outer', null, 1);
+        await db.transaction(async () => {
+          await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'current-inner', null, 2);
+          currentSavepointReady.resolve();
+          await finishCurrent.promise;
+        });
+      });
+      await currentSavepointReady.promise;
+      releaseStale.resolve();
+      await staleFinished.promise;
+      finishCurrent.resolve();
+
+      await expect(current).resolves.toBeUndefined();
+      expect(await db.all<{ id: string }>('SELECT id FROM items ORDER BY n')).toEqual([
+        { id: 'current-outer' },
+        { id: 'current-inner' },
+      ]);
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,13 +69,14 @@ async function main(): Promise<void> {
   enforceUpgradeTripwire();
 
   // 1. Init central DB
-  const db = await initDb(CENTRAL_DB_PATH);
-  await runMigrations(db);
-  log.info('Central DB ready', { path: CENTRAL_DB_PATH });
+  const db = await initDb(CENTRAL_DB_PATH, { role: 'host' });
+  await runMigrations(db, undefined, { mode: 'auto' });
+  log.info('Central DB ready', { dialect: db.dialect });
 
   // 1b. Backfill container_configs from legacy container.json files.
   // Idempotent — skips groups that already have a config row.
-  await backfillContainerConfigs();
+  if (db.dialect === 'sqlite') await backfillContainerConfigs();
+  else log.info('Skipping local container.json backfill for non-local central DB');
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Add backend composition, driver registration, migration modes/hooks, driver conformance tests, and safe central-database tooling while keeping core SQLite-only.

### Why

Skills should be able to install a remote central-database backend through a narrow composition point without putting backend-specific configuration or packages in trunk.

### How it works

The checked-in factory registers SQLite and fails clearly for an uninstalled remote target. Migration hooks support validate/migrate/bootstrap flows. Setup inspection is read-only and fails loudly for remote errors. `scripts/q.ts` routes only the canonical central path through composition; explicit session DB paths stay direct SQLite and preserve DELETE journaling. Startup does not recreate revoked destinations.

### How it was tested

pnpm run lint; pnpm run typecheck; pnpm run build; full SQLite Vitest suite excluding the unchanged macOS /var vs /private/var upstream transaction fixture. 1,661 SQLite tests passed. Driver registry, conformance, migration-mode, q routing, migration CLI, and read-only setup inspection regressions are included.

Stack 7/7. No PostgreSQL names, packages, or environment variables are added to public core.