### PR TITLE
fix(codex): await central database operations

### DIFF
--- a/src/providers/codex-agents-md.test.ts
+++ b/src/providers/codex-agents-md.test.ts
@@ -35,25 +35,25 @@ function group(folder: string): AgentGroup {
 }
 
 describe('composeGroupAgentsMd cap handling', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
     fs.mkdirSync(path.join(TEST_ROOT, 'data'), { recursive: true });
-    const db = initTestDb();
-    runMigrations(db);
+    const db = await initTestDb();
+    await runMigrations(db);
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
   });
 
-  it('writes the doc untouched when under the cap', () => {
+  it('writes the doc untouched when under the cap', async () => {
     const g = group('small');
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
     const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
     try {
-      composeGroupAgentsMd(g, groupDir);
+      await composeGroupAgentsMd(g, groupDir);
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(doc).not.toContain('Omitted for size');
       // Agent-authored skills must be told a home that is BOTH persistent and
@@ -68,10 +68,10 @@ describe('composeGroupAgentsMd cap handling', () => {
     }
   });
 
-  it('never reads or inlines the host memory index', () => {
+  it('never reads or inlines the host memory index', async () => {
     const g = group('with-memory');
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
     const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
     try {
       const sentinel = path.join(TEST_ROOT, 'host-secret');
@@ -79,7 +79,7 @@ describe('composeGroupAgentsMd cap handling', () => {
       fs.mkdirSync(path.join(groupDir, 'memory'), { recursive: true });
       fs.symlinkSync(sentinel, path.join(groupDir, 'memory', 'index.md'));
 
-      composeGroupAgentsMd(g, groupDir);
+      await composeGroupAgentsMd(g, groupDir);
 
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(doc).toContain('supplied by NanoClaw at session startup');
@@ -89,17 +89,17 @@ describe('composeGroupAgentsMd cap handling', () => {
     }
   });
 
-  it('degrades instead of throwing when MCP instructions push the doc over the cap', () => {
+  it('degrades instead of throwing when MCP instructions push the doc over the cap', async () => {
     const g = group('oversized');
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
-    updateContainerConfigJson(g.id, 'mcp_servers', {
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
+    await updateContainerConfigJson(g.id, 'mcp_servers', {
       bloated: { command: 'x', instructions: 'y'.repeat(CODEX_PROJECT_DOC_MAX_BYTES + 1024) },
       lean: { command: 'x', instructions: 'short and useful' },
     });
     const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
     try {
-      composeGroupAgentsMd(g, groupDir); // must not throw
+      await composeGroupAgentsMd(g, groupDir); // must not throw
 
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(Buffer.byteLength(doc, 'utf-8')).toBeLessThanOrEqual(CODEX_PROJECT_DOC_MAX_BYTES);
@@ -115,25 +115,25 @@ describe('composeGroupAgentsMd cap handling', () => {
 });
 
 describe('composeGroupAgentsMd persona', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
     fs.mkdirSync(path.join(TEST_ROOT, 'data'), { recursive: true });
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
   });
 
-  it('inlines the persona as the first section, before the runtime contract', () => {
+  it('inlines the persona as the first section, before the runtime contract', async () => {
     const g = group('persona');
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
     const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
     try {
       fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'You are an SDR agent.\n');
-      composeGroupAgentsMd(g, groupDir);
+      await composeGroupAgentsMd(g, groupDir);
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(doc).toContain('You are an SDR agent.');
       // First markdown heading (the HEADER is an HTML comment, not a `# ` heading).
@@ -144,17 +144,17 @@ describe('composeGroupAgentsMd persona', () => {
     }
   });
 
-  it('never evicts the persona even when the doc exceeds the cap', () => {
+  it('never evicts the persona even when the doc exceeds the cap', async () => {
     const g = group('persona-big');
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
-    updateContainerConfigJson(g.id, 'mcp_servers', {
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
+    await updateContainerConfigJson(g.id, 'mcp_servers', {
       bloat: { command: 'x', instructions: 'B'.repeat(CODEX_PROJECT_DOC_MAX_BYTES + 1024) },
     });
     const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
     try {
       fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'PERSONA_MARKER body');
-      composeGroupAgentsMd(g, groupDir);
+      await composeGroupAgentsMd(g, groupDir);
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(Buffer.byteLength(doc, 'utf-8')).toBeLessThanOrEqual(CODEX_PROJECT_DOC_MAX_BYTES);
       expect(doc).toContain('PERSONA_MARKER'); // survived eviction
@@ -164,13 +164,13 @@ describe('composeGroupAgentsMd persona', () => {
     }
   });
 
-  it('omits the persona section when no prepend file is present', () => {
+  it('omits the persona section when no prepend file is present', async () => {
     const g = group('no-persona');
-    createAgentGroup(g);
-    ensureContainerConfig(g.id);
+    await createAgentGroup(g);
+    await ensureContainerConfig(g.id);
     const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
     try {
-      composeGroupAgentsMd(g, groupDir);
+      await composeGroupAgentsMd(g, groupDir);
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(doc).not.toContain('# Persona');
     } finally {

--- a/src/providers/codex-agents-md.ts
+++ b/src/providers/codex-agents-md.ts
@@ -50,10 +50,10 @@ interface AgentsMdSection {
   content: string;
 }
 
-export function composeGroupAgentsMd(group: AgentGroup, groupDir: string): void {
+export async function composeGroupAgentsMd(group: AgentGroup, groupDir: string): Promise<void> {
   if (!fs.existsSync(groupDir)) fs.mkdirSync(groupDir, { recursive: true });
 
-  const configRow = getContainerConfig(group.id);
+  const configRow = await getContainerConfig(group.id);
   const mcpServers: Record<string, McpServerConfig> = configRow
     ? (JSON.parse(configRow.mcp_servers) as Record<string, McpServerConfig>)
     : {};

--- a/src/providers/codex-host-contribution.test.ts
+++ b/src/providers/codex-host-contribution.test.ts
@@ -40,30 +40,30 @@ function group(id: string, folder: string): AgentGroup {
 }
 
 describe('codex host contribution against real core', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     fs.rmSync(TEST_ROOT, { recursive: true, force: true });
     fs.mkdirSync(DATA_DIR, { recursive: true });
     fs.mkdirSync(GROUPS_DIR, { recursive: true });
-    runMigrations(initTestDb());
+    await runMigrations(await initTestDb());
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     fs.rmSync(TEST_ROOT, { recursive: true, force: true });
   });
 
-  it('creates the per-group state dir, composes AGENTS.md from the real config row, and mounts both', () => {
+  it('creates the per-group state dir, composes AGENTS.md from the real config row, and mounts both', async () => {
     const ag = group('ag-codex', 'codex-group');
-    createAgentGroup(ag);
-    ensureContainerConfig(ag.id);
-    updateContainerConfigJson(ag.id, 'mcp_servers', {
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id);
+    await updateContainerConfigJson(ag.id, 'mcp_servers', {
       tooling: { command: 'x', instructions: 'use the tooling server for builds' },
     });
     const groupDir = path.join(GROUPS_DIR, ag.folder);
 
     const contributionFn = getProviderContainerConfig('codex');
     expect(contributionFn).toBeDefined();
-    const contribution = contributionFn!({
+    const contribution = await contributionFn!({
       sessionDir: path.join(DATA_DIR, 'v2-sessions', ag.id, 'session-1'),
       agentGroupId: ag.id,
       groupDir,
@@ -94,17 +94,17 @@ describe('codex host contribution against real core', () => {
       additionalMounts: [],
       skills: [],
     };
-    const mounts = buildMounts(ag, session, config, 'codex', contribution);
+    const mounts = await buildMounts(ag, session, config, 'codex', contribution);
     const containerPaths = mounts.map((m) => m.containerPath);
     expect(containerPaths).toContain('/home/node/.codex');
     expect(containerPaths.some((p) => p.endsWith('AGENTS.md'))).toBe(true);
     expect(containerPaths).not.toContain('/home/node/.claude');
   });
 
-  it('mirrors per-group template skills from the Claude plane into .agents/skills', () => {
+  it('mirrors per-group template skills from the Claude plane into .agents/skills', async () => {
     const ag = group('ag-codex-skills', 'codex-skills-group');
-    createAgentGroup(ag);
-    ensureContainerConfig(ag.id);
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id);
     // A template stamps its skills as real dirs on the Claude plane; codex reads
     // .agents/skills (RO-mounted), so the contribution must mirror them there.
     const templateSkill = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'skills', 'widget');
@@ -112,7 +112,7 @@ describe('codex host contribution against real core', () => {
     fs.writeFileSync(path.join(templateSkill, 'SKILL.md'), '---\nname: widget\n---\n');
 
     const contributionFn = getProviderContainerConfig('codex');
-    contributionFn!({
+    await contributionFn!({
       sessionDir: path.join(DATA_DIR, 'v2-sessions', ag.id, 'session-1'),
       agentGroupId: ag.id,
       groupDir: path.join(GROUPS_DIR, ag.folder),

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -37,7 +37,7 @@ import { registerProviderContainerConfig } from './provider-container-registry.j
 
 registerProviderContainerConfig(
   'codex',
-  (ctx) => {
+  async (ctx) => {
     // Per-group codex state (config.toml, thread metadata).
     const codexDir = path.join(DATA_DIR, 'v2-sessions', ctx.agentGroupId, '.codex-shared');
     fs.mkdirSync(codexDir, { recursive: true });
@@ -50,8 +50,8 @@ registerProviderContainerConfig(
     fs.closeSync(fs.openSync(path.join(codexDir, 'auth.json'), 'a'));
 
     // Compose this group's AGENTS.md and sync codex-native skill links.
-    const group = getAgentGroup(ctx.agentGroupId);
-    if (group) composeGroupAgentsMd(group, ctx.groupDir);
+    const group = await getAgentGroup(ctx.agentGroupId);
+    if (group) await composeGroupAgentsMd(group, ctx.groupDir);
     syncCodexSkillLinks(ctx.groupDir, ctx.selectedSkills);
     // Template skills live on the Claude plane (.claude-shared/skills); codex
     // reads .agents/skills (RO-mounted), so mirror them here, host-side, via the


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool
- [ ] **Operational/container skill** - adds a workflow or agent skill
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs only

## Description

### What

Adapt the Codex provider payload to NanoClaw's asynchronous central-database API.

### Why

NanoClaw PR #3334 changes central repository reads and provider contribution resolution to asynchronous APIs. Installed Codex provider code must await those operations before it is reapplied after that breaking update.

### How it works

The provider contribution callback becomes async, awaits `getAgentGroup`, and awaits `composeGroupAgentsMd`; that composer in turn awaits `getContainerConfig`. Existing tests are updated to await the same entry points.

This PR is intentionally draft and merge-ordered after nanocoai/nanoclaw#3334. Before merge, rebase the long-lived `providers` branch onto the new main and run its full build/tests. It should not merge against the old synchronous provider callback contract.

### How it was tested

- Diff reviewed against the `providers` branch: four files only
- Async provider payload was exercised in the composed async-stack verification

Companion to nanocoai/nanoclaw#3334.
