### PR TITLE
fix(telegram): remove stale skill payload files

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -19,16 +19,13 @@ safe to re-run; anything a parser can't apply falls back to the prose beside it.
 
 ### 1. Copy the adapter, helpers, and tests
 
-Fetch the `channels` branch and copy the Telegram adapter, its pairing and
-markdown-sanitize helpers (with their tests), and the registration test into
-place (overwrite — the branch is canonical):
+Fetch the `channels` branch and copy the Telegram adapter, its pairing helper
+and tests, and the registration test into place (overwrite — the branch is canonical):
 
 ```nc:copy from-branch:channels
 src/channels/telegram.ts
 src/channels/telegram-pairing.ts
 src/channels/telegram-pairing.test.ts
-src/channels/telegram-markdown-sanitize.ts
-src/channels/telegram-markdown-sanitize.test.ts
 src/channels/telegram-registration.test.ts
 ```
 


### PR DESCRIPTION
## Summary

- remove stale Telegram sanitizer files from the skill payload

## Why

Those files were deleted from the `channels` branch, but the skill still tried to copy them during application.

## Tests

- skill directive lint
- applied successfully in the full `main` + `channels` composition run

Refs #3155
