### PR TITLE
feat(channels): add webex-poll REST polling adapter

### DIFF
--- a/.claude/skills/add-webex-poll/REMOVE.md
+++ b/.claude/skills/add-webex-poll/REMOVE.md
@@ -1,0 +1,6 @@
+# Remove Webex (Polling) Channel
+
+1. Comment out `import './webex-poll.js'` in `src/channels/index.ts`
+2. Remove `WEBEX_BOT_TOKEN` from `.env` (skip if the webhook `webex` adapter also uses it)
+3. Delete `src/channels/webex-poll.ts` and `src/channels/webex-poll-registration.test.ts`
+4. Rebuild and restart

--- a/.claude/skills/add-webex-poll/SKILL.md
+++ b/.claude/skills/add-webex-poll/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: add-webex-poll
+description: Add Webex channel integration via REST polling (no public webhook URL required).
+---
+
+# Add Webex (Polling) Channel
+
+Adds Cisco Webex support via REST polling — no webhook, no public URL. Suitable
+for enterprise installs behind firewalls or NAT where the webhook-based
+`/add-webex` adapter can't receive inbound events.
+
+The adapter polls `/v1/rooms?sortBy=lastactivity` every 5 s, skips rooms whose
+`lastActivity` hasn't changed, then fetches recent messages for changed rooms
+and routes them. Mention detection reads the `mentionedPeople` array from the
+REST response — no webhook subscription needed.
+
+**Trade-offs vs the webhook adapter (`/add-webex`):**
+
+| | `webex-poll` (this skill) | `webex` (webhook) |
+|---|---|---|
+| Public URL required | **No** | Yes |
+| Latency | ~5 s | Instant |
+| Thread support | No | Yes |
+| Mention-sticky wiring | No | Yes |
+
+Uses Node's built-in `fetch` — no new npm dependency. Both adapters can
+coexist; channel type `webex-poll` is distinct from `webex`.
+
+## Install
+
+NanoClaw doesn't ship channels in trunk. This skill copies the Webex polling
+adapter from the `channels` branch.
+
+### Pre-flight (idempotent)
+
+Skip to **Credentials** if all of these are already in place:
+
+- `src/channels/webex-poll.ts` exists
+- `src/channels/index.ts` contains `import './webex-poll.js';`
+
+Otherwise continue. Every step below is safe to re-run.
+
+### 1. Fetch the channels branch
+
+```bash
+git fetch origin channels
+```
+
+### 2. Copy the adapter and registration test
+
+```bash
+git show origin/channels:src/channels/webex-poll.ts > src/channels/webex-poll.ts
+git show origin/channels:src/channels/webex-poll-registration.test.ts > src/channels/webex-poll-registration.test.ts
+```
+
+### 3. Append the self-registration import
+
+Append to `src/channels/index.ts` (skip if the line is already present):
+
+```typescript
+import './webex-poll.js';
+```
+
+### 4. Build and validate
+
+```bash
+pnpm run build
+pnpm exec vitest run src/channels/webex-poll-registration.test.ts
+```
+
+`webex-poll-registration.test.ts` imports the real channel barrel and asserts
+the registry contains `webex-poll`. It goes red if the import line is deleted
+or drifts. End-to-end delivery against a real Webex space is verified manually
+once the service runs.
+
+## Credentials
+
+### Create the Webex bot
+
+1. Go to [developer.webex.com](https://developer.webex.com/my-apps/new/bot) and
+   create a new bot.
+2. Copy the **Bot Access Token** — it is shown once at creation. If lost,
+   regenerate it from the bot's page; regenerating invalidates the old token.
+
+### Configure environment
+
+```bash
+WEBEX_BOT_TOKEN=your-bot-access-token
+```
+
+No webhook secret is needed — the polling adapter makes outbound calls only;
+Webex never calls back.
+
+### Confirm the token works
+
+```bash
+curl -sf https://webexapis.com/v1/people/me \
+  -H "Authorization: Bearer $WEBEX_BOT_TOKEN" | jq -er '.displayName + " (" + .id + ")"'
+```
+
+A failure here means the token is wrong or expired.
+
+## Next Steps
+
+If you're in the middle of `/setup`, return to the setup flow now. Otherwise
+run `/manage-channels` to wire this channel to an agent group.
+
+## Channel Info
+
+- **type**: `webex-poll`
+- **terminology**: Webex has "spaces." A space can be a group conversation or a 1:1 direct message with the bot.
+- **platform-id-format**: `webex-poll:{roomId}` (e.g. `webex-poll:Y2lzY29zcGFyazovL...`)
+- **how-to-find-id**: Open the space in Webex, click the space name > Settings — the Space ID is listed there. Or call `GET https://webexapis.com/v1/rooms` with the bot token. The adapter prefixes room IDs with `webex-poll:` internally.
+- **supports-threads**: no
+- **typical-use**: Enterprise installs that can't expose a public webhook URL — corporate firewalls, VPN-only networks, local dev.
+- **default-isolation**: Same agent group for spaces where you're the primary user. Separate agent group for spaces with different teams or sensitive information.
+
+## Troubleshooting
+
+**Sends fail with 401.** The Bot Access Token is shown once at creation on the
+bot's page at developer.webex.com — it is *not* the 12-hour personal access
+token from the API docs pages (that one works briefly, then everything 401s).
+Regenerate the token on the bot page if needed; update `WEBEX_BOT_TOKEN` right
+away as regenerating invalidates the old value.
+
+**Messages in a space never reach the agent.** The bot must be added as a
+member of the space. The polling adapter fetches `/v1/rooms` which only lists
+spaces the bot is a member of — spaces it isn't in are invisible to the poll.
+Check `logs/nanoclaw.log` for `webex-poll adapter ready` on startup and
+`webex-poll: poll error` for repeated failures.
+
+**Bot sees its own messages.** The adapter filters by `personId` fetched at
+startup via `GET /v1/people/me`. If that fetch fails, no filter is applied and
+the bot's own responses get re-routed. The startup log prints `botPersonId` on
+success; if it's absent, check the bot token.
+
+**Rate limit errors.** The adapter retries with exponential backoff on 429
+responses, reading the `Retry-After` header as the base delay and doubling on
+each successive retry (up to 4 attempts). Sustained rate limiting is logged as
+`webex-poll: rate limited` in `logs/nanoclaw.log`. If it persists, reduce the
+poll frequency by increasing `POLL_INTERVAL_MS` in `src/channels/webex-poll.ts`
+and rebuilding.

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -42,8 +42,11 @@ import './whatsapp-cloud.js';
 // matrix
 // import './matrix.js';
 
-// webex
+// webex (webhook, via Chat SDK bridge)
 // import './webex.js';
+
+// webex-poll (REST polling, no public URL required)
+import './webex-poll.js';
 
 // imessage
 import './imessage.js';

--- a/src/channels/webex-poll-registration.test.ts
+++ b/src/channels/webex-poll-registration.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Integration test for the webex-poll channel's single reach-in: the
+ * self-registration import in the `src/channels/index.ts` barrel. Importing
+ * the barrel runs webex-poll.ts's top-level `registerChannelAdapter('webex-poll', …)`;
+ * without the import the channel is silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. This reflects what happens at host boot — if the
+ * `import './webex-poll.js';` line is deleted, or the barrel fails to evaluate for any
+ * reason (so the channel genuinely would not register), this goes red. A structural
+ * check of the import line would falsely pass in that second case.
+ *
+ * webex-poll is a native adapter (no Chat SDK bridge): webex-poll.ts consumes the
+ * host's built-in fetch API and no extra npm packages, so this test has no external
+ * dependency to guard beyond the adapter source itself.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('webex-poll channel registration', () => {
+  it('registers webex-poll via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('webex-poll');
+  });
+});

