### PR TITLE
feat(drivers): ratify the attach surface — a driver describes its exec argv

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -24,6 +24,11 @@ afterEach(() => {
   closeSessionDb();
 });
 
+// Production always assigns seq (the host writer); a NULL seq makes both the
+// query's ORDER BY and getPendingMessages' final sort ties, so multi-row
+// ordering becomes whatever SQLite returns — the source of a long flake.
+let nextSeq = 1;
+
 function insertMessage(
   id: string,
   kind: string,
@@ -33,10 +38,10 @@ function insertMessage(
   const timestamp = opts?.timestamp ?? new Date().toISOString();
   getInboundDb()
     .prepare(
-      `INSERT INTO messages_in (id, kind, timestamp, status, process_after, content)
-       VALUES (?, ?, ?, 'pending', ?, ?)`,
+      `INSERT INTO messages_in (id, kind, timestamp, status, process_after, content, seq)
+       VALUES (?, ?, ?, 'pending', ?, ?, ?)`,
     )
-    .run(id, kind, timestamp, opts?.processAfter ?? null, JSON.stringify(content));
+    .run(id, kind, timestamp, opts?.processAfter ?? null, JSON.stringify(content), nextSeq++);
 }
 
 describe('context timezone header', () => {

--- a/src/drivers/conformance.test.ts
+++ b/src/drivers/conformance.test.ts
@@ -648,6 +648,27 @@ describe('conformance: lifecycle', () => {
   });
 });
 
+describe('conformance: the attach surface describes, never execs', () => {
+  eachDriver('hands back a runnable argv that carries the client command', async (h) => {
+    const handle = await h.driver.prepare(fixtureSpec());
+    const issuedBefore = h.cli.calls.length;
+
+    const attach = handle.execSpec(['bash', '-lc', 'echo hi']);
+
+    // A client has to be able to spawn this: a program, and a full argv for
+    // each stdin shape. Which runtime words fill them is the driver's business.
+    expect(attach.bin).not.toBe('');
+    expect(attach.argsTty.length).toBeGreaterThan(0);
+    expect(attach.argsPlain.length).toBeGreaterThan(0);
+    // Whatever the driver prefixes, the command reaches the session verbatim.
+    expect(attach.argsTty.slice(-3)).toEqual(['bash', '-lc', 'echo hi']);
+    expect(attach.argsPlain.slice(-3)).toEqual(['bash', '-lc', 'echo hi']);
+    // Pure description — asking for the argv must not touch the runtime, and
+    // must not be the driver quietly running the attach on the caller's behalf.
+    expect(h.cli.calls).toHaveLength(issuedBefore);
+  });
+});
+
 describe('conformance: capabilities are honest', () => {
   eachDriver('declares what it cannot realize', (h) => {
     const capabilities = h.driver.capabilities();

--- a/src/drivers/docker-driver.ts
+++ b/src/drivers/docker-driver.ts
@@ -36,6 +36,7 @@ import {
   type MountSpec,
   type SessionDriver,
   type SessionEvent,
+  type SessionExecSpec,
   type SessionFailure,
   type SessionHandle,
   type SessionKey,
@@ -536,6 +537,15 @@ class DockerHandle implements SessionHandle {
     } catch {
       /* `--rm` usually got there first */
     }
+  }
+
+  /** `docker exec` against this session's container — see `SessionExecSpec`. */
+  execSpec(command: string[]): SessionExecSpec {
+    return {
+      bin: 'docker',
+      argsTty: ['exec', '-it', this.name, ...command],
+      argsPlain: ['exec', '-i', this.name, ...command],
+    };
   }
 }
 

--- a/src/drivers/session-events.test.ts
+++ b/src/drivers/session-events.test.ts
@@ -17,6 +17,7 @@ import type {
   DriverCapabilities,
   SessionDriver,
   SessionEvent,
+  SessionExecSpec,
   SessionHandle,
   SessionKey,
   SessionSnapshot,
@@ -47,6 +48,9 @@ class FakeHandle implements SessionHandle {
       return new Promise((resolve, reject) => this.pendingStatus.push({ resolve, reject }));
     }
     return this.statusValue;
+  }
+  execSpec(command: string[]): SessionExecSpec {
+    return { bin: 'fake', argsTty: command, argsPlain: command };
   }
   async stop(reason: string): Promise<void> {
     this.stops.push(reason);

--- a/src/drivers/session-events.ts
+++ b/src/drivers/session-events.ts
@@ -25,6 +25,7 @@
 import type {
   SessionDriver,
   SessionEvent,
+  SessionExecSpec,
   SessionFailure,
   SessionHandle,
   SessionKey,
@@ -213,6 +214,9 @@ class HubHandle implements SupervisedHandle {
   }
   status(): Promise<SessionStatus> {
     return this.inner.status();
+  }
+  execSpec(command: string[]): SessionExecSpec {
+    return this.inner.execSpec(command);
   }
   stop(reason: string): Promise<void> {
     this.hub.markStopIntent(this.inner.key);

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -198,6 +198,27 @@ export interface SessionWatch {
   stop(): void;
 }
 
+/**
+ * The argv a client shells to attach an interactive session to this runtime.
+ *
+ * The driver describes the invocation; it never performs it. Handing back argv
+ * instead of a stream is what keeps an interactive attach honest: the terminal
+ * belongs to the client's own stdio, so a caller that needs a real TTY gets one
+ * from the process it spawns rather than from a pipe this layer would have to
+ * emulate. It also keeps the driver seam free of process lifetime — nothing
+ * here to supervise, cancel, or leak.
+ *
+ * Two variants because the caller, not the driver, knows whether a TTY is
+ * appropriate: `argsTty` when stdin is a terminal, `argsPlain` when the attach
+ * is piped or scripted. Allocating a TTY for a non-terminal stdin corrupts the
+ * stream with control sequences, so this choice cannot be made from here.
+ */
+export interface SessionExecSpec {
+  bin: string;
+  argsTty: string[];
+  argsPlain: string[];
+}
+
 export interface SessionHandle {
   key: SessionKey;
   /** Stable runtime name for logs and operator commands. */
@@ -213,6 +234,13 @@ export interface SessionHandle {
    * blocking-until-gone.
    */
   stop(reason: string): Promise<void>;
+  /**
+   * The argv for attaching `command` interactively to this session. Pure
+   * description — see `SessionExecSpec`. Valid only while the session is live;
+   * a caller that races teardown gets the runtime's own error from the spawn,
+   * not a lie from this layer.
+   */
+  execSpec(command: string[]): SessionExecSpec;
 }
 
 export interface DriverCapabilities {


### PR DESCRIPTION
Interactive tooling needs to attach a terminal to a live session — and the right seam for that is descriptive, not operational: the driver knows how its runtime spells an exec invocation, and nothing else.

## The contract

- `SessionExecSpec { bin, argsTty, argsPlain }` — the driver **describes** the invocation; it never performs it. Argv over a stream, deliberately: the terminal belongs to the client's own stdio (a caller that needs a real TTY gets one from the process it spawns, not a pipe this layer would emulate), and the seam stays free of process lifetime — nothing to supervise, cancel, or leak. Two variants because only the caller knows whether its stdin is a terminal; allocating a TTY for a piped attach corrupts the stream with control sequences.
- `execSpec(command: string[]): SessionExecSpec` on `SessionHandle`, after `stop()`. Pure description, valid only while the session is live — a caller racing teardown gets the runtime's own spawn error, never a lie from this layer.
- Docker implementation + Hub delegation.
- A conformance case pins the contract mechanically: non-empty `bin`, both variants carrying the client command verbatim, and **zero runtime calls issued** — "the driver never execs" as an assertion, not prose.

Additive: +67/−0 on the contract commit; no behavior change for existing consumers. `drivers/index.ts` already re-exports types, so `SessionExecSpec` is importable with no barrel edit.

## Rider (separable): deterministic formatter-test ordering

The pending-read orders by `seq` twice, but the fixture inserted rows with `seq` NULL — both orderings degenerate to a tie and multi-row expectations ride on unspecified SQLite return order. The fixture now assigns `seq` on insert, matching production, where the writer always assigns it. Drops with a single rebase if review prefers a split.

## Verification

tsc 0 · drivers suites 133/133 · conformance 52/52 (new case verified by name; mutation-checked) · agent-runner formatter 30/30 · full-suite failures proven pre-existing by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)