### PR TITLE
fix(setup): preserve files when git show fails

### DIFF
--- a/scripts/git-show-to-file.test.ts
+++ b/scripts/git-show-to-file.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { gitShowToFileCommand } from './git-show-to-file.js';
+
+const roots: string[] = [];
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'nanoclaw-git-show-'));
+  roots.push(root);
+  execFileSync('git', ['init', '--quiet'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('gitShowToFileCommand', () => {
+  it('preserves the destination on failure and replaces it only after a successful git show', () => {
+    const root = makeRepo();
+    const source = "source/source's file.ts";
+    const destination = "output/destination's file.ts";
+    mkdirSync(dirname(join(root, source)), { recursive: true });
+    mkdirSync(dirname(join(root, destination)), { recursive: true });
+    writeFileSync(join(root, source), 'from git\n');
+    writeFileSync(join(root, destination), 'existing\n');
+    execFileSync('git', ['add', source], { cwd: root });
+    execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], { cwd: root });
+
+    const failed = spawnSync('sh', ['-c', gitShowToFileCommand('HEAD', 'missing.ts', destination)], {
+      cwd: root,
+    });
+    expect(failed.status).not.toBe(0);
+    expect(readFileSync(join(root, destination), 'utf8')).toBe('existing\n');
+    expect(readdirSync(dirname(join(root, destination))).filter((name) => name.startsWith('.git-show.'))).toEqual([]);
+
+    execFileSync('sh', ['-c', gitShowToFileCommand('HEAD', source, destination)], { cwd: root });
+    expect(readFileSync(join(root, destination), 'utf8')).toBe('from git\n');
+    expect(readdirSync(dirname(join(root, destination))).filter((name) => name.startsWith('.git-show.'))).toEqual([]);
+  });
+});

