### PR TITLE
fix(setup): drop stale Slack experimental/public-URL copy, modal-agnostic app-creation walkthrough

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -92,7 +92,7 @@ behaves like Socket Mode minus the walkthrough below.
 For Socket Mode, tell the user:
 ```nc:operator when:connection=socket
 Create the Slack app (Socket Mode):
-1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
+1. Go to api.slack.com/apps and create a new app using whichever creation flow is currently available (e.g. starting from scratch or from a manifest). Name it (e.g. "NanoClaw") and pick your workspace.
 2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Basic Information → App-Level Tokens → "Generate Token and Scopes" → add the connections:write scope → copy the token (starts with xapp-).
@@ -104,7 +104,7 @@ Create the Slack app (Socket Mode):
 For webhook delivery, tell the user:
 ```nc:operator when:connection=webhook
 Create the Slack app (webhook delivery):
-1. Go to api.slack.com/apps → Create New App → From scratch. Name it (e.g. "NanoClaw") and pick your workspace.
+1. Go to api.slack.com/apps and create a new app using whichever creation flow is currently available (e.g. starting from scratch or from a manifest). Name it (e.g. "NanoClaw") and pick your workspace.
 2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Install to Workspace, then copy the Bot User OAuth Token (starts with xoxb-).

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1774,6 +1774,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
     await brightSelect<ChannelChoice>({
       message: 'Want to chat with your assistant from your phone?',
       options: [
+        { value: 'slack', label: 'Yes, connect Slack' },
         { value: 'telegram', label: 'Yes, connect Telegram', hint: 'recommended' },
         { value: 'discord', label: 'Yes, connect Discord' },
         { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
@@ -1786,11 +1787,6 @@ async function askChannelChoice(): Promise<ChannelChoice> {
           value: 'imessage',
           label: 'Yes, connect iMessage',
           hint: 'local Mac or hosted iMessage (via photon.codes)',
-        },
-        {
-          value: 'slack',
-          label: 'Yes, connect Slack (experimental)',
-          hint: 'needs public URL',
         },
         { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
         { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },


### PR DESCRIPTION
## Problem
Same as the main-branch companion PR: setup still labeled Slack "experimental", claimed a public-URL requirement the managed Socket Mode path doesn't have, and the app-creation walkthrough referenced Slack modal options that no longer exist.

## Fix
Copy-only, applied to the channels branch's copy of the setup flow: Slack leads the channel list without the stale hints; the walkthrough's first step describes intent rather than exact button labels.

Companion PR (main): #3389

## Testing
Copy-level change; suite and build state match the branch base.

