### PR TITLE
feat(setup): carry the adapter instance through pairing, init-first-agent and the CLI welcome

### DIFF
--- a/.claude/skills/init-first-agent/SKILL.md
+++ b/.claude/skills/init-first-agent/SKILL.md
@@ -103,6 +103,8 @@ When an existing group was selected, append its exact id:
   --agent-group-id "${AGENT_GROUP_ID}"
 ```
 
+When the channel runs a named adapter instance (e.g. a second Telegram bot registered as `telegram-mega`), append `--instance "${INSTANCE}"` with the registry key (never the short name) so the DM row, the wiring and the welcome all target that bot; omitted = the channel's default instance.
+
 The new group is created on the instance default provider (`DEFAULT_AGENT_PROVIDER` in `.env`, or `claude` when unset). To put it on a different provider, switch after creation with `ncl groups config update --id <group-id> --provider <name>`. Add `--welcome "System instruction: ..."` to override the default welcome prompt.
 
 The script:

--- a/scripts/init-first-agent.test.ts
+++ b/scripts/init-first-agent.test.ts
@@ -1,0 +1,152 @@
+/**
+ * scripts/init-first-agent.ts --instance: the DM row is created for that
+ * exact adapter instance and the welcome is addressed to it.
+ *
+ * What breaks without it: wiring a second Telegram bot (registry key
+ * telegram-mega) lands on the default bot's messaging_groups row and the
+ * welcome goes out through the default bot.
+ * Kill condition: drop `args.instance` from createMessagingGroup (the row's
+ * instance falls back to 'telegram'), or from the getMessagingGroupByPlatform
+ * lookups (the seeded-default case reuses the default row instead of creating
+ * its own), or `instance: dmMg.instance` from the socket payload
+ * (to.instance vanishes), or the URL-safe check in parseArgs (a key with a
+ * space is accepted and stored).
+ *
+ * Drives the real entry point in a child process against a temp cwd
+ * (PROJECT_ROOT = cwd, so data/v2.db and data/cli.sock are temp) with a fake
+ * CLI socket standing in for the running service. Same shape as
+ * scripts/migrate.test.ts.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const SCRIPT = path.resolve(import.meta.dirname, 'init-first-agent.ts');
+const TSX_LOADER = path.resolve(import.meta.dirname, '../node_modules/tsx/dist/loader.mjs');
+
+interface MgRow {
+  channel_type: string;
+  platform_id: string;
+  instance: string;
+}
+
+describe('scripts/init-first-agent.ts --instance', () => {
+  let cwd: string;
+  let server: net.Server;
+  let nextWelcome: ((line: { to: Record<string, unknown> }) => void) | null = null;
+  /** Resolves with the next JSON line the script writes to the CLI socket. */
+  const welcome = () =>
+    new Promise<{ to: Record<string, unknown> }>((resolve) => {
+      nextWelcome = resolve;
+    });
+
+  beforeEach(async () => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-ifa-'));
+    fs.mkdirSync(path.join(cwd, 'data'));
+    server = net.createServer((socket) => {
+      let buf = '';
+      socket.on('data', (chunk) => {
+        buf += chunk.toString('utf8');
+      });
+      socket.on('end', () => nextWelcome?.(JSON.parse(buf.trim())));
+    });
+    await new Promise<void>((resolve) => server.listen(path.join(cwd, 'data', 'cli.sock'), resolve));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  function run(extra: string[]): Promise<{ status: number | null; stderr: string }> {
+    return new Promise((resolve) => {
+      const args = [
+        '--import',
+        TSX_LOADER,
+        SCRIPT,
+        '--channel',
+        'telegram',
+        '--user-id',
+        'telegram:42',
+        '--platform-id',
+        'telegram:42',
+        '--display-name',
+        'Amit',
+        ...extra,
+      ];
+      const child = spawn(process.execPath, args, { cwd, stdio: ['ignore', 'ignore', 'pipe'] });
+      let stderr = '';
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('close', (status) => resolve({ status, stderr }));
+    });
+  }
+
+  function messagingGroups(): MgRow[] {
+    const db = new Database(path.join(cwd, 'data', 'v2.db'), { readonly: true });
+    try {
+      return db
+        .prepare('SELECT channel_type, platform_id, instance FROM messaging_groups ORDER BY instance')
+        .all() as MgRow[];
+    } finally {
+      db.close();
+    }
+  }
+
+  it('creates the DM row for the named instance and addresses the welcome to it', async () => {
+    const w = welcome();
+    const r = await run(['--instance', 'telegram-mega']);
+    expect(r.status, r.stderr).toBe(0);
+    expect(messagingGroups()).toEqual([
+      { channel_type: 'telegram', platform_id: 'telegram:42', instance: 'telegram-mega' },
+    ]);
+    expect((await w).to).toEqual({
+      channelType: 'telegram',
+      platformId: 'telegram:42',
+      threadId: 'telegram:42',
+      instance: 'telegram-mega',
+    });
+  }, 60_000);
+
+  it('without --instance keeps the default-instance row (instance = channel_type)', async () => {
+    const w = welcome();
+    const r = await run([]);
+    expect(r.status, r.stderr).toBe(0);
+    expect(messagingGroups()).toEqual([{ channel_type: 'telegram', platform_id: 'telegram:42', instance: 'telegram' }]);
+    expect((await w).to).toMatchObject({ platformId: 'telegram:42', instance: 'telegram' });
+  }, 60_000);
+
+  // The same chat paired on the default bot and on a named bot: two rows,
+  // the default row untouched, the second welcome through the named bot.
+  it('with the default-instance row already present, --instance creates its own exact row and addresses the welcome to it', async () => {
+    const w1 = welcome();
+    expect((await run([])).status).toBe(0); // bot #1 already wired
+    await w1;
+    const w2 = welcome();
+    const r = await run(['--instance', 'telegram-mega']);
+    expect(r.status, r.stderr).toBe(0);
+    expect(messagingGroups()).toEqual([
+      { channel_type: 'telegram', platform_id: 'telegram:42', instance: 'telegram' },
+      { channel_type: 'telegram', platform_id: 'telegram:42', instance: 'telegram-mega' },
+    ]);
+    expect((await w2).to).toEqual({
+      channelType: 'telegram',
+      platformId: 'telegram:42',
+      threadId: 'telegram:42',
+      instance: 'telegram-mega',
+    });
+  }, 90_000);
+
+  it('rejects an --instance that is not a URL-safe registry key before touching the DB', async () => {
+    const r = await run(['--instance', 'telegram mega']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('--instance must be a URL-safe adapter registry key');
+    expect(fs.existsSync(path.join(cwd, 'data', 'v2.db'))).toBe(false);
+  }, 60_000);
+});

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -27,7 +27,8 @@
  *     [--agent-group-id <id>] \       # wire an agent setup already created
  *     [--welcome "System instruction: ..."] \
  *     [--role owner|admin|member] \  # default: owner
- *     [--engage-pattern "."]         # explicit DM engage regex override
+ *     [--engage-pattern "."] \       # explicit DM engage regex override
+ *     [--instance telegram-mega]     # adapter instance registry key; default = the channel's default instance
  *
  * For direct-addressable channels (telegram, whatsapp, etc.), --platform-id
  * is typically the same as the handle in --user-id, with the channel prefix.
@@ -42,7 +43,7 @@ import path from 'path';
 // declared channel defaults resolve here without live adapters.
 import '../src/channels/index.js';
 import { resolveUnknownSenderPolicy, resolveWiringDefaults } from '../src/channels/channel-defaults.js';
-import { hasDeclaredChannelDefaults } from '../src/channels/channel-registry.js';
+import { hasDeclaredChannelDefaults, INSTANCE_KEY_RE } from '../src/channels/channel-registry.js';
 import { CENTRAL_DB_PATH, DATA_DIR, GROUPS_DIR } from '../src/config.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { initDb } from '../src/db/connection.js';
@@ -75,6 +76,8 @@ interface Args {
   role: Role;
   /** Explicit engage regex for the DM wiring; omitted = channel declaration / '.'. */
   engagePattern?: string;
+  /** Adapter instance registry key (e.g. telegram-mega); omitted = the channel's default instance. */
+  instance?: string;
 }
 
 const DEFAULT_WELCOME = 'System instruction: run /welcome to introduce yourself to the user on this new channel.';
@@ -136,6 +139,18 @@ function parseArgs(argv: string[]): Args {
         out.engagePattern = val;
         i++;
         break;
+      case '--instance':
+        // An unsafe key would store a row nobody serves, and cli.ts parseAddress
+        // would drop it, sending the welcome through the default bot.
+        if (!val || !INSTANCE_KEY_RE.test(val)) {
+          console.error(
+            `--instance must be a URL-safe adapter registry key (e.g. telegram-mega), got: ${JSON.stringify(val)}`,
+          );
+          process.exit(2);
+        }
+        out.instance = val;
+        i++;
+        break;
       case '--role': {
         const raw = (val ?? '').toLowerCase();
         if (raw !== 'owner' && raw !== 'admin' && raw !== 'member') {
@@ -169,6 +184,7 @@ function parseArgs(argv: string[]): Args {
     welcome: out.welcome?.trim() || defaultWelcome(out.channel!),
     role: out.role ?? DEFAULT_ROLE,
     engagePattern: out.engagePattern?.trim() || undefined,
+    instance: out.instance,
   };
 }
 
@@ -340,24 +356,26 @@ async function main(): Promise<void> {
 
   // 3. DM messaging group.
   const platformId = namespacedPlatformId(args.channel, args.platformId);
-  let dmMg = await getMessagingGroupByPlatform(args.channel, platformId);
+  let dmMg = await getMessagingGroupByPlatform(args.channel, platformId, args.instance);
   if (!dmMg) {
     const mgId = generateId('mg');
     // Policy from the channel declaration (DM context); legacy 'strict' for
     // stale (undeclared) adapters so a trunk update alone changes nothing.
-    const unknownSenderPolicy = hasDeclaredChannelDefaults(args.channel)
-      ? resolveUnknownSenderPolicy(args.channel, false)
+    const channelKey = args.instance ?? args.channel;
+    const unknownSenderPolicy = hasDeclaredChannelDefaults(channelKey, args.channel)
+      ? resolveUnknownSenderPolicy(channelKey, false, args.channel)
       : 'strict';
     await createMessagingGroup({
       id: mgId,
       channel_type: args.channel,
       platform_id: platformId,
+      instance: args.instance,
       name: args.displayName,
       is_group: 0,
       unknown_sender_policy: unknownSenderPolicy,
       created_at: now,
     });
-    dmMg = (await getMessagingGroupByPlatform(args.channel, platformId))!;
+    dmMg = (await getMessagingGroupByPlatform(args.channel, platformId, args.instance))!;
     console.log(`Created messaging group: ${dmMg.id} (${platformId})`);
   } else {
     console.log(`Reusing messaging group: ${dmMg.id} (${platformId})`);
@@ -433,6 +451,9 @@ async function sendWelcomeViaCliSocket(
             channelType: dmMg.channel_type,
             platformId: dmMg.platform_id,
             threadId: dmMg.platform_id,
+            // The row's own instance, so the welcome leaves through the bot
+            // that owns this DM (a named instance, never its default sibling).
+            instance: dmMg.instance,
           },
         }) + '\n';
       socket.write(payload, (err) => {

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -82,6 +82,8 @@ describe('runChannelSkill adapter (Option A)', () => {
       role: 'owner',
       agentGroupId: 'ag-template',
     });
+    // no skill-resolved `instance` var: the wire targets the default instance
+    expect(wired[0].instance).toBeUndefined();
     // the adapter no longer emits any ncl wiring itself — that's init-first-agent's job
     expect(cmds.some((c) => c.startsWith('ncl '))).toBe(false);
     // clears the template pick exactly when the wire consumed the stamped
@@ -422,7 +424,9 @@ describe('runChannelSkill adapter (Option A)', () => {
   // (the real teams document needs a streaming exec runChannelSkill doesn't
   // expose): when the skill binds owner_handle + platform_id, the adapter asks
   // nothing extra (agentName/role injected) and reaches the shared wire with
-  // the composed teams user id.
+  // the composed teams user id. A skill-resolved `instance` var (a named
+  // bot's registry key) rides along to the wire; kill condition: drop
+  // `instance: res.vars.instance` from the wire call in run-channel-skill.ts.
   const wireChannel = 'wiretest';
   const wireSkillDir = join(process.cwd(), '.claude/skills', `add-${wireChannel}`);
   afterEach(() => rmSync(wireSkillDir, { recursive: true, force: true }));
@@ -444,6 +448,9 @@ describe('runChannelSkill adapter (Option A)', () => {
         '```nc:run capture:platform_id effect:fetch',
         'echo-platform',
         '```',
