### PR TITLE
docs(telegram): document approved group connection flow

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -162,6 +162,18 @@ flow remains the authority. If the picker is unavailable, add the bot to the
 group manually and post `/start@{{bot_username}} connect` there to reach the
 same approval card.
 
+If the negative Telegram chat ID is already known, the fully manual `ncl`
+equivalent is:
+
+```bash
+ncl messaging-groups create --channel-type telegram --platform-id "telegram:<chat-id>" --name "<group-name>" --is-group 1
+ncl wirings create --channel-type telegram --platform-id "telegram:<chat-id>" --agent-group "<folder>" --session-mode shared
+```
+
+`wirings create` applies Telegram's group defaults and creates the companion
+destination row. Prefer `/connect_group` when the ID is unknown; it discovers
+the group and keeps the approval card in the loop.
+
 ## Channel Info
 
 - **type**: `telegram`

--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -20,14 +20,15 @@ safe to re-run; anything a parser can't apply falls back to the prose beside it.
 ### 1. Copy the adapter, helpers, and tests
 
 Fetch the `channels` branch and copy the Telegram adapter, its pairing helper
-(with its test), and the registration test into place (overwrite — the branch
-is canonical):
+(with its test), and the focused adapter tests into place (overwrite — the
+branch is canonical):
 
 ```nc:copy from-branch:channels
 src/channels/telegram.ts
 src/channels/telegram-pairing.ts
 src/channels/telegram-pairing.test.ts
 src/channels/telegram-registration.test.ts
+src/channels/telegram-connect-group.test.ts
 ```
 
 ### 2. Register the adapter
@@ -61,13 +62,13 @@ Pinned to an exact version — the supply-chain policy rejects ranges and `lates
 ### 5. Build and validate
 
 Build first: it guards the typed `createChatSdkBridge(...)` core call and proves
-the dependency is installed. Then run the one integration test.
+the dependency is installed. Then run the focused tests.
 
 ```nc:run effect:build
 pnpm run build
 ```
 ```nc:run effect:test
