### PR TITLE
fix(setup): allow choosing a different Slack workspace

### DIFF
--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -8,8 +8,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const state = vi.hoisted(() => ({
   account: undefined as { api?: string; token: string } | undefined,
   installToken: undefined as string | undefined,
+  selectLabels: [] as string[],
+  selectPrompts: [] as Array<{
+    message: string;
+    options: Array<{ value: unknown; label: string; hint?: string }>;
+  }>,
   notes: [] as Array<{ message: string; title: string }>,
+  infos: [] as string[],
   warns: [] as string[],
+  userInput: vi.fn(),
   decided: false,
   imageSource: 'local' as 'local' | 'hardened',
   writeImageSource: vi.fn(),
@@ -29,13 +36,27 @@ const state = vi.hoisted(() => ({
 vi.mock('@clack/prompts', () => ({
   note: vi.fn((message: string, title: string) => state.notes.push({ message, title })),
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
-  log: { warn: vi.fn((message: string) => state.warns.push(message)) },
+  log: {
+    info: vi.fn((message: string) => state.infos.push(message)),
+    warn: vi.fn((message: string) => state.warns.push(message)),
+  },
 }));
 
-vi.mock('../logs.js', () => ({ userInput: vi.fn(), step: vi.fn() }));
-vi.mock('../lib/bright-select.js', () => ({ brightSelect: vi.fn(async () => 'auto') }));
+vi.mock('../logs.js', () => ({ userInput: state.userInput, step: vi.fn() }));
+vi.mock('../lib/bright-select.js', () => ({
+  brightSelect: vi.fn(
+    async (prompt: { message: string; options: Array<{ value: unknown; label: string; hint?: string }> }) => {
+      state.selectPrompts.push(prompt);
+      const label = state.selectLabels.shift();
+      return label === undefined
+        ? prompt.options[0]?.value
+        : prompt.options.find((option) => option.label === label)?.value;
+    },
+  ),
+}));
 vi.mock('../lib/browser.js', () => ({ confirmThenOpen: vi.fn() }));
 vi.mock('../lib/inherit-script.js', () => ({ runInheritScript: state.runInheritScript }));
+vi.mock('node:timers/promises', () => ({ setTimeout: vi.fn(async () => undefined) }));
 vi.mock('../lib/registry-state.js', () => ({
   REGISTRY_LOGIN_SCRIPT: 'setup/registry-login.sh',
   clearImageSource: state.clearImageSource,
@@ -91,6 +112,9 @@ function fakeCore(): ProvisioningCore {
  * the next test's starting state.
  */
 function resetBrokerMocks(): void {
+  state.selectLabels.length = 0;
+  state.selectPrompts.length = 0;
+  state.infos.length = 0;
   state.runInheritScript.mockReset();
   state.runInheritScript.mockImplementation(async () => 0);
   state.brokerListWorkspaces.mockReset();
@@ -229,9 +253,10 @@ describe('Slack managed-app sign-in', () => {
     };
   });
 
-  it('validates a saved credential before using it and shows only its service origin', async () => {
+  it('saved credential + Use this account validates without --force and shows only its service origin', async () => {
     const root = track(rootWithModule());
     const core = fakeCore();
+    state.selectLabels.push('Create it for me', 'Use this account', 'Use NanoCo');
     const result = await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
 
     expect(state.runInheritScript).toHaveBeenCalledOnce();
@@ -239,6 +264,7 @@ describe('Slack managed-app sign-in', () => {
     // could not reach the account service to check, must not come back as a
     // success here — this flow is about to spend it.
     expect(state.runInheritScript).toHaveBeenCalledWith('bash', ['setup/registry-login.sh', '--require-verified']);
+    expect(state.userInput).toHaveBeenCalledWith('slack_broker_account', 'saved');
     expect(state.brokerListWorkspaces).toHaveBeenCalledWith('nct-saved');
     expect(result).toMatchObject({
       connection: 'provisioned',
@@ -259,6 +285,162 @@ describe('Slack managed-app sign-in', () => {
     ]);
     expect(state.notes[0].message).not.toContain('password');
     expect(state.notes[0].message).not.toContain('secret');
+    expect(state.selectPrompts[1].message).toBe(
+      'Found saved NanoClaw credentials for https://registry.sandbox.nanoclaw.dev.',
+    );
+    expect(state.selectPrompts[1].message).not.toContain('password');
+    expect(state.selectPrompts[1].message).not.toContain('secret');
+  });
+
+  it('saved credential + Sign in with a different account re-authenticates with --force', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    state.selectLabels.push('Create it for me', 'Sign in with a different account', 'Use NanoCo');
+
+    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    expect(state.runInheritScript).toHaveBeenCalledExactlyOnceWith('bash', [
+      'setup/registry-login.sh',
+      '--require-verified',
+      '--force',
+    ]);
+    expect(state.userInput).toHaveBeenCalledWith('slack_broker_account', 'different');
+  });
+});
+
+describe('Slack broker workspace choice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBrokerMocks();
+    state.notes.length = 0;
+    state.warns.length = 0;
+    state.decided = true;
+    state.imageSource = 'hardened';
+    state.installToken = 'nct-saved';
+    state.account = { token: 'nct-saved', api: 'https://registry.sandbox.nanoclaw.dev' };
+  });
+
+  it('single workspace + Use <name> provisions the confirmed team', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    state.selectLabels.push('Create it for me', 'Use this account', 'Use NanoCo');
+
+    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    const workspacePrompt = state.selectPrompts.find((prompt) => prompt.message === 'Use this Slack workspace?');
+    expect(workspacePrompt?.options.map((option) => option.label)).toEqual([
+      'Use NanoCo',
+      'Connect a different workspace',
+      'Set up manually instead',
+    ]);
+    expect(state.brokerProvision).toHaveBeenCalledWith('nct-saved', {
+      team_id: 'T0TEAM123',
+      name: 'Trusty',
+      requested_by: 'U0OWNER12',
+    });
+    expect(state.userInput).toHaveBeenCalledWith('slack_broker_workspace', 'T0TEAM123');
+  });
+
+  it('single workspace + Connect a different workspace waits for and provisions the new team', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    const oldWorkspace = {
+      team_id: 'T0TEAM123',
+      team_name: 'NanoCo',
+      status: 'active',
+      connected_as: 'U0OWNER12',
+    };
+    const newWorkspace = {
+      team_id: 'T1TEAM456',
+      team_name: 'NewCo',
+      status: 'active',
+      connected_as: 'U1OWNER34',
+    };
+    state.selectLabels.push('Create it for me', 'Use this account', 'Connect a different workspace');
+    state.brokerListWorkspaces
+      .mockResolvedValueOnce([oldWorkspace])
+      .mockResolvedValueOnce([oldWorkspace])
+      .mockResolvedValueOnce([oldWorkspace, newWorkspace]);
+
+    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    expect(core.brokerOauthUrl).toHaveBeenCalledExactlyOnceWith('nct-saved');
+    expect(state.brokerListWorkspaces).toHaveBeenCalledTimes(3);
+    expect(state.brokerProvision).toHaveBeenCalledWith('nct-saved', {
+      team_id: 'T1TEAM456',
+      name: 'Trusty',
+      requested_by: 'U1OWNER34',
+    });
+    expect(state.userInput).toHaveBeenCalledWith('slack_broker_workspace', 'T1TEAM456');
+  });
+
+  it('Set up manually instead returns to the manual path without provisioning', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    state.selectLabels.push('Create it for me', 'Use this account', 'Set up manually instead');
+
+    await expect(maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core })).resolves.toBeUndefined();
+
+    expect(state.brokerProvision).not.toHaveBeenCalled();
+    expect(state.userInput).toHaveBeenCalledWith('slack_broker_workspace', 'manual');
+    expect(state.infos).toEqual(['Okay — walking through manual app creation instead.']);
+  });
+
+  it('no workspace connected yet: connect first, then the picker confirms the new team', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    const newWorkspace = {
+      team_id: 'T1TEAM456',
+      team_name: 'NewCo',
+      status: 'active',
+      connected_as: 'U1OWNER34',
+    };
+    state.selectLabels.push('Create it for me', 'Use this account', 'Use NewCo');
+    state.brokerListWorkspaces.mockResolvedValueOnce([]).mockResolvedValueOnce([newWorkspace]);
+
+    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    expect(core.brokerOauthUrl).toHaveBeenCalledExactlyOnceWith('nct-saved');
+    const workspacePrompt = state.selectPrompts.find((prompt) => prompt.message === 'Use this Slack workspace?');
+    expect(workspacePrompt?.options.map((option) => option.label)).toEqual([
+      'Use NewCo',
+      'Connect a different workspace',
+      'Set up manually instead',
+    ]);
+    expect(state.brokerProvision).toHaveBeenCalledWith('nct-saved', {
+      team_id: 'T1TEAM456',
+      name: 'Trusty',
+      requested_by: 'U1OWNER34',
+    });
+  });
+
+  it('a declined workspace stays out of the re-prompt when several new teams arrive', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    const oldWorkspace = { team_id: 'T0TEAM123', team_name: 'NanoCo', status: 'active', connected_as: 'U0OWNER12' };
+    const betaWorkspace = { team_id: 'T1BETA456', team_name: 'BetaCo', status: 'active', connected_as: 'U1OWNER34' };
+    const gammaWorkspace = { team_id: 'T2GAMMA78', team_name: 'GammaCo', status: 'active', connected_as: 'U2OWNER56' };
+    state.selectLabels.push('Create it for me', 'Use this account', 'Connect a different workspace', 'BetaCo');
+    state.brokerListWorkspaces
+      .mockResolvedValueOnce([oldWorkspace])
+      .mockResolvedValueOnce([oldWorkspace, betaWorkspace, gammaWorkspace]);
+
+    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    const rePrompt = state.selectPrompts.find(
+      (prompt) => prompt.message === 'Which workspace should the agent live in?',
+    );
+    expect(rePrompt?.options.map((option) => option.label)).toEqual([
+      'BetaCo',
+      'GammaCo',
+      'Connect a different workspace',
+      'Set up manually instead',
+    ]);
+    expect(state.brokerProvision).toHaveBeenCalledWith('nct-saved', {
+      team_id: 'T1BETA456',
+      name: 'Trusty',
+      requested_by: 'U1OWNER34',
+    });
   });
 });
 
@@ -334,8 +516,18 @@ describe('a credential the Slack service refuses', () => {
       ['bash', ['setup/registry-login.sh', '--require-verified']],
       ['bash', ['setup/registry-login.sh', '--require-verified', '--force']],
     ]);
+    // The retry knows the saved credential failed — it must re-authenticate
+    // without offering the saved/different choice a second time.
+    const accountPrompts = state.selectPrompts.filter((prompt) =>
+      prompt.message.startsWith('Found saved NanoClaw credentials'),
+    );
+    expect(accountPrompts).toHaveLength(1);
     expect(state.brokerListWorkspaces.mock.calls).toEqual([['nct-stale'], ['nct-fresh']]);
-    expect(state.brokerProvision).toHaveBeenCalledWith('nct-fresh', { team_id: 'T0TEAM123', name: 'Trusty', requested_by: 'U0OWNER12' });
+    expect(state.brokerProvision).toHaveBeenCalledWith('nct-fresh', {
+      team_id: 'T0TEAM123',
+      name: 'Trusty',
+      requested_by: 'U0OWNER12',
+    });
     expect(result).toMatchObject({ connection: 'provisioned', bot_token: 'xoxb-test' });
     expect(state.notes.at(-1)?.message).toContain('would not accept the saved credentials');
   });

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -253,10 +253,10 @@ describe('Slack managed-app sign-in', () => {
     };
   });
 
