### PR TITLE
feat(telegram): named bot instances via TELEGRAM_INSTANCES + instance-bound pairing

### DIFF
--- a/.claude/skills/telegram-multi-instance/SKILL.md
+++ b/.claude/skills/telegram-multi-instance/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: telegram-multi-instance
+description: Run N Telegram bots on one NanoClaw host via TELEGRAM_INSTANCES. Each name gets its own telegram-<name> adapter instance built from a per-instance bot token, with instance-bound pairing and its own messaging-group rows, sharing channelType, formatting, and wiring defaults with the default bot. Documentation only, the registration is native to the installed Telegram adapter.
+---
+
+# Telegram multi-instance (TELEGRAM_INSTANCES)
+
+One NanoClaw host can run **several Telegram bots**, each wired to its own
+agent. There is nothing to install: the Telegram adapter
+(`src/channels/telegram.ts`, installed by `/add-telegram`) reads
+`TELEGRAM_INSTANCES=<name>[,<name>...]` from `.env` at load and registers one
+additional bridge per listed name under the `telegram-<name>` instance key,
+built from that name's own bot token through the same factory as the default
+bot. `channelType` stays `telegram`: instance is a routing key; user ids
+(`telegram:<user id>`), formatting, container config, and the wiring-defaults
+declaration are shared with the default bot. This document records the
+conventions.
+
+## Configuration
+
+Create each extra bot with @BotFather (`/newbot`, exactly like the first bot;
+turn Group Privacy off if it will sit in groups) and store its token under the
+suffixed key. `<NAME>` is the name uppercased with dashes as underscores
+(`gh-bot` becomes `GH_BOT`). Names must match `^[a-z0-9][a-z0-9-]*$`; any
+other entry is logged and skipped at boot.
+
+```
+TELEGRAM_BOT_TOKEN=123456:ABC...          # the first bot, unchanged: instance "telegram"
+TELEGRAM_INSTANCES=mega,gh-bot
+TELEGRAM_BOT_TOKEN_MEGA=234567:DEF...     # instance "telegram-mega"
+TELEGRAM_BOT_TOKEN_GH_BOT=345678:GHI...   # instance "telegram-gh-bot"
+```
+
+Registration is unconditional for every listed name, so a missing token
+surfaces as the registry's "credentials missing, skipping" warning at boot
+rather than a silently absent bot. Telegram allows one `getUpdates` poller per
+bot, so a name whose token equals one already in use (the default bot's, or
+an earlier name's) is skipped with a warning and the first claimant keeps it.
+
+## Pairing and wiring
+
+The `--instance` flags below require a `setup/pair-telegram.ts` and
+`scripts/init-first-agent.ts` that accept `--instance` (trunk after the
+setup-instance change); on an install without them, use the `ncl` commands at
+the end of this section.
+
+Pairing is instance-bound: a code created for `telegram-mega` is consumed only
+by that bot, and a wrong guess sent to one bot invalidates only that bot's
+pending codes. Pass the instance key to the pairing step, send the code to the
+new bot (the default bot does not pair on it: it forwards the message as
+ordinary input and, like any wrong guess, cancels any pairing the default bot
+itself had pending), then wire the exact row:
+
+```bash
+pnpm exec tsx setup/index.ts --step pair-telegram -- --intent new-agent:mega-analyst --instance telegram-mega
+# the interceptor creates the (telegram, telegram:<chat>, telegram-mega) messaging group
+pnpm exec tsx scripts/init-first-agent.ts --channel telegram --instance telegram-mega \
+  --platform-id telegram:<chat> --user-id telegram:<uid> ...
+```
+
+Why re-pair instead of reusing the chat id you already know from the first
+bot: a Telegram private chat id equals the user id across bots, but a bot
+cannot message a user who never opened it. The pairing message is that first
+contact, and it creates the instance-exact messaging group in the same step.
+
+Manual equivalent with `ncl`: `ncl messaging-groups create --channel-type
+telegram --platform-id telegram:<chat> --instance telegram-mega ...`, then
+`ncl wirings create ... --instance telegram-mega`, and `ncl messaging-groups
+send ... --instance telegram-mega` to say hello.
+
+The same Telegram user can talk to every bot: one row, one session, one
+container, one memory per bot. Delivery leaves through the instance that owns
+the row; a named bot whose token is removed fails closed (delivery retry
+path), never through a sibling bot.
+
+## Restart
+
+`TELEGRAM_INSTANCES` is read once, at adapter load. After editing `.env`,
+restart the service (`bash setup/lib/restart.sh`) so the new bot registers and
+starts polling. There is no hot start for Telegram instances.
+
+## Validation
+
+The channel payload ships the guards for all of this, installed by
+`/add-telegram` alongside the adapter. They drive the registration loop
+against a crafted `.env` (shared wiring defaults, env-key mapping, token
+dedupe), the instance-bound pairing store, and the interceptor's exact-row
+lookup against a real central DB:
+
+```bash
+pnpm exec vitest run src/channels/telegram-instances-registration.test.ts \
+  src/channels/telegram-pairing.test.ts src/channels/telegram-pairing-interceptor.test.ts
+```
+
+## Remove
+
+Remove the name from `TELEGRAM_INSTANCES` and delete its
+`TELEGRAM_BOT_TOKEN_<NAME>` line, then restart the service. Messaging groups
+wired to a removed `telegram-<name>` instance stop resolving an adapter until
+rewired or deleted. The default bot and its rows are untouched. (Adapter code
+is unchanged: the registration loop simply finds no names.)

--- a/src/channels/telegram-connect-group.test.ts
+++ b/src/channels/telegram-connect-group.test.ts
@@ -60,7 +60,7 @@ describe('Telegram /connect_group', () => {
     await addRole('42', 'owner');
     await addRole('43', 'admin');
     const hostOnInbound = vi.fn();
-    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token, 'telegram');
 
     await intercept('telegram:42', null, message('/connect_group', '42'));
     await intercept('telegram:43', null, message('/connect_group@nanoclawbot', '43'));
@@ -90,7 +90,7 @@ describe('Telegram /connect_group', () => {
     });
     await addRole('98', 'admin', 'agent-1');
     const hostOnInbound = vi.fn();
-    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token, 'telegram');
 
     await intercept('telegram:98', null, message('/connect_group', '98'));
     await intercept('telegram:99', null, message('/connect_group', '99'));
@@ -105,7 +105,7 @@ describe('Telegram /connect_group', () => {
   it('leaves group messages and near-matches on the normal inbound path', async () => {
     await addRole('42', 'owner');
     const hostOnInbound = vi.fn();
-    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token, 'telegram');
 
     await intercept('telegram:-100', null, message('/connect_group', '42'));
     await intercept('telegram:42', null, message('/connect_group now', '42'));
@@ -116,7 +116,7 @@ describe('Telegram /connect_group', () => {
 
   it('turns the group-picker start command into a routed welcome prompt', async () => {
     const hostOnInbound = vi.fn();
-    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token);
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(botUsername), hostOnInbound, token, 'telegram');
     const inbound = message('/start@NanoClawBot connect', '42');
 
     await intercept('telegram:-100', null, inbound);
@@ -141,7 +141,7 @@ describe('Telegram /connect_group', () => {
       return new Response(JSON.stringify(result), { status: 200 });
     });
     const hostOnInbound = vi.fn();
-    const intercept = createTelegramInboundInterceptor(Promise.resolve(null), hostOnInbound, token);
+    const intercept = createTelegramInboundInterceptor(Promise.resolve(null), hostOnInbound, token, 'telegram');
 
     await intercept('telegram:42', null, message('/connect_group', '42'));
     await intercept('telegram:-100', null, message('/start@NanoClawBot connect', '42'));

--- a/src/channels/telegram-instances-registration.test.ts
+++ b/src/channels/telegram-instances-registration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Guard for the native TELEGRAM_INSTANCES registrations (telegram.ts).
+ *
+ * What breaks without it: a second bot listed in .env never registers, or
+ * registers from the wrong env key, or starts a second getUpdates poller on a
+ * token another bot already holds (Telegram answers that with 409 conflicts),
+ * and nothing at boot says so.
+ *
+ * Integration points under guard, each with its kill condition:
+ *  1. The barrel reach-in, `import './telegram.js';` in src/channels/index.ts.
+ *     Importing the real barrel must run telegram.ts's top-level
+ *     TELEGRAM_INSTANCES loop; delete the import line (or the loop) and the
+ *     `telegram-<name>` keys are absent. The default bot registers before any
+ *     named one (registry insertion order is boot order), so on a duplicate
+ *     token the default bot is the one that keeps it.
+ *  2. The shared declaration: every `telegram-<name>` registration carries the
+ *     same TELEGRAM_DEFAULTS as the default bot. Drop `defaults:` from the
+ *     loop's registerChannelAdapter call and hasDeclaredChannelDefaults() is
+ *     false for the instance keys.
+ *  3. The env-key mapping and the shared factory: TELEGRAM_BOT_TOKEN_GH_BOT
+ *     (name uppercased, dashes to underscores) makes `gh-bot` construct
+ *     through createTelegramBridge with instance 'telegram-gh-bot'; a name
+ *     without a token returns null (the registry's "credentials missing,
+ *     skipping" path). Break instanceEnvKeySuffix or the `_${suffix}` join
+ *     and gh-bot returns null.
+ *  4. Token dedupe: a name whose token is already claimed returns null. Delete
+ *     the claimedBotIds check and `twin` constructs a second poller on
+ *     gh-bot's token.
+ *  5. Name validation: an entry outside ^[a-z0-9][a-z0-9-]*$ is skipped.
+ *  6. The default bot: the zero-suffix createTelegramBridge() call (what the
+ *     'telegram' registration invokes) builds from TELEGRAM_BOT_TOKEN under
+ *     registry key 'telegram', and it claims that token before any named
+ *     instance. Change that default to a suffixed call, or drop the
+ *     claimed-token check, and `dup` (same token as the default bot) turns
+ *     this red.
+ *
+ * TELEGRAM_INSTANCES is read from `.env` at module import (readEnvFile reads
+ * process.cwd()/.env, never process.env), so the test chdirs into a temp dir
+ * carrying a crafted .env BEFORE dynamically importing the barrel. Vitest's
+ * per-file process isolation keeps the chdir and the module cache local to
+ * this file. fetch is stubbed because constructing a bridge kicks off the
+ * bot-username lookup (getMe); nothing here may reach the network.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { getChannelDefaults, getRegisteredChannelNames, hasDeclaredChannelDefaults } from './channel-registry.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'telegram-instances-'));
+  writeFileSync(
+    join(dir, '.env'),
+    [
+      'TELEGRAM_INSTANCES=mega,gh-bot,twin,dup,Bad_Name',
+      'TELEGRAM_BOT_TOKEN=100:default-bot-token-AAAAAAAAAAAAAAAAAAA',
+      'TELEGRAM_BOT_TOKEN_GH_BOT=200:gh-bot-token',
+      // Same value as gh-bot: must be refused, never a second poller.
+      'TELEGRAM_BOT_TOKEN_TWIN=200:gh-bot-token',
+      // Same value as the default bot: refused too, the default bot claimed it first.
+      'TELEGRAM_BOT_TOKEN_DUP=100:default-bot-token-AAAAAAAAAAAAAAAAAAA',
+      '',
+    ].join('\n'),
+  );
+  process.chdir(dir);
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { username: 'bot' } }), { status: 200 })),
+  );
+  await import('./index.js'); // the real barrel, triggers every channel's self-registration
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  process.chdir(originalCwd);
+});
+
+describe('telegram multi-instance registration', () => {
+  it('registers a telegram-<name> adapter per TELEGRAM_INSTANCES entry via the channel barrel', () => {
+    const names = getRegisteredChannelNames();
+    expect(names).toContain('telegram-mega');
+    expect(names).toContain('telegram-gh-bot');
+    // The default bot's registration is untouched, and it boots first.
+    expect(names).toContain('telegram');
+    expect(names.indexOf('telegram')).toBeLessThan(names.indexOf('telegram-mega'));
+    // Outside ^[a-z0-9][a-z0-9-]*$: skipped, not registered under any key.
+    expect(names.filter((n) => n.toLowerCase() === 'telegram-bad_name')).toEqual([]);
+  });
+
+  it("every instance registration declares the default bot's TELEGRAM_DEFAULTS (not the core fallback)", () => {
+    for (const key of ['telegram-mega', 'telegram-gh-bot']) {
+      expect(hasDeclaredChannelDefaults(key)).toBe(true);
+      const defaults = getChannelDefaults(key);
+      // One declaration, shared with the default bot.
+      expect(defaults).toEqual(getChannelDefaults('telegram'));
+      // group.engageMode 'mention' is TELEGRAM_DEFAULTS; the no-live-adapter
+      // fallback would resolve 'mention-sticky'.
+      expect(defaults.group.engageMode).toBe('mention');
+      expect(defaults.dm).toMatchObject({ engageMode: 'pattern', engagePattern: '.', threads: false });
+    }
+  });
+});
+
+describe('instance factory (via the shared createTelegramBridge)', () => {
+  // Imported dynamically, and only once this describe starts, which is AFTER
+  // the registration tests above: a static import of ./telegram.js would run
+  // the registration loop as a side effect of this test file itself (with the
+  // original cwd's .env) and mask a deleted barrel line. Via the barrel the
+  // module is already in the cache, so this import is a no-op read.
+  let tg: typeof import('./telegram.js');
+  beforeAll(async () => {
+    tg = await import('./telegram.js');
+  });
+
+  it('returns null when the instance token is absent: the registry "credentials missing" path', () => {
+    // No TELEGRAM_BOT_TOKEN_MEGA in the temp .env.
+    expect(tg.telegramInstanceBridgeFactory('mega')).toBeNull();
+  });
+
+  it('builds a named instance from TELEGRAM_BOT_TOKEN_<NAME> (uppercased, dashes to underscores)', () => {
+    expect(tg.telegramInstanceBridgeFactory('gh-bot')).toMatchObject({
+      channelType: 'telegram',
+      instance: 'telegram-gh-bot',
+    });
+  });
+
+  it('skips a name whose token another instance already holds: one poller per token', () => {
+    // gh-bot claimed 200:gh-bot-token in the test above, as it would at boot.
+    expect(tg.telegramInstanceBridgeFactory('twin')).toBeNull();
+  });
+
+  describe('default bot claims TELEGRAM_BOT_TOKEN before any named instance', () => {
+    it("builds the 'telegram' adapter from TELEGRAM_BOT_TOKEN and refuses a named instance on the same token", () => {
+      const adapter = tg.createTelegramBridge();
+      expect(adapter).not.toBeNull();
+      expect(adapter).toMatchObject({ name: 'telegram', channelType: 'telegram' });
+      expect(adapter!.instance).toBeUndefined();
+      // dup's token is the default bot's: refused, the default bot keeps its poller.
+      expect(tg.telegramInstanceBridgeFactory('dup')).toBeNull();
+    });
+  });
+});

