### PR TITLE
fix(setup): manage template agents after install

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -38,26 +38,34 @@ or you can populate it yourself.
 
 ## Using a template
 
-**During installation:** run `bash nanoclaw.sh`. Before the sandbox build, setup
-offers a fresh agent, the public template library, or templates already in your
-local `templates/` directory. A library choice is copied locally first, then
-setup stamps the agent through the same `ncl groups create --template` command
-used below. The agent is created even when channel setup is skipped or cannot
-finish wiring yet. When a channel is ready, setup wires that existing agent and
-sends the welcome message. The selected provider remains separate from the
-template.
+**During installation or later:** run `bash nanoclaw.sh`. Before the sandbox
+build, setup offers a fresh agent, the public template library, or templates
+already in your local `templates/` directory. On an existing install, the first
+option becomes **No template changes**. A library choice is copied locally
+first, then setup stamps through the same `ncl groups create --template`
+command used below.
 
-If a group already carries this template's plugin (a rerun over a partial
-install), setup shows the in-place update plan — how many plugin-owned
+When the chosen template is already in use, setup offers **Update** for each
+matching agent, **Connect** for each agent that has no channel wiring, **Create
+another agent**, and **Cancel**. Each option shows the agent's unique
+`groups/<folder>` path. Choosing **Create another agent** then asks for a new,
+unique display name; update and connect never ask for a new name.
+
+A new agent is created even when channel setup is skipped. Its id is not saved
+as an implicit target for a future setup run: wire it manually with `ncl`, or
+select the template later and explicitly choose **Connect**. If it was already
+wired manually, setup reads that wiring from `ncl` and no longer offers it as
+unconnected. Restamping keeps the existing agent's provider, memory, chats,
+and wiring, and does not enter channel setup.
+
+For an in-place update, setup shows the dry-run plan — how many plugin-owned
 surfaces reset, and how many carry local edits that would be lost — and asks
-before applying. **Yes** updates that agent in place; memory, chats, and
-wiring are kept. **No** cancels only the template installation and continues
-setup without it.
+before applying. **Yes** updates and restarts that agent. **No** leaves it
+untouched and continues setup without a template operation.
 
-Advanced setup can preset a local ref with **First-agent template**. The same
-setting is available as `--template-path sales/sdr` or
-`NANOCLAW_TEMPLATE_PATH=sales/sdr`. Existing installs do not see the template
-picker automatically, but an explicit template path is still installed.
+Advanced setup can preset a local ref with **Agent template**. The same setting
+is available as `--template-path sales/sdr` or
+`NANOCLAW_TEMPLATE_PATH=sales/sdr`.
 
 **Anytime, via the CLI:**
 

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -48,7 +48,7 @@ for arg in "$@"; do
     fi
     echo "Usage: bash nanoclaw.sh [options]"
     echo ""
-    echo "  --template-path <ref>  Create the first agent from templates/<ref>"
+    echo "  --template-path <ref>  Create or update an agent from templates/<ref>"
     echo "  --uninstall            Uninstall this NanoClaw copy"
     echo "  --help, -h             Show this help without installing dependencies"
     exit 0

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -67,6 +67,7 @@ import { detectExistingInstall } from './uninstall/scan.js';
 import { detectRegisteredGroups, detectExistingDisplayName, readEnvKey } from './environment.js';
 import { pollHealth } from './onecli.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import type { AgentGroup } from '../src/types.js';
 import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-claude.js';
 import * as setupLog from './logs.js';
 import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
@@ -91,9 +92,13 @@ import {
   cloneRegistry,
   copyTemplate,
   installTemplateAgent,
+  listTemplateAgents,
   listTemplatesFromDir,
+  validateNewTemplateAgentName,
   type ClonedRegistry,
+  type SetupTemplateAgent,
   type TemplateEntry,
+  type TemplateOperation,
 } from './templates.js';
 
 const CLI_AGENT_NAME = 'Terminal Agent';
