### PR TITLE
fix(opencode): update compaction test for mailbox seam

### DIFF
--- a/container/agent-runner/src/providers/opencode.compaction.test.ts
+++ b/container/agent-runner/src/providers/opencode.compaction.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
-import { initTestSessionDb, closeSessionDb, getInboundDb } from '../db/connection.js';
+import { initTestSessionDb, closeSessionDb, getInboundDb } from '../mailbox/sqlite/connection.js';
 import { buildPostCompactionReminder, createCompactionReminder } from './opencode.js';
 
 /**


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

PR #3349 moved the runner SQLite test helpers from `db/connection` to the mailbox seam. The `/add-opencode` skill copies this compaction test into current `main`, so its required provider verification failed with `Cannot find module '../db/connection.js'`.

Point the test at the current SQLite mailbox helper. OpenCode runtime code is unchanged.

## Testing

- `pnpm run build`
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`
- `pnpm exec vitest run --reporter=dot` — 1,917 passed
- `cd container/agent-runner && bun test src/providers/` — 115 passed
- `cd container/agent-runner && bun test` — 409 passed, 1 skipped
- Recorded mocked-message poll-loop suite — 12 passed
