### PR TITLE
fix(slack): restore agent flow after mailbox refactor

### DIFF
--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -210,7 +210,7 @@ pnpm exec vitest run src/modules/slack-agent-flow src/modules/slack-room-members
 ```
 
 ```nc:run effect:test
-source "$PWD/setup/lib/install-slug.sh" && "${CONTAINER_RUNTIME:-docker}" run --rm --entrypoint bun --workdir /app --volume "$PWD/container/agent-runner/src:/app/src:ro" "$(container_image_base):latest" test src/mcp-tools/rooms.test.ts src/mcp-tools/canvas.test.ts
+source "$PWD/setup/lib/install-slug.sh" && "${CONTAINER_RUNTIME:-docker}" run --rm --entrypoint bun --workdir /app --volume "$PWD/container/agent-runner/src:/app/src:ro" "$(container_image_base):latest" test --preload /app/src/modules/index.ts src/mcp-tools/rooms.test.ts src/mcp-tools/canvas.test.ts
 ```
 
 ### 9. Restart the host

--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -57,15 +57,15 @@ test -f src/channels/slack.ts && test -f src/channels/slack-lib.ts && test -f sr
 ### 2. Check the trunk extension seams
 
 Everything this flow plugs into is standard trunk API — the adapter hot-start
-entry, the delivery batch preview, the create-agent notify option, the
-decline-and-notify overrides, the container tool-extension hook, and the setup
-wizard's channel registries. This is a trunk **version requirement, not an
-edit**: if the check below fails, the NanoClaw trunk is too old for this skill
-— bring the install up to date (`/update-nanoclaw`) instead of patching any of
-these files by hand:
+entry, the delivery batch preview, the mailbox delivery/session helpers, the
+create-agent notify option, the decline-and-notify overrides, the container
+tool-extension hook, and the setup wizard's channel registries. This is a
+trunk **version requirement, not an edit**: if the check below fails, the
+NanoClaw trunk is too old for this skill — bring the install up to date
+(`/update-nanoclaw`) instead of patching any of these files by hand:
 
 ```nc:run effect:check
