### PR TITLE
setup: --slack-agents installs the whole Slack agents feature

### DIFF
--- a/.claude/skills/add-slack/REMOVE.md
+++ b/.claude/skills/add-slack/REMOVE.md
@@ -16,8 +16,7 @@ rm -f src/channels/slack.ts src/channels/slack-lib.ts src/channels/slack-lib.tes
   src/channels/slack-registration.test.ts \
   src/channels/slack-instances-registration.test.ts \
   src/provisioning/slack-app.ts src/provisioning/slack-app.test.ts \
-  container/skills/slack-formatting/SKILL.md \
-  container/skills/welcome/addenda/slack.md
+  container/skills/slack-formatting/SKILL.md
 ```
 
 ## 3. Remove credentials
@@ -36,8 +35,9 @@ pnpm uninstall @chat-adapter/slack
 
 ## 5. Feature skills
 
-If the agents feature was applied on top, remove those skills first (each has
-its own REMOVE.md): `slack-agent-flow`, then `slack-a2a-rooms`.
+If the agents feature was applied on top, remove those skills first:
+`slack-agent-flow` (its REMOVE.md), then `slack-a2a-rooms` (removal steps in
+its SKILL.md).
 
 ## 6. Rebuild and restart
 

--- a/.claude/skills/add-slack/REMOVE.md
+++ b/.claude/skills/add-slack/REMOVE.md
@@ -2,33 +2,44 @@
 
 Every step is idempotent — safe to re-run.
 
-## 1. Remove the adapter
+## 1. Remove the registrations
 
-Delete the self-registration import from `src/channels/index.ts` (skip if already gone):
+Delete the appended lines (skip any already gone):
 
-```typescript
-import './slack.js';
-```
+- `src/channels/index.ts`: `import './slack.js';` and `import './slack-a2a-guard.js';`
 
-Then delete the copied adapter, its registration test, and the `slack-formatting`
-container skill (part of the channel payload — trunk doesn't ship it):
+## 2. Remove the payload files
 
 ```bash
-rm -f src/channels/slack.ts src/channels/slack-registration.test.ts container/skills/slack-formatting/SKILL.md
+rm -f src/channels/slack.ts src/channels/slack-lib.ts src/channels/slack-lib.test.ts \
+  src/channels/slack-a2a-guard.ts src/channels/slack-a2a-guard.test.ts \
+  src/channels/slack-registration.test.ts \
+  src/channels/slack-instances-registration.test.ts \
+  src/provisioning/slack-app.ts src/provisioning/slack-app.test.ts \
+  container/skills/slack-formatting/SKILL.md \
+  container/skills/welcome/addenda/slack.md
 ```
 
-## 2. Remove credentials
+## 3. Remove credentials
 
 Remove `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_SIGNING_SECRET` from
-`.env` (each is present only if its delivery mode was configured).
+`.env` (each is present only if its delivery mode was configured). If named
+instances were configured, also remove `SLACK_INSTANCES` and every suffixed
+`SLACK_BOT_TOKEN_<NAME>` / `SLACK_APP_TOKEN_<NAME>` /
+`SLACK_SIGNING_SECRET_<NAME>` line.
 
-## 3. Remove the package
+## 4. Remove the package
 
 ```bash
 pnpm uninstall @chat-adapter/slack
 ```
 
-## 4. Rebuild and restart
+## 5. Feature skills
+
+If the agents feature was applied on top, remove those skills first (each has
+its own REMOVE.md): `slack-agent-flow`, then `slack-a2a-rooms`.
+
+## 6. Rebuild and restart
 
 ```bash
 pnpm run build

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -33,16 +33,17 @@ src/channels/slack-instances-registration.test.ts
 src/provisioning/slack-app.ts
 src/provisioning/slack-app.test.ts
 container/skills/slack-formatting/SKILL.md
-container/skills/welcome/addenda/slack.md
 ```
 
 - **Adapter + shared lib** (`slack.ts`, `slack-lib.ts`): bridge registration, wiring defaults, conversation resolver, the native `SLACK_INSTANCES` loop — pinned by the two registration tests.
 - **Bot-inbound guard** (`slack-a2a-guard.ts`): drops bot-authored inbound at the bridge by default; feature skills register a narrower admission policy on its seam.
 - **Provisioning core** (`src/provisioning/slack-app.ts`): manifest template, scope/event constants, and the broker + manager-token transports for creating a Slack app programmatically. Nothing on the adapter path imports it — the setup wizard's auto-provision pre-step and feature skills do.
-- **Container skills**: `slack-formatting/` (mrkdwn syntax; synced to `~/.claude/skills`), `welcome/addenda/slack.md` (channel-matched welcome addendum — inert on hosts predating the mechanism).
+- **Container skills**: `slack-formatting/` (mrkdwn syntax; synced to `~/.claude/skills`).
 
-The room/canvas/onboarding host modules and their container files are part of
-the agents feature and install with `/slack-agent-flow`, not here.
+The room/canvas/onboarding host modules, their container files, and the Slack
+welcome-tour addendum (it describes rooms, canvases, and the agents access
+model) are part of the agents feature and install with `/slack-agent-flow`,
+not here.
 
 ### 2. Register the payload
 
@@ -79,12 +80,14 @@ pnpm exec vitest run src/channels/slack-registration.test.ts src/channels/slack-
 Socket Mode (an outbound WebSocket — no public URL, the right default behind NAT)
 vs webhook delivery (needs a public HTTPS Request URL); the adapter picks Socket
 Mode automatically whenever `SLACK_APP_TOKEN` is set.
-```nc:prompt connection validate:^(socket|webhook|provisioned)$
+```nc:prompt connection validate:^(socket|webhook|provisioned)$ choices:socket|webhook
 How should Slack deliver events? `socket` (Socket Mode — no public URL, recommended for local or behind-NAT installs) or `webhook` (needs a public HTTPS Request URL).
 ```
 
-`provisioned` is never offered interactively — it arrives only via pre-bound `inputs`
-(a programmatically created app) and behaves like Socket Mode minus the walkthrough below.
+`provisioned` is never offered interactively (`choices:` limits the select;
+`validate:` stays wider because pre-bound inputs may exceed the offered set) —
+it arrives only via pre-bound `inputs` (a programmatically created app) and
+behaves like Socket Mode minus the walkthrough below.
 
 For Socket Mode, tell the user:
 ```nc:operator when:connection=socket

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -5,88 +5,92 @@ description: Add Slack channel integration via Chat SDK.
 
 # Add Slack Channel
 
-Adds Slack support via the Chat SDK bridge. NanoClaw doesn't ship channels in
-trunk — this skill copies the Slack adapter in from the `channels` branch.
+Adds Slack support via the Chat SDK bridge. Trunk ships no channels — this skill
+copies the Slack channel layer (adapter, shared lib, bot-inbound guard,
+provisioning core, container skills) in from the `channels` branch. The **Apply**
+steps carry `nc:` directive fences (an agent applies the prose, a parser the
+directives); all idempotent.
 
-The mechanical steps under **Apply** carry `nc:` directive fences: an agent
-reads the prose and applies them, and a parser can apply them deterministically
-from the same document. Every directive is idempotent, so the whole skill is
-safe to re-run; anything a parser can't apply falls back to the prose beside it.
+This is the base Slack experience: one bot, DM and channel chat. The Slack
+**agents** feature — child bots provisioned from `create_agent`, shared rooms,
+canvases, DM onboarding — ships separately in `/slack-a2a-rooms` +
+`/slack-agent-flow`; the setup wizard applies them automatically when run with
+`--slack-agents`, and they can be applied on top of this install at any time.
 
 ## Apply
 
-### 1. Copy the adapter, registration test, and formatting skill
+### 1. Copy the channel payload
 
-Fetch the `channels` branch and copy the Slack adapter, its registration test,
-and the formatting container skill into place (overwrite — the branch is
-canonical):
-
+Fetch the `channels` branch and copy the payload into place (overwrite — the branch is canonical):
 ```nc:copy from-branch:channels
 src/channels/slack.ts
