### PR TITLE
fix(slack): send immediate ack when agent creation starts

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -18,11 +18,17 @@
  * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
  *
  * The handler never touches inbound DBs (guarded handlers replay without
- * one); all requester notifications go through the approvals module's
- * notifyAgent. Token values never appear in notify texts or logs.
+ * one); completion notifications go through the approvals module's
+ * notifyAgent, while the provisioning acknowledgement goes straight to the
+ * origin conversation. Token values never appear in notify texts or logs.
  */
 import { SlackApiError } from '../../channels/slack-lib.js';
-import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
+import {
+  getDeliveryAdapter,
+  reenterGuardedDeliveryAction,
+  registerDeliveryAction,
+  registerDeliveryBatchPreview,
+} from '../../delivery.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
@@ -106,6 +112,10 @@ function successText(name: string, roomChannelId: string | undefined): string {
   );
 }
 
+function ackText(name: string): string {
+  return `Creating "${name}" — takes about a minute; it will DM you when ready.`;
+}
+
 function failureText(
   name: string,
   localName: string,
@@ -145,6 +155,26 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
   if (!after || after.target_type !== 'agent' || before) return;
   // Non-Slack sessions (and task/a2a sessions with no messaging group) behave exactly as upstream.
   if (!slackOrigin) return;
+
+  const adapter = getDeliveryAdapter();
+  const messagingGroup = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : null;
+  if (!adapter) {
+    log.error('slack-agent-flow creation acknowledgement skipped — no delivery adapter is wired');
+  } else if (messagingGroup) {
+    try {
+      await adapter.deliver(
+        messagingGroup.channel_type,
+        messagingGroup.platform_id,
+        session.thread_id,
+        'chat-sdk',
+        JSON.stringify({ text: ackText(name) }),
+        undefined,
+        messagingGroup.instance,
+      );
+    } catch (err) {
+      log.error('slack-agent-flow creation acknowledgement delivery failed', { err });
+    }
+  }
 
   const slug = await dedupeSlug(deriveInstanceSlug(name), after.target_id);
   try {

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -99,10 +99,10 @@ vi.mock('../approvals/index.js', async () => {
 import './index.js';
 import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
 import { SlackFlowError } from './types.js';
-import { getDeliveryAction } from '../../delivery.js';
+import { getDeliveryAction, setDeliveryAdapter } from '../../delivery.js';
 import { log } from '../../log.js';
 import { registerChannelAdapter } from '../../channels/channel-registry.js';
-import { closeDb, initTestDb } from '../../db/connection.js';
+import { closeDb, getDb, initTestDb } from '../../db/connection.js';
 import { runMigrations } from '../../db/migrations/index.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
 import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
@@ -286,6 +286,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // delivery.ts has no reset helper; clear its module-global test state.
+  setDeliveryAdapter(null!);
   process.chdir(originalCwd);
   delete process.env.NANOCLAW_REGISTRY_TOKEN;
   vi.unstubAllGlobals();
@@ -295,6 +297,51 @@ afterEach(async () => {
 });
 
 describe('slack-aware create_agent — happy path (Slack-origin session)', () => {
+  it('delivers one direct provisioning acknowledgement per created agent', async () => {
+    // Named-instance origin — the very shape this flow provisions. Registry
+    // resolution is exact-key (`instance ?? channelType`, no fallback), so the
+    // ack MUST carry the origin mg's instance or it silently misses the
+    // adapter for every named-instance origin.
+    getDb().prepare(`UPDATE messaging_groups SET instance = 'slack-lion' WHERE id = 'mg-origin'`).run();
+    // S2 origin-auth resolves the token by instance key: slack-lion → SLACK_BOT_TOKEN_LION.
+    fs.appendFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN_LION=${ORIGIN_BOT_TOKEN}\n`);
+
+    const deliveries: Array<{
+      channelType: string;
+      platformId: string;
+      threadId: string | null;
+      content: string;
+      instance: string | undefined;
+    }> = [];
+    setDeliveryAdapter({
+      deliver: vi.fn(async (channelType, platformId, threadId, _kind, content, _files, instance) => {
+        deliveries.push({ channelType, platformId, threadId, content, instance });
+        return undefined;
+      }),
+    });
+
+    await runCreateAgent({ name: 'Research', room: 'none' });
+    await runCreateAgent({ name: 'Writer', room: 'none' });
+
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries).toEqual([
+      {
+        channelType: 'slack',
+        platformId: 'slack:D0OPDM',
+        threadId: null,
+        instance: 'slack-lion',
+        content: JSON.stringify({ text: 'Creating "Research" — takes about a minute; it will DM you when ready.' }),
+      },
+      {
+        channelType: 'slack',
+        platformId: 'slack:D0OPDM',
+        threadId: null,
+        instance: 'slack-lion',
+        content: JSON.stringify({ text: 'Creating "Writer" — takes about a minute; it will DM you when ready.' }),
+      },
+    ]);
+  });
+
   it('creates the group, provisions the bot, wires DM + room, posts intros in order', async () => {
     await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
 


### PR DESCRIPTION
## Problem
Asking an agent to create more agents produced only Slack's persistent typing indicator for the whole multi-minute provisioning run — no acknowledgement, no expectation-setting — with the reply arriving only after every new agent was created. The only prior mitigation was an instructions-level nudge, which depends on model compliance.

## Fix
The `create_agent` flow now delivers a short host-side acknowledgement directly to the origin conversation (same direct `adapter.deliver` pattern the approval flows use) right after the local create is confirmed and before slow provisioning starts. The delivery carries the origin messaging group's adapter **instance**, so named-instance bots (the multi-agent configuration this matters most for) ack through the correct bot. One ack per created agent doubles as a natural progress signal for batches.

## Testing
Regression test with a named-instance origin (`slack-lion`): asserts the ack fires and goes out through that exact instance — fails on the previous code (`instance: undefined`). 15/15 in the flow's test file; zero new type errors versus the branch base.