-pnpm exec vitest run src/channels/telegram-registration.test.ts
+pnpm exec vitest run src/channels/telegram-registration.test.ts src/channels/telegram-connect-group.test.ts
 ```
 
 `telegram-registration.test.ts` imports the real channel barrel and asserts the
@@ -147,12 +148,26 @@ soon as pairing completes.
 If you're in the middle of `/setup`, return to the setup flow now. Otherwise wire
 this channel with `/init-first-agent` (or `/manage-channels`).
 
+## Connect a group
+
+After the first DM is paired, an owner or global admin can send `/connect_group` in
+their bot DM. The bot replies with Telegram's native group picker. Choosing a
+group adds the bot and posts an addressed start command there; NanoClaw then
+sends its existing channel-registration approval card to an eligible
+owner/admin DM. Nothing is wired until that card is approved.
+
+The picker link is navigation, not authorization: it carries no secret and
+creates no role, member, messaging-group, or wiring row. The existing approval
+flow remains the authority. If the picker is unavailable, add the bot to the
+group manually and post `/start@{{bot_username}} connect` there to reach the
+same approval card.
+
 ## Channel Info
 
 - **type**: `telegram`
 - **terminology**: Telegram calls them "groups" and "chats." A "group" has multiple members; a "chat" is a 1:1 conversation with the bot.
 - **platform-id-format**: `telegram:{chatId}` (e.g. `telegram:123456789` for a DM, `telegram:-1001234567890` for a group — negative chat IDs are groups/channels).
-- **how-to-find-id**: Do NOT ask the user for a chat ID. Telegram registration uses pairing — run `pnpm exec tsx setup/index.ts --step pair-telegram -- --intent <main|wire-to:folder|new-agent:folder>`. The step prints a 4-digit code (and re-prints a fresh one if a wrong code invalidates it, up to 5 times); tell the user to send just those 4 digits from the chat they want to register (DM the bot for `main`, post in the group otherwise; with Group Privacy ON, prefix `@<botname> CODE`). Success emits a `PAIR_TELEGRAM` block with `STATUS=success`, `PLATFORM_ID`, `IS_GROUP`, `ADMIN_USER_ID` (the bare Telegram user id) and `PAIRED_USER_ID` (the `telegram:`-prefixed form). The service must be running — the polling adapter is what observes the code.
+- **how-to-find-id**: Do NOT ask the user for a chat ID. Pair the first DM with `pnpm exec tsx setup/index.ts --step pair-telegram -- --intent main`. For another group, have an owner/global admin send `/connect_group` in that paired DM, choose the group, and approve the resulting channel-registration card. The service must be running — the polling adapter observes both flows.
 - **supports-threads**: no
 - **typical-use**: Interactive chat — direct messages or small groups
 - **default-isolation**: Same agent group if you're the only participant across multiple chats. Separate agent group if different people are in different groups.
@@ -165,6 +180,10 @@ this channel with `/init-first-agent` (or `/manage-channels`).
 
 **Pairing never completes.** The live adapter is what observes the code, so the service must be running — the restart step comes before pairing for exactly this reason. Send *just* the 4 digits from the exact chat you want registered; in a group with Group Privacy on, prefix them with `@<botname>`. Wrong guesses are fine (a fresh code is issued, up to 5 times), but a dead adapter waits forever.
 
-**The bot ignores group messages.** Group Privacy is on, so the bot only sees @-mentions and replies. BotFather → `/mybots` → your bot → Bot Settings → Group Privacy → Turn off — then remove and re-add the bot to the group so the change takes effect.
+**The bot ignores group messages.** Group Privacy is on, so the bot only sees addressed commands and replies, not ordinary `@bot` text. BotFather → `/mybots` → your bot → Bot Settings → Group Privacy → Turn off — then remove and re-add the bot to the group so the change takes effect.
+
+**`/connect_group` is denied.** The Telegram sender is not a NanoClaw owner or global admin. The command never grants privileges; inspect them with `ncl roles list` and grant the intended role explicitly if appropriate.
+
+**The group was chosen but no approval card arrived.** Confirm the service is running and post `/start@{{bot_username}} connect` in the group. The card is delivered to an eligible owner/admin DM, not to the group.
 
 **Everything green but no replies.** Run `pnpm exec vitest run src/channels/telegram-registration.test.ts` — red means the barrel import or the `@chat-adapter/telegram` install drifted, so re-run the Apply steps. If green, restart again (`bash setup/lib/restart.sh`) and check `logs/nanoclaw.error.log` for token errors.

--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -118,17 +118,22 @@ For separate agents, also ask for a folder name and optionally a different assis
 
 When adding another group/chat on an already-configured platform (e.g. a second Telegram group):
 
-1. **Telegram:** ask the isolation question first to determine intent (`wire-to:<folder>` for an existing agent, `new-agent:<folder>` for a fresh one). Run `pnpm exec tsx setup/index.ts --step pair-telegram -- --intent <intent>`, show the `CODE` from the `PAIR_TELEGRAM_CODE` status block, and tell the user to post `@<botname> CODE` in the target group (or DM the bot for a private chat). Wait for the final `PAIR_TELEGRAM` block. The inbound interceptor has already created the `messaging_groups` row stamped with the Telegram adapter's declared policy (`request_approval` on current adapter copies; `strict` only on stale pre-declaration copies) and upserted the paired user — `register` only needs to add the wiring:
-
-   ```bash
-   pnpm exec tsx setup/index.ts --step register -- \
-     --platform-id "<PLATFORM_ID>" --name "<group-name>" \
-     --folder "<folder>" --channel "telegram" \
-     --session-mode "<shared|agent-shared|per-thread>" \
-     --assistant-name "<name>"
-   ```
+1. **Telegram:** have an owner or global admin send `/connect_group` in their paired bot DM and choose the group in Telegram's native picker. Telegram adds the bot and posts an addressed start command in the group; the existing unknown-channel gate then sends a registration card to an eligible owner/admin DM. Approve it and choose an existing or new agent. The picker carries no authority and nothing is wired before approval. If the picker is unavailable, add the bot manually and post `/start@<botname> connect` in the group to reach the same card.
 
 2. **Other channels:** read the channel's SKILL.md `## Channel Info` for terminology and how-to-find-id. Ask for the new group/chat ID, ask the isolation question, then register.
