### PR TITLE
opencode provider: fall back to message.part.delta text (#2985)

### DIFF
--- a/container/agent-runner/src/providers/opencode.delta-fallback.test.ts
+++ b/container/agent-runner/src/providers/opencode.delta-fallback.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { OpenCodeProvider, type OpenCodeMemorySessionHook, type OpenCodeRuntimeHandle, type QuestionClient } from './opencode.js';
+import type { ProviderEvent } from './types.js';
+
+/**
+ * Regression coverage for #2985: the answer streams as `message.part.delta`
+ * and is consolidated into a `message.part.updated` snapshot. If the snapshot
+ * doesn't land before `session.idle` breaks the read loop — a timing race, or
+ * it simply isn't emitted — the provider must still surface the answer from
+ * the accumulated deltas instead of silently yielding `null`.
+ */
+
+const MEMORY_HOOK: OpenCodeMemorySessionHook = {
+  command: 'true',
+  legacyCommands: [],
+  sources: ['startup', 'clear', 'compact'],
+};
+
+function createFakeRuntime(script: Array<Array<{ type: string; properties: Record<string, unknown> }>>): {
+  runtime: { getRuntime: () => Promise<OpenCodeRuntimeHandle> };
+  promptIds: string[];
+} {
+  const promptIds: string[] = [];
+  let nextCreate = 0;
+  const queue: Array<{ type: string; properties: Record<string, unknown> }> = [];
+  const waiters: Array<() => void> = [];
+
+  const pushEvents = (events: Array<{ type: string; properties: Record<string, unknown> }>) => {
+    queue.push(...events);
+    while (waiters.length > 0 && queue.length > 0) waiters.shift()!();
+  };
+
+  async function* stream(): AsyncGenerator<{ type: string; properties: Record<string, unknown> }, void, void> {
+    while (true) {
+      if (queue.length === 0) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+      yield queue.shift()!;
+    }
+  }
+
+  const questionClient: QuestionClient = {
+    question: {
+      async reply() {
+        return { data: true };
+      },
+      async list() {
+        return { data: [] };
+      },
+    },
+  };
+
+  const handle: OpenCodeRuntimeHandle = {
+    questionClient,
+    stream: stream(),
+    client: {
+      session: {
+        async create() {
+          nextCreate += 1;
+          return { data: { id: `ses_fresh_${nextCreate}` } };
+        },
+        async promptAsync(params) {
+          promptIds.push(params.path.id);
+          const events = script[promptIds.length - 1];
+          if (!events) throw new Error(`no scripted events for prompt #${promptIds.length}`);
+          pushEvents(events);
+          return {};
+        },
+      },
+    },
+  };
+
+  return { promptIds, runtime: { getRuntime: async () => handle } };
+}
+
+async function collect(events: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+describe('OpenCodeProvider message.part.delta fallback', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-delta-fallback-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('surfaces the answer from accumulated deltas when the snapshot never lands', async () => {
+    const fake = createFakeRuntime([
+      [
+        { type: 'message.updated', properties: { info: { id: 'msg_asst', role: 'assistant' } } },
+        {
+          type: 'message.part.delta',
+          properties: { sessionID: 'ses_1', messageID: 'msg_asst', partID: 'prt_1', field: 'text', delta: 'Hel' },
+        },
+        {
+          type: 'message.part.delta',
+          properties: { sessionID: 'ses_1', messageID: 'msg_asst', partID: 'prt_1', field: 'text', delta: 'lo!' },
+        },
+        // No message.part.updated snapshot for msg_asst — the race from #2985.
+        { type: 'session.idle', properties: { sessionID: 'ses_1' } },
+      ],
+    ]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hi', cwd: dir, continuation: 'ses_1' });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: 'Hello!' }]);
+  });
+
+  it('prefers the consolidated snapshot over raw deltas when both are present', async () => {
+    const fake = createFakeRuntime([
+      [
+        { type: 'message.updated', properties: { info: { id: 'msg_asst', role: 'assistant' } } },
+        {
+          type: 'message.part.delta',
+          properties: { sessionID: 'ses_1', messageID: 'msg_asst', partID: 'prt_1', field: 'text', delta: 'partial' },
+        },
+        {
+          type: 'message.part.updated',
+          properties: { part: { type: 'text', messageID: 'msg_asst', text: 'the full snapshot' } },
+        },
+        { type: 'session.idle', properties: { sessionID: 'ses_1' } },
+      ],
+    ]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hi', cwd: dir, continuation: 'ses_1' });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: 'the full snapshot' }]);
+  });
+
+  it('ignores deltas from a foreign session on the shared stream', async () => {
+    const fake = createFakeRuntime([
+      [
+        { type: 'message.updated', properties: { info: { id: 'msg_asst', role: 'assistant' } } },
+        {
+          type: 'message.part.delta',
+          properties: { sessionID: 'ses_other', messageID: 'msg_asst', partID: 'prt_1', field: 'text', delta: 'nope' },
+        },
+        { type: 'session.idle', properties: { sessionID: 'ses_fresh_1' } },
+      ],
+    ]);
+    const provider = new OpenCodeProvider({}, fake.runtime);
+    provider.registerMemorySessionHook(MEMORY_HOOK);
+    const query = provider.query({ prompt: 'hi', cwd: dir });
+    const done = collect(query.events);
+    query.end();
+    const events = await done;
+
+    expect(events.filter((e) => e.type === 'result')).toEqual([{ type: 'result', text: null }]);
+  });
+});

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -948,6 +948,7 @@ export class OpenCodeProvider implements AgentProvider {
           }
 
           const partTextByMessageId = new Map<string, string>();
+          const deltaTextByMessageId = new Map<string, string>();
           const roleByMessageId = new Map<string, string>();
           const partMessageIds = new Set<string>();
           const erroredMessageIds = new Set<string>();
@@ -1008,6 +1009,26 @@ export class OpenCodeProvider implements AgentProvider {
                     if (part.type === 'text' && part.text) {
                       partTextByMessageId.set(part.messageID, part.text);
                     }
+                  }
+                  break;
+                }
+                case 'message.part.delta': {
+                  // Deltas causally precede the snapshot they'll eventually
+                  // consolidate into (and precede `session.idle`, which can't
+                  // fire mid-stream). Accumulate them as a fallback so a
+                  // snapshot that lands too close to `session.idle` — or never
+                  // lands at all — doesn't discard an answer that already
+                  // streamed.
+                  const delta = ev.properties as
+                    | { sessionID?: string; messageID?: string; field?: string; delta?: string }
+                    | undefined;
+                  if (delta?.sessionID && delta.sessionID !== turnSessionId) break;
+                  if (delta?.messageID && delta.field === 'text' && delta.delta) {
+                    partMessageIds.add(delta.messageID);
+                    deltaTextByMessageId.set(
+                      delta.messageID,
+                      (deltaTextByMessageId.get(delta.messageID) ?? '') + delta.delta,
+                    );
                   }
                   break;
                 }
@@ -1095,7 +1116,7 @@ export class OpenCodeProvider implements AgentProvider {
             if (partMessageIds.has(msgId) || erroredMessageIds.has(msgId)) {
               sawAssistantWork = true;
             }
-            resultText = partTextByMessageId.get(msgId) ?? resultText;
+            resultText = partTextByMessageId.get(msgId) ?? deltaTextByMessageId.get(msgId) ?? resultText;
           }
           return { resultText, sawAssistantWork };
         }


### PR DESCRIPTION
Fixes #2985

## Problem

`OpenCodeProvider`'s event loop only tracked assistant text from
`message.part.updated` snapshots. If the final snapshot for a turn
didn't land before `session.idle` broke the read loop — a timing race
(the issue measured a ~78ms margin), or the snapshot simply wasn't
emitted — assembly found no text and yielded `{ type: 'result', text: null }`,
discarding an answer that had already fully streamed as
`message.part.delta` events.

## Fix

- Add a `message.part.delta` case that accumulates `field: "text"`
  deltas per `messageID` (filtered to the turn's session, matching the
  other cases in this switch).
- Mark the message's id in `partMessageIds` on delta receipt too, so
  `sawAssistantWork` (used by the empty-resume fallback) stays correct
  even when only deltas arrive and no snapshot follows.
- At resolution: `partTextByMessageId.get(id) ?? deltaTextByMessageId.get(id) ?? resultText`
  — the consolidated snapshot still wins when present; deltas are only
  a fallback.

Deltas causally precede `session.idle` (a session can't idle
mid-stream), so accumulating them makes the answer available
regardless of snapshot timing, closing the race described in the
issue.

## Test plan

- Added `container/agent-runner/src/providers/opencode.delta-fallback.test.ts`,
  reusing the existing fake-runtime harness from `opencode.empty-resume.test.ts`:
  - snapshot missing entirely → answer recovered from deltas
  - snapshot present → snapshot still wins over partial delta text
  - deltas from a foreign session (shared server) are ignored
- `bun test src/providers/opencode` — 81 pass, 1 pre-existing failure/error
  (`opencode.compaction.test.ts`, missing native sqlite module — reproduces
  identically on unmodified `providers` HEAD, unrelated to this change)
- `tsc --noEmit` — no new errors vs. baseline (same 5 pre-existing errors
  in `codex.ts`/`opencode.ts` unrelated to this change)