### PR TITLE
docker-driver: fix SELinux-blocked mounts, group-writable rw mounts, stray NUL byte

### DIFF
--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -305,4 +305,40 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
     expect(rm.ok).toBe(true);
     expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
   });
+
+  it('adds a mount with --rw, still subject to the allowlist at spawn time', async () => {
+    const GID = 'ag-mount-rw';
+    await createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
+
+    const add = await dispatch(
+      {
+        id: 'r1',
+        command: 'groups-config-add-mount',
+        args: { id: GID, host: '/data/shared', container: '/home/node/shared', rw: true },
+      },
+      { caller: 'host' },
+    );
+    expect(add.ok).toBe(true);
+    expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([
+      { hostPath: '/data/shared', containerPath: '/home/node/shared', readonly: false },
+    ]);
+  });
+
+  it('rejects --ro and --rw together', async () => {
+    const GID = 'ag-mount-conflict';
+    await createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
+
+    const add = await dispatch(
+      {
+        id: 'r1',
+        command: 'groups-config-add-mount',
+        args: { id: GID, host: '/data/shared', container: '/home/node/shared', ro: true, rw: true },
+      },
+      { caller: 'host' },
+    );
+    expect(add.ok).toBe(false);
+    expect((add as { ok: false; error: { message: string } }).error.message).toMatch(/--ro or --rw, not both/);
+  });
 });

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -559,13 +559,18 @@ registerResource({
       description:
         "Mount a host directory into a group's containers. OPERATOR-ONLY — never runnable from " +
         'inside a container (mounting host paths is a filesystem-access boundary). Requires ' +
-        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> [--ro].',
+        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> ' +
+        '[--ro | --rw]. Neither flag defaults to read-only (mount-security fail-safe); --rw explicitly requests ' +
+        'read-write, which still only takes effect if the matching allowlist root permits it.',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
         const hostPath = (args.host ?? args['host-path']) as string | undefined;
         const containerPath = (args.container ?? args['container-path']) as string | undefined;
         if (!hostPath || !containerPath) throw new Error('Provide --host <host-path> and --container <container-path>');
+        if ((args.ro || args.readonly) && args.rw) {
+          throw new Error('Provide --ro or --rw, not both');
+        }
 
         const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
@@ -573,7 +578,7 @@ registerResource({
         const mount: AdditionalMountConfig = {
           hostPath,
           containerPath,
-          ...(args.ro || args.readonly ? { readonly: true } : {}),
+          ...(args.rw ? { readonly: false } : args.ro || args.readonly ? { readonly: true } : {}),
         };
         const existing = JSON.parse(row.additional_mounts) as AdditionalMountConfig[];
         if (!existing.some((m) => m.hostPath === hostPath && m.containerPath === containerPath)) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -923,6 +923,7 @@ export function toMountSpecs(mounts: readonly VolumeMount[], defaultScope: strin
     containerPath: mount.containerPath,
     mode: mount.readonly ? ('ro' as const) : ('rw' as const),
     groupScope: mount.scope ?? defaultScope,
+    groupId: mount.groupId,
   }));
 }
 

--- a/src/drivers/docker-driver.test.ts
+++ b/src/drivers/docker-driver.test.ts
@@ -10,7 +10,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DockerSessionDriver, dockerEventToSessionEvent, ensureDockerRunning } from './docker-driver.js';
+import { DockerSessionDriver, dockerEventToSessionEvent, ensureDockerRunning, groupAddArgs } from './docker-driver.js';
 import { FakeCli } from './fake-cli.js';
 import { withSessionEvents } from './session-events.js';
 import { FIXTURE_POLICY, fixtureSpec } from './spec-fixture.js';
