### PR TITLE
test(db): run central suites through the driver

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
 import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
-import { sqliteRaw } from '../db/drivers/sqlite.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -213,11 +212,9 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
     await def.setup(hostConfig);
     await def.subscribe!('slack:C1', 'slack:T1');
 
-    const rows = sqliteRaw(getDb())
-      .prepare('SELECT thread_id FROM chat_sdk_subscriptions ORDER BY thread_id')
-      .all() as Array<{
-      thread_id: string;
-    }>;
+    const rows = await getDb().all<{ thread_id: string }>(
+      'SELECT thread_id FROM chat_sdk_subscriptions ORDER BY thread_id',
+    );
     expect(rows.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1', 'slack:T1']);
 
     await named.teardown();
@@ -233,9 +230,7 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
     });
     await bridge.setup(hostConfig);
     await bridge.subscribe!('slack:C1', 'slack:T9');
-    const rows = sqliteRaw(getDb()).prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
-      thread_id: string;
-    }>;
+    const rows = await getDb().all<{ thread_id: string }>('SELECT thread_id FROM chat_sdk_subscriptions');
     expect(rows.map((r) => r.thread_id)).toEqual(['slack:T9']);
     await bridge.teardown();
   });

--- a/src/cli/crud.test.ts
+++ b/src/cli/crud.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { sqliteRaw } from '../db/drivers/sqlite.js';
 
 // `groups.ts`'s postCreate calls `initGroupFilesystem`, which touches the
 // real filesystem (groups/<folder>, data/v2-sessions/<id>/.claude-shared).
