### PR TITLE
fix(upgrade-state): accept a version-matching marker when Git cannot identify the checkout

### DIFF
--- a/src/upgrade-state.test.ts
+++ b/src/upgrade-state.test.ts
@@ -120,3 +120,33 @@ describe('upgrade-state', () => {
     errSpy.mockRestore();
   });
 });
+
+describe('git-less runtimes', () => {
+  const GITLESS = path.join(TEST_DIR, 'gitless-checkout');
+
+  function gitlessCheckout(version: string): string {
+    fs.mkdirSync(GITLESS, { recursive: true });
+    fs.writeFileSync(path.join(GITLESS, 'package.json'), JSON.stringify({ version }));
+    return GITLESS;
+  }
+
+  function writeMarker(marker: Record<string, string>): void {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    fs.writeFileSync(markerPath(), JSON.stringify({ updatedAt: new Date().toISOString(), via: 'update', ...marker }));
+  }
+
+  it('accepts a version-matching marker when Git cannot identify the checkout', () => {
+    writeMarker({ version: '9.9.9', commit: 'a'.repeat(40), tree: 'b'.repeat(40) });
+    expect(isUpgradeCurrent(gitlessCheckout('9.9.9'))).toBe(true);
+  });
+
+  it('still trips on a version mismatch when Git is unavailable', () => {
+    writeMarker({ version: '1.0.0', commit: 'a'.repeat(40), tree: 'b'.repeat(40) });
+    expect(isUpgradeCurrent(gitlessCheckout('9.9.9'))).toBe(false);
+  });
+
+  it('a marker recorded without Git still trips where Git identifies the checkout', () => {
+    writeMarker({ version: getCodeVersion(), commit: 'unknown', tree: 'unknown' });
+    expect(isUpgradeCurrent()).toBe(false);
+  });
+});

--- a/src/upgrade-state.ts
+++ b/src/upgrade-state.ts
@@ -104,7 +104,20 @@ export function isUpgradeCurrent(projectRoot: string = process.cwd()): boolean {
   if (state === null) return false;
   try {
     const code = getCodeIdentity(projectRoot);
-    return state.version === code.version && state.commit === code.commit && state.tree === code.tree;
+    if (state.version !== code.version) return false;
+    if (code.commit === 'unknown' || code.tree === 'unknown') {
+      // Git cannot identify this checkout (no git binary, or a tree
+      // exported/mounted without .git). Commit and tree cannot strengthen
+      // the check here — the sanctioned recovery path in this world records
+      // 'unknown' for both — so the version match is the whole signal.
+      // Accept it, loudly, rather than making the tripwire a permanent
+      // boot-stop wherever Git is absent.
+      log.warn('Upgrade marker accepted on version match alone — Git cannot identify this checkout', {
+        version: code.version,
+      });
+      return true;
+    }
+    return state.commit === code.commit && state.tree === code.tree;
   } catch (err) {
     log.warn('Could not resolve running code identity; upgrade marker fails closed', {
       err: String(err),


### PR DESCRIPTION
## What

`isUpgradeCurrent` requires version+commit+tree equality unconditionally. This PR keeps that everywhere Git works, and falls back to a version-only comparison — with a WARN naming the weaker check — when Git cannot identify the running checkout (`getCodeIdentity` → `unknown`).

## Why

In a runtime without Git identity (no git binary in the image, or a tree exported/mounted without `.git`), a valid marker written where Git worked can never match `unknown` — the tripwire becomes a permanent boot-stop. Observed live as a container crash loop ending in:

```
NanoClaw stopped: update did not go through the supported path
  code commit:      unknown
  recorded commit:  none
```

`docs/upgrade-recovery.md` already sanctions clearing the tripwire "even while Git is unavailable", and `upgrade-state.ts set` records `unknown/unknown` in that world — the check's real strength there is already version-only. This makes that explicit instead of fatal.

The reverse direction stays strict: an `unknown/unknown` marker carried into a Git-identified checkout still trips.

## Tests

Three new cases: a version-matching marker is accepted in a git-less checkout; a version mismatch still trips there; an `unknown/unknown` marker still trips where Git resolves. 14/14 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
