### PR TITLE
fix(add-dashboard): REMOVE.md, portable SQL, shutdown wiring, doc repairs

### DIFF
--- a/.claude/skills/add-dashboard/REMOVE.md
+++ b/.claude/skills/add-dashboard/REMOVE.md
@@ -1,0 +1,58 @@
+# Remove /add-dashboard
+
+Reverses every change the install made: three copied files, one dependency, one
+block in `src/index.ts`, two `.env` lines. Every step is idempotent — safe to
+run even if some pieces are already gone.
+
+## 1. Delete the copied files
+
+```bash
+rm -f src/dashboard-pusher.ts src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts
+```
+
+## 2. Uninstall the dependency
+
+```bash
+pnpm remove @nanoco/nanoclaw-dashboard
+```
+
+## 3. Remove the block from `src/index.ts`
+
+Open `src/index.ts` and delete the dashboard block from `main()` — the comment,
+the dynamic import, and the call:
+
+```typescript
+  // Dashboard (optional; no-ops without DASHBOARD_SECRET)
+  const { startDashboard } = await import('./dashboard-pusher.js');
+  await startDashboard();
+```
+
+That is the only edit the install made to core. Teardown was registered from
+inside `dashboard-pusher.ts` (deleted in step 1), so `shutdown()` has nothing
+to revert.
+
+## 4. Remove the environment variables
+
+Delete both lines from `.env`:
+
+```
+DASHBOARD_SECRET=...
+DASHBOARD_PORT=...
+```
+
+## 5. Rebuild and restart
+
+```bash
+pnpm run build
+source setup/lib/install-slug.sh
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
+
+# Linux
+systemctl --user restart $(systemd_unit)
+```
+
+The build is the check: a forgotten step-3 block fails with
+`TS2307: Cannot find module './dashboard-pusher.js'`. The dashboard port stops
+listening once the host restarts.

--- a/.claude/skills/add-dashboard/SKILL.md
+++ b/.claude/skills/add-dashboard/SKILL.md
@@ -20,13 +20,17 @@ NanoClaw (pusher)              Dashboard (npm package)
                                └──────────────┘
 ```
 
+The pusher reads through two boundaries and never around them: central state via the async `DbDriver` (`getDb()`), per-session messages via the host mailbox seam (`withExistingMailboxSession`) — the same read path `ncl sessions history` uses. So the dashboard works on any composed backend, not just SQLite files under `data/v2-sessions/`.
+
 ## Steps
 
 ### 1. Install the npm package
 
 ```bash
-pnpm install @nanoco/nanoclaw-dashboard
+pnpm install @nanoco/nanoclaw-dashboard@0.3.0
 ```
+
+Pinned, like every other skill dependency: this package owns the snapshot contract, so a caret range could pull a version that renames snapshot fields while the pusher keeps posting the old shape — and the shipped tests mock the package, so they would not notice.
 
 ### 2. Copy the pusher module and its tests
 
@@ -38,8 +42,8 @@ Copy all three resource files into `src/`. The tests ship with the skill and run
 .claude/skills/add-dashboard/resources/dashboard-wiring.test.ts  → src/dashboard-wiring.test.ts
 ```
 
-- `dashboard-pusher.test.ts` — behavior: starts the pusher, posts a real snapshot to a fake dashboard.
-- `dashboard-wiring.test.ts` — the code edit in step 3: asserts (via the TS AST) that `index.ts` dynamically imports `./dashboard-pusher.js` and `await`s `startDashboard()` as colocated statements of `main()`, after DB init and before the boot-complete log. Delete or misplace the edit and this goes red.
+- `dashboard-pusher.test.ts` — behavior: starts the pusher against a real test DB and the real mailbox seam, posts a snapshot to a fake dashboard, and tears down through the host's shutdown registry.
+- `dashboard-wiring.test.ts` — the code edit in step 3: asserts (via the TS AST) that `index.ts` dynamically imports `./dashboard-pusher.js` and `await`s `startDashboard()` as colocated statements of `main()`, after DB init and before the boot-complete log. Delete or misplace the edit and this goes red. It also guards the pusher's two read boundaries, which stay invisible to a behavior test on an all-SQLite install.
 
 ### 3. Wire into src/index.ts
 
@@ -55,6 +59,8 @@ Add this block inside `main()`, just before the `log.info('NanoClaw running')` l
 
 `startDashboard()` reads `DASHBOARD_SECRET`/`DASHBOARD_PORT` itself and no-ops if the secret is unset, so nothing else in core needs to change.
 
+Teardown rides the host's own lifecycle registry: `dashboard-pusher.ts` registers `stopDashboard()` with `onHostShutdown()` at import time, so `shutdown()` → `stopHostModules()` stops the 60s push timer and the 2s log-tail timer and closes the dashboard socket — before `closeDb()`, so a push can never fire into a closed driver. Startup stays the single edit; the `tears down from the host shutdown path` test in `dashboard-pusher.test.ts` covers the teardown leg.
+
 ### 4. Add environment variables to .env
 
 ```
@@ -63,6 +69,12 @@ DASHBOARD_PORT=3100
 ```
 
 Generate the secret: `node -e "console.log('nc-' + require('crypto').randomBytes(16).toString('hex'))"`
