### PR TITLE
fix(channels): restore skill composition on main

### DIFF
--- a/.claude/skills/add-deltachat/SKILL.md
+++ b/.claude/skills/add-deltachat/SKILL.md
@@ -7,50 +7,35 @@ description: Add DeltaChat channel integration via @deltachat/stdio-rpc-server. 
 
 The adapter drives the `@deltachat/stdio-rpc-server` JSON-RPC subprocess directly — pure Node.js against the DeltaChat core library. Messages are delivered over email with Autocrypt/OpenPGP encryption.
 
-## Install
+## Apply
 
-### Pre-flight (idempotent)
+The mechanical steps use the deterministic skill engine and are safe to re-run.
 
-Skip to **Credentials** if all of these are already in place:
+### 1. Copy the adapter and its registration test
 
-- `src/channels/deltachat.ts` exists
-- `src/channels/deltachat-registration.test.ts` exists
-- `src/channels/index.ts` contains `import './deltachat.js';`
-- `@deltachat/stdio-rpc-server` is listed in `package.json` dependencies
-
-Otherwise continue. Every step below is safe to re-run.
-
-### 1. Fetch the channels branch
-
-```bash
-git fetch origin channels
-```
-
-### 2. Copy the adapter and its registration test
-
-```bash
-git show origin/channels:src/channels/deltachat.ts                 > src/channels/deltachat.ts
-git show origin/channels:src/channels/deltachat-registration.test.ts > src/channels/deltachat-registration.test.ts
+```nc:copy from-branch:channels
+src/channels/deltachat.ts
+src/channels/deltachat-registration.test.ts
 ```
 
 ### 3. Append the self-registration import
 
-Append to `src/channels/index.ts` (skip if already present):
-
-```typescript
+```nc:append to:src/channels/index.ts
 import './deltachat.js';
 ```
 
 ### 4. Install the adapter package (pinned)
 
-```bash
-pnpm install @deltachat/stdio-rpc-server@2.49.0
+```nc:dep
+@deltachat/stdio-rpc-server@2.49.0
 ```
 
 ### 5. Build and validate
 
-```bash
+```nc:run effect:build
 pnpm run build
+```
+```nc:run effect:test
 pnpm exec vitest run src/channels/deltachat-registration.test.ts
 ```
 

--- a/.claude/skills/add-emacs/SKILL.md
+++ b/.claude/skills/add-emacs/SKILL.md
@@ -15,50 +15,33 @@ Adds Emacs support via a local HTTP bridge. Works with Doom Emacs, Spacemacs, an
 - **Draft writing** — send org prose; receive revisions or continuations in place
 - **Research capture** — ask a question directly in your org notes; the answer lands exactly where you need it
 
-## Install
+## Apply
 
 NanoClaw doesn't ship channels in trunk. This skill copies the Emacs adapter and the Lisp client in from the `channels` branch. Native HTTP bridge — no Chat SDK, no adapter package.
 
-### Pre-flight (idempotent)
+The mechanical steps use the deterministic skill engine and are safe to re-run.
 
-Skip to **Enable** if all of these are already in place:
+### 1. Copy the adapter and Lisp client
 
-- `src/channels/emacs.ts` exists
-- `src/channels/emacs.test.ts` exists
-- `src/channels/emacs-registration.test.ts` exists
-- `emacs/nanoclaw.el` exists
-- `src/channels/index.ts` contains `import './emacs.js';`
-
-Otherwise continue. Every step below is safe to re-run.
-
-### 1. Fetch the channels branch
-
-```bash
-git fetch origin channels
-```
-
-### 2. Copy the adapter and Lisp client
-
-```bash
-mkdir -p emacs
-git show origin/channels:src/channels/emacs.ts                    > src/channels/emacs.ts
-git show origin/channels:src/channels/emacs.test.ts              > src/channels/emacs.test.ts
-git show origin/channels:src/channels/emacs-registration.test.ts > src/channels/emacs-registration.test.ts
-git show origin/channels:emacs/nanoclaw.el                        > emacs/nanoclaw.el
+```nc:copy from-branch:channels
+src/channels/emacs.ts
+src/channels/emacs.test.ts
+src/channels/emacs-registration.test.ts
+emacs/nanoclaw.el
 ```
 
 ### 3. Append the self-registration import
 
-Append to `src/channels/index.ts` (skip if the line is already present):
-
-```typescript
+```nc:append to:src/channels/index.ts
 import './emacs.js';
 ```
 
 ### 4. Build and validate
 
