### PR TITLE
fix(setup): drop stale Slack experimental/public-URL copy, modal-agnostic app-creation walkthrough

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -92,7 +92,7 @@ behaves like Socket Mode minus the walkthrough below.
 For Socket Mode, tell the user:
 ```nc:operator when:connection=socket
 Create the Slack app (Socket Mode):
-1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
+1. Go to api.slack.com/apps and create a new app using whichever creation flow is currently available (e.g. starting from scratch or from a manifest). Name it (e.g. "NanoClaw") and pick your workspace.
 2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Basic Information → App-Level Tokens → "Generate Token and Scopes" → add the connections:write scope → copy the token (starts with xapp-).
@@ -104,7 +104,7 @@ Create the Slack app (Socket Mode):
 For webhook delivery, tell the user:
 ```nc:operator when:connection=webhook
 Create the Slack app (webhook delivery):
-1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
+1. Go to api.slack.com/apps and create a new app using whichever creation flow is currently available (e.g. starting from scratch or from a manifest). Name it (e.g. "NanoClaw") and pick your workspace.
 2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Install to Workspace, then copy the Bot User OAuth Token (starts with xoxb-).

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1869,6 +1869,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
     await brightSelect<ChannelChoice>({
       message: 'Want to chat with your assistant from your phone?',
       options: [
+        { value: 'slack', label: 'Yes, connect Slack' },
         { value: 'telegram', label: 'Yes, connect Telegram', hint: 'recommended' },
         { value: 'discord', label: 'Yes, connect Discord' },
         { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
@@ -1881,11 +1882,6 @@ async function askChannelChoice(): Promise<ChannelChoice> {
           value: 'imessage',
           label: 'Yes, connect iMessage',
           hint: 'local Mac or hosted iMessage (via photon.codes)',
-        },
-        {
-          value: 'slack',
-          label: 'Yes, connect Slack (experimental)',
-          hint: 'needs public URL',
         },
         { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
         { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },


### PR DESCRIPTION
## Problem
Setup still labeled Slack "experimental" and claimed it needs a public URL — neither is true on the managed Socket Mode path. The manual app-creation walkthrough also referenced exact Slack modal options that Slack has since changed, so operators could not follow it literally.

## Fix
Copy-only: Slack leads the channel list without the stale hints, and the app-creation walkthrough's first step describes intent ("create a new app, from a manifest if offered") rather than exact button labels.

Companion PR (same copy on the channels branch): #3395

## Testing
Copy-level change; setup suite and build green.

