### PR TITLE
fix(dial): post-merge follow-ups — credential re-run, step captions, registry CI

### DIFF
--- a/.claude/skills/add-dial-tool/SKILL.md
+++ b/.claude/skills/add-dial-tool/SKILL.md
@@ -172,15 +172,18 @@ this adds Dial as a layer on top of it; on one that builds its own it rebuilds:
 
 Read the API key from the host auth file — the single source of truth, written
 by `dial auth login` / `dial auth verify-otp` — and put it in the OneCLI vault
-for `api.getdial.ai`. Always **upsert**: the vault is keyed by name, so an
+for `api.getdial.ai`. Always **replace**: the vault is keyed by name, so an
 existing "Dial API" secret is not necessarily this account's (re-onboarding,
 switching accounts, or rotating the key all leave a secret whose value points at
 the previous account, and a sandboxed agent then lists *that* account's numbers).
-The key travels through a `0600` temp file that is removed right after (`--file`), so it
-never sits on a command line or in a captured variable:
+A stale secret is deleted and a fresh one created rather than updated in place:
+`onecli secrets update` accepts a new value only on the command line, and the key
+must never sit on one. It travels through a `0600` temp file that is removed right
+after (`--file`), so it is never on argv or in a captured variable. Selective-mode
+agents pick the new id up in the merge step below:
 
 ```nc:run effect:external
-T=$(mktemp) && chmod 600 "$T" && jq -r '.apiKey // empty' "${XDG_DATA_HOME:-$HOME/.local/share}/dial/auth.v1.json" > "$T" 2>/dev/null; [ -s "$T" ] || { rm -f "$T"; echo "no Dial API key in the host auth file — sign in with dial auth login / verify-otp, then re-run" >&2; exit 1; }; S=$(onecli secrets list | jq -r 'first(.data[] | select(.name | test("(?i)dial"))) | .id // empty'); if [ -n "$S" ]; then onecli secrets update --id "$S" --file "$T" --host-pattern api.getdial.ai >/dev/null; else onecli secrets create --name "Dial API" --type generic --file "$T" --host-pattern api.getdial.ai --header-name Authorization --value-format "Bearer {value}" >/dev/null; fi; rc=$?; rm -f "$T"; exit $rc
+T=$(mktemp) && chmod 600 "$T" && jq -r '.apiKey // empty' "${XDG_DATA_HOME:-$HOME/.local/share}/dial/auth.v1.json" > "$T" 2>/dev/null; [ -s "$T" ] || { rm -f "$T"; echo "no Dial API key in the host auth file — sign in with dial auth login / verify-otp, then re-run" >&2; exit 1; }; S=$(onecli secrets list | jq -r 'first(.data[] | select(.name | test("(?i)dial"))) | .id // empty'); if [ -n "$S" ]; then onecli secrets delete --id "$S" >/dev/null || { rm -f "$T"; echo "could not remove the previous Dial secret $S" >&2; exit 1; }; fi; onecli secrets create --name "Dial API" --type generic --file "$T" --host-pattern api.getdial.ai --header-name Authorization --value-format "Bearer {value}" >/dev/null; rc=$?; rm -f "$T"; exit $rc
 ```
 
 ## Scope it to the chosen agents
@@ -229,9 +232,11 @@ group's `.claude-shared/skills/` holds symlinks into that mount that are synced
 when the container spawns — so nothing is copied per session. A running agent
 keeps its old image until it respawns, so restart every group; without a
 `--message` each one comes back on its next message, on the new image, with the
-CLI on `PATH` and the skill in place:
+CLI on `PATH` and the skill in place. This is a restart effect, so it does not
+fire after an earlier step bounced — agents keep the image they have until the
+gap above is fixed and the skill is re-applied:
 
