### PR TITLE
fix setup ping folder compatibility

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -38,7 +38,7 @@ import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 // — the wizard itself stays free of channel-specific imports.
 import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
 import { runInheritScript } from './lib/inherit-script.js';
-import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
+import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
@@ -551,7 +551,7 @@ async function main(): Promise<void> {
         running: 'Bringing your assistant online…',
         done: 'Assistant wired up.',
       },
-      ['--display-name', displayName!, '--agent-name', CLI_AGENT_NAME, '--folder', '_ping-test'],
+      ['--display-name', displayName!, '--agent-name', CLI_AGENT_NAME, '--folder', PING_AGENT_FOLDER],
     );
     if (!res.ok) {
       await fail(
@@ -576,7 +576,7 @@ async function main(): Promise<void> {
         const cleanupStart = Date.now();
         const cleanup = await spawnQuiet(
           'pnpm',
-          ['exec', 'tsx', 'scripts/delete-cli-agent.ts', '--folder', '_ping-test'],
+          ['exec', 'tsx', 'scripts/delete-cli-agent.ts', '--folder', PING_AGENT_FOLDER],
           cleanupRawLog,
         );
         setupLog.step(

--- a/setup/lib/agent-ping.test.ts
+++ b/setup/lib/agent-ping.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifyPingResult } from './agent-ping.js';
+import { isValidGroupFolder } from '../../src/group-folder.js';
+import { classifyPingResult, PING_AGENT_FOLDER } from './agent-ping.js';
+
+it('uses a runtime-safe folder for the setup ping agent', () => {
+  expect(isValidGroupFolder(PING_AGENT_FOLDER)).toBe(true);
+});
 
 describe('classifyPingResult', () => {
   it('treats a normal text reply as ok', () => {

--- a/setup/lib/agent-ping.ts
+++ b/setup/lib/agent-ping.ts
@@ -13,6 +13,8 @@
  */
 import { spawn } from 'child_process';
 
+export const PING_AGENT_FOLDER = 'ping_test';
+
 export type PingResult = 'ok' | 'no_reply' | 'socket_error' | 'auth_error';
 
 export function classifyPingResult(exitCode: number | null, stdout: string, stderr = ''): PingResult {


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

PR #3307 made runtime group-folder validation reject the setup scratch folder because _ping-test begins with punctuation.

- Rename the private scratch folder to ping_test.
- Share one constant between scratch creation and cleanup.
- Assert the existing runtime folder validator accepts the setup value.
- Keep the current 30-second timeout and add no setup-specific validator.

## Validation

- pnpm run build
- pnpm run lint
- pnpm test: 145 files, 1,835 tests passed
- Real setup E2E: the ping agent passed folder admission and the family-assistant template was created with its instructions, skills, and task payload.
- Verified the channel/provider payload paths fetched by main contain no _ping-test convention.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone