### PR TITLE
feat(slack-agent-flow): carry the template ref through Slack creation

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -26,6 +26,7 @@ import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryB
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
+import { hasLocalTemplate } from '../../templates/registry.js';
 import type { Session } from '../../types.js';
 import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
 import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
@@ -89,20 +90,32 @@ registerDeliveryBatchPreview(async (batch, session) => {
   log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
 });
 
-function successText(name: string, roomChannelId: string | undefined): string {
+function successText(
+  name: string,
+  roomChannelId: string | undefined,
+  template?: { ref: string; commit?: string },
+): string {
+  // Provenance rides the ONE completion signal the Slack path emits (the
+  // upstream created-notify is suppressed here), so the requester still learns
+  // which template and which commit the agent was stamped from.
+  const stamped = template
+    ? ` Stamped from template "${template.ref}"${template.commit ? ` (commit ${template.commit.slice(0, 7)})` : ' (local copy)'}.`
+    : '';
   // room:'none': no shared room was opened — the multi-create
   // pattern finishes with one create_room naming every agent.
   if (roomChannelId === undefined) {
     return (
       `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
       `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
-      `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh`
+      `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+      stamped
     );
   }
   return (
     `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
     `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
-    `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh`
+    `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+    stamped
   );
 }
 
@@ -138,7 +151,7 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
   // report "done" ~a minute early — this wrapper's successText/failureText
   // is the only completion signal. Upstream error notifies (collision,
   // invalid path) still fire either way.
-  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+  const outcome = await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
 
   const after = await getDestinationByName(session.agent_group_id, localName);
   // Creation bailed or collided — upstream already answered the requester.
@@ -149,7 +162,7 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
   const slug = await dedupeSlug(deriveInstanceSlug(name), after.target_id);
   try {
     const r = await runSlackAgentFlow({ content, session, newAgentGroupId: after.target_id, slug });
-    await notifyAgent(session, successText(name, r.roomChannelId));
+    await notifyAgent(session, successText(name, r.roomChannelId, outcome?.template));
   } catch (err) {
     // SlackApiError carries the flow step id its call site passed to the
     // shared Slack lib — surface it like a typed flow step.
@@ -184,9 +197,18 @@ async function requestSlackCreateAgentHold(content: Record<string, unknown>, ses
   }
   const name = typeof content.name === 'string' ? content.name : '';
   const instructions = typeof content.instructions === 'string' ? content.instructions : null;
+  const template = typeof content.template === 'string' && content.template ? content.template : undefined;
   const sourceGroup = await getAgentGroup(session.agent_group_id);
   if (!sourceGroup) return;
 
+  // Same sentence as trunk's requestCreateAgentHold: the admin must see the
+  // template ref and whether it will be fetched or is already local — the
+  // Slack card is the only card a Slack-origin templated create ever shows.
+  const templateNote = template
+    ? ` It will be stamped from template "${template}" (${
+        hasLocalTemplate(template) ? 'using the existing local copy' : 'fetched from the public template registry'
+      }).`
+    : '';
   await requestApproval({
     session,
     agentName: sourceGroup.name,
@@ -202,11 +224,15 @@ async function requestSlackCreateAgentHold(content: Record<string, unknown>, ses
       // room:'none' must survive the hold too — dropping it would grow a
       // room the multi-create pattern deliberately skipped.
       ...(content.room === 'none' ? { room: 'none' } : {}),
+      // The template ref is the grant binding: the guard matches grant.template
+      // against the request, and the approved replay stamps from this payload.
+      // Dropping it would both break that match and create a plain agent.
+      ...(template ? { template } : {}),
     },
     title: `Create agent: ${name}`,
     question:
       `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
-      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room).${templateNote} Approve?`,
   });
 }
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -97,7 +97,7 @@ vi.mock('../approvals/index.js', async () => {
 // Registers the wrapped create_agent delivery action — the path under test.
 // Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
 import './index.js';
-import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
+import { ensureAgentRoom, finishSlackAgentFlow, runSlackAgentFlow } from './orchestrate.js';
 import { SlackFlowError } from './types.js';
 import { getDeliveryAction } from '../../delivery.js';
 import { log } from '../../log.js';
@@ -425,6 +425,52 @@ describe('slack-aware create_agent — manifest variants', () => {
     await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
     const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
     expect(appBody.allow_guests).toBeUndefined();
+  });
+});
+
+describe('slack-aware create_agent — template attribution', () => {
+  // The Slack leg is driven directly here: the upstream template branch of
+  // createAgent (host fetch + stamping) is trunk's, and this pins only the
+  // one thing this module owns — content.template reaching the broker.
+  it('a templated create sends the ref to the broker as attribution', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({
+      id: 'ag-new',
+      name: 'Research',
+      folder: 'research',
+      agent_provider: null,
+      created_at: now,
+    });
+
+    await runSlackAgentFlow({
+      content: { name: 'Research', instructions: 'dig deep', template: 'sales/sdr', room: 'none' },
+      session: SLACK_SESSION,
+      newAgentGroupId: 'ag-new',
+      slug: 'research',
+    });
+
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.template).toBe('sales/sdr');
+  });
+
+  it('a plain create sends no template field', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.template).toBeUndefined();
+  });
+
+  it('hold payload carries the template ref through to the approved replay (confined group)', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', template: 'sales/sdr' });
+
+    expect(await getAgentGroupByFolder('research')).toBeUndefined();
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { payload: Record<string, unknown>; question: string };
+    expect(opts.payload).toMatchObject({ name: 'Research', template: 'sales/sdr' });
+    // Design merge condition: the Slack card (the only card this path shows)
+    // names the template and says fetch-vs-local, same sentence as trunk's.
+    expect(opts.question).toContain('It will be stamped from template "sales/sdr"');
   });
 });
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -415,6 +415,8 @@ interface FlowArgs {
    * N creates with room:'none' followed by one create_room with all of them.
    */
   room?: 'own' | 'none';
+  /** Template ref the agent was stamped from — broker attribution only. */
+  template?: string;
 }
 
 async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