-```nc:run effect:external
+```nc:run effect:restart
 ncl groups list --json | jq -r '.data[].id' | while read -r gid; do ncl groups restart --id "$gid" >/dev/null || { echo "could not restart $gid" >&2; exit 1; }; done
 ```
 

--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -82,14 +82,19 @@ lockfile for what is a single send — and the CLI ships in lockstep with the Di
 API, so a contract change arrives as a CLI release rather than breaking a
 request pinned in the adapter.
 
-### 5. Build and validate
+### 5. Build
 
 Build first: it guards the adapter's typed core calls and proves the dependency
-is installed. Then run the one integration test.
+is installed.
 
 ```nc:run effect:build
 pnpm run build
 ```
+
+### 6. Validate
+
+Then run the one integration test.
+
 ```nc:run effect:test
 pnpm exec vitest run src/channels/dial-registration.test.ts
 ```
@@ -100,6 +105,8 @@ SMS/voice is verified manually once the service runs.
 
 ## Sign in to Dial
 
+### Install the CLI
+
 Dial's CLI owns the account credential (an auth file it writes on sign-in), so
 the setup uses the `dial` CLI here. Ensure it's installed — this installs it if
 it's missing (for the full onboarding/auth reference, see the `dial-cli` skill or
@@ -108,6 +115,8 @@ it's missing (for the full onboarding/auth reference, see the `dial-cli` skill o
 ```nc:run effect:external
 command -v dial || curl -fsSL https://getdial.ai/install | bash
 ```
+
+### Identify this install
 
 Calls this setup makes to Dial identify the install. The `dial` CLI prepends
 `DIAL_USER_AGENT` to its own token, so the account's requests stay attributable
@@ -119,6 +128,8 @@ command below with it:
 ```nc:run capture:dial_ua validate:^nanoclaw/\S+$ effect:fetch
 node -p "'nanoclaw/'+(require('./package.json').version||'unknown')" 2>/dev/null || echo nanoclaw/unknown
 ```
+
+### Pin the CLI path
 
 Now pin the CLI's **absolute** path into `.env`. The adapter shells out to `dial`
 to register its inbound command target, and it runs inside the NanoClaw service,
@@ -136,11 +147,15 @@ command -v dial
 DIAL_CLI_PATH={{dial_cli_path}}
 ```
 
+### Check the sign-in
+
 Check whether you're already signed in:
 
 ```nc:run capture:signed_in=.auth.signedIn validate:^(true|false)$ effect:fetch
 DIAL_USER_AGENT={{dial_ua}} dial doctor --json
 ```
+
+### Skip the reuse question when signed out
 
 If you're **not** signed in, go straight to email verification — default the
 choice so the branch guard below stays single-valued:
@@ -148,6 +163,8 @@ choice so the branch guard below stays single-valued:
 ```nc:run capture:reuse_choice when:signed_in=false effect:external
 echo switch
 ```
