### PR TITLE
setup: the managed Slack experience becomes the default

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -14,9 +14,8 @@ directives); all idempotent.
 This is the base Slack experience: one bot, DM and channel chat. The Slack
 **agents** feature — child bots provisioned from `create_agent`, shared rooms,
 canvases, DM onboarding — ships separately in `/slack-a2a-rooms` +
-`/slack-agent-flow`; the setup wizard applies them automatically (pass `--no-slack-agents` for a
-plain single-bot install), and they can be applied on top of this install at
-any time.
+`/slack-agent-flow`; the setup wizard applies them automatically, and they can be applied on top
+of this install at any time.
 
 ## Apply
 

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -14,8 +14,9 @@ directives); all idempotent.
 This is the base Slack experience: one bot, DM and channel chat. The Slack
 **agents** feature — child bots provisioned from `create_agent`, shared rooms,
 canvases, DM onboarding — ships separately in `/slack-a2a-rooms` +
-`/slack-agent-flow`; the setup wizard applies them automatically when run with
-`--slack-agents`, and they can be applied on top of this install at any time.
+`/slack-agent-flow`; the setup wizard applies them automatically (pass `--no-slack-agents` for a
+plain single-bot install), and they can be applied on top of this install at
+any time.
 
 ## Apply
 
@@ -182,8 +183,7 @@ bash setup/lib/restart.sh
 Mid-`/setup`: return to the setup flow. Otherwise wire the channel with `/init-first-agent`
 (or `/manage-channels`). For the Slack agents feature (child bots from
 `create_agent`, shared rooms, canvases), apply `/slack-a2a-rooms` then
-`/slack-agent-flow` — the setup wizard does both automatically when run with
-`--slack-agents`.
+`/slack-agent-flow` — the setup wizard does both automatically by default.
 
 ## Channel Info
 