--- a/src/channels/telegram-pairing-interceptor.test.ts
+++ b/src/channels/telegram-pairing-interceptor.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The pairing interceptor is instance-exact (createTelegramInboundInterceptor
+ * in telegram.ts).
+ *
+ * What breaks without it: a chat paired on a named bot lands on, and rewrites,
+ * the default bot's messaging-group row (so both bots' traffic shares one
+ * session), and a code issued for one bot pairs on whichever bot sees it first.
+ *
+ * Kill conditions:
+ *  - drop `instanceKey` from the getMessagingGroupByPlatform /
+ *    createMessagingGroup calls: the second pairing updates the default row
+ *    instead of creating its own ("two rows" goes red);
+ *  - drop `instance: instanceKey` from the tryConsume input: the named bot
+ *    looks its code up on the default instance and never pairs ("two rows"
+ *    goes red); drop the instance guard from tryConsume's match in
+ *    telegram-pairing.ts and the default bot consumes the named bot's code
+ *    ("rejected on the default bot" goes red).
+ *
+ * Real central DB (migrations applied) and real pairing store (temp file); the
+ * Telegram send boundary (fetch) is stubbed, so nothing reaches the network.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, getAllMessagingGroups, initTestDb, runMigrations } from '../db/index.js';
+import type { InboundMessage } from './adapter.js';
+import { _resetForTest, _setStorePathForTest, createPairing, getStatus } from './telegram-pairing.js';
+import { createTelegramInboundInterceptor } from './telegram.js';
+
+function message(text: string, userId: string): InboundMessage {
+  return {
+    id: 'message-1',
+    kind: 'chat-sdk',
+    content: { text, author: { userId } },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const hostOnInbound = vi.fn();
+const onDefaultBot = createTelegramInboundInterceptor(
+  Promise.resolve('NanoClawBot'),
+  hostOnInbound,
+  'tok-default',
+  'telegram',
+);
+const onMegaBot = createTelegramInboundInterceptor(
+  Promise.resolve('MegaBot'),
+  hostOnInbound,
+  'tok-mega',
+  'telegram-mega',
+);
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-pair-interceptor-'));
+  _setStorePathForTest(path.join(tmpDir, 'pairings.json'));
+  const db = await initTestDb();
+  await runMigrations(db);
+  hostOnInbound.mockReset();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+  );
+});
+
+afterEach(async () => {
+  await closeDb();
+  vi.unstubAllGlobals();
+  _resetForTest();
+  _setStorePathForTest(null);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Telegram pairing interceptor, instance-exact rows', () => {
+  it('pairs the same chat on the default and a named bot as two rows, default row untouched', async () => {
+    const forDefault = await createPairing('main');
+    const forMega = await createPairing('main', 'telegram-mega');
+
+    await onDefaultBot('telegram:42', null, message(forDefault.code, '42'));
+    const [defaultRow] = await getAllMessagingGroups();
+    expect(defaultRow).toMatchObject({ channel_type: 'telegram', platform_id: 'telegram:42', instance: 'telegram' });
+
+    await onMegaBot('telegram:42', null, message(forMega.code, '42'));
+
+    const rows = await getAllMessagingGroups();
+    expect(rows).toHaveLength(2);
+    expect(rows).toContainEqual(defaultRow);
+    expect(rows.map((r) => r.instance).sort()).toEqual(['telegram', 'telegram-mega']);
+    expect(hostOnInbound).not.toHaveBeenCalled();
+    // Each confirmation leaves through the bot that paired.
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => String(url))).toEqual([
+      'https://api.telegram.org/bottok-default/sendMessage',
+      'https://api.telegram.org/bottok-mega/sendMessage',
+    ]);
+  });
+
+  it("a named bot's code is rejected on the default bot and stays pending for the named bot", async () => {
+    const forMega = await createPairing('main', 'telegram-mega');
+
+    await onDefaultBot('telegram:42', null, message(forMega.code, '42'));
+
+    expect(getStatus(forMega.code)).toBe('pending');
+    expect(await getAllMessagingGroups()).toEqual([]);
+    // Not a pairing for this bot: the message takes the normal inbound path.
+    expect(hostOnInbound).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -265,3 +265,63 @@ describe('intent passthrough', () => {
     expect(cb!.intent).toEqual({ kind: 'new-agent', folder: 'side' });
   });
 });
