### PR TITLE
fix(setup): correct Slack picker requirements

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1884,8 +1884,8 @@ async function askChannelChoice(): Promise<ChannelChoice> {
         },
         {
           value: 'slack',
-          label: 'Yes, connect Slack (experimental)',
-          hint: 'needs public URL',
+          label: 'Yes, connect Slack',
+          hint: 'Socket Mode — no public URL needed',
         },
         { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
         { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1865,6 +1865,7 @@ async function askDisplayName(fallback: string): Promise<string> {
 }
 
 async function askChannelChoice(): Promise<ChannelChoice> {
+  const slackAgentsEnabled = process.env.NANOCLAW_SLACK_AGENTS === '1';
   const choice = ensureAnswer(
     await brightSelect<ChannelChoice>({
       message: 'Want to chat with your assistant from your phone?',
@@ -1885,7 +1886,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
         {
           value: 'slack',
           label: 'Yes, connect Slack',
-          hint: 'Socket Mode — no public URL needed',
+          hint: slackAgentsEnabled ? 'automatic app setup' : 'Socket Mode — no public URL needed',
         },
         { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
         { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },

--- a/setup/channel-picker-contract.test.ts
+++ b/setup/channel-picker-contract.test.ts
@@ -7,11 +7,14 @@ import { describe, expect, it } from 'vitest';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 describe('setup channel picker copy', () => {
-  it('describes Slack by its default Socket Mode behavior', () => {
+  it('describes Slack according to the selected setup experience', () => {
     const src = fs.readFileSync(path.join(repoRoot, 'setup/auto.ts'), 'utf-8');
 
     expect(src).toContain("label: 'Yes, connect Slack'");
-    expect(src).toContain("hint: 'Socket Mode — no public URL needed'");
+    expect(src).toContain("const slackAgentsEnabled = process.env.NANOCLAW_SLACK_AGENTS === '1'");
+    expect(src).toContain(
+      "hint: slackAgentsEnabled ? 'automatic app setup' : 'Socket Mode — no public URL needed'",
+    );
     expect(src).not.toContain('connect Slack (experimental)');
     expect(src).not.toContain("hint: 'needs public URL'");
   });

--- a/setup/channel-picker-contract.test.ts
+++ b/setup/channel-picker-contract.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('setup channel picker copy', () => {
+  it('describes Slack by its default Socket Mode behavior', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'setup/auto.ts'), 'utf-8');
+
+    expect(src).toContain("label: 'Yes, connect Slack'");
+    expect(src).toContain("hint: 'Socket Mode — no public URL needed'");
+    expect(src).not.toContain('connect Slack (experimental)');
+    expect(src).not.toContain("hint: 'needs public URL'");
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Remove the stale `experimental` label and make the Slack picker hint reflect the selected setup experience:

- With `--slack-agents`: `automatic app setup`
- Without the flag: `Socket Mode — no public URL needed`

The agents provisioning path creates a Socket Mode app automatically. The standard path recommends Socket Mode but still offers webhook delivery, where the later setup flow explains the public-URL requirement.

This supersedes the outdated assumption in #2295.

## Testing

- `/Users/moshekrupper/nanoco/nanoclaw/node_modules/.bin/vitest run setup/channel-picker-contract.test.ts setup/channels/slack-auto-register.test.ts scripts/skill-directives.test.ts` (63 passed)
- `/Users/moshekrupper/nanoco/nanoclaw/node_modules/.bin/tsc --project tsconfig.json`
- `git diff --check`