### PR TITLE
fix(add-karpathy-llm-wiki): deliver the wiki through the DB-backed group instructions

### DIFF
--- a/.claude/skills/add-karpathy-llm-wiki/REMOVE.md
+++ b/.claude/skills/add-karpathy-llm-wiki/REMOVE.md
@@ -2,37 +2,75 @@
 
 Every step is idempotent — safe to re-run.
 
-## 1. Remove the shared container skill
-
-The wiki container skill lives in the shared `container/skills/` mount, which is auto-discovered and symlinked into every agent group. Delete it so it stops appearing in all containers:
+Resolve the two values the wiki was installed against, and use them throughout:
 
 ```bash
-rm -rf container/skills/wiki
+GROUP_ID=<ag-...>        # agent group id
+GROUP_FOLDER=<folder>    # the group's folder under groups/
 ```
 
-## 2. Remove the wiki section from the group CLAUDE.md
-
-The wiki section is wrapped in marker comments. Delete the block (markers included) from the group's CLAUDE.md — find it under `groups/<folder>/CLAUDE.md`:
+`ncl groups list` prints both. If `ncl` cannot reach the host, read them with the in-tree query wrapper:
 
 ```bash
-# Replace <folder> with the group folder you set up the wiki for.
-perl -0pi -e 's/\n?<!-- BEGIN karpathy-llm-wiki -->.*?<!-- END karpathy-llm-wiki -->\n?//s' groups/<folder>/CLAUDE.md
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT id, name, folder FROM agent_groups ORDER BY name"
 ```
 
-If the markers are absent, nothing is removed (the block was already gone or never added).
+## 1. Cancel the lint schedule
 
-## 3. Restart so containers drop the skill
+Find the wiki lint series and delete it, otherwise it keeps firing forever:
+
+```bash
+ncl tasks list --group "$GROUP_ID"
+ncl tasks delete --id <series-id>
+```
+
+## 2. Remove the wiki section from the standing instructions
+
+```bash
+perl -0pi -e 's/\n?<!-- BEGIN karpathy-llm-wiki -->.*?<!-- END karpathy-llm-wiki -->\n?//s' \
+  "groups/$GROUP_FOLDER/instructions.prepend.md"
+```
+
+Read the file afterwards. When the wiki section was its only content, delete the now-empty file so the composer stops emitting a persona fragment for it:
+
+```bash
+[ -s "groups/$GROUP_FOLDER/instructions.prepend.md" ] || rm -f "groups/$GROUP_FOLDER/instructions.prepend.md"
+```
+
+Also delete the wiki pointer line from `groups/$GROUP_FOLDER/memory/index.md` — the line referencing `wiki/index.md` — and leave the rest of that file alone.
+
+## 3. Remove the per-group wiki skill
+
+```bash
+rm -rf "data/v2-sessions/$GROUP_ID/.claude-shared/skills/wiki"
+```
+
+## 4. Remove the delivery-seam guard
+
+```bash
+rm -f src/wiki-delivery-seam.test.ts
+```
+
+## 5. Restart so the group drops the wiki context
 
 ```bash
 source setup/lib/install-slug.sh
-launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
-# Linux: systemctl --user restart $(systemd_unit)
+launchctl kickstart -k "gui/$(id -u)/$(launchd_label)"  # macOS
+systemctl --user restart "$(systemd_unit)"              # Linux
 ```
+
+Run only the command for the current platform. If NanoClaw is not service-managed, stop this install's running agent containers by their `nanoclaw-install=<install-slug>` label instead.
 
 ## User content is preserved
 
-The per-group `groups/<folder>/wiki/` and `groups/<folder>/sources/` directories hold the user's own knowledge base and ingested sources. They are left in place. Delete them by hand only if the user explicitly wants their wiki content gone:
+`groups/$GROUP_FOLDER/wiki/` and `groups/$GROUP_FOLDER/sources/` hold the user's own knowledge base and ingested sources, and stay in place. Delete them only when the user explicitly asks for their wiki content gone:
 
 ```bash
-rm -rf groups/<folder>/wiki groups/<folder>/sources
+rm -rf "groups/$GROUP_FOLDER/wiki" "groups/$GROUP_FOLDER/sources"
+```
+
+A group created solely for the wiki also stays. Removing it is a separate decision the user makes:
+
+```bash
+ncl groups delete --id "$GROUP_ID"
 ```

