### PR TITLE
fix(telegram-setup): pairing card says 6 digits

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -122,13 +122,13 @@ bash setup/lib/restart.sh
 ## Pair your chat
 
 Telegram tokens carry no user binding, so the agent proves you own the chat with
-a one-time pairing handshake: it issues a 4-digit code, you send those exact 4
+a one-time pairing handshake: it issues a 6-digit code, you send those exact 6
 digits to the bot from the chat you want to register, and the live adapter
 matches them. Open the bot first so you're on the right screen when the code
 appears. Tell the user:
 
 ```nc:operator
-Open @{{bot_username}} (https://telegram.me/{{bot_username}}) in Telegram now and keep it on screen — a 4-digit pairing code is about to appear in this terminal. When it does, send just those 4 digits to the bot as a message (in a group chat with Group Privacy on, prefix them with @{{bot_username}}). A wrong guess is rejected and a fresh code is issued automatically.
+Open @{{bot_username}} (https://telegram.me/{{bot_username}}) in Telegram now and keep it on screen — a 6-digit pairing code is about to appear in this terminal. When it does, send just those 6 digits to the bot as a message (in a group chat with Group Privacy on, prefix them with @{{bot_username}}). A wrong guess is rejected and a fresh code is issued automatically.
 ```
 
 Run the pairing handshake. It prints the code, streams "waiting…" and wrong-code
@@ -190,7 +190,7 @@ the group and keeps the approval card in the loop.
 
 **`getMe` fails.** The token was revoked (a `/revoke` or a fresh `/token` invalidates the old value) or picked up whitespace in the paste. Get the current token from BotFather and re-paste it.
 
-**Pairing never completes.** The live adapter is what observes the code, so the service must be running — the restart step comes before pairing for exactly this reason. Send *just* the 4 digits from the exact chat you want registered; in a group with Group Privacy on, prefix them with `@<botname>`. Wrong guesses are fine (a fresh code is issued, up to 5 times), but a dead adapter waits forever.
+**Pairing never completes.** The live adapter is what observes the code, so the service must be running — the restart step comes before pairing for exactly this reason. Send *just* the 6 digits from the exact chat you want registered; in a group with Group Privacy on, prefix them with `@<botname>`. Wrong guesses are fine (a fresh code is issued, up to 5 times), but a dead adapter waits forever.
 
 **The bot ignores group messages.** Group Privacy is on, so the bot only sees addressed commands and replies, not ordinary `@bot` text. BotFather → `/mybots` → your bot → Bot Settings → Group Privacy → Turn off — then remove and re-add the bot to the group so the change takes effect.
 

--- a/scripts/skill-policy.test.ts
+++ b/scripts/skill-policy.test.ts
@@ -48,7 +48,7 @@ describe('gatePolicy — §5.1 parity table (real skills)', () => {
   it('telegram: the pairing operator gains a readiness pause before the effect:step', () => {
     const d = decisions(loadSkill('telegram'));
     expect(d.map((g) => g.needsConfirm)).toEqual([false, true]); // BotFather → prompt; pairing → step
-    expect(d[1].flavor).toBe('readiness'); // "a 4-digit code is about to appear"
+    expect(d[1].flavor).toBe('readiness'); // "a 6-digit code is about to appear"
   });
 
   it('signal: readiness pause before the QR device-link step', () => {

--- a/setup/pair-telegram.ts
+++ b/setup/pair-telegram.ts
@@ -64,7 +64,7 @@ function intentToString(intent: PairingIntent): string {
 function printCodeCard(code: string, reason: 'initial' | 'regenerated'): void {
   const spaced = code.split('').join('   ');
   p.note(
-    `${spaced}\n\nSend these 4 digits to your bot from Telegram.`,
+    `${spaced}\n\nSend these ${code.length} digits to your bot from Telegram.`,
     reason === 'initial' ? 'Your pairing code is ready' : 'That code was used up — here is a fresh one',
   );
   p.log.message('Waiting for you to send the code…');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What.** The Telegram pairing card printed by `setup/pair-telegram.ts` said "Send these 4 digits"; the code it shows has 6. The card now derives the count from the code itself (`Send these ${code.length} digits`), and the three "4-digit" / "4 digits" mentions in `.claude/skills/add-telegram/SKILL.md` (pairing intro, the operator readiness note, the "pairing never completes" troubleshooting entry) say 6. One quoted comment in `scripts/skill-policy.test.ts` is updated so it does not go stale; no assertion changed.

**Why.** The pairing generator on the `channels` branch emits 6 CSPRNG digits (`telegram-pairing.ts`: `randomInt(0, 1_000_000).padStart(6, '0')`) and `extractCode` strips whitespace and matches `/^\d{6}$/`, so only the copy was wrong: operators were told to type 4 digits of a 6-digit code. The spaced card rendering is unchanged and still matches.

**Risk.** Nothing. Copy only; no behaviour change. Whole-tree grep on main: no "4-digit" / "4 digits" left. The `channels`-branch copy of the add-telegram skill still says 4 in four places; it is the non-authoritative copy (main's is what users run) and is left for a channels-branch PR.

**Verification.**
- `pnpm exec tsx scripts/skill-directives.ts .claude/skills/add-telegram` -> `problems: [], warnings: []`
- `pnpm exec vitest run scripts/skill-policy.test.ts scripts/skill-apply.test.ts scripts/skill-conformance.test.ts` -> 262 passed (262)
- `pnpm run build` -> clean
- No new test: a cosmetic string change with no nameable failure consequence beyond the copy itself.

Part of the Telegram multi-bot + polling-port train (B0 of six); independent of the others, can land any time. Note for the later `add-telegram` skill PR (B3): it edits the same operator fence header, keep both sides when it rebases over this.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone (text-only change; skill lint and plan mode clean instead)
