### PR TITLE
fix: cross-cutting trunk repairs from the core-skills audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,75 @@
+# NanoClaw — example .env
+#
+# Copy to `.env` and uncomment only what you need. Everything here has a
+# working default; a NanoClaw install with no `.env` at all runs fine.
+#
+# How this file is read: `readEnvFile` in src/env.ts parses `.env` on demand
+# for a named set of keys and deliberately does NOT load anything into
+# process.env, so secrets never leak into child processes. Consequence worth
+# knowing: a key nothing asks for by name is ignored, and `process.env` wins
+# over this file wherever both are consulted. Credentials live in the OneCLI
+# vault, not here — see the "Secrets / Credentials / OneCLI" section of
+# CLAUDE.md and run `/init-onecli`.
+#
+# `/add-<channel>` and `/add-<tool>` skills append their own blocks below.
+# Keep each one under its own heading so REMOVE.md can find it again.
+
+# ---- Identity ---------------------------------------------------------------
+
+# Instance-wide default agent provider stamped onto NEWLY created groups.
+# Existing groups are never retroactively flipped; per-group override is
+# `ncl groups config update --provider <name>`.
+#DEFAULT_AGENT_PROVIDER=claude
+
+# ---- Time -------------------------------------------------------------------
+
+# Install timezone (IANA). Grounds cron interpretation and every timestamp
+# shown to a user or an agent. Falls back to the host timezone, then UTC.
+# A group can override it with `ncl groups config update --timezone <IANA>`.
+#TZ=America/New_York
+
+# ---- Not settable here ------------------------------------------------------
+
+# `LOG_LEVEL` (debug|info|warn|error) and `NANOCLAW_TEMPLATES_DIR` are read
+# from the real process environment only, and the service unit does not source
+# this file. Export them in the service definition or the shell you run
+# `pnpm run dev` from — putting them here does nothing.
+
+# ---- OneCLI gateway ---------------------------------------------------------
+
+# Only set these if the vault does not live at its default local address.
+#ONECLI_URL=http://127.0.0.1:10254
+#ONECLI_API_KEY=
+
+# ---- Container resource caps ------------------------------------------------
+
+# Empty = no flag passed = unbounded (the historical default). Opt in per
+# install; a too-low cap kills containers mid-turn without saying why.
+#CONTAINER_CPU_LIMIT=2
+#CONTAINER_MEMORY_LIMIT=8g
+# Fork-bomb backstop. cgroups v2 counts THREADS and Chromium is thread-hungry,
+# so keep this well above a few hundred. Empty = no cap.
+#CONTAINER_PIDS_LIMIT=2048
+
+# ---- Egress lockdown --------------------------------------------------------
+
+# Force all agent traffic through the OneCLI gateway on a no-internet Docker
+# network. Off by default. See src/egress-lockdown.ts.
+#NANOCLAW_EGRESS_LOCKDOWN=false
+#NANOCLAW_EGRESS_NETWORK=nanoclaw-egress
+#ONECLI_GATEWAY_CONTAINER=onecli
+
+# ---- Image build ------------------------------------------------------------
+
+# Add Chinese/Japanese/Korean fonts to the agent image (~200MB). Without them,
+# Chromium screenshots and PDFs containing CJK text render tofu boxes.
+# Read by container/build.sh as a docker build-arg; rebuild to apply.
+#INSTALL_CJK_FONTS=false
+
+# ---- Seams (advanced) -------------------------------------------------------
+
+# Alternate session runtime driver / gateway provider. Both are overlay seams:
+# leave unset unless you installed a skill that registers one, or the host
+# refuses to start.
+#NANOCLAW_RUNTIME_DRIVER=docker
+#NANOCLAW_GATEWAY_PROVIDER=onecli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ For ad-hoc central queries from skills or scripts, use the in-tree wrapper rathe
 | `src/delivery-guard.ts` | `DeliveryGuardSpec` + `runGuarded` — the guard-consult pipeline for privileged delivery actions (registry stays in `delivery.ts`) |
 | `src/host-sweep.ts` | 60s sweep: `processing_ack` sync, stale detection, due-message wake, recurrence |
 | `src/session-manager.ts` | Resolves sessions; opens `inbound.db` / `outbound.db`; manages heartbeat path |
-| `src/container-runner.ts` | Spawns per-agent-group Docker containers with session DB + outbox mounts, OneCLI `ensureAgent` |
+| `src/container-runner.ts` | Composes the typed `SessionSpec` for a session (mounts, env, argv) and hands it to the session driver; adopt/kill/wake |
 | `src/container-runtime.ts` | Docker CLI wrapper (runtime binary, host-gateway args, mount args), orphan cleanup |
 | `src/guard/` | Privileged-action decision seam: `guard(action, input)` → allow \| hold \| deny. Module-edge `guard.ts` adapters (cli, agent-to-agent, self-mod, permissions) define each action's decision; ncl commands + delivery actions demand a guard at registration; approved replays carry the approval row as a grant and re-run the checks. Conformance test: `src/guard/conformance.test.ts` |
 | `src/modules/permissions/access.ts` | `canAccessAgentGroup` — owner / global admin / scoped admin / member resolution against `user_roles` + `agent_group_members` |
