### PR TITLE
fix(router): mention-sticky subscribes on a mention, not on a session…

### DIFF
--- a/docs/db-session.md
+++ b/docs/db-session.md
@@ -53,6 +53,9 @@ CREATE TABLE messages_in (
   on_wake        INTEGER NOT NULL DEFAULT 0 -- 1 = only deliver on container's first poll
 );
 CREATE INDEX idx_messages_in_series ON messages_in(series_id);
+-- Partial index over the rows that woke the agent. Backs "has this session
+-- ever engaged?", which mention-sticky asks per inbound message.
+CREATE INDEX idx_messages_in_engaged ON messages_in(seq) WHERE trigger = 1;
 ```
 
 Content shapes: see [api-details.md §Session DB Schema Details](api-details.md#session-db-schema-details).

--- a/src/mailbox/sqlite/index.ts
+++ b/src/mailbox/sqlite/index.ts
@@ -172,6 +172,19 @@ function getTaskStats(db: Database.Database, seriesId: string): TaskStats {
   };
 }
 
+/**
+ * The rows where the chat itself addressed the agent: a real chat message
+ * that woke it. Excludes ambient context the agent was never asked about
+ * (trigger = 0) and traffic the runtime injected on its own — cross-session
+ * echoes and agent-to-agent messages.
+ *
+ * `idx_messages_in_engaged` covers exactly this set, so a session that has
+ * never engaged answers from an empty index rather than a full scan.
+ */
+const ENGAGED_MESSAGE_WHERE =
+  "kind IN ('chat','chat-sdk') AND trigger = 1 " +
+  "AND (channel_type IS NULL OR channel_type NOT IN ('session-echo', 'agent'))";
+
 export function wrapSqliteInbound(db: Database.Database, nextSequence = () => nextEvenAcross(db)): InboundMailbox {
   return {
     setRouting: (routing) => {
@@ -269,14 +282,12 @@ export function wrapSqliteInbound(db: Database.Database, nextSequence = () => ne
       ).map((row) => ({ ...row, timestamp: sqliteTimestamp(row.timestamp) })),
     getConversationRoot: () => {
       const row = db
-        .prepare(
-          "SELECT timestamp, content FROM messages_in WHERE kind IN ('chat','chat-sdk') " +
-            "AND trigger = 1 AND (channel_type IS NULL OR channel_type NOT IN ('session-echo', 'agent')) " +
-            'ORDER BY seq ASC LIMIT 1',
-        )
+        .prepare(`SELECT timestamp, content FROM messages_in WHERE ${ENGAGED_MESSAGE_WHERE} ORDER BY seq ASC LIMIT 1`)
         .get() as MailboxTimelineMessage | undefined;
       return row && { ...row, timestamp: sqliteTimestamp(row.timestamp) };
     },
+    hasEngagedMessage: () =>
+      db.prepare(`SELECT 1 FROM messages_in WHERE ${ENGAGED_MESSAGE_WHERE} LIMIT 1`).get() !== undefined,
     findTaskBySeriesSlug: (slug) => {
       const pattern = `${slug}-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]`;
       const row = db

--- a/src/mailbox/sqlite/schema.ts
+++ b/src/mailbox/sqlite/schema.ts
@@ -19,6 +19,10 @@ CREATE TABLE IF NOT EXISTS messages_in (
   on_wake        INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_messages_in_series ON messages_in(series_id);
+-- Partial: only the rows that woke the agent. "Has this session ever engaged?"
+-- is asked per inbound message on sticky wirings, and the answer is most often
+-- no — which is exactly when an unindexed lookup would scan the whole backlog.
+CREATE INDEX IF NOT EXISTS idx_messages_in_engaged ON messages_in(seq) WHERE trigger = 1;
 
 CREATE TABLE IF NOT EXISTS delivered (
   message_out_id      TEXT PRIMARY KEY,

--- a/src/mailbox/sqlite/session-db.test.ts
+++ b/src/mailbox/sqlite/session-db.test.ts
@@ -90,6 +90,40 @@ describe('migrateMessagesInTable', () => {
     expect(getInboundSourceSessionId(db, 'does-not-exist')).toBeNull();
     db.close();
   });
+
+  it('indexes engaged messages on a legacy DB that has no trigger column yet', () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+
+    const db = new Database(DB_PATH);
+    db.exec(`
+      CREATE TABLE messages_in (
+        id             TEXT PRIMARY KEY,
+        seq            INTEGER UNIQUE,
+        kind           TEXT NOT NULL,
+        timestamp      TEXT NOT NULL,
+        status         TEXT DEFAULT 'pending',
+        process_after  TEXT,
+        recurrence     TEXT,
+        tries          INTEGER DEFAULT 0,
+        platform_id    TEXT,
+        channel_type   TEXT,
+        thread_id      TEXT,
+        content        TEXT NOT NULL
+      );
+    `);
+
+    // The index is partial over `trigger`, so it can only be created after
+    // that column has been added — this throws if the order ever slips.
+    migrateMessagesInTable(db);
+    migrateMessagesInTable(db); // idempotent
+
+    const indexes = (db.prepare("PRAGMA index_list('messages_in')").all() as Array<{ name: string }>).map(
+      (i) => i.name,
+    );
+    expect(indexes).toContain('idx_messages_in_engaged');
+    db.close();
+  });
 });
 
 describe('syncProcessingAcks — script-skip counter', () => {

--- a/src/mailbox/sqlite/session-db.ts
+++ b/src/mailbox/sqlite/session-db.ts
@@ -309,6 +309,10 @@ export function migrateMessagesInTable(db: Database.Database): void {
     // All existing rows are normal messages, so default 0.
     db.prepare('ALTER TABLE messages_in ADD COLUMN on_wake INTEGER NOT NULL DEFAULT 0').run();
   }
+  // Last, because the partial index is over `trigger` — the column has to
+  // exist by now. Unconditional: it postdates the baseline schema, so DBs
+  // created before it have every other column and still no index.
+  db.prepare('CREATE INDEX IF NOT EXISTS idx_messages_in_engaged ON messages_in(seq) WHERE trigger = 1').run();
 }
 
 /**

--- a/src/mailbox/sqlite/sqlite.test.ts
+++ b/src/mailbox/sqlite/sqlite.test.ts
@@ -172,4 +172,29 @@ describe('SQLite mailbox canonical serialization', () => {
       { timestamp: '2026-01-01T00:00:04.000Z', content: '{"text":"top level"}' },
     ]);
   });
+
+  it('counts only chat messages that woke the agent as engagement', () => {
+    const inboundDb = new Database(':memory:');
+    databases.push(inboundDb);
+    inboundDb.exec(INBOUND_SCHEMA);
+    const inbound = wrapSqliteInbound(inboundDb);
+    const insert = (id: string, seq: number, kind: string, channelType: string | null, trigger: 0 | 1) =>
+      inboundDb
+        .prepare(
+          `INSERT INTO messages_in (id, seq, timestamp, kind, channel_type, content, trigger)
+           VALUES (?, ?, '2026-01-01T00:00:00.000Z', ?, ?, '{"text":"x"}', ?)`,
+        )
+        .run(id, seq, kind, channelType, trigger);
+
+    expect(inbound.hasEngagedMessage()).toBe(false);
+
+    insert('ambient', 2, 'chat', 'slack', 0); // accumulated context
+    insert('echo', 4, 'chat', 'session-echo', 1); // fanned from a sibling session
+    insert('a2a', 6, 'chat', 'agent', 1); // another agent, not this chat
+    insert('task', 8, 'task', 'slack', 1); // a scheduled run, not a mention
+    expect(inbound.hasEngagedMessage()).toBe(false);
+
+    insert('real', 10, 'chat-sdk', 'slack', 1);
+    expect(inbound.hasEngagedMessage()).toBe(true);
+  });
 });

--- a/src/mailbox/types.ts
+++ b/src/mailbox/types.ts
@@ -120,6 +120,15 @@ export interface InboundMailbox {
   prunePendingMessages(channelType: string, before: string, keep: number): number;
   getInboundHistory(limit: number): MailboxHistoryMessage[];
   getConversationRoot(): MailboxTimelineMessage | undefined;
+  /**
+   * True once a message from this session's own chat has woken the agent —
+   * someone addressed it here, rather than the session merely existing.
+   *
+   * The distinction matters because sessions are also created to hold
+   * context the agent was never asked about: accumulated ambient chatter,
+   * cross-session echoes, agent-to-agent traffic. None of those count.
+   */
+  hasEngagedMessage(): boolean;
   findTaskBySeriesSlug(slug: string): TaskRecord | undefined;
 }
 

--- a/src/router-mention-sticky.test.ts
+++ b/src/router-mention-sticky.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Mention-sticky engagement: a thread is sticky because we were mentioned in
+ * it once, not because a session row happens to exist for it.
+ *
+ * The distinction is load-bearing when the wiring also accumulates ignored
+ * messages: accumulation writes ambient chatter into a session (creating it
+ * on first use) precisely so the context is there if the thread ever engages
+ * us. That must not itself be the engagement.
+ *
+ * Exercised through the REAL routeInbound path, with `wakeContainer` standing
+ * in for "the agent was asked to respond".
+ */
+import fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  initTestDb,
+  closeDb,
+  runMigrations,
+  createAgentGroup,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+} from './db/index.js';
+import { initChannelAdapters, registerChannelAdapter, teardownChannelAdapters } from './channels/channel-registry.js';
+import { routeInbound } from './router.js';
+import type { ChannelAdapter, ChannelDefaults } from './channels/adapter.js';
+import type { MessagingGroupAgent } from './types.js';
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(true),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-mention-sticky' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-mention-sticky';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const channelDefaults: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'public' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+function makeAdapter(): ChannelAdapter {
+  return {
+    name: 'testchat',
+    channelType: 'testchat',
+    supportsThreads: true,
+    defaults: channelDefaults,
+    setup: async () => {},
+    teardown: async () => {},
+    isConnected: () => true,
+    deliver: async () => undefined,
+  };
+}
+
+async function activate(): Promise<void> {
+  registerChannelAdapter('testchat', { factory: () => makeAdapter(), defaults: channelDefaults });
+  await initChannelAdapters(() => ({
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+}
+
+async function seedWiring(
+  options: {
+    engageMode?: MessagingGroupAgent['engage_mode'];
+    ignoredMessagePolicy?: 'drop' | 'accumulate';
+  } = {},
+): Promise<void> {
+  await createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  await createMessagingGroup({
+    id: 'mg-1',
+    channel_type: 'testchat',
+    platform_id: 'testchat:C1',
+    instance: 'testchat',
+    name: 'Test Chat',
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  await createMessagingGroupAgent({
+    id: 'mga-1',
+    messaging_group_id: 'mg-1',
+    agent_group_id: 'ag-1',
+    engage_mode: options.engageMode ?? 'mention-sticky',
+    engage_pattern: null,
+    sender_scope: 'all',
+    ignored_message_policy: options.ignoredMessagePolicy ?? 'accumulate',
+    session_mode: 'per-thread',
+    priority: 0,
+    threads: 1,
+    created_at: now(),
+  });
+}
+
+const THREAD = 'testchat:C1:171';
+
+async function inbound(id: string, text: string, isMention: boolean, threadId: string | null = THREAD): Promise<void> {
+  await routeInbound({
+    channelType: 'testchat',
+    platformId: 'testchat:C1',
+    threadId,
+    message: {
+      id,
+      kind: 'chat-sdk',
+      content: JSON.stringify({ sender: 'Gavriel', senderId: 'U1', text }),
+      timestamp: now(),
+      isMention,
+      isGroup: true,
+    },
+  });
+}
+
+async function wakes(): Promise<number> {
+  const { wakeContainer } = await import('./container-runner.js');
+  return vi.mocked(wakeContainer).mock.calls.length;
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  vi.clearAllMocks();
+  await runMigrations(await initTestDb());
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  await closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('mention-sticky engagement', () => {
+  it('stays silent through ambient chatter it only accumulated', async () => {
+    await activate();
+    await seedWiring();
+
+    // The first message creates the session as accumulated context...
+    await inbound('m1', 'morning all', false);
+    // ...and the second must not read that session into a subscription.
+    await inbound('m2', 'anyone seen the deploy?', false);
+    await inbound('m3', 'never mind, found it', false);
+
+    expect(await wakes()).toBe(0);
+  });
+
+  it('sticks to the thread once it has been mentioned in it', async () => {
+    await activate();
+    await seedWiring();
+
+    await inbound('m1', 'ambient', false);
+    await inbound('m2', '@bot can you look at this', true);
+    expect(await wakes()).toBe(1);
+
+    // Follow-ups in the same thread need no second mention.
+    await inbound('m3', 'and the one after it', false);
+    expect(await wakes()).toBe(2);
+  });
+
+  it('is sticky per thread, not per chat', async () => {
+    await activate();
+    await seedWiring();
+
+    await inbound('m1', '@bot over here', true, 'testchat:C1:171');
+    expect(await wakes()).toBe(1);
+
+    // A different thread in the same chat was never engaged.
+    await inbound('m2', 'unrelated chatter', false, 'testchat:C1:942');
+    expect(await wakes()).toBe(1);
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,7 +31,12 @@ import { findSessionForAgent } from './db/sessions.js';
 import { backfillNewSession, fanInboundMessage } from './modules/cross-session-context/index.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
-import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
+import {
+  resolveSession,
+  withExistingMailboxSession,
+  writeSessionMessage,
+  writeOutboundDirect,
+} from './session-manager.js';
 import { wakeContainer } from './container-runner.js';
 import { getSession } from './db/sessions.js';
 import type { AgentGroup, MessagingGroup, MessagingGroupAgent, Session } from './types.js';
@@ -468,11 +473,10 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
  *                      user wants to disambiguate between multiple agents
  *                      wired to one chat, use engage_mode='pattern' with
  *                      the disambiguator as the regex.
- *   'mention-sticky' — platform mention OR an active per-thread session
- *                      already exists for this (agent, mg, thread). The
- *                      session existence IS our subscription state; once
- *                      a thread has engaged us once, follow-ups arrive
- *                      with no mention and should still fire.
+ *   'mention-sticky' — platform mention OR this (agent, mg, thread) has
+ *                      been mentioned before; once a thread has engaged us
+ *                      once, follow-ups arrive with no mention and should
+ *                      still fire.
  */
 async function evaluateEngage(
   agent: MessagingGroupAgent,
@@ -496,11 +500,18 @@ async function evaluateEngage(
       return isMention;
     case 'mention-sticky': {
       if (isMention) return true;
-      // Sticky follow-up: session already exists for this (agent, mg, thread)
-      // — the thread was activated before, keep firing.
       if (mg.is_group === 0) return false; // DMs never use mention-sticky sensibly
+      // Sticky follow-up: the thread activated us before, so keep firing. A
+      // session row is not that evidence — one also gets created to hold
+      // ambient chatter under ignored_message_policy='accumulate', and
+      // accumulating context we were never asked about must not be what
+      // subscribes us. Ask the mailbox whether anything in it ever woke us.
       const existing = await findSessionForAgent(agent.agent_group_id, mg.id, threadId);
-      return existing !== undefined;
+      if (!existing) return false;
+      const engaged = await withExistingMailboxSession(existing.agent_group_id, existing.id, (mailbox) =>
+        mailbox.hasEngagedMessage(),
+      );
+      return engaged ?? false;
     }
     default:
       // Unrecognized engage_mode (e.g. stale data from a past CLI version,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #3369.

On a `mention-sticky` wiring, the agent starts replying to a group it was never
addressed in. `evaluateEngage` in `src/router.ts` asked whether a session row
existed for `(agent, messaging group, thread)` and treated that as the
subscription. But a session row is also created for context the agent was never
asked about: with `ignored_message_policy='accumulate'`, the *first* ambient
message in a group creates the session to hold it, so the *second* one finds a
session and engages. Accumulation exists so the history is there if the thread
ever engages the agent — it must not itself be the engagement.

The evidence for "were we ever addressed here" is already recorded:
`messages_in.trigger` is `1` for a message that woke the agent and `0` for one
stored as context only. So the fix asks the mailbox — a new
`hasEngagedMessage()` on `InboundMailbox` — instead of inferring it from the
session's existence.

Deriving it rather than storing it is deliberate. A `sessions.subscribed`
column would need a backfill value for every existing row, and there is no
correct one: default `1` and every already-mis-engaged install stays
mis-engaged; default `0` and threads people rely on go silent. Reading the
history each session already has gives the right answer for old and new
installs alike, with no second copy of the state to drift.

What counts as engagement is narrow, and shared with `getConversationRoot` as
`ENGAGED_MESSAGE_WHERE`: a `chat` or `chat-sdk` row with `trigger = 1`, minus
the traffic the runtime injects on its own — cross-session echoes
(`channel_type = 'session-echo'`) and agent-to-agent messages
(`channel_type = 'agent'`). Neither is this chat asking for anything. DMs still
return early, as before.

**Performance.** This runs per inbound message on a sticky wiring, and the
common answer is "never engaged" — precisely the case an unindexed lookup would
pay a full backlog scan for. It is backed by a partial index,
`idx_messages_in_engaged ON messages_in(seq) WHERE trigger = 1`, so a session
that has only ever accumulated answers from an empty index
(`EXPLAIN QUERY PLAN` reports `SCAN messages_in USING INDEX
idx_messages_in_engaged`).

Session DBs have no numbered migrations, and `ensureSchema` only runs when the
file does not yet exist — so the index is added in both places that matter:
`INBOUND_SCHEMA` for new sessions, and the lazy on-open
`migrateMessagesInTable` for existing ones. In the migration it comes last,
after the `trigger` column's `ALTER`, since the index is partial over that
column.

**Tests.** Five new, all failing before the change for the right reason.

- `src/router-mention-sticky.test.ts` (new, 3 cases) drives the real
  `routeInbound` with `wakeContainer` standing in for "the agent was asked to
  respond": it stays silent through ambient chatter it only accumulated (this
  is the reported bug — 2 spurious wakes before, 0 after), it sticks to a
  thread after one mention with no second mention needed, and it stays sticky
  per thread rather than per chat.
- `src/mailbox/sqlite/sqlite.test.ts` pins what does *not* count as engagement:
  accumulated context, a session echo, an agent-to-agent message, and a
  scheduled task run all leave it `false`; a real chat message flips it.
- `src/mailbox/sqlite/session-db.test.ts` migrates a legacy `messages_in` with
  no `trigger` column and asserts the index exists afterwards — the ordering
  inside the migration is load-bearing, and this fails loudly if it slips.

`docs/db-session.md` §2.1 documents the index alongside the schema.

`tsc --noEmit` and `pnpm run build` are clean. The mailbox and router files
run 44/44. On the full host suite 12 tests fail, all of which reproduce
identically on unmodified `main` and are environmental here — 9 in
`src/webhook-server*.test.ts` and `src/webhook-server-raw.test.ts` (a local TLS
proxy intercepts the loopback request) and 3 in `src/cli/stdin-json*.test.ts`
(they compare stderr verbatim, and this environment injects a Node
experimental-feature warning). None of those files is touched here. The change
is host-only; nothing in `container/agent-runner/` is affected.

## For Skills

Not a skill PR — no skill files are touched.

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