+src/channels/slack-lib.ts
+src/channels/slack-lib.test.ts
+src/channels/slack-a2a-guard.ts
+src/channels/slack-a2a-guard.test.ts
 src/channels/slack-registration.test.ts
+src/channels/slack-instances-registration.test.ts
+src/provisioning/slack-app.ts
+src/provisioning/slack-app.test.ts
 container/skills/slack-formatting/SKILL.md
+container/skills/welcome/addenda/slack.md
 ```
 
-The `slack-formatting` container skill is part of the channel payload: it
-reaches agents via `~/.claude/skills` (synced at spawn) and teaches Slack's
-mrkdwn syntax. Trunk does not ship it — without this copy step agents send
-Slack messages with generic markdown that renders literally.
+- **Adapter + shared lib** (`slack.ts`, `slack-lib.ts`): bridge registration, wiring defaults, conversation resolver, the native `SLACK_INSTANCES` loop — pinned by the two registration tests.
+- **Bot-inbound guard** (`slack-a2a-guard.ts`): drops bot-authored inbound at the bridge by default; feature skills register a narrower admission policy on its seam.
+- **Provisioning core** (`src/provisioning/slack-app.ts`): manifest template, scope/event constants, and the broker + manager-token transports for creating a Slack app programmatically. Nothing on the adapter path imports it — the setup wizard's auto-provision pre-step and feature skills do.
+- **Container skills**: `slack-formatting/` (mrkdwn syntax; synced to `~/.claude/skills`), `welcome/addenda/slack.md` (channel-matched welcome addendum — inert on hosts predating the mechanism).
 
-### 2. Register the adapter
+The room/canvas/onboarding host modules and their container files are part of
+the agents feature and install with `/slack-agent-flow`, not here.
 
-Append the self-registration import to the channel barrel (skipped if the line
-is already present). This one line is the skill's only reach-in into core:
+### 2. Register the payload
 
+Append the self-registration imports (each append is skipped if its first
+line is already present). The adapter and the guard, in the channel barrel:
 ```nc:append to:src/channels/index.ts
 import './slack.js';
+```
+```nc:append to:src/channels/index.ts
+import './slack-a2a-guard.js';
 ```
 
 ### 3. Install the adapter package
 
-Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
-
+Pinned exactly — the supply-chain policy rejects ranges and `latest`:
 ```nc:dep
 @chat-adapter/slack@4.29.0
 ```
 
 ### 4. Build and validate
 
-Build first: it guards the typed `createChatSdkBridge(...)` core call and proves
-the dependency is installed. Then run the one integration test.
-
+The build guards the typed `createChatSdkBridge(...)` call and proves the dependency
+installed; the tests pin registration (barrel import, dependency, the `SLACK_INSTANCES`
+loop), the guard, the shared lib, and the provisioning core.
 ```nc:run effect:build
 pnpm run build
 ```
 ```nc:run effect:test
-pnpm exec vitest run src/channels/slack-registration.test.ts
+pnpm exec vitest run src/channels/slack-registration.test.ts src/channels/slack-instances-registration.test.ts src/channels/slack-lib.test.ts src/channels/slack-a2a-guard.test.ts src/provisioning/slack-app.test.ts
 ```
-
-`slack-registration.test.ts` imports the real channel barrel and asserts the
-registry contains `slack`. It goes red if the import line is deleted or drifts,
-if the barrel fails to evaluate, or if `@chat-adapter/slack` isn't installed (the
-import throws) — so it also covers the dependency from step 3. End-to-end
-delivery against a real workspace is verified manually once the service runs.
 
 ## Credentials
 
-Slack can deliver events two ways. Socket Mode holds an outbound WebSocket open
-— no public URL, so it works on a laptop or behind NAT — and is the right
-default. Webhook delivery needs a public HTTPS Request URL but avoids the
-long-lived socket. The adapter picks Socket Mode automatically whenever
-`SLACK_APP_TOKEN` is set; otherwise it serves the webhook.
-
-```nc:prompt connection validate:^(socket|webhook)$
+Socket Mode (an outbound WebSocket — no public URL, the right default behind NAT)
+vs webhook delivery (needs a public HTTPS Request URL); the adapter picks Socket
+Mode automatically whenever `SLACK_APP_TOKEN` is set.
+```nc:prompt connection validate:^(socket|webhook|provisioned)$
 How should Slack deliver events? `socket` (Socket Mode — no public URL, recommended for local or behind-NAT installs) or `webhook` (needs a public HTTPS Request URL).
 ```
 
-Walk the operator through creating the Slack app, then collect the secrets it
-hands back. The adapter is already installed and registered — it just can't
-receive a message until this is done. For Socket Mode, tell the user:
+`provisioned` is never offered interactively — it arrives only via pre-bound `inputs`
+(a programmatically created app) and behaves like Socket Mode minus the walkthrough below.
 
+For Socket Mode, tell the user:
 ```nc:operator when:connection=socket
 Create the Slack app (Socket Mode):
 1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
-2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, users:read, reactions:write, files:read, files:write.
+2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Basic Information → App-Level Tokens → "Generate Token and Scopes" → add the connections:write scope → copy the token (starts with xapp-).
 5. Socket Mode → toggle "Enable Socket Mode" on.
@@ -95,25 +99,24 @@ Create the Slack app (Socket Mode):
 ```
 
 For webhook delivery, tell the user:
-
 ```nc:operator when:connection=webhook
 Create the Slack app (webhook delivery):
 1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
-2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, users:read, reactions:write, files:read, files:write.
+2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Install to Workspace, then copy the Bot User OAuth Token (starts with xoxb-).
 5. Basic Information → copy the Signing Secret.
 ```
 
