### PR TITLE
ncl: warn when group scope overrides an explicit auto-fill arg (#2464)

### DIFF
--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -549,6 +549,70 @@ describe('CLI scope enforcement', () => {
     }
   });
 
+  it('group: warns on stderr when explicit --agent_group_id differs from the locked value', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await dispatch({ id: '1', command: 'sessions-list', args: { agent_group_id: 'other-group' } }, agentCtx());
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--agent_group_id (other-group)'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('overridden by group scope (g1)'));
+    stderrSpy.mockRestore();
+  });
+
+  it('group: warns on stderr when explicit --group differs from the locked value', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await dispatch({ id: '1', command: 'members-add', args: { user: 'u1', group: 'other-group' } }, agentCtx());
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--group (other-group)'));
+    stderrSpy.mockRestore();
+  });
+
+  it('group: warns on stderr when explicit --id differs from the locked group id (groups/destinations)', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await dispatch({ id: '1', command: 'groups-test', args: { id: 'other-group' } }, agentCtx());
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--id (other-group)'));
+    stderrSpy.mockRestore();
+  });
+
+  it('group: warns on stderr when explicit --id differs from the resolved wiring id', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await dispatch({ id: '1', command: 'wirings-get', args: { id: 'w-foreign' } }, agentCtx());
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--id (w-foreign)'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('overridden by group scope (w-current)'));
+    stderrSpy.mockRestore();
+  });
+
+  it('group: does not warn when the explicit auto-fill value matches the locked value', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const resp = await dispatch({ id: '1', command: 'sessions-list', args: { agent_group_id: 'g1' } }, agentCtx());
+
+    expect(resp.ok).toBe(true);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+
+  it('group: does not warn when the auto-fill arg is not explicitly passed', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const resp = await dispatch({ id: '1', command: 'sessions-list', args: {} }, agentCtx());
+
+    expect(resp.ok).toBe(true);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+
   it('global: allows cross-group access', async () => {
     mockGetContainerConfig.mockReturnValue({ cli_scope: 'global' });
 

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -36,6 +36,21 @@ function actorFor(ctx: CallerContext): GuardActor {
     : { kind: 'agent', agentGroupId: ctx.agentGroupId, sessionId: ctx.sessionId };
 }
 
+/**
+ * Warn on stderr when an explicitly-passed auto-fill arg differs from the
+ * value group scope will lock it to. Gated strictly on differing values —
+ * matching-value passes are harmless redundancy and would train operators
+ * to ignore the warning.
+ */
+function warnIfOverridden(key: string, provided: unknown, locked: unknown): void {
+  if (provided !== undefined && provided !== locked) {
+    process.stderr.write(
+      `warning: --${key} (${provided}) overridden by group scope (${locked}). ` +
+        `Cross-group changes must be submitted from the target group's CLI.\n`,
+    );
+  }
+}
+
 export async function dispatch(
   req: RequestFrame,
   ctx: CallerContext,
@@ -78,7 +93,14 @@ export async function dispatch(
 
     if (cliScope === 'group') {
       // Auto-fill agent-group-related args so the agent doesn't need
-      // to pass its own group ID explicitly.
+      // to pass its own group ID explicitly. Warn (stderr) whenever an
+      // explicitly-passed value differs from the locked value: the caller
+      // believes they're targeting one group/resource but the write (or,
+      // for agent_group_id/group, the guard's subsequent deny) lands
+      // somewhere else. Gated strictly on differing values so matching
+      // redundant flags stay silent.
+      warnIfOverridden('agent_group_id', req.args.agent_group_id, ctx.agentGroupId);
+      warnIfOverridden('group', req.args.group, ctx.agentGroupId);
       const fill: Record<string, unknown> = {
         agent_group_id: req.args.agent_group_id ?? ctx.agentGroupId,
         group: req.args.group ?? ctx.agentGroupId,
@@ -86,6 +108,7 @@ export async function dispatch(
       // Only auto-fill --id for resources where it IS the agent group ID
       // (groups, destinations). For sessions/members --id is a different key.
       if (cmd.resource === 'groups' || cmd.resource === 'destinations') {
+        warnIfOverridden('id', req.args.id, ctx.agentGroupId);
         fill.id = req.args.id ?? ctx.agentGroupId;
       }
 
@@ -94,6 +117,7 @@ export async function dispatch(
       if (req.args.help !== true && (req.command === 'wirings-get' || req.command === 'wirings-update')) {
         const wiring = await getMessagingGroupAgentByPair(ctx.messagingGroupId, ctx.agentGroupId);
         if (!wiring) return err(req.id, 'forbidden', 'Wiring not found for this conversation.');
+        warnIfOverridden('id', req.args.id, wiring.id);
         fill.id = wiring.id;
       }
       req = { ...req, args: { ...req.args, ...fill } };


### PR DESCRIPTION
Fixes #2464

## Summary

Under group scope, `dispatch()` auto-fills `agent_group_id`, `group`, and
`id` from the caller's locked context (and, for `wirings-get`/
`wirings-update`, from the resolved wiring for the current conversation).
When a caller explicitly passes a differing value for one of these keys,
nothing on stderr told them their value was overridden — the operator had
no signal that their write target changed.

This adds a single stderr warning, gated strictly on `provided !== undefined
&& provided !== locked`, at each auto-fill point:

- `agent_group_id`
- `group`
- `id` (groups/destinations resources, locked to the caller's own group)
- `id` (wirings-get/wirings-update, locked to the resolved wiring id for the
  current conversation — the case most likely to be missed, since it's a
  second, unconditional override a few lines below the general auto-fill
  block)

Matching-value passes stay silent, per the issue's guidance, so the warning
doesn't get trained out by redundant flags.

Note: for `agent_group_id`/`group`, a differing value is already denied by
the guard's cross-group check (`src/cli/guard.ts`) added in #2986, so those
two no longer reach the handler with the wrong value — but the caller
previously got no stderr signal explaining *why*, only a generic
`forbidden` JSON error. The wirings id case has no such guard check and was
a genuine silent override with no signal at all. This PR adds the warning
uniformly across all four auto-fill points so the operator sees the
mismatch immediately in every case.

## Test plan

- [x] Added 6 new tests to `src/cli/dispatch.test.ts` covering: warn on
      differing `--agent_group_id`, differing `--group`, differing `--id`
      (groups/destinations), differing `--id` (wirings-get resolved-wiring
      override), no warning on a matching value, no warning when the arg
      isn't passed at all.
- [x] `npx vitest run src/cli/dispatch.test.ts` — 64/64 passed.
- [x] `npx vitest run` (full suite) — 156 files / 1986 tests passed.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint src/cli/dispatch.ts src/cli/dispatch.test.ts` — 0 errors (3
      pre-existing unrelated warnings in `dispatch.ts`, untouched by this
      change).