### PR TITLE
feat(slack-agent-flow): carry the template ref through Slack creation (re-port)

### DIFF
--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -28,7 +28,14 @@ import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
-import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
+import {
+  buildCreateAgentHoldPayload,
+  createAgent,
+  formatTemplateProvenance,
+  requestCreateAgentHold,
+  templateApprovalNote,
+  validateCreateAgent,
+} from '../agent-to-agent/create-agent.js';
 import { agentsCreate } from '../agent-to-agent/guard.js';
 import { notifyAgent, registerApprovalHandler, requestApproval } from '../approvals/index.js';
 import { roomsAddAgent, roomsCreate } from './guard.js';
@@ -89,10 +96,21 @@ registerDeliveryBatchPreview(async (batch, session) => {
   log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
 });
 
-function successText(name: string, roomChannelId: string | undefined, deferredInstall = false): string {
+function successText(
+  name: string,
+  roomChannelId: string | undefined,
+  deferredInstall = false,
+  template?: { ref: string; commit?: string },
+): string {
   // The user already knows they were waiting on their workspace — name what
   // unblocked it so the relay reads as an ending, not a fresh announcement.
   const installed = deferredInstall ? ' The workspace approved the install, which is what the wait was for.' : '';
+  // Provenance rides the ONE completion signal the Slack path emits (the
+  // upstream created-notify is suppressed here), so the requester still learns
+  // which template and which commit the agent was stamped from.
+  const stamped = template
+    ? ` Stamped from template "${template.ref}" (${formatTemplateProvenance(template.commit)}).`
+    : '';
   // room:'none': no shared room was opened — the multi-create
   // pattern finishes with one create_room naming every agent.
   if (roomChannelId === undefined) {
@@ -100,14 +118,16 @@ function successText(name: string, roomChannelId: string | undefined, deferredIn
       `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
       `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
       `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
-      installed
+      installed +
+      stamped
     );
   }
   return (
     `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
     `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
     `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
-    installed
+    installed +
+    stamped
   );
 }
 
@@ -140,12 +160,14 @@ async function runSlackLeg(
     localName: string;
     newAgentGroupId: string;
     slug: string;
+    /** Template provenance from the createAgent outcome — absent on the resume path. */
+    template?: { ref: string; commit?: string };
   },
 ): Promise<void> {
   const { name, localName, newAgentGroupId, slug } = args;
   try {
     const r = await runSlackAgentFlow({ content, session, newAgentGroupId, slug });
-    await notifyAgent(session, successText(name, r.roomChannelId, r.deferredInstall));
+    await notifyAgent(session, successText(name, r.roomChannelId, r.deferredInstall, args.template));
   } catch (err) {
     // SlackApiError carries the flow step id its call site passed to the
     // shared Slack lib — surface it like a typed flow step.
@@ -193,24 +215,24 @@ async function slackAwareCreateAgent(content: Record<string, unknown>, session: 
   // report "done" ~a minute early — this wrapper's successText/failureText
   // is the only completion signal. Upstream error notifies (collision,
   // invalid path) still fire either way.
-  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+  const outcome = await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
 
-  const after = await getDestinationByName(session.agent_group_id, localName);
   // Creation bailed or collided — upstream already answered the requester.
-  if (!after || after.target_type !== 'agent' || before) return;
+  if (!outcome) return;
   // Non-Slack sessions (and task/a2a sessions with no messaging group) behave exactly as upstream.
   if (!slackOrigin) return;
 
   await runSlackLeg(content, session, {
     name,
     localName,
-    newAgentGroupId: after.target_id,
-    slug: await dedupeSlug(deriveInstanceSlug(name), after.target_id),
+    newAgentGroupId: outcome.agentGroupId,
+    slug: await dedupeSlug(deriveInstanceSlug(name), outcome.agentGroupId),
+    template: outcome.template,
   });
 }
 
 /**
- * Slack-aware hold: same payload shape as upstream ({ name, instructions })
+ * Slack-aware hold: same payload core as upstream (buildCreateAgentHoldPayload)
  * so the approved replay re-enters this wrapper unchanged; only the card text
  * differs, telling the admin a Slack bot comes with the sub-agent.
  */
@@ -220,7 +242,7 @@ async function requestSlackCreateAgentHold(content: Record<string, unknown>, ses
     return;
   }
   const name = typeof content.name === 'string' ? content.name : '';
-  const instructions = typeof content.instructions === 'string' ? content.instructions : null;
+  const template = typeof content.template === 'string' && content.template ? content.template : undefined;
   const sourceGroup = await getAgentGroup(session.agent_group_id);
   if (!sourceGroup) return;
 
@@ -228,22 +250,33 @@ async function requestSlackCreateAgentHold(content: Record<string, unknown>, ses
     session,
     agentName: sourceGroup.name,
     action: 'create_agent',
-    // allow_guests must survive the hold: the approved replay re-enters the
-    // wrapper with this payload, and dropping it would silently upgrade a
-    // guest-accessible request to the agent-view variant.
+    // Trunk's shared payload core carries name/instructions/template — the
+    // grant binding (a templated hold nulls `instructions`; the ref must
+    // survive or the approved replay creates a plain agent). This wrapper's
+    // extra fields ride on top.
     payload: {
-      name,
-      instructions,
+      ...buildCreateAgentHoldPayload(content),
       ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      // allow_guests must survive the hold: the approved replay re-enters the
+      // wrapper with this payload, and dropping it would silently upgrade a
+      // guest-accessible request to the agent-view variant.
       ...(content.allow_guests === true ? { allow_guests: true } : {}),
       // room:'none' must survive the hold too — dropping it would grow a
       // room the multi-create pattern deliberately skipped.
       ...(content.room === 'none' ? { room: 'none' } : {}),
+      // A templated hold presents NO instructions (the template supplies the
+      // persona; the card must not show the creation prompt as one), but the
+      // Slack leg still derives the bot's avatar from that prompt AFTER the
+      // approved replay — carry the excerpt in this clearly-non-persona field,
+      // which runSlackAgentFlow reads as the avatar fallback.
+      ...(template && typeof content.instructions === 'string'
+        ? { avatar_hint: content.instructions.slice(0, 300) }
+        : {}),
     },
     title: `Create agent: ${name}`,
     question:
       `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
-      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room).${templateApprovalNote(template)} Approve?`,
   });
 }
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -97,7 +97,7 @@ vi.mock('../approvals/index.js', async () => {
 // Registers the wrapped create_agent delivery action — the path under test.
 // Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
 import './index.js';
-import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
+import { ensureAgentRoom, finishSlackAgentFlow, runSlackAgentFlow } from './orchestrate.js';
 import { SlackFlowError } from './types.js';
 import { getDeliveryAction } from '../../delivery.js';
 import { log } from '../../log.js';
@@ -453,6 +453,81 @@ describe('slack-aware create_agent — manifest variants', () => {
   });
 });
 
+describe('slack-aware create_agent — template attribution', () => {
+  // The Slack leg is driven directly here: the upstream template branch of
+  // createAgent (host fetch + stamping) is trunk's, and this pins only the
+  // one thing this module owns — content.template reaching the broker.
+  it('a templated create sends the ref to the broker as attribution', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({
+      id: 'ag-new',
+      name: 'Research',
+      folder: 'research',
+      agent_provider: null,
+      created_at: now,
+    });
+
+    await runSlackAgentFlow({
+      content: { name: 'Research', instructions: 'dig deep', template: 'sales/sdr', room: 'none' },
+      session: SLACK_SESSION,
+      newAgentGroupId: 'ag-new',
+      slug: 'research',
+    });
+
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.template).toBe('sales/sdr');
+  });
+
+  it('a plain create sends no template field', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.template).toBeUndefined();
+  });
+
+  it('hold payload carries the template ref through to the approved replay (confined group)', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', template: 'sales/sdr' });
+
+    expect(await getAgentGroupByFolder('research')).toBeUndefined();
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { payload: Record<string, unknown>; question: string };
+    expect(opts.payload).toMatchObject({ name: 'Research', template: 'sales/sdr' });
+    // Trunk's shared payload core: a templated hold never presents the
+    // creation prompt as persona; the avatar excerpt survives separately in
+    // the clearly-non-persona avatar_hint field.
+    expect(opts.payload.instructions).toBeNull();
+    expect(opts.payload.avatar_hint).toBe('dig deep');
+    // Design merge condition: the Slack card (the only card this path shows)
+    // names the template and says fetch-vs-local, same sentence as trunk's.
+    expect(opts.question).toContain('It will be stamped from template "sales/sdr"');
+  });
+
+  it('an approved templated replay derives the avatar from avatar_hint (instructions nulled by the hold)', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({
+      id: 'ag-new2',
+      name: 'Research',
+      folder: 'research',
+      agent_provider: null,
+      created_at: now,
+    });
+
+    await runSlackAgentFlow({
+      content: { name: 'Research', instructions: null, avatar_hint: 'dig deep', template: 'sales/sdr', room: 'none' },
+      session: SLACK_SESSION,
+      newAgentGroupId: 'ag-new2',
+      slug: 'research',
+    });
+
+    const avatarBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/avatars'))!.body) as Record<
+      string,
+      unknown
+    >;
+    expect(avatarBody.description).toBe('dig deep');
+  });
+});
+
 describe("slack-aware create_agent — room:'none'", () => {
   it('skips the room half entirely: DM only, no MPIM, no a2a entry, no canvas, no intro nudge', async () => {
     mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
@@ -493,7 +568,8 @@ describe("slack-aware create_agent — room:'none'", () => {
     expect(mockRequestApproval).toHaveBeenCalledTimes(1);
     const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
     expect(opts.action).toBe('create_agent');
-    expect(opts.payload).toMatchObject({ name: 'Research', room: 'none' });
+    // A PLAIN hold keeps the persona: only templated holds null instructions.
+    expect(opts.payload).toMatchObject({ name: 'Research', room: 'none', instructions: 'dig deep' });
   });
 });
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -456,6 +456,8 @@ interface FlowArgs {
    * N creates with room:'none' followed by one create_room with all of them.
    */
   room?: 'own' | 'none';
+  /** Template ref the agent was stamped from — broker attribution only. */
+  template?: string;
   /** Wait budget for a deferred workspace install. Tests shorten it. */
   installWait?: { intervalMs?: number; timeoutMs?: number };
   /** Extra sink for the pending-install line — the finish script prints it to
@@ -503,6 +505,7 @@ async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
     description: args.description,
     allowGuests: args.allowGuests,
     requestedBy: operatorUserId,
+    template: args.template,
     installWait: args.installWait ?? resolveInstallWait(rootDir),
     onInstallPending: async (info) => {
       const text = installPendingText(displayName, info);
@@ -686,11 +689,22 @@ export async function runSlackAgentFlow(args: {
     installWait: args.installWait,
     rootDir: process.cwd(),
     hotStart: true,
-    description: typeof content.instructions === 'string' ? content.instructions.slice(0, 300) : undefined,
+    // Avatar excerpt: instructions on the direct path. An approved TEMPLATED
+    // replay carries instructions:null (the hold never presents the creation
+    // prompt as persona) with the same excerpt in avatar_hint — an identical
+    // slice, so a batch-preview prefetch keyed on (name, excerpt) still
+    // matches (see requestSlackCreateAgentHold in index.ts).
+    description:
+      typeof content.instructions === 'string'
+        ? content.instructions.slice(0, 300)
+        : typeof content.avatar_hint === 'string'
+          ? content.avatar_hint.slice(0, 300)
+          : undefined,
     purpose: typeof content.purpose === 'string' ? content.purpose : undefined,
     allowGuests: content.allow_guests === true,
     originSession: session,
     room: content.room === 'none' ? 'none' : 'own',
+    template: typeof content.template === 'string' && content.template ? content.template : undefined,
   });
 }
 


### PR DESCRIPTION
Ask an agent running in Slack to create a sub-agent from a template and it gets a plain agent instead. The `slack-agent-flow` skill replaces the built-in handler for `create_agent` requests so a new sub-agent also gets its own Slack bot, and that wrapper rebuilt the request by hand as `{ name, instructions }` when pausing it for an admin to approve. Everything else in the request, `template` included, was dropped at that point, so once an admin approved and the request ran again, no template was used. Even when no approval was needed the template name went nowhere: the service that creates the Slack app was never told about it, and the completion message the requester sees (the only message the Slack path sends) never said which template the agent came from.

This is the half of templates-from-chat that lives on the `channels` branch, a long-lived branch holding channel code that never merges into `main`. It carries `template` end to end through the Slack creation flow.

## Merge order

> [!IMPORTANT]
> Merge strictly **after** nanocoai/nanoclaw#3396. This module imports `buildCreateAgentHoldPayload`, `templateApprovalNote` and `formatTemplateProvenance` from `src/modules/agent-to-agent/create-agent.ts`, and needs `createAgent` to return a `CreateAgentOutcome`. None of that is on `main` yet; all of it arrives with #3396.

That order is what #3397 got wrong: same feature, merged onto `channels` ahead of the `main` code it needed, then reverted in `ffd9d9b1`. This PR redoes those changes on top of the workspace-gated-install rework that landed since, plus a cleanup that drops the hand-built request in favour of the shared helper on `main`. The template registry index it depends on (nanocoai/nanoclaw-templates#22) is already merged.

## How the template name travels

```mermaid
flowchart TD
  REQ["create_agent<br/>name, instructions, template"]
  HOLD["pause and show an approval card"]
  REPLAY["admin approves, request runs again"]
  CREATE["createAgent (on main)<br/>creates the agent from the template"]
  LEG["Slack part of the flow<br/>runSlackAgentFlow"]
  BROKER["service that creates the Slack app"]
  DONE["completion message"]
  REQ -->|"caller is not the owner agent"| HOLD
  REQ -->|"caller has global scope"| CREATE
  HOLD -->|"keeps template, sets instructions to null,<br/>adds avatar_hint"| REPLAY
  REPLAY --> CREATE
  CREATE -->|"outcome.template = template name + commit"| LEG
  LEG -->|"template + avatar_hint"| BROKER
  LEG --> DONE
```

- **Pausing for approval.** `requestSlackCreateAgentHold` builds the paused request from `buildCreateAgentHoldPayload(content)` on `main` and adds `purpose`, `allow_guests` and `room: 'none'` on top. When a template is used, the paused request carries `template` and sets `instructions` to `null`, because the template supplies the agent's instructions. A request with no template is unchanged.
- **Avatar.** The Slack part of the flow builds the avatar description from the creation prompt *after* the request runs again, so setting `instructions` to `null` would leave the new bot without its generated avatar. A paused request that uses a template therefore also carries `avatar_hint`, a 300-character excerpt in a field that is clearly not the agent's instructions, and `runSlackAgentFlow` reads it as the fallback `description`. The excerpt is identical on both paths, so the multi-create batch prefetch, which keys its avatar cache on `(displayName, description)`, still hits that cache.
- **Approval card, Slack app, completion message.** The approval question appends `templateApprovalNote(template)`: `It will be stamped from template "sales/sdr" (fetched from the public template registry | using the existing local copy)`. `FlowArgs.template` is passed through `runFlow` into `provisionSlackApp`, filling the `template` field that `ProvisionAttribution` already sent in `POST /v1/apps` and that had always been empty. `successText` takes a template argument and appends `Stamped from template "<ref>" (commit 1a2b3c4)`, or `(local copy)` when the local copy of the template was used, added alongside the existing `deferredInstall` wording rather than replacing it.
- **Spotting that an agent was created.** `slackAwareCreateAgent` now reads what `createAgent` returns instead of comparing `getDestinationByName` before and after: `undefined` means it bailed out or hit a name collision, and the returned value supplies both `agentGroupId` and `template`. The `before` lookup is still there for the path that resumes a parked install.

## What trips people up

- `instructions: null` in a paused request that uses a template is deliberate, not a lost field. `orchestrate.test.ts` locks in both cases, so a later change that breaks either one fails: with a template it is null, without a template it is kept.
- `avatar_hint` is never used as the agent's instructions. It exists only so that, after approval, the Slack part of the flow can still ask for an avatar.
- The resume path (an app parked on a workspace install that has not gone through yet) calls `runSlackLeg` without a template, so the message that finishes that flow does not say where the agent came from. The return value only exists on a fresh create.

> [!WARNING]
> An install running the new `main` code with an out-of-date copy of this skill drops the template name when a Slack request is paused for approval, and once approved the request creates a plain agent. The fix is `/update-skills`; this is documented on `main` in `docs/templates.md`.

## Verification

PRs against the `channels` branch run no CI, and GitHub reports that this branch merges cleanly onto the current tip of `channels`. `orchestrate.test.ts` adds four cases covering the template and tightens one existing `room: 'none'` assertion, but none of them can run against the `channels` tree until #3396 merges, because the module under test imports code from `main` that is not there yet. Not tested on a live install: a known gap, to be checked on a live install once this merges.

| File | Change |
|---|---|
| `.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts` | Paused-request core + `avatar_hint`, approval-card note, template line in `successText`, agent creation detected from the return value |
| `.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts` | `FlowArgs.template` into `provisionSlackApp`, `avatar_hint` as avatar-description fallback |
| `.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts` | Tests for carrying the template through |