+
+**`DASHBOARD_SECRET` is the dashboard's only access control, and the dashboard is reachable from your local network.** `@nanoco/nanoclaw-dashboard@0.3.0` listens on `0.0.0.0` and its config accepts only `{ port, secret }` — there is no bind option to narrow it to loopback, so the pusher logs a warning naming the exposure at every boot. The snapshot carries full conversation content (`/api/overview`, `/api/messages`, `/api/logs`), so:
+
+- Use the generator above. A guessable secret is the whole security model.
+- On a shared or untrusted network, block the port at the firewall and reach the UI over an SSH tunnel: `ssh -L 3100:127.0.0.1:3100 <host>`.
+- Confirm what is listening: `ss -lptn | grep <DASHBOARD_PORT>` (Linux) or `lsof -nP -iTCP:<DASHBOARD_PORT> -sTCP:LISTEN` (macOS).
 
 ### 5. Build, test, and restart
 
@@ -76,16 +88,18 @@ systemctl --user restart $(systemd_unit)              # Linux
 # or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```
 
-Run `build` **before** the tests: it's what guards the `@nanoco/nanoclaw-dashboard` dependency. `dashboard-pusher.ts` reaches the package through `await import('@nanoco/nanoclaw-dashboard')`, so if step 4 was skipped, `pnpm run build` fails with `TS2307: Cannot find module`. The behavior test deliberately *mocks* that package — its `startDashboard` binds a real dashboard port, a side effect we don't want in a test — so the test alone would pass with the dependency missing. Build is therefore the leg that verifies the dependency is installed; keep it ahead of the tests in the validate step.
+Run `build` **before** the tests: it's what guards the `@nanoco/nanoclaw-dashboard` dependency. `dashboard-pusher.ts` reaches the package through `await import('@nanoco/nanoclaw-dashboard')`, so if step 1 was skipped, `pnpm run build` fails with `TS2307: Cannot find module '@nanoco/nanoclaw-dashboard'`. The behavior test deliberately *mocks* that package — its `startDashboard` binds a real dashboard port, a side effect we don't want in a test — so the test alone would pass with the dependency missing. Build is therefore the leg that verifies the dependency is installed; keep it ahead of the tests in the validate step.
 
 ### 6. Verify (runtime smoke check)
 
 Once the service is restarted, confirm the dashboard is live:
 
 ```bash
-curl -s http://localhost:3100/api/status
+curl -s -H "Authorization: Bearer <secret>" http://localhost:3100/api/status
 curl -s -H "Authorization: Bearer <secret>" http://localhost:3100/api/overview
 ```
+
+`/api/status` returns `{"ok":true,...}`; without the header it returns `{"error":"Unauthorized"}`, which is itself proof the server is up and enforcing the secret. `hasData` stays `false` until the first push lands.
 
 Open `http://localhost:3100/dashboard` in a browser.
 
@@ -97,7 +111,7 @@ Open `http://localhost:3100/dashboard` in a browser.
 | Agent Groups | Sessions, wirings, destinations, members, admins |
 | Sessions | Status, container state, context window usage bars |
 | Channels | Live/offline status, messaging groups, sender policies |
-| Messages | Per-session inbound/outbound messages |
+| Messages | Per-session inbound/outbound messages (timestamp, kind, content) |
 | Users | Privilege hierarchy: owner > admin > member |
 | Logs | Real-time log streaming with level filter |
 
@@ -107,18 +121,9 @@ Open `http://localhost:3100/dashboard` in a browser.
 - **401 errors**: Verify `DASHBOARD_SECRET` matches in `.env`
 - **Port conflict**: Change `DASHBOARD_PORT` in `.env`
 - **No logs**: Check `logs/nanoclaw.log` exists
+- **Host won't start — `Upgrade tripwire: install not on the sanctioned path`**: this install has no upgrade marker, which is normal in a fresh clone or worktree and blocks step 5's restart before the dashboard ever loads. Record the current state with the project's own command, then restart: `pnpm exec tsx scripts/upgrade-state.ts set`
+- **Sessions or messages missing from the dashboard**: the Messages page and the activity chart list sessions from the central `sessions` table, so a session whose row was deleted no longer appears even if old data lingers on disk. A single session busier than 500 messages per side in 24h contributes only its newest 500 to the chart.
 
 ## Removal
 
