### PR TITLE
feat: expose structured host health

### DIFF
--- a/src/cli/commands/health.test.ts
+++ b/src/cli/commands/health.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { dispatch } from '../dispatch.js';
+import './health.js';
+
+describe('ncl health command', () => {
+  it('is host-only and returns the structured resource model', async () => {
+    const response = await dispatch({ id: 'health-test', command: 'health', args: {} }, { caller: 'host' });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const data = response.data as { resources?: { groups?: unknown; policies?: unknown; skills?: unknown } };
+    expect(data.resources?.groups).toBeDefined();
+    expect(data.resources?.policies).toBeDefined();
+    expect(data.resources?.skills).toBeDefined();
+  });
+});

--- a/src/cli/commands/health.ts
+++ b/src/cli/commands/health.ts
@@ -1,0 +1,14 @@
+import { collectConfiguredHostHealth } from '../../health.js';
+import { register } from '../registry.js';
+
+register({
+  name: 'health',
+  description: 'Return the structured health and resource state for this NanoClaw host.',
+  access: 'open',
+  hostOnly: true,
+  parseArgs: (raw) => {
+    if (Object.keys(raw).length > 0) throw new Error('health does not accept arguments');
+    return {};
+  },
+  handler: async () => collectConfiguredHostHealth(),
+});

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -5,6 +5,7 @@
  * Help commands are registered after resources are loaded.
  */
 import '../resources/index.js';
