### PR TITLE
Auto-drop automated senders in the unknown-sender gate (#3235)

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -61,6 +61,11 @@ export interface InboundEvent {
     isMention?: boolean;
     /** True when the source is a group/channel thread, false for DMs. */
     isGroup?: boolean;
+    /**
+     * Platform-confirmed signal that the sender is a bot/webhook, not a
+     * human. See InboundMessage.isAutomated for the full explanation.
+     */
+    isAutomated?: boolean;
   };
   replyTo?: DeliveryAddress;
 }
@@ -89,6 +94,26 @@ export interface InboundMessage {
   isMention?: boolean;
   /** True when the source is a group/channel thread, false for DMs. */
   isGroup?: boolean;
+  /**
+   * Platform-confirmed signal that the sender is a bot/webhook, not a human.
+   *
+   * Set by adapters that know the platform's own bot-authorship signal —
+   * e.g. the Chat SDK bridge sets it true from `message.author.isBot ===
+   * true` (Discord `author.bot` / webhook_id, Slack `bot_id`, Telegram
+   * `from.is_bot` all normalize to this through Chat SDK's Author type).
+   * `isBot` can also be the literal string `"unknown"` on platforms that
+   * can't tell — that is deliberately NOT treated as automated, since
+   * misclassifying a human as a bot would silently and permanently drop
+   * their messages with no recourse.
+   *
+   * Used by the permissions gate (src/modules/permissions/index.ts) to
+   * auto-drop unknown automated senders before the approval flow instead
+   * of generating an approval card the sender can never click through.
+   *
+   * Adapters that don't set it leave it undefined — treated as "not
+   * automated", i.e. today's behavior.
+   */
+  isAutomated?: boolean;
 }
 
 /** A file attachment to deliver alongside a message. */

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -487,7 +487,8 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     // expects (see src/router.ts extractAndUpsertUser). Native adapters already
     // populate these directly; this brings chat-sdk adapters in line.
     const author = serialized.author as
