### PR TITLE
fix(circuit-breaker): scope crash strikes to the instance that earned them

### DIFF
--- a/src/circuit-breaker.test.ts
+++ b/src/circuit-breaker.test.ts
@@ -1,11 +1,13 @@
 /**
  * Unit tests for the startup circuit breaker.
  *
- * Covers state transitions, the documented backoff schedule, and the
- * fresh-install case where DATA_DIR doesn't exist yet (the breaker runs
- * before initDb, so it has to create the dir itself).
+ * Covers state transitions, the documented backoff schedule, instance
+ * scoping (state left behind in a durable DATA_DIR by a previous instance),
+ * and the fresh-install case where DATA_DIR doesn't exist yet (the breaker
+ * runs before initDb, so it has to create the dir itself).
  */
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -32,12 +34,18 @@ vi.mock('./log.js', () => ({
 
 import { enforceStartupBackoff, resetCircuitBreaker } from './circuit-breaker.js';
 
-function readState(): { attempt: number; timestamp: string } {
+function readState(): { attempt: number; timestamp: string; host?: string } {
   return JSON.parse(fs.readFileSync(CB_PATH, 'utf-8'));
 }
 
-function seedState(attempt: number, timestamp = new Date().toISOString()): void {
-  fs.writeFileSync(CB_PATH, JSON.stringify({ attempt, timestamp }));
+/**
+ * Seed prior state. Defaults to this machine's hostname, i.e. state this same
+ * instance would have written — the case the transition and schedule tests are
+ * about. Pass `host` to stand in for another instance over the same `data/`.
+ */
+function seedState(attempt: number, timestamp = new Date().toISOString(), host: string | null = os.hostname()): void {
+  const state = host === null ? { attempt, timestamp } : { attempt, timestamp, host };
+  fs.writeFileSync(CB_PATH, JSON.stringify(state));
 }
 
 beforeEach(() => {
@@ -122,6 +130,69 @@ describe('enforceStartupBackoff — state transitions', () => {
 
     await enforceStartupBackoff();
     expect(readState().attempt).toBe(1);
+  });
+});
+
+describe('enforceStartupBackoff — instance scoping', () => {
+  /**
+   * `data/` can outlive the instance that wrote it: a working tree on a
+   * durable volume mounted into successive fresh containers, a restored
+   * backup. A new instance is not the crashy one that earned the strikes, so
+   * it starts clean rather than serving backoff on inherited history.
+   */
+  const OTHER_HOST = 'some-other-instance';
+
+  it('state from another instance starts clean', async () => {
+    seedState(4, new Date().toISOString(), OTHER_HOST);
+    await enforceStartupBackoff();
+    expect(readState().attempt).toBe(1);
+  });
+
+  it('state from another instance serves no backoff delay', async () => {
+    // attempt=6 would be a 15min delay if the strikes were counted as ours.
+    seedState(6, new Date().toISOString(), OTHER_HOST);
+
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    const promise = enforceStartupBackoff();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const requestedDelays = setTimeoutSpy.mock.calls.map((c) => c[1] ?? 0);
+    expect(requestedDelays.length ? Math.max(...requestedDelays) : 0).toBe(0);
+  });
+
+  it('takes ownership of the file, so this instance accrues its own strikes', async () => {
+    seedState(4, new Date().toISOString(), OTHER_HOST);
+    await enforceStartupBackoff();
+    expect(readState().host).toBe(os.hostname());
+
+    // Second start now counts: the state on disk is ours.
+    await enforceStartupBackoff();
+    expect(readState().attempt).toBe(2);
+  });
+
+  it('state from this instance still applies', async () => {
+    seedState(3);
+    vi.useFakeTimers();
+    const promise = enforceStartupBackoff();
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(readState().attempt).toBe(4);
+    expect(readState().host).toBe(os.hostname());
+  });
+
+  it('a file with no host (pre-scoping format) is treated as stale', async () => {
+    // No recorded identity is no proof the strikes are ours. Legacy files
+    // reset once, then carry a host like any other.
+    seedState(5, new Date().toISOString(), null);
+    expect(readState().host).toBeUndefined();
+
+    await enforceStartupBackoff();
+
+    expect(readState().attempt).toBe(1);
+    expect(readState().host).toBe(os.hostname());
   });
 });
 

--- a/src/circuit-breaker.ts
+++ b/src/circuit-breaker.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { DATA_DIR } from './config.js';
@@ -13,12 +14,21 @@ const BACKOFF_SCHEDULE_S = [0, 0, 10, 30, 120, 300, 900];
 interface CircuitBreakerState {
   attempt: number;
   timestamp: string;
+  // Which instance earned these strikes. `data/` can outlive the instance that
+  // wrote it — a mounted volume handed to a fresh container, a restored
+  // backup — and strikes from a previous instance say nothing about this one's
+  // health. os.hostname() is stable for the life of a machine or container and
+  // changes when the instance does, which is exactly the boundary we want.
+  host: string;
 }
 
-function read(): CircuitBreakerState | null {
+// As found on disk: files written before the breaker recorded `host` have none.
+type PersistedState = Omit<CircuitBreakerState, 'host'> & { host?: string };
+
+function read(): PersistedState | null {
   try {
     const raw = fs.readFileSync(CB_PATH, 'utf-8');
-    return JSON.parse(raw) as CircuitBreakerState;
+    return JSON.parse(raw) as PersistedState;
   } catch {
     return null;
   }
@@ -47,11 +57,22 @@ export function resetCircuitBreaker(): void {
 
 export async function enforceStartupBackoff(): Promise<void> {
   const now = new Date();
+  const host = os.hostname();
   const prev = read();
 
   let attempt: number;
   if (!prev) {
     attempt = 1;
+  } else if (prev.host !== host) {
+    // Includes files from before the breaker recorded a host: no identity is
+    // no proof the strikes are ours, so a legacy file resets once and is
+    // rewritten with one.
+    attempt = 1;
+    log.info('Circuit breaker reset — prior state was written by a different instance', {
+      previousHost: prev.host ?? '(none recorded)',
+      currentHost: host,
+      previousAttempt: prev.attempt,
+    });
   } else {
     const elapsedMs = now.getTime() - new Date(prev.timestamp).getTime();
     if (elapsedMs < RESET_WINDOW_MS) {
@@ -70,7 +91,7 @@ export async function enforceStartupBackoff(): Promise<void> {
     }
   }
 
-  write({ attempt, timestamp: now.toISOString() });
+  write({ attempt, timestamp: now.toISOString(), host });
 
   const delaySec = getDelay(attempt);
   if (delaySec > 0) {


### PR DESCRIPTION
## The failure mode

The startup circuit breaker counts consecutive crashes in `data/circuit-breaker.json` and delays the next start on a schedule (0s, 0s, 10s, 30s, 2min, 5min, 15min cap). The counter is keyed to nothing but the file's existence, so it silently belongs to whoever mounts `data/` next.

That's fine when `data/` and the host live and die together. It breaks whenever the directory outlives the process that wrote it:

- a working tree on a durable volume mounted into successive fresh containers or pods,
- a `data/` restored from backup or copied to a new machine,
- any deployment where the tree is the durable thing and the host instance is disposable.

In those setups a brand-new, healthy instance reads the strikes of the crashy instance that came before it and starts life mid-backoff — up to a 15 minute delay it never earned, compounding on each start. The only cure was deleting the file by hand, which is not something an operator has any reason to know to do.

## The fix

State now records `os.hostname()` alongside the attempt count. On startup, state whose host doesn't match this instance is treated the same as no state at all: start clean at attempt 1, and take ownership on the write.

`os.hostname()` is the right boundary because it is stable exactly as long as the thing whose health the counter describes:

- On a laptop or a bare-metal box, the hostname doesn't change, so a service restarting under launchd/systemd accrues strikes exactly as it does today.
- A container or pod keeps its hostname for its whole life, so a genuine crash loop inside one is still caught and still backs off.
- A *new* container or pod gets a new hostname, which is precisely the case where the old count was never evidence about the new instance.

Where every start is a fresh instance, the orchestrator's own restart backoff is the layer doing this job; the file-based counter was only ever accumulating wrongly there.

No new configuration, no change to the file's location (other tooling reads that path), and no change to the breaker's public API — `enforceStartupBackoff()` and `resetCircuitBreaker()` are untouched.

## Backward compatibility

Files written before this change carry no host field. A missing identity is no proof the strikes belong to this instance, so legacy files are treated as stale and reset once, then rewritten with a host like any other. That one-time reset is the same medicine the failure mode calls for, applied automatically instead of by hand.

## Tests

Five cases added beside the existing breaker tests: state from another instance starts clean; state from another instance serves no backoff delay (seeded at attempt=6, which would otherwise be the 15min cap); the file is taken over so the new instance accrues its own strikes from there; same-instance state still applies and still increments; and a pre-scoping file with no host resets once and gains one.

The existing seeding helper now defaults to this machine's hostname, so the transition and schedule tests continue to exercise the same-instance path they were always about. All 22 tests in the file pass; the 5 new ones fail against the unpatched breaker. `pnpm exec tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
