### PR TITLE
fix(chat-sdk): polling adapters do not open the webhook server

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -145,11 +145,14 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
   // StateAdapter (chat_sdk_* tables) and an adapter.initialize — nothing
   // platform-side. registerWebhookAdapter is mocked at module level so we
   // can assert the (chat, adapterName, routingPath) triple.
-  function setupStubAdapter(): Adapter {
-    return stubAdapter({
-      name: 'slack',
-      initialize: async () => {},
-    } as unknown as Partial<Adapter>);
+  // runtimeMode is assigned inside initialize(), as the Telegram adapter does
+  // when mode 'auto' resolves: a guard that reads it earlier sees undefined.
+  function setupStubAdapter(runtimeMode?: 'webhook' | 'polling'): Adapter {
+    const adapter = stubAdapter({ name: 'slack' }) as Adapter & { runtimeMode?: string };
+    adapter.initialize = async () => {
+      adapter.runtimeMode = runtimeMode;
+    };
+    return adapter;
   }
 
   beforeEach(async () => {
@@ -194,6 +197,34 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
     const [, adapterName, routingPath] = vi.mocked(registerWebhookAdapter).mock.calls[0];
     expect(adapterName).toBe('slack');
     expect(routingPath ?? adapterName).toBe('slack');
+    await bridge.teardown();
+  });
+
+  // Polling adapters (Telegram) pull updates themselves; a registered route
+  // would lazily bind the shared webhook port, and a busy port then crashes a
+  // Telegram-only host. Kill condition: delete the `runtimeMode === 'polling'`
+  // branch in setup() and the polling case goes red.
+  it('polling adapter (mode resolved inside initialize) registers no webhook route', async () => {
+    const { registerWebhookAdapter } = await import('../webhook-server.js');
+    const bridge = createChatSdkBridge({ adapter: setupStubAdapter('polling'), supportsThreads: true });
+    await bridge.setup(hostConfig);
+    expect(registerWebhookAdapter).not.toHaveBeenCalled();
+    await bridge.teardown();
+  });
+
+  it('webhook adapter registers the route', async () => {
+    const { registerWebhookAdapter } = await import('../webhook-server.js');
+    const bridge = createChatSdkBridge({ adapter: setupStubAdapter('webhook'), supportsThreads: true });
+    await bridge.setup(hostConfig);
+    expect(registerWebhookAdapter).toHaveBeenCalledTimes(1);
+    await bridge.teardown();
+  });
+
+  it('adapter without runtimeMode registers the route (non-Telegram adapters declare none)', async () => {
+    const { registerWebhookAdapter } = await import('../webhook-server.js');
+    const bridge = createChatSdkBridge({ adapter: setupStubAdapter(), supportsThreads: true });
+    await bridge.setup(hostConfig);
+    expect(registerWebhookAdapter).toHaveBeenCalledTimes(1);
     await bridge.teardown();
   });
 

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -740,6 +740,11 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         };
         startGateway();
         log.info('Gateway listener started', { adapter: adapter.name });
+      } else if ('runtimeMode' in adapter && adapter.runtimeMode === 'polling') {
+        // Polling adapters (Telegram) pull updates themselves; a route here
+        // would only bind the shared webhook port for nothing. Read after
+        // initialize(): the adapter resolves mode 'auto' there.
+        log.info('Polling adapter: no webhook route registered', { adapter: adapter.name });
       } else {
         // Non-gateway adapters (Slack, Teams, GitHub, etc.) — register on the
         // shared webhook server. The handler key stays adapter.name (the


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

A Telegram-only install no longer binds port 3000. Polling adapters get no webhook route.

**Why.** The Chat SDK bridge registered a webhook route for every non-gateway adapter, which lazily binds `0.0.0.0:WEBHOOK_PORT||3000`. Telegram polls (`mode: 'polling'`), so the port was bound for nothing, and the host died when another process held it. Port 3000 is our default in `src/webhook-server.ts`, not an SDK default.

**What changed** (`src/channels/chat-sdk-bridge.ts`, 5 lines): after `await chat.initialize()`, if the adapter's public `runtimeMode` is `'polling'`, skip `registerWebhookAdapter` and log `Polling adapter: no webhook route registered`. `undefined` and `'webhook'` behave exactly as before. The check lives here because the mode is only known after `initialize()` and this is the single caller of `registerWebhookAdapter`.

**Risk.** Restart only. Webhook channels (Slack, Teams, GitHub, ...) are byte-identical.

**Verification.**
- `pnpm exec vitest run src/channels/chat-sdk-bridge.test.ts`: 26 passed (3 new: polling skips, webhook registers, no runtimeMode registers). Removing the guard turns the polling case red.
- `pnpm run build` clean.
- [x] Live: port 3000 occupied, Telegram-only host started, pairing completed, no "Webhook server started" in `logs/nanoclaw.log` (author, 2026-08-21).

Related, not required: #3148 (`WEBHOOK_PORT` from `.env`), #2975 (exit on bind failure).

## For Skills

Not applicable.
