### PR TITLE
fix(setup): stop test agent before cleanup

### DIFF
--- a/scripts/delete-cli-agent-runtime.ts
+++ b/scripts/delete-cli-agent-runtime.ts
@@ -1,0 +1,15 @@
+import { INSTALL_SLUG } from '../src/config.js';
+import { getSessionDriver } from '../src/drivers/index.js';
+import type { SessionDriver } from '../src/drivers/types.js';
+
+export async function stopAgentGroupSessions(
+  agentGroupId: string,
+  driver: Pick<SessionDriver, 'listSessions'> = getSessionDriver(),
+  installSlug = INSTALL_SLUG,
+): Promise<number> {
+  const sessions = (await driver.listSessions(installSlug)).filter(
+    ({ handle }) => handle.key.agentGroupId === agentGroupId,
+  );
+  await Promise.all(sessions.map(({ handle }) => handle.stop('setup-test-agent-cleanup')));
+  return sessions.length;
+}

--- a/scripts/delete-cli-agent.test.ts
+++ b/scripts/delete-cli-agent.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SessionDriver, SessionHandle } from '../src/drivers/types.js';
+
+import { stopAgentGroupSessions } from './delete-cli-agent-runtime.js';
+
+function session(agentGroupId: string, sessionId: string): SessionHandle {
+  return {
+    key: { installSlug: 'test-install', agentGroupId, sessionId },
+    name: sessionId,
+    start: vi.fn(),
+    status: vi.fn(),
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('stopAgentGroupSessions', () => {
+  it('stops every discovered session for the scratch agent group only', async () => {
+    const first = session('scratch-group', 'session-1');
+    const second = session('scratch-group', 'session-2');
+    const unrelated = session('real-group', 'session-3');
+    const driver: Pick<SessionDriver, 'listSessions'> = {
+      listSessions: vi.fn().mockResolvedValue([
+        { handle: first, phase: 'running' },
+        { handle: unrelated, phase: 'running' },
+        { handle: second, phase: 'terminal' },
+      ]),
+    };
+
+    await expect(stopAgentGroupSessions('scratch-group', driver, 'test-install')).resolves.toBe(2);
+
+    expect(driver.listSessions).toHaveBeenCalledWith('test-install');
+    expect(first.stop).toHaveBeenCalledWith('setup-test-agent-cleanup');
+    expect(second.stop).toHaveBeenCalledWith('setup-test-agent-cleanup');
+    expect(unrelated.stop).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/delete-cli-agent.ts
+++ b/scripts/delete-cli-agent.ts
@@ -18,6 +18,8 @@ import { closeDb, initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import type { AgentGroup } from '../src/types.js';
 
+import { stopAgentGroupSessions } from './delete-cli-agent-runtime.js';
+
 interface Args {
   folder: string;
 }
@@ -43,6 +45,7 @@ try {
   await runMigrations(db);
   ag = await getAgentGroupByFolder(args.folder);
   if (ag) {
+    await stopAgentGroupSessions(ag.id);
     if (!db.columnOwners) throw new Error(`Central DB driver "${db.dialect}" does not support column discovery`);
     const group = ag;
     await db.transaction(async () => {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Stop every runtime session belonging to the temporary setup agent before deleting its database rows and workspace.

On Docker Desktop for macOS, the running test container keeps `plugins` and `.claude-fragments` bind-mounted. Docker applies a deny-delete ACL to those mount points, so the previous cleanup order failed with `EACCES` and left the container and workspace behind. Runtime discovery uses the existing session-driver seam and only targets the scratch agent group.

## Testing

- `pnpm exec vitest run scripts/delete-cli-agent.test.ts`
- `pnpm run build`
- Prettier and `git diff --check`
- Full suite: 1,908 tests passed; seven unrelated environment-sensitive tests failed under Node 26 in the `/private/tmp` worktree (temporary-path canonicalization and deprecation-warning stderr assertions).
