### PR TITLE
fix(runner): skip wrap-nudge when the turn already sent via tools

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './mailbox/sqlite/connection.js';
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
-import { getUndeliveredMessages } from './db/messages-out.js';
+import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
 import { processQuery } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
@@ -466,6 +466,81 @@ describe('error result with no <message> envelope', () => {
     expect(getUndeliveredMessages()).toHaveLength(0);
     expect(pushes).toHaveLength(1);
     expect(pushes[0]).toContain('was not delivered');
+  });
+
+  it('does not wrapping-nudge a result-door turn that already sent via MCP tools', async () => {
+    const pushes: string[] = [];
+
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 'sess-1' };
+      await writeMessageOut({
+        id: 'mcp-1',
+        kind: 'chat',
+        platform_id: 'chan-1',
+        channel_type: 'discord',
+        content: JSON.stringify({ text: 'already sent via tool' }),
+      });
+      yield { type: 'result', text: 'Welcome flow is live — intro sent.' };
+    }
+
+    await processQuery(
+      {
+        push: (m: string) => {
+          pushes.push(m);
+        },
+        end: () => {},
+        events: events(),
+        abort: () => {},
+      },
+      ERR_ROUTING,
+      ['m1'],
+      'claude',
+      undefined,
+      'prompt',
+      undefined,
+    );
+
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0]!.content).text).toBe('already sent via tool');
+  });
+
+  it('does not wrapping-nudge after an ask_user_question card', async () => {
+    const pushes: string[] = [];
+
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 'sess-1' };
+      await writeMessageOut({
+        id: 'q-1',
+        kind: 'chat-sdk',
+        platform_id: 'chan-1',
+        channel_type: 'discord',
+        content: JSON.stringify({ type: 'ask_question', questionId: 'q-1' }),
+      });
+      yield { type: 'result', text: 'Waiting on the tour pick.' };
+    }
+
+    await processQuery(
+      {
+        push: (m: string) => {
+          pushes.push(m);
+        },
+        end: () => {},
+        events: events(),
+        abort: () => {},
+      },
+      ERR_ROUTING,
+      ['m1'],
+      'claude',
+      undefined,
+      'prompt',
+      undefined,
+    );
+
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(0);
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(getUndeliveredMessages()[0]!.kind).toBe('chat-sdk');
   });
 });
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -563,12 +563,12 @@ export async function processQuery(
             // the nudge decision — see turnDelivered.
             suppressDelivery: emitsMidTurnText,
             // "Did anything user-visible go out this turn?" — door
-            // deliveries (midTurnSent) plus any chat row written since the
-            // turn boundary (which also sees MCP send_message calls the
-            // frame-local count can't). When false and the result still
-            // carries content, the wrap-nudge fires so the model re-sends
-            // and the retry streams through the mid-turn door.
-            turnDelivered: emitsMidTurnText ? midTurnSent > 0 || chatRowWrittenSince(turnStartSeq) : undefined,
+            // deliveries (midTurnSent) plus any chat/chat-sdk row written
+            // since the turn boundary (MCP send_message / ask_user_question
+            // the frame-local count can't see). Consulted for every
+            // provider: result-door agents that already replied via tools
+            // must not get a wrap-nudge that coaxes a second copy.
+            turnDelivered: midTurnSent > 0 || chatRowWrittenSince(turnStartSeq),
           });
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
@@ -747,15 +747,13 @@ export interface ResultDispatchOptions {
   suppressDelivery?: boolean;
   /**
    * Did anything user-visible go out this turn? True when the mid-turn door
-   * delivered (midTurnSent > 0) OR any chat row landed in outbound.db since
-   * the turn boundary (covers MCP send_message calls the frame-local count
-   * cannot see). Only meaningful with `suppressDelivery`. When false and the
-   * result carries content — wrapped blocks or unwrapped prose — the turn
-   * counts as undelivered and the wrap-nudge fires, so the model re-sends
-   * and the retry streams through the mid-turn door. This is the deliberate
-   * degradation path for streaming-door misses (SDK drift, a destination
-   * appearing only after streaming, a block that never closed): nudge and
-   * retry, never a direct result-door send.
+   * delivered (midTurnSent > 0) OR any chat/chat-sdk row landed in
+   * outbound.db since the turn boundary (covers MCP send_message /
+   * ask_user_question the frame-local count cannot see). Used by both
+   * doors: streaming providers skip a wrap-nudge after a mid-turn send;
+   * result-door providers skip it after a tool send so an unwrapped
+   * self-summary is not coaxed into a duplicate. When false and the result
+   * still carries content, the wrap-nudge fires.
    */
   turnDelivered?: boolean;
 }
