### PR TITLE
fix(opencode): recover when a resumed session idles without work

### DIFF
--- a/container/agent-runner/src/providers/opencode.empty-resume.test.ts
+++ b/container/agent-runner/src/providers/opencode.empty-resume.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  isEmptyOpenCodeResume,
+  OpenCodeProvider,
+  type OpenCodeMemorySessionHook,
+  type OpenCodeRuntimeHandle,
+  type QuestionClient,
+} from './opencode.js';
+import type { ProviderEvent } from './types.js';
+
+describe('isEmptyOpenCodeResume', () => {
+  it('falls back only on a first empty resume', () => {
+    expect(
+      isEmptyOpenCodeResume({
+        resumedExistingSession: true,
+        alreadyFellBack: false,
+        sawAssistantWork: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not rotate a brand-new session that stays dry', () => {
+    expect(
+      isEmptyOpenCodeResume({
+        resumedExistingSession: false,
+        alreadyFellBack: false,
+        sawAssistantWork: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not rotate when the resume produced assistant work', () => {
+    expect(
+      isEmptyOpenCodeResume({
+        resumedExistingSession: true,
+        alreadyFellBack: false,
+        sawAssistantWork: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('falls back at most once per query', () => {
+    expect(
+      isEmptyOpenCodeResume({
+        resumedExistingSession: true,
+        alreadyFellBack: true,
+        sawAssistantWork: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+const MEMORY_HOOK: OpenCodeMemorySessionHook = {
+  command: 'true',
+  legacyCommands: [],
+  sources: ['startup', 'clear', 'compact'],
+};
+
+function userIdle(sessionID: string): Array<{ type: string; properties: Record<string, unknown> }> {
+  return [
+    { type: 'message.updated', properties: { info: { id: 'msg_user', role: 'user' } } },
+    {
+      type: 'message.part.updated',
+      properties: { part: { type: 'text', messageID: 'msg_user', text: 'hey' } },
+    },
+    { type: 'session.idle', properties: { sessionID } },
+  ];
+}
+
+function assistantReply(sessionID: string, text: string): Array<{ type: string; properties: Record<string, unknown> }> {
+  return [
+    { type: 'message.updated', properties: { info: { id: 'msg_asst', role: 'assistant' } } },
+    {
+      type: 'message.part.updated',
+      properties: { part: { type: 'text', messageID: 'msg_asst', text } },
+    },
+    { type: 'session.idle', properties: { sessionID } },
+  ];
+}
+
+function permissionOnly(sessionID: string): Array<{ type: string; properties: Record<string, unknown> }> {
+  return [
+    { type: 'permission.updated', properties: { id: 'perm_1', sessionID } },
+    { type: 'session.idle', properties: { sessionID } },
+  ];
+}
+
+function createFakeRuntime(script: Array<Array<{ type: string; properties: Record<string, unknown> }>>): {
+  runtime: { getRuntime: () => Promise<OpenCodeRuntimeHandle> };
+  promptIds: string[];
+  created: string[];
+} {
+  const promptIds: string[] = [];
+  const created: string[] = [];
+  let nextCreate = 0;
+  const queue: Array<{ type: string; properties: Record<string, unknown> }> = [];
+  const waiters: Array<() => void> = [];
+
+  const pushEvents = (events: Array<{ type: string; properties: Record<string, unknown> }>) => {
+    queue.push(...events);
+    while (waiters.length > 0 && queue.length > 0) waiters.shift()!();
+  };
+
+  async function* stream(): AsyncGenerator<{ type: string; properties: Record<string, unknown> }, void, void> {
+    while (true) {
+      if (queue.length === 0) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+      yield queue.shift()!;
+    }
+  }
+
+  const questionClient: QuestionClient = {
+    question: {
+      async reply() {
+        return { data: true };
+      },
+      async list() {
+        return { data: [] };
+      },
+    },
+  };
+
+  const handle: OpenCodeRuntimeHandle = {
+    questionClient,
+    stream: stream(),
+    client: {
+      session: {
+        async create() {
+          nextCreate += 1;
+          const id = `ses_fresh_${nextCreate}`;
+          created.push(id);
+          return { data: { id } };
+        },
+        async promptAsync(params) {
+          promptIds.push(params.path.id);
+          const events = script[promptIds.length - 1];
+          if (!events) throw new Error(`no scripted events for prompt #${promptIds.length}`);
+          pushEvents(events);
+          return {};
+        },
+      },
+    },
+  };
+
+  return {
+    promptIds,
+    created,
+    runtime: { getRuntime: async () => handle },
+  };
+}
+
+async function collect(events: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+describe('OpenCodeProvider empty-resume fallback', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-empty-resume-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('starts a fresh session when a resume idles with only the user echo', async () => {
+    const fake = createFakeRuntime([userIdle('ses_stale'), assistantReply('ses_fresh_1', 'Hey!')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({
+      prompt: 'hey',
+      cwd: dir,
+      continuation: 'ses_stale',
+    });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(fake.promptIds).toEqual(['ses_stale', 'ses_fresh_1']);
+    expect(fake.created).toEqual(['ses_fresh_1']);
+    expect(events.filter((e) => e.type === 'init')).toEqual([
+      { type: 'init', continuation: 'ses_stale' },
+      { type: 'init', continuation: 'ses_fresh_1' },
+    ]);
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: 'Hey!' }]);
+  });
+
+  it('keeps a resume that produced assistant text', async () => {
+    const fake = createFakeRuntime([assistantReply('ses_ok', 'still here')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({
+      prompt: 'hey',
+      cwd: dir,
+      continuation: 'ses_ok',
+    });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(fake.promptIds).toEqual(['ses_ok']);
+    expect(fake.created).toEqual([]);
+    expect(events.filter((e) => e.type === 'init')).toEqual([{ type: 'init', continuation: 'ses_ok' }]);
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: 'still here' }]);
+  });
+
+  it('treats a permission grant as assistant work — tools-only send is not an empty resume', async () => {
+    const fake = createFakeRuntime([permissionOnly('ses_ok')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({
+      prompt: 'hey',
+      cwd: dir,
+      continuation: 'ses_ok',
+    });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(fake.created).toEqual([]);
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: null }]);
+  });
+
+  it('does not create a second session when a new conversation stays dry', async () => {
+    const fake = createFakeRuntime([userIdle('ses_fresh_1')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hey', cwd: dir });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(fake.created).toEqual(['ses_fresh_1']);
+    expect(fake.promptIds).toEqual(['ses_fresh_1']);
+    expect(events.filter((e) => e.type === 'init')).toEqual([{ type: 'init', continuation: 'ses_fresh_1' }]);
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: null }]);
+  });
+
+  it('does not mistake an empty pushed turn for a persisted resume', async () => {
+    const fake = createFakeRuntime([assistantReply('ses_ok', 'first'), userIdle('ses_ok')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'first', cwd: dir, continuation: 'ses_ok' });
+    query.push('follow-up');
+    query.end();
+    await collect(query.events);
+
+    expect(fake.created).toEqual([]);
+    expect(fake.promptIds).toEqual(['ses_ok', 'ses_ok']);
+  });
+
+  it('does not create a replacement session after abort', async () => {
+    const fake = createFakeRuntime([userIdle('ses_stale')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hey', cwd: dir, continuation: 'ses_stale' });
+    const iterator = query.events[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value).toEqual({ type: 'init', continuation: 'ses_stale' });
+    expect((await iterator.next()).value).toEqual({ type: 'activity' });
+    query.abort();
+    expect((await iterator.next()).done).toBe(true);
+    expect(fake.created).toEqual([]);
+  });
+
+  it('does not count an echoed user attachment as assistant work', async () => {
+    const fake = createFakeRuntime([
+      [
+        { type: 'message.updated', properties: { info: { id: 'msg_user', role: 'user' } } },
+        { type: 'message.part.updated', properties: { part: { type: 'file', messageID: 'msg_user' } } },
+        { type: 'session.idle', properties: { sessionID: 'ses_stale' } },
+      ],
+      assistantReply('ses_fresh_1', 'recovered'),
+    ]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'inspect this', cwd: dir, continuation: 'ses_stale' });
+    query.end();
+    await collect(query.events);
+
+    expect(fake.created).toEqual(['ses_fresh_1']);
+  });
+
+  it('ignores foreign assistant events on the shared stream', async () => {
+    const fake = createFakeRuntime([
+      [
+        {
+          type: 'message.updated',
+          properties: { info: { id: 'msg_foreign', role: 'assistant', sessionID: 'ses_other' } },
+        },
+        ...userIdle('ses_stale'),
+      ],
+      assistantReply('ses_fresh_1', 'recovered'),
+    ]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hey', cwd: dir, continuation: 'ses_stale' });
+    query.end();
+    await collect(query.events);
+
+    expect(fake.created).toEqual(['ses_fresh_1']);
+  });
+});

--- a/container/agent-runner/src/providers/opencode.empty-resume.test.ts
+++ b/container/agent-runner/src/providers/opencode.empty-resume.test.ts
@@ -82,6 +82,26 @@ function assistantReply(sessionID: string, text: string): Array<{ type: string; 
   ];
 }
 
+/**
+ * The turn OpenCode opens an assistant record for and then abandons: the
+ * envelope arrives, no part ever follows, and the session idles. This is the
+ * quiet idle the fallback exists for, so a bare envelope must not count as work.
+ */
+function bareAssistantEnvelope(
+  sessionID: string,
+  info: Record<string, unknown> = {},
+): Array<{ type: string; properties: Record<string, unknown> }> {
+  return [
+    { type: 'message.updated', properties: { info: { id: 'msg_user', role: 'user' } } },
+    {
+      type: 'message.part.updated',
+      properties: { part: { type: 'text', messageID: 'msg_user', text: 'hey' } },
+    },
+    { type: 'message.updated', properties: { info: { id: 'msg_asst', role: 'assistant', ...info } } },
+    { type: 'session.idle', properties: { sessionID } },
+  ];
+}
+
 function permissionOnly(sessionID: string): Array<{ type: string; properties: Record<string, unknown> }> {
   return [
     { type: 'permission.updated', properties: { id: 'perm_1', sessionID } },
@@ -92,9 +112,11 @@ function permissionOnly(sessionID: string): Array<{ type: string; properties: Re
 function createFakeRuntime(script: Array<Array<{ type: string; properties: Record<string, unknown> }>>): {
   runtime: { getRuntime: () => Promise<OpenCodeRuntimeHandle> };
   promptIds: string[];
+  promptBodies: Array<{ parts: unknown[] }>;
   created: string[];
 } {
   const promptIds: string[] = [];
+  const promptBodies: Array<{ parts: unknown[] }> = [];
   const created: string[] = [];
   let nextCreate = 0;
   const queue: Array<{ type: string; properties: Record<string, unknown> }> = [];
@@ -138,6 +160,7 @@ function createFakeRuntime(script: Array<Array<{ type: string; properties: Recor
         },
         async promptAsync(params) {
           promptIds.push(params.path.id);
+          promptBodies.push(params.body);
           const events = script[promptIds.length - 1];
           if (!events) throw new Error(`no scripted events for prompt #${promptIds.length}`);
           pushEvents(events);
@@ -149,6 +172,7 @@ function createFakeRuntime(script: Array<Array<{ type: string; properties: Recor
 
   return {
     promptIds,
+    promptBodies,
     created,
     runtime: { getRuntime: async () => handle },
   };
@@ -286,6 +310,72 @@ describe('OpenCodeProvider empty-resume fallback', () => {
     await collect(query.events);
 
     expect(fake.created).toEqual(['ses_fresh_1']);
+  });
+
+  it('an assistant envelope that produced no part does not count as work', async () => {
+    const fake = createFakeRuntime([bareAssistantEnvelope('ses_stale'), assistantReply('ses_fresh_1', 'recovered')]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hey', cwd: dir, continuation: 'ses_stale' });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(fake.created).toEqual(['ses_fresh_1']);
+    expect(fake.promptIds).toEqual(['ses_stale', 'ses_fresh_1']);
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: 'recovered' }]);
+  });
+
+  it('keeps a resume whose assistant message carries a provider error', async () => {
+    const fake = createFakeRuntime([
+      bareAssistantEnvelope('ses_stale', { error: { name: 'ProviderAuthError', data: { message: 'nope' } } }),
+    ]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hey', cwd: dir, continuation: 'ses_stale' });
+    const done = collect(query.events);
+    query.end();
+    await done;
+
+    // An errored turn is a live session, not a dead continuation: rotating it
+    // would drop the history and hide the error behind a replay.
+    expect(fake.created).toEqual([]);
+    expect(fake.promptIds).toEqual(['ses_stale']);
+  });
+
+  it('replays with the prompt shape a first-time session would have received', async () => {
+    const memoryHook: OpenCodeMemorySessionHook = { ...MEMORY_HOOK, command: 'echo MEMORY_BLOCK' };
+    const resumed = createFakeRuntime([userIdle('ses_stale'), assistantReply('ses_fresh_1', 'recovered')]);
+    const resumedProvider = new OpenCodeProvider({}, resumed.runtime);
+    resumedProvider.registerMemorySessionHook(memoryHook);
+    const resumedQuery = resumedProvider.query({
+      prompt: 'hey',
+      cwd: dir,
+      continuation: 'ses_stale',
+      systemContext: { instructions: 'SYS_INSTR' },
+    });
+    const resumedDone = collect(resumedQuery.events);
+    resumedQuery.end();
+    await resumedDone;
+
+    const fresh = createFakeRuntime([assistantReply('ses_fresh_1', 'hi')]);
+    const freshProvider = new OpenCodeProvider({}, fresh.runtime);
+    freshProvider.registerMemorySessionHook(memoryHook);
+    const freshQuery = freshProvider.query({
+      prompt: 'hey',
+      cwd: dir,
+      systemContext: { instructions: 'SYS_INSTR' },
+    });
+    const freshDone = collect(freshQuery.events);
+    freshQuery.end();
+    await freshDone;
+
+    // One <system> block carrying memory then the instructions — byte-identical
+    // to the opening prompt of a query that never resumed anything.
+    expect(resumed.promptBodies[1]).toEqual(fresh.promptBodies[0]);
+    expect((resumed.promptBodies[1].parts[0] as { text: string }).text).toBe(
+      '<system>\nMEMORY_BLOCK\n\nSYS_INSTR\n</system>\n\nhey',
+    );
   });
 
   it('ignores foreign assistant events on the shared stream', async () => {

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -861,7 +861,12 @@ export class OpenCodeProvider implements AgentProvider {
     const pending: Array<{
       text: string;
       attachments?: OpenCodePromptAttachment[];
-      allowEmptyResumeFallback: boolean;
+      // The unwrapped prompt, set only on an opening turn that resumed a
+      // persisted continuation. Its presence is what licenses the empty-resume
+      // fallback; its value is what the replay re-composes from, so the
+      // replacement session gets the same prompt shape a first-time session
+      // would have got instead of a second <system> block stacked on the first.
+      replayPrompt?: string;
     }> = [];
     let waiting: (() => void) | null = null;
     let ended = false;
@@ -883,7 +888,7 @@ export class OpenCodeProvider implements AgentProvider {
     pending.push({
       text: wrapPromptWithContext(input.prompt, memory.openingInstructions(systemInstructions)),
       attachments: openingAttachments,
-      allowEmptyResumeFallback: Boolean(input.continuation),
+      replayPrompt: input.continuation ? input.prompt : undefined,
     });
 
     const kick = (): void => {
@@ -910,7 +915,7 @@ export class OpenCodeProvider implements AgentProvider {
         if (aborted) return;
         if (pending.length === 0 && ended) return;
 
-        const { text, attachments, allowEmptyResumeFallback } = pending.shift()!;
+        const { text, attachments, replayPrompt } = pending.shift()!;
         let sessionId = self.activeSessionId;
 
         if (!sessionId) {
@@ -945,6 +950,10 @@ export class OpenCodeProvider implements AgentProvider {
           const partTextByMessageId = new Map<string, string>();
           const roleByMessageId = new Map<string, string>();
           const partMessageIds = new Set<string>();
+          const erroredMessageIds = new Set<string>();
+          // Set only by signals that have no message record of their own
+          // (permissions, questions, compaction). Message-derived work is
+          // decided once, after the turn, in the loop below.
           let sawAssistantWork = false;
           let lastEventAt = Date.now();
           let eventTimedOut = false;
@@ -977,13 +986,15 @@ export class OpenCodeProvider implements AgentProvider {
 
               switch (ev.type) {
                 case 'message.updated': {
-                  const info = ev.properties.info as { id?: string; role?: string; sessionID?: string } | undefined;
+                  const info = ev.properties.info as
+                    | { id?: string; role?: string; sessionID?: string; error?: unknown }
+                    | undefined;
                   if (info?.sessionID && info.sessionID !== turnSessionId) break;
                   if (info?.id && info?.role) {
                     roleByMessageId.set(info.id, info.role);
-                    if (info.role === 'assistant' && partMessageIds.has(info.id)) {
-                      sawAssistantWork = true;
-                    }
+                    // `message.updated` fires repeatedly for the same record, so
+                    // latch the error rather than reading the last event only.
+                    if (info.error) erroredMessageIds.add(info.id);
                   }
                   break;
                 }
@@ -996,9 +1007,6 @@ export class OpenCodeProvider implements AgentProvider {
                     partMessageIds.add(part.messageID);
                     if (part.type === 'text' && part.text) {
                       partTextByMessageId.set(part.messageID, part.text);
-                    }
-                    if (roleByMessageId.get(part.messageID) === 'assistant') {
-                      sawAssistantWork = true;
                     }
                   }
                   break;
@@ -1076,10 +1084,18 @@ export class OpenCodeProvider implements AgentProvider {
 
           let resultText = '';
           for (const [msgId, role] of roleByMessageId) {
-            if (role === 'assistant') {
+            if (role !== 'assistant') continue;
+            // The bare envelope is the quiet-idle signature. OpenCode opens the
+            // assistant record when the turn starts (`AssistantMessage.time` has
+            // a required `created` and an optional `completed`), so the record
+            // existing proves nothing on its own. Work means it produced at
+            // least one part — or that it carries a provider error, which marks
+            // a live session whose turn failed: replaying that on a fresh
+            // session would discard the history and bury the error.
+            if (partMessageIds.has(msgId) || erroredMessageIds.has(msgId)) {
               sawAssistantWork = true;
-              resultText = partTextByMessageId.get(msgId) ?? resultText;
             }
+            resultText = partTextByMessageId.get(msgId) ?? resultText;
           }
           return { resultText, sawAssistantWork };
         }
@@ -1089,7 +1105,7 @@ export class OpenCodeProvider implements AgentProvider {
 
         if (
           isEmptyOpenCodeResume({
-            resumedExistingSession: allowEmptyResumeFallback,
+            resumedExistingSession: replayPrompt !== undefined,
             alreadyFellBack: emptyResumeFellBack,
             sawAssistantWork: outcome.sawAssistantWork,
           })
@@ -1108,8 +1124,12 @@ export class OpenCodeProvider implements AgentProvider {
           self.activeSessionId = freshId;
           yield { type: 'init', continuation: freshId };
           initYielded = true;
-          const memory = runMemorySessionHook(self.memorySessionHook, 'startup');
-          const retryText = memory ? wrapPromptWithContext(text, memory) : text;
+          // Compose the replay the way a first-time query composes an opening
+          // prompt — one <system> block carrying memory and the instructions —
+          // rather than wrapping the already-wrapped resume text a second time.
+          // `replayPrompt` is defined here: it is what licensed this branch.
+          const freshMemory = createMemoryLifecycle(self.memorySessionHook, false);
+          const retryText = wrapPromptWithContext(replayPrompt!, freshMemory.openingInstructions(systemInstructions));
           outcome = yield* runTurn(freshId, retryText, attachments);
           if (aborted) return;
         }
@@ -1128,7 +1148,6 @@ export class OpenCodeProvider implements AgentProvider {
         pending.push({
           text: wrapPromptWithContext(memory.pushPrefix(justCompacted) + compaction.apply(message), systemInstructions),
           attachments,
-          allowEmptyResumeFallback: false,
         });
         kick();
       },

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -31,6 +31,23 @@ const SESSION_STATUS_RETRY_ERROR_AFTER = 3;
 const STALE_SESSION_RE =
   /no conversation found|ENOENT.*\.jsonl|session.*not found|NotFoundError|connection reset|ECONNRESET|404|event timeout/i;
 
+/**
+ * Codex `startOrResumeCodexThread` starts a fresh thread when `thread/resume`
+ * reports the id gone. OpenCode's equivalent failure is quieter: a poisoned
+ * session accepts `promptAsync`, emits `session.idle` at step 0 with no
+ * assistant work, and the runner treats that as a finished turn. Only a
+ * *resume* that produced no assistant work should fall back, and only once
+ * per query — a brand-new session that stays dry is a model/tools miss, not
+ * a dead continuation.
+ */
+export function isEmptyOpenCodeResume(opts: {
+  resumedExistingSession: boolean;
+  alreadyFellBack: boolean;
+  sawAssistantWork: boolean;
+}): boolean {
+  return opts.resumedExistingSession && !opts.alreadyFellBack && !opts.sawAssistantWork;
+}
+
 function killProcessTree(proc: ChildProcess): void {
   if (!proc.pid) return;
   try {
@@ -655,6 +672,29 @@ export interface QuestionClient {
 }
 
 /**
+ * Narrow runtime surface so tests can drive `query()` without spawning
+ * `opencode serve`. Production uses `ensureSharedRuntime`.
+ */
+export interface OpenCodeRuntimeHandle {
+  client: {
+    session: {
+      create(): Promise<{ data?: { id?: string }; error?: unknown }>;
+      promptAsync(params: { path: { id: string }; body: { parts: unknown[] } }): Promise<{ error?: unknown }>;
+    };
+    postSessionIdPermissionsPermissionId?(params: {
+      path: { id: string; permissionID: string };
+      body: { response: string };
+    }): Promise<unknown>;
+  };
+  stream: AsyncGenerator<{ type: string; properties: Record<string, unknown> }, void, void>;
+  questionClient: QuestionClient;
+}
+
+export interface OpenCodeRuntimeDeps {
+  getRuntime(options: ProviderOptions): Promise<OpenCodeRuntimeHandle>;
+}
+
+/**
  * Answer a single pending question request with the steering text, one
  * custom answer per sub-question (OpenCode's `question` tool defaults
  * `custom: true`, i.e. an answer string that isn't one of the offered
@@ -784,11 +824,13 @@ export class OpenCodeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
   private readonly options: ProviderOptions;
+  private readonly runtime?: OpenCodeRuntimeDeps;
   private activeSessionId: string | undefined;
   private memorySessionHook?: OpenCodeMemorySessionHook;
 
-  constructor(options: ProviderOptions = {}) {
+  constructor(options: ProviderOptions = {}, runtime?: OpenCodeRuntimeDeps) {
     this.options = options;
+    this.runtime = runtime;
   }
 
   // OpenCode has no native session-start hook mechanism to hand the command to
@@ -816,7 +858,11 @@ export class OpenCodeProvider implements AgentProvider {
       this.activeSessionId = undefined;
     }
 
-    const pending: Array<{ text: string; attachments?: OpenCodePromptAttachment[] }> = [];
+    const pending: Array<{
+      text: string;
+      attachments?: OpenCodePromptAttachment[];
+      allowEmptyResumeFallback: boolean;
+    }> = [];
     let waiting: (() => void) | null = null;
     let ended = false;
     let aborted = false;
@@ -837,6 +883,7 @@ export class OpenCodeProvider implements AgentProvider {
     pending.push({
       text: wrapPromptWithContext(input.prompt, memory.openingInstructions(systemInstructions)),
       attachments: openingAttachments,
+      allowEmptyResumeFallback: Boolean(input.continuation),
     });
 
     const kick = (): void => {
@@ -845,10 +892,11 @@ export class OpenCodeProvider implements AgentProvider {
 
     const self = this;
     const IDLE_TIMEOUT_MS = Number(process.env.OPENCODE_IDLE_TIMEOUT_MS) || 300_000;
+    let emptyResumeFellBack = false;
 
     async function* gen(): AsyncGenerator<ProviderEvent> {
       let initYielded = false;
-      const rt = await ensureSharedRuntime(self.options);
+      const rt = self.runtime ? await self.runtime.getRuntime(self.options) : await ensureSharedRuntime(self.options);
       const { client, stream, questionClient } = rt;
 
       while (!aborted) {
@@ -862,7 +910,7 @@ export class OpenCodeProvider implements AgentProvider {
         if (aborted) return;
         if (pending.length === 0 && ended) return;
 
-        const { text, attachments } = pending.shift()!;
+        const { text, attachments, allowEmptyResumeFallback } = pending.shift()!;
         let sessionId = self.activeSessionId;
 
         if (!sessionId) {
@@ -880,136 +928,193 @@ export class OpenCodeProvider implements AgentProvider {
           initYielded = true;
         }
 
-        const promptRes = await client.session.promptAsync({
-          path: { id: sessionId },
-          body: { parts: buildPromptParts(text, attachments) },
-        });
-        if (promptRes.error) {
-          self.activeSessionId = undefined;
-          throw new Error(`OpenCode promptAsync: ${JSON.stringify(promptRes.error)}`);
-        }
-
-        const partTextByMessageId = new Map<string, string>();
-        const roleByMessageId = new Map<string, string>();
-        let lastEventAt = Date.now();
-        let eventTimedOut = false;
-        const timeoutCheck = setInterval(() => {
-          if (Date.now() - lastEventAt > IDLE_TIMEOUT_MS) {
-            log(`OpenCode event timeout (${IDLE_TIMEOUT_MS}ms) — clearing session ${sessionId}`);
-            eventTimedOut = true;
+        async function* runTurn(
+          turnSessionId: string,
+          turnText: string,
+          turnAttachments: typeof attachments,
+        ): AsyncGenerator<ProviderEvent, { resultText: string; sawAssistantWork: boolean }> {
+          const promptRes = await client.session.promptAsync({
+            path: { id: turnSessionId },
+            body: { parts: buildPromptParts(turnText, turnAttachments) },
+          });
+          if (promptRes.error) {
             self.activeSessionId = undefined;
-            destroySharedRuntime();
-            kick();
+            throw new Error(`OpenCode promptAsync: ${JSON.stringify(promptRes.error)}`);
           }
-        }, 5000);
 
-        try {
-          turn: while (true) {
-            if (aborted) return;
-            if (eventTimedOut) {
-              throw new Error(`OpenCode event timeout (${IDLE_TIMEOUT_MS}ms)`);
+          const partTextByMessageId = new Map<string, string>();
+          const roleByMessageId = new Map<string, string>();
+          const partMessageIds = new Set<string>();
+          let sawAssistantWork = false;
+          let lastEventAt = Date.now();
+          let eventTimedOut = false;
+          const timeoutCheck = setInterval(() => {
+            if (Date.now() - lastEventAt > IDLE_TIMEOUT_MS) {
+              log(`OpenCode event timeout (${IDLE_TIMEOUT_MS}ms) — clearing session ${turnSessionId}`);
+              eventTimedOut = true;
+              self.activeSessionId = undefined;
+              destroySharedRuntime();
+              kick();
             }
+          }, 5000);
 
-            const { value: ev, done } = await stream.next();
-            if (done) {
-              throw new Error('OpenCode SSE stream ended unexpectedly');
-            }
-
-            if (!ev?.type || ev.type === 'server.connected' || ev.type === 'server.heartbeat') continue;
-
-            lastEventAt = Date.now();
-            yield { type: 'activity' };
-
-            switch (ev.type) {
-              case 'message.updated': {
-                const info = ev.properties.info as { id?: string; role?: string } | undefined;
-                if (info?.id && info?.role) {
-                  roleByMessageId.set(info.id, info.role);
-                }
-                break;
+          try {
+            turn: while (true) {
+              if (aborted) return { resultText: '', sawAssistantWork };
+              if (eventTimedOut) {
+                throw new Error(`OpenCode event timeout (${IDLE_TIMEOUT_MS}ms)`);
               }
-              case 'message.part.updated': {
-                const part = ev.properties.part as { type?: string; messageID?: string; text?: string } | undefined;
-                if (part?.type === 'text' && part.messageID && part.text) {
-                  partTextByMessageId.set(part.messageID, part.text);
-                }
-                break;
+
+              const { value: ev, done } = await stream.next();
+              if (done) {
+                throw new Error('OpenCode SSE stream ended unexpectedly');
               }
-              case 'permission.updated': {
-                const perm = ev.properties as { id?: string; sessionID?: string };
-                if (perm.sessionID === sessionId && perm.id) {
-                  try {
-                    await client.postSessionIdPermissionsPermissionId({
-                      path: { id: sessionId, permissionID: perm.id },
-                      body: { response: 'always' },
-                    });
-                  } catch (err) {
-                    log(`Failed to auto-reply permission: ${err instanceof Error ? err.message : String(err)}`);
+
+              if (!ev?.type || ev.type === 'server.connected' || ev.type === 'server.heartbeat') continue;
+
+              lastEventAt = Date.now();
+              yield { type: 'activity' };
+
+              switch (ev.type) {
+                case 'message.updated': {
+                  const info = ev.properties.info as { id?: string; role?: string; sessionID?: string } | undefined;
+                  if (info?.sessionID && info.sessionID !== turnSessionId) break;
+                  if (info?.id && info?.role) {
+                    roleByMessageId.set(info.id, info.role);
+                    if (info.role === 'assistant' && partMessageIds.has(info.id)) {
+                      sawAssistantWork = true;
+                    }
                   }
+                  break;
                 }
-                break;
-              }
-              case 'question.asked': {
-                const req = ev.properties as { id?: string; sessionID?: string; questions?: unknown[] };
-                await handleQuestionAsked(questionClient, req);
-                break;
-              }
-              case 'session.status': {
-                const props = ev.properties as {
-                  sessionID?: string;
-                  status?: { type?: string; attempt?: number; message?: string };
-                };
-                if (props.sessionID !== sessionId) break;
-                const st = props.status;
-                if (
-                  st?.type === 'retry' &&
-                  typeof st.attempt === 'number' &&
-                  st.attempt >= SESSION_STATUS_RETRY_ERROR_AFTER &&
-                  st.message
-                ) {
-                  self.activeSessionId = undefined;
-                  throw new Error(`OpenCode retry limit (${st.attempt}): ${st.message}`);
+                case 'message.part.updated': {
+                  const part = ev.properties.part as
+                    | { type?: string; messageID?: string; sessionID?: string; text?: string }
+                    | undefined;
+                  if (part?.sessionID && part.sessionID !== turnSessionId) break;
+                  if (part?.messageID) {
+                    partMessageIds.add(part.messageID);
+                    if (part.type === 'text' && part.text) {
+                      partTextByMessageId.set(part.messageID, part.text);
+                    }
+                    if (roleByMessageId.get(part.messageID) === 'assistant') {
+                      sawAssistantWork = true;
+                    }
+                  }
+                  break;
                 }
-                break;
-              }
-              case 'session.error': {
-                const props = ev.properties as { sessionID?: string; error?: unknown };
-                if (props.sessionID === sessionId || props.sessionID === undefined) {
-                  self.activeSessionId = undefined;
-                  throw new Error(sessionErrorMessage(props));
+                case 'permission.updated': {
+                  const perm = ev.properties as { id?: string; sessionID?: string };
+                  if (perm.sessionID === turnSessionId && perm.id) {
+                    sawAssistantWork = true;
+                    try {
+                      await client.postSessionIdPermissionsPermissionId?.({
+                        path: { id: turnSessionId, permissionID: perm.id },
+                        body: { response: 'always' },
+                      });
+                    } catch (err) {
+                      log(`Failed to auto-reply permission: ${err instanceof Error ? err.message : String(err)}`);
+                    }
+                  }
+                  break;
                 }
-                break;
-              }
-              case 'session.compacted': {
-                // The active session was just auto-compacted; arm the routing
-                // reminder for the next prompt. Filter by sessionID like the
-                // other cases — the shared server emits this for every session.
-                const sid = (ev.properties as { sessionID?: string }).sessionID;
-                compaction.note(sid, sessionId);
-                break;
-              }
-              case 'session.idle': {
-                const sid = (ev.properties as { sessionID?: string }).sessionID;
-                if (sid === sessionId) {
-                  break turn;
+                case 'question.asked': {
+                  const req = ev.properties as { id?: string; sessionID?: string; questions?: unknown[] };
+                  if (req.sessionID === turnSessionId) sawAssistantWork = true;
+                  await handleQuestionAsked(questionClient, req);
+                  break;
                 }
-                break;
+                case 'session.status': {
+                  const props = ev.properties as {
+                    sessionID?: string;
+                    status?: { type?: string; attempt?: number; message?: string };
+                  };
+                  if (props.sessionID !== turnSessionId) break;
+                  const st = props.status;
+                  if (
+                    st?.type === 'retry' &&
+                    typeof st.attempt === 'number' &&
+                    st.attempt >= SESSION_STATUS_RETRY_ERROR_AFTER &&
+                    st.message
+                  ) {
+                    self.activeSessionId = undefined;
+                    throw new Error(`OpenCode retry limit (${st.attempt}): ${st.message}`);
+                  }
+                  break;
+                }
+                case 'session.error': {
+                  const props = ev.properties as { sessionID?: string; error?: unknown };
+                  if (props.sessionID === turnSessionId || props.sessionID === undefined) {
+                    self.activeSessionId = undefined;
+                    throw new Error(sessionErrorMessage(props));
+                  }
+                  break;
+                }
+                case 'session.compacted': {
+                  // The active session was just auto-compacted; arm the routing
+                  // reminder for the next prompt. Filter by sessionID like the
+                  // other cases — the shared server emits this for every session.
+                  const sid = (ev.properties as { sessionID?: string }).sessionID;
+                  compaction.note(sid, turnSessionId);
+                  if (sid === turnSessionId) sawAssistantWork = true;
+                  break;
+                }
+                case 'session.idle': {
+                  const sid = (ev.properties as { sessionID?: string }).sessionID;
+                  if (sid === turnSessionId) {
+                    break turn;
+                  }
+                  break;
+                }
+                default:
+                  break;
               }
-              default:
-                break;
+            }
+          } finally {
+            clearInterval(timeoutCheck);
+          }
+
+          let resultText = '';
+          for (const [msgId, role] of roleByMessageId) {
+            if (role === 'assistant') {
+              sawAssistantWork = true;
+              resultText = partTextByMessageId.get(msgId) ?? resultText;
             }
           }
-        } finally {
-          clearInterval(timeoutCheck);
+          return { resultText, sawAssistantWork };
         }
 
-        let resultText = '';
-        for (const [msgId, role] of roleByMessageId) {
-          if (role === 'assistant') {
-            resultText = partTextByMessageId.get(msgId) ?? resultText;
+        let outcome = yield* runTurn(sessionId, text, attachments);
+        if (aborted) return;
+
+        if (
+          isEmptyOpenCodeResume({
+            resumedExistingSession: allowEmptyResumeFallback,
+            alreadyFellBack: emptyResumeFellBack,
+            sawAssistantWork: outcome.sawAssistantWork,
+          })
+        ) {
+          log(`Empty resume on ${sessionId}; starting fresh session.`);
+          emptyResumeFellBack = true;
+          self.activeSessionId = undefined;
+          const created = await client.session.create();
+          if (aborted) return;
+          if (created.error) {
+            throw new Error(`OpenCode: failed to create session: ${JSON.stringify(created.error)}`);
           }
+          const freshId = created.data?.id;
+          if (!freshId) throw new Error('OpenCode: failed to create session (no id)');
+          sessionId = freshId;
+          self.activeSessionId = freshId;
+          yield { type: 'init', continuation: freshId };
+          initYielded = true;
+          const memory = runMemorySessionHook(self.memorySessionHook, 'startup');
+          const retryText = memory ? wrapPromptWithContext(text, memory) : text;
+          outcome = yield* runTurn(freshId, retryText, attachments);
+          if (aborted) return;
         }
-        yield { type: 'result', text: resultText || null };
+
+        yield { type: 'result', text: outcome.resultText || null };
       }
     }
 
@@ -1023,6 +1128,7 @@ export class OpenCodeProvider implements AgentProvider {
         pending.push({
           text: wrapPromptWithContext(memory.pushPrefix(justCompacted) + compaction.apply(message), systemInstructions),
           attachments,
+          allowEmptyResumeFallback: false,
         });
         kick();
       },


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

A poisoned OpenCode continuation can accept `promptAsync`, echo the user message, and emit `session.idle` with no assistant work. The runner treats that as a completed turn, so tools-only delivery produces an empty result and the triggering message is lost.

This patch detects that pattern on the opening persisted resume, creates a fresh OpenCode session, and replays the same turn once. It emits the replacement continuation, and it keeps attachments and startup-memory injection. It does not rotate new sessions, ordinary pushed turns, valid tools-only turns, or aborted queries. Event accounting is scoped to the active session, so shared-SSE traffic and echoed user attachments cannot suppress recovery.

The runtime dependency seam exists only to test the query lifecycle without spawning `opencode serve`.

### What counts as assistant work

The whole fix turns on that question, so it is answered in one place, after the turn ends.

- An assistant message counts if it produced at least one part, or if it carries a provider error (`AssistantMessage.error`).
- A bare assistant envelope with no parts does not count. OpenCode opens the assistant record when a turn starts (`AssistantMessage.time` has a required `created` and an optional `completed`), so the record existing on its own proves nothing.
- The error case is deliberate. A turn that failed is a live session, not a dead continuation. Rotating it would drop the history and replay over the error instead of surfacing it.
- Permission grants, questions, and compaction count on their own, because they carry no message record.

I do not have a captured trace of a real poisoned resume, so I cannot say whether OpenCode emits that bare envelope in practice. The rule above is safe either way. If OpenCode never emits one, this rule and "any assistant message counts" are the same rule. If it does emit one, the first version of this patch would have missed the case it was written for.

The replayed prompt is rebuilt from the unwrapped text through the same path an opening prompt uses, so it is byte for byte what a first-time session would have received. Wrapping the already-wrapped resume text would have sent two `<system>` blocks instead of one.

### Testing

- `bun test src/providers/opencode* src/providers/mcp-to-opencode.test.ts`, 92 passed
- two of those tests fail against the previous commit `c02f2a7a`, which is how I checked they pin the behaviour rather than the current code
- 89 of the same tests passed in the Spark production agent image at `c02f2a7a`
- private two-turn Nemotron/OpenCode canary passed, resumed turn completed in 3 seconds
- isolated provider-boundary empty-resume fault rotated the persisted continuation, and the real model delivered the replayed turn in 2 seconds

The standalone `providers` branch typecheck has five existing provider and trunk interface errors on base `efc8eff4`. This patch produces the same five and no others. A real removed-model mutation emits an explicit model error, so it was not counted as evidence for the quiet-idle path.

CI does not run on this PR. `.github/workflows/ci.yml` triggers on `pull_request` against `main`, and this targets `providers`. Every number above comes from a local run.

### Related work

Related to [#2864](https://github.com/nanocoai/nanoclaw/pull/2864) and [#2865](https://github.com/nanocoai/nanoclaw/pull/2865), and complementary to both. Those rotate from host ceiling and age signals, or clear a continuation after an empty result. This patch handles OpenCode's quiet idle inside the same query, and adds no ceiling or age policy.

Two notes on [#2865](https://github.com/nanocoai/nanoclaw/pull/2865), which edits the same file on the same base.

- The two conflict around the class fields and the constructor. This one landed first, so #2865 needs the rebase.
- If its rotation fires first at runtime, `input.continuation` is already cleared and this fallback is disarmed by design. That is the order I want, but nothing tests it yet.

Assisted by Claude; reviewed and verified by a human before submission.