+
+describe('instance isolation', () => {
+  // Kill conditions: drop the `(r.instance ?? DEFAULT_INSTANCE) === instance`
+  // guard from tryConsume's match and one bot's code pairs on another bot;
+  // drop it from the miss loop and a wrong guess on one bot cancels the other
+  // bot's pending code; drop it from createPairing's supersede loop and
+  // starting a pairing on bot B invalidates bot A's in-flight pairing for the
+  // same intent.
+  it('stamps the instance on the record, the default bot when omitted', async () => {
+    expect((await createPairing('main')).instance).toBe('telegram');
+    expect((await createPairing('main', 'telegram-mega')).instance).toBe('telegram-mega');
+  });
+
+  it("a wrong guess on one bot invalidates only that bot's pending codes", async () => {
+    const a = await createPairing('main');
+    const b = await createPairing('main', 'telegram-mega');
+    await tryConsume({ text: '999999', botUsername: 'a', platformId: 'p', isGroup: false });
+    expect(getStatus(a.code)).toBe('invalidated');
+    expect(getStatus(b.code)).toBe('pending');
+    expect(getPairing(b.code)?.attempts ?? []).toHaveLength(0);
+  });
+
+  it("one bot's code is rejected on another bot and stays consumable on its own", async () => {
+    const a = await createPairing('main');
+    const onB = await tryConsume({
+      text: a.code,
+      botUsername: 'b',
+      platformId: 'p',
+      isGroup: false,
+      instance: 'telegram-mega',
+    });
+    expect(onB).toBeNull();
+    expect(getStatus(a.code)).toBe('pending');
+    const onA = await tryConsume({ text: a.code, botUsername: 'a', platformId: 'p', isGroup: false });
+    expect(onA?.status).toBe('consumed');
+  });
+
+  it('replace-by-default is scoped to the instance: the same intent can be pending on two bots', async () => {
+    const a = await createPairing('main');
+    const b = await createPairing('main', 'telegram-mega');
+    expect(getStatus(a.code)).toBe('pending');
+    expect(getStatus(b.code)).toBe('pending');
+  });
+
+  it('a legacy record without an instance field pairs on the default bot only', async () => {
+    const legacy = { code: '123456', intent: 'main', createdAt: new Date().toISOString(), status: 'pending' };
+    fs.writeFileSync(path.join(tmpDir, 'pairings.json'), JSON.stringify({ pairings: [legacy] }));
+    const onMega = await tryConsume({
+      text: '123456',
+      botUsername: 'b',
+      platformId: 'p',
+      isGroup: false,
+      instance: 'telegram-mega',
+    });
+    expect(onMega).toBeNull();
+    expect(getStatus('123456')).toBe('pending');
+    const onDefault = await tryConsume({ text: '123456', botUsername: 'b', platformId: 'p', isGroup: false });
+    expect(onDefault?.status).toBe('consumed');
+  });
+});

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -11,6 +11,12 @@
  *
  * Storage is a JSON file at data/telegram-pairings.json — single-process,
  * read-modify-write under an in-process mutex.
