### PR TITLE
fix: harden uninstall ownership and failure handling

### DIFF
--- a/setup/uninstall/flow.test.ts
+++ b/setup/uninstall/flow.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { sameOwnershipSelectors, uninstallIncomplete, uninstallSelectionError } from './flow.js';
+import type { Inventory } from './scan.js';
+
+function inventory(onecliAvailable = true): Pick<Inventory, 'onecli'> {
+  return {
+    onecli: {
+      mine: [],
+      orphans: [],
+      available: onecliAvailable,
+      idsKnown: true,
+    },
+  };
+}
+
+describe('terminal uninstall safety gates', () => {
+  it('rejects destructive choices that preserve the service', () => {
+    expect(
+      uninstallSelectionError(inventory(), {
+        service: false,
+        data: true,
+        user: false,
+      }),
+    ).toMatch(/cannot be removed/);
+  });
+
+  it('preserves app data when OneCLI inventory is unavailable', () => {
+    expect(
+      uninstallSelectionError(inventory(false), {
+        service: true,
+        data: true,
+        user: true,
+      }),
+    ).toMatch(/Restore OneCLI/);
+  });
+
+  it('reports failed or untouched actions as incomplete', () => {
+    expect(uninstallIncomplete([{ outcome: 'removed' }])).toBe(false);
+    expect(uninstallIncomplete([{ outcome: 'failed' }])).toBe(true);
+    expect(uninstallIncomplete([{ outcome: 'untouched' }])).toBe(true);
+  });
+
+  it('rejects a checkout root replaced after approval', () => {
+    const base: Inventory = {
+      slug: 'abcd1234',
+      projectRoot: '/tmp/nanoclaw',
+      containerRuntime: 'docker',
+      service: { containerIds: [] },
+      data: [],
+      runtime: [],
+      user: [],
+      envBackups: [],
+      onecli: inventory().onecli,
+      notes: [],
+      identity: {
+        root: 'node:1:2:16832',
+        exactPaths: {},
+        scopedRoots: {},
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    };
+
+    expect(sameOwnershipSelectors(base, structuredClone(base))).toBe(true);
+    const replaced = structuredClone(base);
+    replaced.identity!.root = 'node:1:3:16832';
+    expect(sameOwnershipSelectors(base, replaced)).toBe(false);
+  });
+});

--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -24,8 +24,8 @@ import { emit as phEmit } from '../lib/diagnostics.js';
 import { note } from '../lib/theme.js';
 import * as setupLog from '../logs.js';
 import { resolveOnecliDeletions, type RunCommand, type VaultAgent } from './onecli-agents.js';
-import { buildRemovalPlan, type Decisions } from './plan.js';
-import { executePlan, type ExecDeps } from './remove.js';
+import { buildRemovalPlan, validateDecisions, type Decisions } from './plan.js';
+import { executePlan, type ExecDeps, type UninstallActionResult } from './remove.js';
 import { scanInstall, tilde, type Inventory } from './scan.js';
 
 const GROUPS = {
@@ -52,7 +52,11 @@ const GROUPS = {
 
 const runCommand: RunCommand = (cmd, args) => {
   const res = spawnSync(cmd, args, { encoding: 'utf-8' });
-  return { status: res.status, stdout: res.stdout ?? '' };
+  return {
+    status: res.status,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  };
 };
 
 export async function runUninstallFlow(opts: {
@@ -71,6 +75,13 @@ export async function runUninstallFlow(opts: {
 
   const projectRoot = process.cwd();
   const home = os.homedir();
+  const scan = (): Inventory =>
+    scanInstall({
+      projectRoot,
+      home,
+      platform: process.platform,
+      runCommand,
+    });
 
   p.intro(k.bold(`Uninstall NanoClaw`));
   // persistId: false — the emit must not create data/install-id, which would
@@ -80,19 +91,23 @@ export async function runUninstallFlow(opts: {
 
   const spinner = p.spinner();
   spinner.start('Checking what exists for this copy…');
-  const inv = scanInstall({
-    projectRoot,
-    home,
-    platform: process.platform,
-    runCommand,
-  });
+  const inv = scan();
   spinner.stop(`Scanned copy ${inv.slug} at ${tilde(projectRoot, home)}.`);
 
   const svcRows = serviceRows(inv, home);
   const dataRows = [...inv.data, ...inv.runtime].map(({ what, where }) => ({ what, where }));
   const userRows = inv.user.map(({ what, where }) => ({ what, where }));
+  const serviceDecisionRows =
+    svcRows.length > 0 || (dataRows.length === 0 && userRows.length === 0)
+      ? svcRows
+      : [
+          {
+            what: 'Checkout-owned processes',
+            where: `install ${inv.slug} (if running)`,
+          },
+        ];
   const totalFound =
-    svcRows.length + dataRows.length + userRows.length + inv.onecli.mine.length + inv.onecli.orphans.length;
+    serviceDecisionRows.length + dataRows.length + userRows.length + inv.onecli.mine.length + inv.onecli.orphans.length;
 
   if (totalFound === 0) {
     p.outro(
@@ -104,7 +119,9 @@ export async function runUninstallFlow(opts: {
 
   if (dryRun) {
     p.log.message(k.cyan('PREVIEW ONLY — this shows what would be deleted and changes nothing.'));
-    if (svcRows.length > 0) note(groupBody(GROUPS.service.desc, svcRows), GROUPS.service.title);
+    if (serviceDecisionRows.length > 0) {
+      note(groupBody(GROUPS.service.desc, serviceDecisionRows), GROUPS.service.title);
+    }
     if (dataRows.length > 0) note(groupBody(GROUPS.data.desc, dataRows), GROUPS.data.title);
     if (userRows.length > 0) note(groupBody(GROUPS.user.desc, userRows), GROUPS.user.title);
     if (inv.onecli.mine.length > 0 || inv.onecli.orphans.length > 0) {
@@ -117,7 +134,7 @@ export async function runUninstallFlow(opts: {
       if (inv.onecli.orphans.length === 0) lines.push('  (none)');
       note(lines.join('\n'), GROUPS.onecli.title);
     }
-    const empty = emptyGroupTitles(svcRows.length, dataRows.length, userRows.length, inv);
+    const empty = emptyGroupTitles(serviceDecisionRows.length, dataRows.length, userRows.length, inv);
     if (empty.length > 0) p.log.message(k.dim(`Nothing found for: ${empty.join(', ')}`));
     for (const n of inv.notes) p.log.message(k.dim(`• ${n}`));
     p.outro('Preview complete. Nothing was changed.');
@@ -137,8 +154,8 @@ export async function runUninstallFlow(opts: {
   // ── confirm phase — nothing is deleted until every decision is made ──
 
   let serviceYes = false;
-  if (svcRows.length > 0) {
-    note(groupBody(GROUPS.service.desc, svcRows), GROUPS.service.title);
+  if (serviceDecisionRows.length > 0) {
+    note(groupBody(GROUPS.service.desc, serviceDecisionRows), GROUPS.service.title);
     serviceYes = await confirmGroup(GROUPS.service.prompt, yes);
   }
 
@@ -154,12 +171,28 @@ export async function runUninstallFlow(opts: {
     userYes = await confirmGroup(GROUPS.user.prompt, yes);
   }
 
-  const keptNotes: string[] = [];
-  if (!serviceYes && svcRows.length > 0) keptNotes.push(`${GROUPS.service.title}: kept by your choice.`);
+  const keptNotes = inv.envBackups.map((backup) => `${backup.what}: ${backup.where} kept.`);
+  if (!serviceYes && serviceDecisionRows.length > 0) {
+    keptNotes.push(`${GROUPS.service.title}: kept by your choice.`);
+  }
   if (!dataYes && dataRows.length > 0) keptNotes.push(`${GROUPS.data.title}: kept by your choice.`);
   if (!userYes && userRows.length > 0) keptNotes.push(`${GROUPS.user.title}: kept by your choice.`);
 
   const onecliDelete = await decideOnecli(inv, yes, keptNotes);
+
+  const selectionError = uninstallSelectionError(inv, {
+    service: serviceYes,
+    data: dataYes,
+    user: userYes,
+  });
+  if (selectionError) {
+    p.log.error(selectionError);
+    process.exit(1);
+  }
+  if (!sameOwnershipSelectors(inv, scan())) {
+    p.log.error('This NanoClaw checkout changed after it was scanned. Nothing was removed; rerun uninstall.');
+    process.exit(1);
+  }
 
   // Record the decisions before execution can delete logs/ — but only into
   // an existing logs/ (userInput would otherwise mkdir it back into
@@ -207,21 +240,62 @@ export async function runUninstallFlow(opts: {
   // modules we're running from are gone.
   const head = actions.filter((a) => a.kind !== 'delete-runtime-path');
   const tail = actions.filter((a) => a.kind === 'delete-runtime-path');
+  const destructiveStart = head.findIndex((action) => action.kind === 'backup-env' || action.kind === 'delete-path');
+  const prerequisites = destructiveStart === -1 ? head : head.slice(0, destructiveStart);
+  const destructive = destructiveStart === -1 ? [] : head.slice(destructiveStart);
 
   const deps: ExecDeps = {
     runCommand,
     log: (line) => p.log.message(line),
     isRoot: process.getuid?.() === 0,
   };
-  const { notes: execNotes } = executePlan(head, deps);
-
-  printLeftAlone([...inv.notes, ...keptNotes, ...execNotes]);
-
-  const { notes: tailNotes } = executePlan(tail, {
+  const prerequisiteResult = executePlan(prerequisites, deps);
+  const onecliFailed = prerequisites.some(
+    (action, index) =>
+      action.kind === 'delete-onecli-agent' &&
+      ['failed', 'untouched'].includes(prerequisiteResult.results[index]?.outcome ?? 'failed'),
+  );
+  const prerequisiteError =
+    onecliFailed && !prerequisiteResult.prerequisiteFailed
+      ? {
+          code: 'credential_prerequisite_failed',
+          message: 'OneCLI agent cleanup failed, so app data was left for a safe retry.',
+        }
+      : undefined;
+  const destructiveResult = executePlan(destructive, {
     ...deps,
+    prerequisiteFailed: prerequisiteResult.prerequisiteFailed || onecliFailed,
+    ...(prerequisiteError ? { prerequisiteError } : {}),
+  });
+
+  printLeftAlone([...inv.notes, ...keptNotes, ...prerequisiteResult.notes, ...destructiveResult.notes]);
+
+  const headIncomplete = uninstallIncomplete([...prerequisiteResult.results, ...destructiveResult.results]);
+  const tailResult = executePlan(tail, {
+    ...deps,
+    prerequisiteFailed: headIncomplete,
+    ...(headIncomplete
+      ? {
+          prerequisiteError: {
+            code: 'removal_incomplete',
+            message: 'Earlier cleanup was incomplete, so runtime files were left for a safe retry.',
+          },
+        }
+      : {}),
     log: (line) => console.log(`  ${line}`),
   });
-  for (const n of tailNotes) console.log(`  • ${n}`);
+  for (const n of tailResult.notes) console.log(`  • ${n}`);
+
+  const incomplete = uninstallIncomplete([
+    ...prerequisiteResult.results,
+    ...destructiveResult.results,
+    ...tailResult.results,
+  ]);
+  if (incomplete) {
+    console.error(`\n! Uninstall incomplete for NanoClaw copy ${inv.slug}. Review the items left alone and rerun.`);
+    process.exit(1);
+  }
+
   console.log(`\n✓ Done. NanoClaw copy ${inv.slug} has been uninstalled.`);
   process.exit(0);
 }
@@ -304,6 +378,12 @@ function serviceRows(inv: Inventory, home: string): { what: string; where: strin
   if (s.systemdUserUnit) rows.push({ what: 'Background service', where: tilde(s.systemdUserUnit, home) });
   if (s.systemdSystemUnit) rows.push({ what: 'Background service (system)', where: s.systemdSystemUnit });
   if (s.pidFile) rows.push({ what: 'Running process', where: 'nanoclaw.pid' });
+  if (s.hostProcessIds && s.hostProcessIds.length > 0) {
+    rows.push({
+      what: 'Running host processes',
+      where: `${s.hostProcessIds.length} process(es)`,
+    });
+  }
   if (s.containerIds.length > 0) {
     rows.push({ what: 'Running containers', where: `${s.containerIds.length} container(s)` });
   }
@@ -339,4 +419,37 @@ function printLeftAlone(notes: string[]): void {
     ...notes.map((n) => `• ${n}`),
   ];
   note(lines.join('\n'), 'Left alone (shared / not ours)');
+}
+
+export function uninstallSelectionError(
+  inventory: Pick<Inventory, 'onecli'>,
+  decisions: Pick<Decisions, 'service' | 'data' | 'user'>,
+): string | undefined {
+  return (
+    validateDecisions(decisions) ??
+    (!inventory.onecli.available && decisions.data
+      ? 'OneCLI agents could not be inspected. Restore OneCLI and rerun uninstall before deleting app data.'
+      : undefined)
+  );
+}
+
+export function uninstallIncomplete(results: readonly Pick<UninstallActionResult, 'outcome'>[]): boolean {
+  return results.some((result) => ['failed', 'untouched'].includes(result.outcome));
+}
+
+export function sameOwnershipSelectors(before: Inventory, after: Inventory): boolean {
+  const beforeIdentity = before.identity;
+  const afterIdentity = after.identity;
+  return (
+    path.resolve(before.projectRoot) === path.resolve(after.projectRoot) &&
+    before.slug === after.slug &&
+    before.containerRuntime === after.containerRuntime &&
+    Boolean(beforeIdentity?.root) &&
+    Boolean(afterIdentity?.root) &&
+    beforeIdentity?.root === afterIdentity?.root &&
+    Object.values(beforeIdentity?.exactPaths ?? {}).every(Boolean) &&
+    beforeIdentity?.containerSelector === afterIdentity?.containerSelector &&
+    Object.values(beforeIdentity?.scopedRoots ?? {}).every(Boolean) &&
+    JSON.stringify(beforeIdentity?.scopedRoots) === JSON.stringify(afterIdentity?.scopedRoots)
+  );
 }

--- a/setup/uninstall/onecli-agents.ts
+++ b/setup/uninstall/onecli-agents.ts
@@ -19,7 +19,7 @@ export interface VaultAgent {
   name: string;
 }
 
-export type RunCommand = (cmd: string, args: string[]) => { status: number | null; stdout: string };
+export type RunCommand = (cmd: string, args: string[]) => { status: number | null; stdout: string; stderr?: string };
 
 /**
  * List non-default vault agents via `onecli agents list`. `available: false`

--- a/setup/uninstall/plan.test.ts
+++ b/setup/uninstall/plan.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { VaultAgent } from './onecli-agents.js';
-import { buildRemovalPlan, type Decisions, type RemovalAction } from './plan.js';
+import { buildRemovalPlan, validateDecisions, type Decisions, type RemovalAction } from './plan.js';
 import type { Inventory, PathItem } from './scan.js';
 
 const item = (p: string, what: string): PathItem => ({ what, where: p, path: p });
@@ -35,7 +35,8 @@ function inventory(overrides: Partial<Inventory> = {}): Inventory {
       item('/proj/dist', 'Build output'),
     ],
     user: [item('/proj/groups', 'Agent memory & files'), item('/proj/store', 'Migrated data store')],
-    onecli: { mine: [], orphans: [], idsKnown: true },
+    envBackups: [],
+    onecli: { mine: [], orphans: [], available: true, idsKnown: true },
     notes: [],
     ...overrides,
   };
@@ -53,8 +54,29 @@ const kinds = (actions: RemovalAction[]) => actions.map((a) => a.kind);
 describe('buildRemovalPlan ordering invariants', () => {
   it('removes .env only via the atomic backup action, never a bare delete', () => {
     const actions = buildRemovalPlan(inventory(), allYes());
+    const backup = actions.find((a) => a.kind === 'backup-env');
+    expect(backup).toEqual(expect.objectContaining({ identityRequired: true }));
     expect(actions.filter((a) => a.kind === 'backup-env')).toHaveLength(1);
     expect(actions.some((a) => a.kind === 'delete-path' && a.item.path === '/proj/.env')).toBe(false);
+  });
+
+  it('attaches exact identities to checkout-owned files while using root identities for directories', () => {
+    const inv = inventory({
+      data: [item('/proj/data', 'Database & conversations'), item('/proj/start-nanoclaw.sh', 'Start script')],
+      identity: {
+        root: 'root',
+        exactPaths: { '/proj/start-nanoclaw.sh': 'file:1' },
+        scopedRoots: { '/proj/data': 'node:1' },
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    });
+    const actions = buildRemovalPlan(inv, allYes());
+    const start = actions.find(
+      (action) => action.kind === 'delete-path' && action.item.path.endsWith('start-nanoclaw.sh'),
+    );
+    const data = actions.find((action) => action.kind === 'delete-path' && action.item.path === '/proj/data');
+    expect(start).toEqual(expect.objectContaining({ expectedIdentity: 'file:1', identityRequired: true }));
+    expect(data).toEqual(expect.objectContaining({ expectedRootIdentity: 'node:1' }));
   });
 
   it('puts the runtime tail strictly last, with node_modules final', () => {
@@ -89,6 +111,12 @@ describe('buildRemovalPlan ordering invariants', () => {
 });
 
 describe('buildRemovalPlan declined groups', () => {
+  it('rejects data or user removal while the service is preserved', () => {
+    expect(validateDecisions({ service: false, data: true, user: false })).toMatch(/cannot be removed/);
+    expect(validateDecisions({ service: false, data: false, user: true })).toMatch(/cannot be removed/);
+    expect(validateDecisions({ service: true, data: true, user: true })).toBeUndefined();
+  });
+
   it('declined data yields no data deletes and no runtime tail', () => {
     const actions = buildRemovalPlan(inventory(), {
       service: true,

--- a/setup/uninstall/plan.ts
+++ b/setup/uninstall/plan.ts
@@ -23,15 +23,25 @@ export interface Decisions {
   onecliDelete: VaultAgent[];
 }
 
+export function validateDecisions(decisions: Pick<Decisions, 'service' | 'data' | 'user'>): string | undefined {
+  if (!decisions.service && (decisions.data || decisions.user)) {
+    return 'App data and user files cannot be removed while the service is preserved.';
+  }
+  return undefined;
+}
+
+type ExactIdentity = { expectedIdentity?: string; identityRequired?: boolean };
+type ScopedRootIdentity = { expectedRootIdentity?: string };
+
 export type RemovalAction =
-  | {
+  | ({
       kind: 'unload-service';
       flavor: 'launchd' | 'systemd-user' | 'systemd-system';
       unitPath: string;
       /** systemd unit name without .service (unused for launchd). */
       unitName: string;
-    }
-  | { kind: 'kill-pid'; pidFile: string }
+    } & ExactIdentity)
+  | ({ kind: 'kill-pid'; pidFile: string; processPattern: string } & ExactIdentity)
   | { kind: 'pkill-host'; pattern: string }
   /**
    * Containers are re-listed by label at removal time, not removed from
@@ -39,17 +49,17 @@ export type RemovalAction =
    * and can spawn new containers after the scan.
    */
   | { kind: 'rm-containers'; runtime: string; labelFilter: string }
-  | { kind: 'rmi'; runtime: string; image: string }
-  | { kind: 'rm-ncl-symlink'; linkPath: string }
-  | { kind: 'delete-onecli-agent'; agent: VaultAgent }
+  | ({ kind: 'rmi'; runtime: string; image: string } & ExactIdentity)
+  | ({ kind: 'rm-ncl-symlink'; linkPath: string } & ExactIdentity)
+  | ({ kind: 'delete-onecli-agent'; agent: VaultAgent } & ExactIdentity)
   /**
    * Backs up AND removes .env as one atomic action: a failed backup must
    * never be followed by the deletion (the backup is the user's only copy
    * of their API keys). .env is deliberately excluded from `delete-path`.
    */
-  | { kind: 'backup-env'; envPath: string }
-  | { kind: 'delete-path'; item: PathItem }
-  | { kind: 'delete-runtime-path'; item: PathItem };
+  | ({ kind: 'backup-env'; envPath: string; backupRoot?: string } & Partial<ExactIdentity>)
+  | ({ kind: 'delete-path'; item: PathItem } & ScopedRootIdentity & Partial<ExactIdentity>)
+  | ({ kind: 'delete-runtime-path'; item: PathItem } & ScopedRootIdentity & Partial<ExactIdentity>);
 
 export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] {
   const actions: RemovalAction[] = [];
@@ -62,6 +72,7 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
         flavor: 'launchd',
         unitPath: s.launchdPlist,
         unitName: path.basename(s.launchdPlist, '.plist'),
+        ...identity(inv, s.launchdPlist),
       });
     }
     if (s.systemdUserUnit) {
@@ -70,6 +81,7 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
         flavor: 'systemd-user',
         unitPath: s.systemdUserUnit,
         unitName: path.basename(s.systemdUserUnit, '.service'),
+        ...identity(inv, s.systemdUserUnit),
       });
     }
     if (s.systemdSystemUnit) {
@@ -78,9 +90,17 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
         flavor: 'systemd-system',
         unitPath: s.systemdSystemUnit,
         unitName: path.basename(s.systemdSystemUnit, '.service'),
+        ...identity(inv, s.systemdSystemUnit),
       });
     }
-    if (s.pidFile) actions.push({ kind: 'kill-pid', pidFile: s.pidFile });
+    if (s.pidFile) {
+      actions.push({
+        kind: 'kill-pid',
+        pidFile: s.pidFile,
+        processPattern: `${inv.projectRoot}/dist/index.js`,
+        ...identity(inv, s.pidFile),
+      });
+    }
     actions.push({
       kind: 'pkill-host',
       pattern: `${inv.projectRoot}/dist/index.js`,
@@ -93,36 +113,75 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
       labelFilter: `nanoclaw-install=${inv.slug}`,
     });
     if (s.image) {
-      actions.push({ kind: 'rmi', runtime: inv.containerRuntime, image: s.image });
+      actions.push({
+        kind: 'rmi',
+        runtime: inv.containerRuntime,
+        image: s.image,
+        ...(s.imageIdentity ? { expectedIdentity: s.imageIdentity } : {}),
+        identityRequired: true,
+      });
     }
     if (s.nclSymlink) {
-      actions.push({ kind: 'rm-ncl-symlink', linkPath: s.nclSymlink });
+      actions.push({ kind: 'rm-ncl-symlink', linkPath: s.nclSymlink, ...identity(inv, s.nclSymlink) });
     }
   }
 
   for (const agent of d.onecliDelete) {
-    actions.push({ kind: 'delete-onecli-agent', agent });
+    actions.push({
+      kind: 'delete-onecli-agent',
+      agent,
+      expectedIdentity: JSON.stringify(agent),
+      identityRequired: true,
+    });
   }
 
   if (d.data) {
     const env = inv.data.find((i) => path.basename(i.path) === '.env');
-    if (env) actions.push({ kind: 'backup-env', envPath: env.path });
+    if (env) {
+      actions.push({
+        kind: 'backup-env',
+        envPath: env.path,
+        backupRoot: inv.credentialBackupRoot,
+        ...identity(inv, env.path),
+      });
+    }
     for (const item of inv.data) {
       if (item === env) continue; // removed by backup-env, never a bare delete
-      actions.push({ kind: 'delete-path', item });
+      actions.push({ kind: 'delete-path', item, ...pathOwnership(inv, item.path) });
     }
   }
 
   if (d.user) {
-    for (const item of inv.user) actions.push({ kind: 'delete-path', item });
+    for (const item of inv.user) {
+      actions.push({ kind: 'delete-path', item, ...pathOwnership(inv, item.path) });
+    }
   }
 
   if (d.data) {
     const tail = [...inv.runtime].sort(
       (a, b) => Number(path.basename(a.path) === 'node_modules') - Number(path.basename(b.path) === 'node_modules'),
     );
-    for (const item of tail) actions.push({ kind: 'delete-runtime-path', item });
+    for (const item of tail) {
+      actions.push({ kind: 'delete-runtime-path', item, ...pathOwnership(inv, item.path) });
+    }
   }
 
   return actions;
+}
+
+function identity(inv: Inventory, target: string): ExactIdentity {
+  const value = inv.identity?.exactPaths[target];
+  return { ...(value ? { expectedIdentity: value } : {}), identityRequired: true };
+}
+
+function scopedRoot(inv: Inventory, target: string): ScopedRootIdentity {
+  const value = inv.identity?.scopedRoots[target];
+  return value ? { expectedRootIdentity: value } : {};
+}
+
+function pathOwnership(inv: Inventory, target: string): ScopedRootIdentity | Partial<ExactIdentity> {
+  if (Object.prototype.hasOwnProperty.call(inv.identity?.scopedRoots ?? {}, target)) {
+    return scopedRoot(inv, target);
+  }
+  return identity(inv, target);
 }

--- a/setup/uninstall/remove.test.ts
+++ b/setup/uninstall/remove.test.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import type { RunCommand } from './onecli-agents.js';
 import type { RemovalAction } from './plan.js';
 import { backupEnv, executePlan, type ExecDeps } from './remove.js';
+import { pathIdentity } from './scan.js';
 
 let tempDir: string;
 
@@ -29,25 +30,28 @@ function deps(overrides: Partial<ExecDeps> = {}): ExecDeps {
 describe('backupEnv', () => {
   it('backs up to .env.bak', () => {
     const envPath = path.join(tempDir, '.env');
+    const backupRoot = path.join(tempDir, 'backup');
     fs.writeFileSync(envPath, 'KEY=secret');
 
-    const backup = backupEnv(envPath);
+    const backup = backupEnv(envPath, backupRoot);
 
-    expect(backup).toBe(path.join(tempDir, '.env.bak'));
+    expect(backup).toBe(path.join(backupRoot, '.env.bak'));
     expect(fs.readFileSync(backup, 'utf-8')).toBe('KEY=secret');
   });
 
   it('falls back to a timestamped name when .env.bak exists', () => {
     const envPath = path.join(tempDir, '.env');
+    const backupRoot = path.join(tempDir, 'backup');
     fs.writeFileSync(envPath, 'KEY=new');
-    fs.writeFileSync(path.join(tempDir, '.env.bak'), 'KEY=old');
+    fs.mkdirSync(backupRoot);
+    fs.writeFileSync(path.join(backupRoot, '.env.bak'), 'KEY=old');
 
-    const backup = backupEnv(envPath);
+    const backup = backupEnv(envPath, backupRoot);
 
-    expect(path.basename(backup)).toMatch(/^\.env\.bak\.\d{8}-\d{6}$/);
+    expect(path.basename(backup)).toMatch(/^\.env\.bak\.\d+-\d+-\d+$/);
     expect(fs.readFileSync(backup, 'utf-8')).toBe('KEY=new');
     // The earlier backup is never clobbered.
-    expect(fs.readFileSync(path.join(tempDir, '.env.bak'), 'utf-8')).toBe('KEY=old');
+    expect(fs.readFileSync(path.join(backupRoot, '.env.bak'), 'utf-8')).toBe('KEY=old');
   });
 });
 
@@ -63,7 +67,7 @@ describe('executePlan', () => {
     expect(notes).toEqual([]);
   });
 
-  it('continues past a failing action and records a note', () => {
+  it('blocks dependent deletion after a service-stop failure', () => {
     const dir = path.join(tempDir, 'logs');
     fs.mkdirSync(dir);
     const actions: RemovalAction[] = [
@@ -79,13 +83,13 @@ describe('executePlan', () => {
       throw new Error('launchctl exploded');
     };
 
-    const { notes } = executePlan(actions, deps({ runCommand: failing }));
+    const { notes, results } = executePlan(actions, deps({ runCommand: failing }));
 
-    expect(notes).toHaveLength(1);
+    expect(notes).toHaveLength(2);
     expect(notes[0]).toContain('unload-service');
     expect(notes[0]).toContain('launchctl exploded');
-    // Later actions still ran.
-    expect(fs.existsSync(dir)).toBe(false);
+    expect(fs.existsSync(dir)).toBe(true);
+    expect(results.at(-1)?.outcome).toBe('untouched');
   });
 
   it('leaves a system unit in place without root and notes the sudo command', () => {
@@ -126,10 +130,10 @@ describe('executePlan', () => {
     const envPath = path.join(tempDir, '.env');
     fs.writeFileSync(envPath, 'KEY=secret');
 
-    const { notes } = executePlan([{ kind: 'backup-env', envPath }], deps());
+    const { notes } = executePlan([{ kind: 'backup-env', envPath, backupRoot: path.join(tempDir, 'backup') }], deps());
 
     expect(fs.existsSync(envPath)).toBe(false);
-    expect(fs.readFileSync(path.join(tempDir, '.env.bak'), 'utf-8')).toBe('KEY=secret');
+    expect(fs.readFileSync(path.join(tempDir, 'backup', '.env.bak'), 'utf-8')).toBe('KEY=secret');
     expect(notes).toEqual([]);
   });
 
@@ -139,7 +143,10 @@ describe('executePlan', () => {
     fs.chmodSync(tempDir, 0o555); // backup destination unwritable
 
     try {
-      const { notes } = executePlan([{ kind: 'backup-env', envPath }], deps());
+      const { notes } = executePlan(
+        [{ kind: 'backup-env', envPath, backupRoot: path.join(tempDir, 'backup') }],
+        deps(),
+      );
       expect(fs.existsSync(envPath)).toBe(true);
       expect(notes.some((n) => n.includes('backup-env'))).toBe(true);
     } finally {
@@ -174,6 +181,66 @@ describe('executePlan', () => {
     expect(notes.some((n) => n.includes('xargs -r docker rm -f'))).toBe(true);
   });
 
+  it('blocks data and runtime deletion when container shutdown fails', () => {
+    const dataPath = path.join(tempDir, 'data');
+    const runtimePath = path.join(tempDir, 'node_modules');
+    fs.mkdirSync(dataPath);
+    fs.mkdirSync(runtimePath);
+
+    const result = executePlan(
+      [
+        {
+          kind: 'rm-containers',
+          runtime: 'docker',
+          labelFilter: 'nanoclaw-install=test',
+        },
+        {
+          kind: 'delete-path',
+          item: { what: 'Data', where: dataPath, path: dataPath },
+        },
+        {
+          kind: 'delete-runtime-path',
+          item: {
+            what: 'Runtime',
+            where: runtimePath,
+            path: runtimePath,
+          },
+        },
+      ],
+      deps({ runCommand: () => ({ status: null, stdout: '' }) }),
+    );
+
+    expect(result.results.map((entry) => entry.outcome)).toEqual(['failed', 'untouched', 'untouched']);
+    expect(fs.existsSync(dataPath)).toBe(true);
+    expect(fs.existsSync(runtimePath)).toBe(true);
+  });
+
+  it('removes an already-stopped launchd service registration', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    fs.writeFileSync(unitPath, 'service');
+
+    const result = executePlan(
+      [
+        {
+          kind: 'unload-service',
+          flavor: 'launchd',
+          unitPath,
+          unitName: 'service',
+        },
+      ],
+      deps({
+        runCommand: () => ({
+          status: 1,
+          stdout: '',
+          stderr: 'Could not find specified service',
+        }),
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('removed');
+    expect(fs.existsSync(unitPath)).toBe(false);
+  });
+
   it('notes a manual delete when onecli itself cannot be run', () => {
     const { notes } = executePlan(
       [
@@ -205,5 +272,260 @@ describe('executePlan', () => {
     );
 
     expect(calls).toEqual([['onecli', 'agents', 'delete', '--id', 'u-123']]);
+  });
+
+  it('leaves an exact filesystem artifact untouched when its identity changed', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    fs.writeFileSync(unitPath, 'approved');
+    const expectedIdentity = pathIdentity(unitPath);
+    fs.writeFileSync(unitPath, 'replacement');
+
+    const result = executePlan(
+      [
+        {
+          kind: 'unload-service',
+          flavor: 'launchd',
+          unitPath,
+          unitName: 'service',
+          expectedIdentity,
+          identityRequired: true,
+        },
+      ],
+      deps(),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(fs.readFileSync(unitPath, 'utf8')).toBe('replacement');
+  });
+
+  it('deletes an unchanged exact file but preserves a replacement', () => {
+    const keptPath = path.join(tempDir, 'start-nanoclaw.sh');
+    fs.writeFileSync(keptPath, '#!/bin/sh\n');
+    const keptIdentity = pathIdentity(keptPath);
+    const removed = executePlan(
+      [
+        {
+          kind: 'delete-path',
+          item: { what: 'Start script', where: keptPath, path: keptPath },
+          expectedIdentity: keptIdentity,
+          identityRequired: true,
+        },
+      ],
+      deps(),
+    );
+    expect(removed.results[0]?.outcome).toBe('removed');
+    expect(fs.existsSync(keptPath)).toBe(false);
+
+    const replacementPath = path.join(tempDir, 'replacement.txt');
+    fs.writeFileSync(replacementPath, 'approved');
+    const replacementIdentity = pathIdentity(replacementPath);
+    fs.writeFileSync(replacementPath, 'replacement');
+    const preserved = executePlan(
+      [
+        {
+          kind: 'delete-path',
+          item: { what: 'Replacement', where: replacementPath, path: replacementPath },
+          expectedIdentity: replacementIdentity,
+          identityRequired: true,
+        },
+      ],
+      deps(),
+    );
+    expect(preserved.results[0]?.outcome).toBe('untouched');
+    expect(fs.readFileSync(replacementPath, 'utf8')).toBe('replacement');
+  });
+
+  it('does not unlink a service unit replaced while the stop command is running', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    const dataPath = path.join(tempDir, 'data');
+    fs.writeFileSync(unitPath, 'approved');
+    fs.mkdirSync(dataPath);
+    const expectedIdentity = pathIdentity(unitPath);
+    const result = executePlan(
+      [
+        {
+          kind: 'unload-service',
+          flavor: 'launchd',
+          unitPath,
+          unitName: 'service',
+          expectedIdentity,
+          identityRequired: true,
+        },
+        { kind: 'delete-path', item: { what: 'Data', where: dataPath, path: dataPath } },
+      ],
+      deps({
+        runCommand: () => {
+          fs.writeFileSync(unitPath, 'replacement');
+          return { status: 0, stdout: '' };
+        },
+      }),
+    );
+
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        outcome: 'untouched',
+        error: expect.objectContaining({ code: 'identity_changed' }),
+      }),
+    );
+    expect(result.results[1]).toEqual(
+      expect.objectContaining({
+        outcome: 'untouched',
+        error: expect.objectContaining({ code: 'service_prerequisite_failed' }),
+      }),
+    );
+    expect(fs.readFileSync(unitPath, 'utf8')).toBe('replacement');
+    expect(fs.existsSync(dataPath)).toBe(true);
+  });
+
+  it('rechecks a checkout-owned directory root immediately before recursive deletion', () => {
+    const dir = path.join(tempDir, 'data');
+    fs.mkdirSync(dir);
+    const expectedRootIdentity = pathIdentity(dir);
+    fs.renameSync(dir, `${dir}.approved`);
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, 'replacement.txt'), 'keep');
+
+    const result = executePlan(
+      [
+        {
+          kind: 'delete-path',
+          item: { what: 'Data', where: dir, path: dir },
+          expectedRootIdentity,
+        },
+      ],
+      deps(),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(fs.readFileSync(path.join(dir, 'replacement.txt'), 'utf8')).toBe('keep');
+  });
+
+  it('does not signal a non-host pidfile target that mentions this checkout', () => {
+    const pidFile = path.join(tempDir, 'nanoclaw.pid');
+    const processPattern = `${tempDir}/dist/index.js`;
+    fs.writeFileSync(pidFile, '321');
+    const killed: number[] = [];
+    const result = executePlan(
+      [
+        {
+          kind: 'kill-pid',
+          pidFile,
+          processPattern,
+          expectedIdentity: pathIdentity(pidFile),
+          identityRequired: true,
+        },
+      ],
+      deps({
+        runCommand: () => ({ status: 0, stdout: `/usr/bin/vim ${processPattern}\n` }),
+        killProcess: (pid) => {
+          killed.push(pid);
+        },
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(killed).toEqual([]);
+    expect(fs.existsSync(pidFile)).toBe(true);
+  });
+
+  it('waits for an owned pidfile process to stop before satisfying the prerequisite', () => {
+    const pidFile = path.join(tempDir, 'nanoclaw.pid');
+    const processPattern = `${tempDir}/dist/index.js`;
+    fs.writeFileSync(pidFile, '321');
+    let checks = 0;
+    const result = executePlan(
+      [
+        {
+          kind: 'kill-pid',
+          pidFile,
+          processPattern,
+          expectedIdentity: pathIdentity(pidFile),
+          identityRequired: true,
+        },
+      ],
+      deps({
+        runCommand: () => ({ status: ++checks < 4 ? 0 : 1, stdout: `/usr/bin/node ${processPattern}\n` }),
+        killProcess: () => {},
+        sleep: () => {},
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('removed');
+    expect(checks).toBeGreaterThanOrEqual(4);
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  it('re-lists only the NanoClaw node argv shape, not editors or grep', () => {
+    const processPattern = `${tempDir}/dist/index.js`;
+    const killed: number[] = [];
+    let listings = 0;
+    const result = executePlan(
+      [{ kind: 'pkill-host', pattern: processPattern }],
+      deps({
+        runCommand: () => ({
+          status: 0,
+          stdout:
+            listings++ === 0
+              ? `321 /usr/bin/node ${processPattern}\n322 /usr/bin/vim ${processPattern}\n323 grep ${processPattern}\n`
+              : `322 /usr/bin/vim ${processPattern}\n323 grep ${processPattern}\n`,
+        }),
+        killProcess: (pid) => {
+          killed.push(pid);
+        },
+        sleep: () => {},
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('removed');
+    expect(killed).toEqual([321]);
+  });
+
+  it('rechecks the exact image identity immediately before removal', () => {
+    const calls: string[][] = [];
+    const result = executePlan(
+      [
+        {
+          kind: 'rmi',
+          runtime: 'docker',
+          image: 'img:latest',
+          expectedIdentity: '{"Id":"approved"}',
+          identityRequired: true,
+        },
+      ],
+      deps({
+        runCommand: (cmd, args) => {
+          calls.push([cmd, ...args]);
+          return { status: 0, stdout: '{"Id":"replacement"}' };
+        },
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(calls).toEqual([['docker', 'image', 'inspect', 'img:latest']]);
+  });
+
+  it('does not delete OneCLI agents after service failure', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    const dataPath = path.join(tempDir, 'data');
+    fs.writeFileSync(unitPath, 'service');
+    fs.mkdirSync(dataPath);
+    const calls: string[][] = [];
+    const runCommand: RunCommand = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (cmd === 'launchctl') return { status: 1, stdout: '' };
+      return { status: 0, stdout: '' };
+    };
+    const result = executePlan(
+      [
+        { kind: 'unload-service', flavor: 'launchd', unitPath, unitName: 'service' },
+        { kind: 'delete-onecli-agent', agent: { uuid: 'u-1', identifier: 'ag-1', name: 'Agent' } },
+        { kind: 'delete-path', item: { what: 'Data', where: dataPath, path: dataPath } },
+      ],
+      deps({ runCommand }),
+    );
+
+    expect(result.results.map((entry) => entry.outcome)).toEqual(['failed', 'untouched', 'untouched']);
+    expect(calls.some((call) => call.join(' ') === 'onecli agents delete --id u-1')).toBe(false);
+    expect(fs.existsSync(dataPath)).toBe(true);
   });
 });

--- a/setup/uninstall/remove.ts
+++ b/setup/uninstall/remove.ts
@@ -8,81 +8,264 @@
  * the injected `log` callback.
  */
 import fs from 'fs';
+import { createHash } from 'node:crypto';
 import path from 'path';
 
-import type { RunCommand } from './onecli-agents.js';
+import { listVaultAgents, type RunCommand } from './onecli-agents.js';
 import type { RemovalAction } from './plan.js';
+import { checkoutHostProcesses, isNanoclawHostCommand, pathIdentity } from './scan.js';
+
+export type ActionOutcome = 'removed' | 'preserved' | 'failed' | 'untouched' | 'alreadyAbsent';
+
+export type UninstallActionResult = {
+  actionId: string;
+  artifactId: string;
+  outcome: ActionOutcome;
+  error?: { code: string; message: string };
+};
 
 export interface ExecDeps {
   runCommand: RunCommand;
   log: (line: string) => void;
   /** True when running as root — required to remove a system-level unit. */
   isRoot: boolean;
+  prerequisiteFailed?: boolean;
+  prerequisiteError?: { code: string; message: string };
+  onResult?: (result: UninstallActionResult) => void;
+  killProcess?: (pid: number) => void;
+  sleep?: (milliseconds: number) => void;
+  processStopTimeoutMs?: number;
 }
 
-export function executePlan(actions: RemovalAction[], deps: ExecDeps): { notes: string[] } {
-  const notes: string[] = [];
-  for (const action of actions) {
-    try {
-      runAction(action, deps, notes);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      notes.push(`${action.kind}: failed (${msg}) — re-run the uninstaller to retry.`);
-    }
+type IdentityResult = {
+  outcome: 'failed' | 'untouched' | 'alreadyAbsent';
+  error?: { code: string; message: string };
+};
+
+function missingExactPath(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return true;
+    throw new IdentityRevalidationError({
+      outcome: 'failed',
+      error: { code: 'identity_check_failed', message: 'The exact filesystem target could not be checked.' },
+    });
   }
-  return { notes };
+}
+
+class IdentityRevalidationError extends Error {
+  constructor(readonly result: IdentityResult) {
+    super(result.error?.message ?? 'The target identity changed during removal.');
+  }
+}
+
+export function executePlan(
+  actions: RemovalAction[],
+  deps: ExecDeps,
+): { notes: string[]; results: UninstallActionResult[]; prerequisiteFailed: boolean } {
+  const notes: string[] = [];
+  const results: UninstallActionResult[] = [];
+  let prerequisiteFailed = deps.prerequisiteFailed === true;
+  for (const action of actions) {
+    let outcome: ActionOutcome = 'failed';
+    let error: { code: string; message: string } | undefined;
+    try {
+      if (prerequisiteFailed && dependsOnStoppedService(action)) {
+        outcome = 'untouched';
+        error = deps.prerequisiteError ?? {
+          code: 'service_prerequisite_failed',
+          message: 'The service could not be stopped safely.',
+        };
+        notes.push(`${action.kind}: left untouched (${error.message})`);
+      } else {
+        const identity = verifyScopedRoot(action) ?? verifyExactIdentity(action, deps.runCommand);
+        if (identity) {
+          outcome = identity.outcome;
+          error = identity.error;
+        } else {
+          outcome = runAction(action, deps, notes);
+        }
+      }
+    } catch (err) {
+      if (err instanceof IdentityRevalidationError) {
+        outcome = err.result.outcome;
+        error = err.result.error;
+        notes.push(`${action.kind}: left untouched (${err.message}); re-run the uninstaller to rescan.`);
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        notes.push(`${action.kind}: failed (${msg}); re-run the uninstaller to retry.`);
+        error = { code: 'action_failed', message: msg };
+        outcome = 'failed';
+      }
+    }
+    if (stopsService(action) && (outcome === 'failed' || outcome === 'untouched')) {
+      prerequisiteFailed = true;
+    }
+    const result: UninstallActionResult = {
+      actionId: actionId(action),
+      artifactId: artifactId(action),
+      outcome,
+      ...(error ? { error } : {}),
+    };
+    results.push(result);
+    deps.onResult?.(result);
+  }
+  return { notes, results, prerequisiteFailed };
+}
+
+export function artifactId(action: RemovalAction): string {
+  return `artifact-${createHash('sha256').update(actionKey(action)).digest('hex').slice(0, 16)}`;
+}
+
+export function actionId(action: RemovalAction): string {
+  return `remove-${createHash('sha256').update(actionKey(action)).digest('hex').slice(0, 16)}`;
 }
 
 /**
  * Copy .env aside before deletion. Never clobbers an existing backup —
  * falls back to a timestamped name on collision. Returns the backup path.
  */
-export function backupEnv(envPath: string): string {
-  const dir = path.dirname(envPath);
-  let backup = path.join(dir, '.env.bak');
-  if (fs.existsSync(backup)) {
-    // Local time (system TZ) — the stamp is read by the human running the
-    // uninstall. sv-SE renders "YYYY-MM-DD HH:mm:ss".
-    const stamp = new Date()
-      .toLocaleString('sv-SE', { hour12: false })
-      .replace(/[-:]/g, '')
-      .replace(' ', '-')
-      .slice(0, 15);
-    backup = path.join(dir, `.env.bak.${stamp}`);
-  }
-  fs.copyFileSync(envPath, backup);
-  return backup;
+export function backupEnv(envPath: string, backupRoot: string, expectedIdentity?: string): string {
+  return backupEnvSecure(envPath, backupRoot, expectedIdentity);
 }
 
-function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void {
+/**
+ * Copy an approved .env without following a symlink. The production plan
+ * always supplies an external backupRoot. The root is explicit so no caller
+ * can accidentally advertise a checkout-local credential backup.
+ */
+function backupEnvSecure(envPath: string, backupRoot: string, expectedIdentity = pathIdentity(envPath)): string {
+  if (!expectedIdentity) throw new Error('credential backup source is unavailable');
+
+  const noFollow = (fs.constants as typeof fs.constants & { O_NOFOLLOW?: number }).O_NOFOLLOW;
+  if (noFollow === undefined) throw new Error('credential backup source could not be opened safely');
+  let sourceFd: number | undefined;
+  let contents: Buffer;
+  try {
+    sourceFd = fs.openSync(envPath, fs.constants.O_RDONLY | noFollow);
+    const stat = fs.fstatSync(sourceFd);
+    if (!stat.isFile()) throw new Error('credential backup source is not a regular file');
+    contents = fs.readFileSync(sourceFd);
+    const openedIdentity = `file:${stat.dev}:${stat.ino}:${createHash('sha256').update(contents).digest('hex')}`;
+    if (openedIdentity !== expectedIdentity) {
+      throw new IdentityRevalidationError({
+        outcome: 'untouched',
+        error: { code: 'identity_changed', message: 'The .env file changed before it could be backed up.' },
+      });
+    }
+  } catch (error) {
+    if (error instanceof IdentityRevalidationError) throw error;
+    throw new Error('credential backup source could not be opened safely');
+  } finally {
+    if (sourceFd !== undefined) fs.closeSync(sourceFd);
+  }
+
+  fs.mkdirSync(backupRoot, { recursive: true, mode: 0o700 });
+  const rootStat = fs.lstatSync(backupRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error('credential backup directory is not a private directory');
+  }
+  fs.chmodSync(backupRoot, 0o700);
+
+  const candidates = [
+    path.join(backupRoot, '.env.bak'),
+    ...Array.from({ length: 8 }, (_, index) => path.join(backupRoot, `.env.bak.${Date.now()}-${process.pid}-${index}`)),
+  ];
+  let backupPath: string | undefined;
+  let backupFd: number | undefined;
+  for (const candidate of candidates) {
+    try {
+      backupFd = fs.openSync(
+        candidate,
+        fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollow,
+        0o600,
+      );
+      backupPath = candidate;
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST')
+        throw new Error('credential backup could not be created safely');
+    }
+  }
+  if (!backupPath || backupFd === undefined) throw new Error('credential backup name is unavailable');
+  try {
+    fs.fchmodSync(backupFd, 0o600);
+    fs.writeFileSync(backupFd, contents);
+  } catch {
+    try {
+      fs.closeSync(backupFd);
+    } catch {
+      /* best effort cleanup */
+    }
+    try {
+      fs.unlinkSync(backupPath);
+    } catch {
+      /* preserve the original on cleanup failure */
+    }
+    throw new Error('credential backup could not be written safely');
+  }
+  fs.closeSync(backupFd);
+
+  // The source may have been replaced while the backup was being written.
+  // Leave both the replacement and the approved backup untouched in that case.
+  if (pathIdentity(envPath) !== expectedIdentity) {
+    throw new IdentityRevalidationError({
+      outcome: 'untouched',
+      error: { code: 'identity_changed', message: 'The .env file changed before it could be removed.' },
+    });
+  }
+  try {
+    fs.unlinkSync(envPath);
+  } catch {
+    throw new Error('credential source could not be removed after backup');
+  }
+  return backupPath;
+}
+
+function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): ActionOutcome {
   const { runCommand, log } = deps;
   switch (action.kind) {
     case 'unload-service':
       switch (action.flavor) {
         case 'launchd':
-          runCommand('launchctl', ['unload', action.unitPath]);
-          fs.rmSync(action.unitPath, { force: true });
+          {
+            const unloaded = runCommand('launchctl', ['unload', action.unitPath]);
+            const alreadyStopped = /could not find|not loaded|no such process/i.test(
+              `${unloaded.stdout}\n${unloaded.stderr ?? ''}`,
+            );
+            if (unloaded.status !== 0 && !alreadyStopped) {
+              throw new Error('launchctl unload failed');
+            }
+          }
+          removeApprovedServiceUnit(action, deps.runCommand);
           log('✓ background service removed');
-          break;
+          return 'removed';
         case 'systemd-user':
-          runCommand('systemctl', ['--user', 'disable', '--now', `${action.unitName}.service`]);
-          fs.rmSync(action.unitPath, { force: true });
-          runCommand('systemctl', ['--user', 'daemon-reload']);
+          requireSuccess(
+            runCommand('systemctl', ['--user', 'disable', '--now', `${action.unitName}.service`]),
+            'systemd user service stop failed',
+          );
+          removeApprovedServiceUnit(action, deps.runCommand);
+          requireSuccess(runCommand('systemctl', ['--user', 'daemon-reload']), 'systemd user daemon-reload failed');
           log('✓ background service removed');
-          break;
+          return 'removed';
         case 'systemd-system':
           if (!deps.isRoot) {
-            log('! system service needs root — left in place');
-            notes.push(`System service ${action.unitPath} — re-run with sudo to remove.`);
-            break;
+            log('! system service needs root; left in place');
+            notes.push(`System service ${action.unitPath}; re-run with sudo to remove.`);
+            throw new Error(`System service ${action.unitPath} needs root.`);
           }
-          runCommand('systemctl', ['disable', '--now', `${action.unitName}.service`]);
-          fs.rmSync(action.unitPath, { force: true });
-          runCommand('systemctl', ['daemon-reload']);
+          requireSuccess(
+            runCommand('systemctl', ['disable', '--now', `${action.unitName}.service`]),
+            'system service stop failed',
+          );
+          removeApprovedServiceUnit(action, deps.runCommand);
+          requireSuccess(runCommand('systemctl', ['daemon-reload']), 'system daemon-reload failed');
           log('✓ system service removed');
-          break;
+          return 'removed';
       }
-      break;
     case 'kill-pid': {
       let pid = NaN;
       try {
@@ -91,19 +274,41 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
         // pidfile already gone
       }
       if (Number.isInteger(pid) && pid > 0) {
-        try {
-          process.kill(pid);
-          log('✓ stopped host process');
-        } catch {
-          // not running
+        const current = processCommand(runCommand, pid);
+        if (!current.available) throw new Error('could not verify the host process');
+        if (current.command) {
+          if (!isNanoclawHostCommand(current.command, action.processPattern)) {
+            throw new Error('pidfile points to a process outside this checkout');
+          }
+          try {
+            (deps.killProcess ?? ((target) => process.kill(target)))(pid);
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+          }
+          waitForStopped(() => {
+            const state = processCommand(runCommand, pid);
+            if (!state.available) throw new Error('could not verify that the host stopped');
+            return !state.command;
+          }, deps);
         }
       }
-      break;
+      fs.rmSync(action.pidFile, { force: true });
+      log('✓ stopped host process');
+      return 'removed';
     }
-    case 'pkill-host':
-      // Exit 1 = no matching process — not a failure.
-      runCommand('pkill', ['-f', action.pattern]);
-      break;
+    case 'pkill-host': {
+      const matching = checkoutProcesses(runCommand, action.pattern);
+      if (matching.length === 0) return 'alreadyAbsent';
+      for (const pid of matching) {
+        try {
+          (deps.killProcess ?? ((target) => process.kill(target)))(pid);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+        }
+      }
+      waitForStopped(() => checkoutProcesses(runCommand, action.pattern).length === 0, deps);
+      return 'removed';
+    }
     case 'rm-containers': {
       // Re-list at removal time: the host was alive during the confirm
       // phase and may have spawned containers the scan never saw.
@@ -113,35 +318,37 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
           `Containers: '${action.runtime}' unavailable — remove later with: ` +
             `${action.runtime} ps -aq --filter label=${action.labelFilter} | xargs -r ${action.runtime} rm -f`,
         );
-        break;
+        throw new Error(`'${action.runtime}' unavailable while listing approved containers`);
       }
       const ids = ps.stdout
         .split('\n')
         .map((s) => s.trim())
         .filter(Boolean);
-      if (ids.length === 0) break;
-      runCommand(action.runtime, ['rm', '-f', ...ids]);
+      if (ids.length === 0) return 'alreadyAbsent';
+      requireSuccess(runCommand(action.runtime, ['rm', '-f', ...ids]), 'container removal failed');
       log(`✓ removed ${ids.length} container(s)`);
-      break;
+      return 'removed';
     }
     case 'rmi': {
       const res = runCommand(action.runtime, ['rmi', action.image]);
       if (res.status === 0) {
         log('✓ removed container image');
+        return 'removed';
       } else {
         log('! could not remove image (in use?)');
-        notes.push(`Image ${action.image}: not removed — retry with: ${action.runtime} rmi ${action.image}`);
+        notes.push(`Image ${action.image}: not removed; retry with: ${action.runtime} rmi ${action.image}`);
       }
-      break;
+      throw new Error(`container image ${action.image} was not removed`);
     }
     case 'rm-ncl-symlink':
       fs.rmSync(action.linkPath, { force: true });
       log('✓ removed ncl command');
-      break;
+      return 'removed';
     case 'delete-onecli-agent': {
       const res = runCommand('onecli', ['agents', 'delete', '--id', action.agent.uuid]);
       if (res.status === 0) {
         log(`✓ deleted OneCLI agent ${action.agent.name} (${action.agent.identifier})`);
+        return 'removed';
       } else if (res.status === null) {
         // spawn failure (binary gone since the scan), not a missing agent
         log(`! couldn't run onecli for ${action.agent.identifier}`);
@@ -149,23 +356,226 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
           `OneCLI agent ${action.agent.name} (${action.agent.identifier}): couldn't run onecli — ` +
             `delete manually with: onecli agents delete --id ${action.agent.uuid}`,
         );
-      } else {
-        log(`! OneCLI agent ${action.agent.identifier} already gone`);
+        throw new Error('onecli could not be started');
       }
-      break;
+      throw new Error(`OneCLI agent ${action.agent.identifier} was not deleted`);
     }
     case 'backup-env': {
+      let envStat: fs.Stats;
+      try {
+        envStat = fs.lstatSync(action.envPath);
+      } catch {
+        return 'alreadyAbsent';
+      }
+      if (!envStat.isFile()) {
+        throw new IdentityRevalidationError({
+          outcome: 'untouched',
+          error: { code: 'identity_changed', message: 'The .env path is no longer a regular file.' },
+        });
+      }
       // Backup and removal are one action so a failed backup (which throws
       // into executePlan's catch) can never be followed by the deletion.
-      const backup = backupEnv(action.envPath);
-      fs.rmSync(action.envPath, { force: true });
+      if (!action.backupRoot) throw new Error('credential backup destination is unavailable');
+      const backup = backupEnvSecure(action.envPath, action.backupRoot, action.expectedIdentity);
       log(`✓ removed .env (backup at ${backup})`);
-      break;
+      return 'removed';
     }
     case 'delete-path':
     case 'delete-runtime-path':
+      if (!fs.existsSync(action.item.path)) return 'alreadyAbsent';
       fs.rmSync(action.item.path, { recursive: true, force: true });
       log(`✓ removed ${action.item.what}`);
-      break;
+      return 'removed';
   }
+}
+
+function actionKey(action: RemovalAction): string {
+  switch (action.kind) {
+    case 'unload-service':
+      return `${action.kind}:${action.unitPath}`;
+    case 'kill-pid':
+      return `${action.kind}:${action.pidFile}:${action.processPattern}`;
+    case 'pkill-host':
+      return `${action.kind}:${action.pattern}`;
+    case 'rm-containers':
+      return `${action.kind}:${action.runtime}:${action.labelFilter}`;
+    case 'rmi':
+      return `${action.kind}:${action.runtime}:${action.image}`;
+    case 'rm-ncl-symlink':
+      return `${action.kind}:${action.linkPath}`;
+    case 'delete-onecli-agent':
+      return `${action.kind}:${action.agent.uuid}`;
+    case 'backup-env':
+      return `${action.kind}:${action.envPath}`;
+    case 'delete-path':
+    case 'delete-runtime-path':
+      return `${action.kind}:${action.item.path}`;
+  }
+}
+
+function stopsService(action: RemovalAction): boolean {
+  return (
+    action.kind === 'unload-service' ||
+    action.kind === 'kill-pid' ||
+    action.kind === 'pkill-host' ||
+    action.kind === 'rm-containers'
+  );
+}
+
+function dependsOnStoppedService(action: RemovalAction): boolean {
+  return ['rm-containers', 'rmi', 'backup-env', 'delete-onecli-agent', 'delete-path', 'delete-runtime-path'].includes(
+    action.kind,
+  );
+}
+
+function verifyExactIdentity(action: RemovalAction, runCommand: RunCommand): IdentityResult | undefined {
+  if (!('identityRequired' in action) || action.identityRequired !== true) return undefined;
+  const expected = action.expectedIdentity;
+  if (!expected) {
+    return {
+      outcome: 'untouched',
+      error: { code: 'identity_uninspectable', message: 'The exact target identity could not be proven.' },
+    };
+  }
+  if (action.kind === 'rmi') {
+    const current = runCommand(action.runtime, ['image', 'inspect', action.image]);
+    if (current.status === 1) return { outcome: 'alreadyAbsent' };
+    if (current.status !== 0) {
+      return {
+        outcome: 'failed',
+        error: { code: 'identity_check_failed', message: 'The container image identity could not be checked.' },
+      };
+    }
+    if (current.stdout.trim() !== expected) {
+      return {
+        outcome: 'untouched',
+        error: { code: 'identity_changed', message: 'The container image changed after approval.' },
+      };
+    }
+    return undefined;
+  }
+  if (action.kind === 'delete-onecli-agent') {
+    const current = listVaultAgents(runCommand);
+    if (!current.available) {
+      return {
+        outcome: 'failed',
+        error: { code: 'identity_check_failed', message: 'The OneCLI agent list could not be checked.' },
+      };
+    }
+    const agent = current.agents.find((candidate) => candidate.uuid === action.agent.uuid);
+    if (!agent) return { outcome: 'alreadyAbsent' };
+    if (JSON.stringify(agent) !== expected) {
+      return {
+        outcome: 'untouched',
+        error: { code: 'identity_changed', message: 'The OneCLI agent changed after approval.' },
+      };
+    }
+    return undefined;
+  }
+  const target =
+    action.kind === 'unload-service'
+      ? action.unitPath
+      : action.kind === 'kill-pid'
+        ? action.pidFile
+        : action.kind === 'backup-env'
+          ? action.envPath
+          : action.kind === 'delete-path' || action.kind === 'delete-runtime-path'
+            ? action.item.path
+            : action.linkPath;
+  const current = pathIdentity(target);
+  if (!current) {
+    if (missingExactPath(target)) return { outcome: 'alreadyAbsent' };
+    return {
+      outcome: 'failed',
+      error: { code: 'identity_check_failed', message: 'The exact filesystem target could not be checked.' },
+    };
+  }
+  if (current !== expected) {
+    return {
+      outcome: 'untouched',
+      error: { code: 'identity_changed', message: 'The exact filesystem target changed after approval.' },
+    };
+  }
+  if (action.kind === 'kill-pid') {
+    const pid = Number(fs.readFileSync(action.pidFile, 'utf8').trim());
+    if (Number.isInteger(pid) && pid > 0) {
+      const process = processCommand(runCommand, pid);
+      if (!process.available) {
+        return {
+          outcome: 'failed',
+          error: { code: 'identity_check_failed', message: 'The host process identity could not be checked.' },
+        };
+      }
+      if (process.command && !isNanoclawHostCommand(process.command, action.processPattern)) {
+        return {
+          outcome: 'untouched',
+          error: { code: 'identity_changed', message: 'The pidfile now points outside this checkout.' },
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+function removeApprovedServiceUnit(
+  action: Extract<RemovalAction, { kind: 'unload-service' }>,
+  runCommand: RunCommand,
+): void {
+  const identity = verifyExactIdentity(action, runCommand);
+  if (identity?.outcome === 'alreadyAbsent') return;
+  if (identity) throw new IdentityRevalidationError(identity);
+  fs.rmSync(action.unitPath, { force: true });
+}
+
+function verifyScopedRoot(
+  action: RemovalAction,
+): { outcome: 'untouched' | 'alreadyAbsent'; error?: { code: string; message: string } } | undefined {
+  if ((action.kind !== 'delete-path' && action.kind !== 'delete-runtime-path') || !action.expectedRootIdentity) {
+    return undefined;
+  }
+  const current = pathIdentity(action.item.path);
+  if (!current) {
+    if (missingExactPath(action.item.path)) return { outcome: 'alreadyAbsent' };
+    return {
+      outcome: 'untouched',
+      error: { code: 'identity_check_failed', message: 'The checkout-owned root could not be checked.' },
+    };
+  }
+  if (current !== action.expectedRootIdentity) {
+    return {
+      outcome: 'untouched',
+      error: { code: 'ownership_root_changed', message: 'The approved checkout-owned root changed before removal.' },
+    };
+  }
+  return undefined;
+}
+
+function processCommand(runCommand: RunCommand, pid: number): { available: boolean; command?: string } {
+  const result = runCommand('ps', ['-p', String(pid), '-o', 'command=']);
+  if (result.status === 0) return { available: true, command: result.stdout.trim() || undefined };
+  if (result.status === 1) return { available: true };
+  return { available: false };
+}
+
+function checkoutProcesses(runCommand: RunCommand, pattern: string): number[] {
+  const pids = checkoutHostProcesses(runCommand, pattern);
+  if (!pids) throw new Error('could not list host processes');
+  return pids;
+}
+
+function waitForStopped(check: () => boolean, deps: ExecDeps): void {
+  const timeout = deps.processStopTimeoutMs ?? 5_000;
+  const deadline = Date.now() + timeout;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('host process did not stop before the timeout');
+    (deps.sleep ?? sleepSync)(50);
+  }
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function requireSuccess(result: { status: number | null }, message: string): void {
+  if (result.status !== 0) throw new Error(message);
 }

--- a/setup/uninstall/scan.test.ts
+++ b/setup/uninstall/scan.test.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 
 import { getInstallSlug, getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
 import type { RunCommand } from './onecli-agents.js';
-import { detectExistingInstall, scanInstall, type ScanDeps } from './scan.js';
+import { credentialBackupRoot, detectExistingInstall, pathIdentity, scanInstall, type ScanDeps } from './scan.js';
 
 let root: string;
 let home: string;
@@ -32,13 +32,18 @@ function deps(overrides: Partial<ScanDeps> = {}): ScanDeps {
     projectRoot: root,
     home,
     platform: 'darwin',
-    runCommand: fakeRun({}),
+    runCommand: fakeRun({
+      ps: () => ({ status: 0, stdout: '' }),
+      onecli: () => ({ status: 0, stdout: '{"data":[]}' }),
+    }),
     ...overrides,
   };
 }
 
 const dockerUp = (containerIds: string[], hasImage: boolean) =>
   fakeRun({
+    ps: () => ({ status: 0, stdout: '' }),
+    onecli: () => ({ status: 0, stdout: '{"data":[]}' }),
     docker: (args) => {
       if (args[0] === 'ps') return { status: 0, stdout: containerIds.join('\n') + '\n' };
       if (args[0] === 'image') return { status: hasImage ? 0 : 1, stdout: '' };
@@ -47,6 +52,20 @@ const dockerUp = (containerIds: string[], hasImage: boolean) =>
   });
 
 describe('scanInstall path groups', () => {
+  it('uses the Linux state directory for credential backups', () => {
+    const previous = process.env.XDG_STATE_HOME;
+    const stateHome = path.join(home, 'state');
+    process.env.XDG_STATE_HOME = stateHome;
+    try {
+      expect(credentialBackupRoot(home, 'linux', 'install-slug')).toBe(
+        path.join(stateHome, 'nanoclaw', 'uninstall-backups', 'install-slug'),
+      );
+    } finally {
+      if (previous === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = previous;
+    }
+  });
+
   it('puts dist and node_modules in runtime, not data', () => {
     for (const dir of ['data', 'logs', 'dist', 'node_modules', 'groups', 'store']) {
       fs.mkdirSync(path.join(root, dir));
@@ -71,6 +90,27 @@ describe('scanInstall path groups', () => {
     expect(inv.user.map((i) => path.basename(i.path))).toEqual(['groups', 'store']);
   });
 
+  it('reports credential backups separately so receipts preserve them', () => {
+    const backupRoot = credentialBackupRoot(home, 'darwin', getInstallSlug(root));
+    fs.mkdirSync(backupRoot, { recursive: true });
+    fs.writeFileSync(path.join(backupRoot, '.env.bak'), 'KEY=old');
+    fs.writeFileSync(path.join(backupRoot, '.env.bak.20260101-120000'), 'KEY=older');
+
+    const inv = scanInstall(deps());
+
+    expect(inv.envBackups.map((item) => path.basename(item.path))).toEqual(['.env.bak', '.env.bak.20260101-120000']);
+    expect(inv.data).toEqual([]);
+  });
+
+  it('reports legacy in-checkout backups separately as unsafe residue', () => {
+    fs.writeFileSync(path.join(root, '.env.bak'), 'KEY=old');
+
+    const inv = scanInstall(deps());
+
+    expect(inv.envBackups).toEqual([]);
+    expect(inv.legacyEnvBackups?.map((item) => path.basename(item.path))).toEqual(['.env.bak']);
+  });
+
   it('finds nothing in an empty checkout', () => {
     const inv = scanInstall(deps());
     expect(inv.data).toEqual([]);
@@ -78,6 +118,17 @@ describe('scanInstall path groups', () => {
     expect(inv.user).toEqual([]);
     expect(inv.service.containerIds).toEqual([]);
     expect(inv.service.image).toBeUndefined();
+  });
+
+  it('inventories a dangling .env symlink without following it', () => {
+    const env = path.join(root, '.env');
+    fs.symlinkSync(path.join(root, 'missing-secret'), env);
+
+    const inv = scanInstall(deps());
+
+    expect(inv.data.map((item) => path.basename(item.path))).toContain('.env');
+    expect(inv.identity?.exactPaths[env]).toBe(pathIdentity(env));
+    expect(inv.identity?.exactPaths[env]).toMatch(/^symlink:/);
   });
 });
 
@@ -111,11 +162,50 @@ describe('scanInstall service artifacts', () => {
     expect(inv.notes).toEqual([]);
   });
 
+  it('inventories only an exact checkout host argv shape', () => {
+    const script = path.join(root, 'dist', 'index.js');
+    const inv = scanInstall(
+      deps({
+        runCommand: fakeRun({
+          ps: () => ({
+            status: 0,
+            stdout: `41 /usr/bin/node ${script}\n42 /usr/bin/vim ${script}\n43 node ${script} --extra\n`,
+          }),
+        }),
+      }),
+    );
+
+    expect(inv.service.hostProcessIds).toEqual([41]);
+  });
+
   it('degrades with a manual-cleanup note when docker is unavailable', () => {
     const inv = scanInstall(deps());
     expect(inv.service.containerIds).toEqual([]);
     expect(inv.service.image).toBeUndefined();
+    expect(inv.service.containerRuntimeAvailable).toBe(false);
     expect(inv.notes.some((n) => n.includes("'docker' unavailable"))).toBe(true);
+  });
+});
+
+describe('scanInstall ownership identity', () => {
+  it('snapshots the checkout, exact files, scoped roots, and container selector', () => {
+    const data = path.join(root, 'data');
+    const pid = path.join(root, 'nanoclaw.pid');
+    const env = path.join(root, '.env');
+    const start = path.join(root, 'start-nanoclaw.sh');
+    fs.mkdirSync(data);
+    fs.writeFileSync(pid, '123');
+    fs.writeFileSync(env, 'TOKEN=secret');
+    fs.writeFileSync(start, '#!/bin/sh');
+
+    const inv = scanInstall(deps({ platform: 'linux' }));
+
+    expect(inv.identity?.root).toBeTruthy();
+    expect(inv.identity?.exactPaths[pid]).toContain('file:');
+    expect(inv.identity?.exactPaths[env]).toContain('file:');
+    expect(inv.identity?.exactPaths[start]).toContain('file:');
+    expect(inv.identity?.scopedRoots[data]).toContain('node:');
+    expect(inv.identity?.containerSelector).toBe(`nanoclaw-install=${inv.slug}`);
   });
 });
 
@@ -147,7 +237,10 @@ describe('scanInstall OneCLI agents', () => {
       { id: 'u-2', identifier: 'ag-other', name: 'Other', isDefault: false },
     ],
   });
-  const onecliUp = fakeRun({ onecli: () => ({ status: 0, stdout: vault }) });
+  const onecliUp = fakeRun({
+    ps: () => ({ status: 0, stdout: '' }),
+    onecli: () => ({ status: 0, stdout: vault }),
+  });
 
   it('splits mine vs orphans against the central DB', () => {
     fs.mkdirSync(path.join(root, 'data'));
@@ -168,6 +261,16 @@ describe('scanInstall OneCLI agents', () => {
     expect(inv.onecli.mine).toEqual([]);
     expect(inv.onecli.orphans.map((a) => a.identifier)).toEqual(['ag-mine', 'ag-other']);
     expect(inv.notes.some((n) => n.includes("Couldn't read agent_groups"))).toBe(true);
+  });
+
+  it('reports an uninspectable artifact when OneCLI cannot be inventoried', () => {
+    const inv = scanInstall(
+      deps({
+        runCommand: fakeRun({ ps: () => ({ status: 0, stdout: '' }) }),
+      }),
+    );
+    expect(inv.onecli.available).toBe(false);
+    expect(inv.notes.some((n) => n.includes("Couldn't inspect OneCLI agents"))).toBe(true);
   });
 });
 

--- a/setup/uninstall/scan.ts
+++ b/setup/uninstall/scan.ts
@@ -15,6 +15,7 @@
  * Deliberately does NOT import src/config.ts (import-time side effects).
  */
 import fs from 'fs';
+import { createHash } from 'node:crypto';
 import os from 'os';
 import path from 'path';
 
@@ -41,14 +42,27 @@ export interface ServiceInventory {
   systemdUserUnit?: string;
   systemdSystemUnit?: string;
   pidFile?: string;
+  /** Exact checkout-owned host processes, or undefined when `ps` was unavailable. */
+  hostProcessIds?: number[];
+  containerRuntimeAvailable?: boolean;
   containerIds: string[];
   image?: string;
   nclSymlink?: string;
+  imageIdentity?: string;
+}
+
+export interface InventoryIdentity {
+  root: string;
+  exactPaths: Record<string, string>;
+  scopedRoots: Record<string, string>;
+  containerSelector: string;
 }
 
 export interface OnecliInventory {
   mine: VaultAgent[];
   orphans: VaultAgent[];
+  /** False when the OneCLI inventory could not be inspected at all. */
+  available: boolean;
   /** False when agent_groups couldn't be read — orphan labels are then unreliable. */
   idsKnown: boolean;
 }
@@ -67,8 +81,15 @@ export interface Inventory {
   runtime: PathItem[];
   /** Group 3: groups/ and store/ — user content, unrecoverable. */
   user: PathItem[];
+  /** Credential backups created by earlier/current uninstalls; never removed here. */
+  envBackups: PathItem[];
+  /** Legacy backups left inside the checkout; these block safe checkout removal. */
+  legacyEnvBackups?: PathItem[];
+  /** Secure external backup directory used by the removal plan. */
+  credentialBackupRoot?: string;
   onecli: OnecliInventory;
   notes: string[];
+  identity?: InventoryIdentity;
 }
 
 export interface ScanDeps {
@@ -78,24 +99,36 @@ export interface ScanDeps {
   runCommand: RunCommand;
 }
 
+/**
+ * Credential backups live outside the checkout so deleting the checkout cannot
+ * delete the only copy of the user's credentials.
+ */
+export function credentialBackupRoot(home: string, platform: NodeJS.Platform, slug: string): string {
+  const root =
+    platform === 'darwin'
+      ? path.join(home, 'Library', 'Application Support', 'NanoClaw', 'uninstall-backups')
+      : path.join(process.env.XDG_STATE_HOME || path.join(home, '.local', 'state'), 'nanoclaw', 'uninstall-backups');
+  return path.join(root, slug);
+}
+
 export function tilde(p: string, home: string): string {
   return p.startsWith(home) ? `~${p.slice(home.length)}` : p;
 }
 
 export function scanInstall(deps: ScanDeps): Inventory {
-  const { projectRoot, home, runCommand } = deps;
+  const { projectRoot, home, platform, runCommand } = deps;
   const slug = getInstallSlug(projectRoot);
   const containerRuntime = process.env.CONTAINER_RUNTIME ?? 'docker';
   const notes: string[] = [];
 
   const service = scanService(deps, slug, containerRuntime, notes);
+  const backupRoot = credentialBackupRoot(home, platform, slug);
 
   const data = existingItems(projectRoot, home, [
     { rel: 'data', what: 'Database & conversations' },
     { rel: 'logs', what: 'Logs' },
     { rel: '.env', what: 'Secrets / API keys (.env)', where: 'backed up before removal' },
     { rel: 'start-nanoclaw.sh', what: 'Start script', where: 'start-nanoclaw.sh' },
-    { rel: 'nanoclaw.pid', what: 'PID file', where: 'nanoclaw.pid' },
   ]);
   const updates = path.join(path.dirname(projectRoot), '.nanoclaw-updates', slug);
   if (fs.existsSync(updates)) {
@@ -115,6 +148,15 @@ export function scanInstall(deps: ScanDeps): Inventory {
     { rel: 'groups', what: 'Agent memory & files' },
     { rel: 'store', what: 'Migrated data store' },
   ]);
+  const envBackups = existingEnvBackups(backupRoot, home);
+  const legacyEnvBackups = existingEnvBackups(projectRoot, home).filter(
+    (item) => path.dirname(item.path) === projectRoot,
+  );
+  if (legacyEnvBackups.length > 0) {
+    notes.push(
+      `Legacy credential backup(s) remain inside the checkout: ${legacyEnvBackups.map((item) => item.path).join(', ')}.`,
+    );
+  }
 
   const onecli = scanOnecli(projectRoot, runCommand, notes);
 
@@ -126,9 +168,90 @@ export function scanInstall(deps: ScanDeps): Inventory {
     data,
     runtime,
     user,
+    envBackups,
+    legacyEnvBackups,
+    credentialBackupRoot: backupRoot,
     onecli,
     notes,
+    identity: {
+      root: pathIdentity(projectRoot) ?? '',
+      exactPaths: Object.fromEntries(
+        [
+          service.launchdPlist,
+          service.systemdUserUnit,
+          service.systemdSystemUnit,
+          service.pidFile,
+          service.nclSymlink,
+          ...[...data, ...runtime, ...user].map((item) => item.path),
+        ]
+          .filter((value): value is string => Boolean(value))
+          .map((value) => [value, pathIdentity(value) ?? '']),
+      ),
+      scopedRoots: Object.fromEntries(
+        [...data, ...runtime, ...user]
+          .filter((item) => {
+            try {
+              return fs.lstatSync(item.path).isDirectory();
+            } catch {
+              return false;
+            }
+          })
+          .map((item) => [item.path, pathIdentity(item.path) ?? '']),
+      ),
+      containerSelector: `nanoclaw-install=${slug}`,
+    },
   };
+}
+
+function existingEnvBackups(projectRoot: string, home: string): PathItem[] {
+  let names: string[] = [];
+  try {
+    names = fs.readdirSync(projectRoot).filter((name) => /^\.env\.bak(?:\.|$)/.test(name));
+  } catch {
+    return [];
+  }
+  return names.sort().map((name) => {
+    const backupPath = path.join(projectRoot, name);
+    return {
+      what: 'Credential backup',
+      where: tilde(backupPath, home),
+      path: backupPath,
+    };
+  });
+}
+
+/** Identity for exact filesystem artifacts; directories are ownership roots. */
+export function pathIdentity(target: string): string | undefined {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch {
+    return undefined;
+  }
+
+  if (stat.isSymbolicLink()) {
+    try {
+      return `symlink:${fs.readlinkSync(target)}`;
+    } catch {
+      return undefined;
+    }
+  }
+  if (!stat.isFile()) return `node:${stat.dev}:${stat.ino}:${stat.mode}`;
+
+  const noFollow = (fs.constants as typeof fs.constants & { O_NOFOLLOW?: number }).O_NOFOLLOW;
+  if (noFollow === undefined) return undefined;
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(target, fs.constants.O_RDONLY | noFollow);
+    const opened = fs.fstatSync(fd);
+    if (!opened.isFile() || opened.dev !== stat.dev || opened.ino !== stat.ino) return undefined;
+    const digest = createHash('sha256').update(fs.readFileSync(fd)).digest('hex');
+    return `file:${opened.dev}:${opened.ino}:${digest}`;
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
 }
 
 /**
@@ -155,17 +278,24 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
   const { projectRoot, home, platform, runCommand } = deps;
   const service: ServiceInventory = { containerIds: [] };
 
+  service.hostProcessIds = checkoutHostProcesses(runCommand, path.join(projectRoot, 'dist', 'index.js'));
+  if (!service.hostProcessIds) {
+    notes.push(
+      'Host processes: could not inspect the process list; no process will be signalled without a fresh exact match.',
+    );
+  }
+
   if (platform === 'darwin') {
     const plist = path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(projectRoot)}.plist`);
-    if (fs.existsSync(plist)) service.launchdPlist = plist;
+    if (knownPath(plist)) service.launchdPlist = plist;
   } else if (platform === 'linux') {
     const unit = getSystemdUnit(projectRoot);
     const userUnit = path.join(home, '.config', 'systemd', 'user', `${unit}.service`);
     const systemUnit = `/etc/systemd/system/${unit}.service`;
-    if (fs.existsSync(userUnit)) service.systemdUserUnit = userUnit;
-    if (fs.existsSync(systemUnit)) service.systemdSystemUnit = systemUnit;
+    if (knownPath(userUnit)) service.systemdUserUnit = userUnit;
+    if (knownPath(systemUnit)) service.systemdSystemUnit = systemUnit;
     const pidFile = path.join(projectRoot, 'nanoclaw.pid');
-    if (fs.existsSync(pidFile)) service.pidFile = pidFile;
+    if (knownPath(pidFile)) service.pidFile = pidFile;
   }
 
   // Container label matches what container-runner.ts stamps at spawn time.
@@ -188,7 +318,10 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
   if (runtimeOk) {
     try {
       const inspect = runCommand(containerRuntime, ['image', 'inspect', image]);
-      if (inspect.status === 0) service.image = image;
+      if (inspect.status === 0) {
+        service.image = image;
+        service.imageIdentity = inspect.stdout.trim() || undefined;
+      }
     } catch {
       runtimeOk = false;
     }
@@ -200,6 +333,7 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
         `${containerRuntime} rmi ${image}`,
     );
   }
+  service.containerRuntimeAvailable = runtimeOk;
 
   const link = path.join(home, '.local', 'bin', 'ncl');
   let linkStat: fs.Stats | null = null;
@@ -223,10 +357,37 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
   return service;
 }
 
+/** Exact host argv shape used both by inventory and immediately before signalling. */
+export function isNanoclawHostCommand(command: string, scriptPath: string): boolean {
+  const suffix = ` ${scriptPath}`;
+  if (!command.endsWith(suffix)) return false;
+  const executable = command.slice(0, -suffix.length);
+  return !/\s/.test(executable) && ['node', 'nodejs'].includes(path.basename(executable));
+}
+
+export function checkoutHostProcesses(runCommand: RunCommand, scriptPath: string): number[] | undefined {
+  const result = runCommand('ps', ['-axo', 'pid=,command=']);
+  if (result.status !== 0) return undefined;
+  const pids: number[] = [];
+  for (const line of result.stdout.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    if (!match || !isNanoclawHostCommand(match[2], scriptPath)) continue;
+    const pid = Number(match[1]);
+    if (Number.isInteger(pid) && pid > 0) pids.push(pid);
+  }
+  return pids;
+}
+
 function scanOnecli(projectRoot: string, runCommand: RunCommand, notes: string[]): OnecliInventory {
   const vault = listVaultAgents(runCommand);
-  if (!vault.available || vault.agents.length === 0) {
-    return { mine: [], orphans: [], idsKnown: false };
+  if (!vault.available) {
+    notes.push(
+      "Couldn't inspect OneCLI agents; agents registered by this copy may remain. Restore OneCLI and rerun uninstall before deleting the checkout.",
+    );
+    return { mine: [], orphans: [], available: false, idsKnown: false };
+  }
+  if (vault.agents.length === 0) {
+    return { mine: [], orphans: [], available: true, idsKnown: false };
   }
 
   const { ids, known } = readAgentGroupIds(path.join(projectRoot, 'data', 'v2.db'));
@@ -236,7 +397,7 @@ function scanOnecli(projectRoot: string, runCommand: RunCommand, notes: string[]
       "Couldn't read agent_groups from data/v2.db; OneCLI agents shown as 'orphan' may actually belong to this copy.",
     );
   }
-  return { mine, orphans, idsKnown: known };
+  return { mine, orphans, available: true, idsKnown: known };
 }
 
 function existingItems(
@@ -247,7 +408,7 @@ function existingItems(
   const items: PathItem[] = [];
   for (const spec of specs) {
     const p = path.join(projectRoot, spec.rel);
-    if (!fs.existsSync(p)) continue;
+    if (!knownPath(p)) continue;
     items.push({
       what: spec.what,
       where: spec.where ?? `${tilde(p, home)}/`,
@@ -255,4 +416,14 @@ function existingItems(
     });
   }
   return items;
+}
+
+/** Treat only a confirmed ENOENT as absence; permission and type errors are known residue. */
+function knownPath(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT';
+  }
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification**
- [ ] **Documentation**

## Description

**Problem.** The uninstall flow could cross preservation boundaries, continue destructive work after a prerequisite failure, and report success while actions had failed or were never attempted.

**Change** (all under `setup/uninstall/`): validate the four decision groups before planning; re-scan ownership selectors immediately before execution and refuse to proceed if they moved; latch service and OneCLI failures ahead of data removal; accept only recognizable already-stopped `launchctl` output; aggregate incomplete outcomes into the final report instead of a blanket success.

**Why it is safe.** Host-only uninstall planning and execution. No setup protocol, runtime schema, dependency, or behavior change for installs that are not being removed. Each new guard has a test that goes red when the guard is removed.

**Scope.** `setup/uninstall/{flow,plan,remove,scan,onecli-agents}.ts` and the matching tests. Nothing else.

**Rebase note.** Upstream reformatted this directory with prettier after the branch was cut; this PR is the same patch re-applied on top of that (and keeps upstream's later rollback-snapshot inventory entry intact).

## Verification

```
pnpm exec vitest run setup/uninstall
  Tests  68 passed (68)
pnpm typecheck                       # OK
```
Full suite on the stack tip that contains this exact patch (`feat/nanoclaw-tz` b3d7eda4, quiet machine): 2123 passed, 4 failed (see note). Leak-gate `--classify`: no payload or wiring rows. Real service and container mutation stays on the integration gate, not unit-tested here.

Environment note: `scripts/update/transaction.e2e.test.ts` (4 tests) fails on this machine for every branch including a clean `upstream/main` checkout, because local git has `tag.gpgSign=true` and the test runs a bare `git tag`. Unrelated to this change.

## For Skills

Not applicable: no skill files touched.