+        '```nc:run capture:instance effect:fetch',
+        'echo-instance',
+        '```',
         '',
       ].join('\n'),
     );
@@ -455,6 +462,7 @@ describe('runChannelSkill adapter (Option A)', () => {
       exec: (c) => {
         if (c === 'echo-owner') return '29:owner-xyz\n';
         if (c === 'echo-platform') return 'teams:enc-conv:enc-url\n';
+        if (c === 'echo-instance') return 'telegram-mega\n';
       },
       resolveRemote: () => 'origin',
       wireIfResolved: true,
@@ -475,6 +483,7 @@ describe('runChannelSkill adapter (Option A)', () => {
       displayName: 'Dan Mill',
       agentName: 'Nano',
       role: 'owner',
+      instance: 'telegram-mega',
     });
     // no template pick in play (NANOCLAW_TEMPLATE_AGENT_ID unset): a fresh-agent
     // wire must leave the persisted pick alone

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -176,6 +176,8 @@ interface WireArgs {
   agentGroupId?: string;
   /** Explicit DM engage regex (e.g. WhatsApp shared-mode "@<name> only" self-chat). */
   engagePattern?: string;
+  /** Adapter instance registry key (e.g. telegram-mega) when the skill wired a named bot; unset = default instance. */
+  instance?: string;
 }
 
 export async function resolveAgentName(): Promise<string> {
@@ -214,6 +216,7 @@ async function initFirstAgent(args: WireArgs): Promise<boolean> {
       args.role,
       ...(args.agentGroupId ? ['--agent-group-id', args.agentGroupId] : []),
       ...(args.engagePattern ? ['--engage-pattern', args.engagePattern] : []),
+      ...(args.instance ? ['--instance', args.instance] : []),
     ],
     { running: `Wiring ${args.agentName} to your ${args.channel} DMs…`, done: 'Agent wired.' },
     { extraFields: { CHANNEL: args.channel, AGENT_NAME: args.agentName, PLATFORM_ID: args.platformId } },
@@ -381,6 +384,7 @@ export async function runChannelSkill(
     role: role!,
     agentGroupId: templateAgentGroupId,
     engagePattern: res.vars.engage_pattern || undefined,
+    instance: res.vars.instance || undefined,
   });
   if (!ok) {
     await failWith(

--- a/setup/pair-telegram.ts
+++ b/setup/pair-telegram.ts
@@ -10,8 +10,14 @@
  *   PAIR_TELEGRAM_CODE       { CODE, REASON=initial|regenerated }
  *   PAIR_TELEGRAM_ATTEMPT    { CANDIDATE }
  *   PAIR_TELEGRAM (final)    { STATUS=success, CODE, INTENT, PLATFORM_ID,
- *                              IS_GROUP, PAIRED_USER_ID }
+ *                              IS_GROUP, PAIRED_USER_ID[, INSTANCE] }
  *                         or { STATUS=failed, CODE, ERROR }
+ *
+ * Args: --intent main|wire-to:<folder>|new-agent:<folder> (default main) and
+ * --instance <registry key> (e.g. telegram-mega) to pair a named bot; omitted
+ * = the default bot. A key that is not URL-safe exits 2 before pairing; a
+ * valid one is passed to createPairing and echoed back as INSTANCE in the
+ * final block.
  *
  * Depends on src/channels/telegram-pairing.js, which the /add-telegram skill
  * copies in from the `channels` branch before this step runs. setup/ is
@@ -20,6 +26,7 @@
  */
 import * as p from '@clack/prompts';
 
+import { INSTANCE_KEY_RE } from '../src/channels/channel-registry.js';
 import { createPairing, waitForPairing, type PairingIntent } from '../src/channels/telegram-pairing.js';
 import { CENTRAL_DB_PATH } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
@@ -27,10 +34,20 @@ import { runMigrations } from '../src/db/migrations/index.js';
 
 import { emitStatus } from './status.js';
 
-function parseArgs(args: string[]): PairingIntent {
+function parseArgs(args: string[]): { intent: PairingIntent; instance?: string } {
   let intent: PairingIntent = 'main';
+  let instance: string | undefined;
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--intent') {
+    if (args[i] === '--instance') {
+      const val = args[++i];
+      if (!val || !INSTANCE_KEY_RE.test(val)) {
+        console.error(
+          `--instance must be a URL-safe adapter registry key (e.g. telegram-mega), got: ${JSON.stringify(val)}`,
+        );
+        process.exit(2);
+      }
+      instance = val;
+    } else if (args[i] === '--intent') {
       const raw = args[++i] || 'main';
       if (raw === 'main') {
         intent = 'main';
@@ -43,7 +60,7 @@ function parseArgs(args: string[]): PairingIntent {
       }
     }
   }
-  return intent;
+  return { intent, instance };
 }
 
 function intentToString(intent: PairingIntent): string {
@@ -75,7 +92,7 @@ function printAttempt(candidate: string): void {
 }
 
 export async function run(args: string[]): Promise<void> {
-  const intent = parseArgs(args);
+  const { intent, instance } = parseArgs(args);
 
   // Pairing stores state under DATA_DIR; the DB isn't strictly needed for the
   // pairing primitive itself, but the inbound interceptor running inside the
@@ -85,7 +102,7 @@ export async function run(args: string[]): Promise<void> {
   await runMigrations(db);
 
   const MAX_REGENERATIONS = 5;
-  let record = await createPairing(intent);
+  let record = await createPairing(intent, instance);
   printCodeCard(record.code, 'initial');
   emitStatus('PAIR_TELEGRAM_CODE', {
     CODE: record.code,
@@ -116,13 +133,14 @@ export async function run(args: string[]): Promise<void> {
         // stays for the agent-driven callers that read it directly.
         ADMIN_USER_ID: consumed.consumed!.adminUserId ?? '',
         PAIRED_USER_ID: consumed.consumed!.adminUserId ? `telegram:${consumed.consumed!.adminUserId}` : '',
+        ...(instance ? { INSTANCE: instance } : {}),
       });
       return;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const invalidated = /invalidated by wrong code/.test(message);
       if (invalidated && regen < MAX_REGENERATIONS) {
-        record = await createPairing(intent);
+        record = await createPairing(intent, instance);
         printCodeCard(record.code, 'regenerated');
         emitStatus('PAIR_TELEGRAM_CODE', {
           CODE: record.code,

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -44,8 +44,9 @@ export interface DeliveryAddress {
  */
 export interface InboundEvent {
   channelType: string;
-  /** Receiving adapter instance; stamped host-side (src/index.ts onInbound).
-   *  Absent (e.g. CLI onInboundEvent) means the default instance (= channelType). */
+  /** Receiving adapter instance; stamped host-side (src/index.ts onInbound) or
+   *  carried by the CLI admin transport's `to.instance`. Absent means the
+   *  default instance (= channelType). */
   instance?: string;
   platformId: string;
   threadId: string | null;

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -8,6 +8,9 @@ import type { ChannelAdapter, ChannelDefaults, ChannelRegistration, ChannelSetup
 import type { ChannelDeliveryAdapter } from '../delivery.js';
 import { log } from '../log.js';
 
+/** Adapter instance registry key shape: a webhook route segment and state-namespace key, so URL-safe only. */
+export const INSTANCE_KEY_RE = /^[A-Za-z0-9._-]+$/;
+
 const SETUP_RETRY_DELAYS_MS = [2000, 5000, 10000];
 
 /** Duck-type check — adapters that throw an Error with `name === 'NetworkError'`

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -25,6 +25,7 @@ import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage } from './adapter.js';
+import { INSTANCE_KEY_RE } from './channel-registry.js';
 import { resolveQuestionRender } from './question-render-registry.js';
 
 /** Adapter with optional gateway support (e.g., Discord). */
@@ -427,7 +428,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
   // whitespace-only names, which are config bugs — '' is falsy, so it
   // would skip a truthiness guard, dead-end the webhook route, and
   // collapse the state namespace into the default instance's keyspace.
-  if (config.instance !== undefined && !/^[A-Za-z0-9._-]+$/.test(config.instance)) {
+  if (config.instance !== undefined && !INSTANCE_KEY_RE.test(config.instance)) {
     throw new Error(
       `chat-sdk bridge instance ${JSON.stringify(config.instance)} must be URL-safe: ` +
         `non-empty, only letters, digits, '.', '_' or '-'`,

--- a/src/channels/cli.test.ts
+++ b/src/channels/cli.test.ts
@@ -1,0 +1,86 @@
+/**
+ * CLI admin transport: a routed line's `to.instance` reaches the router as
+ * InboundEvent.instance.
+ *
+ * What breaks without it: init-first-agent's welcome for a named adapter
+ * instance (a second Telegram bot registered as `telegram-mega`) arrives
+ * instance-less, the router resolves the DEFAULT instance's row, and the
+ * welcome leaves through the wrong bot (or auto-creates an unwired row).
+ * Kill condition: delete `instance: to.instance` from the routed InboundEvent
+ * in handleLine (or the instance parse in parseAddress) and the first case
+ * goes red; drop the `log.warn` on a rejected `to.instance` and the last case
+ * goes red.
+ */
+import fs from 'fs';
+import net from 'net';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { log } from '../log.js';
+import type { InboundEvent } from './adapter.js';
+
+// vi.mock factories are hoisted above imports, so the socket dir is a hoisted
+// literal: the adapter must never bind a running install's data/cli.sock.
+const { TEST_DIR } = vi.hoisted(() => ({ TEST_DIR: `/tmp/nanoclaw-cli-channel-test-${process.pid}` }));
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../config.js')>('../config.js');
+  return { ...actual, DATA_DIR: TEST_DIR };
+});
+
+import './cli.js';
+import { initChannelAdapters, teardownChannelAdapters } from './channel-registry.js';
+
+let nextEvent: ((event: InboundEvent) => void) | null = null;
+
+/** Write one routed (`to`-bearing) line over the socket; resolve with the event the adapter handed the host. */
+function routed(to: Record<string, unknown>): Promise<InboundEvent> {
+  return new Promise((resolve, reject) => {
+    nextEvent = resolve;
+    const socket = net.connect(path.join(TEST_DIR, 'cli.sock'), () => {
+      socket.end(JSON.stringify({ text: 'hello', to }) + '\n');
+    });
+    socket.once('error', reject);
+  });
+}
+
+describe('cli channel: routed message carries to.instance', () => {
+  beforeAll(async () => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    await initChannelAdapters(() => ({
+      onInbound() {},
+      onInboundEvent(event) {
+        nextEvent?.(event);
+      },
+      onMetadata() {},
+      onAction() {},
+    }));
+  });
+
+  afterAll(async () => {
+    await teardownChannelAdapters();
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  const to = { channelType: 'telegram', platformId: 'telegram:42', threadId: null };
+
+  it('stamps a named instance onto the InboundEvent', async () => {
+    const event = await routed({ ...to, instance: 'telegram-mega' });
+    expect(event).toMatchObject({ channelType: 'telegram', platformId: 'telegram:42', instance: 'telegram-mega' });
+  });
+
+  it('leaves instance undefined when the address has none (default instance)', async () => {
+    const event = await routed(to);
+    expect(event.instance).toBeUndefined();
+  });
+
+  it('drops an instance that is not URL-safe and warns so the downgrade is visible', async () => {
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    try {
+      const event = await routed({ ...to, instance: 'bad/key' });
+      expect(event.instance).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('non-URL-safe to.instance'), { instance: 'bad/key' });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/src/channels/cli.ts
+++ b/src/channels/cli.ts
@@ -13,7 +13,9 @@
  *     { "text": "user message" }                          # default — talk to cli/local
  *     { "text": "...", "to": {"channelType": "discord",
  *                             "platformId": "discord:@me:149...",
- *                             "threadId": null} }         # route to a specific mg
+ *                             "threadId": null,
+ *                             "instance": "discord"} }    # route to a specific mg
+ *                                                         # (instance optional; default = channelType)
  *     { "text": "...", "to": {...}, "reply_to": {...} }   # + redirect replies
  *   Server → client:
  *     { "text": "agent reply" }
@@ -47,7 +49,7 @@ import type {
   InboundEvent,
   OutboundMessage,
 } from './adapter.js';
-import { registerChannelAdapter } from './channel-registry.js';
+import { INSTANCE_KEY_RE, registerChannelAdapter } from './channel-registry.js';
 
 const PLATFORM_ID = 'local';
 
@@ -223,6 +225,7 @@ function createAdapter(): ChannelAdapter {
       // Does NOT claim the chat slot, so an active terminal chat isn't evicted.
       const event: InboundEvent = {
         channelType: to.channelType,
+        instance: to.instance,
         platformId: to.platformId,
         threadId: to.threadId,
         message: {
@@ -264,7 +267,7 @@ function createAdapter(): ChannelAdapter {
     }
   }
 
-  function parseAddress(raw: unknown): DeliveryAddress | null {
+  function parseAddress(raw: unknown): (DeliveryAddress & { instance?: string }) | null {
     if (!raw || typeof raw !== 'object') return null;
     const obj = raw as Record<string, unknown>;
     if (typeof obj.channelType !== 'string' || typeof obj.platformId !== 'string') return null;
@@ -274,10 +277,21 @@ function createAdapter(): ChannelAdapter {
         : typeof obj.threadId === 'string'
           ? obj.threadId
           : null;
+    // Anything that is not a registry key resolves as the default instance;
+    // fail closed, but loudly, so a typo in `to.instance` is visible in the log.
+    let instance: string | undefined;
+    if (typeof obj.instance === 'string') {
+      if (INSTANCE_KEY_RE.test(obj.instance)) {
+        instance = obj.instance;
+      } else {
+        log.warn('CLI: ignoring non-URL-safe to.instance, routing to the default instance', { instance: obj.instance });
+      }
+    }
     return {
       channelType: obj.channelType,
       platformId: obj.platformId,
       threadId,
+      instance,
     };
   }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: a small setup feature, no new skill.

## Description

Setup can now target a named adapter instance (for example a second Telegram bot, `telegram-mega`). Without `--instance`, nothing changes.

**Why.** The registry, `messaging_groups.instance`, router and delivery already address instances (#2733), but the setup path did not carry one: pairing, `init-first-agent` and the welcome always went through the default instance.

**What changed.**
- `setup/pair-telegram.ts`: `--instance <key>` passed to `createPairing`, echoed as `INSTANCE`, validated.
- `scripts/init-first-agent.ts`: `--instance` selects or creates the exact messaging-group row and stamps `to.instance` on the welcome; validated like `--role`.
- `src/channels/cli.ts`: `parseAddress` accepts `to.instance` (URL-safe) and sets `InboundEvent.instance`; a malformed value falls back to the default instance with a warn log.
- `setup/channels/run-channel-skill.ts`: forwards a skill's `instance` var to the wire.
- `src/channels/channel-registry.ts`: one exported `INSTANCE_KEY_RE`, used by the bridge, cli, init-first-agent and pair-telegram instead of three inline copies.
- One `--instance` line in the `init-first-agent` skill doc.

**Risk.** None until `--instance` is used.

**Verification.**
- `cli.test.ts` 3, `init-first-agent.test.ts` 4 (real script as a child process against a temp DB and a fake CLI socket), `run-channel-skill.test.ts` 16, plus bridge 23 and registry 7 after the regex move: 53 passed. Each wiring line has a test that goes red when it is removed.
- `pnpm run build` clean.
- Headless: `setup/index.ts --step pair-telegram -- --intent main --instance telegram-mega` writes a pending record with `"instance": "telegram-mega"`.

## For Skills

Not applicable.