+ *
+ * Records are instance-bound: a code is created for one adapter instance
+ * ('telegram' for the default bot, 'telegram-<name>' for a named one) and only
+ * that bot's interceptor can consume it; a wrong guess sent to one bot
+ * invalidates only that bot's pending codes. Records written before instances
+ * existed carry no `instance` field and read as the default bot.
  */
 import { randomInt } from 'node:crypto';
 import fs from 'fs';
@@ -40,6 +46,8 @@ export interface PairingAttempt {
 export interface PairingRecord {
   code: string;
   intent: PairingIntent;
+  /** Adapter instance the code pairs on. Absent on legacy records: the default bot. */
+  instance?: string;
   createdAt: string;
   status: Exclude<PairingStatus, 'unknown'>;
   consumed?: ConsumedDetails;
@@ -48,6 +56,9 @@ export interface PairingRecord {
 }
 
 const MAX_ATTEMPTS_PER_RECORD = 10;
+/** Registry key of the default bot; also what a record with no `instance` means. */
+const DEFAULT_INSTANCE = 'telegram';
+const onInstance = (r: PairingRecord, instance: string) => (r.instance ?? DEFAULT_INSTANCE) === instance;
 
 function intentEquals(a: PairingIntent, b: PairingIntent): boolean {
   if (a === 'main' || b === 'main') return a === b;
@@ -117,29 +128,33 @@ function generateCode(active: Set<string>): string {
   throw new Error('Could not allocate a free pairing code (too many active).');
 }
 
-export async function createPairing(intent: PairingIntent): Promise<PairingRecord> {
+export async function createPairing(
+  intent: PairingIntent,
+  instance: string = DEFAULT_INSTANCE,
+): Promise<PairingRecord> {
   return withLock(() => {
     const store = readStore();
     sweep(store);
     // Replace-by-default: a new pairing for an intent supersedes any existing
-    // pending pairing for the same intent. Old waitForPairing calls observe
-    // `invalidated` and exit on their own.
+    // pending pairing for the same intent on the same instance. Old
+    // waitForPairing calls observe `invalidated` and exit on their own.
     for (const r of store.pairings) {
-      if (r.status === 'pending' && intentEquals(r.intent, intent)) {
+      if (r.status === 'pending' && intentEquals(r.intent, intent) && onInstance(r, instance)) {
         r.status = 'invalidated';
-        log.info('Pairing superseded by new request', { code: r.code, intent });
+        log.info('Pairing superseded by new request', { code: r.code, intent, instance });
       }
     }
     const active = new Set(store.pairings.filter((r) => r.status === 'pending').map((r) => r.code));
     const record: PairingRecord = {
       code: generateCode(active),
       intent,
+      instance,
       createdAt: new Date().toISOString(),
       status: 'pending',
     };
     store.pairings.push(record);
     writeStore(store);
-    log.info('Pairing created', { code: record.code, intent });
+    log.info('Pairing created', { code: record.code, intent, instance });
     return record;
   });
 }
@@ -151,6 +166,8 @@ export interface ConsumeInput {
   isGroup: boolean;
   name?: string | null;
   adminUserId?: string | null;
+  /** Adapter instance that observed the message. Omitted: the default bot. */
+  instance?: string;
 }
 
 /** Strip leading @botname and return the trimmed remainder, or null if not addressed. */
@@ -184,14 +201,17 @@ export function extractCode(text: string, botUsername: string): string | null {
 export async function tryConsume(input: ConsumeInput): Promise<PairingRecord | null> {
   const code = extractCode(input.text, input.botUsername);
   if (!code) return null;
+  const instance = input.instance ?? DEFAULT_INSTANCE;
   return withLock(() => {
     const store = readStore();
     const now = Date.now();
     sweep(store);
-    const record = store.pairings.find((r) => r.code === code && r.status === 'pending');
+    const record = store.pairings.find((r) => r.code === code && r.status === 'pending' && onInstance(r, instance));
     if (!record) {
-      // Miss: record the attempt on every currently-pending record so each
-      // waitForPairing caller can surface it as user feedback.
+      // Miss: record the attempt on every record pending on THIS instance so
+      // each waitForPairing caller can surface it as user feedback. Sibling
+      // bots' pendings are untouched: a wrong guess (or another bot's code)
+      // sent to one bot must not cancel a pairing in flight on another.
       const attempt: PairingAttempt = {
         candidate: code,
         platformId: input.platformId,
@@ -200,7 +220,7 @@ export async function tryConsume(input: ConsumeInput): Promise<PairingRecord | n
       };
       let recorded = false;
       for (const r of store.pairings) {
-        if (r.status !== 'pending') continue;
+        if (r.status !== 'pending' || !onInstance(r, instance)) continue;
         r.attempts = [...(r.attempts ?? []), attempt].slice(-MAX_ATTEMPTS_PER_RECORD);
         // One attempt per code. A wrong guess invalidates the pairing
         // immediately — pair-telegram observes the `invalidated` signal and
@@ -210,7 +230,7 @@ export async function tryConsume(input: ConsumeInput): Promise<PairingRecord | n
       }
       writeStore(store);
       if (recorded) {
-        log.info('Pairing invalidated by wrong attempt', { candidate: code, platformId: input.platformId });
+        log.info('Pairing invalidated by wrong attempt', { candidate: code, platformId: input.platformId, instance });
       }
       return null;
     }
@@ -227,7 +247,7 @@ export async function tryConsume(input: ConsumeInput): Promise<PairingRecord | n
       { candidate: code, platformId: input.platformId, at: new Date(now).toISOString(), matched: true },
     ].slice(-MAX_ATTEMPTS_PER_RECORD);
     writeStore(store);
-    log.info('Pairing consumed', { code, platformId: input.platformId, intent: record.intent });
+    log.info('Pairing consumed', { code, platformId: input.platformId, intent: record.intent, instance });
     return record;
   });
 }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,6 +1,14 @@
 /**
  * Telegram channel adapter (v2) — uses Chat SDK bridge, with an inbound
  * interceptor for setup pairing and the owner/global-admin `/connect_group` command.
+ *
+ * Additional bot identities: set TELEGRAM_INSTANCES=<name>[,<name>...] plus a
+ * per-instance token (TELEGRAM_BOT_TOKEN_<NAME>; name uppercased, dashes to
+ * underscores). Each name registers under the `telegram-<name>` instance key
+ * through the same createTelegramBridge factory as the default bot, so the
+ * interceptor, pairing, and wiring defaults are shared. channelType stays
+ * 'telegram' either way: user ids, formatting, and container config are one
+ * namespace across bots. See .claude/skills/telegram-multi-instance.
  */
 import { createTelegramAdapter } from '@chat-adapter/telegram';
 
@@ -197,10 +205,18 @@ async function sendPairingConfirmation(token: string, platformId: string): Promi
   });
 }
 
+/**
+ * `instanceKey` is this bot's registry key ('telegram' for the default bot,
+ * 'telegram-<name>' for a named one). Pairing and the messaging-group row are
+ * instance-exact: a code issued for one bot never pairs on another, and a
+ * chat paired on a named bot gets its own row instead of updating the
+ * default bot's.
+ */
 export function createTelegramInboundInterceptor(
   botUsernamePromise: Promise<string | null>,
   hostOnInbound: ChannelSetup['onInbound'],
   token: string,
+  instanceKey: string,
 ): ChannelSetup['onInbound'] {
   return async (platformId, threadId, message) => {
     const { text, authorUserId } = readInboundFields(message);
@@ -246,6 +262,7 @@ export function createTelegramInboundInterceptor(
         platformId,
         isGroup: isGroupPlatformId(platformId),
         adminUserId: authorUserId,
+        instance: instanceKey,
       });
       if (!consumed) {
         hostOnInbound(platformId, threadId, message);
@@ -255,7 +272,7 @@ export function createTelegramInboundInterceptor(
       // code-bearing message never reaches an agent. Privilege is now a
       // property of the paired user, not the chat: upsert the user, and if
       // this instance has no owner yet, promote them to owner.
-      const existing = await getMessagingGroupByPlatform('telegram', platformId);
+      const existing = await getMessagingGroupByPlatform('telegram', platformId, instanceKey);
       if (existing) {
         await updateMessagingGroup(existing.id, {
           is_group: consumed.consumed!.isGroup ? 1 : 0,
@@ -265,6 +282,7 @@ export function createTelegramInboundInterceptor(
           id: `mg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           channel_type: 'telegram',
           platform_id: platformId,
+          instance: instanceKey,
           name: consumed.consumed!.name,
           is_group: consumed.consumed!.isGroup ? 1 : 0,
           // Same context-appropriate default as router auto-create, so a
@@ -297,6 +315,7 @@ export function createTelegramInboundInterceptor(
 
       log.info('Telegram pairing accepted — chat registered', {
         platformId,
+        instance: instanceKey,
         pairedUser: pairedUserId,
         promotedToOwner,
         intent: consumed.intent,
@@ -311,57 +330,131 @@ export function createTelegramInboundInterceptor(
   };
 }
 
+/**
+ * Bot id (the part of a token before ':') to the instance key that claimed
+ * it. Telegram allows one getUpdates poller per bot (a second one gets 409
+ * conflicts), so a name whose bot another instance already holds is skipped
+ * at the factory. Keyed by bot id so this module-level map never holds a
+ * secret.
+ */
+const claimedBotIds = new Map<string, string>();
+
+/** Construction knobs for one Telegram bot identity. */
+export interface TelegramBridgeOptions {
+  /**
+   * Uppercased/underscored instance suffix appended to the token env key
+   * after an underscore: 'GH_BOT' reads TELEGRAM_BOT_TOKEN_GH_BOT. Omit for
+   * the default bot's unsuffixed key.
+   */
+  envKeySuffix?: string;
+  /**
+   * Registry/bridge instance key (e.g. 'telegram-gh-bot'). Omit for the
+   * default instance, keyed by channelType.
+   */
+  instanceKey?: string;
+}
+
+/**
+ * Build one Telegram bot identity's bridge from its token. The default bot is
+ * the zero-suffix call (used by the registration below); named instances pass
+ * a suffix + instance key and get the exact same construction: polling
+ * adapter, pairing interceptor, channel-name resolution, TELEGRAM_DEFAULTS
+ * declaration. Returns null when the token is missing (or its bot is already
+ * claimed by another instance) so the registry surfaces its normal
+ * "credentials missing, skipping" warning.
+ */
+export function createTelegramBridge(options: TelegramBridgeOptions = {}): ChannelAdapter | null {
+  const tokenKey = `TELEGRAM_BOT_TOKEN${options.envKeySuffix ? `_${options.envKeySuffix}` : ''}`;
+  const token = readEnvFile([tokenKey])[tokenKey];
+  if (!token) return null;
+  const instanceKey = options.instanceKey ?? 'telegram';
+  const botId = token.split(':')[0];
+  const holder = claimedBotIds.get(botId);
+  if (holder !== undefined && holder !== instanceKey) {
+    log.warn('Telegram bot token already in use by another instance, skipping', { instance: instanceKey, holder });
+    return null;
+  }
+  claimedBotIds.set(botId, instanceKey);
+  const telegramAdapter = createTelegramAdapter({
+    botToken: token,
+    mode: 'polling',
+  });
+  const bridge = createChatSdkBridge({
+    adapter: telegramAdapter,
+    instance: options.instanceKey, // undefined ⇒ default instance (keyed by channelType)
+    concurrency: 'concurrent',
+    extractReplyContext,
+    supportsThreads: false,
+    defaults: TELEGRAM_DEFAULTS,
+    // No transformOutboundText: @chat-adapter/telegram >= 4.29 parses
+    // CommonMark and renders escaped MarkdownV2 itself. The legacy-Markdown
+    // sanitizer this replaced was written for the old converter and, run in
+    // front of the new one, downgraded **bold** to *single-star* — which the
+    // adapter then parsed as emphasis and rendered as _italic_.
+    maxTextLength: 4000,
+  });
+
+  const botUsernamePromise = fetchBotUsername(token);
+
+  const wrapped: ChannelAdapter = {
+    ...bridge,
+    resolveChannelName: async (platformId: string) => {
+      const chatId = platformId.split(':').slice(1).join(':');
+      if (!chatId) return null;
+      try {
+        const res = await fetch(`https://api.telegram.org/bot${token}/getChat`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId }),
+        });
+        const data = (await res.json()) as { ok?: boolean; result?: { title?: string } };
+        return data.ok ? (data.result?.title ?? null) : null;
+      } catch {
+        return null;
+      }
+    },
+    async setup(hostConfig: ChannelSetup) {
+      const intercepted: ChannelSetup = {
+        ...hostConfig,
+        onInbound: createTelegramInboundInterceptor(botUsernamePromise, hostConfig.onInbound, token, instanceKey),
+      };
+      return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
+    },
+  };
+  return wrapped;
+}
+
+/** Env-key suffix for a named instance: uppercased, dashes to underscores. */
+function instanceEnvKeySuffix(name: string): string {
+  return name.toUpperCase().replace(/-/g, '_');
+}
+
+/** Named-instance entry into createTelegramBridge; exported for the registration test. */
+export function telegramInstanceBridgeFactory(name: string): ChannelAdapter | null {
+  return createTelegramBridge({ envKeySuffix: instanceEnvKeySuffix(name), instanceKey: `telegram-${name}` });
+}
+
 registerChannelAdapter('telegram', {
-  factory: () => {
-    const env = readEnvFile(['TELEGRAM_BOT_TOKEN']);
-    if (!env.TELEGRAM_BOT_TOKEN) return null;
-    const token = env.TELEGRAM_BOT_TOKEN;
-    const telegramAdapter = createTelegramAdapter({
-      botToken: token,
-      mode: 'polling',
-    });
-    const bridge = createChatSdkBridge({
-      adapter: telegramAdapter,
-      concurrency: 'concurrent',
-      extractReplyContext,
-      supportsThreads: false,
-      defaults: TELEGRAM_DEFAULTS,
-      // No transformOutboundText: @chat-adapter/telegram >= 4.29 parses
-      // CommonMark and renders escaped MarkdownV2 itself. The legacy-Markdown
-      // sanitizer this replaced was written for the old converter and, run in
-      // front of the new one, downgraded **bold** to *single-star* — which the
-      // adapter then parsed as emphasis and rendered as _italic_.
-      maxTextLength: 4000,
-    });
-
-    const botUsernamePromise = fetchBotUsername(token);
-
-    const wrapped: ChannelAdapter = {
-      ...bridge,
-      resolveChannelName: async (platformId: string) => {
-        const chatId = platformId.split(':').slice(1).join(':');
-        if (!chatId) return null;
-        try {
-          const res = await fetch(`https://api.telegram.org/bot${token}/getChat`, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ chat_id: chatId }),
-          });
-          const data = (await res.json()) as { ok?: boolean; result?: { title?: string } };
-          return data.ok ? (data.result?.title ?? null) : null;
-        } catch {
-          return null;
-        }
-      },
-      async setup(hostConfig: ChannelSetup) {
-        const intercepted: ChannelSetup = {
-          ...hostConfig,
-          onInbound: createTelegramInboundInterceptor(botUsernamePromise, hostConfig.onInbound, token),
-        };
-        return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
-      },
-    };
-    return wrapped;
-  },
+  factory: () => createTelegramBridge(),
   defaults: TELEGRAM_DEFAULTS,
 });