--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -5,47 +5,116 @@ description: Add a persistent wiki knowledge base to a NanoClaw group. Based on 
 
 # Add Karpathy LLM Wiki
 
-Set up a persistent wiki knowledge base on NanoClaw, based on Karpathy's LLM Wiki pattern.
+Set up a persistent wiki knowledge base for **one** agent group, based on Karpathy's LLM Wiki pattern.
 
-Each step is safe to re-run: directory creation uses `mkdir -p`, initial wiki files are created only if absent, the container skill is preserved unless the user opts to update it, and the group CLAUDE.md section is replaced in place via marker comments rather than duplicated.
+Every step is safe to re-run: directory creation uses `mkdir -p`, the initial wiki files are created only when absent, the wiki skill is preserved unless the user opts to update it, and the standing-instructions section is replaced in place through marker comments.
+
+## Where each piece lives
+
+| Piece | Host path | Container path |
+|---|---|---|
+| Raw sources | `groups/<folder>/sources/` | `/workspace/agent/sources/` (read-write) |
+| Wiki pages | `groups/<folder>/wiki/` | `/workspace/agent/wiki/` (read-write) |
+| Wiki schema (the skill) | `data/v2-sessions/<group-id>/.claude-shared/skills/wiki/SKILL.md` | `~/.claude/skills/wiki/SKILL.md` |
+| Standing instructions | `groups/<folder>/instructions.prepend.md` | inlined as the first import of `/workspace/agent/CLAUDE.md` |
+
+Two host behaviors decide those locations, and both run on **every** container spawn:
+
+- `groups/<folder>/CLAUDE.md` is regenerated from the shared base plus fragments (`src/claude-md-compose.ts`). It is a list of `@` imports and nothing else. Wiki text written there is destroyed before the agent reads it. `instructions.prepend.md` is the provider-neutral standing-instructions file the composer inlines as the persona fragment and imports first, so that is where the wiki section goes.
+- The per-group skill store is pruned down to the group's selected shared skills (`syncSkillSymlinks` in `src/container-runner.ts`). The prune removes only symlinks, so a **real** directory in that store survives — which is what keeps the wiki skill scoped to this one group. A skill placed in the install-wide `container/skills/` mount instead appears in every agent group, so do not put it there.
+
+Changes to either surface take effect when the group's container next starts (Step 7).
 
 ## Step 1: Read the pattern
 
-Read `${CLAUDE_SKILL_DIR}/llm-wiki.md` — this is the full LLM Wiki idea as written by Karpathy. Understand it thoroughly before proceeding. Summarize the core idea to the user briefly, then discuss what they want to build.
+Read `${CLAUDE_SKILL_DIR}/llm-wiki.md` — the full LLM Wiki idea as written by Karpathy. Understand it thoroughly before proceeding. Summarize the core idea to the user briefly, then discuss what they want to build.
 
-## Step 2: Choose a group
+## Step 2: Choose the group and pin its identity
 
 AskUserQuestion: "Which group should have the wiki?"
 
-1. **Main group** — add to your existing main chat
-2. **Dedicated group** — create a new group just for the wiki
-3. **Other** — pick an existing group
+1. **Main group** — add to the user's existing main chat
+2. **Dedicated group** — a new group just for the wiki
+3. **Other** — another existing group
 