+
+### Read the account
 
 If you **are** signed in, read which account (for the prompt below) and ask
 whether to reuse it or sign in as a different one (matches the old wizard's
@@ -163,12 +180,16 @@ You're already signed in to Dial as {{connected_email}}.
 Reuse this Dial account, or sign in as a different one? (reuse/switch)
 ```
 
+### Reuse the account
+
 **Reuse** — no verification needed; with no `--code` the command just (re)installs
 the NanoClaw agent skill:
 
 ```nc:run effect:external when:reuse_choice=reuse
 DIAL_USER_AGENT={{dial_ua}} dial auth verify-otp --agent nanoclaw
 ```
+
+### Send the code
 
 **Switch (or not signed in)** — verify an email with a one-time code. Collect the email:
 
@@ -182,6 +203,8 @@ Send the code (`--force` re-sends even if a prior code is pending):
 DIAL_USER_AGENT={{dial_ua}} dial auth login {{owner_email}} --force
 ```
 
+### Verify the code
+
 Collect the code (resolves inline, right after the send above):
 
 ```nc:prompt otp validate:^\d{6}$ when:reuse_choice=switch
@@ -194,6 +217,8 @@ Verify it and provision your number (this also installs the NanoClaw agent skill
 DIAL_USER_AGENT={{dial_ua}} dial auth verify-otp --code {{otp}} --agent nanoclaw
 ```
 
+### Confirm the line
+
 Confirm the account's number — this becomes the agent's public line (its
 `platform_id`):
 
@@ -204,6 +229,8 @@ DIAL_USER_AGENT={{dial_ua}} dial number list --json | jq -er '.numbers[0].number
 Your agent's Dial line is {{platform_id}}.
 ```
 
+### Set the inbound greeting
+
 Set the line's inbound behavior — the system prompt the AI uses on calls *into*
 this number. Verification no longer takes an instruction, so a fresh number
 starts on Dial's default greeting until this runs:
@@ -211,6 +238,8 @@ starts on Dial's default greeting until this runs:
 ```nc:run effect:external
 DIAL_USER_AGENT={{dial_ua}} dial number set {{platform_id}} --inbound-instruction "You are a friendly AI receptionist answering calls to this number. Greet the caller, ask how you can help, and take a clear message — their name, number, and reason for calling — if you cannot help directly."
 ```
+
+### Pin the default sender
 
 Make that line the CLI's default sender. Verification saves whichever number
 the account considers primary — the **oldest** one — while the line picked above
@@ -256,6 +285,8 @@ Open line: anyone who knows {{platform_id}} can text the agent and will get a re
 
 ## Restart
 
+### Restart the service
+
 Restart the service so it loads the Dial adapter, and wait for its CLI socket.
 The adapter must be live and polling before pairing — it's the thing that
 observes the code you text:
@@ -263,6 +294,8 @@ observes the code you text:
 ```nc:run effect:restart
 bash setup/lib/restart.sh
 ```
+
+### Start inbound delivery
 
 Wire inbound event delivery and the command target. Both are best-effort: a
 sandbox/CI without a user-service supervisor can't run the `listen` daemon, but
@@ -272,9 +305,16 @@ Troubleshooting), so these never fail the run:
 ```nc:run effect:external
 DIAL_USER_AGENT={{dial_ua}} dial listen install || true
 ```
+
+### Register the command target
+
+Point the daemon at the adapter's event handler (same best-effort rule):
+
 ```nc:run effect:external
 DIAL_USER_AGENT={{dial_ua}} dial local-target add cmd "$PWD/data/dial/handle-dial-event.sh" || true
 ```
+
+### Register the line (owner-only)
 
 Register the line, carrying the access choice from above onto its own row. One
 `platform_id` serves many correspondents, so it's a group (`--is-group 1`) and
@@ -284,6 +324,11 @@ existing row, and does NOT reset a policy you have since changed with `ncl`:
 ```nc:run effect:wire when:inbound_access=owner
 ncl messaging-groups create --channel-type dial --platform-id {{platform_id}} --is-group 1 --name "Dial {{platform_id}}" --unknown-sender-policy strict
 ```
+
+### Register the line (public)
+
+The same row, open to anyone who texts it:
+
 ```nc:run effect:wire when:inbound_access=public
 ncl messaging-groups create --channel-type dial --platform-id {{platform_id}} --is-group 1 --name "Dial {{platform_id}}" --unknown-sender-policy public
 ```

--- a/scripts/add-dial-tool-scope.test.ts
+++ b/scripts/add-dial-tool-scope.test.ts
@@ -132,7 +132,7 @@ S="$STATE"
 arg() { local k="$1"; shift; while [ $# -gt 0 ]; do if [ "$1" = "$k" ]; then echo "$2"; return; fi; shift; done; }
 case "$1 $2" in
   "secrets list") cat "$S/secrets.json" ;;
-  "secrets update") f=$(arg --file "$@"); [ -n "$f" ] && cat "$f" > "$S/key-seen"; echo '{"status":"updated"}' ;;
+  "secrets delete") i=$(arg --id "$@"); jq --arg i "$i" '.data |= map(select(.id != $i))' "$S/secrets.json" > "$S/t" && mv "$S/t" "$S/secrets.json"; echo '{"status":"deleted"}' ;;
   "secrets create") f=$(arg --file "$@"); [ -n "$f" ] && cat "$f" > "$S/key-seen"; jq '.data += [{"id":"sec-new","name":"Dial API"}]' "$S/secrets.json" > "$S/t" && mv "$S/t" "$S/secrets.json"; echo '{"id":"sec-new"}' ;;
   "agents list") ${opts.agentsListFails ? 'echo "boom" >&2; exit 1' : 'cat "$S/agents.json"'} ;;
   "agents secrets") cat "$S/assigned.json" ;;
@@ -337,18 +337,23 @@ describe('add-dial-tool: scoping Dial to the chosen agents', () => {
 });
 
 describe('add-dial-tool: registering the host credential with OneCLI', () => {
-  it('updates the existing Dial secret with the key the host is signed in with (never create-if-absent)', () => {
+  it('replaces the existing Dial secret (delete, then create from the temp file) — `secrets update` takes the value only on argv', () => {
     const { status, stdout } = sh(CMD.credential);
     expect(status).toBe(0);
     const lines = callLines();
-    const update = lines.find((l) => l.startsWith('onecli secrets update'));
-    expect(update).toMatch(/^onecli secrets update --id sec-dial --file \S+ --host-pattern api\.getdial\.ai$/);
-    expect(lines.some((l) => l.startsWith('onecli secrets create'))).toBe(false);
+    expect(lines).toContain('onecli secrets delete --id sec-dial');
+    const create = lines.find((l) => l.startsWith('onecli secrets create'));
+    expect(create).toMatch(
+      /^onecli secrets create --name Dial API --type generic --file \S+ --host-pattern api\.getdial\.ai --header-name Authorization --value-format Bearer \{value\}$/,
+    );
+    expect(lines.indexOf('onecli secrets delete --id sec-dial')).toBeLessThan(lines.indexOf(create!));
+    expect(lines.some((l) => l.startsWith('onecli secrets update'))).toBe(false);
+    expect(lines.some((l) => /--value(\s|=)/.test(l))).toBe(false);
     // The key reaches OneCLI through the temp file, never argv or stdout, and the file is gone after.
     expect(fs.readFileSync(path.join(state, 'key-seen'), 'utf8')).toBe('sk_test\n');
-    expect(update).not.toContain('sk_test');
+    expect(create).not.toContain('sk_test');
     expect(stdout).not.toContain('sk_test');
-    const tmp = (update ?? '').match(/--file (\S+)/)?.[1] ?? '';
+    const tmp = (create ?? '').match(/--file (\S+)/)?.[1] ?? '';
     expect(fs.existsSync(tmp)).toBe(false);
   });
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Three follow-ups to #3050, all found on a live install running `main@475ba766` today. Skill files only, plus the test that covers the first one.

**`add-dial-tool`: re-run failed at "Register the credential with OneCLI".** `onecli secrets update` accepts a new value only through `--value` (argv) — there is no `--file` — so the re-onboarding / key-rotation path the skill promises failed with `unknown flag --file`. The skill now deletes the stale secret and creates a fresh one from the 0600 temp file; selective-mode agents pick the new id up in the merge step. The group restart is now `effect:restart`, so it no longer fires after an earlier step bounced. The stub-backed test had asserted the bad flag; it now asserts delete-then-create and that `--value` never appears on any OneCLI call. Verified live: first apply, second apply, and a group left out of the list getting `403 blocked_by_policy` from inside its container.

**`add-dial`: step captions were counters.** The wizard labels a step by the nearest heading and numbers repeats, so the sign-in section read `Sign in to Dial (1/12)` … `(12/12)`. Each spinning fence now has its own heading (same treatment `add-dial-tool` got in #3050). Directive order and bodies unchanged.

**`add-dial-number`: Registry skills CI red on main.** The skill refreshed the adapter with a prose bash block (`git fetch origin channels` / `git show origin/channels:…`), which the registry matrix flags as a registry pull with no `nc:copy from-branch` directive. It is now a `from-branch:channels` copy of the same file set `/add-dial` installs. `scripts/test-registry-skills.ts add-dial-number` passes.


## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files) — steps are `nc:` directive fences per the setup-skill convention; no helper scripts
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone — applied on a live install checked out at `main@475ba766` (wizard path for `add-dial`, standalone driver for `add-dial-tool`, registry test for `add-dial-number`)

Assisted by Claude; reviewed and verified by a human before submission.
