### PR TITLE
fix(slack-agent-flow): await the async DB helpers in orchestrate.test

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -796,9 +796,9 @@ describe('slack-aware create_agent — workspace install approval', () => {
     expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
     expect(env()).toMatch(/^SLACK_INSTANCES=.*research/m);
     expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
-    const newGroup = getAgentGroupByFolder('research')!;
-    const dmMg = getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
-    expect(getMessagingGroupAgentByPair(dmMg!.id, newGroup.id)).toBeDefined();
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup.id)).toBeDefined();
     expect(postedTexts().some((t) => t.includes("I'm Research, your new agent"))).toBe(true);
 
     // Exactly one app, and the consumed install link is retired.
@@ -837,7 +837,7 @@ describe('slack-aware create_agent — workspace install approval', () => {
     refuseAutoInstall();
     appStateQueue = [{ status: 'pending_install' }];
     await runCreateAgent({ name: 'Research' });
-    const groupCountAfterPark = getAgentGroupByFolder('research')!.id;
+    const groupCountAfterPark = (await getAgentGroupByFolder('research'))!.id;
     const postsAfterPark = postedTexts().length;
 
     // The operator approves the install, then asks for the same agent again.
@@ -847,8 +847,8 @@ describe('slack-aware create_agent — workspace install approval', () => {
 
     // One Slack app, one agent group — the second ask finished the first.
     expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
-    expect(getAgentGroupByFolder('research')!.id).toBe(groupCountAfterPark);
-    expect(getAgentGroupByFolder('research-2')).toBeUndefined();
+    expect((await getAgentGroupByFolder('research'))!.id).toBe(groupCountAfterPark);
+    expect(await getAgentGroupByFolder('research-2')).toBeUndefined();
     // Upstream's name-collision answer must not be what the user hears.
     expect(notifyTexts().at(-1)).not.toContain('already have a destination');
     expect(notifyTexts().at(-1)).toContain('is live on Slack');
@@ -858,7 +858,7 @@ describe('slack-aware create_agent — workspace install approval', () => {
     expect(appStateReads).toBe(1);
     expect(postedTexts()[postsAfterPark]).toContain('Still waiting on your workspace');
     expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
-    expect(getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research')).toBeDefined();
+    expect(await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research')).toBeDefined();
   });
 
   it('SLACK_INSTALL_WAIT_MS=0 parks immediately — a slow approval queue need not hold delivery open', async () => {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — Adds the missing `await` to seven call sites in the `slack-agent-flow` skill payload's `orchestrate.test.ts`.

**Why** — Applying the skill currently fails. Seven sites were written against the old synchronous DB API, but on `main` these helpers are `async`:

| Helper | Signature |
|---|---|
| `getAgentGroupByFolder` | `src/db/agent-groups.ts:16` |
| `getMessagingGroupByPlatform` | `src/db/messaging-groups.ts:54` |
| `getMessagingGroupAgentByPair` | `src/db/messaging-groups.ts:334` |

Most of the file was migrated; two `it()` blocks were missed (lines 799–801, 840, 850–851, 861).

The install fails in two places:

- **Step 7 `pnpm run build`** — four `TS2339: Property 'id' does not exist on type 'Promise<AgentGroup | undefined>'`
- **Step 8 vitest** — `expected Promise{…} to be undefined` at `orchestrate.test.ts:851`

The second failure is the damaging one: because step 8 fails, **step 9 (`bash setup/lib/restart.sh`) never runs**. Every file still gets copied and both barrels appended, so the install looks complete — but the host is never restarted, the flow module is never loaded, and `create_room`, `add_to_room`, and the wrapped `create_agent` are all silently absent. The tell is that `Delivery action handler overwritten action="create_agent"` — which `SKILL.md` documents as the signal the wrapper won the registry — never appears at boot.

Two of the sites (801, 861) were also silent false-passes: `expect(somePromise).toBeDefined()` always passes, so those assertions were never testing anything. They now assert on the resolved value.

**How it was tested** — Reproduced on a fresh `nanoclaw.sh` setup run that installed Slack via the wizard's companion flow (`/add-slack` → `slack-a2a-rooms` → `slack-agent-flow`), where step 12 failed exactly as above. After the fix, on that install:

- `pnpm run build` — clean, no TS errors
- the skill's own step-8 fence — **213 passed**, 13 files
  (`slack-agent-flow`, `slack-room-membership`, `canvas-actions`, `slack-onboarding`, `env-file`, `adapter-hot-start`)
- step 9 restart then produced the expected `WARN Delivery action handler overwritten action="create_agent"`, confirming the module loaded and the wrapper won

Test-only change; no runtime or source behavior is affected. `prettier --check` clean.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
