### PR TITLE
fix: restore stable CI required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  ci:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,3 +40,12 @@ jobs:
       - name: Container tests
         working-directory: container/agent-runner
         run: bun test
+
+  # Repository rules require exact `ci`; always run it so matrix failures remain blocking.
+  ci:
+    if: always()
+    needs: test
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - run: test "${{ needs.test.result }}" = success


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The main ruleset requires an exact `ci` check. The Node 22/24 matrix changed the reported checks to `ci (22)` and `ci (24)`, leaving the required `ci` check permanently expected.

This renames the matrix job to `test` and adds a stable `ci` aggregate job that succeeds only when the full matrix succeeds.

## Testing

- `act` lists the matrix job followed by the exact `ci` job
- Verified that a failed matrix result makes the aggregate `ci` job fail
- GitHub Actions provides the final real-runner validation
