### PR TITLE
fix(slack): working manual-install fallback, delivered to the requester

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -17,12 +17,18 @@
  * (superset re-open — MPIM fork), each guard-wrapped with the same
  * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
  *
- * The handler never touches inbound DBs (guarded handlers replay without
- * one); all requester notifications go through the approvals module's
- * notifyAgent. Token values never appear in notify texts or logs.
+ * The handler never touches inbound DBs directly (guarded handlers replay
+ * without one). Failure instructions go straight to the origin chat so an
+ * agent cannot summarize away the recovery URL; if delivery is unavailable,
+ * notifyAgent remains the fallback. Token values never appear in texts/logs.
  */
 import { SlackApiError } from '../../channels/slack-lib.js';
-import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
+import {
+  getDeliveryAdapter,
+  reenterGuardedDeliveryAction,
+  registerDeliveryAction,
+  registerDeliveryBatchPreview,
+} from '../../delivery.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
@@ -126,6 +132,31 @@ function failureText(
   );
 }
 
+/** Deliver recovery instructions without an LLM relay that may omit the URL. */
+export async function deliverFailureToOrigin(
+  session: Session,
+  text: string,
+  adapter = getDeliveryAdapter(),
+): Promise<boolean> {
+  const origin = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  if (!adapter || !origin) return false;
+  try {
+    await adapter.deliver(
+      origin.channel_type,
+      origin.platform_id,
+      session.thread_id,
+      'chat',
+      JSON.stringify({ text }),
+      undefined,
+      origin.instance,
+    );
+    return true;
+  } catch (err) {
+    log.warn('Direct Slack agent fallback delivery failed; notifying requester agent instead', { err });
+    return false;
+  }
+}
+
 async function slackAwareCreateAgent(content: Record<string, unknown>, session: Session): Promise<void> {
   const name = typeof content.name === 'string' ? content.name : '';
   const localName = normalizeName(name);
@@ -155,19 +186,17 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
     // shared Slack lib — surface it like a typed flow step.
     const step = err instanceof SlackFlowError || err instanceof SlackApiError ? err.step : 'unknown';
     const message = err instanceof Error ? err.message : String(err);
-    await notifyAgent(
-      session,
-      failureText(
-        name,
-        localName,
-        step,
-        message,
-        after.target_id,
-        slug,
-        session.agent_group_id,
-        content.room === 'none',
-      ),
+    const failure = failureText(
+      name,
+      localName,
+      step,
+      message,
+      after.target_id,
+      slug,
+      session.agent_group_id,
+      content.room === 'none',
     );
+    if (!(await deliverFailureToOrigin(session, failure))) await notifyAgent(session, failure);
     log.error('slack-agent-flow failed', { step });
   }
 }

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -96,7 +96,7 @@ vi.mock('../approvals/index.js', async () => {
 
 // Registers the wrapped create_agent delivery action — the path under test.
 // Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
-import './index.js';
+import { deliverFailureToOrigin } from './index.js';
 import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
 import { SlackFlowError } from './types.js';
 import { getDeliveryAction } from '../../delivery.js';
@@ -651,6 +651,22 @@ describe('slack-aware create_agent — non-Slack parity', () => {
 });
 
 describe('slack-aware create_agent — failure and retry', () => {
+  it('delivers manual fallback text directly to the origin chat', async () => {
+    const deliver = vi.fn().mockResolvedValue('msg-1');
+    const text = 'Install from https://api.slack.com/apps/A0TEST/oauth';
+
+    await expect(deliverFailureToOrigin(SLACK_SESSION, text, { deliver })).resolves.toBe(true);
+
+    expect(deliver.mock.calls[0]!.slice(0, 5)).toEqual([
+      'slack',
+      'slack:D0OPDM',
+      null,
+      'chat',
+      JSON.stringify({ text }),
+    ]);
+    expect(mockNotifyWrite).not.toHaveBeenCalled();
+  });
+
   it('broker failure: group still exists, failure notify carries the finish command', async () => {
     brokerStatus = 500;
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
@@ -27,6 +27,7 @@ import {
   buildManagedAppManifest,
   provisionSlackApp,
   resolveProvisioningCredential,
+  slackAppInstallUrl,
 } from './provision.js';
 
 const CREATE_AGENT_SCRIPT = path.resolve(
@@ -188,6 +189,12 @@ describe('provision.ts congruence with src/provisioning/slack-app.ts', () => {
     expect(src).toContain("'SLACK_SERVICE_BASE'");
     expect(src).toContain("'/v1/apps'");
   });
+
+  it('derives the same working manual-install page from the app id', () => {
+    expect(slackAppInstallUrl('A0TEST123')).toBe('https://api.slack.com/apps/A0TEST123/oauth');
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(src).toContain('https://api.slack.com/apps/${encodeURIComponent(appId)}/oauth');
+  });
 });
 
 describe('provisionSlackApp broker body (allow_guests threading)', () => {
@@ -237,6 +244,32 @@ describe('provisionSlackApp broker body (allow_guests threading)', () => {
   it('threads allowGuests:true into the body as allow_guests (plain variant)', async () => {
     await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1', allowGuests: true });
     expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel', allow_guests: true });
+  });
+
+  it('surfaces the app settings page when the broker returns an unusable raw OAuth URL', async () => {
+    fetchMock.mockImplementation(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith('/v1/avatars')) {
+        return new Response(JSON.stringify({ avatar_id: null, status: 'unavailable' }), { status: 200 });
+      }
+      if (u.endsWith('/v1/apps')) {
+        return new Response(
+          JSON.stringify({
+            app_id: 'A123',
+            app_token: 'xapp-test',
+            bot_token: null,
+            install_url: 'https://slack.com/oauth/v2/authorize?client_id=broken',
+            install_error: 'app_approval_request_denied',
+          }),
+          { status: 201 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+
+    await expect(provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1' })).rejects.toThrow(
+      'https://api.slack.com/apps/A123/oauth',
+    );
   });
 });
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
@@ -186,6 +186,11 @@ interface RawProvisioned {
   installError?: string;
 }
 
+/** Slack's native install surface; raw OAuth URLs need a callback we do not have. */
+export function slackAppInstallUrl(appId: string): string {
+  return `https://api.slack.com/apps/${encodeURIComponent(appId)}/oauth`;
+}
+
 /**
  * Optional request-origin metadata on the broker's POST /v1/apps body
  * (requested_by / parent_app_id / template / client_version on the wire).
@@ -400,7 +405,7 @@ async function provisionViaBroker(
     appId,
     appToken,
     botToken: pick(data.botToken, data.bot_token),
-    installUrl: pick(data.installUrl, data.install_url),
+    installUrl: slackAppInstallUrl(appId),
     installError: pick(data.installError, data.install_error),
   };
 }
@@ -440,12 +445,14 @@ async function provisionDirect(
   displayName: string,
   allowGuests = false,
 ): Promise<RawProvisioned> {
-  const created = await slackApi<
-    SlackApiResponse & { app_id?: string; app_token?: string; oauth_authorize_url?: string }
-  >('apps.manifest.create', managerToken, {
-    manifest: JSON.stringify(buildManagedAppManifest(displayName, { agentView: !allowGuests })),
-    generate_app_token: 'true',
-  });
+  const created = await slackApi<SlackApiResponse & { app_id?: string; app_token?: string }>(
+    'apps.manifest.create',
+    managerToken,
+    {
+      manifest: JSON.stringify(buildManagedAppManifest(displayName, { agentView: !allowGuests })),
+      generate_app_token: 'true',
+    },
+  );
   if (!created.ok || !created.app_id) {
     throw new SlackFlowError(
       'direct-create',
@@ -461,7 +468,7 @@ async function provisionDirect(
   const result: RawProvisioned = {
     appId: created.app_id,
     appToken: created.app_token,
-    installUrl: created.oauth_authorize_url ?? '',
+    installUrl: slackAppInstallUrl(created.app_id),
   };
   const installed = await slackApi<SlackApiResponse & { api_access_tokens?: { bot_access_token?: string } }>(
     'apps.managedInstall',

--- a/src/provisioning/slack-app.test.ts
+++ b/src/provisioning/slack-app.test.ts
@@ -17,6 +17,7 @@ import {
   readInstallToken,
   readManagerToken,
   readServiceBase,
+  slackAppInstallUrl,
   slackServiceForRegistry,
 } from './slack-app.js';
 
@@ -188,6 +189,7 @@ describe('provisionManagedApp attribution fields', () => {
       client_version: '2.2.0',
     });
     expect(app.botToken).toBe('xoxb-1');
+    expect(app.installUrl).toBe('https://api.slack.com/apps/A1/oauth');
 
     const createCall = fetchMock.mock.calls.find(([url]) => url === 'https://slack.com/api/apps.manifest.create');
     expect(createCall).toBeDefined();
@@ -195,6 +197,12 @@ describe('provisionManagedApp attribution fields', () => {
     expect([...params.keys()].sort()).toEqual(['generate_app_token', 'manifest']);
     // The manifest is byte-identical to one built without attribution fields.
     expect(JSON.parse(params.get('manifest')!)).toEqual(buildManagedAppManifest({ name: 'Trusty' }));
+  });
+});
+
+describe('manual install URL', () => {
+  it("uses Slack's app settings page instead of the unusable raw OAuth URL", () => {
+    expect(slackAppInstallUrl('A0TEST123')).toBe('https://api.slack.com/apps/A0TEST123/oauth');
   });
 });
 
@@ -364,7 +372,7 @@ describe('mapBrokerApp', () => {
       appId: 'A0TEST123',
       appToken: 'xapp-1-A0TEST123-x',
       botToken: 'xoxb-000-bot',
-      installUrl: 'https://slack.com/oauth/install/A0TEST123',
+      installUrl: 'https://api.slack.com/apps/A0TEST123/oauth',
       installError: undefined,
     });
   });
@@ -379,16 +387,16 @@ describe('mapBrokerApp', () => {
     });
     expect(app.botToken).toBeUndefined();
     expect(app.installError).toBe('app_approval_request_eligible');
-    expect(app.installUrl).toBe('https://slack.com/oauth/install/A0TEST123');
+    expect(app.installUrl).toBe('https://api.slack.com/apps/A0TEST123/oauth');
   });
 
-  it('tolerates absent optional fields — installUrl falls back to empty string', () => {
+  it('derives the install page even when the broker omits its legacy URL', () => {
     const app = mapBrokerApp({ app_id: 'A1', app_token: 'xapp-1' });
     expect(app).toEqual({
       appId: 'A1',
       appToken: 'xapp-1',
       botToken: undefined,
-      installUrl: '',
+      installUrl: 'https://api.slack.com/apps/A1/oauth',
       installError: undefined,
     });
   });

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -14,7 +14,9 @@
  *
  * Auto-install does not bypass Admin Approved Apps: on workspaces where the
  * admin rules reject it, managedInstall errors and the caller falls back to
- * the manual install URL (oauth_authorize_url from step 1).
+ * the generated app's OAuth & Permissions settings page. The raw
+ * oauth_authorize_url from step 1 is not usable without a configured OAuth
+ * callback and fails with redirect_uri_mismatch.
  *
  * The manager token is read from SLACK_MANAGER_TOKEN (process env or .env).
  * It never persists into the container or session env — only the derived
@@ -193,6 +195,11 @@ export interface ProvisionedApp {
   installError?: string;
 }
 
+/** Slack's native install surface for an app created in this workspace. */
+export function slackAppInstallUrl(appId: string): string {
+  return `https://api.slack.com/apps/${encodeURIComponent(appId)}/oauth`;
+}
+
 interface SlackApiResponse {
   ok: boolean;
   error?: string;
@@ -228,7 +235,6 @@ export async function provisionManagedApp(managerToken: string, spec: ManagedApp
     SlackApiResponse & {
       app_id?: string;
       app_token?: string;
-      oauth_authorize_url?: string;
       team_domain?: string;
     }
   >('apps.manifest.create', managerToken, {
@@ -245,7 +251,7 @@ export async function provisionManagedApp(managerToken: string, spec: ManagedApp
   const result: ProvisionedApp = {
     appId: created.app_id,
     appToken: created.app_token,
-    installUrl: created.oauth_authorize_url ?? '',
+    installUrl: slackAppInstallUrl(created.app_id),
     teamDomain: created.team_domain,
   };
 
@@ -520,6 +526,7 @@ export interface BrokerAppResponse {
   app_token: string;
   /** xoxb-… bot token — null when auto-install was refused. */
   bot_token?: string | null;
+  /** Legacy raw OAuth URL; clients derive the working settings URL from app_id. */
   install_url?: string | null;
   install_error?: string | null;
 }
@@ -533,7 +540,7 @@ export function mapBrokerApp(res: BrokerAppResponse): ProvisionedApp {
     appId: res.app_id,
     appToken: res.app_token,
     botToken: res.bot_token ?? undefined,
-    installUrl: res.install_url ?? '',
+    installUrl: slackAppInstallUrl(res.app_id),
     installError: res.install_error ?? undefined,
   };
 }


### PR DESCRIPTION
## Problem
When a workspace's app-approval policy blocks managed Slack app installation, both recovery paths were broken: the manual-install fallback URL failed Slack's `redirect_uri` validation, and agent-driven provisioning (an existing agent creating another agent) dead-ended with no recovery surfaced to the requester.

## Fix
Two commits:
1. Build a manual-install URL that passes Slack's validation, with a congruence test between the provisioning module and the agent-flow payload.
2. When managed install is refused during agent-driven provisioning, deliver the manual fallback directly to the origin conversation so the requester can finish the install from Slack settings.

## Testing
Provisioning suite 28/28; flow payload tests 36 passed / 2 skipped on the current branch tip.
