### PR TITLE
build: drop better-sqlite3 from onlyBuiltDependencies — use its bundled prebuilds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 onlyBuiltDependencies:
-  - better-sqlite3
   - esbuild
   - protobufjs
   - sharp


### PR DESCRIPTION
## What

Removes `better-sqlite3` from `onlyBuiltDependencies` so pnpm stops running its `node-gyp rebuild` install script.

## Why

better-sqlite3 v13 ships prebuilt bindings for every supported platform inside the npm package (`prebuilds/<platform>-<arch>.node`), and the runtime loads them directly. The forced gyp rebuild adds a hard Python + build-toolchain requirement that fails in minimal containers — while the bundled prebuild sits unused right next to it.

Hit in practice running nanoclaw as a claimed dev instance in a python-less container: `pnpm install` died at `gyp ERR! find Python` with `prebuilds/linux-arm64.node` sitting in the package.

## Verification

On linux-arm64 in a python-less container: install completes with no build step, the prebuilt binding loads, and a live database round-trip works. Platforms without a bundled prebuild can still opt in explicitly with `pnpm rebuild better-sqlite3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