-grep -q "export async function startChannelAdapter" src/channels/channel-registry.ts && grep -q "export function registerDeliveryBatchPreview" src/delivery.ts && grep -q "suppressCreatedNotify" src/modules/agent-to-agent/create-agent.ts && grep -q "dedupeKey?: string" src/modules/permissions/sender-approval.ts && grep -q "declineText?: string" src/modules/permissions/sender-approval.ts && grep -q "fyiText?: string" src/modules/permissions/sender-approval.ts && grep -q "export function extendTool" container/agent-runner/src/mcp-tools/server.ts && grep -q "export function registerChannelPreStep" setup/channels/companions.ts && grep -q "instructions.md" src/claude-md-compose.ts && grep -q "await action.decide" src/guard/guard.ts
+grep -q "export async function startChannelAdapter" src/channels/channel-registry.ts && grep -q "export function registerDeliveryBatchPreview" src/delivery.ts && grep -q "session: Session) => Promise<void>" src/delivery.ts && grep -q "trigger?: boolean" src/session-manager.ts && grep -q "findCliResponse" container/agent-runner/src/db/messages-in.ts && grep -q "Promise<number>" container/agent-runner/src/db/messages-out.ts && grep -q "suppressCreatedNotify" src/modules/agent-to-agent/create-agent.ts && grep -q "dedupeKey?: string" src/modules/permissions/sender-approval.ts && grep -q "declineText?: string" src/modules/permissions/sender-approval.ts && grep -q "fyiText?: string" src/modules/permissions/sender-approval.ts && grep -q "export function extendTool" container/agent-runner/src/mcp-tools/server.ts && grep -q "export function registerChannelPreStep" setup/channels/companions.ts && grep -q "instructions.md" src/claude-md-compose.ts && grep -q "await action.decide" src/guard/guard.ts
 ```
 
 The last term requires an async-capable guard seam: the flow's `create_agent`
@@ -273,6 +273,7 @@ bash setup/lib/restart.sh
   It runs outside the host process, so it cannot hot-start the adapter:
   `--restart` runs `bash setup/lib/restart.sh` for you, otherwise it prints
   the restart instruction.
+
 - **Setup-wizard leg.** On a trunk new enough for step 2's check, running
   `bash nanoclaw.sh --slack-agents` does the whole install: the flag registers
   the managed-provisioning pre-step and the companion list

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
-import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../db/connection.js';
+import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
 import { createAgent } from './agents.js';
 import { addToRoom, createRoom } from './rooms.js';
 

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
@@ -43,7 +43,7 @@ export const createRoom: McpToolDefinition = {
   tool: {
     name: 'create_room',
     description:
-      'Open ONE shared Slack room (group conversation) with the user and several agents at once — the team primitive. Use after creating the agents (create_agent with room:\'none\' for teams): one room with ALL of them, never one room per agent. May require admin approval. Fire-and-forget: the call returns immediately; you will get a system note when the room is live, telling you how to post the intro there.',
+      "Open ONE shared Slack room (group conversation) with the user and several agents at once — the team primitive. Use after creating the agents (create_agent with room:'none' for teams): one room with ALL of them, never one room per agent. May require admin approval. Fire-and-forget: the call returns immediately; you will get a system note when the room is live, telling you how to post the intro there.",
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -74,7 +74,7 @@ export const createRoom: McpToolDefinition = {
     if (agents.length === 0) return err('agents must list at least one agent name');
 
     const requestId = generateId();
-    writeMessageOut({
+    await writeMessageOut({
       id: requestId,
       kind: 'system',
       content: JSON.stringify({
@@ -82,7 +82,9 @@ export const createRoom: McpToolDefinition = {
         requestId,
         name,
         agents,
-        ...(typeof args.purpose === 'string' && args.purpose.trim() ? { purpose: (args.purpose as string).trim() } : {}),
+        ...(typeof args.purpose === 'string' && args.purpose.trim()
+          ? { purpose: (args.purpose as string).trim() }
+          : {}),
         ...(args.include_me === false ? { include_me: false } : {}),
       }),
     });
@@ -113,7 +115,7 @@ export const addToRoom: McpToolDefinition = {
     if (!agent) return err('agent is required');
 
     const requestId = generateId();
-    writeMessageOut({
+    await writeMessageOut({
       id: requestId,
       kind: 'system',
       content: JSON.stringify({ action: 'add_to_room', requestId, room, agent }),

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -222,7 +222,7 @@ function notifyTexts(): string[] {
 async function runCreateAgent(content: Record<string, unknown>, session: Session = SLACK_SESSION): Promise<void> {
   const wrapped = getDeliveryAction('create_agent');
   expect(wrapped).toBeDefined();
-  await wrapped!(content, session, undefined as never);
+  await wrapped!(content, session);
 }
 
 function assertNoTokenLeak(): void {

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
@@ -179,7 +179,7 @@ async function runAction(
 ): Promise<void> {
   const wrapped = getDeliveryAction(action);
   expect(wrapped).toBeDefined();
-  await wrapped!({ action, ...content }, session, undefined as never);
+  await wrapped!({ action, ...content }, session);
 }
 
 function assertNoTokenLeak(): void {

--- a/container/agent-runner/src/mcp-tools/canvas.test.ts
+++ b/container/agent-runner/src/mcp-tools/canvas.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
-import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '../db/connection.js';
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
 import { canvasRead, canvasUpdate } from './canvas.js';
 
 function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {

--- a/container/agent-runner/src/mcp-tools/canvas.ts
+++ b/container/agent-runner/src/mcp-tools/canvas.ts
@@ -7,11 +7,10 @@
  * system note (a `canvas_response` inbound row).
  *
  * canvas_read is blocking (ncl / ask_user_question pattern): it writes a
- * `canvas_read` system action, then polls inbound.db by requestId for the
+ * `canvas_read` system action, then polls the mailbox by requestId for the
  * host's response row and returns the canvas text inline.
  */
-import { openInboundDb, getOutboundDb } from '../db/connection.js';
-import { markCompleted, type MessageInRow } from '../db/messages-in.js';
+import { findCliResponse, markCompleted } from '../db/messages-in.js';
 import { writeMessageOut } from '../db/messages-out.js';
 import { registerTools } from './server.js';
 import type { McpToolDefinition } from './types.js';
@@ -39,26 +38,6 @@ function sleep(ms: number): Promise<void> {
 const EDIT_OPS = ['append', 'replace_section', 'insert_after_section'] as const;
 type EditOp = (typeof EDIT_OPS)[number];
 
-/**
- * Find the host's canvas_response row for a requestId (findQuestionResponse
- * pattern — pending inbound row, not yet acked in processing_ack).
- */
-function findCanvasResponse(requestId: string): MessageInRow | undefined {
-  const inbound = openInboundDb();
-  const outbound = getOutboundDb();
-  try {
-    const response = inbound
-      .prepare("SELECT * FROM messages_in WHERE status = 'pending' AND content LIKE ?")
-      .get(`%"requestId":"${requestId}"%`) as MessageInRow | undefined;
-    if (!response) return undefined;
-    const acked = outbound.prepare('SELECT 1 FROM processing_ack WHERE message_id = ?').get(response.id);
-    if (acked) return undefined;
-    return response;
-  } finally {
-    inbound.close();
-  }
-}
-
 export const canvasUpdate: McpToolDefinition = {
   tool: {
     name: 'canvas_update',
@@ -80,8 +59,7 @@ export const canvasUpdate: McpToolDefinition = {
         markdown: { type: 'string', description: 'Markdown content for the edit' },
         section_text: {
           type: 'string',
-          description:
-            "Required for replace_section / insert_after_section: the target section's exact heading text",
+          description: "Required for replace_section / insert_after_section: the target section's exact heading text",
         },
       },
       required: ['canvas_id', 'op', 'markdown'],
@@ -100,7 +78,7 @@ export const canvasUpdate: McpToolDefinition = {
     }
 
     const requestId = generateId();
-    writeMessageOut({
+    await writeMessageOut({
       id: requestId,
       kind: 'system',
       content: JSON.stringify({
@@ -140,7 +118,7 @@ export const canvasRead: McpToolDefinition = {
     const timeout = ((args.timeout as number) || 20) * 1000;
 
     const requestId = generateId();
-    writeMessageOut({
+    await writeMessageOut({
       id: requestId,
       kind: 'system',
       content: JSON.stringify({
@@ -154,7 +132,7 @@ export const canvasRead: McpToolDefinition = {
 
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
-      const response = findCanvasResponse(requestId);
+      const response = findCliResponse(requestId);
       if (response) {
         markCompleted([response.id]);
         const parsed = JSON.parse(response.content) as {

--- a/src/modules/canvas-actions/canvas-actions.test.ts
+++ b/src/modules/canvas-actions/canvas-actions.test.ts
@@ -3,15 +3,17 @@
  * sequences, whole-doc replace unconstructible), token resolution, response
  * rows into inbound.db, and the HTML→text read-back.
  */
-import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
 import { createMessagingGroup } from '../../db/messaging-groups.js';
-import { INBOUND_SCHEMA } from '../../db/schema.js';
 import type { MessagingGroup, Session } from '../../types.js';
 import { editCanvas, htmlToReadableText, parseCanvasBlocks, resolveHeadingRegion } from './canvas-api.js';
 import { handleCanvasEdit, handleCanvasRead, resolveSessionBotToken } from './handlers.js';
+
+const { mockWriteSessionMessage } = vi.hoisted(() => ({ mockWriteSessionMessage: vi.fn() }));
+
+vi.mock('../../session-manager.js', () => ({ writeSessionMessage: mockWriteSessionMessage }));
 
 const NOW = new Date().toISOString();
 const MG_ID = 'mg-canvas';
@@ -45,17 +47,11 @@ function makeMg(overrides: Partial<MessagingGroup> = {}): MessagingGroup {
   };
 }
 
-function responseRows(
-  inDb: Database.Database,
-): Array<{ id: string; kind: string; trigger: number; content: Record<string, unknown> }> {
-  return (
-    inDb.prepare('SELECT id, kind, "trigger", content FROM messages_in ORDER BY seq').all() as Array<{
-      id: string;
-      kind: string;
-      trigger: number;
-      content: string;
-    }>
-  ).map((r) => ({ id: r.id, kind: r.kind, trigger: r.trigger, content: JSON.parse(r.content) }));
+function responseRows(): Array<{ id: string; kind: string; trigger: boolean; content: Record<string, unknown> }> {
+  return mockWriteSessionMessage.mock.calls.map((call) => {
+    const row = call[2] as { id: string; kind: string; trigger: boolean; content: string };
+    return { ...row, content: JSON.parse(row.content) };
+  });
 }
 
 /** The chat-note text of an edit-outcome row (canvas_edit notes are kind='chat'). */
@@ -69,14 +65,12 @@ function slackJson(body: Record<string, unknown>): Response {
 }
 
 const fetchMock = vi.fn();
-let inDb: Database.Database;
 
 beforeEach(async () => {
   const db = await initTestDb();
   await runMigrations(db);
   await createMessagingGroup(makeMg());
-  inDb = new Database(':memory:');
-  inDb.exec(INBOUND_SCHEMA);
+  mockWriteSessionMessage.mockReset();
   fetchMock.mockReset();
   vi.stubGlobal('fetch', fetchMock);
   process.env.SLACK_BOT_TOKEN_PIXEL = 'xoxb-pixel-token';
@@ -85,7 +79,6 @@ beforeEach(async () => {
 afterEach(async () => {
   delete process.env.SLACK_BOT_TOKEN_PIXEL;
   vi.unstubAllGlobals();
-  inDb.close();
   await closeDb();
 });
 
@@ -117,7 +110,6 @@ describe('handleCanvasEdit', () => {
     await handleCanvasEdit(
       { action: 'canvas_edit', requestId: 'req-1', canvas_id: 'F0C', op: 'append', markdown: '- [ ] new task' },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -129,10 +121,10 @@ describe('handleCanvasEdit', () => {
       { operation: 'insert_at_end', document_content: { type: 'markdown', markdown: '- [ ] new task' } },
     ]);
 
-    const rows = responseRows(inDb);
+    const rows = responseRows();
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe('canvas-resp-req-1');
-    expect(rows[0].trigger).toBe(0);
+    expect(rows[0].trigger).toBe(false);
     expect(editNoteText(rows[0])).toContain('Canvas edit applied');
   });
 
@@ -152,7 +144,6 @@ describe('handleCanvasEdit', () => {
         markdown: '## Tasks\n\n- [x] done',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -171,7 +162,7 @@ describe('handleCanvasEdit', () => {
         document_content: { type: 'markdown', markdown: '## Tasks\n\n- [x] done' },
       },
     ]);
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
   });
 
   it('insert_after_section falls back to insert_after with the looked-up id when the read-back fails', async () => {
@@ -190,7 +181,6 @@ describe('handleCanvasEdit', () => {
         markdown: '> We ship MPIM rooms.',
       },
       makeSession(),
-      inDb,
     );
 
     const [, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
@@ -204,12 +194,11 @@ describe('handleCanvasEdit', () => {
     await handleCanvasEdit(
       { action: 'canvas_edit', requestId: 'req-4', canvas_id: 'F0C', op: 'replace_section', markdown: 'boom' },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(1);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
     const note4 = editNoteText(rows[0]);
     expect(note4).toContain('Canvas edit FAILED');
     expect(note4).toContain('section_text');
@@ -230,26 +219,24 @@ describe('handleCanvasEdit', () => {
         markdown: 'x',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2); // failed files.info + lookup only
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(1);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
     expect(editNoteText(rows[0])).toContain('Nonexistent');
   });
 
-  it('a Slack API error becomes a trigger=1 error row', async () => {
+  it('a Slack API error becomes a triggering error row', async () => {
     fetchMock.mockResolvedValueOnce(slackJson({ ok: false, error: 'canvas_not_found' }));
 
     await handleCanvasEdit(
       { action: 'canvas_edit', requestId: 'req-6', canvas_id: 'F0C', op: 'append', markdown: 'x' },
       makeSession(),
-      inDb,
     );
 
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(1);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
     expect(editNoteText(rows[0])).toContain('canvas_not_found');
   });
 
@@ -284,12 +271,11 @@ describe('duplicate-heading guard (B4)', () => {
         markdown: '## Tasks\n\n- [x] done',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2); // files.info + download only — no lookup, no edit
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(1);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
     const guardNote = editNoteText(rows[0]);
     expect(guardNote).toContain('Canvas edit FAILED');
     expect(guardNote).toContain('replace_section');
@@ -308,11 +294,10 @@ describe('duplicate-heading guard (B4)', () => {
         markdown: '##   tasks  \n\n- [ ] again',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit FAILED');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit FAILED');
   });
 
   it('a non-duplicate heading passes through — region path, no lookup needed', async () => {
@@ -329,7 +314,6 @@ describe('duplicate-heading guard (B4)', () => {
         markdown: '## Retro notes\n\n- went well',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(3); // files.info, download, edit — section id from the read-back
@@ -339,7 +323,7 @@ describe('duplicate-heading guard (B4)', () => {
       operation: 'insert_after',
       section_id: 'temp:C:B',
     });
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
   });
 
   it('a failed read-back never blocks the edit (guard is best-effort)', async () => {
@@ -358,11 +342,10 @@ describe('duplicate-heading guard (B4)', () => {
         markdown: '## Tasks\n\n- [x] done',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(3); // files.info (failed), lookup, edit
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
   });
 
   it('markdown without a heading skips the read-back entirely', async () => {
@@ -371,11 +354,10 @@ describe('duplicate-heading guard (B4)', () => {
     await handleCanvasEdit(
       { action: 'canvas_edit', requestId: 'req-g5', canvas_id: 'F0C', op: 'append', markdown: '- [ ] plain item' },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1); // straight to canvases.edit
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
   });
 
   it('replace_section is exempt — replacing a section with its own heading is the point', async () => {
@@ -394,11 +376,10 @@ describe('duplicate-heading guard (B4)', () => {
         markdown: '## Tasks\n\n- [x] done',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(4); // files.info, download, replace, delete — no refusal
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
   });
 });
 
@@ -445,7 +426,6 @@ describe('heading-region ops (Slack sections are blocks, not regions)', () => {
         markdown: '## Open Questions\n\n- new list',
       },
       makeSession(),
-      inDb,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(6);
@@ -456,7 +436,7 @@ describe('heading-region ops (Slack sections are blocks, not regions)', () => {
       { operation: 'delete', section_id: 'temp:C:LI1' },
       { operation: 'delete', section_id: 'temp:C:NB' },
     ]);
-    expect(editNoteText(responseRows(inDb)[0])).toContain('Canvas edit applied');
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
   });
 
   it('insert_after_section lands after the LAST block of the region, not the heading', async () => {
@@ -473,7 +453,6 @@ describe('heading-region ops (Slack sections are blocks, not regions)', () => {
         markdown: 'A follow-up paragraph.',
       },
       makeSession(),
-      inDb,
     );
 
     expect(editBodies(2)[0]).toMatchObject({ operation: 'insert_after', section_id: 'temp:C:NB' });
@@ -493,7 +472,6 @@ describe('heading-region ops (Slack sections are blocks, not regions)', () => {
         markdown: 'Right under the Notes heading.',
       },
       makeSession(),
-      inDb,
     );
 
     expect(editBodies(2)[0]).toMatchObject({ operation: 'insert_after', section_id: 'temp:C:NOTES' });
@@ -515,11 +493,10 @@ describe('heading-region ops (Slack sections are blocks, not regions)', () => {
         markdown: '## Open Questions\n\n- new list',
       },
       makeSession(),
-      inDb,
     );
 
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(1);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
     const partialNote = editNoteText(rows[0]);
     expect(partialNote).toContain('partially applied');
     expect(partialNote).toContain('3 old block(s)');
@@ -557,11 +534,10 @@ describe('checklist tick-state platform limit', () => {
         markdown: '## Tasks\n\n- [x] done one\n- [ ] open one\n- [ ] new one',
       },
       makeSession(),
-      inDb,
     );
 
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(1); // warning must wake the agent
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true); // warning must wake the agent
     const note = editNoteText(rows[0]);
     expect(note).toContain('Canvas edit applied');
     expect(note).toContain('[x] states in your markdown were NOT applied');
@@ -593,11 +569,10 @@ describe('checklist tick-state platform limit', () => {
         markdown: '## Tasks\n\n- [ ] open one\n- [ ] new one',
       },
       makeSession(),
-      inDb,
     );
 
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(0);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(false);
     expect(editNoteText(rows[0])).toContain('Canvas edit applied');
   });
 });
@@ -626,7 +601,7 @@ describe('htmlToReadableText checklists', () => {
 });
 
 describe('handleCanvasRead', () => {
-  it('fetches files.info, downloads the HTML, and returns stripped text (trigger=0)', async () => {
+  it('fetches files.info, downloads the HTML, and returns stripped text without waking', async () => {
     fetchMock
       .mockResolvedValueOnce(
         slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
@@ -637,7 +612,7 @@ describe('handleCanvasRead', () => {
         }),
       );
 
-    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r1', canvas_id: 'F0C' }, makeSession(), inDb);
+    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r1', canvas_id: 'F0C' }, makeSession());
 
     const [infoUrl] = fetchMock.mock.calls[0] as [string];
     expect(infoUrl).toBe('https://slack.com/api/files.info?file=F0C');
@@ -645,8 +620,8 @@ describe('handleCanvasRead', () => {
     expect(dlUrl).toBe('https://files.slack.com/canvas.html');
     expect((dlInit.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-pixel-token');
 
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(0);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(false);
     expect(rows[0].content).toMatchObject({ type: 'canvas_response', requestId: 'req-r1', status: 'ok' });
     const text = (rows[0].content.result as { text: string }).text;
     expect(text).toContain('# Room');
@@ -654,13 +629,13 @@ describe('handleCanvasRead', () => {
     expect(text).not.toContain('temp:C:X');
   });
 
-  it('read failures come back as trigger=0 error rows (the tool is polling)', async () => {
+  it('read failures come back without waking (the tool is polling)', async () => {
     fetchMock.mockResolvedValueOnce(slackJson({ ok: false, error: 'file_not_found' }));
 
-    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r2', canvas_id: 'F0C' }, makeSession(), inDb);
+    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r2', canvas_id: 'F0C' }, makeSession());
 
-    const rows = responseRows(inDb);
-    expect(rows[0].trigger).toBe(0);
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(false);
     expect(rows[0].content).toMatchObject({ status: 'error' });
     expect((rows[0].content.result as { error: string }).error).toContain('file_not_found');
   });

--- a/src/modules/canvas-actions/handlers.ts
+++ b/src/modules/canvas-actions/handlers.ts
@@ -13,25 +13,23 @@
  *
  * - `canvas_read` outcomes are `kind:'system'` rows carrying `requestId`;
  *   the container tool polls inbound.db for exactly that row and consumes
- *   it. They are trigger=0 always (the requester is already polling) and
+ *   it. They never trigger a wake (the requester is already polling) and
  *   the poll loop deliberately filters system rows out of agent prompts.
  * - `canvas_edit` outcomes are `kind:'chat'` system notes (sender
  *   'system', channelType 'agent') — the membership-note shape. NOT
  *   `kind:'system'`: nothing polls for them, and the poll loop would
  *   filter them out of every batch, so the agent would never learn an
- *   edit failed (and an unconsumed trigger=1 system row keeps the session
+ *   edit failed (and an unconsumed triggering system row keeps the session
  *   permanently "due" for the host sweep — wake churn). As chat rows they
- *   render like any message: successes are trigger=0 (ambient, next
- *   wake); FAILURES are trigger=1 so the agent wakes to correct course —
+ *   render like any message: successes are non-triggering (ambient, next
+ *   wake); failures trigger so the agent wakes to correct course —
  *   it already told the user the edit was submitted.
  */
-import type Database from 'better-sqlite3';
-
 import { botTokenKeyForInstance } from '../../channels/slack-lib.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
-import { insertMessage } from '../../db/session-db.js';
 import { readEnvValue } from '../../env-file.js';
 import { log } from '../../log.js';
+import { writeSessionMessage } from '../../session-manager.js';
 import type { Session } from '../../types.js';
 import {
   editCanvas,
@@ -95,16 +93,16 @@ function readBackHeadings(text: string): Set<string> {
 }
 
 /** canvas_read outcome — a system row the container tool polls for by requestId. */
-function writeCanvasResponse(
-  inDb: Database.Database,
+async function writeCanvasResponse(
+  session: Session,
   args: {
     requestId: string;
     action: 'canvas_read';
     status: 'ok' | 'error';
     result: Record<string, unknown>;
   },
-): void {
-  insertMessage(inDb, {
+): Promise<void> {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `canvas-resp-${args.requestId}`,
     kind: 'system',
     timestamp: new Date().toISOString(),
@@ -120,17 +118,20 @@ function writeCanvasResponse(
     }),
     processAfter: null,
     recurrence: null,
-    trigger: 0,
+    trigger: false,
   });
 }
 
 /**
  * canvas_edit outcome — a renderable chat note (membership-note shape).
- * trigger=1 failures wake the agent with the reason; trigger=0 successes
+ * Triggering failures wake the agent with the reason; non-triggering successes
  * ride along as ambient context on the next wake.
  */
-function writeCanvasEditNote(inDb: Database.Database, args: { requestId: string; text: string; trigger: 0 | 1 }): void {
-  insertMessage(inDb, {
+async function writeCanvasEditNote(
+  session: Session,
+  args: { requestId: string; text: string; trigger: boolean },
+): Promise<void> {
+  await writeSessionMessage(session.agent_group_id, session.id, {
     id: `canvas-resp-${args.requestId}`,
     kind: 'chat',
     timestamp: new Date().toISOString(),
@@ -144,11 +145,7 @@ function writeCanvasEditNote(inDb: Database.Database, args: { requestId: string;
   });
 }
 
-export async function handleCanvasEdit(
-  content: Record<string, unknown>,
-  session: Session,
-  inDb: Database.Database,
-): Promise<void> {
+export async function handleCanvasEdit(content: Record<string, unknown>, session: Session): Promise<void> {
   const requestId =
     typeof content.requestId === 'string' && content.requestId ? content.requestId : `canvas-${Date.now()}`;
   const canvasId = typeof content.canvas_id === 'string' ? content.canvas_id : '';
@@ -159,36 +156,36 @@ export async function handleCanvasEdit(
   const editLabel = `${typeof op === 'string' && op ? op : 'canvas_edit'}${
     canvasId ? ` on canvas ${canvasId}` : ''
   }${sectionText ? `, section "${sectionText}"` : ''}`;
-  const fail = (message: string): void => {
+  const fail = async (message: string): Promise<void> => {
     log.warn('canvas_edit failed', { sessionId: session.id, requestId, error: message });
-    writeCanvasEditNote(inDb, {
+    await writeCanvasEditNote(session, {
       requestId,
       text: `Canvas edit FAILED (${editLabel}): ${message}`,
-      trigger: 1,
+      trigger: true,
     });
   };
-  const succeed = (note?: string): void => {
-    writeCanvasEditNote(inDb, {
+  const succeed = async (note?: string): Promise<void> => {
+    await writeCanvasEditNote(session, {
       requestId,
       text: `Canvas edit applied (${editLabel}).${note ? ` ${note}` : ''}`,
-      trigger: 0,
+      trigger: false,
     });
   };
 
   if (!canvasId || !markdown || !CANVAS_EDIT_OPS.includes(op)) {
-    fail(`canvas_edit needs canvas_id, markdown, and op (one of ${CANVAS_EDIT_OPS.join(', ')})`);
+    await fail(`canvas_edit needs canvas_id, markdown, and op (one of ${CANVAS_EDIT_OPS.join(', ')})`);
     return;
   }
   if (op !== 'append' && !sectionText) {
     // The safe-op invariant: a section-targeted op without lookup criteria
     // can never fall through to an unsectioned (whole-doc) replace.
-    fail(`${op} requires section_text (text the target section contains)`);
+    await fail(`${op} requires section_text (text the target section contains)`);
     return;
   }
 
   const auth = await resolveSessionBotToken(session);
   if ('error' in auth) {
-    fail(auth.error);
+    await fail(auth.error);
     return;
   }
 
@@ -211,7 +208,7 @@ export async function handleCanvasEdit(
   if (op !== 'replace_section' && html) {
     const newHeading = firstMarkdownHeading(markdown);
     if (newHeading && readBackHeadings(htmlToReadableText(html)).has(newHeading.toLowerCase())) {
-      fail(
+      await fail(
         `${op} refused: the canvas already has a "${newHeading}" section — inserting would create a duplicate heading. Use replace_section with section_text "${newHeading}" to update that section instead.`,
       );
       return;
@@ -221,7 +218,7 @@ export async function handleCanvasEdit(
   // Live-probed platform limit: canvases.edit markdown IGNORES `- [x]` —
   // every path (insert, section replace, item replace) lands unticked, so
   // tick state is UI-only and a checklist rewrite RESETS it. Landing the
-  // edit and hiding that would be a silent lie; the note is trigger=1 so
+  // edit and hiding that would be a silent lie; the note triggers so
   // the agent can adjust (item-level edits preserve ticks).
   const tickWarnings: string[] = [];
   if (/^\s*[-*]\s+\[[xX]\]\s/m.test(markdown)) {
@@ -229,15 +226,15 @@ export async function handleCanvasEdit(
       'the [x] states in your markdown were NOT applied — the canvas API cannot set tick state; those items landed unticked',
     );
   }
-  const finish = (note?: string): void => {
+  const finish = async (note?: string): Promise<void> => {
     if (tickWarnings.length === 0) {
-      succeed(note);
+      await succeed(note);
       return;
     }
-    writeCanvasEditNote(inDb, {
+    await writeCanvasEditNote(session, {
       requestId,
       text: `Canvas edit applied (${editLabel}), BUT ${tickWarnings.join('; also ')}.${note ? ` ${note}` : ''} To preserve or mark checklist state, edit items individually (see the canvas-work skill) and leave ticking to humans.`,
-      trigger: 1,
+      trigger: true,
     });
   };
 
@@ -245,7 +242,7 @@ export async function handleCanvasEdit(
     if (op === 'append') {
       await editCanvas(auth.token, canvasId, { operation: 'insert_at_end', markdown });
       log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
-      finish();
+      await finish();
       return;
     }
 
@@ -275,7 +272,7 @@ export async function handleCanvasEdit(
           deleted++;
         }
       } catch (err) {
-        fail(
+        await fail(
           `replace_section partially applied: the new content is in place but ${region.bodyIds.length - deleted} old block(s) of the previous section remain below it — read the canvas and remove the leftovers. Underlying error: ${err instanceof Error ? err.message : String(err)}`,
         );
         return;
@@ -287,7 +284,7 @@ export async function handleCanvasEdit(
         op,
         blocksReplaced: region.bodyIds.length + 1,
       });
-      finish(
+      await finish(
         region.hasUnaddressableBlocks
           ? 'Note: some blocks in the old section could not be addressed and were left in place — re-read to verify.'
           : undefined,
@@ -300,7 +297,7 @@ export async function handleCanvasEdit(
       // heading — inserting right after the heading splits the section body.
       await editCanvas(auth.token, canvasId, { operation: 'insert_after', sectionId: region.lastId, markdown });
       log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
-      finish();
+      await finish();
       return;
     }
 
@@ -308,7 +305,7 @@ export async function handleCanvasEdit(
     // single-block behavior via sections.lookup, as before.
     const sectionId = await lookupCanvasSection(auth.token, canvasId, sectionText);
     if (!sectionId) {
-      fail(
+      await fail(
         `no section matching "${sectionText}" found in canvas ${canvasId} — re-read the canvas and retry with text the section actually contains`,
       );
       return;
@@ -320,44 +317,40 @@ export async function handleCanvasEdit(
     };
     await editCanvas(auth.token, canvasId, change);
     log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
-    finish();
+    await finish();
   } catch (err) {
-    fail(err instanceof Error ? err.message : String(err));
+    await fail(err instanceof Error ? err.message : String(err));
   }
 }
 
-export async function handleCanvasRead(
-  content: Record<string, unknown>,
-  session: Session,
-  inDb: Database.Database,
-): Promise<void> {
+export async function handleCanvasRead(content: Record<string, unknown>, session: Session): Promise<void> {
   const requestId =
     typeof content.requestId === 'string' && content.requestId ? content.requestId : `canvas-${Date.now()}`;
   // Reader responses never wake: the container tool is already polling for
   // this row (errors included — a wake would double-charge the outcome).
-  const respond = (status: 'ok' | 'error', result: Record<string, unknown>): void => {
-    writeCanvasResponse(inDb, { requestId, action: 'canvas_read', status, result });
+  const respond = (status: 'ok' | 'error', result: Record<string, unknown>): Promise<void> => {
+    return writeCanvasResponse(session, { requestId, action: 'canvas_read', status, result });
   };
 
   const canvasId = typeof content.canvas_id === 'string' ? content.canvas_id : '';
   if (!canvasId) {
-    respond('error', { error: 'canvas_read needs canvas_id' });
+    await respond('error', { error: 'canvas_read needs canvas_id' });
     return;
   }
 
   const auth = await resolveSessionBotToken(session);
   if ('error' in auth) {
-    respond('error', { error: auth.error });
+    await respond('error', { error: auth.error });
     return;
   }
 
   try {
     const text = await fetchCanvasText(auth.token, canvasId);
     log.info('canvas_read served', { sessionId: session.id, requestId, canvasId, chars: text.length });
-    respond('ok', { canvas_id: canvasId, text });
+    await respond('ok', { canvas_id: canvasId, text });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn('canvas_read failed', { sessionId: session.id, requestId, error: message });
-    respond('error', { error: message });
+    await respond('error', { error: message });
   }
 }

--- a/src/modules/slack-onboarding/index.ts
+++ b/src/modules/slack-onboarding/index.ts
@@ -24,10 +24,10 @@
 import { setSuggestedPrompts, setThreadTitle } from '../../channels/channel-registry.js';
 import { setAgentDmOpenedHandler } from '../../channels/chat-sdk-bridge.js';
 import { getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
-import type { OutboundMessage } from '../../db/session-db.js';
 import { getActiveSessions } from '../../db/sessions.js';
 import { registerPostDeliveryHook } from '../../delivery.js';
 import { log } from '../../log.js';
+import type { OutboundMessage } from '../../mailbox/index.js';
 import { registerSessionCreatedHook } from '../../router.js';
 
 /**
@@ -100,10 +100,10 @@ setAgentDmOpenedHandler(async ({ channelId }) => {
 
 async function offerWelcomePrompts(msg: OutboundMessage): Promise<void> {
   try {
-    const channelType = msg.channel_type;
-    const platformId = msg.platform_id;
+    const channelType = msg.channelType;
+    const platformId = msg.platformId;
     if (!channelType || !platformId) return;
-    const tidParts = (msg.thread_id ?? '').split(':');
+    const tidParts = (msg.threadId ?? '').split(':');
     if (tidParts.length >= 3 && tidParts[tidParts.length - 1] !== '') return; // threaded → not the welcome
     const mg = await getMessagingGroupByPlatform(channelType, platformId);
     if (!mg || mg.is_group !== 0) return;

--- a/src/modules/slack-onboarding/onboarding.test.ts
+++ b/src/modules/slack-onboarding/onboarding.test.ts
@@ -66,9 +66,9 @@ const EXPECTED_PROMPTS = [
 interface TestMsg {
   id: string;
   kind: string;
-  platform_id: string | null;
-  channel_type: string | null;
-  thread_id: string | null;
+  platformId: string | null;
+  channelType: string | null;
+  threadId: string | null;
   content: string;
 }
 
@@ -76,9 +76,9 @@ function welcomeMsg(overrides: Partial<TestMsg> = {}): TestMsg {
   return {
     id: 'out-1',
     kind: 'chat',
-    platform_id: 'slack:D1',
-    channel_type: 'slack',
-    thread_id: 'slack:D1:',
+    platformId: 'slack:D1',
+    channelType: 'slack',
+    threadId: 'slack:D1:',
     content: JSON.stringify({ text: 'Welcome!' }),
     ...overrides,
   };
@@ -160,11 +160,11 @@ describe('welcome prompts on first delivery (post-delivery hook)', () => {
     expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
   });
 
-  it('a threadless welcome row (thread_id null) also counts as the welcome', async () => {
+  it('a threadless welcome row also counts as the welcome', async () => {
     const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
     getMessagingGroupByPlatform.mockReturnValue(dmMg());
 
-    postDelivery(welcomeMsg({ thread_id: null }), { id: 'sess-1' }, { firstDelivery: true });
+    postDelivery(welcomeMsg({ threadId: null }), { id: 'sess-1' }, { firstDelivery: true });
 
     await flush();
     expect(registry.setSuggestedPrompts).toHaveBeenCalledTimes(1);
@@ -184,7 +184,7 @@ describe('welcome prompts on first delivery (post-delivery hook)', () => {
     const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
     getMessagingGroupByPlatform.mockReturnValue(dmMg());
 
-    postDelivery(welcomeMsg({ thread_id: 'slack:D1:171' }), { id: 'sess-1' }, { firstDelivery: true });
+    postDelivery(welcomeMsg({ threadId: 'slack:D1:171' }), { id: 'sess-1' }, { firstDelivery: true });
 
     await flush();
     expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
@@ -206,8 +206,8 @@ describe('welcome prompts on first delivery (post-delivery hook)', () => {
   it('no-op when the row has no channel/platform address', async () => {
     const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
 
-    postDelivery(welcomeMsg({ channel_type: null }), { id: 'sess-1' }, { firstDelivery: true });
-    postDelivery(welcomeMsg({ platform_id: null }), { id: 'sess-1' }, { firstDelivery: true });
+    postDelivery(welcomeMsg({ channelType: null }), { id: 'sess-1' }, { firstDelivery: true });
+    postDelivery(welcomeMsg({ platformId: null }), { id: 'sess-1' }, { firstDelivery: true });
 
     await flush();
     expect(getMessagingGroupByPlatform).not.toHaveBeenCalled();

--- a/src/modules/slack-room-membership/membership.test.ts
+++ b/src/modules/slack-room-membership/membership.test.ts
@@ -585,12 +585,12 @@ describe('non-bot membership change in a wired room (case 4)', () => {
     const msg = mockWriteSessionMessage.mock.calls[0]![2] as {
       kind: string;
       channelType: string;
-      trigger: number;
+      trigger: boolean;
       content: string;
     };
     // kind 'chat' + sender 'system' (container-restart's system-note shape):
     // the container poll loop filters kind 'system' rows out of agent batches.
-    expect(msg).toMatchObject({ kind: 'chat', channelType: 'agent', trigger: 0 });
+    expect(msg).toMatchObject({ kind: 'chat', channelType: 'agent', trigger: false });
     const content = JSON.parse(msg.content) as { text: string; sender: string };
     expect(content.sender).toBe('system');
     expect(content.text).toContain('<@U0NEWHUMAN> joined this room');

--- a/src/modules/slack-room-membership/membership.ts
+++ b/src/modules/slack-room-membership/membership.ts
@@ -462,7 +462,7 @@ async function handleMemberChange(event: MembershipEvent, platformId: string): P
           channelType: 'agent',
           threadId: null,
           content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
-          trigger: 0,
+          trigger: false,
         });
       } catch (err) {
         log.warn('slack-room-membership: membership note write failed', {


### PR DESCRIPTION
## Summary
- migrate Slack canvas and onboarding payloads from removed session DB APIs to the mailbox seam introduced by #3349
- reuse runner mailbox helpers and await async outbound writes
- update delivery handlers, boolean trigger fields, and mailbox-shaped outbound fields
- extend the slack-agent-flow prerequisite check so incompatible trunk versions fail before files are copied

## Context
#3362 validated the previous trunk contracts, but #3349 merged later and changed the composed runtime API. Main and channels passed independently while the installed main HEAD plus channels HEAD payload failed to build.

## Validation
- composed current origin/main with this channels payload
- pnpm run build
- pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
- 205 host feature tests passed, 2 skipped
- 17 Bun room and canvas tests passed
- 130 skill conformance tests passed
- Prettier and git diff checks passed

## Follow-up
A main-branch CI composition gate should be added in a separate PR so future main changes are checked against channels HEAD before merge.