### PR TITLE
feat(telegram): add approved group connection picker

### DIFF
--- a/src/channels/telegram-connect-group.test.ts
+++ b/src/channels/telegram-connect-group.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, createAgentGroup, getAllMessagingGroups, initTestDb, runMigrations } from '../db/index.js';
+import { getUserRoles, grantRole } from '../modules/permissions/db/user-roles.js';
+import { upsertUser } from '../modules/permissions/db/users.js';
+import type { InboundMessage } from './adapter.js';
+import { createTelegramInboundInterceptor } from './telegram.js';
+
+const token = 'test-token';
+const botUsername = 'NanoClawBot';
+
+function message(text: string, userId: string): InboundMessage {
+  return {
+    id: 'message-1',
+    kind: 'chat-sdk',
+    content: { text, author: { userId } },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function addRole(userId: string, role: 'owner' | 'admin', agentGroupId: string | null = null): Promise<void> {
+  const now = new Date().toISOString();
+  await upsertUser({ id: `telegram:${userId}`, kind: 'telegram', display_name: null, created_at: now });
+  await grantRole({
+    user_id: `telegram:${userId}`,
+    role,
+    agent_group_id: agentGroupId,
+    granted_by: null,
+    granted_at: now,
+  });
+}
+
+function sentBodies(): Array<Record<string, unknown>> {
+  return vi.mocked(fetch).mock.calls.map(([, init]) => JSON.parse(String(init?.body)) as Record<string, unknown>);
+}
+
+describe('Telegram /connect_group', () => {
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    vi.unstubAllGlobals();
+  });
+
+  it('opens the native group picker for owners and global admins without changing authority', async () => {
+    await createAgentGroup({
+      id: 'agent-1',
+      name: 'One',
+      folder: 'one',
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    });
+    await addRole('42', 'owner');
+    await addRole('43', 'admin');
+    const hostOnInbound = vi.fn();
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+
+    await intercept('telegram:42', null, message('/connect_group', '42'));
+    await intercept('telegram:43', null, message('/connect_group@nanoclawbot', '43'));
+
+    expect(hostOnInbound).not.toHaveBeenCalled();
+    expect(sentBodies()).toHaveLength(2);
+    for (const body of sentBodies()) {
+      expect(body).toMatchObject({
+        text: expect.stringContaining('Group Privacy'),
+        reply_markup: {
+          inline_keyboard: [[{ url: 'https://t.me/NanoClawBot?startgroup=connect' }]],
+        },
+      });
+    }
+    expect(await getUserRoles('telegram:42')).toMatchObject([{ role: 'owner', agent_group_id: null }]);
+    expect(await getUserRoles('telegram:43')).toMatchObject([{ role: 'admin', agent_group_id: null }]);
+    expect(await getAllMessagingGroups()).toEqual([]);
+  });
+
+  it('denies scoped admins and unprivileged users without forwarding the control command', async () => {
+    await createAgentGroup({
+      id: 'agent-1',
+      name: 'One',
+      folder: 'one',
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    });
+    await addRole('98', 'admin', 'agent-1');
+    const hostOnInbound = vi.fn();
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+
+    await intercept('telegram:98', null, message('/connect_group', '98'));
+    await intercept('telegram:99', null, message('/connect_group', '99'));
+
+    expect(hostOnInbound).not.toHaveBeenCalled();
+    expect(sentBodies()).toEqual([
+      { chat_id: '98', text: 'Only a NanoClaw owner or global admin can connect a group.' },
+      { chat_id: '99', text: 'Only a NanoClaw owner or global admin can connect a group.' },
+    ]);
+  });
+
+  it('leaves group messages and near-matches on the normal inbound path', async () => {
+    await addRole('42', 'owner');
+    const hostOnInbound = vi.fn();
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+
+    await intercept('telegram:-100', null, message('/connect_group', '42'));
+    await intercept('telegram:42', null, message('/connect_group now', '42'));
+
+    expect(hostOnInbound).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('turns the group-picker start command into a routed welcome prompt', async () => {
+    const hostOnInbound = vi.fn();
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+    const inbound = message('/start@NanoClawBot connect', '42');
+
+    await intercept('telegram:-100', null, inbound);
+
+    expect(hostOnInbound).toHaveBeenCalledWith(
+      'telegram:-100',
+      null,
+      expect.objectContaining({
+        content: expect.objectContaining({
+          text: expect.stringMatching(/welcome skill exactly.*introduce yourself.*back to this same group/),
+          author: { userId: '42' },
+        }),
+      }),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('recognizes the group callback after recovering the bot username', async () => {
+    await addRole('42', 'owner');
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const result = String(input).endsWith('/getMe') ? { ok: true, result: { username: botUsername } } : { ok: true };
+      return new Response(JSON.stringify(result), { status: 200 });
+    });
+    const hostOnInbound = vi.fn();
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(null), hostOnInbound, token);
+
+    await intercept('telegram:42', null, message('/connect_group', '42'));
+    await intercept('telegram:-100', null, message('/start@NanoClawBot connect', '42'));
+
+    expect(hostOnInbound).toHaveBeenCalledWith(
+      'telegram:-100',
+      null,
+      expect.objectContaining({
+        content: expect.objectContaining({ text: expect.stringContaining('introduce yourself in this group first') }),
+      }),
+    );
+  });
+});

--- a/src/channels/telegram-registration.test.ts
+++ b/src/channels/telegram-registration.test.ts
@@ -22,7 +22,7 @@
  * typed call, so the build/typecheck leg (`pnpm run build`) guards it against upstream
  * drift, not this test. Every Chat SDK channel follows this same shape.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getRegisteredChannelNames } from './channel-registry.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,14 +1,13 @@
 /**
- * Telegram channel adapter (v2) — uses Chat SDK bridge, with a pairing
- * interceptor wrapped around onInbound to verify chat ownership before
- * registration. See telegram-pairing.ts for the why.
+ * Telegram channel adapter (v2) — uses Chat SDK bridge, with an inbound
+ * interceptor for setup pairing and the owner/global-admin `/connect_group` command.
  */
 import { createTelegramAdapter } from '@chat-adapter/telegram';
 
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
 import { createMessagingGroup, getMessagingGroupByPlatform, updateMessagingGroup } from '../db/messaging-groups.js';
-import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js';
+import { grantRole, hasAnyOwner, isGlobalAdmin, isOwner } from '../modules/permissions/db/user-roles.js';
 import { upsertUser } from '../modules/permissions/db/users.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
@@ -85,54 +84,158 @@ function readInboundFields(message: InboundMessage): InboundFields {
   if (message.kind !== 'chat-sdk' || !message.content || typeof message.content !== 'object') {
     return { text: '', authorUserId: null };
   }
-  const c = message.content as { text?: string; author?: { userId?: string } };
-  return { text: c.text ?? '', authorUserId: c.author?.userId ?? null };
+  const text = 'text' in message.content && typeof message.content.text === 'string' ? message.content.text : '';
+  const author = 'author' in message.content ? message.content.author : null;
+  const authorUserId =
+    author && typeof author === 'object' && 'userId' in author && typeof author.userId === 'string'
+      ? author.userId
+      : null;
+  return { text, authorUserId };
 }
 
 /**
- * Build an onInbound interceptor that consumes pairing codes before they
- * reach the router. On match: records the chat + its paired user, promotes
- * the user to owner if the instance has no owner yet, and short-circuits.
- * On miss: forwards to the host.
+ * `/connect_group` only opens Telegram's native picker. The existing
+ * unknown-channel approval flow remains the authority that creates a wiring.
  */
-/**
- * Send a one-shot confirmation back to the paired chat. Best-effort — failures
- * are logged but never propagated, so a Telegram outage can't undo a successful
- * pairing or trigger the interceptor's fail-open path.
- */
-async function sendPairingConfirmation(token: string, platformId: string): Promise<void> {
+function isConnectGroupCommand(text: string, botUsername: string | null): boolean {
+  const command = text.trim().toLowerCase();
+  return (
+    command === '/connect_group' || (botUsername !== null && command === `/connect_group@${botUsername.toLowerCase()}`)
+  );
+}
+
+function isStartGroupConnectCommand(text: string, botUsername: string | null): boolean {
+  return botUsername !== null && text.trim().toLowerCase() === `/start@${botUsername.toLowerCase()} connect`;
+}
+
+function withInboundText(message: InboundMessage, text: string): InboundMessage {
+  if (!message.content || typeof message.content !== 'object' || Array.isArray(message.content)) return message;
+  return { ...message, content: { ...message.content, text } };
+}
+
+async function sendTelegramMessage(token: string, platformId: string, body: Record<string, unknown>): Promise<void> {
   const chatId = platformId.split(':').slice(1).join(':');
   if (!chatId) return;
   try {
     const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: chatId,
-        text: 'Pairing success! Head back to the NanoClaw installer to finish setup.',
-      }),
+      body: JSON.stringify({ chat_id: chatId, ...body }),
     });
     if (!res.ok) {
-      log.warn('Telegram pairing confirmation non-OK', { status: res.status });
+      log.warn('Telegram sendMessage non-OK', { status: res.status });
     }
   } catch (err) {
-    log.warn('Telegram pairing confirmation failed', { err });
+    log.warn('Telegram sendMessage failed', { err });
   }
 }
 