+
+For explicit Telegram wiring controls, use the CLI after the group is connected
+(for example, `ncl wirings update <id> --session-mode agent-shared`). If its
+negative Telegram chat ID is already known, the fully manual equivalent is:
+
+```bash
+ncl messaging-groups create --channel-type telegram --platform-id "telegram:<chat-id>" --name "<group-name>" --is-group 1
+ncl wirings create --channel-type telegram --platform-id "telegram:<chat-id>" --agent-group "<folder>" --session-mode shared
+```
+
+`wirings create` applies the adapter's group defaults and creates the companion
+destination row. Prefer `/connect_group` when the ID is unknown; it discovers
+the group through Telegram and keeps the existing approval card in the loop.
 
 ## Change Wiring
 

--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -116,24 +116,9 @@ For separate agents, also ask for a folder name and optionally a different assis
 
 ## Add Channel Group
 
-When adding another group/chat on an already-configured platform (e.g. a second Telegram group):
-
-1. **Telegram:** have an owner or global admin send `/connect_group` in their paired bot DM and choose the group in Telegram's native picker. Telegram adds the bot and posts an addressed start command in the group; the existing unknown-channel gate then sends a registration card to an eligible owner/admin DM. Approve it and choose an existing or new agent. The picker carries no authority and nothing is wired before approval. If the picker is unavailable, add the bot manually and post `/start@<botname> connect` in the group to reach the same card.
-
-2. **Other channels:** read the channel's SKILL.md `## Channel Info` for terminology and how-to-find-id. Ask for the new group/chat ID, ask the isolation question, then register.
-
-For explicit Telegram wiring controls, use the CLI after the group is connected
-(for example, `ncl wirings update <id> --session-mode agent-shared`). If its
-negative Telegram chat ID is already known, the fully manual equivalent is:
-
-```bash
-ncl messaging-groups create --channel-type telegram --platform-id "telegram:<chat-id>" --name "<group-name>" --is-group 1
-ncl wirings create --channel-type telegram --platform-id "telegram:<chat-id>" --agent-group "<folder>" --session-mode shared
-```
-
-`wirings create` applies the adapter's group defaults and creates the companion
-destination row. Prefer `/connect_group` when the ID is unknown; it discovers
-the group through Telegram and keeps the existing approval card in the loop.
+When adding another group/chat on an already-configured platform, read the
+channel's SKILL.md `## Channel Info`, follow its current discovery instructions,
+ask the isolation question, then register.
 
 ## Change Wiring
 

--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -116,9 +116,10 @@ For separate agents, also ask for a folder name and optionally a different assis
 
 ## Add Channel Group
 
-When adding another group/chat on an already-configured platform, read the
-channel's SKILL.md `## Channel Info`, follow its current discovery instructions,
-ask the isolation question, then register.
+When adding another group/chat on an already-configured platform, open
+`.claude/skills/add-<channel>/SKILL.md`, follow its current group-discovery
+instructions, ask the isolation question, then register. Channel-specific
+procedures belong in that channel's skill, not here.
 
 ## Change Wiring
 


### PR DESCRIPTION
## Summary

- teach `/add-telegram` to install and validate the group-connection behavior test
- keep the `/connect_group` flow, security boundary, troubleshooting, and manual `ncl` path in `/add-telegram`
- make `/manage-channels` delegate channel-specific discovery to each channel's own skill

## Why

Telegram group setup should follow the normal channel approval and wiring model. The Telegram-specific procedure belongs to `/add-telegram`; the broad `/manage-channels` skill remains channel-agnostic.

Companion adapter change: #3351. This PR is based directly on `main`, not on the companion branch.

## Validation

- skill conformance: 143 passed
- skill directive/policy tests: 76 passed
- `git diff --check`