@@ -161,7 +161,7 @@ Key files: `src/container-restart.ts`, `src/container-runner.ts` (`killContainer
 
 ## Secrets / Credentials / OneCLI
 
-API keys, OAuth tokens, and auth credentials are managed by the OneCLI gateway. Secrets are injected into per-agent containers at request time — none are passed in env vars or through chat context. The container agent sees this via the `onecli-gateway` container skill (`container/skills/onecli-gateway/SKILL.md`), which teaches it how the proxy works, how to handle auth errors, and to never ask for raw credentials. Host-side wiring: `src/modules/approvals/onecli-approvals.ts`, `ensureAgent()` in `container-runner.ts`. Run `onecli --help`.
+API keys, OAuth tokens, and auth credentials are managed by the OneCLI gateway. Secrets are injected into per-agent containers at request time — none are passed in env vars or through chat context. The container agent sees this via the `onecli-gateway` container skill (`container/skills/onecli-gateway/SKILL.md`), which teaches it how the proxy works, how to handle auth errors, and to never ask for raw credentials. Host-side wiring: `src/modules/approvals/onecli-approvals.ts`, and `ensureAgent()` in `src/gateway-providers/onecli.ts` (the gateway provider the spawn path consults — it moved out of `container-runner.ts` with the gateway seam). Run `onecli --help`.
 
 ### Secret modes
 
@@ -227,7 +227,7 @@ Run commands directly — don't tell the user to run them.
 # Host (Node + pnpm)
 pnpm run dev          # Host via tsx (no watch)
 pnpm run build        # Compile host TypeScript (src/)
-./container/build.sh  # Rebuild agent container image (nanoclaw-agent:latest)
+./container/build.sh  # Rebuild agent container image (tag: nanoclaw-agent-v2-<install-slug>:latest)
 pnpm test             # Host tests (vitest)
 
 # Agent-runner (Bun — separate package tree under container/agent-runner/)
@@ -317,8 +317,8 @@ The agent container runs on **Bun**; the host runs on **Node** (pnpm). They comm
 - **Bumping `@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`, or any agent-runner runtime dep** → no `minimumReleaseAge` policy applies to this tree. Check the release date on npm, pin deliberately, never `bun update` blindly.
 - **Writing a new named-param SQL insert/update in the container** → use `$name` in both SQL and JS keys: `.run({ $id: msg.id })`. `bun:sqlite` does not auto-strip the prefix the way `better-sqlite3` does on the host. Positional `?` params work normally.
 - **Adding a test in `container/agent-runner/src/`** → import from `bun:test`, not `vitest`. Vitest runs on Node and can't load `bun:sqlite`. `vitest.config.ts` excludes this tree.
-- **Adding a Node CLI the agent invokes at runtime** (like `agent-browser`, `claude-code`, `vercel`) → put it in the Dockerfile's pnpm global-install block, pinned to an exact version via a new `ARG`. Don't use `bun install -g` — that bypasses the pnpm supply-chain policy.
-- **Changing the Dockerfile entrypoint or the dynamic-spawn command** (`src/container-runner.ts` line ~503) → keep `exec bun ...` so signals forward cleanly. The image has no `/app/dist`; don't reintroduce a tsc build step.
+- **Adding a Node CLI the agent invokes at runtime** (like `agent-browser`, `claude-code`) → append a `{ "name", "version" }` entry to `container/cli-tools.json`, pinned to an exact version; add `"onlyBuilt": true` only if the package has a native postinstall. Do NOT edit the Dockerfile: `container/install-cli-tools.sh` reads the manifest and installs every entry with `pnpm install -g`, so the supply-chain policy still applies and a skill's reach-in is a json-merge. `container/cli-tools.test.ts` guards the manifest shape and the Dockerfile wiring. Don't use `bun install -g` or a hand-rolled `ARG` — both bypass the manifest.
+- **Changing the Dockerfile entrypoint or the dynamic-spawn command** (the `command`/`args` of the agent `ContainerSpec` in `composeSessionSpec`, `src/container-runner.ts`) → keep `exec bun ...` so signals forward cleanly. The image has no `/app/dist`; don't reintroduce a tsc build step.
 - **Changing session-DB pragmas** (`container/agent-runner/src/mailbox/sqlite/connection.ts`) → `journal_mode=DELETE` is load-bearing for cross-mount visibility. Read the comment block at the top of the file first.
 
 ## CJK font support

--- a/container/cli-tools.test.ts
+++ b/container/cli-tools.test.ts
@@ -52,12 +52,32 @@ describe('cli-tools manifest', () => {
     }
   });
 
-  it('bakes in nothing that a skill is meant to add on request', () => {
-    // Regression guard for the opt-in boundary. `vercel` was baked in and is
-    // now added by /add-vercel; anything reintroducing it here silently puts a
-    // deployment CLI, and its credential surface, into every agent again.
-    const names = manifest.map((t) => t.name);
-    expect(names).not.toContain('vercel');
+  it('carries only the keys the installer reads, correctly typed', () => {
+    // The installer consumes exactly `name`, `version` and `onlyBuilt`. A key
+    // it does not read is either a typo (`onlyBuild`, `pin`) that silently
+    // does nothing, or an expectation the seam does not honour. Deliberately
+    // NOT a name blacklist: this manifest is the opt-in surface every
+    // `/add-<cli>` skill appends to, so a test that named specific tools as
+    // forbidden could never be green after a legitimate install.
+    const allowed = new Set(['name', 'version', 'onlyBuilt']);
+    for (const tool of manifest) {
+      for (const key of Object.keys(tool)) {
+        expect(allowed.has(key), `${(tool as { name?: string }).name}: unknown manifest key "${key}"`).toBe(true);
+      }
+      if ('onlyBuilt' in tool) {
+        expect(typeof tool.onlyBuilt, `${tool.name}: onlyBuilt must be a boolean`).toBe('boolean');
+      }
+    }
+  });
+
+  it('every name is an installable npm package name (the spec is name@version)', () => {
+    // `pnpm install -g <name>@<version>` word-splits on spaces and reads `@`
+    // as the version delimiter, so a scope typo or an embedded range in the
+    // name installs the wrong thing (or nothing) with no build error.
+    const npmName = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+    for (const tool of manifest) {
+      expect(tool.name, `"${tool.name}" is not a valid npm package name`).toMatch(npmName);
+    }
   });
 
   it('is wired into the Dockerfile build (COPY manifest + run installer)', () => {

--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -152,7 +152,9 @@ You do *not* need to test the dependency's own API contract; that's optional ext
 
 ### When there is genuinely nothing to test in-tree
 
-Some skills' only functional integration is a runtime operator action with no source footprint: registering an MCP server through `ncl`, or a mount through the sanctioned query wrapper (until the `ncl` add-mount verb lands). There's no line in the tree whose deletion a test could catch, so a registration test is structurally inapplicable. **State this explicitly in SKILL.md** rather than inventing a hollow test; conformance is then anatomy plus the dependency guard. This is a conformant outcome, valid only when the reach-in has no in-tree representation. (A raw-SQL write into core's schema to achieve the same thing is a smell, not a workaround.)
+Some skills' only functional integration is a runtime operator action with no source footprint: registering an MCP server through `ncl`, for instance. There's no line in the tree whose deletion a test could catch, so a registration test is structurally inapplicable.
+
+A **mount is no longer such a case**. `ncl groups config add-mount` has landed, and admissibility is a pure in-tree function: `checkMountAdmissibleAtWrite` / `validateMount` in `src/modules/mount-security/index.ts`. A skill that mounts a host path owes a two-line assertion that its exact `{ hostPath, containerPath }` is admissible — that guard catches both the container-path rule (relative only; spawn rewrites to `/workspace/extra/<name>`) and a later addition to the blocked-pattern list. **State this explicitly in SKILL.md** rather than inventing a hollow test; conformance is then anatomy plus the dependency guard. This is a conformant outcome, valid only when the reach-in has no in-tree representation. (A raw-SQL write into core's schema to achieve the same thing is a smell, not a workaround.)
 
 ### Test rules
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:skills": "vitest run --config vitest.skills.config.ts"
   },
   "dependencies": {
     "@clack/core": "^1.2.0",

--- a/scripts/harness-bootstrap.test.ts
+++ b/scripts/harness-bootstrap.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Guard for the in-tree E2E harnesses.
+ *
+ * All four broke at once when the mailbox seam landed, and nothing noticed for
+ * a release: they are scripts, so no build, typecheck or test leg touches them.
+ * These assertions are the cheapest thing that goes red on the same class of
+ * break — a harness that stops composing the host, or drifts back onto a
+ * hard-coded image tag.
+ *
+ * They are structural on purpose. Running a harness needs Docker and a built
+ * image, which a unit suite must not require; what can be checked here is that
+ * each one still wires itself to the seams it depends on.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const read = (name: string) => readFileSync(path.join(here, name), 'utf8');
+
+// Harnesses that drive the real host path, and so need the composition slots
+// filled before they resolve a session.
+const HOST_HARNESSES = ['test-v2-host.ts', 'test-v2-channel-e2e.ts'];
+
+describe('host E2E harnesses', () => {
+  for (const name of HOST_HARNESSES) {
+    it(`${name} imports the composition bootstrap`, () => {
+      const source = read(name);
+      expect(
+        source,
+        `${name} must import './harness-bootstrap.js' or it dies on "No agent mailbox registered"`,
+      ).toMatch(/import '\.\/harness-bootstrap\.js';/);
+    });
+
+    it(`${name} scaffolds the container_configs row via initGroupFilesystem`, () => {
+      // Creating the agent group row alone is not enough: spawn calls
+      // materializeContainerJson, which throws "Container config not found for
+      // agent group" without the config row.
+      const source = read(name);
+      expect(source).toMatch(/initGroupFilesystem\(/);
+    });
+  }
+
+  it('the bootstrap fills the mailbox slot through the real modules barrel', () => {
+    // Importing src/mailbox/compose.js directly would work today and drift
+    // tomorrow — the barrel is what src/index.ts imports.
+    expect(read('harness-bootstrap.ts')).toMatch(/import '\.\.\/src\/modules\/index\.js';/);
+  });
+
+  it('the offline gateway is registered only from scripts/, never from src/', () => {
+    // If src/ ever imported this, a stray NANOCLAW_GATEWAY_PROVIDER could make
+    // the real host spawn agents with no credentials.
+    const gateway = read('harness-gateway-noop.ts');
+    expect(gateway).toMatch(/registerGatewayProvider\('harness-noop'|HARNESS_NOOP_GATEWAY_KIND/);
+    expect(read('harness-bootstrap.ts')).toMatch(/import '\.\/harness-gateway-noop\.js';/);
+  });
+});
+
+describe('container-side harness', () => {
+  it('test-v2-agent.ts fills the container mailbox slot', () => {
+    expect(read('test-v2-agent.ts')).toMatch(/import '\.\.\/container\/agent-runner\/src\/modules\/index\.js';/);
+  });
+});
+
+describe('sanity-live-poll.ts', () => {
+  const source = read('sanity-live-poll.ts');
+
+  it('resolves the agent image per install instead of hard-coding a tag', () => {
+    // `nanoclaw-agent:latest` has not been a real tag since image names became
+    // per-checkout; the hard-coded name made every run silently vacuous.
+    expect(source).not.toMatch(/nanoclaw-agent:latest/);
+    expect(source).toMatch(/CONTAINER_IMAGE/);
+  });
+
+  it('fails loudly when the container reader misses host writes', () => {
+    // The whole point is to detect a cross-mount visibility regression; a
+    // version that only prints is not a regression test.
+    expect(source).toMatch(/process\.exit\(1\)/);
+  });
+});

--- a/scripts/harness-bootstrap.ts
+++ b/scripts/harness-bootstrap.ts
@@ -1,0 +1,31 @@
+/**
+ * Composition bootstrap for the in-tree host harnesses.
+ *
+ * Import this FIRST (before anything that touches a session) from any script
+ * that drives the real host path — `scripts/test-v2-host.ts`,
+ * `scripts/test-v2-channel-e2e.ts`, and anything modeled on them.
+ *
+ * Why it exists. The host is composed, not monolithic: `src/index.ts` imports
+ * `src/modules/index.js` for side effects, and that barrel is where the
+ * singular mailbox composition slot is filled (`src/mailbox/compose.ts` →
+ * `registerAgentMailbox`). A script that skips it dies the first time it
+ * resolves a session, with `No agent mailbox registered` thrown from
+ * `getAgentMailbox` — deep inside `initSessionFolder`, several frames below
+ * `routeInbound`, where it reads like a router bug rather than a missing
+ * import. Every harness in this directory acquired exactly that break when
+ * the mailbox seam landed (#3349).
+ *
+ * So the harnesses import the composition through here, in one place, and the
+ * next seam extraction is a one-line change to this file instead of a silent
+ * break in four scripts. Keep this list in step with the side-effect imports
+ * in `src/index.ts`; a harness that needs a specific channel adapter or the
+ * `ncl` command registry imports those itself, since most do not.
+ */
+
+// Modules barrel — registration modules, including the mailbox slot.
+import '../src/modules/index.js';
+
+// Offline gateway, registered but never selected unless the operator asks for
+// it with NANOCLAW_GATEWAY_PROVIDER=harness-noop. See the file header for why
+// a harness needs one and why it cannot leak into the host.
+import './harness-gateway-noop.js';

--- a/scripts/harness-gateway-noop.ts
+++ b/scripts/harness-gateway-noop.ts
@@ -1,0 +1,36 @@
+/**
+ * Offline gateway provider for the in-tree harnesses. Contributes nothing.
+ *
+ * The real gateway (`onecli`) calls out to the vault on every spawn: it
+ * registers the agent, then fetches the per-session credential contribution,
+ * and a throw there aborts the spawn on purpose — "a session without its
+ * gateway is a session without credentials, and it must not launch". Correct
+ * in production, and it means the harnesses below cannot spawn a single
+ * container on a machine with no vault: they stop at
+ * `wakeContainer failed ... OneCLIRequestError` having proved only the
+ * routing half.
+ *
+ * This registers a no-credential gateway under the kind `harness-noop` so a
+ * harness run can exercise the whole spawn path — spec composition, mount
+ * admission, `docker create/start`, the runner's first poll of inbound.db —
+ * without any credential at all. Select it explicitly:
+ *
+ *   NANOCLAW_GATEWAY_PROVIDER=harness-noop pnpm exec tsx scripts/test-v2-host.ts
+ *
+ * Safety: the registration lives in `scripts/`, which nothing under `src/`
+ * imports, so the host cannot select this kind however the variable is set —
+ * `getGatewayProvider()` finds no factory and throws its operator error. The
+ * agent it spawns has no proxy env and no credential stubs, so a provider
+ * that needs a key fails on its first call. That is the point: use this to
+ * verify plumbing, not to run an agent.
+ */
+import { registerGatewayProvider } from '../src/gateway-providers/gateway-provider-registry.js';
+
+export const HARNESS_NOOP_GATEWAY_KIND = 'harness-noop';
+
+registerGatewayProvider(HARNESS_NOOP_GATEWAY_KIND, () => ({
+  kind: HARNESS_NOOP_GATEWAY_KIND,
+  async contribute() {
+    return {};
+  },
+}));

--- a/scripts/sanity-live-poll.ts
+++ b/scripts/sanity-live-poll.ts
@@ -15,14 +15,26 @@
  * reader either sees nothing, sees only the first write, or sees updates
  * only after the host closes its connection for good.
  *
- * Expected passing output (DELETE mode, close-per-write):
- *   reader sees each seq within ~1s of it being written.
- * Anything else is a regression — investigate BEFORE assuming it's flaky.
+ * DELETE mode is the assertion: the reader must observe all 8 writes, and the
+ * script exits non-zero if it does not. WAL mode runs afterwards purely as a
+ * contrast case and is never asserted on — `-shm` is memory-mapped, and
+ * whether a host write propagates depends on the mount driver (it does not
+ * under VirtioFS/Colima/Lima; it may under a plain Linux bind mount). Read the
+ * WAL section as information about this machine, not as a pass or a fail.
  *
  * Keep this around. It ran for ~20 minutes once to map the failure modes
  * and it takes about 60s to run — cheap insurance.
  *
- * Requires: Docker Desktop running, nanoclaw-agent:latest image built.
+ * The reader mirrors production's `getInboundDb()` (container/agent-runner/
+ * src/mailbox/sqlite/connection.ts): read-only, busy_timeout=5000,
+ * mmap_size=0. It also runs under Bun with `bun:sqlite`, like the real runner —
+ * the agent image ships no `better-sqlite3`, so the previous Node-based reader
+ * could not have worked even with the right image name.
+ *
+ * Requires: Docker running, and this checkout's agent image built
+ * (`./container/build.sh`). The tag is per-install; see src/install-slug.ts.
+ *
+ * Usage: pnpm exec tsx scripts/sanity-live-poll.ts
  */
 
 import { spawn, spawnSync } from 'node:child_process';
@@ -30,25 +42,62 @@ import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
 import Database from 'better-sqlite3';
 
+import { CONTAINER_IMAGE } from '../src/config.js';
+
+const WRITES = 8;
+const POLLS = 10;
+
+// Fail early and legibly rather than emitting a docker "pull access denied"
+// per journal mode after a full minute of host writes. The old hard-coded
+// hard-coded shared tag predates per-install image names, so every run of this
+// script has been silently vacuous: the host wrote, no container ever read, and
+// the script still exited 0.
+const inspect = spawnSync('docker', ['image', 'inspect', CONTAINER_IMAGE], { stdio: 'ignore' });
+if (inspect.status !== 0) {
+  console.error(`✗ Agent image not found: ${CONTAINER_IMAGE}`);
+  console.error('  Build it with ./container/build.sh (the tag is per-checkout — see src/install-slug.ts).');
+  process.exit(1);
+}
+console.log(`Using image: ${CONTAINER_IMAGE}`);
+
+const sleep = (ms: number) => new Promise<void>((res) => setTimeout(res, ms));
+
 const dbDir = join('/tmp', `nanoclaw-live-${Date.now()}`);
 mkdirSync(dbDir, { recursive: true });
 spawnSync('chmod', ['777', dbDir]);
 const dbPath = join(dbDir, 'live.db');
 
-for (const journalMode of ['DELETE', 'WAL']) {
+// The container-side reader: same pragmas as the real agent-runner's
+// long-lived inbound connection.
+const readerSource = `
+  import { Database } from 'bun:sqlite';
+  const db = new Database('/workspace/live.db', { readonly: true });
+  db.exec('PRAGMA busy_timeout = 5000');
+  db.exec('PRAGMA mmap_size = 0');
+  const stmt = db.prepare('SELECT COUNT(*) as n, MAX(seq) as hi FROM msgs');
+  let count = 0;
+  const timer = setInterval(() => {
+    const r = stmt.get();
+    console.log('poll t=' + (Date.now() % 100000) + ' count=' + r.n + ' max=' + r.hi);
+    if (++count >= ${POLLS}) { clearInterval(timer); db.close(); }
+  }, 1000);
+`;
+
+/** Highest `max=` the container reported, or 0 if it reported nothing. */
+async function runMode(journalMode: 'DELETE' | 'WAL'): Promise<number> {
   console.log(`\n=== ${journalMode} ===`);
-  rmSync(dbPath, { force: true });
-  rmSync(dbPath + '-wal', { force: true });
-  rmSync(dbPath + '-shm', { force: true });
-  rmSync(dbPath + '-journal', { force: true });
+  for (const suffix of ['', '-wal', '-shm', '-journal']) {
+    rmSync(dbPath + suffix, { force: true });
+  }
 
   const db = new Database(dbPath);
   db.pragma(`journal_mode = ${journalMode}`);
   db.pragma('synchronous = FULL');
   db.exec('CREATE TABLE msgs (seq INTEGER PRIMARY KEY, content TEXT)');
   db.close();
+  spawnSync('chmod', ['666', dbPath]);
 
-  // Start container poller in background
+  let observed = 0;
   const contProc = spawn(
     'docker',
     [
@@ -59,44 +108,59 @@ for (const journalMode of ['DELETE', 'WAL']) {
       '-v',
       `${dbDir}:/workspace`,
       '--entrypoint',
-      'node',
-      'nanoclaw-agent:latest',
+      'bun',
+      CONTAINER_IMAGE,
       '-e',
-      `const Database = require('better-sqlite3');
-     const db = new Database('/workspace/live.db', { readonly: true });
-     db.pragma('busy_timeout = 2000');
-     const stmt = db.prepare('SELECT COUNT(*) as n, MAX(seq) as hi FROM msgs');
-     let count = 0;
-     const timer = setInterval(() => {
-       const r = stmt.get();
-       console.log('poll t=' + (Date.now() % 100000) + ' count=' + r.n + ' max=' + r.hi);
-       if (++count >= 10) { clearInterval(timer); db.close(); }
-     }, 1000);`,
+      readerSource,
     ],
     { stdio: ['ignore', 'pipe', 'pipe'] },
   );
 
-  contProc.stdout.on('data', (d) => process.stdout.write(`  [cont] ${d}`));
-  contProc.stderr.on('data', (d) => process.stderr.write(`  [cont-err] ${d}`));
+  contProc.stdout.on('data', (d: Buffer) => {
+    const text = d.toString();
+    process.stdout.write(`  [cont] ${text}`);
+    for (const m of text.matchAll(/max=(\d+)/g)) {
+      observed = Math.max(observed, Number(m[1]));
+    }
+  });
+  contProc.stderr.on('data', (d: Buffer) => process.stderr.write(`  [cont-err] ${d}`));
 
-  // Give container a moment to start
-  const waitUntil = Date.now() + 2000;
-  while (Date.now() < waitUntil) {}
+  // Give the container a moment to start.
+  await sleep(2000);
 
   // Host opens, writes, CLOSES each time (matches production session-manager pattern)
-  for (let i = 1; i <= 8; i++) {
+  for (let i = 1; i <= WRITES; i++) {
     const h = new Database(dbPath);
     h.pragma(`journal_mode = ${journalMode}`);
     h.pragma('synchronous = FULL');
     h.prepare('INSERT INTO msgs (seq, content) VALUES (?, ?)').run(i, `msg-${i}`);
     h.close();
     console.log(`  [host] wrote+closed seq=${i} t=${Date.now() % 100000}`);
-    const sleepUntil = Date.now() + 1000;
-    while (Date.now() < sleepUntil) {}
+    await sleep(1000);
   }
 
-  // Wait for container to finish
   await new Promise<void>((res) => contProc.once('exit', () => res()));
+  console.log(`  → reader's highest observed seq: ${observed || 'none'} (host wrote ${WRITES})`);
+  return observed;
 }
 
