### PR TITLE
refactor(db): add async central database seam

### DIFF
--- a/docs/central-db-async-migration.md
+++ b/docs/central-db-async-migration.md
@@ -1,0 +1,115 @@
+# Central database async migration
+
+NanoClaw's central database now sits behind the asynchronous `DbDriver`
+interface. The built-in implementation still uses the existing SQLite
+`data/v2.db`; this change does not move or rewrite stored data.
+
+## Detect affected customizations
+
+Search custom source, installed skills, and long-lived channel/provider
+branches for direct central-database access and calls whose return type changed
+from a value or `void` to a promise:
+
+```bash
+rg -n "getDb\(\)|initDb\(|initTestDb\(|runMigrations\(|hasTable\(" src setup scripts .claude/skills
+rg -n "\.prepare\(|\.transaction\(" src setup scripts .claude/skills
+rg -n "guard\(|gateCommand\(|canAccessAgentGroup\(|resolveSession\(" src setup scripts .claude/skills
+```
+
+Direct `better-sqlite3` access is still valid for the per-session
+`inbound.db`/`outbound.db` mailboxes. For the central database, use the async
+wrappers under `src/db/` or the `DbDriver` methods instead.
+
+## Why the interface changed
+
+The old central-database boundary exposed synchronous SQLite statements. That
+made SQLite's connection and transaction behavior part of every caller. The
+new boundary can support storage backends whose statements are naturally
+asynchronous while preserving SQLite as the default.
+
+These transaction rules are required for both backends:
+
+- Issue database calls sequentially inside `transaction()`; do not use
+  `Promise.all` for central-database work.
+- Never await mailbox sessions, container operations, channel adapters, or
+  network work while a central transaction is open. Run those effects after
+  commit.
+- Nested transactions are allowed in the same async scope and use savepoints.
+  An unrelated statement waits for the outer transaction rather than silently
+  joining it.
+- A transaction that outlives the watchdog is rolled back and fails. Code that
+  continues using a closed transaction scope trips an explicit error.
+
+## Update custom modules
+
+Await central-database initialization, migrations, wrappers, and driver calls,
+then propagate `async` through their callers:
+
+```ts
+const db = await initDb(CENTRAL_DB_PATH);
+await runMigrations(db);
+
+const group = await getAgentGroup(groupId);
+await db.transaction(async () => {
+  await db.run('UPDATE agent_groups SET name = ? WHERE id = ?', name, groupId);
+});
+```
+
+Do not use `getDb().prepare(...)`. The driver surface is `get`, `all`, `run`,
+`exec`, `transaction`, `hasTable`, and `close`, and every operation returns a
+promise.
+
+The following extension seams now accept or return promises:
+
+- `guard()` and guard `decide` callbacks
+- `SenderResolverFn`, `AccessGateFn`, and `SenderScopeGateFn`
+- `QuestionRenderResolver`
+- `ProviderContainerConfigFn`
+- `gateCommand()` and `canAccessAgentGroup()`
+- `HostStartContext.db`, which is now a `DbDriver`
+- resource `postCreate`
+- `Migration.up()` and `runMigrations()`
+
+Migration code receives a `DbDriver`. Frozen legacy migrations are explicitly
+marked `sqliteOnly: true`; the migration runner supplies their raw SQLite
+handle through `sqliteRaw(db)`. New migrations should use the portable async
+driver API. Keep `sqliteRaw` limited to legacy SQLite-only migrations and tests
+that intentionally inspect SQLite behavior.
+
+## Known external updates
+
+The matching public channel/provider branches must be updated in lockstep:
+
+- `telegram.ts`: await messaging-group reads/writes and user upserts.
+- `deltachat.ts`: make `isDcAdmin` async and await `hasTable` and its database
+  lookups.
+- `codex.ts`: await `getAgentGroup` from the async provider configuration
+  callback.
+
+The `groups-purge` and `nanoco-gateway-approvals` recipes also require async
+updates. The latter includes its `QuestionRenderResolver` and migrations
+`020`/`022`, which should use the portable async migration shape. Until those
+branches and recipes are updated, applying them over this boundary may fail
+type-checking or treat promises as values.
+
+## Verify the migration
+
+Run the host checks and repeat the searches above:
+
+```bash
+pnpm run lint
+pnpm run typecheck
+pnpm run build
+pnpm test
+```
+
+With the default SQLite composition, start NanoClaw and exercise a real
+channel, an `ncl` command, and a scheduled or approval action. Confirm the
+central `data/v2.db` is reused and the session mailbox files still receive the
+message and response.
+
+## Roll back
+
+No stored-data migration occurs. Return NanoClaw and custom modules to the
+previous revision, rebuild, and restart the service. The same central SQLite
+file and session mailbox files remain usable after rollback.