-If dedicated: ask which channel and chat, then register with `pnpm exec tsx setup/index.ts --step register`.
+List the candidates:
+
+```bash
+ncl groups list
+```
+
+If `ncl` cannot reach the host (the service is not running), read the same rows with the in-tree query wrapper:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT id, name, folder FROM agent_groups ORDER BY name"
+```
+
+For a dedicated group, create it and wire a chat to it:
+
+```bash
+ncl groups create --folder <slug> --name "<display name>"
+```
+
+Then run `/manage-channels` to wire a chat to the new group, or wire it directly when the platform ids are already known:
+
+```bash
+ncl messaging-groups create --channel-type <channel> --platform-id <platform id> --name "<chat name>"
+ncl wirings create --messaging-group-id <mg-id> --agent-group-id <ag-id>
+```
+
+Record the two values the rest of this skill needs, and confirm them with the user:
+
+```bash
+GROUP_ID=<ag-...>        # agent group id
+GROUP_FOLDER=<folder>    # the group's folder under groups/
+```
+
+Provision the group's filesystem before writing into it — `ncl groups create` is idempotent on `--folder`, so this returns the existing group and repairs a missing scaffold:
+
+```bash
+ncl groups create --folder "$GROUP_FOLDER"
+```
 
 ## Step 3: Design collaboratively
 
 Discuss with the user based on the pattern:
-- What's the wiki's domain or topic?
-- What kinds of sources will they add? (URLs, PDFs, images, voice notes, books, transcripts)
+
+- What is the wiki's domain or topic?
+- What kinds of sources will they add? (URLs, PDFs, office documents, images, transcripts, books)
 - Do they want the full three-layer architecture or a lighter version?
 - Any specific conventions they care about? (The pattern intentionally leaves this open.)
 
-Based on this discussion, create three things:
+Carry the answers into every file written in Step 4 — the domain shapes the index categories, the page types, and the ingest checklist.
 
-### 3a. Directory structure
+## Step 4: Install
 
-Create `wiki/` and `sources/` directories in the group folder (`mkdir -p` — safe if they already exist). Create initial `index.md` and `log.md` per the pattern's Indexing and Logging section, adapted to the user's domain. Skip any of these files that already exist so a populated wiki is never clobbered on re-run.
+### 4a. Wiki and sources directories
 
-### 3b. Container skill
+```bash
+mkdir -p "groups/$GROUP_FOLDER/wiki" "groups/$GROUP_FOLDER/sources"
+```
 
-Create `container/skills/wiki/SKILL.md` tailored to this user's wiki. This is the schema layer from the pattern — it tells the agent how to maintain the wiki. Base it on the pattern's Operations section (ingest, query, lint) and the conventions you agreed on with the user. Don't over-prescribe — the pattern says "your LLM figures out the rest."
+Create `groups/$GROUP_FOLDER/wiki/index.md` and `groups/$GROUP_FOLDER/wiki/log.md` per the pattern's Indexing and Logging section, adapted to the user's domain. Skip either file when it already exists, so a populated wiki is never clobbered.
 
-If `container/skills/wiki/SKILL.md` already exists, ask the user whether to update it before overwriting, so an existing tailored schema is preserved on re-run.
+### 4b. The wiki skill, scoped to this group
 
-### 3c. Group CLAUDE.md
+```bash
+mkdir -p "data/v2-sessions/$GROUP_ID/.claude-shared/skills/wiki"
+```
 
-Edit the group's CLAUDE.md to add a wiki section, wrapped in marker comments so it can be located and replaced on re-run:
+Write `data/v2-sessions/$GROUP_ID/.claude-shared/skills/wiki/SKILL.md` — the schema layer from the pattern, tailored to this user's wiki. Base it on the pattern's Operations section (ingest, query, lint) and the conventions agreed in Step 3. Don't over-prescribe; the pattern says "your LLM figures out the rest." Give it YAML frontmatter with `name: wiki` and a `description` that says when to use it, then cover:
+
+- the three layers and where each lives inside the container (`/workspace/agent/sources`, `/workspace/agent/wiki`, this skill)
+- the ingest workflow, one source at a time, ending in updates to `wiki/index.md` and an entry appended to `wiki/log.md`
+- the query workflow: read `wiki/index.md` first, then drill into pages, cite the pages used, and offer to file good answers back as new pages
+- the lint workflow: contradictions, stale claims, orphan pages, missing cross-references, data gaps
+- fetching full sources rather than summaries (see Step 5)
+
+When that file already exists, ask the user whether to update it before overwriting, so an existing tailored schema is preserved.
+
+### 4c. Standing instructions
+
+Write this marker-wrapped section into `groups/$GROUP_FOLDER/instructions.prepend.md`, creating the file when absent, replacing an existing `<!-- BEGIN karpathy-llm-wiki -->` block in place, and appending it after any other standing instructions otherwise:
 
 ```markdown
 <!-- BEGIN karpathy-llm-wiki -->
