### PR TITLE
fix(pnpm): turn the minimumReleaseAge gate on (channels twin)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,4 @@ onlyBuiltDependencies:
   - protobufjs
   - sharp
 
-pnpm:
-  minimumReleaseAge: 4320
+minimumReleaseAge: 4320

--- a/scripts/supply-chain-gate.test.ts
+++ b/scripts/supply-chain-gate.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+// pnpm reads workspace settings from the top level; nested under `pnpm:` the gate is silently off.
+describe('pnpm supply-chain gate', () => {
+  it('minimumReleaseAge is a top-level pnpm-workspace.yaml setting', () => {
+    const workspace = readFileSync('pnpm-workspace.yaml', 'utf8');
+    expect(workspace).toMatch(/^minimumReleaseAge: 4320$/m);
+    expect(workspace).not.toMatch(/^pnpm:/m);
+  });
+});


### PR DESCRIPTION
`pnpm-workspace.yaml` on this branch sets `minimumReleaseAge: 4320`, the 3-day rule from `CLAUDE.md` that stops pnpm installing a package version published less than 3 days ago. But the setting sits one level down, under a `pnpm:` key. pnpm reads its workspace settings from the **top level** of `pnpm-workspace.yaml`; `pnpm:` is how you write the same config in `package.json`. Nested inside this YAML file it is just a key pnpm does not recognize: no warning, no error, and the rule has never run on this branch. A package version published minutes ago has been installable here the whole time.

The same file shows it. `onlyBuiltDependencies` sits at the top level and takes effect; `minimumReleaseAge` sat under `pnpm:` and did not.

| `pnpm config get <key>` (pnpm 10.34.5, pinned in `packageManager`) | on `channels` today | with this PR |
|---|---|---|
| `minimumReleaseAge` | `undefined` | `4320` |
| `onlyBuiltDependencies` | `esbuild`, ... | unchanged |

```diff
-pnpm:
-  minimumReleaseAge: 4320
+minimumReleaseAge: 4320
```

The PR also adds `scripts/supply-chain-gate.test.ts`, which checks the file as it really is: `minimumReleaseAge: 4320` must appear as a top-level line, and there must be no top-level `pnpm:` key at all. A future edit that nests the setting again, or deletes it, fails the test instead of quietly switching the rule back off. `scripts/**/*.test.ts` is already in the vitest `include` list, so this needs no config change to run.

> [!NOTE]
> Turning the rule on blocks nothing that is already installed: every version in the current lockfile is more than 3 days old, so `pnpm install --frozen-lockfile` still exits 0. What changes is *new* versions, which now have to sit on the registry for 3 days before pnpm will install them. Per `CLAUDE.md`, getting around that needs a `minimumReleaseAgeExclude` entry pinned to an exact version, with a human signing off.

**How this relates to the `main` side.** This is the `channels`-branch copy of #3492, which makes the same fix on `main`. It targets `channels` directly and does not sit on top of any other PR, so the two halves are independent: either can land first.

**Verification.** `pnpm config get minimumReleaseAge` gives `4320` here and `undefined` on `channels` today; `pnpm install --frozen-lockfile` exits 0; `pnpm exec vitest run scripts/supply-chain-gate.test.ts` passes, and fails if the setting goes back under `pnpm:`.
