### PR TITLE
fix: expose decline notification overrides

### DIFF
--- a/src/modules/approvals/expired-card-instance.test.ts
+++ b/src/modules/approvals/expired-card-instance.test.ts
@@ -34,9 +34,8 @@ vi.mock('@onecli-sh/sdk', () => ({
   },
 }));
 
-const { editCardExpired, startOneCLIApprovalHandler, stopOneCLIApprovalHandler, ONECLI_ACTION } = await import(
-  './onecli-approvals.js'
-);
+const { editCardExpired, startOneCLIApprovalHandler, stopOneCLIApprovalHandler, ONECLI_ACTION } =
+  await import('./onecli-approvals.js');
 
 const TEST_DIR = '/tmp/nanoclaw-test-expired-card-instance';
 

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -200,6 +200,12 @@ export interface DeclineAndNotifyInput {
   senderIdentity: string | null; // namespaced user id, when resolvable
   senderName: string | null;
   event: InboundEvent;
+  /** Override when the decline is scoped to the conversation, not the sender. */
+  dedupeKey?: string;
+  /** Override the sender-facing decline copy. */
+  declineText?: string;
+  /** Override the owner-facing FYI copy. */
+  fyiText?: string;
 }
 
 /**
@@ -214,7 +220,7 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
   const { messagingGroupId, agentGroupId, senderIdentity, senderName, event } = input;
 
   // Dedupe: at most one decline + FYI per (sender, messaging group) per 24h.
-  const senderKey = senderIdentity ?? UNKNOWN_SENDER_KEY;
+  const senderKey = input.dedupeKey ?? senderIdentity ?? UNKNOWN_SENDER_KEY;
   const stampedAt = await getDeclineStampAt(messagingGroupId, senderKey);
   if (stampedAt && Date.now() - new Date(stampedAt).getTime() < DECLINE_NOTIFY_DEDUPE_MS) {
     log.debug('decline_notify deduped — declined within the last 24h', { messagingGroupId, senderIdentity });
@@ -251,7 +257,7 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
   // a per-agent bot identity registered as its own adapter instance
   // answers as itself.
   const owner = await ownerDisplayName();
-  const declineText = `I'm ${owner ?? 'my owner'}'s personal agent — I can't help you directly.`;
+  const declineText = input.declineText ?? `I'm ${owner ?? 'my owner'}'s personal agent — I can't help you directly.`;
   try {
     await adapter.deliver(
       event.channelType,
@@ -282,7 +288,9 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
   const senderDisplay = senderName && senderName.length > 0 ? senderName : (senderIdentity ?? 'An unknown sender');
   const who =
     senderIdentity && senderDisplay !== senderIdentity ? `${senderDisplay} (${senderIdentity})` : senderDisplay;
-  const fyiText = `FYI: ${who} DMed your agent on ${event.channelType} — I sent a polite decline. Allow them any time with \`ncl members add\`.`;
+  const fyiText =
+    input.fyiText ??
+    `FYI: ${who} DMed your agent on ${event.channelType} — I sent a polite decline. Allow them any time with \`ncl members add\`.`;
   try {
     await adapter.deliver(
       target.messagingGroup.channel_type,

--- a/src/modules/permissions/sender-decline-notify.test.ts
+++ b/src/modules/permissions/sender-decline-notify.test.ts
@@ -163,6 +163,35 @@ async function waitForDeliveries(count: number): Promise<void> {
 }
 
 describe('unknown-sender decline_notify flow', () => {
+  it('honors caller-supplied copy and conversation-scoped dedupe', async () => {
+    const { declineAndNotify } = await import('./sender-approval.js');
+    const event = strangerDm('hello');
+    const input = {
+      messagingGroupId: 'mg-dm-stranger',
+      agentGroupId: 'ag-1',
+      senderIdentity: 'telegram:stranger-1',
+      senderName: 'Stranger One',
+      event,
+      dedupeKey: 'conversation',
+      declineText: 'Only the owner can connect me here.',
+      fyiText: 'FYI: I declined an unauthorized channel invitation.',
+    };
+
+    await declineAndNotify(input);
+    await waitForDeliveries(2);
+    expect(JSON.parse(deliverMock.mock.calls[0][4] as string).text).toBe(input.declineText);
+    expect(JSON.parse(deliverMock.mock.calls[1][4] as string).text).toBe(input.fyiText);
+
+    await declineAndNotify({
+      ...input,
+      senderIdentity: 'telegram:stranger-2',
+      senderName: 'Stranger Two',
+    });
+    await settle();
+
+    expect(deliverMock).toHaveBeenCalledTimes(2);
+  });
+
   it('declines in the DM, FYIs the owner, records the drop — no card', async () => {
     const { routeInbound } = await import('../../router.js');
     await routeInbound(strangerDm('hi, can you book me a flight?'));


### PR DESCRIPTION
## What changed

- Add optional `dedupeKey`, `declineText`, and `fyiText` inputs to the generic `declineAndNotify` seam.
- Preserve the existing sender-scoped dedupe and default DM/FYI copy when callers omit them.
- Cover custom copy and conversation-scoped dedupe with a regression test.

## Root cause

The Slack channel-invite flow merged a caller for these overrides on the `channels` branch, but the generic permission seam on `main` never received the matching contract. Applying `slack-agent-flow` to a main-based install therefore copied in a typed caller that the host build rejected.

## Impact

Channel payloads can reuse the existing decline delivery, approver resolution, and persisted dedupe path without duplicating it. Existing unknown-sender behavior is unchanged.

This is one prerequisite for the `bash nanoclaw.sh --slack-agents` setup repair and is intentionally independent from #3360.

## Validation

- `pnpm exec vitest run src/modules/permissions/sender-decline-notify.test.ts` — 7 passed
- `pnpm run build`
