### PR TITLE
fix(session-db): use INSERT OR IGNORE for duplicate inbound message ids

### DIFF
--- a/src/mailbox/sqlite/session-db.ts
+++ b/src/mailbox/sqlite/session-db.ts
@@ -95,8 +95,13 @@ export function nextEvenSeq(db: Database.Database): number {
 
 export function insertMessage(db: Database.Database, message: InboundWrite, sequence = nextEvenSeq(db)): void {
   const record = createInboundRecord(message, sequence);
+  // OR IGNORE: a delivery retry (e.g. a card whose first delivery attempt
+  // timed out but actually landed) can insert the same message id twice.
+  // Same id means same message, so the duplicate is a benign no-op rather
+  // than the UNIQUE constraint violation that was previously surfaced as a
+  // "Message delivery failed, will retry" error and drove spurious retries.
   db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
+    `INSERT OR IGNORE INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
      VALUES (@id, @sequence, @kind, @timestamp, @status, @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @seriesId, @trigger, @sourceSessionId, @onWake)`,
   ).run({
     ...record,


### PR DESCRIPTION
Fixes #3457

## Summary

A delivery retry can attempt to insert a message with an id already present in \`messages_in\` (e.g. a card delivery whose confirmation timed out but actually landed). \`insertMessage()\` used a plain \`INSERT\`, so the retry hit the \`UNIQUE\` constraint on \`id\` and surfaced as "Message delivery failed, will retry" — which then drove further retries against the same already-inserted message.

Fix: \`INSERT OR IGNORE\`. Same id means same message, so a duplicate insert is a benign no-op — the original row (same content) is kept and seq/ordering is unaffected.

## Test plan

- [x] \`pnpm vitest run src/mailbox/sqlite/session-db.test.ts\` — 5/5 pass

## Related

- #3455 / #3454 and #3456 / #3458 — separate bugs found and fixed during the same troubleshooting session on the same install. Unrelated code paths, listed only for cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)