### PR TITLE
fix(permissions): disclose shared agent-group scope on approval cards

### DIFF
--- a/src/modules/permissions/channel-approval.test.ts
+++ b/src/modules/permissions/channel-approval.test.ts
@@ -187,6 +187,7 @@ describe('unknown-channel registration flow', () => {
     expect(payload.type).toBe('ask_question');
     // Card tells the approver the resolved engage rule.
     expect(payload.question).toContain('will respond to @-mentions in this group');
+    expect(payload.question).toContain('reach anything it can reach');
     // Single-agent card offers a direct "Connect to <name>" button.
     const connectOption = payload.options.find((o: { value: string }) => o.value.startsWith('connect:'));
     expect(connectOption).toBeDefined();
@@ -561,8 +562,10 @@ describe('unknown-channel registration flow', () => {
     }
 
     const followupPayload = JSON.parse(deliverMock.mock.calls[1][4] as string) as {
+      question: string;
       options: Array<{ label: string; value: string }>;
     };
+    expect(followupPayload.question).toContain('reach anything it can reach');
     expect(followupPayload.options.map((option) => option.value)).toContain('connect:ag-1');
     expect(followupPayload.options.map((option) => option.value)).not.toContain('connect:ag-2');
 

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -65,6 +65,10 @@ export const CONNECT_PREFIX = 'connect:';
 export const NEW_AGENT_VALUE = 'new_agent';
 export const CHOOSE_EXISTING_VALUE = 'choose_existing';
 export const REJECT_VALUE = 'reject';
+// This deliberately does not claim "the same authority as you": approved members cannot run admin commands,
+// which command-gate.ts gates on hasAdminPrivilege, but it names the real shared context, workspace, memory, and tool blast radius.
+export const AGENT_ACCESS_SCOPE_WARNING =
+  "Anyone approved here can direct the agent and reach anything it can reach — including other conversations' context, its workspace files and memory, and any connected tools.";
 
 // ── Channel-card interceptor seam (B2/D24) ──
 // A channel module can claim the escalation for its own channel type before
@@ -156,9 +160,9 @@ function buildQuestionText(
   const note = ruleNote ? ` If connected, the agent ${ruleNote}.` : '';
   if (isGroup) {
     const where = channelName ? `${channelName} on ${channelType}` : `a ${channelType} channel`;
-    return `${who} mentioned your bot in ${where}.${note} How would you like to handle this channel?`;
+    return `${who} mentioned your bot in ${where}.${note} ${AGENT_ACCESS_SCOPE_WARNING} How would you like to handle this channel?`;
   }
-  return `${who} sent your bot a DM on ${channelType}.${note} How would you like to handle it?`;
+  return `${who} sent your bot a DM on ${channelType}.${note} ${AGENT_ACCESS_SCOPE_WARNING} How would you like to handle it?`;
 }
 
 /**

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -68,7 +68,7 @@ export const REJECT_VALUE = 'reject';
 // This deliberately does not claim "the same authority as you": approved members cannot run admin commands,
 // which command-gate.ts gates on hasAdminPrivilege, but it names the real shared context, workspace, memory, and tool blast radius.
 export const AGENT_ACCESS_SCOPE_WARNING =
-  "Anyone approved here can direct the agent and reach anything it can reach — including other conversations' context, its workspace files and memory, and any connected tools.";
+  "Anyone approved here can interact with the agent and potentially access anything the agent can access, including other conversations' context, its workspace files and memory, and any connected tools.";
 
 // ── Channel-card interceptor seam (B2/D24) ──
 // A channel module can claim the escalation for its own channel type before

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -37,6 +37,7 @@ import { guard } from '../../guard/index.js';
 import { channelsRegister, sendersAdmit } from './guard.js';
 import { canAccessAgentGroup } from './access.js';
 import {
+  AGENT_ACCESS_SCOPE_WARNING,
   buildAgentSelectionOptions,
   CHOOSE_EXISTING_VALUE,
   CONNECT_PREFIX,
@@ -504,7 +505,7 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
     const agentGroups = await getAllAgentGroups();
     const options = await buildAgentSelectionOptions(agentGroups, approverId);
     const title = '📋 Choose an agent';
-    const question = 'Which agent should handle this channel?';
+    const question = `Which agent should handle this channel? ${AGENT_ACCESS_SCOPE_WARNING}`;
     await updatePendingChannelApprovalCard(row.messaging_group_id, title, question, JSON.stringify(options));
 
     try {

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -175,6 +175,7 @@ describe('unknown-sender request_approval flow', () => {
     const payload = JSON.parse(content as string);
     expect(payload.type).toBe('ask_question');
     expect(payload.questionId).toMatch(/^nsa-/);
+    expect(payload.question).toContain('reach anything it can reach');
 
     const { getDb } = await import('../../db/connection.js');
     const rows = await getDb().all('SELECT * FROM pending_sender_approvals');

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -47,6 +47,7 @@ import {
 } from './db/pending-sender-approvals.js';
 import { getOwners } from './db/user-roles.js';
 import { getUser } from './db/users.js';
+import { AGENT_ACCESS_SCOPE_WARNING } from './channel-approval.js';
 
 const APPROVAL_OPTIONS: RawOption[] = [
   { label: 'Allow', selectedLabel: '✅ Allowed', value: 'approve', style: 'primary' },
@@ -111,7 +112,7 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
   const originName = originMg?.name ?? `a ${originChannelType} channel`;
 
   const title = '👤 New sender';
-  const question = `${senderDisplay} wants to talk to your agent in ${originName}. Allow?`;
+  const question = `${senderDisplay} wants to talk to your agent in ${originName}. ${AGENT_ACCESS_SCOPE_WARNING} Allow?`;
   const options = normalizeOptions(APPROVAL_OPTIONS);
 
   await createPendingSenderApproval({


### PR DESCRIPTION
## Problem
Approving someone via the unknown-channel or unknown-sender card admits them to the agent group's shared runtime — session context, workspace, memory, connected tools. The card copy only said the agent "will respond to @-mentions", which reads as permission to converse, not consent to that scope.

## Fix
Copy-only: a shared scope-disclosure line is appended to every approval question (channel card, its choose-existing-agent follow-up, and the unknown-sender card). The authorization model is unchanged.

## Testing
Permissions suite passes (51 tests, including updated copy assertions); `tsc` clean; full host suite green apart from the pre-existing `scripts/update/transaction.e2e.test.ts` failures on main.
