### PR TITLE
fix(add-macos-statusbar): make Swift code and plist labels slug-aware

### DIFF
--- a/.claude/skills/add-macos-statusbar/REMOVE.md
+++ b/.claude/skills/add-macos-statusbar/REMOVE.md
@@ -4,16 +4,20 @@ Every step is idempotent — safe to re-run.
 
 ## 1. Unload the launchd service
 
+Compute the install slug to find the correct plist:
+
 ```bash
-launchctl bootout gui/$(id -u)/com.nanoclaw.statusbar 2>/dev/null \
-  || launchctl unload ~/Library/LaunchAgents/com.nanoclaw.statusbar.plist 2>/dev/null \
+INSTALL_SLUG=$(echo -n "$(pwd)" | shasum | cut -c1-8)
+launchctl bootout gui/$(id -u)/com.nanoclaw-v2-${INSTALL_SLUG}.statusbar 2>/dev/null \
+  || launchctl unload ~/Library/LaunchAgents/com.nanoclaw-v2-${INSTALL_SLUG}.statusbar.plist 2>/dev/null \
   || true
 ```
 
 ## 2. Delete the produced files
 
 ```bash
-rm -f ~/Library/LaunchAgents/com.nanoclaw.statusbar.plist \
+INSTALL_SLUG=$(echo -n "$(pwd)" | shasum | cut -c1-8)
+rm -f ~/Library/LaunchAgents/com.nanoclaw-v2-${INSTALL_SLUG}.statusbar.plist \
       dist/statusbar \
       logs/statusbar.log \
       logs/statusbar.error.log

--- a/.claude/skills/add-macos-statusbar/SKILL.md
+++ b/.claude/skills/add-macos-statusbar/SKILL.md
@@ -37,10 +37,14 @@ If not found, tell the user:
 ### Check if already installed
 
 ```bash
-launchctl list | grep com.nanoclaw.statusbar
+launchctl list | grep com.nanoclaw-v2
 ```
 
-If it returns a PID (not `-`), tell the user it's already installed and skip to Phase 3 (Verify).
+If it returns entries with PIDs (not `-`), tell the user the statusbar is already installed and skip to Phase 3 (Verify).
+
+#### About install slugs
+
+Each NanoClaw install gets a unique identifier (the "install slug") derived from the project root: `sha1(projectRoot)[:8]` in hex. This ensures multiple installs on the same Mac don't conflict. The statusbar service is named `com.nanoclaw-v2-{slug}.statusbar`, and the launchd plist is `com.nanoclaw-v2-{slug}.statusbar.plist`. The Swift binary computes this slug automatically at runtime.
 
 ## Phase 2: Compile and Install
 
@@ -63,23 +67,28 @@ xattr -cr dist/statusbar
 
 ### Create the launchd plist
 
-Determine the absolute project root and home directory:
+First, compute the install slug (same way the Swift binary does it):
 
 ```bash
-pwd
-echo $HOME
+INSTALL_SLUG=$(echo -n "$(pwd)" | shasum | cut -c1-8)
 ```
 
-Create `~/Library/LaunchAgents/com.nanoclaw.statusbar.plist`, substituting the actual values
-for `{PROJECT_ROOT}` and `{HOME}`:
+Then create the plist file. Substitute the actual values for `{PROJECT_ROOT}` and `{HOME}`:
 
-```xml
+```bash
+PROJECT_ROOT=$(pwd)
+HOME=$HOME
+INSTALL_SLUG=$(echo -n "$PROJECT_ROOT" | shasum | cut -c1-8)
+
+mkdir -p ~/Library/LaunchAgents
+
+cat > ~/Library/LaunchAgents/com.nanoclaw-v2-${INSTALL_SLUG}.statusbar.plist <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.nanoclaw.statusbar</string>
+    <string>com.nanoclaw-v2-{INSTALL_SLUG}.statusbar</string>
     <key>ProgramArguments</key>
     <array>
         <string>{PROJECT_ROOT}/dist/statusbar</string>
@@ -99,18 +108,23 @@ for `{PROJECT_ROOT}` and `{HOME}`:
     <string>{PROJECT_ROOT}/logs/statusbar.error.log</string>
 </dict>
 </plist>
+EOF
 ```
+
+**Note:** Replace `{INSTALL_SLUG}`, `{PROJECT_ROOT}`, and `{HOME}` with the actual values from the commands above.
 
 ### Load the service
 
 ```bash
-launchctl load ~/Library/LaunchAgents/com.nanoclaw.statusbar.plist
+INSTALL_SLUG=$(echo -n "$(pwd)" | shasum | cut -c1-8)
+launchctl load ~/Library/LaunchAgents/com.nanoclaw-v2-${INSTALL_SLUG}.statusbar.plist
 ```
 
 ## Phase 3: Verify
 
 ```bash
-launchctl list | grep com.nanoclaw.statusbar
+INSTALL_SLUG=$(echo -n "$(pwd)" | shasum | cut -c1-8)
+launchctl list | grep com.nanoclaw-v2-${INSTALL_SLUG}.statusbar
 ```
 
 The first column should show a PID (not `-`).