--- a/scripts/git-show-to-file.ts
+++ b/scripts/git-show-to-file.ts
@@ -1,0 +1,16 @@
+import { posix } from 'node:path';
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export function gitShowToFileCommand(revision: string, source: string, destination: string): string {
+  const tempPattern = posix.join(posix.dirname(destination), `.${posix.basename(destination)}.XXXXXX`);
+  return [
+    `temp_file=$(mktemp ${shellQuote(tempPattern)})`,
+    `trap 'rm -f -- "$temp_file"' EXIT`,
+    `git show ${shellQuote(`${revision}:${source}`)} > "$temp_file"`,
+    `mv -- "$temp_file" ${shellQuote(destination)}`,
+    `trap - EXIT`,
+  ].join(' && ');
+}

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { gitShowToFileCommand } from './git-show-to-file.js';
 import {
   applySkill,
   removeSkill,
@@ -190,7 +191,7 @@ describe('apply engine lifecycle', () => {
 
 // from-branch copy: the dest may live only on the registry branch (e.g. a
 // container skill trunk no longer ships), so the engine must create the
-// parent directory itself — the shell redirect in `git show src > dest` can't.
+// parent directory before running the atomic git-show helper.
 const FROM_BRANCH_SKILL = `# from-branch demo
 
 ## Pull the formatting skill from the channels branch
@@ -200,7 +201,7 @@ container/skills/demo-formatting/SKILL.md
 `;
 
 describe('from-branch copy apply path', () => {
-  it('creates the missing dest parent dir before the git-show redirect', async () => {
+  it('creates the missing dest parent dir before the atomic git-show copy', async () => {
     const fskill = mkdtempSync(join(tmpdir(), 'nc-skill-fb-'));
     const froot = mkdtempSync(join(tmpdir(), 'nc-proj-fb-'));
     writeFileSync(join(fskill, 'SKILL.md'), FROM_BRANCH_SKILL);
@@ -211,15 +212,18 @@ describe('from-branch copy apply path', () => {
     const { cmds, exec } = recordingExec();
     const res = await applySkill(fskill, froot, { exec, resolveRemote: () => 'origin' });
 
-    // the redirect target's parent now exists, so the exec'd `git show … > dest`
-    // (mocked here) would not fail with ENOENT on a real run
+    // The destination parent exists before the helper runs (mocked here).
     expect(existsSync(join(froot, 'container/skills/demo-formatting'))).toBe(true);
     expect(cmds).toContain('git fetch origin channels');
     expect(
-      cmds.some((c) =>
-        /^git show origin\/channels:container\/skills\/demo-formatting\/SKILL\.md > container\/skills\/demo-formatting\/SKILL\.md$/.test(
-          c,
-        ),
+      cmds.some(
+        (c) =>
+          c ===
+          gitShowToFileCommand(
+            'origin/channels',
+            'container/skills/demo-formatting/SKILL.md',
+            'container/skills/demo-formatting/SKILL.md',
+          ),
       ),
     ).toBe(true);
     expect(res.journal).toContainEqual({ op: 'wrote', path: 'container/skills/demo-formatting/SKILL.md' });

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -25,6 +25,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, appendFileSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { gitShowToFileCommand } from './git-show-to-file.js';
 import { parseDirectives, promptVar, type Directive } from './skill-directives.js';
 
 // What an `nc:prompt` DECLARES about the value it needs — the core seam's input
@@ -656,7 +657,7 @@ async function applyOne(
           // may not exist on trunk (e.g. container skills that live only on
           // the channels branch). Mirror the local-copy path's mkdir.
           mkdirSync(dirname(join(root, destOf(l))), { recursive: true });
-          await exec(`git show ${remote}/${b}:${srcOf(l)} > ${destOf(l)}`);
+          await exec(gitShowToFileCommand(`${remote}/${b}`, srcOf(l), destOf(l)));
         }
       } else {
         for (const l of d.body) {

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
 import { runChannelSkill } from './run-channel-skill.js';
 import { runSkill } from '../lib/skill-driver.js';
 import { fullyApplied } from '../../scripts/skill-apply.js';
@@ -630,11 +631,18 @@ describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs
     expect(materializeCompanionSkill('slack-agent-flow', root, { exec, resolveRemote: () => 'upstream' })).toBe(true);
     expect(cmds[0]).toBe('git fetch upstream channels');
     expect(cmds[1]).toBe("git ls-tree -r --name-only 'upstream/channels' -- '.claude/skills/slack-agent-flow'");
-    // One git-show per listed file, into the same relative path — quoted so a
-    // future filename with spaces fails loudly instead of word-splitting.
+    // One atomic git-show copy per listed file, into the same relative path.
     expect(cmds.slice(2)).toEqual([
-      "git show 'upstream/channels:.claude/skills/slack-agent-flow/SKILL.md' > '.claude/skills/slack-agent-flow/SKILL.md'",
-      "git show 'upstream/channels:.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts' > '.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts'",
+      gitShowToFileCommand(
+        'upstream/channels',
+        '.claude/skills/slack-agent-flow/SKILL.md',
+        '.claude/skills/slack-agent-flow/SKILL.md',
+      ),
+      gitShowToFileCommand(
+        'upstream/channels',
+        '.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts',
+        '.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts',
+      ),
     ]);
     rmSync(root, { recursive: true, force: true });
   });
@@ -653,7 +661,7 @@ describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs
     const exec = (command: string): string => {
       if (command.includes('ls-tree')) return '.claude/skills/slack-agent-flow/SKILL.md\n';
       if (command.includes('git show')) {
-        // Simulate the redirect creating the parent dir then failing.
+        // Simulate the helper starting the copy and then failing.
         mkdirSync(join(root, '.claude/skills/slack-agent-flow'), { recursive: true });
         throw new Error('fatal: bad object');
       }

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -21,6 +21,7 @@ import { dirname, join } from 'node:path';
 
 import * as p from '@clack/prompts';
 
+import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
 import { firstFailureHint, fullyApplied } from '../../scripts/skill-apply.js';
 import * as setupLog from '../logs.js';
 import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../lib/back-nav.js';
@@ -57,8 +58,7 @@ export function materializeCompanionSkill(
   if (existsSync(join(projectRoot, dir, 'SKILL.md'))) return true;
   const exec =
     deps.exec ??
-    ((command: string) =>
-      execSync(command, { cwd: projectRoot, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
+    ((command: string) => execSync(command, { cwd: projectRoot, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
   try {
     const remote = (deps.resolveRemote ?? channelsRemote(projectRoot))();
     exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
@@ -69,7 +69,7 @@ export function materializeCompanionSkill(
     if (files.length === 0) return false;
     for (const file of files) {
       mkdirSync(dirname(join(projectRoot, file)), { recursive: true });
-      exec(`git show '${remote}/${CHANNELS_BRANCH}:${file}' > '${file}'`);
+      exec(gitShowToFileCommand(`${remote}/${CHANNELS_BRANCH}`, file, file));
     }
     return true;
   } catch {

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
+
 const state = vi.hoisted(() => ({
   account: undefined as { api?: string; token: string } | undefined,
   installToken: undefined as string | undefined,
@@ -186,9 +188,9 @@ describe('provisioning-core bootstrap', () => {
       'git remote',
       'git ls-remote --heads origin channels',
       'git fetch origin channels',
-      `git show origin/channels:${PROVISIONING_MODULE} > ${PROVISIONING_MODULE}`,
+      gitShowToFileCommand('origin/channels', PROVISIONING_MODULE, PROVISIONING_MODULE),
     ]);
-    // the parent directory exists before the git show redirect runs
+    // The parent directory exists before the atomic git-show copy runs.
     expect(fs.existsSync(path.join(root, 'src/provisioning'))).toBe(true);
     expect(importModule).toHaveBeenCalledExactlyOnceWith(pathToFileURL(path.join(root, PROVISIONING_MODULE)).href);
   });

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -36,6 +36,7 @@ import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
+import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
 import * as setupLog from '../logs.js';
 import { brightSelect } from '../lib/bright-select.js';
 import { confirmThenOpen } from '../lib/browser.js';
@@ -191,7 +192,7 @@ export async function loadProvisioningCore(deps: BootstrapDeps = {}): Promise<Pr
       const remote = resolveChannelsRemote(exec);
       exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
       fs.mkdirSync(path.dirname(modulePath), { recursive: true });
-      exec(`git show ${remote}/${CHANNELS_BRANCH}:${PROVISIONING_MODULE} > ${PROVISIONING_MODULE}`);
+      exec(gitShowToFileCommand(`${remote}/${CHANNELS_BRANCH}`, PROVISIONING_MODULE, PROVISIONING_MODULE));
       setupLog.step('slack-provision-bootstrap', 'success', Date.now() - start, { REMOTE: remote });
     }
     return await importModule(pathToFileURL(modulePath).href);

--- a/setup/channels/whatsapp-flow.test.ts
+++ b/setup/channels/whatsapp-flow.test.ts
@@ -39,7 +39,13 @@ async function run(inputs: Record<string, string>): Promise<Recorded> {
     inputs,
     exec: (cmd: string) => {
       seq.push({ type: 'exec', text: cmd });
-      if (/^(git|pnpm|bash)\b/.test(cmd) || cmd.startsWith('grep') || cmd.startsWith('touch')) return '';
+      if (
+        /^(git|pnpm|bash)\b/.test(cmd) ||
+        cmd.includes('git show') ||
+        cmd.startsWith('grep') ||
+        cmd.startsWith('touch')
+      )
+        return '';
       return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
     },
     execStream: async () => ({ ok: true, fields: { PHONE: BOT_PHONE } }),

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -29,7 +29,11 @@ echo "STEP: fetch-channels-branch"
 git fetch origin channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/github.ts > src/channels/github.ts
+temp_file="$(mktemp src/channels/.github.ts.XXXXXX)"
+trap 'rm -f -- "$temp_file"' EXIT
+git show origin/channels:src/channels/github.ts > "$temp_file"
+mv -- "$temp_file" src/channels/github.ts
+trap - EXIT
 
 echo "STEP: register-import"
 if ! grep -q "import './github.js';" src/channels/index.ts; then

--- a/setup/install-github.test.ts
+++ b/setup/install-github.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const roots: string[] = [];
+
+function makeFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'nanoclaw-install-github-'));
+  roots.push(root);
+  mkdirSync(join(root, 'setup'), { recursive: true });
+  mkdirSync(join(root, 'src/channels'), { recursive: true });
+  mkdirSync(join(root, 'bin'), { recursive: true });
+  copyFileSync(join(process.cwd(), 'setup/install-github.sh'), join(root, 'setup/install-github.sh'));
+  writeFileSync(join(root, 'src/channels/index.ts'), '');
+  writeFileSync(join(root, 'src/channels/github.ts'), 'existing\n');
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  return root;
+}
+
+function writeExecutable(root: string, name: string, body: string): void {
+  const file = join(root, 'bin', name);
+  writeFileSync(file, `#!/bin/sh\n${body}\n`);
+  chmodSync(file, 0o755);
+}
+
+function runInstaller(root: string) {
+  return spawnSync('bash', ['setup/install-github.sh'], {
+    cwd: root,
+    env: { ...process.env, PATH: `${join(root, 'bin')}:${process.env.PATH}` },
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('install-github channel copy', () => {
+  it('preserves the destination and removes the temporary file when git show fails', () => {
+    const root = makeFixture();
+    writeExecutable(root, 'git', 'if [ "$1" = fetch ]; then exit 0; fi\nexit 1');
+
+    const result = runInstaller(root);
+
+    expect(result.status).not.toBe(0);
+    expect(readFileSync(join(root, 'src/channels/github.ts'), 'utf8')).toBe('existing\n');
+    expect(readdirSync(join(root, 'src/channels')).filter((name) => name.startsWith('.github.ts.'))).toEqual([]);
+  });
+
+  it('replaces the destination only after git show succeeds', () => {
+    const root = makeFixture();
+    writeExecutable(
+      root,
+      'git',
+      'if [ "$1" = fetch ]; then exit 0; fi\nif [ "$1" = show ]; then printf "from git\\n"; exit 0; fi\nexit 1',
+    );
+    writeExecutable(root, 'pnpm', 'exit 0');
+
+    const result = runInstaller(root);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(join(root, 'src/channels/github.ts'), 'utf8')).toBe('from git\n');
+    expect(readdirSync(join(root, 'src/channels')).filter((name) => name.startsWith('.github.ts.'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Setup copy steps now write `git show` output to a temporary file and move it into place only after Git succeeds. A shared helper applies the same atomic behavior to the TypeScript setup paths, while the shell installer uses the equivalent sequence directly. This preserves an existing destination and removes temporary files when a ref or path is unavailable.

Addresses Bug 1 of #3354.

## Testing

- `pnpm exec vitest run scripts/git-show-to-file.test.ts scripts/skill-apply.test.ts setup/channels/run-channel-skill.test.ts setup/channels/slack-auto.test.ts setup/channels/whatsapp-flow.test.ts setup/install-github.test.ts --testTimeout 20000` (132 passed)
- `pnpm typecheck`
- Prettier check for all changed TypeScript files
- `bash -n setup/install-github.sh`