+const deleteObserved = await runMode('DELETE');
+const walObserved = await runMode('WAL');
+
 rmSync(dbDir, { recursive: true, force: true });
+
+console.log('\n=== Verdict ===');
+console.log(`  WAL (contrast only, not asserted): reader saw seq ${walObserved || 'none'} of ${WRITES}`);
+
+if (deleteObserved < WRITES) {
+  console.error(
+    `✗ REGRESSION: in DELETE mode the container reader saw only seq ${deleteObserved || 'none'} of ${WRITES}. ` +
+      'Host→container visibility is broken — investigate BEFORE assuming this is flaky. ' +
+      'Start with the pragma block in container/agent-runner/src/mailbox/sqlite/connection.ts ' +
+      'and the open-write-close pattern in src/session-manager.ts.',
+  );
+  process.exit(1);
+}
+
+console.log(`✓ DELETE mode: reader observed all ${WRITES} host writes within one poll period each.`);
+process.exit(0);

--- a/scripts/test-v2-agent.ts
+++ b/scripts/test-v2-agent.ts
@@ -1,107 +1,167 @@
 /**
- * Quick integration test: create a session DB, insert a message,
- * run the v2 poll loop with the Claude provider, verify output.
+ * Container-side integration test: seed a session mailbox, run the REAL poll
+ * loop against a provider, verify a message comes out the other end.
  *
- * Usage: pnpm exec tsx scripts/test-v2-agent.ts
+ * Runs under BUN, not tsx. Everything under container/agent-runner/ reaches
+ * `bun:sqlite`, which Node cannot load, so:
+ *
+ *   bun scripts/test-v2-agent.ts                        # mock provider, offline
+ *   AGENT_PROVIDER=claude bun scripts/test-v2-agent.ts  # real Claude
+ *
+ * Exits 0 when an outbound message lands, 1 on timeout. The `claude` path needs
+ * both credentials and the `claude-code` CLI on PATH — that binary is installed
+ * into the agent image (container/cli-tools.json), not onto the host, so on a
+ * bare host it stops at "Claude Code native binary not found". Use the mock
+ * here to exercise the loop, and scripts/test-v2-host.ts or
+ * scripts/test-v2-channel-e2e.ts to exercise a real provider inside a container.
+ *
+ * The previous version could not run at all: it was invoked with `pnpm exec
+ * tsx`, wrote a single `session.db` with a hand-rolled schema, and pointed the
+ * runner at it with `SESSION_DB_PATH` — a variable nothing has read since the
+ * two-DB split. It also called `runPollLoop` with an `mcpServers`/`env` config
+ * shape the loop no longer accepts, and never registered the mailbox
+ * composition slot, so it died on `No agent mailbox registered`.
+ *
+ * The session state here is the in-memory pair from `initTestSessionDb()`,
+ * which is what the container's own test suite uses — the real connection
+ * layer hard-codes /workspace/inbound.db and /workspace/outbound.db, so a
+ * host-side harness cannot point it anywhere else.
  */
