### PR TITLE
Revert "feat(slack-agent-flow): carry the template ref through Slack creation"

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -26,7 +26,6 @@ import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryB
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
-import { hasLocalTemplate } from '../../templates/registry.js';
 import type { Session } from '../../types.js';
 import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
 import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
@@ -90,18 +89,7 @@ registerDeliveryBatchPreview(async (batch, session) => {
   log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
 });
 
-function successText(
-  name: string,
-  roomChannelId: string | undefined,
-  template?: { ref: string; commit?: string },
-  deferredInstall = false,
-): string {
-  // Provenance rides the ONE completion signal the Slack path emits (the
-  // upstream created-notify is suppressed here), so the requester still learns
-  // which template and which commit the agent was stamped from.
-  const stamped = template
-    ? ` Stamped from template "${template.ref}"${template.commit ? ` (commit ${template.commit.slice(0, 7)})` : ' (local copy)'}.`
-    : '';
+function successText(name: string, roomChannelId: string | undefined, deferredInstall = false): string {
   // The user already knows they were waiting on their workspace — name what
   // unblocked it so the relay reads as an ending, not a fresh announcement.
   const installed = deferredInstall ? ' The workspace approved the install, which is what the wait was for.' : '';
@@ -112,7 +100,6 @@ function successText(
       `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
       `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
       `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
-      stamped +
       installed
     );
   }
@@ -120,7 +107,6 @@ function successText(
     `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
     `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
     `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
-    stamped +
     installed
   );
 }
@@ -145,13 +131,7 @@ function failureText(
   );
 }
 
-/**
- * Run the Slack leg for an already-created agent group and report the outcome.
- *
- * `template` is the stamping result createAgent just returned, so it is
- * present on a fresh create and absent on a resume — by then the stamping is
- * long done and its commit is not ours to restate.
- */
+/** Run the Slack leg for an already-created agent group and report the outcome. */
 async function runSlackLeg(
   content: Record<string, unknown>,
   session: Session,
@@ -160,13 +140,12 @@ async function runSlackLeg(
     localName: string;
     newAgentGroupId: string;
     slug: string;
-    template?: { ref: string; commit?: string };
   },
 ): Promise<void> {
   const { name, localName, newAgentGroupId, slug } = args;
   try {
     const r = await runSlackAgentFlow({ content, session, newAgentGroupId, slug });
-    await notifyAgent(session, successText(name, r.roomChannelId, args.template, r.deferredInstall));
+    await notifyAgent(session, successText(name, r.roomChannelId, r.deferredInstall));
   } catch (err) {
     // SlackApiError carries the flow step id its call site passed to the
     // shared Slack lib — surface it like a typed flow step.
@@ -214,7 +193,7 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
   // report "done" ~a minute early — this wrapper's successText/failureText
   // is the only completion signal. Upstream error notifies (collision,
   // invalid path) still fire either way.
-  const outcome = await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
 
   const after = await getDestinationByName(session.agent_group_id, localName);
   // Creation bailed or collided — upstream already answered the requester.
@@ -227,7 +206,6 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
     localName,
     newAgentGroupId: after.target_id,
     slug: await dedupeSlug(deriveInstanceSlug(name), after.target_id),
-    template: outcome?.template,
   });
 }
 
@@ -243,18 +221,9 @@ async function requestSlackCreateAgentHold(content: Record<string, unknown>, ses
   }
   const name = typeof content.name === 'string' ? content.name : '';
   const instructions = typeof content.instructions === 'string' ? content.instructions : null;
-  const template = typeof content.template === 'string' && content.template ? content.template : undefined;
   const sourceGroup = await getAgentGroup(session.agent_group_id);
   if (!sourceGroup) return;
 