--- a/src/db/driver.ts
+++ b/src/db/driver.ts
@@ -1,0 +1,24 @@
+export type DbDialect = 'sqlite' | 'postgres';
+
+export interface RunResult {
+  changes: number;
+}
+
+/**
+ * Async central-database boundary. Session mailboxes deliberately do not use
+ * this interface: inbound.db and outbound.db remain direct SQLite databases.
+ *
+ * Transaction callbacks must issue DB calls sequentially. Do not use
+ * Promise.all, and never await mailbox, container, adapter, or network work
+ * while a central transaction is open. Put those effects after commit.
+ */
+export interface DbDriver {
+  readonly dialect: DbDialect;
+  get<T = unknown>(sql: string, ...params: unknown[]): Promise<T | undefined>;
+  all<T = unknown>(sql: string, ...params: unknown[]): Promise<T[]>;
+  run(sql: string, ...params: unknown[]): Promise<RunResult>;
+  exec(sql: string): Promise<void>;
+  transaction<T>(fn: () => Promise<T>): Promise<T>;
+  hasTable(name: string): Promise<boolean>;
+  close(): Promise<void>;
+}

--- a/src/db/drivers/shared.ts
+++ b/src/db/drivers/shared.ts
@@ -1,0 +1,67 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export const DEFAULT_TRANSACTION_WATCHDOG_MS = 10_000;
+
+export interface TransactionScope<TConnection> {
+  connection: TConnection;
+  depth: number;
+  closed: boolean;
+  savepointSequence: number;
+}
+
+export class TransactionScopeStore<TConnection> {
+  private readonly storage = new AsyncLocalStorage<TransactionScope<TConnection>>();
+
+  current(): TransactionScope<TConnection> | undefined {
+    return this.storage.getStore();
+  }
+
+  run<T>(scope: TransactionScope<TConnection>, fn: () => Promise<T>): Promise<T> {
+    return this.storage.run(scope, fn);
+  }
+
+  assertOpen(scope: TransactionScope<TConnection>): void {
+    if (scope.closed) {
+      throw new Error('Central DB transaction scope is closed; an async continuation escaped its callback');
+    }
+  }
+
+  nextSavepoint(scope: TransactionScope<TConnection>): string {
+    this.assertOpen(scope);
+    scope.savepointSequence += 1;
+    return `nanoclaw_sp_${scope.savepointSequence}`;
+  }
+}
+
+export class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async acquire(): Promise<() => void> {
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.tail;
+    this.tail = previous.then(() => next);
+    await previous;
+    return release;
+  }
+}
+
+export async function withTransactionWatchdog<T>(
+  fn: () => Promise<T>,
+  timeoutMs = DEFAULT_TRANSACTION_WATCHDOG_MS,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Central DB transaction exceeded ${timeoutMs}ms watchdog`));
+    }, timeoutMs);
+    timer.unref();
+  });
+  try {
+    return await Promise.race([fn(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/db/drivers/sqlite.test.ts
+++ b/src/db/drivers/sqlite.test.ts
@@ -1,0 +1,130 @@
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SqliteDriver } from './sqlite.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('SqliteDriver transactions', () => {
+  let driver: SqliteDriver;
+
+  beforeEach(async () => {
+    driver = new SqliteDriver(new Database(':memory:'), 25);
+    await driver.exec('CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT NOT NULL)');
+  });
+
+  afterEach(async () => {
+    await driver.close();
+  });
+
+  it('commits successful callbacks and rolls back failed callbacks', async () => {
+    await driver.transaction(async () => {
+      await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'committed', 'yes');
+    });
+
+    await expect(
+      driver.transaction(async () => {
+        await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'rolled-back', 'no');
+        throw new Error('abort');
+      }),
+    ).rejects.toThrow('abort');
+
+    expect(await driver.all<{ id: string }>('SELECT id FROM items ORDER BY id')).toEqual([{ id: 'committed' }]);
+  });
+
+  it('uses savepoints for nested transactions', async () => {
+    await driver.transaction(async () => {
+      await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'outer-before', 'yes');
+      await expect(
+        driver.transaction(async () => {
+          await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'inner', 'no');
+          throw new Error('rollback savepoint');
+        }),
+      ).rejects.toThrow('rollback savepoint');
+      await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'outer-after', 'yes');
+    });
+
+    expect(await driver.all<{ id: string }>('SELECT id FROM items ORDER BY id')).toEqual([
+      { id: 'outer-after' },
+      { id: 'outer-before' },
+    ]);
+  });
+
+  it('rolls back nested success when the outer transaction fails', async () => {
+    await expect(
+      driver.transaction(async () => {
+        await driver.transaction(async () => {
+          await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'inner', 'temporary');
+        });
+        throw new Error('outer abort');
+      }),
+    ).rejects.toThrow('outer abort');
+
+    expect(await driver.all('SELECT id FROM items')).toEqual([]);
+  });
+
+  it('makes outside statements wait for the active transaction', async () => {
+    const started = deferred();
+    const release = deferred();
+    const events: string[] = [];
+
+    const transaction = driver.transaction(async () => {
+      await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'inside', 'first');
+      events.push('transaction-started');
+      started.resolve();
+      await release.promise;
+      events.push('transaction-ending');
+    });
+    await started.promise;
+
+    const outside = driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'outside', 'second').then(() => {
+      events.push('outside-finished');
+    });
+    await Promise.resolve();
+    expect(events).toEqual(['transaction-started']);
+
+    release.resolve();
+    await transaction;
+    await outside;
+    expect(events).toEqual(['transaction-started', 'transaction-ending', 'outside-finished']);
+  });
+
+  it('rejects a continuation that escapes its transaction callback', async () => {
+    const resume = deferred();
+    let escaped!: Promise<unknown>;
+
+    await driver.transaction(async () => {
+      escaped = resume.promise.then(() => driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'late', 'no'));
+    });
+    resume.resolve();
+
+    await expect(escaped).rejects.toThrow('transaction scope is closed');
+    expect(await driver.all('SELECT id FROM items')).toEqual([]);
+  });
+
+  it('watchdog timeout rolls back and releases waiting statements', async () => {
+    const release = deferred();
+    const timedOut = driver.transaction(async () => {
+      await driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'timed-out', 'no');
+      await release.promise;
+    });
+    const waiting = driver.run('INSERT INTO items (id, value) VALUES (?, ?)', 'after-timeout', 'yes');
+
+    await expect(timedOut).rejects.toThrow('exceeded 25ms watchdog');
+    await waiting;
+    release.resolve();
+
+    expect(await driver.all<{ id: string }>('SELECT id FROM items ORDER BY id')).toEqual([{ id: 'after-timeout' }]);
+  });
+
+  it('rejects access after close', async () => {
+    await driver.close();
+    await expect(driver.get('SELECT 1')).rejects.toThrow('driver is closed');
+  });
+});

--- a/src/db/drivers/sqlite.ts
+++ b/src/db/drivers/sqlite.ts
@@ -1,0 +1,156 @@
+import Database from 'better-sqlite3';
+
+import type { DbDriver, RunResult } from '../driver.js';
+import {
+  AsyncMutex,
+  DEFAULT_TRANSACTION_WATCHDOG_MS,
+  TransactionScopeStore,
+  withTransactionWatchdog,
+} from './shared.js';
+
+type SqliteDatabase = Database.Database;
+
+function isNamedParams(params: unknown[]): params is [Record<string, unknown>] {
+  return params.length === 1 && typeof params[0] === 'object' && params[0] !== null && !Array.isArray(params[0]);
+}
+
+export class SqliteDriver implements DbDriver {
+  readonly dialect = 'sqlite' as const;
+
+  private readonly scopes = new TransactionScopeStore<SqliteDatabase>();
+  private readonly transactionMutex = new AsyncMutex();
+  private activeTransaction: Promise<void> | null = null;
+  private finishActiveTransaction: (() => void) | null = null;
+  private readonly tableCache = new Set<string>();
+  private closed = false;
+
+  constructor(
+    private readonly raw: SqliteDatabase,
+    private readonly transactionWatchdogMs = DEFAULT_TRANSACTION_WATCHDOG_MS,
+  ) {}
+
+  rawDatabase(): SqliteDatabase {
+    return this.raw;
+  }
+
+  private assertDriverOpen(): void {
+    if (this.closed) throw new Error('Central DB driver is closed');
+  }
+
+  private async access<T>(fn: (db: SqliteDatabase) => T): Promise<T> {
+    this.assertDriverOpen();
+    const scope = this.scopes.current();
+    if (scope) {
+      this.scopes.assertOpen(scope);
+      return fn(scope.connection);
+    }
+    while (this.activeTransaction) await this.activeTransaction;
+    this.assertDriverOpen();
+    return fn(this.raw);
+  }
+
+  async get<T = unknown>(sql: string, ...params: unknown[]): Promise<T | undefined> {
+    return this.access((db) => {
+      const statement = db.prepare(sql);
+      return (isNamedParams(params) ? statement.get(params[0]) : statement.get(...params)) as T | undefined;
+    });
+  }
+
+  async all<T = unknown>(sql: string, ...params: unknown[]): Promise<T[]> {
+    return this.access((db) => {
+      const statement = db.prepare(sql);
+      return (isNamedParams(params) ? statement.all(params[0]) : statement.all(...params)) as T[];
+    });
+  }
+
+  async run(sql: string, ...params: unknown[]): Promise<RunResult> {
+    return this.access((db) => {
+      const statement = db.prepare(sql);
+      const result = isNamedParams(params) ? statement.run(params[0]) : statement.run(...params);
+      return { changes: result.changes };
+    });
+  }
+
+  async exec(sql: string): Promise<void> {
+    await this.access((db) => {
+      db.exec(sql);
+    });
+  }
+
+  async transaction<T>(fn: () => Promise<T>): Promise<T> {
+    this.assertDriverOpen();
+    const parent = this.scopes.current();
+    if (parent) {
+      this.scopes.assertOpen(parent);
+      const savepoint = this.scopes.nextSavepoint(parent);
+      parent.connection.exec(`SAVEPOINT ${savepoint}`);
+      parent.depth += 1;
+      try {
+        const result = await fn();
+        this.scopes.assertOpen(parent);
+        parent.connection.exec(`RELEASE SAVEPOINT ${savepoint}`);
+        return result;
+      } catch (error) {
+        if (!parent.closed) {
+          parent.connection.exec(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+          parent.connection.exec(`RELEASE SAVEPOINT ${savepoint}`);
+        }
+        throw error;
+      } finally {
+        parent.depth -= 1;
+      }
+    }
+
+    const releaseMutex = await this.transactionMutex.acquire();
+    let resolveGate!: () => void;
+    this.activeTransaction = new Promise<void>((resolve) => {
+      resolveGate = resolve;
+    });
+    this.finishActiveTransaction = resolveGate;
+    const scope = { connection: this.raw, depth: 1, closed: false, savepointSequence: 0 };
+    let began = false;
+    try {
+      this.raw.exec('BEGIN IMMEDIATE');
+      began = true;
+      const result = await this.scopes.run(scope, () => withTransactionWatchdog(fn, this.transactionWatchdogMs));
+      this.scopes.assertOpen(scope);
+      scope.closed = true;
+      this.raw.exec('COMMIT');
+      began = false;
+      return result;
+    } catch (error) {
+      scope.closed = true;
+      if (began && this.raw.inTransaction) this.raw.exec('ROLLBACK');
+      throw error;
+    } finally {
+      scope.closed = true;
+      this.finishActiveTransaction?.();
+      this.finishActiveTransaction = null;
+      this.activeTransaction = null;
+      releaseMutex();
+    }
+  }
+
+  async hasTable(name: string): Promise<boolean> {
+    if (this.tableCache.has(name)) return true;
+    const row = await this.get<{ present: number }>(
+      `SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1`,
+      name,
+    );
+    if (row) this.tableCache.add(name);
+    return row !== undefined;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    if (this.activeTransaction) await this.activeTransaction;
+    this.raw.close();
+    this.closed = true;
+    this.tableCache.clear();
+  }
+}
+
+export function sqliteRaw(driver: DbDriver): SqliteDatabase {
+  if (!(driver instanceof SqliteDriver)) throw new Error('SQLite-only operation requires the SQLite central DB driver');
+  return driver.rawDatabase();
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool
- [ ] **Operational/container skill** - adds a workflow or agent skill
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs only

## Description

### What

Add an asynchronous central-database driver interface, shared transaction-scope controls, and a SQLite adapter.

### Why

Storage needs a small backend-neutral seam before call sites migrate. Keeping this additive makes the interface independently reviewable.

### How it works

This PR contains exactly five files: the interface, shared mutex/scope/watchdog utilities, SQLite implementation and tests, and the async migration guide. Nothing calls the seam yet. Transaction scopes close before commit or rollback so stale continuations cannot escape.

Session inbound.db and outbound.db remain direct SQLite with journal_mode=DELETE and are outside this seam.

### How it was tested

- pnpm run lint
- pnpm run typecheck
- pnpm run build
- SQLite suite: 1,626 passed
- Four existing macOS /var versus /private/var transaction fixtures remain platform-red; Linux CI covers them

Native stack 2/4; additive and non-breaking.