@@ -84,6 +84,42 @@ describe('spec realization', () => {
     // SIGKILL after the full grace period.
     expect(args).toContain('--init');
     expect(args.join(' ')).toContain('--pids-limit 2048');
+  });
+
+  it('disables SELinux type enforcement so unlabeled bind mounts are not denied', async () => {
+    // Bind mounts here carry no :z/:Z relabeling, so an enforcing host (e.g.
+    // Fedora) denies the mapped-uid process access to arbitrary host paths
+    // regardless of the --user/cap-drop posture. This only removes that
+    // additional MAC layer; --user, --cap-drop and the rest are unaffected.
+    await driver().prepare(fixtureSpec());
+    const args = createArgs();
+
+    expect(args.join(' ')).toContain('--security-opt label=disable');
+    expect(args).toContain('--cap-drop=ALL');
+  });
+
+  it('grants supplementary group access for a groupId-bearing rw mount', async () => {
+    const spec = fixtureSpec();
+    spec.containers[0].mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: '/pki/shared-writable',
+      containerPath: '/workspace/extra/shared',
+      mode: 'rw',
+      groupScope: 'g1',
+      groupId: 1004,
+    });
+    await driver().prepare(spec);
+    const args = createArgs();
+
+    expect(args).toContain('--group-add');
+    expect(args[args.indexOf('--group-add') + 1]).toBe('1004');
+  });
+
+  it('omits --group-add entirely when no mount carries a groupId', async () => {
+    await driver().prepare(fixtureSpec());
+    const args = createArgs();
+
+    expect(args).not.toContain('--group-add');
   });
 
   it('omits the pids limit for 0, negatives and absent values', async () => {
@@ -670,5 +706,37 @@ describe('ensureDockerRunning', () => {
     cli.responses = [{ match: /^info$/, throws: new Error('Cannot connect to the Docker daemon') }];
     expect(() => ensureDockerRunning(cli)).toThrow('Container runtime is required but failed to start');
     expect(log.error).toHaveBeenCalled();
+  });
+});
+
+describe('groupAddArgs', () => {
+  const mount = (groupId: number | undefined) => ({
+    class: 'allowlisted-extra' as const,
+    hostPath: '/h',
+    containerPath: '/c',
+    mode: 'rw' as const,
+    groupScope: 'g1',
+    groupId,
+  });
+
+  it('emits one --group-add pair per distinct gid', () => {
+    expect(groupAddArgs([mount(1004), mount(1005)])).toEqual(['--group-add', '1004', '--group-add', '1005']);
+  });
+
+  it('dedupes a gid shared by multiple mounts', () => {
+    expect(groupAddArgs([mount(1004), mount(1004)])).toEqual(['--group-add', '1004']);
+  });
+
+  it('sorts numerically so the argv is deterministic', () => {
+    expect(groupAddArgs([mount(2000), mount(100)])).toEqual(['--group-add', '100', '--group-add', '2000']);
+  });
+
+  it('skips mounts with no groupId', () => {
+    expect(groupAddArgs([mount(undefined), mount(1004)])).toEqual(['--group-add', '1004']);
+  });
+
+  it('returns an empty array when nothing needs a supplementary group', () => {
+    expect(groupAddArgs([mount(undefined)])).toEqual([]);
+    expect(groupAddArgs([])).toEqual([]);
   });
 });

