### PR TITLE
fix(add-slack): add missing app_mentions:read bot scope

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -96,7 +96,7 @@ For Socket Mode, tell the user:
 ```nc:operator when:connection=socket
 Create the Slack app (Socket Mode):
 1. Go to api.slack.com/apps and create a new app using whichever creation flow is currently available (e.g. starting from scratch or from a manifest). Name it (e.g. "NanoClaw") and pick your workspace.
-2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
+2. OAuth & Permissions → add these Bot Token Scopes: app_mentions:read, chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Basic Information → App-Level Tokens → "Generate Token and Scopes" → add the connections:write scope → copy the token (starts with xapp-).
 5. Socket Mode → toggle "Enable Socket Mode" on.
@@ -108,7 +108,7 @@ For webhook delivery, tell the user:
 ```nc:operator when:connection=webhook
 Create the Slack app (webhook delivery):
 1. Go to api.slack.com/apps and create a new app using whichever creation flow is currently available (e.g. starting from scratch or from a manifest). Name it (e.g. "NanoClaw") and pick your workspace.
-2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
+2. OAuth & Permissions → add these Bot Token Scopes: app_mentions:read, chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.
 3. App Home → enable the Messages Tab, and check "Allow users to send Slash commands and messages from the messages tab."
 4. Install to Workspace, then copy the Bot User OAuth Token (starts with xoxb-).
 5. Basic Information → copy the Signing Secret.


### PR DESCRIPTION
## Problem

`/add-slack` step 6 subscribes the bot to the `app_mention` event:

> 6. Event Subscriptions → ... under "Subscribe to bot events" add: message.channels, message.groups, message.im, **app_mention**.

But the scope list in step 2 omits `app_mentions:read`, which that event requires:

> 2. OAuth & Permissions → add these Bot Token Scopes: chat:write, im:write, channels:history, groups:history, im:history, channels:read, groups:read, mpim:read, users:read, reactions:write, files:read, files:write.

Following the walkthrough literally produces an app that cannot receive `app_mention`. That matters here because the wiring's default `engage_mode` is `mention` / `mention-sticky`, so a channel-wired agent stays silent.

## How it surfaced

Creating the app from a manifest built out of the documented scope list is rejected with:

> We can't translate a manifest with errors.

Slack highlights the `bot_events` block, not the missing scope, so the message points away from the cause. Adding `app_mentions:read` clears it immediately; the app then creates with 13 scopes and all 4 bot events, and an `@mention` in a private channel gets a reply over Socket Mode.

## Change

Adds `app_mentions:read` to the scope list. Applied to **both** the Socket Mode and webhook variants, which carry the same list. Docs only, no code, no behavior change to existing installs.

Existing installs that already receive mentions are unaffected. Anyone whose bot ignores `@mention` can add the single scope in **OAuth & Permissions** and reinstall.

## Verified on

Fresh v2 install (local build), Linux/WSL2, Docker Engine, Socket Mode, private Slack channel.