### PR TITLE
fix(wechat): make skill apply deterministic

### DIFF
--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -20,52 +20,37 @@ Adds WeChat support via **iLink Bot API** — the first-party Tencent API for pe
 - A phone to scan the QR code for login
 - Node.js >= 20 (already required by NanoClaw)
 
-## Install
+## Apply
 
 NanoClaw doesn't ship channels in trunk. This skill copies the WeChat adapter in from the `channels` branch.
 
-### Pre-flight (idempotent)
+The mechanical steps use the deterministic skill engine and are safe to re-run.
 
-Skip to **Credentials** if all of these are already in place:
+### 1. Copy the adapter and its registration test
 
-- `src/channels/wechat.ts` exists
-- `src/channels/wechat-registration.test.ts` exists
-- `src/channels/index.ts` contains `import './wechat.js';`
-- `wechat-ilink-client` is listed in `package.json` dependencies
-
-Otherwise continue. Every step below is safe to re-run.
-
-### 1. Fetch the channels branch
-
-```bash
-git fetch origin channels
-```
-
-### 2. Copy the adapter and its registration test
-
-```bash
-git show origin/channels:src/channels/wechat.ts                 > src/channels/wechat.ts
-git show origin/channels:src/channels/wechat-registration.test.ts > src/channels/wechat-registration.test.ts
+```nc:copy from-branch:channels
+src/channels/wechat.ts
+src/channels/wechat-registration.test.ts
 ```
 
 ### 3. Append the self-registration import
 
-Append to `src/channels/index.ts` (skip if the line is already present):
-
-```typescript
+```nc:append to:src/channels/index.ts
 import './wechat.js';
 ```
 
 ### 4. Install the library (pinned)
 
-```bash
-pnpm install wechat-ilink-client@0.1.0
+```nc:dep
+wechat-ilink-client@0.1.0
 ```
 
 ### 5. Build and validate
 
-```bash
+```nc:run effect:build
 pnpm run build
+```
+```nc:run effect:test
 pnpm exec vitest run src/channels/wechat-registration.test.ts
 ```
 


### PR DESCRIPTION
## Summary

- encode WeChat installation as deterministic `nc:` directives
- keep setup-driven and agent-driven skill application on the same path

## Why

The previous manual install section could not be exercised by the skill engine during composition testing.

## Tests

- skill directive lint
- included in the full `main` + `channels` composition run: 2,308 Vitest tests and 349 Bun tests passed

Refs #3155