--- a/src/drivers/docker-driver.ts
+++ b/src/drivers/docker-driver.ts
@@ -147,6 +147,7 @@ export class DockerSessionDriver implements SessionDriver {
     args.push(...envArgs(agent.env));
     args.push(...envArgs(agent.contributedEnv ?? {}));
     args.push(...mountArgs(agent.mounts));
+    args.push(...groupAddArgs(agent.mounts));
     // Network topology is driver-private: injected at registration (see
     // `drivers/index.ts`), never carried on the spec. Argv-shaped input has no
     // remaining channel through composition.
@@ -612,7 +613,7 @@ export function dockerEventToSessionEvent(doc: unknown, installSlug: string): Se
 export function agentContainerName(spec: SessionSpec): string {
   const raw = `${spec.key.installSlug}-${spec.key.sessionId}`.replaceAll(/[^a-zA-Z0-9_.-]/g, '-');
   if (raw.length <= 48) return `ncl-${raw}`;
-  const hash = createHash('sha256').update(`${spec.key.installSlug} ${spec.key.sessionId}`).digest('hex').slice(0, 8);
+  const hash = createHash('sha256').update(`${spec.key.installSlug} ${spec.key.sessionId}`).digest('hex').slice(0, 8);
   return `ncl-${raw.slice(0, 39)}-${hash}`;
 }
 
@@ -626,9 +627,17 @@ export function agentContainerName(spec: SessionSpec): string {
  * leaving the runtime as PID 1 with no signal handler, and Linux discards
  * default-action signals to PID 1. Without docker-init, SIGTERM is ignored and
  * every stop ends in SIGKILL after the full grace period.
+ *
+ * `label=disable` opts the container out of SELinux type enforcement on a host
+ * that has it enabled (e.g. Fedora). Bind mounts here (`mountArgs`) carry no
+ * `:z`/`:Z` relabeling, so an enforcing host denies the mapped-UID process
+ * access to arbitrary host paths regardless of the `--user`/cap-drop posture
+ * above. The actual containment this project relies on — non-root UID,
+ * dropped capabilities, no docker.sock, egress-locked network — is unaffected;
+ * this only removes the additional MAC layer SELinux would otherwise apply.
  */
 export function hardeningArgs(spec: SessionSpec): string[] {
-  const args = ['--cap-drop=ALL', '--security-opt', 'no-new-privileges', '--init'];
+  const args = ['--cap-drop=ALL', '--security-opt', 'no-new-privileges', '--security-opt', 'label=disable', '--init'];
   // Test >0, not truthiness: cgroups v2 rejects `--pids-limit 0` with EINVAL.
   const pids = spec.resources.pidsLimit;
   if (typeof pids === 'number' && Number.isFinite(pids) && pids > 0) {
@@ -661,6 +670,20 @@ export function mountArgs(mounts: readonly MountSpec[]): string[] {
     '-v',
     m.mode === 'ro' ? `${m.hostPath}:${m.containerPath}:ro` : `${m.hostPath}:${m.containerPath}`,
   ]);
+}
+
+/**
+ * Supplementary groups for mounts whose host directory is writable only via
+ * group membership — see `MountSpec.groupId`. `--user uid:gid` sets a primary
+ * group only, so without this a `mode: 'rw'` mount on such a directory would
+ * validate as writable but fail with EACCES in practice. Deduplicated and
+ * sorted so the resulting argv is deterministic.
+ */
+export function groupAddArgs(mounts: readonly MountSpec[]): string[] {
+  const gids = [...new Set(mounts.map((m) => m.groupId).filter((gid): gid is number => gid !== undefined))].sort(
+    (a, b) => a - b,
+  );
+  return gids.flatMap((gid) => ['--group-add', String(gid)]);
 }
 
 export function envArgs(env: Record<string, string>): string[] {

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -49,6 +49,15 @@ export interface MountSpec {
   mode: 'rw' | 'ro';
   /** Lets a realization — by admission or by in-code checks — pin group-state to the group subtree. */
   groupScope: string;
+  /**
+   * Host GID a realization should grant the agent process as a supplementary
+   * group (Docker's `--group-add`), so a `mode: 'rw'` mount whose host
+   * directory is only group-writable is actually writable — `--user uid:gid`
+   * sets a primary GID only and drops supplementary groups otherwise. Set for
+   * 'allowlisted-extra' rw mounts by `validateAdditionalMounts`, from the
+   * mount root's owning gid; absent when the mount doesn't need it.
+   */
+  groupId?: number;
 }
 
 export interface ContainerSpec {

--- a/src/modules/mount-security/index.test.ts
+++ b/src/modules/mount-security/index.test.ts
@@ -117,3 +117,68 @@ describe('loadMountAllowlist', () => {
     expect(loadMountAllowlist()).toBeNull();
   });
 });
+
+describe('validateMount groupId (supplementary group for group-writable rw mounts)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('grants the mount root owning gid as groupId when the mount is read-write', () => {
+    writeAllowlist({
+      allowedRoots: [{ path: projectsDir, allowReadWrite: true }],
+      blockedPatterns: [],
+    });
+    vi.spyOn(fs, 'statSync').mockReturnValue({ gid: 1004 } as fs.Stats);
+
+    const result = validateMount({ hostPath: repoDir, readonly: false });
+    expect(result.allowed).toBe(true);
+    expect(result.effectiveReadonly).toBe(false);
+    expect(result.groupId).toBe(1004);
+  });
+
+  it('does not grant groupId when the mount stays read-only', () => {
+    writeAllowlist({
+      allowedRoots: [{ path: projectsDir, allowReadWrite: true }],
+      blockedPatterns: [],
+    });
+    vi.spyOn(fs, 'statSync').mockReturnValue({ gid: 1004 } as fs.Stats);
+
+    const result = validateMount({ hostPath: repoDir, readonly: true });
+    expect(result.allowed).toBe(true);
+    expect(result.effectiveReadonly).toBe(true);
+    expect(result.groupId).toBeUndefined();
+  });
+
+  it('does not grant root-group (gid 0) membership even on a read-write mount', () => {
+    writeAllowlist({
+      allowedRoots: [{ path: projectsDir, allowReadWrite: true }],
+      blockedPatterns: [],
+    });
+    vi.spyOn(fs, 'statSync').mockReturnValue({ gid: 0 } as fs.Stats);
+
+    const result = validateMount({ hostPath: repoDir, readonly: false });
+    expect(result.allowed).toBe(true);
+    expect(result.effectiveReadonly).toBe(false);
+    expect(result.groupId).toBeUndefined();
+  });
+
+  it('leaves groupId unset when stat fails, without failing the mount', () => {
+    writeAllowlist({
+      allowedRoots: [{ path: projectsDir, allowReadWrite: true }],
+      blockedPatterns: [],
+    });
+    // Only the mount-root stat (not the allowlist file's own mtime-cache stat)
+    // should fail here, or loadMountAllowlist itself would report "no
+    // allowlist configured" for an unrelated reason.
+    const realStatSync = fs.statSync.bind(fs);
+    vi.spyOn(fs, 'statSync').mockImplementation((p, ...rest) => {
+      if (p === configFile) return realStatSync(p, ...rest);
+      throw new Error('EACCES');
+    });
+
+    const result = validateMount({ hostPath: repoDir, readonly: false });
+    expect(result.allowed).toBe(true);
+    expect(result.effectiveReadonly).toBe(false);
+    expect(result.groupId).toBeUndefined();
+  });
+});