@@ -201,4 +201,4 @@ Mid-`/setup`: return to the setup flow. Otherwise wire the channel with `/init-f
 - **`auth.test` fails, or `conversations.open` returns no channel.** A failing `auth.test` means the bot token is wrong or the app was never installed to the workspace. An empty `conversations.open` means the `im:write` scope is missing — add it and **reinstall the app**; scope changes only take effect after reinstall, which also mints a new `xoxb-` token to store.
 - **The greeting arrives but your replies vanish.** Sending works with just the bot token; *receiving* needs the event path. Socket Mode: the toggle on, `SLACK_APP_TOKEN` set with `connections:write`, and the bot events (`message.im`, `message.channels`, `message.groups`, `app_mention`) subscribed. Webhook: the Request URL must have passed Slack's challenge and the same events subscribed. Either way, App Home's Messages Tab must be enabled or Slack refuses DMs to the app.
 - **Adapter registered but Slack never connects.** Run `pnpm exec vitest run src/channels/slack-registration.test.ts` — red means the barrel import or the `@chat-adapter/slack` install drifted, so re-run the Apply steps. If green, restart the service (`bash setup/lib/restart.sh`) and check `logs/nanoclaw.error.log`.
-- **Rooms, canvases, or DM onboarding are missing.** Those are the agents feature, not this adapter install — they arrive with `/slack-a2a-rooms` + `/slack-agent-flow` (setup applies both when run with `--slack-agents`). If those skills were applied, check `src/modules/index.ts` carries their module imports, then restart.
+- **Rooms, canvases, or DM onboarding are missing.** Those are the agents feature, not this adapter install — they arrive with `/slack-a2a-rooms` + `/slack-agent-flow` (setup applies both by default). If those skills were applied, check `src/modules/index.ts` carries their module imports, then restart.

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -25,14 +25,18 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
-# ─── --slack-agents: opt-in flag → env passthrough ─────────────────────
+# ─── --[no-]slack-agents: env passthrough ──────────────────────────────
 # Consumed here rather than forwarded: setup:auto reads the env var
-# (NANOCLAW_SLACK_AGENTS=1, checked in setup/channels/slack-auto-register.ts).
-# Without the flag, nothing changes.
+# (NANOCLAW_SLACK_AGENTS, checked in setup/channels/slack-auto-register.ts).
+# The managed Slack experience is the default; --no-slack-agents opts out
+# (single plain bot, no provisioning offer). --slack-agents is accepted for
+# compatibility and is a no-op.
 _filtered_args=()
 for arg in "$@"; do
   if [ "$arg" = "--slack-agents" ]; then
     export NANOCLAW_SLACK_AGENTS=1
+  elif [ "$arg" = "--no-slack-agents" ]; then
+    export NANOCLAW_SLACK_AGENTS=0
   else
     _filtered_args+=("$arg")
   fi
@@ -49,6 +53,7 @@ for arg in "$@"; do
     echo "Usage: bash nanoclaw.sh [options]"
     echo ""
     echo "  --template-path <ref>  Create or update an agent from templates/<ref>"
+    echo "  --no-slack-agents      Slack connects as a single plain bot (no managed provisioning)"
     echo "  --uninstall            Uninstall this NanoClaw copy"
     echo "  --help, -h             Show this help without installing dependencies"
     exit 0

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -25,18 +25,13 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
-# ─── --[no-]slack-agents: env passthrough ──────────────────────────────
-# Consumed here rather than forwarded: setup:auto reads the env var
-# (NANOCLAW_SLACK_AGENTS, checked in setup/channels/slack-auto-register.ts).
-# The managed Slack experience is the default; --no-slack-agents opts out
-# (single plain bot, no provisioning offer). --slack-agents is accepted for
-# compatibility and is a no-op.
+# ─── --slack-agents: former testing flag, accepted and ignored ─────────
+# The managed Slack experience is simply the default; the flag that once
+# enabled it is swallowed so older invocations keep working.
 _filtered_args=()
 for arg in "$@"; do
   if [ "$arg" = "--slack-agents" ]; then
-    export NANOCLAW_SLACK_AGENTS=1
-  elif [ "$arg" = "--no-slack-agents" ]; then
-    export NANOCLAW_SLACK_AGENTS=0
+    :
   else
     _filtered_args+=("$arg")
   fi
@@ -53,7 +48,6 @@ for arg in "$@"; do
     echo "Usage: bash nanoclaw.sh [options]"
     echo ""
     echo "  --template-path <ref>  Create or update an agent from templates/<ref>"
-    echo "  --no-slack-agents      Slack connects as a single plain bot (no managed provisioning)"
     echo "  --uninstall            Uninstall this NanoClaw copy"
     echo "  --help, -h             Show this help without installing dependencies"
     exit 0

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -90,7 +90,7 @@ describe('skill-directives parser, on the converted add-slack', () => {
     expect(appends[0].body).toEqual(["import './slack.js';"]);
     expect(appends[1].body).toEqual(["import './slack-a2a-guard.js';"]);
     // The agents-feature module/tool barrel appends live in /slack-agent-flow;
-    // the companion declaration is trunk's, gated on NANOCLAW_SLACK_AGENTS
+    // the companion declaration is trunk's, registered by default
     // (setup/channels/slack-auto-register.ts) — no skill appends it anymore.
   });
 

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1870,7 +1870,8 @@ async function askChannelChoice(): Promise<ChannelChoice> {
       message: 'Want to chat with your assistant from your phone?',
       options: [
         { value: 'slack', label: 'Yes, connect Slack' },
-        { value: 'telegram', label: 'Yes, connect Telegram', hint: 'recommended' },
+        { value: 'teams', label: 'Yes, connect Microsoft Teams' },
+        { value: 'telegram', label: 'Yes, connect Telegram' },
         { value: 'discord', label: 'Yes, connect Discord' },
         { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
         {
@@ -1883,7 +1884,6 @@ async function askChannelChoice(): Promise<ChannelChoice> {
           label: 'Yes, connect iMessage',
           hint: 'local Mac or hosted iMessage (via photon.codes)',
         },
-        { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
         { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
         { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
       ],

--- a/setup/channels/slack-auto-register.test.ts
+++ b/setup/channels/slack-auto-register.test.ts
@@ -1,11 +1,11 @@
 /**
- * The NANOCLAW_SLACK_AGENTS opt-in gate.
+ * The NANOCLAW_SLACK_AGENTS opt-out gate.
  *
- * Flag off (the default) must leave the wizard exactly as shipped: no
- * pre-step registered for slack, no companion skills declared, and the
- * provisioning flow never evaluated. Flag on registers the pre-step (which
- * lazy-loads the flow only when the wizard actually invokes it) and declares
- * the Slack agents companion skills, in prerequisite order.
+ * The managed Slack experience registers by default: pre-step for slack,
+ * companion skills declared in prerequisite order, flow lazy-loaded only
+ * when the wizard actually invokes it. Setting the flag to "0" must leave
+ * the wizard exactly as a build without the feature: no pre-step, no
+ * companions, the provisioning flow never evaluated.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -18,27 +18,9 @@ afterEach(() => {
 });
 
 describe('registerSlackAutoProvision', () => {
-  it('flag unset: registers nothing', () => {
+  it('flag unset (the default): registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
     const register = vi.fn();
-    const registerCompanions = vi.fn();
-    registerSlackAutoProvision(register, registerCompanions, {});
-    expect(register).not.toHaveBeenCalled();
-    expect(registerCompanions).not.toHaveBeenCalled();
-  });
-
-  it('only "1" enables — other values register nothing', () => {
-    const register = vi.fn();
-    const registerCompanions = vi.fn();
-    for (const value of ['', '0', 'false', 'yes', 'true']) {
-      registerSlackAutoProvision(register, registerCompanions, { NANOCLAW_SLACK_AGENTS: value });
-    }
-    expect(register).not.toHaveBeenCalled();
-    expect(registerCompanions).not.toHaveBeenCalled();
-  });
-
-  it('flag "1": registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
-    const register = vi.fn();
-    registerSlackAutoProvision(register, vi.fn(), { NANOCLAW_SLACK_AGENTS: '1' });
+    registerSlackAutoProvision(register, vi.fn(), {});
 
     expect(register).toHaveBeenCalledTimes(1);
     const [channel, step] = register.mock.calls[0];
@@ -51,27 +33,37 @@ describe('registerSlackAutoProvision', () => {
     expect(maybeAutoProvisionSlack).toHaveBeenCalledExactlyOnceWith('Nano');
   });
 
-  it('flag "1": declares the agents companion skills in prerequisite order', () => {
+  it('flag unset (the default): declares the agents companion skills in prerequisite order', () => {
     const registerCompanions = vi.fn();
-    registerSlackAutoProvision(vi.fn(), registerCompanions, { NANOCLAW_SLACK_AGENTS: '1' });
+    registerSlackAutoProvision(vi.fn(), registerCompanions, {});
 
     expect(registerCompanions).toHaveBeenCalledExactlyOnceWith('slack', SLACK_AGENTS_COMPANION_SKILLS);
     // The room admission policy is the flow's prerequisite — order is the API.
     expect(SLACK_AGENTS_COMPANION_SKILLS).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
   });
+
+  it('only "0" opts out — registers nothing at all', () => {
+    const register = vi.fn();
+    const registerCompanions = vi.fn();
+    registerSlackAutoProvision(register, registerCompanions, { NANOCLAW_SLACK_AGENTS: '0' });
+    expect(register).not.toHaveBeenCalled();
+    expect(registerCompanions).not.toHaveBeenCalled();
+  });
+
+  it('"1" and other values keep the default-on behavior', () => {
+    const register = vi.fn();
+    const registerCompanions = vi.fn();
+    for (const value of ['1', '', 'false', 'yes', 'true']) {
+      registerSlackAutoProvision(register, registerCompanions, { NANOCLAW_SLACK_AGENTS: value });
+    }
+    expect(register).toHaveBeenCalledTimes(5);
+    expect(registerCompanions).toHaveBeenCalledTimes(5);
+  });
 });
 
 describe('companions registry wiring', () => {
-  it('flag unset: a fresh companions module has no slack hooks at all', async () => {
+  it('flag unset: a fresh companions module carries the slack pre-step and companion list', async () => {
     delete process.env.NANOCLAW_SLACK_AGENTS;
-    vi.resetModules();
-    const companions = await import('./companions.js');
-    expect(companions.getChannelPreStep('slack')).toBeUndefined();
-    expect(companions.getCompanionSkills('slack')).toEqual([]);
-  });
-
-  it('flag "1": a fresh companions module carries the slack pre-step and companion list', async () => {
-    process.env.NANOCLAW_SLACK_AGENTS = '1';
     vi.resetModules();
     const companions = await import('./companions.js');
     expect(companions.getChannelPreStep('slack')).toBeTypeOf('function');
@@ -79,5 +71,13 @@ describe('companions registry wiring', () => {
     // mid-run would be invisible to the already-imported module, so the whole
     // agents install rides on this boot-time declaration.
     expect(companions.getCompanionSkills('slack')).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
+  });
+
+  it('flag "0": a fresh companions module has no slack hooks at all', async () => {
+    process.env.NANOCLAW_SLACK_AGENTS = '0';
+    vi.resetModules();
+    const companions = await import('./companions.js');
+    expect(companions.getChannelPreStep('slack')).toBeUndefined();
+    expect(companions.getCompanionSkills('slack')).toEqual([]);
   });
 });

--- a/setup/channels/slack-auto-register.test.ts
+++ b/setup/channels/slack-auto-register.test.ts
@@ -1,26 +1,23 @@
 /**
- * The NANOCLAW_SLACK_AGENTS opt-out gate.
+ * The Slack auto-provision registration — the default Slack experience.
  *
- * The managed Slack experience registers by default: pre-step for slack,
- * companion skills declared in prerequisite order, flow lazy-loaded only
- * when the wizard actually invokes it. Setting the flag to "0" must leave
- * the wizard exactly as a build without the feature: no pre-step, no
- * companions, the provisioning flow never evaluated.
+ * Registration is unconditional: pre-step for slack, companion skills
+ * declared in prerequisite order, and the provisioning flow lazy-loaded
+ * only when the wizard actually invokes the pre-step.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { registerSlackAutoProvision, SLACK_AGENTS_COMPANION_SKILLS } from './slack-auto-register.js';
 
 afterEach(() => {
-  delete process.env.NANOCLAW_SLACK_AGENTS;
   vi.doUnmock('./slack-auto.js');
   vi.resetModules();
 });
 
 describe('registerSlackAutoProvision', () => {
-  it('flag unset (the default): registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
+  it('registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
     const register = vi.fn();
-    registerSlackAutoProvision(register, vi.fn(), {});
+    registerSlackAutoProvision(register, vi.fn());
 
     expect(register).toHaveBeenCalledTimes(1);
     const [channel, step] = register.mock.calls[0];
@@ -33,37 +30,18 @@ describe('registerSlackAutoProvision', () => {
     expect(maybeAutoProvisionSlack).toHaveBeenCalledExactlyOnceWith('Nano');
   });
 
-  it('flag unset (the default): declares the agents companion skills in prerequisite order', () => {
+  it('declares the agents companion skills in prerequisite order', () => {
     const registerCompanions = vi.fn();
-    registerSlackAutoProvision(vi.fn(), registerCompanions, {});
+    registerSlackAutoProvision(vi.fn(), registerCompanions);
 
     expect(registerCompanions).toHaveBeenCalledExactlyOnceWith('slack', SLACK_AGENTS_COMPANION_SKILLS);
     // The room admission policy is the flow's prerequisite — order is the API.
     expect(SLACK_AGENTS_COMPANION_SKILLS).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
   });
-
-  it('only "0" opts out — registers nothing at all', () => {
-    const register = vi.fn();
-    const registerCompanions = vi.fn();
-    registerSlackAutoProvision(register, registerCompanions, { NANOCLAW_SLACK_AGENTS: '0' });
-    expect(register).not.toHaveBeenCalled();
-    expect(registerCompanions).not.toHaveBeenCalled();
-  });
-
-  it('"1" and other values keep the default-on behavior', () => {
-    const register = vi.fn();
-    const registerCompanions = vi.fn();
-    for (const value of ['1', '', 'false', 'yes', 'true']) {
-      registerSlackAutoProvision(register, registerCompanions, { NANOCLAW_SLACK_AGENTS: value });
-    }
-    expect(register).toHaveBeenCalledTimes(5);
-    expect(registerCompanions).toHaveBeenCalledTimes(5);
-  });
 });
 
 describe('companions registry wiring', () => {
-  it('flag unset: a fresh companions module carries the slack pre-step and companion list', async () => {
-    delete process.env.NANOCLAW_SLACK_AGENTS;
+  it('a fresh companions module carries the slack pre-step and companion list', async () => {
     vi.resetModules();
     const companions = await import('./companions.js');
     expect(companions.getChannelPreStep('slack')).toBeTypeOf('function');
@@ -71,13 +49,5 @@ describe('companions registry wiring', () => {
     // mid-run would be invisible to the already-imported module, so the whole
     // agents install rides on this boot-time declaration.
     expect(companions.getCompanionSkills('slack')).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
-  });
-
-  it('flag "0": a fresh companions module has no slack hooks at all', async () => {
-    process.env.NANOCLAW_SLACK_AGENTS = '0';
-    vi.resetModules();
-    const companions = await import('./companions.js');
-    expect(companions.getChannelPreStep('slack')).toBeUndefined();
-    expect(companions.getCompanionSkills('slack')).toEqual([]);
   });
 });

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -2,11 +2,8 @@
  * Registration for automatic Slack app provisioning — the default Slack
  * experience.
  *
- * This shim is the only piece of the feature on the wizard's boot path. The
- * managed flow registers by default; setting NANOCLAW_SLACK_AGENTS=0 (or
- * passing `--no-slack-agents` to nanoclaw.sh) opts out, for installs that
- * want a single plain bot with no provisioning offer — the wizard then runs
- * exactly as a build without the feature. The flow itself (slack-auto.ts
+ * This shim is the only piece of the feature on the wizard's boot path;
+ * it always registers. The flow itself (slack-auto.ts
  * plus the provisioning core it bootstraps from the channels branch — the
  * module's permanent home is the add-slack channel payload, at
  * src/provisioning/slack-app.ts on an installed tree) loads via dynamic
@@ -26,12 +23,9 @@
  *
  * The register functions are injected by the caller (companions.ts passes
  * `registerChannelPreStep` / `registerCompanionSkills`) so this module has
- * zero runtime imports — no import cycle with the registry, nothing
- * evaluated beyond the env check.
+ * zero runtime imports — no import cycle with the registry.
  */
 import type { ChannelPreStep } from './companions.js';
-
-export const SLACK_AGENTS_FLAG = 'NANOCLAW_SLACK_AGENTS';
 
 /**
  * Applied in order after `/add-slack`: the room admission policy first (the
@@ -42,9 +36,7 @@ export const SLACK_AGENTS_COMPANION_SKILLS = ['slack-a2a-rooms', 'slack-agent-fl
 export function registerSlackAutoProvision(
   register: (channel: string, step: ChannelPreStep) => void,
   registerCompanions: (channel: string, skills: readonly string[]) => void,
-  env: NodeJS.ProcessEnv = process.env,
 ): void {
-  if (env[SLACK_AGENTS_FLAG] === '0') return;
   register('slack', async (agentName) => {
     const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
     return maybeAutoProvisionSlack(agentName);

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -1,19 +1,19 @@
 /**
- * Opt-in registration for automatic Slack app provisioning.
+ * Registration for automatic Slack app provisioning — the default Slack
+ * experience.
  *
- * This shim is the only piece of the feature on the default wizard path.
- * It checks the NANOCLAW_SLACK_AGENTS env flag ("1" enables it — set the
- * var directly or pass `--slack-agents` to nanoclaw.sh) and returns without
- * registering anything when the flag is off, leaving the wizard identical
- * to a build without the feature. The flow itself (slack-auto.ts plus the
- * provisioning core it bootstraps from the channels branch — the module's
- * permanent home is the add-slack channel payload, at
+ * This shim is the only piece of the feature on the wizard's boot path. The
+ * managed flow registers by default; setting NANOCLAW_SLACK_AGENTS=0 (or
+ * passing `--no-slack-agents` to nanoclaw.sh) opts out, for installs that
+ * want a single plain bot with no provisioning offer — the wizard then runs
+ * exactly as a build without the feature. The flow itself (slack-auto.ts
+ * plus the provisioning core it bootstraps from the channels branch — the
+ * module's permanent home is the add-slack channel payload, at
  * src/provisioning/slack-app.ts on an installed tree) loads via dynamic
- * import only after the flag check passes AND the wizard actually invokes
- * the Slack pre-step. No fetch, no import, nothing runs while the flag is
- * off.
+ * import only when the wizard actually invokes the Slack pre-step. No
+ * fetch, no import, nothing runs unless Slack is chosen.
  *
- * The flag also declares the Slack agents companion skills. `/add-slack`
+ * Registration also declares the Slack agents companion skills. `/add-slack`
  * alone is the base experience (one bot, DM/channel chat); the agents
  * feature — child bots provisioned from `create_agent`, shared a2a rooms,
  * canvases, DM onboarding — ships in the `slack-a2a-rooms` and
@@ -44,7 +44,7 @@ export function registerSlackAutoProvision(
   registerCompanions: (channel: string, skills: readonly string[]) => void,
   env: NodeJS.ProcessEnv = process.env,
 ): void {
-  if (env[SLACK_AGENTS_FLAG] !== '1') return;
+  if (env[SLACK_AGENTS_FLAG] === '0') return;
   register('slack', async (agentName) => {
     const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
     return maybeAutoProvisionSlack(agentName);

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -20,9 +20,9 @@
  * payloads (git fetch + git show, remote resolution included). Setup runs
  * under tsx, so importing the fetched .ts file directly works.
  *
- * Loaded through slack-auto-register.ts — the default Slack experience,
- * with NANOCLAW_SLACK_AGENTS=0 as the opt-out — so a wizard run that skips
- * never evaluates this file or its strings.
+ * Loaded through slack-auto-register.ts via dynamic import, so a wizard run
+ * that never reaches the Slack pre-step never evaluates this file or its
+ * strings.
  *
  * Returns undefined to mean "walk the manual path" — never throws for
  * expected declines (not signed in, provisioning refused, cancel) or for

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -20,8 +20,8 @@
  * payloads (git fetch + git show, remote resolution included). Setup runs
  * under tsx, so importing the fetched .ts file directly works.
  *
- * Loaded ONLY behind the NANOCLAW_SLACK_AGENTS opt-in: slack-auto-register.ts
- * dynamic-imports this module when the flag is set, so the default wizard
+ * Loaded through slack-auto-register.ts — the default Slack experience,
+ * with NANOCLAW_SLACK_AGENTS=0 as the opt-out — so a wizard run that skips
  * never evaluates this file or its strings.
  *
  * Returns undefined to mean "walk the manual path" — never throws for
@@ -236,13 +236,13 @@ export async function maybeAutoProvisionSlack(
           value: 'auto',
           label: 'Create it for me',
           hint: needsSignIn
-            ? 'sign in with your NanoClaw account, then app + install in one step'
-            : 'app + install in one step, no token pasting',
+            ? 'Add Agent to Slack — sign in with your NanoClaw account, then app + install in one step'
+            : 'Add Agent to Slack — app + install in one step, no token pasting',
         },
         {
           value: 'manual',
-          label: 'I will supply my own bot token',
-          hint: 'advanced — walk through api.slack.com/apps by hand',
+          label: 'I will create it myself',
+          hint: 'walk through api.slack.com/apps by hand',
         },
       ],
     }),

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -145,6 +145,13 @@ export function printHelp(stream: NodeJS.WritableStream = process.stdout): void 
     lines.push(`  ${flag}${e.help}`);
   }
   lines.push('');
+  // Consumed by nanoclaw.sh before this process starts, so it lives outside
+  // the registry — listed here so --help stays the one complete reference.
+  lines.push(
+    '  --no-slack-agents'.padEnd(Math.max(...CONFIG.map((e) => flagFor(e).length)) + 4) +
+      'Slack connects as a single plain bot (no managed provisioning)',
+  );
+  lines.push('');
   lines.push('Each flag also reads from its corresponding NANOCLAW_<KEY> env var.');
   lines.push('Run without flags for the default interactive flow.');
   stream.write(lines.join('\n') + '\n');

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -145,13 +145,6 @@ export function printHelp(stream: NodeJS.WritableStream = process.stdout): void 
     lines.push(`  ${flag}${e.help}`);
   }
   lines.push('');
-  // Consumed by nanoclaw.sh before this process starts, so it lives outside
-  // the registry — listed here so --help stays the one complete reference.
-  lines.push(
-    '  --no-slack-agents'.padEnd(Math.max(...CONFIG.map((e) => flagFor(e).length)) + 4) +
-      'Slack connects as a single plain bot (no managed provisioning)',
-  );
-  lines.push('');
   lines.push('Each flag also reads from its corresponding NANOCLAW_<KEY> env var.');
   lines.push('Run without flags for the default interactive flow.');
   stream.write(lines.join('\n') + '\n');


### PR DESCRIPTION
# setup: the managed Slack experience becomes the default

The Slack channel pre-step — automatic app provisioning through the operator's NanoClaw account — and the agents companion skills (`slack-a2a-rooms`, `slack-agent-flow`) previously registered only when `NANOCLAW_SLACK_AGENTS=1` was set. The flag is gone entirely:

- Choosing Slack in the wizard offers "Create it for me" (app + install in one step), and the agents companion skills apply after `/add-slack`. A plain single-bot install is the manual choice inside the flow ("I will create it myself"), not a build-level switch.
- There is no `NANOCLAW_SLACK_AGENTS` and no opt-out flag. `nanoclaw.sh` still swallows a passed `--slack-agents` so older invocations keep working — it has no semantics.

## Wizard content

- The provisioning choice's hints name the Add Agent to Slack flow; the manual option reads "I will create it myself" (walk through api.slack.com/apps by hand).
- Channel list: Microsoft Teams moves next to Slack, and the `recommended` / `complex setup` hints that contradicted the ordering are gone.

## SKILL.md

`add-slack/SKILL.md` prose now describes the companions as applied by default. No directive changed — `scripts/skill-directives.test.ts` is untouched and green.

## Tests

- `setup/` + `skill-directives`: 334 passing (the auto-register suite is rewritten around unconditional registration: pre-step + companions always, flow still lazy-loaded only when the pre-step runs).
- Full suite: identical to the `main` baseline — same 7 pre-existing failures in `scripts/update/transaction.e2e.test.ts` (4) and `src/modules/permissions/{channel,sender}-approval.test.ts` (3), byte-for-byte the same on unmodified `main` in the same environment. The approval-card baseline failures predate this change and are worth a separate look.
- `tsc --noEmit` clean; `bash -n nanoclaw.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
