### PR TITLE
fix(update-skills): attribute a barrel import to the skill that appends it

### DIFF
--- a/scripts/update-skills.test.ts
+++ b/scripts/update-skills.test.ts
@@ -50,6 +50,37 @@ describe('installed skill detection', () => {
       { name: 'slack', skillName: 'add-slack', kind: 'channel' },
     ]);
   });
+
+  it('attributes a companion import to the skill that appends it', () => {
+    const root = temp('nanoclaw-skills-detect-companion-');
+    // What /add-slack actually installs: the adapter plus its a2a guard, both
+    // appended to the barrel by the one skill.
+    write(root, 'src/channels/index.ts', "import './cli.js';\nimport './slack.js';\nimport './slack-a2a-guard.js';\n");
+    write(
+      root,
+      '.claude/skills/add-slack/SKILL.md',
+      [
+        '# Apply',
+        '```nc:append to:src/channels/index.ts',
+        "import './slack.js';",
+        '```',
+        '```nc:append to:src/channels/index.ts',
+        "import './slack-a2a-guard.js';",
+        '```',
+      ].join('\n'),
+    );
+
+    // One entry, not two: the guard is add-slack's, so it must not be
+    // attributed to a nonexistent add-slack-a2a-guard skill.
+    expect(detectInstalledSkills(root)).toEqual([{ name: 'slack', skillName: 'add-slack', kind: 'channel' }]);
+  });
+
+  it('still attributes an unclaimed import to add-<name>', () => {
+    const root = temp('nanoclaw-skills-detect-unclaimed-');
+    write(root, 'src/channels/index.ts', "import './cli.js';\nimport './discord.js';\n");
+
+    expect(detectInstalledSkills(root)).toEqual([{ name: 'discord', skillName: 'add-discord', kind: 'channel' }]);
+  });
 });
 
 describe('registry refresh end to end', () => {

--- a/scripts/update-skills.ts
+++ b/scripts/update-skills.ts
@@ -90,10 +90,59 @@ function readImports(file: string): string[] {
   return names;
 }
 
+/**
+ * Which installed skill owns each barrel import, read from the skills' own
+ * `append to:<barrel>` directives.
+ *
+ * A skill may append more than one import to a barrel: `add-slack` registers
+ * both `slack.js` and the `slack-a2a-guard.js` companion module. Mapping every
+ * import to its own `add-<name>` skill would demand an `add-slack-a2a-guard`
+ * that does not and should not exist. An import a skill declares belongs to
+ * that skill; only an unclaimed one is attributed to `add-<name>`, which is
+ * what keeps the missing-skill check meaningful for a channel installed
+ * without one.
+ */
+function importOwners(root: string, barrel: string): Map<string, string> {
+  const owners = new Map<string, string>();
+  const skillsDir = path.join(root, '.claude/skills');
+  if (!fs.existsSync(skillsDir)) return owners;
+
+  for (const skillName of fs.readdirSync(skillsDir)) {
+    const skillFile = path.join(skillsDir, skillName, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    let directives;
+    try {
+      directives = parseDirectives(fs.readFileSync(skillFile, 'utf8'));
+    } catch {
+      // A skill we cannot parse simply claims nothing; refresh reports its own
+      // parse failure with a better message than detection could.
+      continue;
+    }
+    for (const directive of directives) {
+      if (directive.kind !== 'append' || directive.attrs.to !== barrel) continue;
+      for (const line of directive.body) {
+        const match = /^\s*import\s+['"]\.\/([a-z0-9-]+)\.js['"];?\s*$/.exec(line);
+        if (match && !owners.has(match[1])) owners.set(match[1], skillName);
+      }
+    }
+  }
+  return owners;
+}
+
 export function detectInstalledSkills(root: string): InstalledSkill[] {
-  const channels = readImports(path.join(root, 'src/channels/index.ts'))
+  const channelBarrel = 'src/channels/index.ts';
+  const owners = importOwners(root, channelBarrel);
+  const seen = new Set<string>();
+  const channels = readImports(path.join(root, channelBarrel))
     .filter((name) => name !== 'cli')
-    .map((name) => ({ name, skillName: `add-${name}`, kind: 'channel' as const }));
+    .map((name) => ({ name, skillName: owners.get(name) ?? `add-${name}` }))
+    // A skill that owns several imports is refreshed once, under its own name.
+    .filter(({ skillName }) => !seen.has(skillName) && seen.add(skillName))
+    .map(({ name, skillName }) => ({
+      name: skillName.startsWith('add-') ? skillName.slice('add-'.length) : name,
+      skillName,
+      kind: 'channel' as const,
+    }));
   const providers = new Set([
     ...readImports(path.join(root, 'src/providers/index.ts')),
     ...readImports(path.join(root, 'container/agent-runner/src/providers/index.ts')),


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — `detectInstalledSkills` attributes a channel-barrel import to the skill that actually appends it, instead of assuming every import has its own `add-<name>` skill.

**Why** — `/add-slack` appends two imports to `src/channels/index.ts`: `slack.js` and its `slack-a2a-guard.js` companion. Detection maps each one to `add-<name>`, so the refresh looks for a skill that does not exist and fails:

```
Missing .claude/skills/add-slack-a2a-guard/SKILL.md
```

`refreshInstalledSkills` treats that as a failed skill, which blocks `/update-nanoclaw` validation on any install with Slack. I hit this on a routine update.

**How it works** — ownership is read from the skills' own `nc:append to:src/channels/index.ts` directives: an import a skill declares belongs to that skill, and a skill owning several imports is refreshed once under its own name. An unclaimed import still maps to `add-<name>`, so a channel installed without a skill is still reported — the missing-skill check keeps its point. A `SKILL.md` that fails to parse simply claims nothing; refresh reports the parse failure itself with a better message than detection could.

**How it was tested** — two cases added to `scripts/update-skills.test.ts`: the companion case (asserts one entry, not two) and an unclaimed import (asserts `add-<name>` attribution still happens). I verified the companion test fails on `main` and passes with the fix. Full file green (6/6), `tsc --noEmit` clean, and the real update that surfaced this now validates end to end.