--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -303,6 +303,14 @@ export interface MountValidationResult {
   realHostPath?: string;
   resolvedContainerPath?: string;
   effectiveReadonly?: boolean;
+  /**
+   * Owning gid of the mount root, set only when the mount is granted
+   * read-write. `docker run --user uid:gid` sets a primary group only and
+   * drops supplementary groups, so a host directory that's writable via group
+   * membership (not world-writable) needs its gid granted back explicitly —
+   * see `MountSpec.groupId`.
+   */
+  groupId?: number;
 }
 
 /**
@@ -379,12 +387,38 @@ export function validateMount(mount: AdditionalMount): MountValidationResult {
     }
   }
 
+  // Grant the mount root's owning gid as a supplementary group so a
+  // group-writable-only directory (not world-writable) is actually writable —
+  // `--user uid:gid` sets a primary group and drops supplementary ones.
+  // Skip gid 0: granting the container process root-group membership is a
+  // broader escalation than "let this rw mount work", so a root-group-owned
+  // rw mount stays write-denied rather than silently widened.
+  let groupId: number | undefined;
+  if (!effectiveReadonly) {
+    try {
+      const gid = fs.statSync(realPath).gid;
+      if (gid > 0) {
+        groupId = gid;
+      } else {
+        log.info('Mount root is group-0 owned - not granting root-group supplementary access', {
+          mount: mount.hostPath,
+        });
+      }
+    } catch (err) {
+      log.warn('Could not stat mount root to resolve owning gid', {
+        mount: mount.hostPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   return {
     allowed: true,
     reason: `Allowed under root "${allowedRoot.path}"${allowedRoot.description ? ` (${allowedRoot.description})` : ''}`,
     realHostPath: realPath,
     resolvedContainerPath: containerPath,
     effectiveReadonly,
+    groupId,
   };
 }
 
@@ -400,11 +434,13 @@ export function validateAdditionalMounts(
   hostPath: string;
   containerPath: string;
   readonly: boolean;
+  groupId?: number;
 }> {
   const validatedMounts: Array<{
     hostPath: string;
     containerPath: string;
     readonly: boolean;
+    groupId?: number;
   }> = [];
 
   for (const mount of mounts) {
@@ -415,6 +451,7 @@ export function validateAdditionalMounts(
         hostPath: result.realHostPath!,
         containerPath: `/workspace/extra/${result.resolvedContainerPath}`,
         readonly: result.effectiveReadonly!,
+        groupId: result.groupId,
       });
 
       log.debug('Mount validated successfully', {
@@ -422,6 +459,7 @@ export function validateAdditionalMounts(
         hostPath: result.realHostPath,
         containerPath: result.resolvedContainerPath,
         readonly: result.effectiveReadonly,
+        groupId: result.groupId,
         reason: result.reason,
       });
     } else {

--- a/src/providers/provider-container-registry.ts
+++ b/src/providers/provider-container-registry.ts
@@ -28,6 +28,8 @@ export interface VolumeMount {
   mountClass?: import('../drivers/types.js').MountClass;
   /** Agent group this mount is pinned to, for `group-state`. */
   scope?: string;