@@ -223,9 +228,8 @@ async function main(): Promise<void> {
 
   // Nothing loads .env into the wizard process — bridge the persisted pick so
   // it survives not just self re-execs (`sg docker`, fail-retry) but full
-  // process restarts. Without this, a run that aborted after the pick leaves a
-  // partial install whose registered groups silently gate the picker off on
-  // rerun, and the pick is lost.
+  // process restarts. Without this, a run that aborted after the pick silently
+  // loses that choice on a full rerun.
   let savedPickBridged = false;
   if (!process.env.NANOCLAW_TEMPLATE_PATH?.trim()) {
     const savedPick = readEnvKey('NANOCLAW_TEMPLATE_PATH')?.trim();
@@ -234,10 +238,8 @@ async function main(): Promise<void> {
       savedPickBridged = true;
     }
   }
-  // Existing installs do not get an unsolicited first-agent picker, but an
-  // explicit --template-path is always honoured.
-  if (!isResume && (process.env.NANOCLAW_TEMPLATE_PATH?.trim() || !(await detectRegisteredGroups(process.cwd())))) {
-    await runTemplateSetup(savedPickBridged);
+  if (!isResume) {
+    await runTemplateSetup(savedPickBridged, await detectRegisteredGroups(process.cwd()));
   }
 
   if (!skip.has('container')) {
@@ -657,14 +659,14 @@ async function main(): Promise<void> {
     await runTimezoneStep();
   }
 
-  await installSelectedTemplateAgent(agentProvider);
+  const templateAgentOutcome = await installSelectedTemplateAgent(agentProvider);
 
   // v1 → v2 migration is handled by `bash migrate-v2.sh`, not the setup flow.
   // Users migrating from v1 run that script before (or instead of) setup.
 
   let channelChoice: ChannelChoice = 'skip';
 
-  if (!skip.has('channel')) {
+  if (!skip.has('channel') && templateAgentOutcome !== 'restamped') {
     // Loop so a channel sub-flow can return BACK_TO_CHANNEL_SELECTION on
     // its first prompt and bounce the user back to the chooser without
     // restarting setup. Channels not yet wired with the back option just
@@ -711,6 +713,9 @@ async function main(): Promise<void> {
       if (result === BACK_TO_CHANNEL_SELECTION) backed = true;
     }
   }
+  // Setup-selected targets are one-run-only. A later setup derives connect
+  // choices from current wirings instead of inheriting an old agent id.
+  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
 
   // Deferred wire (Teams): verify passes with zero groups because the
   // platform id only exists after the first DM. Tracked here so the ENDING
@@ -962,7 +967,7 @@ const INSTALLABLE_PROVIDERS = [
 // the operator may be rerunning precisely to change it. In-process presets
 // (--template-path, the Advanced screen, self re-execs, an exported env var)
 // keep the silent skip.
-async function runTemplateSetup(pickSavedByPreviousRun: boolean): Promise<void> {
+async function runTemplateSetup(pickSavedByPreviousRun: boolean, hasRegisteredAgents: boolean): Promise<void> {
   const preset = process.env.NANOCLAW_TEMPLATE_PATH?.trim();
   if (preset) {
     if (listLocalTemplates().some((template) => template.ref === preset)) {
@@ -999,9 +1004,13 @@ async function runTemplateSetup(pickSavedByPreviousRun: boolean): Promise<void> 
   for (;;) {
     const source = ensureAnswer(
       await brightSelect<'none' | 'library' | 'local'>({
-        message: 'How should we create your first agent?',
+        message: hasRegisteredAgents
+          ? 'Would you like to add or update an agent from a template?'
+          : 'How should we create your first agent?',
         options: [
-          { value: 'none', label: 'Fresh agent', hint: 'recommended — shape it by chatting' },
+          hasRegisteredAgents
+            ? { value: 'none', label: 'No template changes', hint: 'recommended' }
+            : { value: 'none', label: 'Fresh agent', hint: 'recommended — shape it by chatting' },
           { value: 'library', label: 'From the NanoClaw template library', hint: 'prebuilt agents' },
           { value: 'local', label: 'From local templates', hint: 'templates/ in this install' },
         ],
@@ -1109,14 +1118,20 @@ async function chooseTemplate(templates: TemplateEntry[]): Promise<string | unde
   return ref === BACK_TO_TEMPLATE_SOURCE ? undefined : ref;
 }
 
-async function installSelectedTemplateAgent(provider?: string): Promise<void> {
+type TemplateAgentOutcome = 'none' | 'channel-target' | 'restamped';
+type TemplateSetupOperation =
+  | TemplateOperation
+  | { kind: 'connect'; agentGroupId: string };
+
+async function installSelectedTemplateAgent(provider?: string): Promise<TemplateAgentOutcome> {
   const ref = process.env.NANOCLAW_TEMPLATE_PATH?.trim();
-  if (!ref || process.env.NANOCLAW_TEMPLATE_AGENT_ID?.trim()) return;
+  if (!ref) return 'none';
+  if (process.env.NANOCLAW_TEMPLATE_AGENT_ID?.trim()) return 'channel-target';
 
   // Only an explicit operator name overrides the template: the CLI's own
   // fallback chain (--name → the manifest's agentName → the folder leaf) must
   // stay reachable through the wizard, or a template's agentName is dead.
-  const name = process.env.NANOCLAW_AGENT_NAME?.trim() || undefined;
+  const presetName = process.env.NANOCLAW_AGENT_NAME?.trim() || undefined;
   const transport = new SocketTransport();
   const runNcl = async (command: string, args: Record<string, unknown>): Promise<unknown> => {
     const response = await transport.sendFrame({ id: randomUUID(), command, args });
@@ -1126,10 +1141,46 @@ async function installSelectedTemplateAgent(provider?: string): Promise<void> {
 
   const start = Date.now();
   phEmit('step_started', { step: 'template-agent' });
-  p.log.step(brandBody(`Installing the "${ref}" template…`));
   try {
+    const agents = await listTemplateAgents(ref, runNcl);
+    const operation = await chooseTemplateOperation(ref, agents);
+    if (!operation) {
+      clearTemplatePick();
+      setupLog.step('template-agent', 'success', Date.now() - start, { ref, cancelled: true });
+      phEmit('step_completed', { step: 'template-agent', status: 'success' });
+      p.log.info('No template changes made.');
+      return 'none';
+    }
+
+    if (operation.kind === 'connect') {
+      const group = agents.find((agent) => agent.id === operation.agentGroupId);
+      if (!group) throw new Error('Selected template agent no longer exists');
+      clearTemplatePick();
+      process.env.NANOCLAW_TEMPLATE_AGENT_ID = group.id;
+      process.env.NANOCLAW_AGENT_NAME = group.name;
+      setupLog.step('template-agent', 'success', Date.now() - start, {
+        ref,
+        agent_group_id: group.id,
+        operation: 'connect',
+      });
+      phEmit('step_completed', { step: 'template-agent', status: 'success' });
+      p.log.success(`Ready to connect agent "${group.name}".`);
+      return 'channel-target';
+    }
+
+    const name =
+      operation.kind === 'create' && agents.length > 0
+        ? await askNewTemplateAgentName(agents, presetName)
+        : presetName;
+
+    p.log.step(
+      brandBody(
+        operation.kind === 'create' ? `Installing the "${ref}" template…` : `Preparing the "${ref}" template update…`,
+      ),
+    );
     const result = await installTemplateAgent({
       ref,
+      operation,
       name,
       timezone: readEnvKey('TZ') ?? undefined,
       provider,
@@ -1143,7 +1194,7 @@ async function installSelectedTemplateAgent(provider?: string): Promise<void> {
               `Agent "${plan.group.name}" is already stamped from this template. Update it in place? ` +
               `${resets.length} plugin-owned surface${resets.length === 1 ? '' : 's'} will be reset` +
               (customized > 0 ? ` (${customized} with local edits that will be lost)` : '') +
-              '. Memory, chats, and wiring are kept.',
+              '. Provider, memory, chats, and wiring are kept.',
             initialValue: customized === 0,
           }),
         );
@@ -1152,35 +1203,38 @@ async function installSelectedTemplateAgent(provider?: string): Promise<void> {
       },
     });
 
-    if (result.status === 'kept') {
-      process.env.NANOCLAW_TEMPLATE_AGENT_ID = result.group.id;
-      process.env.NANOCLAW_AGENT_NAME = result.group.name;
+    if (result.status === 'cancelled') {
+      clearTemplatePick();
       setupLog.step('template-agent', 'success', Date.now() - start, {
         ref,
-        agent_group_id: result.group.id,
-        kept: true,
+        cancelled: true,
       });
       phEmit('step_completed', { step: 'template-agent', status: 'success' });
-      p.log.success(`Keeping agent "${result.group.name}" as-is — local edits preserved. Wiring it unchanged.`);
-      return;
+      p.log.info('Template update cancelled. The agent was left unchanged.');
+      return 'none';
     }
 
-    // The pick is NOT cleared here: it must survive until the wire that
-    // consumes the stamped agent succeeds (run-channel-skill), or a rerun
-    // after a failed channel step silently wires a fresh vanilla agent while
-    // this one sits orphaned. Contract comment: setup/templates.ts.
-    process.env.NANOCLAW_TEMPLATE_AGENT_ID = result.group.id;
-    process.env.NANOCLAW_AGENT_NAME = result.group.name;
     setupLog.step('template-agent', 'success', Date.now() - start, {
       ref,
       agent_group_id: result.group.id,
     });
     phEmit('step_completed', { step: 'template-agent', status: 'success' });
-    p.log.success(
-      result.status === 'updated'
-        ? `Template agent "${result.group.name}" updated in place.`
-        : `Template agent "${result.group.name}" created.`,
-    );
+    if (result.status === 'updated') {
+      // Restamping preserves wiring, so it has no deferred channel work and
+      // must not make the channel step consume this existing agent as "new".
+      clearTemplatePick();
+      p.log.success(`Template agent "${result.group.name}" updated in place.`);
+      return 'restamped';
+    }
+
+    // The id is intentionally one-run-only. A later setup derives unwired
+    // agents from ncl and offers an explicit Connect action instead of silently
+    // targeting whatever id a previous run left behind.
+    clearTemplatePick();
+    process.env.NANOCLAW_TEMPLATE_AGENT_ID = result.group.id;
+    process.env.NANOCLAW_AGENT_NAME = result.group.name;
+    p.log.success(`Template agent "${result.group.name}" created.`);
+    return 'channel-target';
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     setupLog.step('template-agent', 'failed', Date.now() - start, { ref, error: message });
@@ -1200,7 +1254,63 @@ async function installSelectedTemplateAgent(provider?: string): Promise<void> {
       ].join('\n'),
       'Skipping the template',
     );
+    return 'none';
   }
+}
+
+async function chooseTemplateOperation(
+  ref: string,
+  agents: readonly SetupTemplateAgent[],
+): Promise<TemplateSetupOperation | undefined> {
+  if (agents.length === 0) return { kind: 'create' };
+
+  const options = agents.flatMap((agent) => [
+    ...(agent.isWired
+      ? []
+      : [{
+          value: { kind: 'connect', agentGroupId: agent.id } as const,
+          label: `Connect "${agent.name}" to a channel`,
+          hint: `groups/${agent.folder} · not connected`,
+        }]),
+    {
+      value: { kind: 'restamp', agentGroupId: agent.id } as const,
+      label: `Update "${agent.name}" in place`,
+      hint: `groups/${agent.folder} · keeps provider, memory, chats, and wiring`,
+    },
+  ]);
+  const choice = ensureAnswer(
+    await brightSelect<TemplateSetupOperation | { kind: 'cancel' }>({
+      message: `The "${ref}" template is already in use. What would you like to do?`,
+      options: [
+        ...options,
+        { value: { kind: 'create' }, label: 'Create another agent' },
+        { value: { kind: 'cancel' }, label: 'Cancel' },
+      ],
+      initialValue: options[0].value,
+    }),
+  ) as TemplateSetupOperation | { kind: 'cancel' };
+  setupLog.userInput(
+    'template_operation',
+    'agentGroupId' in choice ? `${choice.kind}:${choice.agentGroupId}` : choice.kind,
+  );
+  return choice.kind === 'cancel' ? undefined : choice;
+}
+
+async function askNewTemplateAgentName(
+  agents: readonly AgentGroup[],
+  initialValue?: string,
+): Promise<string> {
+  const answer = ensureAnswer(
+    await p.text({
+      message: 'Name the new agent',
+      placeholder: 'e.g. EMEA Sales',
+      ...(initialValue ? { initialValue } : {}),
+      validate: (value) => validateNewTemplateAgentName(value, agents),
+    }),
+  );
+  const name = (answer as string).trim();
+  setupLog.userInput('template_agent_name', name);
+  return name;
 }
 
 /**

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -227,9 +227,9 @@ export interface ChannelSkillOverrides extends Partial<RunSkillOptions> {
   /** The shared wire; defaults to init-first-agent. Injectable for tests. */
   wire?: (args: WireArgs) => Promise<boolean> | boolean;
   /**
-   * Clears the persisted template pick once the wire consumed the stamped
-   * agent; defaults to the real .env writer (setup/templates.ts). Injectable
-   * so tests never touch the repo's .env.
+   * Clears any persisted template pick after a targeted wire. Modern setup
+   * clears it when the operator chooses an action; this remains idempotent for
+   * re-exec and direct-driver paths. Injectable so tests never touch .env.
    */
   clearTemplatePick?: () => void;
   /**
@@ -389,11 +389,8 @@ export async function runChannelSkill(
       'You can retry later with `/init-first-agent`.',
     );
   }
-  // This wire is the seam that consumes the template pick: only now has the
-  // pick done its job. Clearing earlier (at stamp time) orphans the agent on
-  // a rerun after a failed channel step; never clearing makes every future
-  // setup run re-enter template setup. Pinned by run-channel-skill.test.ts
-  // ("clears the template pick…").
+  // Idempotently clear any legacy/re-exec template pick after the targeted
+  // wire succeeds. Pinned by run-channel-skill.test.ts.
   if (templateAgentGroupId) (overrides.clearTemplatePick ?? clearTemplatePick)();
 }
 

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -106,8 +106,8 @@ export const CONFIG: Entry[] = [
   },
   {
     key: 'templatePath',
-    label: 'First-agent template',
-    help: 'Create the first agent from a local template ref under templates/ (for example, sales/sdr).',
+    label: 'Agent template',
+    help: 'Create or update an agent from a local template ref under templates/ (for example, sales/sdr).',
     surface: 'flag+ui',
     group: 'Agent',
     type: 'string',

--- a/setup/templates.test.ts
+++ b/setup/templates.test.ts
@@ -31,19 +31,28 @@ vi.mock('../src/log.js', () => ({
   log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
 }));
 
-import { closeDb, initTestDb, runMigrations } from '../src/db/index.js';
+import {
+  closeDb,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  initTestDb,
+  runMigrations,
+} from '../src/db/index.js';
 import { MCP_SCHEMA_URL, PLUGIN_SCHEMA_URL } from '../src/templates/manifest.js';
 import { NANOCLAW_EXTENSION_NS } from '../src/templates/extension.js';
 import { dispatch } from '../src/cli/dispatch.js';
 // Side-effect import: registers the `groups-*` commands for the contract test.
 import '../src/cli/resources/groups.js';
+import '../src/cli/resources/wirings.js';
 import type { AgentGroup } from '../src/types.js';
 import {
   applyTemplatePick,
   clearTemplatePick,
   copyTemplate,
   installTemplateAgent,
+  listTemplateAgents,
   listTemplatesFromDir,
+  validateNewTemplateAgentName,
   type TemplateReplacePlan,
 } from './templates.js';
 
@@ -87,6 +96,22 @@ describe('setup template library', () => {
     expect(() => listTemplatesFromDir(source)).toThrow(/predate the plugin format.*sales\/sdr.*Re-fetch/s);
   });
 
+  it('requires a distinct name only when setup creates another template agent', () => {
+    const agents: AgentGroup[] = [
+      {
+        id: 'ag-existing',
+        name: 'EMEA Sales',
+        folder: 'emea-sales',
+        agent_provider: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+
+    expect(validateNewTemplateAgentName('', agents)).toBe('Required');
+    expect(validateNewTemplateAgentName('  emea sales  ', agents)).toContain('different name');
+    expect(validateNewTemplateAgentName('US Sales', agents)).toBeUndefined();
+  });
+
   it('creates through ncl and applies the provider', async () => {
     const created: AgentGroup = {
       id: 'ag-new',
@@ -98,6 +123,7 @@ describe('setup template library', () => {
     const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
     const result = await installTemplateAgent({
       ref: 'sales/sdr',
+      operation: { kind: 'create' },
       name: 'SDR',
       timezone: 'Asia/Jerusalem',
       provider: 'codex',
@@ -115,7 +141,7 @@ describe('setup template library', () => {
     expect(calls).toEqual([
       {
         command: 'groups-create',
-        args: { template: 'sales/sdr', name: 'SDR', timezone: 'Asia/Jerusalem' },
+        args: { template: 'sales/sdr', new: true, name: 'SDR', timezone: 'Asia/Jerusalem' },
       },
       {
         command: 'groups-config-update',
@@ -143,10 +169,11 @@ describe('setup template library', () => {
     };
     const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
     let confirmed: TemplateReplacePlan | undefined;
-    // No operator name: the create call must omit it entirely so the CLI's
-    // fallback to the template's own agentName stays reachable.
+    // Restamping must ignore create-only settings, including provider.
     const result = await installTemplateAgent({
       ref: 'sales/sdr',
+      operation: { kind: 'restamp', agentGroupId: 'ag-old' },
+      provider: 'codex',
       runNcl: async (command, args) => {
         calls.push({ command, args });
         if (command === 'groups-create') return args.yes ? { ...plan, applied: true } : plan;
@@ -161,16 +188,15 @@ describe('setup template library', () => {
     expect(result).toEqual({ status: 'updated', group: stamped });
     expect(confirmed?.changes).toEqual(plan.changes);
     expect(calls).toEqual([
-      { command: 'groups-create', args: { template: 'sales/sdr' } },
+      { command: 'groups-create', args: { template: 'sales/sdr', id: 'ag-old' } },
       { command: 'groups-create', args: { template: 'sales/sdr', id: 'ag-old', yes: true } },
       { command: 'groups-restart', args: { id: 'ag-old' } },
     ]);
   });
 
-  // Declining the reset keeps the customized group untouched but still
-  // returns it, so the wizard wires it as-is instead of orphaning it. No
-  // apply, no provider update, no restart — declining means zero mutations.
-  it('keeps the group untouched (and usable) when the update plan is declined', async () => {
+  // Declining is a real cancel: the existing group must not be returned as a
+  // newly-created agent for the channel step to consume.
+  it('cancels without mutating or returning the existing group when the update is declined', async () => {
     const stamped: AgentGroup = {
       id: 'ag-old',
       name: 'SDR',
@@ -181,6 +207,7 @@ describe('setup template library', () => {
     const calls: string[] = [];
     const result = await installTemplateAgent({
       ref: 'sales/sdr',
+      operation: { kind: 'restamp', agentGroupId: 'ag-old' },
       name: 'SDR',
       provider: 'claude',
       runNcl: async (command) => {
@@ -190,7 +217,7 @@ describe('setup template library', () => {
       confirmReplace: async () => false,
     });
 
-    expect(result).toEqual({ status: 'kept', group: stamped });
+    expect(result).toEqual({ status: 'cancelled' });
     expect(calls).toEqual(['groups-create']);
   });
 
@@ -275,6 +302,7 @@ describe('setup templates ncl contract (real dispatch)', () => {
   it('parses the real create result and the real rerun update plan', async () => {
     const fresh = await installTemplateAgent({
       ref: 'sales/sdr',
+      operation: { kind: 'create' },
       name: 'SDR',
       runNcl,
       confirmReplace: async () => {
@@ -287,6 +315,7 @@ describe('setup templates ncl contract (real dispatch)', () => {
     let plan: TemplateReplacePlan | undefined;
     const rerun = await installTemplateAgent({
       ref: 'sales/sdr',
+      operation: { kind: 'restamp', agentGroupId: fresh.group.id },
       name: 'SDR',
       runNcl,
       confirmReplace: async (p) => {
@@ -297,5 +326,78 @@ describe('setup templates ncl contract (real dispatch)', () => {
     expect(rerun).toMatchObject({ status: 'updated', group: { id: fresh.group.id } });
     expect(plan?.group.id).toBe(fresh.group.id);
     expect(plan?.changes.length).toBeGreaterThan(0);
+  });
+
+  it('lists every matching agent with wiring state so setup can connect, restamp, or create another', async () => {
+    const first = await installTemplateAgent({
+      ref: 'sales/sdr',
+      operation: { kind: 'create' },
+      runNcl,
+      confirmReplace: async () => {
+        throw new Error('no plan expected on create');
+      },
+    });
+    const second = await installTemplateAgent({
+      ref: 'sales/sdr',
+      operation: { kind: 'create' },
+      runNcl,
+      confirmReplace: async () => {
+        throw new Error('no plan expected on create');
+      },
+    });
+    if (first.status !== 'installed' || second.status !== 'installed') {
+      throw new Error('expected two installed agents');
+    }
+
+    let carriers = await listTemplateAgents('sales/sdr', runNcl);
+    expect(new Map(carriers.map((group) => [group.id, group.isWired]))).toEqual(
+      new Map([
+        [first.group.id, false],
+        [second.group.id, false],
+      ]),
+    );
+
+    await createMessagingGroup({
+      id: 'mg-template-test',
+      channel_type: 'test',
+      platform_id: 'test:owner',
+      name: 'Owner',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: '2026-01-03T00:00:00.000Z',
+    });
+    await createMessagingGroupAgent({
+      id: 'mga-template-test',
+      messaging_group_id: 'mg-template-test',
+      agent_group_id: second.group.id,
+      engage_mode: 'mention',
+      engage_pattern: null,
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: '2026-01-03T00:00:00.000Z',
+    });
+
+    carriers = await listTemplateAgents('sales/sdr', runNcl);
+    expect(new Map(carriers.map((group) => [group.id, group.isWired]))).toEqual(
+      new Map([
+        [first.group.id, false],
+        [second.group.id, true],
+      ]),
+    );
+
+    let target: string | undefined;
+    const updated = await installTemplateAgent({
+      ref: 'sales/sdr',
+      operation: { kind: 'restamp', agentGroupId: second.group.id },
+      runNcl,
+      confirmReplace: async (plan) => {
+        target = plan.group.id;
+        return true;
+      },
+    });
+    expect(updated).toMatchObject({ status: 'updated', group: { id: second.group.id } });
+    expect(target).toBe(second.group.id);
   });
 });

--- a/setup/templates.ts
+++ b/setup/templates.ts
@@ -5,20 +5,17 @@ import os from 'os';
 import path from 'path';
 
 import { resolveLocalTemplate } from '../src/templates/local-dir.js';
+import { groupsCarryingPlugin } from '../src/templates/restamp.js';
 import type { AgentGroup } from '../src/types.js';
 import { upsertEnvVar } from './set-env.js';
 
 export const DEFAULT_TEMPLATES_SOURCE = 'https://github.com/nanocoai/nanoclaw-templates';
 
 // The template pick lives in process.env for this run AND in .env for the
-// next: the wizard re-execs itself (`sg docker`, fail-retry) and a rerun over
-// a partial install must not lose the choice. It deliberately survives stamp
-// success, channel skip, and any failure — only the wire that consumes the
-// stamped agent (run-channel-skill), the operator declining it, or an invalid
-// preset clears it. The agent group id itself is never persisted: each run
-// re-derives it from the pick (`groups create --template` resolves the
-// existing group through its plugin carrier — groupsCarryingPlugin — instead
-// of creating a duplicate), so a stale id can never override a fresh choice.
+// next: the wizard can re-exec itself (`sg docker`, fail-retry) before the
+// selected operation runs. Every completed operation clears the pick; setup
+// derives later connect/update choices from ncl instead of persisting an agent
+// id that could accidentally target a future setup run.
 export function applyTemplatePick(ref: string): void {
   process.env.NANOCLAW_TEMPLATE_PATH = ref;
   upsertEnvVar('NANOCLAW_TEMPLATE_PATH', ref);
@@ -44,8 +41,11 @@ type RunNcl = (command: string, args: Record<string, unknown>) => Promise<unknow
 export type TemplateAgentInstallResult =
   | { status: 'installed'; group: AgentGroup }
   | { status: 'updated'; group: AgentGroup }
-  /** Update plan declined: the stamped group is untouched but still usable. */
-  | { status: 'kept'; group: AgentGroup };
+  | { status: 'cancelled' };
+
+export type TemplateOperation = { kind: 'create' } | { kind: 'restamp'; agentGroupId: string };
+
+export type SetupTemplateAgent = AgentGroup & { isWired: boolean };
 
 /** One plugin-owned surface from the dry-run update plan `groups create --template` returns. */
 export interface TemplateChange {
@@ -64,12 +64,38 @@ export interface TemplateReplacePlan {
 
 export interface TemplateAgentInstallOptions {
   ref: string;
+  operation: TemplateOperation;
   /** Explicit operator name. Omit to let the CLI fall back to the template's own agentName. */
   name?: string;
   timezone?: string;
   provider?: string;
   runNcl: RunNcl;
   confirmReplace: (plan: TemplateReplacePlan) => Promise<boolean>;
+}
+
+/** Resolve template agents and their wiring state through canonical ncl data. */
+export async function listTemplateAgents(ref: string, runNcl: RunNcl): Promise<SetupTemplateAgent[]> {
+  const groupRows = await runNcl('groups-list', { limit: Number.MAX_SAFE_INTEGER });
+  if (!Array.isArray(groupRows)) throw new Error('ncl returned an invalid agent group list');
+  const wiringRows = await runNcl('wirings-list', { limit: Number.MAX_SAFE_INTEGER });
+  if (!Array.isArray(wiringRows)) throw new Error('ncl returned an invalid wiring list');
+
+  const wiredAgentIds = new Set(wiringRows.map(parseWiringAgentGroupId));
+  const groups = await groupsCarryingPlugin(ref, groupRows.map(parseAgentGroup));
+  return groups.map((group) => ({ ...group, isWired: wiredAgentIds.has(group.id) }));
+}
+
+/** Validation used only after the operator chooses "Create another agent". */
+export function validateNewTemplateAgentName(
+  value: string | undefined,
+  agents: readonly AgentGroup[],
+): string | undefined {
+  const name = (value ?? '').trim();
+  if (!name) return 'Required';
+  if (agents.some((agent) => agent.name.toLowerCase() === name.toLowerCase())) {
+    return 'Choose a different name so you can tell these agents apart';
+  }
+  return undefined;
 }
 
 // A directory is a template iff it is an Agent Plugins directory — the
@@ -145,42 +171,43 @@ export function copyTemplate(srcDir: string, ref: string, destDir: string): stri
 
 /**
  * Stamp the setup-selected template through the same ncl command used after
- * setup. `groups create --template` decides what happens: a fresh stamp when
- * no group carries the plugin, or (on a rerun over a partial install) a
- * dry-run update plan for the group that does. The plan goes to
- * `confirmReplace`; on yes, the same command applies it with --yes and the
- * group restarts so skill/MCP changes take effect. In-place updates never
- * touch memory, sessions, wiring, or anything else the plugin does not own.
+ * setup. The caller supplies an explicit create or targeted-restamp operation;
+ * the CLI remains the sole owner of applying it. Restamps dry-run first, apply
+ * only after confirmation, and restart so skill/MCP changes take effect.
  */
 export async function installTemplateAgent(options: TemplateAgentInstallOptions): Promise<TemplateAgentInstallResult> {
+  if (options.operation.kind === 'create') {
+    const created = await options.runNcl('groups-create', {
+      template: options.ref,
+      new: true,
+      ...(options.name ? { name: options.name } : {}),
+      ...(options.timezone ? { timezone: options.timezone } : {}),
+    });
+    if (parseReplacePlan(created)) throw new Error('ncl returned an update plan for a new template agent');
+    const group = parseAgentGroup(created);
+    if (options.provider) {
+      await options.runNcl('groups-config-update', { id: group.id, provider: options.provider });
+    }
+    return { status: 'installed', group };
+  }
+
   const first = await options.runNcl('groups-create', {
     template: options.ref,
-    ...(options.name ? { name: options.name } : {}),
-    ...(options.timezone ? { timezone: options.timezone } : {}),
+    id: options.operation.agentGroupId,
   });
-
-  let group: AgentGroup;
   const plan = parseReplacePlan(first);
-  if (plan) {
-    // Declining the reset means "don't touch my edits", not "abandon my
-    // agent": the untouched group is returned so the wizard can wire it as-is
-    // (provider update and restart are skipped — those are mutations too).
-    if (!(await options.confirmReplace(plan))) return { status: 'kept', group: plan.group };
-    const applied = parseReplacePlan(
-      await options.runNcl('groups-create', { template: options.ref, id: plan.group.id, yes: true }),
-    );
-    if (!applied?.applied) throw new Error('ncl did not apply the template update');
-    group = applied.group;
-  } else {
-    group = parseAgentGroup(first);
+  if (!plan || plan.group.id !== options.operation.agentGroupId) {
+    throw new Error('ncl did not return the requested template update plan');
   }
+  if (!(await options.confirmReplace(plan))) return { status: 'cancelled' };
 
-  if (options.provider) {
-    await options.runNcl('groups-config-update', { id: group.id, provider: options.provider });
-  }
-  if (plan) await options.runNcl('groups-restart', { id: group.id });
+  const applied = parseReplacePlan(
+    await options.runNcl('groups-create', { template: options.ref, id: plan.group.id, yes: true }),
+  );
+  if (!applied?.applied) throw new Error('ncl did not apply the template update');
+  await options.runNcl('groups-restart', { id: applied.group.id });
 
-  return { status: plan ? 'updated' : 'installed', group };
+  return { status: 'updated', group: applied.group };
 }
 
 /**
@@ -225,6 +252,13 @@ function parseAgentGroup(value: unknown): AgentGroup {
     throw new Error('ncl returned an invalid agent group');
   }
   return { id, name, folder, agent_provider: provider ?? null, created_at: createdAt };
+}
+
+function parseWiringAgentGroupId(value: unknown): string {
+  if (!isRecord(value) || typeof value.agent_group_id !== 'string') {
+    throw new Error('ncl returned an invalid wiring');
+  }
+  return value.agent_group_id;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/templates/restamp.ts
+++ b/src/templates/restamp.ts
@@ -63,7 +63,7 @@ export interface RestampResult {
  * manifest (the full walk/caps/lint pass runs in the stamp it gates, not in
  * this probe).
  */
-export async function groupsCarryingPlugin(ref: string): Promise<AgentGroup[]> {
+export async function groupsCarryingPlugin(ref: string, groups?: readonly AgentGroup[]): Promise<AgentGroup[]> {
   const dir = resolveLocalTemplate(ref);
   const manifestPath = path.join(dir, PLUGIN_MANIFEST_FILE);
   // The fast path reads ONLY a regular manifest file. Anything else — absent
@@ -74,7 +74,7 @@ export async function groupsCarryingPlugin(ref: string): Promise<AgentGroup[]> {
     parseTemplate(dir);
   }
   const manifest = parsePluginManifest(JSON.parse(fs.readFileSync(manifestPath, 'utf-8')));
-  return (await getAllAgentGroups()).filter((g) =>
+  return (groups ?? (await getAllAgentGroups())).filter((g) =>
     fs.existsSync(path.join(resolveGroupFolderPath(g.folder), 'plugins', manifest.name, PLUGIN_MANIFEST_FILE)),
   );
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Existing NanoClaw installs stopped offering the template flow after agents were registered, leaving create-again and in-place restamp available only through `ncl`.

This restores templates in setup and reuses the existing group, wiring, and template command seams. For a template already in use, setup now offers explicit Connect, Update, Create another, and Cancel actions. Existing agents are identified by `groups/<folder>`; only Create another asks for a distinct name. A created-but-unwired agent remains available for manual `ncl` wiring without persisting or locking its ID into a later setup run. Restamping targets the selected agent and preserves its provider, memory, chats, and wiring.

Usage: run `bash nanoclaw.sh`, select a library or local template, then choose the desired action.


## Testing

- Manual E2E existing-install flow in a disposable worktree
- `pnpm exec vitest run setup/templates.test.ts setup/channels/run-channel-skill.test.ts src/cli/resources/groups-plugin-guard.test.ts setup/lib/setup-config-parse.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- Independent Amit/Gavriel review found no blockers or suggestions