-Reverse the apply steps. Safe to re-run even if some pieces are already gone.
-
-```bash
-rm -f src/dashboard-pusher.ts src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts
-pnpm uninstall @nanoco/nanoclaw-dashboard 2>/dev/null || true
-```
-
-Then, by hand, remove the single dashboard block the skill added to `main()` in `src/index.ts` (the `// Dashboard (optional…)` comment, the `await import('./dashboard-pusher.js')` line, and the `await startDashboard();` call), and remove `DASHBOARD_SECRET` and `DASHBOARD_PORT` from `.env`.
-
-```bash
-pnpm run build
-```
+See [REMOVE.md](REMOVE.md).

--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts
@@ -3,11 +3,13 @@
  * `startDashboard()`, the single call wired into src/index.ts.
  *
  * Archetype: in-process seam. It drives the *real* entry point against a
- * *real* (in-memory) central DB and a *fake* dashboard HTTP endpoint. The
- * only things stubbed are the external dashboard package (not needed to prove
- * the wiring) and env-file reads (so the test doesn't depend on the real
- * .env). This proves the skill works once applied: with a secret set it
- * collects a DB snapshot and posts it; with no secret it does nothing.
+ * *real* (in-memory) central DB, the *real* host mailbox seam, and a *fake*
+ * dashboard HTTP endpoint. The only things stubbed are the external dashboard
+ * package (not needed to prove the wiring) and env-file reads (so the test
+ * doesn't depend on the real .env). This proves the skill works once applied:
+ * with a secret set it collects a snapshot and posts it; with no secret it
+ * does nothing; the per-session message reads go through the mailbox seam;
+ * and teardown runs from the host's own shutdown path.
  *
  * Ships with the add-dashboard skill; apply copies it to src/ alongside the
  * pusher so it runs against the composed project.
@@ -22,14 +24,20 @@ vi.mock('./config.js', async () => {
   return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-dashboard', ASSISTANT_NAME: 'TestBot' };
 });
 // The dashboard server package isn't needed to prove the integration point.
-vi.mock('@nanoco/nanoclaw-dashboard', () => ({ startDashboard: vi.fn() }));
+const dashboardServer = { startDashboard: vi.fn(), stopDashboard: vi.fn(async () => {}) };
+vi.mock('@nanoco/nanoclaw-dashboard', () => dashboardServer);
 // Don't read the real .env — the test controls config via process.env only.
 vi.mock('./env.js', () => ({ readEnvFile: () => ({}) }));
 
 const TEST_DIR = '/tmp/nanoclaw-test-dashboard';
 
-import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
-import { startDashboard, stopDashboardPusher } from './dashboard-pusher.js';
+// The singular mailbox composition slot: the per-session reads below go
+// through the real registered mailbox, not a hand-rolled SQLite handle.
+import './mailbox/compose.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createSession } from './db/index.js';
+import { stopHostModules } from './host-lifecycle.js';
+import { withMailboxSession } from './session-manager.js';
+import { startDashboard, startDashboardPusher, stopDashboard } from './dashboard-pusher.js';
 
 function now(): string {
   return new Date().toISOString();
@@ -77,15 +85,40 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
+/** The snapshot from the first /api/ingest post. */
+function ingestOf(posts: CapturedPost[]): Record<string, unknown> {
+  return posts.find((p) => p.path === '/api/ingest')!.body;
+}
+
+function seedGroup(id = 'ag-1'): Promise<void> {
+  return createAgentGroup({ id, name: 'Test Agent', folder: 'test-agent', agent_provider: null, created_at: now() });
+}
+
+function seedSession(id: string, agentGroupId: string, lastActive: string | null): Promise<void> {
+  return createSession({
+    id,
+    agent_group_id: agentGroupId,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: lastActive,
+    created_at: now(),
+  });
+}
+
 describe('add-dashboard integration point (startDashboard)', () => {
   beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    dashboardServer.startDashboard.mockClear();
+    dashboardServer.stopDashboard.mockClear();
     const db = await initTestDb();
     await runMigrations(db);
   });
 
   afterEach(async () => {
-    stopDashboardPusher();
+    await stopDashboard();
     await closeDb();
     delete process.env.DASHBOARD_SECRET;
     delete process.env.DASHBOARD_PORT;
@@ -93,13 +126,7 @@ describe('add-dashboard integration point (startDashboard)', () => {
   });
 
   it('posts a snapshot of the seeded state when DASHBOARD_SECRET is set', async () => {
-    await createAgentGroup({
-      id: 'ag-1',
-      name: 'Test Agent',
-      folder: 'test-agent',
-      agent_provider: null,
-      created_at: now(),
-    });
+    await seedGroup();
 
     const dash = await startFakeDashboard();
     process.env.DASHBOARD_SECRET = 'test-secret';
@@ -140,6 +167,110 @@ describe('add-dashboard integration point (startDashboard)', () => {
     await new Promise((r) => setTimeout(r, 100));
 
     expect(dash.posts).toHaveLength(0);
+    await dash.close();
+  });
+
+  it('reads per-session messages through the host mailbox seam', async () => {
+    await seedGroup();
+    await seedSession('sess-1', 'ag-1', now());
+
+    // Write one message per side through the seam the host itself writes with,
+    // so the read path under test is the only thing being proven.
+    await withMailboxSession('ag-1', 'sess-1', async (mailbox) => {
+      await mailbox.insertMessage({
+        id: 'in-1',
+        kind: 'chat',
+        timestamp: now(),
+        platformId: 'chat-1',
+        channelType: 'echo',
+        threadId: null,
+        content: JSON.stringify({ text: 'ping from the operator' }),
+        processAfter: null,
+        recurrence: null,
+      });
+      await mailbox.writeDirect({
+        id: 'out-1',
+        kind: 'chat',
+        platformId: 'chat-1',
+        channelType: 'echo',
+        threadId: null,
+        content: JSON.stringify({ text: 'pong from the agent' }),
+      });
+    });
+
+    const dash = await startFakeDashboard();
+    process.env.DASHBOARD_SECRET = 'test-secret';
+    process.env.DASHBOARD_PORT = String(dash.port);
+    await startDashboard();
+    await waitFor(() => dash.posts.some((p) => p.path === '/api/ingest'));
+
+    const body = ingestOf(dash.posts);
+
+    const messages = body.messages as Array<{
+      agentGroupId: string;
+      sessionId: string;
+      inbound: Array<{ kind: string; content: string; timestamp: string }>;
+      outbound: Array<{ kind: string; content: string; timestamp: string }>;
+    }>;
+    const entry = messages.find((m) => m.agentGroupId === 'ag-1' && m.sessionId === 'sess-1');
+    expect(entry, 'the seeded session must appear in the Messages payload').toBeDefined();
+    expect(entry!.inbound.map((m) => m.content)).toContain(JSON.stringify({ text: 'ping from the operator' }));
+    expect(entry!.outbound.map((m) => m.content)).toContain(JSON.stringify({ text: 'pong from the agent' }));
+    // The dashboard's Messages page renders exactly timestamp + kind + content.
+    for (const row of [...entry!.inbound, ...entry!.outbound]) {
+      expect(row.kind).toBe('chat');
+      expect(Date.parse(row.timestamp)).not.toBeNaN();
+    }
+
+    const activity = body.activity as Array<{ hour: string; inbound: number; outbound: number }>;
+    expect(activity).toHaveLength(24);
+    expect(activity.reduce((n, b) => n + b.inbound, 0)).toBe(1);
+    expect(activity.reduce((n, b) => n + b.outbound, 0)).toBe(1);
+
+    await dash.close();
+  });
+
+  it('orders sessions most-recently-active first with never-active last', async () => {
+    await seedGroup();
+    await seedSession('sess-old', 'ag-1', '2020-01-01T00:00:00.000Z');
+    await seedSession('sess-never', 'ag-1', null);
+    await seedSession('sess-new', 'ag-1', '2030-01-01T00:00:00.000Z');
+
+    const dash = await startFakeDashboard();
+    process.env.DASHBOARD_SECRET = 'test-secret';
+    process.env.DASHBOARD_PORT = String(dash.port);
+    await startDashboard();
+    await waitFor(() => dash.posts.some((p) => p.path === '/api/ingest'));
+
+    const sessions = ingestOf(dash.posts).sessions as Array<{ id: string }>;
+    expect(sessions.map((s) => s.id)).toEqual(['sess-new', 'sess-old', 'sess-never']);
+
+    await dash.close();
+  });
+
+  it('tears down from the host shutdown path and stops pushing', async () => {
+    const dash = await startFakeDashboard();
+    process.env.DASHBOARD_SECRET = 'test-secret';
+    process.env.DASHBOARD_PORT = String(dash.port);
+
+    await startDashboard();
+    await waitFor(() => dash.posts.some((p) => p.path === '/api/ingest'));
+
+    // The host's graceful shutdown runs stopHostModules() before it closes the
+    // DB — the pusher registers its teardown there, so this is the real path.
+    await stopHostModules();
+    expect(dashboardServer.stopDashboard).toHaveBeenCalled();
+
+    // And the timers are actually cleared: a fast-interval pusher stops pushing.
+    startDashboardPusher({ port: dash.port, secret: 'test-secret', intervalMs: 20 });
+    await waitFor(() => dash.posts.filter((p) => p.path === '/api/ingest').length >= 2);
+    await stopDashboard();
+    // Let any in-flight POST land before taking the baseline.
+    await new Promise((r) => setTimeout(r, 100));
+    const settled = dash.posts.filter((p) => p.path === '/api/ingest').length;
+    await new Promise((r) => setTimeout(r, 150));
+    expect(dash.posts.filter((p) => p.path === '/api/ingest').length).toBe(settled);
+
     await dash.close();
   });
 });

--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
@@ -1,11 +1,18 @@
 /**
  * Dashboard pusher — collects NanoClaw state and POSTs a JSON
  * snapshot to the dashboard's /api/ingest endpoint every interval.
+ *
+ * Two read boundaries, both deliberate:
+ * - Central state goes through the async `DbDriver` (`getDb()`), so every
+ *   hand-written query here stays dialect-agnostic — no SQLite-only syntax.
+ * - Per-session messages go through the host mailbox seam
+ *   (`withExistingMailboxSession`), the same read path `ncl sessions history`
+ *   uses. Session storage is not necessarily SQLite files on disk, so this
+ *   file never opens `inbound.db` / `outbound.db` itself.
  */
 import fs from 'fs';
 import path from 'path';
 import http from 'http';
-import Database from 'better-sqlite3';
 
 import { getAllAgentGroups, getAgentGroup } from './db/agent-groups.js';
 import { getSessionsByAgentGroup } from './db/sessions.js';
@@ -20,6 +27,8 @@ import { DATA_DIR, ASSISTANT_NAME } from './config.js';
 import { getDb } from './db/connection.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { log } from './log.js';
+import { onHostShutdown } from './host-lifecycle.js';
+import { withExistingMailboxSession } from './session-manager.js';
 import { readEnvFile } from './env.js';
 
 interface PusherConfig {
@@ -31,6 +40,7 @@ interface PusherConfig {
 let timer: ReturnType<typeof setInterval> | null = null;
 let logTimer: ReturnType<typeof setInterval> | null = null;
 let logOffset = 0;
+let serverStarted = false;
 
 export function startDashboardPusher(config: PusherConfig): void {
   const interval = config.intervalMs || 60000;
@@ -59,7 +69,7 @@ export function stopDashboardPusher(): void {
 }
 
 /**
- * Skill entry point — the single call wired into the host boot sequence.
+ * Skill entry point — the single startup call wired into the host boot sequence.
  *
  * All of the dashboard's startup logic lives here, in the skill's own file,
  * so the integration point in src/index.ts is just `await startDashboard()`.
@@ -75,8 +85,37 @@ export async function startDashboard(): Promise<void> {
   }
   const { startDashboard: startServer } = await import('@nanoco/nanoclaw-dashboard');
   startServer({ port, secret });
+  serverStarted = true;
+  // @nanoco/nanoclaw-dashboard@0.3.0 listens on 0.0.0.0 and its config accepts
+  // only { port, secret } — there is no bind option to narrow it to loopback.
+  // The snapshot carries full message content, so say the exposure out loud
+  // once per boot instead of letting the operator discover it from `ss -lptn`.
+  log.warn('Dashboard listening on all interfaces (0.0.0.0) — DASHBOARD_SECRET is the only access control', { port });
   startDashboardPusher({ port, secret, intervalMs: 60000 });
 }
+
+/**
+ * Teardown counterpart of startDashboard(), driven by the host's shutdown
+ * registry (see the onHostShutdown call below). Stops the two pusher timers
+ * and closes the dashboard's listening socket, so nothing pushes into a closed
+ * DB driver and the port is released before the process exits. Safe to call
+ * when startDashboard() never ran, and safe to call twice.
+ */
+export async function stopDashboard(): Promise<void> {
+  stopDashboardPusher();
+  if (!serverStarted) return;
+  serverStarted = false;
+  const { stopDashboard: stopServer } = await import('@nanoco/nanoclaw-dashboard');
+  await stopServer();
+  log.info('Dashboard stopped');
+}
+
+// Teardown rides the host's own lifecycle registry, registered here at import
+// time and inert until shutdown — so the integration point in src/index.ts
+// stays a single startup call with nothing to remember in shutdown().
+// stopHostModules() runs before the delivery polls stop and before closeDb(),
+// so the push timer can never fire into a closed driver.
+onHostShutdown(() => stopDashboard());
 
 /** Fire-and-forget POST to the dashboard. */
 function postJson(config: PusherConfig, urlPath: string, data: unknown): void {
@@ -156,6 +195,9 @@ async function collectSnapshot(): Promise<Record<string, unknown>> {
     collectTokens(),
     collectContextWindows(),
   ]);
+  // The activity chart and the Messages page read the same per-session
+  // mailboxes, so they share one pass over the sessions we just listed.
+  const { activity, messages } = await collectSessionMailboxes(sessions);
   return {
     timestamp: new Date().toISOString(),
     assistant_name: ASSISTANT_NAME,
@@ -166,8 +208,8 @@ async function collectSnapshot(): Promise<Record<string, unknown>> {
     users,
     tokens,
     context_windows: contextWindows,
-    activity: collectActivity(),
-    messages: collectMessages(),
+    activity,
+    messages,
   };
 }
 
@@ -221,15 +263,30 @@ async function collectAgentGroups() {
   );
 }
 
-async function collectSessions() {
-  return getDb().all<Record<string, unknown>>(
+interface SessionRow extends Record<string, unknown> {
+  id: string;
+  agent_group_id: string;
+  last_active: string | null;
+}
+
+async function collectSessions(): Promise<SessionRow[]> {
+  const rows = await getDb().all<SessionRow>(
     `SELECT s.*, ag.name as agent_group_name, ag.folder as agent_group_folder,
               mg.channel_type, mg.platform_id, mg.name as messaging_group_name
        FROM sessions s
        LEFT JOIN agent_groups ag ON ag.id = s.agent_group_id
-       LEFT JOIN messaging_groups mg ON mg.id = s.messaging_group_id
-       ORDER BY s.last_active DESC NULLS LAST`,
+       LEFT JOIN messaging_groups mg ON mg.id = s.messaging_group_id`,
   );
+  // Most-recently-active first, sessions that never ran last. Sorted here, not
+  // in SQL: `ORDER BY ... DESC NULLS LAST` is SQLite/Postgres-only syntax, and
+  // getDb() fronts a dialect-agnostic driver (src/db/driver.ts). ISO-8601 UTC
+  // timestamps compare correctly as strings.
+  return [...rows].sort((a, b) => {
+    if (a.last_active === b.last_active) return a.id.localeCompare(b.id);
+    if (!a.last_active) return 1;
+    if (!b.last_active) return -1;
+    return a.last_active < b.last_active ? 1 : -1;
+  });
 }
 
 async function collectChannels() {
@@ -522,106 +579,89 @@ function localHourKey(d: Date): string {
     .replace(' ', 'T');
 }
 
-function collectActivity() {
-  const now = Date.now();
-  const buckets: Record<string, { inbound: number; outbound: number }> = {};
-
-  for (let i = 0; i < 24; i++) {
-    const key = localHourKey(new Date(now - i * 3600000));
-    buckets[key] = { inbound: 0, outbound: 0 };
-  }
-
-  const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
-  if (!fs.existsSync(sessionsDir)) return toBucketArray(buckets);
-
-  const cutoff = new Date(now - 86400000).toISOString();
-
-  try {
-    for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
-      const agPath = path.join(sessionsDir, agDir);
-      for (const sessDir of fs.readdirSync(agPath).filter((d) => d.startsWith('sess-'))) {
-        for (const [dbName, direction] of [
-          ['outbound.db', 'outbound'],
-          ['inbound.db', 'inbound'],
-        ] as const) {
-          const dbPath = path.join(agPath, sessDir, dbName);
-          if (!fs.existsSync(dbPath)) continue;
-          try {
-            const db = new Database(dbPath, { readonly: true });
-            const table = direction === 'outbound' ? 'messages_out' : 'messages_in';
-            const rows = db.prepare(`SELECT timestamp FROM ${table} WHERE timestamp > ?`).all(cutoff) as {
-              timestamp: string;
-            }[];
-            for (const row of rows) {
-              const key = localHourKey(new Date(row.timestamp));
-              if (buckets[key]) buckets[key][direction]++;
-            }
-            db.close();
-          } catch {
-            /* skip */
-          }
-        }
-      }
-    }
-  } catch {
-    /* skip */
-  }
-
-  return toBucketArray(buckets);
-}
-
 function toBucketArray(buckets: Record<string, { inbound: number; outbound: number }>) {
   return Object.entries(buckets)
     .map(([hour, counts]) => ({ hour, ...counts }))
     .sort((a, b) => a.hour.localeCompare(b.hour));
 }
 
-function collectMessages() {
-  const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
-  if (!fs.existsSync(sessionsDir)) return [];
+/** Newest messages read per session per side. Caps both consumers below. */
+const MAILBOX_READ_LIMIT = 500;
+/** What the Messages page shows per session per side. */
+const MESSAGES_PAGE_LIMIT = 50;
 
-  const results: Array<{ agentGroupId: string; sessionId: string; inbound: unknown[]; outbound: unknown[] }> = [];
-  const limit = 50;
+interface MailboxMessage {
+  timestamp: string;
+  kind: string;
+  content: string;
+}
 
-  try {
-    for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
-      const agPath = path.join(sessionsDir, agDir);
-      for (const sessDir of fs.readdirSync(agPath).filter((d) => d.startsWith('sess-'))) {
-        const inbound: unknown[] = [];
-        const outbound: unknown[] = [];
+/**
+ * Activity buckets (last 24 local hours) + the Messages page, in one pass.
+ *
+ * Reads through the host mailbox seam — `withExistingMailboxSession`, the same
+ * read path `ncl sessions history` uses — so this works on whatever mailbox
+ * implementation is composed, not just SQLite files under
+ * `data/v2-sessions/`. Sessions come from the central `sessions` table rather
+ * than a directory scan, and read-only callers never provision storage: a
+ * session with no mailbox yet resolves to `undefined` and is skipped.
+ *
+ * The seam serves the newest `MAILBOX_READ_LIMIT` messages per side, which is
+ * exactly the {timestamp, kind, content} triple the dashboard renders. A
+ * session with more than that inside 24h contributes only its newest
+ * MAILBOX_READ_LIMIT to the chart.
+ */
+async function collectSessionMailboxes(sessions: SessionRow[]): Promise<{
+  activity: Array<{ hour: string; inbound: number; outbound: number }>;
+  messages: Array<{
+    agentGroupId: string;
+    sessionId: string;
+    inbound: MailboxMessage[];
+    outbound: MailboxMessage[];
+  }>;
+}> {
+  const now = Date.now();
+  const buckets: Record<string, { inbound: number; outbound: number }> = {};
+  for (let i = 0; i < 24; i++) {
+    buckets[localHourKey(new Date(now - i * 3600000))] = { inbound: 0, outbound: 0 };
+  }
+  const cutoff = new Date(now - 86400000).toISOString();
+  const messages: Array<{
+    agentGroupId: string;
+    sessionId: string;
+    inbound: MailboxMessage[];
+    outbound: MailboxMessage[];
+  }> = [];
 
-        const inDbPath = path.join(agPath, sessDir, 'inbound.db');
-        if (fs.existsSync(inDbPath)) {
-          try {
-            const db = new Database(inDbPath, { readonly: true });
-            const rows = db.prepare('SELECT * FROM messages_in ORDER BY seq DESC LIMIT ?').all(limit);
-            inbound.push(...(rows as unknown[]).reverse());
-            db.close();
-          } catch {
-            /* skip */
-          }
-        }
+  for (const session of sessions) {
+    let history: { inbound: MailboxMessage[]; outbound: MailboxMessage[] } | undefined;
+    try {
+      history = await withExistingMailboxSession(session.agent_group_id, session.id, (mailbox) => ({
+        inbound: mailbox.getInboundHistory(MAILBOX_READ_LIMIT),
+        outbound: mailbox.getOutboundHistory(MAILBOX_READ_LIMIT),
+      }));
+    } catch (err) {
+      log.debug('Dashboard mailbox read failed', { sessionId: session.id, err });
+      continue;
+    }
+    if (!history) continue;
 
-        const outDbPath = path.join(agPath, sessDir, 'outbound.db');
-        if (fs.existsSync(outDbPath)) {
-          try {
-            const db = new Database(outDbPath, { readonly: true });
-            const rows = db.prepare('SELECT * FROM messages_out ORDER BY seq DESC LIMIT ?').all(limit);
-            outbound.push(...(rows as unknown[]).reverse());
-            db.close();
-          } catch {
-            /* skip */
-          }
-        }
-
-        if (inbound.length > 0 || outbound.length > 0) {
-          results.push({ agentGroupId: agDir, sessionId: sessDir, inbound, outbound });
-        }
+    for (const direction of ['inbound', 'outbound'] as const) {
+      for (const row of history[direction]) {
+        // Seam timestamps are ISO-8601 UTC, so the cutoff compares as a string.
+        if (!row.timestamp || row.timestamp <= cutoff) continue;
+        const key = localHourKey(new Date(row.timestamp));
+        if (buckets[key]) buckets[key][direction]++;
       }
     }
-  } catch {
-    /* skip */
+
+    // The seam returns newest-first; the Messages page reads chronologically.
+    const inbound = [...history.inbound].reverse().slice(-MESSAGES_PAGE_LIMIT);
+    const outbound = [...history.outbound].reverse().slice(-MESSAGES_PAGE_LIMIT);
+    if (inbound.length > 0 || outbound.length > 0) {
+      messages.push({ agentGroupId: session.agent_group_id, sessionId: session.id, inbound, outbound });
+    }
   }
 
-  return results;
+  return { activity: toBucketArray(buckets), messages };
 }

--- a/.claude/skills/add-dashboard/resources/dashboard-wiring.test.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-wiring.test.ts
@@ -19,6 +19,13 @@
  * the three together cover deletion, misplacement, drift, and behavior — for
  * a true code edit, with no registry required.
  *
+ * Startup is the skill's only edit to core: teardown rides the host's
+ * `onHostShutdown` registry from inside dashboard-pusher.ts, so it is a
+ * behavior test in dashboard-pusher.test.ts rather than an assertion here.
+ *
+ * The second describe guards the pusher's two read boundaries, which no
+ * behavior test can see on the default all-SQLite composition.
+ *
  * Ships with the skill; apply copies it to src/.
  */
 import { describe, it, expect } from 'vitest';
@@ -29,6 +36,34 @@ import ts from 'typescript';
 const indexPath = path.resolve(process.cwd(), 'src/index.ts');
 const source = fs.readFileSync(indexPath, 'utf8');
 const sf = ts.createSourceFile('index.ts', source, ts.ScriptTarget.Latest, true);
+
+const pusherPath = path.resolve(process.cwd(), 'src/dashboard-pusher.ts');
+const pusherSf = ts.createSourceFile(
+  'dashboard-pusher.ts',
+  fs.readFileSync(pusherPath, 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+);
+
+/** Module specifiers the pusher imports — code, so comments can't fake it. */
+function pusherImports(): string[] {
+  const specifiers: string[] = [];
+  pusherSf.forEachChild((n) => {
+    if (ts.isImportDeclaration(n) && ts.isStringLiteral(n.moduleSpecifier)) specifiers.push(n.moduleSpecifier.text);
+  });
+  return specifiers;
+}
+
+/** Every string/template literal in the pusher — the SQL and paths it runs. */
+function pusherLiterals(): string[] {
+  const literals: string[] = [];
+  const walk = (node: ts.Node): void => {
+    if (ts.isStringLiteralLike(node) || ts.isTemplateLiteralToken(node)) literals.push(node.text);
+    node.forEachChild(walk);
+  };
+  pusherSf.forEachChild(walk);
+  return literals;
+}
 
 function mainBody(): ts.NodeArray<ts.Statement> {
   let body: ts.NodeArray<ts.Statement> | undefined;
@@ -70,12 +105,46 @@ describe('add-dashboard wiring in src/index.ts', () => {
     const migrateIdx = stmts.findIndex((s) => s.getText(sf).includes('runMigrations('));
     const runningIdx = stmts.findIndex((s) => s.getText(sf).includes("log.info('NanoClaw running')"));
 
-    expect(importIdx, "dynamic import('./dashboard-pusher.js') must be a statement of main()").toBeGreaterThanOrEqual(0);
+    expect(importIdx, "dynamic import('./dashboard-pusher.js') must be a statement of main()").toBeGreaterThanOrEqual(
+      0,
+    );
     expect(callIdx, 'await startDashboard() must be a statement of main()').toBeGreaterThanOrEqual(0);
     expect(migrateIdx, 'runMigrations() anchor not found').toBeGreaterThanOrEqual(0);
     expect(runningIdx, 'boot-complete log anchor not found').toBeGreaterThanOrEqual(0);
     expect(importIdx, 'the dynamic import must come after DB init').toBeGreaterThan(migrateIdx);
     expect(callIdx, 'the call must come after its import (colocated)').toBeGreaterThan(importIdx);
     expect(callIdx, 'startDashboard() must run before the boot-complete log').toBeLessThan(runningIdx);
+  });
+});
+
+/**
+ * The pusher's two read boundaries. Both are invisible to a behavior test on
+ * the default composition — SQLite central DB, SQLite session mailboxes — so
+ * they are asserted on the source: a regression here would keep every test
+ * green locally and only fail on someone else's backend.
+ */
+describe('add-dashboard read boundaries in src/dashboard-pusher.ts', () => {
+  it('never opens session storage directly — per-session reads go through the mailbox seam', () => {
+    const imports = pusherImports();
+    expect(imports, 'session messages must be read through the seam, not a better-sqlite3 handle').not.toContain(
+      'better-sqlite3',
+    );
+    expect(imports, 'the pusher reads sessions via session-manager (withExistingMailboxSession)').toContain(
+      './session-manager.js',
+    );
+    for (const literal of pusherLiterals()) {
+      expect(literal, 'the mailbox owns its storage layout — no session DB file paths here').not.toMatch(
+        /(in|out)bound\.db/,
+      );
+    }
+  });
+
+  it('keeps its central-DB queries dialect-agnostic', () => {
+    // getDb() fronts a driver that is not necessarily SQLite (src/db/driver.ts).
+    for (const literal of pusherLiterals()) {
+      for (const construct of ['NULLS LAST', 'NULLS FIRST', "datetime('now')", 'strftime(']) {
+        expect(literal, `${construct} is backend-specific; keep it out of getDb() queries`).not.toContain(construct);
+      }
+    }
   });
 });


### PR DESCRIPTION
Stacked on #3408. Audit verdict: healthiest of the twelve — minor drift only, but plenty of it.

## What changed

- Ships the mandatory REMOVE.md (apply leaves 3 files, a dep, a src/index.ts edit and 2 .env lines); the dependency is now exactly pinned like every other skill.
- `collectSessions()` no longer sends SQLite-only `NULLS LAST` through the dialect-agnostic async DbDriver; `stopDashboardPusher()`/`stopDashboard()` are wired into the host shutdown path instead of leaking two timers and a socket through teardown.
- Docs: the smoke-check curl gains its required Authorization header (following the skill as written produced a 401 that read as a failed install); the wrong step-number reference fixed; the 0.0.0.0-plus-bearer-token network exposure is now stated plainly; the fresh-worktree upgrade-tripwire recovery step added to Troubleshooting.

## Verification

Applied end to end; pusher e2e against a mock ingest endpoint delivers a well-formed snapshot from the async central DB. All gates green (158 files / 1939 host tests applied). Deferred upstream: `@nanoco/nanoclaw-dashboard@0.3.0` hardcodes `server.listen(port, '0.0.0.0')` — a localhost default needs a package release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhS5pL3inQ46UdQUvo4g56