--- a/src/channels/webex-poll.ts
+++ b/src/channels/webex-poll.ts
@@ -1,0 +1,268 @@
+/**
+ * Webex polling adapter — polls the Webex REST API for new messages.
+ *
+ * Unlike the webhook adapter (`webex`), this one polls periodically so it
+ * works behind firewalls and NAT without a public inbound URL.
+ *
+ * Flow:
+ *   1. Factory gated on WEBEX_BOT_TOKEN in .env.
+ *   2. On setup: fetch the bot's personId to filter self-messages.
+ *   3. Poll /v1/rooms every POLL_INTERVAL_MS, sorted by lastActivity.
+ *      Rooms whose lastActivity hasn't advanced are skipped — zero wasted
+ *      fetches for idle spaces.
+ *   4. For each changed room, fetch recent messages and route anything newer
+ *      than the room's last-seen timestamp via config.onInbound.
+ *   5. Outbound: POST /v1/messages with roomId + markdown or text.
+ *
+ * Mention detection: inbound messages carry `mentionedPeople`; the adapter
+ * marks isMention=true when the bot's personId is in that list (or always,
+ * for DMs). Group wirings default to `mention` mode; DM wirings to
+ * `pattern: '.'` (respond to everything).
+ *
+ * Self-registers on import.
+ */
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { registerChannelAdapter } from './channel-registry.js';
+import type {
+  ChannelAdapter,
+  ChannelDefaults,
+  ChannelSetup,
+  ConversationInfo,
+  InboundMessage,
+  OutboundMessage,
+} from './adapter.js';
+
+const WEBEX_API = 'https://webexapis.com/v1';
+const POLL_INTERVAL_MS = 5000;
+const RATE_LIMIT_BASE_SECS = 10;
+const RATE_LIMIT_MAX_RETRIES = 4;
+
+interface WebexRoom {
+  id: string;
+  title: string;
+  type: 'direct' | 'group';
+  lastActivity: string;
+}
+
+interface WebexMessage {
+  id: string;
+  roomId: string;
+  personId: string;
+  personEmail: string;
+  text?: string;
+  markdown?: string;
+  mentionedPeople?: string[];
+  created: string;
+}
+
+/**
+ * Conservative group default — mention engagement only; no sticky because the
+ * polling adapter has no webhook subscription primitive. DMs: respond to all.
+ * Mentions: platform (mentionedPeople array in the REST response).
+ */
+const WEBEX_POLL_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  group: { engageMode: 'mention', threads: false, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+registerChannelAdapter('webex-poll', {
+  factory: () => {
+    const env = readEnvFile(['WEBEX_BOT_TOKEN']);
+    if (!env.WEBEX_BOT_TOKEN) return null;
+
+    const token = env.WEBEX_BOT_TOKEN;
+    const authHeaders = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+
+    let botPersonId = '';
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+    let connected = false;
+    let setupConfig: ChannelSetup;
+
+    // Per-room: ISO timestamp of last processed message (oldest-first scan stops here)
+    const roomCursor = new Map<string, string>();
+    // Per-room: lastActivity from Webex — skip the room on poll if unchanged
+    const roomActivity = new Map<string, string>();
+
+    async function apiFetch<T>(path: string, init?: RequestInit, attempt = 0): Promise<T> {
+      const url = path.startsWith('http') ? path : `${WEBEX_API}${path}`;
+      const res = await fetch(url, {
+        ...init,
+        headers: { ...authHeaders, ...((init?.headers as Record<string, string> | undefined) ?? {}) },
+      });
+
+      if (res.status === 429) {
+        if (attempt >= RATE_LIMIT_MAX_RETRIES) {
+          throw new Error(`Webex API ${path} → 429: rate limited after ${attempt} retries`);
+        }
+        // Respect Retry-After, then double on each successive retry.
+        const retryAfterSecs = parseInt(res.headers.get('Retry-After') ?? String(RATE_LIMIT_BASE_SECS), 10);
+        const delaySecs = retryAfterSecs * Math.pow(2, attempt);
+        log.warn('webex-poll: rate limited', { path, attempt, delaySecs });
+        await new Promise((r) => setTimeout(r, delaySecs * 1000));
+        return apiFetch<T>(path, init, attempt + 1);
+      }
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`Webex API ${path} → ${res.status}: ${body.slice(0, 200)}`);
+      }
+      return res.json() as Promise<T>;
+    }
+
+    async function pollRoom(room: WebexRoom): Promise<void> {
+      const platformId = `webex-poll:${room.id}`;
+      const isGroup = room.type === 'group';
+      const cursor = roomCursor.get(room.id);
+
+      // Fetch newest-first (API default), up to 50 messages
+      const result = await apiFetch<{ items: WebexMessage[] }>(
+        `/messages?roomId=${encodeURIComponent(room.id)}&max=50`,
+      );
+
+      // Reverse to process oldest-first so cursor advances monotonically
+      const messages = [...result.items].reverse();
+
+      setupConfig.onMetadata(platformId, room.title, isGroup);
+
+      let newCursor = cursor;
+
+      for (const msg of messages) {
+        // Skip if already seen (cursor is the `created` timestamp of the last processed msg)
+        if (cursor && msg.created <= cursor) continue;
+        // Skip the bot's own messages
+        if (msg.personId === botPersonId) {
+          if (!newCursor || msg.created > newCursor) newCursor = msg.created;
+          continue;
+        }
+
+        const isMention = isGroup ? (msg.mentionedPeople ?? []).includes(botPersonId) : true;
+
+        const inbound: InboundMessage = {
+          id: msg.id,
+          kind: 'chat',
+          content: {
+            text: msg.text ?? '',
+            senderId: `webex-poll:${msg.personId}`,
+            sender: msg.personId,
+            senderName: msg.personEmail,
+            isGroup,
+          },
+          isMention,
+          isGroup,
+          timestamp: new Date(msg.created).toISOString(),
+        };
+
+        await setupConfig.onInbound(platformId, null, inbound);
+
+        if (!newCursor || msg.created > newCursor) newCursor = msg.created;
+      }
+
+      if (newCursor && newCursor !== cursor) {
+        roomCursor.set(room.id, newCursor);
+      }
+    }
+
+    async function poll(): Promise<void> {
+      try {
+        const { items: rooms } = await apiFetch<{ items: WebexRoom[] }>('/rooms?sortBy=lastactivity&max=100');
+
+        for (const room of rooms) {
+          const prev = roomActivity.get(room.id);
+          if (prev === room.lastActivity) continue;
+
+          try {
+            await pollRoom(room);
+          } catch (err) {
+            log.warn('webex-poll: pollRoom error', { roomId: room.id, err });
+          }
+
+          roomActivity.set(room.id, room.lastActivity);
+        }
+      } catch (err) {
+        log.warn('webex-poll: poll error', { err });
+      }
+
+      if (connected) {
+        pollTimer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+      }
+    }
+
+    const adapter: ChannelAdapter = {
+      name: 'webex-poll',
+      channelType: 'webex-poll',
+      supportsThreads: false,
+      defaults: WEBEX_POLL_DEFAULTS,
+
+      async setup(config: ChannelSetup): Promise<void> {
+        setupConfig = config;
+        const me = await apiFetch<{ id: string }>('/people/me');
+        botPersonId = me.id;
+        log.info('webex-poll adapter ready', { botPersonId });
+        connected = true;
+        void poll();
+      },
+
+      async teardown(): Promise<void> {
+        connected = false;
+        if (pollTimer) {
+          clearTimeout(pollTimer);
+          pollTimer = null;
+        }
+      },
+
+      isConnected(): boolean {
+        return connected;
+      },
+
+      async deliver(
+        platformId: string,
+        _threadId: string | null,
+        message: OutboundMessage,
+      ): Promise<string | undefined> {
+        const roomId = platformId.replace(/^webex-poll:/, '');
+        const content = message.content as Record<string, unknown>;
+        const markdown = content.markdown as string | undefined;
+        const text = content.text as string | undefined;
+
+        if (!markdown && !text) return undefined;
+
+        try {
+          const body: Record<string, string> = { roomId };
+          if (markdown) body.markdown = markdown;
+          else body.text = text!;
+
+          const result = await apiFetch<{ id: string }>('/messages', {
+            method: 'POST',
+            body: JSON.stringify(body),
+          });
+          return result.id;
+        } catch (err) {
+          log.error('webex-poll: deliver failed', { platformId, err });
+          return undefined;
+        }
+      },
+
+      async syncConversations(): Promise<ConversationInfo[]> {
+        try {
+          const { items: rooms } = await apiFetch<{ items: WebexRoom[] }>('/rooms?sortBy=lastactivity&max=100');
+          return rooms.map((room) => ({
+            platformId: `webex-poll:${room.id}`,
+            name: room.title,
+            isGroup: room.type === 'group',
+          }));
+        } catch (err) {
+          log.warn('webex-poll: syncConversations error', { err });
+          return [];
+        }
+      },
+    };
+
+    return adapter;
+  },
+  defaults: WEBEX_POLL_DEFAULTS,
+});