-Collect the secrets and store them (the bridge reads them from `.env`; the
-app-level token doubles as the Socket Mode switch, the signing secret
-authenticates webhook requests — each mode needs only its own):
-
+Store the secrets in `.env` (the app-level token doubles as the Socket Mode switch, the signing secret authenticates webhook requests):
 ```nc:prompt bot_token secret validate:^xoxb-
 Paste the Bot User OAuth Token — OAuth & Permissions, starts with `xoxb-`.
 ```
 ```nc:prompt app_token secret validate:^xapp- reuse:SLACK_APP_TOKEN when:connection=socket
 Paste the App-Level Token — Basic Information → App-Level Tokens, starts with `xapp-`.
+```
+```nc:prompt app_token secret validate:^xapp- when:connection=provisioned
+Paste the App-Level Token of the provisioned app (starts with `xapp-`).
 ```
 ```nc:prompt signing_secret secret validate:^[a-fA-F0-9]{16,}$ when:connection=webhook
 Paste the Signing Secret — Basic Information.
@@ -124,16 +127,19 @@ SLACK_BOT_TOKEN={{bot_token}}
 ```nc:env-set when:connection=socket
 SLACK_APP_TOKEN={{app_token}}
 ```
+```nc:env-set when:connection=provisioned
+SLACK_APP_TOKEN={{app_token}}
+```
 ```nc:env-set when:connection=webhook
 SLACK_SIGNING_SECRET={{signing_secret}}
 ```
 
-With webhook delivery, the bridge serves port 3000 at `/webhook/slack`
-automatically; to receive replies, that port must be reachable from the internet
-and registered with Slack as the Request URL (Socket Mode needs no public URL —
-with the bot events subscribed above, events arrive over the socket as soon as
-the service restarts). Tell the user:
+**Additional bot identities (optional).** The adapter natively reads
+`SLACK_INSTANCES=<name>[,…]` from `.env`, registering one `slack-<name>` instance per
+name from suffixed keys (`SLACK_BOT_TOKEN_<NAME>` etc.) — see `/slack-multi-instance`.
 
+With webhook delivery, the bridge serves port 3000 at `/webhook/slack`; that
+URL must be publicly reachable and registered with Slack. Tell the user:
 ```nc:operator when:connection=webhook
 Set up event delivery (needs a public HTTPS URL for port 3000 — ngrok, a Cloudflare Tunnel, or a reverse proxy on a VPS):
 1. Event Subscriptions → Enable Events. Set the Request URL to https://<your-public-host>/webhook/slack and wait for the challenge to pass.
@@ -143,50 +149,38 @@ Set up event delivery (needs a public HTTPS URL for port 3000 — ngrok, a Cloud
 
 ## Resolve your DM channel
 
-The agent talks to you in your direct-message channel with the bot. Resolve its
-address so the owner-wiring step can target it. Validating the token here, before
-the restart, fast-fails a bad credential while it's still cheap to fix. You'll
-need your Slack member ID: open your profile (your avatar, bottom-left), then
-**⋮** → **Copy member ID** — it starts with `U`.
-
+Resolve the owner DM address the owner-wiring step needs; validating the token here, before the restart, fast-fails a bad credential.
 ```nc:prompt owner_handle validate:^U[A-Z0-9]{8,}$
 Your Slack member ID (Profile → ⋮ → "Copy member ID"; starts with U).
 ```
 
-Confirm the bot token works and capture the bot identity — `auth.test` returns the
-bot user and workspace, and fails here if the token is bad:
-
+`auth.test` confirms the bot token works and captures the bot identity:
 ```nc:run capture:connected_as effect:fetch
 curl -sf -X POST https://slack.com/api/auth.test -H "Authorization: Bearer {{bot_token}}" | jq -er '"@" + .user + " in " + .team'
 ```
 
-Open the DM with `conversations.open` and take the channel id it returns as the
-conversation address `slack:<channelId>` (if Slack returns no channel, the bot is
-missing the `im:write` scope — add it and reinstall):
-
+`conversations.open` yields the DM address `slack:<channelId>` (no channel back = the `im:write` scope is missing — add it and reinstall):
 ```nc:run capture:platform_id effect:fetch
 curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer {{bot_token}}" -H "Content-Type: application/json" -d '{"users":"{{owner_handle}}"}' | jq -er '"slack:" + .channel.id'
 ```
 
-`owner_handle` and `platform_id` are what the owner-wiring step needs. The
-greeting goes out over `chat.postMessage`, which works right away. Receiving
-replies needs the event path live: with Socket Mode that happens as soon as the
-service restarts below; with webhook delivery, finish the Event Subscriptions
-and Interactivity steps above first.
+`owner_handle` and `platform_id` feed the owner-wiring step. Sending works immediately;
+receiving needs the event path (Socket Mode: live after the restart below; webhook: the steps above first).
 
 ## Restart
 
-With the credential validated, restart the service so it loads the Slack adapter
-and the secrets you just stored, and wait for its CLI socket before wiring:
-
+Restart so the service loads the adapter and secrets; wait for its CLI socket before wiring:
 ```nc:run effect:restart
 bash setup/lib/restart.sh
 ```
 
 ## Next Steps
 
-If you're in the middle of `/setup`, return to the setup flow now. Otherwise wire
-this channel with `/init-first-agent` (or `/manage-channels`).
+Mid-`/setup`: return to the setup flow. Otherwise wire the channel with `/init-first-agent`
+(or `/manage-channels`). For the Slack agents feature (child bots from
+`create_agent`, shared rooms, canvases), apply `/slack-a2a-rooms` then
+`/slack-agent-flow` — the setup wizard does both automatically when run with
+`--slack-agents`.
 
 ## Channel Info
 
@@ -200,10 +194,8 @@ this channel with `/init-first-agent` (or `/manage-channels`).
 
 ## Troubleshooting
 
-**A token paste is rejected.** Each secret has a fixed shape: the Bot User OAuth Token starts `xoxb-` (OAuth & Permissions, after Install to Workspace), the App-Level Token starts `xapp-` (Basic Information → App-Level Tokens), and the Signing Secret is a hex string (Basic Information). The classic mix-up is pasting a user token (`xoxp-`) instead of the bot token, or the app's Client Secret instead of the Signing Secret.
-
-**`auth.test` fails, or `conversations.open` returns no channel.** A failing `auth.test` means the bot token is wrong or the app was never installed to the workspace. `conversations.open` coming back empty means the `im:write` scope is missing — add it under OAuth & Permissions and **reinstall the app**; scope changes only take effect after reinstall, which also mints a new `xoxb-` token to store.
-
-**The greeting arrives but your replies vanish.** Sending works with just the bot token; *receiving* needs the event path. Socket Mode: the toggle on, `SLACK_APP_TOKEN` set with `connections:write`, and the bot events (`message.im`, `message.channels`, `message.groups`, `app_mention`) subscribed. Webhook: the Request URL must have passed Slack's challenge and the same events subscribed. Either way, App Home's Messages Tab must be enabled or Slack refuses DMs to the app.
-
-**Adapter registered but Slack never connects.** Run `pnpm exec vitest run src/channels/slack-registration.test.ts` — red means the barrel import or the `@chat-adapter/slack` install drifted, so re-run the Apply steps. If green, restart the service (`bash setup/lib/restart.sh`) so it picks up the adapter and tokens, then check `logs/nanoclaw.error.log`.
+- **A token paste is rejected.** Each secret has a fixed shape: the Bot User OAuth Token starts `xoxb-` (OAuth & Permissions, after Install to Workspace), the App-Level Token starts `xapp-` (Basic Information → App-Level Tokens), and the Signing Secret is a hex string (Basic Information). The classic mix-up is pasting a user token (`xoxp-`) instead of the bot token, or the app's Client Secret instead of the Signing Secret.
+- **`auth.test` fails, or `conversations.open` returns no channel.** A failing `auth.test` means the bot token is wrong or the app was never installed to the workspace. An empty `conversations.open` means the `im:write` scope is missing — add it and **reinstall the app**; scope changes only take effect after reinstall, which also mints a new `xoxb-` token to store.
+- **The greeting arrives but your replies vanish.** Sending works with just the bot token; *receiving* needs the event path. Socket Mode: the toggle on, `SLACK_APP_TOKEN` set with `connections:write`, and the bot events (`message.im`, `message.channels`, `message.groups`, `app_mention`) subscribed. Webhook: the Request URL must have passed Slack's challenge and the same events subscribed. Either way, App Home's Messages Tab must be enabled or Slack refuses DMs to the app.
+- **Adapter registered but Slack never connects.** Run `pnpm exec vitest run src/channels/slack-registration.test.ts` — red means the barrel import or the `@chat-adapter/slack` install drifted, so re-run the Apply steps. If green, restart the service (`bash setup/lib/restart.sh`) and check `logs/nanoclaw.error.log`.
+- **Rooms, canvases, or DM onboarding are missing.** Those are the agents feature, not this adapter install — they arrive with `/slack-a2a-rooms` + `/slack-agent-flow` (setup applies both when run with `--slack-agents`). If those skills were applied, check `src/modules/index.ts` carries their module imports, then restart.

--- a/.claude/skills/add-slack/apply-fixtures.json
+++ b/.claude/skills/add-slack/apply-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — shaped fake values only, never real credentials. Two scenarios cover both when:connection= legs; the auth.test stub answers the connected_as capture and conversations.open answers platform_id.",
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — shaped fake values only, never real credentials. Three scenarios cover all when:connection= legs (socket, webhook, provisioned); the auth.test stub answers the connected_as capture and conversations.open answers platform_id. The payload copy/append/dep/build/test steps need no stubs — they run through the stubbed exec.",
   "scenarios": [
     {
       "name": "socket",
@@ -10,8 +10,14 @@
         "owner_handle": "U12345678"
       },
       "exec": [
-        { "match": "auth.test", "stdout": "@nano in Acme" },
-        { "match": "conversations.open", "stdout": "slack:D0FAKE" }
+        {
+          "match": "auth.test",
+          "stdout": "@nano in Acme"
+        },
+        {
+          "match": "conversations.open",
+          "stdout": "slack:D0FAKE"
+        }
       ]
     },
     {
@@ -23,8 +29,33 @@
         "owner_handle": "U12345678"
       },
       "exec": [
-        { "match": "auth.test", "stdout": "@nano in Acme" },
-        { "match": "conversations.open", "stdout": "slack:D0FAKE" }
+        {
+          "match": "auth.test",
+          "stdout": "@nano in Acme"
+        },
+        {
+          "match": "conversations.open",
+          "stdout": "slack:D0FAKE"
+        }
+      ]
+    },
+    {
+      "name": "provisioned",
+      "inputs": {
+        "connection": "provisioned",
+        "bot_token": "xoxb-fake-bot-token",
+        "app_token": "xapp-fake-app-token",
+        "owner_handle": "U12345678"
+      },
+      "exec": [
+        {
+          "match": "auth.test",
+          "stdout": "@nano in Acme"
+        },
+        {
+          "match": "conversations.open",
+          "stdout": "slack:D0FAKE"
+        }
       ]
     }
   ]

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -37,6 +37,11 @@ export interface InputMeta {
   validate?: string; // regex source (nc:prompt validate:<re>)
   flags?: string; // regex flags   (nc:prompt flags:<f>)
   normalize?: 'trim' | 'rstrip-slash' | 'lower'; // applied by the ENGINE at bind
+  // Interactive select options, `|`-separated (nc:prompt choices:a|b). When a
+  // value is legal only via pre-bound inputs (e.g. slack's `provisioned`
+  // connection), validate stays wider than the offered set — so a consumer
+  // must prefer this over options derived from the validate alternation.
+  choices?: string;
 }
 
 // Everything the engine EMITS — the core seam's output contract. Every
