### PR TITLE
feat(provisioning): optional request-origin metadata on app creation

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -438,11 +438,6 @@ async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
   const originAuth = await slackAuthTest(originBotToken, 'origin-auth');
   const originBotUserId = originAuth.userId;
 
-  // S3/S4 provision + .env persist (reuse path: tokens already in .env, no network).
-  // requestedBy: the S1 operator is the requesting human — the only Slack
-  // member id in scope. The origin app's own A… id is NOT in scope (auth.test
-  // carries no app id and .env persists tokens only) and the flow has no
-  // template concept, so parentAppId / template are not sent from this path.
   const app = await provisionSlackApp({
     slug,
     displayName,

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -439,6 +439,10 @@ async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
   const originBotUserId = originAuth.userId;
 
   // S3/S4 provision + .env persist (reuse path: tokens already in .env, no network).
+  // requestedBy: the S1 operator is the requesting human — the only Slack
+  // member id in scope. The origin app's own A… id is NOT in scope (auth.test
+  // carries no app id and .env persists tokens only) and the flow has no
+  // template concept, so parentAppId / template are not sent from this path.
   const app = await provisionSlackApp({
     slug,
     displayName,
@@ -446,6 +450,7 @@ async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
     teamId: originAuth.teamId,
     description: args.description,
     allowGuests: args.allowGuests,
+    requestedBy: operatorUserId,
   });
 
   // S5 adapter-start. The multi-instance module must be installed regardless

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
@@ -187,7 +187,7 @@ interface RawProvisioned {
 }
 
 /**
- * Optional fleet-analytics fields on the broker's POST /v1/apps body
+ * Optional request-origin metadata on the broker's POST /v1/apps body
  * (requested_by / parent_app_id / template / client_version on the wire).
  * Sent only when defined; a broker that predates them ignores unknown body
  * fields. Names and no-value-no-key behavior are pinned across every
@@ -202,7 +202,7 @@ interface ProvisionAttribution {
 }
 
 /**
- * The installing host's package.json version — the client_version analytics
+ * The installing host's package.json version — the client_version metadata
  * field. Optional-shaped: unreadable/absent → undefined and the field is
  * simply omitted (never a placeholder value).
  */
@@ -357,7 +357,7 @@ async function provisionViaBroker(
         name: displayName,
         ...(avatarId ? { avatar_id: avatarId } : {}),
         ...(allowGuests ? { allow_guests: true } : {}),
-        // Fleet-analytics attribution — optional both ways: omitted when
+        // Request-origin metadata — optional both ways: omitted when
         // unknown, ignored by a broker that predates the fields.
         ...(attribution.requestedBy ? { requested_by: attribution.requestedBy } : {}),
         ...(attribution.parentAppId ? { parent_app_id: attribution.parentAppId } : {}),

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
@@ -186,6 +186,36 @@ interface RawProvisioned {
   installError?: string;
 }
 
+/**
+ * Optional fleet-analytics fields on the broker's POST /v1/apps body
+ * (requested_by / parent_app_id / template / client_version on the wire).
+ * Sent only when defined; a broker that predates them ignores unknown body
+ * fields. Names and no-value-no-key behavior are pinned across every
+ * provisioning home by provision.congruence.test.ts. The direct transport has
+ * nowhere to record them and never forwards them.
+ */
+interface ProvisionAttribution {
+  requestedBy?: string;
+  parentAppId?: string;
+  template?: string;
+  clientVersion?: string;
+}
+
+/**
+ * The installing host's package.json version — the client_version analytics
+ * field. Optional-shaped: unreadable/absent → undefined and the field is
+ * simply omitted (never a placeholder value).
+ */
+function readClientVersion(rootDir: string): string | undefined {
+  try {
+    const pkg: unknown = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
+    const version = (pkg as { version?: unknown } | null)?.version;
+    return typeof version === 'string' && version.trim() ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Broker mode: POST /v1/apps with the install token; 60s budget. */
 /** Poll cap for the pre-create avatar job — beyond it the bot is born with the mascot. */
 const AVATAR_WAIT_MS = 75_000;
@@ -301,6 +331,7 @@ async function provisionViaBroker(
   teamId: string | undefined,
   description: string | undefined,
   allowGuests = false,
+  attribution: ProvisionAttribution = {},
 ): Promise<RawProvisioned> {
   if (!teamId) {
     throw new SlackFlowError(
@@ -326,6 +357,12 @@ async function provisionViaBroker(
         name: displayName,
         ...(avatarId ? { avatar_id: avatarId } : {}),
         ...(allowGuests ? { allow_guests: true } : {}),
+        // Fleet-analytics attribution — optional both ways: omitted when
+        // unknown, ignored by a broker that predates the fields.
+        ...(attribution.requestedBy ? { requested_by: attribution.requestedBy } : {}),
+        ...(attribution.parentAppId ? { parent_app_id: attribution.parentAppId } : {}),
+        ...(attribution.template ? { template: attribution.template } : {}),
+        ...(attribution.clientVersion ? { client_version: attribution.clientVersion } : {}),
       }),
       signal: AbortSignal.timeout(60_000),
     });
@@ -493,6 +530,12 @@ export async function provisionSlackApp(input: ProvisionInput): Promise<Provisio
           input.teamId,
           input.description,
           allowGuests,
+          {
+            requestedBy: input.requestedBy,
+            parentAppId: input.parentAppId,
+            template: input.template,
+            clientVersion: readClientVersion(rootDir),
+          },
         )
       : await provisionDirect(credential.managerToken, displayName, allowGuests);
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
@@ -55,7 +55,7 @@ export interface ProvisionInput {
    */
   allowGuests?: boolean;
   /**
-   * Fleet-analytics attribution, all optional — sent on the broker's
+   * Request-origin metadata, all optional — sent on the broker's
    * POST /v1/apps body only when defined (requested_by / parent_app_id /
    * template on the wire; a broker that predates them ignores unknown body
    * fields). client_version is derived from rootDir's package.json inside

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
@@ -54,6 +54,19 @@ export interface ProvisionInput {
    * default variant — a one-way door decided at provision time.
    */
   allowGuests?: boolean;
+  /**
+   * Fleet-analytics attribution, all optional — sent on the broker's
+   * POST /v1/apps body only when defined (requested_by / parent_app_id /
+   * template on the wire; a broker that predates them ignores unknown body
+   * fields). client_version is derived from rootDir's package.json inside
+   * provisionSlackApp, not supplied here.
+   */
+  /** Slack user id (U…/W…) of the human who asked for this agent. */
+  requestedBy?: string;
+  /** The creating agent's own Slack app id (A…) when an agent created this one. */
+  parentAppId?: string;
+  /** Template name, when the agent was stamped from one. */
+  template?: string;
 }
 
 export interface ProvisionResult {

--- a/src/provisioning/slack-app.test.ts
+++ b/src/provisioning/slack-app.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AGENT_BOT_EVENTS,
@@ -10,8 +10,10 @@ import {
   BOT_SCOPES,
   DEFAULT_SLACK_SERVICE_BASE,
   MANAGED_APP_DESCRIPTION,
+  brokerProvision,
   buildManagedAppManifest,
   mapBrokerApp,
+  provisionManagedApp,
   readInstallToken,
   readManagerToken,
   readServiceBase,
@@ -67,6 +69,132 @@ describe('buildManagedAppManifest', () => {
       };
       expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
     }
+  });
+
+  it('attribution fields never alter the manifest — they ride the broker body only', () => {
+    const plain = buildManagedAppManifest({ name: 'Trusty' });
+    const attributed = buildManagedAppManifest({
+      name: 'Trusty',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    expect(attributed).toEqual(plain);
+  });
+});
+
+describe('brokerProvision attribution fields', () => {
+  const fetchMock = vi.fn<(url: string, init?: { body?: unknown }) => Promise<unknown>>();
+  const appResponse = { app_id: 'A0NEW1', app_token: 'xapp-1-new', bot_token: 'xoxb-new' };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    process.env.SLACK_SERVICE_BASE = 'https://broker.test';
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(payload: object): object {
+    return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+  }
+
+  /** Route the module's outbound calls: avatar create, avatar poll, app create. */
+  function routeFetch(avatar: { avatar_id?: string | null; status?: string }): void {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://broker.test/v1/avatars') return jsonResponse({ avatar_id: avatar.avatar_id ?? null });
+      if (url.startsWith('https://broker.test/v1/avatars/')) return jsonResponse({ status: avatar.status ?? 'ready' });
+      if (url === 'https://broker.test/v1/apps') return jsonResponse(appResponse);
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+  }
+
+  function sentAppBody(): Record<string, unknown> {
+    const call = fetchMock.mock.calls.find(([url]) => url === 'https://broker.test/v1/apps');
+    expect(call).toBeDefined();
+    return JSON.parse((call![1] as { body: string }).body) as Record<string, unknown>;
+  }
+
+  it('rides the POST /v1/apps body verbatim when supplied', async () => {
+    routeFetch({ avatar_id: null });
+    const app = await brokerProvision('nct_x', {
+      team_id: 'T1',
+      name: 'Pixel',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    expect(sentAppBody()).toEqual({
+      team_id: 'T1',
+      name: 'Pixel',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    // The response mapping is untouched by the extra request fields.
+    expect(app.appId).toBe('A0NEW1');
+    expect(app.botToken).toBe('xoxb-new');
+  });
+
+  it('sends nothing extra when the fields are absent or explicitly undefined', async () => {
+    routeFetch({ avatar_id: null });
+    await brokerProvision('nct_x', { team_id: 'T1', name: 'Pixel', requested_by: undefined });
+    expect(sentAppBody()).toEqual({ team_id: 'T1', name: 'Pixel' });
+  });
+
+  it('keeps the avatar_id merge unchanged alongside attribution fields', async () => {
+    routeFetch({ avatar_id: 'av1', status: 'ready' });
+    await brokerProvision('nct_x', { team_id: 'T1', name: 'Pixel', client_version: '2.2.0' });
+    expect(sentAppBody()).toEqual({ team_id: 'T1', name: 'Pixel', avatar_id: 'av1', client_version: '2.2.0' });
+  });
+});
+
+describe('provisionManagedApp attribution fields', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('never forwards them to Slack — neither in the manifest nor as call params', async () => {
+    const fetchMock = vi.fn(async (url: string, _init?: { body?: unknown }) => {
+      if (url === 'https://slack.com/api/apps.manifest.create') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, app_id: 'A1', app_token: 'xapp-1', oauth_authorize_url: 'https://x' }),
+        };
+      }
+      if (url === 'https://slack.com/api/apps.managedInstall') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, api_access_tokens: { bot_access_token: 'xoxb-1' } }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const app = await provisionManagedApp('xoxp-mgr', {
+      name: 'Trusty',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    expect(app.botToken).toBe('xoxb-1');
+
+    const createCall = fetchMock.mock.calls.find(([url]) => url === 'https://slack.com/api/apps.manifest.create');
+    expect(createCall).toBeDefined();
+    const params = new URLSearchParams((createCall![1] as { body: string }).body);
+    expect([...params.keys()].sort()).toEqual(['generate_app_token', 'manifest']);
+    // The manifest is byte-identical to one built without attribution fields.
+    expect(JSON.parse(params.get('manifest')!)).toEqual(buildManagedAppManifest({ name: 'Trusty' }));
   });
 });
 

--- a/src/provisioning/slack-app.test.ts
+++ b/src/provisioning/slack-app.test.ts
@@ -15,6 +15,7 @@ import {
   readInstallToken,
   readManagerToken,
   readServiceBase,
+  slackServiceForRegistry,
 } from './slack-app.js';
 
 interface ManifestShape {
@@ -97,29 +98,79 @@ describe('readManagerToken', () => {
   });
 });
 
-describe('readServiceBase', () => {
-  let dir: string | undefined;
-  afterEach(() => {
-    delete process.env.SLACK_SERVICE_BASE;
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-    dir = undefined;
+describe('slackServiceForRegistry', () => {
+  it('swaps the host, keeping everything else about the deployment', () => {
+    expect(slackServiceForRegistry('https://registry.nanoclaw.dev')).toBe('https://slack.nanoclaw.dev');
+    expect(slackServiceForRegistry('https://registry.sandbox.nanoclaw.dev')).toBe('https://slack.sandbox.nanoclaw.dev');
+    expect(slackServiceForRegistry('http://registry.localhost:8080')).toBe('http://slack.localhost:8080');
   });
 
-  it('defaults to the deployed service', () => {
+  it('drops the path, query and userinfo a credential may have recorded', () => {
+    expect(slackServiceForRegistry('https://user:pw@registry.sandbox.nanoclaw.dev/private?token=secret')).toBe(
+      'https://slack.sandbox.nanoclaw.dev',
+    );
+  });
+
+  it('declines to guess for anything that is not a registry host', () => {
+    expect(slackServiceForRegistry(undefined)).toBeUndefined();
+    expect(slackServiceForRegistry('')).toBeUndefined();
+    expect(slackServiceForRegistry('not a url')).toBeUndefined();
+    expect(slackServiceForRegistry('file:///registry.nanoclaw.dev')).toBeUndefined();
+    // Same deployment, different naming: derive nothing rather than invent it.
+    expect(slackServiceForRegistry('https://accounts.example.test')).toBeUndefined();
+  });
+});
+
+describe('readServiceBase', () => {
+  let dir: string | undefined;
+  let configDir: string | undefined;
+
+  /** An isolated pair of directories: never the developer's own credential. */
+  function dirs(accountApi?: string): [string, string] {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
-    expect(readServiceBase(dir)).toBe(DEFAULT_SLACK_SERVICE_BASE);
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-cfg-'));
+    if (accountApi !== undefined) {
+      fs.writeFileSync(path.join(configDir, 'account.json'), JSON.stringify({ api: accountApi, token: 'nct_x' }));
+    }
+    return [dir, configDir];
+  }
+
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    for (const d of [dir, configDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+    dir = configDir = undefined;
+  });
+
+  it('defaults to the deployed service when nothing says otherwise', () => {
+    expect(readServiceBase(...dirs())).toBe(DEFAULT_SLACK_SERVICE_BASE);
   });
 
   it('prefers process env and strips trailing slashes', () => {
     process.env.SLACK_SERVICE_BASE = 'https://slack-sandbox.example.dev/';
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
-    expect(readServiceBase(dir)).toBe('https://slack-sandbox.example.dev');
+    expect(readServiceBase(...dirs())).toBe('https://slack-sandbox.example.dev');
   });
 
   it('reads from .env, stripping quotes', () => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
-    fs.writeFileSync(path.join(dir, '.env'), 'SLACK_SERVICE_BASE="https://broker.example.test"\n');
-    expect(readServiceBase(dir)).toBe('https://broker.example.test');
+    const [root, cfg] = dirs();
+    fs.writeFileSync(path.join(root, '.env'), 'SLACK_SERVICE_BASE="https://broker.example.test"\n');
+    expect(readServiceBase(root, cfg)).toBe('https://broker.example.test');
+  });
+
+  it('follows the credential to its own deployment rather than the default', () => {
+    expect(readServiceBase(...dirs('https://registry.sandbox.nanoclaw.dev'))).toBe(
+      'https://slack.sandbox.nanoclaw.dev',
+    );
+  });
+
+  it('lets an explicit setting override the credential it was issued against', () => {
+    process.env.SLACK_SERVICE_BASE = 'https://slack.example.test';
+    expect(readServiceBase(...dirs('https://registry.sandbox.nanoclaw.dev'))).toBe('https://slack.example.test');
+  });
+
+  it('falls back to the default when the credential records nothing to derive from', () => {
+    expect(readServiceBase(...dirs('https://accounts.example.test'))).toBe(DEFAULT_SLACK_SERVICE_BASE);
+    for (const d of [dir, configDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+    expect(readServiceBase(...dirs())).toBe(DEFAULT_SLACK_SERVICE_BASE);
   });
 });
 

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -267,9 +267,70 @@ export function readManagerToken(projectRoot = process.cwd()): string | undefine
 // ---------------------------------------------------------------------------
 // Broker transport — the managed-Slack service at slack.nanoclaw.dev.
 
-/** Broker base URL: SLACK_SERVICE_BASE (process env or .env), else the default. */
-export function readServiceBase(projectRoot = process.cwd()): string {
-  const value = readEnvSetting('SLACK_SERVICE_BASE', projectRoot) ?? DEFAULT_SLACK_SERVICE_BASE;
+/** Per-user credential directory — where enrollment persists account.json. */
+function defaultConfigDir(): string {
+  return path.join(os.homedir(), '.config', 'nanoclaw');
+}
+
+/**
+ * The managed-Slack service belonging to a given account service.
+ *
+ * The two are halves of one deployment: this service authenticates the
+ * install token that service minted, so a token from one is not a credential
+ * at the other. Nothing on disk records the pairing, and the two are
+ * configured independently — which is how an install ends up presenting a
+ * token from one deployment to the other and reading the refusal as an
+ * outage.
+ *
+ * Host swap only, `registry.<rest>` → `slack.<rest>`, so a deployment that
+ * follows the same naming is derived correctly and one that does not yields
+ * undefined rather than a guess.
+ */
+export function slackServiceForRegistry(api: string | undefined): string | undefined {
+  if (!api) return undefined;
+  let url: URL;
+  try {
+    url = new URL(api);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+  if (!url.hostname.startsWith('registry.')) return undefined;
+  url.hostname = `slack.${url.hostname.slice('registry.'.length)}`;
+  // `origin` drops any path, query and userinfo the credential recorded.
+  return url.origin;
+}
+
+/** The account service that issued the credential on disk, if it recorded one. */
+function readAccountApi(configDir: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(configDir, 'account.json'), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const api = (parsed as { api?: unknown }).api;
+  return typeof api === 'string' && api.trim() ? api.trim() : undefined;
+}
+
+/**
+ * Broker base URL: SLACK_SERVICE_BASE (process env or .env) first, then the
+ * service implied by whoever issued the credential we are about to send, and
+ * only then the default.
+ *
+ * Deriving beats defaulting because the credential is the thing being spent:
+ * pairing it with a service that cannot know it produces a 401 that reads as
+ * "Slack is down". An explicit setting still wins — pointing the two halves
+ * at different deployments is a thing an operator may need to do deliberately.
+ *
+ * A token supplied through NANOCLAW_REGISTRY_TOKEN has no account record to
+ * derive from and falls through to the default, so a CI caller retargeting
+ * the service must set SLACK_SERVICE_BASE too.
+ */
+export function readServiceBase(projectRoot = process.cwd(), configDir = defaultConfigDir()): string {
+  const explicit = readEnvSetting('SLACK_SERVICE_BASE', projectRoot);
+  const value = explicit ?? slackServiceForRegistry(readAccountApi(configDir)) ?? DEFAULT_SLACK_SERVICE_BASE;
   return value.replace(/\/+$/, '');
 }
 
@@ -286,10 +347,7 @@ export function readServiceBase(projectRoot = process.cwd()): string {
  * `readManagerToken` but the credential is deliberately per-user;
  * `configDir` is overridable for tests only.
  */
-export function readInstallToken(
-  _projectRoot = process.cwd(),
-  configDir = path.join(os.homedir(), '.config', 'nanoclaw'),
-): string | undefined {
+export function readInstallToken(_projectRoot = process.cwd(), configDir = defaultConfigDir()): string | undefined {
   const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
   if (fromEnv) return fromEnv;
   let parsed: unknown;

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -116,7 +116,27 @@ export const AGENT_BOT_EVENTS = ['app_home_opened', 'app_context_changed'];
 export const MANAGED_APP_DESCRIPTION =
   'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
 
-export interface ManagedAppSpec {
+/**
+ * Optional fleet/operations attribution fields, all additive. On the broker
+ * transport they ride the POST /v1/apps HTTP body verbatim (sent only when
+ * defined — JSON serialization drops undefined values); a service that does
+ * not know them ignores them. They NEVER influence the Slack app manifest,
+ * scopes, or events, and the direct-Slack transport has nowhere to record
+ * them, so it ignores them entirely. Field names are the wire contract —
+ * snake_case, shared across every transport that provisions managed apps.
+ */
+export interface ProvisionAttribution {
+  /** Slack user id of the human who asked for this app, when known. */
+  requested_by?: string;
+  /** The creating agent's own Slack app id, when an agent created this agent. */
+  parent_app_id?: string;
+  /** Template name, when the app was stamped from one. */
+  template?: string;
+  /** The installing host's package.json version. */
+  client_version?: string;
+}
+
+export interface ManagedAppSpec extends ProvisionAttribution {
   name: string;
   description?: string;
   /**
@@ -525,7 +545,13 @@ export function mapBrokerApp(res: BrokerAppResponse): ProvisionedApp {
  */
 export async function brokerProvision(
   token: string,
-  spec: { team_id: string; name: string; description?: string; icon_url?: string; allow_guests?: boolean },
+  spec: {
+    team_id: string;
+    name: string;
+    description?: string;
+    icon_url?: string;
+    allow_guests?: boolean;
+  } & ProvisionAttribution,
 ): Promise<ProvisionedApp> {
   // Avatar-first: generate the avatar BEFORE the app exists so the bot's
   // first appearance already wears it — undefined degrades to the default icon.

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -117,7 +117,7 @@ export const MANAGED_APP_DESCRIPTION =
   'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
 
 /**
- * Optional fleet/operations attribution fields, all additive. On the broker
+ * Optional request-origin metadata fields, all additive. On the broker
  * transport they ride the POST /v1/apps HTTP body verbatim (sent only when
  * defined — JSON serialization drops undefined values); a service that does
  * not know them ignores them. They NEVER influence the Slack app manifest,

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -273,7 +273,7 @@ function defaultConfigDir(): string {
 }
 
 /**
- * The managed-Slack service belonging to a given account service.
+ * The Slack-side service belonging to a given account service.
  *
  * The two are halves of one deployment: this service authenticates the
  * install token that service minted, so a token from one is not a credential


### PR DESCRIPTION
# feat(provisioning): optional request-origin metadata on app creation

Adds four optional, additive metadata fields to the provisioning core, describing where an app-creation request came from — who asked for it, what created it, and which client shipped the request:

| Field | Meaning |
|---|---|
| `requested_by` | Slack user id of the human who asked for the app |
| `parent_app_id` | the creating agent's own Slack app id, when an agent created this agent |
| `template` | template name, when the app was stamped from one |
| `client_version` | the installing host's `package.json` version |

## Scope of the change

- `ProvisionAttribution` interface, extended onto `ManagedAppSpec` and `brokerProvision`'s spec type in `src/provisioning/slack-app.ts`.
- The fields ride the broker `POST /v1/apps` HTTP body only, and only when defined (the spec is serialized verbatim; undefined values drop out of the JSON).
- **No manifest, scope, or event changes.** The manifest builder reads only `name` / `description` / `agentView`, and a new test pins that a spec carrying attribution fields produces a byte-identical manifest.
- The direct-Slack transport has nowhere to record these fields and ignores them entirely — a test pins that they never reach the Slack API calls.
- **The slack-agent-flow skill payload** (`.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/`) carries the same fields, so every `POST /v1/apps` constructor in the tree now identifies itself. Its copy mirrors the fork's: a `ProvisionAttribution` shape threaded through `provisionViaBroker` onto the body as `requested_by` / `parent_app_id` / `template` / `client_version`, each spread in only when defined, with `client_version` read from `rootDir`'s `package.json` (unreadable → omitted, never a placeholder). `ProvisionInput` grows the three caller-supplied fields, and `orchestrate.ts` supplies `requestedBy: operatorUserId` — the S1 operator is the only Slack member id in scope on that path, and without a producer the plumbing would never send anything. `parentAppId` / `template` stay unset there: no app id is in scope and the flow has no templates.

## Compatibility

Bidirectional and additive: the deployed service reads only the request fields it knows and ignores the rest, so clients carrying these fields can ship ahead of any service-side handling; clients that do not send them are byte-for-byte unchanged.

## Tests

`src/provisioning/slack-app.test.ts` — attribution fields present on the body verbatim when supplied, absent when not (including explicit `undefined`), `avatar_id` merge unchanged alongside them, manifest purity on both transports. Suite: 27 passed.

The skill payload's own tests are not collected on this branch (`vitest.config.ts` includes `src/**`, `setup/**`, `scripts/**`, `container/*.test.ts` — not `.claude/skills/**`); they run once the skill is installed and the module lands at `src/modules/slack-agent-flow/`. Verified there by copying the payload to that path and running it: `provision.congruence.test.ts` + `orchestrate.test.ts`, 33 passed / 2 skipped (the 2 skip on `describe.skipIf` because `slack-managed-agents/scripts/` is not present on this branch — pre-existing), plus a clean `tsc -p tsconfig.json` for the three touched files. The strict-equality body assertions still hold: with no attribution supplied and no `package.json` in the test's temp `rootDir`, the request body is byte-identical to before.

## Merge order

Based on the service-base-derivation branch — merge after that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

