### PR TITLE
[channels] fix(whatsapp-cloud): keep skill payload compatible with main

### DIFF
--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -257,11 +257,6 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
   return registry.get(name)?.containerConfig;
 }
 
-/** Get a channel's registration (factory + container config) by its registry name. */
-export function getChannelRegistration(name: string): ChannelRegistration | undefined {
-  return registry.get(name);
-}
-
 /**
  * Instantiate and set up all registered channel adapters.
  * Skips adapters that return null (missing credentials).

--- a/src/channels/whatsapp-cloud-registration.test.ts
+++ b/src/channels/whatsapp-cloud-registration.test.ts
@@ -26,8 +26,8 @@
  * bridge (#2911). `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', so the bridge's
  * channelType is 'whatsapp' — shared with the native Baileys adapter. The factory must pass
  * `instance: 'whatsapp-cloud'` so the registry keys the two apart (`instance ?? channelType`)
- * instead of last-write-wins. We build the adapter through its registered factory (the real
- * code path) with credentials mocked in, since the factory returns null when they are absent.
+ * instead of last-write-wins. We build the adapter through the exported registration object
+ * used by self-registration, with credentials mocked in since the factory otherwise returns null.
  */
 import { describe, it, expect, vi } from 'vitest';
 
@@ -43,8 +43,9 @@ vi.mock('../env.js', () => ({
   }),
 }));
 
-import { getRegisteredChannelNames, getChannelRegistration } from './channel-registry.js';
+import { getRegisteredChannelNames } from './channel-registry.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration
+import { whatsappCloudRegistration } from './whatsapp-cloud.js';
 
 describe('whatsapp-cloud channel registration', () => {
   it('registers whatsapp-cloud via the channel barrel', () => {
@@ -52,10 +53,7 @@ describe('whatsapp-cloud channel registration', () => {
   });
 
   it('builds under a distinct instance key while keeping channelType whatsapp', async () => {
-    const registration = getChannelRegistration('whatsapp-cloud');
-    expect(registration).toBeDefined();
-
-    const adapter = await registration!.factory();
+    const adapter = await whatsappCloudRegistration.factory();
     expect(adapter).not.toBeNull();
 
     // instance keeps this bridge off the native Baileys adapter's 'whatsapp'

--- a/src/channels/whatsapp-cloud.ts
+++ b/src/channels/whatsapp-cloud.ts
@@ -6,7 +6,7 @@
 import { createWhatsAppAdapter } from '@chat-adapter/whatsapp';
 
 import { readEnvFile } from '../env.js';
-import type { ChannelDefaults } from './adapter.js';
+import type { ChannelDefaults, ChannelRegistration } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
@@ -21,7 +21,7 @@ const WHATSAPP_CLOUD_DEFAULTS: ChannelDefaults = {
   mentions: 'platform',
 };
 
-registerChannelAdapter('whatsapp-cloud', {
+export const whatsappCloudRegistration: ChannelRegistration = {
   factory: () => {
     const env = readEnvFile([
       'WHATSAPP_ACCESS_TOKEN',
@@ -51,4 +51,6 @@ registerChannelAdapter('whatsapp-cloud', {
     });
   },
   defaults: WHATSAPP_CLOUD_DEFAULTS,
-});
+};
+
+registerChannelAdapter('whatsapp-cloud', whatsappCloudRegistration);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The add-whatsapp-cloud test depended on a registry helper available only on channels, so the skill failed when composed with main. Export and type the registration in the adapter, then test that same object directly while keeping the barrel self-registration check.

## Testing

- Focused WhatsApp Cloud registration test: 2 passed
- Exact add-whatsapp-cloud application against main: build and registration test passed