### PR TITLE
fix(poll-loop): touch heartbeat at claim time, not just on first SDK event

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -138,6 +138,14 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     const ids = messages.map((m) => m.id);
     markProcessing(ids);
+    // Cover the gap between claim and the first SDK stream event — cold
+    // resume + auto-compaction on a large transcript can take a while before
+    // query.events yields anything, and host-sweep's claim-stuck watchdog
+    // (src/host-sweep.ts) has no other signal during that window. Without
+    // this, a legitimately busy (not stuck) turn on a big session gets
+    // killed and retried forever, since retrying just repeats the same slow
+    // resume.
+    touchHeartbeat();
 
     const routing = extractRouting(messages);
 


### PR DESCRIPTION
Fixes #3455

## Summary

- \`host-sweep\`'s claim-stuck watchdog (\`src/host-sweep.ts\`) measures elapsed time since \`markProcessing()\` stamps a claim, but \`touchHeartbeat()\` in the agent-runner poll loop wasn't called until inside the \`for await (const event of query.events)\` loop — leaving no heartbeat coverage for setup time before the first SDK event (cold session resume, large-transcript auto-compaction, provider init).
- On a busy/tool-heavy session, that setup time alone can exceed the 60s \`CLAIM_STUCK_MS\` tolerance. The watchdog kills the container as "stuck," resets the message with backoff, and the retry repeats the same slow resume — looping forever without ever replying, even though the container was doing real (not stuck) work the whole time.
- Fix: touch the heartbeat right after \`markProcessing(ids)\`, closing the blind spot. This doesn't loosen the watchdog for genuinely-hung containers — if nothing happens after this point, no further heartbeat follows, so a truly stuck turn is still caught and killed as before.

## Repro

Observed on a real install: a tool-heavy setup conversation (Community Support agent, ~2.2MB / 1500-line transcript — well under the existing 12MB rotate threshold) hit this every time it tried to resume:

```
[poll-loop] Resuming agent session <id>
[poll-loop] Processing 1 message(s), kinds: chat-sdk
[poll-loop] Session: <id>
[claude-provider] Archived conversation to <file>.md   ← PreCompact hook fires
                                                          (no heartbeat touched yet)
```
```
WARN Killing container — message claimed then silent  claimAgeMs=78797 toleranceMs=60000
```
Repeats indefinitely with increasing backoff; the DM is never replied to.

## Test plan

- [x] \`bun test\` in \`container/agent-runner\` — all 33 \`poll-loop.test.ts\` tests pass, 330/332 total pass (1 pre-existing unrelated failure, confirmed present on clean \`main\` too)
- [x] \`bunx tsc --noEmit\` — clean
- [x] Verified against the failing install: clearing the stuck session's stored continuation and confirming the mechanism (heartbeat gap between claim and first stream event) against \`src/host-sweep.ts\`'s \`decideStuckAction\`

## Related

- #137 (closed) — origin of the transcript-rotation safety net (12MB / 14-day cap) this bug slips under.
- #2147 (closed) — a different, adjacent claim-stuck race (orphan \`processing_ack\` cleanup ordering), not the same root cause.
- #3456 / #3458 and #3457 / #3459 — separate bugs found and fixed during the same troubleshooting session on the same install. Unrelated code paths, listed only for cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)