### PR TITLE
fix(approvals): preserve adapter instance for DMs

### DIFF
--- a/src/channels/chat-sdk-bridge-byline.test.ts
+++ b/src/channels/chat-sdk-bridge-byline.test.ts
@@ -133,11 +133,11 @@ describe('chat-sdk-bridge approval-card terminal state', () => {
   });
 
   it('renders a rejected decision with the actor and original body', async () => {
-    const { edits, actions } = await fireAction({ userId: 'U4', userName: 'daniel' }, 'reject');
+    const { edits, actions } = await fireAction({ userId: 'U4', userName: 'reviewer' }, 'reject');
 
     expect(terminalText(edits[0])).toEqual([
       { type: 'text', content: 'Keep these full request details.' },
-      { type: 'text', content: '❌ Rejected by daniel', style: 'muted' },
+      { type: 'text', content: '❌ Rejected by reviewer', style: 'muted' },
     ]);
     expect(actions).toEqual(['q-1:reject:U4']);
   });

--- a/src/modules/approvals/expired-card-instance.test.ts
+++ b/src/modules/approvals/expired-card-instance.test.ts
@@ -114,14 +114,14 @@ describe('expired OneCLI card edits carry the posting instance', () => {
   });
 
   it('round-trips the instance through the row — a swept card resolves the same identity', async () => {
-    await seedPending({ instance: 'slack-mickey' });
+    await seedPending({ instance: 'slack-secondary' });
 
     // What sweepStaleApprovals does: re-read the persisted row, then edit.
     const persisted = await getPendingApproval('oa-test0001');
-    expect(persisted?.instance).toBe('slack-mickey');
+    expect(persisted?.instance).toBe('slack-secondary');
     await editCardExpired(persisted!, 'host restarted');
 
-    expect(delivered[0].instance).toBe('slack-mickey');
+    expect(delivered[0].instance).toBe('slack-secondary');
   });
 
   it('a NULL instance falls back to the channel type', async () => {

--- a/src/modules/approvals/picks.test.ts
+++ b/src/modules/approvals/picks.test.ts
@@ -33,12 +33,14 @@ afterEach(async () => {
 async function mountMockAdapter(
   channelType: string,
   openDM?: (handle: string) => Promise<string>,
+  instance: string = channelType,
 ): Promise<{ delivered: OutboundMessage[]; openDMCalls: string[] }> {
   const delivered: OutboundMessage[] = [];
   const openDMCalls: string[] = [];
   const adapter: ChannelAdapter = {
-    name: channelType,
+    name: instance,
     channelType,
+    instance,
     supportsThreads: false,
     async setup() {},
     async teardown() {},
@@ -57,7 +59,7 @@ async function mountMockAdapter(
       return openDM(handle);
     };
   }
-  registerChannelAdapter(channelType, { factory: () => adapter });
+  registerChannelAdapter(instance, { factory: () => adapter });
   await initChannelAdapters(() => ({
     conversations: [],
     onInbound: () => {},
@@ -142,5 +144,20 @@ describe('pickApprovalDelivery', () => {
   it('returns null when nobody is reachable', async () => {
     await seedUser('telegram:111', 'telegram');
     expect(await pickApprovalDelivery(['telegram:111'], 'telegram')).toBeNull();
+  });
+
+  it('resolves a named origin through its own bot instead of a cached sibling', async () => {
+    const primary = await mountMockAdapter('slack', async (handle) => `D-primary-${handle}`);
+    const secondary = await mountMockAdapter('slack', async (handle) => `D-secondary-${handle}`, 'slack-secondary');
+    await seedUser('slack:admin', 'slack');
+
+    const cached = await pickApprovalDelivery(['slack:admin'], 'slack');
+    expect(cached?.messagingGroup.platform_id).toBe('D-primary-admin');
+
+    const exact = await pickApprovalDelivery(['slack:admin'], 'slack', 'slack-secondary');
+    expect(exact?.messagingGroup.platform_id).toBe('D-secondary-admin');
+    expect(exact?.messagingGroup.instance).toBe('slack-secondary');
+    expect(primary.openDMCalls).toEqual(['admin']);
+    expect(secondary.openDMCalls).toEqual(['admin']);
   });
 });

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -160,21 +160,23 @@ export async function pickApprover(agentGroupId: string | null): Promise<string[
  * pair we can actually deliver to. Returns null if nobody is reachable.
  *
  * Tie-break: prefer approvers reachable on the same channel kind as the
- * origin; else first in list. Resolution uses ensureUserDm, which may
- * trigger a platform openDM call on cache miss.
+ * origin; else first in list. A same-channel origin resolves through its
+ * exact adapter instance.
  */
 export async function pickApprovalDelivery(
   approvers: string[],
   originChannelType: string,
+  originInstance?: string,
 ): Promise<{ userId: string; messagingGroup: MessagingGroup } | null> {
   if (originChannelType) {
     for (const userId of approvers) {
       if (channelTypeOf(userId) !== originChannelType) continue;
-      const mg = await ensureUserDm(userId);
+      const mg = await ensureUserDm(userId, originInstance === undefined ? undefined : { instance: originInstance });
       if (mg) return { userId, messagingGroup: mg };
     }
   }
   for (const userId of approvers) {
+    if (originChannelType && channelTypeOf(userId) === originChannelType) continue;
     const mg = await ensureUserDm(userId);
     if (mg) return { userId, messagingGroup: mg };
   }
@@ -233,11 +235,10 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
     return;
   }
 
-  const originChannelType = session.messaging_group_id
-    ? ((await getMessagingGroup(session.messaging_group_id))?.channel_type ?? '')
-    : '';
+  const origin = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  const originChannelType = origin?.channel_type ?? '';
 
-  const target = await pickApprovalDelivery(approvers, originChannelType);
+  const target = await pickApprovalDelivery(approvers, originChannelType, origin?.instance);
   if (!target) {
     await notifyAgent(session, `${action} failed: no DM channel found for any eligible approver.`);
     return;
@@ -252,9 +253,8 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
     action,
     payload: JSON.stringify(payload),
     created_at: new Date().toISOString(),
-    // The bot identity this card goes out as. This flow persists no delivery
-    // address (it has no card-edit path today), but the instance is the one
-    // piece that cannot be re-derived later, so record it while we hold it.
+    channel_type: target.messagingGroup.channel_type,
+    platform_id: target.messagingGroup.platform_id,
     instance: target.messagingGroup.instance ?? null,
     title,
     question,
@@ -277,6 +277,8 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
           question,
           options: APPROVAL_OPTIONS,
         }),
+        undefined,
+        target.messagingGroup.instance,
       );
     } catch (err) {
       log.error('Failed to deliver approval card', { action, approvalId, err });

--- a/src/modules/approvals/reason-capture.test.ts
+++ b/src/modules/approvals/reason-capture.test.ts
@@ -16,7 +16,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { InboundEvent } from '../../channels/adapter.js';
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
-import { createMessagingGroup } from '../../db/messaging-groups.js';
 import {
   createSession,
   createPendingApproval,
@@ -27,7 +26,6 @@ import {
 import { setDeliveryAdapter, type ChannelDeliveryAdapter } from '../../delivery.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import { upsertUser } from '../permissions/db/users.js';
-import { upsertUserDm } from '../permissions/db/user-dms.js';
 import { grantRole } from '../permissions/db/user-roles.js';
 import { REJECT_WITH_REASON_VALUE } from './primitive.js';
 
@@ -48,16 +46,17 @@ vi.mock('../../session-manager.js', async () => {
 const TEST_DIR = '/tmp/nanoclaw-test-reject-reason';
 const DM_CHANNEL = 'slack';
 const DM_PLATFORM = 'D-admin-1';
+const DM_INSTANCE = 'slack-secondary';
 
 function now(): string {
   return new Date().toISOString();
 }
 
-let delivered: Array<{ channelType: string; platformId: string; content: string }>;
+let delivered: Array<{ channelType: string; platformId: string; content: string; instance?: string }>;
 
 const fakeAdapter: ChannelDeliveryAdapter = {
-  async deliver(channelType, platformId, _threadId, _kind, content) {
-    delivered.push({ channelType, platformId, content });
+  async deliver(channelType, platformId, _threadId, _kind, content, _files, instance) {
+    delivered.push({ channelType, platformId, content, instance });
     return 'pm-1';
   },
 };
@@ -70,6 +69,9 @@ async function seedApproval(approvalId: string, action = 'create_agent'): Promis
     action,
     payload: JSON.stringify({ name: 'child' }),
     created_at: now(),
+    channel_type: DM_CHANNEL,
+    platform_id: DM_PLATFORM,
+    instance: DM_INSTANCE,
     title: 'Approval',
     options_json: JSON.stringify([]),
   });
@@ -80,6 +82,7 @@ function dmReply(text?: string): InboundEvent {
   if (text !== undefined) content.text = text;
   return {
     channelType: DM_CHANNEL,
+    instance: DM_INSTANCE,
     platformId: DM_PLATFORM,
     threadId: null,
     message: { id: 'm-1', kind: 'chat', content: JSON.stringify(content), timestamp: now() },
@@ -94,7 +97,7 @@ async function clickRejectWithReason(approvalId: string): Promise<void> {
     value: REJECT_WITH_REASON_VALUE,
     userId: 'admin-1',
     channelType: DM_CHANNEL,
-    platformId: '', // not surfaced by the click payload — resolved via ensureUserDm
+    platformId: DM_PLATFORM,
     threadId: null,
   });
 }
@@ -127,8 +130,7 @@ beforeEach(async () => {
     created_at: now(),
   });
 
-  // Authorized approver + a cached DM so ensureUserDm resolves without a
-  // platform openDM call.
+  // Authorized approver for the stored delivery address.
   await upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
   await grantRole({
     user_id: 'slack:admin-1',
@@ -137,22 +139,6 @@ beforeEach(async () => {
     granted_by: null,
     granted_at: now(),
   });
-  await createMessagingGroup({
-    id: 'mg-dm-1',
-    channel_type: DM_CHANNEL,
-    platform_id: DM_PLATFORM,
-    name: 'Admin DM',
-    is_group: 0,
-    unknown_sender_policy: 'strict',
-    created_at: now(),
-  });
-  await upsertUserDm({
-    user_id: 'slack:admin-1',
-    channel_type: DM_CHANNEL,
-    messaging_group_id: 'mg-dm-1',
-    resolved_at: now(),
-  });
-
   setDeliveryAdapter(fakeAdapter);
 });
 
@@ -174,6 +160,7 @@ describe('reject with reason', () => {
     expect(delivered).toHaveLength(1);
     expect(delivered[0].channelType).toBe(DM_CHANNEL);
     expect(delivered[0].platformId).toBe(DM_PLATFORM);
+    expect(delivered[0].instance).toBe(DM_INSTANCE);
     expect((JSON.parse(delivered[0].content) as { text: string }).text).toMatch(/reason/i);
 
     // Agent is not notified yet — the hold is still open.

--- a/src/modules/approvals/reason-capture.ts
+++ b/src/modules/approvals/reason-capture.ts
@@ -30,7 +30,6 @@ import {
 import { log } from '../../log.js';
 import { registerMessageInterceptor } from '../../router.js';
 import type { PendingApproval, Session } from '../../types.js';
-import { ensureUserDm } from '../permissions/user-dm.js';
 import { finalizeReject } from './finalize.js';
 
 /** How long an awaiting-reason hold waits for the admin's reply before the sweep finalizes a plain reject. */
@@ -50,15 +49,15 @@ interface ReasonArming {
 
 /**
  * Approvers waiting to type a rejection reason, keyed by their DM channel
- * (`<channelType>:<dmPlatformId>`). A DM's platform id is unique per user, so
+ * (`<instance>:<dmPlatformId>`). A DM's platform id is unique per user, so
  * the inbound reply matches by channel alone — no sender re-parsing needed, and
  * a group message can never collide with an armed DM. Cleared on receipt,
  * staleness, or restart.
  */
 const awaitingReason = new Map<string, ReasonArming>();
 
-function dmKey(channelType: string, platformId: string): string {
-  return `${channelType}:${platformId}`;
+function dmKey(channelType: string, platformId: string, instance: string = channelType): string {
+  return `${instance}:${platformId}`;
 }
 
 function clampReason(raw: string): string {
@@ -86,13 +85,15 @@ export async function armReasonCapture(approval: PendingApproval, session: Sessi
   const expiresAt = new Date(Date.now() + REASON_CAPTURE_WINDOW_MS).toISOString();
   if (!(await markApprovalAwaitingReason(approval.approval_id, expiresAt))) return;
 
-  const dm = userId ? await ensureUserDm(userId) : null;
+  const channelType = approval.channel_type;
+  const platformId = approval.platform_id;
+  const instance = approval.instance ?? channelType ?? undefined;
   const adapter = getDeliveryAdapter();
-  if (!dm || !adapter) {
+  if (!userId || !channelType || !platformId || !adapter) {
     log.warn('reject-with-reason: cannot reach approver, finalizing plain reject', {
       approvalId: approval.approval_id,
       userId,
-      hasDm: Boolean(dm),
+      hasDeliveryAddress: Boolean(channelType && platformId),
       hasAdapter: Boolean(adapter),
     });
     await finalizeReject(approval, session, userId, undefined, 'awaiting_reason');
@@ -100,7 +101,15 @@ export async function armReasonCapture(approval: PendingApproval, session: Sessi
   }
 
   try {
-    await adapter.deliver(dm.channel_type, dm.platform_id, null, 'chat-sdk', JSON.stringify({ text: PROMPT_TEXT }));
+    await adapter.deliver(
+      channelType,
+      platformId,
+      null,
+      'chat-sdk',
+      JSON.stringify({ text: PROMPT_TEXT }),
+      undefined,
+      instance,
+    );
   } catch (err) {
     log.error('reject-with-reason: reason prompt delivery failed, finalizing plain reject', {
       approvalId: approval.approval_id,
@@ -112,7 +121,7 @@ export async function armReasonCapture(approval: PendingApproval, session: Sessi
 
   // Prompt is out — now hold the row and arm capture. Order matters: a reply
   // can't arrive before the prompt is read, so there's no lost-message window.
-  awaitingReason.set(dmKey(dm.channel_type, dm.platform_id), { approvalId: approval.approval_id, userId });
+  awaitingReason.set(dmKey(channelType, platformId, instance), { approvalId: approval.approval_id, userId });
   log.info('reject-with-reason: awaiting reason reply', { approvalId: approval.approval_id, userId });
 }
 
@@ -124,11 +133,12 @@ export async function armReasonCapture(approval: PendingApproval, session: Sessi
  * Exported for tests; registered as the interceptor below.
  */
 export async function captureReasonReply(event: InboundEvent): Promise<boolean> {
-  const arming = awaitingReason.get(dmKey(event.channelType, event.platformId));
+  const key = dmKey(event.channelType, event.platformId, event.instance);
+  const arming = awaitingReason.get(key);
   if (!arming) return false;
 
   // This DM is an armed reason channel — disarm regardless of outcome.
-  awaitingReason.delete(dmKey(event.channelType, event.platformId));
+  awaitingReason.delete(key);
 
   const approval = await getPendingApproval(arming.approvalId);
   if (!approval || approval.status !== 'awaiting_reason') {

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -264,7 +264,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     }
   }
 
-  const delivery = await pickApprovalDelivery(approvers, originChannelType);
+  const delivery = await pickApprovalDelivery(approvers, originChannelType, originMg?.instance);
   if (!delivery) {
     log.warn('Channel registration skipped — no DM channel for any approver', {
       messagingGroupId,
@@ -327,6 +327,8 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
         question,
         options,
       }),
+      undefined,
+      delivery.messagingGroup.instance,
     );
     log.info('Channel registration card delivered', {
       messagingGroupId,

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -66,6 +66,7 @@ interface PendingNameInput {
   channelMgId: string;
   dmChannelType: string;
   dmPlatformId: string;
+  dmInstance: string;
 }
 const awaitingNameInput = new Map<string, PendingNameInput>();
 
@@ -490,7 +491,10 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
 
   // ── Choose existing agent — send agent-selection follow-up card ──
   if (payload.value === CHOOSE_EXISTING_VALUE) {
-    const approverDm = await ensureUserDm(row.approver_user_id);
+    const origin = await getMessagingGroup(row.messaging_group_id);
+    const approverDm = await ensureUserDm(row.approver_user_id, {
+      instance: payload.channelType === origin?.channel_type ? origin.instance : undefined,
+    });
     if (!approverDm) {
       log.error('Channel registration: no DM channel for approver', {
         messagingGroupId: row.messaging_group_id,
@@ -521,6 +525,8 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
           question,
           options,
         }),
+        undefined,
+        approverDm.instance,
       );
     } catch (err) {
       log.error('Channel registration: agent-selection card delivery failed', {
@@ -533,7 +539,10 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
 
   // ── Create new agent — prompt for free-text name ──
   if (payload.value === NEW_AGENT_VALUE) {
-    const approverDm = await ensureUserDm(row.approver_user_id);
+    const origin = await getMessagingGroup(row.messaging_group_id);
+    const approverDm = await ensureUserDm(row.approver_user_id, {
+      instance: payload.channelType === origin?.channel_type ? origin.instance : undefined,
+    });
     if (!approverDm) {
       log.error('Channel registration: no DM channel for approver', {
         messagingGroupId: row.messaging_group_id,
@@ -549,11 +558,11 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
       });
       return true;
     }
-
     awaitingNameInput.set(row.approver_user_id, {
       channelMgId: row.messaging_group_id,
       dmChannelType: approverDm.channel_type,
       dmPlatformId: approverDm.platform_id,
+      dmInstance: approverDm.instance ?? approverDm.channel_type,
     });
 
     try {
@@ -563,6 +572,8 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
         null,
         'chat-sdk',
         JSON.stringify({ text: 'Reply with the name for your new agent:' }),
+        undefined,
+        approverDm.instance,
       );
     } catch (err) {
       log.error('Channel registration: name prompt delivery failed', {
@@ -622,6 +633,7 @@ registerMessageInterceptor(async (event: InboundEvent): Promise<boolean> => {
   const pending = awaitingNameInput.get(userId);
   if (!pending) return false;
   if (event.channelType !== pending.dmChannelType || event.platformId !== pending.dmPlatformId) return false;
+  if ((event.instance ?? event.channelType) !== pending.dmInstance) return false;
 
   awaitingNameInput.delete(userId);
 
@@ -653,22 +665,21 @@ registerMessageInterceptor(async (event: InboundEvent): Promise<boolean> => {
 
   const adapter = getDeliveryAdapter();
   if (adapter) {
-    const dm = await ensureUserDm(row.approver_user_id);
-    if (dm) {
-      adapter
-        .deliver(
-          dm.channel_type,
-          dm.platform_id,
-          null,
-          'chat-sdk',
-          JSON.stringify({
-            text: wired
-              ? `✅ Agent "${ag.name}" created and connected.`
-              : `⚠️ Agent "${ag.name}" was created but the channel couldn't be connected — check the host logs.`,
-          }),
-        )
-        .catch(() => {});
-    }
+    adapter
+      .deliver(
+        event.channelType,
+        event.platformId,
+        null,
+        'chat-sdk',
+        JSON.stringify({
+          text: wired
+            ? `✅ Agent "${ag.name}" created and connected.`
+            : `⚠️ Agent "${ag.name}" was created but the channel couldn't be connected — check the host logs.`,
+        }),
+        undefined,
+        event.instance,
+      )
+      .catch(() => {});
   }
   return true;
 });

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -97,7 +97,7 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
 
   const originMg = await getMessagingGroup(messagingGroupId);
   const originChannelType = originMg?.channel_type ?? '';
-  const target = await pickApprovalDelivery(approvers, originChannelType);
+  const target = await pickApprovalDelivery(approvers, originChannelType, originMg?.instance);
   if (!target) {
     log.warn('Unknown-sender approval skipped — no DM channel for any approver', {
       messagingGroupId,
@@ -153,6 +153,8 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
         question,
         options,
       }),
+      undefined,
+      target.messagingGroup.instance,
     );
     log.info('Unknown-sender approval card delivered', {
       approvalId,
@@ -280,7 +282,7 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
     log.warn('decline_notify FYI skipped — no owner or admin configured', { messagingGroupId, senderIdentity });
     return;
   }
-  const target = await pickApprovalDelivery(approvers, event.channelType);
+  const target = await pickApprovalDelivery(approvers, event.channelType, originMg?.instance ?? event.instance);
   if (!target) {
     log.warn('decline_notify FYI skipped — no DM channel for any approver', { messagingGroupId, senderIdentity });
     return;
@@ -299,6 +301,8 @@ export async function declineAndNotify(input: DeclineAndNotifyInput): Promise<vo
       null,
       'chat-sdk',
       JSON.stringify({ text: fyiText }),
+      undefined,
+      target.messagingGroup.instance,
     );
     log.info('decline_notify handled — decline sent, owner notified', {
       messagingGroupId,

--- a/src/modules/permissions/user-dm.ts
+++ b/src/modules/permissions/user-dm.ts
@@ -22,17 +22,17 @@
  *
  * ## Caching
  *
- * Successful resolutions are persisted in `user_dms (user_id, channel_type
- * → messaging_group_id)`. The cache survives restarts; first-time DMs on a
- * given channel pay one `openDM` round trip, everyone after is a pure DB
- * read.
+ * Default-instance resolutions are persisted in `user_dms (user_id,
+ * channel_type → messaging_group_id)`. Named instances resolve directly
+ * because the cache has no instance dimension. The underlying messaging-group
+ * row is still reused; only the idempotent `openDM` lookup repeats.
  *
  * The underlying platform APIs (`POST /users/@me/channels` on Discord,
  * `conversations.open` on Slack, etc.) are idempotent and return the same
  * channel on repeated calls, so re-resolving after a cache miss is always
  * safe — worst case we round-trip redundantly.
  */
-import { getChannelAdapter } from '../../channels/channel-registry.js';
+import { getChannelAdapter, getChannelAdapterExact } from '../../channels/channel-registry.js';
 import { getMessagingGroup, getMessagingGroupByPlatform, createMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
 import type { MessagingGroup, User } from '../../types.js';
@@ -53,7 +53,7 @@ import { getUserDm, upsertUserDm } from './db/user-dms.js';
  */
 export async function ensureUserDm(
   userId: string,
-  { privacySafeLogs = false }: { privacySafeLogs?: boolean } = {},
+  { privacySafeLogs = false, instance }: { privacySafeLogs?: boolean; instance?: string } = {},
 ): Promise<MessagingGroup | null> {
   const user = await getUser(userId);
   if (!user) {
@@ -67,32 +67,42 @@ export async function ensureUserDm(
     return null;
   }
 
-  // Cache hit: existing user_dms row → load and return the messaging_group.
-  const cached = await getUserDm(userId, channelType);
-  if (cached) {
-    const mg = await getMessagingGroup(cached.messaging_group_id);
-    if (mg) return mg;
-    // Row points to a deleted messaging_group — fall through and re-resolve.
-    log.warn(
-      'ensureUserDm: cached row references missing messaging_group, re-resolving',
-      privacySafeLogs ? { channelType } : { userId, messagingGroupId: cached.messaging_group_id },
-    );
+  // The cache has no instance key. Keep it for the default instance; named
+  // instances resolve directly unless repeated openDM calls become a measured
+  // problem worth a schema migration.
+  const cacheable = instance === undefined || instance === channelType;
+  if (cacheable) {
+    const cached = await getUserDm(userId, channelType);
+    if (cached) {
+      const mg = await getMessagingGroup(cached.messaging_group_id);
+      if (mg && (instance === undefined || (mg.instance ?? mg.channel_type) === instance)) return mg;
+      if (mg) {
+        log.debug('ensureUserDm: cached row belongs to a different instance, re-resolving', { channelType, instance });
+      } else {
+        // Row points to a deleted messaging_group — fall through and re-resolve.
+        log.warn(
+          'ensureUserDm: cached row references missing messaging_group, re-resolving',
+          privacySafeLogs ? { channelType } : { userId, messagingGroupId: cached.messaging_group_id },
+        );
+      }
+    }
   }
 
   // Cache miss: resolve the DM platform_id either via openDM or directly.
-  const dmPlatformId = await resolveDmPlatformId(channelType, handle, privacySafeLogs);
+  const dmPlatformId = await resolveDmPlatformId(channelType, handle, privacySafeLogs, instance);
   if (!dmPlatformId) return null;
 
   // Find-or-create the underlying messaging_group. A DM we received
   // earlier may already have a row matching (channel_type, platform_id).
   const now = new Date().toISOString();
-  let mg = await getMessagingGroupByPlatform(channelType, dmPlatformId);
+  let mg = await getMessagingGroupByPlatform(channelType, dmPlatformId, instance);
   if (!mg) {
     const mgId = `mg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     mg = {
       id: mgId,
       channel_type: channelType,
       platform_id: dmPlatformId,
+      instance: instance ?? channelType,
       name: user.display_name,
       is_group: 0,
       // Deliberately 'strict', NOT the channel's declared DM policy: this row
@@ -109,12 +119,14 @@ export async function ensureUserDm(
     );
   }
 
-  await upsertUserDm({
-    user_id: userId,
-    channel_type: channelType,
-    messaging_group_id: mg.id,
-    resolved_at: now,
-  });
+  if (cacheable) {
+    await upsertUserDm({
+      user_id: userId,
+      channel_type: channelType,
+      messaging_group_id: mg.id,
+      resolved_at: now,
+    });
+  }
 
   return mg;
 }
@@ -127,10 +139,11 @@ async function resolveDmPlatformId(
   channelType: string,
   handle: string,
   privacySafeLogs: boolean,
+  instance?: string,
 ): Promise<string | null> {
-  const adapter = getChannelAdapter(channelType);
+  const adapter = instance === undefined ? getChannelAdapter(channelType) : getChannelAdapterExact(instance);
   if (!adapter) {
-    log.warn('ensureUserDm: no adapter for channel', { channelType });
+    log.warn('ensureUserDm: no adapter for channel', { channelType, instance });
     return null;
   }
   if (!adapter.openDM) {


### PR DESCRIPTION
## Problem
In a multi-instance channel install, `user_dms` caches one DM surface per `(user_id, channel_type)`. Approval flows could therefore reuse a sibling adapter's cached DM and send the card or a follow-up through the wrong bot identity.

## Fix
- Keep the existing `user_dms` schema and default-instance cache behavior.
- When an approval originates from a named instance, resolve the approver DM through that exact adapter and bypass the channel-only cache. The platform `openDM` operation is idempotent, and the existing messaging-group row is still reused.
- Carry the resolved instance into initial approval delivery.
- Reuse the exact stored or inbound delivery address for rejection-reason prompts and subsequent free-text responses.
- Use generic role and instance labels in test fixtures.

This deliberately avoids a database migration: the cache remains an optimization for default instances, while named instances favor correctness over avoiding one idempotent lookup.

## Testing
- Regression: cache a DM for one adapter, then request approval delivery for a named sibling; the DM is opened and delivered through the requested instance.
- `pnpm test` — 162 files / 2,071 tests passed.
- `pnpm run build` — passed.
- `pnpm run typecheck` — passed.
- Prettier passed; changed-file lint reports 0 errors.

Resolves SAF-011.