+  /** See `MountSpec.groupId` in `src/drivers/types.ts`. */
+  groupId?: number;
 }
 
 export interface ProviderContainerContext {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** Three related fixes to the additional-mount pipeline (`docker-driver.ts`, `mount-security/index.ts`), found while debugging container mounts failing silently on a SELinux-enforcing Fedora host:

1. Adds `--security-opt label=disable` to every agent container launch, so bind mounts work on SELinux-enforcing hosts without per-mount `:z`/`:Z` relabeling.
2. Adds supplementary-group support for allowlisted read-write mounts: `validateMount()` now resolves the mount root's owning gid (skipping gid 0, to avoid granting root-group membership) and threads it through `MountSpec.groupId` to a new `groupAddArgs()` emitting `--group-add`.
3. Adds `--rw` to `ncl groups config add-mount` (previously `readonly` could only be `true` or omitted-to-`true`, with no way to explicitly request read-write from the CLI), and removes a stray NUL byte that had been sitting inside `agentContainerName`'s hash-input string (it made `file` misclassify the whole source file as binary, silently defeating plain `grep` against it).

**Why:** On a SELinux-enforcing host, bind-mounted host paths carry no relabeling, so an enforcing host denies the mapped-uid process access to arbitrary host paths regardless of the container's `--user`/cap-drop posture — mounts fail with permission denied. Separately, `docker run --user uid:gid` sets a primary group only and drops supplementary groups, so a host directory that's writable only via group membership (not world-writable) was silently unwritable even after being allowlisted as `rw`.

**How it works:** See the three points above. The gid-0 exclusion and the "still subject to the allowlist" framing on `--rw` keep the fix narrowly scoped — it makes previously-broken allowlisted mounts actually work, without widening what the allowlist permits.

**How it was tested:** Full host suite passes (`pnpm test`, 156 files / 1961 tests) plus new targeted coverage: `groupAddArgs()` dedup/sort/gid-skip behavior, `validateMount()` granting (and correctly withholding, for gid 0 or a failed `stat`) a supplementary `groupId` on rw mounts, and the CLI `--rw` flag plus its `--ro`/`--rw` conflict guard. Also verified live: the SELinux fix was confirmed against a real Fedora host where mounts were previously failing.

**Note on #1530:** There's an existing open PR (#1530) also addressing SELinux mounts via per-mount `:z` labels on `readonlyMountArgs()`/`container-runtime.ts`. Those functions no longer exist on current `main` — that mount-arg-building logic has since moved to the driver abstraction (`src/drivers/docker-driver.ts`), so this PR targets the current code path and shouldn't conflict with or duplicate #1530.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>