### PR TITLE
setup: keep pasted auth secrets out of argv

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -71,6 +71,7 @@ import type { AgentGroup } from '../src/types.js';
 import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-claude.js';
 import * as setupLog from './logs.js';
 import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
+import { withSecretFile } from './lib/secret-file.js';
 import { emit as phEmit } from './lib/diagnostics.js';
 import {
   accentGreen,
@@ -1626,28 +1627,30 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
   );
   const token = (answer as string).replace(/\s+/g, '');
 
-  const res = await runQuietChild(
-    'auth',
-    'onecli',
-    [
-      'secrets',
-      'create',
-      '--name',
-      'Anthropic',
-      '--type',
-      'anthropic',
-      '--value',
-      token,
-      '--host-pattern',
-      'api.anthropic.com',
-    ],
-    {
-      running: `Saving your ${label} to your OneCLI vault…`,
-      done: 'Claude account connected.',
-    },
-    {
-      extraFields: { METHOD: method },
-    },
+  const res = await withSecretFile(token, (filePath) =>
+    runQuietChild(
+      'auth',
+      'onecli',
+      [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'anthropic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        'api.anthropic.com',
+      ],
+      {
+        running: `Saving your ${label} to your OneCLI vault…`,
+        done: 'Claude account connected.',
+      },
+      {
+        extraFields: { METHOD: method },
+      },
+    ),
   );
   if (!res.ok) {
     await fail(
@@ -1673,30 +1676,34 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
     return;
   }
 
-  const res = await runQuietChild(
-    'auth',
-    'onecli',
-    [
-      'secrets',
-      'create',
-      '--name',
-      'Anthropic',
-      '--type',
-      'generic',
-      '--value',
-      token,
-      '--host-pattern',
-      host,
-      '--header-name',
-      'Authorization',
-      '--value-format',
-      'Bearer {value}',
-    ],
-    {
-      running: `Saving your Anthropic auth token to your OneCLI vault…`,
-      done: 'Claude account connected.',
-    },
-    { extraFields: { METHOD: 'custom-endpoint', HOST: host } },
+  const res = await withSecretFile(token, (filePath) =>
+    runQuietChild(
+      'auth',
+      'onecli',
+      [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'generic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        host,
+        '--header-name',
+        'Authorization',
+        '--value-format',
+        'Bearer {value}',
+      ],
+      {
+        running: `Saving your Anthropic auth token to your OneCLI vault…`,
+        done: 'Claude account connected.',
+      },
+      {
+        extraFields: { METHOD: 'custom-endpoint', HOST: host },
+      },
+    ),
   );
   if (!res.ok) {
     await fail(

--- a/setup/lib/secret-file.test.ts
+++ b/setup/lib/secret-file.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { withSecretFile } from './secret-file.js';
+
+describe('withSecretFile', () => {
+  it('provides a private file and removes it after the operation', async () => {
+    const secret = 'machine-only-secret';
+    let secretPath = '';
+
+    await withSecretFile(secret, async (filePath) => {
+      secretPath = filePath;
+      expect(fs.readFileSync(filePath, 'utf8')).toBe(secret);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(path.dirname(filePath)).mode & 0o777).toBe(0o700);
+    });
+
+    expect(fs.existsSync(secretPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+
+  it('removes the file when the operation fails', async () => {
+    let secretPath = '';
+
+    await expect(
+      withSecretFile('secret', async (filePath) => {
+        secretPath = filePath;
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+
+    expect(fs.existsSync(secretPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+});

--- a/setup/lib/secret-file.ts
+++ b/setup/lib/secret-file.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** Run an operation with a private one-use secret file, then remove it. */
+export async function withSecretFile<T>(secret: string, operation: (filePath: string) => Promise<T>): Promise<T> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-secret-'));
+  const filePath = path.join(directory, 'value');
+  let fd: number | undefined;
+
+  try {
+    fs.chmodSync(directory, 0o700);
+    fd = fs.openSync(
+      filePath,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.writeFileSync(fd, secret, { encoding: 'utf8' });
+    fs.fchmodSync(fd, 0o600);
+    fs.closeSync(fd);
+    fd = undefined;
+    return await operation(filePath);
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+    fs.rmSync(filePath, { force: true });
+    fs.rmdirSync(directory);
+  }
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification**
- [ ] **Documentation**

## Description

**Problem.** The setup wizard passed pasted OAuth, API, and custom-endpoint tokens to OneCLI as process arguments (`onecli secrets create --value <token>`). Argv is visible to local process inspection, and this is the same path the app protocol will drive.

**Change.** `setup/lib/secret-file.ts`: write the value to a private one-use file (0700 dir, 0600 file), close it before invoking OneCLI, remove file and directory after success or failure. The two wizard callsites in `setup/auto.ts` switch to `--file`. Nothing else about those calls changes.

**Why it is safe.** Only the two wizard callsites change; other terminal and runtime authentication paths are untouched. OneCLI already supports `--file`. Cleanup is in `finally`, covered for both outcomes.

**Scope.** `setup/auto.ts`, `setup/lib/secret-file.ts`, `setup/lib/secret-file.test.ts`. Nothing else.

**Relation to other PRs.** Carried by `feat/setup-driver-v1`, which keeps the private-file path for both renderers.

## Verification

```
pnpm exec vitest run setup/lib/secret-file.test.ts
  Tests  2 passed (2)      # private dir/file modes, cleanup on success and on failure
pnpm typecheck             # OK
```
Full suite on the stack tip that contains this exact patch (`feat/nanoclaw-tz` b3d7eda4, quiet machine): 2123 passed, 4 failed (see note). Leak-gate `--classify`: no payload or wiring rows.

Environment note: `scripts/update/transaction.e2e.test.ts` (4 tests) fails on this machine for every branch including a clean `upstream/main` checkout, because local git has `tag.gpgSign=true` and the test runs a bare `git tag`. Unrelated to this change.

## For Skills

Not applicable: no skill files touched.
