### PR TITLE
fix(provisioning): derive the Slack service from the credential's issuer

### DIFF
--- a/src/provisioning/slack-app.test.ts
+++ b/src/provisioning/slack-app.test.ts
@@ -15,6 +15,7 @@ import {
   readInstallToken,
   readManagerToken,
   readServiceBase,
+  slackServiceForRegistry,
 } from './slack-app.js';
 
 interface ManifestShape {
@@ -97,29 +98,79 @@ describe('readManagerToken', () => {
   });
 });
 
-describe('readServiceBase', () => {
-  let dir: string | undefined;
-  afterEach(() => {
-    delete process.env.SLACK_SERVICE_BASE;
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-    dir = undefined;
+describe('slackServiceForRegistry', () => {
+  it('swaps the host, keeping everything else about the deployment', () => {
+    expect(slackServiceForRegistry('https://registry.nanoclaw.dev')).toBe('https://slack.nanoclaw.dev');
+    expect(slackServiceForRegistry('https://registry.sandbox.nanoclaw.dev')).toBe('https://slack.sandbox.nanoclaw.dev');
+    expect(slackServiceForRegistry('http://registry.localhost:8080')).toBe('http://slack.localhost:8080');
   });
 
-  it('defaults to the deployed service', () => {
+  it('drops the path, query and userinfo a credential may have recorded', () => {
+    expect(slackServiceForRegistry('https://user:pw@registry.sandbox.nanoclaw.dev/private?token=secret')).toBe(
+      'https://slack.sandbox.nanoclaw.dev',
+    );
+  });
+
+  it('declines to guess for anything that is not a registry host', () => {
+    expect(slackServiceForRegistry(undefined)).toBeUndefined();
+    expect(slackServiceForRegistry('')).toBeUndefined();
+    expect(slackServiceForRegistry('not a url')).toBeUndefined();
+    expect(slackServiceForRegistry('file:///registry.nanoclaw.dev')).toBeUndefined();
+    // Same deployment, different naming: derive nothing rather than invent it.
+    expect(slackServiceForRegistry('https://accounts.example.test')).toBeUndefined();
+  });
+});
+
+describe('readServiceBase', () => {
+  let dir: string | undefined;
+  let configDir: string | undefined;
+
+  /** An isolated pair of directories: never the developer's own credential. */
+  function dirs(accountApi?: string): [string, string] {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
-    expect(readServiceBase(dir)).toBe(DEFAULT_SLACK_SERVICE_BASE);
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-cfg-'));
+    if (accountApi !== undefined) {
+      fs.writeFileSync(path.join(configDir, 'account.json'), JSON.stringify({ api: accountApi, token: 'nct_x' }));
+    }
+    return [dir, configDir];
+  }
+
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    for (const d of [dir, configDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+    dir = configDir = undefined;
+  });
+
+  it('defaults to the deployed service when nothing says otherwise', () => {
+    expect(readServiceBase(...dirs())).toBe(DEFAULT_SLACK_SERVICE_BASE);
   });
 
   it('prefers process env and strips trailing slashes', () => {
     process.env.SLACK_SERVICE_BASE = 'https://slack-sandbox.example.dev/';
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
-    expect(readServiceBase(dir)).toBe('https://slack-sandbox.example.dev');
+    expect(readServiceBase(...dirs())).toBe('https://slack-sandbox.example.dev');
   });
 
   it('reads from .env, stripping quotes', () => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
-    fs.writeFileSync(path.join(dir, '.env'), 'SLACK_SERVICE_BASE="https://broker.example.test"\n');
-    expect(readServiceBase(dir)).toBe('https://broker.example.test');
+    const [root, cfg] = dirs();
+    fs.writeFileSync(path.join(root, '.env'), 'SLACK_SERVICE_BASE="https://broker.example.test"\n');
+    expect(readServiceBase(root, cfg)).toBe('https://broker.example.test');
+  });
+
+  it('follows the credential to its own deployment rather than the default', () => {
+    expect(readServiceBase(...dirs('https://registry.sandbox.nanoclaw.dev'))).toBe(
+      'https://slack.sandbox.nanoclaw.dev',
+    );
+  });
+
+  it('lets an explicit setting override the credential it was issued against', () => {
+    process.env.SLACK_SERVICE_BASE = 'https://slack.example.test';
+    expect(readServiceBase(...dirs('https://registry.sandbox.nanoclaw.dev'))).toBe('https://slack.example.test');
+  });
+
+  it('falls back to the default when the credential records nothing to derive from', () => {
+    expect(readServiceBase(...dirs('https://accounts.example.test'))).toBe(DEFAULT_SLACK_SERVICE_BASE);
+    for (const d of [dir, configDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+    expect(readServiceBase(...dirs())).toBe(DEFAULT_SLACK_SERVICE_BASE);
   });
 });
 

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -267,9 +267,70 @@ export function readManagerToken(projectRoot = process.cwd()): string | undefine
 // ---------------------------------------------------------------------------
 // Broker transport — the managed-Slack service at slack.nanoclaw.dev.
 
-/** Broker base URL: SLACK_SERVICE_BASE (process env or .env), else the default. */
-export function readServiceBase(projectRoot = process.cwd()): string {
-  const value = readEnvSetting('SLACK_SERVICE_BASE', projectRoot) ?? DEFAULT_SLACK_SERVICE_BASE;
+/** Per-user credential directory — where enrollment persists account.json. */
+function defaultConfigDir(): string {
+  return path.join(os.homedir(), '.config', 'nanoclaw');
+}
+
+/**
+ * The managed-Slack service belonging to a given account service.
+ *
+ * The two are halves of one deployment: this service authenticates the
+ * install token that service minted, so a token from one is not a credential
+ * at the other. Nothing on disk records the pairing, and the two are
+ * configured independently — which is how an install ends up presenting a
+ * token from one deployment to the other and reading the refusal as an
+ * outage.
+ *
+ * Host swap only, `registry.<rest>` → `slack.<rest>`, so a deployment that
+ * follows the same naming is derived correctly and one that does not yields
+ * undefined rather than a guess.
+ */
+export function slackServiceForRegistry(api: string | undefined): string | undefined {
+  if (!api) return undefined;
+  let url: URL;
+  try {
+    url = new URL(api);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+  if (!url.hostname.startsWith('registry.')) return undefined;
+  url.hostname = `slack.${url.hostname.slice('registry.'.length)}`;
+  // `origin` drops any path, query and userinfo the credential recorded.
+  return url.origin;
+}
+
+/** The account service that issued the credential on disk, if it recorded one. */
+function readAccountApi(configDir: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(configDir, 'account.json'), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const api = (parsed as { api?: unknown }).api;
+  return typeof api === 'string' && api.trim() ? api.trim() : undefined;
+}
+
+/**
+ * Broker base URL: SLACK_SERVICE_BASE (process env or .env) first, then the
+ * service implied by whoever issued the credential we are about to send, and
+ * only then the default.
+ *
+ * Deriving beats defaulting because the credential is the thing being spent:
+ * pairing it with a service that cannot know it produces a 401 that reads as
+ * "Slack is down". An explicit setting still wins — pointing the two halves
+ * at different deployments is a thing an operator may need to do deliberately.
+ *
+ * A token supplied through NANOCLAW_REGISTRY_TOKEN has no account record to
+ * derive from and falls through to the default, so a CI caller retargeting
+ * the service must set SLACK_SERVICE_BASE too.
+ */
+export function readServiceBase(projectRoot = process.cwd(), configDir = defaultConfigDir()): string {
+  const explicit = readEnvSetting('SLACK_SERVICE_BASE', projectRoot);
+  const value = explicit ?? slackServiceForRegistry(readAccountApi(configDir)) ?? DEFAULT_SLACK_SERVICE_BASE;
   return value.replace(/\/+$/, '');
 }
 
@@ -286,10 +347,7 @@ export function readServiceBase(projectRoot = process.cwd()): string {
  * `readManagerToken` but the credential is deliberately per-user;
  * `configDir` is overridable for tests only.
  */
-export function readInstallToken(
-  _projectRoot = process.cwd(),
-  configDir = path.join(os.homedir(), '.config', 'nanoclaw'),
-): string | undefined {
+export function readInstallToken(_projectRoot = process.cwd(), configDir = defaultConfigDir()): string | undefined {
   const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
   if (fromEnv) return fromEnv;
   let parsed: unknown;

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -273,7 +273,7 @@ function defaultConfigDir(): string {
 }
 
 /**
- * The managed-Slack service belonging to a given account service.
+ * The Slack-side service belonging to a given account service.
  *
  * The two are halves of one deployment: this service authenticates the
  * install token that service minted, so a token from one is not a credential


### PR DESCRIPTION
## The bug

The install token is minted by the account service and spent at the Slack service. Those are halves of one deployment — the second authenticates what the first issued — but nothing in the code pairs them.

They are configured independently, in different files, with different keys:

| | setting | default |
|---|---|---|
| account service | `NANOCLAW_REGISTRY_API` | `setup/lib/registry-state.ts` |
| Slack service | `SLACK_SERVICE_BASE` | `src/provisioning/slack-app.ts` |

Point the account half at another deployment and nothing pairs it back up. The install presents a token to a service that cannot know it, and the 401 surfaces as "couldn't reach the Slack service" — an outage report for a service that is answering fine.

The two settings can drift independently, and a credential minted under one pairing outlives any later change to either default.

## The change

`readServiceBase` now resolves in this order:

1. an explicit `SLACK_SERVICE_BASE` (process env, then `.env`)
2. the service implied by whoever issued the credential on disk
3. `DEFAULT_SLACK_SERVICE_BASE`

Deriving beats defaulting because the credential is the thing being spent. An explicit setting still wins — pointing the halves apart is something an operator may need to do deliberately.

`slackServiceForRegistry` swaps the host and nothing else, `registry.<rest>` → `slack.<rest>`, returning an origin so any path, query or userinfo the credential recorded is dropped. A deployment that does not follow that naming derives nothing rather than a guess.

A token supplied through `NANOCLAW_REGISTRY_TOKEN` has no account record to derive from and keeps the default, so a CI caller retargeting the service must set `SLACK_SERVICE_BASE` too. Called out in the docstring.

`readServiceBase` takes the credential directory as a second parameter, matching `readInstallToken`, so its tests never read the developer's own account record — which the existing "defaults to the deployed service" test would otherwise have done, passing or failing depending on whose machine ran it.

## Tests

`src/provisioning/slack-app.test.ts`: the host-swap mapping, its refusals (not a URL, not an http(s) scheme, not a `registry.` host), userinfo and path stripping, and each branch of the resolution order.

`pnpm exec vitest run src/provisioning/slack-app.test.ts` — 22 tests, all passing. Only the touched suite was run; the branch's whole-tree baseline is red by construction.