-import Database from 'better-sqlite3';
-import fs from 'fs';
 
-const TEST_DIR = '/tmp/nanoclaw-v2-test';
-const DB_PATH = `${TEST_DIR}/session.db`;
+// Mailbox composition slot. Must precede anything that touches the mailbox.
+import '../container/agent-runner/src/modules/index.js';
+// Provider barrel (registers `claude`), plus the mock, which the barrel
+// deliberately does not carry.
+import '../container/agent-runner/src/providers/index.js';
+import '../container/agent-runner/src/providers/mock.js';
 
-// Clean up
-if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
-fs.mkdirSync(TEST_DIR, { recursive: true });
+import { loadConfig } from '../container/agent-runner/src/config.js';
+import {
+  closeSessionDb,
+  getInboundDb,
+  getOutboundDb,
+  initTestSessionDb,
+} from '../container/agent-runner/src/mailbox/sqlite/connection.js';
+import { getUndeliveredMessages } from '../container/agent-runner/src/db/messages-out.js';
+import { getAgentMailbox } from '../container/agent-runner/src/mailbox/index.js';
+import { runPollLoop } from '../container/agent-runner/src/poll-loop.js';
+import { MEMORY_SESSION_HOOK } from '../container/agent-runner/src/memory/session-hook.js';
+import { createProvider } from '../container/agent-runner/src/providers/factory.js';
+import { MockProvider } from '../container/agent-runner/src/providers/mock.js';
+import type { AgentProvider } from '../container/agent-runner/src/providers/types.js';
 
-// Create session DB
-const db = new Database(DB_PATH);
-db.pragma('journal_mode = WAL');
-db.exec(`
-  CREATE TABLE messages_in (
-    id TEXT PRIMARY KEY, kind TEXT NOT NULL, timestamp TEXT NOT NULL,
-    status TEXT DEFAULT 'pending', status_changed TEXT, process_after TEXT,
-    recurrence TEXT, tries INTEGER DEFAULT 0, platform_id TEXT,
-    channel_type TEXT, thread_id TEXT, content TEXT NOT NULL
+const DEST = 'test-chat';
+const TIMEOUT_MS = 60_000;
+const providerName = process.env.AGENT_PROVIDER || 'mock';
+
+// container.json is absent on the host, so this falls back to defaults and
+// says so on stderr. It has to run: getConfig() throws until it does.
+loadConfig();
+
+initTestSessionDb();
+
+// A destination the agent can address. The poll loop only emits an outbound
+// message for a `<message to="name">` block whose name resolves here, so
+// without this row nothing is ever written to messages_out. A 'channel'
+// destination carries channel_type + platform_id and NO agent_group_id — the
+// mailbox model rejects the mixed shape ('channel routing fields').
+getInboundDb()
+  .prepare(
+    `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+     VALUES (?, ?, 'channel', 'test', 'test-platform-1', NULL)`,
+  )
+  .run(DEST, 'Test Chat');
+
+getInboundDb()
+  .prepare(
+    `INSERT INTO messages_in (id, seq, kind, timestamp, status, trigger, on_wake, platform_id, channel_type, content)
+     VALUES (?, 2, 'chat', ?, 'pending', 1, 0, 'test-platform-1', 'test', ?)`,
+  )
+  .run(
+    'test-1',
+    new Date().toISOString(),
+    JSON.stringify({
+      sender: 'Gavriel',
+      text: `Reply with exactly <message to="${DEST}">Hello from v2!</message> and nothing else. Do not use any tools.`,
+    }),
   );
-  CREATE TABLE messages_out (
-    id TEXT PRIMARY KEY, in_reply_to TEXT, timestamp TEXT NOT NULL,
-    delivered INTEGER DEFAULT 0, deliver_after TEXT, recurrence TEXT,
-    kind TEXT NOT NULL, platform_id TEXT, channel_type TEXT,
-    thread_id TEXT, content TEXT NOT NULL
-  );
-`);
 
-// Insert test message
-db.prepare(`INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES (?, 'chat', ?, 'pending', ?)`).run(
-  'test-1',
-  new Date().toISOString(),
-  JSON.stringify({ sender: 'Gavriel', text: 'Say "Hello from v2!" and nothing else. Do not use any tools.' }),
-);
-console.log('✓ Session DB created with test message');
-db.close();
+console.log('✓ Session mailbox seeded with 1 pending message');
 
-// Set env and run the poll loop
-process.env.SESSION_DB_PATH = DB_PATH;
-process.env.AGENT_PROVIDER = 'claude';
+await getAgentMailbox().start(null);
 