@@ -553,6 +558,7 @@ function inputMetaOf(d: Directive, secret: boolean, validate: string | undefined
   if (typeof d.attrs.normalize === 'string' && NORMALIZE_KINDS.has(d.attrs.normalize)) {
     meta.normalize = d.attrs.normalize as InputMeta['normalize'];
   }
+  if (typeof d.attrs.choices === 'string') meta.choices = d.attrs.choices;
   return meta;
 }
 

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -75,7 +75,6 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'src/provisioning/slack-app.ts',
       'src/provisioning/slack-app.test.ts',
       'container/skills/slack-formatting/SKILL.md',
-      'container/skills/welcome/addenda/slack.md',
     ]);
   });
 
@@ -114,6 +113,9 @@ describe('skill-directives parser, on the converted add-slack', () => {
     const prompts = directives.filter((d) => d.kind === 'prompt');
     expect(prompts.map(promptVar)).toEqual(['connection', 'bot_token', 'app_token', 'app_token', 'signing_secret', 'owner_handle']);
     expect(prompts[0].args).not.toContain('secret'); // connection — a mode choice, not a secret
+    // The interactive select offers two modes; validate stays wider because
+    // `provisioned` arrives only via pre-bound inputs (the --slack-agents pre-step).
+    expect(prompts[0].attrs.choices).toBe('socket|webhook');
     expect(prompts[1].args).toContain('secret'); // bot_token
     expect(prompts[2].args).toContain('secret'); // app_token (socket)
     expect(prompts[3].args).toContain('secret'); // app_token (provisioned twin)
@@ -163,7 +165,6 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(parseDirectives(withProse).map((d) => d.kind)).toEqual(directives.map((d) => d.kind));
   });
 });
