### PR TITLE
ci(channels): compose PRs with current main

### DIFF
--- a/.github/workflows/channels-composition.yml
+++ b/.github/workflows/channels-composition.yml
@@ -1,0 +1,36 @@
+name: Channels composition
+
+on:
+  pull_request:
+    branches: [channels]
+
+permissions:
+  contents: read
+
+jobs:
+  channels-composition:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Fetch candidate channels branch
+        run: git fetch origin refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/candidate/channels
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - run: pnpm install --frozen-lockfile
+      - name: Install agent-runner deps (Bun)
+        working-directory: container/agent-runner
+        run: bun install --frozen-lockfile
+      - name: Compose candidate channels and run the shared gate
+        run: pnpm exec tsx scripts/test-channel-composition.ts
+        env:
+          CHANNELS_REMOTE: candidate
+          CHANNELS_REF: candidate/channels


### PR DESCRIPTION
## Summary

- compose each candidate `channels` pull request with current `main`
- run the shared skill-application, build, typecheck, Vitest, and Bun gate

## Why

`main` and `channels` previously passed independently while their runtime composition was broken.

## Coordination

- depends on the shared runner in #3368
- intended to merge after #3370, #3371, #3372, #3373, #3374, #3375, #3376, and #3377

## Tests

- exact candidate-ref workflow path exercised locally
- full composition: 2,308 Vitest tests passed, 6 skipped; 349 Bun tests passed, 1 skipped

Refs #3155