@@ -54,29 +123,58 @@ Edit the group's CLAUDE.md to add a wiki section, wrapped in marker comments so 
 <!-- END karpathy-llm-wiki -->
 ```
 
-If a `<!-- BEGIN karpathy-llm-wiki -->` block already exists, replace it in place rather than appending a second copy. This is critical — it's what turns the agent into a wiki maintainer. The section should:
+This section is what turns the agent into a wiki maintainer, so write it deliberately. It covers:
 
-- Explain the wiki system concisely: what it is, the three layers (sources, wiki, schema), the three operations (ingest, query, lint)
-- Index the key files and folders (`wiki/`, `sources/`, `wiki/index.md`, `wiki/log.md`)
-- Point to the container skill for detailed workflow
-- **Ingest discipline:** Be very explicit that when the user provides multiple files or points at a folder with many files, the agent MUST process them one at a time. For each file: read it, discuss takeaways, create/update all wiki pages (summary, entities, concepts, cross-references, index, log), and completely finish with that file before moving to the next. Never batch-read all files and then process them together — this produces shallow, generic pages instead of the deep integration the pattern requires.
+- **The system, concisely:** what the wiki is, the three layers (sources, wiki, schema), the three operations (ingest, query, lint).
+- **The file map:** `sources/` (immutable raw material), `wiki/` (the agent's own pages), `wiki/index.md` (the catalog to read first), `wiki/log.md` (append-only chronology).
+- **The store boundary**, so the agent is never choosing between two knowledge bases: `memory/` holds durable facts about the user and this group; `wiki/` holds compiled knowledge about the wiki's subject domain, sourced from `sources/`. A fact about the user goes in `memory/`; a fact about the domain goes in `wiki/`. The always-loaded `memory/index.md` gets one line pointing at `wiki/index.md` so the agent can find the wiki from a cold context.
+- **A pointer to the `wiki` skill** for the detailed workflow.
+- **Ingest discipline**, explicitly: when the user provides multiple files or points at a folder of them, process them **one at a time**. For each file — read it, discuss takeaways, create and update all affected wiki pages (summary, entities, concepts, cross-references, index, log), and finish completely before opening the next. Never batch-read every file and then process them together; that produces shallow, generic pages instead of the deep integration the pattern requires.
+- **Full sources, not summaries:** `WebFetch` returns a summary, so fetch full documents with `curl` or `agent-browser` instead (see Step 5).
 
-## Step 4: Source handling capabilities
+Add the pointer line to `groups/$GROUP_FOLDER/memory/index.md` under its map section, and leave the rest of that file alone. That file is scaffolded when the group's container first boots, so on a brand-new group add the line after the restart in Step 7.
 
-Based on the source types the user plans to ingest (discussed in Step 3), check whether the agent can already handle those formats — some are supported natively, others need a skill (e.g. `/add-image-vision`, `/add-pdf-reader`, `/add-voice-transcription`). If a needed capability isn't installed, check if there's an available skill for it and help the user get it set up.
+Do not edit `groups/$GROUP_FOLDER/CLAUDE.md`; it is regenerated on every spawn.
 
-### URL handling note
+When the group carries an agent plugin, a later `ncl groups create --template <ref> --yes` restamp rewrites `instructions.prepend.md` and flags the section as a lost customization. Re-run this step after any restamp of this group.
 
-claude has built-in `WebFetch`, but it returns a summary, not the full document. For wiki ingestion of a URL where the full text matters, the container skill and CLAUDE.md should instruct claude to use bash commands to download full files instead. For example:
+### 4d. Install the delivery-seam guard
+
+The wiki section only works because the composer inlines `instructions.prepend.md` and the skill prune spares real per-group directories. Copy the test that guards both, and run it:
 
 ```bash