-const { getInboundDb, closeSessionDb } = await import('../container/agent-runner/src/mailbox/sqlite/connection.js');
-const { getUndeliveredMessages } = await import('../container/agent-runner/src/db/messages-out.js');
-const { getPendingMessages } = await import('../container/agent-runner/src/db/messages-in.js');
-const { createProvider } = await import('../container/agent-runner/src/providers/factory.js');
-const { runPollLoop } = await import('../container/agent-runner/src/poll-loop.js');
+// The stock MockProvider echoes the prompt unwrapped, and unwrapped text is
+// scratchpad the loop drops on purpose — so the mock path supplies the
+// `<message>` envelope the formatter requires. Any other provider name is
+// resolved through the real registry.
+const provider: AgentProvider =
+  providerName === 'mock'
+    ? new MockProvider({}, () => `<message to="${DEST}">Hello from v2!</message>`)
+    : createProvider(providerName);
 
-const provider = createProvider('claude');
+// Same wiring the real runner does at startup (container/agent-runner/
+// src/index.ts): the Claude provider refuses to query until the memory
+// session hook is registered. The mock's implementation is a no-op.
+provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
 
-console.log('✓ Claude provider created');
-console.log('⏳ Starting poll loop (will timeout after 60s)...');
+console.log(`✓ Provider: ${providerName}`);
+console.log(`⏳ Running the poll loop (timeout ${TIMEOUT_MS / 1000}s)...`);
 
-// Run with timeout
-const timeout = setTimeout(() => {
-  console.log('\n✗ Timed out after 60s');
-  printResults();
-  process.exit(1);
-}, 60_000);
+// The loop runs until aborted; the watcher below stops it as soon as an
+// outbound message lands. Without a signal an abandoned loop keeps polling.
+const stop = new AbortController();
 
-// Poll for results in parallel
-const resultChecker = setInterval(() => {
-  try {
-    const out = getUndeliveredMessages();
-    if (out.length > 0) {
-      clearTimeout(timeout);
-      clearInterval(resultChecker);
-      console.log('\n✓ Got response!');
-      printResults();
-      process.exit(0);
-    }
-  } catch {
-    // DB might be locked, retry
-  }
-}, 500);
-
-function printResults() {
-  const db2 = new Database(DB_PATH, { readonly: true });
-  const inRows = db2.prepare('SELECT * FROM messages_in').all() as Array<Record<string, unknown>>;
-  const outRows = db2.prepare('SELECT * FROM messages_out').all() as Array<Record<string, unknown>>;
-  console.log('\n--- messages_in ---');
+function printResults(): void {
+  const inRows = getInboundDb().prepare('SELECT * FROM messages_in').all() as Array<Record<string, unknown>>;
+  const outRows = getOutboundDb().prepare('SELECT * FROM messages_out').all() as Array<Record<string, unknown>>;
+  console.log('\n--- messages_in (inbound) ---');
   for (const r of inRows) {
-    console.log(`  [${r.id}] status=${r.status} kind=${r.kind} content=${r.content}`);
+    console.log(`  [${r.id}] status=${r.status} kind=${r.kind}`);
   }
-  console.log('\n--- messages_out ---');
+  console.log('\n--- messages_out (outbound) ---');
   for (const r of outRows) {
     console.log(`  [${r.id}] kind=${r.kind} content=${r.content}`);
   }
-  db2.close();
+  // messages_in.status stays 'pending' here on purpose: it is the HOST's
+  // column. The container records its own progress in processing_ack, in
+  // outbound.db — that is the row to read to see the loop finish a message.
+  const ackRows = getOutboundDb().prepare('SELECT * FROM processing_ack').all() as Array<Record<string, unknown>>;
+  console.log('\n--- processing_ack (outbound) ---');
+  for (const r of ackRows) {
+    console.log(`  [${r.message_id}] status=${r.status} changed=${r.status_changed}`);
+  }
 }
 
-// Start the poll loop (runs forever, we exit from the checker above)
-try {
-  await runPollLoop({
-    provider,
-    cwd: TEST_DIR,
-    mcpServers: {},
-    env: { ...process.env },
-  });
-} catch (err) {
-  // Expected — we force exit
-}
+const deadline = Date.now() + TIMEOUT_MS;
+const watcher = new Promise<boolean>((resolve) => {
+  const timer = setInterval(() => {
+    let delivered = 0;
+    try {
+      delivered = getUndeliveredMessages().length;
+    } catch {
+      // The loop may hold a write lock; retry on the next tick.
+    }
+    if (delivered > 0) {
+      clearInterval(timer);
+      resolve(true);
+    } else if (Date.now() > deadline) {
+      clearInterval(timer);
+      resolve(false);
+    }
+  }, 500);
+});
+
+const loop = runPollLoop({ provider, providerName, cwd: '/tmp', signal: stop.signal }).catch((err) => {
+  console.error('poll loop threw:', err);
+});
+
+const ok = await watcher;
+stop.abort();
+await loop;
+
+if (ok) console.log('\n✓ Got a response through the real poll loop');
+else console.log(`\n✗ No outbound message within ${TIMEOUT_MS / 1000}s`);
+
+printResults();
+closeSessionDb();
+process.exit(ok ? 0 : 1);

--- a/scripts/test-v2-channel-e2e.ts
+++ b/scripts/test-v2-channel-e2e.ts
@@ -5,7 +5,18 @@
  * agent-runner → Claude → messages_out → delivery → mock adapter.deliver()
  *
  * Usage: pnpm exec tsx scripts/test-v2-channel-e2e.ts
+ *
+ * Needs the agent image for this checkout (`./container/build.sh`) and, for a
+ * real answer, Claude credentials via the OneCLI vault. To exercise the whole
+ * pipeline up to and including the container spawn without a vault, select the
+ * harness's offline gateway:
+ *
+ *   NANOCLAW_GATEWAY_PROVIDER=harness-noop pnpm exec tsx scripts/test-v2-channel-e2e.ts
  */
+// Fills the host composition slots (mailbox today). Must come first: every
+// path below resolves a session, and an unregistered mailbox throws.
+import './harness-bootstrap.js';
+
 import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
@@ -20,24 +31,33 @@ console.log('\n=== Step 1: Init central DB ===');
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup } from '../src/db/agent-groups.js';
+import { initGroupFilesystem } from '../src/group-init.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../src/db/messaging-groups.js';
+import { GROUP_FOLDER_LABEL, LABELS } from '../src/drivers/types.js';
+import { INSTALL_SLUG } from '../src/config.js';
+import type { AgentGroup } from '../src/types.js';
 
 const centralDb = await initDb(path.join(TEST_DIR, 'v2.db'));
 await runMigrations(centralDb);
 