-function createPairingInterceptor(
+function sendConnectGroupReply(token: string, platformId: string, text: string, botUsername?: string): Promise<void> {
+  return sendTelegramMessage(token, platformId, {
+    text,
+    ...(botUsername
+      ? {
+          reply_markup: {
+            inline_keyboard: [
+              [
+                {
+                  text: 'Add me to a group',
+                  url: `https://t.me/${encodeURIComponent(botUsername)}?startgroup=connect`,
+                },
+              ],
+            ],
+          },
+        }
+      : {}),
+  });
+}
+
+async function handleConnectGroupCommand(
+  token: string,
+  platformId: string,
+  authorUserId: string | null,
+  knownBotUsername: string | null,
+): Promise<string | null> {
+  const userId = authorUserId ? `telegram:${authorUserId}` : null;
+  const isAuthorized = userId ? (await isOwner(userId)) || (await isGlobalAdmin(userId)) : false;
+
+  if (!isAuthorized) {
+    log.warn('Telegram connect-group command denied', { userId, platformId });
+    await sendConnectGroupReply(token, platformId, 'Only a NanoClaw owner or global admin can connect a group.');
+    return null;
+  }
+
+  // Startup's best-effort lookup may have failed transiently. Retry only when
+  // this command actually needs the username; normal inbound stays unchanged.
+  const botUsername = knownBotUsername ?? (await fetchBotUsername(token));
+  if (!botUsername) {
+    await sendConnectGroupReply(
+      token,
+      platformId,
+      "I couldn't open Telegram's group picker right now. Please try /connect_group again.",
+    );
+    return null;
+  }
+
+  await sendConnectGroupReply(
+    token,
+    platformId,
+    'First, make sure Group Privacy is off in BotFather (changing it requires removing and re-adding me). Then choose a group below and approve the registration card when it arrives.',
+    botUsername,
+  );
+  return botUsername;
+}
+
+/**
+ * Send a one-shot confirmation back to the paired chat. Best-effort — failures
+ * are logged but never propagated, so a Telegram outage can't undo a successful
+ * pairing or trigger the interceptor's fail-open path.
+ */
+async function sendPairingConfirmation(token: string, platformId: string): Promise<void> {
+  await sendTelegramMessage(token, platformId, {
+    text: 'Pairing success! Head back to the NanoClaw installer to finish setup.',
+  });
+}
+
+export function createTelegramInboundInterceptor(
   botUsernamePromise: Promise<string | null>,
   hostOnInbound: ChannelSetup['onInbound'],
   token: string,
 ): ChannelSetup['onInbound'] {
   return async (platformId, threadId, message) => {
+    const { text, authorUserId } = readInboundFields(message);
+    const botUsername = await botUsernamePromise;
+
+    if (!isGroupPlatformId(platformId) && isConnectGroupCommand(text, botUsername)) {
+      try {
+        const resolvedBotUsername = await handleConnectGroupCommand(token, platformId, authorUserId, botUsername);
+        if (resolvedBotUsername) botUsernamePromise = Promise.resolve(resolvedBotUsername);
+      } catch (err) {
+        // A recognized host command is consumed even when authorization or DB
+        // access fails; forwarding it would turn a denied control action into
+        // an ordinary agent prompt.
+        log.error('Telegram connect-group command failed', { err, platformId, authorUserId });
+      }
+      return;
+    }
+
+    if (isGroupPlatformId(platformId) && isStartGroupConnectCommand(text, botUsername)) {
+      await hostOnInbound(
+        platformId,
+        threadId,
+        withInboundText(
+          message,
+          'This Telegram group was just connected. Follow the welcome skill exactly: introduce yourself in this group first, then begin onboarding. Send every response back to this same group.',
+        ),
+      );
+      return;
+    }
+
     try {
-      const botUsername = await botUsernamePromise;
       if (!botUsername) {
         hostOnInbound(platformId, threadId, message);
         return;
       }
-      const { text, authorUserId } = readInboundFields(message);
       if (!text) {
         hostOnInbound(platformId, threadId, message);
         return;
@@ -253,7 +356,7 @@ registerChannelAdapter('telegram', {
       async setup(hostConfig: ChannelSetup) {
         const intercepted: ChannelSetup = {
           ...hostConfig,
-          onInbound: createPairingInterceptor(botUsernamePromise, hostConfig.onInbound, token),
+          onInbound: createTelegramInboundInterceptor(botUsernamePromise, hostConfig.onInbound, token),
         };
         return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
       },


### PR DESCRIPTION
## Summary

- add an owner/global-admin `/connect_group` DM command backed by Telegram's native group picker
- route the picker callback through NanoClaw's existing unknown-channel approval and wiring flow
- start approved group connections with a group-scoped welcome/onboarding turn
- cover authorization, normal-message passthrough, callback routing, and registration independently

## Why

Connecting a Telegram group should not require copying chat IDs or issuing a second pairing code. The picker is navigation only: it grants no role or wiring, and the existing approval card remains the trusted authorization boundary.

## Validation

- `pnpm run build` in a current-main assembled install
- Telegram registration/connect-group tests: 6 passed
- approval and wiring integration coverage: 30 passed
- Prettier, ESLint, and `git diff --check`