@@ -87,7 +86,7 @@ registerResource({
 });
 
 beforeEach(async () => {
-  const db = await initTestDb();
+  const db = await initTestDb({ fresh: true });
   await runMigrations(db);
   ensureContainerConfigSpy.mockClear();
   writeDestinationsSpy.mockClear();
@@ -103,13 +102,11 @@ beforeEach(async () => {
 });
 
 describe('genericList portable filters and ordering', () => {
-  beforeEach(() => {
-    const insert = sqliteRaw(getDb()).prepare(
-      'INSERT INTO listtest_rows (id, enabled, score, payload, created_at) VALUES (?, ?, ?, ?, ?)',
-    );
-    insert.run('b', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
-    insert.run('a', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
-    insert.run('c', 0, 3, '{"kind":"other"}', '2026-08-17T11:00:00.000Z');
+  beforeEach(async () => {
+    const sql = 'INSERT INTO listtest_rows (id, enabled, score, payload, created_at) VALUES (?, ?, ?, ?, ?)';
+    await getDb().run(sql, 'b', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
+    await getDb().run(sql, 'a', 1, 2, '{"kind":"match"}', '2026-08-17T10:00:00.000Z');
+    await getDb().run(sql, 'c', 0, 3, '{"kind":"other"}', '2026-08-17T11:00:00.000Z');
   });
 
   it('coerces boolean, number, and JSON filters by column type', async () => {
@@ -292,7 +289,7 @@ describe('genericCreate resolveDefaults hook (two-pass create)', () => {
 
   it('a hook throw rejects the create and nothing is inserted', async () => {
     await expect(lookup('hooktests-create')!.handler({ kind: 'boom' }, hostCtx)).rejects.toThrow('hook rejected');
-    const count = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS n FROM hooktest_rows').get() as { n: number };
-    expect(count.n).toBe(0);
+    const count = await getDb().get<{ n: number }>('SELECT COUNT(*) AS n FROM hooktest_rows');
+    expect(count!.n).toBe(0);
   });
 });

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -13,7 +13,6 @@
  */
 import fs from 'fs';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
 
 vi.mock('../../container-runner.js', () => ({
   wakeContainer: vi.fn().mockResolvedValue(undefined),
@@ -41,12 +40,8 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function count(sql: string, ...params: unknown[]): number {
-  return (
-    sqliteRaw(getDb())
-      .prepare(sql)
-      .get(...params) as { c: number }
-  ).c;
+async function count(sql: string, ...params: unknown[]): Promise<number> {
+  return (await getDb().get<{ c: number }>(sql, ...params))!.c;
 }
 
 describe('groups CLI delete cascades dependent rows (#2525)', () => {
@@ -87,77 +82,92 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     // Direct inserts for the dependent tables. Keeps the fixture minimal —
     // we only need rows that establish FK relationships, not full domain
     // entities.
-    sqliteRaw(db)
-      .prepare(`INSERT INTO users (id, kind, display_name, created_at) VALUES (?, 'telegram', 'someone', ?)`)
-      .run(UID, now());
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+    await db.run(
+      `INSERT INTO users (id, kind, display_name, created_at) VALUES (?, 'telegram', 'someone', ?)`,
+      UID,
+      now(),
+    );
+    await db.run(
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
        VALUES (?, 'telegram', 'tg-1', 'telegram', 'chat', 1, 'strict', ?)`,
-      )
-      .run(MGID, now());
+      MGID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+    await db.run(
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES (?, 'chan', 'channel', ?, ?)`,
-      )
-      .run(GID, MGID, now());
+      GID,
+      MGID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO pending_questions (question_id, session_id, message_out_id, title, options_json, created_at)
+    await db.run(
+      `INSERT INTO pending_questions (question_id, session_id, message_out_id, title, options_json, created_at)
        VALUES (?, ?, 'mout-1', 'q', '[]', ?)`,
-      )
-      .run('q-1', SID, now());
+      'q-1',
+      SID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO pending_approvals (approval_id, session_id, request_id, action, payload, created_at, agent_group_id, status, title, options_json)
+    await db.run(
+      `INSERT INTO pending_approvals (approval_id, session_id, request_id, action, payload, created_at, agent_group_id, status, title, options_json)
        VALUES (?, ?, 'req-1', 'cli_command', '{}', ?, ?, 'pending', '', '[]')`,
-      )
-      .run('pa-1', SID, now(), GID);
+      'pa-1',
+      SID,
+      now(),
+      GID,
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO pending_sender_approvals (id, messaging_group_id, agent_group_id, sender_identity, sender_name, original_message, approver_user_id, created_at)
+    await db.run(
+      `INSERT INTO pending_sender_approvals (id, messaging_group_id, agent_group_id, sender_identity, sender_name, original_message, approver_user_id, created_at)
        VALUES ('psa-1', ?, ?, 'tg:99', 'them', '{}', ?, ?)`,
-      )
-      .run(MGID, GID, UID, now());
+      MGID,
+      GID,
+      UID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at)
+    await db.run(
+      `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at)
        VALUES (?, ?, '{}', ?, ?)`,
-      )
-      .run(MGID, GID, UID, now());
+      MGID,
+      GID,
+      UID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, session_mode, priority, created_at)
+    await db.run(
+      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, session_mode, priority, created_at)
        VALUES ('mga-1', ?, ?, 'mention', 'all', 'drop', 'shared', 0, ?)`,
-      )
-      .run(MGID, GID, now());
+      MGID,
+      GID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(`INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at) VALUES (?, ?, NULL, ?)`)
-      .run(UID, GID, now());
+    await db.run(
+      `INSERT INTO agent_group_members (user_id, agent_group_id, added_by, added_at) VALUES (?, ?, NULL, ?)`,
+      UID,
+      GID,
+      now(),
+    );
 
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at) VALUES (?, 'admin', ?, NULL, ?)`,
-      )
-      .run(UID, GID, now());
+    await db.run(
+      `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at) VALUES (?, 'admin', ?, NULL, ?)`,
+      UID,
+      GID,
+      now(),
+    );
 
     // Container config row exercises the ON DELETE CASCADE on container_configs.
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO container_configs
+    await db.run(
+      `INSERT INTO container_configs
          (agent_group_id, provider, model, effort, image_tag, assistant_name, max_messages_per_prompt,
           skills, mcp_servers, packages_apt, packages_npm, additional_mounts, cli_scope, updated_at)
        VALUES (?, NULL, NULL, NULL, NULL, NULL, NULL, '"all"', '{}', '[]', '[]', '[]', 'group', ?)`,
-      )
-      .run(GID, now());
+      GID,
+      now(),
+    );
 
     const resp = await dispatch({ id: 'req-del', command: 'groups-delete', args: { id: GID } }, { caller: 'host' });
 
@@ -179,23 +189,23 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     });
 
     // The group and every dependent row must be gone.
-    expect(count('SELECT COUNT(*) AS c FROM agent_groups WHERE id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM sessions WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM pending_questions WHERE session_id = ?', SID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM agent_groups WHERE id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM sessions WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM pending_questions WHERE session_id = ?', SID)).toBe(0);
     expect(
-      count('SELECT COUNT(*) AS c FROM pending_approvals WHERE agent_group_id = ? OR session_id = ?', GID, SID),
+      await count('SELECT COUNT(*) AS c FROM pending_approvals WHERE agent_group_id = ? OR session_id = ?', GID, SID),
     ).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM agent_destinations WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM pending_sender_approvals WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM pending_channel_approvals WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM agent_group_members WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM user_roles WHERE agent_group_id = ?', GID)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM container_configs WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM agent_destinations WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM pending_sender_approvals WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM pending_channel_approvals WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM agent_group_members WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM user_roles WHERE agent_group_id = ?', GID)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM container_configs WHERE agent_group_id = ?', GID)).toBe(0);
 
     // Unrelated tables untouched.
-    expect(count('SELECT COUNT(*) AS c FROM users WHERE id = ?', UID)).toBe(1);
-    expect(count('SELECT COUNT(*) AS c FROM messaging_groups WHERE id = ?', MGID)).toBe(1);
+    expect(await count('SELECT COUNT(*) AS c FROM users WHERE id = ?', UID)).toBe(1);
+    expect(await count('SELECT COUNT(*) AS c FROM messaging_groups WHERE id = ?', MGID)).toBe(1);
   });
 
   it('removes polymorphic agent_destinations that point at the deleted group', async () => {
@@ -209,12 +219,13 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     // B has a destination pointing at A. target_id is polymorphic — no FK
     // constraint enforces it, so without explicit cleanup the row would
     // dangle after A is deleted.
-    sqliteRaw(db)
-      .prepare(
-        `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+    await db.run(
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES (?, 'sibling', 'agent', ?, ?)`,
-      )
-      .run(B, A, now());
+      B,
+      A,
+      now(),
+    );
 
     const resp = await dispatch({ id: 'req-del-a', command: 'groups-delete', args: { id: A } }, { caller: 'host' });
 
@@ -223,9 +234,9 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     expect(data.removed.agent_destinations_pointing).toBe(1);
 
     // A is gone, B remains, and B's stale destination is cleaned up.
-    expect(count('SELECT COUNT(*) AS c FROM agent_groups WHERE id = ?', A)).toBe(0);
-    expect(count('SELECT COUNT(*) AS c FROM agent_groups WHERE id = ?', B)).toBe(1);
-    expect(count('SELECT COUNT(*) AS c FROM agent_destinations WHERE agent_group_id = ?', B)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM agent_groups WHERE id = ?', A)).toBe(0);
+    expect(await count('SELECT COUNT(*) AS c FROM agent_groups WHERE id = ?', B)).toBe(1);
+    expect(await count('SELECT COUNT(*) AS c FROM agent_destinations WHERE agent_group_id = ?', B)).toBe(0);
   });
 
   it('returns a handler error for an unknown group id', async () => {
@@ -277,91 +288,5 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
     );
     expect(rm.ok).toBe(true);
     expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
-  });
-});
-
-describe('groups CLI MCP config', () => {
-  beforeEach(async () => {
-    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
-    fs.mkdirSync(TEST_DIR, { recursive: true });
-    await runMigrations(await initTestDb());
-    await createAgentGroup({
-      id: 'ag-mcp',
-      name: 'mcp',
-      folder: 'mcp',
-      agent_provider: null,
-      created_at: now(),
-    });
-    await ensureContainerConfig('ag-mcp');
-  });
-
-  afterEach(async () => {
-    await closeDb();
-    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
-  });
-
-  it('adds stdio and HTTPS MCP servers through the same command', async () => {
-    const local = await dispatch(
-      {
-        id: 'req-local',
-        command: 'groups-config-add-mcp-server',
-        args: { id: 'ag-mcp', name: 'local', command: 'pnpm', args: '["dlx","server"]' },
-      },
-      { caller: 'host' },
-    );
-    const remote = await dispatch(
-      {
-        id: 'req-remote',
-        command: 'groups-config-add-mcp-server',
-        args: { id: 'ag-mcp', name: 'remote', url: 'https://mcp.example.com/mcp' },
-      },
-      { caller: 'host' },
-    );
-
-    expect(local.ok).toBe(true);
-    expect(remote.ok).toBe(true);
-    expect(JSON.parse((await getContainerConfig('ag-mcp'))!.mcp_servers)).toEqual({
-      local: { command: 'pnpm', args: ['dlx', 'server'], env: {} },
-      remote: { type: 'http', url: 'https://mcp.example.com/mcp' },
-    });
-  });
-
-  it('rejects ambiguous and insecure remote MCP config', async () => {
-    const both = await dispatch(
-      {
-        id: 'req-both',
-        command: 'groups-config-add-mcp-server',
-        args: { id: 'ag-mcp', name: 'bad', command: 'server', url: 'https://mcp.example.com/mcp' },
-      },
-      { caller: 'host' },
-    );
-    const insecure = await dispatch(
-      {
-        id: 'req-http',
-        command: 'groups-config-add-mcp-server',
-        args: { id: 'ag-mcp', name: 'bad', url: 'http://mcp.example.com/mcp' },
-      },
-      { caller: 'host' },
-    );
-
-    expect(both.ok).toBe(false);
-    expect(both.ok ? '' : both.error.message).toMatch(/exactly one/);
-    expect(insecure.ok).toBe(false);
-    expect(insecure.ok ? '' : insecure.error.message).toMatch(/HTTPS/);
-  });
-
-  it('rejects a server name that fails the shared name validation', async () => {
-    const badName = await dispatch(
-      {
-        id: 'req-bad-name',
-        command: 'groups-config-add-mcp-server',
-        args: { id: 'ag-mcp', name: 'docs]\n[mcp_servers.evil]', url: 'https://mcp.example.com/mcp' },
-      },
-      { caller: 'host' },
-    );
-
-    expect(badName.ok).toBe(false);
-    expect(badName.ok ? '' : badName.error.message).toMatch(/1-64 characters/);
-    expect(JSON.parse((await getContainerConfig('ag-mcp'))!.mcp_servers)).toEqual({});
   });
 });

--- a/src/cli/resources/programmatic-wiring.test.ts
+++ b/src/cli/resources/programmatic-wiring.test.ts
@@ -20,7 +20,6 @@
 import fs from 'fs';
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
 
 vi.mock('../../container-runner.js', () => ({
   wakeContainer: vi.fn().mockResolvedValue(undefined),
@@ -77,12 +76,8 @@ function now(): string {
 function send(command: string, args: Record<string, unknown>) {
   return dispatch({ id: 'test', command, args }, HOST);
 }
-function count(sql: string, ...params: unknown[]): number {
-  return (
-    sqliteRaw(getDb())
-      .prepare(sql)
-      .get(...params) as { c: number }
-  ).c;
+async function count(sql: string, ...params: unknown[]): Promise<number> {
+  return (await getDb().get<{ c: number }>(sql, ...params))!.c;
 }
 
 describe('programmatic wiring verbs', () => {
@@ -115,7 +110,9 @@ describe('programmatic wiring verbs', () => {
     });
     expect(r2.ok).toBe(true);
     expect((r2 as { data: { id: string } }).data.id).toBe((mg1 as { id: string }).id); // same row
-    expect(count(`SELECT COUNT(*) c FROM messaging_groups WHERE platform_id = ?`, 'resend:you@example.com')).toBe(1);
+    expect(await count(`SELECT COUNT(*) c FROM messaging_groups WHERE platform_id = ?`, 'resend:you@example.com')).toBe(
+      1,
+    );
   });
 
   it('returns the winner when natural-key creates race', async () => {
@@ -132,14 +129,14 @@ describe('programmatic wiring verbs', () => {
     expect(first.ok).toBe(true);
     expect(second.ok).toBe(true);
     expect((first as { data: { id: string } }).data.id).toBe((second as { data: { id: string } }).data.id);
-    expect(count(`SELECT COUNT(*) c FROM messaging_groups WHERE platform_id = ?`, args.platform_id)).toBe(1);
+    expect(await count(`SELECT COUNT(*) c FROM messaging_groups WHERE platform_id = ?`, args.platform_id)).toBe(1);
   });
 
   it('users create is idempotent on the user id', async () => {
     const args = { id: 'resend:you@example.com', kind: 'resend', display_name: 'Owner' };
     expect((await send('users-create', args)).ok).toBe(true);
     expect((await send('users-create', args)).ok).toBe(true); // no UNIQUE violation
-    expect(count(`SELECT COUNT(*) c FROM users WHERE id = ?`, 'resend:you@example.com')).toBe(1);
+    expect(await count(`SELECT COUNT(*) c FROM users WHERE id = ?`, 'resend:you@example.com')).toBe(1);
   });
 
   it('wirings create resolves natural keys (platform_id + agent-group folder) and is idempotent', async () => {
@@ -167,7 +164,7 @@ describe('programmatic wiring verbs', () => {
     const w2 = await send('wirings-create', wireArgs);
     expect(w2.ok).toBe(true);
     expect((w2 as { data: { id: string } }).data.id).toBe((wiring as { id: string }).id); // idempotent on the pair
-    expect(count(`SELECT COUNT(*) c FROM messaging_group_agents WHERE agent_group_id = ?`, 'ag-1')).toBe(1);
+    expect(await count(`SELECT COUNT(*) c FROM messaging_group_agents WHERE agent_group_id = ?`, 'ag-1')).toBe(1);
   });
 
   it('retries destination-name conflicts from concurrent wiring creates', async () => {
@@ -223,11 +220,11 @@ describe('programmatic wiring verbs', () => {
     const ag = (r1 as { data: { id: string } }).data;
     expect(ag.id).toBeTruthy();
     // a working group needs a container_config row — generic create never made one
-    expect(count('SELECT COUNT(*) c FROM container_configs WHERE agent_group_id = ?', ag.id)).toBe(1);
+    expect(await count('SELECT COUNT(*) c FROM container_configs WHERE agent_group_id = ?', ag.id)).toBe(1);
     // idempotent on folder
     const r2 = await send('groups-create', { folder: 'dm-with-bob', name: 'Bob' });
     expect((r2 as { data: { id: string } }).data.id).toBe(ag.id);
-    expect(count('SELECT COUNT(*) c FROM agent_groups WHERE folder = ?', 'dm-with-bob')).toBe(1);
+    expect(await count('SELECT COUNT(*) c FROM agent_groups WHERE folder = ?', 'dm-with-bob')).toBe(1);
   });
 
   it('messaging-groups send errors when no group exists (lookup before routeInbound)', async () => {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,7 +1,11 @@
+import Database from 'better-sqlite3';
+
 import { CENTRAL_DB_PATH } from '../config.js';
 import { log } from '../log.js';
 import type { DbConfig, DbDriver, DbInitOptions } from './driver.js';
 import { createDbDriver } from './driver-registry.js';
+import { SqliteDriver } from './drivers/sqlite.js';
+import { runMigrations } from './migrations/index.js';
 
 import './compose.js';
 
@@ -41,8 +45,20 @@ export interface InitTestDbOptions {
 export async function initTestDb(options: InitTestDbOptions = {}): Promise<DbDriver> {
   await closeDb();
   const db = await initDb(':memory:', { role: 'test' });
-  await db.prepareTestSchema?.(options);
+  if (db.prepareTestSchema) {
+    await db.prepareTestSchema(options);
+    await runMigrations(db, undefined, { mode: 'migrate' });
+  }
   return db;
+}
+
+/** For tests that intentionally exercise SQLite-specific migrations or pragmas. */
+export async function initSqliteTestDb(): Promise<DbDriver> {
+  await closeDb();
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  _db = new SqliteDriver(raw);
+  return _db;
 }
 
 export async function closeDb(): Promise<void> {

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { sqliteRaw } from './drivers/sqlite.js';
 
 import {
-  initTestDb,
+  initSqliteTestDb,
   closeDb,
   runMigrations,
   createAgentGroup,
@@ -41,7 +41,7 @@ function now() {
 }
 
 beforeEach(async () => {
-  const db = await initTestDb();
+  const db = await initSqliteTestDb();
   await runMigrations(db);
 });
 
@@ -53,14 +53,14 @@ afterEach(async () => {
 
 describe('migrations', () => {
   it('should be idempotent', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
     // Running again should not throw
     await runMigrations(db);
   });
 
   it('adds messaging_group_agents.threads as a nullable, default-free override column (019)', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
     const col = sqliteRaw(db)
       .prepare(
@@ -76,7 +76,7 @@ describe('migrations', () => {
   });
 
   it('persists approval card bodies for terminal rendering (021)', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
     for (const table of ['pending_approvals', 'pending_channel_approvals', 'pending_sender_approvals']) {
       const col = sqliteRaw(db)

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,4 @@
-export { initDb, initTestDb, getDb, closeDb } from './connection.js';
+export { initDb, initTestDb, initSqliteTestDb, getDb, closeDb } from './connection.js';
 export type { DbConfig, DbDriver, DbDialect, DbInitOptions, DbRole, RunResult } from './driver.js';
 export { runMigrations } from './migrations/index.js';
 export type { MigrationMode, MigrationRunOptions } from './migrations/index.js';

--- a/src/db/messaging-groups-instance.test.ts
+++ b/src/db/messaging-groups-instance.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-import { initTestDb, closeDb, getDb } from './connection.js';
+import { initSqliteTestDb, closeDb, getDb } from './connection.js';
 import { sqliteRaw } from './drivers/sqlite.js';
 import { runMigrations, migrations, type Migration } from './migrations/index.js';
 import {
@@ -49,7 +49,7 @@ afterEach(async () => {
 
 describe('migration 016 — fresh DB', () => {
   beforeEach(async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
   });
 
@@ -91,7 +91,7 @@ describe('migration 016 — fresh DB', () => {
 
 describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () => {
   it('recreates messaging_groups under FK children without violations and backfills instance', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     // Bring the DB to the pre-016 schema.
     await runMigrations(
       db,
@@ -149,7 +149,7 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
   });
 
   it('tolerates pre-existing FK orphans: the migration still applies (no boot crash-loop)', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(
       db,
       migrations.filter((m) => m.name !== 'messaging-group-instance'),
@@ -183,7 +183,7 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
   });
 
   it('still rejects a migration that ITSELF introduces FK violations', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
 
     const rogue: Migration = {
@@ -210,7 +210,7 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
   });
 
   it('is idempotent — re-running the full barrel is a no-op', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
     await createMessagingGroup(mg({ id: 'mg-keep', instance: 'slack-tester' }));
     await expect(runMigrations(db)).resolves.toBeUndefined();
@@ -223,7 +223,7 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
 
 describe('lookup asymmetry — inbound exact-only vs outbound default-first', () => {
   beforeEach(async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
     // The named instance ('alpha-tester') sorts lexically BEFORE the
     // channel type ('slack') and is inserted first — so both rowid order

--- a/src/db/migrations/023-user-roles-unique.test.ts
+++ b/src/db/migrations/023-user-roles-unique.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { closeDb, initTestDb } from '../connection.js';
+import { closeDb, initSqliteTestDb } from '../connection.js';
 import { sqliteRaw } from '../drivers/sqlite.js';
 import { lookup } from '../../cli/registry.js';
 import { migration023 } from './023-user-roles-unique.js';
@@ -11,7 +11,7 @@ afterEach(async () => await closeDb());
 
 describe('user-roles-unique migration', () => {
   it('deduplicates nullable global grants and enforces both logical key shapes', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(
       db,
       migrations.filter((migration) => migration.name !== migration023.name),
@@ -41,7 +41,7 @@ describe('user-roles-unique migration', () => {
   });
 
   it('makes repeated global grants through ncl idempotent', async () => {
-    const db = await initTestDb();
+    const db = await initSqliteTestDb();
     await runMigrations(db);
     sqliteRaw(db)
       .prepare('INSERT INTO users (id, kind, created_at) VALUES (?, ?, ?)')

--- a/src/db/migrations/registry.test.ts
+++ b/src/db/migrations/registry.test.ts
@@ -30,7 +30,7 @@ async function freshRegistry() {
 
 async function freshTestDb() {
   const connection = await import('../connection.js');
-  const db = await connection.initTestDb();
+  const db = await connection.initSqliteTestDb();
   closeCurrentDb = connection.closeDb;
   return db;
 }

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -29,7 +29,6 @@ import {
   clearOutbox,
 } from './session-manager.js';
 import { getSession, findSession } from './db/sessions.js';
-import { sqliteRaw } from './db/drivers/sqlite.js';
 import type { InboundEvent } from './channels/adapter.js';
 
 // Mock container runner to prevent actual Docker spawning
@@ -923,7 +922,7 @@ describe('router — per-wiring thread policy', () => {
   });
 
   it('wiring threads=0 nulls the event-derived thread for session and delivery', async () => {
-    sqliteRaw(getDb()).prepare("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'").run();
+    await getDb().run("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'");
 
     await withThreadedAdapter(async () => {
       const { routeInbound } = await import('./router.js');
@@ -945,7 +944,7 @@ describe('router — per-wiring thread policy', () => {
   });
 
   it('wiring threads=0 never strips replyTo (operator intent)', async () => {
-    sqliteRaw(getDb()).prepare("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'").run();
+    await getDb().run("UPDATE messaging_group_agents SET threads = 0 WHERE id = 'mga-tp'");
 
     await withThreadedAdapter(async () => {
       const { routeInbound } = await import('./router.js');
@@ -1352,17 +1351,19 @@ describe('agent-to-agent routing', () => {
     });
 
     // Wire bidirectional A2A destinations (table created by runMigrations)
-    const db = sqliteRaw(getDb());
-    db.prepare(
+    const db = getDb();
+    await db.run(
       `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES ('ag-pa', 'researcher', 'agent', 'ag-researcher', ?)
        ON CONFLICT (agent_group_id, local_name) DO NOTHING`,
-    ).run(now());
-    db.prepare(
+      now(),
+    );
+    await db.run(
       `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
        VALUES ('ag-researcher', 'pa', 'agent', 'ag-pa', ?)
        ON CONFLICT (agent_group_id, local_name) DO NOTHING`,
-    ).run(now());
+      now(),
+    );
   });
 
   it('A2A outbound lands in a session for the target agent', async () => {

--- a/src/modules/agent-to-agent/message-gate.test.ts
+++ b/src/modules/agent-to-agent/message-gate.test.ts
@@ -9,7 +9,6 @@ import { getMessagePolicy, removeMessagePolicy, setMessagePolicy } from './db/ag
 import { applyA2aMessageGate } from './message-gate.js';
 import { initTestDb, closeDb, runMigrations, createAgentGroup } from '../../db/index.js';
 import { getDb } from '../../db/connection.js';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createPendingApproval, createSession, deletePendingApproval, getPendingApproval } from '../../db/sessions.js';
 import { requestApproval } from '../approvals/index.js';
 import { initSessionFolder, inboundDbPath } from '../../session-manager.js';
@@ -40,8 +39,8 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function policyCount(): number {
-  return (sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS n FROM agent_message_policies').get() as { n: number }).n;
+async function policyCount(): Promise<number> {
+  return (await getDb().get<{ n: number }>('SELECT COUNT(*) AS n FROM agent_message_policies'))!.n;
 }
 
 function readInbound(agentGroupId: string, sessionId: string) {
@@ -131,12 +130,12 @@ describe('agent message policies', () => {
       to_agent_group_id: B,
       approver: 'telegram:sam',
     });
-    expect(policyCount()).toBe(1);
+    expect(await policyCount()).toBe(1);
 
     // Upsert updates the approver without inserting a duplicate row.
     await setMessagePolicy(A, B, 'telegram:dana', now());
     expect((await getMessagePolicy(A, B))!.approver).toBe('telegram:dana');
-    expect(policyCount()).toBe(1);
+    expect(await policyCount()).toBe(1);
 
     expect(await removeMessagePolicy(A, B)).toBe(true);
     expect(await getMessagePolicy(A, B)).toBeUndefined();

--- a/src/modules/permissions/channel-approval.test.ts
+++ b/src/modules/permissions/channel-approval.test.ts
@@ -16,8 +16,7 @@
 import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
-import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
+import { initTestDb, closeDb, runMigrations, getDb } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
 import { registerChannelAdapter } from '../../channels/channel-registry.js';
@@ -56,13 +55,12 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const row = sqliteRaw(getDb())
-      .prepare(
-        `SELECT mg.* FROM messaging_groups mg
+    const row = await getDb().get(
+      `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
           WHERE ud.user_id = ?`,
-      )
-      .get(userId);
+      userId,
+    );
     return row;
   }),
 }));
@@ -80,6 +78,18 @@ const TEST_DIR = '/tmp/nanoclaw-test-channel-approval';
 
 function now() {
   return new Date().toISOString();
+}
+
+async function countRows(sql: string, ...params: unknown[]): Promise<number> {
+  return (await getDb().get<{ c: number }>(sql, ...params))!.c;
+}
+
+async function expectAsyncDelivery(action: () => Promise<void>): Promise<void> {
+  const previousDeliveryCount = deliverMock.mock.calls.length;
+  await action();
+  await vi.waitFor(() => {
+    expect(deliverMock.mock.calls.length).toBeGreaterThan(previousDeliveryCount);
+  });
 }
 
 beforeEach(async () => {
@@ -112,13 +122,14 @@ beforeEach(async () => {
     unknown_sender_policy: 'public',
     created_at: now(),
   });
-  const { getDb } = await import('../../db/connection.js');
-  sqliteRaw(getDb())
-    .prepare(
-      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
-       VALUES (?, ?, ?, ?)`,
-    )
-    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+  await getDb().run(
+    `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+     VALUES (?, ?, ?, ?)`,
+    'telegram:owner',
+    'telegram',
+    'mg-dm-owner',
+    now(),
+  );
 
   deliverMock.mockClear();
 });
@@ -162,8 +173,7 @@ function dmEvent(platformId: string, text = 'hello') {
 describe('unknown-channel registration flow', () => {
   it('delivers an approval card on mention into an unwired group', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound(groupMention('chat-new'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-new')));
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
     const [channel, platformId, thread, kind, content] = deliverMock.mock.calls[0];
@@ -180,40 +190,29 @@ describe('unknown-channel registration flow', () => {
     expect(connectOption).toBeDefined();
     expect(connectOption.label).toContain('Andy');
 
-    const { getDb } = await import('../../db/connection.js');
-    const rows = sqliteRaw(getDb()).prepare('SELECT * FROM pending_channel_approvals').all() as Array<{
-      messaging_group_id: string;
-    }>;
+    const rows = await getDb().all<{ messaging_group_id: string }>('SELECT * FROM pending_channel_approvals');
     expect(rows).toHaveLength(1);
   });
 
   it('delivers a card on DM too (non-threaded event)', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound(dmEvent('dm-new-user'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(dmEvent('dm-new-user')));
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(deliverMock.mock.calls[0][4] as string) as { question: string };
     expect(payload.question).toContain('will respond to all messages');
-    const { getDb } = await import('../../db/connection.js');
-    const count = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const count = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(count).toBe(1);
   });
 
   it('dedups a second mention while the card is pending', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound(groupMention('chat-busy'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-busy')));
     await routeInbound(groupMention('chat-busy', '@bot still here'));
     await new Promise((r) => setTimeout(r, 10));
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
-    const { getDb } = await import('../../db/connection.js');
-    const count = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const count = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(count).toBe(1);
   });
 
@@ -223,13 +222,11 @@ describe('unknown-channel registration flow', () => {
     const { wakeContainer } = await import('../../container-runner.js');
     (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
 
-    await routeInbound(groupMention('chat-approve'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-approve')));
 
-    const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
     expect(pending).toBeDefined();
 
     // Owner clicks "Connect to Andy" (single-agent card).
@@ -246,9 +243,10 @@ describe('unknown-channel registration flow', () => {
     }
 
     // Wiring created with defaults.
-    const mga = sqliteRaw(getDb())
-      .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ?')
-      .get(pending.messaging_group_id) as {
+    const mga = (await getDb().get(
+      'SELECT * FROM messaging_group_agents WHERE messaging_group_id = ?',
+      pending.messaging_group_id,
+    )) as {
       engage_mode: string;
       engage_pattern: string | null;
       sender_scope: string;
@@ -264,15 +262,15 @@ describe('unknown-channel registration flow', () => {
 
     // Triggering sender auto-admitted so sender_scope='known' doesn't
     // bounce the replay into sender-approval.
-    const member = sqliteRaw(getDb())
-      .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
-      .get('telegram:caller', 'ag-1');
+    const member = await getDb().get(
+      'SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+      'telegram:caller',
+      'ag-1',
+    );
     expect(member).toBeDefined();
 
     // Pending row cleared and container woken via replay.
-    const stillPending = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const stillPending = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(stillPending).toBe(0);
     expect(wakeContainer).toHaveBeenCalled();
   });
@@ -281,13 +279,11 @@ describe('unknown-channel registration flow', () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
 
-    await routeInbound(dmEvent('dm-approve-user'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(dmEvent('dm-approve-user')));
 
-    const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
 
     for (const handler of getResponseHandlers()) {
       const claimed = await handler({
@@ -301,9 +297,10 @@ describe('unknown-channel registration flow', () => {
       if (claimed) break;
     }
 
-    const mga = sqliteRaw(getDb())
-      .prepare('SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?')
-      .get(pending.messaging_group_id) as { engage_mode: string; engage_pattern: string };
+    const mga = (await getDb().get(
+      'SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?',
+      pending.messaging_group_id,
+    )) as { engage_mode: string; engage_pattern: string };
     expect(mga.engage_mode).toBe('pattern');
     expect(mga.engage_pattern).toBe('.');
   });
@@ -332,10 +329,9 @@ describe('unknown-channel registration flow', () => {
 
   async function approvePending(agentGroupId = 'ag-1') {
     const { getResponseHandlers } = await import('../../response-registry.js');
-    const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
     expect(pending).toBeDefined();
     for (const handler of getResponseHandlers()) {
       const claimed = await handler({
@@ -353,15 +349,14 @@ describe('unknown-channel registration flow', () => {
 
   it('non-threaded group (isGroup flag, null threadId) wires the GROUP default, sticky coerced to mention', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound(waGroupMention('wa-group-1'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(waGroupMention('wa-group-1')));
 
     const mgId = await approvePending();
 
-    const { getDb } = await import('../../db/connection.js');
-    const mga = sqliteRaw(getDb())
-      .prepare('SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?')
-      .get(mgId) as { engage_mode: string; engage_pattern: string | null };
+    const mga = (await getDb().get(
+      'SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?',
+      mgId,
+    )) as { engage_mode: string; engage_pattern: string | null };
     // Faithful fallback group default is mention-sticky, but with no live
     // adapter threads resolve false → coerced to plain mention. NOT the old
     // pattern '.' DM misclassification.
@@ -371,18 +366,19 @@ describe('unknown-channel registration flow', () => {
 
   it('DM on an undeclared channel stays pattern "." through the faithful fallback', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound({
-      ...waGroupMention('wa-dm-1'),
-      message: { ...waGroupMention('wa-dm-1').message, isGroup: false },
-    });
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() =>
+      routeInbound({
+        ...waGroupMention('wa-dm-1'),
+        message: { ...waGroupMention('wa-dm-1').message, isGroup: false },
+      }),
+    );
 
     const mgId = await approvePending();
 
-    const { getDb } = await import('../../db/connection.js');
-    const mga = sqliteRaw(getDb())
-      .prepare('SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?')
-      .get(mgId) as { engage_mode: string; engage_pattern: string | null };
+    const mga = (await getDb().get(
+      'SELECT engage_mode, engage_pattern FROM messaging_group_agents WHERE messaging_group_id = ?',
+      mgId,
+    )) as { engage_mode: string; engage_pattern: string | null };
     expect(mga.engage_mode).toBe('pattern');
     expect(mga.engage_pattern).toBe('.');
   });
@@ -390,19 +386,16 @@ describe('unknown-channel registration flow', () => {
   it('connect-existing and new-agent approve paths produce identical wirings', async () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
-    const { getDb } = await import('../../db/connection.js');
 
     // Path 1: connect to existing agent.
-    await routeInbound(groupMention('chat-path-connect'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-path-connect')));
     const mgIdConnect = await approvePending();
 
     // Path 2: new agent via free-text name reply.
-    await routeInbound(groupMention('chat-path-newagent'));
-    await new Promise((r) => setTimeout(r, 10));
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-path-newagent')));
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
     for (const handler of getResponseHandlers()) {
       const claimed = await handler({
         questionId: pending.messaging_group_id,
@@ -431,8 +424,8 @@ describe('unknown-channel registration flow', () => {
     const select =
       'SELECT engage_mode, engage_pattern, sender_scope, ignored_message_policy, session_mode, priority ' +
       'FROM messaging_group_agents WHERE messaging_group_id = ?';
-    const viaConnect = sqliteRaw(getDb()).prepare(select).get(mgIdConnect);
-    const viaNewAgent = sqliteRaw(getDb()).prepare(select).get(pending.messaging_group_id);
+    const viaConnect = await getDb().get(select, mgIdConnect);
+    const viaNewAgent = await getDb().get(select, pending.messaging_group_id);
     expect(viaNewAgent).toBeDefined();
     expect(viaNewAgent).toEqual(viaConnect);
   });
@@ -441,12 +434,10 @@ describe('unknown-channel registration flow', () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
 
-    await routeInbound(groupMention('chat-deny'));
-    await new Promise((r) => setTimeout(r, 10));
-    const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-deny')));
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
 
     for (const handler of getResponseHandlers()) {
       const claimed = await handler({
@@ -464,11 +455,10 @@ describe('unknown-channel registration flow', () => {
     const mg = await getMessagingGroupByPlatform('telegram', 'chat-deny');
     expect(mg?.denied_at).not.toBeNull();
     expect(mg?.denied_at).toBeTruthy();
-    const mgaCount = (
-      sqliteRaw(getDb())
-        .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
-        .get(pending.messaging_group_id) as { c: number }
-    ).c;
+    const mgaCount = await countRows(
+      'SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?',
+      pending.messaging_group_id,
+    );
     expect(mgaCount).toBe(0);
 
     // A follow-up mention on the denied channel: no new card, no new pending row.
@@ -476,9 +466,7 @@ describe('unknown-channel registration flow', () => {
     await routeInbound(groupMention('chat-deny', '@bot please'));
     await new Promise((r) => setTimeout(r, 10));
     expect(deliverMock).not.toHaveBeenCalled();
-    const stillPending = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const stillPending = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(stillPending).toBe(0);
   });
 
@@ -486,12 +474,10 @@ describe('unknown-channel registration flow', () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
 
-    await routeInbound(groupMention('chat-unauth'));
-    await new Promise((r) => setTimeout(r, 10));
-    const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-unauth')));
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
 
     for (const handler of getResponseHandlers()) {
       const claimed = await handler({
@@ -506,22 +492,18 @@ describe('unknown-channel registration flow', () => {
     }
 
     // No wiring created, pending row preserved so a real approver can act on it.
-    const mgaCount = (
-      sqliteRaw(getDb())
-        .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
-        .get(pending.messaging_group_id) as { c: number }
-    ).c;
+    const mgaCount = await countRows(
+      'SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?',
+      pending.messaging_group_id,
+    );
     expect(mgaCount).toBe(0);
-    const stillPending = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const stillPending = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(stillPending).toBe(1);
   });
 
   it('does not let a scoped admin connect an unknown channel to another agent group', async () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
-    const { getDb } = await import('../../db/connection.js');
 
     await createAgentGroup({ id: 'ag-2', name: 'Betty', folder: 'betty', agent_provider: null, created_at: now() });
     await upsertUser({
@@ -546,19 +528,20 @@ describe('unknown-channel registration flow', () => {
       unknown_sender_policy: 'public',
       created_at: now(),
     });
-    sqliteRaw(getDb())
-      .prepare(
-        `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+    await getDb().run(
+      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
        VALUES (?, ?, ?, ?)`,
-      )
-      .run('telegram:scoped-admin', 'telegram', 'mg-dm-scoped-admin', now());
+      'telegram:scoped-admin',
+      'telegram',
+      'mg-dm-scoped-admin',
+      now(),
+    );
 
-    await routeInbound(groupMention('chat-scoped-cross-group'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-scoped-cross-group')));
 
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
     expect(pending).toBeDefined();
     expect(deliverMock).toHaveBeenCalledTimes(1);
     expect(deliverMock.mock.calls[0][1]).toBe('dm-scoped-admin');
@@ -593,28 +576,23 @@ describe('unknown-channel registration flow', () => {
       if (claimed) break;
     }
 
-    const mgaCount = (
-      sqliteRaw(getDb())
-        .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
-        .get(pending.messaging_group_id) as { c: number }
-    ).c;
+    const mgaCount = await countRows(
+      'SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?',
+      pending.messaging_group_id,
+    );
     expect(mgaCount).toBe(0);
-    const stillPending = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const stillPending = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(stillPending).toBe(1);
   });
 
   it('create new agent: the free-text name reply creates the group and wires the channel', async () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
-    const { getDb } = await import('../../db/connection.js');
 
-    await routeInbound(groupMention('chat-create-new'));
-    await new Promise((r) => setTimeout(r, 10));
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-create-new')));
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
 
     // Owner clicks "Connect new agent" → name prompt lands in their DM.
     for (const handler of getResponseHandlers()) {
@@ -643,32 +621,26 @@ describe('unknown-channel registration flow', () => {
       },
     });
 
-    const created = sqliteRaw(getDb()).prepare("SELECT id FROM agent_groups WHERE name = 'Newbie'").get() as
-      | { id: string }
-      | undefined;
+    const created = await getDb().get<{ id: string }>("SELECT id FROM agent_groups WHERE name = 'Newbie'");
     expect(created).toBeDefined();
-    const mgaCount = (
-      sqliteRaw(getDb())
-        .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?')
-        .get(pending.messaging_group_id, created!.id) as { c: number }
-    ).c;
+    const mgaCount = await countRows(
+      'SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?',
+      pending.messaging_group_id,
+      created!.id,
+    );
     expect(mgaCount).toBe(1);
-    const stillPending = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const stillPending = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(stillPending).toBe(0);
   });
 
   it('a name reply after the registration vanished is consumed without creating anything', async () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
-    const { getDb } = await import('../../db/connection.js');
 
-    await routeInbound(groupMention('chat-vanished'));
-    await new Promise((r) => setTimeout(r, 10));
-    const pending = sqliteRaw(getDb()).prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
-      messaging_group_id: string;
-    };
+    await expectAsyncDelivery(() => routeInbound(groupMention('chat-vanished')));
+    const pending = (await getDb().get<{ messaging_group_id: string }>(
+      'SELECT messaging_group_id FROM pending_channel_approvals',
+    ))!;
 
     for (const handler of getResponseHandlers()) {
       const claimed = await handler({
@@ -685,13 +657,9 @@ describe('unknown-channel registration flow', () => {
     // The registration disappears between the click and the reply (rejected
     // from another card, group delete cascade, …) — the interceptor no
     // longer finds a pending registration, so the reply must not create.
-    sqliteRaw(getDb())
-      .prepare('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?')
-      .run(pending.messaging_group_id);
+    await getDb().run('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?', pending.messaging_group_id);
 
-    const agentGroupsBefore = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM agent_groups').get() as { c: number }
-    ).c;
+    const agentGroupsBefore = await countRows('SELECT COUNT(*) AS c FROM agent_groups');
     await routeInbound({
       channelType: 'telegram',
       platformId: 'dm-owner',
@@ -704,13 +672,9 @@ describe('unknown-channel registration flow', () => {
       },
     });
 
-    const agentGroupsAfter = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM agent_groups').get() as { c: number }
-    ).c;
+    const agentGroupsAfter = await countRows('SELECT COUNT(*) AS c FROM agent_groups');
     expect(agentGroupsAfter).toBe(agentGroupsBefore);
-    const mgaCount = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM messaging_group_agents').get() as { c: number }
-    ).c;
+    const mgaCount = await countRows('SELECT COUNT(*) AS c FROM messaging_group_agents');
     expect(mgaCount).toBe(0);
   });
 });
@@ -718,34 +682,28 @@ describe('unknown-channel registration flow', () => {
 describe('no-owner / no-agent failure modes', () => {
   it('no owner → no card, no pending row (fresh-install bootstrap path)', async () => {
     // Wipe the owner grant set up in the outer beforeEach.
-    const { getDb } = await import('../../db/connection.js');
-    sqliteRaw(getDb()).prepare('DELETE FROM user_roles').run();
+    await getDb().run('DELETE FROM user_roles');
 
     const { routeInbound } = await import('../../router.js');
     await routeInbound(groupMention('chat-noowner'));
     await new Promise((r) => setTimeout(r, 10));
 
     expect(deliverMock).not.toHaveBeenCalled();
-    const count = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const count = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(count).toBe(0);
   });
 
   it('no agent groups → no card, no pending row', async () => {
-    const { getDb } = await import('../../db/connection.js');
     // Drop foreign-key-dependent rows first, then the agent group itself.
-    sqliteRaw(getDb()).prepare('DELETE FROM user_roles').run();
-    sqliteRaw(getDb()).prepare('DELETE FROM agent_groups').run();
+    await getDb().run('DELETE FROM user_roles');
+    await getDb().run('DELETE FROM agent_groups');
 
     const { routeInbound } = await import('../../router.js');
     await routeInbound(groupMention('chat-noagent'));
     await new Promise((r) => setTimeout(r, 10));
 
     expect(deliverMock).not.toHaveBeenCalled();
-    const count = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }
-    ).c;
+    const count = await countRows('SELECT COUNT(*) AS c FROM pending_channel_approvals');
     expect(count).toBe(0);
   });
 });

--- a/src/modules/permissions/channel-card-interceptor.test.ts
+++ b/src/modules/permissions/channel-card-interceptor.test.ts
@@ -13,8 +13,7 @@
 import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
-import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
+import { initTestDb, closeDb, getDb, runMigrations } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup } from '../../db/messaging-groups.js';
 import type { InboundEvent } from '../../channels/adapter.js';
@@ -40,14 +39,12 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const { sqliteRaw } = await import('../../db/drivers/sqlite.js');
-    const row = sqliteRaw(getDb())
-      .prepare(
-        `SELECT mg.* FROM messaging_groups mg
+    const row = await getDb().get(
+      `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
           WHERE ud.user_id = ?`,
-      )
-      .get(userId);
+      userId,
+    );
     return row;
   }),
 }));
@@ -88,10 +85,13 @@ beforeEach(async () => {
     unknown_sender_policy: 'public',
     created_at: now(),
   });
-  const { getDb } = await import('../../db/connection.js');
-  sqliteRaw(getDb())
-    .prepare(`INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at) VALUES (?, ?, ?, ?)`)
-    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+  await getDb().run(
+    `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at) VALUES (?, ?, ?, ?)`,
+    'telegram:owner',
+    'telegram',
+    'mg-dm-owner',
+    now(),
+  );
 
   deliverMock.mockClear();
 });
@@ -133,8 +133,7 @@ function mention(mg: MessagingGroup): InboundEvent {
 }
 
 async function pendingCount(): Promise<number> {
-  const { getDb } = await import('../../db/connection.js');
-  return (sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number }).c;
+  return (await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_channel_approvals'))!.c;
 }
 
 describe('channel-card interceptor seam', () => {

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -15,7 +15,6 @@ import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../../db/messaging-groups.js';
 import { upsertUser } from './db/users.js';
@@ -42,13 +41,12 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const row = sqliteRaw(getDb())
-      .prepare(
-        `SELECT mg.* FROM messaging_groups mg
+    const row = await getDb().get(
+      `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
           WHERE ud.user_id = ?`,
-      )
-      .get(userId);
+      userId,
+    );
     return row;
   }),
 }));
@@ -120,12 +118,14 @@ beforeEach(async () => {
     created_at: now(),
   });
   const { getDb } = await import('../../db/connection.js');
-  sqliteRaw(getDb())
-    .prepare(
-      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
-       VALUES (?, ?, ?, ?)`,
-    )
-    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+  await getDb().run(
+    `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+     VALUES (?, ?, ?, ?)`,
+    'telegram:owner',
+    'telegram',
+    'mg-dm-owner',
+    now(),
+  );
 
   deliverMock.mockClear();
 });
@@ -153,13 +153,18 @@ function stranger(text: string) {
   };
 }
 
+async function expectAsyncDelivery(action: () => Promise<void>): Promise<void> {
+  const previousDeliveryCount = deliverMock.mock.calls.length;
+  await action();
+  await vi.waitFor(() => {
+    expect(deliverMock.mock.calls.length).toBeGreaterThan(previousDeliveryCount);
+  });
+}
+
 describe('unknown-sender request_approval flow', () => {
   it('delivers an approval card on first unknown message', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound(stranger('hi'));
-
-    // Wait for the fire-and-forget requestSenderApproval to resolve.
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(stranger('hi')));
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
     const [channel, platformId, thread, kind, content] = deliverMock.mock.calls[0];
@@ -172,22 +177,19 @@ describe('unknown-sender request_approval flow', () => {
     expect(payload.questionId).toMatch(/^nsa-/);
 
     const { getDb } = await import('../../db/connection.js');
-    const rows = sqliteRaw(getDb()).prepare('SELECT * FROM pending_sender_approvals').all();
+    const rows = await getDb().all('SELECT * FROM pending_sender_approvals');
     expect(rows).toHaveLength(1);
   });
 
   it('dedups a second message from the same stranger while pending', async () => {
     const { routeInbound } = await import('../../router.js');
-    await routeInbound(stranger('hello'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(stranger('hello')));
     await routeInbound(stranger('are you there?'));
     await new Promise((r) => setTimeout(r, 10));
 
     expect(deliverMock).toHaveBeenCalledTimes(1);
     const { getDb } = await import('../../db/connection.js');
-    const count = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }
-    ).c;
+    const count = (await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals'))!.c;
     expect(count).toBe(1);
   });
 
@@ -197,11 +199,10 @@ describe('unknown-sender request_approval flow', () => {
     const { wakeContainer } = await import('../../container-runner.js');
     (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
 
-    await routeInbound(stranger('please let me in'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(stranger('please let me in')));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = (await getDb().get<{ id: string }>('SELECT id FROM pending_sender_approvals'))!;
     expect(pending).toBeDefined();
 
     // Fire the approve click through the response-handler chain.
@@ -221,16 +222,16 @@ describe('unknown-sender request_approval flow', () => {
     }
 
     // Member row added for the stranger against the wired agent group.
-    const member = sqliteRaw(getDb())
-      .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
-      .get('tg:stranger', 'ag-1');
+    const member = await getDb().get(
+      'SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+      'tg:stranger',
+      'ag-1',
+    );
     expect(member).toBeDefined();
 
     // Pending row cleared.
-    const stillPending = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as {
-      c: number;
-    };
-    expect(stillPending.c).toBe(0);
+    const stillPending = await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals');
+    expect(stillPending!.c).toBe(0);
 
     // Message replayed + container woken.
     expect(wakeContainer).toHaveBeenCalled();
@@ -240,11 +241,10 @@ describe('unknown-sender request_approval flow', () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
 
-    await routeInbound(stranger('hello'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(stranger('hello')));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = (await getDb().get<{ id: string }>('SELECT id FROM pending_sender_approvals'))!;
     expect(pending).toBeDefined();
 
     for (const handler of getResponseHandlers()) {
@@ -259,13 +259,13 @@ describe('unknown-sender request_approval flow', () => {
       if (claimed) break;
     }
 
-    const count = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }
-    ).c;
+    const count = (await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals'))!.c;
     expect(count).toBe(0);
-    const member = sqliteRaw(getDb())
-      .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
-      .get('tg:stranger', 'ag-1');
+    const member = await getDb().get(
+      'SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+      'tg:stranger',
+      'ag-1',
+    );
     expect(member).toBeUndefined();
   });
 
@@ -274,11 +274,10 @@ describe('unknown-sender request_approval flow', () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
 
-    await routeInbound(stranger('can I play'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(stranger('can I play')));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = (await getDb().get<{ id: string }>('SELECT id FROM pending_sender_approvals'))!;
     expect(pending).toBeDefined();
 
     // A random user (not the stranger, not the owner, not an admin) tries to
@@ -297,15 +296,15 @@ describe('unknown-sender request_approval flow', () => {
     }
 
     // No member added for the stranger.
-    const member = sqliteRaw(getDb())
-      .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
-      .get('tg:stranger', 'ag-1');
+    const member = await getDb().get(
+      'SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+      'tg:stranger',
+      'ag-1',
+    );
     expect(member).toBeUndefined();
 
     // Pending row is still there — a legitimate approver can still act on it.
-    const stillPending = (
-      sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number }
-    ).c;
+    const stillPending = (await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals'))!.c;
     expect(stillPending).toBe(1);
   });
 
@@ -323,11 +322,10 @@ describe('unknown-sender request_approval flow', () => {
     const { routeInbound } = await import('../../router.js');
     const { getResponseHandlers } = await import('../../response-registry.js');
 
-    await routeInbound(stranger('knock knock'));
-    await new Promise((r) => setTimeout(r, 10));
+    await expectAsyncDelivery(() => routeInbound(stranger('knock knock')));
 
     const { getDb } = await import('../../db/connection.js');
-    const pending = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    const pending = (await getDb().get<{ id: string }>('SELECT id FROM pending_sender_approvals'))!;
     expect(pending).toBeDefined();
 
     // Admin clicks approve (not the designated approver, which was owner).
@@ -344,9 +342,11 @@ describe('unknown-sender request_approval flow', () => {
     }
 
     // Stranger admitted thanks to the admin's authority.
-    const member = sqliteRaw(getDb())
-      .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
-      .get('tg:stranger', 'ag-1');
+    const member = await getDb().get(
+      'SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+      'tg:stranger',
+      'ag-1',
+    );
     expect(member).toBeDefined();
   });
 });

--- a/src/modules/permissions/sender-decline-notify.test.ts
+++ b/src/modules/permissions/sender-decline-notify.test.ts
@@ -14,8 +14,7 @@
 import fs from 'fs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
-import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
-import { sqliteRaw } from '../../db/drivers/sqlite.js';
+import { initTestDb, closeDb, getDb, runMigrations } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent, updateMessagingGroup } from '../../db/messaging-groups.js';
 import { upsertUser } from './db/users.js';
@@ -42,14 +41,12 @@ vi.mock('../../delivery.js', () => ({
 vi.mock('./user-dm.js', () => ({
   ensureUserDm: vi.fn(async (userId: string) => {
     const { getDb } = await import('../../db/connection.js');
-    const { sqliteRaw } = await import('../../db/drivers/sqlite.js');
-    const row = sqliteRaw(getDb())
-      .prepare(
-        `SELECT mg.* FROM messaging_groups mg
+    const row = await getDb().get(
+      `SELECT mg.* FROM messaging_groups mg
            JOIN user_dms ud ON ud.messaging_group_id = mg.id
           WHERE ud.user_id = ?`,
-      )
-      .get(userId);
+      userId,
+    );
     return row;
   }),
 }));
@@ -119,13 +116,14 @@ beforeEach(async () => {
     unknown_sender_policy: 'public',
     created_at: now(),
   });
-  const { getDb } = await import('../../db/connection.js');
-  sqliteRaw(getDb())
-    .prepare(
-      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
-       VALUES (?, ?, ?, ?)`,
-    )
-    .run('telegram:owner', 'telegram', 'mg-dm-owner', now());
+  await getDb().run(
+    `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+     VALUES (?, ?, ?, ?)`,
+    'telegram:owner',
+    'telegram',
+    'mg-dm-owner',
+    now(),
+  );
 
   deliverMock.mockClear();
 });
@@ -157,16 +155,18 @@ function strangerDm(text: string) {
 
 async function settle() {
   // The decline flow is fire-and-forget off the access gate.
-  await new Promise((r) => setTimeout(r, 10));
+  await new Promise((r) => setTimeout(r, 25));
+}
+
+async function waitForDeliveries(count: number): Promise<void> {
+  await vi.waitFor(() => expect(deliverMock).toHaveBeenCalledTimes(count));
 }
 
 describe('unknown-sender decline_notify flow', () => {
   it('declines in the DM, FYIs the owner, records the drop — no card', async () => {
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hi, can you book me a flight?'));
-    await settle();
-
-    expect(deliverMock).toHaveBeenCalledTimes(2);
+    await waitForDeliveries(2);
 
     // (a) Polite decline into the stranger's DM, as the bot.
     const [dChannel, dPlatform, dThread, dKind, dContent] = deliverMock.mock.calls[0];
@@ -190,30 +190,29 @@ describe('unknown-sender decline_notify flow', () => {
     expect(fyi.text).toContain('Stranger (tg:stranger)');
     expect(fyi.text).toContain('ncl members add');
 
-    const { getDb } = await import('../../db/connection.js');
     // Drop recorded. (The gate writes reason 'unknown_sender_decline_notify';
     // core's structural no_agent_engaged record then upserts the same row —
     // pre-existing behavior shared with every refusal path.)
-    const drop = sqliteRaw(getDb())
-      .prepare('SELECT user_id FROM unregistered_senders WHERE platform_id = ?')
-      .get('dm-stranger') as { user_id: string };
-    expect(drop.user_id).toBe('tg:stranger');
+    const drop = await getDb().get<{ user_id: string }>(
+      'SELECT user_id FROM unregistered_senders WHERE platform_id = ?',
+      'dm-stranger',
+    );
+    expect(drop).toBeDefined();
+    expect(drop!.user_id).toBe('tg:stranger');
 
     // No card rows anywhere — only the decline stamp.
-    const rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    const rows = await getDb().all<{ id: string }>('SELECT id FROM pending_sender_approvals');
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^decline:/);
-    const channelRows = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as {
-      c: number;
-    };
-    expect(channelRows.c).toBe(0);
+    const channelRows = await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_channel_approvals');
+    expect(channelRows).toBeDefined();
+    expect(channelRows!.c).toBe(0);
   });
 
   it('dedupes: a second message within 24h sends no further decline or FYI', async () => {
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hello'));
-    await settle();
-    expect(deliverMock).toHaveBeenCalledTimes(2);
+    await waitForDeliveries(2);
 
     await routeInbound(strangerDm('are you there?'));
     await settle();
@@ -222,34 +221,30 @@ describe('unknown-sender decline_notify flow', () => {
     // message upserts twice: the gate's policy record + core's structural
     // no_agent_engaged record — pre-existing double-count on refusals).
     expect(deliverMock).toHaveBeenCalledTimes(2);
-    const { getDb } = await import('../../db/connection.js');
-    const drop = sqliteRaw(getDb())
-      .prepare('SELECT message_count FROM unregistered_senders WHERE platform_id = ?')
-      .get('dm-stranger') as { message_count: number };
-    expect(drop.message_count).toBe(4);
+    const drop = await getDb().get<{ message_count: number }>(
+      'SELECT message_count FROM unregistered_senders WHERE platform_id = ?',
+      'dm-stranger',
+    );
+    expect(drop).toBeDefined();
+    expect(drop!.message_count).toBe(4);
   });
 
   it('declines again once the 24h stamp expires', async () => {
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hello'));
-    await settle();
-    expect(deliverMock).toHaveBeenCalledTimes(2);
+    await waitForDeliveries(2);
 
     // Age the stamp past the window.
-    const { getDb } = await import('../../db/connection.js');
     const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
-    sqliteRaw(getDb()).prepare(`UPDATE pending_sender_approvals SET created_at = ? WHERE id LIKE 'decline:%'`).run(old);
+    await getDb().run(`UPDATE pending_sender_approvals SET created_at = ? WHERE id LIKE 'decline:%'`, old);
 
     await routeInbound(strangerDm('hello again'));
-    await settle();
-
-    expect(deliverMock).toHaveBeenCalledTimes(4); // second decline + FYI pair
-    const stamp = sqliteRaw(getDb())
-      .prepare(`SELECT created_at FROM pending_sender_approvals WHERE id LIKE 'decline:%'`)
-      .get() as {
-      created_at: string;
-    };
-    expect(new Date(stamp.created_at).getTime()).toBeGreaterThan(Date.now() - 60_000); // refreshed
+    await waitForDeliveries(4);
+    const stamp = await getDb().get<{ created_at: string }>(
+      `SELECT created_at FROM pending_sender_approvals WHERE id LIKE 'decline:%'`,
+    );
+    expect(stamp).toBeDefined();
+    expect(new Date(stamp!.created_at).getTime()).toBeGreaterThan(Date.now() - 60_000); // refreshed
   });
 
   it('flip request_approval→decline_notify with a card pending: card row converts to a stamp, dedupe holds', async () => {
@@ -257,11 +252,9 @@ describe('unknown-sender decline_notify flow', () => {
     await updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hello'));
-    await settle();
-    expect(deliverMock).toHaveBeenCalledTimes(1); // the approval card
+    await waitForDeliveries(1); // the approval card
 
-    const { getDb } = await import('../../db/connection.js');
-    let rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    let rows = await getDb().all<{ id: string }>('SELECT id FROM pending_sender_approvals');
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^nsa-/);
 
@@ -270,12 +263,11 @@ describe('unknown-sender decline_notify flow', () => {
     deliverMock.mockClear();
 
     await routeInbound(strangerDm('are you there?'));
-    await settle();
+    await waitForDeliveries(2);
 
     // Decline + FYI went out; the pending card row became the stamp (the
     // UNIQUE(messaging_group_id, sender_identity) collision converts it).
-    expect(deliverMock).toHaveBeenCalledTimes(2);
-    rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    rows = await getDb().all<{ id: string }>('SELECT id FROM pending_sender_approvals');
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^decline:/);
 
@@ -315,38 +307,35 @@ describe('unknown-sender decline_notify flow', () => {
     // Nothing delivered anywhere — the DM-phrased decline must never be
     // posted publicly into the group channel; no stamp either.
     expect(deliverMock).not.toHaveBeenCalled();
-    const { getDb } = await import('../../db/connection.js');
-    const drop = sqliteRaw(getDb())
-      .prepare('SELECT user_id FROM unregistered_senders WHERE platform_id = ?')
-      .get('group-team') as { user_id: string };
-    expect(drop.user_id).toBe('tg:stranger');
-    const stamps = sqliteRaw(getDb()).prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as {
-      c: number;
-    };
-    expect(stamps.c).toBe(0);
+    const drop = await getDb().get<{ user_id: string }>(
+      'SELECT user_id FROM unregistered_senders WHERE platform_id = ?',
+      'group-team',
+    );
+    expect(drop).toBeDefined();
+    expect(drop!.user_id).toBe('tg:stranger');
+    const stamps = await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals');
+    expect(stamps).toBeDefined();
+    expect(stamps!.c).toBe(0);
   });
 
   it('policy flip back to request_approval clears the stale stamp and cards normally', async () => {
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hello'));
-    await settle();
-    expect(deliverMock).toHaveBeenCalledTimes(2);
+    await waitForDeliveries(2);
 
     await updateMessagingGroup('mg-dm-stranger', { unknown_sender_policy: 'request_approval' });
     deliverMock.mockClear();
 
     await routeInbound(strangerDm('let me in'));
-    await settle();
+    await waitForDeliveries(1);
 
     // One card to the owner — the decline stamp did not block the UNIQUE key.
-    expect(deliverMock).toHaveBeenCalledTimes(1);
     const [, platform, , , content] = deliverMock.mock.calls[0];
     expect(platform).toBe('dm-owner');
     const payload = JSON.parse(content as string);
     expect(payload.type).toBe('ask_question');
 
-    const { getDb } = await import('../../db/connection.js');
-    const rows = sqliteRaw(getDb()).prepare('SELECT id FROM pending_sender_approvals').all() as Array<{ id: string }>;
+    const rows = await getDb().all<{ id: string }>('SELECT id FROM pending_sender_approvals');
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toMatch(/^nsa-/); // real card row; stamp gone
   });

--- a/src/modules/permissions/user-dm.test.ts
+++ b/src/modules/permissions/user-dm.test.ts
@@ -16,7 +16,7 @@ import {
   registerChannelAdapter,
   teardownChannelAdapters,
 } from '../../channels/channel-registry.js';
-import { closeDb, getDb, initTestDb } from '../../db/connection.js';
+import { closeDb, getDb, initSqliteTestDb } from '../../db/connection.js';
 import { sqliteRaw } from '../../db/drivers/sqlite.js';
 import { createMessagingGroup } from '../../db/messaging-groups.js';
 import { runMigrations } from '../../db/migrations/index.js';
@@ -61,7 +61,7 @@ async function startRegisteredAdapters(): Promise<void> {
 
 beforeEach(async () => {
   vi.clearAllMocks();
-  const db = await initTestDb();
+  const db = await initSqliteTestDb();
   await runMigrations(db);
 });
 


### PR DESCRIPTION
## What

Moves central-database integration tests from raw `better-sqlite3` access to the `DbDriver` API, adds an explicit SQLite-only test initializer for pragma/migration-shape tests, and lets installed remote backends reset and migrate their test schema through the existing hook.

## Why

The central-DB seam was exercised by driver conformance tests, but much of the application suite still bypassed it. That allowed backend-specific query and timing regressions to hide until a full PostgreSQL run.

## How

- Use async driver queries in central application tests.
- Keep intentional SQLite pragma/migration tests on `initSqliteTestDb()`.
- After an installed backend prepares a fresh test schema, run migrations in explicit migrate mode.
- Replace remote-sensitive fixed sleeps with `vi.waitFor`.

Session `inbound.db` and `outbound.db` remain direct SQLite and are not changed.

## Tested

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- SQLite focused suite: 206 passed
- PostgreSQL 17 full suite: 1,705 passed; only 4 pre-existing macOS `/var` path fixture failures

- [x] Simplification
- [ ] Fix