@@ -450,6 +452,7 @@ async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
     description: args.description,
     allowGuests: args.allowGuests,
     requestedBy: operatorUserId,
+    template: args.template,
   });
 
   // S5 adapter-start. The multi-instance module must be installed regardless
@@ -611,6 +614,7 @@ export async function runSlackAgentFlow(args: {
     allowGuests: content.allow_guests === true,
     originSession: session,
     room: content.room === 'none' ? 'none' : 'own',
+    template: typeof content.template === 'string' && content.template ? content.template : undefined,
   });
 }
 


### PR DESCRIPTION
## What

The channels half of templates-from-chat (~85 lines in the `slack-agent-flow` skill payload): the Slack creation flow carries the `template` ref end to end.

- `requestSlackCreateAgentHold`'s payload spread includes `template` (it was silently dropped on approved replays otherwise), and the hold card appends the same sentence trunk uses: stamped from template "ref" (fetched from the public template registry | using the existing local copy).
- Success text names the template.
- `ProvisionAttribution.template` (shipped unset in #3344) is set on broker provisioning.

## Base + merge order

Based on `channels` (`d7fc4c39`). Lands after the nanoclaw trunk PR (it imports `src/templates/registry.js`, which arrives there) — merge order: registry index PR → trunk PR → this. Cross-linked in all three bodies.

## Verification

Registry-branch PRs run no CI. `git apply --check` clean against `d7fc4c39`; hold-payload spread, card wording, and attribution changes covered by the updated `orchestrate.test.ts`, which cannot execute against the channels tree until the trunk PR merges (it imports trunk code) — declared gap, to be exercised on a live install as the post-merge gate. Reviewed pre-PR by the same two independent passes as the trunk PR.

## Known gap (deliberate)

An install running new trunk with a stale copy of this skill drops the ref from Slack-origin holds (approved replay creates a plain agent); documented on trunk in `docs/templates.md`, remedy `/update-skills`.