+import './health.js';
 import { registerResourceHelpCommands } from './help.js';
 
 registerResourceHelpCommands();

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,0 +1,50 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { collectHostHealth } from './health.js';
+
+describe('collectHostHealth', () => {
+  it('reports zero groups and policies as explicit empty resources', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_message_policies (from_agent_group_id TEXT, to_agent_group_id TEXT, approver TEXT, created_at TEXT);
+    `);
+    const report = collectHostHealth(process.cwd(), db);
+    expect(report.status).toBe('healthy');
+    expect(report.resources.groups).toEqual({ state: 'empty', count: 0 });
+    expect(report.resources.policies).toEqual({ state: 'empty', count: 0 });
+    expect(report.process.pid).toBeGreaterThan(0);
+    db.close();
+  });
+
+  it('counts only skills loaded into per-group session stores', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-'));
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_message_policies (from_agent_group_id TEXT, to_agent_group_id TEXT, approver TEXT, created_at TEXT);
+    `);
+
+    try {
+      fs.mkdirSync(path.join(root, '.claude', 'skills', 'bundled'), {
+        recursive: true,
+      });
+      fs.writeFileSync(path.join(root, '.claude', 'skills', 'bundled', 'SKILL.md'), '# Bundled');
+      const installed = path.join(root, 'data', 'v2-sessions', 'agent-1', '.claude-shared', 'skills', 'installed');
+      fs.mkdirSync(installed, { recursive: true });
+      fs.writeFileSync(path.join(installed, 'SKILL.md'), '# Installed');
+
+      expect(collectHostHealth(root, db).resources.skills).toEqual({
+        state: 'loaded',
+        count: 1,
+      });
+    } finally {
+      db.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,130 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type HealthResource = {
+  state: 'loaded' | 'empty';
+  count: number;
+};
+
+export type HostHealth = {
+  status: 'healthy' | 'unhealthy';
+  checkoutRoot: string;
+  process: {
+    pid: number;
+    ppid: number;
+    executable: string;
+    script: string;
+    cwd: string;
+  };
+  resources: {
+    groups: HealthResource;
+    policies: HealthResource;
+    skills: HealthResource;
+  };
+};
+
+type CountRow = { count: number };
+
+/** Collect the host-owned health model used by both `ncl health` and setup. */
+export function collectHostHealth(projectRoot: string = process.cwd(), db?: Database.Database): HostHealth {
+  const checkoutRoot = path.resolve(projectRoot);
+  const processIdentity = {
+    pid: process.pid,
+    ppid: process.ppid,
+    executable: process.execPath,
+    script: process.argv[1] ? path.resolve(process.cwd(), process.argv[1]) : '',
+    cwd: process.cwd(),
+  };
+  let ownedDb: Database.Database | undefined;
+  let healthy = processIdentity.pid > 0 && processIdentity.cwd === checkoutRoot;
+  let groups = 0;
+  let policies = 0;
+  try {
+    const connection = db ?? (ownedDb = new Database(path.join(checkoutRoot, 'data', 'v2.db'), { readonly: true }));
+    if (!hasTable(connection, 'agent_groups')) {
+      healthy = false;
+    } else {
+      groups = count(connection, 'agent_groups');
+      if (hasTable(connection, 'agent_message_policies')) {
+        policies = count(connection, 'agent_message_policies');
+      } else {
+        healthy = false;
+      }
+    }
+  } catch {
+    healthy = false;
+  } finally {
+    ownedDb?.close();
+  }
+
+  const skills = countInstalledSkills(checkoutRoot);
+  return {
+    status: healthy ? 'healthy' : 'unhealthy',
+    checkoutRoot,
+    process: processIdentity,
+    resources: {
+      groups: resource(groups),
+      policies: resource(policies),
+      skills: resource(skills),
+    },
+  };
+}
+
+/** The default root is kept here for callers that already import src/config. */
+export function collectConfiguredHostHealth(db?: Database.Database): HostHealth {
+  return collectHostHealth(process.cwd(), db);
+}
+
+function resource(count: number): HealthResource {
+  return { state: count > 0 ? 'loaded' : 'empty', count };
+}
+
+function hasTable(db: Database.Database, name: string): boolean {
+  return db.prepare('SELECT 1 FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1').get('table', name) !== undefined;
+}
+
+function count(db: Database.Database, table: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as CountRow;
+  return Number.isInteger(row.count) && row.count >= 0 ? row.count : 0;
+}
+
+function countInstalledSkills(root: string): number {
+  let total = 0;
+  try {
+    for (const entry of fs.readdirSync(path.join(root, 'data', 'v2-sessions'), { withFileTypes: true })) {
+      if (!entry.isSymbolicLink() && entry.isDirectory()) {
+        total += countGroupSkills(path.join(root, 'data', 'v2-sessions', entry.name, '.claude-shared', 'skills'));
+      }
+    }
+  } catch {
+    // A checkout can legitimately have no group session directory yet.
+  }
+  return total;
+}
+
+function countGroupSkills(location: string): number {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(location, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const entry of entries) {
+    // Shared skills are container-resolving symlinks; template skills are real
+    // directories. Both forms are loaded entries in this per-group store.
+    if (entry.isSymbolicLink()) {
+      total++;
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    const child = path.join(location, entry.name);
+    try {
+      if (fs.statSync(path.join(child, 'SKILL.md')).isFile()) total++;
+    } catch {
+      // Ignore incomplete directories.
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [ ] **Fix**
- [ ] **Simplification**
- [ ] **Documentation**

No box fits: this is an additive engine feature (a new read-only host CLI command), not a skill. Stating it rather than mis-ticking.

## Description

**Problem.** App and setup consumers need checkout and process identity plus live resource state, but the host CLI has no read-only aggregate that can tell an empty install from a broken one. Today they shell out to several commands and guess.

**Change.** Register a host-only `health` command (`src/cli/commands/health.ts`, wired in `src/cli/commands/index.ts`) backed by `src/health.ts`: process identity, database-backed group and policy counts, and skills loaded from the canonical per-group session stores. Bundled skill definitions are excluded so the count reflects what is installed.

**Why it is safe.** Additive and read-only. No schema, persisted state, dependency, restart, or operator action. The command is host-only (container dispatch is refused, covered by test).

**Scope.** `src/health.ts`, `src/health.test.ts`, `src/cli/commands/health.ts`, `src/cli/commands/health.test.ts`, `src/cli/commands/index.ts`. Nothing else.

**Relation to other PRs.** First of the setup-driver stack; `feat/setup-driver-v1` carries this commit. Lands independently.

## Verification

```
pnpm exec vitest run src/health.test.ts src/cli/commands/health.test.ts
  Tests  3 passed (3)
pnpm typecheck                       # OK
```
Coverage: empty resources, installed-versus-bundled skills, host-only dispatch, JSON output.
Full suite on the stack tip that contains this exact patch (`feat/nanoclaw-tz` b3d7eda4, quiet machine): `pnpm exec vitest run` 2123 passed, 4 failed (see note). Leak-gate `--classify`: no payload or wiring rows.

Environment note: `scripts/update/transaction.e2e.test.ts` (4 tests) fails on this machine for every branch including a clean `upstream/main` checkout, because local git has `tag.gpgSign=true` and the test runs a bare `git tag`. Unrelated to this change.

## For Skills

Not applicable: no skill files touched.