-      { userId?: string; fullName?: string; userName?: string; isBot?: boolean | 'unknown' } | undefined;
+      | { userId?: string; fullName?: string; userName?: string; isBot?: boolean | 'unknown' }
+      | undefined;
     if (author) {
       const name = author.fullName ?? author.userName;
       serialized.senderId = author.userId;

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -486,13 +486,20 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     // Project chat-sdk's nested author into the flat sender fields the router
     // expects (see src/router.ts extractAndUpsertUser). Native adapters already
     // populate these directly; this brings chat-sdk adapters in line.
-    const author = serialized.author as { userId?: string; fullName?: string; userName?: string } | undefined;
+    const author = serialized.author as
+      { userId?: string; fullName?: string; userName?: string; isBot?: boolean | 'unknown' } | undefined;
     if (author) {
       const name = author.fullName ?? author.userName;
       serialized.senderId = author.userId;
       serialized.sender = name;
       serialized.senderName = name;
     }
+    // Chat SDK normalizes each adapter's own bot-authorship signal (Discord
+    // author.bot/webhook_id, Slack bot_id, Telegram from.is_bot) onto
+    // author.isBot. `isBot === true` is the only automated signal we act
+    // on — `"unknown"` stays unautomated so an unclassifiable sender is
+    // never silently and permanently dropped.
+    const isAutomated = author?.isBot === true;
 
     // Drop raw to save DB space (can be very large)
     serialized.raw = undefined;
@@ -504,6 +511,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       timestamp: message.metadata.dateSent.toISOString(),
       isMention,
       isGroup,
+      isAutomated,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ async function main(): Promise<void> {
             timestamp: message.timestamp,
             isMention: message.isMention,
             isGroup: message.isGroup,
+            isAutomated: message.isAutomated,
           },
         }).catch((err) => {
           log.error('Failed to route inbound message', { channelType: adapter.channelType, err });

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -10,7 +10,9 @@
  *      unknown_sender_policy (strict/request_approval/decline_notify/public) and the
  *      owner/global-admin/scoped-admin/member access hierarchy. Records its
  *      own `dropped_messages` row on refusal (structural drops are recorded
- *      by core).
+ *      by core). Automated senders (event.message.isAutomated) are always
+ *      denied silently regardless of policy — never held for approval,
+ *      never sent a decline (see handleUnknownSender, issue #3235).
  *
  * Without this module: sender resolution is a no-op (userId=null); the
  * access gate is not registered and core defaults to allow-all.
@@ -133,6 +135,25 @@ async function handleUnknownSender(
     messaging_group_id: mg.id,
     agent_group_id: agentGroupId,
   };
+
+  // Automated senders (platform webhooks/bots — event.message.isAutomated,
+  // set by the adapter from a platform-confirmed bot signal) can never
+  // click through an approval card, and Allow is worse for this sender
+  // class (it adds a stable bot identity to agent_group_members, so the
+  // agent then engages on every future automated post). Treat them as
+  // strict regardless of unknown_sender_policy — deny silently, no card,
+  // no decline-notify DM — so a recurring webhook can't generate an
+  // unbounded stream of cards (issue #3235).
+  if (event.message.isAutomated) {
+    log.info('MESSAGE DROPPED — automated sender (treated as strict)', {
+      messagingGroupId: mg.id,
+      agentGroupId,
+      userId,
+      accessReason,
+    });
+    await recordDroppedMessage({ ...dropRecord, reason: `automated_sender_${mg.unknown_sender_policy}` });
+    return;
+  }
 
   // The admission decision is the guard's senders.admit decision (./guard.ts)
   // — unknown_sender_policy verbatim: strict → deny, request_approval → hold,

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -136,7 +136,7 @@ afterEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
-function stranger(text: string) {
+function stranger(text: string, opts?: { isAutomated?: boolean }) {
   return {
     channelType: 'telegram',
     platformId: 'chat-123',
@@ -150,6 +150,7 @@ function stranger(text: string) {
         text,
       }),
       timestamp: now(),
+      isAutomated: opts?.isAutomated,
     },
   };
 }
@@ -350,5 +351,47 @@ describe('unknown-sender request_approval flow', () => {
       'ag-1',
     );
     expect(member).toBeDefined();
+  });
+
+  it('drops an automated sender silently instead of issuing an approval card (#3235)', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(stranger('scheduled digest post', { isAutomated: true }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    // No card delivered, no pending-approval row created.
+    expect(deliverMock).not.toHaveBeenCalled();
+    const { getDb } = await import('../../db/connection.js');
+    const pendingCount = (await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals'))!.c;
+    expect(pendingCount).toBe(0);
+
+    // A single drop is recorded (the gate's own automated_sender_* reason is
+    // superseded on the same (channel_type, platform_id) row by core's
+    // no_agent_engaged structural drop — the same upsert-overwrite behavior
+    // that already applies to every other access-gate denial).
+    const { getUnregisteredSenders } = await import('../../db/dropped-messages.js');
+    const dropped = await getUnregisteredSenders();
+    expect(dropped).toHaveLength(1);
+
+    // Not added as a member — repeated automated posts stay droppable, they
+    // never silently gain the ability to trigger the agent.
+    const member = await getDb().get(
+      'SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?',
+      'tg:stranger',
+      'ag-1',
+    );
+    expect(member).toBeUndefined();
+  });
+
+  it('an automated sender never accumulates duplicate cards across repeated posts (#3235)', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(stranger('digest #1', { isAutomated: true }));
+    await routeInbound(stranger('digest #2', { isAutomated: true }));
+    await routeInbound(stranger('digest #3', { isAutomated: true }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(deliverMock).not.toHaveBeenCalled();
+    const { getDb } = await import('../../db/connection.js');
+    const pendingCount = (await getDb().get<{ c: number }>('SELECT COUNT(*) AS c FROM pending_sender_approvals'))!.c;
+    expect(pendingCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3235. Bot/webhook senders (Discord `author.bot`/`webhook_id`, Slack `bot_id`, Telegram `from.is_bot`) tripped the `request_approval` unknown-sender gate exactly like humans, producing an approval card the sender could never click through. Deny is non-persistent by design, so a recurring webhook generates an unbounded stream of fresh cards.

Implements the issue's preferred option 1: surface a bot/automated signal on `InboundEvent` and have the gate treat such senders as strict regardless of `unknown_sender_policy`.

## Changes

- `src/channels/adapter.ts` — add `isAutomated?: boolean` to `InboundMessage` and `InboundEvent.message`.
- `src/channels/chat-sdk-bridge.ts` — populate it from Chat SDK's `author.isBot === true` in `messageToInbound`. `isBot` can also be the literal `"unknown"` on platforms that can't tell; that is deliberately **not** treated as automated, since misclassifying a human as a bot would silently and permanently drop their messages.
- `src/index.ts` — forward `message.isAutomated` through the host's `onInbound` stamping seam.
- `src/modules/permissions/index.ts` — `handleUnknownSender` now checks `event.message.isAutomated` before the policy switch: automated senders are denied silently (recorded as a drop) with no approval card and no decline-notify DM, regardless of `unknown_sender_policy`.

## Scope note

This repo checkout has no Discord/Slack/Telegram native adapter implementations on `main` (those live on a separate `channels` branch per the issue) — every adapter that would carry a bot signal (Discord, Slack) routes through `src/channels/chat-sdk-bridge.ts`, which is where this is wired. Native/legacy adapters that don't set `isAutomated` are unaffected (`undefined` == not automated == today's behavior).

## Test plan

- Added two tests in `src/modules/permissions/sender-approval.test.ts`:
  - An automated sender is dropped silently: no card delivered, no `pending_sender_approvals` row, no `agent_group_members` row.
  - Three consecutive automated posts never accumulate cards or pending rows (the unbounded-loop scenario from the issue).
- `npx vitest run src/modules/permissions/sender-approval.test.ts` — 8/8 passed.
- `npx vitest run src/channels/ src/modules/permissions/` — 161/161 passed (no regressions).
- `npx tsc --noEmit` — clean.
- `npx eslint` on touched files — 0 errors (pre-existing warnings only, none introduced).

Closes #3235