### PR TITLE
Telegram: trust channel's own identity in sender_scope gate

### DIFF
--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -230,16 +230,33 @@ setAccessGate((event, userId, mg, agentGroupId): AccessGateResult => {
 });
 
 /**
+ * Telegram broadcast-channel posts carry no individual sender — the Bot API
+ * attributes them to the channel itself (`sender_chat`, no `from`), which
+ * `@chat-adapter/telegram` maps to author userId `chat:<chatId>` (see its
+ * `toReactionActorAuthor`). That identity is the channel's own posting
+ * identity, not an unknown third party, so a wiring on that same messaging
+ * group should treat it as trusted even under `sender_scope='known'` —
+ * otherwise a channel wiring can never engage (#2991).
+ */
+function isChannelSelfSender(userId: string, mg: MessagingGroup): boolean {
+  if (mg.channel_type !== 'telegram' || !userId.startsWith('chat:')) return false;
+  const chatId = userId.slice('chat:'.length);
+  return mg.platform_id.split(':').pop() === chatId;
+}
+
+/**
  * Per-wiring sender-scope enforcement. Stricter than the messaging-group
  * `unknown_sender_policy` — a wiring can require `sender_scope='known'`
  * (explicit owner / admin / member) even on a 'public' messaging group.
  *
  * 'all' is a no-op; any sender passes. 'known' requires a userId that
- * canAccessAgentGroup accepts (owner, admin, or group member).
+ * canAccessAgentGroup accepts (owner, admin, or group member), or the
+ * channel's own posting identity on an anonymous channel post.
  */
 setSenderScopeGate(
-  (_event: InboundEvent, userId: string | null, _mg: MessagingGroup, agent: MessagingGroupAgent): AccessGateResult => {
+  (_event: InboundEvent, userId: string | null, mg: MessagingGroup, agent: MessagingGroupAgent): AccessGateResult => {
     if (agent.sender_scope === 'all') return { allowed: true };
+    if (userId && isChannelSelfSender(userId, mg)) return { allowed: true };
     if (!userId) return { allowed: false, reason: 'unknown_user_scope' };
     const decision = canAccessAgentGroup(userId, agent.agent_group_id);
     if (decision.allowed) return { allowed: true };

--- a/src/modules/permissions/telegram-channel-sender-scope.test.ts
+++ b/src/modules/permissions/telegram-channel-sender-scope.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression test for #2991 — Telegram broadcast-channel posts are
+ * anonymous (Bot API attributes them to the channel itself via
+ * `sender_chat`, no `from`). `@chat-adapter/telegram` maps that to author
+ * userId `chat:<chatId>`. A wiring with sender_scope='known' must still
+ * engage for that identity when it matches the wired chat's own id —
+ * otherwise a channel wiring can never engage.
+ */
+import fs from 'fs';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createMessagingGroup, createMessagingGroupAgent } from '../../db/messaging-groups.js';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+const deliverMock = vi.fn().mockResolvedValue('plat-msg-id');
+vi.mock('../../delivery.js', () => ({
+  getDeliveryAdapter: () => ({
+    deliver: deliverMock,
+  }),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-telegram-channel-scope' };
+});
+
+const { wakeContainer } = await import('../../container-runner.js');
+
+const TEST_DIR = '/tmp/nanoclaw-test-telegram-channel-scope';
+
+function now() {
+  return new Date().toISOString();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+
+  await import('./index.js');
+
+  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+
+  createMessagingGroup({
+    id: 'mg-channel',
+    channel_type: 'telegram',
+    platform_id: 'telegram:-1009999',
+    name: 'Broadcast Channel',
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  createMessagingGroupAgent({
+    id: 'mga-known',
+    messaging_group_id: 'mg-channel',
+    agent_group_id: 'ag-1',
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'known',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now(),
+  });
+
+  vi.mocked(wakeContainer).mockClear();
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+function channelPost(text: string, chatId: string) {
+  return {
+    channelType: 'telegram',
+    platformId: 'telegram:-1009999',
+    threadId: null,
+    message: {
+      id: `post-${Math.random().toString(36).slice(2, 8)}`,
+      kind: 'chat' as const,
+      content: JSON.stringify({
+        author: { userId: `chat:${chatId}` },
+        senderName: 'Broadcast Channel',
+        text,
+      }),
+      timestamp: now(),
+    },
+  };
+}
+
+describe('sender_scope=known on a Telegram channel wiring', () => {
+  it('engages on an anonymous channel post from the wired channel itself', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(channelPost('hello subscribers', '-1009999'));
+
+    expect(wakeContainer).toHaveBeenCalled();
+  });
+
+  it('still refuses an anonymous post from a different chat id', async () => {
+    const { routeInbound } = await import('../../router.js');
+    await routeInbound(channelPost('spoofed', '-1000000'));
+
+    expect(wakeContainer).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #2991

## Problem

Telegram broadcast-channel posts are anonymous — the Bot API attributes them to the channel itself via `sender_chat` (no `from`). `@chat-adapter/telegram`'s `toReactionActorAuthor` maps that to an author `userId` of `chat:<chatId>`. That identity is never a member of `agent_group_members`, so a wiring with `sender_scope='known'` (the default the channel-registration flow produces) could never engage on any channel post — every message failed the sender-scope gate silently.

## Fix

`setSenderScopeGate` in `src/modules/permissions/index.ts` now recognizes the wired channel's own posting identity — `userId` of the form `chat:<chatId>` where `<chatId>` matches the messaging group's own `platform_id` — and treats it as trusted, alongside the existing owner/global-admin/admin-of-group/member checks. This is suggested fix #2 from the issue: the channel posting to itself is not an unknown third party, so it shouldn't be gated by `sender_scope='known'`.

Scoped to `channel_type === 'telegram'` and the `chat:` prefix convention, which is specific to `@chat-adapter/telegram`'s anonymous-sender_chat/reaction-actor mapping — no other adapter uses this identity shape.

## Test plan

- Added `src/modules/permissions/telegram-channel-sender-scope.test.ts`:
  - a `sender_scope='known'` wiring now engages on an anonymous channel post whose `sender_chat` id matches the wired channel
  - a post claiming a different chat id is still correctly refused
- Verified against the pre-fix code that the first test fails without the change (reproduces #2991) and passes with it
- `npx vitest run src/modules/permissions src/router.test.ts` — 51/51 passed
- `npx tsc --noEmit` — no new errors (pre-existing unrelated errors in other files)
- `npx eslint src/modules/permissions/index.ts ...test.ts` — no new warnings/errors