### PR TITLE
chore(deps): bump chat SDK 4.29.0 -> 4.38.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@clack/prompts": "^1.2.0",
     "@onecli-sh/sdk": "2.2.1",
     "better-sqlite3": "13.0.3",
-    "chat": "4.29.0",
+    "chat": "4.38.1",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
     "yaml": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 13.0.3
         version: 13.0.3
       chat:
-        specifier: 4.29.0
-        version: 4.29.0
+        specifier: 4.38.1
+        version: 4.38.1
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
@@ -601,14 +601,17 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
-  chat@4.29.0:
-    resolution: {integrity: sha512-KdPfzaie5ivYytyRICTERg5xT+LeCbYefokvNAqTHe92eqkFaoTMXXkSitikxJVWhZIb2YoXF1b9UZHyzSzKzw==}
+  chat@4.38.1:
+    resolution: {integrity: sha512-FD6vNLT8clXHKhN3I1m+3Bn2nz0rsB6/bmNPsJeh6Cr7kwWLg0MYl2uor9YaKBp38F77sBRVKdYKVA6ihUby3w==}
     engines: {node: '>=20'}
     peerDependencies:
-      ai: ^6.0.182
+      ai: ^6.0.182 || ^7.0.0
+      workflow: ^5.0.0-beta.35
       zod: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       ai:
+        optional: true
+      workflow:
         optional: true
       zod:
         optional: true
@@ -1850,7 +1853,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat@4.29.0:
+  chat@4.38.1:
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0


### PR DESCRIPTION
## Summary

Trunk's \`chat\` dependency was pinned at \`4.29.0\`, 9 minor versions behind current (\`4.38.1\`, published 2026-08-17). Bumps it.

Scope note: trunk's \`package.json\` only pins the core \`chat\` package — channel adapters (\`@chat-adapter/discord\`, etc.) are skill-installed from the \`channels\` registry branch and are pinned there separately. A companion PR bumping those follows separately on that branch.

## Test plan

- [x] \`pnpm install\` — lockfile updated cleanly, no peer conflicts
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm test\` — 1968/1981 pass; 13 pre-existing failures in \`scripts/update/transaction.e2e.test.ts\`, confirmed present on unmodified \`main\` too (environment-specific path issue, unrelated to this bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)