@@ -916,17 +914,19 @@ function maxOutboundSeq(): number {
 }
 
 /**
- * Has ANY chat row been written to outbound.db after `afterSeq`? Feeds the
- * result door's nudge decision: unlike the frame-local midTurnSent count,
- * this also sees MCP send_message / send_file deliveries made this turn, so
- * an agent that already replied via tools is not nudged into repeating
- * itself. Fail-open to false: if the lookup breaks, the nudge may fire
- * spuriously (a repeat coax), never silently swallow an undelivered turn.
+ * Has ANY user-visible outbound row been written after `afterSeq`? Feeds the
+ * wrap-nudge decision: unlike the frame-local midTurnSent count, this also
+ * sees MCP send_message / send_file / ask_user_question deliveries made
+ * this turn, so an agent that already replied via tools is not nudged into
+ * repeating itself. Fail-open to false: if the lookup breaks, the nudge may
+ * fire spuriously (a repeat coax), never silently swallow an undelivered turn.
  */
 function chatRowWrittenSince(afterSeq: number): boolean {
   try {
     // ponytail: reuse the existing semantic read; add a cursor operation only if history scans show up in profiles.
-    return getUndeliveredMessages().some((message) => (message.seq ?? 0) > afterSeq && message.kind === 'chat');
+    return getUndeliveredMessages().some(
+      (message) => (message.seq ?? 0) > afterSeq && (message.kind === 'chat' || message.kind === 'chat-sdk'),
+    );
   } catch (err) {
     log(`chatRowWrittenSince failed: ${err instanceof Error ? err.message : String(err)}`);
     return false;
@@ -1062,10 +1062,12 @@ export async function dispatchResultText(
 
   // In a task run, plain final text is the NORMAL ending (it becomes the run
   // log) — never treat it as an undelivered reply or nudge the agent to wrap it.
-  // With suppressDelivery the delivered-this-turn question is answered by
-  // turnDelivered (door deliveries + DB-visible sends like MCP send_message);
-  // otherwise by this dispatch's own send count.
-  const anythingDelivered = options?.suppressDelivery ? options.turnDelivered === true : sent > 0;
+  // Streaming door: turnDelivered (mid-turn blocks + MCP sends). Result door:
+  // this dispatch's own <message> sends plus the same MCP/tool rows, so a
+  // send_message turn that finishes with scratchpad is not wrap-nudged.
+  const anythingDelivered = options?.suppressDelivery
+    ? options.turnDelivered === true
+    : sent > 0 || options?.turnDelivered === true;
   const hasUnwrapped = !routing.taskRun && !anythingDelivered && !!scratchpad;
   if (hasUnwrapped) {
     log(`WARNING: agent output had no <message to="..."> blocks — nothing was sent`);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`#3284` already skips the wrap-nudge when a *streaming* provider delivered mid-turn (including MCP `send_message`). Result-door providers never passed `turnDelivered`, so a welcome/`send_message` turn that finished with an unwrapped self-summary still got "your response was not delivered" — the model re-sent, and the user saw a duplicate greeting.

Always consult `turnDelivered` (chat **and** chat-sdk rows since the turn boundary) so `ask_user_question` cards count too. Bare unwrapped results with no prior send still nudge.

## Test plan

- [x] `cd container/agent-runner && bun test src/poll-loop.test.ts`
- [ ] Result-door agent: `/welcome` via `send_message` / `ask_user_question`, then an unwrapped summary — only the tool-sent messages go out
- [ ] Bare unwrapped reply with no prior send still gets the wrap-nudge


Made with [Cursor](https://cursor.com)