### PR TITLE
ci: add zvi-fried to core team roster

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -32,7 +32,7 @@ jobs:
             if (body.includes('contributing-guide: v1')) labels.push('follows-guidelines');
 
             // Lowercase GitHub logins; keep in sync with the core team roster.
-            const CORE_TEAM = ['gavrielc', 'koshkoshinsk', 'glifocat', 'gabi-simons', 'omri-maya', 'amit-shafnir', 'moshe-nanoco'];
+            const CORE_TEAM = ['gavrielc', 'koshkoshinsk', 'glifocat', 'gabi-simons', 'omri-maya', 'amit-shafnir', 'moshe-nanoco', 'zvi-fried'];
             const author = context.payload.pull_request.user.login.toLowerCase();
             if (CORE_TEAM.includes(author)) {
               labels.push('core-team');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Description

Adds `zvi-fried` to the `CORE_TEAM` roster in the PR auto-label workflow (`.github/workflows/label-pr.yml`) so their PRs are labeled `core-team`.

None of the template's change-type boxes apply — this is CI/workflow maintenance, same shape as #2978 which introduced the roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)