### PR TITLE
fix(pnpm): turn the minimumReleaseAge gate on (providers twin)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,4 @@ onlyBuiltDependencies:
   - protobufjs
   - sharp
 
-pnpm:
-  minimumReleaseAge: 4320
+minimumReleaseAge: 4320


### PR DESCRIPTION
<!-- contributing-guide: v1 -->

`pnpm-workspace.yaml` on the `providers` branch puts `minimumReleaseAge: 4320` inside a `pnpm:` key. pnpm only reads workspace settings from the top level of that file, so the setting was treated as an ordinary nested value and never took effect: the 3-day wait before a newly published package version may be installed, which `CLAUDE.md` says this tree enforces, has been off the whole time. This moves the setting up one level, which turns it on.

| Form in `pnpm-workspace.yaml` | `pnpm config get minimumReleaseAge` (pnpm 10.34.5, pinned in `packageManager`) |
|---|---|
| `pnpm:` → `minimumReleaseAge: 4320` (tip of `providers`) | `undefined` |
| `minimumReleaseAge: 4320` (this PR) | `4320` |

> [!WARNING]
> `pnpm config list` prints `[pnpm] minimumReleaseAge=4320` even in the broken nested form, because it dumps the file it parsed as ini sections instead of the settings pnpm actually applies. Checking with `list` looks right while the wait is doing nothing. `pnpm config get <key>` is the one that tells the truth.

## Verification

- `pnpm config get minimumReleaseAge` → `4320` on this branch, `undefined` on the tip of `providers`
- `pnpm install --frozen-lockfile` → exit 0. A frozen install resolves nothing, so the wait first applies the next time someone adds or upgrades a dependency.
- `onlyBuiltDependencies` above it is untouched; it was already at the top level and already working.

No test comes with this one: this tree's `vitest.config.ts` includes only `src/**/*.test.ts` and `setup/**/*.test.ts`, so the `scripts/supply-chain-gate.test.ts` from the other two PRs would never run here.

## Related

| PR | Base | Also carries |
|---|---|---|
| #3492 | `feat/per-channel-typing-cadence-main` (part of a stack of PRs against `main`) | `scripts/supply-chain-gate.test.ts`, CHANGELOG entry |
| #3470 | `channels` | `scripts/supply-chain-gate.test.ts` |
| this one | `providers` | nothing else |

The same nested key sits in all three trees. `channels` and `providers` are long-lived branches that hold channel and provider code and never merge into `main`, so these three land independently: nothing here waits on either of the others, and any merge order works.