--- a/.claude/skills/add-macos-statusbar/add/src/statusbar.swift
+++ b/.claude/skills/add-macos-statusbar/add/src/statusbar.swift
@@ -1,11 +1,10 @@
 import AppKit
+import Foundation
 
 class StatusBarController: NSObject {
     private var statusItem: NSStatusItem!
     private var isRunning = false
     private var timer: Timer?
-
-    private let plistPath = "\(NSHomeDirectory())/Library/LaunchAgents/com.nanoclaw.plist"
 
     /// Derive the NanoClaw project root from the binary location.
     /// The binary is compiled to {project}/dist/statusbar, so the parent of
@@ -14,6 +13,38 @@ class StatusBarController: NSObject {
         let binary = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
         return binary.deletingLastPathComponent().deletingLastPathComponent().path
     }()
+
+    /// Compute the install slug (sha1(projectRoot)[:8]) to make service labels unique per install.
+    /// Uses `echo -n <projectRoot> | shasum` to compute the hash.
+    private static let installSlug: String = {
+        let task = Process()
+        task.launchPath = "/bin/sh"
+        task.arguments = ["-c", "echo -n '\(projectRoot.replacingOccurrences(of: "'", with: "'\\''"))' | shasum | cut -c1-8"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "default"
+            return output.isEmpty ? "default" : output
+        } catch {
+            return "default"
+        }
+    }()
+
+    /// Main NanoClaw service label: com.nanoclaw-v2-{slug}
+    private static let mainServiceLabel: String = "com.nanoclaw-v2-\(installSlug)"
+
+    /// Statusbar service label: com.nanoclaw-v2-{slug}.statusbar
+    private static let statusbarLabel: String = "com.nanoclaw-v2-\(installSlug).statusbar"
+
+    /// Plist path for the statusbar service
+    private let statusbarPlistPath: String = "\(NSHomeDirectory())/Library/LaunchAgents/com.nanoclaw-v2-\(StatusBarController.installSlug).statusbar.plist"
+
+    /// Plist path for the main NanoClaw service
+    private let mainPlistPath: String = "\(NSHomeDirectory())/Library/LaunchAgents/com.nanoclaw-v2-\(StatusBarController.installSlug).plist"
 
     override init() {
         super.init()
@@ -47,7 +78,7 @@ class StatusBarController: NSObject {
     private func checkRunning() -> Bool {
         let task = Process()
         task.launchPath = "/bin/launchctl"
-        task.arguments = ["list", "com.nanoclaw"]
+        task.arguments = ["list", StatusBarController.mainServiceLabel]
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = Pipe()
@@ -100,18 +131,18 @@ class StatusBarController: NSObject {
     }
 
     @objc private func startService() {
-        run("/bin/launchctl", ["load", plistPath])
+        run("/bin/launchctl", ["load", mainPlistPath])
         refresh(after: 2)
     }
 
     @objc private func stopService() {
-        run("/bin/launchctl", ["unload", plistPath])
+        run("/bin/launchctl", ["unload", mainPlistPath])
         refresh(after: 2)
     }
 
     @objc private func restartService() {
         let uid = getuid()
-        run("/bin/launchctl", ["kickstart", "-k", "gui/\(uid)/com.nanoclaw"])
+        run("/bin/launchctl", ["kickstart", "-k", "gui/\(uid)/\(StatusBarController.mainServiceLabel)"])
         refresh(after: 3)
     }
 


### PR DESCRIPTION
Stacked on #3408.

## What changed

- The Swift code hardcoded `com.nanoclaw.plist` and checked launchctl for `com.nanoclaw` — labels trunk retired for `com.nanoclaw-v2-<installSlug>` (sha1(projectRoot)[:8], per `src/install-slug.ts`). On any current install the statusbar watched a service that doesn't exist. The Swift code now derives the slug from the projectRoot it already computes.
- The statusbar's own service label is versioned too (`com.nanoclaw-v2-<slug>.statusbar`) so two installs on one Mac don't fight over it; SKILL.md and REMOVE.md updated to match, with slug derivation explained.

## Verification

macOS-only skill audited/fixed on Linux: changes verified by careful review against `src/install-slug.ts` (whose sh/ts parity test lives on the base branch); no Swift compilation was possible here — flagged for a quick smoke on a Mac before merge. Host/container suites green (the skill touches no trunk code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhS5pL3inQ46UdQUvo4g56