+
+// Named instances: registration is unconditional for every listed name (a
+// missing token is then reported at boot instead of leaving a bot silently
+// absent), and every registration carries the same TELEGRAM_DEFAULTS
+// declaration as the default bot, so offline creation paths (setup, ncl)
+// resolve declared wiring defaults for named instances too. Names are
+// lowercase kebab so the env-key mapping is one-to-one and the instance key
+// is URL-safe for the bridge.
+for (const raw of (readEnvFile(['TELEGRAM_INSTANCES']).TELEGRAM_INSTANCES ?? '').split(',')) {
+  const name = raw.trim();
+  if (!name) continue;
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    log.warn('TELEGRAM_INSTANCES name must match ^[a-z0-9][a-z0-9-]*$, skipping', { name });
+    continue;
+  }
+  registerChannelAdapter(`telegram-${name}`, {
+    factory: () => telegramInstanceBridgeFactory(name),
+    defaults: TELEGRAM_DEFAULTS,
+  });
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

(Closest box: update to the existing Telegram payload on `channels` plus a doc skill.)

## Description

Run several Telegram bots on one host. Same shape as Slack:

```
TELEGRAM_BOT_TOKEN=<first bot>            # unchanged, instance "telegram"
TELEGRAM_INSTANCES=mega,research
TELEGRAM_BOT_TOKEN_MEGA=<second bot>      # instance "telegram-mega"
TELEGRAM_BOT_TOKEN_RESEARCH=<third bot>   # instance "telegram-research"
```