-// Create groups dir for agent folder mount
-const groupsDir = path.resolve(process.cwd(), 'groups');
-const testGroupDir = path.join(groupsDir, 'test-channel-e2e');
-fs.mkdirSync(testGroupDir, { recursive: true });
-fs.writeFileSync(path.join(testGroupDir, 'CLAUDE.md'), '# Test Agent\nYou are a test agent. Be brief.\n');
-
-await createAgentGroup({
+// The agent group's filesystem AND its container_configs row are both
+// scaffolded by initGroupFilesystem. Hand-rolling the folder is not enough:
+// spawn calls materializeContainerJson, which throws
+// `Container config not found for agent group: ...` when the row is missing.
+const group: AgentGroup = {
   id: 'ag-chan',
   name: 'Channel E2E Agent',
   folder: 'test-channel-e2e',
   agent_provider: 'claude',
   created_at: new Date().toISOString(),
+};
+await createAgentGroup(group);
+await initGroupFilesystem(group, {
+  instructions: 'You are a test agent. Be brief.',
+  provider: 'claude',
 });
+
+const testGroupDir = path.resolve(process.cwd(), 'groups', group.folder);
 
 await createMessagingGroup({
   id: 'mg-chan',
@@ -71,7 +91,7 @@ import { routeInbound } from '../src/router.js';
 import { setDeliveryAdapter, startActiveDeliveryPoll, stopDeliveryPolls } from '../src/delivery.js';
 import { getChannelAdapter, registerChannelAdapter, initChannelAdapters } from '../src/channels/channel-registry.js';
 import { findSession } from '../src/db/sessions.js';
-import { inboundDbPath } from '../src/mailbox/sqlite/paths.js';
+import { inboundDbPath, outboundDbPath } from '../src/mailbox/sqlite/paths.js';
 import type { ChannelAdapter, ChannelSetup, OutboundMessage } from '../src/channels/adapter.js';
 
 // Track delivered messages
@@ -150,10 +170,8 @@ console.log('✓ Mock adapter & delivery configured');
 // --- Step 3: Simulate inbound message through adapter ---
 console.log('\n=== Step 3: Simulate inbound message ===');
 
-// This is what a real adapter would do when receiving a platform message
-const adapterSetup = (mockAdapter as { _setup?: ChannelSetup })._setup;
-
-// Call routeInbound directly (simulating onInbound callback)
+// Call routeInbound directly — exactly what the adapter's onInbound callback
+// above does when a real platform message arrives.
 await routeInbound({
   channelType: 'mock',
   platformId: 'mock-channel-1',
@@ -181,7 +199,13 @@ console.log(`✓ Container status: ${session.container_status}`);
 import { execSync } from 'child_process';
 const checkContainerLogs = () => {
   try {
-    const containers = execSync('docker ps -a --filter label=nanoclaw-group-folder=test-channel --format "{{.Names}}"')
+    // Scope to THIS install and this group's folder — the label is
+    // `nanoclaw-group-folder` carrying the full folder name, and a peer
+    // install's containers must never be read (or reported) as ours.
+    const containers = execSync(
+      `docker ps -a --filter label=${LABELS.install}=${INSTALL_SLUG} ` +
+        `--filter label=${GROUP_FOLDER_LABEL}=${group.folder} --format "{{.Names}}"`,
+    )
       .toString()
       .trim();
     for (const name of containers.split('\n').filter(Boolean)) {
@@ -193,8 +217,10 @@ const checkContainerLogs = () => {
   }
 };
 
-const sessDbPath = inboundDbPath('ag-chan', session.id);
-console.log(`✓ Session DB: ${sessDbPath}`);
+const inDbPath = inboundDbPath('ag-chan', session.id);
+const outDbPath = outboundDbPath('ag-chan', session.id);
+console.log(`✓ Inbound DB:  ${inDbPath}`);
+console.log(`✓ Outbound DB: ${outDbPath}`);
 
 // --- Step 4: Wait for delivery through mock adapter ---
 console.log('\n=== Step 4: Waiting for delivery through mock adapter... ===');
@@ -211,13 +237,16 @@ await new Promise<void>((resolve) => {
       console.log(`\n✗ Timed out after ${TIMEOUT_MS / 1000}s`);
       // Check session DB directly
       try {
-        const db = new Database(sessDbPath, { readonly: true });
+        // messages_out lives in outbound.db (the container is its sole
+        // writer); reading it from inbound.db threw and the surrounding catch
+        // swallowed the whole diagnostic.
+        const db = new Database(outDbPath, { readonly: true });
         const out = db.prepare('SELECT * FROM messages_out').all();
         console.log(`  messages_out rows: ${out.length}`);
         if (out.length > 0) console.log('  (messages exist but delivery failed)');
         db.close();
-      } catch {
-        /* ignore */
+      } catch (err) {
+        console.log(`  (could not read outbound DB: ${err})`);
       }
       checkContainerLogs();
       cleanup();
@@ -235,25 +264,35 @@ await new Promise<void>((resolve) => {
 // --- Step 5: Print results ---
 console.log('\n\n=== Results ===');
 
-console.log('\nSession DB:');
+console.log('\nSession DBs:');
 try {
-  const db = new Database(sessDbPath, { readonly: true });
-  const inRows = db.prepare('SELECT * FROM messages_in').all() as Array<Record<string, unknown>>;
-  const outRows = db.prepare('SELECT * FROM messages_out').all() as Array<Record<string, unknown>>;
-  db.close();
+  const inDb = new Database(inDbPath, { readonly: true });
+  const inRows = inDb.prepare('SELECT * FROM messages_in').all() as Array<Record<string, unknown>>;
+  inDb.close();
 
-  console.log(`  messages_in: ${inRows.length} row(s)`);
+  console.log(`  messages_in (inbound.db): ${inRows.length} row(s)`);
   for (const r of inRows) {
     console.log(`    [${r.id}] status=${r.status} kind=${r.kind}`);
   }
-  console.log(`  messages_out: ${outRows.length} row(s)`);
+} catch (err) {
+  console.log(`  (could not read inbound DB: ${err})`);
+}
+
+try {
+  // Separate try/catch per file: the two DBs fail independently, and one
+  // unreadable file must not hide the other's rows.
+  const outDb = new Database(outDbPath, { readonly: true });
+  const outRows = outDb.prepare('SELECT * FROM messages_out').all() as Array<Record<string, unknown>>;
+  outDb.close();
+
+  console.log(`  messages_out (outbound.db): ${outRows.length} row(s)`);
   for (const r of outRows) {
     const content = JSON.parse(r.content as string);
-    console.log(`    [${r.id}] kind=${r.kind} delivered=${r.delivered}`);
+    console.log(`    [${r.id}] kind=${r.kind}`);
     console.log(`    → ${content.text}`);
   }
 } catch (err) {
-  console.log(`  (could not read session DB: ${err})`);
+  console.log(`  (could not read outbound DB: ${err})`);
 }
 
 console.log('\nDelivered through mock adapter:');

--- a/scripts/test-v2-host.ts
+++ b/scripts/test-v2-host.ts
@@ -7,7 +7,22 @@
  * 4. Poll outbound.db for messages_out response
  *
  * Usage: pnpm exec tsx scripts/test-v2-host.ts
+ *
+ * Needs the agent image for this checkout (`./container/build.sh`) and, for
+ * step 3 to actually answer, working Claude credentials via the OneCLI vault.
+ * To exercise everything up to and including the container spawn without a
+ * vault, select the harness's offline gateway:
+ *
+ *   NANOCLAW_GATEWAY_PROVIDER=harness-noop pnpm exec tsx scripts/test-v2-host.ts
+ *
+ * The agent then has no credentials, so step 3 times out by design — the run
+ * is still proof that routing, session creation, inbound.db, spec composition
+ * and `docker create/start` all work.
  */
+// Fills the host composition slots (mailbox today). Must come first: every
+// path below resolves a session, and an unregistered mailbox throws.
+import './harness-bootstrap.js';
+
 import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
@@ -22,24 +37,31 @@ console.log('\n=== Step 1: Init central DB ===');
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup } from '../src/db/agent-groups.js';
+import { initGroupFilesystem } from '../src/group-init.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../src/db/messaging-groups.js';
+import type { AgentGroup } from '../src/types.js';
 
 const centralDb = await initDb(path.join(TEST_DIR, 'v2.db'));
 await runMigrations(centralDb);
 
-// Create groups dir for agent folder mount
-const groupsDir = path.resolve(process.cwd(), 'groups');
-const testGroupDir = path.join(groupsDir, 'test-agent-e2e');
-fs.mkdirSync(testGroupDir, { recursive: true });
-fs.writeFileSync(path.join(testGroupDir, 'CLAUDE.md'), '# Test Agent\nYou are a test agent. Be brief.\n');
-
-await createAgentGroup({
+// The agent group's filesystem AND its container_configs row are both
+// scaffolded by initGroupFilesystem. Hand-rolling the folder is not enough:
+// spawn calls materializeContainerJson, which throws
+// `Container config not found for agent group: ...` when the row is missing.
+const group: AgentGroup = {
   id: 'ag-e2e',
   name: 'E2E Test Agent',
   folder: 'test-agent-e2e',
   agent_provider: 'claude',
   created_at: new Date().toISOString(),
+};
+await createAgentGroup(group);
+await initGroupFilesystem(group, {
+  instructions: 'You are a test agent. Be brief.',
+  provider: 'claude',
 });
+
+const testGroupDir = path.resolve(process.cwd(), 'groups', group.folder);
 
 await createMessagingGroup({
   id: 'mg-e2e',

--- a/setup/lib/install-slug.sh
+++ b/setup/lib/install-slug.sh
@@ -1,14 +1,18 @@
-# install-slug.sh — shell mirror of setup/lib/install-slug.ts.
+# install-slug.sh — shell mirror of src/install-slug.ts.
 #
 # Source this file after $PROJECT_ROOT is set:
 #
 #   source "$PROJECT_ROOT/setup/lib/install-slug.sh"
-#   label=$(launchd_label)        # com.nanoclaw-v2-<slug>
-#   unit=$(systemd_unit)          # nanoclaw-v2-<slug>
-#   image=$(container_image_base) # nanoclaw-agent-v2-<slug>
+#   label=$(launchd_label)        # com.nanoclaw-v2-<slug>  <- getLaunchdLabel
+#   unit=$(systemd_unit)          # nanoclaw-v2-<slug>      <- getSystemdUnit
+#   image=$(container_image_base) # nanoclaw-agent-v2-<slug> <- getContainerImageBase
 #
-# Slug is sha1(PROJECT_ROOT)[:8] — must match the TS helper exactly so both
-# halves of setup name things consistently.
+# Slug is sha1(PROJECT_ROOT)[:8] — must match `getInstallSlug` in
+# src/install-slug.ts exactly. The lockstep now spans src/ (the host and the
+# CLI) and setup/ + container/build.sh (the shell half), not just setup: the
+# host resolves the image tag it spawns from the TS helper while build.sh tags
+# the image from this one, so a divergence means the host looks for an image
+# nobody built. src/install-slug.test.ts asserts the two halves agree.
 
 _nanoclaw_install_slug() {
   local root="${NANOCLAW_PROJECT_ROOT:-${PROJECT_ROOT:-$PWD}}"

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -278,16 +278,20 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
+  // The container path is RELATIVE — spawn places every additional mount at
+  // /workspace/extra/<containerPath>. This test used to pass an absolute
+  // '/home/node/.gmail-mcp', which the CLI accepted and mount security then
+  // silently dropped at spawn, so the fixture taught an unusable shape.
   it('adds a mount idempotently and removes it (host caller)', async () => {
     const GID = 'ag-mount';
     await createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
     await ensureContainerConfig(GID);
-    const args = { id: GID, host: '/data/.gmail-mcp', container: '/home/node/.gmail-mcp', ro: true };
+    const args = { id: GID, host: '/data/gmail-mcp', container: 'gmail-mcp', ro: true };
 
     const add = await dispatch({ id: 'r1', command: 'groups-config-add-mount', args }, { caller: 'host' });
     expect(add.ok).toBe(true);
     expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([
-      { hostPath: '/data/.gmail-mcp', containerPath: '/home/node/.gmail-mcp', readonly: true },
+      { hostPath: '/data/gmail-mcp', containerPath: 'gmail-mcp', readonly: true },
     ]);
 
     // idempotent: a second add does not duplicate
@@ -298,11 +302,52 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
       {
         id: 'r3',
         command: 'groups-config-remove-mount',
-        args: { id: GID, host: '/data/.gmail-mcp', container: '/home/node/.gmail-mcp' },
+        args: { id: GID, host: '/data/gmail-mcp', container: 'gmail-mcp' },
       },
       { caller: 'host' },
     );
     expect(rm.ok).toBe(true);
+    expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
+  });
+
+  it('rejects an absolute container path instead of persisting a row spawn will drop', async () => {
+    const GID = 'ag-mount-abs';
+    await createAgentGroup({ id: GID, name: 'm2', folder: 'm2', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
+
+    const resp = await dispatch(
+      {
+        id: 'r4',
+        command: 'groups-config-add-mount',
+        args: { id: GID, host: '/data/rtk', container: '/usr/local/bin/rtk', ro: true },
+      },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(false);
+    const err = (resp as { ok: false; error: { message: string } }).error.message;
+    expect(err).toMatch(/RELATIVE/);
+    expect(err).toMatch(/workspace\/extra/);
+    // and nothing was written
+    expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
+  });
+
+  it('rejects a host path on the blocked list at write time', async () => {
+    const GID = 'ag-mount-blocked';
+    await createAgentGroup({ id: GID, name: 'm3', folder: 'm3', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
+
+    const resp = await dispatch(
+      {
+        id: 'r5',
+        command: 'groups-config-add-mount',
+        args: { id: GID, host: '~/.local/bin', container: 'bin', ro: true },
+      },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(false);
+    expect((resp as { ok: false; error: { message: string } }).error.message).toMatch(/blocked pattern/);
     expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
   });
 });

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -21,6 +21,7 @@ import {
 import { getSessionDriver } from '../../drivers/index.js';
 import { assertValidGroupFolder, groupFolderExistsOnDisk } from '../../group-folder.js';
 import { initGroupFilesystem } from '../../group-init.js';
+import { checkMountAdmissibleAtWrite } from '../../modules/mount-security/index.js';
 import { createAgentFromTemplate } from '../../templates/create-agent.js';
 import {
   formatRestampResult,
@@ -558,7 +559,9 @@ registerResource({
       description:
         "Mount a host directory into a group's containers. OPERATOR-ONLY — never runnable from " +
         'inside a container (mounting host paths is a filesystem-access boundary). Requires ' +
-        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> [--ro].',
+        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> ' +
+        '--container <relative-name> [--ro]. The container path must be RELATIVE — the mount ' +
+        'lands at /workspace/extra/<relative-name>.',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
@@ -568,6 +571,13 @@ registerResource({
 
         const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
+
+        // Fail here rather than persist a row that spawn will silently drop.
+        // Only the permanently-inadmissible rules are enforced at write time;
+        // see checkMountAdmissibleAtWrite for what is deliberately left to
+        // spawn (allowed roots, host-path existence, rw eligibility).
+        const admissible = checkMountAdmissibleAtWrite({ hostPath, containerPath });
+        if (!admissible.ok) throw new Error(admissible.reason);
 
         const mount: AdditionalMountConfig = {
           hostPath,

--- a/src/drivers/docker-driver.ts
+++ b/src/drivers/docker-driver.ts
@@ -602,7 +602,10 @@ export function dockerEventToSessionEvent(doc: unknown, installSlug: string): Se
 export function agentContainerName(spec: SessionSpec): string {
   const raw = `${spec.key.installSlug}-${spec.key.sessionId}`.replaceAll(/[^a-zA-Z0-9_.-]/g, '-');
   if (raw.length <= 48) return `ncl-${raw}`;
-  const hash = createHash('sha256').update(`${spec.key.installSlug} ${spec.key.sessionId}`).digest('hex').slice(0, 8);
+  const hash = createHash('sha256')
+    .update(`${spec.key.installSlug}\u0000${spec.key.sessionId}`)
+    .digest('hex')
+    .slice(0, 8);
   return `ncl-${raw.slice(0, 39)}-${hash}`;
 }
 

--- a/src/install-slug.test.ts
+++ b/src/install-slug.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Lockstep guard for the two halves of the install-slug derivation.
+ *
+ * src/install-slug.ts names the service and the agent image for the host and
+ * the CLI; setup/lib/install-slug.sh names the same things for the setup
+ * wizard and container/build.sh. They are independent implementations of
+ * sha1(projectRoot)[:8], and a divergence is invisible until the host tries to
+ * spawn from an image tag nobody built. So assert they agree, on more than one
+ * root, rather than trusting the comment at the top of the .sh.
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { getContainerImageBase, getInstallSlug, getLaunchdLabel, getSystemdUnit } from './install-slug.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const shPath = path.join(repoRoot, 'setup', 'lib', 'install-slug.sh');
+
+function shellNames(projectRoot: string): { label: string; unit: string; image: string } {
+  const script = `. "${shPath}"; printf '%s\\n%s\\n%s\\n' "$(launchd_label)" "$(systemd_unit)" "$(container_image_base)"`;
+  const out = execFileSync('bash', ['-c', script], {
+    encoding: 'utf8',
+    env: { ...process.env, PROJECT_ROOT: projectRoot, NANOCLAW_PROJECT_ROOT: projectRoot },
+  });
+  const [label, unit, image] = out.trim().split('\n');
+  return { label, unit, image };
+}
+
+describe('install-slug shell/TS lockstep', () => {
+  // The real checkout, plus a synthetic root, so a fluke collision on one path
+  // cannot make a divergent implementation look correct.
+  for (const root of [repoRoot, '/tmp/some/other/root']) {
+    it(`agrees on every install name for ${root === repoRoot ? 'this checkout' : 'a synthetic root'}`, () => {
+      const sh = shellNames(root);
+      expect(sh.label).toBe(getLaunchdLabel(root));
+      expect(sh.unit).toBe(getSystemdUnit(root));
+      expect(sh.image).toBe(getContainerImageBase(root));
+      expect(sh.image.endsWith(getInstallSlug(root))).toBe(true);
+    });
+  }
+});

--- a/src/modules/mount-security/index.test.ts
+++ b/src/modules/mount-security/index.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../config.js', async () => {
   };
 });
 
-import { loadMountAllowlist, validateMount } from './index.js';
+import { checkMountAdmissibleAtWrite, loadMountAllowlist, validateMount } from './index.js';
 
 let tmpDir: string;
 let configFile: string;
@@ -115,5 +115,44 @@ describe('loadMountAllowlist', () => {
   it('returns null when the allowlist file is missing', () => {
     // No file written.
     expect(loadMountAllowlist()).toBeNull();
+  });
+});
+
+describe('checkMountAdmissibleAtWrite', () => {
+  it('rejects an absolute container path and names the relative rule', () => {
+    writeAllowlist({ allowedRoots: [{ path: projectsDir, allowReadWrite: true }], blockedPatterns: [] });
+
+    const result = checkMountAdmissibleAtWrite({ hostPath: repoDir, containerPath: '/usr/local/bin/rtk' });
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; reason: string }).reason).toMatch(/RELATIVE/);
+    expect((result as { ok: false; reason: string }).reason).toMatch(/\/workspace\/extra\/rtk/);
+  });
+
+  it('rejects a traversing or colon-bearing container path', () => {
+    writeAllowlist({ allowedRoots: [{ path: projectsDir, allowReadWrite: true }], blockedPatterns: [] });
+
+    expect(checkMountAdmissibleAtWrite({ hostPath: repoDir, containerPath: '../escape' }).ok).toBe(false);
+    expect(checkMountAdmissibleAtWrite({ hostPath: repoDir, containerPath: 'repo:rw' }).ok).toBe(false);
+  });
+
+  it('rejects a blocked host pattern even with no allowlist on disk', () => {
+    // No allowlist file: the default blocked list is still the floor, because
+    // loadMountAllowlist merges it into every allowlist it does parse.
+    const result = checkMountAdmissibleAtWrite({ hostPath: path.join(tmpDir, '.local', 'bin'), containerPath: 'bin' });
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; reason: string }).reason).toMatch(/blocked pattern "\.local\/bin"/);
+  });
+
+  it('accepts a relative container path, leaving allowed-root and existence checks to spawn', () => {
+    // Deliberately NOT under any allowed root, and the host path does not
+    // exist: both are spawn-time concerns that can legitimately change before
+    // the next spawn, so the write-time check must not refuse them.
+    expect(checkMountAdmissibleAtWrite({ hostPath: '/data/gmail-mcp', containerPath: 'gmail-mcp' })).toEqual({
+      ok: true,
+    });
+  });
+
+  it('derives the container path from the host basename when none is given', () => {
+    expect(checkMountAdmissibleAtWrite({ hostPath: repoDir })).toEqual({ ok: true });
   });
 });

--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -306,6 +306,64 @@ export interface MountValidationResult {
 }
 
 /**
+ * Write-time admissibility check for a mount an operator is about to persist.
+ *
+ * `validateMount` below is the spawn-time gate: it needs the allowlist, needs
+ * the host path to exist NOW, and its verdict is a log line — a rejected mount
+ * is silently dropped from the container. That is correct at spawn (a mount
+ * whose root vanished must not block the agent) but useless as operator
+ * feedback, because by then the row is long since written.
+ *
+ * So this is the subset of the same rules that is stable at write time and
+ * whose violation can never become admissible later:
+ *
+ *   - the container path shape. Spawn always rewrites the mount to
+ *     `/workspace/extra/<containerPath>`, so an absolute container path is not
+ *     "wrong for now", it is unusable forever.
+ *   - the blocked host patterns. `.ssh`, `.local/bin`, `.config/nanoclaw` and
+ *     friends are refused by every allowlist (they are merged in, not
+ *     overridable), so naming one is likewise permanently inadmissible.
+ *
+ * Deliberately NOT checked here: allowed roots, host-path existence, and
+ * read-write eligibility. All three legitimately change between the `ncl` call
+ * and the next spawn (allowlist edited, directory created later), so failing on
+ * them would refuse mounts that will work. Spawn stays the authority.
+ */
+export function checkMountAdmissibleAtWrite(mount: AdditionalMount): { ok: true } | { ok: false; reason: string } {
+  const containerPath = mount.containerPath || path.basename(mount.hostPath);
+  if (!isValidContainerPath(containerPath)) {
+    return {
+      ok: false,
+      reason:
+        `Invalid container path "${containerPath}": additional mounts must use a RELATIVE ` +
+        'container path. Every additional mount is placed under /workspace/extra/, so pass ' +
+        `--container ${JSON.stringify(path.basename(containerPath.replace(/\/+$/, '')) || 'name')} ` +
+        `and the agent will find it at /workspace/extra/${path.basename(containerPath.replace(/\/+$/, '')) || 'name'}. ` +
+        'Absolute paths, "..", and ":" are refused (an absolute path would be silently dropped at spawn).',
+    };
+  }
+
+  // Blocked patterns are merged into every allowlist, so the default list is
+  // the floor whether or not an allowlist exists yet. Match on the resolved
+  // real path when the path exists, on the expanded path when it does not —
+  // the check is a substring test either way.
+  const allowlist = loadMountAllowlist();
+  const blockedPatterns = allowlist?.blockedPatterns ?? DEFAULT_BLOCKED_PATTERNS;
+  const expanded = expandPath(mount.hostPath);
+  const blocked = matchesBlockedPattern(getRealPath(expanded) ?? expanded, blockedPatterns);
+  if (blocked !== null) {
+    return {
+      ok: false,
+      reason:
+        `Host path "${mount.hostPath}" matches blocked pattern "${blocked}" and can never be ` +
+        'mounted. Blocked patterns are merged into every allowlist and cannot be overridden.',
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
  * Validate a single additional mount against the allowlist.
  * Returns validation result with reason.
  */

--- a/vitest.skills.config.ts
+++ b/vitest.skills.config.ts
@@ -1,7 +1,37 @@
 import { defineConfig } from 'vitest/config';
 
+/**
+ * Opt-in project for the guard tests that `/add-*` skills ship.
+ *
+ * Run it with `pnpm run test:skills`. It is deliberately NOT part of
+ * `pnpm test` (vitest.config.ts), because these tests assert the *applied*
+ * state of the skill they ship with — `add-vercel/vercel-manifest.test.ts`
+ * asserts `vercel` is present in `container/cli-tools.json`, and so on. On a
+ * pristine checkout, where no skill has been applied, they are expected to
+ * fail. That is the point: they are the post-install verification the skill's
+ * own SKILL.md tells the applier to run, and the copy that lands in `src/`
+ * during install is what the main suite then guards.
+ *
+ * The include glob used to be `.claude/skills/**\/tests/*.test.ts`, which
+ * matched zero files on trunk — no skill has ever used a `tests/` subdirectory.
+ * Skills keep their guard tests either at the skill root
+ * (`add-vercel/vercel-manifest.test.ts`) or beside the payload they guard
+ * (`add-dashboard/resources/dashboard-wiring.test.ts`), so the glob below
+ * matches anywhere under a skill directory.
+ *
+ * Excluded: tests whose runner is not vitest, or which the applier copies
+ * elsewhere before running. Add an exclusion here with a one-line reason
+ * rather than loosening the include.
+ */
 export default defineConfig({
   test: {
-    include: ['.claude/skills/**/tests/*.test.ts'],
+    include: ['.claude/skills/**/*.test.ts'],
+    exclude: [
+      '**/node_modules/**',
+      // Skill payload destined for container/agent-runner/src/, whose tests
+      // import from `bun:test` and only run under Bun (see vitest.config.ts).
+      '.claude/skills/add-atomic-chat-tool/atomic-chat-registration.test.ts',
+      '.claude/skills/add-ollama-tool/ollama-registration.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
An audit that applied all 12 core (non-channel/provider) install skills on fresh trees found several trunk-level issues that two or more skills hit independently. This branch fixes those; 12 per-skill PRs are stacked on it.

## What changed

- **All four e2e harnesses restored** (`scripts/test-v2-host.ts`, `test-v2-agent.ts`, `test-v2-channel-e2e.ts`, `sanity-live-poll.ts`) — broken since the mailbox-seam merge (#3349): they never filled the mailbox composition slot and never created a `container_configs` row. A shared `scripts/harness-bootstrap.ts` imports the real modules barrel; `test-v2-agent.ts` is now a Bun script (it was tsx-invoked and couldn't load `bun:sqlite`); `sanity-live-poll.ts` was vacuous (its reader used better-sqlite3, absent from the Bun image, so it never read anything and always exited 0) and now asserts all 8 cross-mount writes under production pragmas.
- **New offline gateway for harnesses**: `NANOCLAW_GATEWAY_PROVIDER=harness-noop` (registered only from `scripts/`, unreachable from host code) lets harnesses spawn real containers on vault-less machines.
- **Regression guard**: `scripts/harness-bootstrap.test.ts` (9 structural tests) covers this class of break — nothing previously built, typechecked, or tested `scripts/`.
- **Skill tests now collectable**: `vitest.skills.config.ts` globbed `.claude/skills/**/tests/*.test.ts`, a path no skill has ever used — zero files matched repo-wide. Fixed to `.claude/skills/**/*.test.ts` with a new `pnpm run test:skills`; deliberately outside `pnpm test` because these guards assert the applied state.
- **NUL byte removed** from `src/drivers/docker-driver.ts` — a committed `0x00` made grep/file classify it as binary, so searches silently returned nothing.
- **`container/cli-tools.test.ts`**: replaced the "vercel must NOT be present" blacklist (which made a legitimate `/add-vercel` permanently red) with shape/pin validation, green pre- and post-install.
- **`ncl groups config add-mount` fails fast** on absolute container paths and blocked host patterns instead of silently dropping them at spawn (spawn-time behavior unchanged).
- **Doc rot**: CLAUDE.md's stale "add a Node CLI via Dockerfile ARG" gotcha rewritten to the `cli-tools.json` manifest flow; `setup/lib/install-slug.sh` stale reference fixed plus a sh/ts parity test; `.env.example` populated (was a tracked 0-byte file skills appended to).

## Verification

Both host harnesses complete full pipeline round trips (session → real Docker spawn → agent-runner poll → outbound.db → delivery). All gates green: `pnpm run build`, container typecheck, `pnpm exec vitest run` (156 files / 1931 tests), `bun test` (332 pass), `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhS5pL3inQ46UdQUvo4g56