-curl -sLo sources/filename.pdf "<url>"
+skill_dir="${CLAUDE_SKILL_DIR:-$(git rev-parse --show-toplevel)/.claude/skills/add-karpathy-llm-wiki}"
+cp "$skill_dir/wiki-delivery-seam.test.ts" src/wiki-delivery-seam.test.ts
+pnpm exec vitest run src/wiki-delivery-seam.test.ts
 ```
 
-If the document is a webpage, then claude can use fetch or `agent-browser` to open the page and extract full text if available. The container skill and CLAUDE.md should note this so claude gets full content for sources rather than summaries.
+If it fails, stop and report which seam moved — the wiki instructions would not reach the agent.
 
+## Step 5: Source handling capabilities
 
-## Step 5: Optional lint schedule
+Ingestion is worth nothing if the agent cannot read the source. From the source types agreed in Step 3, check what this install already handles, and list the installed skills before naming one:
+
+```bash
+ls .claude/skills
+```
+
+Match each planned source type against that list rather than assuming a skill exists:
+
+- **Images and text-layer PDFs** — the container agent reads them with its own file tools; no skill needed.
+- **Office documents** (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV) and **scanned-text PDFs** — `/add-anydoc` installs a local converter.
+- **Anything else** (audio, video, a proprietary format) — search the list for a match, offer to install it, and when nothing matches say so plainly and agree on a manual path (the user exports text themselves).
+
+### URL handling
+
+`WebFetch` returns a summary, not the full document, so it loses exactly the detail wiki ingestion needs. Fetch the real file instead:
+
+```bash
+curl -sLo "sources/<filename>" "<url>"
+```
+
+For a web page, `agent-browser` opens it and extracts the full text. Both the wiki skill (4b) and the standing instructions (4c) say this, so the agent files full sources rather than summaries.
+
+## Step 6: Optional lint schedule
 
 AskUserQuestion: "Want periodic wiki health checks?"
 
@@ -84,16 +182,52 @@ AskUserQuestion: "Want periodic wiki health checks?"
 2. **Monthly**
 3. **Skip** — lint manually
 
-If yes, ask the agent to schedule the lint task using the `schedule_task` MCP tool in conversation.
+For weekly or monthly, create a scheduled task for the group. The cron expression is interpreted in the group's timezone; the first run comes off the cron grid:
 
-## Step 6: Restart
+```bash
+# Weekly, Monday 09:00
+ncl tasks create --group "$GROUP_ID" --name "wiki lint" --recurrence "0 9 * * 1" \
+  --prompt "Run a wiki lint pass over /workspace/agent/wiki using the wiki skill: find contradictions, stale claims superseded by newer sources, orphan pages, concepts that deserve their own page, missing cross-references, and data gaps. Fix what is unambiguous, append a lint entry to wiki/log.md, and report the rest with suggested sources to pursue."
 
-Run from your NanoClaw project root:
+# Monthly, the 1st at 09:00 — same command with:
+#   --recurrence "0 9 1 * *"
+```
+
+Record the series id it returns; REMOVE.md needs it to cancel the schedule. Confirm and re-read it any time with:
+
+```bash
+ncl tasks list --group "$GROUP_ID"
+```
+
+## Step 7: Restart and verify
+
+The composed project document and the per-group skill store are read when a container starts, so restart this install's service:
 
 ```bash
 source setup/lib/install-slug.sh
-launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
-systemctl --user restart $(systemd_unit)              # Linux
+launchctl kickstart -k "gui/$(id -u)/$(launchd_label)"  # macOS
+systemctl --user restart "$(systemd_unit)"              # Linux
 ```
 
-Tell the user to test by sending a source to the wiki group.
+Run only the command for the current platform. If NanoClaw is not service-managed, stop this install's running agent containers by their `nanoclaw-install=<install-slug>` label so the group respawns with the new context.
+
+Then send a real source to the wiki group and confirm the round trip: the agent files it under `sources/`, writes or updates wiki pages, refreshes `wiki/index.md`, and appends to `wiki/log.md`. Confirm the files changed on the host:
+
+```bash
+ls "groups/$GROUP_FOLDER/sources" "groups/$GROUP_FOLDER/wiki"
+grep '^## \[' "groups/$GROUP_FOLDER/wiki/log.md" | tail -5
+```
+
+Report to the user which group has the wiki, where its files live, and that `groups/<folder>/CLAUDE.md` is generated — wiki instructions are edited in `instructions.prepend.md`.
+
+## Troubleshooting
+
+**The agent replies but ignores the wiki entirely.** Its container started before Step 4 landed. Restart per Step 7, or `ncl groups restart --id "$GROUP_ID" --message "reloaded wiki context"`.
+
+**The agent produces no output at all.** Check `logs/nanoclaw.error.log` before suspecting the wiki wiring — a credential-gateway `401` on `ensureAgent` fails the spawn well before any group context is read.
+
+**The wiki section is missing from the agent's context.** Confirm it is in `groups/$GROUP_FOLDER/instructions.prepend.md` (not in `CLAUDE.md`, which is regenerated), then re-run the Step 4d test.
+
+**The wiki skill shows up in other groups.** A copy landed in the install-wide `container/skills/wiki/`. Remove it; the per-group copy under `data/v2-sessions/$GROUP_ID/.claude-shared/skills/wiki/` is the one this skill installs.
+
+**Pages read shallow and generic.** The agent batched the ingest. Strengthen the ingest-discipline wording in 4b and 4c, and re-ingest the sources one at a time.

--- a/.claude/skills/add-karpathy-llm-wiki/wiki-delivery-seam.test.ts
+++ b/.claude/skills/add-karpathy-llm-wiki/wiki-delivery-seam.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Delivery-seam guard for the add-karpathy-llm-wiki skill.
+ *
+ * The wiki schema — the text that turns the agent from a chatbot into a
+ * disciplined wiki maintainer — is the whole point of this skill, and it only
+ * counts if it survives into the project document the container actually
+ * mounts. Two host seams decide that, and both are outside the skill:
+ *
+ *   1. `composeGroupClaudeMd` rewrites `groups/<folder>/CLAUDE.md` from scratch
+ *      on every spawn. Text placed in that file is destroyed before the agent
+ *      reads it; text placed in `instructions.prepend.md` is inlined as the
+ *      persona fragment and imported first.
+ *   2. `syncSkillSymlinks` prunes the per-group skill store on every spawn. A
+ *      real per-group skill directory has to survive that prune, or the wiki
+ *      skill vanishes on the next restart.
+ *
+ * Each case below goes red if its seam moves, including the negative one:
+ * the day `CLAUDE.md` stops being generated, case 2 fails and this skill can
+ * be simplified. Ships with the skill; apply copies it to
+ * `src/wiki-delivery-seam.test.ts`.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_ROOT = '/tmp/nanoclaw-wiki-delivery-seam-test';
+const GROUPS_DIR = path.join(TEST_ROOT, 'groups');
+
+vi.mock('./config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./config.js')>()),
+  GROUPS_DIR: '/tmp/nanoclaw-wiki-delivery-seam-test/groups',
+}));
+
+vi.mock('./log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import { composeGroupClaudeMd } from './claude-md-compose.js';
+import type { ContainerConfig } from './container-config.js';
+import { syncSkillSymlinks } from './container-runner.js';
+import { ensureContainerConfig } from './db/container-configs.js';
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from './db/index.js';
+import { PERSONA_PREPEND_FILE } from './group-persona.js';
+import { log } from './log.js';
+import type { AgentGroup } from './types.js';
+
+const BEGIN = '<!-- BEGIN karpathy-llm-wiki -->';
+const END = '<!-- END karpathy-llm-wiki -->';
+
+/** The shape the skill's Step 4c writes, trimmed to its load-bearing lines. */
+const WIKI_SECTION = [
+  BEGIN,
+  '## Wiki',
+  '',
+  'Sources live in `sources/`, compiled knowledge in `wiki/`.',
+  'Catalog: `wiki/index.md`. Chronology: `wiki/log.md`.',
+  'Ingest sources one at a time; finish each before starting the next.',
+  'Full workflow: the `wiki` skill.',
+  END,
+].join('\n');
+
+function group(id: string, folder: string): AgentGroup {
+  return { id, name: folder, folder, agent_provider: null, created_at: new Date().toISOString() } as AgentGroup;
+}
+
+async function seedGroup(ag: AgentGroup): Promise<string> {
+  await createAgentGroup(ag);
+  await ensureContainerConfig(ag.id);
+  const dir = path.join(GROUPS_DIR, ag.folder);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Read the composed entry document and inline every `@./…` import it emits —
+ * the same resolution the provider performs inside the container. Symlinked
+ * fragments target container paths and are unreadable on the host, so they
+ * contribute their target path instead of their body.
+ */
+function resolveComposedDocument(groupDir: string): string {
+  const entry = fs.readFileSync(path.join(groupDir, 'CLAUDE.md'), 'utf-8');
+  let text = entry;
+  for (const line of entry.split('\n')) {
+    const match = line.trim().match(/^@(\.\/.+)$/);
+    if (!match) continue;
+    const target = path.join(groupDir, match[1]);
+    try {
+      text += `\n${fs.readFileSync(target, 'utf-8')}`;
+    } catch {
+      text += `\n<!-- ${match[1]} -> ${fs.readlinkSync(target)} -->`;
+    }
+  }
+  return text;
+}
+
+function importsOf(groupDir: string): string[] {
+  return fs
+    .readFileSync(path.join(groupDir, 'CLAUDE.md'), 'utf-8')
+    .split('\n')
+    .filter((line) => line.startsWith('@'));
+}
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(GROUPS_DIR, { recursive: true });
+  await runMigrations(await initTestDb());
+  vi.mocked(log.warn).mockClear();
+});
+
+afterEach(async () => {
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('wiki standing instructions', () => {
+  it('reach the composed project document through instructions.prepend.md', async () => {
+    const ag = group('ag-wiki-prepend', 'wiki-prepend');
+    const dir = await seedGroup(ag);
+    fs.writeFileSync(path.join(dir, PERSONA_PREPEND_FILE), `${WIKI_SECTION}\n`);
+
+    await composeGroupClaudeMd(ag);
+
+    // Imported first, so the wiki schema tops the composed system prompt.
+    expect(importsOf(dir)[0]).toBe('@./.claude-fragments/persona.md');
+
+    const composed = resolveComposedDocument(dir);
+    expect(composed).toContain(BEGIN);
+    expect(composed).toContain(END);
+    expect(composed).toContain('wiki/index.md');
+    expect(composed).toContain('wiki/log.md');
+    expect(composed).toContain('one at a time');
+  });
+
+  it('survive a second compose, so a container restart keeps the wiki schema', async () => {
+    const ag = group('ag-wiki-respawn', 'wiki-respawn');
+    const dir = await seedGroup(ag);
+    fs.writeFileSync(path.join(dir, PERSONA_PREPEND_FILE), `${WIKI_SECTION}\n`);
+
+    await composeGroupClaudeMd(ag);
+    await composeGroupClaudeMd(ag);
+
+    expect(resolveComposedDocument(dir)).toContain(BEGIN);
+  });
+
+  it('are destroyed when written into the generated group CLAUDE.md', async () => {
+    // This is the case the skill used to document. `CLAUDE.md` is regenerated
+    // on every spawn, so a marker block there never reaches the agent — which
+    // is exactly why Step 4c targets the standing-instructions file instead.
+    const ag = group('ag-wiki-claudemd', 'wiki-claudemd');
+    const dir = await seedGroup(ag);
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), `# Group\n\n${WIKI_SECTION}\n`);
+
+    await composeGroupClaudeMd(ag);
+
+    const regenerated = fs.readFileSync(path.join(dir, 'CLAUDE.md'), 'utf-8');
+    expect(regenerated).not.toContain(BEGIN);
+    expect(regenerated).toContain('Composed at spawn - do not edit');
+  });
+
+  it('are not delivered by a container skill that ships only SKILL.md', async () => {
+    // Step 4b installs a per-group skill, not a fragment: the composer's skill
+    // fragments come from `container/skills/<name>/instructions.md`, so a
+    // SKILL.md alone contributes no import. If that ever changes, this goes
+    // red and the skill can lean on the fragment layer instead.
+    const ag = group('ag-wiki-fragment', 'wiki-fragment');
+    const dir = await seedGroup(ag);
+
+    await composeGroupClaudeMd(ag);
+
+    expect(importsOf(dir)).not.toContain('@./.claude-fragments/skill-wiki.md');
+  });
+});
+
+describe('the per-group wiki skill', () => {
+  const containerConfig = {
+    mcpServers: {},
+    packages: { apt: [], npm: [] },
+    additionalMounts: [],
+    skills: ['welcome'],
+  } as unknown as ContainerConfig;
+
+  it('survives the spawn-time shared-skill sync', () => {
+    const claudeDir = path.join(TEST_ROOT, 'v2-sessions', 'ag-wiki-skill', '.claude-shared');
+    const wikiSkill = path.join(claudeDir, 'skills', 'wiki');
+    fs.mkdirSync(wikiSkill, { recursive: true });
+    fs.writeFileSync(path.join(wikiSkill, 'SKILL.md'), '---\nname: wiki\n---\n');
+
+    syncSkillSymlinks(claudeDir, containerConfig);
+    syncSkillSymlinks(claudeDir, containerConfig);
+
+    // Real directory, not a symlink into the install-wide /app/skills mount:
+    // that is what keeps the wiki skill scoped to this one agent group.
+    expect(fs.lstatSync(wikiSkill).isDirectory()).toBe(true);
+    expect(fs.lstatSync(wikiSkill).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(wikiSkill, 'SKILL.md'), 'utf-8')).toContain('name: wiki');
+    // A shadowing warning here would mean a shared `container/skills/wiki`
+    // exists too, which is the install-wide leak this skill must not create.
+    expect(vi.mocked(log.warn).mock.calls.flat()).not.toContainEqual(expect.objectContaining({ skill: 'wiki' }));
+  });
+});