-  // Same sentence as trunk's requestCreateAgentHold: the admin must see the
-  // template ref and whether it will be fetched or is already local — the
-  // Slack card is the only card a Slack-origin templated create ever shows.
-  const templateNote = template
-    ? ` It will be stamped from template "${template}" (${
-        hasLocalTemplate(template) ? 'using the existing local copy' : 'fetched from the public template registry'
-      }).`
-    : '';
   await requestApproval({
     session,
     agentName: sourceGroup.name,
@@ -270,15 +239,11 @@ async function requestSlackCreateAgentHold(content: Record<string, unknown>, ses
       // room:'none' must survive the hold too — dropping it would grow a
       // room the multi-create pattern deliberately skipped.
       ...(content.room === 'none' ? { room: 'none' } : {}),
-      // The template ref is the grant binding: the guard matches grant.template
-      // against the request, and the approved replay stamps from this payload.
-      // Dropping it would both break that match and create a plain agent.
-      ...(template ? { template } : {}),
     },
     title: `Create agent: ${name}`,
     question:
       `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
-      `Slack bot for it (new Slack app, DM with you, and a shared three-way room).${templateNote} Approve?`,
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
   });
 }
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -97,7 +97,7 @@ vi.mock('../approvals/index.js', async () => {
 // Registers the wrapped create_agent delivery action — the path under test.
 // Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
 import './index.js';
-import { ensureAgentRoom, finishSlackAgentFlow, runSlackAgentFlow } from './orchestrate.js';
+import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
 import { SlackFlowError } from './types.js';
 import { getDeliveryAction } from '../../delivery.js';
 import { log } from '../../log.js';
@@ -450,52 +450,6 @@ describe('slack-aware create_agent — manifest variants', () => {
     await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
     const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
     expect(appBody.allow_guests).toBeUndefined();
-  });
-});
-
-describe('slack-aware create_agent — template attribution', () => {
-  // The Slack leg is driven directly here: the upstream template branch of
-  // createAgent (host fetch + stamping) is trunk's, and this pins only the
-  // one thing this module owns — content.template reaching the broker.
-  it('a templated create sends the ref to the broker as attribution', async () => {
-    const now = new Date().toISOString();
-    await createAgentGroup({
-      id: 'ag-new',
-      name: 'Research',
-      folder: 'research',
-      agent_provider: null,
-      created_at: now,
-    });
-
-    await runSlackAgentFlow({
-      content: { name: 'Research', instructions: 'dig deep', template: 'sales/sdr', room: 'none' },
-      session: SLACK_SESSION,
-      newAgentGroupId: 'ag-new',
-      slug: 'research',
-    });
-
-    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
-    expect(appBody.template).toBe('sales/sdr');
-  });
-
-  it('a plain create sends no template field', async () => {
-    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
-    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
-    expect(appBody.template).toBeUndefined();
-  });
-
-  it('hold payload carries the template ref through to the approved replay (confined group)', async () => {
-    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
-
-    await runCreateAgent({ name: 'Research', instructions: 'dig deep', template: 'sales/sdr' });
-
-    expect(await getAgentGroupByFolder('research')).toBeUndefined();
-    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
-    const opts = mockRequestApproval.mock.calls[0]![0] as { payload: Record<string, unknown>; question: string };
-    expect(opts.payload).toMatchObject({ name: 'Research', template: 'sales/sdr' });
-    // Design merge condition: the Slack card (the only card this path shows)
-    // names the template and says fetch-vs-local, same sentence as trunk's.
-    expect(opts.question).toContain('It will be stamped from template "sales/sdr"');
   });
 });
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -461,8 +461,6 @@ interface FlowArgs {
   /** Extra sink for the pending-install line — the finish script prints it to
    *  the operator's terminal, which has no Slack conversation to post into. */
   onInstallPending?: (text: string) => void;
-  /** Template ref the agent was stamped from — broker attribution only. */
-  template?: string;
 }
 
 async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
@@ -505,7 +503,6 @@ async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
     description: args.description,
     allowGuests: args.allowGuests,
     requestedBy: operatorUserId,
-    template: args.template,
     installWait: args.installWait ?? resolveInstallWait(rootDir),
     onInstallPending: async (info) => {
       const text = installPendingText(displayName, info);
@@ -694,7 +691,6 @@ export async function runSlackAgentFlow(args: {
     allowGuests: content.allow_guests === true,
     originSession: session,
     room: content.room === 'none' ? 'none' : 'own',
-    template: typeof content.template === 'string' && content.template ? content.template : undefined,
   });
 }
 


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Reverts #3397, removing template-ref propagation from the Slack agent creation flow while preserving the deferred workspace-install behavior merged afterward in #3398.

This removes the template approval-card copy, replay payload field, success attribution, broker attribution, and their focused tests.

## Testing

- git diff --check
- Prettier check passes for all three changed files
- ESLint reports zero errors; three pre-existing catch-all warnings remain
- pnpm run build matches an untouched channels checkout exactly: both report the same five unrelated baseline errors
- The focused test cannot run directly from the payload branch because its relative imports resolve only after skill installation