**Why.** The engine already routes and delivers per instance (#2733). The Telegram payload registered only one key, and its pairing store and interceptor could not tell bots apart: a wrong code sent to one bot cancelled every pending pairing, and a chat paired on a second bot would have overwritten the first bot's row. Explicit list rather than auto-discovering `TELEGRAM_BOT_TOKEN_*`: a stray duplicate token never starts a second poller, and `main` needs no change.

**What changed.**
- `telegram.ts`: `createTelegramBridge({ envKeySuffix, instanceKey })` (mirrors `createSlackBridge`); default registration is the zero-suffix call; `TELEGRAM_INSTANCES` loop registers `telegram-<name>` with the same defaults; a token for a bot already claimed is skipped with a warning (one poller per bot).
- Interceptor: pairing, row lookup and row create are instance-exact.
- `telegram-pairing.ts`: records carry `instance` (old records read as `telegram`); a code pairs only on its own bot; a wrong guess invalidates only that bot's pending codes.
- `.claude/skills/telegram-multi-instance/SKILL.md`: the reference (like `slack-multi-instance`).

**Risk.** Restart (payload reinstall via `/add-telegram`). Single-token installs unchanged: same key, DB instance, state.

**Verification.**
- On the channels tree: `vitest run src/channels/telegram-*.test.ts src/channels/slack-instances-registration.test.ts`: 52 passed (13 new: keys and boot order, env mapping, name validation, token dedupe, pairing isolation both ways, exact-row interceptor with fetch stubbed). `tsc --noEmit`: 0 telegram errors.
- Materialised onto a clean `main` checkout: build clean, telegram tests 48 passed.
- [x] Live: two bots, second paired by sending the code to it, two rows for the same chat, each bot replies through itself (author, 2026-08-21).

**Train.** Merge this before the `add-telegram` skill PR on `main`, which copies two test files added here. Supersedes #2853 (credit for the direction). The doc skill mentions the `--instance` flags from #3435; drop that paragraph once both are in.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone (payload materialised onto a clean `main` checkout; the doc skill installs nothing)