-```bash
+```nc:run effect:build
 pnpm run build
+```
+```nc:run effect:test
 pnpm exec vitest run src/channels/emacs-registration.test.ts
 ```
 

--- a/.claude/skills/add-matrix/SKILL.md
+++ b/.claude/skills/add-matrix/SKILL.md
@@ -44,25 +44,19 @@ track (not the `@chat-adapter/*` family), so it carries its own pin:
 @beeper/chat-adapter-matrix@0.2.0
 ```
 
-### 4. Patch matrix-js-sdk ESM imports
+### 4. Wire the ESM-fix pnpm patch
 
 The adapter's published dist references `matrix-js-sdk/lib/...` without `.js`
-extensions, which fails under Node 22 strict ESM resolution. Add the missing
-extensions (idempotent — safe to re-run). Re-run this after every `pnpm install`
-that touches the adapter:
+extensions, which Node's ESM loader rejects. Trunk ships the fix as
+`patches/@beeper__chat-adapter-matrix@0.2.0.patch`; wire it into the workspace
+so every future install reapplies it:
 
 ```nc:run effect:external
-node -e '
-  const fs = require("fs"), path = require("path");
-  const root = "node_modules/.pnpm";
-  const dir = fs.readdirSync(root).find(d => d.startsWith("@beeper+chat-adapter-matrix@"));
-  if (!dir) { console.log("Matrix adapter not installed"); process.exit(0); }
-  const f = path.join(root, dir, "node_modules/@beeper/chat-adapter-matrix/dist/index.js");
-  fs.writeFileSync(f, fs.readFileSync(f, "utf8").replace(
-    /from "(matrix-js-sdk\/lib\/[^"]+?)(?<!\.js)"/g, "from \"$1.js\""
-  ));
-  console.log("Patched", f);
-'
+node -e 'const fs=require("fs"),f="pnpm-workspace.yaml";let s=fs.readFileSync(f,"utf8");if(s.includes("@beeper/chat-adapter-matrix@0.2.0"))console.log("patchedDependencies entry already present");else{if(!/^patchedDependencies:/m.test(s))s=s.trimEnd()+"\n\npatchedDependencies:\n";s=s.replace(/^patchedDependencies:\n/m,"patchedDependencies:\n  \x27@beeper/chat-adapter-matrix@0.2.0\x27: patches/@beeper__chat-adapter-matrix@0.2.0.patch\n");fs.writeFileSync(f,s);console.log("patchedDependencies entry added")}'
+```
+
+```nc:run effect:external
+pnpm install --no-frozen-lockfile
 ```
 
 ### 5. Build

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -10,39 +10,25 @@ Adds Mattermost support via the Chat SDK bridge, wrapping the community
 package. Events arrive over an outbound WebSocket (`/api/v4/websocket`) — no
 public URL or webhook is needed for basic messaging.
 
-## Install
+The mechanical steps under **Apply** carry deterministic `nc:` directives and are safe to re-run.
+
+## Apply
 
 NanoClaw doesn't ship channels in trunk. This skill copies the Mattermost
 adapter in from the `channels` branch.
 
-### Pre-flight (idempotent)
+### 1. Copy the adapter and registration test
 
-Skip to **Credentials** if all of these are already in place:
-
-- `src/channels/mattermost.ts` exists
-- `src/channels/index.ts` contains `import './mattermost.js';`
-- `chat-adapter-mattermost` is listed in `package.json` dependencies
-
-Otherwise continue. Every step below is safe to re-run.
-
-### 1. Fetch the channels branch
-
-```bash
-git fetch origin channels
-```
-
-### 2. Copy the adapter and registration test
-
-```bash
-git show origin/channels:src/channels/mattermost.ts > src/channels/mattermost.ts
-git show origin/channels:src/channels/mattermost-registration.test.ts > src/channels/mattermost-registration.test.ts
+```nc:copy from-branch:channels
+src/channels/mattermost.ts
+src/channels/mattermost-registration.test.ts
 ```
 
 ### 3. Append the self-registration import
 
 Append to `src/channels/index.ts` (skip if the line is already present):
 
-```typescript
+```nc:append to:src/channels/index.ts
 import './mattermost.js';
 ```
 
@@ -52,14 +38,16 @@ import './mattermost.js';
 individual maintainer, a handful of releases) — a materially higher risk tier
 than the official `@chat-adapter/*` packages, so pin it exactly:
 
-```bash
-pnpm install chat-adapter-mattermost@1.1.3
+```nc:dep
+chat-adapter-mattermost@1.1.3
 ```
 
 ### 5. Build and validate
 
-```bash
+```nc:run effect:build
 pnpm run build
+```
+```nc:run effect:test
 pnpm exec vitest run src/channels/mattermost-registration.test.ts
 ```
 

--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -19,16 +19,13 @@ safe to re-run; anything a parser can't apply falls back to the prose beside it.
 
 ### 1. Copy the adapter, helpers, and tests
 
-Fetch the `channels` branch and copy the Telegram adapter, its pairing and
-markdown-sanitize helpers (with their tests), and the registration test into
-place (overwrite — the branch is canonical):
+Fetch the `channels` branch and copy the Telegram adapter, its pairing helper
+and tests, and the registration test into place (overwrite — the branch is canonical):
 
 ```nc:copy from-branch:channels
 src/channels/telegram.ts
 src/channels/telegram-pairing.ts
 src/channels/telegram-pairing.test.ts
-src/channels/telegram-markdown-sanitize.ts
-src/channels/telegram-markdown-sanitize.test.ts
 src/channels/telegram-registration.test.ts
 ```
 

--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -20,52 +20,37 @@ Adds WeChat support via **iLink Bot API** — the first-party Tencent API for pe
 - A phone to scan the QR code for login
 - Node.js >= 20 (already required by NanoClaw)
 
-## Install
+## Apply
 
 NanoClaw doesn't ship channels in trunk. This skill copies the WeChat adapter in from the `channels` branch.
 
-### Pre-flight (idempotent)
+The mechanical steps use the deterministic skill engine and are safe to re-run.
 
-Skip to **Credentials** if all of these are already in place:
+### 1. Copy the adapter and its registration test
 
-- `src/channels/wechat.ts` exists
-- `src/channels/wechat-registration.test.ts` exists
-- `src/channels/index.ts` contains `import './wechat.js';`
-- `wechat-ilink-client` is listed in `package.json` dependencies
-
-Otherwise continue. Every step below is safe to re-run.
-
-### 1. Fetch the channels branch
-
-```bash
-git fetch origin channels
-```
-
-### 2. Copy the adapter and its registration test
-
-```bash
-git show origin/channels:src/channels/wechat.ts                 > src/channels/wechat.ts
-git show origin/channels:src/channels/wechat-registration.test.ts > src/channels/wechat-registration.test.ts
+```nc:copy from-branch:channels
+src/channels/wechat.ts
+src/channels/wechat-registration.test.ts
 ```
 
 ### 3. Append the self-registration import
 
-Append to `src/channels/index.ts` (skip if the line is already present):
-
-```typescript
+```nc:append to:src/channels/index.ts
 import './wechat.js';
 ```
 
 ### 4. Install the library (pinned)
 
-```bash
-pnpm install wechat-ilink-client@0.1.0
+```nc:dep
+wechat-ilink-client@0.1.0
 ```
 
 ### 5. Build and validate
 
-```bash
+```nc:run effect:build
 pnpm run build
+```
+```nc:run effect:test
 pnpm exec vitest run src/channels/wechat-registration.test.ts
 ```
 

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -105,7 +105,7 @@ Baileys is the WhatsApp Web client; `qrcode` renders the device-link QR in the
 terminal; `pino` is Baileys' logger:
 
 ```nc:dep
-@whiskeysockets/baileys@7.0.0-rc.9
+@whiskeysockets/baileys@7.0.0-rc14
 qrcode@1.5.4
 @types/qrcode@1.5.6
 pino@9.6.0

--- a/.github/workflows/channels-composition.yml
+++ b/.github/workflows/channels-composition.yml
@@ -1,0 +1,36 @@
+name: Channels composition
+
+on:
+  pull_request:
+    branches: [channels]
+
+permissions:
+  contents: read
+
+jobs:
+  channels-composition:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Fetch candidate channels branch
+        run: git fetch origin refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/candidate/channels
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - run: pnpm install --frozen-lockfile
+      - name: Install agent-runner deps (Bun)
+        working-directory: container/agent-runner
+        run: bun install --frozen-lockfile
+      - name: Compose candidate channels and run the shared gate
+        run: pnpm exec tsx scripts/test-channel-composition.ts
+        env:
+          CHANNELS_REMOTE: candidate
+          CHANNELS_REF: candidate/channels

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@onecli-sh/sdk": "2.2.1",
     "@resend/chat-sdk-adapter": "^0.1.1",
     "@types/qrcode": "^1.5.6",
-    "@whiskeysockets/baileys": "7.0.0-rc.9",
+    "@whiskeysockets/baileys": "7.0.0-rc14",
     "better-sqlite3": "11.10.0",
     "chat": "4.29.0",
     "chat-adapter-imessage": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^1.5.6
         version: 1.5.6
       '@whiskeysockets/baileys':
-        specifier: 7.0.0-rc.9
-        version: 7.0.0-rc.9(sharp@0.34.5)
+        specifier: 7.0.0-rc14
+        version: 7.0.0-rc14(sharp@0.34.5)
       better-sqlite3:
         specifier: 11.10.0
         version: 11.10.0
@@ -1335,16 +1335,12 @@ packages:
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
-  '@whiskeysockets/baileys@7.0.0-rc.9':
-    resolution: {integrity: sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==}
+  '@whiskeysockets/baileys@7.0.0-rc14':
+    resolution: {integrity: sha512-WK+X8ju8TPGxvWIsP8hrY6JB6FltYuFe+vsqKfjOYX25JObij9qLf2c3ZGdl1Q+vhFwbnT+AZmWAB5pTvzmSiQ==}
     engines: {node: '>=20.0.0'}
-    deprecated: |-
-      This version is affected by a zero-day vulnerability that allows spoofing of messages, please update to
-        the latest versions (6.7.22^ or 7.0.0-rc12^)! For more information, check out the public advisory at
-        https://github.com/WhiskeySockets/Baileys/security/advisories/GHSA-qvv5-jq5g-4cgg
     peerDependencies:
       audio-decode: ^2.1.3
-      jimp: ^1.6.0
+      jimp: ^1.6.1
       link-preview-js: ^3.0.0
       sharp: '*'
     peerDependenciesMeta:
@@ -2247,9 +2243,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
-    version: 6.0.0
+  libsignal@6.0.0:
+    resolution: {integrity: sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3337,6 +3332,9 @@ packages:
   wechat-ilink-client@0.1.0:
     resolution: {integrity: sha512-/gsWGEGEsWA7C5cgfKtguCL7QPdT95I1HfHHiRcHtwQppwVfgD8aDL4m4soANp1qQDl5RgiJ7q9gh9X5cXUfqA==}
     engines: {node: '>=20'}
+
+  whatsapp-rust-bridge@0.5.4:
+    resolution: {integrity: sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -4645,18 +4643,19 @@ snapshots:
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
 
-  '@whiskeysockets/baileys@7.0.0-rc.9(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc14(sharp@0.34.5)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
+      libsignal: 6.0.0
       lru-cache: 11.5.2
       music-metadata: 11.14.0
       p-queue: 9.3.3
       pino: 9.14.0
       protobufjs: 7.6.5
       sharp: 0.34.5
+      whatsapp-rust-bridge: 0.5.4
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -5655,7 +5654,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+  libsignal@6.0.0:
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 7.6.5
@@ -6935,6 +6934,8 @@ snapshots:
   wechat-ilink-client@0.1.0:
     optionalDependencies:
       qrcode-terminal: 0.12.0
+
+  whatsapp-rust-bridge@0.5.4: {}
 
   which-module@2.0.1: {}
 

--- a/src/channels/whatsapp-cloud-registration.test.ts
+++ b/src/channels/whatsapp-cloud-registration.test.ts
@@ -43,7 +43,8 @@ vi.mock('../env.js', () => ({
   }),
 }));
 
-import { getRegisteredChannelNames, getChannelRegistration } from './channel-registry.js';
+import { getRegisteredChannelNames } from './channel-registry.js';
+import { createWhatsAppCloudBridge } from './whatsapp-cloud.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration
 
 describe('whatsapp-cloud channel registration', () => {
@@ -52,10 +53,7 @@ describe('whatsapp-cloud channel registration', () => {
   });
 
   it('builds under a distinct instance key while keeping channelType whatsapp', async () => {
-    const registration = getChannelRegistration('whatsapp-cloud');
-    expect(registration).toBeDefined();
-
-    const adapter = await registration!.factory();
+    const adapter = createWhatsAppCloudBridge();
     expect(adapter).not.toBeNull();
 
     // instance keeps this bridge off the native Baileys adapter's 'whatsapp'

--- a/src/channels/whatsapp-cloud.ts
+++ b/src/channels/whatsapp-cloud.ts
@@ -21,34 +21,36 @@ const WHATSAPP_CLOUD_DEFAULTS: ChannelDefaults = {
   mentions: 'platform',
 };
 
+export function createWhatsAppCloudBridge() {
+  const env = readEnvFile([
+    'WHATSAPP_ACCESS_TOKEN',
+    'WHATSAPP_PHONE_NUMBER_ID',
+    'WHATSAPP_APP_SECRET',
+    'WHATSAPP_VERIFY_TOKEN',
+  ]);
+  if (!env.WHATSAPP_ACCESS_TOKEN) return null;
+  const whatsappAdapter = createWhatsAppAdapter({
+    accessToken: env.WHATSAPP_ACCESS_TOKEN,
+    phoneNumberId: env.WHATSAPP_PHONE_NUMBER_ID,
+    appSecret: env.WHATSAPP_APP_SECRET,
+    verifyToken: env.WHATSAPP_VERIFY_TOKEN,
+  });
+  // `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', which the bridge
+  // uses as channelType. Without a distinct instance the registry would key
+  // this bridge under 'whatsapp' and collide with the native Baileys adapter
+  // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
+  // silently kills one channel. The instance key keeps them apart while
+  // channelType stays 'whatsapp' (the semantic platform key). See #2911.
+  return createChatSdkBridge({
+    adapter: whatsappAdapter,
+    instance: 'whatsapp-cloud',
+    concurrency: 'concurrent',
+    supportsThreads: false,
+    defaults: WHATSAPP_CLOUD_DEFAULTS,
+  });
+}
+
 registerChannelAdapter('whatsapp-cloud', {
-  factory: () => {
-    const env = readEnvFile([
-      'WHATSAPP_ACCESS_TOKEN',
-      'WHATSAPP_PHONE_NUMBER_ID',
-      'WHATSAPP_APP_SECRET',
-      'WHATSAPP_VERIFY_TOKEN',
-    ]);
-    if (!env.WHATSAPP_ACCESS_TOKEN) return null;
-    const whatsappAdapter = createWhatsAppAdapter({
-      accessToken: env.WHATSAPP_ACCESS_TOKEN,
-      phoneNumberId: env.WHATSAPP_PHONE_NUMBER_ID,
-      appSecret: env.WHATSAPP_APP_SECRET,
-      verifyToken: env.WHATSAPP_VERIFY_TOKEN,
-    });
-    // `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', which the bridge
-    // uses as channelType. Without a distinct instance the registry would key
-    // this bridge under 'whatsapp' and collide with the native Baileys adapter
-    // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
-    // silently kills one channel. The instance key keeps them apart while
-    // channelType stays 'whatsapp' (the semantic platform key). See #2911.
-    return createChatSdkBridge({
-      adapter: whatsappAdapter,
-      instance: 'whatsapp-cloud',
-      concurrency: 'concurrent',
-      supportsThreads: false,
-      defaults: WHATSAPP_CLOUD_DEFAULTS,
-    });
-  },
+  factory: createWhatsAppCloudBridge,
   defaults: WHATSAPP_CLOUD_DEFAULTS,
 });


### PR DESCRIPTION
## Summary

- make the DeltaChat, Emacs, Matrix, Mattermost, Telegram, and WeChat skills apply deterministically
- adapt WhatsApp Cloud registration coverage to the supported factory seam
- bump Baileys to the patched `7.0.0-rc.14` release
- compose each future `channels` pull request with current `main` in CI

## Why

The Slack regression exposed a wider protected-branch gap: channel skills can pass on `channels` while failing after setup composes them with current `main`. This repairs the channel-side drift found by applying and testing every code-carrying channel skill.

## Coordination

- paired with the `main` composition gate in #3368
- Matrix patch wiring depends on #3080
- refs #3155

## Tests

- modified skill directive lint
- targeted channel adapter tests
- exact `main` + `channels` composition gate
- host build and agent-runner typecheck
- Vitest: 2,308 passed, 6 skipped
- Bun: 349 passed, 1 skipped