-
 
 describe('validation catches malformed directives', () => {
   it('flags an unpinned dependency and an unknown directive', () => {

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -17,8 +17,9 @@ const directives = parseDirectives(slack);
 describe('skill-directives parser, on the converted add-slack', () => {
   it('extracts every directive in document order — install, credentials, resolve, restart', () => {
     expect(directives.map((d) => d.kind)).toEqual([
-      'copy', // step 1: adapter + test from the channels branch
-      'append', // step 2: barrel registration
+      'copy', // step 1: the base channel payload from the channels branch
+      'append', // step 2: channel barrel — adapter registration
+      'append', // step 2: channel barrel — bot-inbound guard
       'dep', // step 3: pinned package
       'run', // step 4: build
       'run', // step 4: test
@@ -27,9 +28,11 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'operator', // credentials: create-app walkthrough, webhook variant
       'prompt', // credentials: capture bot token
       'prompt', // credentials: capture app-level token (socket only)
+      'prompt', // credentials: app-level token twin (provisioned mode — binds from inputs)
       'prompt', // credentials: capture signing secret (webhook only)
       'env-set', // credentials: bot token (both modes)
       'env-set', // credentials: app token — doubles as the Socket Mode switch
+      'env-set', // credentials: app token, provisioned-mode twin
       'env-set', // credentials: signing secret (webhook only)
       'operator', // credentials: event-delivery walkthrough (webhook only)
       'prompt', // resolve: owner member id (owner_handle)
@@ -56,20 +59,40 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(ops[2].attrs.when).toBe('connection=webhook');
   });
 
-  it('reads copy as a branch fetch with the full channel payload', () => {
+  it('reads copy as a branch fetch with the base channel payload', () => {
     const copy = directives.find((d) => d.kind === 'copy')!;
     expect(copy.attrs['from-branch']).toBe('channels');
+    // Base experience only — the agents feature payload (room membership,
+    // canvas, onboarding, their env-file plumbing) moved to /slack-agent-flow.
     expect(copy.body).toEqual([
       'src/channels/slack.ts',
+      'src/channels/slack-lib.ts',
+      'src/channels/slack-lib.test.ts',
+      'src/channels/slack-a2a-guard.ts',
+      'src/channels/slack-a2a-guard.test.ts',
       'src/channels/slack-registration.test.ts',
+      'src/channels/slack-instances-registration.test.ts',
+      'src/provisioning/slack-app.ts',
+      'src/provisioning/slack-app.test.ts',
       'container/skills/slack-formatting/SKILL.md',
+      'container/skills/welcome/addenda/slack.md',
     ]);
   });
 
-  it('reads the barrel append target and line', () => {
-    const append = directives.find((d) => d.kind === 'append')!;
-    expect(append.attrs.to).toBe('src/channels/index.ts');
-    expect(append.body).toEqual(["import './slack.js';"]);
+  it('reads the barrel appends: adapter and guard only', () => {
+    const appends = directives.filter((d) => d.kind === 'append');
+    expect(appends.map((d) => d.attrs.to)).toEqual([
+      'src/channels/index.ts',
+      'src/channels/index.ts',
+    ]);
+    // The adapter and the guard are SEPARATE fences (idempotency is keyed on a
+    // fence's first line): an install that already has `import './slack.js';`
+    // from the pre-payload skill still gains the guard on a re-run.
+    expect(appends[0].body).toEqual(["import './slack.js';"]);
+    expect(appends[1].body).toEqual(["import './slack-a2a-guard.js';"]);
+    // The agents-feature module/tool barrel appends live in /slack-agent-flow;
+    // the companion declaration is trunk's, gated on NANOCLAW_SLACK_AGENTS
+    // (setup/channels/slack-auto-register.ts) — no skill appends it anymore.
   });
 
   it('reads the dependency pinned exactly', () => {
@@ -89,15 +112,17 @@ describe('skill-directives parser, on the converted add-slack', () => {
 
   it('captures prompts into named vars — credentials secret, the mode and handle not', () => {
     const prompts = directives.filter((d) => d.kind === 'prompt');
-    expect(prompts.map(promptVar)).toEqual(['connection', 'bot_token', 'app_token', 'signing_secret', 'owner_handle']);
+    expect(prompts.map(promptVar)).toEqual(['connection', 'bot_token', 'app_token', 'app_token', 'signing_secret', 'owner_handle']);
     expect(prompts[0].args).not.toContain('secret'); // connection — a mode choice, not a secret
     expect(prompts[1].args).toContain('secret'); // bot_token
-    expect(prompts[2].args).toContain('secret'); // app_token
-    expect(prompts[3].args).toContain('secret'); // signing_secret
-    expect(prompts[4].args).not.toContain('secret'); // owner_handle — a plain id, not a secret
+    expect(prompts[2].args).toContain('secret'); // app_token (socket)
+    expect(prompts[3].args).toContain('secret'); // app_token (provisioned twin)
+    expect(prompts[4].args).toContain('secret'); // signing_secret
+    expect(prompts[5].args).not.toContain('secret'); // owner_handle — a plain id, not a secret
     // Each mode's credential is guard-scoped to its branch.
     expect(prompts[2].attrs.when).toBe('connection=socket');
-    expect(prompts[3].attrs.when).toBe('connection=webhook');
+    expect(prompts[3].attrs.when).toBe('connection=provisioned');
+    expect(prompts[4].attrs.when).toBe('connection=webhook');
     // The prompt body is the question; it does not mention env at all.
     expect(prompts[1].body.join(' ')).toMatch(/Bot User OAuth Token/);
   });
@@ -115,10 +140,12 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(envSets.map((d) => d.body)).toEqual([
       ['SLACK_BOT_TOKEN={{bot_token}}'],
       ['SLACK_APP_TOKEN={{app_token}}'],
+      ['SLACK_APP_TOKEN={{app_token}}'],
       ['SLACK_SIGNING_SECRET={{signing_secret}}'],
     ]);
     expect(envSets[1].attrs.when).toBe('connection=socket');
-    expect(envSets[2].attrs.when).toBe('connection=webhook');
+    expect(envSets[2].attrs.when).toBe('connection=provisioned');
+    expect(envSets[3].attrs.when).toBe('connection=webhook');
   });
 
   it('passes validation (well-formed, pinned, every {{var}} captured first)', () => {
@@ -136,6 +163,7 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(parseDirectives(withProse).map((d) => d.kind)).toEqual(directives.map((d) => d.kind));
   });
 });
+
 
 describe('validation catches malformed directives', () => {
   it('flags an unpinned dependency and an unknown directive', () => {

--- a/setup/channels/companions.ts
+++ b/setup/channels/companions.ts
@@ -63,4 +63,4 @@ export function getCompanionSkills(channel: string): readonly string[] {
 // flag and returns without touching the registries when it is off; the
 // register function is passed in (rather than the shim importing it) so the
 // shim stays cycle-free and evaluates nothing beyond the flag check.
-registerSlackAutoProvision(registerChannelPreStep);
+registerSlackAutoProvision(registerChannelPreStep, registerCompanionSkills);

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -591,17 +591,32 @@ describe('backGate (first-prompt back-to-channel-selection)', () => {
 describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs)', () => {
   const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'nc-companion-'));
 
-  it('skill dir already present: true, no git traffic', async () => {
+  it('skill already present (SKILL.md exists): true, no git traffic', async () => {
     const { materializeCompanionSkill } = await import('./run-channel-skill.js');
     const root = makeRoot();
     mkdirSync(join(root, '.claude/skills/slack-a2a-rooms'), { recursive: true });
+    writeFileSync(join(root, '.claude/skills/slack-a2a-rooms/SKILL.md'), '# x\n');
     const exec = vi.fn();
     expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(true);
     expect(exec).not.toHaveBeenCalled();
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('absent dir: fetches the channels branch and materializes every listed file', async () => {
+  it('a leftover dir WITHOUT SKILL.md does not read as installed — it re-fetches', async () => {
+    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+    const root = makeRoot();
+    mkdirSync(join(root, '.claude/skills/slack-a2a-rooms/src'), { recursive: true });
+    const cmds: string[] = [];
+    const exec = (command: string): string => {
+      cmds.push(command);
+      return command.includes('ls-tree') ? '.claude/skills/slack-a2a-rooms/SKILL.md\n' : '';
+    };
+    expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(true);
+    expect(cmds[0]).toBe('git fetch origin channels');
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('absent dir: fetches the channels branch and materializes every listed file, quoted', async () => {
     const { materializeCompanionSkill } = await import('./run-channel-skill.js');
     const root = makeRoot();
     const cmds: string[] = [];
@@ -614,11 +629,12 @@ describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs
     };
     expect(materializeCompanionSkill('slack-agent-flow', root, { exec, resolveRemote: () => 'upstream' })).toBe(true);
     expect(cmds[0]).toBe('git fetch upstream channels');
-    expect(cmds[1]).toBe('git ls-tree -r --name-only upstream/channels -- .claude/skills/slack-agent-flow');
-    // One git-show per listed file, into the same relative path.
+    expect(cmds[1]).toBe("git ls-tree -r --name-only 'upstream/channels' -- '.claude/skills/slack-agent-flow'");
+    // One git-show per listed file, into the same relative path — quoted so a
+    // future filename with spaces fails loudly instead of word-splitting.
     expect(cmds.slice(2)).toEqual([
-      'git show upstream/channels:.claude/skills/slack-agent-flow/SKILL.md > .claude/skills/slack-agent-flow/SKILL.md',
-      'git show upstream/channels:.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts > .claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts',
+      "git show 'upstream/channels:.claude/skills/slack-agent-flow/SKILL.md' > '.claude/skills/slack-agent-flow/SKILL.md'",
+      "git show 'upstream/channels:.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts' > '.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts'",
     ]);
     rmSync(root, { recursive: true, force: true });
   });
@@ -628,6 +644,24 @@ describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs
     const root = makeRoot();
     const exec = (command: string): string => (command.includes('ls-tree') ? '\n' : '');
     expect(materializeCompanionSkill('nope', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('failure mid-materialization: false, and the partial dir is removed (no poisoned retry)', async () => {
+    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+    const root = makeRoot();
+    const exec = (command: string): string => {
+      if (command.includes('ls-tree')) return '.claude/skills/slack-agent-flow/SKILL.md\n';
+      if (command.includes('git show')) {
+        // Simulate the redirect creating the parent dir then failing.
+        mkdirSync(join(root, '.claude/skills/slack-agent-flow'), { recursive: true });
+        throw new Error('fatal: bad object');
+      }
+      return '';
+    };
+    expect(materializeCompanionSkill('slack-agent-flow', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
+    // The dir created before the failing git-show must be gone.
+    expect(existsSync(join(root, '.claude/skills/slack-agent-flow'))).toBe(false);
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -587,3 +587,57 @@ describe('backGate (first-prompt back-to-channel-selection)', () => {
     expect(wired).toHaveLength(0); // the wire was never reached
   });
 });
+
+describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs)', () => {
+  const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'nc-companion-'));
+
+  it('skill dir already present: true, no git traffic', async () => {
+    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+    const root = makeRoot();
+    mkdirSync(join(root, '.claude/skills/slack-a2a-rooms'), { recursive: true });
+    const exec = vi.fn();
+    expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(true);
+    expect(exec).not.toHaveBeenCalled();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('absent dir: fetches the channels branch and materializes every listed file', async () => {
+    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+    const root = makeRoot();
+    const cmds: string[] = [];
+    const exec = (command: string): string => {
+      cmds.push(command);
+      if (command.includes('ls-tree')) {
+        return '.claude/skills/slack-agent-flow/SKILL.md\n.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts\n';
+      }
+      return '';
+    };
+    expect(materializeCompanionSkill('slack-agent-flow', root, { exec, resolveRemote: () => 'upstream' })).toBe(true);
+    expect(cmds[0]).toBe('git fetch upstream channels');
+    expect(cmds[1]).toBe('git ls-tree -r --name-only upstream/channels -- .claude/skills/slack-agent-flow');
+    // One git-show per listed file, into the same relative path.
+    expect(cmds.slice(2)).toEqual([
+      'git show upstream/channels:.claude/skills/slack-agent-flow/SKILL.md > .claude/skills/slack-agent-flow/SKILL.md',
+      'git show upstream/channels:.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts > .claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts',
+    ]);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('branch does not carry the skill: false', async () => {
+    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+    const root = makeRoot();
+    const exec = (command: string): string => (command.includes('ls-tree') ? '\n' : '');
+    expect(materializeCompanionSkill('nope', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('git failure: false, never throws', async () => {
+    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+    const root = makeRoot();
+    const exec = (): string => {
+      throw new Error('no network');
+    };
+    expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -16,7 +16,7 @@
  * duplicated across channel skills.
  */
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import * as p from '@clack/prompts';
@@ -50,7 +50,11 @@ export function materializeCompanionSkill(
   deps: { exec?: (command: string) => string; resolveRemote?: () => string } = {},
 ): boolean {
   const dir = `.claude/skills/${skill}`;
-  if (existsSync(join(projectRoot, dir))) return true;
+  // Key the short-circuit on SKILL.md, not the directory: a directory left by
+  // an interrupted materialization would otherwise read as installed, and a
+  // missing SKILL.md parses as zero directives — "fully applied" while the
+  // feature is absent.
+  if (existsSync(join(projectRoot, dir, 'SKILL.md'))) return true;
   const exec =
     deps.exec ??
     ((command: string) =>
@@ -58,17 +62,21 @@ export function materializeCompanionSkill(
   try {
     const remote = (deps.resolveRemote ?? channelsRemote(projectRoot))();
     exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
-    const files = exec(`git ls-tree -r --name-only ${remote}/${CHANNELS_BRANCH} -- ${dir}`)
+    const files = exec(`git ls-tree -r --name-only '${remote}/${CHANNELS_BRANCH}' -- '${dir}'`)
       .split('\n')
       .map((s) => s.trim())
       .filter(Boolean);
     if (files.length === 0) return false;
     for (const file of files) {
       mkdirSync(dirname(join(projectRoot, file)), { recursive: true });
-      exec(`git show ${remote}/${CHANNELS_BRANCH}:${file} > ${file}`);
+      exec(`git show '${remote}/${CHANNELS_BRANCH}:${file}' > '${file}'`);
     }
     return true;
   } catch {
+    // Leave no partial directory behind — the SKILL.md short-circuit above
+    // makes a leftover half-fetched dir permanent on the next run. Deleting
+    // is safe here: this path only runs when the skill was absent on entry.
+    rmSync(join(projectRoot, dir), { recursive: true, force: true });
     return false;
   }
 }
@@ -99,13 +107,15 @@ async function applyCompanionSkills(
 ): Promise<void> {
   const companions = getCompanionSkills(channel);
   let applied = false;
+  let degraded = false;
   for (const skill of companions) {
     if (!materializeCompanionSkill(skill, projectRoot)) {
+      degraded = true;
       p.log.warn(
         `Companion skill ${skill} is not in this checkout and could not be fetched from the ` +
           `${CHANNELS_BRANCH} branch. The ${channel} channel works, but the capability that ` +
           `skill adds is missing until you fetch and apply it: ` +
-          `pnpm exec tsx scripts/skill-apply.ts .claude/skills/${skill}`,
+          `pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/${skill}`,
       );
       continue;
     }
@@ -124,16 +134,28 @@ async function applyCompanionSkills(
       applied = true;
       continue;
     }
+    degraded = true;
     // Degraded, not fatal: the main channel install still works. Name the
     // skill and the exact re-apply command so the warning is actionable.
     p.log.warn(
       `Couldn't fully apply companion skill ${skill}. The ${channel} channel works, but the ` +
         `capability that skill adds stays degraded until you re-apply it: ` +
-        `pnpm exec tsx scripts/skill-apply.ts .claude/skills/${skill}`,
+        `pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/${skill}`,
     );
   }
 
   if (!applied) return;
+  if (degraded) {
+    // A half-applied companion may have copied files and appended barrel
+    // imports before failing its build or tests — restarting could boot that
+    // state. The channel itself already works (its own restart ran before the
+    // companions), so hold the deferred restart until the operator repairs.
+    p.log.warn(
+      'Skipping the deferred service restart: a companion skill did not fully apply. ' +
+        'Re-apply it with the command above, then restart: bash setup/lib/restart.sh',
+    );
+    return;
+  }
   try {
     await (overrides.exec ?? hostExec(projectRoot))('bash setup/lib/restart.sh');
   } catch {

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -15,7 +15,9 @@
  * So the wire lives in exactly one place (init-first-agent) and is never
  * duplicated across channel skills.
  */
-import { writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import * as p from '@clack/prompts';
 
@@ -24,11 +26,52 @@ import * as setupLog from '../logs.js';
 import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../lib/back-nav.js';
 import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
-import { hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
+import { channelsRemote, hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
 import { clearTemplatePick } from '../templates.js';
 import { getChannelPreStep, getCompanionSkills } from './companions.js';
 
 const DEFAULT_AGENT_NAME = 'Nano';
+
+const CHANNELS_BRANCH = 'channels';
+
+/**
+ * Trunk ships no channel payloads, and that includes companion skill
+ * directories — a declared companion may exist only on the channels registry
+ * branch (e.g. the flag-gated Slack agents skills). Materialize an absent
+ * directory from there — the same remote resolution and fetch/show mechanics
+ * the skill engine uses for `from-branch` payload copies — so runSkill has a
+ * document to apply. A directory already in the checkout short-circuits with
+ * no git traffic. Returns false when the skill can't be produced; the caller
+ * warns and skips it.
+ */
+export function materializeCompanionSkill(
+  skill: string,
+  projectRoot: string,
+  deps: { exec?: (command: string) => string; resolveRemote?: () => string } = {},
+): boolean {
+  const dir = `.claude/skills/${skill}`;
+  if (existsSync(join(projectRoot, dir))) return true;
+  const exec =
+    deps.exec ??
+    ((command: string) =>
+      execSync(command, { cwd: projectRoot, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
+  try {
+    const remote = (deps.resolveRemote ?? channelsRemote(projectRoot))();
+    exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
+    const files = exec(`git ls-tree -r --name-only ${remote}/${CHANNELS_BRANCH} -- ${dir}`)
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (files.length === 0) return false;
+    for (const file of files) {
+      mkdirSync(dirname(join(projectRoot, file)), { recursive: true });
+      exec(`git show ${remote}/${CHANNELS_BRANCH}:${file} > ${file}`);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Apply a channel's declared companion skills (setup/channels/companions.ts)
@@ -57,6 +100,15 @@ async function applyCompanionSkills(
   const companions = getCompanionSkills(channel);
   let applied = false;
   for (const skill of companions) {
+    if (!materializeCompanionSkill(skill, projectRoot)) {
+      p.log.warn(
+        `Companion skill ${skill} is not in this checkout and could not be fetched from the ` +
+          `${CHANNELS_BRANCH} branch. The ${channel} channel works, but the capability that ` +
+          `skill adds is missing until you fetch and apply it: ` +
+          `pnpm exec tsx scripts/skill-apply.ts .claude/skills/${skill}`,
+      );
+      continue;
+    }
     const res = await runSkill(`.claude/skills/${skill}`, {
       projectRoot,
       exec: overrides.exec,

--- a/setup/channels/slack-auto-register.test.ts
+++ b/setup/channels/slack-auto-register.test.ts
@@ -3,12 +3,13 @@
  *
  * Flag off (the default) must leave the wizard exactly as shipped: no
  * pre-step registered for slack, no companion skills declared, and the
- * provisioning flow never evaluated. Flag on registers the pre-step, which
- * lazy-loads the flow only when the wizard actually invokes it.
+ * provisioning flow never evaluated. Flag on registers the pre-step (which
+ * lazy-loads the flow only when the wizard actually invokes it) and declares
+ * the Slack agents companion skills, in prerequisite order.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { registerSlackAutoProvision } from './slack-auto-register.js';
+import { registerSlackAutoProvision, SLACK_AGENTS_COMPANION_SKILLS } from './slack-auto-register.js';
 
 afterEach(() => {
   delete process.env.NANOCLAW_SLACK_AGENTS;
@@ -19,21 +20,25 @@ afterEach(() => {
 describe('registerSlackAutoProvision', () => {
   it('flag unset: registers nothing', () => {
     const register = vi.fn();
-    registerSlackAutoProvision(register, {});
+    const registerCompanions = vi.fn();
+    registerSlackAutoProvision(register, registerCompanions, {});
     expect(register).not.toHaveBeenCalled();
+    expect(registerCompanions).not.toHaveBeenCalled();
   });
 
   it('only "1" enables — other values register nothing', () => {
     const register = vi.fn();
+    const registerCompanions = vi.fn();
     for (const value of ['', '0', 'false', 'yes', 'true']) {
-      registerSlackAutoProvision(register, { NANOCLAW_SLACK_AGENTS: value });
+      registerSlackAutoProvision(register, registerCompanions, { NANOCLAW_SLACK_AGENTS: value });
     }
     expect(register).not.toHaveBeenCalled();
+    expect(registerCompanions).not.toHaveBeenCalled();
   });
 
   it('flag "1": registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
     const register = vi.fn();
-    registerSlackAutoProvision(register, { NANOCLAW_SLACK_AGENTS: '1' });
+    registerSlackAutoProvision(register, vi.fn(), { NANOCLAW_SLACK_AGENTS: '1' });
 
     expect(register).toHaveBeenCalledTimes(1);
     const [channel, step] = register.mock.calls[0];
@@ -44,6 +49,15 @@ describe('registerSlackAutoProvision', () => {
     vi.doMock('./slack-auto.js', () => ({ maybeAutoProvisionSlack }));
     await expect(step('Nano')).resolves.toEqual({ bot_token: 'xoxb-for-Nano' });
     expect(maybeAutoProvisionSlack).toHaveBeenCalledExactlyOnceWith('Nano');
+  });
+
+  it('flag "1": declares the agents companion skills in prerequisite order', () => {
+    const registerCompanions = vi.fn();
+    registerSlackAutoProvision(vi.fn(), registerCompanions, { NANOCLAW_SLACK_AGENTS: '1' });
+
+    expect(registerCompanions).toHaveBeenCalledExactlyOnceWith('slack', SLACK_AGENTS_COMPANION_SKILLS);
+    // The room admission policy is the flow's prerequisite — order is the API.
+    expect(SLACK_AGENTS_COMPANION_SKILLS).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
   });
 });
 
@@ -56,13 +70,14 @@ describe('companions registry wiring', () => {
     expect(companions.getCompanionSkills('slack')).toEqual([]);
   });
 
-  it('flag "1": a fresh companions module carries the slack pre-step', async () => {
+  it('flag "1": a fresh companions module carries the slack pre-step and companion list', async () => {
     process.env.NANOCLAW_SLACK_AGENTS = '1';
     vi.resetModules();
     const companions = await import('./companions.js');
     expect(companions.getChannelPreStep('slack')).toBeTypeOf('function');
-    // Companion skills stay undeclared either way — the add-slack skill
-    // payload owns those; an absent declaration just means none run.
-    expect(companions.getCompanionSkills('slack')).toEqual([]);
+    // Declared at wizard boot — a registration appended to the registry file
+    // mid-run would be invisible to the already-imported module, so the whole
+    // agents install rides on this boot-time declaration.
+    expect(companions.getCompanionSkills('slack')).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
   });
 });

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -13,16 +13,35 @@
  * the Slack pre-step. No fetch, no import, nothing runs while the flag is
  * off.
  *
- * The register function is injected by the caller (companions.ts passes
- * `registerChannelPreStep`) so this module has zero runtime imports — no
- * import cycle with the registry, nothing evaluated beyond the env check.
+ * The flag also declares the Slack agents companion skills. `/add-slack`
+ * alone is the base experience (one bot, DM/channel chat); the agents
+ * feature — child bots provisioned from `create_agent`, shared a2a rooms,
+ * canvases, DM onboarding — ships in the `slack-a2a-rooms` and
+ * `slack-agent-flow` skills on the channels branch. Declaring them HERE, at
+ * wizard boot, is load-bearing: the wizard imports the companion registry
+ * once, so a registration appended to the registry file mid-run is invisible
+ * to the process that would apply it. The channel flow materializes the
+ * skill directories from the channels branch when this checkout doesn't
+ * carry them.
+ *
+ * The register functions are injected by the caller (companions.ts passes
+ * `registerChannelPreStep` / `registerCompanionSkills`) so this module has
+ * zero runtime imports — no import cycle with the registry, nothing
+ * evaluated beyond the env check.
  */
 import type { ChannelPreStep } from './companions.js';
 
 export const SLACK_AGENTS_FLAG = 'NANOCLAW_SLACK_AGENTS';
 
+/**
+ * Applied in order after `/add-slack`: the room admission policy first (the
+ * flow's prerequisite), then the create_agent → provisioned-bot flow.
+ */
+export const SLACK_AGENTS_COMPANION_SKILLS = ['slack-a2a-rooms', 'slack-agent-flow'] as const;
+
 export function registerSlackAutoProvision(
   register: (channel: string, step: ChannelPreStep) => void,
+  registerCompanions: (channel: string, skills: readonly string[]) => void,
   env: NodeJS.ProcessEnv = process.env,
 ): void {
   if (env[SLACK_AGENTS_FLAG] !== '1') return;
@@ -30,4 +49,5 @@ export function registerSlackAutoProvision(
     const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
     return maybeAutoProvisionSlack(agentName);
   });
+  registerCompanions('slack', SLACK_AGENTS_COMPANION_SKILLS);
 }

--- a/setup/channels/wizard-hooks.test.ts
+++ b/setup/channels/wizard-hooks.test.ts
@@ -230,7 +230,7 @@ describe('companion skills', () => {
     expect(cmds.indexOf('bash setup/lib/restart.sh')).toBeGreaterThan(bAt);
   });
 
-  it('a partially-failed companion degrades with the exact re-apply command; the restart still runs', async () => {
+  it('a partially-failed companion degrades with the exact re-apply command; the restart is held', async () => {
     const root = scratchRoot('wh-degraded-');
     roots.push(root);
     writeChannelSkill(root, 'fixturedeg');
@@ -252,12 +252,17 @@ describe('companion skills', () => {
       wire: () => true,
     });
 
-    // Degraded, not fatal: the warning names the skill and the re-apply command.
+    // Degraded, not fatal: the warning names the skill and the re-apply command
+    // (the driver CLI, which actually applies — not the planner).
     const degraded = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('fixture-companion-bad'));
     expect(degraded).toHaveLength(1);
-    expect(degraded[0]).toContain('pnpm exec tsx scripts/skill-apply.ts .claude/skills/fixture-companion-bad');
-    // The applied companion still triggers the single deferred restart.
-    expect(cmds.filter((c) => c === 'bash setup/lib/restart.sh')).toHaveLength(1);
+    expect(degraded[0]).toContain('pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/fixture-companion-bad');
+    // The deferred restart is HELD: the failed companion may have copied files
+    // and appended barrel imports before failing, and restarting could boot
+    // that half-applied state. The operator is told to repair, then restart.
+    expect(cmds.filter((c) => c === 'bash setup/lib/restart.sh')).toHaveLength(0);
+    const held = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('Skipping the deferred service restart'));
+    expect(held).toHaveLength(1);
   });
 
   it('no declaration: no companion runs, no deferred restart (unchanged flow)', async () => {

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -107,10 +107,14 @@ export function clackResolveInput(
     const guarded = validateWithHelpEscape(check);
     // clearOnError wipes a rejected secret so the operator re-pastes cleanly
     // (a half-pasted token isn't left masked in the field).
-    // An either/or prompt renders as an arrow-key select — the options come
-    // straight from the validate regex (literalChoices). No re-ask loop and no
-    // `?` help-escape there: every choice is valid and self-describing.
-    const choices = meta.secret ? null : literalChoices(meta.validate);
+    // An either/or prompt renders as an arrow-key select — options come from
+    // an explicit `choices:` attr when declared (validate may accept MORE
+    // values than are offered, for modes that only arrive via pre-bound
+    // inputs), else straight from the validate regex (literalChoices). No
+    // re-ask loop and no `?` help-escape there: every choice is valid and
+    // self-describing.
+    const declared = meta.choices?.split('|').filter(Boolean);
+    const choices = meta.secret ? null : declared?.length ? declared : literalChoices(meta.validate);
     const ans = choices
       ? await p.select({ message: meta.question, options: choices.map((c) => ({ value: c, label: c })) })
       : meta.secret

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -445,7 +445,7 @@ function defaultOnEvent(
 }
 
 /** Fork-aware registry-branch remote (same resolver setup/channels/slack.ts uses). */
-function channelsRemote(projectRoot: string): () => string {
+export function channelsRemote(projectRoot: string): () => string {
   return () =>
     execSync('source setup/lib/channels-remote.sh; resolve_channels_remote', {
       cwd: projectRoot,


### PR DESCRIPTION
## What

`bash nanoclaw.sh` now yields the **base Slack experience** (one bot, DM and channel chat) and `bash nanoclaw.sh --slack-agents` the **full agents feature** — child bots provisioned from `create_agent`, shared a2a rooms, canvases, DM onboarding. Previously the flag only auto-provisioned the first app: the runtime flow was never installed, so agents created from chat existed only as `send_message` destinations.

## How

- **Flag-gated companion declaration at wizard boot** — the `NANOCLAW_SLACK_AGENTS` shim now also registers the companion skills `['slack-a2a-rooms', 'slack-agent-flow']`. Boot-time registration is load-bearing: the wizard imports the companion registry once, so a registration appended to the registry file mid-run (the mechanism channel payloads used) is invisible to the very run that should apply it. Flag off → nothing registered, wizard byte-identical to today.
- **`materializeCompanionSkill`** — a declared companion whose directory is absent from the checkout (trunk ships no channel payloads) is fetched from the `channels` branch with the same remote resolution the skill engine uses for `from-branch` copies. Keys its installed-check on `SKILL.md`, quotes interpolated paths, and removes the partial directory on failure so retries re-fetch instead of inheriting poisoned state.
- **Held restart on partial failure** — the deferred companion restart is skipped when any companion failed to fully apply (it may have copied files and appended barrel imports before failing its build), and recovery warnings now name the driver CLI that actually applies (`setup/lib/skill-driver.ts`), not the planner.
- **In-tree `/add-slack` synced to the canonical base-split version** — the old slim copy also predated the `provisioned` connection mode, so the flag's own pre-bound input was rejected on a clean checkout.
- **New `nc:prompt choices:` attr** (engine meta + driver select) — the interactive select offers only the declared options while `validate:` stays wider, so modes that arrive exclusively via pre-bound inputs (Slack's `provisioned`) are no longer offered interactively.

## Landing order

The companion payloads (base/agents skill split + async-DB adaptation) land via the sibling channels-branch PR — #3358. This PR must merge for `--slack-agents` to apply the companions; without it the flag keeps today's provision-only behavior.

## Verification

- 647 tests green across `scripts/` + `setup/` (new: materialization contract incl. poisoned-retry cleanup, flag-registration tests; updated: add-slack directive contract, wizard-hooks held-restart).
- Real-engine end-to-end: `applySkill` drove `/add-slack` → `/slack-a2a-rooms` → `/slack-agent-flow` from committed state — materialization, copies, appends, dep, build and test fences all executed live and passed.
- Two independent adversarial review passes; all confirmed findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9dWEYJ7r47wQ4VBs5SQNX