### PR DESCRIPTION
 <!-- contributing-guide: v1 -->

  ## Type of Change

  - [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

  ## Description

  Adds a Cisco Webex channel adapter (`webex-poll`) that polls the REST API
  instead of requiring an inbound webhook. Enterprise installs behind corporate
  firewalls or NAT cannot expose a public URL for Webex to push events; this
  adapter removes that requirement entirely.

  Modelled after the Mattermost PR (#3202) — retargeted directly at the
  `channels` branch, SKILL.md in prose/bash format, REMOVE.md included.

  **How it works:**
  - Polls `/v1/rooms?sortBy=lastactivity` every 5 s
  - Skips rooms whose `lastActivity` timestamp hasn't changed — zero wasted
    fetches for idle spaces
  - Per-room ISO timestamp cursor prevents reprocessing messages across polls
  - Mention detection reads `mentionedPeople` from the REST message object —
    no webhook subscription needed
  - On 429: reads `Retry-After` header and retries with exponential backoff
    (×1, ×2, ×4, ×8 of the header value); gives up after 4 attempts, lets
    the poll loop reschedule normally


| Mention-sticky wiring | No | Yes |

Channel type is `webex-poll` — distinct from `webex`; both can coexist in
the same install.

**Verified end-to-end against a live Webex space:** inbound DM, inbound group
message with @mention, outbound reply with markdown.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone

  - Uses Node's built-in `fetch` — no new npm dependency

  **Trade-offs vs the existing `webex` webhook adapter:**

  | | `webex-poll` (this PR) | `webex` (existing) |
  |---|---|---|
  | Public URL required | **No** | Yes |
  | Latency | ~5 s | Instant |
  | Thread support | No | Yes |
  | Mention-sticky wiring | No | Yes |

  Channel type is `webex-poll` — distinct from `webex`; both can coexist in
  the same install.

