### PR TITLE
feat(whatsapp-cloud): declare the 25 s typing-indicator lifetime (channels twin)

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -225,6 +225,14 @@ export interface ChannelAdapter {
     status?: string,
     statusKind?: 'auto' | 'agent',
   ): Promise<void>;
+
+  /**
+   * How long, in ms, the platform shows a typing indicator after one `setTyping`
+   * (Telegram ~5 s, WhatsApp Cloud 25 s); undeclared = 5000. The host re-fires it
+   * 20% before it would expire.
+   */
+  typingTimeoutMs?: number;
+
   syncConversations?(): Promise<ConversationInfo[]>;
   resolveChannelName?(platformId: string): Promise<string | null>;
 

--- a/src/channels/whatsapp-cloud-registration.test.ts
+++ b/src/channels/whatsapp-cloud-registration.test.ts
@@ -61,5 +61,7 @@ describe('whatsapp-cloud channel registration', () => {
     expect(adapter!.instance).toBe('whatsapp-cloud');
     // channelType stays the semantic platform key, shared with native whatsapp.
     expect(adapter!.channelType).toBe('whatsapp');
+    // The declared indicator lifetime reaches the registry.
+    expect(adapter!.typingTimeoutMs).toBe(25_000);
   });
 });

--- a/src/channels/whatsapp-cloud.ts
+++ b/src/channels/whatsapp-cloud.ts
@@ -42,13 +42,17 @@ export const whatsappCloudRegistration: ChannelRegistration = {
     // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
     // silently kills one channel. The instance key keeps them apart while
     // channelType stays 'whatsapp' (the semantic platform key). See #2911.
-    return createChatSdkBridge({
+    const bridge = createChatSdkBridge({
       adapter: whatsappAdapter,
       instance: 'whatsapp-cloud',
       concurrency: 'concurrent',
       supportsThreads: false,
       defaults: WHATSAPP_CLOUD_DEFAULTS,
     });
+    // Meta shows the indicator for 25 s per call (at Chat SDK 4.32 each call is a live
+    // Graph request that also marks the message read); the host re-fires before it expires.
+    bridge.typingTimeoutMs = 25_000;
+    return bridge;
   },
   defaults: WHATSAPP_CLOUD_DEFAULTS,
 };


### PR DESCRIPTION
WhatsApp Cloud keeps a typing indicator on screen for 25 seconds after a single `setTyping` call, but the host refreshes every 4 seconds, a rate tuned for Telegram, so one WhatsApp Cloud session fires about 15 typing calls a minute where 3 would do. At Chat SDK 4.32.0 (#3465) those extra calls stopped being free: WhatsApp Cloud's `startTyping` became a live Graph API request that also marks the inbound message read, so every redundant refresh is real traffic to Meta.

Half of the fix is #3491 on `main`, in the shared host code: a `ChannelAdapter` may declare `typingTimeoutMs`, and the host re-fires `setTyping` 20% before that lifetime would expire. This PR is the other half, the WhatsApp Cloud files that declare the value. They live on `channels`, a long-lived branch holding channel code that never merges into `main`, so this PR targets that branch on its own rather than sitting on top of the `main` chain: the two have different bases, and channel code never goes to the canonical repo. The merge order between the two sides is therefore written out here in prose.

| File | Change |
|---|---|
| `src/channels/whatsapp-cloud.ts` | The factory names the bridge it builds and sets `bridge.typingTimeoutMs = 25_000` before returning it. |
| `src/channels/adapter.ts` | Adds the optional `typingTimeoutMs` field to `ChannelAdapter`, so these files typecheck against the copy of the shared code this branch carries. It is the same change as the hunk in #3491, byte for byte (same before and after blob hashes on both sides), copied rather than stacked because the two branches never merge into each other. |
| `src/channels/whatsapp-cloud-registration.test.ts` | One added assertion: the declared 25 s survives the factory and reaches the registry. |

Once both halves are in place, how often a session re-fires typing is decided entirely by what its adapter declares:

| Adapter | Declared lifetime | Host re-fires | Typing calls per minute |
|---|---|---|---|
| Telegram, and anything that declares nothing | none, host default 5000 ms | every 4 s | 15 |
| WhatsApp Cloud | `25_000` ms | every 20 s | 3 |

This does nothing on its own: no code on the `channels` branch reads `typingTimeoutMs`. The copy of the typing module kept here still uses the fixed 4 s interval, by design, and an install copies these channel files on top of the shared code from `main` rather than running the copy on this branch. The declaration therefore changes no behavior until #3491 lands on `main`.

> [!WARNING]
> Merge order: #3491 first, then this. Running `/update-skills`, which refreshes only the channel files, against a `main` older than #3491 would fail the build, because `bridge.typingTimeoutMs` does not exist on the older `ChannelAdapter`. `/update-nanoclaw` moves both halves together and is safe either way.

## Verification

`pnpm exec tsc --noEmit` (only the same pre-existing errors as the `channels` tip, none in these files) and `pnpm exec vitest run src/channels/whatsapp-cloud-registration.test.ts`, plus the same two run with these files copied into a `main` that carries #3491. Not live-tested against the WhatsApp Cloud API, only exercised through the registration test with mocked credentials.