-  it('saved credential + Use this account validates without --force and shows only its service origin', async () => {
+  it('saved credential validates silently without --force and shows only its service origin', async () => {
     const root = track(rootWithModule());
     const core = fakeCore();
-    state.selectLabels.push('Create it for me', 'Use this account', 'Use NanoCo');
+    state.selectLabels.push('Create it for me', 'Use NanoCo');
     const result = await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
 
     expect(state.runInheritScript).toHaveBeenCalledOnce();
@@ -264,7 +264,6 @@ describe('Slack managed-app sign-in', () => {
     // could not reach the account service to check, must not come back as a
     // success here — this flow is about to spend it.
     expect(state.runInheritScript).toHaveBeenCalledWith('bash', ['setup/registry-login.sh', '--require-verified']);
-    expect(state.userInput).toHaveBeenCalledWith('slack_broker_account', 'saved');
     expect(state.brokerListWorkspaces).toHaveBeenCalledWith('nct-saved');
     expect(result).toMatchObject({
       connection: 'provisioned',
@@ -285,26 +284,8 @@ describe('Slack managed-app sign-in', () => {
     ]);
     expect(state.notes[0].message).not.toContain('password');
     expect(state.notes[0].message).not.toContain('secret');
-    expect(state.selectPrompts[1].message).toBe(
-      'Found saved NanoClaw credentials for https://registry.sandbox.nanoclaw.dev.',
-    );
-    expect(state.selectPrompts[1].message).not.toContain('password');
-    expect(state.selectPrompts[1].message).not.toContain('secret');
-  });
-
-  it('saved credential + Sign in with a different account re-authenticates with --force', async () => {
-    const root = track(rootWithModule());
-    const core = fakeCore();
-    state.selectLabels.push('Create it for me', 'Sign in with a different account', 'Use NanoCo');
-
-    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
-
-    expect(state.runInheritScript).toHaveBeenCalledExactlyOnceWith('bash', [
-      'setup/registry-login.sh',
-      '--require-verified',
-      '--force',
-    ]);
-    expect(state.userInput).toHaveBeenCalledWith('slack_broker_account', 'different');
+    expect(state.selectPrompts).toHaveLength(2);
+    expect(state.selectPrompts[1].message).toBe('Use this Slack workspace?');
   });
 });
 
@@ -323,7 +304,7 @@ describe('Slack broker workspace choice', () => {
   it('single workspace + Use <name> provisions the confirmed team', async () => {
     const root = track(rootWithModule());
     const core = fakeCore();
-    state.selectLabels.push('Create it for me', 'Use this account', 'Use NanoCo');
+    state.selectLabels.push('Create it for me', 'Use NanoCo');
 
     await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
 
@@ -356,7 +337,7 @@ describe('Slack broker workspace choice', () => {
       status: 'active',
       connected_as: 'U1OWNER34',
     };
-    state.selectLabels.push('Create it for me', 'Use this account', 'Connect a different workspace');
+    state.selectLabels.push('Create it for me', 'Connect a different workspace');
     state.brokerListWorkspaces
       .mockResolvedValueOnce([oldWorkspace])
       .mockResolvedValueOnce([oldWorkspace])
@@ -377,7 +358,7 @@ describe('Slack broker workspace choice', () => {
   it('Set up manually instead returns to the manual path without provisioning', async () => {
     const root = track(rootWithModule());
     const core = fakeCore();
-    state.selectLabels.push('Create it for me', 'Use this account', 'Set up manually instead');
+    state.selectLabels.push('Create it for me', 'Set up manually instead');
 
     await expect(maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core })).resolves.toBeUndefined();
 
@@ -395,7 +376,7 @@ describe('Slack broker workspace choice', () => {
       status: 'active',
       connected_as: 'U1OWNER34',
     };
-    state.selectLabels.push('Create it for me', 'Use this account', 'Use NewCo');
+    state.selectLabels.push('Create it for me', 'Use NewCo');
     state.brokerListWorkspaces.mockResolvedValueOnce([]).mockResolvedValueOnce([newWorkspace]);
 
     await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
@@ -420,7 +401,7 @@ describe('Slack broker workspace choice', () => {
     const oldWorkspace = { team_id: 'T0TEAM123', team_name: 'NanoCo', status: 'active', connected_as: 'U0OWNER12' };
     const betaWorkspace = { team_id: 'T1BETA456', team_name: 'BetaCo', status: 'active', connected_as: 'U1OWNER34' };
     const gammaWorkspace = { team_id: 'T2GAMMA78', team_name: 'GammaCo', status: 'active', connected_as: 'U2OWNER56' };
-    state.selectLabels.push('Create it for me', 'Use this account', 'Connect a different workspace', 'BetaCo');
+    state.selectLabels.push('Create it for me', 'Connect a different workspace', 'BetaCo');
     state.brokerListWorkspaces
       .mockResolvedValueOnce([oldWorkspace])
       .mockResolvedValueOnce([oldWorkspace, betaWorkspace, gammaWorkspace]);
@@ -516,12 +497,6 @@ describe('a credential the Slack service refuses', () => {
       ['bash', ['setup/registry-login.sh', '--require-verified']],
       ['bash', ['setup/registry-login.sh', '--require-verified', '--force']],
     ]);
-    // The retry knows the saved credential failed — it must re-authenticate
-    // without offering the saved/different choice a second time.
-    const accountPrompts = state.selectPrompts.filter((prompt) =>
-      prompt.message.startsWith('Found saved NanoClaw credentials'),
-    );
-    expect(accountPrompts).toHaveLength(1);
     expect(state.brokerListWorkspaces.mock.calls).toEqual([['nct-stale'], ['nct-fresh']]);
     expect(state.brokerProvision).toHaveBeenCalledWith('nct-fresh', {
       team_id: 'T0TEAM123',

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -355,6 +355,37 @@ describe('Slack broker workspace choice', () => {
     expect(state.userInput).toHaveBeenCalledWith('slack_broker_workspace', 'T1TEAM456');
   });
 
+  it('reconnecting the same workspace completes when connected_at changes', async () => {
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    const oldWorkspace = {
+      team_id: 'T0TEAM123',
+      team_name: 'NanoCo',
+      status: 'active',
+      connected_as: 'U0OWNER12',
+      connected_at: '2026-08-20T13:40:00.000Z',
+    };
+    const reconnectedWorkspace = {
+      ...oldWorkspace,
+      connected_at: '2026-08-20T13:47:41.414Z',
+    };
+    state.selectLabels.push('Create it for me', 'Connect a different workspace');
+    state.brokerListWorkspaces
+      .mockResolvedValueOnce([oldWorkspace])
+      .mockResolvedValueOnce([oldWorkspace])
+      .mockResolvedValueOnce([reconnectedWorkspace]);
+
+    await maybeAutoProvisionSlack('Trusty', { root, importModule: async () => core });
+
+    expect(state.brokerListWorkspaces).toHaveBeenCalledTimes(3);
+    expect(state.brokerProvision).toHaveBeenCalledWith('nct-saved', {
+      team_id: 'T0TEAM123',
+      name: 'Trusty',
+      requested_by: 'U0OWNER12',
+    });
+    expect(state.userInput).toHaveBeenCalledWith('slack_broker_workspace', 'T0TEAM123');
+  });
+
   it('Set up manually instead returns to the manual path without provisioning', async () => {
     const root = track(rootWithModule());
     const core = fakeCore();

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -431,17 +431,12 @@ async function provisionViaBroker(
     }
     if (choice === 'connect') {
       setupLog.userInput('slack_broker_workspace', 'connect');
-      const knownTeamIds = workspaces.map((candidate) => candidate.team_id);
-      const refreshed = await connectWorkspace(core, token, knownTeamIds);
-      if (refreshed.length === 0) return undefined;
-      const known = new Set(knownTeamIds);
-      // "Connect a different workspace" declined everything on offer — the
-      // known teams stay out of the next round. And the operator connected the
-      // new one to use it: asking again would be the recognized-workspace
-      // auto-pick in reverse, so re-prompt only when more than one arrived.
-      const newWorkspaces = refreshed.filter((candidate) => !known.has(candidate.team_id));
-      if (newWorkspaces.length === 1) workspace = newWorkspaces[0];
-      else workspaces = newWorkspaces;
+      const connected = await connectWorkspace(core, token, workspaces);
+      if (connected.length === 0) return undefined;
+      // Slack already asked the operator which workspace to connect. Use the
+      // single confirmed choice directly; only re-prompt if several changed.
+      if (connected.length === 1) workspace = connected[0];
+      else workspaces = connected;
       continue;
     }
     workspace = choice;
@@ -519,15 +514,14 @@ function finishProvisioned(
 }
 
 /**
- * `alreadyKnownTeamIds` makes "connect a different workspace" waitable: the
- * poll succeeds only on a team that wasn't connected before it started —
- * a bare non-empty check would return instantly with the workspace the
- * operator just declined.
+ * The prior workspace snapshot makes OAuth waitable: a new team id or a
+ * changed `connected_at` proves the callback completed, while the unchanged
+ * list present before the browser opened does not.
  */
 async function connectWorkspace(
   core: ProvisioningCore,
   installToken: string,
-  alreadyKnownTeamIds: readonly string[] = [],
+  alreadyKnownWorkspaces: readonly BrokerWorkspace[] = [],
 ): Promise<BrokerWorkspace[]> {
   let url: string;
   try {
@@ -553,7 +547,9 @@ async function connectWorkspace(
 
   const s = p.spinner();
   const start = Date.now();
-  const knownTeamIds = new Set(alreadyKnownTeamIds);
+  const knownConnections = new Map(
+    alreadyKnownWorkspaces.map((workspace) => [workspace.team_id, workspace.connected_at]),
+  );
   s.start('Waiting for Slack to confirm the connection…');
   const deadline = start + OAUTH_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -572,15 +568,19 @@ async function connectWorkspace(
       }
       continue;
     }
-    const newlyConnected = found.filter((workspace) => !knownTeamIds.has(workspace.team_id));
-    if (newlyConnected.length > 0) {
+    const confirmed = found.filter(
+      (workspace) =>
+        !knownConnections.has(workspace.team_id) ||
+        (workspace.connected_at !== undefined && workspace.connected_at !== knownConnections.get(workspace.team_id)),
+    );
+    if (confirmed.length > 0) {
       const elapsedS = Math.round((Date.now() - start) / 1000);
-      s.stop(`Connected to ${newlyConnected[0].team_name}. ${k.dim(`(${elapsedS}s)`)}`);
+      s.stop(`Connected to ${confirmed[0].team_name}. ${k.dim(`(${elapsedS}s)`)}`);
       setupLog.step('slack-broker-oauth', 'success', Date.now() - start, {
-        TEAM_ID: newlyConnected[0].team_id,
-        TEAM_NAME: newlyConnected[0].team_name,
+        TEAM_ID: confirmed[0].team_id,
+        TEAM_NAME: confirmed[0].team_name,
       });
-      return found;
+      return confirmed;
     }
   }
   s.stop("Slack didn't confirm the connection in time.", 1);

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -269,6 +269,28 @@ export async function maybeAutoProvisionSlack(
 async function signInForBroker(core: ProvisioningCore, opts: { retry?: boolean } = {}): Promise<string | undefined> {
   const savedAccount = readRegistryAccount();
   const savedService = displayServiceOrigin(savedAccount?.api);
+  let force = opts.retry === true;
+  if (savedAccount && !opts.retry) {
+    const accountChoice = ensureAnswer(
+      await brightSelect<'saved' | 'different'>({
+        message: `Found saved NanoClaw credentials for ${savedService ?? 'an unknown service'}.`,
+        options: [
+          {
+            value: 'saved',
+            label: 'Use this account',
+            hint: 'validate the saved sign-in without opening a browser',
+          },
+          {
+            value: 'different',
+            label: 'Sign in with a different account',
+            hint: 'opens your browser and replaces the saved sign-in',
+          },
+        ],
+      }),
+    );
+    setupLog.userInput('slack_broker_account', accountChoice);
+    force = accountChoice === 'different';
+  }
   p.note(
     wrapForGutter(
       opts.retry
@@ -277,17 +299,21 @@ async function signInForBroker(core: ProvisioningCore, opts: { retry?: boolean }
             'Signing in again — finish it in your browser, then come',
             'back here.',
           ].join('\n')
-        : savedAccount
-          ? [
-              'Found saved NanoClaw credentials.',
-              `Service: ${savedService ?? 'unknown'}`,
-              'Checking whether they are valid for this setup…',
-            ].join('\n')
-          : [
-              'Creating the app for you runs through your NanoClaw account.',
-              'A code appears below — finish the sign-in in your browser,',
-              'then come back here.',
-            ].join('\n'),
+        : savedAccount && force
+          ? ['Signing in with a different NanoClaw account.', 'Finish it in your browser, then come back here.'].join(
+              '\n',
+            )
+          : savedAccount
+            ? [
+                'Found saved NanoClaw credentials.',
+                `Service: ${savedService ?? 'unknown'}`,
+                'Checking whether they are valid for this setup…',
+              ].join('\n')
+            : [
+                'Creating the app for you runs through your NanoClaw account.',
+                'A code appears below — finish the sign-in in your browser,',
+                'then come back here.',
+              ].join('\n'),
       6,
     ),
     'NanoClaw sign-in',
@@ -295,7 +321,7 @@ async function signInForBroker(core: ProvisioningCore, opts: { retry?: boolean }
   const wasDecided = imageSourceDecided();
   const priorSource = wasDecided ? readImageSource() : undefined;
   const start = Date.now();
-  const args = [REGISTRY_LOGIN_SCRIPT, '--require-verified', ...(opts.retry ? ['--force'] : [])];
+  const args = [REGISTRY_LOGIN_SCRIPT, '--require-verified', ...(force ? ['--force'] : [])];
   const code = await runInheritScript('bash', args);
   if (priorSource === 'local') writeImageSource('local');
   else if (!wasDecided) clearImageSource();
@@ -421,7 +447,32 @@ async function provisionViaBroker(
     if (workspaces.length === 0) return undefined;
   }
 
-  const workspace = await pickWorkspace(workspaces);
+  let workspace: BrokerWorkspace | undefined;
+  while (!workspace) {
+    const choice = await pickWorkspace(workspaces);
+    if (choice === 'manual') {
+      setupLog.userInput('slack_broker_workspace', 'manual');
+      p.log.info('Okay — walking through manual app creation instead.');
+      return undefined;
+    }
+    if (choice === 'connect') {
+      setupLog.userInput('slack_broker_workspace', 'connect');
+      const knownTeamIds = workspaces.map((candidate) => candidate.team_id);
+      const refreshed = await connectWorkspace(core, token, knownTeamIds);
+      if (refreshed.length === 0) return undefined;
+      const known = new Set(knownTeamIds);
+      // "Connect a different workspace" declined everything on offer — the
+      // known teams stay out of the next round. And the operator connected the
+      // new one to use it: asking again would be the recognized-workspace
+      // auto-pick in reverse, so re-prompt only when more than one arrived.
+      const newWorkspaces = refreshed.filter((candidate) => !known.has(candidate.team_id));
+      if (newWorkspaces.length === 1) workspace = newWorkspaces[0];
+      else workspaces = newWorkspaces;
+      continue;
+    }
+    workspace = choice;
+  }
+  setupLog.userInput('slack_broker_workspace', workspace.team_id);
   const s2 = p.spinner();
   start = Date.now();
   s2.start(`Creating ${name} in ${workspace.team_name}… (~30s — generating its avatar first)`);
@@ -493,7 +544,17 @@ function finishProvisioned(
   return { connection: 'provisioned', app_token: app.appToken };
 }
 
-async function connectWorkspace(core: ProvisioningCore, installToken: string): Promise<BrokerWorkspace[]> {
+/**
+ * `alreadyKnownTeamIds` makes "connect a different workspace" waitable: the
+ * poll succeeds only on a team that wasn't connected before it started —
+ * a bare non-empty check would return instantly with the workspace the
+ * operator just declined.
+ */
+async function connectWorkspace(
+  core: ProvisioningCore,
+  installToken: string,
+  alreadyKnownTeamIds: readonly string[] = [],
+): Promise<BrokerWorkspace[]> {
   let url: string;
   try {
     ({ url } = await core.brokerOauthUrl(installToken));
@@ -518,6 +579,7 @@ async function connectWorkspace(core: ProvisioningCore, installToken: string): P
 
   const s = p.spinner();
   const start = Date.now();
+  const knownTeamIds = new Set(alreadyKnownTeamIds);
   s.start('Waiting for Slack to confirm the connection…');
   const deadline = start + OAUTH_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -536,12 +598,13 @@ async function connectWorkspace(core: ProvisioningCore, installToken: string): P
       }
       continue;
     }
-    if (found.length > 0) {
+    const newlyConnected = found.filter((workspace) => !knownTeamIds.has(workspace.team_id));
+    if (newlyConnected.length > 0) {
       const elapsedS = Math.round((Date.now() - start) / 1000);
-      s.stop(`Connected to ${found[0].team_name}. ${k.dim(`(${elapsedS}s)`)}`);
+      s.stop(`Connected to ${newlyConnected[0].team_name}. ${k.dim(`(${elapsedS}s)`)}`);
       setupLog.step('slack-broker-oauth', 'success', Date.now() - start, {
-        TEAM_ID: found[0].team_id,
-        TEAM_NAME: found[0].team_name,
+        TEAM_ID: newlyConnected[0].team_id,
+        TEAM_NAME: newlyConnected[0].team_name,
       });
       return found;
     }
@@ -552,21 +615,29 @@ async function connectWorkspace(core: ProvisioningCore, installToken: string): P
   return [];
 }
 
-async function pickWorkspace(workspaces: BrokerWorkspace[]): Promise<BrokerWorkspace> {
-  if (workspaces.length === 1) {
-    setupLog.userInput('slack_broker_workspace', workspaces[0].team_id);
-    return workspaces[0];
-  }
-  const choice = ensureAnswer(
-    await brightSelect<BrokerWorkspace>({
-      message: 'Which workspace should the agent live in?',
-      options: workspaces.map((w) => ({
-        value: w,
-        label: w.team_name,
-        hint: w.connected_as ? `connected as ${w.connected_as}` : w.team_id,
-      })),
+type WorkspaceChoice = BrokerWorkspace | 'connect' | 'manual';
+
+async function pickWorkspace(workspaces: BrokerWorkspace[]): Promise<WorkspaceChoice> {
+  return ensureAnswer(
+    await brightSelect<WorkspaceChoice>({
+      message: workspaces.length === 1 ? 'Use this Slack workspace?' : 'Which workspace should the agent live in?',
+      options: [
+        ...workspaces.map((workspace) => ({
+          value: workspace,
+          label: workspaces.length === 1 ? `Use ${workspace.team_name}` : workspace.team_name,
+          hint: workspace.connected_as ? `connected as ${workspace.connected_as}` : workspace.team_id,
+        })),
+        {
+          value: 'connect',
+          label: 'Connect a different workspace',
+          hint: 'open Slack to connect another workspace',
+        },
+        {
+          value: 'manual',
+          label: 'Set up manually instead',
+          hint: 'walk through api.slack.com/apps by hand',
+        },
+      ],
     }),
   );
-  setupLog.userInput('slack_broker_workspace', choice.team_id);
-  return choice;
 }

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -269,28 +269,6 @@ export async function maybeAutoProvisionSlack(
 async function signInForBroker(core: ProvisioningCore, opts: { retry?: boolean } = {}): Promise<string | undefined> {
   const savedAccount = readRegistryAccount();
   const savedService = displayServiceOrigin(savedAccount?.api);
-  let force = opts.retry === true;
-  if (savedAccount && !opts.retry) {
-    const accountChoice = ensureAnswer(
-      await brightSelect<'saved' | 'different'>({
-        message: `Found saved NanoClaw credentials for ${savedService ?? 'an unknown service'}.`,
-        options: [
-          {
-            value: 'saved',
-            label: 'Use this account',
-            hint: 'validate the saved sign-in without opening a browser',
-          },
-          {
-            value: 'different',
-            label: 'Sign in with a different account',
-            hint: 'opens your browser and replaces the saved sign-in',
-          },
-        ],
-      }),
-    );
-    setupLog.userInput('slack_broker_account', accountChoice);
-    force = accountChoice === 'different';
-  }
   p.note(
     wrapForGutter(
       opts.retry
@@ -299,21 +277,17 @@ async function signInForBroker(core: ProvisioningCore, opts: { retry?: boolean }
             'Signing in again — finish it in your browser, then come',
             'back here.',
           ].join('\n')
-        : savedAccount && force
-          ? ['Signing in with a different NanoClaw account.', 'Finish it in your browser, then come back here.'].join(
-              '\n',
-            )
-          : savedAccount
-            ? [
-                'Found saved NanoClaw credentials.',
-                `Service: ${savedService ?? 'unknown'}`,
-                'Checking whether they are valid for this setup…',
-              ].join('\n')
-            : [
-                'Creating the app for you runs through your NanoClaw account.',
-                'A code appears below — finish the sign-in in your browser,',
-                'then come back here.',
-              ].join('\n'),
+        : savedAccount
+          ? [
+              'Found saved NanoClaw credentials.',
+              `Service: ${savedService ?? 'unknown'}`,
+              'Checking whether they are valid for this setup…',
+            ].join('\n')
+          : [
+              'Creating the app for you runs through your NanoClaw account.',
+              'A code appears below — finish the sign-in in your browser,',
+              'then come back here.',
+            ].join('\n'),
       6,
     ),
     'NanoClaw sign-in',
@@ -321,7 +295,7 @@ async function signInForBroker(core: ProvisioningCore, opts: { retry?: boolean }
   const wasDecided = imageSourceDecided();
   const priorSource = wasDecided ? readImageSource() : undefined;
   const start = Date.now();
-  const args = [REGISTRY_LOGIN_SCRIPT, '--require-verified', ...(force ? ['--force'] : [])];
+  const args = [REGISTRY_LOGIN_SCRIPT, '--require-verified', ...(opts.retry ? ['--force'] : [])];
   const code = await runInheritScript('bash', args);
   if (priorSource === 'local') writeImageSource('local');
   else if (!wasDecided) clearImageSource();


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Managed Slack setup previously auto-selected a single connected workspace without an opt-out.

Setup now reuses and validates saved NanoClaw credentials silently, then asks only which Slack workspace to use. The operator can use the recognized workspace, connect another workspace, or return to manual app creation. OAuth polling recognizes either a new Slack team or an updated `connected_at` value, so reconfirming an existing workspace also completes instead of timing out.

## Testing

- `pnpm exec vitest run setup/channels/slack-auto.test.ts` (22 tests passed)
- `pnpm exec prettier --check setup/channels/slack-auto.ts setup/channels/slack-auto.test.ts`