--- a/.claude/skills/add-karpathy-llm-wiki/wiki-delivery-seam.test.ts
+++ b/.claude/skills/add-karpathy-llm-wiki/wiki-delivery-seam.test.ts
@@ -143,9 +143,9 @@ describe('wiki standing instructions', () => {
   });
 
   it('are destroyed when written into the generated group CLAUDE.md', async () => {
-    // This is the case the skill used to document. `CLAUDE.md` is regenerated
-    // on every spawn, so a marker block there never reaches the agent — which
-    // is exactly why Step 4c targets the standing-instructions file instead.
+    // The negative control for the seam above: `CLAUDE.md` is regenerated on
+    // every spawn, so a marker block there never reaches the agent — which is
+    // exactly why Step 4c targets the standing-instructions file instead.
     const ag = group('ag-wiki-claudemd', 'wiki-claudemd');
     const dir = await seedGroup(ag);
     fs.writeFileSync(path.join(dir, 'CLAUDE.md'), `# Group\n\n${WIKI_SECTION}\n`);

--- a/vitest.skills.config.ts
+++ b/vitest.skills.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
       // import from `bun:test` and only run under Bun (see vitest.config.ts).
       '.claude/skills/add-atomic-chat-tool/atomic-chat-registration.test.ts',
       '.claude/skills/add-ollama-tool/ollama-registration.test.ts',
+      // Skill payload destined for src/: it imports host core by relative
+      // specifier (`./claude-md-compose.js`), which only resolves once the
+      // applier has copied it into src/.
+      '.claude/skills/add-karpathy-llm-wiki/wiki-delivery-seam.test.ts',
     ],
   },
 });


### PR DESCRIPTION
Stacked on #3408. Audit verdict: delivers zero wiki instructions — step 3c wrote into `groups/<folder>/CLAUDE.md`, which trunk regenerates from the central DB at every container spawn.

## What changed

- Delivery moved onto the DB-backed group instruction surface so the wiki section survives every spawn; scoping moved from the shared `container/skills/` mount (which leaked the wiki into every agent group) to the per-group location.
- Scheduling instruction moved from the removed `schedule_task` MCP tool to `ncl tasks create`; step 2's argument-less register command and the step-2/3 ordering hole fixed; the three nonexistent capability-skill references dropped; REMOVE.md rewritten to undo what apply actually does; wiki-vs-shared-memory reconciliation added so the agent isn't told to keep two competing stores.
- New seam test (`wiki-delivery-seam.test.ts`, 5 cases against the real composer) would have caught the original blocker outright.

## Verification

Full mocked round trip three ways (retagged image, offline gateway, probe provider — all diagnostic files removed before commit), confirming the wiki instructions reach the composed CLAUDE.md the container actually mounts. All gates green (157 files / 1936 host tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhS5pL3inQ46UdQUvo4g56