### PR TITLE
fix(whatsapp-cloud): use registration factory in test

### DIFF
--- a/src/channels/whatsapp-cloud-registration.test.ts
+++ b/src/channels/whatsapp-cloud-registration.test.ts
@@ -43,7 +43,8 @@ vi.mock('../env.js', () => ({
   }),
 }));
 
-import { getRegisteredChannelNames, getChannelRegistration } from './channel-registry.js';
+import { getRegisteredChannelNames } from './channel-registry.js';
+import { createWhatsAppCloudBridge } from './whatsapp-cloud.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration
 
 describe('whatsapp-cloud channel registration', () => {
@@ -52,10 +53,7 @@ describe('whatsapp-cloud channel registration', () => {
   });
 
   it('builds under a distinct instance key while keeping channelType whatsapp', async () => {
-    const registration = getChannelRegistration('whatsapp-cloud');
-    expect(registration).toBeDefined();
-
-    const adapter = await registration!.factory();
+    const adapter = createWhatsAppCloudBridge();
     expect(adapter).not.toBeNull();
 
     // instance keeps this bridge off the native Baileys adapter's 'whatsapp'

--- a/src/channels/whatsapp-cloud.ts
+++ b/src/channels/whatsapp-cloud.ts
@@ -21,34 +21,36 @@ const WHATSAPP_CLOUD_DEFAULTS: ChannelDefaults = {
   mentions: 'platform',
 };
 
+export function createWhatsAppCloudBridge() {
+  const env = readEnvFile([
+    'WHATSAPP_ACCESS_TOKEN',
+    'WHATSAPP_PHONE_NUMBER_ID',
+    'WHATSAPP_APP_SECRET',
+    'WHATSAPP_VERIFY_TOKEN',
+  ]);
+  if (!env.WHATSAPP_ACCESS_TOKEN) return null;
+  const whatsappAdapter = createWhatsAppAdapter({
+    accessToken: env.WHATSAPP_ACCESS_TOKEN,
+    phoneNumberId: env.WHATSAPP_PHONE_NUMBER_ID,
+    appSecret: env.WHATSAPP_APP_SECRET,
+    verifyToken: env.WHATSAPP_VERIFY_TOKEN,
+  });
+  // `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', which the bridge
+  // uses as channelType. Without a distinct instance the registry would key
+  // this bridge under 'whatsapp' and collide with the native Baileys adapter
+  // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
+  // silently kills one channel. The instance key keeps them apart while
+  // channelType stays 'whatsapp' (the semantic platform key). See #2911.
+  return createChatSdkBridge({
+    adapter: whatsappAdapter,
+    instance: 'whatsapp-cloud',
+    concurrency: 'concurrent',
+    supportsThreads: false,
+    defaults: WHATSAPP_CLOUD_DEFAULTS,
+  });
+}
+
 registerChannelAdapter('whatsapp-cloud', {
-  factory: () => {
-    const env = readEnvFile([
-      'WHATSAPP_ACCESS_TOKEN',
-      'WHATSAPP_PHONE_NUMBER_ID',
-      'WHATSAPP_APP_SECRET',
-      'WHATSAPP_VERIFY_TOKEN',
-    ]);
-    if (!env.WHATSAPP_ACCESS_TOKEN) return null;
-    const whatsappAdapter = createWhatsAppAdapter({
-      accessToken: env.WHATSAPP_ACCESS_TOKEN,
-      phoneNumberId: env.WHATSAPP_PHONE_NUMBER_ID,
-      appSecret: env.WHATSAPP_APP_SECRET,
-      verifyToken: env.WHATSAPP_VERIFY_TOKEN,
-    });
-    // `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', which the bridge
-    // uses as channelType. Without a distinct instance the registry would key
-    // this bridge under 'whatsapp' and collide with the native Baileys adapter
-    // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
-    // silently kills one channel. The instance key keeps them apart while
-    // channelType stays 'whatsapp' (the semantic platform key). See #2911.
-    return createChatSdkBridge({
-      adapter: whatsappAdapter,
-      instance: 'whatsapp-cloud',
-      concurrency: 'concurrent',
-      supportsThreads: false,
-      defaults: WHATSAPP_CLOUD_DEFAULTS,
-    });
-  },
+  factory: createWhatsAppCloudBridge,
   defaults: WHATSAPP_CLOUD_DEFAULTS,
 });


### PR DESCRIPTION
## Summary

- expose the WhatsApp Cloud bridge factory used by registration
- test the factory directly instead of reaching into removed registry internals

## Why

The registration test depended on an old private registry reset API and broke against current `main`.

## Tests

- WhatsApp Cloud registration test
- included in the full `main` + `channels` composition run

Refs #3155
