### PR TITLE
fix(permissions): assert the scope warning via its constant, not a copy of it

### DIFF
--- a/src/modules/permissions/channel-approval.test.ts
+++ b/src/modules/permissions/channel-approval.test.ts
@@ -19,7 +19,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initTestDb, closeDb, runMigrations, getDb } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
-import { createNewAgentGroup } from './channel-approval.js';
+import { AGENT_ACCESS_SCOPE_WARNING, createNewAgentGroup } from './channel-approval.js';
 import { createMessagingGroup, getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
 import { registerChannelAdapter } from '../../channels/channel-registry.js';
 import type { ChannelDefaults } from '../../channels/adapter.js';
@@ -187,7 +187,7 @@ describe('unknown-channel registration flow', () => {
     expect(payload.type).toBe('ask_question');
     // Card tells the approver the resolved engage rule.
     expect(payload.question).toContain('will respond to @-mentions in this group');
-    expect(payload.question).toContain('reach anything it can reach');
+    expect(payload.question).toContain(AGENT_ACCESS_SCOPE_WARNING);
     // Single-agent card offers a direct "Connect to <name>" button.
     const connectOption = payload.options.find((o: { value: string }) => o.value.startsWith('connect:'));
     expect(connectOption).toBeDefined();
@@ -565,7 +565,7 @@ describe('unknown-channel registration flow', () => {
       question: string;
       options: Array<{ label: string; value: string }>;
     };
-    expect(followupPayload.question).toContain('reach anything it can reach');
+    expect(followupPayload.question).toContain(AGENT_ACCESS_SCOPE_WARNING);
     expect(followupPayload.options.map((option) => option.value)).toContain('connect:ag-1');
     expect(followupPayload.options.map((option) => option.value)).not.toContain('connect:ag-2');
 

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -19,6 +19,7 @@ import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../../db/messaging-groups.js';
 import { upsertUser } from './db/users.js';
 import { grantRole } from './db/user-roles.js';
+import { AGENT_ACCESS_SCOPE_WARNING } from './channel-approval.js';
 
 // Mock container runner — prevent actual docker spawn.
 vi.mock('../../container-runner.js', () => ({
@@ -175,7 +176,7 @@ describe('unknown-sender request_approval flow', () => {
     const payload = JSON.parse(content as string);
     expect(payload.type).toBe('ask_question');
     expect(payload.questionId).toMatch(/^nsa-/);
-    expect(payload.question).toContain('reach anything it can reach');
+    expect(payload.question).toContain(AGENT_ACCESS_SCOPE_WARNING);
 
     const { getDb } = await import('../../db/connection.js');
     const rows = await getDb().all('SELECT * FROM pending_sender_approvals');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — Fixes three failing tests on `main` by asserting against the exported `AGENT_ACCESS_SCOPE_WARNING` constant instead of a hardcoded transcription of it.

**Why** — `main` is currently red:

```
FAIL src/modules/permissions/channel-approval.test.ts:190
     delivers an approval card on mention into an unwired group
FAIL src/modules/permissions/channel-approval.test.ts:568
     does not let a scoped admin connect an unknown channel to another agent group
FAIL src/modules/permissions/sender-approval.test.ts:178
     delivers an approval card on first unknown message

AssertionError: expected '…' to contain 'reach anything it can reach'
```

a670f659 added `AGENT_ACCESS_SCOPE_WARNING` and these three assertions in the same commit, so they agreed at the time. The review suggestion applied in 44d04281 then reworded the constant:

```diff
-"Anyone approved here can direct the agent and reach anything it can reach — including …"
+"Anyone approved here can interact with the agent and potentially access anything the agent can access, including …"
```

A GitHub suggestion commit rewrites only the suggested lines, so the three assertions kept asserting the pre-review copy and have been failing since.

**The source is correct.** The reworded copy is the reviewed wording and the authorization model was never involved — this is a copy-only drift, and only the tests are stale.

**How it works** — Rather than re-transcribing the new wording (which would just reset the same trap), each assertion now references the exported constant, so the copy lives in exactly one place and a future reword cannot desync the tests again. `sender-approval.ts` already imports the constant from `channel-approval.js`, and that module has no import-time side effects — only exported declarations — so neither test picks up a new runtime dependency.

**How it was tested** — On a clean checkout of `main` (`510a364c`):

- before: `3 failed | 19 passed` in the two files
- after: `src/modules/permissions/` — **51 passed**, 6 files
- full host suite — **1922 passed, 154 files, 0 failures**
- `tsc --noEmit` clean; `prettier --check` clean; `eslint` 0 errors (17 pre-existing warnings unchanged)

Test-only change; no runtime behavior is affected.
