### PR TITLE
[stacked on #3475] feat(setup): expose the build-time preseed catalog (--catalog-preseeds)

### DIFF
--- a/docs/hardened-image.md
+++ b/docs/hardened-image.md
@@ -95,6 +95,11 @@ All optional, all read from `.env` or the environment.
 | `NANOCLAW_REGISTRY_TOKEN` | Adopt an existing account token directly. |
 | `NANOCLAW_ALLOW_UNLABELED_IMAGE` | Accept an image with no agent-runner lock label — needed for a `docker save`/`load` or third-party image. |
 
+`NANOCLAW_REGISTRY_API` is a trust boundary, not just a routing override. When
+you point it at a self-hosted account service, that service may declare the
+HTTPS identity-provider endpoints used for browser sign-in. Set it only to a
+service you trust; the setup driver rejects non-HTTPS sign-in URLs.
+
 If you point this at your own registry you need none of these beyond
 `NANOCLAW_HARDENED_IMAGE` and a reference: authentication is whatever
 `docker login` already holds, and there is no account involved.

--- a/docs/setup-driver-design.md
+++ b/docs/setup-driver-design.md
@@ -1,0 +1,124 @@
+# Structured setup driver: design
+
+## Outcome
+
+A desktop client or a future process proxy can drive NanoClaw setup and
+uninstall without parsing terminal prose or copying NanoClaw policy. NanoClaw
+still decides what happens and validates what actually happened. The client
+renders structured events and returns structured answers.
+
+The terminal stays the default. Machine mode is explicit and versioned:
+
+```text
+bash nanoclaw.sh --protocol nanoclaw.driver.v1
+bash nanoclaw.sh --uninstall --protocol nanoclaw.driver.v1
+```
+
+The exact contract is in
+[setup-driver-protocol.md](setup-driver-protocol.md).
+
+## Ownership boundary
+
+```text
+desktop / proxy
+  │  NDJSON events and commands
+  ▼
+SetupDriver adapter
+  │  same prompts, policy, ordering, and checks
+  ├──────── setup orchestration ─────── service + structured health
+  └──────── uninstall planner ───────── identity checks + exact receipt
+```
+
+| NanoClaw owns | Client owns |
+|---|---|
+| Step order and conditional branches | Layout and controls |
+| Prompt definitions and validation | Secure answer collection |
+| Side effects and postcondition checks | Declarative external-action attempts |
+| Health and service identity | Acquisition provenance |
+| Artifact discovery and uninstall safety | Deleting the checkout only when permitted |
+
+The client never predicts the next step, branches on a label, supplies an
+executable, or decides that an action succeeded. Only one item awaits input at a
+time, so NanoClaw remains the state machine.
+
+## Setup flow
+
+The shell recognizes the protocol before normal output or mutation. It can emit
+structured preflight and bootstrap progress before Node exists, then hands the
+same stream to the TypeScript driver. Unsupported provisioning or a provider
+without a machine adapter returns a typed error with safe recovery instead of
+a command for the client to execute.
+
+The TypeScript adapter exposes progress, prompts, displays, declarative external
+actions, errors, cancellation, and completion. External actions are limited to
+opening an HTTPS URL, starting a named application, or presenting system
+permission instructions. `attempted` is not trusted; NanoClaw rechecks the real
+postcondition.
+
+Completion means healthy, not merely finished. NanoClaw proves that the running
+service belongs to this checkout, queries the same structured host-health model
+used by `ncl health --json`, and reports groups, policies, and skills as loaded
+or explicitly empty. Only that receipt plus exit code `0` is success.
+
+## Secret boundary
+
+Machine secrets arrive only through protocol stdin. They do not enter the
+driver's arguments or environment. OneCLI receives a path to a no-follow,
+private temporary file. Secret-bearing curl effects receive a private curl
+configuration file, so the secret is absent from curl arguments and environment.
+Temporary files are removed in `finally`. Child output stays captured and
+redacted. Terminal setup keeps its existing credential path.
+
+Interactive provider CLIs use inherited stdio only in terminal mode. In machine
+mode a bounded private process seam pipes their bytes to the provider adapter;
+the adapter emits semantic URL, code, prompt, progress, and external-action
+events. Raw provider output never becomes protocol output.
+
+Teams device login follows the same boundary. Machine mode emits the Microsoft
+URL as an external action and the device code as sensitive display content,
+then clears both displays when the login process ends.
+
+Registry sign-in is not an interactive-provider child. Both renderers call one
+RFC 8628 implementation directly. It presents the verification URL, pairing
+code, progress, and cancellation through the selected driver.
+
+Sensitive display content, such as a pairing code, is allowed only in the
+marked display event. A client renders it without logging or persistence and
+clears it when instructed or when the process ends.
+
+## Uninstall flow
+
+Uninstall remains plan-first:
+
+```text
+scan (read only) → emit plan → receive category choices → rescan ownership
+→ execute approved actions → emit each result → emit receipt
+```
+
+Callers approve categories, not paths or process IDs. Exact files have
+`lstat`-based snapshots; checkout-owned directories use scoped root identity.
+Every exact target is revalidated before its action. A changed service blocks
+dependent deletion. A changed `.env`, symlink replacement, or uninspectable
+identity stays untouched, while unrelated approved work may continue.
+
+Credential backups live in a private NanoClaw state directory outside the
+checkout and are returned as external artifacts. Plan artifacts, action results,
+and remaining artifacts stream one item per event. The terminal receipt says
+whether the caller may safely delete the checkout:
+
+```ts
+checkoutRemoval: { safe: boolean; blockers: string[] }
+```
+
+NanoClaw never deletes the checkout.
+
+## Cancellation and compatibility
+
+Commands and presentation data are bounded. Closing stdin is disconnection, not
+success. Cancellation reaches the current bootstrap/setup child process tree;
+uninstall finishes the current atomic action and starts no new one. Exit codes
+remain `0` complete, `1` error or incomplete uninstall, and `2` cancelled.
+
+No protocol flag means the established terminal setup and uninstall behavior.
+V1 intentionally adds no daemon, HTTP or WebSocket transport, remote auth,
+persisted session, resume token, second setup engine, or new dependency.

--- a/docs/setup-driver-protocol.md
+++ b/docs/setup-driver-protocol.md
@@ -1,0 +1,329 @@
+# NanoClaw setup driver protocol v1
+
+`nanoclaw.driver.v1` lets a client render setup or uninstall without parsing
+terminal output. NanoClaw remains the state machine and owns validation, side
+effects, and completion checks.
+
+## Starting a session
+
+```sh
+bash nanoclaw.sh --protocol nanoclaw.driver.v1
+bash nanoclaw.sh --uninstall --protocol nanoclaw.driver.v1
+```
+
+Without `--protocol`, behavior is unchanged. An unsupported protocol fails
+before setup output or mutation.
+
+The process writes one JSON object per line to stdout and reads one JSON object
+per line from stdin. Stderr is empty during a protocol session. Every object has
+this envelope:
+
+```ts
+type Envelope = {
+  protocol: 'nanoclaw.driver.v1';
+  operation: 'setup' | 'uninstall';
+};
+```
+
+The first event is `hello`. It is emitted once across the shell bootstrap and
+TypeScript handoff.
+
+```json
+{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"hello"}
+```
+
+Exit codes are `0` for complete, `1` for error or incomplete uninstall, and `2`
+for cancellation.
+
+## Renderer parity
+
+Terminal and protocol mode call the same setup flow. `auto.ts` defines ordering,
+choices, side effects, and postconditions through `SetupDriver`; each renderer
+only presents those operations. Parity tests run the production first-agent
+choice through both renderers and exercise production template stamping through
+the real socket contract. A parity lint prevents direct prompt primitives from
+returning to `auto.ts`.
+
+Transport still creates three intentional differences. Protocol mode requires
+structured healthy completion, transports secrets on stdin, and removes
+terminal-only back navigation because the app owns its preflight navigation.
+These differences do not create a second setup policy or runner.
+
+## Commands
+
+Only the current outstanding item accepts an answer. A command with a different
+ID, or a command sent when nothing is pending, is rejected as `stale_command`.
+There is no replay cache or command fingerprint protocol.
+
+```ts
+type Command = Envelope & (
+  | { type: 'answer'; promptId: string; value: boolean | string }
+  | {
+      type: 'externalActionCompleted';
+      actionId: string;
+      result: 'attempted' | 'declined' | 'unsupported';
+    }
+  | {
+      type: 'applyUninstall';
+      planId: string;
+      choices: Array<{
+        groupId: 'service' | 'data' | 'user' | 'onecli';
+        choice: 'preserve' | 'remove';
+      }>;
+    }
+  | { type: 'cancel'; reason?: string }
+);
+```
+
+Each command string is bounded to 64 KiB, arrays are bounded to 64 entries,
+and an input line is bounded to 1 MiB.
+
+## Common events
+
+### Progress
+
+```ts
+type ProgressEvent = Envelope & {
+  type: 'progress';
+  stepId: string;
+  state: 'pending' | 'running' | 'succeeded' | 'failed';
+  label?: string;
+};
+```
+
+A step that successfully falls back to another supported path is `succeeded`.
+There is no `skipped` wire state.
+
+### Prompt
+
+```ts
+type PromptEvent = Envelope & {
+  type: 'prompt';
+  prompt: {
+    id: string;
+    kind: 'confirm' | 'singleChoice' | 'text' | 'secret';
+    message: string;
+    sensitive: boolean;
+    choices?: Array<{ id: string; label: string }>;
+    default?: boolean | string;
+    validation?: {
+      required?: boolean;
+      minLength?: number;
+      maxLength?: number;
+      pattern?: string;
+    };
+  };
+};
+```
+
+The client answers with `answer`. A secret answer must arrive on protocol stdin.
+Secrets are forbidden in launch arguments and environment variables. A client
+must not log or persist a prompt marked `sensitive`.
+
+### Display
+
+```ts
+type Display =
+  | { id: string; kind: 'text' | 'code'; content: string; label?: string; sensitive: boolean }
+  | { id: string; kind: 'url'; url: string; label: string; sensitive: boolean }
+  | { id: string; kind: 'qr'; payload: string; label?: string; sensitive: boolean };
+
+type DisplayEvent = Envelope & { type: 'display'; display: Display };
+type ClearDisplayEvent = Envelope & { type: 'clearDisplay'; displayId: string };
+```
+
+Sensitive displays are the only events allowed to carry a pairing code or
+verification URL containing a code. Render them without persistence and clear
+them on `clearDisplay` or process exit.
+
+### External action
+
+```ts
+type ExternalActionEvent = Envelope & {
+  type: 'externalAction';
+  action:
+    | { id: string; kind: 'openURL'; title: string; url: string }
+    | { id: string; kind: 'startApplication'; title: string; application: string }
+    | { id: string; kind: 'systemPermission'; title: string; instructions: string[] };
+};
+```
+
+An `openURL` action always uses HTTPS. The client reports only whether it
+attempted, declined, or could not support the action. NanoClaw checks any
+required postcondition itself.
+
+### Rejected input
+
+```ts
+type InputRejectedEvent = Envelope & {
+  type: 'inputRejected';
+  itemId?: string;
+  code: string;
+  message: string;
+};
+```
+
+Rejection is nonterminal. The current item remains pending unless another valid
+command has already resolved it.
+
+### Error and cancellation
+
+```ts
+type Recovery =
+  | { kind: 'rerun'; args: string[] }
+  | { kind: 'manual'; title: string; instructions: string[] };
+
+type ErrorEvent = Envelope & {
+  type: 'error';
+  code: string;
+  stepId?: string;
+  message: string;
+  recovery: Recovery[];
+};
+
+type CancelledEvent = Envelope & {
+  type: 'cancelled';
+  lastStepId?: string;
+};
+```
+
+`error` and `cancelled` are terminal. Closing stdin requests cancellation. During
+uninstall, NanoClaw completes the current atomic action and starts no new action.
+
+## Setup completion
+
+```ts
+type SetupCompleteEvent = Envelope & {
+  type: 'complete';
+  receipt: {
+    version: 1;
+    service: {
+      state: 'running';
+      manager: 'launchd' | 'systemd-user' | 'systemd-system' | 'pidfile';
+      checkoutRoot: string;
+    };
+    health: { status: 'healthy' };
+    resources: {
+      groups: { state: 'loaded' | 'empty'; count: number };
+      policies: { state: 'loaded' | 'empty'; count: number };
+      skills: { state: 'loaded' | 'empty'; count: number };
+    };
+    completedAt: string;
+  };
+};
+```
+
+Setup completes only after service ownership and structured host health are
+verified.
+
+## Uninstall
+
+Uninstall is plan-first and defaults every group to preservation. NanoClaw emits
+each artifact as it is discovered, then emits the actionable plan header.
+
+```ts
+type Artifact = {
+  id: string;
+  kind: string;
+  label: string;
+  location: string;
+  disposition: 'owned' | 'shared' | 'external' | 'uninspectable' | 'alreadyAbsent';
+  decisionGroup?: 'service' | 'data' | 'user' | 'onecli';
+};
+
+type UninstallPlanItemEvent = Envelope & {
+  type: 'uninstallPlanItem';
+  planId: string;
+  artifact: Artifact;
+};
+
+type UninstallPlanEvent = Envelope & {
+  type: 'uninstallPlan';
+  plan: {
+    id: string;
+    groups: Array<{
+      id: 'service' | 'data' | 'user' | 'onecli';
+      label: string;
+      description: string;
+      default: 'preserve';
+      choices: ['preserve', 'remove'];
+    }>;
+  };
+};
+```
+
+The client must send exactly one choice for each group. NanoClaw rejects unsafe
+combinations, rescans ownership after approval, and executes only the accepted
+plan.
+
+Each result is streamed once:
+
+```ts
+type UninstallActionEvent = Envelope & {
+  type: 'uninstallAction';
+  result: {
+    actionId: string;
+    artifactId: string;
+    outcome: 'removed' | 'preserved' | 'failed' | 'untouched' | 'alreadyAbsent';
+    error?: { code: string; message: string };
+  };
+};
+```
+
+Remaining artifacts, including credential backups outside the checkout, are
+streamed before the terminal event:
+
+```ts
+type UninstallReceiptItemEvent = Envelope & {
+  type: 'uninstallReceiptItem';
+  section: 'remaining';
+  artifact: Artifact;
+};
+
+type UninstallCompleteEvent = Envelope & {
+  type: 'complete';
+  receipt: {
+    version: 1;
+    outcome: 'success' | 'incomplete';
+    checkoutRemoval: { safe: boolean; blockers: string[] };
+    completedAt: string;
+  };
+};
+```
+
+There are no pages and no pagination counters. The client may delete the source
+checkout only when exit code is `0`, the receipt outcome is `success`, and
+`checkoutRemoval.safe` is `true`. NanoClaw never deletes the checkout.
+
+## Minimal client loop
+
+```ts
+for await (const event of readNdjson(child.stdout)) {
+  switch (event.type) {
+    case 'prompt':
+      write({ ...envelope, type: 'answer', promptId: event.prompt.id, value: await renderPrompt(event.prompt) });
+      break;
+    case 'externalAction':
+      write({ ...envelope, type: 'externalActionCompleted', actionId: event.action.id, result: await attempt(event.action) });
+      break;
+    case 'uninstallPlanItem':
+      renderArtifact(event.artifact);
+      break;
+    case 'uninstallPlan':
+      write({ ...envelope, type: 'applyUninstall', planId: event.plan.id, choices: await approve(event.plan.groups) });
+      break;
+    case 'uninstallAction':
+    case 'uninstallReceiptItem':
+    case 'progress':
+    case 'display':
+    case 'clearDisplay':
+    case 'inputRejected':
+      render(event);
+      break;
+    case 'complete':
+    case 'error':
+    case 'cancelled':
+      return event;
+  }
+}
+```

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -121,13 +121,14 @@ On failure the completion block names the failing step and its error:
 ### Level 3: raw per-step logs
 
 `logs/setup-steps/NN-step-name.log` — one file per step, numbered in
-execution order (zero-padded 2-digit prefix for natural sorting). Full
-verbatim stdout + stderr from the child process. Truncated and rewritten
-on each run (not appended).
+execution order (zero-padded 2-digit prefix for natural sorting). Full verbatim
+stdout + stderr from the child process. Truncated and rewritten on each run
+(not appended).
 
-Contents are whatever the step emits: apt output, docker build layers,
-pnpm install spam, `curl` bodies, etc. This is the evidence plane —
-"what did the shell actually see?" Nothing is filtered.
+Contents are whatever the step emits: apt output, docker build layers, pnpm
+install spam, `curl` bodies, etc. This is the evidence plane: "what did the shell
+actually see?" Nothing is filtered in terminal mode. Protocol mode keeps secret
+values and sensitive QR or pairing displays out of these logs.
 
 ## Contract for a new step
 
@@ -160,10 +161,10 @@ installer invoked from `auto.ts`), it must:
 The driver handles the rest: spinner in level 1, structured append to
 level 2, raw capture to level 3.
 
-## The Anthropic exception
+## The Anthropic terminal exception
 
-Anthropic credential registration (`setup/register-claude-token.sh`) is
-the **one** permitted break in the visual flow. Why:
+Anthropic credential registration (`setup/register-claude-token.sh`) is the
+**one** permitted break in the normal terminal visual flow. Why:
 
 - `claude setup-token` opens a browser, runs its own OAuth prompt, and
   prints the token. It owns the TTY via `script(1)`.
@@ -182,6 +183,13 @@ The level-2 log still gets an entry (`auth [interactive] → success`
 with the method — subscription / oauth / api). Level-3 captures
 are optional here; mirroring `script -q` output is tricky and the risk of
 leaking the token to disk outweighs the debugging value.
+
+Machine mode does not run this terminal script. It pipes `claude setup-token`
+through the private interactive-process seam, and the Claude adapter translates
+only the provider URL, authorization-code prompt, and progress into driver
+events. The returned token is registered as sensitive, passed to OneCLI through
+a one-use `0600` file, and removed with the isolated auth home in `finally`.
+Terminal users still take the inherited-stdio path above.
 
 ## Channel installs are skill-driven
 
@@ -205,6 +213,8 @@ convention — [skill-engine-seam.md](skill-engine-seam.md) §6).
 | `setup/logs.ts` | The logging primitives (`step`, `userInput`, `complete`, `stepRawLog`, `reset`). Single source of truth for level 2/3 formatting and file paths. |
 | `setup/<step>.ts` | Individual step implementations. Must emit one terminal status block; must not write directly to the terminal. |
 | `setup/register-claude-token.sh` | The Anthropic exception. Inherits stdio, prints its own UI, returns a status to the driver. |
+| `setup/lib/claude-subscription-auth.ts` | Machine-only Claude subscription adapter: provider output interpretation, semantic driver events, isolated credential capture, and vault handoff. |
+| `setup/lib/interactive-process.ts` | Provider-neutral private child boundary for terminal inheritance or bounded machine pipes, minimal environment, and process-group cancellation. |
 | `setup/lib/skill-driver.ts` | Generic skill runner: applies a SKILL.md's `nc:` directives via the engine (`scripts/skill-apply.ts`) and renders its events through clack — prompts via `resolveInput`, spinners for step events, operator notes with the gate/URL-offer policy from `scripts/skill-policy.ts`. Owns all prompting/gating presentation; the engine only declares and emits. |
 | `setup/channels/run-channel-skill.ts` | The generic channel-install entry: drives the channel's `/add-<channel>` SKILL.md through the skill driver, then owns the shared wire (agent name + operator role → `scripts/init-first-agent.ts`). One flow for every channel — no bespoke per-channel code. |
 | `setup/pair-telegram.ts` | Emits `PAIR_TELEGRAM_CODE` / `PAIR_TELEGRAM_ATTEMPT` / `PAIR_TELEGRAM` status blocks. Never prints UI. The driver renders it via clack notes. |
@@ -234,6 +244,3 @@ convention — [skill-engine-seam.md](skill-engine-seam.md) §6).
 - **Raw log rotation for multi-run installs.** Currently each run
   overwrites. Fine for now; revisit if support needs to compare
   successive attempts.
-- **Structured output from `register-claude-token.sh`.** The interactive
-  step emits no machine-readable status today. Future could add a
-  post-interaction status block with the method used.

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -39,9 +39,127 @@ done
 set -- ${_filtered_args[@]+"${_filtered_args[@]}"}
 unset _filtered_args
 
+# Parse the opt-in machine protocol before any output or mutation.
+DRIVER_MODE=false
+DRIVER_OPERATION=setup
+DRIVER_PROTOCOL=""
+DRIVER_PROTOCOL_COUNT=0
+DRIVER_EXPECT_PROTOCOL=false
+for arg in "$@"; do
+  if [ "$DRIVER_EXPECT_PROTOCOL" = true ]; then
+    DRIVER_PROTOCOL="$arg"
+    DRIVER_EXPECT_PROTOCOL=false
+    continue
+  fi
+  case "$arg" in
+    --protocol) DRIVER_PROTOCOL_COUNT=$((DRIVER_PROTOCOL_COUNT + 1)); DRIVER_EXPECT_PROTOCOL=true ;;
+    --protocol=*) DRIVER_PROTOCOL_COUNT=$((DRIVER_PROTOCOL_COUNT + 1)); DRIVER_PROTOCOL="${arg#--protocol=}" ;;
+    --uninstall) DRIVER_OPERATION=uninstall ;;
+  esac
+done
+
+if [ "$DRIVER_EXPECT_PROTOCOL" = true ]; then
+  echo "error: --protocol requires a value" >&2
+  exit 1
+fi
+if [ -n "$DRIVER_PROTOCOL" ] && [ "$DRIVER_PROTOCOL" != "nanoclaw.driver.v1" ]; then
+  echo "error: unsupported protocol '$DRIVER_PROTOCOL'" >&2
+  exit 1
+fi
+if [ "$DRIVER_PROTOCOL_COUNT" -gt 1 ]; then
+  if [ "$DRIVER_PROTOCOL" = "nanoclaw.driver.v1" ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"duplicate_protocol","message":"--protocol may be supplied only once.","recovery":[]}\n' "$DRIVER_OPERATION"
+  else
+    echo "error: --protocol may be supplied only once" >&2
+  fi
+  exit 1
+fi
+
+DRIVER_ARGS=()
+DRIVER_ACKS=""
+if [ "$DRIVER_PROTOCOL" = "nanoclaw.driver.v1" ]; then
+  DRIVER_MODE=true
+  DRIVER_SKIP_NEXT=""
+  for arg in "$@"; do
+    if [ "$DRIVER_SKIP_NEXT" = protocol ]; then DRIVER_SKIP_NEXT=""; continue; fi
+    if [ "$DRIVER_SKIP_NEXT" = ack ]; then
+      case "$arg" in low-memory|gce|root) ;; *)
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_driver_ack","message":"Unknown driver acknowledgement.","recovery":[]}\n' "$DRIVER_OPERATION"
+        exit 1
+      esac
+      DRIVER_ACKS="${DRIVER_ACKS:+${DRIVER_ACKS},}${arg}"
+      DRIVER_SKIP_NEXT=""
+      continue
+    fi
+    case "$arg" in
+      --protocol) DRIVER_SKIP_NEXT=protocol ;;
+      --protocol=*) ;;
+      --driver-ack) DRIVER_SKIP_NEXT=ack ;;
+      --driver-ack=*)
+        ack="${arg#--driver-ack=}"
+        case "$ack" in low-memory|gce|root) DRIVER_ACKS="${DRIVER_ACKS:+${DRIVER_ACKS},}${ack}" ;; *)
+          printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+          printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_driver_ack","message":"Unknown driver acknowledgement.","recovery":[]}\n' "$DRIVER_OPERATION"
+          exit 1
+        esac
+        ;;
+      --onecli-api-token|--anthropic-auth-token|--onecli-api-token=*|--anthropic-auth-token=*)
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"secret_transport_forbidden","message":"Secret answers must arrive through protocol stdin, not driver arguments.","recovery":[]}\n' "$DRIVER_OPERATION"
+        exit 1
+        ;;
+      *) DRIVER_ARGS+=("$arg") ;;
+    esac
+  done
+  if [ "$DRIVER_SKIP_NEXT" = ack ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_driver_ack","message":"--driver-ack requires a value.","recovery":[]}\n' "$DRIVER_OPERATION"
+    exit 1
+  fi
+  printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+  for arg in ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"}; do
+    if [[ "$arg" =~ [[:cntrl:]] ]]; then
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_arguments","message":"Driver arguments may not contain control characters.","recovery":[]}\n' "$DRIVER_OPERATION"
+      exit 1
+    fi
+  done
+  if [ -n "${NANOCLAW_ONECLI_API_TOKEN:-}" ] || [ -n "${NANOCLAW_ANTHROPIC_AUTH_TOKEN:-}" ] || [ -n "${NANOCLAW_REGISTRY_ENROLL_CODE:-}" ] || [ -n "${NANOCLAW_REGISTRY_TOKEN:-}" ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"secret_transport_forbidden","message":"Secret answers must arrive through protocol stdin, not the launch environment.","recovery":[]}\n' "$DRIVER_OPERATION"
+    exit 1
+  fi
+  set -- ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"}
+fi
+
+driver_has_ack() { case ",$DRIVER_ACKS," in *,$1,*) return 0 ;; *) return 1 ;; esac; }
+driver_json_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '"%s"' "$value"
+}
+driver_recovery_args() {
+  local ack="$1"
+  shift
+  printf '["--protocol","nanoclaw.driver.v1"'
+  for arg in "$@"; do printf ',%s' "$(driver_json_string "$arg")"; done
+  for known in low-memory gce root; do
+    if driver_has_ack "$known"; then printf ',"--driver-ack","%s"' "$known"; fi
+  done
+  printf ',"--driver-ack","%s"]' "$ack"
+}
+
 # ─── --help: show usage without bootstrapping ──────────────────────────
 for arg in "$@"; do
   if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then
+    if [ "$DRIVER_MODE" = true ]; then
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"help_requested","message":"Machine mode does not render terminal help.","recovery":[{"kind":"rerun","args":["--help"]}]}\n' "$DRIVER_OPERATION"
+      exit 1
+    fi
     if command -v node >/dev/null 2>&1 && [ -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; then
       exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/auto.ts" "$@"
     fi
@@ -67,7 +185,16 @@ for arg in "$@"; do
     # everything after it as positional args and the flags get dropped.
     # Gate on node (tsx's shebang interpreter) — pnpm isn't used here.
     if command -v node >/dev/null 2>&1 && [ -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; then
+      if [ "$DRIVER_MODE" = true ]; then
+        export NANOCLAW_PROTOCOL=nanoclaw.driver.v1
+        export NANOCLAW_OPERATION=uninstall
+        export NANOCLAW_DRIVER_SHELL_HELLO=1
+      fi
       exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/auto.ts" "$@"
+    fi
+    if [ "$DRIVER_MODE" = true ]; then
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"uninstall","type":"error","code":"runtime_missing","message":"The TypeScript runtime is unavailable; uninstall left everything untouched.","recovery":[{"kind":"manual","title":"Restore the runtime","instructions":["Run bash nanoclaw.sh once without uninstall, then retry."]}]}\n'
+      exit 1
     fi
     export NANOCLAW_PROJECT_ROOT="$PROJECT_ROOT"
     # shellcheck source=setup/lib/install-slug.sh
@@ -97,13 +224,15 @@ LOGS_DIR="$PROJECT_ROOT/logs"
 STEPS_DIR="$LOGS_DIR/setup-steps"
 PROGRESS_LOG="$LOGS_DIR/setup.log"
 
-# Diagnostics: persisted install-id + fire-and-forget emit. Sourced early
-# so `setup_launched` covers dropoff before bootstrap even starts.
+# Diagnostics: persisted install-id + fire-and-forget emit.
 # shellcheck source=setup/lib/diagnostics.sh
 source "$PROJECT_ROOT/setup/lib/diagnostics.sh"
-ph_event setup_launched \
-  platform="$(uname -s | tr 'A-Z' 'a-z')" \
-  is_wsl="$([ -f /proc/version ] && grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && echo true || echo false)"
+emit_launch_diagnostic() {
+  ph_event setup_launched \
+    platform="$(uname -s | tr 'A-Z' 'a-z')" \
+    is_wsl="$([ -f /proc/version ] && grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && echo true || echo false)"
+}
+[ "$DRIVER_MODE" = true ] || emit_launch_diagnostic
 
 # ─── log helpers ────────────────────────────────────────────────────────
 
@@ -185,17 +314,39 @@ brand_bold() {
 }
 clear_line() { use_ansi && printf '\r\033[2K' || printf '\n'; }
 
-spinner_start()   { printf '%s  %s…' "$(gray '◒')" "$1"; }
-spinner_update()  { clear_line; printf '%s  %s… %s' "$(gray '◒')" "$1" "$(dim "(${2}s)")"; }
-spinner_success() { clear_line; printf '%s  %s %s\n' "$(gray '◇')" "$1" "$(dim "(${2}s)")"; }
-spinner_failure() { clear_line; printf '%s  %s %s\n' "$(red '✗')"  "$1" "$(dim "(${2}s)")"; }
+spinner_start() {
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"progress","stepId":"bootstrap","state":"running","label":"Installing the basics"}\n'
+  else
+    printf '%s  %s…' "$(gray '◒')" "$1"
+  fi
+}
+spinner_update()  { [ "$DRIVER_MODE" = true ] || { clear_line; printf '%s  %s… %s' "$(gray '◒')" "$1" "$(dim "(${2}s)")"; }; }
+spinner_success() {
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"progress","stepId":"bootstrap","state":"succeeded","label":"Basics ready"}\n'
+  else
+    clear_line; printf '%s  %s %s\n' "$(gray '◇')" "$1" "$(dim "(${2}s)")"
+  fi
+}
+spinner_failure() {
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"progress","stepId":"bootstrap","state":"failed","label":"Installing the basics"}\n'
+  else
+    clear_line; printf '%s  %s %s\n' "$(red '✗')" "$1" "$(dim "(${2}s)")"
+  fi
+}
 
 # ─── fresh-run setup ────────────────────────────────────────────────────
 
-rm -rf "$STEPS_DIR"
-rm -f  "$PROGRESS_LOG"
-mkdir -p "$STEPS_DIR" "$LOGS_DIR"
-write_header
+# Machine preflight failures must not create setup state. Terminal mode keeps
+# its established log timing.
+if [ "$DRIVER_MODE" = false ]; then
+  rm -rf "$STEPS_DIR"
+  rm -f  "$PROGRESS_LOG"
+  mkdir -p "$STEPS_DIR" "$LOGS_DIR"
+  write_header
+fi
 
 # NanoClaw splash — under-the-sea lobster mascot in truecolor braille,
 # with the figlet wordmark and taglines below. Pre-rendered into
@@ -203,7 +354,7 @@ write_header
 # figlet); the bash script just streams the literal frame. clack's intro
 # then carries the "let's get you set up" framing — setup:auto sees
 # NANOCLAW_BOOTSTRAPPED=1 and skips re-printing the wordmark.
-cat "$PROJECT_ROOT/assets/setup-splash.txt"
+[ "$DRIVER_MODE" = true ] || cat "$PROJECT_ROOT/assets/setup-splash.txt"
 
 # ─── pre-flight: minimum hardware specs ────────────────────────────────
 # NanoClaw runs an agent container per session. Below this threshold the
@@ -234,6 +385,13 @@ LOW_MEM=false
 [ "$MEM_MB" -gt 0 ] && [ "$MEM_MB" -lt "$MIN_MEM_MB" ] && LOW_MEM=true
 
 if [ "$LOW_MEM" = true ]; then
+  if [ "$DRIVER_MODE" = true ]; then
+    if ! driver_has_ack low-memory; then
+      DRIVER_RERUN_ARGS=$(driver_recovery_args low-memory ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"})
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"low_memory","message":"This machine has less than the recommended 4 GB of memory.","recovery":[{"kind":"rerun","args":%s}]}\n' "$DRIVER_RERUN_ARGS"
+      exit 1
+    fi
+  else
   printf '  %s\n' "$(red 'Warning: this machine likely cannot run NanoClaw.')"
   printf '  %s\n' "$(dim 'NanoClaw recommends a 4 GB+ RAM machine. Below this, the host + agent')"
   printf '  %s\n' "$(dim 'container will run out of memory under most workloads. A stronger')"
@@ -253,6 +411,7 @@ if [ "$LOW_MEM" = true ]; then
       exit 1
       ;;
   esac
+  fi
 fi
 
 # ─── pre-flight: Google Cloud VM warning (Linux) ──────────────────────
@@ -264,6 +423,13 @@ fi
 if [ "$(uname -s)" = "Linux" ] \
   && { grep -qi 'Google' /sys/class/dmi/id/product_name 2>/dev/null \
     || grep -qi 'Google' /sys/class/dmi/id/sys_vendor   2>/dev/null; }; then
+  if [ "$DRIVER_MODE" = true ]; then
+    if ! driver_has_ack gce; then
+      DRIVER_RERUN_ARGS=$(driver_recovery_args gce ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"})
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"gce_unsupported","message":"Google Cloud VM detected; NanoClaw is unlikely to run reliably there.","recovery":[{"kind":"rerun","args":%s},{"kind":"manual","title":"Use another provider","instructions":["Move this checkout to a supported non-GCE host, then rerun setup."]}]}\n' "$DRIVER_RERUN_ARGS"
+      exit 1
+    fi
+  else
   printf '  %s\n' "$(red 'Warning: Google Cloud VM detected.')"
   printf '  %s\n' "$(dim 'Google blocks sudo commands, so NanoClaw is unlikely to run successfully on this VM.')"
   printf '  %s\n\n' "$(dim 'If you want to run NanoClaw successfully, switch to a different provider (Hetzner, Hostinger, exe.dev and others..).')"
@@ -280,10 +446,18 @@ if [ "$(uname -s)" = "Linux" ] \
       exit 1
       ;;
   esac
+  fi
 fi
 
 # ─── pre-flight: root user warning (Linux) ────────────────────────────
 if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -eq 0 ]; then
+  if [ "$DRIVER_MODE" = true ]; then
+    if ! driver_has_ack root; then
+      DRIVER_RERUN_ARGS=$(driver_recovery_args root ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"})
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"root_user","message":"Running NanoClaw as root can cause unsafe service and file ownership.","recovery":[{"kind":"rerun","args":%s},{"kind":"manual","title":"Create a regular Linux user","instructions":["Create a non-root user with sudo access.","Log in as that user and rerun setup."]}]}\n' "$DRIVER_RERUN_ARGS"
+      exit 1
+    fi
+  else
   printf '  %s\n' \
     "$(red 'Warning: you are running as root.')"
   printf '  %s\n' \
@@ -313,6 +487,7 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -eq 0 ]; then
       exit 1
       ;;
   esac
+  fi
 fi
 
 # ─── pre-flight: Homebrew on macOS ─────────────────────────────────────
@@ -322,6 +497,10 @@ fi
 # before the spinner starts, so the user knows what's about to happen and
 # brew's own interactive sudo/CLT prompts stay readable.
 if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"homebrew_required","message":"Homebrew is required before machine setup can continue.","recovery":[{"kind":"manual","title":"Install Homebrew","instructions":["Install Homebrew from https://brew.sh in a terminal.","Rerun the same NanoClaw setup command."]}]}\n'
+    exit 1
+  fi
   printf '  %s\n' \
     "$(dim "Homebrew isn't installed. NanoClaw uses it to install Node and Docker on your Mac.")"
   printf '  %s\n\n' \
@@ -365,26 +544,73 @@ fi
 
 # ─── first step: install the basics (Node + pnpm + native modules) ─────
 
+if [ "$DRIVER_MODE" = true ]; then
+  rm -rf "$STEPS_DIR"
+  rm -f  "$PROGRESS_LOG"
+  mkdir -p "$STEPS_DIR" "$LOGS_DIR"
+  write_header
+  emit_launch_diagnostic
+fi
+
 BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"
 BOOTSTRAP_LABEL="Installing the basics"
 BOOTSTRAP_START=$(date +%s)
 
-spinner_start "$BOOTSTRAP_LABEL"
-
-# Run in the background so we can tick elapsed time. Capture exit code via
-# a tmpfile (subshell $? is lost after the while loop finishes).
-BOOTSTRAP_EXIT_FILE=$(mktemp -t nanoclaw-bootstrap-exit.XXXXXX)
-(
-  # setup.sh's legacy `log()` writes to a file; point it at the raw log
-  # so its verbose entries land alongside the stdout we're capturing.
-  export NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW"
-  if bash setup.sh > "$BOOTSTRAP_RAW" 2>&1; then
-    echo 0 > "$BOOTSTRAP_EXIT_FILE"
+# Run in the background so terminal mode can tick elapsed time. Machine mode
+# owns the process group so cancellation reaches bootstrap descendants.
+BOOTSTRAP_EXIT_FILE=""
+BOOTSTRAP_MONITOR=false
+BOOTSTRAP_PID=""
+DRIVER_STDIN_WATCH_PID=""
+if [ "$DRIVER_MODE" = true ]; then
+  DRIVER_PARENT_PID=$$
+  exec 3<&0
+  driver_stop_stdin_watcher() {
+    if [ -n "$DRIVER_STDIN_WATCH_PID" ]; then
+      kill "$DRIVER_STDIN_WATCH_PID" 2>/dev/null || true
+      wait "$DRIVER_STDIN_WATCH_PID" 2>/dev/null || true
+      DRIVER_STDIN_WATCH_PID=""
+    fi
+    exec 3<&-
+  }
+  driver_cancel_bootstrap() {
+    trap - INT TERM
+    driver_stop_stdin_watcher
+    if [ -n "$BOOTSTRAP_PID" ]; then
+      kill -TERM -- "-$BOOTSTRAP_PID" 2>/dev/null || kill -TERM "$BOOTSTRAP_PID" 2>/dev/null || true
+      sleep 0.25
+      kill -KILL -- "-$BOOTSTRAP_PID" 2>/dev/null || kill -KILL "$BOOTSTRAP_PID" 2>/dev/null || true
+      wait "$BOOTSTRAP_PID" 2>/dev/null || true
+    fi
+    [ "$BOOTSTRAP_MONITOR" = false ] || set +m
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"cancelled","lastStepId":"bootstrap"}\n'
+    exit 2
+  }
+  trap driver_cancel_bootstrap INT TERM
+  (IFS= read -r _ || true; kill -TERM "$DRIVER_PARENT_PID" 2>/dev/null || true) <&3 &
+  DRIVER_STDIN_WATCH_PID=$!
+  spinner_start "$BOOTSTRAP_LABEL"
+  if [ "${NANOCLAW_DISABLE_SETSID:-0}" != 1 ] && command -v setsid >/dev/null 2>&1; then
+    NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW" setsid bash setup.sh </dev/null > "$BOOTSTRAP_RAW" 2>&1 &
   else
-    echo $? > "$BOOTSTRAP_EXIT_FILE"
+    set -m
+    BOOTSTRAP_MONITOR=true
+    NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW" bash setup.sh </dev/null > "$BOOTSTRAP_RAW" 2>&1 &
   fi
-) &
-BOOTSTRAP_PID=$!
+  BOOTSTRAP_PID=$!
+else
+  spinner_start "$BOOTSTRAP_LABEL"
+  BOOTSTRAP_EXIT_FILE=$(mktemp -t nanoclaw-bootstrap-exit.XXXXXX)
+  (
+    export NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW"
+    if bash setup.sh > "$BOOTSTRAP_RAW" 2>&1; then
+      echo 0 > "$BOOTSTRAP_EXIT_FILE"
+    else
+      echo $? > "$BOOTSTRAP_EXIT_FILE"
+    fi
+  ) &
+  BOOTSTRAP_PID=$!
+fi
 
 while kill -0 "$BOOTSTRAP_PID" 2>/dev/null; do
   sleep 1
@@ -392,11 +618,23 @@ while kill -0 "$BOOTSTRAP_PID" 2>/dev/null; do
     spinner_update "$BOOTSTRAP_LABEL" "$(( $(date +%s) - BOOTSTRAP_START ))"
   fi
 done
-# `wait` surfaces the child's exit code; we've already captured it.
-wait "$BOOTSTRAP_PID" 2>/dev/null || true
-
-BOOTSTRAP_RC=$(cat "$BOOTSTRAP_EXIT_FILE")
-rm -f "$BOOTSTRAP_EXIT_FILE"
+if [ "$DRIVER_MODE" = true ]; then
+  if wait "$BOOTSTRAP_PID"; then BOOTSTRAP_RC=0; else BOOTSTRAP_RC=$?; fi
+  driver_stop_stdin_watcher
+  [ "$BOOTSTRAP_MONITOR" = false ] || set +m
+  trap - INT TERM
+  BOOTSTRAP_STATUS=$(grep '^STATUS:' "$BOOTSTRAP_RAW" 2>/dev/null | tail -1 | sed 's/^STATUS: *//' || true)
+  if [ "$BOOTSTRAP_RC" -eq 0 ] \
+    && { [ "$BOOTSTRAP_STATUS" != success ] \
+      || ! command -v node >/dev/null 2>&1 \
+      || [ ! -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; }; then
+    BOOTSTRAP_RC=1
+  fi
+else
+  wait "$BOOTSTRAP_PID" 2>/dev/null || true
+  BOOTSTRAP_RC=$(cat "$BOOTSTRAP_EXIT_FILE")
+  rm -f "$BOOTSTRAP_EXIT_FILE"
+fi
 BOOTSTRAP_DUR=$(( $(date +%s) - BOOTSTRAP_START ))
 
 if [ "$BOOTSTRAP_RC" -eq 0 ]; then
@@ -406,6 +644,11 @@ else
   spinner_failure "Couldn't install the basics" "$BOOTSTRAP_DUR"
   write_bootstrap_entry failed "$BOOTSTRAP_DUR" "$BOOTSTRAP_RAW"
   write_abort_entry bootstrap "exit-${BOOTSTRAP_RC}"
+
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"bootstrap_failed","stepId":"bootstrap","message":"Could not install the required runtime non-interactively.","recovery":[{"kind":"manual","title":"Inspect the bootstrap log","instructions":["Review logs/setup-steps/01-bootstrap.log without sharing secrets.","Complete any terminal-owned prerequisite, then rerun setup."]}]}\n'
+    exit 1
+  fi
 
   echo
   echo "$(dim '── last 40 lines of ')$(dim "$BOOTSTRAP_RAW")$(dim ' ──')"
@@ -439,4 +682,10 @@ fi
 # into setup:auto's spinner. exec so signals (Ctrl-C) propagate directly.
 # pnpm forwards arguments after the script name directly. Passing an extra
 # `--` would reach setup:auto and make its parser stop before our flags.
+if [ "$DRIVER_MODE" = true ]; then
+  export NANOCLAW_PROTOCOL=nanoclaw.driver.v1
+  export NANOCLAW_OPERATION=setup
+  export NANOCLAW_DRIVER_SHELL_HELLO=1
+  exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/auto.ts" "$@"
+fi
 exec pnpm --silent run setup:auto "$@"

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -25,6 +25,22 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
+# --catalog-preseeds is a read-only build-time contract. Never bootstrap or
+# create setup state just to inspect it.
+for arg in "$@"; do
+  if [ "$arg" = "--catalog-preseeds" ]; then
+    if [ "$#" -ne 1 ]; then
+      echo "--catalog-preseeds does not accept other arguments" >&2
+      exit 2
+    fi
+    if ! command -v node >/dev/null 2>&1 || [ ! -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; then
+      echo "Cannot print the preseed catalog: run pnpm install first." >&2
+      exit 1
+    fi
+    exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/catalog-preseeds.ts"
+  fi
+done
+
 # ─── --slack-agents: former testing flag, accepted and ignored ─────────
 # The managed Slack experience is simply the default; the flag that once
 # enabled it is swallowed so older invocations keep working.
@@ -165,6 +181,7 @@ for arg in "$@"; do
     fi
     echo "Usage: bash nanoclaw.sh [options]"
     echo ""
+    echo "  --catalog-preseeds    Print the build-time preseed contract as JSON"
     echo "  --template-path <ref>  Create or update an agent from templates/<ref>"
     echo "  --uninstall            Uninstall this NanoClaw copy"
     echo "  --help, -h             Show this help without installing dependencies"

--- a/scripts/photon-setup.test.ts
+++ b/scripts/photon-setup.test.ts
@@ -528,6 +528,30 @@ describe('photon setup flow (mocked API)', () => {
     expect(written.join('')).toContain('Text +15558887777');
   });
 
+  it('emits replaceable opt-in instructions in embedded mode', async () => {
+    const { fetchFn } = makeMockFetch({ optInAfterListPolls: 2 });
+    const written: string[] = [];
+    const realWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      expect(
+        await main(
+          ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive', '--embedded'],
+          fetchFn,
+          noSleep,
+        ),
+      ).toBe(0);
+    } finally {
+      process.stdout.write = realWrite;
+    }
+    const output = written.join('');
+    expect(output).toContain('=== NANOCLAW SETUP: PHOTON_OPT_IN ===\nPHONE: +15551234567\nLINE: +15558887777');
+    expect(output).toContain('=== NANOCLAW SETUP: PHOTON_OPT_IN_CLEAR ===');
+  });
+
   it('does not create a second row when a completed setup is re-run', async () => {
     const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 1 });
     expect(

--- a/scripts/photon-setup.ts
+++ b/scripts/photon-setup.ts
@@ -831,6 +831,7 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
     p.log.step('[1/5] Photon device login');
     const code = await requestDeviceCode(fetchFn, args.dashboardHost);
     const target = code.verification_uri_complete || code.verification_uri;
+    if (args.embedded) emitEmbeddedBlock('PHOTON_DEVICE', { URL: target, CODE: code.user_code });
     p.note(`Open:  ${target}\nCode:  ${code.user_code}`, 'Approve this device');
     if (!args.noBrowser) openBrowser(target);
     const spin = p.spinner();
@@ -844,6 +845,7 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
       return 1;
     }
     spin.stop('Logged in');
+    if (args.embedded) emitEmbeddedBlock('PHOTON_DEVICE_CLEAR');
     saveAuth({ access_token: token });
   }
 
@@ -920,6 +922,12 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
         p.log.info('Phone already opted in');
         assigned = line;
       } else {
+        if (args.embedded) {
+          emitEmbeddedBlock('PHOTON_OPT_IN', {
+            PHONE: phone,
+            ...(line ? { LINE: line } : {}),
+          });
+        }
         p.note(optInInstructions(phone, line).join('\n'), 'One step needed on your phone');
         const opted = await waitForOptedInUser(fetchFn, args.spectrumHost, projectId, secret, phone, {
           sleepFn: deps.sleepFn,
@@ -928,6 +936,7 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
             if (attempt % 6 === 0) p.log.message(`Still waiting for the opt-in for ${phone}…`);
           },
         });
+        if (args.embedded) emitEmbeddedBlock('PHOTON_OPT_IN_CLEAR');
         p.log.info('Phone registered and opted in');
         assigned = userAssignedLine(opted) ?? line;
       }
@@ -990,6 +999,17 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
     process.stdout.write(fields.join('\n') + '\n');
   }
   return 0;
+}
+
+function emitEmbeddedBlock(type: string, fields: Record<string, string> = {}): void {
+  process.stdout.write(
+    [
+      `=== NANOCLAW SETUP: ${type} ===`,
+      ...Object.entries(fields).map(([key, value]) => `${key}: ${value}`),
+      '=== END ===',
+      '',
+    ].join('\n'),
+  );
 }
 
 export async function main(argv: string[], fetchFn: FetchFn = fetch, deps: SetupDeps = {}): Promise<number> {

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -53,7 +53,15 @@ const headless =
     vals[name];
 const recordingExec = () => {
   const cmds: string[] = [];
-  return { cmds, exec: (c: string) => void cmds.push(c) };
+  const calls: Array<{ command: string; args: string[] }> = [];
+  return {
+    cmds,
+    calls,
+    exec: (command: string, args: string[] = []) => {
+      cmds.push(command);
+      calls.push({ command, args });
+    },
+  };
 };
 
 beforeEach(() => {
@@ -409,14 +417,16 @@ describe('nc:run variable substitution', () => {
   });
 
   it('interpolates a prompted {{var}} into run commands; var-free runs pass through unchanged', async () => {
-    const { cmds, exec } = recordingExec();
+    const { cmds, calls, exec } = recordingExec();
     await applySkill(rskill, rroot, { resolveInput: headless({ owner_email: 'you@example.com' }), exec });
-    expect(cmds).toContain(
-      'ncl messaging-groups create --channel-type resend --platform-id resend:you@example.com --is-group 0',
-    );
-    expect(cmds).toContain(
-      'ncl messaging-groups send --channel-type resend --platform-id resend:you@example.com --text "hello"',
-    );
+    expect(calls).toContainEqual({
+      command: 'ncl messaging-groups create --channel-type resend --platform-id resend:"${1}" --is-group 0',
+      args: ['you@example.com'],
+    });
+    expect(calls).toContainEqual({
+      command: 'ncl messaging-groups send --channel-type resend --platform-id resend:"${1}" --text "hello"',
+      args: ['you@example.com'],
+    });
     expect(cmds).toContain('pnpm run build');
   });
 
@@ -471,15 +481,18 @@ describe('nc:run capture', () => {
   });
 
   it('binds a command stdout (trimmed) into {{var}} and substitutes it downstream', async () => {
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     // exec returns stdout for the resolve command (simulating `… | jq -r .channel.id`).
-    const exec = (c: string): string | void => {
-      cmds.push(c);
-      if (c.startsWith('resolve-dm')) return 'D0SLACK123\n';
+    const exec = (command: string, args: string[] = []): string | void => {
+      calls.push({ command, args });
+      if (command.startsWith('resolve-dm')) return 'D0SLACK123\n';
     };
     await applySkill(cskill, croot, { resolveInput: headless({ user_id: 'U999' }), exec });
-    expect(cmds).toContain('resolve-dm U999'); // resolved with the prompted id
-    expect(cmds).toContain('ncl messaging-groups create --channel-type slack --platform-id slack:D0SLACK123'); // captured value flowed downstream
+    expect(calls).toContainEqual({ command: 'resolve-dm "${1}"', args: ['U999'] });
+    expect(calls).toContainEqual({
+      command: 'ncl messaging-groups create --channel-type slack --platform-id slack:"${1}"',
+      args: ['D0SLACK123'],
+    });
   });
 
   it('lint accepts {{dm_channel}} as defined by the earlier capture', () => {
@@ -656,17 +669,20 @@ describe('programmatic apply via inputs', () => {
 
   it('runs the whole skill from inputs alone — no resolver, nothing deferred or bounced', async () => {
     writeFileSync(join(pskill, 'SKILL.md'), PROGRAMMATIC_SKILL);
-    const cmds: string[] = [];
-    const exec = (c: string): string | void => {
-      cmds.push(c);
-      if (c.startsWith('resolve-thing')) return 'T-42\n';
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const exec = (command: string, args: string[] = []): string | void => {
+      calls.push({ command, args });
+      if (command.startsWith('resolve-thing')) return 'T-42\n';
     };
     const res = await applySkill(pskill, proot, { inputs: { owner: 'ada' }, exec });
     expect(fullyApplied(res)).toBe(true);
     expect(res.deferred).toEqual([]);
     expect(res.agentTasks).toEqual([]);
-    expect(cmds).toContain('resolve-thing ada'); // prompt input flowed through
-    expect(cmds).toContain('ncl wire --owner ada --thing T-42'); // captured value flowed through
+    expect(calls).toContainEqual({ command: 'resolve-thing "${1}"', args: ['ada'] });
+    expect(calls).toContainEqual({
+      command: 'ncl wire --owner "${1}" --thing "${2}"',
+      args: ['ada', 'T-42'],
+    });
     expect(res.operatorMessages).toEqual(['Go create the thing, ada.']); // human step collected for relay
   });
 

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -75,6 +75,9 @@ export interface StepOutcome {
   fields: Record<string, string>;
 }
 
+export type SkillExec = (command: string, args?: string[]) => string | void | Promise<string | void>;
+export type SkillExecStream = (command: string, args?: string[]) => Promise<StepOutcome>;
+
 export type StepStatus = 'skip' | 'apply' | 'needs-input' | 'agent';
 export interface PlanStep {
   n: number;
@@ -294,7 +297,7 @@ export interface ApplyOptions {
   onEvent?: (e: ApplyEvent) => void | Promise<void>;
   // dep/run/branch-fetch; injectable for tests. Returns the command's stdout so
   // a `run capture:<var>` can bind it into a {{var}} (the twin of `prompt`).
-  exec?: (cmd: string) => string | void | Promise<string | void>;
+  exec?: SkillExec;
   // Override dependency commands when the declared package manager is not
   // directly available on the host (for example, run the container's pinned
   // Bun through pnpm dlx during a refresh).
@@ -304,7 +307,7 @@ export interface ApplyOptions {
   // `=== NANOCLAW SETUP: … ===` status blocks, renders them to the operator live,
   // and resolves with the terminal block's fields (bound via capture:<var>=<FIELD>).
   // Absent ⇒ a step directive degrades to an agent (runs the step from the prose).
-  execStream?: (cmd: string) => Promise<StepOutcome>;
+  execStream?: SkillExecStream;
   // Run effects the CALLER owns and will perform itself — those runs are skipped
   // (not executed). e.g. a headless rebuild or a setup that restarts once at the
   // end passes ['restart']; applyProviderSkill passes ['build','test'].
@@ -570,6 +573,50 @@ function substitute(value: string, vars: Map<string, { value: string; secret: bo
   });
 }
 
+/**
+ * Bind prompt values as positional arguments to NanoClaw-authored shell text.
+ * Values never enter the script string. Existing skills place placeholders
+ * bare and inside both quote kinds, so the generated parameter reference must
+ * preserve the authored quote context.
+ */
+function bindShell(
+  value: string,
+  vars: Map<string, { value: string; secret: boolean }>,
+): { command: string; args: string[] } {
+  const args: string[] = [];
+  const command = value.replace(VAR_REF, (_match, name: string, offset: number) => {
+    const variable = vars.get(name);
+    if (!variable) throw new Error(`unresolved {{${name}}}`);
+    args.push(variable.value);
+    const ref = `\${${args.length}}`;
+    const quote = shellQuoteAt(value, offset);
+    if (quote === 'single') return `'"${ref}"'`;
+    if (quote === 'double') return ref;
+    return `"${ref}"`;
+  });
+  return { command, args };
+}
+
+function shellQuoteAt(source: string, end: number): 'none' | 'single' | 'double' {
+  let quote: 'none' | 'single' | 'double' = 'none';
+  for (let i = 0; i < end; i += 1) {
+    const char = source[i];
+    if (quote === 'single') {
+      if (char === "'") quote = 'none';
+    } else if (quote === 'double') {
+      if (char === '\\') i += 1;
+      else if (char === '"') quote = 'none';
+    } else if (char === '\\') {
+      i += 1;
+    } else if (char === "'") {
+      quote = 'single';
+    } else if (char === '"') {
+      quote = 'double';
+    }
+  }
+  return quote;
+}
+
 // A `when:<var>=<value>` guard: the directive applies only when an earlier
 // prompt/capture bound <var> to exactly <value>. Unmet — including the var still
 // unresolved (a deferred prompt) — skips the directive, so a guarded prompt is
@@ -635,8 +682,8 @@ async function applyOne(
   ctx: {
     root: string;
     skillDir: string;
-    exec: (c: string) => string | void | Promise<string | void>;
-    execStream?: (c: string) => Promise<StepOutcome>;
+    exec: SkillExec;
+    execStream?: SkillExecStream;
     resolveRemote: (b: string) => string;
     resolveDependencyCommand?: (request: DependencyCommandRequest) => string;
     vars: Map<string, { value: string; secret: boolean }>;
@@ -730,7 +777,10 @@ async function applyOne(
       // (a restart, a pairing/QR step, a wire) that follow — a broken local
       // config or an un-registered app never reaches a doomed restart/QR.
       if (d.attrs.effect === 'check') {
-        for (const cmd of d.body) await exec(substitute(cmd, vars));
+        for (const cmd of d.body) {
+          const bound = bindShell(cmd, vars);
+          await exec(bound.command, bound.args);
+        }
         break;
       }
       // effect:step runs a long-running, operator-interactive step (a pairing
@@ -741,7 +791,8 @@ async function applyOne(
       if (d.attrs.effect === 'step') {
         if (!ctx.execStream)
           throw new Error('effect:step needs a streaming exec — an agent runs the step from the prose');
-        const { ok, fields } = await ctx.execStream(substitute(d.body.join('\n'), vars));
+        const bound = bindShell(d.body.join('\n'), vars);
+        const { ok, fields } = await ctx.execStream(bound.command, bound.args);
         if (!ok) throw new Error('the step did not complete');
         if (capture) {
           for (const pair of capture.split(',')) {
@@ -757,11 +808,11 @@ async function applyOne(
         break;
       }
       for (const cmd of d.body) {
-        // Interpolate prompted {{vars}} the same way env-set does, so a run can
-        // call `ncl ... {{owner_email}}` to wire from collected input. A command
-        // with no {{...}} (build/test) is returned unchanged; an unresolved var
-        // throws → caught → deferred (the prompt hasn't been answered yet).
-        const out = await exec(substitute(cmd, vars));
+        // Bind prompted {{vars}} as positional arguments, so a run can call
+        // `ncl ... {{owner_email}}` without caller data becoming shell text.
+        // An unresolved var throws → caught → deferred.
+        const bound = bindShell(cmd, vars);
+        const out = await exec(bound.command, bound.args);
         // Last command wins for capture (a capture run should be a single command).
         // bindCapture binds stdout-as-is OR a multi-field JSON spec, and enforces
         // validate:<re> — a mismatch / unparseable JSON throws → bounced to an agent.

--- a/scripts/skill-conformance.test.ts
+++ b/scripts/skill-conformance.test.ts
@@ -131,6 +131,9 @@ interface RunOutcome {
   events: ApplyEvent[];
 }
 
+const renderedCommand = (command: string, args: string[] = []): string =>
+  command.replace(/\$\{(\d+)\}/g, (_match, index: string) => args[Number(index) - 1] ?? '');
+
 async function runScenario(skillDir: string, sc: Scenario): Promise<RunOutcome> {
   const root = scratchRoot();
   const cmds: string[] = [];
@@ -141,7 +144,8 @@ async function runScenario(skillDir: string, sc: Scenario): Promise<RunOutcome> 
     // resolveRemote MUST be injected: the default shells out to real
     // `git remote` + `git ls-remote` — network in CI, nondeterministic on forks.
     resolveRemote: () => 'origin',
-    exec: (c) => {
+    exec: (command, args) => {
+      const c = renderedCommand(command, args);
       cmds.push(c);
       return sc.exec?.find((e) => c.includes(e.match))?.stdout;
     },
@@ -339,7 +343,8 @@ describe.each(SKILLS)('%s', (name) => {
           current = byLine.get(e.line);
           if (sabotagedLine >= 0 && isSideEffectRun(current)) sideEffectStartsAfterSabotage.push(e.line);
         },
-        exec: (c) => {
+        exec: (command, args) => {
+          const c = renderedCommand(command, args);
           if (
             sabotagedLine < 0 &&
             current?.kind === 'run' &&

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -71,6 +71,7 @@ import type { AgentGroup } from '../src/types.js';
 import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-claude.js';
 import * as setupLog from './logs.js';
 import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
+import { withSecretFile } from './lib/secret-file.js';
 import { emit as phEmit } from './lib/diagnostics.js';
 import {
   accentGreen,
@@ -1626,28 +1627,30 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
   );
   const token = (answer as string).replace(/\s+/g, '');
 
-  const res = await runQuietChild(
-    'auth',
-    'onecli',
-    [
-      'secrets',
-      'create',
-      '--name',
-      'Anthropic',
-      '--type',
-      'anthropic',
-      '--value',
-      token,
-      '--host-pattern',
-      'api.anthropic.com',
-    ],
-    {
-      running: `Saving your ${label} to your OneCLI vault…`,
-      done: 'Claude account connected.',
-    },
-    {
-      extraFields: { METHOD: method },
-    },
+  const res = await withSecretFile(token, (filePath) =>
+    runQuietChild(
+      'auth',
+      'onecli',
+      [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'anthropic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        'api.anthropic.com',
+      ],
+      {
+        running: `Saving your ${label} to your OneCLI vault…`,
+        done: 'Claude account connected.',
+      },
+      {
+        extraFields: { METHOD: method },
+      },
+    ),
   );
   if (!res.ok) {
     await fail(
@@ -1673,30 +1676,34 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
     return;
   }
 
-  const res = await runQuietChild(
-    'auth',
-    'onecli',
-    [
-      'secrets',
-      'create',
-      '--name',
-      'Anthropic',
-      '--type',
-      'generic',
-      '--value',
-      token,
-      '--host-pattern',
-      host,
-      '--header-name',
-      'Authorization',
-      '--value-format',
-      'Bearer {value}',
-    ],
-    {
-      running: `Saving your Anthropic auth token to your OneCLI vault…`,
-      done: 'Claude account connected.',
-    },
-    { extraFields: { METHOD: 'custom-endpoint', HOST: host } },
+  const res = await withSecretFile(token, (filePath) =>
+    runQuietChild(
+      'auth',
+      'onecli',
+      [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'generic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        host,
+        '--header-name',
+        'Authorization',
+        '--value-format',
+        'Bearer {value}',
+      ],
+      {
+        running: `Saving your Anthropic auth token to your OneCLI vault…`,
+        done: 'Claude account connected.',
+      },
+      {
+        extraFields: { METHOD: 'custom-endpoint', HOST: host },
+      },
+    ),
   );
   if (!res.ok) {
     await fail(

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -40,7 +40,7 @@ import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
 import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
-import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './providers/registry.js';
+import { getSetupProvider, listSetupProviderChoices, runSetupProviderAuth } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
@@ -1312,15 +1312,6 @@ function sendChatMessage(driver: SetupDriver, message: string): Promise<void> {
 
 // ─── auth step (select → branch) ────────────────────────────────────────
 
-// Providers offered for install are hard-wired in trunk — an audited control
-// surface (no branch enumeration that anyone with write access could extend).
-// Codex is the only one offered here; opencode/ollama install via their own
-// /add-* skills. Each is installed by applying its `/add-<name>` SKILL.md
-// in-process via the directive engine.
-const INSTALLABLE_PROVIDERS = [
-  { value: 'codex', label: 'Codex', hint: 'OpenAI — ChatGPT subscription or API key' },
-] as const;
-
 // `pickSavedByPreviousRun`: the .env bridge promoted a pick persisted by a
 // PREVIOUS run. That pick is a default to confirm, not a decision to replay:
 // the operator may be rerunning precisely to change it. In-process presets
@@ -1831,11 +1822,6 @@ function finishRegistryLogin(driver: SetupDriver, durationMs: number, method?: s
 }
 
 async function askAgentProviderChoice(driver: SetupDriver): Promise<string> {
-  const installed = listSetupProviders();
-  const installedNames = new Set(installed.map((entry) => entry.value));
-  // Offer the hard-wired installable providers this install hasn't wired yet —
-  // selecting one applies its `/add-<name>` SKILL.md in-process.
-  const available = INSTALLABLE_PROVIDERS.filter((prov) => !installedNames.has(prov.value));
   // On a pinned install every non-Claude runtime forces a local rebuild — the
   // image bakes /app/node_modules and the CLI manifest, and each changes one.
   // Say so on the option rather than only at the confirm two steps later, so
@@ -1845,14 +1831,11 @@ async function askAgentProviderChoice(driver: SetupDriver): Promise<string> {
   const note = (value: string, hint: string): string =>
     pinned && value !== 'claude' ? `${hint} — ⚠ not in the pre-built image; needs a local build` : hint;
 
-  const options = [
-    ...installed.map(({ value, label, hint }) => ({ value, label, hint: note(value, hint) })),
-    ...available.map((prov) => ({
-      value: prov.value,
-      label: prov.label,
-      hint: note(prov.value, `${prov.hint} — installs now`),
-    })),
-  ];
+  const options = listSetupProviderChoices().map(({ value, label, hint }) => ({
+    value,
+    label,
+    hint: note(value, hint),
+  }));
   const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
   if (preset) {
     if (!options.some((option) => option.value === preset)) {

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -28,6 +28,7 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import * as os from 'os';
 import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 import * as p from '@clack/prompts';
 import k from 'kleur';
@@ -39,21 +40,18 @@ import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
 import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
-import { getSetupProvider, listSetupProviders } from './providers/registry.js';
+import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
-import { brightSelect } from './lib/bright-select.js';
 import { buildContainerImage } from './lib/container-build.js';
 import { offerClaudeOnFailure } from './lib/claude-handoff.js';
 import { setPickedProvider } from './lib/picked-provider.js';
 import {
   AGENT_IMAGE_PIN,
   AGENT_IMAGE_REF_ENV_KEY,
-  REGISTRY_LOGIN_SCRIPT,
   imageSourceDecided,
   readAgentImagePin,
-  loginScriptAvailable,
   readImageSource,
   writeImageSource,
   type ImageSource,
@@ -61,8 +59,18 @@ import {
 import { upsertEnvVar } from './set-env.js';
 import { applyToEnv, parseFlags, printHelp, readFromEnv } from './lib/setup-config-parse.js';
 import { runAdvancedScreen } from './lib/setup-config-screen.js';
+import { CONFIG, envVarFor, validateHttpUrl } from './lib/setup-config.js';
 import { runWindowedStep } from './lib/windowed-runner.js';
 import { runUninstallFlow } from './uninstall/flow.js';
+import {
+  createSetupDriver,
+  DriverCancelled,
+  DriverTerminalError,
+  type DriverPrompt,
+  type SetupReceipt,
+  type SetupDriver,
+} from './lib/setup-driver.js';
+import { buildSetupReceipt, inspectService, queryHostHealth } from './lib/service-health.js';
 import { detectExistingInstall } from './uninstall/scan.js';
 import { detectRegisteredGroups, detectExistingDisplayName, readEnvKey } from './environment.js';
 import { pollHealth } from './onecli.js';
@@ -70,8 +78,7 @@ import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import type { AgentGroup } from '../src/types.js';
 import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-claude.js';
 import * as setupLog from './logs.js';
-import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
-import { withSecretFile } from './lib/secret-file.js';
+import { fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
 import { emit as phEmit } from './lib/diagnostics.js';
 import {
   accentGreen,
@@ -81,12 +88,15 @@ import {
   dimWrap,
   fitToWidth,
   fmtDuration,
-  note,
   wrapForGutter,
 } from './lib/theme.js';
 import { isValidTimezone } from '../src/timezone.js';
 import { DEFAULT_AGENT_PROVIDER, TEMPLATES_DIR } from '../src/config.js';
 import { SocketTransport } from '../src/cli/socket-client.js';
+import { registerSensitiveValue } from './lib/redaction.js';
+import { childEnvWithoutSetupSecrets, withSecretFile } from './lib/secret-file.js';
+import { runClaudeSubscriptionMachineAuth } from './lib/claude-subscription-auth.js';
+import { runRegistryLoginWithDriver } from './registry-login.js';
 import {
   applyTemplatePick,
   clearTemplatePick,
@@ -102,13 +112,15 @@ import {
   type TemplateOperation,
 } from './templates.js';
 
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CLI_AGENT_NAME = 'Terminal Agent';
 const RUN_START = Date.now();
+const MAX_MACHINE_CHAT_OUTPUT_BYTES = 64 * 1024;
 
 /** How an operator reaches the registry step again once setup has finished. */
 const REGISTRY_STEP = 'pnpm exec tsx setup/index.ts --step registry';
 
-/** `setup/registry-login.sh`'s "nothing was signed in, and that is fine" code. */
+/** Metric-compatible code for "nothing was signed in, and that is fine". */
 const LOGIN_EXIT_SKIPPED = 2;
 
 type ChannelChoice =
@@ -123,7 +135,45 @@ type ChannelChoice =
   | 'other'
   | 'skip';
 
-async function main(): Promise<void> {
+async function selectPrompt<T extends string>(
+  driver: SetupDriver,
+  id: string,
+  opts: {
+    message: string;
+    options: Array<{ value: T; label: string; hint?: string }>;
+    initialValue?: T;
+  },
+): Promise<T> {
+  return driver.prompt({
+    id,
+    kind: 'singleChoice',
+    message: opts.message,
+    choices: opts.options.map(({ value, label, hint }) => ({ id: value, label, hint })),
+    ...(opts.initialValue !== undefined ? { default: opts.initialValue } : {}),
+  }) as Promise<T>;
+}
+
+async function confirmPrompt(driver: SetupDriver, id: string, message: string, initialValue = false): Promise<boolean> {
+  return driver.prompt({ id, kind: 'confirm', message, default: initialValue }) as Promise<boolean>;
+}
+
+async function textPrompt(
+  driver: SetupDriver,
+  id: string,
+  spec: Omit<DriverPrompt, 'id' | 'kind' | 'sensitive'>,
+): Promise<string> {
+  return driver.prompt({ ...spec, id, kind: 'text', sensitive: false }) as Promise<string>;
+}
+
+async function secretPrompt(
+  driver: SetupDriver,
+  id: string,
+  spec: Omit<DriverPrompt, 'id' | 'kind' | 'sensitive'>,
+): Promise<string> {
+  return driver.prompt({ ...spec, id, kind: 'secret', sensitive: true }) as Promise<string>;
+}
+
+async function main(driver: SetupDriver): Promise<void> {
   // Make sure ~/.local/bin is on PATH for every child process we spawn.
   // Installers we run mid-setup (OneCLI, claude) drop binaries there and
   // append a PATH line to the user's shell rc, but rc updates don't reach
@@ -136,30 +186,64 @@ async function main(): Promise<void> {
   // NANOCLAW_* sees them unchanged.
   const flagResult = parseFlags(process.argv.slice(2));
   if (flagResult.help) {
+    if (driver.mode === 'ndjson') {
+      driver.error('help_requested', 'Machine mode does not render terminal help.', [
+        { kind: 'rerun', args: ['--help'] },
+      ]);
+    }
     printHelp();
-    process.exit(0);
+    return;
   }
   if (flagResult.errors.length > 0) {
+    if (driver.mode === 'ndjson') {
+      driver.error('invalid_arguments', flagResult.errors.join('; '));
+    }
     for (const err of flagResult.errors) console.error(`error: ${err}`);
     console.error('');
     console.error('Run with --help for the full list of supported flags.');
     process.exit(1);
   }
   let configValues = { ...readFromEnv(), ...flagResult.values };
+  if (driver.mode === 'ndjson') {
+    const secretEntries = CONFIG.filter((entry) => entry.secret);
+    const secretLaunch =
+      secretEntries.some((entry) => process.env[envVarFor(entry)] !== undefined) ||
+      process.env.NANOCLAW_REGISTRY_ENROLL_CODE !== undefined ||
+      process.env.NANOCLAW_REGISTRY_TOKEN !== undefined;
+    const secretFlag = secretEntries.some((entry) => entry.key in flagResult.values);
+    if (secretLaunch || secretFlag) {
+      driver.error(
+        'secret_transport_forbidden',
+        'Machine setup does not accept secrets through flags or environment. Use the structured authentication prompts instead.',
+      );
+    }
+    if (configValues.anthropicBaseUrl !== undefined) {
+      driver.error(
+        'custom_endpoint_unsupported',
+        'Machine setup does not accept custom Anthropic endpoints through advanced configuration.',
+      );
+    }
+  }
+  for (const value of [configValues.onecliApiToken, configValues.anthropicAuthToken]) {
+    if (typeof value === 'string') registerSensitiveValue(value);
+  }
   applyToEnv(configValues);
 
   // --uninstall routes to the uninstall flow before any setup side effects —
   // in particular before initProgressionLog(), so an uninstall never resets
   // logs/setup.log on its way to (possibly) deleting logs/ entirely.
   if (configValues.uninstall === true) {
-    await runUninstallFlow({
-      dryRun: configValues.dryRun === true,
-      yes: configValues.yes === true,
-      invokedFrom: 'flag',
-    });
+    await runUninstallFlow(
+      {
+        dryRun: configValues.dryRun === true,
+        yes: configValues.yes === true,
+        invokedFrom: 'flag',
+      },
+      driver,
+    );
   }
 
-  printIntro();
+  printIntro(driver);
   initProgressionLog();
   phEmit('auto_started');
 
@@ -168,20 +252,24 @@ async function main(): Promise<void> {
   // On sg re-exec, the user already chose — skip straight to standard.
   let startChoice: 'default' | 'advanced' = 'default';
   if (process.env.NANOCLAW_REEXEC_SG !== '1') {
-    startChoice = ensureAnswer(
-      await brightSelect<'default' | 'advanced'>({
-        message: 'How would you like to begin?',
-        options: [
-          { value: 'default', label: 'Standard setup' },
-          { value: 'advanced', label: 'Advanced', hint: 'override defaults' },
-        ],
-        initialValue: 'default',
-      }),
-    ) as 'default' | 'advanced';
+    startChoice = await selectPrompt(driver, 'setup-start-choice', {
+      message: 'How would you like to begin?',
+      options: [
+        { value: 'default', label: 'Standard setup' },
+        { value: 'advanced', label: 'Advanced', hint: 'override defaults' },
+      ],
+      initialValue: 'default',
+    });
     setupLog.userInput('start_choice', startChoice);
   }
   if (startChoice === 'advanced') {
-    configValues = await runAdvancedScreen(configValues);
+    configValues = await runAdvancedScreen(configValues, driver);
+    if (driver.mode === 'ndjson' && configValues.anthropicBaseUrl !== undefined) {
+      driver.error(
+        'custom_endpoint_unsupported',
+        'Machine setup does not accept custom Anthropic endpoints through advanced configuration.',
+      );
+    }
     applyToEnv(configValues);
   }
 
@@ -191,48 +279,63 @@ async function main(): Promise<void> {
       .map((s) => s.trim())
       .filter(Boolean),
   );
+  if (driver.mode === 'ndjson' && skip.has('verify')) {
+    driver.error('verify_cannot_be_skipped', 'Machine setup must run the existing verification step.');
+  }
 
   // Offer removal when setup lands on an existing install. Skipped on every
   // resume path — both the fail() retry and the sg-docker re-exec pass
   // NANOCLAW_SKIP (and the latter sets NANOCLAW_REEXEC_SG) — so the prompt
   // appears at most once per fresh run.
   const isResume = process.env.NANOCLAW_REEXEC_SG === '1' || skip.size > 0;
-  if (!isResume && detectExistingInstall(process.cwd())) {
-    const action = ensureAnswer(
-      await brightSelect<'keep' | 'uninstall'>({
-        message: 'NanoClaw is already installed in this folder. What would you like to do?',
-        options: [
-          {
-            value: 'keep',
-            label: 'Keep it & continue setup',
-            hint: 'recommended — re-running setup is safe',
-          },
-          {
-            value: 'uninstall',
-            label: 'Uninstall NanoClaw & exit',
-            hint: 'removes service, data, and agent files — asks before each step',
-          },
-        ],
-        initialValue: 'keep',
-      }),
-    ) as 'keep' | 'uninstall';
+  if (!isResume && detectExistingInstall(PROJECT_ROOT)) {
+    const action = await selectPrompt(driver, 'existing-install-action', {
+      message: 'NanoClaw is already installed in this folder. What would you like to do?',
+      options: [
+        {
+          value: 'keep',
+          label: 'Keep it & continue setup',
+          hint: 'recommended - re-running setup is safe',
+        },
+        {
+          value: 'uninstall',
+          label: 'Uninstall NanoClaw & exit',
+          hint: 'removes service, data, and agent files - asks before each step',
+        },
+      ],
+      initialValue: 'keep',
+    });
     setupLog.userInput('existing_install', action);
     phEmit('existing_install_detected', { action });
     if (action === 'uninstall') {
-      await runUninstallFlow({ dryRun: false, yes: false, invokedFrom: 'setup-detection' });
+      if (driver.mode === 'ndjson') {
+        driver.error(
+          'uninstall_requires_fresh_run',
+          'Start a fresh uninstall operation so its plan and receipt use the uninstall envelope.',
+          [{ kind: 'rerun', args: ['--uninstall', '--protocol', 'nanoclaw.driver.v1'] }],
+        );
+      }
+      await runUninstallFlow({ dryRun: false, yes: false, invokedFrom: 'setup-detection' }, driver);
     }
   }
 
   if (!skip.has('environment')) {
-    const res = await runQuietStep('environment', {
-      running: 'Checking your system…',
-      done: 'Your system looks good.',
-    });
+    const res = await runQuietStep(
+      'environment',
+      {
+        running: 'Checking your system…',
+        done: 'Your system looks good.',
+      },
+      [],
+      driver,
+    );
     if (!res.ok) {
       await fail(
         'environment',
         "Your system doesn't look quite right.",
         'See logs/setup-steps/ for details, then retry.',
+        undefined,
+        driver,
       );
     }
   }
@@ -243,23 +346,26 @@ async function main(): Promise<void> {
   // loses that choice on a full rerun.
   let savedPickBridged = false;
   if (!process.env.NANOCLAW_TEMPLATE_PATH?.trim()) {
-    const savedPick = readEnvKey('NANOCLAW_TEMPLATE_PATH')?.trim();
+    const savedPick = readEnvKey('NANOCLAW_TEMPLATE_PATH', PROJECT_ROOT)?.trim();
     if (savedPick) {
       process.env.NANOCLAW_TEMPLATE_PATH = savedPick;
       savedPickBridged = true;
     }
   }
   if (!isResume) {
-    await runTemplateSetup(savedPickBridged, await detectRegisteredGroups(process.cwd()));
+    await runTemplateSetup(driver, savedPickBridged, await detectRegisteredGroups(PROJECT_ROOT));
   }
 
   if (!skip.has('container')) {
-    p.log.message(
+    await ensureMachineContainerRuntime(driver);
+    driver.log(
+      'message',
       brandBody(dimWrap('Your assistant lives in its own sandbox. It can only see what you explicitly share.', 4)),
     );
     // Asked before the step runs, because the step is what acts on the answer.
-    await chooseImageSource();
-    p.log.message(
+    await chooseImageSource(driver);
+    driver.log(
+      'message',
       brandBody(
         dimWrap(
           readImageSource() === 'hardened'
@@ -269,11 +375,16 @@ async function main(): Promise<void> {
         ),
       ),
     );
-    const res = await runWindowedStep('container', {
-      running: "Preparing your assistant's sandbox…",
-      done: 'Sandbox ready.',
-      failed: "Couldn't prepare the sandbox.",
-    });
+    const res = await runWindowedStep(
+      'container',
+      {
+        running: "Preparing your assistant's sandbox…",
+        done: 'Sandbox ready.',
+        failed: "Couldn't prepare the sandbox.",
+      },
+      [],
+      driver,
+    );
     if (!res.ok) {
       const err = res.terminal?.fields.ERROR;
       if (err === 'runtime_not_available') {
@@ -281,6 +392,8 @@ async function main(): Promise<void> {
           'container',
           "Docker isn't available.",
           'Install Docker Desktop (or start it if already installed), then retry.',
+          undefined,
+          driver,
         );
       }
       if (err === 'docker_group_not_active') {
@@ -288,6 +401,8 @@ async function main(): Promise<void> {
           'container',
           "Docker was just installed but your shell doesn't know yet.",
           'Log out and back in (or run `newgrp docker` in a new shell), then retry.',
+          undefined,
+          driver,
         );
       }
       // The pull path fails for reasons a build never has, and "prune the build
@@ -297,6 +412,8 @@ async function main(): Promise<void> {
           'container',
           'This install is set to fetch a pre-built sandbox image, but nothing says which one.',
           `Set ${AGENT_IMAGE_REF_ENV_KEY} in .env (or add an "${AGENT_IMAGE_PIN}" pin to versions.json), or run \`${REGISTRY_STEP} -- --opt-out\` to build it here instead.`,
+          undefined,
+          driver,
         );
       }
       if (err === 'image_pull_failed') {
@@ -304,19 +421,24 @@ async function main(): Promise<void> {
           'container',
           "Couldn't fetch the sandbox image.",
           `Check your connection and that authentication finished, then retry — or run \`${REGISTRY_STEP} -- --opt-out\` to build it here instead.`,
+          undefined,
+          driver,
         );
       }
       await fail(
         'container',
         "Couldn't build the sandbox.",
         'If Docker has a stale cache, try: `docker builder prune -f`, then retry.',
+        undefined,
+        driver,
       );
     }
-    maybeReexecUnderSg();
+    maybeReexecUnderSg(driver);
   }
 
   if (!skip.has('onecli')) {
-    p.log.message(
+    driver.log(
+      'message',
       brandBody(
         dimWrap(
           'Your assistant never gets your API keys directly. The vault adds them to approved requests as they leave the sandbox.',
@@ -332,18 +454,24 @@ async function main(): Promise<void> {
       // so skip the local-vs-fresh prompt entirely. Health-check it here
       // rather than letting the step fail silently — a typo in the URL is a
       // common mistake and the answer is human-fixable.
-      const s = p.spinner();
-      s.start(`Checking remote OneCLI at ${remoteHost}…`);
+      const remoteSpinner = driver.mode === 'terminal' ? p.spinner() : null;
+      if (remoteSpinner) remoteSpinner.start(`Checking remote OneCLI at ${remoteHost}…`);
+      else driver.progress('onecli-remote-check', 'running', `Checking remote OneCLI at ${remoteHost}`);
       const healthy = await pollHealth(remoteHost, 5000);
+      driver.throwIfCancelled();
       if (!healthy) {
-        s.stop(`Couldn't reach OneCLI at ${remoteHost}.`, 1);
+        if (remoteSpinner) remoteSpinner.error(`Couldn't reach OneCLI at ${remoteHost}.`);
+        else driver.progress('onecli-remote-check', 'failed');
         await fail(
           'onecli',
           `Couldn't reach OneCLI at ${remoteHost}.`,
           'Check the URL and that OneCLI is running on the remote machine, then retry.',
+          undefined,
+          driver,
         );
       }
-      s.stop('Remote OneCLI is reachable.');
+      if (remoteSpinner) remoteSpinner.stop('Remote OneCLI is reachable.');
+      else driver.progress('onecli-remote-check', 'succeeded');
 
       const res = await runQuietStep(
         'onecli',
@@ -352,6 +480,7 @@ async function main(): Promise<void> {
           done: 'OneCLI vault ready.',
         },
         ['--remote-url', remoteHost],
+        driver,
       );
       if (!res.ok) {
         const err = res.terminal?.fields.ERROR;
@@ -359,6 +488,8 @@ async function main(): Promise<void> {
           'onecli',
           `Couldn't connect to remote OneCLI (${err ?? 'unknown error'}).`,
           'Check the URL and that OneCLI is running on the remote machine, then retry.',
+          undefined,
+          driver,
         );
       }
     } else {
@@ -368,23 +499,21 @@ async function main(): Promise<void> {
       const existing = detectExistingOnecli();
       let reuse = false;
       if (existing) {
-        const choice = ensureAnswer(
-          await brightSelect({
-            message: `Found an existing OneCLI at ${existing.apiHost}. What would you like to do?`,
-            options: [
-              {
-                value: 'reuse',
-                label: 'Use the existing instance',
-                hint: 'recommended — keeps other apps bound to this vault working',
-              },
-              {
-                value: 'fresh',
-                label: 'Install a fresh instance for NanoClaw',
-                hint: 'reinstalls onecli; other apps may need to reconnect',
-              },
-            ],
-          }),
-        ) as 'reuse' | 'fresh';
+        const choice = await selectPrompt(driver, 'onecli-existing-choice', {
+          message: `Found an existing OneCLI at ${existing.apiHost}. What would you like to do?`,
+          options: [
+            {
+              value: 'reuse',
+              label: 'Use the existing instance',
+              hint: 'recommended - keeps other apps bound to this vault working',
+            },
+            {
+              value: 'fresh',
+              label: 'Install a fresh instance for NanoClaw',
+              hint: 'reinstalls onecli; other apps may need to reconnect',
+            },
+          ],
+        });
         setupLog.userInput('onecli_choice', choice);
         reuse = choice === 'reuse';
       }
@@ -396,6 +525,7 @@ async function main(): Promise<void> {
           done: 'OneCLI vault ready.',
         },
         reuse ? ['--reuse'] : [],
+        driver,
       );
       if (!res.ok) {
         const err = res.terminal?.fields.ERROR;
@@ -404,12 +534,16 @@ async function main(): Promise<void> {
             'onecli',
             'OneCLI was installed but your shell needs to refresh to see it.',
             'Open a new shell or run `export PATH="$HOME/.local/bin:$PATH"`, then retry.',
+            undefined,
+            driver,
           );
         }
         await fail(
           'onecli',
           `Couldn't set up OneCLI (${err ?? 'unknown error'}).`,
           'Make sure curl is installed and ~/.local/bin is writable, then retry.',
+          undefined,
+          driver,
         );
       }
     }
@@ -427,7 +561,7 @@ async function main(): Promise<void> {
     // each via `ncl groups config update --provider` right after creating it
     // (the creation scripts inherit it and apply at create — see picked-provider). Existing groups switch the
     // same way (docs/provider-migration.md).
-    agentProvider = await askAgentProviderChoice();
+    agentProvider = await askAgentProviderChoice(driver);
     setPickedProvider(agentProvider);
 
     // A pulled image bakes /app/node_modules and the CLI manifest, and every
@@ -436,22 +570,24 @@ async function main(): Promise<void> {
     // pinned install, and reaching that refusal aborts setup with no way out
     // short of re-running it.
     if (agentProvider !== 'claude' && readImageSource() === 'hardened') {
-      const leave = ensureAnswer(
-        await p.confirm({
-          message: `${agentProvider} needs a sandbox image built on this machine. Stop using the pre-built one?`,
-          initialValue: true,
-        }),
+      const leave = await confirmPrompt(
+        driver,
+        'provider-leave-hardened-image',
+        `${agentProvider} needs a sandbox image built on this machine. Stop using the pre-built one?`,
+        true,
       );
       if (!leave) {
         await fail(
           'auth',
           `${agentProvider} can't run on the pre-built sandbox image.`,
           'Re-run setup and choose Claude to keep the pre-built image.',
+          undefined,
+          driver,
         );
       }
       writeImageSource('local');
       setupLog.userInput('image_source', 'local');
-      p.log.info(brandBody('Switched back to a locally built sandbox image.'));
+      driver.log('info', brandBody('Switched back to a locally built sandbox image.'));
     }
 
     let providerEntry = getSetupProvider(agentProvider);
@@ -463,42 +599,53 @@ async function main(): Promise<void> {
       // already ran, the CLI manifest just changed), then load the payload's
       // setup module so it self-registers.
       const skillDir = `.claude/skills/add-${agentProvider}`;
-      const s = p.spinner();
-      s.start(`Installing ${agentProvider}…`);
+      const providerSpinner = driver.mode === 'terminal' ? p.spinner() : null;
+      if (providerSpinner) providerSpinner.start(`Installing ${agentProvider}…`);
+      else driver.progress(`add-${agentProvider}`, 'running', `Installing ${agentProvider}`);
       let blockers: string[];
       try {
-        ({ blockers } = await applyProviderSkill(skillDir, process.cwd()));
+        ({ blockers } = await applyProviderSkill(skillDir, PROJECT_ROOT));
       } catch (err) {
-        s.stop(`Couldn't install ${agentProvider}.`, 1);
+        if (providerSpinner) providerSpinner.error(`Couldn't install ${agentProvider}.`);
+        else driver.progress(`add-${agentProvider}`, 'failed');
         const message = err instanceof Error ? err.message : String(err);
-        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, message);
+        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, message, undefined, driver);
         return; // unreachable — fail() exits — but narrows blockers for TS
       }
       if (blockers.length) {
-        s.stop(`Couldn't install ${agentProvider}.`, 1);
-        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, blockers.join('; '));
+        if (providerSpinner) providerSpinner.error(`Couldn't install ${agentProvider}.`);
+        else driver.progress(`add-${agentProvider}`, 'failed');
+        await fail(
+          `add-${agentProvider}`,
+          `Couldn't install ${agentProvider}.`,
+          blockers.join('; '),
+          undefined,
+          driver,
+        );
       }
-      s.stop(`${agentProvider} installed.`);
-      p.log.info(brandBody('Rebuilding the container image with the new provider…'));
+      if (providerSpinner) providerSpinner.stop(`${agentProvider} installed.`);
+      else driver.progress(`add-${agentProvider}`, 'succeeded');
+      driver.log('info', brandBody('Rebuilding the container image with the new provider…'));
       // The rebuild is not optional here: the provider's CLI manifest is baked
       // into the image, so continuing past a failed build would authenticate a
       // runtime the container cannot actually start.
-      const rebuild = buildContainerImage();
+      const rebuild = driver.mode === 'ndjson' ? await rebuildProviderImage(driver) : buildContainerImage();
       if (!rebuild.ok) {
         await fail(
           `add-${agentProvider}`,
           `Couldn't rebuild the container image for ${agentProvider}. ${rebuild.message}`,
           rebuild.hint,
+          undefined,
+          driver,
         );
       }
       await import(`./providers/${agentProvider}.js`);
       providerEntry = getSetupProvider(agentProvider);
     }
     if (providerEntry?.runAuth) {
-      await providerEntry.runAuth();
-      await providerEntry.runInstallCheck?.();
+      await runSetupProviderAuth(providerEntry, driver);
     } else {
-      await runAuthStep();
+      await runAuthStep(driver);
     }
     // Persist the pick as the instance-wide default so every future group
     // (channel-approved, ncl-created) is created on this provider. Read from
@@ -517,23 +664,31 @@ async function main(): Promise<void> {
         skipped: 'Access rules already set.',
       },
       ['--empty'],
+      driver,
     );
     if (!res.ok) {
-      await fail('mounts', "Couldn't write access rules.");
+      await fail('mounts', "Couldn't write access rules.", undefined, undefined, driver);
     }
   }
 
   if (!skip.has('service')) {
-    const res = await runQuietStep('service', {
-      running: 'Starting NanoClaw in the background…',
-      done: 'NanoClaw is running.',
-    });
+    await ensureMachineServicePermissions(driver);
+    const res = await runQuietStep(
+      'service',
+      {
+        running: 'Starting NanoClaw in the background…',
+        done: 'NanoClaw is running.',
+      },
+      [],
+      driver,
+    );
     if (!res.ok) {
-      await fail('service', "Couldn't start NanoClaw.", 'See logs/nanoclaw.error.log for details.');
+      await fail('service', "Couldn't start NanoClaw.", 'See logs/nanoclaw.error.log for details.', undefined, driver);
     }
     if (res.terminal?.fields.DOCKER_GROUP_STALE === 'true') {
-      p.log.warn(brandBody("NanoClaw's permissions need a tweak before it can reach Docker."));
-      p.log.message(
+      driver.log('warn', brandBody("NanoClaw's permissions need a tweak before it can reach Docker."));
+      driver.log(
+        'message',
         brandBody(
           '  sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' + `  systemctl --user restart ${getSystemdUnit()}`,
         ),
@@ -545,13 +700,13 @@ async function main(): Promise<void> {
   async function resolveDisplayName(): Promise<string> {
     if (displayName) return displayName;
     const preset = process.env.NANOCLAW_DISPLAY_NAME?.trim();
-    const existing = await detectExistingDisplayName(process.cwd());
+    const existing = await detectExistingDisplayName(PROJECT_ROOT);
     const fallback = process.env.USER?.trim() || 'Operator';
-    displayName = preset || existing || (await askDisplayName(fallback));
+    displayName = preset || existing || (await askDisplayName(driver, fallback));
     return displayName;
   }
 
-  if (!skip.has('cli-agent') && (await detectRegisteredGroups(process.cwd()))) {
+  if (!skip.has('cli-agent') && (await detectRegisteredGroups(PROJECT_ROOT))) {
     skip.add('cli-agent');
     skip.add('first-chat');
   }
@@ -565,16 +720,20 @@ async function main(): Promise<void> {
         done: 'Assistant wired up.',
       },
       ['--display-name', displayName!, '--agent-name', CLI_AGENT_NAME, '--folder', PING_AGENT_FOLDER],
+      driver,
     );
     if (!res.ok) {
       await fail(
         'cli-agent',
         "Couldn't bring your assistant online.",
         `You can retry later with \`pnpm exec tsx scripts/init-cli-agent.ts --display-name "${displayName!}" --agent-name "${CLI_AGENT_NAME}"\`.`,
+        undefined,
+        driver,
       );
     }
     if (!skip.has('first-chat')) {
-      p.log.message(
+      driver.log(
+        'message',
         brandBody(
           dimWrap(
             "Your assistant runs in an isolated sandbox. I'm going to send it a quick test message (ping) and wait for a reply (pong) to confirm it's responding. First startup typically takes 30–60 seconds while the sandbox warms up.",
@@ -582,7 +741,7 @@ async function main(): Promise<void> {
           ),
         ),
       );
-      const ping = await confirmAssistantResponds();
+      const ping = await confirmAssistantResponds(driver);
       if (ping === 'ok') {
         phEmit('first_chat_ready');
         const cleanupRawLog = setupLog.stepRawLog('cleanup-cli-agent');
@@ -591,6 +750,8 @@ async function main(): Promise<void> {
           'pnpm',
           ['exec', 'tsx', 'scripts/delete-cli-agent.ts', '--folder', PING_AGENT_FOLDER],
           cleanupRawLog,
+          undefined,
+          driver,
         );
         setupLog.step(
           'cleanup-cli-agent',
@@ -600,28 +761,27 @@ async function main(): Promise<void> {
           cleanupRawLog,
         );
         if (!cleanup.ok) {
-          p.log.warn(
+          driver.log(
+            'warn',
             brandBody(
               `Couldn't clean up the test agent — it may still appear in your agent list. See ${cleanupRawLog} for details.`,
             ),
           );
         }
-        const next = ensureAnswer(
-          await brightSelect<'continue' | 'chat'>({
-            message: 'What next?',
-            options: [
-              {
-                value: 'continue',
-                label: 'Continue with setup',
-                hint: 'recommended',
-              },
-              {
-                value: 'chat',
-                label: 'Pause here and chat with your agent from the terminal',
-              },
-            ],
-          }),
-        ) as 'continue' | 'chat';
+        const next = await selectPrompt(driver, 'first-chat-next', {
+          message: 'What next?',
+          options: [
+            {
+              value: 'continue',
+              label: 'Continue with setup',
+              hint: 'recommended',
+            },
+            {
+              value: 'chat',
+              label: 'Pause here and chat with your agent from the terminal',
+            },
+          ],
+        });
         setupLog.userInput('first_chat_choice', next);
         if (next === 'chat') {
           const terminalAgentName = `${displayName!}'s Terminal`;
@@ -638,39 +798,49 @@ async function main(): Promise<void> {
               terminalAgentName,
             ],
             { running: `Creating ${terminalAgentName}…`, done: `${terminalAgentName} is ready.` },
+            undefined,
+            driver,
           );
           if (!createRes.ok) {
             await fail(
               'create-terminal-agent',
               `Couldn't create ${terminalAgentName}.`,
               'You can retry later with `pnpm exec tsx scripts/init-cli-agent.ts`.',
+              undefined,
+              driver,
             );
           }
-          await runFirstChat();
+          await runFirstChat(driver);
         }
       } else {
         phEmit('first_chat_failed', { reason: ping });
-        renderPingFailureNote(ping);
-        await offerClaudeOnFailure({
-          stepName: 'cli-agent',
-          msg:
-            ping === 'socket_error'
-              ? "NanoClaw service isn't listening on its CLI socket."
-              : 'No reply from the assistant within 30 seconds.',
-          hint:
-            ping === 'socket_error'
-              ? 'Socket at data/cli.sock did not accept a connection.'
-              : 'Agent container may be failing to start or authenticate.',
-        });
+        renderPingFailureNote(driver, ping);
+        if (driver.mode === 'terminal') {
+          await offerClaudeOnFailure({
+            stepName: 'cli-agent',
+            msg:
+              ping === 'socket_error'
+                ? "NanoClaw service isn't listening on its CLI socket."
+                : ping === 'output_limit'
+                  ? 'The assistant returned more output than setup can safely display.'
+                  : 'No reply from the assistant within 30 seconds.',
+            hint:
+              ping === 'socket_error'
+                ? 'Socket at data/cli.sock did not accept a connection.'
+                : ping === 'output_limit'
+                  ? 'Inspect logs/nanoclaw.log for a runaway response.'
+                  : 'Agent container may be failing to start or authenticate.',
+          });
+        }
       }
     }
   }
 
   if (!skip.has('timezone')) {
-    await runTimezoneStep();
+    await runTimezoneStep(driver);
   }
 
-  const templateAgentOutcome = await installSelectedTemplateAgent(agentProvider);
+  const templateAgentOutcome = await installSelectedTemplateAgent(driver, agentProvider);
 
   // v1 → v2 migration is handled by `bash migrate-v2.sh`, not the setup flow.
   // Users migrating from v1 run that script before (or instead of) setup.
@@ -685,36 +855,41 @@ async function main(): Promise<void> {
     let backed = true;
     while (backed) {
       backed = false;
-      channelChoice = await askChannelChoice();
+      channelChoice = await askChannelChoice(driver);
       if (channelChoice !== 'skip' && channelChoice !== 'other') {
         await resolveDisplayName();
       }
-      let result: void | typeof BACK_TO_CHANNEL_SELECTION;
+      let result: void | typeof BACK_TO_CHANNEL_SELECTION = undefined;
       // Every channel now runs through the SKILL.md-driven flow — the whole
       // connect+wire procedure lives in each add-<channel>/SKILL.md.
       if (channelChoice === 'telegram') {
-        result = await runChannelSkillWithPreStep('telegram', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('telegram', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'discord') {
-        result = await runChannelSkillWithPreStep('discord', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('discord', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'whatsapp') {
-        result = await runChannelSkillWithPreStep('whatsapp', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('whatsapp', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'signal') {
-        result = await runChannelSkillWithPreStep('signal', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('signal', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'teams') {
         // Fresh create resolves the owner DM proactively and wires inline (the
         // welcome message reaches the human first); a drop-through re-run
         // resolves nothing and falls back to the deferred-wire ending.
-        result = await runChannelSkillWithPreStep('teams', displayName!, { wireIfResolved: true, offerBack: true });
+        result = await runChannelSkillWithPreStep('teams', displayName!, {
+          wireIfResolved: true,
+          offerBack: true,
+          driver,
+        });
       } else if (channelChoice === 'slack') {
-        result = await runChannelSkillWithPreStep('slack', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('slack', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'imessage') {
-        result = await runChannelSkillWithPreStep('imessage', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('imessage', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'dial') {
-        result = await runChannelSkillWithPreStep('dial', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('dial', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'other') {
-        result = await askOtherChannelName();
+        result = await askOtherChannelName(driver);
       } else {
-        p.log.info(
+        driver.log(
+          'info',
           brandBody(
             wrapForGutter(
               'No messaging app for now. You can add one later (like Telegram, Discord, WhatsApp, Teams, Slack, or iMessage).',
@@ -736,13 +911,19 @@ async function main(): Promise<void> {
   // premature "your assistant is saying hi" (no welcome DM exists yet).
   let wiringPending = false;
 
+  let verified = false;
   if (!skip.has('verify')) {
-    const res = await runQuietStep('verify', {
-      running: 'Making sure everything works together…',
-      done: "Everything's connected.",
-      failed: 'A few things still need your attention.',
-    });
-    if (!res.ok) {
+    const res = await runQuietStep(
+      'verify',
+      {
+        running: 'Making sure everything works together…',
+        done: "Everything's connected.",
+        failed: 'A few things still need your attention.',
+      },
+      [],
+      driver,
+    );
+    if (!res.ok || (driver.mode === 'ndjson' && res.terminal?.fields.STATUS !== 'success')) {
       const notes: string[] = [];
       if (res.terminal?.fields.CREDENTIALS !== 'configured') {
         notes.push("• Your Claude account isn't connected. Re-run setup and try again.");
@@ -768,7 +949,7 @@ async function main(): Promise<void> {
         );
       }
       if (notes.length > 0) {
-        note(notes.join('\n'), "What's left");
+        driver.note(notes.join('\n'), "What's left");
       }
       // "What's left" is a soft failure — we don't abort like fail(), but the
       // user is still stuck and a fix is exactly what claude-assist is for.
@@ -781,17 +962,43 @@ async function main(): Promise<void> {
         service_running: res.terminal?.fields.SERVICE === 'running',
         has_credentials: res.terminal?.fields.CREDENTIALS === 'configured',
       });
-      await offerClaudeOnFailure({
-        stepName: 'verify',
-        msg: summary || 'Verification completed with unresolved issues.',
-        hint: `Terminal block: ${JSON.stringify(res.terminal?.fields ?? {})}`,
-        rawLogPath: res.rawLog,
-      });
-      p.outro(k.yellow('Almost there. A few things still need your attention.'));
-      return;
+      if (driver.mode === 'terminal') {
+        await offerClaudeOnFailure({
+          stepName: 'verify',
+          msg: summary || 'Verification completed with unresolved issues.',
+          hint: `Terminal block: ${JSON.stringify(res.terminal?.fields ?? {})}`,
+          rawLogPath: res.rawLog,
+        });
+        driver.outro(k.yellow('Almost there. A few things still need your attention.'));
+        return;
+      }
+      driver.error(
+        'verification_failed',
+        summary || 'Verification completed with unresolved issues.',
+        [
+          {
+            kind: 'manual',
+            title: 'Resolve verification issues',
+            instructions: notes.length ? notes : ['Inspect the verify raw log, fix the issue, and rerun setup.'],
+          },
+        ],
+        'verify',
+      );
     }
+    verified = res.terminal?.fields.STATUS === 'success';
     wiringPending = res.terminal?.fields.WIRING === 'pending_first_dm';
   }
+
+  if (driver.mode === 'ndjson' && !verified) {
+    driver.error(
+      'verification_required',
+      'Setup cannot complete until verification reports STATUS: success.',
+      [],
+      'verify',
+    );
+  }
+
+  const setupReceipt = await completionReceipt(driver);
 
   const rows: [string, string][] = [
     ['Chat in the terminal:', 'pnpm run chat hi'],
@@ -800,11 +1007,11 @@ async function main(): Promise<void> {
   ];
   const labelWidth = Math.max(...rows.map(([l]) => l.length));
   const nextSteps = rows.map(([l, c]) => `${k.cyan(l.padEnd(labelWidth))}  ${c}`).join('\n');
-  note(nextSteps, 'Try these');
+  driver.note(nextSteps, 'Try these');
 
   // Always-on warning goes before the "check your DMs" directive so the
   // caveat doesn't land after the user's already looked away at their phone.
-  note(
+  driver.note(
     wrapForGutter(
       "NanoClaw runs on this machine. It's only reachable while this computer is on and connected to the internet. For always-on availability, run it on a cloud VM — or keep this machine awake.",
       6,
@@ -812,6 +1019,7 @@ async function main(): Promise<void> {
     'Heads up',
   );
 
+  driver.throwIfCancelled();
   setupLog.complete(Date.now() - RUN_START);
   phEmit('setup_completed', { duration_ms: Date.now() - RUN_START });
 
@@ -819,21 +1027,65 @@ async function main(): Promise<void> {
   if (wiringPending) {
     // No welcome DM exists yet — the one remaining action is the last thing
     // on screen, in the same bright framed style as the "go say hi" banner.
-    note(
+    driver.note(
       `${brandBold('→')} ${k.bold(`Have the person you want wired DM the bot once in ${dmTarget ?? 'your chat app'} ("hi" works).`)}\nNanoClaw registers their identity and chat from that first message; then run /init-first-agent with your coding agent and pick them.`,
       "What's left",
     );
-    p.outro(k.green("You're set — one DM to go."));
+    driver.outro(k.green("You're set - one DM to go."));
   } else if (dmTarget) {
     // Bright framed banner (not dim) — the whole point of the feedback was
     // that the welcome-message signal was too easy to miss. Use p.note so it
     // renders with a visible box, cyan-bold the directive line, and put it
     // as the last thing before outro.
-    note(`${brandBold('→')} ${k.bold(`Check your ${dmTarget} — your assistant is saying hi.`)}`, 'Go say hi');
-    p.outro(k.green("You're set."));
+    driver.note(`${brandBold('→')} ${k.bold(`Check your ${dmTarget} - your assistant is saying hi.`)}`, 'Go say hi');
+    driver.outro(k.green("You're set."));
   } else {
-    p.outro(k.green("You're ready! Chat with `pnpm run chat hi`."));
+    driver.outro(k.green("You're ready! Chat with `pnpm run chat hi`."));
   }
+  driver.throwIfCancelled();
+  driver.completeSetup(setupReceipt);
+}
+
+async function completionReceipt(driver: SetupDriver): Promise<SetupReceipt> {
+  if (driver.mode === 'terminal') {
+    return {
+      version: 1,
+      service: { state: 'running', manager: 'pidfile', checkoutRoot: PROJECT_ROOT },
+      health: { status: 'healthy' },
+      resources: {
+        groups: { state: 'empty', count: 0 },
+        policies: { state: 'empty', count: 0 },
+        skills: { state: 'empty', count: 0 },
+      },
+      completedAt: new Date().toISOString(),
+    };
+  }
+  driver.throwIfCancelled();
+  const service = inspectService(PROJECT_ROOT);
+  let health = await queryHostHealth(PROJECT_ROOT, { signal: driver.cancellationSignal });
+  for (let attempt = 0; !health && attempt < 20; attempt++) {
+    driver.throwIfCancelled();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    driver.throwIfCancelled();
+    health = await queryHostHealth(PROJECT_ROOT, { signal: driver.cancellationSignal });
+  }
+  driver.throwIfCancelled();
+  const result = buildSetupReceipt(PROJECT_ROOT, service, health);
+  if (!result.ok) {
+    driver.error(
+      result.code,
+      result.message,
+      [
+        {
+          kind: 'manual',
+          title: 'Inspect the running service',
+          instructions: ['Confirm the service points at this checkout and rerun machine setup.'],
+        },
+      ],
+      'verify',
+    );
+  }
+  return result.receipt;
 }
 
 function channelDmLabel(choice: ChannelChoice): string | null {
@@ -868,7 +1120,14 @@ function channelDmLabel(choice: ChannelChoice): string | null {
  * "patient" and "is this hung?". Returns the raw result so the caller can
  * branch between the chat loop (ok) and a diagnostic note (anything else).
  */
-async function confirmAssistantResponds(): Promise<PingResult> {
+async function confirmAssistantResponds(driver: SetupDriver): Promise<PingResult> {
+  if (driver.mode === 'ndjson') {
+    driver.progress('first-chat-ping', 'running', 'Waking your assistant');
+    const result = await pingCliAgent(30_000, driver);
+    driver.throwIfCancelled();
+    driver.progress('first-chat-ping', result === 'ok' ? 'succeeded' : 'failed');
+    return result;
+  }
   const s = p.spinner();
   const start = Date.now();
   const label = 'Waking your assistant…';
@@ -886,13 +1145,17 @@ async function confirmAssistantResponds(): Promise<PingResult> {
     s.stop(`${k.bold(fitToWidth('Your assistant is ready.', suffix))}${k.dim(suffix)}`);
   } else {
     const msg =
-      result === 'socket_error' ? "Couldn't reach the NanoClaw service." : "Your assistant didn't reply in time.";
-    s.stop(`${k.bold(fitToWidth(msg, suffix))}${k.dim(suffix)}`, 1);
+      result === 'socket_error'
+        ? "Couldn't reach the NanoClaw service."
+        : result === 'output_limit'
+          ? 'Your assistant returned too much output.'
+          : "Your assistant didn't reply in time.";
+    s.error(`${k.bold(fitToWidth(msg, suffix))}${k.dim(suffix)}`);
   }
   return result;
 }
 
-function renderPingFailureNote(result: PingResult): void {
+function renderPingFailureNote(driver: SetupDriver, result: PingResult): void {
   const body =
     result === 'socket_error'
       ? [
@@ -904,11 +1167,16 @@ function renderPingFailureNote(result: PingResult): void {
           `  macOS:  launchctl kickstart -k gui/$(id -u)/${getLaunchdLabel()}`,
           `  Linux:  systemctl --user restart ${getSystemdUnit()}`,
         ].join('\n')
-      : wrapForGutter(
-          'No reply from your assistant within 30 seconds. Check `logs/nanoclaw.log` for clues, then try `pnpm run chat hi`.',
-          6,
-        );
-  note(body, 'Skipping the first chat');
+      : result === 'output_limit'
+        ? wrapForGutter(
+            'The assistant returned more output than setup can safely display. Check `logs/nanoclaw.log`, then try `pnpm run chat hi`.',
+            6,
+          )
+        : wrapForGutter(
+            'No reply from your assistant within 30 seconds. Check `logs/nanoclaw.log` for clues, then try `pnpm run chat hi`.',
+            6,
+          );
+  driver.note(body, 'Skipping the first chat');
 }
 
 /**
@@ -922,8 +1190,8 @@ function renderPingFailureNote(result: PingResult): void {
  * explain once, then offer "message or Enter to continue" so the chat is
  * clearly optional.
  */
-async function runFirstChat(): Promise<void> {
-  note(
+async function runFirstChat(driver: SetupDriver): Promise<void> {
+  driver.note(
     wrapForGutter(
       [
         'Your assistant runs in a sandbox on this machine.',
@@ -936,31 +1204,107 @@ async function runFirstChat(): Promise<void> {
     'How this works',
   );
   let first = true;
-  while (true) {
-    const answer = ensureAnswer(
-      await p.text({
+  try {
+    while (true) {
+      const answer = await textPrompt(driver, first ? 'first-chat-message' : 'first-chat-another', {
         message: first
           ? 'Try a quick hello — or press Enter to continue setup'
           : 'Another message? Press Enter to continue setup',
         placeholder: first ? 'e.g. "hi, what can you do?"' : 'press Enter to continue',
-      }),
-    );
-    first = false;
-    const text = ((answer as string | undefined) ?? '').trim();
-    if (!text) return;
-    await sendChatMessage(text);
+      });
+      first = false;
+      const text = answer.trim();
+      if (!text) return;
+      await sendChatMessage(driver, text);
+    }
+  } finally {
+    if (driver.mode === 'ndjson') driver.clearDisplay('first-chat-response');
   }
 }
 
-function sendChatMessage(message: string): Promise<void> {
-  return new Promise((resolve) => {
+function sendChatMessage(driver: SetupDriver, message: string): Promise<void> {
+  return new Promise((resolve, reject) => {
     // `pnpm --silent` suppresses the `> nanoclaw@… chat` preamble so the
     // agent's reply reads as a clean block under the prompt. Splitting on
     // whitespace mirrors `pnpm run chat hello world` — chat.ts joins argv
     // with spaces on the far side.
-    const child = spawn('pnpm', ['--silent', 'run', 'chat', ...message.split(/\s+/)], {
-      stdio: ['ignore', 'inherit', 'inherit'],
-    });
+    const child = spawn(
+      'pnpm',
+      ['--silent', 'run', 'chat', ...message.split(/\s+/)],
+      driver.mode === 'ndjson'
+        ? { stdio: ['ignore', 'pipe', 'pipe'], detached: true, env: childEnvWithoutSetupSecrets() }
+        : { stdio: ['ignore', 'inherit', 'inherit'] },
+    );
+    const stopGroup = (): void => {
+      if (driver.mode !== 'ndjson' || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    driver.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+    if (driver.cancellationSignal?.aborted) stopGroup();
+    if (driver.mode === 'ndjson') {
+      let response = '';
+      let responseBytes = 0;
+      let outputLimitExceeded = false;
+      let settled = false;
+      const append = (chunk: Buffer): void => {
+        if (outputLimitExceeded) return;
+        responseBytes += chunk.byteLength;
+        if (responseBytes > MAX_MACHINE_CHAT_OUTPUT_BYTES) {
+          outputLimitExceeded = true;
+          stopGroup();
+          return;
+        }
+        response += chunk.toString('utf8');
+      };
+      child.stdout?.on('data', (chunk: Buffer) => {
+        append(chunk);
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        append(chunk);
+      });
+      child.on('close', () => {
+        if (settled) return;
+        settled = true;
+        driver.cancellationSignal?.removeEventListener('abort', stopGroup);
+        if (outputLimitExceeded) {
+          try {
+            driver.error('first_chat_output_limit', 'The terminal chat returned more than 64 KiB of output.');
+          } catch (error) {
+            reject(error);
+          }
+          return;
+        }
+        if (response.trim()) {
+          driver.display({
+            id: 'first-chat-response',
+            kind: 'text',
+            content: response.trim(),
+            sensitive: false,
+            label: 'Assistant',
+          });
+        }
+        resolve();
+      });
+      child.on('error', () => {
+        if (settled) return;
+        settled = true;
+        driver.cancellationSignal?.removeEventListener('abort', stopGroup);
+        resolve();
+      });
+      return;
+    }
     child.on('close', () => resolve());
     child.on('error', () => resolve());
   });
@@ -982,118 +1326,128 @@ const INSTALLABLE_PROVIDERS = [
 // the operator may be rerunning precisely to change it. In-process presets
 // (--template-path, the Advanced screen, self re-execs, an exported env var)
 // keep the silent skip.
-async function runTemplateSetup(pickSavedByPreviousRun: boolean, hasRegisteredAgents: boolean): Promise<void> {
+export async function runTemplateSetup(
+  driver: SetupDriver,
+  pickSavedByPreviousRun: boolean,
+  hasRegisteredAgents: boolean,
+): Promise<void> {
   const preset = process.env.NANOCLAW_TEMPLATE_PATH?.trim();
   if (preset) {
-    if (listLocalTemplates().some((template) => template.ref === preset)) {
+    if (listLocalTemplates(driver).some((template) => template.ref === preset)) {
       if (!pickSavedByPreviousRun) {
         applyTemplatePick(preset);
-        p.log.success(`Using template "${preset}".`);
+        driver.log('success', `Using template "${preset}".`);
         return;
       }
-      const resume = ensureAnswer(
-        await p.confirm({
-          message: `Continue with template "${preset}" from the previous run?`,
-          initialValue: true,
-        }),
+      const resume = await confirmPrompt(
+        driver,
+        'template-resume',
+        `Continue with template "${preset}" from the previous run?`,
+        true,
       );
       setupLog.userInput('template_resume', String(resume));
       if (resume) {
         applyTemplatePick(preset);
-        p.log.success(`Using template "${preset}".`);
+        driver.log('success', `Using template "${preset}".`);
         return;
       }
       clearTemplatePick();
-      p.log.info(
-        `If that run already stamped an agent from "${preset}", it is kept — pick it again anytime, or wire it later with /init-first-agent.`,
+      driver.log(
+        'info',
+        `If that run already stamped an agent from "${preset}", it is kept. Pick it again anytime, or wire it later with /init-first-agent.`,
       );
     } else {
       clearTemplatePick();
-      p.log.warn(`Template "${preset}" not found under ${TEMPLATES_DIR} — pick one below.`);
-      p.log.info(
-        `If a previous run already stamped an agent from "${preset}", it is kept — wire it later with /init-first-agent.`,
+      driver.log('warn', `Template "${preset}" not found under ${TEMPLATES_DIR}. Pick one below.`);
+      driver.log(
+        'info',
+        `If a previous run already stamped an agent from "${preset}", it is kept. Wire it later with /init-first-agent.`,
       );
     }
   }
 
   for (;;) {
-    const source = ensureAnswer(
-      await brightSelect<'none' | 'library' | 'local'>({
-        message: hasRegisteredAgents
-          ? 'Would you like to add or update an agent from a template?'
-          : 'How should we create your first agent?',
-        options: [
-          hasRegisteredAgents
-            ? { value: 'none', label: 'No template changes', hint: 'recommended' }
-            : { value: 'none', label: 'Fresh agent', hint: 'recommended — shape it by chatting' },
-          { value: 'library', label: 'From the NanoClaw template library', hint: 'prebuilt agents' },
-          { value: 'local', label: 'From local templates', hint: 'templates/ in this install' },
-        ],
-        initialValue: 'none',
-      }),
-    ) as 'none' | 'library' | 'local';
+    const source = await selectPrompt(driver, 'template-source', {
+      message: hasRegisteredAgents
+        ? 'Would you like to add or update an agent from a template?'
+        : 'How should we create your first agent?',
+      options: [
+        hasRegisteredAgents
+          ? { value: 'none', label: 'No template changes', hint: 'recommended' }
+          : { value: 'none', label: 'Fresh agent', hint: 'recommended - shape it by chatting' },
+        { value: 'library', label: 'From the NanoClaw template library', hint: 'prebuilt agents' },
+        { value: 'local', label: 'From local templates', hint: 'templates/ in this install' },
+      ],
+      initialValue: 'none',
+    });
     setupLog.userInput('template_source', source);
     if (source === 'none') return;
 
-    const ref = source === 'library' ? await pickLibraryTemplate() : await pickLocalTemplate();
+    const ref = source === 'library' ? await pickLibraryTemplate(driver) : await pickLocalTemplate(driver);
     if (!ref) continue;
     applyTemplatePick(ref);
     setupLog.userInput('template_ref', ref);
-    p.log.success(`Template "${ref}" selected.`);
+    driver.log('success', `Template "${ref}" selected.`);
     return;
   }
 }
 
-// listTemplatesFromDir throws the migration error for a pre-plugin layout.
-// A stale local templates/ must not abort an otherwise-working install:
-// surface the message as a warning and treat the dir as empty.
-function listLocalTemplates(): TemplateEntry[] {
+function listLocalTemplates(driver: SetupDriver): TemplateEntry[] {
   try {
     return listTemplatesFromDir(TEMPLATES_DIR);
-  } catch (err) {
-    p.log.warn(err instanceof Error ? err.message : String(err));
+  } catch (error) {
+    driver.log('warn', error instanceof Error ? error.message : String(error));
     return [];
   }
 }
 
-async function pickLibraryTemplate(): Promise<string | undefined> {
-  const spinner = p.spinner();
-  spinner.start('Fetching the template library…');
+async function pickLibraryTemplate(driver: SetupDriver): Promise<string | undefined> {
+  const spinner = driver.mode === 'terminal' ? p.spinner() : null;
+  if (spinner) spinner.start('Fetching the template library…');
+  else driver.progress('template-source', 'running', 'Fetching the template library');
   let registry: ClonedRegistry;
   try {
     registry = cloneRegistry();
-  } catch (err) {
-    spinner.stop('Could not reach the template library.');
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    if (spinner) spinner.stop('Could not reach the template library.');
+    else driver.progress('template-source', 'failed');
+    const message = error instanceof Error ? error.message : String(error);
     setupLog.step('template-source', 'interactive', 0, { source: 'library', error: message });
-    p.log.warn(message);
+    driver.log('warn', message);
     return undefined;
   }
 
   try {
     const templates = listTemplatesFromDir(registry.dir).filter((template) => template.ref !== '.');
     if (templates.length === 0) {
-      spinner.stop('The template library is empty.');
+      if (spinner) spinner.stop('The template library is empty.');
+      else driver.progress('template-source', 'succeeded', 'The template library is empty');
       return undefined;
     }
-    spinner.stop(`Found ${templates.length} template${templates.length === 1 ? '' : 's'}.`);
-    const ref = await chooseTemplate(templates);
+    if (spinner) spinner.stop(`Found ${templates.length} template${templates.length === 1 ? '' : 's'}.`);
+    else
+      driver.progress(
+        'template-source',
+        'succeeded',
+        `Found ${templates.length} template${templates.length === 1 ? '' : 's'}`,
+      );
+    const ref = await chooseTemplate(driver, templates);
     if (!ref) return undefined;
 
     const destination = path.join(TEMPLATES_DIR, ref);
     if (fs.existsSync(destination)) {
-      if (!listLocalTemplates().some((template) => template.ref === ref)) {
-        p.log.warn(`Can't install "${ref}": that path already exists but isn't a valid template.`);
+      if (!listLocalTemplates(driver).some((template) => template.ref === ref)) {
+        driver.log('warn', `Can't install "${ref}": that path already exists but is not a valid template.`);
         return undefined;
       }
-      p.log.info(`Keeping your existing local copy of "${ref}".`);
+      driver.log('info', `Keeping your existing local copy of "${ref}".`);
     } else {
       try {
         copyTemplate(registry.dir, ref, TEMPLATES_DIR);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
         setupLog.step('template-copy', 'interactive', 0, { ref, error: message });
-        p.log.warn(`Couldn't copy "${ref}" into templates/: ${message}`);
+        driver.log('warn', `Couldn't copy "${ref}" into templates/: ${message}`);
         return undefined;
       }
     }
@@ -1103,42 +1457,43 @@ async function pickLibraryTemplate(): Promise<string | undefined> {
   }
 }
 
-async function pickLocalTemplate(): Promise<string | undefined> {
-  const templates = listLocalTemplates().filter((template) => template.ref !== '.');
+async function pickLocalTemplate(driver: SetupDriver): Promise<string | undefined> {
+  const templates = listLocalTemplates(driver).filter((template) => template.ref !== '.');
   if (templates.length === 0) {
-    p.log.info(`No local templates in ${TEMPLATES_DIR}.`);
+    driver.log('info', `No local templates in ${TEMPLATES_DIR}.`);
     return undefined;
   }
-  return chooseTemplate(templates);
+  return chooseTemplate(driver, templates);
 }
 
 const BACK_TO_TEMPLATE_SOURCE = '\0back';
 
-async function chooseTemplate(templates: TemplateEntry[]): Promise<string | undefined> {
-  const ref = ensureAnswer(
-    await p.autocomplete<string>({
-      message: 'Choose a template',
-      options: [
-        ...templates.map((template) => ({
-          value: template.ref,
-          label: template.name,
-          hint: template.ref.includes('/') ? template.ref : undefined,
-        })),
-        { value: BACK_TO_TEMPLATE_SOURCE, label: '← Back' },
-      ],
-      maxItems: 5,
-      placeholder: 'type to search',
-    }),
-  ) as string;
-  return ref === BACK_TO_TEMPLATE_SOURCE ? undefined : ref;
+async function chooseTemplate(driver: SetupDriver, templates: TemplateEntry[]): Promise<string | undefined> {
+  const ref = await driver.prompt({
+    id: 'template-choice',
+    kind: 'singleChoice',
+    message: 'Choose a template',
+    choices: [
+      ...templates.map((template) => ({
+        id: template.ref,
+        label: template.name,
+        ...(template.ref.includes('/') ? { hint: template.ref } : {}),
+      })),
+      { id: BACK_TO_TEMPLATE_SOURCE, label: '← Back' },
+    ],
+    searchable: true,
+    placeholder: 'type to search',
+  });
+  return ref === BACK_TO_TEMPLATE_SOURCE ? undefined : String(ref);
 }
 
 type TemplateAgentOutcome = 'none' | 'channel-target' | 'restamped';
-type TemplateSetupOperation =
-  | TemplateOperation
-  | { kind: 'connect'; agentGroupId: string };
+type TemplateSetupOperation = TemplateOperation | { kind: 'connect'; agentGroupId: string };
 
-async function installSelectedTemplateAgent(provider?: string): Promise<TemplateAgentOutcome> {
+export async function installSelectedTemplateAgent(
+  driver: SetupDriver,
+  provider?: string,
+): Promise<TemplateAgentOutcome> {
   const ref = process.env.NANOCLAW_TEMPLATE_PATH?.trim();
   if (!ref) return 'none';
   if (process.env.NANOCLAW_TEMPLATE_AGENT_ID?.trim()) return 'channel-target';
@@ -1149,21 +1504,26 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
   const presetName = process.env.NANOCLAW_AGENT_NAME?.trim() || undefined;
   const transport = new SocketTransport();
   const runNcl = async (command: string, args: Record<string, unknown>): Promise<unknown> => {
-    const response = await transport.sendFrame({ id: randomUUID(), command, args });
+    const response = await transport.sendFrame(
+      { id: randomUUID(), command, args },
+      { signal: driver.cancellationSignal },
+    );
     if (!response.ok) throw new Error(response.error.message);
     return response.data;
   };
 
   const start = Date.now();
   phEmit('step_started', { step: 'template-agent' });
+  driver.progress('template-agent', 'running', `Preparing the "${ref}" template`);
   try {
     const agents = await listTemplateAgents(ref, runNcl);
-    const operation = await chooseTemplateOperation(ref, agents);
+    const operation = await chooseTemplateOperation(driver, ref, agents);
     if (!operation) {
       clearTemplatePick();
       setupLog.step('template-agent', 'success', Date.now() - start, { ref, cancelled: true });
       phEmit('step_completed', { step: 'template-agent', status: 'success' });
-      p.log.info('No template changes made.');
+      driver.progress('template-agent', 'succeeded');
+      driver.log('info', 'No template changes made.');
       return 'none';
     }
 
@@ -1179,39 +1539,39 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
         operation: 'connect',
       });
       phEmit('step_completed', { step: 'template-agent', status: 'success' });
-      p.log.success(`Ready to connect agent "${group.name}".`);
+      driver.progress('template-agent', 'succeeded');
+      driver.log('success', `Ready to connect agent "${group.name}".`);
       return 'channel-target';
     }
 
     const name =
       operation.kind === 'create' && agents.length > 0
-        ? await askNewTemplateAgentName(agents, presetName)
+        ? await askNewTemplateAgentName(driver, agents, presetName)
         : presetName;
 
-    p.log.step(
-      brandBody(
-        operation.kind === 'create' ? `Installing the "${ref}" template…` : `Preparing the "${ref}" template update…`,
-      ),
+    driver.progress(
+      'template-agent',
+      'running',
+      operation.kind === 'create' ? `Installing the "${ref}" template` : `Preparing the "${ref}" template update`,
     );
     const result = await installTemplateAgent({
       ref,
       operation,
       name,
-      timezone: readEnvKey('TZ') ?? undefined,
+      timezone: readEnvKey('TZ', PROJECT_ROOT) ?? undefined,
       provider,
       runNcl,
       confirmReplace: async (plan) => {
-        const resets = plan.changes.filter((c) => c.action !== 'unchanged' && c.action !== 'skip');
-        const customized = resets.filter((c) => c.customized).length;
-        const replace = ensureAnswer(
-          await p.confirm({
-            message:
-              `Agent "${plan.group.name}" is already stamped from this template. Update it in place? ` +
-              `${resets.length} plugin-owned surface${resets.length === 1 ? '' : 's'} will be reset` +
-              (customized > 0 ? ` (${customized} with local edits that will be lost)` : '') +
-              '. Provider, memory, chats, and wiring are kept.',
-            initialValue: customized === 0,
-          }),
+        const resets = plan.changes.filter((change) => change.action !== 'unchanged' && change.action !== 'skip');
+        const customized = resets.filter((change) => change.customized).length;
+        const replace = await confirmPrompt(
+          driver,
+          'template-replace',
+          `Agent "${plan.group.name}" is already stamped from this template. Update it in place? ` +
+            `${resets.length} plugin-owned surface${resets.length === 1 ? '' : 's'} will be reset` +
+            (customized > 0 ? ` (${customized} with local edits that will be lost)` : '') +
+            '. Provider, memory, chats, and wiring are kept.',
+          customized === 0,
         );
         setupLog.userInput('template_replace', String(replace));
         return replace;
@@ -1225,7 +1585,8 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
         cancelled: true,
       });
       phEmit('step_completed', { step: 'template-agent', status: 'success' });
-      p.log.info('Template update cancelled. The agent was left unchanged.');
+      driver.progress('template-agent', 'succeeded');
+      driver.log('info', 'Template update cancelled. The agent was left unchanged.');
       return 'none';
     }
 
@@ -1234,11 +1595,12 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
       agent_group_id: result.group.id,
     });
     phEmit('step_completed', { step: 'template-agent', status: 'success' });
+    driver.progress('template-agent', 'succeeded');
     if (result.status === 'updated') {
       // Restamping preserves wiring, so it has no deferred channel work and
       // must not make the channel step consume this existing agent as "new".
       clearTemplatePick();
-      p.log.success(`Template agent "${result.group.name}" updated in place.`);
+      driver.log('success', `Template agent "${result.group.name}" updated in place.`);
       return 'restamped';
     }
 
@@ -1248,17 +1610,18 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
     clearTemplatePick();
     process.env.NANOCLAW_TEMPLATE_AGENT_ID = result.group.id;
     process.env.NANOCLAW_AGENT_NAME = result.group.name;
-    p.log.success(`Template agent "${result.group.name}" created.`);
+    driver.log('success', `Template agent "${result.group.name}" created.`);
     return 'channel-target';
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     setupLog.step('template-agent', 'failed', Date.now() - start, { ref, error: message });
     phEmit('step_completed', { step: 'template-agent', status: 'failed' });
+    driver.progress('template-agent', 'failed');
     // Warn-and-continue (the ping-skip pattern): a template failure must not
     // abort an otherwise-working install. The pick stays in .env so a rerun
     // retries this template.
-    p.log.warn(`Couldn't install the "${ref}" template: ${message}`);
-    note(
+    driver.log('warn', `Couldn't install the "${ref}" template: ${message}`);
+    driver.note(
       [
         wrapForGutter('Setup continues without it; you still get a fresh default agent. To retry the template:', 6),
         '',
@@ -1274,56 +1637,60 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
 }
 
 async function chooseTemplateOperation(
+  driver: SetupDriver,
   ref: string,
   agents: readonly SetupTemplateAgent[],
 ): Promise<TemplateSetupOperation | undefined> {
   if (agents.length === 0) return { kind: 'create' };
 
+  // Choice ids are `<kind>:<agentGroupId>` so the same wire shape serves the
+  // terminal renderer and the machine protocol (which carries string ids only).
   const options = agents.flatMap((agent) => [
     ...(agent.isWired
       ? []
-      : [{
-          value: { kind: 'connect', agentGroupId: agent.id } as const,
-          label: `Connect "${agent.name}" to a channel`,
-          hint: `groups/${agent.folder} · not connected`,
-        }]),
+      : [
+          {
+            value: `connect:${agent.id}`,
+            label: `Connect "${agent.name}" to a channel`,
+            hint: `groups/${agent.folder} · not connected`,
+          },
+        ]),
     {
-      value: { kind: 'restamp', agentGroupId: agent.id } as const,
+      value: `restamp:${agent.id}`,
       label: `Update "${agent.name}" in place`,
       hint: `groups/${agent.folder} · keeps provider, memory, chats, and wiring`,
     },
   ]);
-  const choice = ensureAnswer(
-    await brightSelect<TemplateSetupOperation | { kind: 'cancel' }>({
-      message: `The "${ref}" template is already in use. What would you like to do?`,
-      options: [
-        ...options,
-        { value: { kind: 'create' }, label: 'Create another agent' },
-        { value: { kind: 'cancel' }, label: 'Cancel' },
-      ],
-      initialValue: options[0].value,
-    }),
-  ) as TemplateSetupOperation | { kind: 'cancel' };
-  setupLog.userInput(
-    'template_operation',
-    'agentGroupId' in choice ? `${choice.kind}:${choice.agentGroupId}` : choice.kind,
-  );
-  return choice.kind === 'cancel' ? undefined : choice;
+  const choice = await selectPrompt(driver, 'template-operation', {
+    message: `The "${ref}" template is already in use. What would you like to do?`,
+    options: [...options, { value: 'create', label: 'Create another agent' }, { value: 'cancel', label: 'Cancel' }],
+    initialValue: options[0].value,
+  });
+  setupLog.userInput('template_operation', choice);
+  if (choice === 'cancel') return undefined;
+  if (choice === 'create') return { kind: 'create' };
+  const separator = choice.indexOf(':');
+  const kind = choice.slice(0, separator);
+  const agentGroupId = choice.slice(separator + 1);
+  if (kind === 'connect') return { kind: 'connect', agentGroupId };
+  if (kind === 'restamp') return { kind: 'restamp', agentGroupId };
+  throw new Error(`Unknown template operation: ${choice}`);
 }
 
 async function askNewTemplateAgentName(
+  driver: SetupDriver,
   agents: readonly AgentGroup[],
   initialValue?: string,
 ): Promise<string> {
-  const answer = ensureAnswer(
-    await p.text({
-      message: 'Name the new agent',
-      placeholder: 'e.g. EMEA Sales',
-      ...(initialValue ? { initialValue } : {}),
-      validate: (value) => validateNewTemplateAgentName(value, agents),
-    }),
-  );
-  const name = (answer as string).trim();
+  const preset = initialValue?.trim() || undefined;
+  const answer = await textPrompt(driver, 'template-agent-name', {
+    message: 'Name the new agent',
+    placeholder: 'e.g. EMEA Sales',
+    ...(preset ? { default: preset } : {}),
+    // An empty answer accepts the default; anything typed must be unique.
+    validateValue: (value) => validateNewTemplateAgentName(String(value).trim() || preset, agents),
+  });
+  const name = answer.trim() || preset || '';
   setupLog.userInput('template_agent_name', name);
   return name;
 }
@@ -1341,7 +1708,7 @@ async function askNewTemplateAgentName(
  * Returns having done nothing when the question is already settled, which also
  * covers `NANOCLAW_HARDENED_IMAGE=true` passed in by a packaged flow.
  */
-async function chooseImageSource(): Promise<void> {
+async function chooseImageSource(driver: SetupDriver): Promise<void> {
   if (imageSourceDecided()) return;
 
   // The runtime pick happens later (the auth step), so this is the best signal
@@ -1353,7 +1720,8 @@ async function chooseImageSource(): Promise<void> {
     'claude'
   ).toLowerCase();
   if (plannedProvider !== 'claude') {
-    p.log.info(
+    driver.log(
+      'info',
       brandBody(
         `Building the sandbox here — the pre-built image is Claude-only, and ${plannedProvider} needs an image of its own.`,
       ),
@@ -1367,7 +1735,8 @@ async function chooseImageSource(): Promise<void> {
   // good answer cannot be honoured.
   if (!readAgentImagePin()) return;
 
-  p.log.message(
+  driver.log(
+    'message',
     brandBody(
       dimWrap(
         "Your assistant's sandbox contains a browser and a language runtime — Chromium, Node, Bun and a handful of tools. Isolation keeps a misbehaving agent away from your machine, but it does nothing about known vulnerabilities in that software itself.",
@@ -1375,7 +1744,8 @@ async function chooseImageSource(): Promise<void> {
       ),
     ),
   );
-  p.log.message(
+  driver.log(
+    'message',
     brandBody(
       dimWrap(
         'Our partner Echo (echo.ai) rebuilds those components from scratch with only the essentials and patches what remains, which takes the known-vulnerability count from thousands to near zero. Building here instead gives you the same software, straight from its public base image.',
@@ -1383,7 +1753,8 @@ async function chooseImageSource(): Promise<void> {
       ),
     ),
   );
-  p.log.message(
+  driver.log(
+    'message',
     brandBody(
       dimWrap(
         'Fetching it means authenticating with NanoClaw: we record your email address and that you fetched an image, nothing else. Building sends nothing at all.',
@@ -1392,70 +1763,74 @@ async function chooseImageSource(): Promise<void> {
     ),
   );
 
-  const choice = ensureAnswer(
-    await brightSelect<ImageSource>({
-      message: "Where should your assistant's sandbox image come from?",
-      options: [
-        {
-          value: 'hardened',
-          label: 'Fetch the hardened image, built by Echo',
-          hint: 'recommended — patched components; needs authentication',
-        },
-        {
-          value: 'local',
-          label: 'Build it here',
-          hint: 'no account, nothing recorded; takes 3-10 min',
-        },
-      ],
-      initialValue: 'hardened',
-    }),
-  ) as ImageSource;
+  const choice = await selectPrompt(driver, 'image-source', {
+    message: "Where should your assistant's sandbox image come from?",
+    options: [
+      {
+        value: 'hardened',
+        label: 'Fetch the hardened image, built by Echo',
+        hint: 'recommended - patched components; needs authentication',
+      },
+      {
+        value: 'local',
+        label: 'Build it here',
+        hint: 'no account, nothing recorded; takes 3-10 min',
+      },
+    ],
+    initialValue: 'hardened',
+  });
   setupLog.userInput('image_source', choice);
   phEmit('image_source_chosen', { source: choice });
 
   writeImageSource(choice);
   if (choice === 'local') return;
 
-  if (!loginScriptAvailable()) {
-    p.log.warn(brandBody(`This copy of NanoClaw has no ${REGISTRY_LOGIN_SCRIPT} — building the sandbox here instead.`));
-    writeImageSource('local');
-    return;
-  }
-
-  p.log.step(brandBody('Authenticating with NanoClaw…'));
-  console.log(k.dim('   (a code appears below; finish in your browser)'));
-  console.log();
+  driver.log('step', brandBody('Authenticating with NanoClaw…'));
   const start = Date.now();
-  const code = await runInheritScript('bash', [REGISTRY_LOGIN_SCRIPT]);
+  const result = await runRegistryLoginWithDriver(driver);
   const durationMs = Date.now() - start;
-  console.log();
-
-  if (code !== 0) {
-    // Falling back rather than aborting: a local build is a complete, supported
-    // install, and stranding someone at the first step because a device flow
-    // timed out would be a worse trade than the patch currency they lose.
-    // The script exits 2 for a deliberate skip, which is not a failure and
-    // should not read as one in the log.
-    const skipped = code === LOGIN_EXIT_SKIPPED;
-    setupLog.step('registry-login', skipped ? 'skipped' : 'failed', durationMs, { EXIT_CODE: code });
-    phEmit('registry_login_declined', { exit_code: code, skipped });
-    writeImageSource('local');
-    p.log.warn(
-      brandBody(
-        skipped
-          ? 'Not authenticated — building the sandbox here instead.'
-          : "Authentication didn't finish — building the sandbox here instead.",
-      ),
+  if (result.kind !== 'ready') {
+    useLocalImageAfterRegistryLogin(
+      driver,
+      result.kind === 'skipped',
+      result.kind === 'skipped' ? LOGIN_EXIT_SKIPPED : 1,
+      durationMs,
+      { REASON: result.reason },
     );
-    p.log.message(k.dim(`Re-run setup to try again, or check with \`${REGISTRY_STEP} -- --status\`.`));
     return;
   }
-
-  setupLog.step('registry-login', 'interactive', durationMs, {});
-  p.log.success(brandBody("Authenticated. Your assistant's sandbox will be fetched, not built."));
+  finishRegistryLogin(driver, durationMs, result.method);
 }
 
-async function askAgentProviderChoice(): Promise<string> {
+function useLocalImageAfterRegistryLogin(
+  driver: SetupDriver,
+  skipped: boolean,
+  exitCode: number,
+  durationMs: number,
+  fields: Record<string, string | number>,
+): void {
+  // A local build is a complete supported install, so a declined or failed
+  // registry sign-in never strands setup.
+  setupLog.step('registry-login', skipped ? 'skipped' : 'failed', durationMs, fields);
+  phEmit('registry_login_declined', { exit_code: exitCode, skipped });
+  writeImageSource('local');
+  driver.log(
+    'warn',
+    brandBody(
+      skipped
+        ? 'Not authenticated - building the sandbox here instead.'
+        : "Authentication didn't finish - building the sandbox here instead.",
+    ),
+  );
+  driver.log('message', k.dim(`Re-run setup to try again, or check with \`${REGISTRY_STEP} -- --status\`.`));
+}
+
+function finishRegistryLogin(driver: SetupDriver, durationMs: number, method?: string): void {
+  setupLog.step('registry-login', 'interactive', durationMs, method ? { METHOD: method } : {});
+  driver.log('success', brandBody("Authenticated. Your assistant's sandbox will be fetched, not built."));
+}
+
+async function askAgentProviderChoice(driver: SetupDriver): Promise<string> {
   const installed = listSetupProviders();
   const installedNames = new Set(installed.map((entry) => entry.value));
   // Offer the hard-wired installable providers this install hasn't wired yet —
@@ -1492,21 +1867,19 @@ async function askAgentProviderChoice(): Promise<string> {
   // instead of silently resetting it to claude. Fall back to claude if the
   // persisted default isn't an offered option (e.g. its provider was removed).
   const currentDefault = options.some((o) => o.value === DEFAULT_AGENT_PROVIDER) ? DEFAULT_AGENT_PROVIDER : 'claude';
-  const choice = ensureAnswer(
-    await brightSelect<string>({
-      message: 'Which agent runtime should power your assistant?',
-      options,
-      initialValue: currentDefault,
-    }),
-  ) as string;
+  const choice = await selectPrompt(driver, 'agent-provider', {
+    message: 'Which agent runtime should power your assistant?',
+    options,
+    initialValue: currentDefault,
+  });
   setupLog.userInput('agent_provider', choice);
   phEmit('agent_provider_chosen', { provider: choice });
   return choice;
 }
 
-async function runAuthStep(): Promise<void> {
+async function runAuthStep(driver: SetupDriver): Promise<void> {
   if (anthropicSecretExists()) {
-    p.log.success(brandBody('Your Claude account is already connected.'));
+    driver.log('success', brandBody('Your Claude account is already connected.'));
     setupLog.step('auth', 'skipped', 0, { REASON: 'secret-already-present' });
     return;
   }
@@ -1517,72 +1890,96 @@ async function runAuthStep(): Promise<void> {
   const customBaseUrl = process.env.NANOCLAW_ANTHROPIC_BASE_URL?.trim();
   const customAuthToken = process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN?.trim();
   if (customBaseUrl && customAuthToken) {
-    await runCustomEndpointAuth(customBaseUrl, customAuthToken);
+    registerSensitiveValue(customAuthToken);
+    await runCustomEndpointAuth(driver, customBaseUrl, customAuthToken);
     return;
   }
 
-  const method = ensureAnswer(
-    await brightSelect({
-      message: 'How would you like to connect to Claude?',
-      options: [
-        {
-          value: 'subscription',
-          label: 'Sign in with my Claude subscription',
-          hint: 'recommended if you have Pro or Max',
-        },
-        {
-          value: 'oauth',
-          label: 'Paste an OAuth token I already have',
-          hint: 'sk-ant-oat…',
-        },
-        {
-          value: 'api',
-          label: 'Paste an Anthropic API key',
-          hint: 'pay-per-use via console.anthropic.com',
-        },
-        {
-          value: 'skip',
-          label: "Skip — I'll connect later",
-          hint: 'not recommended — Claude helps debug setup issues',
-        },
-      ],
-    }),
-  ) as 'subscription' | 'oauth' | 'api' | 'skip';
+  const method = await selectPrompt(driver, 'anthropic-auth-method', {
+    message: 'How would you like to connect to Claude?',
+    options: [
+      {
+        value: 'subscription',
+        label: 'Sign in with my Claude subscription',
+        hint: 'recommended if you have Pro or Max',
+      },
+      {
+        value: 'oauth',
+        label: 'Paste an OAuth token I already have',
+        hint: 'sk-ant-oat…',
+      },
+      {
+        value: 'api',
+        label: 'Paste an Anthropic API key',
+        hint: 'pay-per-use via console.anthropic.com',
+      },
+      {
+        value: 'skip',
+        label: "Skip - I'll connect later",
+        hint: 'not recommended - Claude helps debug setup issues',
+      },
+    ],
+  });
   setupLog.userInput('auth_method', method);
   phEmit('auth_method_chosen', { method });
 
   if (method === 'skip') {
-    const confirmed = ensureAnswer(
-      await p.confirm({
-        message:
-          "Skip Claude sign-in? The agent won't be able to run until you connect, and we won't be able to help debug setup errors.",
-        initialValue: false,
-      }),
+    const confirmed = await confirmPrompt(
+      driver,
+      'anthropic-auth-skip-confirm',
+      "Skip Claude sign-in? The agent won't be able to run until you connect, and we won't be able to help debug setup errors.",
+      false,
     );
     if (!confirmed) {
       // Loop back to the auth picker so they can choose a real method.
-      return runAuthStep();
+      return runAuthStep(driver);
     }
     setupLog.step('auth', 'skipped', 0, { REASON: 'user-skipped' });
-    p.log.warn(brandBody('Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.'));
+    driver.log('warn', brandBody('Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.'));
     return;
   }
 
   if (method === 'subscription') {
-    await runSubscriptionAuth();
+    await runSubscriptionAuth(driver);
   } else {
-    await runPasteAuth(method);
+    await runPasteAuth(driver, method);
   }
 }
 
-async function runSubscriptionAuth(): Promise<void> {
-  p.log.step(brandBody('Opening the Claude sign-in flow…'));
-  console.log(k.dim('   (a browser will open for sign-in; this part is interactive)'));
-  console.log();
+async function runSubscriptionAuth(driver: SetupDriver): Promise<void> {
+  driver.log('step', brandBody('Opening the Claude sign-in flow…'));
+  if (driver.mode === 'ndjson') {
+    const start = Date.now();
+    const result = await runClaudeSubscriptionMachineAuth(driver);
+    const durationMs = Date.now() - start;
+    if (!result.ok) {
+      setupLog.step('auth', 'failed', durationMs, {
+        METHOD: 'subscription',
+        ERROR: result.reason,
+        ...(result.detail ? { DETAIL: result.detail } : {}),
+      });
+      await fail(
+        'auth',
+        "Couldn't complete the Claude sign-in.",
+        result.reason === 'spawn_failed'
+          ? 'Install the Claude CLI, then rerun setup or choose a paste option.'
+          : 'Re-run setup and try again, or choose a paste option instead.',
+        undefined,
+        driver,
+      );
+    }
+    setupLog.step('auth', 'interactive', durationMs, { METHOD: 'subscription' });
+    driver.log('success', brandBody('Claude account connected.'));
+    return;
+  }
+  if (driver.mode === 'terminal') {
+    console.log(k.dim('   (a browser will open for sign-in; this part is interactive)'));
+    console.log();
+  }
   const start = Date.now();
   const code = await runInheritScript('bash', ['setup/register-claude-token.sh']);
   const durationMs = Date.now() - start;
-  console.log();
+  if (driver.mode === 'terminal') console.log();
   if (code !== 0) {
     setupLog.step('auth', 'failed', durationMs, {
       EXIT_CODE: code,
@@ -1592,71 +1989,77 @@ async function runSubscriptionAuth(): Promise<void> {
       'auth',
       "Couldn't complete the Claude sign-in.",
       'Re-run setup and try again, or choose a paste option instead.',
+      undefined,
+      driver,
     );
   }
   setupLog.step('auth', 'interactive', durationMs, { METHOD: 'subscription' });
-  p.log.success(brandBody('Claude account connected.'));
+  driver.log('success', brandBody('Claude account connected.'));
 }
 
-async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
+async function runPasteAuth(driver: SetupDriver, method: 'oauth' | 'api'): Promise<void> {
   const label = method === 'oauth' ? 'OAuth token' : 'API key';
   const prefix = method === 'oauth' ? 'sk-ant-oat' : 'sk-ant-api';
 
-  const answer = ensureAnswer(
-    await p.password({
-      message: `Paste your ${label}`,
-      clearOnError: true,
-      validate: (v) => {
-        // Strip any internal whitespace so a line-wrapped paste that did
-        // survive into clack can still validate. The mid-token-newline
-        // case where clack only sees the first line is caught by the
-        // shape check below.
-        const cleaned = (v ?? '').replace(/\s+/g, '');
-        if (!cleaned) return 'Required';
-        if (!cleaned.startsWith(prefix)) {
-          return `Should start with ${prefix}…`;
-        }
-        if (method === 'oauth' && !/^sk-ant-oat[A-Za-z0-9_-]{80,500}AA$/.test(cleaned)) {
-          return cleaned.length < 90
-            ? 'Token looks truncated — line breaks in the paste can cut it off. Widen your terminal so the token fits on one line, then paste again.'
-            : "Token shape doesn't look right (expected sk-ant-oat…AA).";
-        }
-        return undefined;
-      },
-    }),
-  );
+  const answer = await secretPrompt(driver, `anthropic-${method}-secret`, {
+    message: `Paste your ${label}`,
+    validateValue: (answerValue) => {
+      const v = String(answerValue);
+      // Strip any internal whitespace so a line-wrapped paste that did
+      // survive into clack can still validate. The mid-token-newline
+      // case where clack only sees the first line is caught by the
+      // shape check below.
+      const cleaned = (v ?? '').replace(/\s+/g, '');
+      if (!cleaned) return 'Required';
+      if (!cleaned.startsWith(prefix)) {
+        return `Should start with ${prefix}…`;
+      }
+      if (method === 'oauth' && !/^sk-ant-oat[A-Za-z0-9_-]{80,500}AA$/.test(cleaned)) {
+        return cleaned.length < 90
+          ? 'Token looks truncated - line breaks in the paste can cut it off. Widen your terminal so the token fits on one line, then paste again.'
+          : "Token shape doesn't look right (expected sk-ant-oat…AA).";
+      }
+      return undefined;
+    },
+  });
   const token = (answer as string).replace(/\s+/g, '');
 
-  const res = await withSecretFile(token, (filePath) =>
+  const run = (childArgs: string[]): Promise<Awaited<ReturnType<typeof runQuietChild>>> =>
     runQuietChild(
       'auth',
       'onecli',
-      [
-        'secrets',
-        'create',
-        '--name',
-        'Anthropic',
-        '--type',
-        'anthropic',
-        '--file',
-        filePath,
-        '--host-pattern',
-        'api.anthropic.com',
-      ],
+      childArgs,
       {
         running: `Saving your ${label} to your OneCLI vault…`,
         done: 'Claude account connected.',
       },
       {
         extraFields: { METHOD: method },
+        ...(driver.mode === 'ndjson' ? { env: childEnvWithoutSetupSecrets() } : {}),
       },
-    ),
+      driver,
+    );
+  const res = await withSecretFile(token, (filePath) =>
+    run([
+      'secrets',
+      'create',
+      '--name',
+      'Anthropic',
+      '--type',
+      'anthropic',
+      '--file',
+      filePath,
+      '--host-pattern',
+      'api.anthropic.com',
+    ]),
   );
   if (!res.ok) {
     await fail(
       'auth',
       `Couldn't save your ${label} to the vault.`,
       'Make sure OneCLI is running (`onecli version`), then retry.',
+      undefined,
+      driver,
     );
   }
 }
@@ -1667,56 +2070,72 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
  * Authorization header on the wire — the container only ever sees
  * ANTHROPIC_BASE_URL + a placeholder bearer.
  */
-async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<void> {
+async function runCustomEndpointAuth(driver: SetupDriver, baseUrl: string, token: string): Promise<void> {
   let host: string;
+  let canonicalBaseUrl: string;
   try {
-    host = new URL(baseUrl).hostname;
+    const invalid = validateHttpUrl(baseUrl);
+    if (invalid) throw new Error(invalid);
+    const parsed = new URL(baseUrl);
+    host = parsed.hostname;
+    canonicalBaseUrl = parsed.toString();
   } catch {
-    await fail('auth', `Invalid Anthropic base URL: ${baseUrl}`, 'Check --anthropic-base-url and retry.');
+    await fail(
+      'auth',
+      `Invalid Anthropic base URL: ${baseUrl}`,
+      'Check --anthropic-base-url and retry.',
+      undefined,
+      driver,
+    );
     return;
   }
 
-  const res = await withSecretFile(token, (filePath) =>
+  const args = (filePath: string): string[] => [
+    'secrets',
+    'create',
+    '--name',
+    'Anthropic',
+    '--type',
+    'generic',
+    '--file',
+    filePath,
+    '--host-pattern',
+    host,
+    '--header-name',
+    'Authorization',
+    '--value-format',
+    'Bearer {value}',
+  ];
+  const run = (childArgs: string[]): Promise<Awaited<ReturnType<typeof runQuietChild>>> =>
     runQuietChild(
       'auth',
       'onecli',
-      [
-        'secrets',
-        'create',
-        '--name',
-        'Anthropic',
-        '--type',
-        'generic',
-        '--file',
-        filePath,
-        '--host-pattern',
-        host,
-        '--header-name',
-        'Authorization',
-        '--value-format',
-        'Bearer {value}',
-      ],
+      childArgs,
       {
         running: `Saving your Anthropic auth token to your OneCLI vault…`,
         done: 'Claude account connected.',
       },
       {
         extraFields: { METHOD: 'custom-endpoint', HOST: host },
+        ...(driver.mode === 'ndjson' ? { env: childEnvWithoutSetupSecrets() } : {}),
       },
-    ),
-  );
+      driver,
+    );
+  const res = await withSecretFile(token, (filePath) => run(args(filePath)));
   if (!res.ok) {
     await fail(
       'auth',
       `Couldn't save your Anthropic auth token to the vault.`,
       'Make sure OneCLI is running (`onecli version`), then retry.',
+      undefined,
+      driver,
     );
   }
 
   // ANTHROPIC_BASE_URL has to be in .env so the runtime provider config
   // reads it when building container env. The token is *not* written —
   // OneCLI holds it.
-  writeEnvLine('ANTHROPIC_BASE_URL', baseUrl);
+  writeEnvLine('ANTHROPIC_BASE_URL', canonicalBaseUrl);
 
   // Register the claude provider so the runtime passes ANTHROPIC_BASE_URL
   // and the placeholder bearer into the container. Only appended when the
@@ -1726,7 +2145,7 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
 }
 
 function writeEnvLine(key: string, value: string): void {
-  const envFile = path.join(process.cwd(), '.env');
+  const envFile = path.join(PROJECT_ROOT, '.env');
   const content = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf-8') : '';
   const re = new RegExp(`^${key}=.*$`, 'm');
   const next = re.test(content)
@@ -1736,7 +2155,7 @@ function writeEnvLine(key: string, value: string): void {
 }
 
 function appendProviderImport(modulePath: string): void {
-  const file = path.join(process.cwd(), 'src', 'providers', 'index.ts');
+  const file = path.join(PROJECT_ROOT, 'src', 'providers', 'index.ts');
   const content = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
   const line = `import '${modulePath}';`;
   if (content.includes(line)) return;
@@ -1752,13 +2171,18 @@ function appendProviderImport(modulePath: string): void {
  * the usual `--step timezone -- --tz <zone>` path. Free-text answers get
  * a headless `claude -p` pass to resolve them to a real IANA zone.
  */
-async function runTimezoneStep(): Promise<void> {
-  const res = await runQuietStep('timezone', {
-    running: 'Checking your timezone…',
-    done: 'Timezone set.',
-  });
+async function runTimezoneStep(driver: SetupDriver): Promise<void> {
+  const res = await runQuietStep(
+    'timezone',
+    {
+      running: 'Checking your timezone…',
+      done: 'Timezone set.',
+    },
+    [],
+    driver,
+  );
   if (!res.ok && res.terminal?.fields.NEEDS_USER_INPUT !== 'true') {
-    await fail('timezone', "Couldn't determine your timezone.");
+    await fail('timezone', "Couldn't determine your timezone.", undefined, undefined, driver);
   }
 
   const fields = res.terminal?.fields ?? {};
@@ -1773,11 +2197,11 @@ async function runTimezoneStep(): Promise<void> {
   //     persisting — users shouldn't be surprised the agent "already knew"
   //     their timezone from system settings they didn't think about.
   if (!needsInput && !isUtc && resolvedTz && resolvedTz !== 'none') {
-    const confirmed = ensureAnswer(
-      await p.confirm({
-        message: `I detected ${resolvedTz} from your computer settings. Is that right?`,
-        initialValue: true,
-      }),
+    const confirmed = await confirmPrompt(
+      driver,
+      'timezone-detected-confirm',
+      `I detected ${resolvedTz} from your computer settings. Is that right?`,
+      true,
     );
     setupLog.userInput('timezone_confirm_detected', String(confirmed));
     if (confirmed) return;
@@ -1793,41 +2217,39 @@ async function runTimezoneStep(): Promise<void> {
   // straight to the free-text prompt — the user already said "not that".
   let choice: 'keep' | 'answer' = 'answer';
   if (needsInput || isUtc) {
-    choice = ensureAnswer(
-      await brightSelect({
-        message,
-        options: needsInput
-          ? [
-              { value: 'answer', label: "I'll tell you where I am" },
-              { value: 'keep', label: 'Leave it as UTC' },
-            ]
-          : [
-              { value: 'keep', label: 'Keep UTC', hint: 'remote server / happy with UTC' },
-              { value: 'answer', label: "I'm somewhere else" },
-            ],
-      }),
-    ) as 'keep' | 'answer';
+    choice = await selectPrompt(driver, 'timezone-choice', {
+      message,
+      options: needsInput
+        ? [
+            { value: 'answer', label: "I'll tell you where I am" },
+            { value: 'keep', label: 'Leave it as UTC' },
+          ]
+        : [
+            { value: 'keep', label: 'Keep UTC', hint: 'remote server / happy with UTC' },
+            { value: 'answer', label: "I'm somewhere else" },
+          ],
+    });
     setupLog.userInput('timezone_choice', choice);
   }
 
   if (choice === 'keep') return;
 
-  const answer = ensureAnswer(
-    await p.text({
-      message: 'Where are you? (city, region, or IANA zone)',
-      placeholder: 'e.g. New York, London, Asia/Tokyo',
-      validate: (v) => (v && v.trim() ? undefined : 'Required'),
-    }),
-  );
+  const answer = await textPrompt(driver, 'timezone-location', {
+    message: 'Where are you? (city, region, or IANA zone)',
+    placeholder: 'e.g. New York, London, Asia/Tokyo',
+    validation: { required: true },
+    validateValue: (value) => (String(value).trim() ? undefined : 'Required'),
+  });
   const raw = (answer as string).trim();
   setupLog.userInput('timezone_input', raw);
 
   let tz: string | null = isValidTimezone(raw) ? raw : null;
   if (!tz) {
-    if (claudeCliAvailable()) {
-      tz = await resolveTimezoneViaClaude(raw);
+    if (claudeCliAvailable(driver)) {
+      tz = await resolveTimezoneViaClaude(raw, driver);
     } else {
-      p.log.warn(
+      driver.log(
+        'warn',
         brandBody(
           wrapForGutter(
             "That's not a standard IANA zone and I can't call Claude to interpret it here — try again with a zone like `America/New_York` or `Europe/London`.",
@@ -1841,18 +2263,17 @@ async function runTimezoneStep(): Promise<void> {
   if (!tz) {
     // One retry with a direct-IANA ask; if that fails too, leave the
     // previously-detected value in .env and move on rather than looping.
-    const retryAnswer = ensureAnswer(
-      await p.text({
-        message: 'Enter an IANA timezone string',
-        placeholder: 'e.g. America/New_York',
-        validate: (v) => {
-          const s = (v ?? '').trim();
-          if (!s) return 'Required';
-          if (!isValidTimezone(s)) return 'Not a valid IANA zone';
-          return undefined;
-        },
-      }),
-    );
+    const retryAnswer = await textPrompt(driver, 'timezone-iana', {
+      message: 'Enter an IANA timezone string',
+      placeholder: 'e.g. America/New_York',
+      validation: { required: true },
+      validateValue: (value) => {
+        const s = String(value).trim();
+        if (!s) return 'Required';
+        if (!isValidTimezone(s)) return 'Not a valid IANA zone';
+        return undefined;
+      },
+    });
     tz = (retryAnswer as string).trim();
     setupLog.userInput('timezone_retry', tz);
   }
@@ -1864,61 +2285,62 @@ async function runTimezoneStep(): Promise<void> {
       done: `Timezone set to ${tz}.`,
     },
     ['--tz', tz],
+    driver,
   );
   if (!persist.ok) {
-    await fail('timezone', `Couldn't save timezone ${tz}.`);
+    await fail('timezone', `Couldn't save timezone ${tz}.`, undefined, undefined, driver);
   }
 }
 
 // ─── prompts owned by the sequencer ────────────────────────────────────
 
-async function askDisplayName(fallback: string): Promise<string> {
-  const answer = ensureAnswer(
-    await p.text({
-      message: `What should your assistant call ${accentGreen('you')}?`,
-      placeholder: fallback,
-      defaultValue: fallback,
-    }),
-  );
+async function askDisplayName(driver: SetupDriver, fallback: string): Promise<string> {
+  const answer = await textPrompt(driver, 'display-name', {
+    message: `What should your assistant call ${accentGreen('you')}?`,
+    placeholder: fallback,
+    default: fallback,
+  });
   const value = (answer as string).trim() || fallback;
   setupLog.userInput('display_name', value);
   return value;
 }
 
-async function askChannelChoice(): Promise<ChannelChoice> {
-  const choice = ensureAnswer(
-    await brightSelect<ChannelChoice>({
-      message: 'Want to chat with your assistant from your phone?',
-      options: [
-        { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
-        { value: 'teams', label: 'Yes, connect Microsoft Teams' },
-        { value: 'telegram', label: 'Yes, connect Telegram' },
-        { value: 'discord', label: 'Yes, connect Discord' },
-        { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
-        { value: 'dial', label: 'Yes, connect Dial', hint: 'a dedicated phone number for your agent — place calls, SMS — worldwide' },
-        {
-          value: 'signal',
-          label: 'Yes, connect Signal',
-          hint: 'needs signal-cli installed',
-        },
-        {
-          value: 'imessage',
-          label: 'Yes, connect iMessage',
-          hint: 'local Mac or hosted iMessage (via photon.codes)',
-        },
-        { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
-        { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
-      ],
-    }),
-  );
+async function askChannelChoice(driver: SetupDriver): Promise<ChannelChoice> {
+  const choice = await selectPrompt(driver, 'channel-choice', {
+    message: 'Want to chat with your assistant from your phone?',
+    options: [
+      { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
+      { value: 'teams', label: 'Yes, connect Microsoft Teams' },
+      { value: 'telegram', label: 'Yes, connect Telegram' },
+      { value: 'discord', label: 'Yes, connect Discord' },
+      { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
+      {
+        value: 'dial',
+        label: 'Yes, connect Dial',
+        hint: 'a dedicated phone number for your agent — place calls, SMS — worldwide',
+      },
+      {
+        value: 'signal',
+        label: 'Yes, connect Signal',
+        hint: 'needs signal-cli installed',
+      },
+      {
+        value: 'imessage',
+        label: 'Yes, connect iMessage',
+        hint: 'local Mac or hosted iMessage (via photon.codes)',
+      },
+      { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
+      { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
+    ],
+  });
   setupLog.userInput('channel_choice', String(choice));
   phEmit('channel_chosen', { channel: String(choice) });
   return choice;
 }
 
-async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELECTION> {
-  const action = ensureAnswer(
-    await brightSelect<'type' | 'back'>({
+async function askOtherChannelName(driver: SetupDriver): Promise<void | typeof BACK_TO_CHANNEL_SELECTION> {
+  if (driver.mode === 'terminal') {
+    const action = await selectPrompt(driver, 'other-channel-action', {
       message: 'Which channel would you like to install?',
       options: [
         {
@@ -1929,23 +2351,22 @@ async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELE
         { value: 'back', label: '← Back to channel selection' },
       ],
       initialValue: 'type',
-    }),
-  );
-  if (action === 'back') return BACK_TO_CHANNEL_SELECTION;
+    });
+    if (action === 'back') return BACK_TO_CHANNEL_SELECTION;
+  }
 
-  const answer = ensureAnswer(
-    await p.text({
-      message: 'Channel name',
-      placeholder: 'e.g. matrix, github, linear, webex',
-    }),
-  );
+  const answer = await textPrompt(driver, 'other-channel-name', {
+    message: 'Channel name',
+    placeholder: 'e.g. matrix, github, linear, webex',
+  });
   const name = (answer as string)
     .trim()
     .toLowerCase()
     .replace(/^\/?(add-)?/, '');
   setupLog.userInput('other_channel', name);
   phEmit('channel_other_named', { channel: name });
-  p.log.info(
+  driver.log(
+    'info',
     brandBody(
       wrapForGutter(
         `No bash installer for ${k.bold(name)} — open Claude Code after setup and run ${k.bold(`/add-${name}`)} to install it.`,
@@ -1956,6 +2377,125 @@ async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELE
 }
 
 // ─── interactive / env helpers ─────────────────────────────────────────
+
+type ContainerRuntimeStatus = 'ready' | 'missing' | 'stopped' | 'permission' | 'other';
+
+function containerRuntimeStatus(): ContainerRuntimeStatus {
+  const result = spawnSync('docker', ['info'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') return 'missing';
+  if (result.status === 0) return 'ready';
+  const output = `${result.stderr ?? ''}\n${result.stdout ?? ''}`;
+  if (/permission denied/i.test(output)) return 'permission';
+  if (/cannot connect|is the docker daemon running|no such file/i.test(output)) return 'stopped';
+  return 'other';
+}
+
+async function waitForContainerRuntime(): Promise<boolean> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    if (containerRuntimeStatus() === 'ready') return true;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  return false;
+}
+
+async function ensureMachineContainerRuntime(driver: SetupDriver): Promise<void> {
+  if (driver.mode !== 'ndjson') return;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const status = containerRuntimeStatus();
+    if (status === 'ready') return;
+    if (status === 'missing') {
+      driver.error('container_runtime_required', 'Docker must be installed before setup can continue.', [
+        {
+          kind: 'manual',
+          title: 'Install Docker',
+          instructions: ['Install Docker Desktop on macOS or Docker Engine on Linux, then rerun setup.'],
+        },
+      ]);
+    }
+    if (status === 'stopped') {
+      const action =
+        process.platform === 'darwin'
+          ? {
+              id: 'start-docker',
+              kind: 'startApplication' as const,
+              title: 'Start Docker Desktop',
+              application: 'Docker',
+            }
+          : null;
+      if (!action)
+        driver.error('container_runtime_not_started', 'Docker must be running before setup can continue.', [
+          {
+            kind: 'manual',
+            title: 'Start Docker',
+            instructions: ['Start the Docker service in a terminal, then rerun setup.'],
+          },
+        ]);
+      const result = await driver.externalAction(action, waitForContainerRuntime);
+      if (result === 'attempted') continue;
+      driver.error('container_runtime_not_started', 'Docker must be running before setup can continue.', [
+        { kind: 'manual', title: 'Start Docker', instructions: ['Start Docker Desktop, then rerun setup.'] },
+      ]);
+    }
+    if (status === 'permission') {
+      const user = process.env.USER?.trim();
+      const groups = user
+        ? (spawnSync('id', ['-nG', user], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).stdout ?? '')
+        : '';
+      if (groups.split(/\s+/).includes('docker')) maybeReexecUnderSg(driver);
+      driver.error('container_runtime_permission', 'This login session cannot access Docker yet.', [
+        {
+          kind: 'manual',
+          title: 'Refresh Docker group membership',
+          instructions: ['Add your user to the docker group if needed.', 'Log out and back in, then rerun setup.'],
+        },
+      ]);
+    }
+    driver.error('container_runtime_unavailable', 'Docker is installed but its status could not be verified.', [
+      {
+        kind: 'manual',
+        title: 'Check Docker',
+        instructions: ['Run docker info in a terminal, fix the reported problem, then rerun setup.'],
+      },
+    ]);
+  }
+  driver.error('container_runtime_unavailable', 'Docker did not become ready.');
+}
+
+async function ensureMachineServicePermissions(driver: SetupDriver): Promise<void> {
+  if (driver.mode !== 'ndjson' || process.platform !== 'linux' || process.getuid?.() === 0) return;
+  if (spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' }).status !== 0) return;
+  if (containerRuntimeStatus() !== 'ready') return;
+  const probe = (): boolean =>
+    spawnSync('systemd-run', ['--user', '--pipe', '--wait', 'docker', 'info'], { stdio: 'ignore' }).status === 0;
+  if (probe() || spawnSync('which', ['setfacl'], { stdio: 'ignore' }).status !== 0) return;
+  const user = process.env.USER?.trim();
+  if (!user) driver.error('service_permission_unknown_user', 'Could not determine the user for Docker socket access.');
+  driver.error('service_permission_required', 'The service cannot access Docker in machine mode.', [
+    {
+      kind: 'manual',
+      title: 'Grant Docker socket access',
+      instructions: [`Run setfacl for ${user} in a terminal, then rerun setup.`],
+    },
+  ]);
+}
+
+async function rebuildProviderImage(driver: SetupDriver): Promise<ReturnType<typeof buildContainerImage>> {
+  const result = await runQuietChild(
+    'provider-image-build',
+    path.join(PROJECT_ROOT, 'container', 'build.sh'),
+    [],
+    { running: 'Rebuilding the sandbox image…', done: 'Sandbox image rebuilt.' },
+    undefined,
+    driver,
+  );
+  return result.ok
+    ? { ok: true }
+    : {
+        ok: false,
+        message: `The container image build failed (exit ${result.exitCode}).`,
+        hint: `Inspect ${result.rawLog}, fix Docker or the build input, then retry.`,
+      };
+}
 
 function ensureLocalBinOnPath(): void {
   const localBin = path.join(os.homedir(), '.local', 'bin');
@@ -2025,7 +2565,7 @@ function detectExistingOnecli(): { version: string; apiHost: string } | null {
  * daemon is up. Detect that and re-exec the whole driver under `sg docker`
  * so the rest of the run inherits the docker group without a re-login.
  */
-function maybeReexecUnderSg(): void {
+function maybeReexecUnderSg(driver: SetupDriver): void {
   if (process.env.NANOCLAW_REEXEC_SG === '1') return;
   if (process.platform !== 'linux') return;
   const info = spawnSync('docker', ['info'], { encoding: 'utf-8' });
@@ -2034,27 +2574,34 @@ function maybeReexecUnderSg(): void {
   if (!/permission denied/i.test(err)) return;
   if (spawnSync('which', ['sg'], { stdio: 'ignore' }).status !== 0) return;
 
-  p.log.warn(brandBody('Docker socket not accessible in current group. Re-executing under `sg docker`.'));
+  driver.log('warn', brandBody('Docker socket not accessible in current group. Re-executing under `sg docker`.'));
   const existingSkip = (process.env.NANOCLAW_SKIP ?? '')
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
   const skipList = [...new Set([...existingSkip, ...setupLog.completedStepNames()])].join(',');
-  const res = spawnSync('sg', ['docker', '-c', 'pnpm run setup:auto'], {
+  if (driver.mode === 'ndjson') driver.handoff();
+  const command = driver.mode === 'ndjson' ? 'exec ./node_modules/.bin/tsx setup/auto.ts' : 'pnpm run setup:auto';
+  const res = spawnSync('sg', ['docker', '-c', command], {
     stdio: 'inherit',
-    env: { ...process.env, NANOCLAW_REEXEC_SG: '1', ...(skipList ? { NANOCLAW_SKIP: skipList } : {}) },
+    env: {
+      ...process.env,
+      NANOCLAW_REEXEC_SG: '1',
+      ...(driver.mode === 'ndjson' ? { NANOCLAW_DRIVER_CONTINUATION: '1' } : {}),
+      ...(skipList ? { NANOCLAW_SKIP: skipList } : {}),
+    },
   });
   process.exit(res.status ?? 1);
 }
 
 // ─── intro + progression-log init ──────────────────────────────────────
 
-function printIntro(): void {
+function printIntro(driver: SetupDriver): void {
   const isReexec = process.env.NANOCLAW_REEXEC_SG === '1';
   const wordmark = `${k.bold('Nano')}${brandBold('Claw')}`;
 
   if (isReexec) {
-    p.intro(`${brandChip(' Welcome ')}  ${wordmark}  ${k.dim('· picking up where we left off')}`);
+    driver.intro(`${brandChip(' Welcome ')}  ${wordmark}  ${k.dim('· picking up where we left off')}`);
     return;
   }
 
@@ -2062,7 +2609,7 @@ function printIntro(): void {
   // welcome framing alone so the two don't double up. Standalone runs of
   // setup:auto still see this as the first line — fine without the wordmark
   // since the line itself signals the start of the flow.
-  p.intro("Let's get you set up.");
+  driver.intro("Let's get you set up.");
 }
 
 /**
@@ -2076,6 +2623,7 @@ function initProgressionLog(): void {
   let commit = '';
   try {
     commit = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: PROJECT_ROOT,
       encoding: 'utf-8',
     }).stdout.trim();
   } catch {
@@ -2084,6 +2632,7 @@ function initProgressionLog(): void {
   let branch = '';
   try {
     branch = spawnSync('git', ['branch', '--show-current'], {
+      cwd: PROJECT_ROOT,
       encoding: 'utf-8',
     }).stdout.trim();
   } catch {
@@ -2092,14 +2641,45 @@ function initProgressionLog(): void {
   setupLog.reset({
     invocation: 'setup:auto (standalone)',
     user: process.env.USER ?? 'unknown',
-    cwd: process.cwd(),
+    cwd: PROJECT_ROOT,
     branch: branch || 'unknown',
     commit: commit || 'unknown',
   });
 }
 
-main().catch((err) => {
-  p.log.error(err instanceof Error ? err.message : String(err));
-  p.cancel('Setup aborted.');
-  process.exit(1);
-});
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  const rootDriver = createSetupDriver(
+    process.argv.includes('--uninstall') || process.env.NANOCLAW_OPERATION === 'uninstall' ? 'uninstall' : 'setup',
+  );
+
+  main(rootDriver).catch((err) => {
+    if (err instanceof DriverCancelled) {
+      rootDriver.cancelled();
+      process.exitCode = rootDriver.mode === 'ndjson' ? 2 : 0;
+      return;
+    }
+    if (err instanceof DriverTerminalError) {
+      process.exitCode = err.exitCode;
+      return;
+    }
+    if (rootDriver.mode === 'ndjson') {
+      try {
+        rootDriver.error('unexpected_error', err instanceof Error ? err.message : String(err), [
+          {
+            kind: 'rerun',
+            args:
+              rootDriver.operation === 'uninstall'
+                ? ['--uninstall', '--protocol', 'nanoclaw.driver.v1']
+                : ['--protocol', 'nanoclaw.driver.v1'],
+          },
+        ]);
+      } catch {
+        process.exitCode = 1;
+      }
+      return;
+    }
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.cancel('Setup aborted.');
+    process.exitCode = 1;
+  });
+}

--- a/setup/catalog-preseeds.test.ts
+++ b/setup/catalog-preseeds.test.ts
@@ -14,12 +14,12 @@ describe('--catalog-preseeds', () => {
         'nanoclaw.sh',
         'setup/catalog-preseeds.ts',
         'setup/lib/setup-config.ts',
-        'setup/providers/index.ts',
         'setup/providers/registry.ts',
       ]) {
         fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
         fs.copyFileSync(path.join(process.cwd(), file), path.join(root, file));
       }
+      fs.writeFileSync(path.join(root, 'setup', 'providers', 'index.ts'), '');
       fs.symlinkSync(path.join(process.cwd(), 'node_modules'), path.join(root, 'node_modules'));
 
       const result = spawnSync('bash', ['nanoclaw.sh', '--catalog-preseeds'], {

--- a/setup/catalog-preseeds.test.ts
+++ b/setup/catalog-preseeds.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import { describe, expect, it } from 'vitest';
+
+describe('--catalog-preseeds', () => {
+  it('prints the UI preseed contract before setup can mutate the checkout', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-preseeds-'));
+    try {
+      fs.mkdirSync(path.join(root, 'setup', 'lib'), { recursive: true });
+      for (const file of [
+        'nanoclaw.sh',
+        'setup/catalog-preseeds.ts',
+        'setup/lib/setup-config.ts',
+        'setup/providers/index.ts',
+        'setup/providers/registry.ts',
+      ]) {
+        fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+        fs.copyFileSync(path.join(process.cwd(), file), path.join(root, file));
+      }
+      fs.symlinkSync(path.join(process.cwd(), 'node_modules'), path.join(root, 'node_modules'));
+
+      const result = spawnSync('bash', ['nanoclaw.sh', '--catalog-preseeds'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      const catalog = JSON.parse(result.stdout) as {
+        preseeds: Array<{
+          key: string;
+          kind: string;
+          default: unknown;
+          options: Array<unknown>;
+          validation: unknown;
+        }>;
+      };
+      expect(catalog.preseeds.map((entry) => entry.key).sort()).toEqual(
+        [
+          'agentName',
+          'agentProvider',
+          'anthropicAuthToken',
+          'anthropicBaseUrl',
+          'displayName',
+          'hardenedImage',
+          'onecliApiHost',
+          'onecliApiToken',
+          'skip',
+          'templatePath',
+        ].sort(),
+      );
+      expect(catalog.preseeds.every((entry) => entry.kind && Array.isArray(entry.options))).toBe(true);
+      expect(
+        catalog.preseeds
+          .find((entry) => entry.key === 'agentProvider')
+          ?.options.map((option) => (option as { value: string }).value),
+      ).toEqual(['claude', 'codex']);
+      expect(catalog.preseeds.find((entry) => entry.key === 'hardenedImage')?.options).toEqual([true, false]);
+      expect(catalog.preseeds.find((entry) => entry.key === 'onecliApiHost')?.default).toBeNull();
+      expect(catalog.preseeds.find((entry) => entry.key === 'onecliApiHost')?.validation).toEqual({
+        kind: 'httpUrl',
+        message: 'Must be http(s)://…',
+      });
+      expect(fs.existsSync(path.join(root, 'logs'))).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/catalog-preseeds.ts
+++ b/setup/catalog-preseeds.ts
@@ -1,0 +1,39 @@
+import { CONFIG, envVarFor, flagFor, type Entry } from './lib/setup-config.js';
+import './providers/index.js';
+import { listSetupProviderChoices } from './providers/registry.js';
+
+function catalogEntry(entry: Entry) {
+  return {
+    key: entry.key,
+    envVar: envVarFor(entry),
+    flag: flagFor(entry),
+    kind: entry.type,
+    label: entry.label,
+    help: entry.help,
+    group: entry.group ?? null,
+    secret: entry.secret ?? false,
+    default: entry.default ?? null,
+    options:
+      entry.key === 'agentProvider'
+        ? listSetupProviderChoices()
+        : entry.type === 'enum'
+          ? entry.options
+          : entry.type === 'boolean'
+            ? [true, false]
+            : [],
+    validation:
+      entry.type === 'string' || entry.type === 'url'
+        ? (entry.validation ?? null)
+        : entry.type === 'integer'
+          ? { min: entry.min ?? null, max: entry.max ?? null }
+          : null,
+  };
+}
+
+process.stdout.write(
+  `${JSON.stringify(
+    { preseeds: CONFIG.filter((entry) => entry.surface === 'flag+ui' || entry.preseed).map(catalogEntry) },
+    null,
+    2,
+  )}\n`,
+);

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -23,6 +23,9 @@ vi.mock('../lib/bright-select.js', async (importActual) => {
 
 afterEach(() => delete process.env.NANOCLAW_TEMPLATE_AGENT_ID);
 
+const renderedCommand = (command: string, args: string[] = []): string =>
+  command.replace(/\$\{(\d+)\}/g, (_match, index: string) => args[Number(index) - 1] ?? '');
+
 // Drives the real add-slack skill through the adapter with every side effect
 // injected (no real ncl/git/clack/init-first-agent): confirms it runs the skill
 // (install + creds + resolve), reads the resolved owner_handle + platform_id from
@@ -37,7 +40,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
 
     const cmds: string[] = [];
-    const exec = (c: string): string | void => {
+    const exec = (command: string, args: string[] = []): string | void => {
+      const c = renderedCommand(command, args);
       cmds.push(c);
       if (c.includes('auth.test')) return '@bot in Acme\n'; // identity capture
       // the resolve run: conversations.open piped through jq → "slack:<channel>"
@@ -107,7 +111,8 @@ describe('runChannelSkill adapter (Option A)', () => {
 
     await runChannelSkill('teams', 'Acme Corp', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'yes'; // the have_creds probe
       },
@@ -204,7 +209,8 @@ describe('runChannelSkill adapter (Option A)', () => {
 
     const res = await runSkill('.claude/skills/add-teams', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'no'; // the have_creds probe: nothing configured yet
         if (c.includes(' app create ')) {
@@ -266,7 +272,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     expect(
       log.some(
         (c) =>
-          c.includes(' app update tapp-123') &&
+          c.includes(' app update ') &&
+          c.includes('tapp-123') &&
           c.includes('--color-icon setup/assets/teams/color.png') &&
           c.includes('--outline-icon setup/assets/teams/outline.png'),
       ),
@@ -317,7 +324,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     const log: string[] = [];
     const res = await runSkill('.claude/skills/add-teams', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'no';
         if (c.includes(' app create ')) {
@@ -376,7 +384,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     const log: string[] = [];
     const res = await runSkill('.claude/skills/add-teams', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'no'; // probe first — it also contains "echo yes"
         if (c.trim() === 'echo yes') return 'yes'; // the logged-in-account rebind

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -27,6 +27,7 @@ import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../
 import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
 import { channelsRemote, hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
+import type { SetupDriver } from '../lib/setup-driver.js';
 import { clearTemplatePick } from '../templates.js';
 import { getChannelPreStep, getCompanionSkills } from './companions.js';
 
@@ -178,9 +179,18 @@ interface WireArgs {
   engagePattern?: string;
 }
 
-export async function resolveAgentName(): Promise<string> {
+export async function resolveAgentName(driver?: SetupDriver): Promise<string> {
   const preset = process.env.NANOCLAW_AGENT_NAME?.trim();
   if (preset) return preset;
+  if (driver) {
+    const answer = await driver.prompt({
+      kind: 'text',
+      message: 'What should your assistant be called?',
+      placeholder: DEFAULT_AGENT_NAME,
+      default: DEFAULT_AGENT_NAME,
+    });
+    return String(answer).trim() || DEFAULT_AGENT_NAME;
+  }
   const answer = ensureAnswer(
     await p.text({
       message: 'What should your assistant be called?',
@@ -192,7 +202,7 @@ export async function resolveAgentName(): Promise<string> {
 }
 
 /** The shared wire: init-first-agent (group + owner role + cli_scope + wiring + /welcome). */
-async function initFirstAgent(args: WireArgs): Promise<boolean> {
+async function initFirstAgent(args: WireArgs, driver?: SetupDriver): Promise<boolean> {
   const res = await runQuietChild(
     'init-first-agent',
     'pnpm',
@@ -217,6 +227,7 @@ async function initFirstAgent(args: WireArgs): Promise<boolean> {
     ],
     { running: `Wiring ${args.agentName} to your ${args.channel} DMs…`, done: 'Agent wired.' },
     { extraFields: { CHANNEL: args.channel, AGENT_NAME: args.agentName, PLATFORM_ID: args.platformId } },
+    driver,
   );
   return res.ok;
 }
@@ -263,25 +274,27 @@ export async function runChannelSkill(
   // First-prompt back gate — the very first thing, before any side effect
   // (agent-name/role prompts, the skill run, the wire).
   // Opt-in via offerBack so headless callers + existing tests are unaffected.
-  if (overrides.offerBack) {
+  if (overrides.offerBack && overrides.driver?.mode !== 'ndjson') {
     const label = channel.charAt(0).toUpperCase() + channel.slice(1);
     const gate = await (overrides.backGate ?? backGate)(label);
     if (gate === BACK_TO_CHANNEL_SELECTION) return BACK_TO_CHANNEL_SELECTION;
   }
 
   const projectRoot = overrides.projectRoot ?? process.cwd();
-  const failWith = overrides.fail ?? fail;
+  const failWith =
+    overrides.fail ?? ((stepName, msg, hint, rawLogPath) => fail(stepName, msg, hint, rawLogPath, overrides.driver));
   // The agent name + role are wire inputs — in wireIfResolved mode, defer the
   // prompts past the skill run (only a fresh create resolves the wire inputs;
   // a drop-through re-run asks nothing).
   const askLater = overrides.wireIfResolved;
-  let agentName = askLater ? '' : (overrides.agentName ?? (await resolveAgentName()));
-  let role = askLater ? undefined : (overrides.role ?? (await askOperatorRole(channel)));
+  let agentName = askLater ? '' : (overrides.agentName ?? (await resolveAgentName(overrides.driver)));
+  let role = askLater ? undefined : (overrides.role ?? (await askOperatorRole(channel, overrides.driver)));
 
   // Channel-specific: install adapter, collect credentials, resolve the wire
   // inputs. The whole channel-specific procedure lives in the SKILL.md.
   const res = await runSkill(`.claude/skills/add-${channel}`, {
     projectRoot,
+    driver: overrides.driver,
     exec: overrides.exec,
     resolveInput: overrides.resolveInput,
     resolveRemote: overrides.resolveRemote,
@@ -305,14 +318,18 @@ export async function runChannelSkill(
     step: overrides.step ?? `${channel}-install`,
   });
   if (!fullyApplied(res)) {
-    if (res.deferred.length) p.log.warn(`Still needs: ${res.deferred.join(', ')}`);
+    if (res.deferred.length) {
+      const warning = `Still needs: ${res.deferred.join(', ')}`;
+      if (overrides.driver) overrides.driver.log('warn', warning);
+      else p.log.warn(warning);
+    }
     // A bounced reason can carry a full stderr dump (a Node stacktrace). The
     // terminal gets ONE line per bounce — the first line, which hostExec
     // composes as `exit <code>: <first stderr line>` — and the full text goes
     // to a raw step log, written only when there's actually more than one line
     // to keep (SSF-004; the reference prose is deliberately not dumped either).
     let rawLog: string | undefined;
-    if (res.agentTasks.some((t) => t.reason.includes('\n'))) {
+    if (overrides.driver?.mode !== 'ndjson' && res.agentTasks.some((t) => t.reason.includes('\n'))) {
       rawLog = setupLog.stepRawLog(`${channel}-install-bounce`);
       writeFileSync(rawLog, res.agentTasks.map((t) => `## ${t.kind} (line ${t.line})\n${t.reason}\n`).join('\n'));
     }
@@ -322,7 +339,12 @@ export async function runChannelSkill(
         .map((l) => l.trim())
         .filter(Boolean);
       const more = lines.length > 1 ? ` (+${lines.length - 1} more lines in ${rawLog})` : '';
-      p.log.warn(`Needs an agent (${t.kind}): ${lines[0] ?? t.reason}${more}`);
+      const warning =
+        overrides.driver?.mode === 'ndjson'
+          ? `Needs an agent (${t.kind}); see the authored recovery below.`
+          : `Needs an agent (${t.kind}): ${lines[0] ?? t.reason}${more}`;
+      if (overrides.driver) overrides.driver.log('warn', warning);
+      else p.log.warn(warning);
     }
     // Surface the bounced step's OWN prose as the failure hint + Claude-handoff
     // context (fail() dims the hint and forwards it to offerClaudeOnFailure),
@@ -343,7 +365,11 @@ export async function runChannelSkill(
   await applyCompanionSkills(channel, projectRoot, overrides);
 
   // Identity confirmation captured by the skill (e.g. add-slack's auth.test).
-  if (res.vars.connected_as) p.log.success(`Connected to ${channel} as ${res.vars.connected_as}.`);
+  if (res.vars.connected_as) {
+    const message = `Connected to ${channel} as ${res.vars.connected_as}.`;
+    if (overrides.driver) overrides.driver.log('success', message);
+    else p.log.success(message);
+  }
 
   const ownerHandle = res.vars.owner_handle;
   const platformId = res.vars.platform_id;
@@ -361,13 +387,13 @@ export async function runChannelSkill(
     );
   }
   if (overrides.wireIfResolved) {
-    agentName = overrides.agentName ?? (await resolveAgentName());
-    role = overrides.role ?? (await askOperatorRole(channel));
+    agentName = overrides.agentName ?? (await resolveAgentName(overrides.driver));
+    role = overrides.role ?? (await askOperatorRole(channel, overrides.driver));
   }
 
   // Shared wire — the same procedure for every channel. role is defined here:
   // it's only undefined in an unresolved wireIfResolved run (returned above).
-  const wire = overrides.wire ?? initFirstAgent;
+  const wire = overrides.wire ?? ((args) => initFirstAgent(args, overrides.driver));
   // A skill-resolved engage pattern (WhatsApp shared-mode "@<name> only"
   // self-chat) rides along to init-first-agent's --engage-pattern; unset means
   // the wiring's own DM default applies.
@@ -414,14 +440,16 @@ export async function runChannelSkillWithPreStep(
   overrides: ChannelSkillOverrides = {},
 ): Promise<ChannelFlowResult> {
   const preStep = getChannelPreStep(channel);
-  if (!preStep) return runChannelSkill(channel, displayName, overrides);
+  // Pre-steps own terminal prompts of their own. Under the machine protocol every
+  // prompt must flow through the driver, so the manual skill path runs instead.
+  if (!preStep || overrides.driver?.mode === 'ndjson') return runChannelSkill(channel, displayName, overrides);
 
   if (overrides.offerBack) {
     const label = channel.charAt(0).toUpperCase() + channel.slice(1);
     const gate = await (overrides.backGate ?? backGate)(label);
     if (gate === BACK_TO_CHANNEL_SELECTION) return BACK_TO_CHANNEL_SELECTION;
   }
-  const agentName = overrides.agentName ?? (await resolveAgentName());
+  const agentName = overrides.agentName ?? (await resolveAgentName(overrides.driver));
   const preBound = await preStep(agentName);
   return runChannelSkill(channel, displayName, {
     ...overrides,

--- a/setup/channels/whatsapp-flow.test.ts
+++ b/setup/channels/whatsapp-flow.test.ts
@@ -37,10 +37,11 @@ async function run(inputs: Record<string, string>): Promise<Recorded> {
   const seq: Recorded['seq'] = [];
   const res = await applySkill(SKILL_DIR, root, {
     inputs,
-    exec: (cmd: string) => {
-      seq.push({ type: 'exec', text: cmd });
+    exec: (cmd: string, args: string[] = []) => {
+      const rendered = cmd.replace(/\$\{(\d+)\}/g, (_match, index: string) => args[Number(index) - 1] ?? '');
+      seq.push({ type: 'exec', text: rendered });
       if (/^(git|pnpm|bash)\b/.test(cmd) || cmd.startsWith('grep') || cmd.startsWith('touch')) return '';
-      return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
+      return execFileSync('bash', ['-c', cmd, 'nanoclaw-skill', ...args], { cwd: root, encoding: 'utf-8' });
     },
     execStream: async () => ({ ok: true, fields: { PHONE: BOT_PHONE } }),
     resolveRemote: () => 'origin',

--- a/setup/channels/wizard-hooks.test.ts
+++ b/setup/channels/wizard-hooks.test.ts
@@ -82,9 +82,12 @@ function scratchRoot(prefix: string): string {
   return root;
 }
 
-/** Exec fixture: records commands, answers the channel skill's resolve runs. */
+/** Exec fixture: records rendered commands, answers the channel skill's resolve runs. */
 function makeExec(channel: string, cmds: string[], failOn?: string) {
-  return (c: string): string | void => {
+  return (command: string, args: string[] = []): string | void => {
+    // The skill engine hands bound values separately from the command template,
+    // as double-quoted positional parameters; render them the way a shell would.
+    const c = command.replace(/"?\$\{(\d+)\}"?/g, (_match, index: string) => args[Number(index) - 1] ?? '');
     cmds.push(c);
     if (failOn && c.includes(failOn)) throw new Error(`boom: ${failOn}`);
     if (c.startsWith(`${channel}-resolve-owner`)) return 'U777\n';
@@ -261,7 +264,9 @@ describe('companion skills', () => {
     // and appended barrel imports before failing, and restarting could boot
     // that half-applied state. The operator is told to repair, then restart.
     expect(cmds.filter((c) => c === 'bash setup/lib/restart.sh')).toHaveLength(0);
-    const held = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('Skipping the deferred service restart'));
+    const held = warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('Skipping the deferred service restart'));
     expect(held).toHaveLength(1);
   });
 

--- a/setup/driver-shell.test.ts
+++ b/setup/driver-shell.test.ts
@@ -1,0 +1,456 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const ACKS = ['--driver-ack', 'low-memory', '--driver-ack', 'gce', '--driver-ack', 'root'];
+
+let fixtureRoot: string;
+
+beforeEach(() => {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-shell-'));
+  fs.mkdirSync(path.join(fixtureRoot, 'setup', 'lib'), { recursive: true });
+  fs.copyFileSync(path.join(ROOT, 'nanoclaw.sh'), path.join(fixtureRoot, 'nanoclaw.sh'));
+  fs.copyFileSync(
+    path.join(ROOT, 'setup', 'lib', 'diagnostics.sh'),
+    path.join(fixtureRoot, 'setup', 'lib', 'diagnostics.sh'),
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+function parseEvents(stdout: string): Array<Record<string, unknown>> {
+  expect(stdout[0]).toBe('{');
+  return stdout
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function driverEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, NANOCLAW_NO_DIAGNOSTICS: '1' };
+}
+
+function executable(name: string, body: string): string {
+  const file = path.join(fixtureRoot, 'fake-bin', name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+  return file;
+}
+
+async function collectShell(
+  child: ReturnType<typeof spawn>,
+  onStdout?: (chunk: string) => void,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString('utf8');
+    stdout += text;
+    onStdout?.(text);
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+  const status = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  return { status, stdout, stderr };
+}
+
+describe('nanoclaw.sh NDJSON boundary', () => {
+  it('reports missing uninstall runtime without creating setup state', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--uninstall', '--protocol', 'nanoclaw.driver.v1'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.map((event) => event.type)).toEqual(['hello', 'error']);
+    expect(events[1].code).toBe('runtime_missing');
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixtureRoot, 'data'))).toBe(false);
+  });
+
+  it('keeps terminal uninstall as the default presentation', () => {
+    const tsx = path.join(fixtureRoot, 'node_modules', '.bin', 'tsx');
+    fs.mkdirSync(path.dirname(tsx), { recursive: true });
+    fs.writeFileSync(tsx, '#!/bin/sh\nprintf \'%s\\n\' "$*" > "$PWD/tsx.args"\necho terminal-uninstall-child\n', {
+      mode: 0o755,
+    });
+
+    const result = spawnSync('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--uninstall'], {
+      cwd: fixtureRoot,
+      env: driverEnv(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('terminal-uninstall-child');
+    expect(result.stdout.trimStart().startsWith('{')).toBe(false);
+    expect(fs.readFileSync(path.join(fixtureRoot, 'tsx.args'), 'utf8').trim()).toBe(
+      `${path.join(fixtureRoot, 'setup', 'auto.ts')} --uninstall`,
+    );
+  });
+
+  it('keeps cold bootstrap output private and hands frontend stdin to TypeScript', async () => {
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'setup.sh'),
+      '#!/usr/bin/env bash\nif IFS= read -r line; then echo "unexpected-stdin:$line"; else echo stdin-closed; fi\necho bootstrap-private-output\necho "STATUS: success"\n',
+    );
+    const tsx = path.join(fixtureRoot, 'node_modules', '.bin', 'tsx');
+    fs.mkdirSync(path.dirname(tsx), { recursive: true });
+    fs.writeFileSync(
+      tsx,
+      '#!/usr/bin/env bash\nprintf \'{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"prompt","prompt":{"id":"handoff","kind":"confirm","message":"Continue?","sensitive":false}}\\n\'\nIFS= read -r _\nprintf \'{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"complete","completedAt":"2026-01-01T00:00:00.000Z"}\\n\'\n',
+    );
+    fs.chmodSync(tsx, 0o755);
+
+    const child = spawn('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS], {
+      cwd: fixtureRoot,
+      env: driverEnv(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let buffer = '';
+    const result = await collectShell(child, (chunk) => {
+      buffer += chunk;
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line && (JSON.parse(line) as { type: string }).type === 'prompt') {
+          child.stdin?.write(
+            '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"answer","promptId":"handoff","value":true}\n',
+          );
+        }
+      }
+    });
+
+    const bootstrapLog = path.join(fixtureRoot, 'logs', 'setup-steps', '01-bootstrap.log');
+    expect(
+      result.status,
+      `${result.stderr}\n${result.stdout}\n${fs.existsSync(bootstrapLog) ? fs.readFileSync(bootstrapLog, 'utf8') : ''}`,
+    ).toBe(0);
+    const events = parseEvents(result.stdout);
+    expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(events.some((event) => event.type === 'progress' && event.stepId === 'bootstrap')).toBe(true);
+    expect(events.at(-1)?.type).toBe('complete');
+    expect(result.stdout).not.toContain('bootstrap-private-output');
+    expect(result.stdout).not.toContain('stdin-closed');
+    expect(fs.readFileSync(bootstrapLog, 'utf8')).toContain('stdin-closed\nbootstrap-private-output\nSTATUS: success');
+  });
+
+  it('SIGKILLs a bootstrap grandchild that ignores SIGTERM after its leader exits', async () => {
+    executable('uname', 'echo Linux');
+    executable('awk', 'echo 8192');
+    executable('grep', 'exit 1');
+    executable('id', 'echo 1000');
+    const marker = path.join(fixtureRoot, 'descendant.pid');
+    const stubborn = executable('stubborn', `trap '' TERM\necho $$ > ${JSON.stringify(marker)}\nexec sleep 30`);
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'setup.sh'),
+      `#!/usr/bin/env bash\n${JSON.stringify(stubborn)} &\necho "STATUS: success"\nwait\n`,
+      { mode: 0o755 },
+    );
+    const child = spawn('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS], {
+      cwd: fixtureRoot,
+      env: { ...driverEnv(), PATH: `${path.join(fixtureRoot, 'fake-bin')}:/bin`, NANOCLAW_DISABLE_SETSID: '1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let buffer = '';
+    let cancelled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as { type: string; stepId?: string };
+        if (event.type === 'progress' && event.stepId === 'bootstrap' && !cancelled) {
+          cancelled = true;
+          void (async () => {
+            const deadline = Date.now() + 5_000;
+            while (!fs.existsSync(marker) && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            child.kill('SIGINT');
+          })();
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    let pid = 0;
+    try {
+      expect(code, stdout).toBe(2);
+      expect(fs.existsSync(marker)).toBe(true);
+      pid = Number(fs.readFileSync(marker, 'utf8').trim());
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  }, 15_000);
+
+  it.each(['disconnect', 'cancel'] as const)(
+    'cancels bootstrap when the frontend sends %s',
+    async (mode) => {
+      fs.writeFileSync(path.join(fixtureRoot, 'setup.sh'), '#!/usr/bin/env bash\nexec sleep 30\n');
+      const child = spawn(
+        'bash',
+        [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS],
+        { cwd: fixtureRoot, env: driverEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      let buffer = '';
+      let sent = false;
+      const result = await collectShell(child, (chunk) => {
+        buffer += chunk;
+        let newline: number;
+        while ((newline = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (!line) continue;
+          const event = JSON.parse(line) as { type: string; stepId?: string };
+          if (!sent && event.type === 'progress' && event.stepId === 'bootstrap') {
+            sent = true;
+            if (mode === 'disconnect') child.stdin?.end();
+            else
+              child.stdin?.write(
+                '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"cancel","reason":"test"}\n',
+              );
+          }
+        }
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
+      expect(parseEvents(result.stdout).at(-1)?.type).toBe('cancelled');
+    },
+    10_000,
+  );
+
+  it('requires the bootstrap status postcondition before handing off', async () => {
+    fs.writeFileSync(path.join(fixtureRoot, 'setup.sh'), '#!/usr/bin/env bash\necho "STATUS: deps_failed"\n');
+    const tsx = path.join(fixtureRoot, 'node_modules', '.bin', 'tsx');
+    fs.mkdirSync(path.dirname(tsx), { recursive: true });
+    fs.writeFileSync(tsx, '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+
+    const child = spawn('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS], {
+      cwd: fixtureRoot,
+      env: driverEnv(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const result = await collectShell(child);
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.at(-1)?.type).toBe('error');
+    expect(events.at(-1)?.code).toBe('bootstrap_failed');
+    expect(events.some((event) => event.type === 'complete')).toBe(false);
+  });
+
+  it.each([
+    ['gce_unsupported', 'rerun'],
+    ['root_user', 'rerun'],
+    ['homebrew_required', 'manual'],
+  ] as const)('reports the %s pre-Node decision before mutation', (code, recoveryKind) => {
+    if (code === 'homebrew_required') {
+      executable('uname', 'echo Darwin');
+      executable('sysctl', 'echo 8589934592');
+    } else {
+      executable('uname', 'echo Linux');
+      executable('awk', 'echo 8192');
+      executable('grep', code === 'gce_unsupported' ? 'exit 0' : 'exit 1');
+      executable('id', code === 'root_user' ? 'echo 0' : 'echo 1000');
+    }
+    const result = spawnSync('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1'], {
+      cwd: fixtureRoot,
+      env: {
+        ...driverEnv(),
+        PATH: `${path.join(fixtureRoot, 'fake-bin')}:/usr/bin:/bin`,
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    const event = parseEvents(result.stdout).at(-1);
+    expect(event?.code, `${result.stdout}\n${result.stderr}`).toBe(code);
+    expect((event?.recovery as Array<{ kind: string }>)[0].kind).toBe(recoveryKind);
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixtureRoot, 'data'))).toBe(false);
+  });
+
+  it('rejects an unrecognized acknowledgement before creating setup state', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', '--driver-ack', 'invented'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.map((event) => event.type)).toEqual(['hello', 'error']);
+    expect(events[1].code).toBe('invalid_driver_ack');
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixtureRoot, 'data'))).toBe(false);
+  });
+
+  it('rejects duplicate versioned protocol flags with hello then typed error', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', '--protocol', 'nanoclaw.driver.v1'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+    expect(result.status).toBe(1);
+    expect(parseEvents(result.stdout).map((event) => event.type)).toEqual(['hello', 'error']);
+    expect(parseEvents(result.stdout).at(-1)?.code).toBe('duplicate_protocol');
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+  });
+
+  it('preserves non-secret setup arguments in acknowledgement recovery', () => {
+    const bin = path.join(fixtureRoot, 'fake-bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(bin, 'uname'), '#!/bin/sh\necho Linux\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(bin, 'awk'), '#!/bin/sh\necho 1024\n', { mode: 0o755 });
+    const result = spawnSync(
+      'bash',
+      [
+        path.join(fixtureRoot, 'nanoclaw.sh'),
+        '--display-name',
+        'A "B"',
+        '--protocol',
+        'nanoclaw.driver.v1',
+        '--driver-ack',
+        'gce',
+      ],
+      {
+        cwd: fixtureRoot,
+        env: { ...driverEnv(), PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}` },
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.at(-1)?.code).toBe('low_memory');
+    expect((events.at(-1)?.recovery as Array<{ args?: string[] }>)[0].args).toEqual([
+      '--protocol',
+      'nanoclaw.driver.v1',
+      '--display-name',
+      'A "B"',
+      '--driver-ack',
+      'gce',
+      '--driver-ack',
+      'low-memory',
+    ]);
+  });
+
+  it.each([
+    ['argument', ['--onecli-api-token', 'launch-secret'], {}],
+    ['environment', [], { NANOCLAW_ONECLI_API_TOKEN: 'launch-secret' }],
+    ['registry enrollment environment', [], { NANOCLAW_REGISTRY_ENROLL_CODE: 'launch-secret' }],
+    ['registry token environment', [], { NANOCLAW_REGISTRY_TOKEN: 'launch-secret' }],
+  ] as const)('rejects secret transport through the launch %s', (_source, args, extraEnv) => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...args],
+      { cwd: fixtureRoot, env: { ...driverEnv(), ...extraEnv }, encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    expect(parseEvents(result.stdout).at(-1)?.code).toBe('secret_transport_forbidden');
+    expect(`${result.stdout}${result.stderr}`).not.toContain('launch-secret');
+  });
+
+  it('rejects control characters before recovery JSON is constructed', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', '--display-name', 'bad\u0001value'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    expect(parseEvents(result.stdout).at(-1)?.code).toBe('invalid_arguments');
+  });
+
+  it('keeps terminal setup as the default path and preserves bootstrap ordering', () => {
+    executable('uname', 'echo Darwin');
+    executable('sysctl', 'echo 8589934592');
+    executable('brew', 'exit 0');
+    executable('pnpm', 'echo pnpm >> "$PWD/order"\necho "$*" > "$PWD/pnpm.args"\necho terminal-setup-child');
+    fs.mkdirSync(path.join(fixtureRoot, 'assets'));
+    fs.writeFileSync(path.join(fixtureRoot, 'assets', 'setup-splash.txt'), 'terminal-splash\n');
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'setup.sh'),
+      '#!/usr/bin/env bash\necho bootstrap >> "$PWD/order"\necho STATUS: success\n',
+    );
+
+    const result = spawnSync('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--display-name', 'Terminal'], {
+      cwd: fixtureRoot,
+      env: {
+        ...driverEnv(),
+        PATH: `${path.join(fixtureRoot, 'fake-bin')}:/usr/bin:/bin`,
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('terminal-splash');
+    expect(result.stdout).toContain('terminal-setup-child');
+    expect(result.stdout.trimStart().startsWith('{')).toBe(false);
+    expect(fs.readFileSync(path.join(fixtureRoot, 'order'), 'utf8').trim().split('\n')).toEqual(['bootstrap', 'pnpm']);
+    expect(fs.readFileSync(path.join(fixtureRoot, 'pnpm.args'), 'utf8').trim()).toBe(
+      '--silent run setup:auto --display-name Terminal',
+    );
+  });
+
+  it.each(['SIGINT', 'SIGTERM'] as const)(
+    'turns a bootstrap %s into cancelled and exit 2',
+    async (signal) => {
+      fs.writeFileSync(path.join(fixtureRoot, 'setup.sh'), '#!/usr/bin/env bash\nexec sleep 30\n');
+      const child = spawn(
+        'bash',
+        [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS],
+        { cwd: fixtureRoot, env: driverEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      let stdout = '';
+      let signalled = false;
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+        if (!signalled && stdout.includes('"stepId":"bootstrap"')) {
+          signalled = true;
+          child.kill(signal);
+        }
+      });
+
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', resolve);
+      });
+
+      expect(code).toBe(2);
+      const events = parseEvents(stdout);
+      expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+      expect(events.at(-1)?.type).toBe('cancelled');
+    },
+    10_000,
+  );
+});

--- a/setup/lib/agent-ping.test.ts
+++ b/setup/lib/agent-ping.test.ts
@@ -1,7 +1,12 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { isValidGroupFolder } from '../../src/group-folder.js';
-import { classifyPingResult, PING_AGENT_FOLDER } from './agent-ping.js';
+import { classifyPingResult, PING_AGENT_FOLDER, pingCliAgent } from './agent-ping.js';
+import type { SetupDriver } from './setup-driver.js';
 
 it('uses a runtime-safe folder for the setup ping agent', () => {
   expect(isValidGroupFolder(PING_AGENT_FOLDER)).toBe(true);
@@ -37,4 +42,101 @@ describe('classifyPingResult', () => {
   it('treats empty output as no reply', () => {
     expect(classifyPingResult(0, '')).toBe('no_reply');
   });
+
+  it('stops a noisy machine ping before its output can grow without bound', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-ping-limit-'));
+    const bin = path.join(temp, 'bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, 'pnpm'),
+      `#!/usr/bin/env node
+process.stdout.write('x'.repeat(70 * 1024));
+setInterval(() => {}, 1000);
+`,
+      { mode: 0o755 },
+    );
+    const previousPath = process.env.PATH;
+    try {
+      process.env.PATH = `${bin}:${previousPath ?? ''}`;
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      await expect(pingCliAgent(30_000, driver)).resolves.toBe('output_limit');
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it('scrubs machine credentials and kills the ping process group on cancellation', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-ping-cancel-'));
+    const bin = path.join(temp, 'bin');
+    const envMarker = path.join(temp, 'env');
+    const pidMarker = path.join(temp, 'pid');
+    fs.mkdirSync(bin);
+    const stubborn = path.join(bin, 'stubborn');
+    fs.writeFileSync(
+      stubborn,
+      `#!/bin/sh
+trap '' TERM
+echo $$ > "$PING_PID_MARKER"
+exec sleep 30
+`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(bin, 'pnpm'),
+      `#!/bin/sh
+printf '%s' "\${ANTHROPIC_API_KEY-missing}" > "$PING_ENV_MARKER"
+${JSON.stringify(stubborn)} &
+wait
+`,
+      { mode: 0o755 },
+    );
+    const previous = {
+      path: process.env.PATH,
+      key: process.env.ANTHROPIC_API_KEY,
+      envMarker: process.env.PING_ENV_MARKER,
+      pidMarker: process.env.PING_PID_MARKER,
+    };
+    const controller = new AbortController();
+    let pid = 0;
+    try {
+      process.env.PATH = `${bin}:${previous.path ?? ''}`;
+      process.env.ANTHROPIC_API_KEY = 'must-not-reach-child';
+      process.env.PING_ENV_MARKER = envMarker;
+      process.env.PING_PID_MARKER = pidMarker;
+      const driver = { mode: 'ndjson', cancellationSignal: controller.signal } as SetupDriver;
+      const result = pingCliAgent(30_000, driver);
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(pidMarker) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(fs.readFileSync(envMarker, 'utf8')).toBe('missing');
+      controller.abort();
+      expect(await result).toBe('no_reply');
+      pid = Number(fs.readFileSync(pidMarker, 'utf8'));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      controller.abort();
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      for (const [key, value] of Object.entries({
+        PATH: previous.path,
+        ANTHROPIC_API_KEY: previous.key,
+        PING_ENV_MARKER: previous.envMarker,
+        PING_PID_MARKER: previous.pidMarker,
+      })) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 10_000);
 });

--- a/setup/lib/agent-ping.ts
+++ b/setup/lib/agent-ping.ts
@@ -13,9 +13,14 @@
  */
 import { spawn } from 'child_process';
 
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
+
 export const PING_AGENT_FOLDER = 'ping_test';
 
-export type PingResult = 'ok' | 'no_reply' | 'socket_error' | 'auth_error';
+const MAX_MACHINE_PING_OUTPUT_BYTES = 64 * 1024;
+
+export type PingResult = 'ok' | 'no_reply' | 'socket_error' | 'auth_error' | 'output_limit';
 
 export function classifyPingResult(exitCode: number | null, stdout: string, stderr = ''): PingResult {
   const output = `${stdout}\n${stderr}`;
@@ -34,38 +39,79 @@ export function classifyPingResult(exitCode: number | null, stdout: string, stde
   return 'no_reply';
 }
 
-export function pingCliAgent(timeoutMs = 30_000): Promise<PingResult> {
+export function pingCliAgent(timeoutMs = 30_000, driver?: SetupDriver): Promise<PingResult> {
   return new Promise((resolve) => {
+    const machine = driver?.mode === 'ndjson';
     const child = spawn('pnpm', ['run', 'chat', 'ping'], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      ...(machine ? { detached: true, env: childEnvWithoutSetupSecrets() } : {}),
     });
     let stdout = '';
     let stderr = '';
+    let outputBytes = 0;
     let settled = false;
-    const timer = setTimeout(() => {
+    const stopGroup = (): void => {
+      if (!child.pid) return;
+      if (!machine) {
+        child.kill('SIGKILL');
+        return;
+      }
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    const onAbort = (): void => {
+      stopGroup();
+      settle('no_reply');
+    };
+    const settle = (result: PingResult): void => {
       if (settled) return;
       settled = true;
-      child.kill('SIGKILL');
-      resolve('no_reply');
+      clearTimeout(timer);
+      driver?.cancellationSignal?.removeEventListener('abort', onAbort);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      stopGroup();
+      settle('no_reply');
     }, timeoutMs);
+    driver?.cancellationSignal?.addEventListener('abort', onAbort, { once: true });
+    if (driver?.cancellationSignal?.aborted) onAbort();
 
+    const append = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+      if (settled) return;
+      if (machine) {
+        outputBytes += chunk.byteLength;
+        if (outputBytes > MAX_MACHINE_PING_OUTPUT_BYTES) {
+          stopGroup();
+          settle('output_limit');
+          return;
+        }
+      }
+      if (stream === 'stdout') stdout += chunk.toString('utf-8');
+      else stderr += chunk.toString('utf-8');
+    };
     child.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString('utf-8');
+      append(chunk, 'stdout');
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString('utf-8');
+      append(chunk, 'stderr');
     });
     child.on('close', (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(classifyPingResult(code, stdout, stderr));
+      settle(classifyPingResult(code, stdout, stderr));
     });
     child.on('error', () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve('socket_error');
+      settle('socket_error');
     });
   });
 }

--- a/setup/lib/claude-handoff.ts
+++ b/setup/lib/claude-handoff.ts
@@ -153,14 +153,14 @@ export const HELP_ESCAPE_SENTINEL = '__NANOCLAW_HELP_ESCAPE__';
  */
 export function validateWithHelpEscape(
   inner?: (value: string) => string | Error | undefined,
-): (value: string) => string | Error | undefined {
-  return (value: string) => {
+): (value: string | undefined) => string | Error | undefined {
+  return (value) => {
     if ((value ?? '').trim() === '?') {
       // Returning undefined lets clack accept the `?` as the "answer". The
       // caller sees a literal "?" and should compare + escape to handoff.
       return undefined;
     }
-    return inner ? inner(value) : undefined;
+    return inner ? inner(value ?? '') : undefined;
   };
 }
 

--- a/setup/lib/claude-subscription-auth.test.ts
+++ b/setup/lib/claude-subscription-auth.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+
+const mockRunInteractiveProcess = vi.fn();
+
+vi.mock('./interactive-process.js', () => ({
+  machineChildEnvironment: () => ({ PATH: process.env.PATH }),
+  runInteractiveProcess: (...args: unknown[]) => mockRunInteractiveProcess(...args),
+}));
+import { runClaudeSubscriptionMachineAuth } from './claude-subscription-auth.js';
+
+const TOKEN = `sk-ant-oat${'A'.repeat(90)}AA`;
+const URL = 'https://claude.com/cai/oauth/authorize?code=true&state=test-state';
+
+function driver(): SetupDriver & {
+  actions: unknown[];
+  displays: unknown[];
+  cleared: string[];
+  progresses: Array<{ stepId: string; state: string; label?: string }>;
+} {
+  const actions: unknown[] = [];
+  const displays: unknown[] = [];
+  const cleared: string[] = [];
+  const progresses: Array<{ stepId: string; state: string; label?: string }> = [];
+  return {
+    mode: 'ndjson',
+    operation: 'setup',
+    actions,
+    displays,
+    cleared,
+    progresses,
+    prompt: vi.fn().mockResolvedValue('authorization-code'),
+    externalAction: vi.fn(async (action) => {
+      actions.push(action);
+      return 'attempted';
+    }),
+    display(value) {
+      displays.push(value);
+    },
+    clearDisplay(id) {
+      cleared.push(id);
+    },
+    progress(stepId, state, label) {
+      progresses.push({ stepId, state, ...(label ? { label } : {}) });
+    },
+    log: vi.fn(),
+    throwIfCancelled: vi.fn(),
+  } as unknown as SetupDriver & {
+    actions: unknown[];
+    displays: unknown[];
+    cleared: string[];
+    progresses: Array<{ stepId: string; state: string; label?: string }>;
+  };
+}
+
+describe('runClaudeSubscriptionMachineAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the provider URL, sends the code on stdin, and vaults through a private file', async () => {
+    let isolatedEnv: Record<string, string> | undefined;
+    const writes: string[] = [];
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const command = args[1] as string;
+      const childArgs = args[2] as string[];
+      const options = args[3] as {
+        env: Record<string, string>;
+        timeoutMs: number;
+        onOutput: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      if (command === 'onecli') {
+        const filePath = childArgs[childArgs.indexOf('--file') + 1];
+        expect(childArgs).not.toContain('--value');
+        expect(fs.readFileSync(filePath, 'utf8')).toBe(TOKEN);
+        expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+        expect(options.timeoutMs).toBe(2 * 60 * 1000);
+        return { reason: 'exited', exitCode: 0 };
+      }
+      isolatedEnv = options.env;
+      const input = {
+        write(value: string) {
+          writes.push(value);
+        },
+        end: vi.fn(),
+      };
+      await options.onOutput(`Open this URL:\n${URL}\n`, 'stdout', input);
+      await options.onOutput(`Your OAuth token:\n${TOKEN}\n`, 'stdout', input);
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    const fake = driver();
+    await expect(runClaudeSubscriptionMachineAuth(fake)).resolves.toEqual({ ok: true });
+
+    expect(fake.actions).toEqual([]);
+    expect(fake.displays).toEqual([expect.objectContaining({ kind: 'url', url: URL, sensitive: true })]);
+    expect(fake.cleared).toEqual(['claude-subscription-url']);
+    expect(writes).toEqual(['authorization-code\n']);
+    expect(fake.progresses).toEqual([
+      { stepId: 'claude-login', state: 'running', label: 'Waiting for Claude sign-in' },
+      { stepId: 'claude-login', state: 'succeeded' },
+      { stepId: 'auth', state: 'running', label: 'Saving your Claude credentials to your OneCLI vault' },
+      { stepId: 'auth', state: 'succeeded' },
+    ]);
+    expect(mockRunInteractiveProcess.mock.calls.map((call) => call[1])).toEqual(['claude', 'onecli']);
+    expect(isolatedEnv).toBeDefined();
+    for (const location of Object.values(isolatedEnv!)) expect(fs.existsSync(location)).toBe(false);
+  });
+
+  it('fails closed when provider output has no allowlisted login URL', async () => {
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const options = args[3] as {
+        onOutput: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      await options.onOutput(`https://evil.example/oauth/authorize\n${TOKEN}\n`, 'stdout', {
+        write: vi.fn(),
+        end: vi.fn(),
+      });
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    const fake = driver();
+    await expect(runClaudeSubscriptionMachineAuth(fake)).resolves.toEqual({
+      ok: false,
+      reason: 'login_url_missing',
+    });
+    expect(fake.progresses.at(-1)).toEqual({ stepId: 'claude-login', state: 'failed' });
+    expect(mockRunInteractiveProcess).toHaveBeenCalledOnce();
+  });
+
+  it('waits for a complete URL line and ignores interleaved stderr', async () => {
+    const fake = driver();
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      if (args[1] === 'onecli') return { reason: 'exited', exitCode: 0 };
+      const options = args[3] as {
+        onOutput: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      const input = { write: vi.fn(), end: vi.fn() };
+      await options.onOutput('https://claude.com/cai/oauth/authorize?code=true&sta', 'stdout', input);
+      await options.onOutput('opening browser…\n', 'stderr', input);
+      expect(fake.actions).toEqual([]);
+      await options.onOutput(`te=split\n${TOKEN}\n`, 'stdout', input);
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    await expect(runClaudeSubscriptionMachineAuth(fake)).resolves.toEqual({ ok: true });
+
+    expect(fake.actions).toEqual([]);
+    expect(fake.displays).toEqual([
+      expect.objectContaining({
+        url: 'https://claude.com/cai/oauth/authorize?code=true&state=split',
+        sensitive: true,
+      }),
+    ]);
+  });
+
+  it('removes the isolated home when the driver cancels', async () => {
+    let isolatedRoot = '';
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const options = args[3] as { env: Record<string, string> };
+      isolatedRoot = options.env.HOME.replace(/\/home$/, '');
+      throw new DriverCancelled('test');
+    });
+
+    await expect(runClaudeSubscriptionMachineAuth(driver())).rejects.toBeInstanceOf(DriverCancelled);
+    expect(fs.existsSync(isolatedRoot)).toBe(false);
+  });
+
+  it('removes both credential files when cancellation happens during vaulting', async () => {
+    let isolatedRoot = '';
+    let secretFile = '';
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const command = args[1] as string;
+      const childArgs = args[2] as string[];
+      const options = args[3] as {
+        env: Record<string, string>;
+        onOutput?: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      if (command === 'onecli') {
+        secretFile = childArgs[childArgs.indexOf('--file') + 1];
+        throw new DriverCancelled('test');
+      }
+      isolatedRoot = options.env.HOME.replace(/\/home$/, '');
+      await options.onOutput?.(`Open this URL:\n${URL}\n${TOKEN}\n`, 'stdout', {
+        write: vi.fn(),
+        end: vi.fn(),
+      });
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    await expect(runClaudeSubscriptionMachineAuth(driver())).rejects.toBeInstanceOf(DriverCancelled);
+
+    expect(fs.existsSync(isolatedRoot)).toBe(false);
+    expect(secretFile).not.toBe('');
+    expect(fs.existsSync(secretFile)).toBe(false);
+  });
+});

--- a/setup/lib/claude-subscription-auth.ts
+++ b/setup/lib/claude-subscription-auth.ts
@@ -1,0 +1,159 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { extractClaudeOAuthToken } from './captured-token.js';
+import { machineChildEnvironment, runInteractiveProcess } from './interactive-process.js';
+import { registerSensitiveValue } from './redaction.js';
+import { withSecretFile } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
+
+const PROVIDER_STREAM_BUFFER_BYTES = 64 * 1024;
+const LOGIN_TIMEOUT_MS = 15 * 60 * 1000;
+const VAULT_TIMEOUT_MS = 2 * 60 * 1000;
+
+export type ClaudeSubscriptionMachineResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | 'login_url_missing'
+        | 'login_failed'
+        | 'output_limit'
+        | 'spawn_failed'
+        | 'timed_out'
+        | 'token_missing'
+        | 'vault_failed';
+      detail?: string;
+    };
+
+function makePrivateDirectory(parent: string, name: string): string {
+  const directory = path.join(parent, name);
+  fs.mkdirSync(directory, { mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  return directory;
+}
+
+function findClaudeLoginUrl(output: string): string | undefined {
+  const clean = output.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+  for (const match of clean.matchAll(/https:\/\/[^\s<>"']+/g)) {
+    const candidate = match[0].replace(/[),.;]+$/, '');
+    try {
+      const url = new URL(candidate);
+      if ((url.hostname === 'claude.ai' || url.hostname === 'claude.com') && url.pathname.includes('/oauth/authorize'))
+        return url.toString();
+    } catch {
+      // A partial chunk is expected; the next chunk extends the rolling buffer.
+    }
+  }
+  return undefined;
+}
+
+/** Run Claude's subscription setup-token flow through semantic driver events. */
+export async function runClaudeSubscriptionMachineAuth(driver: SetupDriver): Promise<ClaudeSubscriptionMachineResult> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-claude-login-'));
+  fs.chmodSync(root, 0o700);
+  const home = makePrivateDirectory(root, 'home');
+  const config = makePrivateDirectory(root, 'config');
+  const cache = makePrivateDirectory(root, 'cache');
+  const data = makePrivateDirectory(root, 'data');
+
+  const buffers = { stdout: '', stderr: '' };
+  let loginUrl: string | undefined;
+  let token: string | undefined;
+  let urlDisplayed = false;
+
+  const failed = (
+    reason: Exclude<ClaudeSubscriptionMachineResult, { ok: true }>['reason'],
+    detail?: string,
+  ): ClaudeSubscriptionMachineResult => {
+    driver.progress('claude-login', 'failed');
+    return { ok: false, reason, ...(detail ? { detail } : {}) };
+  };
+
+  try {
+    driver.progress('claude-login', 'running', 'Waiting for Claude sign-in');
+    const login = await runInteractiveProcess(driver, 'claude', ['setup-token'], {
+      timeoutMs: LOGIN_TIMEOUT_MS,
+      env: {
+        HOME: home,
+        XDG_CONFIG_HOME: config,
+        XDG_CACHE_HOME: cache,
+        XDG_DATA_HOME: data,
+      },
+      async onOutput(chunk, stream, input) {
+        buffers[stream] = `${buffers[stream]}${chunk}`.slice(-PROVIDER_STREAM_BUFFER_BYTES);
+        const completeOutput = buffers[stream].slice(
+          0,
+          Math.max(buffers[stream].lastIndexOf('\n'), buffers[stream].lastIndexOf('\r')) + 1,
+        );
+        token ??= extractClaudeOAuthToken(completeOutput) ?? undefined;
+        if (token) registerSensitiveValue(token);
+
+        loginUrl ??= findClaudeLoginUrl(completeOutput);
+        if (!loginUrl || urlDisplayed) return;
+        urlDisplayed = true;
+        registerSensitiveValue(loginUrl);
+        driver.display({
+          id: 'claude-subscription-url',
+          kind: 'url',
+          url: loginUrl,
+          label: 'Claude sign-in',
+          sensitive: true,
+        });
+        const code = String(
+          await driver.prompt({
+            id: 'claude-authorization-code',
+            kind: 'secret',
+            message: 'Paste the Claude authorization code',
+            validation: { required: true, maxLength: 4096 },
+          }),
+        ).trim();
+        input.write(`${code}\n`);
+        input.end();
+      },
+    });
+
+    token ??= extractClaudeOAuthToken(`${buffers.stdout}\n${buffers.stderr}`) ?? undefined;
+    if (token) registerSensitiveValue(token);
+
+    if (login.reason === 'spawn_failed') {
+      return failed('spawn_failed', login.message);
+    }
+    if (login.reason === 'output_limit') return failed('output_limit');
+    if (login.reason === 'timed_out') return failed('timed_out');
+    if (login.exitCode !== 0) {
+      return failed('login_failed', `exit ${login.exitCode}`);
+    }
+    if (!loginUrl) return failed('login_url_missing');
+    if (!token) return failed('token_missing');
+    driver.progress('claude-login', 'succeeded');
+
+    const saved = await withSecretFile(token, async (filePath) => {
+      const args = [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'anthropic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        'api.anthropic.com',
+      ];
+      driver.progress('auth', 'running', 'Saving your Claude credentials to your OneCLI vault');
+      const result = await runInteractiveProcess(driver, 'onecli', args, {
+        env: machineChildEnvironment(),
+        timeoutMs: VAULT_TIMEOUT_MS,
+      });
+      const ok = result.reason === 'exited' && result.exitCode === 0;
+      driver.progress('auth', ok ? 'succeeded' : 'failed');
+      return ok;
+    });
+    return saved ? { ok: true } : { ok: false, reason: 'vault_failed' };
+  } finally {
+    if (urlDisplayed) driver.clearDisplay('claude-subscription-url');
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/setup/lib/claude-subscription-driver.test.ts
+++ b/setup/lib/claude-subscription-driver.test.ts
@@ -1,0 +1,143 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const TOKEN = `sk-ant-oat${'A'.repeat(90)}AA`;
+const URL = 'https://claude.com/cai/oauth/authorize?code=true&state=driver-test';
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-claude-driver-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function executable(name: string, contents: string): string {
+  const file = path.join(root, 'bin', name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents, { mode: 0o755 });
+  return file;
+}
+
+describe('Claude subscription through the NDJSON driver', () => {
+  it('translates a bidirectional provider login into semantic events only', async () => {
+    const marker = path.join(root, 'vaulted');
+    executable(
+      'claude',
+      `#!/usr/bin/env bash
+printf 'private provider noise\\n%s\\n' '${URL}'
+IFS= read -r code
+test "$code" = 'authorization-code' || exit 9
+printf '%s\\n' '${TOKEN}'
+`,
+    );
+    executable(
+      'onecli',
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const index = args.indexOf('--file');
+if (index < 0 || args.includes('--value')) process.exit(7);
+const file = args[index + 1];
+const secret = fs.readFileSync(file, 'utf8');
+if (!/^sk-ant-oat[A-Za-z0-9_-]{80,500}AA$/.test(secret)) process.exit(8);
+if ((fs.statSync(file).mode & 0o777) !== 0o600) process.exit(9);
+fs.writeFileSync(${JSON.stringify(marker)}, 'ok');
+`,
+    );
+
+    const fixture = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'claude-subscription-driver.ts',
+    );
+    const tsx = path.resolve('node_modules/tsx/dist/cli.mjs');
+    const child = spawn(process.execPath, [tsx, fixture], {
+      env: { ...process.env, PATH: `${path.join(root, 'bin')}${path.delimiter}${process.env.PATH ?? ''}` },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const events: Array<Record<string, unknown>> = [];
+    let stdout = '';
+    let stderr = '';
+    let buffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stdout += text;
+      buffer += text;
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({
+              protocol: 'nanoclaw.driver.v1',
+              operation: 'setup',
+              type: 'externalActionCompleted',
+              actionId: action.id,
+              result: 'attempted',
+            })}\n`,
+          );
+        }
+        if (event.type === 'prompt') {
+          const prompt = event.prompt as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({
+              protocol: 'nanoclaw.driver.v1',
+              operation: 'setup',
+              type: 'answer',
+              promptId: prompt.id,
+              value: 'authorization-code',
+            })}\n`,
+          );
+        }
+      }
+    });
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+
+    expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
+    expect(events[0]?.type).toBe('hello');
+    expect(events.at(-1)?.type).toBe('complete');
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'display',
+        display: expect.objectContaining({ kind: 'url', url: URL, sensitive: true }),
+      }),
+    );
+    expect(events.some((event) => event.type === 'externalAction')).toBe(false);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'prompt',
+        prompt: expect.objectContaining({ id: 'claude-authorization-code', sensitive: true }),
+      }),
+    );
+    expect(events.filter((event) => event.type === 'progress').map((event) => event.state)).toEqual([
+      'running',
+      'succeeded',
+      'running',
+      'succeeded',
+    ]);
+    expect(stdout).not.toContain(TOKEN);
+    expect(stdout).not.toContain('private provider noise');
+    expect(stderr).not.toContain(TOKEN);
+    expect(fs.readFileSync(marker, 'utf8')).toBe('ok');
+  }, 10_000);
+});

--- a/setup/lib/diagnostics.ts
+++ b/setup/lib/diagnostics.ts
@@ -10,6 +10,8 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
+import { redactSensitiveValues } from './redaction.js';
+
 const POSTHOG_KEY = 'phc_fx1Hhx9ucz8GuaJC8LVZWO8u03yXZZJJ6ObS4yplnaP';
 const POSTHOG_URL = 'https://us.i.posthog.com/capture/';
 const INSTALL_ID_PATH = path.join('data', 'install-id');
@@ -56,7 +58,8 @@ export function emit(
   const cleaned: Record<string, unknown> = { platform: process.platform };
   for (const [k, v] of Object.entries(props)) {
     if (v === undefined) continue;
-    cleaned[k] = v;
+    cleaned[k] =
+      typeof v === 'string' && process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1' ? redactSensitiveValues(v) : v;
   }
 
   const body = JSON.stringify({

--- a/setup/lib/fixtures/claude-subscription-driver.ts
+++ b/setup/lib/fixtures/claude-subscription-driver.ts
@@ -1,0 +1,13 @@
+import { runClaudeSubscriptionMachineAuth } from '../claude-subscription-auth.js';
+import { DriverTerminalError, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  const result = await runClaudeSubscriptionMachineAuth(driver);
+  if (!result.ok) driver.error('claude_auth_failed', 'Claude authentication failed in the fixture.');
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverTerminalError)) throw error;
+  process.exitCode = error.exitCode;
+}

--- a/setup/lib/fixtures/interactive-process-parent-exit.ts
+++ b/setup/lib/fixtures/interactive-process-parent-exit.ts
@@ -1,0 +1,28 @@
+import { runInteractiveProcess } from '../interactive-process.js';
+import type { SetupDriver } from '../setup-driver.js';
+
+const driver = {
+  mode: 'ndjson',
+  operation: 'setup',
+  throwIfCancelled() {},
+} as SetupDriver;
+
+void runInteractiveProcess(
+  driver,
+  process.execPath,
+  [
+    '-e',
+    `
+    const { spawn } = require('node:child_process');
+    const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+    process.stdout.write(String(grandchild.pid) + '\\n');
+    setInterval(() => {}, 1000);
+  `,
+  ],
+  {
+    onOutput(chunk) {
+      process.stdout.write(chunk);
+      process.exit(23);
+    },
+  },
+);

--- a/setup/lib/fixtures/setup-driver-cancel-race.ts
+++ b/setup/lib/fixtures/setup-driver-cancel-race.ts
@@ -1,0 +1,23 @@
+import { DriverCancelled, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  await driver.externalAction(
+    {
+      id: 'slow-postcondition',
+      kind: 'systemPermission',
+      title: 'Complete the slow action',
+      instructions: ['Test only.'],
+    },
+    async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return false;
+    },
+  );
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverCancelled)) throw error;
+  driver.cancelled();
+  process.exitCode = 2;
+}

--- a/setup/lib/fixtures/setup-driver-child-cancel.ts
+++ b/setup/lib/fixtures/setup-driver-child-cancel.ts
@@ -1,0 +1,37 @@
+import { DriverCancelled, NdjsonSetupDriver } from '../setup-driver.js';
+import { runQuietChild } from '../runner.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+const marker = process.env.NANOCLAW_TEST_CHILD_MARKER;
+if (!marker) driver.error('test_fixture', 'missing child marker');
+const stubbornGrandchild = `
+  process.on('SIGTERM', () => {});
+  process.stdout.write('ready\\n');
+  setInterval(() => {}, 1000);
+`;
+const childScript = `
+  const { spawn } = require('node:child_process');
+  const fs = require('node:fs');
+  const child = spawn(process.execPath, ['-e', ${JSON.stringify(stubbornGrandchild)}], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  child.stdout.once('data', () => fs.writeFileSync(${JSON.stringify(marker)}, String(child.pid)));
+  setInterval(() => {}, 1000);
+`;
+
+try {
+  await runQuietChild(
+    'cancel-child',
+    process.execPath,
+    ['-e', childScript],
+    { running: 'Starting child…', done: 'Child done.' },
+    undefined,
+    driver,
+  );
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverCancelled)) throw error;
+  driver.cancelled();
+  process.exitCode = 2;
+}

--- a/setup/lib/fixtures/setup-driver-child.ts
+++ b/setup/lib/fixtures/setup-driver-child.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { emit as emitDiagnostic } from '../../lib/diagnostics.js';
+import * as setupLog from '../../logs.js';
+import { NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const outputDir = process.env.NANOCLAW_TEST_OUTPUT_DIR;
+if (outputDir) process.chdir(outputDir);
+
+const driver = new NdjsonSetupDriver('setup');
+
+driver.display({ id: 'rotating-code', kind: 'code', content: 'display-one', sensitive: true });
+driver.display({ id: 'rotating-code', kind: 'code', content: 'display-two', sensitive: true });
+driver.clearDisplay('rotating-code');
+driver.note('display-one and display-two are no longer live');
+
+const secret = await driver.prompt({
+  id: 'credential',
+  kind: 'secret',
+  message: 'Credential',
+  sensitive: true,
+  validation: { required: true, pattern: '^secret-' },
+});
+driver.note(`accepted ${secret}`);
+if (outputDir) {
+  setupLog.reset({ accepted: `${secret} display-one display-two` });
+  setupLog.userInput('credential', String(secret));
+  setupLog.step('fixture', 'success', 1, { value: `${secret} display-one display-two` });
+  globalThis.fetch = (async (_input, init) => {
+    fs.writeFileSync(path.join(outputDir, 'diagnostic-body.json'), String(init?.body ?? ''));
+    return { ok: true } as Response;
+  }) as typeof fetch;
+  emitDiagnostic('driver_fixture', { value: `${secret} display-one display-two` }, { persistId: false });
+}
+
+await driver.prompt({ id: 'continue', kind: 'confirm', message: 'Continue?', default: true });
+
+let postconditionChecks = 0;
+await driver.externalAction(
+  {
+    id: 'permission',
+    kind: 'systemPermission',
+    title: 'Grant test permission',
+    instructions: ['Enable the test permission.'],
+  },
+  () => ++postconditionChecks > 1,
+);
+driver.completeSetup(fixtureSetupReceipt());

--- a/setup/lib/fixtures/setup-driver-continuation.ts
+++ b/setup/lib/fixtures/setup-driver-continuation.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+
+import { createSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const tsxLoader = process.env.NANOCLAW_TEST_TSX_LOADER;
+if (!tsxLoader) throw new Error('NANOCLAW_TEST_TSX_LOADER is required');
+
+const driver = createSetupDriver('setup');
+if (process.env.NANOCLAW_TEST_CONTINUED === '1') {
+  await driver.prompt({ id: 'continued-confirm', kind: 'confirm', message: 'Continue?', default: true });
+  driver.completeSetup(fixtureSetupReceipt());
+} else {
+  driver.handoff();
+  const result = spawnSync(process.execPath, ['--import', tsxLoader, process.argv[1]], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NANOCLAW_TEST_CONTINUED: '1',
+      NANOCLAW_DRIVER_CONTINUATION: '1',
+    },
+  });
+  process.exit(result.status ?? 1);
+}

--- a/setup/lib/fixtures/setup-driver-skill.ts
+++ b/setup/lib/fixtures/setup-driver-skill.ts
@@ -1,0 +1,22 @@
+import { fullyApplied } from '../../../scripts/skill-apply.js';
+import { hostExec, runSkill } from '../skill-driver.js';
+import { DriverTerminalError, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const skillDir = process.env.NANOCLAW_TEST_SKILL_DIR;
+const projectRoot = process.env.NANOCLAW_TEST_PROJECT_ROOT;
+if (!skillDir || !projectRoot) throw new Error('missing skill fixture paths');
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  const result = await runSkill(skillDir, {
+    driver,
+    projectRoot,
+    exec: hostExec(projectRoot),
+  });
+  if (!fullyApplied(result)) driver.error('skill_incomplete', 'The fixture skill did not complete.');
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (error instanceof DriverTerminalError) process.exitCode = error.exitCode;
+  else throw error;
+}

--- a/setup/lib/fixtures/setup-driver-transcript-child.ts
+++ b/setup/lib/fixtures/setup-driver-transcript-child.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import net, { type Socket } from 'node:net';
+import path from 'node:path';
+
+import { PLUGIN_SCHEMA_URL } from '../../../src/templates/manifest.js';
+import { NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const scenario = process.argv[2];
+if (scenario !== 'standard' && scenario !== 'template-first-agent') {
+  throw new Error('unknown production parity scenario');
+}
+
+const driver = new NdjsonSetupDriver('setup');
+const auto = await import('../../auto.js');
+
+if (scenario === 'standard') {
+  await auto.runTemplateSetup(driver, false, false);
+} else {
+  // The production helper lists template carriers before creating one, which
+  // reads the template's manifest from the local templates directory.
+  const templateDir = path.join(process.cwd(), 'templates', 'sales', 'sdr');
+  fs.mkdirSync(templateDir, { recursive: true });
+  fs.writeFileSync(path.join(templateDir, 'plugin.json'), JSON.stringify({ $schema: PLUGIN_SCHEMA_URL, name: 'sdr' }));
+  const socketPath = path.join(process.cwd(), 'data', 'ncl.sock');
+  const requests: Array<{ command: string; args: Record<string, unknown> }> = [];
+  const sockets = new Set<Socket>();
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    let buffer = '';
+    socket.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const newline = buffer.indexOf('\n');
+      if (newline < 0) return;
+      const request = JSON.parse(buffer.slice(0, newline)) as {
+        id: string;
+        command: string;
+        args: Record<string, unknown>;
+      };
+      requests.push({ command: request.command, args: request.args });
+      const data =
+        request.command === 'groups-create'
+          ? {
+              id: 'ag-template',
+              name: 'SDR',
+              folder: 'sdr',
+              agent_provider: null,
+              created_at: '2026-01-01T00:00:00.000Z',
+            }
+          : request.command === 'groups-list' || request.command === 'wirings-list'
+            ? []
+            : {};
+      socket.end(`${JSON.stringify({ id: request.id, ok: true, data })}\n`);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  try {
+    await auto.installSelectedTemplateAgent(driver, 'claude');
+    if (process.env.NANOCLAW_TEST_REQUESTS) {
+      fs.writeFileSync(process.env.NANOCLAW_TEST_REQUESTS, JSON.stringify(requests));
+    }
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+driver.completeSetup(fixtureSetupReceipt());

--- a/setup/lib/fixtures/setup-driver-tty.ts
+++ b/setup/lib/fixtures/setup-driver-tty.ts
@@ -1,0 +1,16 @@
+import { hostExecStream } from '../skill-driver.js';
+import { DriverTerminalError, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  const result = await hostExecStream(
+    process.cwd(),
+    driver,
+  )('"$(npm prefix -g 2>/dev/null)/bin/teams" login && echo \'"loggedIn": true\'');
+  if (!result.ok) driver.error('tty_action_failed', 'The terminal-owned action did not satisfy its postcondition.');
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverTerminalError)) throw error;
+  process.exitCode = error.exitCode;
+}

--- a/setup/lib/fixtures/setup-driver-windowed-cancel.ts
+++ b/setup/lib/fixtures/setup-driver-windowed-cancel.ts
@@ -1,0 +1,28 @@
+import { DriverCancelled, NdjsonSetupDriver } from '../setup-driver.js';
+import { runWindowedStep } from '../windowed-runner.js';
+
+const driver = new NdjsonSetupDriver('setup');
+
+try {
+  await runWindowedStep(
+    'cancel-window',
+    { running: 'Starting windowed step…', done: 'Windowed step done.' },
+    [],
+    driver,
+  );
+  driver.completeSetup({
+    version: 1,
+    service: { state: 'running', manager: 'pidfile', checkoutRoot: process.cwd() },
+    health: { status: 'healthy' },
+    resources: {
+      groups: { state: 'empty', count: 0 },
+      policies: { state: 'empty', count: 0 },
+      skills: { state: 'empty', count: 0 },
+    },
+    completedAt: new Date().toISOString(),
+  });
+} catch (error) {
+  if (!(error instanceof DriverCancelled)) throw error;
+  driver.cancelled();
+  process.exitCode = 2;
+}

--- a/setup/lib/fixtures/setup-receipt.ts
+++ b/setup/lib/fixtures/setup-receipt.ts
@@ -1,0 +1,15 @@
+import type { SetupReceipt } from '../setup-driver.js';
+
+export function fixtureSetupReceipt(): SetupReceipt {
+  return {
+    version: 1,
+    service: { state: 'running', manager: 'pidfile', checkoutRoot: process.cwd() },
+    health: { status: 'healthy' },
+    resources: {
+      groups: { state: 'empty', count: 0 },
+      policies: { state: 'empty', count: 0 },
+      skills: { state: 'empty', count: 0 },
+    },
+    completedAt: new Date().toISOString(),
+  };
+}

--- a/setup/lib/interactive-process.test.ts
+++ b/setup/lib/interactive-process.test.ts
@@ -1,0 +1,203 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { runInteractiveProcess } from './interactive-process.js';
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+
+const STUBBORN_GRANDCHILD = `
+  process.on('SIGTERM', () => {});
+  process.stdout.write('ready\\n');
+  setInterval(() => {}, 1000);
+`;
+
+function machineDriver(controller = new AbortController()): SetupDriver {
+  return {
+    mode: 'ndjson',
+    operation: 'setup',
+    cancellationSignal: controller.signal,
+    throwIfCancelled() {
+      if (controller.signal.aborted) throw new DriverCancelled('test');
+    },
+  } as SetupDriver;
+}
+
+describe('runInteractiveProcess', () => {
+  it('pipes provider output and accepts provider input in machine mode', async () => {
+    const seen: string[] = [];
+    let answered = false;
+    const result = await runInteractiveProcess(
+      machineDriver(),
+      process.execPath,
+      [
+        '-e',
+        `
+        process.stdout.write('code?\\n');
+        process.stdin.once('data', (chunk) => {
+          process.stdout.write(chunk.toString() === 'answer\\n' ? 'accepted\\n' : 'rejected\\n');
+        });
+      `,
+      ],
+      {
+        onOutput(chunk, _stream, input) {
+          seen.push(chunk);
+          if (!answered && chunk.includes('code?')) {
+            answered = true;
+            input.write('answer\n');
+            input.end();
+          }
+        },
+      },
+    );
+
+    expect(result).toEqual({ reason: 'exited', exitCode: 0 });
+    expect(seen.join('')).toContain('accepted');
+  });
+
+  it('passes only the machine allowlist plus explicit isolated overrides', async () => {
+    const previous = process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN;
+    process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN = 'must-not-leak';
+    let output = '';
+    try {
+      const result = await runInteractiveProcess(
+        machineDriver(),
+        process.execPath,
+        [
+          '-e',
+          `process.stdout.write(JSON.stringify({ home: process.env.HOME, leaked: process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN, color: process.env.NO_COLOR }))`,
+        ],
+        {
+          env: { HOME: '/tmp/isolated-auth-home' },
+          onOutput(chunk) {
+            output += chunk;
+          },
+        },
+      );
+      expect(result).toEqual({ reason: 'exited', exitCode: 0 });
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN;
+      else process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN = previous;
+    }
+
+    expect(JSON.parse(output)).toEqual({
+      home: '/tmp/isolated-auth-home',
+      color: '1',
+    });
+  });
+
+  it('stops a machine child whose output exceeds the fixed bound', async () => {
+    const result = await runInteractiveProcess(machineDriver(), process.execPath, [
+      '-e',
+      `process.stdout.write(Buffer.alloc(${256 * 1024 + 1}, 120))`,
+    ]);
+
+    expect(result).toEqual({ reason: 'output_limit' });
+  });
+
+  it('stops a machine child at the provider deadline', async () => {
+    const result = await runInteractiveProcess(
+      machineDriver(),
+      process.execPath,
+      ['-e', 'setInterval(() => {}, 1000)'],
+      { timeoutMs: 25 },
+    );
+
+    expect(result).toEqual({ reason: 'timed_out' });
+  });
+
+  it.skipIf(process.platform === 'win32')('kills the whole process group on cancellation', async () => {
+    const controller = new AbortController();
+    let grandchildPid = 0;
+    const running = runInteractiveProcess(
+      machineDriver(controller),
+      process.execPath,
+      [
+        '-e',
+        `
+        const { spawn } = require('node:child_process');
+        const child = spawn(process.execPath, ['-e', ${JSON.stringify(STUBBORN_GRANDCHILD)}], {
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        child.stdout.once('data', () => process.stdout.write(String(child.pid) + '\\n'));
+        setInterval(() => {}, 1000);
+      `,
+      ],
+      {
+        onOutput(chunk) {
+          grandchildPid = Number(chunk.trim());
+          controller.abort();
+        },
+      },
+    );
+
+    try {
+      await expect(running).rejects.toBeInstanceOf(DriverCancelled);
+      expect(grandchildPid).toBeGreaterThan(0);
+      await waitUntilGone(grandchildPid);
+      expect(() => process.kill(grandchildPid, 0)).toThrow();
+    } finally {
+      if (grandchildPid > 0) {
+        try {
+          process.kill(grandchildPid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')('kills the whole process group when the setup parent exits', async () => {
+    const fixture = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'interactive-process-parent-exit.ts',
+    );
+    const tsx = path.resolve('node_modules/tsx/dist/cli.mjs');
+    const child = spawn(process.execPath, [tsx, fixture], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+
+    expect(exitCode).toBe(23);
+    const grandchildPid = Number(stdout.trim());
+    expect(grandchildPid).toBeGreaterThan(0);
+    await waitUntilGone(grandchildPid);
+    expect(() => process.kill(grandchildPid, 0)).toThrow();
+  });
+});
+
+describe('setup process-group escalation', () => {
+  it('does not gate SIGKILL on the process-group leader still running', () => {
+    const setupDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    for (const file of [
+      'auto.ts',
+      'lib/agent-ping.ts',
+      'lib/interactive-process.ts',
+      'lib/runner.ts',
+      'lib/skill-driver.ts',
+      'lib/tz-from-claude.ts',
+    ]) {
+      const source = fs.readFileSync(path.join(setupDir, file), 'utf8');
+      expect(source, file).not.toContain('child.exitCode === null');
+    }
+  });
+});
+
+async function waitUntilGone(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}

--- a/setup/lib/interactive-process.ts
+++ b/setup/lib/interactive-process.ts
@@ -1,0 +1,194 @@
+import { spawn } from 'node:child_process';
+
+import { redactSensitiveValues } from './redaction.js';
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
+
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const MACHINE_ENV_KEYS = [
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'PATH',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
+  'TEMP',
+  'TMP',
+  'TMPDIR',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME',
+] as const;
+
+export type InteractiveProcessResult =
+  | { reason: 'exited'; exitCode: number }
+  | { reason: 'spawn_failed'; message: string }
+  | { reason: 'output_limit' }
+  | { reason: 'timed_out' };
+
+export type InteractiveProcessInput = {
+  write(value: string): void;
+  end(): void;
+};
+
+type InteractiveProcessOptions = {
+  env?: Record<string, string | undefined>;
+  /** Machine-mode deadline. Terminal mode remains operator-controlled. */
+  timeoutMs?: number;
+  onOutput?: (chunk: string, stream: 'stdout' | 'stderr', input: InteractiveProcessInput) => void | Promise<void>;
+};
+
+export function machineChildEnvironment(
+  overrides: Record<string, string | undefined> = {},
+  source: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { NO_COLOR: '1' };
+  for (const key of MACHINE_ENV_KEYS) {
+    if (source[key] !== undefined) env[key] = source[key];
+  }
+  return childEnvWithoutSetupSecrets({ ...env, ...overrides });
+}
+
+/**
+ * Run one provider-owned interactive CLI.
+ *
+ * Terminal mode preserves inherited stdio. Machine mode exposes bounded raw
+ * chunks only to the provider callback, which owns interpretation and
+ * redaction, while this helper owns child lifetime and process-group cleanup.
+ */
+export function runInteractiveProcess(
+  driver: SetupDriver,
+  command: string,
+  args: string[],
+  options: InteractiveProcessOptions = {},
+): Promise<InteractiveProcessResult> {
+  driver.throwIfCancelled();
+  const machine = driver.mode === 'ndjson';
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: machine ? ['pipe', 'pipe', 'pipe'] : 'inherit',
+      env: machine
+        ? machineChildEnvironment(options.env)
+        : options.env
+          ? { ...process.env, ...options.env }
+          : process.env,
+      ...(machine ? { detached: true } : {}),
+    });
+
+    let outputBytes = 0;
+    let outputLimitExceeded = false;
+    let timedOut = false;
+    let spawnFailure: string | undefined;
+    let callbackFailure: unknown;
+    let callbackChain = Promise.resolve();
+    let finished = false;
+
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+
+    const onParentExit = (): void => {
+      if (!machine || !child.pid) return;
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    };
+    if (machine) process.once('exit', onParentExit);
+    const timeout =
+      machine && options.timeoutMs !== undefined
+        ? setTimeout(() => {
+            timedOut = true;
+            stopGroup();
+          }, options.timeoutMs).unref()
+        : undefined;
+
+    const input: InteractiveProcessInput = {
+      write(value) {
+        if (machine && child.stdin?.writable) child.stdin.write(value);
+      },
+      end() {
+        if (machine && child.stdin?.writable) child.stdin.end();
+      },
+    };
+
+    const forward = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+      if (outputLimitExceeded || callbackFailure !== undefined) return;
+      outputBytes += chunk.byteLength;
+      if (outputBytes > MAX_OUTPUT_BYTES) {
+        outputLimitExceeded = true;
+        stopGroup();
+        return;
+      }
+      if (!options.onOutput) return;
+      const text = chunk.toString('utf8');
+      callbackChain = callbackChain
+        .then(() => options.onOutput?.(text, stream, input))
+        .catch((error: unknown) => {
+          callbackFailure = error;
+          stopGroup();
+        });
+    };
+
+    if (machine) {
+      child.stdout?.on('data', (chunk: Buffer) => forward(chunk, 'stdout'));
+      child.stderr?.on('data', (chunk: Buffer) => forward(chunk, 'stderr'));
+    }
+
+    const onCancel = (): void => stopGroup();
+    driver.cancellationSignal?.addEventListener('abort', onCancel, { once: true });
+    if (driver.cancellationSignal?.aborted) stopGroup();
+
+    const finish = async (code: number | null): Promise<void> => {
+      if (finished) return;
+      finished = true;
+      if (timeout) clearTimeout(timeout);
+      if (machine) process.removeListener('exit', onParentExit);
+      driver.cancellationSignal?.removeEventListener('abort', onCancel);
+      await callbackChain;
+      if (callbackFailure !== undefined) {
+        reject(callbackFailure);
+        return;
+      }
+      try {
+        driver.throwIfCancelled();
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      if (timedOut) {
+        resolve({ reason: 'timed_out' });
+      } else if (outputLimitExceeded) {
+        resolve({ reason: 'output_limit' });
+      } else if (spawnFailure !== undefined) {
+        resolve({ reason: 'spawn_failed', message: spawnFailure });
+      } else {
+        resolve({ reason: 'exited', exitCode: code ?? 1 });
+      }
+    };
+
+    child.on('error', (error) => {
+      spawnFailure = redactSensitiveValues(error.message);
+    });
+    child.on('close', (code) => {
+      void finish(code);
+    });
+  });
+}

--- a/setup/lib/redaction.test.ts
+++ b/setup/lib/redaction.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearSensitiveValuesForTest, createSensitiveRedactor, registerSensitiveValue } from './redaction.js';
+
+afterEach(clearSensitiveValuesForTest);
+
+describe('streaming sensitive-value redaction', () => {
+  it('redacts a secret split across child-output chunks', () => {
+    registerSensitiveValue('secret-value');
+    const redactor = createSensitiveRedactor();
+    const output = redactor.write('before secret-') + redactor.write('value after') + redactor.end();
+    expect(output).toBe('before [REDACTED] after');
+  });
+
+  it('streams safe output while retaining only a possible secret boundary', () => {
+    registerSensitiveValue('secret-value');
+    const redactor = createSensitiveRedactor();
+    const output = redactor.write('visible output '.repeat(100));
+    expect(output.length).toBeGreaterThan(1_000);
+    expect(output).not.toContain('secret-value');
+  });
+
+  it('prefers a longer secret when registered values overlap', () => {
+    registerSensitiveValue('secret');
+    registerSensitiveValue('secret-value');
+    const redactor = createSensitiveRedactor();
+    const output = redactor.write('before secret-value after') + redactor.end();
+    expect(output).toBe('before [REDACTED] after');
+  });
+});

--- a/setup/lib/redaction.ts
+++ b/setup/lib/redaction.ts
@@ -1,0 +1,56 @@
+const sensitiveValues = new Set<string>();
+
+export function registerSensitiveValue(value: string): void {
+  if (value.length > 0) sensitiveValues.add(value);
+}
+
+export function redactSensitiveValues(value: string): string {
+  let redacted = value;
+  for (const secret of [...sensitiveValues].sort((a, b) => b.length - a.length)) {
+    redacted = redacted.split(secret).join('[REDACTED]');
+  }
+  return redacted;
+}
+
+export function createSensitiveRedactor(): { write(chunk: string): string; end(): string } {
+  const secrets = [...sensitiveValues].sort((a, b) => b.length - a.length);
+  const maxLength = Math.max(0, ...secrets.map((secret) => secret.length));
+  let pending = '';
+
+  const drain = (flush: boolean): string => {
+    if (flush) {
+      const output = redactSensitiveValues(pending);
+      pending = '';
+      return output;
+    }
+    const limit = pending.length - Math.max(0, maxLength - 1);
+    let index = 0;
+    let output = '';
+    while (index < limit) {
+      const secret = secrets.find((candidate) => pending.startsWith(candidate, index));
+      if (secret) {
+        output += '[REDACTED]';
+        index += secret.length;
+      } else {
+        output += pending[index];
+        index++;
+      }
+    }
+    pending = pending.slice(index);
+    return output;
+  };
+
+  return {
+    write(chunk) {
+      pending += chunk;
+      return drain(false);
+    },
+    end() {
+      return drain(true);
+    },
+  };
+}
+
+export function clearSensitiveValuesForTest(): void {
+  sensitiveValues.clear();
+}

--- a/setup/lib/role-prompt.ts
+++ b/setup/lib/role-prompt.ts
@@ -10,10 +10,25 @@
  */
 import { brightSelect } from './bright-select.js';
 import { ensureAnswer } from './runner.js';
+import type { SetupDriver } from './setup-driver.js';
 
 export type OperatorRole = 'owner' | 'admin' | 'member';
 
-export async function askOperatorRole(channelLabel: string): Promise<OperatorRole> {
+export async function askOperatorRole(channelLabel: string, driver?: SetupDriver): Promise<OperatorRole> {
+  if (driver) {
+    return String(
+      await driver.prompt({
+        kind: 'singleChoice',
+        message: `How should this ${channelLabel} account be registered?`,
+        default: 'owner',
+        choices: [
+          { id: 'owner', label: 'Owner', hint: 'full access - recommended for your own account' },
+          { id: 'admin', label: 'Admin', hint: 'can manage the agent for this channel' },
+          { id: 'member', label: 'Member', hint: 'can chat with the agent but nothing more' },
+        ],
+      }),
+    ) as OperatorRole;
+  }
   const choice = ensureAnswer(
     await brightSelect<OperatorRole>({
       message: `How should this ${channelLabel} account be registered?`,

--- a/setup/lib/runner.test.ts
+++ b/setup/lib/runner.test.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { spawnQuiet } from './runner.js';
+import type { SetupDriver } from './setup-driver.js';
+
+describe('machine child output bounds', () => {
+  it('stops a noisy quiet child before its in-memory transcript can grow without bound', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-runner-limit-'));
+    const rawLog = path.join(root, 'raw.log');
+    const driver = { mode: 'ndjson' } as SetupDriver;
+    try {
+      const result = await spawnQuiet(
+        process.execPath,
+        ['-e', `process.stdout.write('x'.repeat(5 * 1024 * 1024))`],
+        rawLog,
+        undefined,
+        driver,
+      );
+
+      expect(result).toMatchObject({ ok: false, failure: 'output_limit' });
+      expect(Buffer.byteLength(result.transcript, 'utf8')).toBeLessThanOrEqual(4 * 1024 * 1024);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/lib/runner.ts
+++ b/setup/lib/runner.ts
@@ -20,7 +20,12 @@ import k from 'kleur';
 import * as setupLog from '../logs.js';
 import { offerClaudeOnFailure } from './claude-handoff.js';
 import { emit as phEmit } from './diagnostics.js';
+import { createSensitiveRedactor, redactSensitiveValues } from './redaction.js';
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
 import { brandBody, fitToWidth, fmtDuration } from './theme.js';
+
+const MAX_MACHINE_CHILD_OUTPUT_BYTES = 4 * 1024 * 1024;
 
 export type Fields = Record<string, string>;
 export type Block = { type: string; fields: Fields };
@@ -28,6 +33,7 @@ export type Block = { type: string; fields: Fields };
 export type StepResult = {
   ok: boolean;
   exitCode: number;
+  failure?: 'output_limit';
   blocks: Block[];
   transcript: string;
   /** The last block with a STATUS field (the terminal/result block). */
@@ -37,6 +43,7 @@ export type StepResult = {
 export type QuietChildResult = {
   ok: boolean;
   exitCode: number;
+  failure?: 'output_limit';
   transcript: string;
   terminal: Block | null;
   blocks: Block[];
@@ -115,15 +122,51 @@ export function spawnStep(
   onBlock: (block: Block) => void,
   rawLogPath: string,
   onLine?: (line: string) => void,
+  driver?: SetupDriver,
 ): Promise<StepResult> {
   return new Promise((resolve) => {
     const args = ['exec', 'tsx', 'setup/index.ts', '--step', stepName];
     if (extra.length > 0) args.push('--', ...extra);
 
-    const child = spawn('pnpm', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const machine = driver?.mode === 'ndjson';
+    const child = spawn('pnpm', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...(machine ? { detached: true, env: childEnvWithoutSetupSecrets() } : {}),
+    });
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+    if (driver?.cancellationSignal?.aborted) stopGroup();
     const stream = new StatusStream(onBlock);
+    const stdoutRedactor = machine ? createSensitiveRedactor() : undefined;
+    const stderrRedactor = machine ? createSensitiveRedactor() : undefined;
     const raw = fs.createWriteStream(rawLogPath, { flags: 'w' });
     raw.write(`# ${stepName} — ${new Date().toISOString()}\n\n`);
+    let outputBytes = 0;
+    let outputLimitExceeded = false;
+    const accepts = (chunk: Buffer): boolean => {
+      if (!machine) return true;
+      if (outputLimitExceeded) return false;
+      outputBytes += chunk.byteLength;
+      if (outputBytes <= MAX_MACHINE_CHILD_OUTPUT_BYTES) return true;
+      outputLimitExceeded = true;
+      stopGroup();
+      return false;
+    };
 
     // Per-line forwarder for the optional onLine callback. We keep our own
     // buffer (separate from StatusStream's) so the parser still gets raw
@@ -143,31 +186,54 @@ export function spawnStep(
     };
 
     child.stdout.on('data', (chunk: Buffer) => {
+      if (!accepts(chunk)) return;
       const s = chunk.toString('utf-8');
-      stream.write(s);
-      raw.write(chunk);
-      pushLines(s);
+      const safe = stdoutRedactor?.write(s) ?? s;
+      stream.write(safe);
+      raw.write(safe);
+      pushLines(safe);
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      const s = chunk.toString('utf-8');
-      stream.transcript += s;
-      raw.write(chunk);
-      pushLines(s);
+      if (!accepts(chunk)) return;
+      const safe = stderrRedactor?.write(chunk.toString('utf-8')) ?? chunk.toString('utf-8');
+      stream.transcript += safe;
+      raw.write(safe);
+      pushLines(safe);
     });
 
-    child.on('close', (code) => {
+    let finished = false;
+    const finish = (code: number | null): void => {
+      if (finished) return;
+      finished = true;
+      driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+      const stdoutTail = stdoutRedactor?.end() ?? '';
+      const stderrTail = stderrRedactor?.end() ?? '';
+      stream.write(stdoutTail);
+      stream.transcript += stderrTail;
+      raw.write(stdoutTail);
+      raw.write(stderrTail);
+      pushLines(stdoutTail);
+      pushLines(stderrTail);
       raw.end();
       const terminal = [...stream.blocks].reverse().find((b) => b.fields.STATUS) ?? null;
       const status = terminal?.fields.STATUS;
-      const ok = code === 0 && (status === 'success' || status === 'skipped');
+      const ok = !outputLimitExceeded && code === 0 && (status === 'success' || status === 'skipped');
       resolve({
         ok,
         exitCode: code ?? 1,
+        ...(outputLimitExceeded ? { failure: 'output_limit' as const } : {}),
         blocks: stream.blocks,
         transcript: stream.transcript,
         terminal,
       });
+    };
+    child.on('error', (error) => {
+      const safe = machine ? redactSensitiveValues(error.message) : error.message;
+      stream.transcript += safe;
+      raw.write(safe);
+      finish(1);
     });
+    child.on('close', finish);
   });
 }
 
@@ -176,32 +242,103 @@ export function spawnQuiet(
   args: string[],
   rawLogPath: string,
   envOverride?: NodeJS.ProcessEnv,
+  driver?: SetupDriver,
 ): Promise<QuietChildResult> {
   return new Promise((resolve) => {
+    const machine = driver?.mode === 'ndjson';
     const child = spawn(cmd, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: envOverride ? { ...process.env, ...envOverride } : process.env,
+      // Machine callers pass a complete sanitized environment. Merging it
+      // with the parent environment would reintroduce setup secrets; terminal
+      // callers retain the existing partial-override behavior.
+      env: machine
+        ? childEnvWithoutSetupSecrets(envOverride ?? process.env)
+        : envOverride
+          ? { ...process.env, ...envOverride }
+          : process.env,
+      ...(machine ? { detached: true } : {}),
     });
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+    if (driver?.cancellationSignal?.aborted) stopGroup();
     let transcript = '';
     const raw = fs.createWriteStream(rawLogPath, { flags: 'w' });
-    raw.write(`# ${[cmd, ...args].join(' ')} — ${new Date().toISOString()}\n\n`);
+    raw.write(
+      `# ${machine ? redactSensitiveValues([cmd, ...args].join(' ')) : [cmd, ...args].join(' ')} - ${new Date().toISOString()}\n\n`,
+    );
     const blocks: Block[] = [];
     const stream = new StatusStream((b) => blocks.push(b));
+    const stdoutRedactor = machine ? createSensitiveRedactor() : undefined;
+    const stderrRedactor = machine ? createSensitiveRedactor() : undefined;
+    let outputBytes = 0;
+    let outputLimitExceeded = false;
+    const accepts = (chunk: Buffer): boolean => {
+      if (!machine) return true;
+      if (outputLimitExceeded) return false;
+      outputBytes += chunk.byteLength;
+      if (outputBytes <= MAX_MACHINE_CHILD_OUTPUT_BYTES) return true;
+      outputLimitExceeded = true;
+      stopGroup();
+      return false;
+    };
     child.stdout.on('data', (c: Buffer) => {
+      if (!accepts(c)) return;
       const s = c.toString('utf-8');
-      transcript += s;
-      stream.write(s);
-      raw.write(c);
+      const safe = stdoutRedactor?.write(s) ?? s;
+      transcript += safe;
+      stream.write(safe);
+      raw.write(safe);
     });
     child.stderr.on('data', (c: Buffer) => {
-      transcript += c.toString('utf-8');
-      raw.write(c);
+      if (!accepts(c)) return;
+      const safe = stderrRedactor?.write(c.toString('utf-8')) ?? c.toString('utf-8');
+      transcript += safe;
+      raw.write(safe);
     });
-    child.on('close', (code) => {
+    let finished = false;
+    const finish = (code: number | null): void => {
+      if (finished) return;
+      finished = true;
+      driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+      const stdoutTail = stdoutRedactor?.end() ?? '';
+      const stderrTail = stderrRedactor?.end() ?? '';
+      transcript += stdoutTail + stderrTail;
+      stream.write(stdoutTail);
+      raw.write(stdoutTail);
+      raw.write(stderrTail);
       raw.end();
       const terminal = [...blocks].reverse().find((b) => b.fields.STATUS) ?? null;
-      resolve({ ok: code === 0, exitCode: code ?? 1, transcript, terminal, blocks });
+      resolve({
+        ok: !outputLimitExceeded && code === 0,
+        exitCode: code ?? 1,
+        ...(outputLimitExceeded ? { failure: 'output_limit' as const } : {}),
+        transcript,
+        terminal,
+        blocks,
+      });
+    };
+    child.on('error', (error) => {
+      const safe = machine ? redactSensitiveValues(error.message) : error.message;
+      transcript += safe;
+      raw.write(safe);
+      finish(1);
     });
+    child.on('close', finish);
   });
 }
 
@@ -210,18 +347,27 @@ export async function runQuietStep(
   stepName: string,
   labels: SpinnerLabels,
   extra: string[] = [],
+  driver?: SetupDriver,
 ): Promise<StepResult & { rawLog: string; durationMs: number }> {
   const rawLog = setupLog.stepRawLog(stepName);
   const start = Date.now();
+  driver?.throwIfCancelled();
+  driver?.progress(stepName, 'pending', labels.running.replace(/…$/, ''));
   phEmit('step_started', { step: stepName });
-  const result = await runUnderSpinner(labels, () => spawnStep(stepName, extra, () => {}, rawLog));
+  const result = await runUnderSpinner(
+    labels,
+    () => spawnStep(stepName, extra, () => {}, rawLog, undefined, driver),
+    driver,
+    stepName,
+  );
   const durationMs = Date.now() - start;
-  writeStepEntry(stepName, result, durationMs, rawLog);
+  writeStepEntry(stepName, result, durationMs, rawLog, driver?.mode === 'ndjson');
   phEmit('step_completed', {
     step: stepName,
     status: outcomeStatus(result),
     duration_ms: durationMs,
   });
+  driver?.throwIfCancelled();
   return { ...result, rawLog, durationMs };
 }
 
@@ -237,14 +383,17 @@ export async function runQuietChild(
     /** Environment overrides to pass to the child process. */
     env?: NodeJS.ProcessEnv;
   },
+  driver?: SetupDriver,
 ): Promise<QuietChildResult & { rawLog: string; durationMs: number }> {
   const rawLog = setupLog.stepRawLog(logName);
   const start = Date.now();
+  driver?.throwIfCancelled();
+  driver?.progress(logName, 'pending', labels.running.replace(/…$/, ''));
   phEmit('step_started', { step: logName });
-  const result = await runUnderSpinner(labels, () => spawnQuiet(cmd, args, rawLog, opts?.env));
+  const result = await runUnderSpinner(labels, () => spawnQuiet(cmd, args, rawLog, opts?.env, driver), driver, logName);
   const durationMs = Date.now() - start;
 
-  const blockFields = summariseTerminalFields(result.terminal);
+  const blockFields = summariseTerminalFields(result.terminal, driver?.mode === 'ndjson');
   const fields = { ...blockFields, ...(opts?.extraFields ?? {}) };
   const rawStatus = result.terminal?.fields.STATUS;
   const status: 'success' | 'skipped' | 'failed' = !result.ok
@@ -254,6 +403,7 @@ export async function runQuietChild(
       : 'success';
   setupLog.step(logName, status, durationMs, fields, rawLog);
   phEmit('step_completed', { step: logName, status, duration_ms: durationMs });
+  driver?.throwIfCancelled();
   return { ...result, rawLog, durationMs };
 }
 
@@ -265,25 +415,31 @@ function outcomeStatus(result: StepResult): 'success' | 'skipped' | 'failed' {
 }
 
 /** Turn a step's terminal-block fields into a concise progression-log entry. */
-export function writeStepEntry(stepName: string, result: StepResult, durationMs: number, rawLog: string): void {
+export function writeStepEntry(
+  stepName: string,
+  result: StepResult,
+  durationMs: number,
+  rawLog: string,
+  redact = false,
+): void {
   const rawStatus = result.terminal?.fields.STATUS;
   const logStatus: 'success' | 'skipped' | 'failed' = !result.ok
     ? 'failed'
     : rawStatus === 'skipped'
       ? 'skipped'
       : 'success';
-  const fields = summariseTerminalFields(result.terminal);
+  const fields = summariseTerminalFields(result.terminal, redact);
   setupLog.step(stepName, logStatus, durationMs, fields, rawLog);
 }
 
 /** Strip STATUS + LOG (redundant) and any oversize values from the terminal block's fields. */
-export function summariseTerminalFields(block: Block | null): Record<string, string> {
+export function summariseTerminalFields(block: Block | null, redact = false): Record<string, string> {
   if (!block) return {};
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(block.fields)) {
     if (k === 'STATUS' || k === 'LOG') continue;
     if (v.length > 120) continue; // keep it skimmable; full value lives in the raw log
-    out[k] = v;
+    out[k] = redact ? redactSensitiveValues(v) : v;
   }
   return out;
 }
@@ -300,9 +456,24 @@ export function summariseTerminalFields(block: Block | null): Record<string, str
  * done/skipped/failed headline (bold) with the elapsed time (dim); on a failure
  * it also dumps the transcript tail when one is supplied.
  */
-export function startSpinner(labels: SpinnerLabels): {
+export function startSpinner(
+  labels: SpinnerLabels,
+  driver?: SetupDriver,
+  stepId = labels.running
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase(),
+): {
   stop: (outcome: { ok: boolean; skipped?: boolean; transcript?: string }) => void;
 } {
+  if (driver?.mode === 'ndjson') {
+    driver.progress(stepId, 'running', labels.running.replace(/…$/, ''));
+    return {
+      stop({ ok, skipped }) {
+        driver.progress(stepId, ok ? 'succeeded' : 'failed');
+      },
+    };
+  }
   const s = p.spinner();
   const start = Date.now();
   s.start(fitToWidth(labels.running, ' (99m 59s)'));
@@ -321,7 +492,7 @@ export function startSpinner(labels: SpinnerLabels): {
         s.stop(`${k.bold(fitToWidth(msg, suffix))}${k.dim(suffix)}`);
       } else {
         const failMsg = labels.failed ?? labels.running.replace(/…$/, ' failed');
-        s.stop(`${k.bold(fitToWidth(failMsg, suffix))}${k.dim(suffix)}`, 1);
+        s.error(`${k.bold(fitToWidth(failMsg, suffix))}${k.dim(suffix)}`);
         if (transcript) dumpTranscriptOnFailure(transcript);
       }
     },
@@ -331,8 +502,10 @@ export function startSpinner(labels: SpinnerLabels): {
 async function runUnderSpinner<T extends { ok: boolean; transcript: string; terminal?: Block | null }>(
   labels: SpinnerLabels,
   work: () => Promise<T>,
+  driver?: SetupDriver,
+  stepId?: string,
 ): Promise<T> {
-  const spinner = startSpinner(labels);
+  const spinner = startSpinner(labels, driver, stepId);
   const result = await work();
   spinner.stop({
     ok: result.ok,
@@ -366,9 +539,33 @@ export function dumpTranscriptOnFailure(transcript: string): void {
  * process.exit. The return type is `Promise<never>`; control-flow
  * narrowing still works after `await`.
  */
-export async function fail(stepName: string, msg: string, hint?: string, rawLogPath?: string): Promise<never> {
+export async function fail(
+  stepName: string,
+  msg: string,
+  hint?: string,
+  rawLogPath?: string,
+  driver?: SetupDriver,
+): Promise<never> {
+  // A signal received during an atomic child/health operation wins over that
+  // operation's failure result: machine cancellation is terminal exit 2.
+  driver?.throwIfCancelled();
   setupLog.abort(stepName, msg);
   phEmit('setup_aborted', { step: stepName, reason: msg });
+  if (driver?.mode === 'ndjson') {
+    driver.progress(stepName, 'failed');
+    driver.error(
+      'step_failed',
+      msg,
+      [
+        {
+          kind: 'manual',
+          title: 'Fix the failed prerequisite and rerun',
+          instructions: [hint ?? 'Inspect logs/setup.log and the matching raw step log.'],
+        },
+      ],
+      stepName,
+    );
+  }
   p.log.error(msg);
   if (hint) p.log.message(k.dim(hint));
   p.log.message(k.dim('Logs: logs/setup.log · Raw: logs/setup-steps/'));

--- a/setup/lib/secret-file.test.ts
+++ b/setup/lib/secret-file.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { withSecretFile } from './secret-file.js';
+
+describe('withSecretFile', () => {
+  it('provides a private file and removes it after the operation', async () => {
+    const secret = 'machine-only-secret';
+    let secretPath = '';
+
+    await withSecretFile(secret, async (filePath) => {
+      secretPath = filePath;
+      expect(fs.readFileSync(filePath, 'utf8')).toBe(secret);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(path.dirname(filePath)).mode & 0o777).toBe(0o700);
+    });
+
+    expect(fs.existsSync(secretPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+
+  it('removes the file when the operation fails', async () => {
+    let secretPath = '';
+
+    await expect(
+      withSecretFile('secret', async (filePath) => {
+        secretPath = filePath;
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+
+    expect(fs.existsSync(secretPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+});

--- a/setup/lib/secret-file.test.ts
+++ b/setup/lib/secret-file.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { withSecretFile } from './secret-file.js';
+import { childEnvWithoutSetupSecrets, withSecretFile } from './secret-file.js';
 
 describe('withSecretFile', () => {
   it('provides a private file and removes it after the operation', async () => {
@@ -33,5 +33,17 @@ describe('withSecretFile', () => {
 
     expect(fs.existsSync(secretPath)).toBe(false);
     expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+
+  it('removes setup credentials from machine child environments', () => {
+    expect(
+      childEnvWithoutSetupSecrets({
+        NANOCLAW_ANTHROPIC_AUTH_TOKEN: 'secret',
+        NANOCLAW_REGISTRY_ENROLL_CODE: 'secret',
+        NANOCLAW_REGISTRY_TOKEN: 'secret',
+        ONECLI_API_KEY: 'secret',
+        PATH: '/bin',
+      }),
+    ).toEqual({ PATH: '/bin' });
   });
 });

--- a/setup/lib/secret-file.ts
+++ b/setup/lib/secret-file.ts
@@ -26,3 +26,19 @@ export async function withSecretFile<T>(secret: string, operation: (filePath: st
     fs.rmdirSync(directory);
   }
 }
+
+export function childEnvWithoutSetupSecrets(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const safe = { ...env };
+  for (const key of [
+    'NANOCLAW_ANTHROPIC_AUTH_TOKEN',
+    'NANOCLAW_ONECLI_API_TOKEN',
+    'NANOCLAW_REGISTRY_ENROLL_CODE',
+    'NANOCLAW_REGISTRY_TOKEN',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ONECLI_API_KEY',
+  ])
+    delete safe[key];
+  return safe;
+}

--- a/setup/lib/secret-file.ts
+++ b/setup/lib/secret-file.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** Run an operation with a private one-use secret file, then remove it. */
+export async function withSecretFile<T>(secret: string, operation: (filePath: string) => Promise<T>): Promise<T> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-secret-'));
+  const filePath = path.join(directory, 'value');
+  let fd: number | undefined;
+
+  try {
+    fs.chmodSync(directory, 0o700);
+    fd = fs.openSync(
+      filePath,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.writeFileSync(fd, secret, { encoding: 'utf8' });
+    fs.fchmodSync(fd, 0o600);
+    fs.closeSync(fd);
+    fd = undefined;
+    return await operation(filePath);
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+    fs.rmSync(filePath, { force: true });
+    fs.rmdirSync(directory);
+  }
+}

--- a/setup/lib/service-health.test.ts
+++ b/setup/lib/service-health.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import net, { type Server, type Socket } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { getLaunchdLabel } from '../../src/install-slug.js';
+import { buildSetupReceipt, inspectService, queryHostHealth } from './service-health.js';
+
+async function stalledServer(root: string): Promise<{ server: Server; sockets: Set<Socket> }> {
+  const socketPath = path.join(root, 'data', 'ncl.sock');
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+  const sockets = new Set<Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  return { server, sockets };
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) socket.destroy();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe('inspectService', () => {
+  it.skipIf(process.platform !== 'darwin')('uses the launchd PID and verifies the NanoClaw script identity', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-'));
+    const calls: string[][] = [];
+    const result = inspectService(root, (file, args) => {
+      calls.push([file, ...args]);
+      if (file === 'launchctl') return `${process.pid}\t0\t${getLaunchdLabel(root)}`;
+      if (file === 'ps') return `node ${root}/dist/index.js`;
+      throw new Error('not used');
+    });
+    expect(result.state).toBe('running');
+    expect(result.manager).toBe('launchd');
+    expect(result.pid).toBe(process.pid);
+    expect(result.checkoutRoot).toBe(root);
+    expect(calls.some(([file]) => file === 'ps')).toBe(true);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform !== 'darwin')('verifies a NanoClaw script path containing spaces', () => {
+    const root = '/tmp/nano claw';
+    const result = inspectService(root, (file) => {
+      if (file === 'launchctl') return `${process.pid}\t0\t${getLaunchdLabel(root)}`;
+      if (file === 'ps') return `node ${root}/dist/index.js`;
+      throw new Error('not used');
+    });
+
+    expect(result).toMatchObject({
+      state: 'running',
+      manager: 'launchd',
+      pid: process.pid,
+      checkoutRoot: root,
+    });
+  });
+});
+
+describe('buildSetupReceipt', () => {
+  const root = process.cwd();
+  const service = { state: 'running' as const, manager: 'pidfile' as const, pid: 42, checkoutRoot: root };
+  const health = {
+    status: 'healthy' as const,
+    checkoutRoot: root,
+    process: { pid: 42, ppid: 1, executable: '/usr/bin/node', script: `${root}/dist/index.js`, cwd: root },
+    resources: {
+      groups: { state: 'empty' as const, count: 0 },
+      policies: { state: 'empty' as const, count: 0 },
+      skills: { state: 'empty' as const, count: 0 },
+    },
+  };
+
+  it('builds a complete-ready receipt for a valid zero-group health report', () => {
+    const result = buildSetupReceipt(root, service, health);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.receipt.resources.groups).toEqual({ state: 'empty', count: 0 });
+      expect(result.receipt.resources.policies).toEqual({ state: 'empty', count: 0 });
+      expect(result.receipt.health.status).toBe('healthy');
+    }
+  });
+
+  it('rejects mismatched service PID, checkout, or unhealthy health', () => {
+    expect(buildSetupReceipt(root, { ...service, pid: 43 }, health)).toMatchObject({
+      ok: false,
+      code: 'health_postcondition_failed',
+    });
+    expect(buildSetupReceipt('/other/checkout', service, health)).toMatchObject({
+      ok: false,
+      code: 'service_identity_unproven',
+    });
+    expect(buildSetupReceipt(root, service, { ...health, status: 'unhealthy' })).toMatchObject({
+      ok: false,
+      code: 'health_postcondition_failed',
+    });
+  });
+});
+
+describe('queryHostHealth', () => {
+  it('bounds a stalled socket request', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-socket-'));
+    const { server, sockets } = await stalledServer(root);
+    try {
+      await expect(queryHostHealth(root, { timeoutMs: 20 })).resolves.toBeNull();
+    } finally {
+      await closeServer(server, sockets);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('cancels an in-flight socket request', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-abort-'));
+    const { server, sockets } = await stalledServer(root);
+    const controller = new AbortController();
+    try {
+      const pending = queryHostHealth(root, { signal: controller.signal, timeoutMs: 5_000 });
+      controller.abort();
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      await closeServer(server, sockets);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/lib/service-health.ts
+++ b/setup/lib/service-health.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
+import { SocketTransport } from '../../src/cli/socket-client.js';
+import type { ResponseFrame } from '../../src/cli/frame.js';
+import type { HostHealth, HealthResource } from '../../src/health.js';
+import type { SetupReceipt } from './setup-driver.js';
+import { getPlatform, getServiceManager, isRoot } from '../platform.js';
+
+export type ServiceState = 'running' | 'stopped' | 'not_found' | 'running_other_checkout' | 'identity_unknown';
+
+export type ServiceCheck = {
+  state: ServiceState;
+  manager: 'launchd' | 'systemd-user' | 'systemd-system' | 'pidfile';
+  pid?: number;
+  checkoutRoot?: string;
+  reason?: string;
+};
+
+export type ReceiptBuildResult =
+  | { ok: true; receipt: SetupReceipt }
+  | { ok: false; code: 'service_identity_unproven' | 'health_postcondition_failed'; message: string };
+
+type Exec = (file: string, args: string[]) => string;
+
+const run: Exec = (file, args) => execFileSync(file, args, { encoding: 'utf8' });
+
+/** Inspect the install-owned service without trusting a human status string. */
+export function inspectService(projectRoot: string, execute: Exec = run): ServiceCheck {
+  const root = path.resolve(projectRoot);
+  const manager = serviceManager();
+  if (manager === 'launchd') return inspectLaunchd(root, execute);
+  if (manager === 'systemd-user' || manager === 'systemd-system') return inspectSystemd(root, manager, execute);
+  return inspectPidfile(root, execute);
+}
+
+export async function queryHostHealth(
+  projectRoot: string,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<HostHealth | null> {
+  const socketPath = path.join(path.resolve(projectRoot), 'data', 'ncl.sock');
+  let response: ResponseFrame;
+  try {
+    response = await new SocketTransport(socketPath).sendFrame(
+      { id: randomUUID(), command: 'health', args: {} },
+      { signal: options.signal, timeoutMs: options.timeoutMs ?? 1_000, maxResponseBytes: 256 * 1024 },
+    );
+  } catch {
+    return null;
+  }
+  if (!response.ok || !isHostHealth(response.data)) return null;
+  return response.data;
+}
+
+export function buildSetupReceipt(
+  projectRoot: string,
+  service: ServiceCheck,
+  health: HostHealth | null,
+): ReceiptBuildResult {
+  const checkoutRoot = path.resolve(projectRoot);
+  if (service.state !== 'running' || service.checkoutRoot !== checkoutRoot || service.pid === undefined) {
+    return {
+      ok: false,
+      code: 'service_identity_unproven',
+      message:
+        service.state === 'running_other_checkout'
+          ? 'NanoClaw is running from a different checkout.'
+          : 'NanoClaw service identity could not be proven.',
+    };
+  }
+  if (
+    !health ||
+    health.status !== 'healthy' ||
+    health.checkoutRoot !== checkoutRoot ||
+    health.process.cwd !== checkoutRoot ||
+    health.process.pid !== service.pid
+  ) {
+    return {
+      ok: false,
+      code: 'health_postcondition_failed',
+      message: 'NanoClaw service is running, but structured health could not prove this checkout is healthy.',
+    };
+  }
+  return {
+    ok: true,
+    receipt: {
+      version: 1,
+      service: { state: 'running', manager: service.manager, checkoutRoot },
+      health: { status: 'healthy' },
+      resources: health.resources,
+      completedAt: new Date().toISOString(),
+    },
+  };
+}
+
+function serviceManager(): ServiceCheck['manager'] {
+  if (getPlatform() === 'macos') return 'launchd';
+  if (getServiceManager() === 'systemd') return isRoot() ? 'systemd-system' : 'systemd-user';
+  return 'pidfile';
+}
+
+function inspectLaunchd(root: string, execute: Exec): ServiceCheck {
+  const manager = 'launchd' as const;
+  const label = getLaunchdLabel(root);
+  let output: string;
+  try {
+    output = execute('launchctl', ['list']);
+  } catch {
+    return { state: 'identity_unknown', manager, reason: 'launchctl_unavailable' };
+  }
+  const line = output.split('\n').find((candidate) => candidate.trim().split(/\s+/).at(-1) === label);
+  if (!line) return { state: 'not_found', manager };
+  const pidText = line.trim().split(/\s+/)[0];
+  if (pidText === '-') return { state: 'stopped', manager };
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid <= 0) return { state: 'identity_unknown', manager, reason: 'invalid_launchd_pid' };
+  return finishIdentity(manager, pid, root, execute);
+}
+
+function inspectSystemd(root: string, manager: 'systemd-user' | 'systemd-system', execute: Exec): ServiceCheck {
+  const unit = getSystemdUnit(root);
+  const command = manager === 'systemd-system' ? 'systemctl' : 'systemctl';
+  const prefix = manager === 'systemd-system' ? [] : ['--user'];
+  try {
+    execute(command, [...prefix, 'is-active', unit]);
+  } catch {
+    return { state: 'stopped', manager };
+  }
+  let pidText: string;
+  try {
+    pidText = execute(command, [...prefix, 'show', unit, '-p', 'MainPID', '--value']).trim();
+  } catch {
+    return { state: 'identity_unknown', manager, reason: 'systemd_pid_unavailable' };
+  }
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid <= 0) return { state: 'identity_unknown', manager, reason: 'invalid_systemd_pid' };
+  return finishIdentity(manager, pid, root, execute);
+}
+
+function inspectPidfile(root: string, execute: Exec): ServiceCheck {
+  const manager = 'pidfile' as const;
+  const pidPath = path.join(root, 'nanoclaw.pid');
+  let pidText: string;
+  try {
+    pidText = fs.readFileSync(pidPath, 'utf8').trim();
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+      ? { state: 'not_found', manager }
+      : { state: 'identity_unknown', manager, reason: 'pidfile_unreadable' };
+  }
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid <= 0) return { state: 'identity_unknown', manager, reason: 'invalid_pidfile_pid' };
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return { state: 'stopped', manager, pid };
+  }
+  return finishIdentity(manager, pid, root, execute);
+}
+
+function finishIdentity(
+  manager: ServiceCheck['manager'],
+  pid: number,
+  expectedRoot: string,
+  execute: Exec,
+): ServiceCheck {
+  const actualRoot = resolveProcessCheckout(pid, expectedRoot, execute);
+  if (!actualRoot) return { state: 'identity_unknown', manager, pid, reason: 'process_checkout_unavailable' };
+  return {
+    state: actualRoot === expectedRoot ? 'running' : 'running_other_checkout',
+    manager,
+    pid,
+    checkoutRoot: actualRoot,
+  };
+}
+
+function resolveProcessCheckout(pid: number, expectedRoot: string, execute: Exec): string | null {
+  const script = resolveProcessScript(pid, expectedRoot, execute);
+  if (!script) return null;
+  return path.resolve(script, '..', '..');
+}
+
+function resolveProcessScript(pid: number, expectedRoot: string, execute: Exec): string | null {
+  try {
+    const args = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8').split('\0').filter(Boolean);
+    const script = args.find((arg) => /\/dist\/index\.(?:js|mjs|cjs|ts)$/.test(arg));
+    if (script) return path.resolve(script);
+  } catch {
+    // macOS has no /proc; use lsof/ps below.
+  }
+  try {
+    const output = execute('ps', ['-p', String(pid), '-o', 'command=']).trim();
+    const expectedScript = ['js', 'mjs', 'cjs', 'ts']
+      .map((extension) => path.join(expectedRoot, 'dist', `index.${extension}`))
+      .find((candidate) =>
+        new RegExp(`(?:^|\\s)${candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$)`).test(output),
+      );
+    if (expectedScript) return expectedScript;
+    const marker = output.indexOf('/dist/index.');
+    if (marker > 0) {
+      const start = output.lastIndexOf(' ', marker) + 1;
+      const script = output.slice(start, marker + output.slice(marker).search(/(?:\s|$)/));
+      if (/\/dist\/index\.(?:js|mjs|cjs|ts)$/.test(script)) return path.resolve(script);
+    }
+  } catch {
+    // Identity is intentionally fail-closed.
+  }
+  try {
+    const output = execute('lsof', ['-a', '-p', String(pid), '-d', 'txt', '-Fn']);
+    const script = output
+      .split('\n')
+      .find((line) => line.startsWith('n') && /\/dist\/index\.(?:js|mjs|cjs|ts)$/.test(line.slice(1)))
+      ?.slice(1)
+      .trim();
+    if (script) return path.resolve(script);
+  } catch {
+    // Identity is intentionally fail-closed.
+  }
+  return null;
+}
+
+function isResource(value: unknown): value is HealthResource {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.state === 'loaded' || record.state === 'empty') &&
+    typeof record.count === 'number' &&
+    Number.isInteger(record.count) &&
+    record.count >= 0
+  );
+}
+
+function isHostHealth(value: unknown): value is HostHealth {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  const processIdentity = record.process;
+  const resources = record.resources;
+  if (
+    record.status !== 'healthy' ||
+    typeof record.checkoutRoot !== 'string' ||
+    !processIdentity ||
+    typeof processIdentity !== 'object' ||
+    !resources ||
+    typeof resources !== 'object'
+  )
+    return false;
+  const processRecord = processIdentity as Record<string, unknown>;
+  const resourceRecord = resources as Record<string, unknown>;
+  return (
+    typeof processRecord.pid === 'number' &&
+    processRecord.pid > 0 &&
+    typeof processRecord.ppid === 'number' &&
+    typeof processRecord.executable === 'string' &&
+    typeof processRecord.script === 'string' &&
+    typeof processRecord.cwd === 'string' &&
+    isResource(resourceRecord.groups) &&
+    isResource(resourceRecord.policies) &&
+    isResource(resourceRecord.skills)
+  );
+}

--- a/setup/lib/setup-config-parse.test.ts
+++ b/setup/lib/setup-config-parse.test.ts
@@ -38,4 +38,10 @@ describe('public setup flags', () => {
       errors: [],
     });
   });
+
+  it('uses the cataloged validation rules when parsing flags', () => {
+    expect(parseFlags(['--onecli-api-host', 'not-a-url']).errors).toEqual(['--onecli-api-host: Must be http(s)://…']);
+    expect(parseFlags(['--onecli-api-token', 'wrong']).errors).toEqual(['--onecli-api-token: Must start with oc_']);
+    expect(parseFlags(['--onecli-api-host', 'https://api.onecli.sh']).errors).toEqual([]);
+  });
 });

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -13,7 +13,7 @@
  *   --key            booleans only (sets true)
  *   --no-key         booleans only (sets false)
  */
-import { CONFIG, envVarFor, flagFor, findByFlag, type Entry } from './setup-config.js';
+import { CONFIG, envVarFor, flagFor, findByFlag, validateEntry, type Entry } from './setup-config.js';
 
 export type ConfigValues = Record<string, string | boolean | number>;
 
@@ -40,7 +40,7 @@ export function readFromEnv(env: NodeJS.ProcessEnv = process.env): ConfigValues 
     const raw = env[envVarFor(e)];
     if (raw === undefined || raw === '') continue;
     const v = coerce(e, raw);
-    if ((e.type === 'string' || e.type === 'url') && e.validate?.(raw)) continue;
+    if ((e.type === 'string' || e.type === 'url') && validateEntry(e, raw)) continue;
     if (v !== undefined) out[e.key] = v;
   }
   return out;
@@ -115,7 +115,7 @@ export function parseFlags(argv: string[]): FlagParseResult {
       continue;
     }
     if (entry.type === 'string' || entry.type === 'url') {
-      const err = entry.validate?.(raw);
+      const err = validateEntry(entry, raw);
       if (err) {
         errors.push(`${name}: ${err}`);
         continue;

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -40,6 +40,7 @@ export function readFromEnv(env: NodeJS.ProcessEnv = process.env): ConfigValues 
     const raw = env[envVarFor(e)];
     if (raw === undefined || raw === '') continue;
     const v = coerce(e, raw);
+    if ((e.type === 'string' || e.type === 'url') && e.validate?.(raw)) continue;
     if (v !== undefined) out[e.key] = v;
   }
   return out;

--- a/setup/lib/setup-config-screen.test.ts
+++ b/setup/lib/setup-config-screen.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runAdvancedScreen } from './setup-config-screen.js';
+import type { SetupDriver } from './setup-driver.js';
+
+describe('machine advanced configuration', () => {
+  const envKey = 'NANOCLAW_ONECLI_API_TOKEN';
+  let previousToken: string | undefined;
+
+  afterEach(() => {
+    if (previousToken === undefined) delete process.env[envKey];
+    else process.env[envKey] = previousToken;
+    previousToken = undefined;
+  });
+
+  it('rejects secret entries before an answer can reach process.env', async () => {
+    previousToken = process.env[envKey];
+    delete process.env[envKey];
+    const driver = {
+      mode: 'ndjson' as const,
+      prompt: async () => 'onecliApiToken',
+      error(code: string): never {
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+
+    await expect(runAdvancedScreen({}, driver)).rejects.toThrow('secret_transport_forbidden');
+    expect(process.env[envKey]).toBeUndefined();
+  });
+});

--- a/setup/lib/setup-config-screen.ts
+++ b/setup/lib/setup-config-screen.ts
@@ -16,12 +16,13 @@ import { brightSelect } from './bright-select.js';
 import { ensureAnswer } from './runner.js';
 import { CONFIG, type Entry } from './setup-config.js';
 import type { ConfigValues } from './setup-config-parse.js';
+import type { SetupDriver } from './setup-driver.js';
 
 const SKIP_SENTINEL = '__leave_unchanged__';
 const DONE_SENTINEL = '__done__';
 const MASK = '••••••••';
 
-export async function runAdvancedScreen(initial: ConfigValues): Promise<ConfigValues> {
+export async function runAdvancedScreen(initial: ConfigValues, driver?: SetupDriver): Promise<ConfigValues> {
   const result: ConfigValues = { ...initial };
   const visible = CONFIG.filter((e) => e.surface === 'flag+ui');
 
@@ -32,20 +33,36 @@ export async function runAdvancedScreen(initial: ConfigValues): Promise<ConfigVa
         label: e.label,
         hint: hintFor(e, result),
       })),
-      { value: DONE_SENTINEL, label: 'Done — continue with setup' },
+      { value: DONE_SENTINEL, label: 'Done - continue with setup', hint: undefined },
     ];
 
-    const choice = ensureAnswer(
-      await brightSelect<string>({
-        message: 'Pick a setting to override',
-        options,
-        initialValue: DONE_SENTINEL,
-      }),
-    ) as string;
+    const choice = driver
+      ? String(
+          await driver.prompt({
+            id: 'advanced-setting',
+            kind: 'singleChoice',
+            message: 'Pick a setting to override',
+            choices: options.map(({ value, label, hint }) => ({ id: value, label, hint })),
+            default: DONE_SENTINEL,
+          }),
+        )
+      : (ensureAnswer(
+          await brightSelect<string>({
+            message: 'Pick a setting to override',
+            options,
+            initialValue: DONE_SENTINEL,
+          }),
+        ) as string);
 
     if (choice === DONE_SENTINEL) return result;
     const entry = visible.find((e) => e.key === choice);
-    if (entry) await promptOne(entry, result);
+    if (entry?.secret && driver?.mode === 'ndjson') {
+      driver.error(
+        'secret_transport_forbidden',
+        'Machine setup does not accept secrets through advanced configuration. Use the structured authentication prompts instead.',
+      );
+    }
+    if (entry) await promptOne(entry, result, driver);
   }
 }
 
@@ -56,42 +73,62 @@ function hintFor(e: Entry, values: ConfigValues): string {
   return String(v);
 }
 
-async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
+async function promptOne(e: Entry, values: ConfigValues, driver?: SetupDriver): Promise<void> {
   if (e.type === 'boolean') {
     const init = typeof values[e.key] === 'boolean' ? (values[e.key] as boolean) : (e.default ?? false);
-    const ans = ensureAnswer(await p.confirm({ message: e.label, initialValue: init }));
+    const ans = driver
+      ? await driver.prompt({ id: `advanced-${e.key}`, kind: 'confirm', message: e.label, default: init })
+      : ensureAnswer(await p.confirm({ message: e.label, initialValue: init }));
     values[e.key] = ans as boolean;
     return;
   }
 
   if (e.type === 'enum') {
-    const ans = ensureAnswer(
-      await brightSelect<string>({
-        message: e.label,
-        options: [{ value: SKIP_SENTINEL, label: 'Leave unchanged' }, ...e.options],
-        initialValue: SKIP_SENTINEL,
-      }),
-    );
+    const options = [{ value: SKIP_SENTINEL, label: 'Leave unchanged' }, ...e.options];
+    const ans = driver
+      ? await driver.prompt({
+          id: `advanced-${e.key}`,
+          kind: 'singleChoice',
+          message: e.label,
+          choices: options.map(({ value, label }) => ({ id: value, label })),
+          default: SKIP_SENTINEL,
+        })
+      : ensureAnswer(
+          await brightSelect<string>({
+            message: e.label,
+            options,
+            initialValue: SKIP_SENTINEL,
+          }),
+        );
     if (ans !== SKIP_SENTINEL) values[e.key] = ans as string;
     return;
   }
 
   if (e.type === 'integer') {
-    const ans = ensureAnswer(
-      await p.text({
-        message: e.label,
-        placeholder: e.default !== undefined ? String(e.default) : undefined,
-        validate: (v) => {
-          const s = (v ?? '').trim();
-          if (!s) return undefined;
-          const n = Number(s);
-          if (!Number.isFinite(n)) return 'Must be a number';
-          if (e.min !== undefined && n < e.min) return `Must be ≥ ${e.min}`;
-          if (e.max !== undefined && n > e.max) return `Must be ≤ ${e.max}`;
-          return undefined;
-        },
-      }),
-    );
+    const validate = (value: boolean | string): string | undefined => {
+      const s = String(value).trim();
+      if (!s) return undefined;
+      const n = Number(s);
+      if (!Number.isFinite(n)) return 'Must be a number';
+      if (e.min !== undefined && n < e.min) return `Must be ≥ ${e.min}`;
+      if (e.max !== undefined && n > e.max) return `Must be ≤ ${e.max}`;
+      return undefined;
+    };
+    const ans = driver
+      ? await driver.prompt({
+          id: `advanced-${e.key}`,
+          kind: 'text',
+          message: e.label,
+          placeholder: e.default !== undefined ? String(e.default) : undefined,
+          validateValue: validate,
+        })
+      : ensureAnswer(
+          await p.text({
+            message: e.label,
+            placeholder: e.default !== undefined ? String(e.default) : undefined,
+            validate: (v) => validate(v ?? ''),
+          }),
+        );
     const trimmed = ((ans as string) ?? '').trim();
     if (trimmed) values[e.key] = Number(trimmed);
     return;
@@ -103,15 +140,24 @@ async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
     if (!s) return undefined;
     return e.validate?.(s);
   };
-  const ans = ensureAnswer(
-    e.secret
-      ? await p.password({ message: e.label, clearOnError: true, validate })
-      : await p.text({
-          message: e.label,
-          placeholder: e.placeholder ?? e.default,
-          validate,
-        }),
-  );
+  const ans = driver
+    ? await driver.prompt({
+        id: `advanced-${e.key}`,
+        kind: e.secret ? 'secret' : 'text',
+        message: e.label,
+        sensitive: e.secret,
+        placeholder: e.placeholder ?? e.default,
+        validateValue: (value) => validate(String(value)),
+      })
+    : ensureAnswer(
+        e.secret
+          ? await p.password({ message: e.label, clearOnError: true, validate })
+          : await p.text({
+              message: e.label,
+              placeholder: e.placeholder ?? e.default,
+              validate,
+            }),
+      );
   const trimmed = ((ans as string) ?? '').trim();
   if (trimmed) values[e.key] = trimmed;
 }

--- a/setup/lib/setup-config-screen.ts
+++ b/setup/lib/setup-config-screen.ts
@@ -14,7 +14,7 @@ import * as p from '@clack/prompts';
 
 import { brightSelect } from './bright-select.js';
 import { ensureAnswer } from './runner.js';
-import { CONFIG, type Entry } from './setup-config.js';
+import { CONFIG, validateEntry, type Entry } from './setup-config.js';
 import type { ConfigValues } from './setup-config-parse.js';
 import type { SetupDriver } from './setup-driver.js';
 
@@ -138,7 +138,7 @@ async function promptOne(e: Entry, values: ConfigValues, driver?: SetupDriver): 
   const validate = (v: string | undefined): string | undefined => {
     const s = (v ?? '').trim();
     if (!s) return undefined;
-    return e.validate?.(s);
+    return validateEntry(e, s);
   };
   const ans = driver
     ? await driver.prompt({

--- a/setup/lib/setup-config.test.ts
+++ b/setup/lib/setup-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFlags, readFromEnv } from './setup-config-parse.js';
+import { validateHttpUrl } from './setup-config.js';
+
+describe('setup URL validation', () => {
+  it('accepts only fully parsed HTTP(S) URLs without control characters', () => {
+    expect(validateHttpUrl('https://api.example.com/v1')).toBeUndefined();
+    expect(validateHttpUrl('https://api.example.com\nINJECTED=value')).toMatch(/control/);
+    expect(validateHttpUrl('https://api.example.com trailing')).toMatch(/whitespace/);
+    expect(validateHttpUrl('file:///tmp/secret')).toMatch(/http/);
+  });
+
+  it('rejects unsafe URL flags and environment values at both config boundaries', () => {
+    const unsafe = 'https://api.example.com\nINJECTED=value';
+    expect(parseFlags(['--anthropic-base-url', unsafe]).errors).toHaveLength(1);
+    expect(readFromEnv({ NANOCLAW_ANTHROPIC_BASE_URL: unsafe })).toEqual({});
+  });
+});

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -59,7 +59,15 @@ interface IntEntry extends BaseEntry {
 
 export type Entry = StringEntry | EnumEntry | BoolEntry | IntEntry;
 
-const httpUrl = (v: string): string | undefined => (/^https?:\/\/\S+/.test(v) ? undefined : 'Must be http(s)://…');
+export function validateHttpUrl(value: string): string | undefined {
+  if (/[\u0000-\u0020\u007f]/.test(value)) return 'Must not contain whitespace or control characters';
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.hostname ? undefined : 'Must be http(s)://…';
+  } catch {
+    return 'Must be http(s)://…';
+  }
+}
 
 export const CONFIG: Entry[] = [
   {
@@ -71,7 +79,7 @@ export const CONFIG: Entry[] = [
     type: 'url',
     default: 'https://api.onecli.sh',
     placeholder: 'https://api.onecli.sh',
-    validate: httpUrl,
+    validate: validateHttpUrl,
   },
   {
     key: 'onecliApiToken',
@@ -92,7 +100,7 @@ export const CONFIG: Entry[] = [
     group: 'Anthropic',
     type: 'url',
     placeholder: 'https://api.anthropic.com',
-    validate: httpUrl,
+    validate: validateHttpUrl,
   },
   {
     key: 'anthropicAuthToken',

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -30,13 +30,18 @@ interface BaseEntry {
   group?: string;
   /** Mask in UI, redact in logs. */
   secret?: boolean;
+  /** Expose this flag-only setting to app setup preflight. */
+  preseed?: boolean;
 }
 
 interface StringEntry extends BaseEntry {
   type: 'string' | 'url';
   default?: string;
   placeholder?: string;
-  validate?: (v: string) => string | undefined;
+  validation?:
+    | { kind: 'httpUrl'; message: string }
+    | { kind: 'prefix'; value: string; message: string }
+    | { kind: 'nonEmpty'; message: string };
 }
 
 interface EnumEntry extends BaseEntry {
@@ -77,9 +82,8 @@ export const CONFIG: Entry[] = [
     surface: 'flag+ui',
     group: 'OneCLI',
     type: 'url',
-    default: 'https://api.onecli.sh',
     placeholder: 'https://api.onecli.sh',
-    validate: validateHttpUrl,
+    validation: { kind: 'httpUrl', message: 'Must be http(s)://…' },
   },
   {
     key: 'onecliApiToken',
@@ -90,7 +94,7 @@ export const CONFIG: Entry[] = [
     type: 'string',
     secret: true,
     placeholder: 'oc_…',
-    validate: (v) => (v.startsWith('oc_') ? undefined : 'Must start with oc_'),
+    validation: { kind: 'prefix', value: 'oc_', message: 'Must start with oc_' },
   },
   {
     key: 'anthropicBaseUrl',
@@ -100,7 +104,7 @@ export const CONFIG: Entry[] = [
     group: 'Anthropic',
     type: 'url',
     placeholder: 'https://api.anthropic.com',
-    validate: validateHttpUrl,
+    validation: { kind: 'httpUrl', message: 'Must be http(s)://…' },
   },
   {
     key: 'anthropicAuthToken',
@@ -110,7 +114,7 @@ export const CONFIG: Entry[] = [
     group: 'Anthropic',
     type: 'string',
     secret: true,
-    validate: (v) => (v.trim() ? undefined : 'Required'),
+    validation: { kind: 'nonEmpty', message: 'Required' },
   },
   {
     key: 'templatePath',
@@ -129,6 +133,7 @@ export const CONFIG: Entry[] = [
     label: 'Skip steps',
     help: 'Comma-separated step names to skip (debugging only).',
     surface: 'flag',
+    preseed: true,
     type: 'string',
   },
   {
@@ -137,6 +142,7 @@ export const CONFIG: Entry[] = [
     label: 'Display name',
     help: 'Skip the "what should your assistant call you?" prompt.',
     surface: 'flag',
+    preseed: true,
     type: 'string',
   },
   {
@@ -145,7 +151,26 @@ export const CONFIG: Entry[] = [
     label: 'Agent provider',
     help: 'Preselect the setup provider and skip the provider picker.',
     surface: 'flag',
+    preseed: true,
     type: 'string',
+  },
+  {
+    key: 'agentName',
+    envVar: 'NANOCLAW_AGENT_NAME',
+    label: 'Agent name',
+    help: 'Name the first messaging-channel agent.',
+    surface: 'flag',
+    preseed: true,
+    type: 'string',
+  },
+  {
+    key: 'hardenedImage',
+    envVar: 'NANOCLAW_HARDENED_IMAGE',
+    label: 'Use pre-built image',
+    help: 'Use the hardened pre-built image instead of building locally.',
+    surface: 'flag',
+    preseed: true,
+    type: 'boolean',
   },
   {
     key: 'assistMode',
@@ -198,4 +223,19 @@ export function flagFor(e: Entry): string {
 
 export function findByFlag(flag: string): Entry | null {
   return CONFIG.find((e) => flagFor(e) === flag) ?? null;
+}
+
+export function validateEntry(entry: Entry, value: string): string | undefined {
+  if (entry.type !== 'string' && entry.type !== 'url') return undefined;
+  const rule = entry.validation;
+  if (!rule) return undefined;
+
+  switch (rule.kind) {
+    case 'httpUrl':
+      return validateHttpUrl(value);
+    case 'prefix':
+      return value.startsWith(rule.value) ? undefined : rule.message;
+    case 'nonEmpty':
+      return value.trim() ? undefined : rule.message;
+  }
 }

--- a/setup/lib/setup-driver.test.ts
+++ b/setup/lib/setup-driver.test.ts
@@ -1,0 +1,509 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child.ts');
+const CONTINUATION_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-continuation.ts');
+const TTY_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-tty.ts');
+const SKILL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-skill.ts');
+const CANCEL_RACE_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-cancel-race.ts');
+const CHILD_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child-cancel.ts');
+const WINDOWED_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-windowed-cancel.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
+
+describe('NDJSON setup driver child boundary', () => {
+  it('keeps stdout parseable, rejects bad commands, and redacts accepted secrets', async () => {
+    const secret = 'secret-value"\nnext\\part';
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-output-'));
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, HARNESS], {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_NO_DIAGNOSTICS: '0',
+        NANOCLAW_TEST_OUTPUT_DIR: outputDir,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let stdout = '';
+    let stderr = '';
+    let buffer = '';
+    let answeredCredential = false;
+    let answeredContinue = false;
+    const send = (command: Record<string, unknown>): void => {
+      child.stdin.write(`${JSON.stringify({ ...envelope, ...command })}\n`);
+    };
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stdout += text;
+      buffer += text;
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'prompt') {
+          const prompt = event.prompt as { id: string };
+          if (prompt.id === 'credential' && !answeredCredential) {
+            answeredCredential = true;
+            child.stdin.write('not-json\n');
+            send({ operation: 'uninstall', type: 'answer', promptId: prompt.id, value: secret });
+            send({ type: 'futureCommand', promptId: prompt.id });
+            send({ type: 'answer', promptId: 'stale', value: secret });
+            send({ type: 'answer', promptId: prompt.id, value: false });
+            const valid = { type: 'answer', promptId: prompt.id, value: secret, futureField: 'ignored' };
+            send(valid);
+            send(valid);
+          } else if (prompt.id === 'continue' && !answeredContinue) {
+            answeredContinue = true;
+            send({ type: 'answer', promptId: prompt.id, value: true });
+          }
+          continue;
+        }
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          send({ type: 'externalActionCompleted', actionId: action.id, result: 'attempted' });
+          send({ type: 'externalActionCompleted', actionId: action.id, result: 'attempted' });
+        }
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout[0]).toBe('{');
+    expect(stdout).not.toMatch(/\x1b\[[0-9;]*[A-Za-z]/);
+    expect(
+      stdout
+        .trim()
+        .split('\n')
+        .every((line) => JSON.parse(line)),
+    ).toBe(true);
+    expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'complete')).toHaveLength(1);
+    for (const event of events.filter((candidate) => candidate.type === 'externalAction')) {
+      const action = event.action as Record<string, unknown>;
+      expect(['openURL', 'startApplication', 'systemPermission']).toContain(action.kind);
+      expect(action).not.toHaveProperty('executable');
+      expect(action).not.toHaveProperty('args');
+      expect(action).not.toHaveProperty('command');
+    }
+    expect(events.filter((event) => event.type === 'inputRejected').map((event) => event.code)).toEqual([
+      'invalid_json',
+      'wrong_envelope',
+      'unknown_command',
+      'stale_command',
+      'invalid_answer',
+      'stale_command',
+      'postcondition_failed',
+    ]);
+    expect(stdout).not.toContain('secret-value');
+    expect(stdout.match(/display-one/g)).toHaveLength(1);
+    expect(stdout.match(/display-two/g)).toHaveLength(1);
+    expect(events.some((event) => event.type === 'clearDisplay' && event.displayId === 'rotating-code')).toBe(true);
+    const persisted =
+      fs.readFileSync(path.join(outputDir, 'logs', 'setup.log'), 'utf8') +
+      fs.readFileSync(path.join(outputDir, 'diagnostic-body.json'), 'utf8');
+    expect(persisted).not.toContain('secret-value');
+    expect(persisted).not.toContain('display-one');
+    expect(persisted).not.toContain('display-two');
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('continues an sg-style re-exec with one hello and one stdin reader', () => {
+    const result = spawnSync(process.execPath, ['--import', TSX_LOADER, CONTINUATION_HARNESS], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      input: JSON.stringify({ ...envelope, type: 'answer', promptId: 'continued-confirm', value: true }) + '\n',
+      env: {
+        ...process.env,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_TEST_TSX_LOADER: TSX_LOADER,
+      },
+    });
+    const events = result.stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { type: string });
+    expect(result.status).toBe(0);
+    expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'prompt')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'complete')).toHaveLength(1);
+  });
+
+  it('rejects an oversized raw line before a newline is received', async () => {
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, HARNESS], {
+      cwd: ROOT,
+      env: { ...process.env, NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let buffer = '';
+    let sentOversized = false;
+    let sentValid = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'prompt') {
+          const prompt = event.prompt as { id: string };
+          if (prompt.id === 'credential' && !sentOversized) {
+            sentOversized = true;
+            child.stdin.write(`${'x'.repeat(1_048_577)}\n`);
+          } else if (prompt.id === 'continue' && !sentValid) {
+            sentValid = true;
+            child.stdin.write(`${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: true })}\n`);
+          }
+        }
+        if (event.type === 'inputRejected' && event.code === 'command_too_large') {
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'answer', promptId: 'credential', value: 'secret-value' })}\n`,
+          );
+        }
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+          );
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+          );
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    expect(code).toBe(0);
+    expect(events.some((event) => event.type === 'inputRejected' && event.code === 'command_too_large')).toBe(true);
+    expect(events.at(-1)?.type).toBe('complete');
+  }, 15_000);
+
+  it('renders a TTY-owning device login through machine semantics', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-tty-'));
+    const prefix = path.join(temp, 'global');
+    const fakeBin = path.join(temp, 'bin');
+    const calls = path.join(temp, 'teams.calls');
+    fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'npm'), '#!/bin/sh\nprintf \'%s\\n\' "$TEST_TEAMS_PREFIX"\n', { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(prefix, 'bin', 'teams'),
+      '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$TEST_TEAMS_CALLS"\nprintf \'Open https://microsoft.com/devicelogin\\nEnter code ABCD-EFGH\\n=== NANOCLAW SETUP: TEAMS-LOGIN ===\\nSTATUS: success\\n=== END ===\\n\'\n',
+      { mode: 0o755 },
+    );
+    try {
+      const child = spawn(process.execPath, ['--import', TSX_LOADER, TTY_HARNESS], {
+        cwd: temp,
+        env: {
+          ...process.env,
+          NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          TEST_TEAMS_PREFIX: prefix,
+          TEST_TEAMS_CALLS: calls,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const events: Array<Record<string, unknown>> = [];
+      let stdout = '';
+      let stderr = '';
+      let buffer = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf8');
+        stdout += text;
+        buffer += text;
+        let newline: number;
+        while ((newline = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (!line) continue;
+          const event = JSON.parse(line) as Record<string, unknown>;
+          events.push(event);
+          if (event.type === 'externalAction') {
+            const action = event.action as { id: string };
+            child.stdin.write(
+              `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+            );
+          }
+        }
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', resolve);
+      });
+
+      expect(code, `${stdout}\n${stderr}`).toBe(0);
+      expect(stderr).toBe('');
+      expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'externalAction',
+          action: expect.objectContaining({ kind: 'openURL', url: 'https://microsoft.com/devicelogin' }),
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'display',
+          display: expect.objectContaining({ id: 'teams-login-code', content: 'ABCD-EFGH', sensitive: true }),
+        }),
+      );
+      expect(events).toContainEqual(expect.objectContaining({ type: 'clearDisplay', displayId: 'teams-login-url' }));
+      expect(events).toContainEqual(expect.objectContaining({ type: 'clearDisplay', displayId: 'teams-login-code' }));
+      expect(events.at(-1)?.type).toBe('complete');
+      expect(fs.readFileSync(calls, 'utf8')).toContain('login');
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('treats a machine skill answer as data, not shell syntax', async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-skill-project-'));
+    const skillDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-skill-'));
+    const markers = ['single-injected', 'double-injected', 'bare-injected'].map((name) => path.join(projectRoot, name));
+    const answer = `x'; touch ${markers[0]}; #' "$(touch ${markers[1]})" \`touch ${markers[2]}\` $HOME`;
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{"name":"fixture"}');
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      "# fixture\n\n```nc:prompt agent_name normalize:trim validate:^.+$\nAssistant name?\n```\n```nc:run effect:external\nprintf '%s\\n' '{{agent_name}}' > single.txt\nprintf '%s\\n' \"{{agent_name}}\" > double.txt\nprintf '%s\\n' {{agent_name}} > bare.txt\n```\n",
+    );
+    try {
+      const child = spawn(process.execPath, ['--import', TSX_LOADER, SKILL_HARNESS], {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+          NANOCLAW_TEST_PROJECT_ROOT: projectRoot,
+          NANOCLAW_TEST_SKILL_DIR: skillDir,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const events: Array<Record<string, unknown>> = [];
+      let buffer = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        let newline: number;
+        while ((newline = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (!line) continue;
+          const event = JSON.parse(line) as Record<string, unknown>;
+          events.push(event);
+          if (event.type === 'prompt') {
+            const prompt = event.prompt as { id: string };
+            child.stdin.write(
+              `${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: answer })}\n`,
+            );
+          }
+        }
+      });
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', resolve);
+      });
+
+      expect(code).toBe(0);
+      expect(events.at(-1)?.type).toBe('complete');
+      expect(markers.every((marker) => !fs.existsSync(marker))).toBe(true);
+      for (const file of ['single.txt', 'double.txt', 'bare.txt']) {
+        expect(fs.readFileSync(path.join(projectRoot, file), 'utf8')).toBe(`${answer}\n`);
+      }
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+      fs.rmSync(skillDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('keeps cancelled terminal when an in-flight postcondition finishes later', async () => {
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, CANCEL_RACE_HARNESS], {
+      cwd: ROOT,
+      env: { ...process.env, NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let buffer = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+          );
+          setTimeout(() => child.kill('SIGINT'), 20);
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    expect(code).toBe(2);
+    expect(events.filter((event) => event.type === 'cancelled')).toHaveLength(1);
+    expect(events.at(-1)?.type).toBe('cancelled');
+    expect(events.some((event) => event.type === 'inputRejected')).toBe(false);
+  }, 15_000);
+
+  it('SIGKILLs a runner grandchild that ignores SIGTERM after its leader exits', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-child-cancel-'));
+    const marker = path.join(temp, 'child.pid');
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, CHILD_CANCEL_HARNESS], {
+      cwd: ROOT,
+      env: { ...process.env, NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1', NANOCLAW_TEST_CHILD_MARKER: marker },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<{ type: string; state?: string }> = [];
+    let buffer = '';
+    let stderr = '';
+    let cancelled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as { type: string; state?: string };
+        events.push(event);
+        if (event.type === 'progress' && event.state === 'running' && !cancelled) {
+          cancelled = true;
+          void (async () => {
+            const deadline = Date.now() + 5_000;
+            while (!fs.existsSync(marker) && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            child.stdin.write(`${JSON.stringify({ ...envelope, type: 'cancel', reason: 'test' })}\n`);
+          })();
+        }
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    let pid = 0;
+    try {
+      expect(code, `${JSON.stringify(events)}\n${stderr}`).toBe(2);
+      expect(events.at(-1)?.type).toBe('cancelled');
+      expect(fs.existsSync(marker)).toBe(true);
+      pid = Number(fs.readFileSync(marker, 'utf8').trim());
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('SIGKILLs a windowed-step grandchild that ignores SIGTERM after its leader exits', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-windowed-cancel-'));
+    const marker = path.join(temp, 'child.pid');
+    const bin = path.join(temp, 'bin');
+    fs.mkdirSync(bin);
+    const stubborn = path.join(bin, 'stubborn');
+    fs.writeFileSync(stubborn, `#!/bin/sh\ntrap '' TERM\necho $$ > ${JSON.stringify(marker)}\nexec sleep 30\n`, {
+      mode: 0o755,
+    });
+    fs.writeFileSync(
+      path.join(bin, 'pnpm'),
+      `#!/bin/sh\n${JSON.stringify(stubborn)} &\nwhile [ ! -s ${JSON.stringify(marker)} ]; do sleep 0.01; done\nprintf '%s\\n' '=== NANOCLAW SETUP: cancel-window ===' 'STATUS: success' '=== END ==='\nwait\n`,
+      { mode: 0o755 },
+    );
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, WINDOWED_CANCEL_HARNESS], {
+      cwd: temp,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_NO_DIAGNOSTICS: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<{ type: string; state?: string }> = [];
+    let buffer = '';
+    let cancelled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as { type: string; state?: string; stepId?: string };
+        events.push(event);
+        if (event.type === 'progress' && event.state === 'running' && !cancelled) {
+          cancelled = true;
+          void (async () => {
+            const deadline = Date.now() + 5_000;
+            while (!fs.existsSync(marker) && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            child.stdin.write(`${JSON.stringify({ ...envelope, type: 'cancel', reason: 'test' })}\n`);
+          })();
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    let pid = 0;
+    try {
+      expect(code).toBe(2);
+      expect(events.at(-1)?.type).toBe('cancelled');
+      expect(fs.existsSync(marker)).toBe(true);
+      pid = Number(fs.readFileSync(marker, 'utf8').trim());
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/setup/lib/setup-driver.ts
+++ b/setup/lib/setup-driver.ts
@@ -1,0 +1,929 @@
+import { randomUUID } from 'node:crypto';
+
+import * as p from '@clack/prompts';
+
+import { brightSelect } from './bright-select.js';
+import { redactSensitiveValues, registerSensitiveValue } from './redaction.js';
+
+export const DRIVER_PROTOCOL = 'nanoclaw.driver.v1' as const;
+
+export type DriverOperation = 'setup' | 'uninstall';
+export type ProgressState = 'pending' | 'running' | 'succeeded' | 'failed';
+export type UninstallGroup = 'service' | 'data' | 'user' | 'onecli';
+export type UninstallChoice = 'preserve' | 'remove';
+export type ActionOutcome = 'removed' | 'preserved' | 'failed' | 'untouched' | 'alreadyAbsent';
+
+export type Validation = {
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+};
+
+export type DriverPrompt = {
+  id?: string;
+  kind: 'confirm' | 'singleChoice' | 'text' | 'secret';
+  message: string;
+  sensitive?: boolean;
+  choices?: Array<{ id: string; label: string; hint?: string }>;
+  default?: boolean | string;
+  /** Terminal-only hint; deliberately absent from the wire schema. */
+  placeholder?: string;
+  /** Terminal-only search UI; deliberately absent from the wire schema. */
+  searchable?: boolean;
+  validation?: Validation;
+  /** Driver-side validation that is enforced but not serialized on the wire. */
+  validateValue?: (value: boolean | string) => string | undefined;
+};
+
+export type DriverDisplay =
+  | { id: string; kind: 'text' | 'code'; content: string; sensitive: boolean; label?: string }
+  | { id: string; kind: 'url'; url: string; label: string; sensitive: boolean }
+  | { id: string; kind: 'qr'; payload: string; sensitive: boolean; label?: string };
+
+export type ExternalAction =
+  | { id?: string; kind: 'openURL'; title: string; url: string }
+  | { id?: string; kind: 'startApplication'; title: string; application: string }
+  | { id?: string; kind: 'systemPermission'; title: string; instructions: string[] };
+
+export type ExternalActionResult = 'attempted' | 'declined' | 'unsupported';
+
+export type Recovery = { kind: 'rerun'; args: string[] } | { kind: 'manual'; title: string; instructions: string[] };
+
+export type Artifact = {
+  id: string;
+  kind: string;
+  label: string;
+  location: string;
+  disposition: 'owned' | 'shared' | 'external' | 'uninspectable' | 'alreadyAbsent';
+  decisionGroup?: UninstallGroup;
+};
+
+export type UninstallPlan = {
+  id: string;
+  groups: Array<{
+    id: UninstallGroup;
+    label: string;
+    description: string;
+    default: 'preserve';
+    choices: ['preserve', 'remove'];
+  }>;
+  artifacts: Artifact[];
+};
+
+export type UninstallActionResult = {
+  actionId: string;
+  artifactId: string;
+  outcome: ActionOutcome;
+  error?: { code: string; message: string };
+};
+
+export type UninstallReceipt = {
+  version: 1;
+  outcome: 'success' | 'incomplete';
+  results: UninstallActionResult[];
+  remaining: Artifact[];
+  checkoutRemoval: {
+    safe: boolean;
+    blockers: string[];
+  };
+  completedAt: string;
+};
+
+export type SetupReceipt = {
+  version: 1;
+  service: {
+    state: 'running';
+    manager: 'launchd' | 'systemd-user' | 'systemd-system' | 'pidfile';
+    checkoutRoot: string;
+  };
+  health: { status: 'healthy' };
+  resources: {
+    groups: { state: 'loaded' | 'empty'; count: number };
+    policies: { state: 'loaded' | 'empty'; count: number };
+    skills: { state: 'loaded' | 'empty'; count: number };
+  };
+  completedAt: string;
+};
+
+export class DriverCancelled extends Error {
+  constructor(readonly reason?: string) {
+    super('driver cancelled');
+  }
+}
+
+type LogLevel = 'info' | 'success' | 'warn' | 'error' | 'step' | 'message';
+
+export interface SetupDriver {
+  readonly mode: 'terminal' | 'ndjson';
+  readonly operation: DriverOperation;
+  readonly cancellationSignal?: AbortSignal;
+  prompt(spec: DriverPrompt): Promise<boolean | string>;
+  progress(stepId: string, state: ProgressState, label?: string): void;
+  display(display: DriverDisplay): void;
+  clearDisplay(displayId: string): void;
+  note(content: string, label?: string): void;
+  log(level: LogLevel, message: string): void;
+  intro(message: string): void;
+  outro(message: string): void;
+  externalAction(action: ExternalAction, verify: () => boolean | Promise<boolean>): Promise<ExternalActionResult>;
+  waitForUninstall(
+    plan: UninstallPlan,
+    validate: (choices: Map<UninstallGroup, UninstallChoice>) => string | undefined,
+  ): Promise<Map<UninstallGroup, UninstallChoice>>;
+  uninstallAction(result: UninstallActionResult): void;
+  throwIfCancelled(): void;
+  error(code: string, message: string, recovery?: Recovery[], stepId?: string): never;
+  completeSetup(receipt: SetupReceipt): void;
+  completeUninstall(receipt: UninstallReceipt): void;
+  cancelled(details?: { lastStepId?: string; results?: UninstallActionResult[]; remaining?: Artifact[] }): void;
+  handoff(): void;
+  close(): void;
+}
+
+function validateValue(spec: DriverPrompt, value: unknown): string | undefined {
+  if (spec.kind === 'confirm') return typeof value === 'boolean' ? undefined : 'Expected a boolean.';
+  if (typeof value !== 'string') return 'Expected a string.';
+  if (spec.kind === 'singleChoice') {
+    return spec.choices?.some((choice) => choice.id === value) ? undefined : 'Unknown choice.';
+  }
+  const validation = spec.validation;
+  if (validation?.required && value.length === 0) return 'A value is required.';
+  if (validation?.minLength !== undefined && value.length < validation.minLength) {
+    return `Value must be at least ${validation.minLength} characters.`;
+  }
+  if (validation?.maxLength !== undefined && value.length > validation.maxLength) {
+    return `Value must be at most ${validation.maxLength} characters.`;
+  }
+  if (validation?.pattern !== undefined) {
+    try {
+      if (!new RegExp(validation.pattern).test(value)) return 'Value does not match the expected format.';
+    } catch {
+      return 'Prompt validation is invalid.';
+    }
+  }
+  return spec.validateValue?.(value);
+}
+
+function isUninstallGroup(value: unknown): value is UninstallGroup {
+  return typeof value === 'string' && ['service', 'data', 'user', 'onecli'].includes(value);
+}
+
+const PRESENTATION_FIELDS = new Set(['content', 'instructions', 'label', 'location', 'message', 'payload', 'title']);
+
+function redactProtocolPresentation(value: unknown, field?: string): unknown {
+  if (typeof value === 'string') {
+    return field && PRESENTATION_FIELDS.has(field) ? redactSensitiveValues(value) : value;
+  }
+  if (Array.isArray(value)) return value.map((item) => redactProtocolPresentation(item, field));
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactProtocolPresentation(item, key)]));
+}
+
+export class TerminalSetupDriver implements SetupDriver {
+  readonly mode = 'terminal' as const;
+
+  constructor(readonly operation: DriverOperation) {}
+
+  async prompt(spec: DriverPrompt): Promise<boolean | string> {
+    const validate = (value: string | undefined): string | undefined => validateValue(spec, value ?? '');
+    let answer: boolean | string | symbol;
+    if (spec.kind === 'confirm') {
+      answer = await p.confirm({
+        message: spec.message,
+        initialValue: spec.default === undefined ? true : spec.default === true,
+      });
+    } else if (spec.kind === 'singleChoice') {
+      const options = (spec.choices ?? []).map(({ id, label, hint }) => ({ value: id, label, hint }));
+      answer = spec.searchable
+        ? await p.autocomplete({
+            message: spec.message,
+            options,
+            initialValue: typeof spec.default === 'string' ? spec.default : undefined,
+            maxItems: 5,
+            placeholder: spec.placeholder,
+          })
+        : await brightSelect({
+            message: spec.message,
+            options,
+            initialValue: typeof spec.default === 'string' ? spec.default : undefined,
+          });
+    } else if (spec.kind === 'secret') {
+      answer = await p.password({ message: spec.message, clearOnError: true, validate });
+    } else {
+      answer = await p.text({
+        message: spec.message,
+        placeholder: spec.placeholder,
+        defaultValue: typeof spec.default === 'string' ? spec.default : undefined,
+        validate,
+      });
+    }
+    if (p.isCancel(answer)) throw new DriverCancelled();
+    const value = typeof answer === 'boolean' ? answer : String(answer);
+    if (spec.kind === 'secret' && typeof value === 'string') registerSensitiveValue(value);
+    return value;
+  }
+
+  progress(_stepId: string, _state: ProgressState, _label?: string): void {}
+
+  display(display: DriverDisplay): void {
+    const content = 'content' in display ? display.content : 'url' in display ? display.url : display.payload;
+    p.note(content, display.label);
+  }
+
+  clearDisplay(_displayId: string): void {}
+
+  note(content: string, label?: string): void {
+    p.note(content, label);
+  }
+
+  log(level: LogLevel, message: string): void {
+    p.log[level](message);
+  }
+
+  intro(message: string): void {
+    p.intro(message);
+  }
+
+  outro(message: string): void {
+    p.outro(message);
+  }
+
+  async externalAction(
+    action: ExternalAction,
+    verify: () => boolean | Promise<boolean>,
+  ): Promise<ExternalActionResult> {
+    if (action.kind === 'openURL') {
+      const answer = await this.prompt({
+        kind: 'confirm',
+        message: `Open ${action.url} in your browser?`,
+        default: true,
+      });
+      if (answer !== true) return 'declined';
+    }
+    return (await verify()) ? 'attempted' : 'unsupported';
+  }
+
+  async waitForUninstall(): Promise<Map<UninstallGroup, UninstallChoice>> {
+    throw new Error('terminal uninstall collects choices through its existing prompts');
+  }
+
+  uninstallAction(_result: UninstallActionResult): void {}
+
+  throwIfCancelled(): void {}
+
+  error(_code: string, message: string, _recovery: Recovery[] = [], _stepId?: string): never {
+    throw new Error(message);
+  }
+
+  completeSetup(_receipt: SetupReceipt): void {}
+  completeUninstall(_receipt: UninstallReceipt): void {}
+
+  cancelled(): void {
+    p.cancel(this.operation === 'setup' ? 'Setup cancelled.' : 'Uninstall cancelled.');
+  }
+
+  handoff(): void {}
+  close(): void {}
+}
+
+type Pending = {
+  id: string;
+  accept(command: Record<string, unknown>): Promise<{ done: boolean; rejected?: boolean; value?: unknown }>;
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+};
+
+const MAX_INPUT_LINE_BYTES = 1_048_576;
+const MAX_COMMAND_STRING_BYTES = 64 * 1024;
+const MAX_COMMAND_ARRAY_LENGTH = 64;
+
+type DriverCommand =
+  | {
+      protocol: typeof DRIVER_PROTOCOL;
+      operation: DriverOperation;
+      type: 'answer';
+      promptId: string;
+      value: boolean | string;
+    }
+  | {
+      protocol: typeof DRIVER_PROTOCOL;
+      operation: DriverOperation;
+      type: 'externalActionCompleted';
+      actionId: string;
+      result: ExternalActionResult;
+    }
+  | {
+      protocol: typeof DRIVER_PROTOCOL;
+      operation: DriverOperation;
+      type: 'applyUninstall';
+      planId: string;
+      choices: Array<{ groupId: UninstallGroup; choice: UninstallChoice }>;
+    }
+  | { protocol: typeof DRIVER_PROTOCOL; operation: DriverOperation; type: 'cancel'; reason?: string };
+
+function boundedString(value: unknown, maxBytes = MAX_COMMAND_STRING_BYTES): value is string {
+  return typeof value === 'string' && Buffer.byteLength(value, 'utf8') <= maxBytes;
+}
+
+function validUninstallArtifact(artifact: Artifact): boolean {
+  return (
+    boundedString(artifact.id, 256) &&
+    boundedString(artifact.kind, 256) &&
+    boundedString(artifact.label) &&
+    boundedString(artifact.location) &&
+    (artifact.decisionGroup === undefined || isUninstallGroup(artifact.decisionGroup))
+  );
+}
+
+function validUninstallResult(result: UninstallActionResult): boolean {
+  return (
+    boundedString(result.actionId, 256) &&
+    boundedString(result.artifactId, 256) &&
+    (result.error === undefined || (boundedString(result.error.code, 256) && boundedString(result.error.message)))
+  );
+}
+
+function validUninstallPlan(plan: UninstallPlan): boolean {
+  return (
+    boundedString(plan.id, 256) &&
+    plan.groups.length <= MAX_COMMAND_ARRAY_LENGTH &&
+    plan.groups.every(
+      (group) =>
+        isUninstallGroup(group.id) &&
+        boundedString(group.label) &&
+        boundedString(group.description) &&
+        group.default === 'preserve' &&
+        group.choices.length === 2 &&
+        group.choices.every((choice) => choice === 'preserve' || choice === 'remove'),
+    ) &&
+    plan.artifacts.every(validUninstallArtifact)
+  );
+}
+
+function validRecovery(recovery: Recovery[]): boolean {
+  return (
+    recovery.length <= MAX_COMMAND_ARRAY_LENGTH &&
+    recovery.every((item) =>
+      item.kind === 'rerun'
+        ? item.args.length <= MAX_COMMAND_ARRAY_LENGTH && item.args.every((arg) => boundedString(arg))
+        : boundedString(item.title) &&
+          item.instructions.length <= MAX_COMMAND_ARRAY_LENGTH &&
+          item.instructions.every((instruction) => boundedString(instruction)),
+    )
+  );
+}
+
+function parseCommand(value: unknown, operation: DriverOperation): DriverCommand | { error: string; itemId?: string } {
+  if (!isRecord(value)) return { error: 'Command must be a JSON object.' };
+  if (value.protocol !== DRIVER_PROTOCOL || value.operation !== operation) {
+    return { error: 'Protocol or operation does not match this run.' };
+  }
+  const type = value.type;
+  if (type === 'answer') {
+    if (!boundedString(value.promptId, 256)) return { error: 'promptId must be a bounded string.' };
+    if (!(typeof value.value === 'boolean' || boundedString(value.value)))
+      return { error: 'answer value is invalid.', itemId: value.promptId };
+    return { protocol: DRIVER_PROTOCOL, operation, type, promptId: value.promptId, value: value.value };
+  }
+  if (type === 'externalActionCompleted') {
+    if (!boundedString(value.actionId, 256)) return { error: 'actionId must be a bounded string.' };
+    const result = value.result;
+    if (result !== 'attempted' && result !== 'declined' && result !== 'unsupported') {
+      return { error: 'result must be attempted, declined, or unsupported.', itemId: value.actionId };
+    }
+    return { protocol: DRIVER_PROTOCOL, operation, type, actionId: value.actionId, result };
+  }
+  if (type === 'applyUninstall') {
+    if (
+      !boundedString(value.planId, 256) ||
+      !Array.isArray(value.choices) ||
+      value.choices.length > MAX_COMMAND_ARRAY_LENGTH
+    ) {
+      return {
+        error: 'Uninstall choices are invalid.',
+        itemId: typeof value.planId === 'string' ? value.planId : undefined,
+      };
+    }
+    const choices: Array<{ groupId: UninstallGroup; choice: UninstallChoice }> = [];
+    for (const entry of value.choices) {
+      if (
+        !isRecord(entry) ||
+        !isUninstallGroup(entry.groupId) ||
+        (entry.choice !== 'preserve' && entry.choice !== 'remove')
+      ) {
+        return { error: 'Uninstall choices are invalid.', itemId: value.planId };
+      }
+      choices.push({ groupId: entry.groupId, choice: entry.choice });
+    }
+    return { protocol: DRIVER_PROTOCOL, operation, type, planId: value.planId, choices };
+  }
+  if (type === 'cancel') {
+    if (value.reason !== undefined && !boundedString(value.reason, 4 * 1024))
+      return { error: 'Cancel reason is invalid.' };
+    return {
+      protocol: DRIVER_PROTOCOL,
+      operation,
+      type,
+      ...(value.reason === undefined ? {} : { reason: value.reason }),
+    };
+  }
+  return { error: 'Unknown command type.' };
+}
+
+class InputLines {
+  private buffer = Buffer.alloc(0);
+  private discarding = false;
+  constructor(private readonly onLine: (line: string | null) => void) {}
+
+  push(chunk: Buffer): void {
+    let start = 0;
+    while (start < chunk.length) {
+      const newline = chunk.indexOf(0x0a, start);
+      const end = newline === -1 ? chunk.length : newline;
+      const part = chunk.subarray(start, end);
+      if (this.discarding) {
+        if (newline !== -1) this.discarding = false;
+      } else if (this.buffer.length + part.length > MAX_INPUT_LINE_BYTES) {
+        this.buffer = Buffer.alloc(0);
+        this.discarding = newline === -1;
+        this.onLine(null);
+      } else {
+        this.buffer = Buffer.concat([this.buffer, part]);
+        if (newline !== -1) {
+          const line = this.buffer.toString('utf8').replace(/\r$/, '');
+          this.buffer = Buffer.alloc(0);
+          this.onLine(line);
+        }
+      }
+      if (newline === -1) break;
+      start = newline + 1;
+    }
+  }
+
+  end(): void {
+    if (this.discarding) return;
+    if (this.buffer.length > 0) this.onLine(this.buffer.toString('utf8'));
+    this.buffer = Buffer.alloc(0);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export class NdjsonSetupDriver implements SetupDriver {
+  readonly mode = 'ndjson' as const;
+  readonly cancellationSignal: AbortSignal;
+  private input: typeof process.stdin | undefined;
+  private readonly inputLines: InputLines;
+  private readonly abortController = new AbortController();
+  private pending: Pending | undefined;
+  private isCancelled = false;
+  private isTerminal = false;
+  private cancelReason: string | undefined;
+  private inputChain = Promise.resolve();
+  private readonly write: (text: string) => boolean;
+  private readonly onSignal = (): void => this.requestCancellation();
+  private readonly onInputData = (chunk: Buffer | string): void =>
+    this.inputLines.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  private readonly onInputEnd = (): void => {
+    this.inputLines.end();
+    if (!this.isTerminal) this.requestCancellation('stdin_closed');
+  };
+  private readonly onInputError = (): void => this.requestCancellation('stdin_error');
+
+  constructor(
+    readonly operation: DriverOperation,
+    opts: { emitHello?: boolean } = {},
+  ) {
+    this.cancellationSignal = this.abortController.signal;
+    this.write = process.stdout.write.bind(process.stdout);
+    if (opts.emitHello !== false) this.emit({ type: 'hello' });
+    this.inputLines = new InputLines((line) => {
+      this.inputChain = this.inputChain
+        .then(() =>
+          line === null
+            ? this.rejectInput(
+                this.pending?.id,
+                'command_too_large',
+                `Command exceeds the ${MAX_INPUT_LINE_BYTES} byte limit.`,
+              )
+            : this.handleLine(line),
+        )
+        .catch((error: unknown) => {
+          if (error instanceof DriverCancelled || error instanceof DriverTerminalError) return;
+          const message = error instanceof Error ? error.message : String(error);
+          try {
+            this.error('protocol_input_failed', message);
+          } catch (terminal) {
+            if (!(terminal instanceof DriverTerminalError)) throw terminal;
+          }
+        });
+    });
+    this.input = process.stdin;
+    process.stdin.on('data', this.onInputData);
+    process.stdin.on('end', this.onInputEnd);
+    process.stdin.on('error', this.onInputError);
+    process.once('SIGINT', this.onSignal);
+    process.once('SIGTERM', this.onSignal);
+  }
+
+  async prompt(spec: DriverPrompt): Promise<boolean | string> {
+    this.throwIfCancelled();
+    if (
+      !boundedString(spec.message) ||
+      (spec.choices?.length ?? 0) > MAX_COMMAND_ARRAY_LENGTH ||
+      spec.choices?.some(
+        (choice) =>
+          !boundedString(choice.id, 256) ||
+          !boundedString(choice.label) ||
+          (choice.hint !== undefined && !boundedString(choice.hint)),
+      )
+    ) {
+      this.error('presentation_too_large', 'Prompt presentation exceeds protocol limits.');
+    }
+    const prompt = {
+      id: spec.id ?? randomUUID(),
+      kind: spec.kind,
+      message: redactSensitiveValues(spec.message),
+      sensitive: spec.sensitive ?? spec.kind === 'secret',
+      ...(spec.choices
+        ? { choices: spec.choices.map(({ id, label }) => ({ id, label: redactSensitiveValues(label) })) }
+        : {}),
+      ...(spec.default !== undefined && spec.kind !== 'secret' ? { default: spec.default } : {}),
+      ...(spec.validation ? { validation: spec.validation } : {}),
+    };
+    this.emit({ type: 'prompt', prompt });
+    const value = await this.wait(prompt.id, async (command) => {
+      if (command.type !== 'answer' || command.promptId !== prompt.id) return { done: false };
+      const error = validateValue(spec, command.value);
+      if (error) {
+        this.rejectInput(prompt.id, 'invalid_answer', error);
+        return { done: false, rejected: true };
+      }
+      if (spec.kind === 'secret' && typeof command.value === 'string') registerSensitiveValue(command.value);
+      return { done: true, value: command.value };
+    });
+    return typeof value === 'boolean' ? value : String(value);
+  }
+
+  progress(stepId: string, state: ProgressState, label?: string): void {
+    if (!boundedString(stepId, 256) || (label !== undefined && !boundedString(label))) {
+      this.error('presentation_too_large', 'Progress presentation exceeds protocol limits.');
+    }
+    this.emit({ type: 'progress', stepId, state, ...(label ? { label: redactSensitiveValues(label) } : {}) });
+  }
+
+  display(display: DriverDisplay): void {
+    const payload = 'content' in display ? display.content : 'url' in display ? display.url : display.payload;
+    if (
+      !boundedString(display.id, 256) ||
+      !boundedString(payload) ||
+      (display.label !== undefined && !boundedString(display.label))
+    ) {
+      this.error('presentation_too_large', 'Display payload exceeds protocol limits.');
+    }
+    if (display.kind === 'qr' && payload.length > MAX_COMMAND_STRING_BYTES) {
+      this.error('presentation_too_large', 'Display payload exceeds protocol limits.');
+    }
+    if (display.sensitive) {
+      const value = 'content' in display ? display.content : 'url' in display ? display.url : display.payload;
+      registerSensitiveValue(value);
+    }
+    const safeDisplay =
+      !display.sensitive && 'url' in display ? { ...display, url: redactSensitiveValues(display.url) } : display;
+    this.emit(
+      {
+        type: 'display',
+        display: {
+          ...safeDisplay,
+          ...(display.label ? { label: redactSensitiveValues(display.label) } : {}),
+        },
+      },
+      display.sensitive,
+    );
+  }
+
+  clearDisplay(displayId: string): void {
+    if (!boundedString(displayId, 256)) this.error('presentation_too_large', 'Display id exceeds protocol limits.');
+    this.emit({ type: 'clearDisplay', displayId });
+  }
+
+  note(content: string, label?: string): void {
+    this.display({ id: randomUUID(), kind: 'text', content, sensitive: false, ...(label ? { label } : {}) });
+  }
+
+  log(_level: LogLevel, message: string): void {
+    this.note(message);
+  }
+
+  intro(message: string): void {
+    this.note(message);
+  }
+
+  outro(message: string): void {
+    this.note(message);
+  }
+
+  async externalAction(
+    action: ExternalAction,
+    verify: () => boolean | Promise<boolean>,
+  ): Promise<ExternalActionResult> {
+    this.throwIfCancelled();
+    if (!boundedString(action.title) || !boundedString(action.id ?? '', 256)) {
+      this.error('invalid_external_action', 'External action presentation exceeds protocol limits.');
+    }
+    if (action.kind === 'openURL' && new URL(action.url).protocol !== 'https:') {
+      this.error('invalid_external_action', 'openURL actions require an HTTPS URL.');
+    }
+    if (action.kind === 'openURL' && !boundedString(action.url))
+      this.error('invalid_external_action', 'External action URL exceeds protocol limits.');
+    if (action.kind === 'startApplication' && !boundedString(action.application, 256))
+      this.error('invalid_external_action', 'Application name exceeds protocol limits.');
+    if (
+      action.kind === 'systemPermission' &&
+      (action.instructions.length > MAX_COMMAND_ARRAY_LENGTH ||
+        action.instructions.some((instruction) => !boundedString(instruction)))
+    ) {
+      this.error('invalid_external_action', 'Permission instructions exceed protocol limits.');
+    }
+    const withId = { ...action, id: action.id ?? randomUUID() };
+    this.emit({ type: 'externalAction', action: withId });
+    const value = await this.wait(withId.id, async (command) => {
+      if (command.type !== 'externalActionCompleted' || command.actionId !== withId.id) {
+        return { done: false };
+      }
+      if (command.result === 'declined' || command.result === 'unsupported')
+        return { done: true, value: command.result };
+      if (!(await verify())) {
+        this.rejectInput(withId.id, 'postcondition_failed', 'The required postcondition is not satisfied.');
+        return { done: false, rejected: true };
+      }
+      return { done: true, value: 'attempted' };
+    });
+    return value as ExternalActionResult;
+  }
+
+  async waitForUninstall(
+    plan: UninstallPlan,
+    validate: (choices: Map<UninstallGroup, UninstallChoice>) => string | undefined,
+  ): Promise<Map<UninstallGroup, UninstallChoice>> {
+    if (!validUninstallPlan(plan)) {
+      this.error('presentation_too_large', 'Uninstall plan presentation exceeds protocol limits.');
+    }
+    for (const artifact of plan.artifacts) {
+      this.emit({ type: 'uninstallPlanItem', planId: plan.id, artifact });
+    }
+    this.emit({
+      type: 'uninstallPlan',
+      plan: { id: plan.id, groups: plan.groups },
+    });
+    const value = await this.wait(plan.id, async (command) => {
+      if (command.type !== 'applyUninstall' || command.planId !== plan.id) return { done: false };
+      if (!Array.isArray(command.choices)) {
+        this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Expected a choices array.');
+        return { done: false, rejected: true };
+      }
+      const choices = new Map<UninstallGroup, UninstallChoice>();
+      for (const entry of command.choices) {
+        if (!isRecord(entry)) {
+          this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Every choice must be an object.');
+          return { done: false, rejected: true };
+        }
+        const groupId = entry.groupId;
+        const choice = entry.choice;
+        if (!isUninstallGroup(groupId)) {
+          this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Unknown uninstall group.');
+          return { done: false, rejected: true };
+        }
+        if (choice !== 'preserve' && choice !== 'remove') {
+          this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Unknown uninstall choice.');
+          return { done: false, rejected: true };
+        }
+        const group = groupId;
+        if (choices.has(group)) {
+          this.rejectInput(plan.id, 'duplicate_uninstall_group', `Duplicate choice for ${group}.`);
+          return { done: false, rejected: true };
+        }
+        choices.set(group, choice);
+      }
+      if (choices.size !== plan.groups.length || plan.groups.some((group) => !choices.has(group.id))) {
+        this.rejectInput(plan.id, 'incomplete_uninstall_choices', 'Supply exactly one choice for every group.');
+        return { done: false, rejected: true };
+      }
+      const error = validate(choices);
+      if (error) {
+        this.rejectInput(plan.id, 'unsafe_uninstall_choices', error);
+        return { done: false, rejected: true };
+      }
+      return { done: true, value: choices };
+    });
+    if (!(value instanceof Map)) throw new Error('invalid uninstall command result');
+    return value;
+  }
+
+  uninstallAction(result: UninstallActionResult): void {
+    if (!validUninstallResult(result)) {
+      this.error('presentation_too_large', 'Uninstall action presentation exceeds protocol limits.');
+    }
+    this.emit({ type: 'uninstallAction', result });
+  }
+
+  throwIfCancelled(): void {
+    if (this.isCancelled) throw new DriverCancelled(this.cancelReason);
+  }
+
+  error(code: string, message: string, recovery: Recovery[] = [], stepId?: string): never {
+    if (
+      !boundedString(code, 256) ||
+      !boundedString(message) ||
+      (stepId !== undefined && !boundedString(stepId, 256)) ||
+      !validRecovery(recovery)
+    ) {
+      code = 'presentation_too_large';
+      message = 'Error presentation exceeds protocol limits.';
+      recovery = [];
+      stepId = undefined;
+    }
+    this.terminate({
+      type: 'error',
+      code,
+      ...(stepId ? { stepId } : {}),
+      message: redactSensitiveValues(message),
+      recovery,
+    });
+    throw new DriverTerminalError(1);
+  }
+
+  completeSetup(receipt: SetupReceipt): void {
+    this.throwIfCancelled();
+    this.terminate({ type: 'complete', receipt });
+  }
+
+  completeUninstall(receipt: UninstallReceipt): void {
+    this.throwIfCancelled();
+    if (
+      !receipt.results.every(validUninstallResult) ||
+      !receipt.remaining.every(validUninstallArtifact) ||
+      !receipt.checkoutRemoval.blockers.every((blocker) => boundedString(blocker)) ||
+      !boundedString(receipt.completedAt, 256)
+    ) {
+      this.error('presentation_too_large', 'Uninstall receipt presentation exceeds protocol limits.');
+    }
+    for (const artifact of receipt.remaining) {
+      this.emit({ type: 'uninstallReceiptItem', section: 'remaining', artifact });
+    }
+    this.terminate({
+      type: 'complete',
+      receipt: {
+        version: receipt.version,
+        outcome: receipt.outcome,
+        checkoutRemoval: receipt.checkoutRemoval,
+        completedAt: receipt.completedAt,
+      },
+    });
+  }
+
+  cancelled(
+    details: {
+      lastStepId?: string;
+      results?: UninstallActionResult[];
+      remaining?: Artifact[];
+    } = {},
+  ): void {
+    if (this.operation !== 'uninstall') {
+      this.terminate({ type: 'cancelled', ...details });
+      return;
+    }
+    if (
+      (details.results !== undefined && !details.results.every(validUninstallResult)) ||
+      (details.remaining !== undefined && !details.remaining.every(validUninstallArtifact)) ||
+      (details.lastStepId !== undefined && !boundedString(details.lastStepId, 256))
+    ) {
+      this.error('presentation_too_large', 'Uninstall cancellation details exceed protocol limits.');
+    }
+    for (const artifact of details.remaining ?? []) {
+      this.emit({ type: 'uninstallReceiptItem', section: 'remaining', artifact });
+    }
+    this.terminate({
+      type: 'cancelled',
+      ...(details.lastStepId ? { lastStepId: details.lastStepId } : {}),
+    });
+  }
+
+  handoff(): void {
+    this.input?.off('data', this.onInputData);
+    this.input?.off('end', this.onInputEnd);
+    this.input?.off('error', this.onInputError);
+    this.input?.pause();
+    this.input = undefined;
+  }
+
+  close(): void {
+    this.handoff();
+    process.off('SIGINT', this.onSignal);
+    process.off('SIGTERM', this.onSignal);
+  }
+
+  private emit(event: Record<string, unknown>, allowSensitive = false): void {
+    if (this.isTerminal) return;
+    this.writeEvent(event, allowSensitive);
+  }
+
+  private terminate(event: Record<string, unknown>): void {
+    if (this.isTerminal) return;
+    this.isTerminal = true;
+    this.writeEvent(event);
+    this.close();
+  }
+
+  private writeEvent(event: Record<string, unknown>, allowSensitive = false): void {
+    const payload = allowSensitive ? event : (redactProtocolPresentation(event) as Record<string, unknown>);
+    this.write(JSON.stringify({ protocol: DRIVER_PROTOCOL, operation: this.operation, ...payload }) + '\n');
+  }
+
+  private wait(id: string, accept: Pending['accept']): Promise<unknown> {
+    if (this.pending) throw new Error('driver already has a pending item');
+    return new Promise((resolve, reject) => {
+      this.pending = { id, accept, resolve, reject };
+    });
+  }
+
+  private async handleLine(line: string): Promise<void> {
+    if (this.isTerminal) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.rejectInput(undefined, 'invalid_json', 'Command must be one JSON object.');
+      return;
+    }
+    const command = parseCommand(parsed, this.operation);
+    if ('error' in command) {
+      const code =
+        isRecord(parsed) && parsed.protocol === DRIVER_PROTOCOL && parsed.operation === this.operation
+          ? typeof parsed.type === 'string' &&
+            !['answer', 'externalActionCompleted', 'applyUninstall', 'cancel'].includes(parsed.type)
+            ? 'unknown_command'
+            : 'invalid_command'
+          : 'wrong_envelope';
+      this.rejectInput(command.itemId, code, command.error);
+      return;
+    }
+    if (command.type === 'cancel') {
+      this.requestCancellation(command.reason);
+      return;
+    }
+    const pending = this.pending;
+    if (!pending) {
+      this.rejectInput(this.commandItemId(command), 'stale_command', 'There is no matching pending item.');
+      return;
+    }
+    const result = await pending.accept(command);
+    if (this.isTerminal || this.isCancelled) return;
+    if (!result.done) {
+      if (!result.rejected) {
+        this.rejectInput(this.commandItemId(command), 'stale_command', 'Command does not match the pending item.');
+      }
+      return;
+    }
+    this.pending = undefined;
+    pending.resolve(result.value);
+  }
+
+  private commandItemId(command: Record<string, unknown>): string | undefined {
+    for (const key of ['promptId', 'actionId', 'planId']) {
+      if (typeof command[key] === 'string') return command[key];
+    }
+    return undefined;
+  }
+
+  private rejectInput(itemId: string | undefined, code: string, message: string): void {
+    this.emit({ type: 'inputRejected', ...(itemId ? { itemId } : {}), code, message });
+  }
+
+  private requestCancellation(reason?: string): void {
+    if (this.isTerminal) return;
+    this.isCancelled = true;
+    this.cancelReason = reason;
+    this.abortController.abort(reason);
+    const pending = this.pending;
+    this.pending = undefined;
+    pending?.reject(new DriverCancelled(this.cancelReason));
+  }
+}
+
+export class DriverTerminalError extends Error {
+  constructor(readonly exitCode: 0 | 1 | 2) {
+    super(`driver terminated with exit ${exitCode}`);
+  }
+}
+
+export function createSetupDriver(operation: DriverOperation): SetupDriver {
+  return process.env.NANOCLAW_PROTOCOL === DRIVER_PROTOCOL
+    ? new NdjsonSetupDriver(operation, {
+        emitHello: process.env.NANOCLAW_DRIVER_SHELL_HELLO !== '1' && process.env.NANOCLAW_DRIVER_CONTINUATION !== '1',
+      })
+    : new TerminalSetupDriver(operation);
+}

--- a/setup/lib/skill-driver.test.ts
+++ b/setup/lib/skill-driver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as p from '@clack/prompts';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -17,6 +17,8 @@ import {
   type RunSkillOptions,
 } from './skill-driver.js';
 import { fullyApplied, type ApplyEvent, type ApplyResult } from '../../scripts/skill-apply.js';
+import { clearSensitiveValuesForTest, registerSensitiveValue } from './redaction.js';
+import type { SetupDriver } from './setup-driver.js';
 
 // Shared test state for the clack + claude-handoff mocks (hoisted so the vi.mock
 // factories — which run before imports — can close over it). `answers` is the
@@ -86,7 +88,7 @@ describe('thin skill driver', () => {
     const { root, skill } = scratch();
     const asked: Array<{ name: string; secret: boolean }> = [];
     const told: string[] = [];
-    const ran: string[] = [];
+    const ran: Array<{ command: string; args: string[] }> = [];
     const opts: RunSkillOptions = {
       projectRoot: root,
       resolveInput: async (name, meta) => {
@@ -97,26 +99,26 @@ describe('thin skill driver', () => {
       onEvent: (e: ApplyEvent) => {
         if (e.type === 'operator') told.push(e.text);
       },
-      exec: (c) => void ran.push(c),
+      exec: (command, args = []) => void ran.push({ command, args }),
     };
     const res = await runSkill(skill, opts);
 
     expect(asked).toEqual([{ name: 'token', secret: true }]); // the prompt was driven through resolveInput, meta intact
     expect(told).toEqual(['Go create the app and copy the token.']); // operator relayed through the event
-    expect(ran).toContain('ncl wire --token T0KEN'); // wiring executed with the answer substituted in
+    expect(ran).toContainEqual({ command: 'ncl wire --token "${1}"', args: ['T0KEN'] });
     expect(res.operatorMessages).toEqual(['Go create the app and copy the token.']);
   });
 
   it('runs fully from inputs — resolveInput never touched', async () => {
     const { root, skill } = scratch();
-    const ran: string[] = [];
+    const ran: Array<{ command: string; args: string[] }> = [];
     const res = await runSkill(skill, {
       projectRoot: root,
       inputs: { token: 'FROM-INPUTS' },
-      exec: (c) => void ran.push(c),
+      exec: (command, args = []) => void ran.push({ command, args }),
     });
     expect(fullyApplied(res)).toBe(true);
-    expect(ran).toContain('ncl wire --token FROM-INPUTS');
+    expect(ran).toContainEqual({ command: 'ncl wire --token "${1}"', args: ['FROM-INPUTS'] });
   });
 
   it('emits step events through an injected onEvent — the wire run under its heading', async () => {
@@ -169,6 +171,206 @@ describe('thin skill driver', () => {
     expect(log).toContain('dying-gasp'); // the failing command's output survives too
   });
 
+  it('leaves terminal command logs unchanged by protocol redaction', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-secret-'));
+    const rawLog = join(root, 'raw.log');
+    const secret = 'token-value';
+    registerSensitiveValue(secret);
+    try {
+      const out = await hostExec(root, rawLog)(`printf '%s' 'prefix ${secret} suffix'`);
+      expect(out).toBe(`prefix ${secret} suffix`);
+      expect(readFileSync(rawLog, 'utf8')).toContain(secret);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain('[REDACTED]');
+    } finally {
+      clearSensitiveValuesForTest();
+    }
+  });
+
+  it('keeps machine-mode captured output in memory and out of raw logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-capture-'));
+    const rawLog = join(root, 'raw.log');
+    const previous = process.env.NANOCLAW_PROTOCOL;
+    process.env.NANOCLAW_PROTOCOL = 'nanoclaw.driver.v1';
+    try {
+      const out = await hostExec(root, rawLog)("printf 'minted-credenti%s' al");
+      expect(out).toBe('minted-credential');
+      expect(readFileSync(rawLog, 'utf8')).not.toContain('minted-credential');
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_PROTOCOL;
+      else process.env.NANOCLAW_PROTOCOL = previous;
+    }
+  });
+
+  it('keeps machine-mode secret runs out of child argv, env, and raw logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-secret-'));
+    const bin = join(root, 'bin');
+    const probe = join(root, 'probe.json');
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, 'onecli'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const file = args[args.indexOf('--file') + 1];
+fs.writeFileSync(${JSON.stringify(probe)}, JSON.stringify({ args, env: process.env, file, value: fs.readFileSync(file, 'utf8') }));
+`,
+    );
+    chmodSync(join(bin, 'onecli'), 0o755);
+    const secret = 'machine-secret-value';
+    const rawLog = join(root, 'raw.log');
+    const previous = process.env.DRIVER_SECRET_PROBE;
+    process.env.DRIVER_SECRET_PROBE = secret;
+    try {
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      await hostExec(root, rawLog, driver, new Set([secret]))('onecli secrets create --value "${1}"', [secret]);
+      const observed = JSON.parse(readFileSync(probe, 'utf8')) as {
+        args: string[];
+        env: NodeJS.ProcessEnv;
+        file: string;
+        value: string;
+      };
+      expect(observed.args).toContain('--file');
+      expect(observed.args).not.toContain('--value');
+      expect(observed.args).not.toContain(secret);
+      expect(observed.env.DRIVER_SECRET_PROBE).toBeUndefined();
+      expect(observed.value).toBe(secret);
+      expect(existsSync(observed.file)).toBe(false);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain(secret);
+    } finally {
+      if (previous === undefined) delete process.env.DRIVER_SECRET_PROBE;
+      else process.env.DRIVER_SECRET_PROBE = previous;
+    }
+  });
+
+  it('keeps curl secrets in a private config and out of child argv, env, and raw logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-curl-secret-'));
+    const bin = join(root, 'bin');
+    const probe = join(root, 'curl.json');
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, 'curl'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const file = args[args.indexOf('--config') + 1];
+fs.writeFileSync(${JSON.stringify(probe)}, JSON.stringify({ args, env: process.env, file, config: fs.readFileSync(file, 'utf8') }));
+process.stdout.write('ok');
+`,
+    );
+    chmodSync(join(bin, 'curl'), 0o755);
+    const telegram = 'telegram-machine-secret';
+    const slack = 'slack-machine-secret';
+    const rawLog = join(root, 'raw.log');
+    process.env.DRIVER_TELEGRAM_SECRET = telegram;
+    process.env.DRIVER_SLACK_SECRET = slack;
+    try {
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      await hostExec(
+        root,
+        rawLog,
+        driver,
+        new Set([telegram, slack]),
+      )('curl -sf -X POST https://example.com/channel -H "Authorization: Bot ${1}" --data-urlencode "token=${2}"', [
+        telegram,
+        slack,
+      ]);
+      const observed = JSON.parse(readFileSync(probe, 'utf8')) as {
+        args: string[];
+        env: NodeJS.ProcessEnv;
+        file: string;
+        config: string;
+      };
+      expect(observed.args).toEqual(['--config', observed.file]);
+      expect(JSON.stringify(observed.env)).not.toContain(telegram);
+      expect(JSON.stringify(observed.env)).not.toContain(slack);
+      expect(observed.config).toContain(`Authorization: Bot ${telegram}`);
+      expect(observed.config).toContain(`token=${slack}`);
+      expect(existsSync(observed.file)).toBe(false);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain(telegram);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain(slack);
+    } finally {
+      delete process.env.DRIVER_TELEGRAM_SECRET;
+      delete process.env.DRIVER_SLACK_SECRET;
+    }
+  });
+
+  it('rejects unsupported machine secret interpolation before spawning', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-secret-reject-'));
+    const errors: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      error: (code: string): never => {
+        errors.push(code);
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+    await expect(
+      hostExec(root, undefined, driver, new Set(['machine-secret']))('printf "%s" "${1}"', ['machine-secret']),
+    ).rejects.toThrow('secret_transport_unsupported');
+    expect(errors).toEqual(['secret_transport_unsupported']);
+  });
+
+  it('stops a machine capture when combined child output exceeds its byte limit', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-output-limit-'));
+    const errors: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      error: (code: string): never => {
+        errors.push(code);
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+
+    await expect(
+      hostExec(root, undefined, driver)(`node -e 'process.stdout.write("x".repeat(300000))'`),
+    ).rejects.toThrow('skill_output_limit');
+    expect(errors).toEqual(['skill_output_limit']);
+  });
+
+  it('keeps machine-mode streaming secret runs out of child argv and env', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-stream-secret-'));
+    const bin = join(root, 'bin');
+    const probe = join(root, 'probe.json');
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, 'onecli'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const file = args[args.indexOf('--file') + 1];
+fs.writeFileSync(${JSON.stringify(probe)}, JSON.stringify({ args, env: process.env, file, value: fs.readFileSync(file, 'utf8') }));
+process.stdout.write('=== NANOCLAW SETUP: TEST ===\\nSTATUS: success\\n=== END ===\\n');
+`,
+    );
+    chmodSync(join(bin, 'onecli'), 0o755);
+    const secret = 'machine-stream-secret';
+    const previous = process.env.DRIVER_STREAM_SECRET;
+    process.env.DRIVER_STREAM_SECRET = secret;
+    try {
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      const result = await hostExecStream(
+        root,
+        driver,
+        new Set([secret]),
+      )('onecli secrets create --value "${1}"', [secret]);
+      const observed = JSON.parse(readFileSync(probe, 'utf8')) as {
+        args: string[];
+        env: NodeJS.ProcessEnv;
+        file: string;
+        value: string;
+      };
+      expect(result.ok).toBe(true);
+      expect(observed.args).toContain('--file');
+      expect(observed.args).not.toContain(secret);
+      expect(observed.env.DRIVER_STREAM_SECRET).toBeUndefined();
+      expect(observed.value).toBe(secret);
+      expect(existsSync(observed.file)).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.DRIVER_STREAM_SECRET;
+      else process.env.DRIVER_STREAM_SECRET = previous;
+    }
+  });
+
   it('hostExecStream runs a step and captures the terminal status block fields (for effect:step)', async () => {
     const root = mkdtempSync(join(tmpdir(), 'driver-step-'));
     const out = await hostExecStream(root)(
@@ -176,6 +378,23 @@ describe('thin skill driver', () => {
     );
     expect(out.ok).toBe(true);
     expect(out.fields.PLATFORM_ID).toBe('telegram:42');
+  });
+
+  it('stops a machine streaming step before an unterminated line can grow without bound', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-stream-limit-'));
+    const errors: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      error: (code: string): never => {
+        errors.push(code);
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+
+    await expect(hostExecStream(root, driver)(`node -e 'process.stdout.write("x".repeat(300000))'`)).rejects.toThrow(
+      'skill_output_limit',
+    );
+    expect(errors).toEqual(['skill_output_limit']);
   });
 
   it('hostExecStream children run with LOG_LEVEL=warn — host logger info noise stays off the wizard', async () => {
@@ -190,6 +409,81 @@ describe('thin skill driver', () => {
     } finally {
       if (prev !== undefined) process.env.LOG_LEVEL = prev;
     }
+  });
+
+  it('maps Photon embedded blocks to replaceable sensitive displays', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-photon-'));
+    const seen: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      display: (display: { id: string; sensitive: boolean }) => seen.push(`display:${display.id}:${display.sensitive}`),
+      clearDisplay: (id: string) => seen.push(`clear:${id}`),
+    } as unknown as SetupDriver;
+    const out = await hostExecStream(
+      root,
+      driver,
+    )(
+      [
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_DEVICE ===' 'URL: https://example.com/device' 'CODE: ABCD-1234' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_DEVICE_CLEAR ===' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_OPT_IN ===' 'PHONE: +15551234567' 'LINE: +15558887777' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_OPT_IN_CLEAR ===' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON ===' 'STATUS: success' 'PHONE: +15551234567' '=== END ==='",
+      ].join('; '),
+    );
+    expect(out.ok).toBe(true);
+    expect(seen).toEqual([
+      'display:photon-device:true',
+      'clear:photon-device',
+      'display:photon-opt-in:true',
+      'clear:photon-opt-in',
+    ]);
+  });
+
+  it('renders Teams device login as an external action in machine mode', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-teams-'));
+    const prefix = join(root, 'global');
+    const bin = join(root, 'bin');
+    mkdirSync(join(prefix, 'bin'), { recursive: true });
+    mkdirSync(bin);
+    writeFileSync(join(bin, 'npm'), `#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(prefix)}\n`);
+    writeFileSync(
+      join(prefix, 'bin', 'teams'),
+      "#!/bin/sh\nprintf 'Open https://microsoft.com/devicelogin\\nEnter code ABCD-EFGH\\n=== NANOCLAW SETUP: TEAMS-LOGIN ===\\nSTATUS: success\\n=== END ===\\n'\n",
+    );
+    chmodSync(join(bin, 'npm'), 0o755);
+    chmodSync(join(prefix, 'bin', 'teams'), 0o755);
+    const actions: Array<{ kind: string; url?: string }> = [];
+    const displays: Array<{ id: string; kind: string; sensitive: boolean; content?: string }> = [];
+    const cleared: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      externalAction: async (action: { kind: string; url?: string }, verify: () => boolean | Promise<boolean>) => {
+        actions.push(action);
+        expect(await verify()).toBe(true);
+        return 'attempted' as const;
+      },
+      display: (display: { id: string; kind: string; sensitive: boolean; content?: string }) => displays.push(display),
+      clearDisplay: (id: string) => cleared.push(id),
+    } as unknown as SetupDriver;
+    const result = await hostExecStream(
+      root,
+      driver,
+    )('"$(npm prefix -g 2>/dev/null)/bin/teams" login && echo \'"loggedIn": true\'');
+    expect(result.ok).toBe(true);
+    expect(actions).toEqual([
+      {
+        id: 'teams-login-open-url',
+        kind: 'openURL',
+        title: 'Open Microsoft device login',
+        url: 'https://microsoft.com/devicelogin',
+      },
+    ]);
+    expect(displays).toEqual([
+      expect.objectContaining({ id: 'teams-login-url', kind: 'url', sensitive: true }),
+      expect.objectContaining({ id: 'teams-login-code', kind: 'code', content: 'ABCD-EFGH', sensitive: true }),
+    ]);
+    expect(cleared).toEqual(['teams-login-url', 'teams-login-code']);
   });
 
   function reuseScratch(): { root: string; skill: string } {
@@ -208,7 +502,7 @@ describe('thin skill driver', () => {
   it('reuse:true offers an existing .env credential via the confirm seam and skips the prompt when accepted', async () => {
     const { root, skill } = reuseScratch();
     const asked: string[] = [];
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     await runSkill(skill, {
       projectRoot: root,
       reuse: true,
@@ -217,16 +511,39 @@ describe('thin skill driver', () => {
         asked.push(n);
         return 'NEWLY-PASTED';
       },
-      exec: (c) => void cmds.push(c),
+      exec: (command, args = []) => void calls.push({ command, args }),
     });
     expect(asked).not.toContain('bot_token'); // reused from .env → never prompted
-    expect(cmds).toContain('use xoxb-existing-token'); // the reused value flowed downstream
+    expect(calls).toContainEqual({ command: 'use "${1}"', args: ['xoxb-existing-token'] });
+  });
+
+  it('does not expose credential fragments in a machine reuse prompt', async () => {
+    const { root, skill } = reuseScratch();
+    const prompts: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      prompt: async (spec: { message: string }) => {
+        prompts.push(spec.message);
+        return true;
+      },
+    } as unknown as SetupDriver;
+
+    await runSkill(skill, {
+      projectRoot: root,
+      reuse: true,
+      driver,
+      exec: () => {},
+    });
+
+    expect(prompts).toContain('Found an existing SLACK_BOT_TOKEN. Use it?');
+    expect(prompts.join('\n')).not.toContain('xoxb-e');
+    expect(prompts.join('\n')).not.toContain('oken');
   });
 
   it('reuse: declining keeps the prompt', async () => {
     const { root, skill } = reuseScratch();
     const asked: string[] = [];
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     await runSkill(skill, {
       projectRoot: root,
       reuse: true,
@@ -235,10 +552,10 @@ describe('thin skill driver', () => {
         asked.push(n);
         return 'NEWLY-PASTED';
       },
-      exec: (c) => void cmds.push(c),
+      exec: (command, args = []) => void calls.push({ command, args }),
     });
     expect(asked).toContain('bot_token'); // declined → prompted
-    expect(cmds).toContain('use NEWLY-PASTED');
+    expect(calls).toContainEqual({ command: 'use "${1}"', args: ['NEWLY-PASTED'] });
   });
 
   // A cred a HELPER SCRIPT owns (written by effect:external, not nc:env-set) has no
@@ -260,7 +577,7 @@ describe('thin skill driver', () => {
   it('reuse: offers an existing .env value for a HELPER-owned cred (no env-set linkage)', async () => {
     const { root, skill } = helperReuseScratch();
     const asked: string[] = [];
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     const confirmed: string[] = [];
     await runSkill(skill, {
       projectRoot: root,
@@ -273,11 +590,14 @@ describe('thin skill driver', () => {
         asked.push(n);
         return 'https://typed.example';
       },
-      exec: (c) => void cmds.push(c),
+      exec: (command, args = []) => void calls.push({ command, args }),
     });
     expect(confirmed.some((m) => /IMESSAGE_SERVER_URL/.test(m))).toBe(true); // the reuse: link surfaced the offer
     expect(asked).not.toContain('server_url'); // accepted → never re-prompted
-    expect(cmds).toContain('bash configure.sh "https://photon.example.com"'); // reused value flowed downstream
+    expect(calls).toContainEqual({
+      command: 'bash configure.sh "${1}"',
+      args: ['https://photon.example.com'],
+    });
   });
 
   // §5.4 pre-filter: a stale .env value that would fail the prompt's declared
@@ -364,6 +684,87 @@ describe('thin skill driver', () => {
       "Done with the steps above? Continue when you're ready.", // run barrier, completed flavor
     ]);
     expect(fullyApplied(res)).toBe(true);
+  });
+
+  it('machine driver preserves URL-offer and natural-barrier policy before the side effect', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'machine-policy-'));
+    const skill = mkdtempSync(join(tmpdir(), 'machine-policy-skill-'));
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+    writeFileSync(
+      join(skill, 'SKILL.md'),
+      '# machine policy\n\n```nc:operator\nOpen https://example.com/setup and finish.\n```\n```nc:run effect:build\necho build\n```\n',
+    );
+    const calls: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      operation: 'setup',
+      prompt: async (spec: { message: string }) => {
+        calls.push(`prompt:${spec.message}`);
+        return true;
+      },
+      display: (display: { kind: string }) => {
+        calls.push(`display:${display.kind}`);
+      },
+      note: () => {
+        calls.push('note');
+      },
+      progress: (_id: string, state: string) => {
+        calls.push(`progress:${state}`);
+      },
+      throwIfCancelled: () => {},
+    } as unknown as SetupDriver;
+
+    await runSkill(skill, {
+      projectRoot: root,
+      driver,
+      exec: () => {
+        calls.push('exec');
+      },
+    });
+
+    expect(calls).toEqual([
+      'note',
+      'prompt:Open https://example.com/setup in your browser?',
+      'display:url',
+      "prompt:Done with the steps above? Continue when you're ready.",
+      'progress:pending',
+      'progress:running',
+      'exec',
+      'progress:succeeded',
+    ]);
+  });
+
+  it('stops before a later skill side effect when the driver is cancelled', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'machine-cancel-'));
+    const skill = mkdtempSync(join(tmpdir(), 'machine-cancel-skill-'));
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+    writeFileSync(
+      join(skill, 'SKILL.md'),
+      '# cancel\n\n```nc:run effect:build\nfirst\n```\n```nc:run effect:wire\nsecond\n```\n',
+    );
+    let cancelled = false;
+    const commands: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      operation: 'setup',
+      progress: () => {},
+      throwIfCancelled: () => {
+        if (cancelled) throw new Error('driver cancelled');
+      },
+    } as unknown as SetupDriver;
+
+    await expect(
+      runSkill(skill, {
+        projectRoot: root,
+        driver,
+        exec: (command) => {
+          commands.push(command);
+          cancelled = true;
+        },
+      }),
+    ).rejects.toThrow('driver cancelled');
+
+    expect(commands).toEqual(['first']);
   });
 
   it('default handler: readiness flavor before an effect:step; decline = proceed (never an abort)', async () => {

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -12,7 +12,7 @@
  * policy module (scripts/skill-policy.ts): the natural-barrier gate confirm,
  * the URL offer, the prose-derived validation message.
  */
-import { execSync, spawn } from 'node:child_process';
+import { execSync, spawn, spawnSync } from 'node:child_process';
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
@@ -26,6 +26,8 @@ import {
   type ApplyEvent,
   type ApplyResult,
   type InputMeta,
+  type SkillExec,
+  type SkillExecStream,
   type StepOutcome,
 } from '../../scripts/skill-apply.js';
 import { parseDirectives, promptVar } from '../../scripts/skill-directives.js';
@@ -35,7 +37,23 @@ import { isHeadless } from '../platform.js';
 import { emitStatus } from '../status.js';
 import { openUrl } from './browser.js';
 import { isHelpEscape, offerClaudeHandoff, validateWithHelpEscape } from './claude-handoff.js';
+import { redactSensitiveValues, registerSensitiveValue } from './redaction.js';
+import { childEnvWithoutSetupSecrets, withSecretFile } from './secret-file.js';
 import { startSpinner } from './runner.js';
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+
+const MAX_MACHINE_EFFECT_OUTPUT_BYTES = 256 * 1024;
+
+function machineEffectOutputLimitError(driver?: SetupDriver): Error {
+  const message = 'A setup command exceeded the 256 KiB machine-output limit.';
+  if (!driver) return new Error(message);
+  try {
+    driver.error('skill_output_limit', message);
+  } catch (error) {
+    return error instanceof Error ? error : new Error(message);
+  }
+  return new Error(message);
+}
 
 /**
  * Build the clack `validate` callback an `nc:prompt` carries — the interactive
@@ -192,6 +210,7 @@ async function reuseFromEnv(
   projectRoot: string,
   alreadyHave: Record<string, string>,
   confirm: (message: string) => Promise<boolean>,
+  showMaskedValue = true,
 ): Promise<Record<string, string>> {
   let md: string;
   try {
@@ -243,9 +262,186 @@ async function reuseFromEnv(
     const shape = promptShape.get(v);
     if (shape?.validate && !new RegExp(shape.validate, shape.flags).test(normalizeValue(existing, shape.normalize)))
       continue;
-    if (await confirm(`Found an existing ${key} (${maskValue(existing)}). Use it?`)) reuse[v] = existing;
+    const existingLabel = showMaskedValue ? ` (${maskValue(existing)})` : '';
+    if (await confirm(`Found an existing ${key}${existingLabel}. Use it?`)) reuse[v] = existing;
   }
   return reuse;
+}
+
+class MachineSecretTransportError extends Error {
+  readonly code = 'secret_transport_unsupported';
+
+  constructor() {
+    super('A secret-valued skill command cannot be transported safely in machine mode.');
+  }
+}
+
+function failMachineSecretTransport(driver?: SetupDriver): never {
+  const message = 'This skill needs a secret transport that machine mode does not support.';
+  if (driver && typeof driver.error === 'function') {
+    return driver.error('secret_transport_unsupported', message, [
+      {
+        kind: 'manual',
+        title: 'Complete this step in a terminal',
+        instructions: ['Run this skill from a terminal, then retry setup.'],
+      },
+    ]);
+  }
+  throw new MachineSecretTransportError();
+}
+
+function isOneCliCommand(command: string): boolean {
+  return /^\s*(?:[^\s;&|]+\/)?onecli(?:\s|$)/.test(command);
+}
+
+function replaceOneCliValue(command: string, argIndex: number): string | undefined {
+  if (!isOneCliCommand(command)) return undefined;
+  const ref = `\\$\\{${argIndex + 1}\\}`;
+  const value = new RegExp(`--value(\\s+)("${ref}"|'${ref}'|'"${ref}"'|${ref})`);
+  const match = value.exec(command);
+  if (!match || match.index === undefined) return undefined;
+  return `${command.slice(0, match.index)}--file${match[0].slice('--value'.length)}${command.slice(match.index + match[0].length)}`;
+}
+
+function oneCliValueArgs(command: string): Set<number> {
+  const indexes = new Set<number>();
+  const value = /--value\s+(?:"\$\{(\d+)\}"|'\$\{(\d+)\}'|'"\$\{(\d+)\}"'|\$\{(\d+)\})/g;
+  let match: RegExpExecArray | null;
+  while ((match = value.exec(command)) !== null) {
+    const index = Number(match[1] ?? match[2] ?? match[3] ?? match[4]);
+    if (Number.isSafeInteger(index) && index > 0) indexes.add(index - 1);
+  }
+  return indexes;
+}
+
+function isCurlCommand(command: string): boolean {
+  return /^\s*(?:[^\s;&|]+\/)?curl(?:\s|$)/.test(command);
+}
+
+function curlSecretCommand(command: string, indexes: number[], configPath: string): string | undefined {
+  if (!isCurlCommand(command)) return undefined;
+  let safeCommand = command;
+  const markers = indexes.map((index) => `__NANOCLAW_SECRET_${index}__`);
+  for (const [position, index] of indexes.entries()) {
+    const reference = `\${${index + 1}}`;
+    if (!safeCommand.includes(reference)) return undefined;
+    safeCommand = safeCommand.replaceAll(reference, markers[position]);
+  }
+
+  const resolveSecrets = indexes.flatMap((index, position) => [`nc_secret_${position}=$(<"\${${index + 1}}")`]);
+  const replaceMarkers = markers.map(
+    (marker, position) =>
+      `  case "$value" in *${marker}*) value="\${value%%${marker}*}$nc_secret_${position}\${value#*${marker}}" ;; esac`,
+  );
+  return [
+    `nc_curl_config=${JSON.stringify(configPath)}`,
+    ...resolveSecrets,
+    'nc_curl_resolve() {',
+    '  local value="$1"',
+    ...replaceMarkers,
+    '  printf %s "$value"',
+    '}',
+    'nc_curl_quote() {',
+    '  local value="$1"',
+    '  value="${value//\\\\/\\\\\\\\}"',
+    '  value="${value//\\"/\\\\\\"}"',
+    '  value="${value//$\'\\n\'/\\n}"',
+    '  value="${value//$\'\\r\'/\\r}"',
+    '  printf %s "$value"',
+    '}',
+    'nc_curl_option() {',
+    '  local value',
+    '  value=$(nc_curl_resolve "$2")',
+    '  printf \'%s = "%s"\\n\' "$1" "$(nc_curl_quote "$value")" >> "$nc_curl_config"',
+    '}',
+    'curl() {',
+    '  : > "$nc_curl_config"',
+    '  while [ "$#" -gt 0 ]; do',
+    '    case "$1" in',
+    '      -s) printf \'silent\\n\' >> "$nc_curl_config" ;;',
+    '      -f) printf \'fail\\n\' >> "$nc_curl_config" ;;',
+    '      -S) printf \'show-error\\n\' >> "$nc_curl_config" ;;',
+    '      -L) printf \'location\\n\' >> "$nc_curl_config" ;;',
+    '      -sf|-fs) printf \'silent\\nfail\\n\' >> "$nc_curl_config" ;;',
+    '      -X|--request|-H|--header|-d|--data|--data-raw|--data-binary|--data-urlencode|--url|--connect-timeout|--max-time)',
+    '        case "$1" in',
+    '          -X|--request) nc_curl_name=request ;;',
+    '          -H|--header) nc_curl_name=header ;;',
+    '          -d|--data|--data-raw|--data-binary) nc_curl_name=data ;;',
+    '          --data-urlencode) nc_curl_name=data-urlencode ;;',
+    '          --url) nc_curl_name=url ;;',
+    '          --connect-timeout) nc_curl_name=connect-timeout ;;',
+    '          --max-time) nc_curl_name=max-time ;;',
+    '        esac',
+    '        shift',
+    '        [ "$#" -gt 0 ] || return 64',
+    '        nc_curl_option "$nc_curl_name" "$1"',
+    '        ;;',
+    '      --) shift; while [ "$#" -gt 0 ]; do nc_curl_option url "$1"; shift; done; break ;;',
+    '      -*) return 64 ;;',
+    '      *) nc_curl_option url "$1" ;;',
+    '    esac',
+    '    shift',
+    '  done',
+    '  command curl --config "$nc_curl_config"',
+    '}',
+    safeCommand,
+  ].join('\n');
+}
+
+async function withMachineSecretTransport<T>(
+  command: string,
+  args: string[],
+  secrets: ReadonlySet<string>,
+  driver: SetupDriver | undefined,
+  run: (command: string, args: string[]) => Promise<T>,
+): Promise<T> {
+  const secretArgs = new Set<number>(oneCliValueArgs(command));
+  args.forEach((value, index) => {
+    if (secrets.has(value)) secretArgs.add(index);
+  });
+  if (secretArgs.size === 0) return run(command, args);
+
+  let safeCommand = command;
+  const indexes = [...secretArgs];
+  const onecli = isOneCliCommand(command);
+  if (onecli) {
+    for (const index of indexes) {
+      const replaced = replaceOneCliValue(safeCommand, index);
+      if (replaced === undefined) failMachineSecretTransport(driver);
+      safeCommand = replaced;
+    }
+  } else if (!isCurlCommand(command)) {
+    failMachineSecretTransport(driver);
+  }
+
+  const pass = async (position: number, currentArgs: string[]): Promise<T> => {
+    if (position === indexes.length) {
+      if (onecli) return run(safeCommand, currentArgs);
+      return withSecretFile('', (configPath) => {
+        const wrapped = curlSecretCommand(safeCommand, indexes, configPath);
+        if (wrapped === undefined) failMachineSecretTransport(driver);
+        return run(wrapped, currentArgs);
+      });
+    }
+    const index = indexes[position];
+    const secret = args[index];
+    if (secret === undefined) failMachineSecretTransport(driver);
+    return withSecretFile(secret, (filePath) => {
+      const nextArgs = [...currentArgs];
+      nextArgs[index] = filePath;
+      return pass(position + 1, nextArgs);
+    });
+  };
+  return pass(0, [...args]);
+}
+
+function machineChildEnv(secrets: ReadonlySet<string>): NodeJS.ProcessEnv {
+  const env = childEnvWithoutSetupSecrets();
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined && [...secrets].some((secret) => value.includes(secret))) delete env[key];
+  }
+  return env;
 }
 
 /**
@@ -267,32 +463,76 @@ async function reuseFromEnv(
  * appended there (level 3, like runner.ts's per-step raw logs) so the silenced
  * noise stays inspectable.
  */
-export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) => Promise<string> {
-  const tee = (cmd: string, stdout: string, stderr: string): void => {
+export function hostExec(
+  projectRoot: string,
+  rawLog?: string,
+  driver?: SetupDriver,
+  secrets: ReadonlySet<string> = new Set<string>(),
+): SkillExec {
+  const tee = (cmd: string, stdout: string, stderr: string, machine: boolean): void => {
     if (!rawLog) return;
-    const body = [stdout, stderr].filter(Boolean).join('');
-    appendFileSync(rawLog, `$ ${cmd}\n${body}${body && !body.endsWith('\n') ? '\n' : ''}\n`);
+    // A capture can mint a credential before the engine knows which field is
+    // sensitive. Machine runs keep that output in memory for capture only.
+    const body = machine ? '' : [stdout, stderr].filter(Boolean).join('');
+    const header = machine ? '$ [machine command omitted]' : `$ ${cmd}`;
+    appendFileSync(rawLog, `${header}\n${body}${body && !body.endsWith('\n') ? '\n' : ''}\n`);
   };
-  return (cmd) =>
+  const run = (cmd: string, args: string[]): Promise<string> =>
     new Promise((resolve, reject) => {
-      const child = spawn('bash', ['-c', cmd], {
+      const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+      const baseEnv = machine ? machineChildEnv(secrets) : process.env;
+      const child = spawn('bash', ['-c', cmd, 'nanoclaw-skill', ...args], {
         cwd: projectRoot,
-        env: { ...process.env, PATH: `${join(projectRoot, 'bin')}:${process.env.PATH ?? ''}` },
+        env: { ...baseEnv, PATH: `${join(projectRoot, 'bin')}:${baseEnv.PATH ?? ''}` },
         stdio: ['ignore', 'pipe', 'pipe'],
+        ...(machine ? { detached: true } : {}),
       });
+      const stopGroup = (): void => {
+        if (!machine || !child.pid) return;
+        const processGroupId = child.pid;
+        try {
+          process.kill(-processGroupId, 'SIGTERM');
+        } catch {
+          /* already gone */
+        }
+        setTimeout(() => {
+          try {
+            process.kill(-processGroupId, 'SIGKILL');
+          } catch {
+            /* already gone */
+          }
+        }, 250);
+      };
+      driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+      if (driver?.cancellationSignal?.aborted) stopGroup();
       let out = '';
       let err = '';
-      child.stdout.on('data', (c: Buffer) => {
-        out += c.toString('utf8');
-      });
-      child.stderr.on('data', (c: Buffer) => {
-        err += c.toString('utf8');
-      });
+      let outputBytes = 0;
+      let outputLimitExceeded = false;
+      const capture = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+        if (outputLimitExceeded) return;
+        if (machine) {
+          outputBytes += chunk.byteLength;
+          if (outputBytes > MAX_MACHINE_EFFECT_OUTPUT_BYTES) {
+            outputLimitExceeded = true;
+            stopGroup();
+            return;
+          }
+        }
+        if (stream === 'stdout') out += chunk.toString('utf8');
+        else err += chunk.toString('utf8');
+      };
+      child.stdout.on('data', (chunk: Buffer) => capture(chunk, 'stdout'));
+      child.stderr.on('data', (chunk: Buffer) => capture(chunk, 'stderr'));
       child.on('error', reject);
       child.on('close', (code) => {
-        tee(cmd, out, err);
+        driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+        tee(cmd, out, err, machine);
+        if (driver?.cancellationSignal?.aborted) return reject(new DriverCancelled('cancelled'));
+        if (outputLimitExceeded) return reject(machineEffectOutputLimitError(driver));
         if (code === 0) return resolve(out);
-        const stderr = err.trim();
+        if (machine) return reject(new Error(`exit ${code ?? '?'}: command failed`));
+        const stderr = machine ? redactSensitiveValues(err.trim()) : err.trim();
         const head =
           stderr
             .split('\n')
@@ -301,6 +541,10 @@ export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) =>
         reject(new Error(`exit ${code ?? '?'}: ${head}${stderr ? `\n${stderr}` : ''}`));
       });
     });
+  return (cmd, args = []) => {
+    const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+    return machine ? withMachineSecretTransport(cmd, args, secrets, driver, run) : run(cmd, args);
+  };
 }
 
 /**
@@ -311,14 +555,21 @@ export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) =>
  * fields so the engine can `capture:<var>=<FIELD>` them. The block protocol mirrors
  * setup/lib/runner.ts's StatusStream — a step is just a command that emits blocks.
  */
-export function hostExecStream(projectRoot: string): (cmd: string) => Promise<StepOutcome> {
-  return (cmd) =>
-    new Promise((resolve) => {
-      const child = spawn('bash', ['-c', cmd], {
+export function hostExecStream(
+  projectRoot: string,
+  driver?: SetupDriver,
+  secrets: ReadonlySet<string> = new Set<string>(),
+): SkillExecStream {
+  const run = async (cmd: string, args: string[] = []) => {
+    return new Promise<StepOutcome>((resolve, reject) => {
+      const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+      const teamsLogin = machine && cmd.includes('/bin/teams" login &&');
+      const baseEnv = machine ? machineChildEnv(secrets) : process.env;
+      const child = spawn('bash', ['-c', cmd, 'nanoclaw-skill', ...args], {
         cwd: projectRoot,
         env: {
-          ...process.env,
-          PATH: `${join(projectRoot, 'bin')}:${process.env.PATH ?? ''}`,
+          ...baseEnv,
+          PATH: `${join(projectRoot, 'bin')}:${baseEnv.PATH ?? ''}`,
           // A step renders curated operator UI (a code card, a QR) — the host
           // logger's info noise doesn't belong on the wizard screen, and it
           // always emits ANSI so it can't be filtered by stream. Warnings and
@@ -330,23 +581,160 @@ export function hostExecStream(projectRoot: string): (cmd: string) => Promise<St
           // there — force color so the child's card matches the parent.
           ...(process.stdout.isTTY ? { FORCE_COLOR: '1' } : {}),
         },
-        stdio: ['inherit', 'pipe', 'pipe'],
+        stdio: [machine ? 'ignore' : 'inherit', 'pipe', 'pipe'],
+        ...(machine ? { detached: true } : {}),
       });
-      const blocks: Array<{ fields: Record<string, string> }> = [];
-      let current: { fields: Record<string, string> } | null = null;
+      const stopGroup = (): void => {
+        if (!machine || !child.pid) return;
+        const processGroupId = child.pid;
+        try {
+          process.kill(-processGroupId, 'SIGTERM');
+        } catch {
+          /* already gone */
+        }
+        setTimeout(() => {
+          try {
+            process.kill(-processGroupId, 'SIGKILL');
+          } catch {
+            /* already gone */
+          }
+        }, 250);
+      };
+      driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+      if (driver?.cancellationSignal?.aborted) stopGroup();
+      const blocks: Array<{ type: string; fields: Record<string, string> }> = [];
+      let current: { type: string; fields: Record<string, string> } | null = null;
+      let outputBytes = 0;
+      let outputLimitExceeded = false;
+      const activeDisplayIds = new Set<string>();
+      let teamsAction: Promise<unknown> | undefined;
+      const renderTeamsDeviceLine = (line: string): void => {
+        if (!teamsLogin || !driver) return;
+        const url = line.match(/https:\/\/[^\s]+/)?.[0];
+        if (url && !activeDisplayIds.has('teams-login-url')) {
+          activeDisplayIds.add('teams-login-url');
+          driver.display({
+            id: 'teams-login-url',
+            kind: 'url',
+            url,
+            sensitive: true,
+            label: 'Microsoft device login',
+          });
+          teamsAction = driver
+            .externalAction(
+              { id: 'teams-login-open-url', kind: 'openURL', title: 'Open Microsoft device login', url },
+              () => true,
+            )
+            .catch((error: unknown) => {
+              stopGroup();
+              throw error;
+            });
+        }
+        const code = line.match(/\b[A-Z0-9]{4,}(?:-[A-Z0-9]{4,})+\b/)?.[0];
+        if (code && !activeDisplayIds.has('teams-login-code')) {
+          activeDisplayIds.add('teams-login-code');
+          driver.display({
+            id: 'teams-login-code',
+            kind: 'code',
+            content: code,
+            sensitive: true,
+            label: 'Microsoft device code',
+          });
+        }
+      };
+      const renderBlock = (block: { type: string; fields: Record<string, string> }): void => {
+        if (driver?.mode !== 'ndjson') return;
+        if (block.type === 'PAIR_TELEGRAM_CODE' && block.fields.CODE) {
+          activeDisplayIds.add('telegram-pairing-code');
+          driver.display({
+            id: 'telegram-pairing-code',
+            kind: 'code',
+            content: block.fields.CODE,
+            sensitive: true,
+            label: 'Telegram pairing code',
+          });
+        } else if (block.type === 'WHATSAPP_AUTH_QR' && block.fields.QR) {
+          activeDisplayIds.add('whatsapp-auth');
+          driver.display({
+            id: 'whatsapp-auth',
+            kind: 'qr',
+            payload: block.fields.QR,
+            sensitive: true,
+            label: 'WhatsApp QR code',
+          });
+        } else if (block.type === 'WHATSAPP_AUTH_PAIRING_CODE' && block.fields.CODE) {
+          activeDisplayIds.add('whatsapp-auth');
+          driver.display({
+            id: 'whatsapp-auth',
+            kind: 'code',
+            content: block.fields.CODE,
+            sensitive: true,
+            label: 'WhatsApp pairing code',
+          });
+        } else if (block.type === 'SIGNAL_AUTH_QR' && block.fields.QR) {
+          activeDisplayIds.add('signal-auth');
+          driver.display({
+            id: 'signal-auth',
+            kind: 'qr',
+            payload: block.fields.QR,
+            sensitive: true,
+            label: 'Signal linking QR',
+          });
+        } else if (block.type === 'PHOTON_DEVICE' && block.fields.URL && block.fields.CODE) {
+          activeDisplayIds.add('photon-device');
+          driver.display({
+            id: 'photon-device',
+            kind: 'code',
+            content: `${block.fields.URL}\n${block.fields.CODE}`,
+            sensitive: true,
+            label: 'Approve this Photon device',
+          });
+        } else if (block.type === 'PHOTON_DEVICE_CLEAR') {
+          activeDisplayIds.delete('photon-device');
+          driver.clearDisplay('photon-device');
+        } else if (block.type === 'PHOTON_OPT_IN' && block.fields.PHONE) {
+          activeDisplayIds.add('photon-opt-in');
+          driver.display({
+            id: 'photon-opt-in',
+            kind: 'text',
+            content: block.fields.LINE
+              ? `Open Messages on ${block.fields.PHONE} and send one message to ${block.fields.LINE}. Setup continues when Photon confirms the opt-in.`
+              : `Photon has not assigned an iMessage line to ${block.fields.PHONE} yet. Setup is waiting for the line and the first message from that phone.`,
+            sensitive: true,
+            label: 'One step needed on your phone',
+          });
+        } else if (block.type === 'PHOTON_OPT_IN_CLEAR') {
+          activeDisplayIds.delete('photon-opt-in');
+          driver.clearDisplay('photon-opt-in');
+        }
+      };
       let buf = '';
       const onChunk = (chunk: Buffer): void => {
+        if (outputLimitExceeded) return;
+        if (machine) {
+          outputBytes += chunk.byteLength;
+          if (outputBytes > MAX_MACHINE_EFFECT_OUTPUT_BYTES) {
+            outputLimitExceeded = true;
+            stopGroup();
+            return;
+          }
+        }
         buf += chunk.toString('utf8');
         let idx: number;
         while ((idx = buf.indexOf('\n')) !== -1) {
           const line = buf.slice(0, idx);
           buf = buf.slice(idx + 1);
-          if (/^=== NANOCLAW SETUP: \S+ ===/.test(line)) {
-            current = { fields: {} };
+          renderTeamsDeviceLine(line);
+          const start = line.match(/^=== NANOCLAW SETUP: (\S+) ===/);
+          if (start) {
+            current = { type: start[1], fields: {} };
             continue;
           }
           if (line.startsWith('=== END ===')) {
-            if (current) blocks.push(current);
+            if (current) {
+              blocks.push(current);
+              renderBlock(current);
+            }
             current = null;
             continue;
           }
@@ -355,17 +743,35 @@ export function hostExecStream(projectRoot: string): (cmd: string) => Promise<St
             if (c > 0) current.fields[line.slice(0, c).trim()] = line.slice(c + 1).trim();
             continue;
           }
-          process.stdout.write(line + '\n'); // operator-facing line (a QR, a code) — show it live
+          if (driver?.mode !== 'ndjson') process.stdout.write(line + '\n');
         }
       };
       child.stdout.on('data', onChunk);
       child.stderr.on('data', onChunk);
-      child.on('close', (code) => {
+      child.on('error', () => {
+        for (const id of activeDisplayIds) driver?.clearDisplay(id);
+        resolve({ ok: false, fields: {} });
+      });
+      child.on('close', async (code) => {
+        driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+        if (driver?.cancellationSignal?.aborted) return reject(new DriverCancelled('cancelled'));
+        for (const id of activeDisplayIds) driver?.clearDisplay(id);
+        if (outputLimitExceeded) return reject(machineEffectOutputLimitError(driver));
+        try {
+          await teamsAction;
+        } catch (error) {
+          return reject(error);
+        }
         const terminal = [...blocks].reverse().find((b) => b.fields.STATUS) ?? null;
         const status = terminal?.fields.STATUS;
         resolve({ ok: code === 0 && (status === 'success' || status === 'skipped'), fields: terminal?.fields ?? {} });
       });
     });
+  };
+  return (cmd, args = []) => {
+    const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+    return machine ? withMachineSecretTransport(cmd, args, secrets, driver, run) : run(cmd, args);
+  };
 }
 
 // The barrier-confirm wording per gate flavor (§5.1.5). Decline = proceed: the
@@ -421,6 +827,7 @@ function defaultOnEvent(
   md: string,
   confirm: (message: string) => Promise<boolean>,
   open: (url: string) => Promise<void>,
+  driver?: SetupDriver,
 ): (e: ApplyEvent) => Promise<void> {
   const gates = gatePolicy(md);
   const ordinals = labelOrdinals(md);
@@ -432,6 +839,12 @@ function defaultOnEvent(
   let plain: { base: string; start: number } | null = null;
   return async (e) => {
     if (e.type === 'step-start') {
+      if (driver?.mode === 'ndjson') {
+        const id = `skill-${e.line}`;
+        driver.progress(id, 'pending', e.label ?? e.kind);
+        driver.progress(id, 'running', e.label ?? e.kind);
+        return;
+      }
       if (e.label === null) return; // instant/cheap step — no caption declared
       const base = e.label.replace(/…+$/, '') + (ordinals.get(e.line) ?? '');
       if (!process.stdout.isTTY) {
@@ -442,6 +855,11 @@ function defaultOnEvent(
       return;
     }
     if (e.type === 'step-end') {
+      if (driver?.mode === 'ndjson') {
+        driver.progress(`skill-${e.line}`, e.ok ? 'succeeded' : 'failed', e.label ?? e.kind);
+        driver.throwIfCancelled();
+        return;
+      }
       if (active) {
         active.stop({ ok: e.ok });
         active = null;
@@ -454,7 +872,8 @@ function defaultOnEvent(
       return;
     }
     // operator: note → URL offer → natural-barrier confirm.
-    p.note(e.text, 'Your turn');
+    if (driver) driver.note(e.text, 'Your turn');
+    else p.note(e.text, 'Your turn');
     const url = extractOfferUrl(e.text);
     if (url !== undefined && (await confirm(`Open ${url} in your browser?`))) await open(url);
     const gate = gates.get(e.line);
@@ -481,6 +900,8 @@ export function channelsRemote(projectRoot: string): () => string {
 }
 
 export interface RunSkillOptions {
+  /** Shared setup presentation; omitted by standalone and test consumers. */
+  driver?: SetupDriver;
   projectRoot?: string;
   /** Pre-supplied prompt answers — pass them all for a fully programmatic run. */
   inputs?: Record<string, string>;
@@ -491,9 +912,9 @@ export interface RunSkillOptions {
    */
   resolveInput?: (name: string, meta: InputMeta) => Promise<string | undefined>;
   /** Defaults to `hostExec`. */
-  exec?: (cmd: string) => string | void | Promise<string | void>;
+  exec?: SkillExec;
   /** Defaults to `hostExecStream`. Streaming exec for `nc:run effect:step`. */
-  execStream?: (cmd: string) => Promise<StepOutcome>;
+  execStream?: SkillExecStream;
   /** Defaults to the fork-aware channels-branch resolver. */
   resolveRemote?: (branch: string) => string;
   /** Run effects the caller owns (e.g. `['restart']` when it restarts once). */
@@ -537,14 +958,41 @@ export interface RunSkillOptions {
  */
 export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Promise<ApplyResult> {
   const projectRoot = opts.projectRoot ?? process.cwd();
-  const confirm = opts.confirm ?? defaultConfirm;
-  const open = opts.openUrl ?? defaultOpenUrl;
+  const confirm =
+    opts.confirm ??
+    (opts.driver
+      ? async (message: string) =>
+          (await opts.driver!.prompt({
+            kind: 'confirm',
+            message,
+            default: true,
+          })) === true
+      : defaultConfirm);
+  const open =
+    opts.openUrl ??
+    (opts.driver?.mode === 'ndjson'
+      ? async (url: string) => {
+          // Browser opens have no NanoClaw-observable postcondition. Keep the
+          // URL in the typed display channel instead of trusting a client's
+          // `attempted` response from an external action.
+          opts.driver!.display({
+            id: `url-${basename(skillDir)}`,
+            kind: 'url',
+            url,
+            label: 'Open this URL',
+            sensitive: false,
+          });
+        }
+      : defaultOpenUrl);
   let inputs = opts.inputs;
   // Offer to reuse credentials already in .env before the engine prompts for them.
   if (opts.reuse) {
-    const reused = await reuseFromEnv(skillDir, projectRoot, inputs ?? {}, confirm);
-    if (Object.keys(reused).length) inputs = { ...inputs, ...reused };
+    const reused = await reuseFromEnv(skillDir, projectRoot, inputs ?? {}, confirm, opts.driver?.mode !== 'ndjson');
+    if (Object.keys(reused).length) {
+      inputs = { ...inputs, ...reused };
+    }
   }
+  const machineSecrets = new Set<string>();
   // The default operator policy derives from the skill document itself
   // (gatePolicy keys on directive lines) — read it once here; the engine reads
   // the same file for the actual apply.
@@ -554,6 +1002,49 @@ export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Pr
   } catch {
     // missing SKILL.md — the engine will produce an empty result anyway
   }
+  for (const directive of parseDirectives(md)) {
+    if (directive.kind !== 'prompt') continue;
+    const name = promptVar(directive);
+    const value = name ? inputs?.[name] : undefined;
+    if (!value) continue;
+    const normalized = normalizeValue(
+      value,
+      typeof directive.attrs.normalize === 'string' ? directive.attrs.normalize : undefined,
+    );
+    if (!directive.args.includes('secret')) continue;
+    registerSensitiveValue(value);
+    registerSensitiveValue(normalized);
+    machineSecrets.add(value);
+    machineSecrets.add(normalized);
+  }
+  const acquireInput =
+    opts.resolveInput ??
+    (opts.driver?.mode === 'ndjson'
+      ? async (name: string, meta: InputMeta): Promise<string | undefined> => {
+          const choices = meta.secret ? null : literalChoices(meta.validate);
+          const value = await opts.driver!.prompt({
+            id: `skill-${basename(skillDir)}-${name}`,
+            kind: choices ? 'singleChoice' : meta.secret ? 'secret' : 'text',
+            message: meta.question,
+            sensitive: meta.secret,
+            ...(choices ? { choices: choices.map((choice) => ({ id: choice, label: choice })) } : {}),
+            validateValue: (answer) => promptValidator(meta.validate, meta.flags, meta.question)?.(String(answer)),
+          });
+          return typeof value === 'string' && value.length > 0 ? value : undefined;
+        }
+      : clackResolveInput({ channel: opts.channel, step: opts.step }));
+  const resolveInput = async (name: string, meta: InputMeta): Promise<string | undefined> => {
+    const value = await acquireInput(name, meta);
+    if (!value) return undefined;
+    const normalized = normalizeValue(value, meta.normalize);
+    if (meta.secret) {
+      registerSensitiveValue(value);
+      registerSensitiveValue(normalized);
+      machineSecrets.add(value);
+      machineSecrets.add(normalized);
+    }
+    return value;
+  };
   // One raw log per skill apply (level 3): every default-exec command appends
   // its `$ cmd` + output there. Allocated only when the default exec is used —
   // an injected exec (tests, agent relay) owns its own capture.
@@ -562,15 +1053,38 @@ export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Pr
     rawLog = setupLog.stepRawLog(`skill-${basename(skillDir)}`);
     writeFileSync(rawLog, `# skill ${basename(skillDir)} — ${new Date().toISOString()}\n\n`);
   }
-  return applySkill(skillDir, projectRoot, {
+  const defaultExec = opts.exec ?? hostExec(projectRoot, rawLog, opts.driver, machineSecrets);
+  const defaultExecStream = opts.execStream ?? hostExecStream(projectRoot, opts.driver, machineSecrets);
+  const machine = opts.driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+  const exec =
+    machine && opts.exec
+      ? (command: string, args: string[] = []) =>
+          withMachineSecretTransport(command, args, machineSecrets, opts.driver, async (safeCommand, safeArgs) =>
+            opts.exec!(safeCommand, safeArgs),
+          )
+      : defaultExec;
+  const execStream =
+    machine && opts.execStream
+      ? (command: string, args: string[] = []) =>
+          withMachineSecretTransport(command, args, machineSecrets, opts.driver, opts.execStream!)
+      : defaultExecStream;
+  const onEvent = opts.onEvent ?? defaultOnEvent(md, confirm, open, opts.driver);
+  opts.driver?.throwIfCancelled?.();
+  const result = await applySkill(skillDir, projectRoot, {
     inputs,
-    resolveInput: opts.resolveInput ?? clackResolveInput({ channel: opts.channel, step: opts.step }),
-    onEvent: opts.onEvent ?? defaultOnEvent(md, confirm, open),
-    exec: opts.exec ?? hostExec(projectRoot, rawLog),
-    execStream: opts.execStream ?? hostExecStream(projectRoot),
+    resolveInput,
+    onEvent: async (event) => {
+      opts.driver?.throwIfCancelled?.();
+      await onEvent(event);
+      opts.driver?.throwIfCancelled?.();
+    },
+    exec,
+    execStream,
     resolveRemote: opts.resolveRemote ?? channelsRemote(projectRoot),
     skipEffects: opts.skipEffects,
   });
+  opts.driver?.throwIfCancelled?.();
+  return result;
 }
 
 /**

--- a/setup/lib/tz-from-claude.test.ts
+++ b/setup/lib/tz-from-claude.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+import { resolveTimezoneViaClaude } from './tz-from-claude.js';
+
+describe('machine timezone lookup', () => {
+  it('stops a noisy machine lookup before its output can grow without bound', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-timezone-limit-'));
+    const bin = path.join(temp, 'bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, 'claude'),
+      `#!/usr/bin/env node
+process.stdout.write('x'.repeat(70 * 1024));
+setInterval(() => {}, 1000);
+`,
+      { mode: 0o755 },
+    );
+    const previousPath = process.env.PATH;
+    try {
+      process.env.PATH = `${bin}:${previousPath ?? ''}`;
+      const driver = {
+        mode: 'ndjson',
+        progress: () => {},
+        throwIfCancelled: () => {},
+      } as unknown as SetupDriver;
+      await expect(resolveTimezoneViaClaude('Jerusalem', driver)).resolves.toBeNull();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it('scrubs credentials and kills the Claude process group on cancellation', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-timezone-cancel-'));
+    const bin = path.join(temp, 'bin');
+    const envMarker = path.join(temp, 'env');
+    const pidMarker = path.join(temp, 'pid');
+    fs.mkdirSync(bin);
+    const stubborn = path.join(bin, 'stubborn');
+    fs.writeFileSync(
+      stubborn,
+      `#!/bin/sh
+trap '' TERM
+echo $$ > "$TZ_PID_MARKER"
+exec sleep 30
+`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(bin, 'claude'),
+      `#!/bin/sh
+printf '%s' "\${ANTHROPIC_AUTH_TOKEN-missing}" > "$TZ_ENV_MARKER"
+${JSON.stringify(stubborn)} &
+wait
+`,
+      { mode: 0o755 },
+    );
+    const previous = {
+      path: process.env.PATH,
+      token: process.env.ANTHROPIC_AUTH_TOKEN,
+      envMarker: process.env.TZ_ENV_MARKER,
+      pidMarker: process.env.TZ_PID_MARKER,
+    };
+    const controller = new AbortController();
+    const driver = {
+      mode: 'ndjson',
+      cancellationSignal: controller.signal,
+      progress: () => {},
+      throwIfCancelled: () => {
+        if (controller.signal.aborted) throw new DriverCancelled('test');
+      },
+    } as unknown as SetupDriver;
+    let pid = 0;
+    try {
+      process.env.PATH = `${bin}:${previous.path ?? ''}`;
+      process.env.ANTHROPIC_AUTH_TOKEN = 'must-not-reach-child';
+      process.env.TZ_ENV_MARKER = envMarker;
+      process.env.TZ_PID_MARKER = pidMarker;
+      const result = resolveTimezoneViaClaude('Jerusalem', driver);
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(pidMarker) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(fs.readFileSync(envMarker, 'utf8')).toBe('missing');
+      controller.abort();
+      await expect(result).rejects.toBeInstanceOf(DriverCancelled);
+      pid = Number(fs.readFileSync(pidMarker, 'utf8'));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      controller.abort();
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      for (const [key, value] of Object.entries({
+        PATH: previous.path,
+        ANTHROPIC_AUTH_TOKEN: previous.token,
+        TZ_ENV_MARKER: previous.envMarker,
+        TZ_PID_MARKER: previous.pidMarker,
+      })) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/setup/lib/tz-from-claude.ts
+++ b/setup/lib/tz-from-claude.ts
@@ -17,11 +17,18 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import { isValidTimezone } from '../../src/timezone.js';
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
 import { fitToWidth, fmtDuration } from './theme.js';
+import type { SetupDriver } from './setup-driver.js';
 
-export function claudeCliAvailable(): boolean {
+const MAX_MACHINE_TIMEZONE_OUTPUT_BYTES = 64 * 1024;
+
+export function claudeCliAvailable(driver?: SetupDriver): boolean {
   try {
-    execSync('command -v claude', { stdio: 'ignore' });
+    execSync('command -v claude', {
+      stdio: 'ignore',
+      ...(driver?.mode === 'ndjson' ? { env: childEnvWithoutSetupSecrets() } : {}),
+    });
     return true;
   } catch {
     return false;
@@ -34,10 +41,19 @@ export function claudeCliAvailable(): boolean {
  * resolved zone string on success, or null if the CLI is missing, Claude
  * errored, or the reply wasn't a valid IANA zone.
  */
-export async function resolveTimezoneViaClaude(input: string): Promise<string | null> {
-  if (!claudeCliAvailable()) return null;
+export async function resolveTimezoneViaClaude(input: string, driver?: SetupDriver): Promise<string | null> {
+  if (!claudeCliAvailable(driver)) return null;
 
   const prompt = buildPrompt(input);
+
+  if (driver?.mode === 'ndjson') {
+    driver.progress('timezone-lookup', 'running', 'Looking up that timezone');
+    const reply = await queryClaude(prompt, driver);
+    driver.throwIfCancelled();
+    const resolved = reply ? extractTimezone(reply) : null;
+    driver.progress('timezone-lookup', resolved ? 'succeeded' : 'failed');
+    return resolved;
+  }
 
   const s = p.spinner();
   const start = Date.now();
@@ -58,7 +74,7 @@ export async function resolveTimezoneViaClaude(input: string): Promise<string | 
     s.stop(`${fitToWidth(`Interpreted as ${resolved}.`, suffix)}${k.dim(suffix)}`);
     return resolved;
   }
-  s.stop(`${fitToWidth("Couldn't interpret that as a timezone.", suffix)}${k.dim(suffix)}`, 1);
+  s.error(`${fitToWidth("Couldn't interpret that as a timezone.", suffix)}${k.dim(suffix)}`);
   return null;
 }
 
@@ -75,26 +91,69 @@ function buildPrompt(input: string): string {
   ].join('\n');
 }
 
-function queryClaude(prompt: string): Promise<string | null> {
+function queryClaude(prompt: string, driver?: SetupDriver): Promise<string | null> {
   return new Promise((resolve) => {
+    const machine = driver?.mode === 'ndjson';
     const child = spawn('claude', ['-p', '--output-format', 'text'], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(machine ? { detached: true, env: childEnvWithoutSetupSecrets() } : {}),
     });
     let stdout = '';
+    let outputBytes = 0;
     let settled = false;
     const settle = (value: string | null): void => {
       if (settled) return;
       settled = true;
+      driver?.cancellationSignal?.removeEventListener('abort', onAbort);
       resolve(value);
     };
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    const onAbort = (): void => {
+      stopGroup();
+      settle(null);
+    };
+    driver?.cancellationSignal?.addEventListener('abort', onAbort, { once: true });
+    if (driver?.cancellationSignal?.aborted) onAbort();
 
+    const accepts = (chunk: Buffer): boolean => {
+      if (settled) return false;
+      if (machine) {
+        outputBytes += chunk.byteLength;
+        if (outputBytes > MAX_MACHINE_TIMEZONE_OUTPUT_BYTES) {
+          stopGroup();
+          settle(null);
+          return false;
+        }
+      }
+      return true;
+    };
     child.stdout.on('data', (c: Buffer) => {
+      if (!accepts(c)) return;
       stdout += c.toString('utf-8');
+    });
+    child.stderr.on('data', (c: Buffer) => {
+      accepts(c);
     });
     child.on('close', (code) => {
       settle(code === 0 && stdout.trim() ? stdout : null);
     });
     child.on('error', () => settle(null));
+    child.stdin.on('error', () => settle(null));
 
     child.stdin.end(prompt);
   });

--- a/setup/lib/windowed-runner.ts
+++ b/setup/lib/windowed-runner.ts
@@ -24,6 +24,7 @@ import type { StepResult, SpinnerLabels } from './runner.js';
 import { dumpTranscriptOnFailure, spawnStep, writeStepEntry } from './runner.js';
 import * as setupLog from '../logs.js';
 import { brandBody, fitToWidth, fmtDuration } from './theme.js';
+import type { SetupDriver } from './setup-driver.js';
 
 const WINDOW_SIZE = 3;
 const SPINNER_FRAMES = ['◒', '◐', '◓', '◑'];
@@ -40,20 +41,31 @@ export async function runWindowedStep(
   stepName: string,
   labels: SpinnerLabels,
   extra: string[] = [],
+  driver?: SetupDriver,
 ): Promise<StepResult & { rawLog: string; durationMs: number }> {
   const rawLog = setupLog.stepRawLog(stepName);
   const start = Date.now();
+  driver?.throwIfCancelled();
   phEmit('step_started', { step: stepName });
 
-  const result = await runUnderWindow(stepName, labels, extra, rawLog);
+  let result: StepResult;
+  if (driver?.mode === 'ndjson') {
+    driver.progress(stepName, 'pending', labels.running.replace(/…$/, ''));
+    driver.progress(stepName, 'running', labels.running.replace(/…$/, ''));
+    result = await spawnStep(stepName, extra, () => {}, rawLog, undefined, driver);
+    driver.progress(stepName, result.ok ? 'succeeded' : 'failed');
+  } else {
+    result = await runUnderWindow(stepName, labels, extra, rawLog, driver);
+  }
 
   const durationMs = Date.now() - start;
-  writeStepEntry(stepName, result, durationMs, rawLog);
+  writeStepEntry(stepName, result, durationMs, rawLog, driver?.mode === 'ndjson');
   phEmit('step_completed', {
     step: stepName,
     status: outcomeStatus(result),
     duration_ms: durationMs,
   });
+  driver?.throwIfCancelled();
   return { ...result, rawLog, durationMs };
 }
 
@@ -73,6 +85,7 @@ async function runUnderWindow(
   labels: SpinnerLabels,
   extra: string[],
   rawLog: string,
+  driver?: SetupDriver,
 ): Promise<StepResult> {
   const out = process.stdout;
   const start = Date.now();
@@ -155,7 +168,7 @@ async function runUnderWindow(
     redraw();
   };
 
-  const result = await spawnStep(stepName, extra, () => {}, rawLog, onLine);
+  const result = await spawnStep(stepName, extra, () => {}, rawLog, onLine, driver);
 
   clearInterval(frameTick);
   clearInterval(stallCheck);

--- a/setup/logs.ts
+++ b/setup/logs.ts
@@ -23,9 +23,13 @@
 import fs from 'fs';
 import path from 'path';
 
+import { redactSensitiveValues } from './lib/redaction.js';
+
 const LOGS_DIR = 'logs';
 const STEPS_DIR = path.join(LOGS_DIR, 'setup-steps');
 const PROGRESS_LOG = path.join(LOGS_DIR, 'setup.log');
+const logValue = (value: string): string =>
+  process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1' ? redactSensitiveValues(value) : value;
 
 export const progressLogPath = PROGRESS_LOG;
 export const stepsDir = STEPS_DIR;
@@ -56,7 +60,7 @@ export function header(meta: Record<string, string>): void {
   const ts = new Date().toISOString();
   const lines = [`## ${ts} · setup:auto started`];
   for (const [k, v] of Object.entries(meta)) {
-    lines.push(`  ${k}: ${v}`);
+    lines.push(`  ${k}: ${logValue(v)}`);
   }
   lines.push('');
   fs.appendFileSync(PROGRESS_LOG, lines.join('\n') + '\n');
@@ -76,7 +80,7 @@ export function step(
   const lines = [`=== [${ts}] ${name} [${dur}] → ${status} ===`];
   for (const [k, v] of Object.entries(fields)) {
     if (v === undefined || v === null || v === '') continue;
-    lines.push(`  ${k.toLowerCase()}: ${String(v)}`);
+    lines.push(`  ${k.toLowerCase()}: ${logValue(String(v))}`);
   }
   if (rawRel) lines.push(`  raw: ${rawRel}`);
   lines.push('');
@@ -91,7 +95,7 @@ export function step(
 export function userInput(key: string, value: string): void {
   fs.mkdirSync(LOGS_DIR, { recursive: true });
   const ts = new Date().toISOString();
-  fs.appendFileSync(PROGRESS_LOG, `=== [${ts}] user-input → ${key} ===\n  value: ${value}\n\n`);
+  fs.appendFileSync(PROGRESS_LOG, `=== [${ts}] user-input → ${key} ===\n  value: ${logValue(value)}\n\n`);
 }
 
 /** Append the success footer. */
@@ -103,7 +107,7 @@ export function complete(totalMs: number): void {
 /** Append the failure footer. Keep error short — full context lives in the failing step's raw log. */
 export function abort(stepName: string, error: string): void {
   const ts = new Date().toISOString();
-  fs.appendFileSync(PROGRESS_LOG, `## ${ts} · aborted at ${stepName} (${error})\n`);
+  fs.appendFileSync(PROGRESS_LOG, `## ${ts} · aborted at ${stepName} (${logValue(error)})\n`);
 }
 
 /**

--- a/setup/protocol.test.ts
+++ b/setup/protocol.test.ts
@@ -1,0 +1,191 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const AUTO = path.join(ROOT, 'setup', 'auto.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
+
+let setupRoot: string;
+let testHome: string;
+
+beforeEach(() => {
+  setupRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-setup-protocol-'));
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-setup-home-'));
+  const bin = path.join(testHome, '.local', 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(
+    path.join(bin, 'pnpm'),
+    '#!/bin/sh\nprintf \'=== NANOCLAW SETUP: verify ===\\nSTATUS: %s\\nCREDENTIALS: configured\\nSERVICE: running\\nCONFIGURED_CHANNELS: 0\\n=== END ===\\n\' "$VERIFY_STATUS"\n',
+    { mode: 0o755 },
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(setupRoot, { recursive: true, force: true });
+  fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+async function run(status: 'success' | 'failed' | 'skipped'): Promise<{
+  code: number | null;
+  stdout: string;
+  events: Array<Record<string, unknown>>;
+}> {
+  const child = spawn(process.execPath, ['--import', TSX_LOADER, AUTO], {
+    cwd: setupRoot,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+      NANOCLAW_OPERATION: 'setup',
+      NANOCLAW_NO_DIAGNOSTICS: '1',
+      NANOCLAW_SKIP: 'environment,container,onecli,auth,mounts,service,cli-agent,timezone,channel,first-chat',
+      VERIFY_STATUS: status,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const events: Array<Record<string, unknown>> = [];
+  let stdout = '';
+  let buffer = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString('utf8');
+    buffer += chunk.toString('utf8');
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const event = JSON.parse(line) as Record<string, unknown>;
+      events.push(event);
+      const prompt = event.prompt as { id?: string } | undefined;
+      if (event.type === 'prompt' && prompt?.id === 'setup-start-choice') {
+        child.stdin.write(
+          `${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: 'default' })}\n`,
+        );
+      }
+    }
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  return { code, stdout, events };
+}
+
+describe('machine setup completion boundary', () => {
+  it.each([
+    ['flag', ['--onecli-api-token', 'oc_direct-secret'], {}],
+    ['environment', [], { NANOCLAW_ONECLI_API_TOKEN: 'oc_direct-secret' }],
+    ['registry enrollment environment', [], { NANOCLAW_REGISTRY_ENROLL_CODE: 'oc_direct-secret' }],
+    ['registry token environment', [], { NANOCLAW_REGISTRY_TOKEN: 'oc_direct-secret' }],
+  ] as const)('rejects direct machine secret transport through %s', (_source, args, extraEnv) => {
+    const result = spawnSync(process.execPath, ['--import', TSX_LOADER, AUTO, ...args], {
+      cwd: setupRoot,
+      env: {
+        ...process.env,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_OPERATION: 'setup',
+        NANOCLAW_NO_DIAGNOSTICS: '1',
+        ...extraEnv,
+      },
+      encoding: 'utf8',
+      input: '',
+    });
+
+    expect(result.status, result.stderr).toBe(1);
+    const events = result.stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        type: 'error',
+        code: 'secret_transport_forbidden',
+      }),
+    );
+    expect(`${result.stdout}${result.stderr}`).not.toContain('oc_direct-secret');
+  });
+
+  it.each([
+    ['success', 1, false, 'service_identity_unproven'],
+    ['failed', 1, false, 'verification_failed'],
+    ['skipped', 1, false, 'verification_failed'],
+  ] as const)(
+    'requires verify and service health before completion (%s)',
+    async (status, exitCode, completes, errorCode) => {
+      const result = await run(status);
+
+      expect(result.code, result.stdout).toBe(exitCode);
+      expect(result.stdout[0]).toBe('{');
+      expect(result.events.filter((event) => event.type === 'hello')).toHaveLength(1);
+      expect(result.events.some((event) => event.type === 'complete')).toBe(completes);
+      if (!completes) {
+        expect(result.events.at(-1)).toEqual(
+          expect.objectContaining({
+            type: 'error',
+            code: errorCode,
+          }),
+        );
+      }
+    },
+    15_000,
+  );
+
+  it('reports SIGINT during the remote health check as cancelled with exit 2', async () => {
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, AUTO], {
+      cwd: setupRoot,
+      env: {
+        ...process.env,
+        HOME: testHome,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_OPERATION: 'setup',
+        NANOCLAW_NO_DIAGNOSTICS: '1',
+        NANOCLAW_ONECLI_API_HOST: 'http://127.0.0.1:1',
+        NANOCLAW_SKIP: 'environment,container,auth,mounts,service,cli-agent,timezone,channel,first-chat',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let buffer = '';
+    let signalled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        const prompt = event.prompt as { id?: string } | undefined;
+        if (event.type === 'prompt' && prompt?.id === 'setup-start-choice') {
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: 'default' })}\n`,
+          );
+        }
+        if (
+          event.type === 'progress' &&
+          event.stepId === 'onecli-remote-check' &&
+          event.state === 'running' &&
+          !signalled
+        ) {
+          signalled = true;
+          child.kill('SIGINT');
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    expect(signalled).toBe(true);
+    expect(code).toBe(2);
+    expect(events.at(-1)?.type).toBe('cancelled');
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+  }, 15_000);
+});

--- a/setup/provider-auth.ts
+++ b/setup/provider-auth.ts
@@ -12,8 +12,12 @@
  * provider rewrite, no service changes. Provider install skills call this as
  * their auth step so there is exactly one auth implementation per provider.
  */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { buildContainerImage } from './lib/container-build.js';
-import { getSetupProvider, listSetupProviders } from './providers/registry.js';
+import { TerminalSetupDriver } from './lib/setup-driver.js';
+import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register on import.
 import './providers/index.js';
@@ -26,8 +30,10 @@ import './providers/index.js';
 const INSTALL_SKILLS: Record<string, string> = {
   codex: '.claude/skills/add-codex',
 };
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 export async function run(args: string[]): Promise<void> {
+  process.chdir(PROJECT_ROOT);
   const name = args[0]?.trim().toLowerCase();
   const withAuth = listSetupProviders().filter((entry) => entry.runAuth);
 
@@ -49,14 +55,14 @@ export async function run(args: string[]): Promise<void> {
     // we rebuild the image whenever the install mutated anything (the container
     // CLI manifest is baked into the image, unlike the mounted payload code).
     console.log(`${entry ? 'Refreshing' : 'Installing'} ${name}…`);
-    const { changed, blockers } = await applyProviderSkill(skillDir, process.cwd());
+    const { changed, blockers } = await applyProviderSkill(skillDir, PROJECT_ROOT);
     if (blockers.length) {
       console.error(`Couldn't install ${name}: ${blockers.join('; ')}`);
       process.exit(1);
     }
     if (changed) {
       console.log('Provider payload installed — rebuilding the container image…');
-      const rebuild = buildContainerImage();
+      const rebuild = buildContainerImage(PROJECT_ROOT);
       if (!rebuild.ok) {
         // Stop here rather than authenticating a runtime the image can't start:
         // the payload files are mounted, but the CLI manifest is baked in.
@@ -86,6 +92,6 @@ export async function run(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  await entry.runAuth();
-  await entry.runInstallCheck?.();
+  const driver = new TerminalSetupDriver('setup');
+  await runSetupProviderAuth(entry, driver);
 }

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -13,9 +13,11 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { getSetupProvider, listSetupProviders } from './registry.js';
+import { NdjsonSetupDriver } from '../lib/setup-driver.js';
+import type { SetupDriver } from '../lib/setup-driver.js';
+import { getSetupProvider, listSetupProviders, registerSetupProvider, runSetupProviderAuth } from './registry.js';
 import './index.js'; // the real setup provider barrel — triggers self-registration
 
 describe('setup provider registry', () => {
@@ -24,6 +26,98 @@ describe('setup provider registry', () => {
     expect(claude).toBeDefined();
     expect(claude!.runAuth).toBeUndefined();
     expect(listSetupProviders()[0]!.value).toBe('claude');
+  });
+
+  it('gives structured provider auth and install checks the machine driver without raw stdout', async () => {
+    let received: NdjsonSetupDriver | undefined;
+    registerSetupProvider({
+      value: 'driver-check-fixture',
+      label: 'Driver check fixture',
+      hint: '',
+      supportsStructuredAuth: true,
+      async runAuth(driver) {
+        received = driver as NdjsonSetupDriver;
+      },
+      async runInstallCheck(driver) {
+        expect(driver).toBe(received);
+        driver.log('success', 'Provider install check passed.');
+      },
+    });
+    const output: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+    const driver = new NdjsonSetupDriver('setup', { emitHello: false });
+    try {
+      await runSetupProviderAuth(getSetupProvider('driver-check-fixture')!, driver);
+    } finally {
+      driver.close();
+      write.mockRestore();
+    }
+
+    expect(received).toBe(driver);
+    expect(output).toHaveLength(1);
+    expect(JSON.parse(output[0])).toMatchObject({
+      protocol: 'nanoclaw.driver.v1',
+      operation: 'setup',
+      type: 'display',
+      display: { kind: 'text', content: 'Provider install check passed.', sensitive: false },
+    });
+  });
+
+  it('fails before invoking an old terminal-only provider in machine mode', async () => {
+    let invoked = false;
+    registerSetupProvider({
+      value: 'terminal-only-fixture',
+      label: 'Terminal-only fixture',
+      hint: '',
+      async runAuth() {
+        invoked = true;
+      },
+    });
+    const output: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+    const driver = new NdjsonSetupDriver('setup', { emitHello: false });
+    try {
+      await expect(runSetupProviderAuth(getSetupProvider('terminal-only-fixture')!, driver)).rejects.toMatchObject({
+        exitCode: 1,
+      });
+    } finally {
+      driver.close();
+      write.mockRestore();
+    }
+
+    expect(invoked).toBe(false);
+    expect(output).toHaveLength(1);
+    expect(JSON.parse(output[0])).toMatchObject({
+      type: 'error',
+      code: 'provider_auth_update_required',
+      stepId: 'auth',
+    });
+  });
+
+  it('keeps old provider auth working through the terminal driver', async () => {
+    const calls: string[] = [];
+    const entry = {
+      value: 'old-terminal-fixture',
+      label: 'Old terminal fixture',
+      hint: '',
+      async runAuth(driver: SetupDriver) {
+        expect(driver.mode).toBe('terminal');
+        calls.push('auth');
+      },
+      async runInstallCheck(driver: SetupDriver) {
+        expect(driver.mode).toBe('terminal');
+        calls.push('check');
+      },
+    };
+
+    await runSetupProviderAuth(entry, { mode: 'terminal' } as SetupDriver);
+    expect(calls).toEqual(['auth', 'check']);
   });
 });
 
@@ -35,6 +129,7 @@ describe('setup flow consumes the registry (structural)', () => {
     expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
     // The capability-keyed branch — a provider's own auth runs iff it declares one.
     expect(src).toMatch(/providerEntry\?\.runAuth/);
+    expect(src).toContain('await runSetupProviderAuth(providerEntry, driver);');
   });
 
   it('the provider preset is exposed as an env setup knob', () => {
@@ -46,5 +141,8 @@ describe('setup flow consumes the registry (structural)', () => {
   it('the standalone provider-auth step is reachable from the STEPS map', () => {
     const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'index.ts'), 'utf-8');
     expect(src).toContain("'provider-auth'");
+    const auth = fs.readFileSync(path.join(process.cwd(), 'setup', 'provider-auth.ts'), 'utf-8');
+    expect(auth).toContain("const driver = new TerminalSetupDriver('setup');");
+    expect(auth).toContain('await runSetupProviderAuth(entry, driver);');
   });
 });

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -122,9 +122,9 @@ describe('setup provider registry', () => {
 });
 
 describe('setup flow consumes the registry (structural)', () => {
-  it('the picker renders options from listSetupProviders', () => {
+  it('the picker renders the shared provider choices', () => {
     const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'auto.ts'), 'utf-8');
-    expect(src).toContain('listSetupProviders()');
+    expect(src).toContain('listSetupProviderChoices()');
     expect(src).toContain("import './providers/index.js'");
     expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
     // The capability-keyed branch — a provider's own auth runs iff it declares one.

--- a/setup/providers/registry.ts
+++ b/setup/providers/registry.ts
@@ -11,6 +11,7 @@
  * provider registries, guarded the same way (a barrel-driven registration test).
  */
 import type { AssistContext } from '../lib/claude-assist.js'; // type-only — registry stays runtime-dependency-free
+import type { SetupDriver } from '../lib/setup-driver.js';
 
 /**
  * Outcome of a provider-owned failure-assist hook:
@@ -26,9 +27,11 @@ export interface SetupProviderEntry {
   label: string;
   hint: string;
   /** Provider-owned auth walk-through (vault-only). Absent → standard auth step. */
-  runAuth?: () => Promise<void>;
+  runAuth?: (driver: SetupDriver) => Promise<void>;
+  /** The provider-owned auth walk-through emits only SetupDriver semantics in machine mode. */
+  supportsStructuredAuth?: true;
   /** Verifies the provider's payload is wired (files, barrels, Dockerfile pin). */
-  runInstallCheck?: () => Promise<void>;
+  runInstallCheck?: (driver: SetupDriver) => Promise<void>;
   /** Provider-owned interactive failure debugger. 'unavailable' → dispatcher
    *  falls back to the guarded Claude offer (never install/sign-in). */
   offerFailureAssist?: (ctx: AssistContext, projectRoot: string) => Promise<FailureAssistResult>;
@@ -51,6 +54,27 @@ export function registerSetupProvider(entry: SetupProviderEntry): void {
 
 export function getSetupProvider(name: string): SetupProviderEntry | undefined {
   return registry.get(name.toLowerCase());
+}
+
+/** Run one provider-owned auth flow without letting an old terminal-only adapter corrupt NDJSON. */
+export async function runSetupProviderAuth(entry: SetupProviderEntry, driver: SetupDriver): Promise<void> {
+  if (!entry.runAuth) throw new Error(`Setup provider has no auth flow: ${entry.value}`);
+  if (driver.mode === 'ndjson' && entry.supportsStructuredAuth !== true) {
+    driver.error(
+      'provider_auth_update_required',
+      `${entry.label} setup does not support structured authentication yet.`,
+      [
+        {
+          kind: 'manual',
+          title: `Update the ${entry.label} provider`,
+          instructions: ['Install the matching provider update, then rerun setup.'],
+        },
+      ],
+      'auth',
+    );
+  }
+  await entry.runAuth(driver);
+  await entry.runInstallCheck?.(driver);
 }
 
 /** Claude (the default) first, then the rest in registration order. */

--- a/setup/providers/registry.ts
+++ b/setup/providers/registry.ts
@@ -39,6 +39,12 @@ export interface SetupProviderEntry {
 
 const registry = new Map<string, SetupProviderEntry>();
 
+// Audited providers offered for installation when their payload is not
+// already present. Provider branches register themselves in the map above.
+const INSTALLABLE_PROVIDERS = [
+  { value: 'codex', label: 'Codex', hint: 'OpenAI - ChatGPT subscription or API key' },
+] as const;
+
 registry.set('claude', {
   value: 'claude',
   label: 'Claude',
@@ -80,4 +86,17 @@ export async function runSetupProviderAuth(entry: SetupProviderEntry, driver: Se
 /** Claude (the default) first, then the rest in registration order. */
 export function listSetupProviders(): SetupProviderEntry[] {
   return [...registry.values()];
+}
+
+/** The shared picker/catalog choices, including provider payloads installable from trunk. */
+export function listSetupProviderChoices(): Array<{ value: string; label: string; hint: string }> {
+  const installed = listSetupProviders();
+  const installedNames = new Set(installed.map((entry) => entry.value));
+  return [
+    ...installed.map(({ value, label, hint }) => ({ value, label, hint })),
+    ...INSTALLABLE_PROVIDERS.filter(({ value }) => !installedNames.has(value)).map((provider) => ({
+      ...provider,
+      hint: `${provider.hint} - installs now`,
+    })),
+  ];
 }

--- a/setup/registry-login.driver.test.ts
+++ b/setup/registry-login.driver.test.ts
@@ -1,0 +1,498 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DriverCancelled } from './lib/setup-driver.js';
+import type {
+  DriverDisplay,
+  DriverPrompt,
+  ExternalAction,
+  ExternalActionResult,
+  SetupDriver,
+} from './lib/setup-driver.js';
+
+vi.mock('./install-cred-helper.js', () => ({
+  installCredentialHelper: () => ({ helperPath: '/tmp/docker-credential-nanoclaw', onPath: true }),
+}));
+vi.mock('./lib/registry-state.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./lib/registry-state.js')>()),
+  writeImageSource: vi.fn(),
+}));
+
+const ENV_KEYS = [
+  'NANOCLAW_REGISTRY_API',
+  'NANOCLAW_REGISTRY_TOKEN',
+  'NANOCLAW_REGISTRY_ENROLL_CODE',
+  'NANOCLAW_WORKOS_CLIENT_ID',
+  'NANOCLAW_WORKOS_DEVICE_ENDPOINT',
+  'NANOCLAW_WORKOS_TOKEN_ENDPOINT',
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+const originalHome = process.env.HOME;
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-registry-driver-'));
+const configDir = path.join(testHome, '.config', 'nanoclaw');
+const accountFile = path.join(configDir, 'account.json');
+const registryAuthFile = path.join(configDir, 'registry-auth.json');
+
+let runRegistryLoginWithDriver: typeof import('./registry-login.js').runRegistryLoginWithDriver;
+const servers: Server[] = [];
+
+beforeAll(async () => {
+  process.env.HOME = testHome;
+  ({ runRegistryLoginWithDriver } = await import('./registry-login.js'));
+});
+
+beforeEach(() => {
+  fs.rmSync(configDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+afterAll(() => {
+  fs.rmSync(testHome, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+interface DriverHarness extends SetupDriver {
+  actions: ExternalAction[];
+  cleared: string[];
+  displays: DriverDisplay[];
+  logs: string[];
+  notes: string[];
+  progresses: Array<{ stepId: string; state: string; label?: string }>;
+  prompts: DriverPrompt[];
+}
+
+function driver(
+  answers: Array<boolean | string>,
+  controller = new AbortController(),
+  externalResult: ExternalActionResult = 'attempted',
+): DriverHarness {
+  const prompts: DriverPrompt[] = [];
+  const displays: DriverDisplay[] = [];
+  const actions: ExternalAction[] = [];
+  const cleared: string[] = [];
+  const logs: string[] = [];
+  const notes: string[] = [];
+  const progresses: DriverHarness['progresses'] = [];
+  return {
+    mode: 'ndjson',
+    operation: 'setup',
+    cancellationSignal: controller.signal,
+    prompts,
+    displays,
+    actions,
+    cleared,
+    logs,
+    notes,
+    progresses,
+    async prompt(spec) {
+      prompts.push(spec);
+      const answer = answers.shift();
+      if (answer === undefined) throw new Error(`No answer for ${spec.id}`);
+      return answer;
+    },
+    async externalAction(action, verify): Promise<ExternalActionResult> {
+      actions.push(action);
+      if (externalResult !== 'attempted') return externalResult;
+      return (await verify()) ? 'attempted' : 'unsupported';
+    },
+    display(value) {
+      displays.push(value);
+    },
+    clearDisplay(id) {
+      cleared.push(id);
+    },
+    note(content) {
+      notes.push(content);
+    },
+    log(_level, message) {
+      logs.push(message);
+    },
+    progress(stepId, state, label) {
+      progresses.push({ stepId, state, ...(label ? { label } : {}) });
+    },
+    throwIfCancelled() {
+      if (controller.signal.aborted) throw new DriverCancelled('test');
+    },
+  } as unknown as DriverHarness;
+}
+
+interface FixtureOptions {
+  idp?: boolean;
+  device?: Record<string, unknown>;
+  tokens?: Array<{ status: number; body: Record<string, unknown> }>;
+  enroll?: Record<string, unknown>;
+  probe?: { status: number; body: Record<string, unknown> };
+  onTokenRequest?: (res: ServerResponse) => boolean;
+}
+
+interface Fixture {
+  api: string;
+  requests: Array<{ method: string; path: string; body: string }>;
+}
+
+async function fixture(options: FixtureOptions = {}): Promise<Fixture> {
+  const requests: Fixture['requests'] = [];
+  let api = '';
+  let tokenIndex = 0;
+  const server = createServer(async (req, res) => {
+    const body = await requestBody(req);
+    const pathname = new URL(req.url ?? '/', 'http://fixture').pathname;
+    requests.push({ method: req.method ?? 'GET', path: pathname, body });
+    if (pathname === '/v1/auth-config') {
+      send(
+        res,
+        options.idp === false ? 503 : 200,
+        options.idp === false
+          ? { device_flow_available: false }
+          : {
+              device_flow_available: true,
+              client_id: 'fixture-client',
+              device_authorization_endpoint: `${api}/device`,
+              token_endpoint: `${api}/token`,
+            },
+      );
+      return;
+    }
+    if (pathname === '/device') {
+      send(
+        res,
+        200,
+        options.device ?? {
+          device_code: 'device-secret',
+          user_code: 'ABCD-EFGH',
+          verification_uri: 'https://idp.example/verify',
+          verification_uri_complete: 'https://idp.example/verify?user_code=ABCD-EFGH',
+          expires_in: 60,
+          interval: 1,
+        },
+      );
+      return;
+    }
+    if (pathname === '/token') {
+      if (options.onTokenRequest?.(res)) return;
+      const responses = options.tokens ?? [{ status: 200, body: { access_token: 'idp-secret' } }];
+      const response = responses[Math.min(tokenIndex++, responses.length - 1)];
+      send(res, response.status, response.body);
+      return;
+    }
+    if (pathname === '/v1/enroll') {
+      send(
+        res,
+        201,
+        options.enroll ?? {
+          token: 'registry-secret',
+          account_id: 'acct-1',
+          email: 'owner@example.com',
+          registry: 'registry.example.com',
+          entitlements: ['hardened-image'],
+          email_updates: false,
+        },
+      );
+      return;
+    }
+    if (pathname === '/v1/session/probe') {
+      const response = options.probe ?? { status: 401, body: {} };
+      send(res, response.status, response.body);
+      return;
+    }
+    if (pathname === '/v1/account/preferences') {
+      send(res, 200, {});
+      return;
+    }
+    send(res, 404, {});
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('fixture did not bind');
+  api = `http://127.0.0.1:${address.port}`;
+  return { api, requests };
+}
+
+function send(res: ServerResponse, status: number, body: Record<string, unknown>): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function requestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function expectNoCredential(): void {
+  expect(fs.existsSync(accountFile)).toBe(false);
+  expect(fs.existsSync(registryAuthFile)).toBe(false);
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('condition was not reached');
+}
+
+describe('runRegistryLoginWithDriver', () => {
+  it('completes pending device auth, emits sensitive semantics, records consent, and writes owner-only credentials', async () => {
+    const local = await fixture({
+      tokens: [
+        { status: 400, body: { error: 'authorization_pending' } },
+        { status: 200, body: { access_token: 'idp-secret' } },
+      ],
+      enroll: {
+        token: 'registry-secret',
+        account_id: 'acct-1',
+        registry: 'registry.example.com',
+        entitlements: [],
+        email_updates: null,
+      },
+    });
+    fs.mkdirSync(configDir, { recursive: true });
+    for (const file of [`${accountFile}.tmp`, `${registryAuthFile}.tmp`]) {
+      fs.writeFileSync(file, 'stale', { mode: 0o644 });
+      fs.chmodSync(file, 0o644);
+    }
+    const harness = driver(['', false]);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'device',
+    });
+
+    expect(local.requests.filter((request) => request.path === '/token')).toHaveLength(2);
+    expect(local.requests.find((request) => request.path === '/v1/account/preferences')?.body).toContain(
+      '"email_updates":false',
+    );
+    expect(harness.displays).toEqual([
+      expect.objectContaining({ kind: 'url', sensitive: true, url: expect.stringMatching(/^https:/) }),
+      expect.objectContaining({ kind: 'code', sensitive: true, content: 'ABCD-EFGH' }),
+    ]);
+    expect(harness.actions).toEqual([expect.objectContaining({ kind: 'openURL', url: 'https://idp.example/verify' })]);
+    expect(harness.cleared).toEqual(['registry-verification-url', 'registry-user-code']);
+    expect(harness.progresses).toEqual([
+      { stepId: 'registry-login', state: 'running', label: 'Authenticating with NanoClaw' },
+      { stepId: 'registry-login', state: 'running', label: 'Waiting for browser approval' },
+      { stepId: 'registry-login', state: 'succeeded' },
+    ]);
+    for (const file of [accountFile, registryAuthFile, path.join(configDir, 'host-id')]) {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+    expect(fs.existsSync(`${accountFile}.tmp`)).toBe(false);
+    expect(fs.existsSync(`${registryAuthFile}.tmp`)).toBe(false);
+    expect(JSON.stringify(harness)).not.toContain('registry-secret');
+    expect(JSON.parse(fs.readFileSync(registryAuthFile, 'utf8'))).toMatchObject({
+      broker_url: local.api,
+      registry: 'registry.example.com',
+      token: 'registry-secret',
+    });
+  }, 5_000);
+
+  it('honors slow_down before accepting the next token response', async () => {
+    const local = await fixture({
+      tokens: [
+        { status: 400, body: { error: 'slow_down' } },
+        { status: 200, body: { access_token: 'idp-secret' } },
+      ],
+    });
+
+    await expect(runRegistryLoginWithDriver(driver(['', 'browser']), { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'device',
+    });
+    expect(local.requests.filter((request) => request.path === '/token')).toHaveLength(2);
+  }, 9_000);
+
+  it.each([
+    ['declined', { tokens: [{ status: 400, body: { error: 'access_denied' } }] }],
+    [
+      'expired',
+      {
+        device: {
+          device_code: 'd',
+          user_code: 'u',
+          verification_uri: 'https://idp.example/verify',
+          expires_in: 0,
+          interval: 1,
+        },
+      },
+    ],
+    ['malformed device response', { device: { device_code: 'd', verification_uri: 'https://idp.example/verify' } }],
+    ['malformed token response', { tokens: [{ status: 200, body: {} }] }],
+    [
+      'unsafe browser URL',
+      {
+        device: {
+          device_code: 'd',
+          user_code: 'u',
+          verification_uri: 'http://idp.example/verify',
+          expires_in: 60,
+          interval: 1,
+        },
+      },
+    ],
+  ] satisfies Array<[string, FixtureOptions]>)(
+    'fails closed for a %s',
+    async (_name, options) => {
+      const local = await fixture(options);
+      const harness = driver(['', 'browser']);
+
+      await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+        kind: 'failed',
+        reason: 'sign-in-failed',
+      });
+      expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'failed' });
+      expectNoCredential();
+    },
+    3_000,
+  );
+
+  it.each([
+    ['unsupported', { kind: 'ready', method: 'device' }],
+    ['declined', { kind: 'skipped', reason: 'declined' }],
+  ] as const)(
+    'handles an %s browser action and clears its sensitive displays',
+    async (action, expected) => {
+      const local = await fixture();
+      const harness = driver(['', 'browser'], new AbortController(), action);
+
+      await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual(expected);
+      expect(harness.cleared).toEqual(['registry-verification-url', 'registry-user-code']);
+      expect(local.requests.filter((request) => request.path === '/token')).toHaveLength(action === 'declined' ? 0 : 1);
+      expect(harness.progresses.at(-1)).toEqual({
+        stepId: 'registry-login',
+        state: 'succeeded',
+      });
+    },
+    3_000,
+  );
+
+  it('cancels promptly during the polling wait and clears sensitive displays', async () => {
+    const controller = new AbortController();
+    const local = await fixture();
+    const harness = driver(['', 'browser'], controller);
+    const running = runRegistryLoginWithDriver(harness, { api: local.api });
+    await waitUntil(() => harness.actions.length === 1);
+    controller.abort('operator_cancelled');
+
+    await expect(running).rejects.toBeInstanceOf(DriverCancelled);
+    expect(harness.cleared).toEqual(['registry-verification-url', 'registry-user-code']);
+    expectNoCredential();
+  });
+
+  it('aborts an in-flight token request without persisting a partial credential', async () => {
+    const controller = new AbortController();
+    const local = await fixture({
+      onTokenRequest() {
+        controller.abort('operator_cancelled');
+        return true;
+      },
+    });
+
+    await expect(
+      runRegistryLoginWithDriver(driver(['', 'browser'], controller), { api: local.api }),
+    ).rejects.toBeInstanceOf(DriverCancelled);
+    expectNoCredential();
+  }, 3_000);
+
+  it('uses a secret enrollment prompt when the broker has no identity provider', async () => {
+    const local = await fixture({ idp: false });
+    const harness = driver(['enroll-secret']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'code',
+    });
+    expect(harness.prompts).toEqual([
+      expect.objectContaining({ id: 'registry-enrollment-code', kind: 'secret', sensitive: true }),
+    ]);
+    expect(local.requests.find((request) => request.path === '/v1/enroll')?.body).toContain('enroll-secret');
+    expect(JSON.stringify({ logs: harness.logs, notes: harness.notes, prompts: harness.prompts })).not.toContain(
+      'enroll-secret',
+    );
+  });
+
+  it('accepts an enrollment code when browser authentication is available', async () => {
+    const local = await fixture();
+    const harness = driver(['enroll-secret']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'code',
+    });
+    expect(harness.prompts).toEqual([
+      expect.objectContaining({ id: 'registry-enrollment-code', kind: 'secret', sensitive: true }),
+    ]);
+    expect(local.requests.some((request) => request.path === '/device')).toBe(false);
+    expect(local.requests.find((request) => request.path === '/v1/enroll')?.body).toContain('enroll-secret');
+  });
+
+  it('keeps a valid existing credential without prompting again', async () => {
+    const local = await fixture({
+      probe: {
+        status: 200,
+        body: { account_id: 'acct-1', email: 'fresh@example.com', registry: 'registry.example.com', entitlements: [] },
+      },
+    });
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      accountFile,
+      JSON.stringify({
+        version: 1,
+        api: local.api,
+        account_id: 'acct-1',
+        token: 'existing-secret',
+        entitlements: [],
+        created_at: new Date(0).toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+    const harness = driver([]);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'existing',
+    });
+    expect(harness.prompts).toHaveLength(0);
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'succeeded' });
+    expect(JSON.parse(fs.readFileSync(accountFile, 'utf8'))).toMatchObject({ email: 'fresh@example.com' });
+  });
+
+  it('returns a skip result when the enrollment code is left blank', async () => {
+    const local = await fixture({ idp: false });
+    const harness = driver(['']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'declined',
+    });
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'succeeded' });
+    expectNoCredential();
+  });
+
+  it('fails without buffering an oversized registry response', async () => {
+    const local = await fixture({ idp: false, enroll: { padding: 'x'.repeat(300_000) } });
+    const harness = driver(['enroll-secret']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'failed',
+      reason: 'sign-in-failed',
+    });
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'failed' });
+    expectNoCredential();
+  });
+});

--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -47,6 +47,7 @@ import * as p from '@clack/prompts';
 import { installCredentialHelper } from './install-cred-helper.js';
 import { readEnvFile } from '../src/env.js';
 import { DEFAULT_BROKER_URL, readAgentImagePin, writeImageSource } from './lib/registry-state.js';
+import { DriverCancelled, DriverTerminalError, type SetupDriver } from './lib/setup-driver.js';
 import { commandExists, isHeadless, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
@@ -79,6 +80,7 @@ const HOST_ID_FILE = path.join(CONFIG_DIR, 'host-id');
 const MAX_DEVICE_WAIT_MS = 900_000;
 const HTTP_TIMEOUT_MS = 20_000;
 const PROBE_TIMEOUT_MS = 8_000;
+const MAX_HTTP_RESPONSE_BYTES = 256 * 1024;
 /**
  * RFC 8628 §3.5 puts the `slow_down` step at 5 seconds. WorkOS documents a
  * smaller one; the spec's is compliant with both and costs a few seconds of
@@ -163,6 +165,11 @@ class LoginError extends Error {
 
 type LoginMethod = 'device' | 'code' | 'token';
 
+export type RegistryLoginDriverResult =
+  | { kind: 'ready'; method: 'device' | 'code' | 'existing' }
+  | { kind: 'skipped'; reason: 'declined' }
+  | { kind: 'failed'; reason: 'sign-in-failed' };
+
 interface Options {
   interactive: boolean;
   /** Sign in again even when a valid credential is already on disk. */
@@ -199,6 +206,11 @@ function message(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw new DriverCancelled(typeof signal.reason === 'string' ? signal.reason : undefined);
+}
+
 // ---------------------------------------------------------------------------
 // HTTP
 
@@ -213,23 +225,66 @@ interface HttpResult {
   body: Record<string, unknown> | undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function readBoundedResponseBody(res: Response): Promise<string> {
+  // A body-less response (204, HEAD, or a minimal test double) has nothing to
+  // bound; `text()` resolves to what little there is.
+  if (!res.body) return res.text();
+  const reader = res.body.getReader();
+  const chunks: Buffer[] = [];
+  let receivedBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      receivedBytes += value.byteLength;
+      if (receivedBytes > MAX_HTTP_RESPONSE_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The size failure below is the useful diagnosis; cancellation is best-effort cleanup.
+        }
+        throw new LoginError(
+          'The authentication service returned more than 256 KiB of data.',
+          'Check the configured registry and identity-provider endpoints, then retry.',
+        );
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, receivedBytes).toString('utf8');
+}
+
 /**
- * Throws only on transport failure — an HTTP error status is data here, because
- * the device grant signals `authorization_pending` as a 400 and that is the
- * normal case, not an exception.
+ * Throws on transport failure or an oversized body. An HTTP error status is
+ * data here, because the device grant signals `authorization_pending` as a 400
+ * and that is the normal case, not an exception.
  */
-async function http(url: string, req: HttpRequest, timeoutMs: number): Promise<HttpResult> {
+async function http(
+  url: string,
+  req: HttpRequest,
+  timeoutMs: number,
+  cancellationSignal?: AbortSignal,
+): Promise<HttpResult> {
+  throwIfAborted(cancellationSignal);
   const res = await fetch(url, {
     method: req.method,
     headers: req.headers,
     body: req.body,
-    signal: AbortSignal.timeout(timeoutMs),
+    signal: cancellationSignal
+      ? AbortSignal.any([AbortSignal.timeout(timeoutMs), cancellationSignal])
+      : AbortSignal.timeout(timeoutMs),
   });
-  const text = await res.text();
+  const text = await readBoundedResponseBody(res);
   let body: Record<string, unknown> | undefined;
   try {
     const parsed: unknown = text ? JSON.parse(text) : undefined;
-    body = parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+    body = isRecord(parsed) ? parsed : undefined;
   } catch {
     // A proxy's HTML error page, most likely. The status still tells us enough.
   }
@@ -320,14 +375,14 @@ function readFileOrUndefined(file: string): string | undefined {
   }
 }
 
-function readAccountCredential(): AccountCredential | undefined {
+function readAccountCredential(report: (line: string) => void = console.log): AccountCredential | undefined {
   const raw = readFileOrUndefined(ACCOUNT_FILE);
   if (!raw) return undefined;
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    console.log(`Ignoring an unreadable credential at ${ACCOUNT_FILE}; signing in again.`);
+    report(`Ignoring an unreadable credential at ${ACCOUNT_FILE}; signing in again.`);
     return undefined;
   }
   if (!parsed || typeof parsed !== 'object') return undefined;
@@ -373,7 +428,7 @@ function resolveRegistryHost(fromBroker: string | undefined): string | undefined
  * worth trusting. Any cached password the helper stashed there is dropped: a
  * new token invalidates it.
  */
-function persistCredential(cred: AccountCredential): void {
+function persistCredential(cred: AccountCredential, report: (line: string) => void = console.log): void {
   const record: AccountCredential = { ...cred, registry: resolveRegistryHost(cred.registry) };
   writeSecretFile(ACCOUNT_FILE, `${JSON.stringify(record, null, 2)}\n`);
   ensureHostId();
@@ -382,9 +437,9 @@ function persistCredential(cred: AccountCredential): void {
     `${JSON.stringify({ version: 1, broker_url: record.api, registry: record.registry ?? '', token: record.token }, null, 2)}\n`,
   );
   if (!record.registry) {
-    console.log('   Note: no registry is pinned yet, so the image pull will have nothing to authenticate against.');
+    report('   Note: no registry is pinned yet, so the image pull will have nothing to authenticate against.');
   }
-  wireDockerCredentialHelper(record.registry);
+  wireDockerCredentialHelper(record.registry, report);
 
   // Record that this install pulls, HERE rather than at the call sites.
   //
@@ -411,16 +466,16 @@ function persistCredential(cred: AccountCredential): void {
  * succeeded is worth keeping even when we cannot write to a bin directory, and
  * `--step registry -- --status` reports the gap.
  */
-function wireDockerCredentialHelper(registry?: string): void {
+function wireDockerCredentialHelper(registry?: string, report: (line: string) => void = console.log): void {
   if (!registry) return;
   try {
     const result = installCredentialHelper({ registryHost: registry });
     if (!result.onPath) {
-      console.log(`   Note: ${path.dirname(result.helperPath)} is not on PATH, so docker will not find the helper.`);
+      report(`   Note: ${path.dirname(result.helperPath)} is not on PATH, so docker will not find the helper.`);
     }
   } catch (err) {
-    console.log(`   Note: couldn't point docker at the credential helper (${message(err)}).`);
-    console.log('   Run `pnpm exec tsx setup/install-cred-helper.ts` once that is fixed.');
+    report(`   Note: couldn't point docker at the credential helper (${message(err)}).`);
+    report('   Run `pnpm exec tsx setup/install-cred-helper.ts` once that is fixed.');
   }
 }
 
@@ -460,11 +515,12 @@ type ProbeState =
   | { state: 'unreachable'; reason: string };
 
 /** Is this token still good? Used for idempotence, so it must not be fatal. */
-async function probeSession(api: string, token: string): Promise<ProbeState> {
+async function probeSession(api: string, token: string, cancellationSignal?: AbortSignal): Promise<ProbeState> {
   let res: HttpResult;
   try {
-    res = await http(`${api}/v1/session/probe`, bearerGet(token), PROBE_TIMEOUT_MS);
+    res = await http(`${api}/v1/session/probe`, bearerGet(token), PROBE_TIMEOUT_MS, cancellationSignal);
   } catch (err) {
+    throwIfAborted(cancellationSignal);
     return { state: 'unreachable', reason: message(err) };
   }
   if (res.status === 401 || res.status === 403) return { state: 'unauthorized' };
@@ -499,11 +555,13 @@ function enrollWire(body: EnrollBody): Record<string, unknown> {
   return body.method === 'idp' ? { ...common, workos_token: body.access_token } : common;
 }
 
-async function enroll(api: string, body: EnrollBody): Promise<EnrollResult> {
+async function enroll(api: string, body: EnrollBody, cancellationSignal?: AbortSignal): Promise<EnrollResult> {
   let res: HttpResult;
   try {
-    res = await http(`${api}/v1/enroll`, json(enrollWire(body)), HTTP_TIMEOUT_MS);
+    res = await http(`${api}/v1/enroll`, json(enrollWire(body)), HTTP_TIMEOUT_MS, cancellationSignal);
   } catch (err) {
+    throwIfAborted(cancellationSignal);
+    if (err instanceof LoginError) throw err;
     throw new LoginError(
       `Couldn't reach the NanoClaw account service at ${api}: ${message(err)}`,
       `Check your network, then re-run. Point ${ENV.api} elsewhere if you run your own.`,
@@ -633,7 +691,7 @@ interface IdpConfig {
  */
 type BrokerProbe = { kind: 'idp'; config: IdpConfig } | { kind: 'no-idp' } | { kind: 'not-a-broker'; detail: string };
 
-async function probeBroker(api: string): Promise<BrokerProbe> {
+async function probeBroker(api: string, cancellationSignal?: AbortSignal): Promise<BrokerProbe> {
   const fromEnv = str(process.env[ENV.clientId]);
   if (fromEnv) {
     return {
@@ -652,8 +710,10 @@ async function probeBroker(api: string): Promise<BrokerProbe> {
       `${api}/v1/auth-config`,
       { method: 'GET', headers: { accept: 'application/json' } },
       PROBE_TIMEOUT_MS,
+      cancellationSignal,
     );
   } catch (err) {
+    throwIfAborted(cancellationSignal);
     return { kind: 'not-a-broker', detail: message(err) };
   }
 
@@ -694,11 +754,16 @@ interface DeviceAuthorization {
   intervalS: number;
 }
 
-async function requestDeviceAuthorization(cfg: IdpConfig): Promise<DeviceAuthorization> {
+async function requestDeviceAuthorization(
+  cfg: IdpConfig,
+  cancellationSignal?: AbortSignal,
+): Promise<DeviceAuthorization> {
   let res: HttpResult;
   try {
-    res = await http(cfg.deviceEndpoint, form({ client_id: cfg.clientId }), HTTP_TIMEOUT_MS);
+    res = await http(cfg.deviceEndpoint, form({ client_id: cfg.clientId }), HTTP_TIMEOUT_MS, cancellationSignal);
   } catch (err) {
+    throwIfAborted(cancellationSignal);
+    if (err instanceof LoginError) throw err;
     throw new LoginError(`Couldn't reach the sign-in provider: ${message(err)}`, 'Check your network and re-run.');
   }
 
@@ -785,16 +850,26 @@ function openInBrowser(url: string): void {
   }
 }
 
-async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Promise<string> {
+async function pollForIdpToken(
+  cfg: IdpConfig,
+  device: DeviceAuthorization,
+  cancellationSignal?: AbortSignal,
+): Promise<string> {
   let intervalMs = device.intervalS * 1000;
   const deadline = Date.now() + Math.min(device.expiresInS * 1000, MAX_DEVICE_WAIT_MS);
   let transportFailures = 0;
 
   for (;;) {
+    throwIfAborted(cancellationSignal);
     if (Date.now() >= deadline) {
       throw new LoginError('Timed out waiting for the sign-in to be approved.', 'Re-run setup to get a fresh code.');
     }
-    await sleep(intervalMs);
+    try {
+      await sleep(intervalMs, undefined, cancellationSignal ? { signal: cancellationSignal } : undefined);
+    } catch (err) {
+      throwIfAborted(cancellationSignal);
+      throw err;
+    }
 
     let res: HttpResult;
     try {
@@ -802,8 +877,11 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
         cfg.tokenEndpoint,
         form({ grant_type: DEVICE_GRANT_TYPE, device_code: device.deviceCode, client_id: cfg.clientId }),
         HTTP_TIMEOUT_MS,
+        cancellationSignal,
       );
     } catch (err) {
+      throwIfAborted(cancellationSignal);
+      if (err instanceof LoginError) throw err;
       // A closed lid or a flaky hotspot must not cost the user their code, so a
       // transport failure is retried rather than surfaced.
       if (++transportFailures > MAX_POLL_TRANSPORT_FAILURES) {
@@ -850,14 +928,107 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
   }
 }
 
-async function deviceLogin(api: string, cfg: IdpConfig): Promise<EnrollResult> {
-  const device = await requestDeviceAuthorization(cfg);
-  const headless = isHeadless();
-  printDeviceCard(device, headless);
-  if (!headless) openInBrowser(device.verificationUriComplete ?? device.verificationUri);
+type DevicePresentation = (device: DeviceAuthorization) => boolean | Promise<boolean>;
 
-  const idpToken = await pollForIdpToken(cfg, device);
-  return enroll(api, { method: 'idp', provider: 'workos', access_token: idpToken, client: clientRecord() });
+async function deviceLogin(
+  api: string,
+  cfg: IdpConfig,
+  present: DevicePresentation = (device) => {
+    const headless = isHeadless();
+    printDeviceCard(device, headless);
+    if (!headless) openInBrowser(device.verificationUriComplete ?? device.verificationUri);
+    return true;
+  },
+  cancellationSignal?: AbortSignal,
+): Promise<{ kind: 'ready'; enrollment: EnrollResult } | { kind: 'skipped' }> {
+  const device = await requestDeviceAuthorization(cfg, cancellationSignal);
+  if (!(await present(device))) return { kind: 'skipped' };
+  const idpToken = await pollForIdpToken(cfg, device, cancellationSignal);
+  const enrollment = await enroll(
+    api,
+    { method: 'idp', provider: 'workos', access_token: idpToken, client: clientRecord() },
+    cancellationSignal,
+  );
+  return { kind: 'ready', enrollment };
+}
+
+function httpsUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'https:') return url.href;
+  } catch {
+    // Rejected below with a fixed message so untrusted URL text never reaches output.
+  }
+  throw new LoginError('The sign-in provider returned an unsafe verification URL.');
+}
+
+async function presentDeviceAuthorization(driver: SetupDriver, device: DeviceAuthorization): Promise<boolean> {
+  driver.throwIfCancelled();
+  const verificationUrl = httpsUrl(device.verificationUri);
+  const displayUrl = httpsUrl(device.verificationUriComplete ?? device.verificationUri);
+  driver.display({
+    id: 'registry-verification-url',
+    kind: 'url',
+    url: displayUrl,
+    label: 'NanoClaw sign-in URL',
+    sensitive: true,
+  });
+  driver.display({
+    id: 'registry-user-code',
+    kind: 'code',
+    content: device.userCode,
+    label: 'Verification code',
+    sensitive: true,
+  });
+  const action = await driver.externalAction(
+    {
+      id: 'registry-open-browser',
+      kind: 'openURL',
+      title: 'Open NanoClaw sign-in',
+      // The complete URL embeds the code. Keep it in the sensitive display;
+      // the action uses the provider's code-free verification page.
+      url: verificationUrl,
+    },
+    () => true,
+  );
+  if (action === 'attempted' && driver.mode === 'terminal' && !isHeadless()) {
+    openInBrowser(displayUrl);
+  }
+  if (action !== 'declined') {
+    driver.progress('registry-login', 'running', 'Waiting for browser approval');
+  }
+  return action !== 'declined';
+}
+
+type StoredCredentialResult =
+  | { kind: 'none' | 'invalid' }
+  | { kind: 'different'; api: string }
+  | { kind: 'ready'; credential: AccountCredential; verified: true }
+  | { kind: 'ready'; credential: AccountCredential; verified: false; reason: string };
+
+async function resolveStoredCredential(
+  api: string,
+  force: boolean,
+  cancellationSignal?: AbortSignal,
+  report: (line: string) => void = console.log,
+): Promise<StoredCredentialResult> {
+  const existing = readAccountCredential(report);
+  if (!existing || force) return { kind: 'none' };
+  if (existing.api !== api) return { kind: 'different', api: existing.api };
+
+  const probe = await probeSession(existing.api, existing.token, cancellationSignal);
+  if (probe.state === 'unauthorized') return { kind: 'invalid' };
+  if (probe.state === 'unreachable') {
+    return { kind: 'ready', credential: existing, verified: false, reason: probe.reason };
+  }
+  const refreshed: AccountCredential = {
+    ...existing,
+    email: probe.email ?? existing.email,
+    registry: probe.registry ?? existing.registry,
+    entitlements: probe.entitlements,
+  };
+  persistCredential(refreshed, report);
+  return { kind: 'ready', credential: refreshed, verified: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -1012,6 +1183,37 @@ async function maybeAskEmailConsent(api: string, cred: AccountCredential, curren
   if (optIn) p.log.success("You're on the list.");
 }
 
+async function maybeAskEmailConsentWithDriver(
+  api: string,
+  cred: AccountCredential,
+  current: boolean | null,
+  driver: SetupDriver,
+): Promise<void> {
+  if (current !== null) return;
+  driver.note(CONSENT_LINES.join('\n'));
+  const answer = await driver.prompt({
+    id: 'registry-email-consent',
+    kind: 'confirm',
+    message: 'Email me security and project updates?',
+    default: true,
+  });
+  const optIn = answer === true;
+  try {
+    const res = await http(
+      `${api}/v1/account/preferences`,
+      json({ email_updates: optIn, consent_version: CONSENT_VERSION, source: 'cli' }, cred.token),
+      HTTP_TIMEOUT_MS,
+      driver.cancellationSignal,
+    );
+    if (res.status !== 200) throw new Error(`HTTP ${res.status}`);
+  } catch (err) {
+    throwIfAborted(driver.cancellationSignal);
+    if (optIn) driver.log('warn', "Couldn't record the email preference. Sign in again to retry.");
+    return;
+  }
+  if (optIn) driver.log('success', "You're on the list.");
+}
+
 function reportSuccess(cred: AccountCredential, method: LoginMethod): void {
   // The wizard reports the outcome itself, in its own voice, immediately after
   // we exit. Saying it here too gives the user the same fact twice in two
@@ -1038,6 +1240,86 @@ function reportSkipped(reason: string, detail?: string): void {
   emitLoginStatus({ STATUS: 'skipped', REASON: reason });
 }
 
+function finishDriverLogin(driver: SetupDriver, result: RegistryLoginDriverResult): RegistryLoginDriverResult {
+  driver.progress('registry-login', result.kind === 'ready' || result.kind === 'skipped' ? 'succeeded' : 'failed');
+  return result;
+}
+
+/** Registry authentication rendered by either setup driver. */
+export async function runRegistryLoginWithDriver(
+  driver: SetupDriver,
+  options: { force?: boolean; api?: string } = {},
+): Promise<RegistryLoginDriverResult> {
+  const api = resolveApiBase(options.api);
+  const report = (line: string): void => driver.log('info', line.trim());
+
+  try {
+    driver.throwIfCancelled();
+    driver.progress('registry-login', 'running', 'Authenticating with NanoClaw');
+    const stored = await resolveStoredCredential(api, options.force ?? false, driver.cancellationSignal, report);
+    if (stored.kind === 'ready') return finishDriverLogin(driver, { kind: 'ready', method: 'existing' });
+
+    const broker = await probeBroker(api, driver.cancellationSignal);
+    if (broker.kind === 'not-a-broker') {
+      return finishDriverLogin(driver, { kind: 'failed', reason: 'sign-in-failed' });
+    }
+
+    if (broker.kind === 'no-idp') driver.note('Browser authentication is not configured for this registry.');
+    const code = await driver.prompt({
+      id: 'registry-enrollment-code',
+      kind: 'secret',
+      message:
+        broker.kind === 'no-idp'
+          ? 'Enrollment code (leave blank to build locally)'
+          : 'Enrollment code (optional, leave blank to sign in with your browser)',
+      sensitive: true,
+      validation: { maxLength: 4096 },
+    });
+
+    let enrollment: EnrollResult;
+    let loginMethod: 'device' | 'code';
+    if (typeof code === 'string' && code.length > 0) {
+      enrollment = await enroll(api, { method: 'code', code, client: clientRecord() }, driver.cancellationSignal);
+      loginMethod = 'code';
+    } else if (broker.kind === 'no-idp') {
+      return finishDriverLogin(driver, { kind: 'skipped', reason: 'declined' });
+    } else {
+      let displayed = false;
+      let deviceResult: Awaited<ReturnType<typeof deviceLogin>>;
+      try {
+        deviceResult = await deviceLogin(
+          api,
+          broker.config,
+          async (device) => {
+            displayed = true;
+            return presentDeviceAuthorization(driver, device);
+          },
+          driver.cancellationSignal,
+        );
+      } finally {
+        if (displayed) {
+          driver.clearDisplay('registry-verification-url');
+          driver.clearDisplay('registry-user-code');
+        }
+      }
+      if (deviceResult.kind === 'skipped') {
+        return finishDriverLogin(driver, { kind: 'skipped', reason: 'declined' });
+      }
+      enrollment = deviceResult.enrollment;
+      loginMethod = 'device';
+    }
+
+    driver.throwIfCancelled();
+    persistCredential(enrollment.credential, report);
+    await maybeAskEmailConsentWithDriver(api, enrollment.credential, enrollment.emailUpdates, driver);
+    return finishDriverLogin(driver, { kind: 'ready', method: loginMethod });
+  } catch (err) {
+    if (err instanceof DriverCancelled || err instanceof DriverTerminalError) throw err;
+    throwIfAborted(driver.cancellationSignal);
+    return finishDriverLogin(driver, { kind: 'failed', reason: 'sign-in-failed' });
+  }
+}
+
 export async function run(argv: string[]): Promise<void> {
   const opts = parseArgs(argv);
   // Only a non-interactive caller can be parsing us. See `emitLoginStatus`.
@@ -1048,57 +1330,48 @@ export async function run(argv: string[]): Promise<void> {
   // through a browser dance it already completed. A credential for a different
   // service is not that — tokens are meaningless across brokers, so retargeting
   // has to mean signing in again rather than probing the old one.
-  const existing = readAccountCredential();
-  if (existing && !opts.force && existing.api !== api) {
-    console.log(`The stored sign-in is for ${existing.api}; signing in to ${api} instead.`);
-  } else if (existing && !opts.force) {
-    const probe = await probeSession(existing.api, existing.token);
-    if (probe.state === 'ok') {
-      const refreshed: AccountCredential = {
-        ...existing,
-        email: probe.email ?? existing.email,
-        registry: probe.registry ?? existing.registry,
-        entitlements: probe.entitlements,
-      };
-      persistCredential(refreshed);
-      console.log(`Already authenticated as ${refreshed.email ?? refreshed.account_id}.`);
+  const stored = await resolveStoredCredential(api, opts.force);
+  if (stored.kind === 'different') {
+    console.log(`The stored sign-in is for ${stored.api}; signing in to ${api} instead.`);
+  } else if (stored.kind === 'ready') {
+    if (stored.verified) {
+      console.log(`Already authenticated as ${stored.credential.email ?? stored.credential.account_id}.`);
       emitLoginStatus({
         STATUS: 'skipped',
         REASON: 'already-signed-in',
-        ACCOUNT: refreshed.account_id,
-        EMAIL: refreshed.email ?? '',
-        ENTITLEMENTS: refreshed.entitlements.join(','),
+        ACCOUNT: stored.credential.account_id,
+        EMAIL: stored.credential.email ?? '',
+        ENTITLEMENTS: stored.credential.entitlements.join(','),
       });
       return;
     }
-    if (probe.state === 'unreachable') {
-      // `unreachable` is broader than "offline": probeSession reports it for
-      // every status that is not 200/401/403, so a gateway 404, a proxy error
-      // and a credential the service no longer knows all land here. Keeping
-      // the credential is therefore a guess, and which way to guess depends
-      // on what the caller does next.
-      //
-      // It is also the only outcome a stale credential can reach without
-      // being caught: the `existing.api !== api` check above cannot fire on
-      // a record written before that field existed, because
-      // `readAccountCredential` fills the gap with the current target.
-      if (opts.requireVerified) {
-        reportSkipped(
-          'unverified',
-          `Couldn't reach the account service (${probe.reason}); the stored sign-in could not be checked.`,
-        );
-        return;
-      }
-      // Offline is not a reason to discard a working credential — the pull that
-      // needs it may well be served from the local image cache anyway.
-      console.log(`Couldn't reach the account service (${probe.reason}); keeping the stored sign-in.`);
-      emitLoginStatus({
-        STATUS: 'skipped',
-        REASON: 'already-signed-in-unverified',
-        ACCOUNT: existing.account_id,
-      });
+    // `unreachable` is broader than "offline": probeSession reports it for
+    // every status that is not 200/401/403, so a gateway 404, a proxy error
+    // and a credential the service no longer knows all land here. Keeping
+    // the credential is therefore a guess, and which way to guess depends
+    // on what the caller does next.
+    //
+    // It is also the only outcome a stale credential can reach without
+    // being caught: the `different` check above cannot fire on a record
+    // written before the api field existed, because `readAccountCredential`
+    // fills the gap with the current target.
+    if (opts.requireVerified) {
+      reportSkipped(
+        'unverified',
+        `Couldn't reach the account service (${stored.reason}); the stored sign-in could not be checked.`,
+      );
       return;
     }
+    // Offline is not a reason to discard a working credential. The pull that
+    // needs it may well be served from the local image cache anyway.
+    console.log(`Couldn't reach the account service (${stored.reason}); keeping the stored sign-in.`);
+    emitLoginStatus({
+      STATUS: 'skipped',
+      REASON: 'already-signed-in-unverified',
+      ACCOUNT: stored.credential.account_id,
+    });
+    return;
+  } else if (stored.kind === 'invalid') {
     console.log('The stored NanoClaw sign-in is no longer valid — signing in again.');
   }
 
@@ -1182,9 +1455,14 @@ export async function run(argv: string[]): Promise<void> {
     reportSkipped('declined');
     return;
   }
-  const { credential: cred, emailUpdates } = typed
-    ? await enroll(api, { method: 'code', code: typed, client: clientRecord() })
+  const result = typed
+    ? { kind: 'ready' as const, enrollment: await enroll(api, { method: 'code', code: typed, client: clientRecord() }) }
     : await deviceLogin(api, idp);
+  if (result.kind === 'skipped') {
+    reportSkipped('declined');
+    return;
+  }
+  const { credential: cred, emailUpdates } = result.enrollment;
   persistCredential(cred);
 
   reportSuccess(cred, typed ? 'code' : 'device');

--- a/setup/setup-driver-parity.test.ts
+++ b/setup/setup-driver-parity.test.ts
@@ -1,0 +1,260 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const terminal = vi.hoisted(() => ({
+  events: [] as Array<Record<string, unknown>>,
+  confirmAnswers: [] as boolean[],
+  selectAnswers: [] as string[],
+}));
+const socket = vi.hoisted(() => ({
+  requests: [] as Array<{ command: string; args: Record<string, unknown> }>,
+}));
+
+vi.mock('@clack/prompts', () => ({
+  autocomplete: vi.fn(
+    async (opts: { options: Array<{ value: string }> }) => terminal.selectAnswers.shift() ?? opts.options[0]?.value,
+  ),
+  confirm: vi.fn(async (opts: { message: string; initialValue?: boolean }) => {
+    terminal.events.push({
+      type: 'prompt',
+      kind: 'confirm',
+      message: opts.message,
+      default: opts.initialValue,
+    });
+    return terminal.confirmAnswers.shift() ?? opts.initialValue ?? true;
+  }),
+  intro: vi.fn(),
+  isCancel: vi.fn(() => false),
+  note: vi.fn(),
+  outro: vi.fn(),
+  password: vi.fn(),
+  text: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock('./lib/bright-select.js', () => ({
+  brightSelect: vi.fn(
+    async (opts: { message: string; options: Array<{ value: string; label: string }>; initialValue?: string }) => {
+      terminal.events.push({
+        type: 'prompt',
+        kind: 'singleChoice',
+        message: opts.message,
+        choices: opts.options.map(({ value, label }) => ({ id: value, label })),
+        default: opts.initialValue,
+      });
+      return terminal.selectAnswers.shift() ?? opts.initialValue ?? opts.options[0]?.value;
+    },
+  ),
+}));
+
+// The production helper lists template carriers before creating one, which
+// reads the template manifest from the local templates directory. Point it
+// at a scratch root so the test never depends on the checkout's templates/.
+const PARITY_TEMPLATES_DIR = '/tmp/nanoclaw-setup-driver-parity/templates';
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/config.js')>()),
+  TEMPLATES_DIR: '/tmp/nanoclaw-setup-driver-parity/templates',
+}));
+vi.mock('../src/cli/socket-client.js', () => ({
+  SocketTransport: class {
+    async sendFrame(request: { command: string; args: Record<string, unknown> }) {
+      socket.requests.push({ command: request.command, args: request.args });
+      return {
+        id: 'fixture',
+        ok: true,
+        data:
+          request.command === 'groups-create'
+            ? {
+                id: 'ag-template',
+                name: 'SDR',
+                folder: 'sdr',
+                agent_provider: null,
+                created_at: '2026-01-01T00:00:00.000Z',
+              }
+            : request.command === 'groups-list' || request.command === 'wirings-list'
+              ? []
+              : {},
+      };
+    }
+  },
+}));
+
+import { PLUGIN_SCHEMA_URL } from '../src/templates/manifest.js';
+import { installSelectedTemplateAgent, runTemplateSetup } from './auto.js';
+import { TerminalSetupDriver } from './lib/setup-driver.js';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const CHILD = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-transcript-child.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
+
+beforeEach(() => {
+  terminal.events.length = 0;
+  terminal.confirmAnswers.length = 0;
+  terminal.selectAnswers.length = 0;
+  socket.requests.length = 0;
+  fs.rmSync(PARITY_TEMPLATES_DIR, { recursive: true, force: true });
+  fs.mkdirSync(path.join(PARITY_TEMPLATES_DIR, 'sales', 'sdr'), { recursive: true });
+  fs.writeFileSync(
+    path.join(PARITY_TEMPLATES_DIR, 'sales', 'sdr', 'plugin.json'),
+    JSON.stringify({ $schema: PLUGIN_SCHEMA_URL, name: 'sdr' }),
+  );
+  process.env.NANOCLAW_NO_DIAGNOSTICS = '1';
+  delete process.env.NANOCLAW_TEMPLATE_PATH;
+  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
+  delete process.env.NANOCLAW_AGENT_NAME;
+});
+
+afterEach(() => {
+  fs.rmSync(PARITY_TEMPLATES_DIR, { recursive: true, force: true });
+  delete process.env.NANOCLAW_NO_DIAGNOSTICS;
+  delete process.env.NANOCLAW_TEMPLATE_PATH;
+  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
+  delete process.env.NANOCLAW_AGENT_NAME;
+});
+
+async function machineProduction(scenario: 'standard' | 'template-first-agent') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-production-parity-'));
+  const requestsPath = path.join(root, 'requests.json');
+  const child = spawn(process.execPath, ['--import', TSX_LOADER, CHILD, scenario], {
+    cwd: root,
+    env: {
+      ...process.env,
+      NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+      NANOCLAW_OPERATION: 'setup',
+      NANOCLAW_NO_DIAGNOSTICS: '1',
+      NANOCLAW_TEMPLATE_PATH: scenario === 'template-first-agent' ? 'sales/sdr' : '',
+      NANOCLAW_TEMPLATE_AGENT_ID: '',
+      NANOCLAW_AGENT_NAME: '',
+      NANOCLAW_TEST_REQUESTS: requestsPath,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const events: Array<Record<string, unknown>> = [];
+  let buffer = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString('utf8');
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const event = JSON.parse(line) as Record<string, unknown>;
+      events.push(event);
+      if (event.type !== 'prompt') continue;
+      const prompt = event.prompt as { id: string };
+      child.stdin.write(`${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: 'none' })}\n`);
+    }
+  });
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  try {
+    expect(code, stderr).toBe(0);
+    return {
+      events,
+      requests: fs.existsSync(requestsPath)
+        ? (JSON.parse(fs.readFileSync(requestsPath, 'utf8')) as Array<{
+            command: string;
+            args: Record<string, unknown>;
+          }>)
+        : [],
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function promptShape(value: Record<string, unknown>) {
+  const prompt = value.prompt as Record<string, unknown> | undefined;
+  return prompt
+    ? {
+        kind: prompt.kind,
+        message: prompt.message,
+        choices: prompt.choices,
+        default: prompt.default,
+      }
+    : {
+        kind: value.kind,
+        message: value.message,
+        choices: value.choices,
+        default: value.default,
+      };
+}
+
+describe('setup driver production parity', () => {
+  it('uses the production first-agent choice in both renderers', async () => {
+    terminal.selectAnswers.push('none');
+    await runTemplateSetup(new TerminalSetupDriver('setup'), false, false);
+    const machine = await machineProduction('standard');
+
+    const terminalPrompt = terminal.events.find((event) => event.type === 'prompt');
+    const machinePrompt = machine.events.find((event) => event.type === 'prompt');
+    expect(terminalPrompt).toBeDefined();
+    expect(machinePrompt).toBeDefined();
+    expect(promptShape(machinePrompt!)).toEqual(promptShape(terminalPrompt!));
+  });
+
+  it('stamps the selected template through the real socket-backed production helper', async () => {
+    process.env.NANOCLAW_TEMPLATE_PATH = 'sales/sdr';
+    await installSelectedTemplateAgent(new TerminalSetupDriver('setup'), 'claude');
+    const machine = await machineProduction('template-first-agent');
+
+    // Production lists the template's existing carriers (to offer connect /
+    // update / create another) before stamping a fresh agent.
+    const expected = [
+      { command: 'groups-list', args: { limit: Number.MAX_SAFE_INTEGER } },
+      { command: 'wirings-list', args: { limit: Number.MAX_SAFE_INTEGER } },
+      { command: 'groups-create', args: { template: 'sales/sdr', new: true } },
+      { command: 'groups-config-update', args: { id: 'ag-template', provider: 'claude' } },
+    ];
+    expect(socket.requests).toEqual(expected);
+    expect(machine.requests).toEqual(expected);
+    expect(machine.events).toContainEqual(
+      expect.objectContaining({
+        type: 'progress',
+        stepId: 'template-agent',
+        state: 'succeeded',
+      }),
+    );
+    expect(process.env.NANOCLAW_TEMPLATE_AGENT_ID).toBe('ag-template');
+  });
+
+  it('keeps production ordering and direct prompt primitives behind the driver', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'setup', 'auto.ts'), 'utf8');
+    expect(source).not.toMatch(/\bp\.(confirm|text|password)\s*\(/);
+    expect(source).not.toMatch(/\bbrightSelect\s*\(/);
+    expect(source.match(/createSetupDriver\s*\(/g)).toHaveLength(1);
+    expect(source.indexOf('await runTemplateSetup(driver')).toBeLessThan(source.indexOf("if (!skip.has('container'))"));
+    expect(source.indexOf('await runTimezoneStep(driver)')).toBeLessThan(
+      source.indexOf('await installSelectedTemplateAgent(driver'),
+    );
+    expect(source.indexOf('await installSelectedTemplateAgent(driver')).toBeLessThan(
+      source.indexOf("if (!skip.has('channel')"),
+    );
+    const registryFlow = source.slice(
+      source.indexOf('async function chooseImageSource'),
+      source.indexOf('async function askAgentProviderChoice'),
+    );
+    expect(registryFlow).not.toContain("driver.mode === 'terminal'");
+    expect(registryFlow.match(/runRegistryLoginWithDriver\s*\(/g)).toHaveLength(1);
+    expect(fs.existsSync(path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-transcript.ts'))).toBe(false);
+  });
+});

--- a/setup/signal-auth.ts
+++ b/setup/signal-auth.ts
@@ -20,7 +20,8 @@
  * SIGNAL_AUTH block is parsed — the driver's `capture:<var>=ACCOUNT` reads the
  * phone number from it.
  *
- * Block schema (parent parses this one block):
+ * Block schema:
+ *   SIGNAL_AUTH_QR       { QR: "sgnl://…" }                  sensitive display
  *   SIGNAL_AUTH          { STATUS: success, ACCOUNT: +<digits> }  — terminal
  *                        { STATUS: skipped, ACCOUNT, REASON: already-authenticated }
  *                        { STATUS: failed, ERROR: <reason> }
@@ -170,6 +171,7 @@ export async function run(_args: string[]): Promise<void> {
         // NANOCLAW SETUP block would be consumed, not shown).
         if (/^(sgnl|tsdevice):\/\/linkdevice\?/.test(line) && !qrEmitted) {
           qrEmitted = true;
+          emitStatus('SIGNAL_AUTH_QR', { QR: line });
           printLink(line);
         }
       }

--- a/setup/uninstall/flow.test.ts
+++ b/setup/uninstall/flow.test.ts
@@ -66,4 +66,29 @@ describe('terminal uninstall safety gates', () => {
     replaced.identity!.root = 'node:1:3:16832';
     expect(sameOwnershipSelectors(base, replaced)).toBe(false);
   });
+
+  it('leaves artifact identity changes to each removal action', () => {
+    const base: Inventory = {
+      slug: 'abcd1234',
+      projectRoot: '/tmp/nanoclaw',
+      containerRuntime: 'docker',
+      service: { containerIds: [] },
+      data: [],
+      runtime: [],
+      user: [],
+      envBackups: [],
+      onecli: inventory().onecli,
+      notes: [],
+      identity: {
+        root: 'node:1:2:16832',
+        exactPaths: { '/tmp/nanoclaw/logs': 'node:1:3:16832' },
+        scopedRoots: {},
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    };
+    const changed = structuredClone(base);
+    changed.identity!.exactPaths['/tmp/nanoclaw/logs'] = 'node:1:4:16832';
+
+    expect(sameOwnershipSelectors(base, changed)).toBe(true);
+  });
 });

--- a/setup/uninstall/flow.test.ts
+++ b/setup/uninstall/flow.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { sameOwnershipSelectors, uninstallIncomplete, uninstallSelectionError } from './flow.js';
+import type { Inventory } from './scan.js';
+
+function inventory(onecliAvailable = true): Pick<Inventory, 'onecli'> {
+  return {
+    onecli: {
+      mine: [],
+      orphans: [],
+      available: onecliAvailable,
+      idsKnown: true,
+    },
+  };
+}
+
+describe('terminal uninstall safety gates', () => {
+  it('rejects destructive choices that preserve the service', () => {
+    expect(
+      uninstallSelectionError(inventory(), {
+        service: false,
+        data: true,
+        user: false,
+      }),
+    ).toMatch(/cannot be removed/);
+  });
+
+  it('preserves app data when OneCLI inventory is unavailable', () => {
+    expect(
+      uninstallSelectionError(inventory(false), {
+        service: true,
+        data: true,
+        user: true,
+      }),
+    ).toMatch(/Restore OneCLI/);
+  });
+
+  it('reports failed or untouched actions as incomplete', () => {
+    expect(uninstallIncomplete([{ outcome: 'removed' }])).toBe(false);
+    expect(uninstallIncomplete([{ outcome: 'failed' }])).toBe(true);
+    expect(uninstallIncomplete([{ outcome: 'untouched' }])).toBe(true);
+  });
+
+  it('rejects a checkout root replaced after approval', () => {
+    const base: Inventory = {
+      slug: 'abcd1234',
+      projectRoot: '/tmp/nanoclaw',
+      containerRuntime: 'docker',
+      service: { containerIds: [] },
+      data: [],
+      runtime: [],
+      user: [],
+      envBackups: [],
+      onecli: inventory().onecli,
+      notes: [],
+      identity: {
+        root: 'node:1:2:16832',
+        exactPaths: {},
+        scopedRoots: {},
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    };
+
+    expect(sameOwnershipSelectors(base, structuredClone(base))).toBe(true);
+    const replaced = structuredClone(base);
+    replaced.identity!.root = 'node:1:3:16832';
+    expect(sameOwnershipSelectors(base, replaced)).toBe(false);
+  });
+});

--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -13,6 +13,7 @@
  * Ctrl-C anywhere in the confirm phase leaves the install untouched.
  */
 import { spawnSync } from 'child_process';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -24,9 +25,19 @@ import { emit as phEmit } from '../lib/diagnostics.js';
 import { note } from '../lib/theme.js';
 import * as setupLog from '../logs.js';
 import { resolveOnecliDeletions, type RunCommand, type VaultAgent } from './onecli-agents.js';
-import { buildRemovalPlan, validateDecisions, type Decisions } from './plan.js';
-import { executePlan, type ExecDeps, type UninstallActionResult } from './remove.js';
+import { buildRemovalPlan, validateDecisions, type Decisions, type RemovalAction } from './plan.js';
+import { actionId, artifactId, executePlan, type ExecDeps, type UninstallActionResult } from './remove.js';
 import { scanInstall, tilde, type Inventory } from './scan.js';
+import {
+  DriverCancelled,
+  DriverTerminalError,
+  type Artifact,
+  type SetupDriver,
+  type UninstallChoice,
+  type UninstallGroup,
+  type UninstallPlan,
+  type UninstallReceipt,
+} from '../lib/setup-driver.js';
 
 const GROUPS = {
   service: {
@@ -59,12 +70,17 @@ const runCommand: RunCommand = (cmd, args) => {
   };
 };
 
-export async function runUninstallFlow(opts: {
-  dryRun: boolean;
-  yes: boolean;
-  invokedFrom: 'flag' | 'setup-detection';
-}): Promise<never> {
+export async function runUninstallFlow(
+  opts: {
+    dryRun: boolean;
+    yes: boolean;
+    invokedFrom: 'flag' | 'setup-detection';
+  },
+  driver?: SetupDriver,
+): Promise<never> {
   const { dryRun, yes } = opts;
+
+  if (driver?.mode === 'ndjson') return runMachineUninstall(opts, driver);
 
   if (!process.stdin.isTTY && !yes && !dryRun) {
     console.error(
@@ -300,6 +316,304 @@ export async function runUninstallFlow(opts: {
   process.exit(0);
 }
 
+async function runMachineUninstall(
+  opts: { dryRun: boolean; yes: boolean; invokedFrom: 'flag' | 'setup-detection' },
+  driver: SetupDriver,
+): Promise<never> {
+  if (opts.dryRun || opts.yes) {
+    driver.error(
+      'unsupported_machine_option',
+      'Machine uninstall is already plan-first; --dry-run and --yes are terminal-only options.',
+      [{ kind: 'rerun', args: ['--uninstall', '--protocol', 'nanoclaw.driver.v1'] }],
+    );
+  }
+
+  const projectRoot = process.cwd();
+  const home = os.homedir();
+  const scan = (): Inventory => scanInstall({ projectRoot, home, platform: process.platform, runCommand });
+
+  driver.progress('uninstall-scan', 'running', 'Checking this NanoClaw copy');
+  const approved = scan();
+  driver.progress('uninstall-scan', 'succeeded');
+  const plan = protocolPlan(approved);
+  const choices = await driver.waitForUninstall(plan, (candidate) =>
+    uninstallSelectionError(approved, decisionsFromChoices(approved, candidate)),
+  );
+  driver.throwIfCancelled();
+
+  const actions = buildRemovalPlan(approved, decisionsFromChoices(approved, choices));
+  const selectedIds = new Set(actions.map(artifactId));
+  const results: UninstallActionResult[] = [];
+  const emit = (result: UninstallActionResult): void => {
+    results.push(result);
+    driver.uninstallAction(result);
+  };
+
+  for (const artifact of plan.artifacts) {
+    if (!selectedIds.has(artifact.id)) {
+      emit({
+        actionId: `preserve-${artifact.id}`,
+        artifactId: artifact.id,
+        outcome: artifact.disposition === 'alreadyAbsent' ? 'alreadyAbsent' : 'preserved',
+      });
+    }
+  }
+
+  const current = scan();
+  if (!sameOwnershipSelectors(approved, current)) {
+    for (const action of actions) {
+      emit({
+        actionId: actionId(action),
+        artifactId: artifactId(action),
+        outcome: 'untouched',
+        error: { code: 'checkout_identity_changed', message: 'The checkout identity changed after approval.' },
+      });
+    }
+    driver.completeUninstall(receiptFor('incomplete', results, current));
+    throw new DriverTerminalError(1);
+  }
+
+  let prerequisiteFailed = false;
+  let lastStepId: string | undefined;
+  for (const action of actions) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (driverCancelled(driver)) break;
+    lastStepId = actionId(action);
+    prerequisiteFailed = executePlan([action], {
+      runCommand,
+      log: () => {},
+      isRoot: process.getuid?.() === 0,
+      prerequisiteFailed,
+      onResult: emit,
+    }).prerequisiteFailed;
+  }
+
+  if (driverCancelled(driver)) {
+    driver.cancelled({ lastStepId, results, remaining: remainingArtifacts(scan()) });
+    throw new DriverTerminalError(2);
+  }
+
+  const after = scan();
+  const remaining = remainingArtifacts(after);
+  const residueIds = new Set(remaining.map((artifact) => artifact.id));
+  const incomplete =
+    results.some((result) => result.outcome === 'failed' || result.outcome === 'untouched') ||
+    [...selectedIds].some((id) => residueIds.has(id));
+  driver.completeUninstall(receiptFor(incomplete ? 'incomplete' : 'success', results, after));
+  throw new DriverTerminalError(incomplete ? 1 : 0);
+}
+
+function driverCancelled(driver: SetupDriver): boolean {
+  try {
+    driver.throwIfCancelled();
+    return false;
+  } catch (error) {
+    if (error instanceof DriverCancelled) return true;
+    throw error;
+  }
+}
+
+function decisionsFromChoices(inventory: Inventory, choices: Map<UninstallGroup, UninstallChoice>): Decisions {
+  return {
+    service: choices.get('service') === 'remove',
+    data: choices.get('data') === 'remove',
+    user: choices.get('user') === 'remove',
+    onecliDelete: choices.get('onecli') === 'remove' ? inventory.onecli.mine : [],
+  };
+}
+
+function protocolPlan(inventory: Inventory): UninstallPlan {
+  const actions = buildRemovalPlan(inventory, {
+    service: true,
+    data: true,
+    user: true,
+    onecliDelete: inventory.onecli.mine,
+  });
+  const artifacts = actions.map((action) => artifactForAction(inventory, action));
+  artifacts.push(
+    sharedArtifact('checkout-root', 'checkout', 'NanoClaw source checkout', inventory.projectRoot),
+    sharedArtifact(
+      'onecli-shared-vault',
+      'shared-vault',
+      'OneCLI app, vault, and credentials',
+      '~/.local/share/onecli',
+    ),
+    sharedArtifact('host-shared-config', 'shared-config', 'Host-wide NanoClaw configuration', '~/.config/nanoclaw'),
+  );
+  for (const backup of inventory.envBackups) {
+    artifacts.push({
+      id: `credential-backup-${shortHash(backup.path)}`,
+      kind: 'credential-backup',
+      label: backup.what,
+      location: backup.path,
+      disposition: 'external',
+    });
+  }
+  for (const backup of inventory.legacyEnvBackups ?? []) {
+    artifacts.push({
+      id: `legacy-credential-backup-${shortHash(backup.path)}`,
+      kind: 'credential-backup-inside-checkout',
+      label: 'Legacy credential backup inside checkout',
+      location: backup.path,
+      disposition: 'uninspectable',
+    });
+  }
+  for (const agent of inventory.onecli.orphans) {
+    artifacts.push({
+      id: `onecli-orphan-${agent.uuid}`,
+      kind: 'onecli-agent',
+      label: agent.name || agent.identifier,
+      location: `onecli-agent:${agent.uuid}`,
+      disposition: 'uninspectable',
+    });
+  }
+  for (const [index, message] of inventory.notes.entries()) {
+    artifacts.push({
+      id: `uninspectable-${index + 1}`,
+      kind: 'uninspectable',
+      label: message,
+      location: inventory.projectRoot,
+      disposition: 'uninspectable',
+    });
+  }
+
+  return {
+    id: randomUUID(),
+    groups: [
+      protocolGroup('service', GROUPS.service.title, GROUPS.service.desc),
+      protocolGroup('data', GROUPS.data.title, GROUPS.data.desc),
+      protocolGroup('user', GROUPS.user.title, GROUPS.user.desc),
+      protocolGroup('onecli', GROUPS.onecli.title, GROUPS.onecli.desc),
+    ],
+    artifacts,
+  };
+}
+
+function protocolGroup(id: UninstallGroup, label: string, description: string): UninstallPlan['groups'][number] {
+  return { id, label, description, default: 'preserve', choices: ['preserve', 'remove'] };
+}
+
+function sharedArtifact(id: string, kind: string, label: string, location: string): Artifact {
+  return { id, kind, label, location, disposition: 'shared' };
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+function artifactForAction(inventory: Inventory, action: RemovalAction): Artifact {
+  const identityMissing = 'identityRequired' in action && action.identityRequired === true && !action.expectedIdentity;
+  const processListMissing = action.kind === 'pkill-host' && inventory.service.hostProcessIds === undefined;
+  const containerListMissing = action.kind === 'rm-containers' && inventory.service.containerRuntimeAvailable === false;
+  const absent =
+    (action.kind === 'rm-containers' && !containerListMissing && inventory.service.containerIds.length === 0) ||
+    (action.kind === 'pkill-host' && inventory.service.hostProcessIds?.length === 0);
+  return {
+    id: artifactId(action),
+    kind: action.kind,
+    label: actionLabel(action),
+    location: actionLocation(action),
+    disposition:
+      identityMissing || processListMissing || containerListMissing
+        ? 'uninspectable'
+        : absent
+          ? 'alreadyAbsent'
+          : 'owned',
+    decisionGroup: groupForAction(inventory, action),
+  };
+}
+
+function groupForAction(inventory: Inventory, action: RemovalAction): UninstallGroup {
+  if (action.kind === 'delete-onecli-agent') return 'onecli';
+  if (['unload-service', 'kill-pid', 'pkill-host', 'rm-containers', 'rmi', 'rm-ncl-symlink'].includes(action.kind)) {
+    return 'service';
+  }
+  if (
+    (action.kind === 'delete-path' || action.kind === 'delete-runtime-path') &&
+    inventory.user.some((item) => item.path === action.item.path)
+  )
+    return 'user';
+  return 'data';
+}
+
+function actionLocation(action: RemovalAction): string {
+  switch (action.kind) {
+    case 'unload-service':
+      return action.unitPath;
+    case 'kill-pid':
+      return action.pidFile;
+    case 'pkill-host':
+      return action.pattern;
+    case 'rm-containers':
+      return `${action.runtime}:${action.labelFilter}`;
+    case 'rmi':
+      return action.image;
+    case 'rm-ncl-symlink':
+      return action.linkPath;
+    case 'delete-onecli-agent':
+      return `onecli-agent:${action.agent.uuid}`;
+    case 'backup-env':
+      return action.envPath;
+    case 'delete-path':
+    case 'delete-runtime-path':
+      return action.item.path;
+  }
+}
+
+function actionLabel(action: RemovalAction): string {
+  if (action.kind === 'delete-onecli-agent') return `OneCLI agent ${action.agent.name || action.agent.identifier}`;
+  if (action.kind === 'delete-path' || action.kind === 'delete-runtime-path') return action.item.what;
+  if (action.kind === 'backup-env') return 'Secrets and API keys (.env, backed up first)';
+  return action.kind.replaceAll('-', ' ');
+}
+
+function remainingArtifacts(inventory: Inventory): Artifact[] {
+  return protocolPlan(inventory).artifacts.filter((artifact) => artifact.disposition !== 'alreadyAbsent');
+}
+
+function receiptFor(
+  outcome: 'success' | 'incomplete',
+  results: UninstallActionResult[],
+  inventory: Inventory,
+): UninstallReceipt {
+  return {
+    version: 1,
+    outcome,
+    results,
+    remaining: remainingArtifacts(inventory),
+    checkoutRemoval: checkoutRemovalFor(inventory),
+    completedAt: new Date().toISOString(),
+  };
+}
+
+function checkoutRemovalFor(inventory: Inventory): { safe: boolean; blockers: string[] } {
+  const blockers: string[] = [];
+  const service = inventory.service;
+  if (service.launchdPlist) blockers.push(`background service remains: ${service.launchdPlist}`);
+  if (service.systemdUserUnit) blockers.push(`background service remains: ${service.systemdUserUnit}`);
+  if (service.systemdSystemUnit) blockers.push(`system service remains: ${service.systemdSystemUnit}`);
+  if (service.pidFile) blockers.push(`pidfile remains: ${service.pidFile}`);
+  if (service.hostProcessIds === undefined) blockers.push('host process identity could not be inspected');
+  else if (service.hostProcessIds.length > 0) blockers.push('checkout-owned host process remains');
+  if (service.containerIds.length > 0) blockers.push('checkout-owned container remains');
+  if (service.nclSymlink) blockers.push(`ncl symlink remains: ${service.nclSymlink}`);
+  if (service.containerRuntimeAvailable === false) blockers.push('container runtime state could not be inspected');
+
+  for (const item of [...inventory.data, ...inventory.runtime, ...inventory.user]) {
+    try {
+      fs.lstatSync(item.path);
+      blockers.push(`checkout artifact remains: ${item.path}`);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') blockers.push(`checkout artifact could not be inspected: ${item.path}`);
+    }
+  }
+  for (const item of inventory.legacyEnvBackups ?? []) {
+    blockers.push(`credential backup remains inside checkout: ${item.path}`);
+  }
+  return { safe: blockers.length === 0, blockers };
+}
+
 /** Unwrap a confirm result; Ctrl-C / Esc cancels the whole uninstall — nothing deleted. */
 function answered<T>(value: T | symbol): T {
   if (p.isCancel(value)) {
@@ -447,9 +761,6 @@ export function sameOwnershipSelectors(before: Inventory, after: Inventory): boo
     Boolean(beforeIdentity?.root) &&
     Boolean(afterIdentity?.root) &&
     beforeIdentity?.root === afterIdentity?.root &&
-    Object.values(beforeIdentity?.exactPaths ?? {}).every(Boolean) &&
-    beforeIdentity?.containerSelector === afterIdentity?.containerSelector &&
-    Object.values(beforeIdentity?.scopedRoots ?? {}).every(Boolean) &&
-    JSON.stringify(beforeIdentity?.scopedRoots) === JSON.stringify(afterIdentity?.scopedRoots)
+    beforeIdentity?.containerSelector === afterIdentity?.containerSelector
   );
 }

--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -24,8 +24,8 @@ import { emit as phEmit } from '../lib/diagnostics.js';
 import { note } from '../lib/theme.js';
 import * as setupLog from '../logs.js';
 import { resolveOnecliDeletions, type RunCommand, type VaultAgent } from './onecli-agents.js';
-import { buildRemovalPlan, type Decisions } from './plan.js';
-import { executePlan, type ExecDeps } from './remove.js';
+import { buildRemovalPlan, validateDecisions, type Decisions } from './plan.js';
+import { executePlan, type ExecDeps, type UninstallActionResult } from './remove.js';
 import { scanInstall, tilde, type Inventory } from './scan.js';
 
 const GROUPS = {
@@ -52,7 +52,11 @@ const GROUPS = {
 
 const runCommand: RunCommand = (cmd, args) => {
   const res = spawnSync(cmd, args, { encoding: 'utf-8' });
-  return { status: res.status, stdout: res.stdout ?? '' };
+  return {
+    status: res.status,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  };
 };
 
 export async function runUninstallFlow(opts: {
@@ -71,6 +75,13 @@ export async function runUninstallFlow(opts: {
 
   const projectRoot = process.cwd();
   const home = os.homedir();
+  const scan = (): Inventory =>
+    scanInstall({
+      projectRoot,
+      home,
+      platform: process.platform,
+      runCommand,
+    });
 
   p.intro(k.bold(`Uninstall NanoClaw`));
   // persistId: false — the emit must not create data/install-id, which would
@@ -80,19 +91,23 @@ export async function runUninstallFlow(opts: {
 
   const spinner = p.spinner();
   spinner.start('Checking what exists for this copy…');
-  const inv = scanInstall({
-    projectRoot,
-    home,
-    platform: process.platform,
-    runCommand,
-  });
+  const inv = scan();
   spinner.stop(`Scanned copy ${inv.slug} at ${tilde(projectRoot, home)}.`);
 
   const svcRows = serviceRows(inv, home);
   const dataRows = [...inv.data, ...inv.runtime].map(({ what, where }) => ({ what, where }));
   const userRows = inv.user.map(({ what, where }) => ({ what, where }));
+  const serviceDecisionRows =
+    svcRows.length > 0 || (dataRows.length === 0 && userRows.length === 0)
+      ? svcRows
+      : [
+          {
+            what: 'Checkout-owned processes',
+            where: `install ${inv.slug} (if running)`,
+          },
+        ];
   const totalFound =
-    svcRows.length + dataRows.length + userRows.length + inv.onecli.mine.length + inv.onecli.orphans.length;
+    serviceDecisionRows.length + dataRows.length + userRows.length + inv.onecli.mine.length + inv.onecli.orphans.length;
 
   if (totalFound === 0) {
     p.outro(
@@ -104,7 +119,9 @@ export async function runUninstallFlow(opts: {
 
   if (dryRun) {
     p.log.message(k.cyan('PREVIEW ONLY — this shows what would be deleted and changes nothing.'));
-    if (svcRows.length > 0) note(groupBody(GROUPS.service.desc, svcRows), GROUPS.service.title);
+    if (serviceDecisionRows.length > 0) {
+      note(groupBody(GROUPS.service.desc, serviceDecisionRows), GROUPS.service.title);
+    }
     if (dataRows.length > 0) note(groupBody(GROUPS.data.desc, dataRows), GROUPS.data.title);
     if (userRows.length > 0) note(groupBody(GROUPS.user.desc, userRows), GROUPS.user.title);
     if (inv.onecli.mine.length > 0 || inv.onecli.orphans.length > 0) {
@@ -117,7 +134,7 @@ export async function runUninstallFlow(opts: {
       if (inv.onecli.orphans.length === 0) lines.push('  (none)');
       note(lines.join('\n'), GROUPS.onecli.title);
     }
-    const empty = emptyGroupTitles(svcRows.length, dataRows.length, userRows.length, inv);
+    const empty = emptyGroupTitles(serviceDecisionRows.length, dataRows.length, userRows.length, inv);
     if (empty.length > 0) p.log.message(k.dim(`Nothing found for: ${empty.join(', ')}`));
     for (const n of inv.notes) p.log.message(k.dim(`• ${n}`));
     p.outro('Preview complete. Nothing was changed.');
@@ -137,8 +154,8 @@ export async function runUninstallFlow(opts: {
   // ── confirm phase — nothing is deleted until every decision is made ──
 
   let serviceYes = false;
-  if (svcRows.length > 0) {
-    note(groupBody(GROUPS.service.desc, svcRows), GROUPS.service.title);
+  if (serviceDecisionRows.length > 0) {
+    note(groupBody(GROUPS.service.desc, serviceDecisionRows), GROUPS.service.title);
     serviceYes = await confirmGroup(GROUPS.service.prompt, yes);
   }
 
@@ -154,12 +171,28 @@ export async function runUninstallFlow(opts: {
     userYes = await confirmGroup(GROUPS.user.prompt, yes);
   }
 
-  const keptNotes: string[] = [];
-  if (!serviceYes && svcRows.length > 0) keptNotes.push(`${GROUPS.service.title}: kept by your choice.`);
+  const keptNotes = inv.envBackups.map((backup) => `${backup.what}: ${backup.where} kept.`);
+  if (!serviceYes && serviceDecisionRows.length > 0) {
+    keptNotes.push(`${GROUPS.service.title}: kept by your choice.`);
+  }
   if (!dataYes && dataRows.length > 0) keptNotes.push(`${GROUPS.data.title}: kept by your choice.`);
   if (!userYes && userRows.length > 0) keptNotes.push(`${GROUPS.user.title}: kept by your choice.`);
 
   const onecliDelete = await decideOnecli(inv, yes, keptNotes);
+
+  const selectionError = uninstallSelectionError(inv, {
+    service: serviceYes,
+    data: dataYes,
+    user: userYes,
+  });
+  if (selectionError) {
+    p.log.error(selectionError);
+    process.exit(1);
+  }
+  if (!sameOwnershipSelectors(inv, scan())) {
+    p.log.error('This NanoClaw checkout changed after it was scanned. Nothing was removed; rerun uninstall.');
+    process.exit(1);
+  }
 
   // Record the decisions before execution can delete logs/ — but only into
   // an existing logs/ (userInput would otherwise mkdir it back into
@@ -207,21 +240,62 @@ export async function runUninstallFlow(opts: {
   // modules we're running from are gone.
   const head = actions.filter((a) => a.kind !== 'delete-runtime-path');
   const tail = actions.filter((a) => a.kind === 'delete-runtime-path');
+  const destructiveStart = head.findIndex((action) => action.kind === 'backup-env' || action.kind === 'delete-path');
+  const prerequisites = destructiveStart === -1 ? head : head.slice(0, destructiveStart);
+  const destructive = destructiveStart === -1 ? [] : head.slice(destructiveStart);
 
   const deps: ExecDeps = {
     runCommand,
     log: (line) => p.log.message(line),
     isRoot: process.getuid?.() === 0,
   };
-  const { notes: execNotes } = executePlan(head, deps);
-
-  printLeftAlone([...inv.notes, ...keptNotes, ...execNotes]);
-
-  const { notes: tailNotes } = executePlan(tail, {
+  const prerequisiteResult = executePlan(prerequisites, deps);
+  const onecliFailed = prerequisites.some(
+    (action, index) =>
+      action.kind === 'delete-onecli-agent' &&
+      ['failed', 'untouched'].includes(prerequisiteResult.results[index]?.outcome ?? 'failed'),
+  );
+  const prerequisiteError =
+    onecliFailed && !prerequisiteResult.prerequisiteFailed
+      ? {
+          code: 'credential_prerequisite_failed',
+          message: 'OneCLI agent cleanup failed, so app data was left for a safe retry.',
+        }
+      : undefined;
+  const destructiveResult = executePlan(destructive, {
     ...deps,
+    prerequisiteFailed: prerequisiteResult.prerequisiteFailed || onecliFailed,
+    ...(prerequisiteError ? { prerequisiteError } : {}),
+  });
+
+  printLeftAlone([...inv.notes, ...keptNotes, ...prerequisiteResult.notes, ...destructiveResult.notes]);
+
+  const headIncomplete = uninstallIncomplete([...prerequisiteResult.results, ...destructiveResult.results]);
+  const tailResult = executePlan(tail, {
+    ...deps,
+    prerequisiteFailed: headIncomplete,
+    ...(headIncomplete
+      ? {
+          prerequisiteError: {
+            code: 'removal_incomplete',
+            message: 'Earlier cleanup was incomplete, so runtime files were left for a safe retry.',
+          },
+        }
+      : {}),
     log: (line) => console.log(`  ${line}`),
   });
-  for (const n of tailNotes) console.log(`  • ${n}`);
+  for (const n of tailResult.notes) console.log(`  • ${n}`);
+
+  const incomplete = uninstallIncomplete([
+    ...prerequisiteResult.results,
+    ...destructiveResult.results,
+    ...tailResult.results,
+  ]);
+  if (incomplete) {
+    console.error(`\n! Uninstall incomplete for NanoClaw copy ${inv.slug}. Review the items left alone and rerun.`);
+    process.exit(1);
+  }
+
   console.log(`\n✓ Done. NanoClaw copy ${inv.slug} has been uninstalled.`);
   process.exit(0);
 }
@@ -304,6 +378,12 @@ function serviceRows(inv: Inventory, home: string): { what: string; where: strin
   if (s.systemdUserUnit) rows.push({ what: 'Background service', where: tilde(s.systemdUserUnit, home) });
   if (s.systemdSystemUnit) rows.push({ what: 'Background service (system)', where: s.systemdSystemUnit });
   if (s.pidFile) rows.push({ what: 'Running process', where: 'nanoclaw.pid' });
+  if (s.hostProcessIds && s.hostProcessIds.length > 0) {
+    rows.push({
+      what: 'Running host processes',
+      where: `${s.hostProcessIds.length} process(es)`,
+    });
+  }
   if (s.containerIds.length > 0) {
     rows.push({ what: 'Running containers', where: `${s.containerIds.length} container(s)` });
   }
@@ -339,4 +419,37 @@ function printLeftAlone(notes: string[]): void {
     ...notes.map((n) => `• ${n}`),
   ];
   note(lines.join('\n'), 'Left alone (shared / not ours)');
+}
+
+export function uninstallSelectionError(
+  inventory: Pick<Inventory, 'onecli'>,
+  decisions: Pick<Decisions, 'service' | 'data' | 'user'>,
+): string | undefined {
+  return (
+    validateDecisions(decisions) ??
+    (!inventory.onecli.available && decisions.data
+      ? 'OneCLI agents could not be inspected. Restore OneCLI and rerun uninstall before deleting app data.'
+      : undefined)
+  );
+}
+
+export function uninstallIncomplete(results: readonly Pick<UninstallActionResult, 'outcome'>[]): boolean {
+  return results.some((result) => ['failed', 'untouched'].includes(result.outcome));
+}
+
+export function sameOwnershipSelectors(before: Inventory, after: Inventory): boolean {
+  const beforeIdentity = before.identity;
+  const afterIdentity = after.identity;
+  return (
+    path.resolve(before.projectRoot) === path.resolve(after.projectRoot) &&
+    before.slug === after.slug &&
+    before.containerRuntime === after.containerRuntime &&
+    Boolean(beforeIdentity?.root) &&
+    Boolean(afterIdentity?.root) &&
+    beforeIdentity?.root === afterIdentity?.root &&
+    Object.values(beforeIdentity?.exactPaths ?? {}).every(Boolean) &&
+    beforeIdentity?.containerSelector === afterIdentity?.containerSelector &&
+    Object.values(beforeIdentity?.scopedRoots ?? {}).every(Boolean) &&
+    JSON.stringify(beforeIdentity?.scopedRoots) === JSON.stringify(afterIdentity?.scopedRoots)
+  );
 }

--- a/setup/uninstall/onecli-agents.ts
+++ b/setup/uninstall/onecli-agents.ts
@@ -19,7 +19,7 @@ export interface VaultAgent {
   name: string;
 }
 
-export type RunCommand = (cmd: string, args: string[]) => { status: number | null; stdout: string };
+export type RunCommand = (cmd: string, args: string[]) => { status: number | null; stdout: string; stderr?: string };
 
 /**
  * List non-default vault agents via `onecli agents list`. `available: false`

--- a/setup/uninstall/plan.test.ts
+++ b/setup/uninstall/plan.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { VaultAgent } from './onecli-agents.js';
-import { buildRemovalPlan, type Decisions, type RemovalAction } from './plan.js';
+import { buildRemovalPlan, validateDecisions, type Decisions, type RemovalAction } from './plan.js';
 import type { Inventory, PathItem } from './scan.js';
 
 const item = (p: string, what: string): PathItem => ({ what, where: p, path: p });
@@ -35,7 +35,8 @@ function inventory(overrides: Partial<Inventory> = {}): Inventory {
       item('/proj/dist', 'Build output'),
     ],
     user: [item('/proj/groups', 'Agent memory & files'), item('/proj/store', 'Migrated data store')],
-    onecli: { mine: [], orphans: [], idsKnown: true },
+    envBackups: [],
+    onecli: { mine: [], orphans: [], available: true, idsKnown: true },
     notes: [],
     ...overrides,
   };
@@ -53,8 +54,29 @@ const kinds = (actions: RemovalAction[]) => actions.map((a) => a.kind);
 describe('buildRemovalPlan ordering invariants', () => {
   it('removes .env only via the atomic backup action, never a bare delete', () => {
     const actions = buildRemovalPlan(inventory(), allYes());
+    const backup = actions.find((a) => a.kind === 'backup-env');
+    expect(backup).toEqual(expect.objectContaining({ identityRequired: true }));
     expect(actions.filter((a) => a.kind === 'backup-env')).toHaveLength(1);
     expect(actions.some((a) => a.kind === 'delete-path' && a.item.path === '/proj/.env')).toBe(false);
+  });
+
+  it('attaches exact identities to checkout-owned files while using root identities for directories', () => {
+    const inv = inventory({
+      data: [item('/proj/data', 'Database & conversations'), item('/proj/start-nanoclaw.sh', 'Start script')],
+      identity: {
+        root: 'root',
+        exactPaths: { '/proj/start-nanoclaw.sh': 'file:1' },
+        scopedRoots: { '/proj/data': 'node:1' },
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    });
+    const actions = buildRemovalPlan(inv, allYes());
+    const start = actions.find(
+      (action) => action.kind === 'delete-path' && action.item.path.endsWith('start-nanoclaw.sh'),
+    );
+    const data = actions.find((action) => action.kind === 'delete-path' && action.item.path === '/proj/data');
+    expect(start).toEqual(expect.objectContaining({ expectedIdentity: 'file:1', identityRequired: true }));
+    expect(data).toEqual(expect.objectContaining({ expectedRootIdentity: 'node:1' }));
   });
 
   it('puts the runtime tail strictly last, with node_modules final', () => {
@@ -89,6 +111,12 @@ describe('buildRemovalPlan ordering invariants', () => {
 });
 
 describe('buildRemovalPlan declined groups', () => {
+  it('rejects data or user removal while the service is preserved', () => {
+    expect(validateDecisions({ service: false, data: true, user: false })).toMatch(/cannot be removed/);
+    expect(validateDecisions({ service: false, data: false, user: true })).toMatch(/cannot be removed/);
+    expect(validateDecisions({ service: true, data: true, user: true })).toBeUndefined();
+  });
+
   it('declined data yields no data deletes and no runtime tail', () => {
     const actions = buildRemovalPlan(inventory(), {
       service: true,

--- a/setup/uninstall/plan.ts
+++ b/setup/uninstall/plan.ts
@@ -23,15 +23,25 @@ export interface Decisions {
   onecliDelete: VaultAgent[];
 }
 
+export function validateDecisions(decisions: Pick<Decisions, 'service' | 'data' | 'user'>): string | undefined {
+  if (!decisions.service && (decisions.data || decisions.user)) {
+    return 'App data and user files cannot be removed while the service is preserved.';
+  }
+  return undefined;
+}
+
+type ExactIdentity = { expectedIdentity?: string; identityRequired?: boolean };
+type ScopedRootIdentity = { expectedRootIdentity?: string };
+
 export type RemovalAction =
-  | {
+  | ({
       kind: 'unload-service';
       flavor: 'launchd' | 'systemd-user' | 'systemd-system';
       unitPath: string;
       /** systemd unit name without .service (unused for launchd). */
       unitName: string;
-    }
-  | { kind: 'kill-pid'; pidFile: string }
+    } & ExactIdentity)
+  | ({ kind: 'kill-pid'; pidFile: string; processPattern: string } & ExactIdentity)
   | { kind: 'pkill-host'; pattern: string }
   /**
    * Containers are re-listed by label at removal time, not removed from
@@ -39,17 +49,17 @@ export type RemovalAction =
    * and can spawn new containers after the scan.
    */
   | { kind: 'rm-containers'; runtime: string; labelFilter: string }
-  | { kind: 'rmi'; runtime: string; image: string }
-  | { kind: 'rm-ncl-symlink'; linkPath: string }
-  | { kind: 'delete-onecli-agent'; agent: VaultAgent }
+  | ({ kind: 'rmi'; runtime: string; image: string } & ExactIdentity)
+  | ({ kind: 'rm-ncl-symlink'; linkPath: string } & ExactIdentity)
+  | ({ kind: 'delete-onecli-agent'; agent: VaultAgent } & ExactIdentity)
   /**
    * Backs up AND removes .env as one atomic action: a failed backup must
    * never be followed by the deletion (the backup is the user's only copy
    * of their API keys). .env is deliberately excluded from `delete-path`.
    */
-  | { kind: 'backup-env'; envPath: string }
-  | { kind: 'delete-path'; item: PathItem }
-  | { kind: 'delete-runtime-path'; item: PathItem };
+  | ({ kind: 'backup-env'; envPath: string; backupRoot?: string } & Partial<ExactIdentity>)
+  | ({ kind: 'delete-path'; item: PathItem } & ScopedRootIdentity & Partial<ExactIdentity>)
+  | ({ kind: 'delete-runtime-path'; item: PathItem } & ScopedRootIdentity & Partial<ExactIdentity>);
 
 export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] {
   const actions: RemovalAction[] = [];
@@ -62,6 +72,7 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
         flavor: 'launchd',
         unitPath: s.launchdPlist,
         unitName: path.basename(s.launchdPlist, '.plist'),
+        ...identity(inv, s.launchdPlist),
       });
     }
     if (s.systemdUserUnit) {
@@ -70,6 +81,7 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
         flavor: 'systemd-user',
         unitPath: s.systemdUserUnit,
         unitName: path.basename(s.systemdUserUnit, '.service'),
+        ...identity(inv, s.systemdUserUnit),
       });
     }
     if (s.systemdSystemUnit) {
@@ -78,9 +90,17 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
         flavor: 'systemd-system',
         unitPath: s.systemdSystemUnit,
         unitName: path.basename(s.systemdSystemUnit, '.service'),
+        ...identity(inv, s.systemdSystemUnit),
       });
     }
-    if (s.pidFile) actions.push({ kind: 'kill-pid', pidFile: s.pidFile });
+    if (s.pidFile) {
+      actions.push({
+        kind: 'kill-pid',
+        pidFile: s.pidFile,
+        processPattern: `${inv.projectRoot}/dist/index.js`,
+        ...identity(inv, s.pidFile),
+      });
+    }
     actions.push({
       kind: 'pkill-host',
       pattern: `${inv.projectRoot}/dist/index.js`,
@@ -93,36 +113,75 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
       labelFilter: `nanoclaw-install=${inv.slug}`,
     });
     if (s.image) {
-      actions.push({ kind: 'rmi', runtime: inv.containerRuntime, image: s.image });
+      actions.push({
+        kind: 'rmi',
+        runtime: inv.containerRuntime,
+        image: s.image,
+        ...(s.imageIdentity ? { expectedIdentity: s.imageIdentity } : {}),
+        identityRequired: true,
+      });
     }
     if (s.nclSymlink) {
-      actions.push({ kind: 'rm-ncl-symlink', linkPath: s.nclSymlink });
+      actions.push({ kind: 'rm-ncl-symlink', linkPath: s.nclSymlink, ...identity(inv, s.nclSymlink) });
     }
   }
 
   for (const agent of d.onecliDelete) {
-    actions.push({ kind: 'delete-onecli-agent', agent });
+    actions.push({
+      kind: 'delete-onecli-agent',
+      agent,
+      expectedIdentity: JSON.stringify(agent),
+      identityRequired: true,
+    });
   }
 
   if (d.data) {
     const env = inv.data.find((i) => path.basename(i.path) === '.env');
-    if (env) actions.push({ kind: 'backup-env', envPath: env.path });
+    if (env) {
+      actions.push({
+        kind: 'backup-env',
+        envPath: env.path,
+        backupRoot: inv.credentialBackupRoot,
+        ...identity(inv, env.path),
+      });
+    }
     for (const item of inv.data) {
       if (item === env) continue; // removed by backup-env, never a bare delete
-      actions.push({ kind: 'delete-path', item });
+      actions.push({ kind: 'delete-path', item, ...pathOwnership(inv, item.path) });
     }
   }
 
   if (d.user) {
-    for (const item of inv.user) actions.push({ kind: 'delete-path', item });
+    for (const item of inv.user) {
+      actions.push({ kind: 'delete-path', item, ...pathOwnership(inv, item.path) });
+    }
   }
 
   if (d.data) {
     const tail = [...inv.runtime].sort(
       (a, b) => Number(path.basename(a.path) === 'node_modules') - Number(path.basename(b.path) === 'node_modules'),
     );
-    for (const item of tail) actions.push({ kind: 'delete-runtime-path', item });
+    for (const item of tail) {
+      actions.push({ kind: 'delete-runtime-path', item, ...pathOwnership(inv, item.path) });
+    }
   }
 
   return actions;
+}
+
+function identity(inv: Inventory, target: string): ExactIdentity {
+  const value = inv.identity?.exactPaths[target];
+  return { ...(value ? { expectedIdentity: value } : {}), identityRequired: true };
+}
+
+function scopedRoot(inv: Inventory, target: string): ScopedRootIdentity {
+  const value = inv.identity?.scopedRoots[target];
+  return value ? { expectedRootIdentity: value } : {};
+}
+
+function pathOwnership(inv: Inventory, target: string): ScopedRootIdentity | Partial<ExactIdentity> {
+  if (Object.prototype.hasOwnProperty.call(inv.identity?.scopedRoots ?? {}, target)) {
+    return scopedRoot(inv, target);
+  }
+  return identity(inv, target);
 }

--- a/setup/uninstall/protocol.test.ts
+++ b/setup/uninstall/protocol.test.ts
@@ -1,0 +1,339 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getInstallSlug } from '../../src/install-slug.js';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const AUTO = path.join(ROOT, 'setup', 'auto.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'uninstall' } as const;
+
+type Child = ReturnType<typeof spawn>;
+type Event = Record<string, unknown>;
+type Artifact = { id: string; kind: string; location: string; disposition: string };
+
+let installRoot: string;
+
+beforeEach(() => {
+  installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-uninstall-protocol-'));
+});
+
+afterEach(() => {
+  fs.rmSync(installRoot, { recursive: true, force: true });
+});
+
+function start(env: NodeJS.ProcessEnv = {}): Child {
+  return spawn(process.execPath, ['--import', TSX_LOADER, AUTO, '--uninstall'], {
+    cwd: installRoot,
+    env: {
+      ...process.env,
+      NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+      NANOCLAW_OPERATION: 'uninstall',
+      NANOCLAW_NO_DIAGNOSTICS: '1',
+      ...env,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+function installEmptyOnecli(): string {
+  const fakeBin = path.join(installRoot, 'fake-bin');
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nprintf %s \'{"data":[]}\'\n', { mode: 0o755 });
+  return fakeBin;
+}
+
+function choices(service: 'preserve' | 'remove', data: 'preserve' | 'remove') {
+  return [
+    { groupId: 'service', choice: service },
+    { groupId: 'data', choice: data },
+    { groupId: 'user', choice: 'preserve' },
+    { groupId: 'onecli', choice: 'preserve' },
+  ];
+}
+
+function apply(child: Child, planId: string, values = choices('preserve', 'preserve')): void {
+  child.stdin!.write(
+    `${JSON.stringify({
+      ...envelope,
+      type: 'applyUninstall',
+      planId,
+      choices: values,
+    })}\n`,
+  );
+}
+
+async function collect(
+  child: Child,
+  onEvent: (event: Event) => void,
+): Promise<{ code: number | null; stdout: string; stderr: string; events: Event[] }> {
+  const events: Event[] = [];
+  let stdout = '';
+  let stderr = '';
+  let buffer = '';
+  child.stdout!.on('data', (chunk: Buffer) => {
+    const text = chunk.toString('utf8');
+    stdout += text;
+    buffer += text;
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const event = JSON.parse(line) as Event;
+      events.push(event);
+      onEvent(event);
+    }
+  });
+  child.stderr!.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  return { code, stdout, stderr, events };
+}
+
+function planItems(events: Event[]): Artifact[] {
+  return events.filter((event) => event.type === 'uninstallPlanItem').map((event) => event.artifact as Artifact);
+}
+
+function receiptItems(events: Event[]): Artifact[] {
+  return events.filter((event) => event.type === 'uninstallReceiptItem').map((event) => event.artifact as Artifact);
+}
+
+describe('machine uninstall session', () => {
+  it('rejects unsafe choices, then preserves the four-group streamed plan', async () => {
+    const child = start();
+    let answered = false;
+    const result = await collect(child, (event) => {
+      if (event.type !== 'uninstallPlan' || answered) return;
+      answered = true;
+      const plan = event.plan as { id: string; groups: Array<{ id: string; default: string }> };
+      expect(plan).not.toHaveProperty('artifacts');
+      expect(plan.groups.map((group) => group.id)).toEqual(['service', 'data', 'user', 'onecli']);
+      expect(plan.groups.every((group) => group.default === 'preserve')).toBe(true);
+      apply(child, plan.id, choices('preserve', 'remove'));
+      apply(child, plan.id);
+    });
+
+    const items = planItems(result.events);
+    const actions = result.events
+      .filter((event) => event.type === 'uninstallAction')
+      .map((event) => event.result as { artifactId: string });
+    const complete = result.events.find((event) => event.type === 'complete') as {
+      receipt: { outcome: string };
+    };
+
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout[0]).toBe('{');
+    expect(result.events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(
+      result.events.some((event) => event.type === 'inputRejected' && event.code === 'unsafe_uninstall_choices'),
+    ).toBe(true);
+    expect(new Set(actions.map((action) => action.artifactId))).toEqual(new Set(items.map((item) => item.id)));
+    expect(complete.receipt.outcome).toBe('success');
+    expect(complete.receipt).not.toHaveProperty('results');
+    expect(complete.receipt).not.toHaveProperty('remaining');
+    expect(result.events.some((event) => String(event.type).includes('Page'))).toBe(false);
+    expect(fs.readdirSync(installRoot)).toEqual([]);
+  }, 15_000);
+
+  it('rejects app-data deletion when OneCLI cannot be inspected', async () => {
+    const fakeBin = path.join(installRoot, 'fake-unavailable-bin');
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    const localBin = path.join(os.homedir(), '.local', 'bin');
+    const child = start({ PATH: `${fakeBin}${path.delimiter}${localBin}` });
+    let answered = false;
+    const result = await collect(child, (event) => {
+      if (event.type !== 'uninstallPlan' || answered) return;
+      answered = true;
+      const planId = (event.plan as { id: string }).id;
+      apply(child, planId, choices('remove', 'remove'));
+      apply(child, planId);
+    });
+
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        type: 'inputRejected',
+        code: 'unsafe_uninstall_choices',
+        message: expect.stringContaining('Restore OneCLI'),
+      }),
+    );
+  }, 15_000);
+
+  it('skips a replaced data directory while removing an unchanged logs directory', async () => {
+    const data = path.join(installRoot, 'data');
+    fs.mkdirSync(data);
+    fs.writeFileSync(path.join(data, 'approved.txt'), 'approved');
+    const logs = path.join(installRoot, 'logs');
+    fs.mkdirSync(logs);
+    fs.writeFileSync(path.join(logs, 'remove.txt'), 'remove');
+    const fakeBin = installEmptyOnecli();
+    const child = start({ PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}` });
+    const result = await collect(child, (event) => {
+      if (event.type !== 'uninstallPlan') return;
+      fs.renameSync(data, path.join(installRoot, 'data.old'));
+      fs.mkdirSync(data);
+      fs.writeFileSync(path.join(data, 'replacement.txt'), 'replacement');
+      apply(child, (event.plan as { id: string }).id, choices('remove', 'remove'));
+    });
+
+    const complete = result.events.find((event) => event.type === 'complete') as {
+      receipt: { outcome: string };
+    };
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(1);
+    expect(complete.receipt.outcome).toBe('incomplete');
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        type: 'uninstallAction',
+        result: expect.objectContaining({
+          outcome: 'untouched',
+          error: expect.objectContaining({ code: 'ownership_root_changed' }),
+        }),
+      }),
+    );
+    expect(fs.readFileSync(path.join(data, 'replacement.txt'), 'utf8')).toBe('replacement');
+    expect(fs.readFileSync(path.join(installRoot, 'data.old', 'approved.txt'), 'utf8')).toBe('approved');
+    expect(fs.existsSync(logs)).toBe(false);
+  }, 15_000);
+
+  it('streams the external credential backup after successful .env removal', async () => {
+    fs.writeFileSync(path.join(installRoot, '.env'), 'TOKEN=fixture-secret');
+    const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-uninstall-backup-home-'));
+    const runtime = path.join(installRoot, 'fake-container-runtime');
+    const fakeBin = path.join(installRoot, 'fake-bin');
+    fs.writeFileSync(runtime, '#!/bin/sh\n[ "$1" = ps ] && exit 0\nexit 1\n', { mode: 0o755 });
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nprintf %s \'{"data":[]}\'\n', { mode: 0o755 });
+
+    try {
+      const child = start({
+        HOME: testHome,
+        CONTAINER_RUNTIME: runtime,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+      });
+      const result = await collect(child, (event) => {
+        if (event.type === 'uninstallPlan') {
+          apply(child, (event.plan as { id: string }).id, choices('remove', 'remove'));
+        }
+      });
+      const complete = result.events.find((event) => event.type === 'complete') as {
+        receipt: { outcome: string; checkoutRemoval: { safe: boolean; blockers: string[] } };
+      };
+      const backupRoot = path.join(
+        testHome,
+        'Library',
+        'Application Support',
+        'NanoClaw',
+        'uninstall-backups',
+        getInstallSlug(fs.realpathSync(installRoot)),
+      );
+      const backupPath = path.join(backupRoot, '.env.bak');
+
+      expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(complete.receipt).toEqual(
+        expect.objectContaining({
+          outcome: 'success',
+          checkoutRemoval: { safe: true, blockers: [] },
+        }),
+      );
+      expect(receiptItems(result.events)).toContainEqual(
+        expect.objectContaining({
+          kind: 'credential-backup',
+          location: backupPath,
+          disposition: 'external',
+        }),
+      );
+      expect(fs.readFileSync(backupPath, 'utf8')).toBe('TOKEN=fixture-secret');
+      expect(fs.statSync(backupRoot).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(backupPath).mode & 0o777).toBe(0o600);
+      expect(JSON.stringify(result.events)).not.toContain('fixture-secret');
+    } finally {
+      fs.rmSync(testHome, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('stops before the next action when cancelled during apply', async () => {
+    fs.writeFileSync(path.join(installRoot, '.env'), 'TOKEN=still-here');
+    const fakeBin = path.join(installRoot, 'fake-bin');
+    const runtime = path.join(installRoot, 'fake-runtime');
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nprintf %s \'{"data":[]}\'\n', { mode: 0o755 });
+    fs.writeFileSync(runtime, '#!/bin/sh\n[ "$1" = ps ] && exit 0\nexit 1\n', { mode: 0o755 });
+
+    const child = start({
+      CONTAINER_RUNTIME: runtime,
+      PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+    });
+    let cancelled = false;
+    const result = await collect(child, (event) => {
+      if (event.type === 'uninstallPlan') {
+        apply(child, (event.plan as { id: string }).id, choices('remove', 'remove'));
+      } else if (event.type === 'uninstallAction' && !cancelled) {
+        const action = event.result as { actionId: string };
+        if (!action.actionId.startsWith('preserve-')) {
+          cancelled = true;
+          child.stdin!.write(`${JSON.stringify({ ...envelope, type: 'cancel', reason: 'stop now' })}\n`);
+        }
+      }
+    });
+
+    const terminal = result.events.at(-1) as Event;
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(2);
+    expect(terminal.type).toBe('cancelled');
+    expect(terminal).not.toHaveProperty('results');
+    expect(terminal).not.toHaveProperty('remaining');
+    expect(receiptItems(result.events)).toContainEqual(
+      expect.objectContaining({
+        location: path.join(fs.realpathSync(installRoot), '.env'),
+      }),
+    );
+    expect(fs.readFileSync(path.join(installRoot, '.env'), 'utf8')).toBe('TOKEN=still-here');
+  }, 15_000);
+
+  it('streams a large plan and one result per artifact without pagination', async () => {
+    const fakeBin = path.join(installRoot, 'fake-bin');
+    const runtime = path.join(installRoot, 'fake-runtime');
+    fs.mkdirSync(fakeBin);
+    const agents = Array.from({ length: 65 }, (_, index) => ({
+      id: `agent-${index}`,
+      identifier: `ag-${index}`,
+      name: `Agent ${index}`,
+      isDefault: false,
+    }));
+    fs.writeFileSync(
+      path.join(fakeBin, 'onecli'),
+      `#!/bin/sh\nprintf %s ${JSON.stringify(JSON.stringify({ data: agents }))}\n`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(path.join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(runtime, '#!/bin/sh\n[ "$1" = ps ] && exit 0\nexit 1\n', { mode: 0o755 });
+
+    const child = start({
+      CONTAINER_RUNTIME: runtime,
+      PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+    });
+    const result = await collect(child, (event) => {
+      if (event.type === 'uninstallPlan') apply(child, (event.plan as { id: string }).id);
+    });
+    const artifacts = planItems(result.events);
+    const actionIds = result.events
+      .filter((event) => event.type === 'uninstallAction')
+      .map((event) => (event.result as { artifactId: string }).artifactId);
+
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(artifacts.length).toBeGreaterThan(65);
+    expect(new Set(actionIds)).toEqual(new Set(artifacts.map((artifact) => artifact.id)));
+    expect(result.events.some((event) => String(event.type).includes('Page'))).toBe(false);
+  }, 15_000);
+});

--- a/setup/uninstall/remove.test.ts
+++ b/setup/uninstall/remove.test.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import type { RunCommand } from './onecli-agents.js';
 import type { RemovalAction } from './plan.js';
 import { backupEnv, executePlan, type ExecDeps } from './remove.js';
+import { pathIdentity } from './scan.js';
 
 let tempDir: string;
 
@@ -29,25 +30,28 @@ function deps(overrides: Partial<ExecDeps> = {}): ExecDeps {
 describe('backupEnv', () => {
   it('backs up to .env.bak', () => {
     const envPath = path.join(tempDir, '.env');
+    const backupRoot = path.join(tempDir, 'backup');
     fs.writeFileSync(envPath, 'KEY=secret');
 
-    const backup = backupEnv(envPath);
+    const backup = backupEnv(envPath, backupRoot);
 
-    expect(backup).toBe(path.join(tempDir, '.env.bak'));
+    expect(backup).toBe(path.join(backupRoot, '.env.bak'));
     expect(fs.readFileSync(backup, 'utf-8')).toBe('KEY=secret');
   });
 
   it('falls back to a timestamped name when .env.bak exists', () => {
     const envPath = path.join(tempDir, '.env');
+    const backupRoot = path.join(tempDir, 'backup');
     fs.writeFileSync(envPath, 'KEY=new');
-    fs.writeFileSync(path.join(tempDir, '.env.bak'), 'KEY=old');
+    fs.mkdirSync(backupRoot);
+    fs.writeFileSync(path.join(backupRoot, '.env.bak'), 'KEY=old');
 
-    const backup = backupEnv(envPath);
+    const backup = backupEnv(envPath, backupRoot);
 
-    expect(path.basename(backup)).toMatch(/^\.env\.bak\.\d{8}-\d{6}$/);
+    expect(path.basename(backup)).toMatch(/^\.env\.bak\.\d+-\d+-\d+$/);
     expect(fs.readFileSync(backup, 'utf-8')).toBe('KEY=new');
     // The earlier backup is never clobbered.
-    expect(fs.readFileSync(path.join(tempDir, '.env.bak'), 'utf-8')).toBe('KEY=old');
+    expect(fs.readFileSync(path.join(backupRoot, '.env.bak'), 'utf-8')).toBe('KEY=old');
   });
 });
 
@@ -63,7 +67,7 @@ describe('executePlan', () => {
     expect(notes).toEqual([]);
   });
 
-  it('continues past a failing action and records a note', () => {
+  it('blocks dependent deletion after a service-stop failure', () => {
     const dir = path.join(tempDir, 'logs');
     fs.mkdirSync(dir);
     const actions: RemovalAction[] = [
@@ -79,13 +83,13 @@ describe('executePlan', () => {
       throw new Error('launchctl exploded');
     };
 
-    const { notes } = executePlan(actions, deps({ runCommand: failing }));
+    const { notes, results } = executePlan(actions, deps({ runCommand: failing }));
 
-    expect(notes).toHaveLength(1);
+    expect(notes).toHaveLength(2);
     expect(notes[0]).toContain('unload-service');
     expect(notes[0]).toContain('launchctl exploded');
-    // Later actions still ran.
-    expect(fs.existsSync(dir)).toBe(false);
+    expect(fs.existsSync(dir)).toBe(true);
+    expect(results.at(-1)?.outcome).toBe('untouched');
   });
 
   it('leaves a system unit in place without root and notes the sudo command', () => {
@@ -126,10 +130,10 @@ describe('executePlan', () => {
     const envPath = path.join(tempDir, '.env');
     fs.writeFileSync(envPath, 'KEY=secret');
 
-    const { notes } = executePlan([{ kind: 'backup-env', envPath }], deps());
+    const { notes } = executePlan([{ kind: 'backup-env', envPath, backupRoot: path.join(tempDir, 'backup') }], deps());
 
     expect(fs.existsSync(envPath)).toBe(false);
-    expect(fs.readFileSync(path.join(tempDir, '.env.bak'), 'utf-8')).toBe('KEY=secret');
+    expect(fs.readFileSync(path.join(tempDir, 'backup', '.env.bak'), 'utf-8')).toBe('KEY=secret');
     expect(notes).toEqual([]);
   });
 
@@ -139,7 +143,10 @@ describe('executePlan', () => {
     fs.chmodSync(tempDir, 0o555); // backup destination unwritable
 
     try {
-      const { notes } = executePlan([{ kind: 'backup-env', envPath }], deps());
+      const { notes } = executePlan(
+        [{ kind: 'backup-env', envPath, backupRoot: path.join(tempDir, 'backup') }],
+        deps(),
+      );
       expect(fs.existsSync(envPath)).toBe(true);
       expect(notes.some((n) => n.includes('backup-env'))).toBe(true);
     } finally {
@@ -174,6 +181,66 @@ describe('executePlan', () => {
     expect(notes.some((n) => n.includes('xargs -r docker rm -f'))).toBe(true);
   });
 
+  it('blocks data and runtime deletion when container shutdown fails', () => {
+    const dataPath = path.join(tempDir, 'data');
+    const runtimePath = path.join(tempDir, 'node_modules');
+    fs.mkdirSync(dataPath);
+    fs.mkdirSync(runtimePath);
+
+    const result = executePlan(
+      [
+        {
+          kind: 'rm-containers',
+          runtime: 'docker',
+          labelFilter: 'nanoclaw-install=test',
+        },
+        {
+          kind: 'delete-path',
+          item: { what: 'Data', where: dataPath, path: dataPath },
+        },
+        {
+          kind: 'delete-runtime-path',
+          item: {
+            what: 'Runtime',
+            where: runtimePath,
+            path: runtimePath,
+          },
+        },
+      ],
+      deps({ runCommand: () => ({ status: null, stdout: '' }) }),
+    );
+
+    expect(result.results.map((entry) => entry.outcome)).toEqual(['failed', 'untouched', 'untouched']);
+    expect(fs.existsSync(dataPath)).toBe(true);
+    expect(fs.existsSync(runtimePath)).toBe(true);
+  });
+
+  it('removes an already-stopped launchd service registration', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    fs.writeFileSync(unitPath, 'service');
+
+    const result = executePlan(
+      [
+        {
+          kind: 'unload-service',
+          flavor: 'launchd',
+          unitPath,
+          unitName: 'service',
+        },
+      ],
+      deps({
+        runCommand: () => ({
+          status: 1,
+          stdout: '',
+          stderr: 'Could not find specified service',
+        }),
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('removed');
+    expect(fs.existsSync(unitPath)).toBe(false);
+  });
+
   it('notes a manual delete when onecli itself cannot be run', () => {
     const { notes } = executePlan(
       [
@@ -205,5 +272,260 @@ describe('executePlan', () => {
     );
 
     expect(calls).toEqual([['onecli', 'agents', 'delete', '--id', 'u-123']]);
+  });
+
+  it('leaves an exact filesystem artifact untouched when its identity changed', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    fs.writeFileSync(unitPath, 'approved');
+    const expectedIdentity = pathIdentity(unitPath);
+    fs.writeFileSync(unitPath, 'replacement');
+
+    const result = executePlan(
+      [
+        {
+          kind: 'unload-service',
+          flavor: 'launchd',
+          unitPath,
+          unitName: 'service',
+          expectedIdentity,
+          identityRequired: true,
+        },
+      ],
+      deps(),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(fs.readFileSync(unitPath, 'utf8')).toBe('replacement');
+  });
+
+  it('deletes an unchanged exact file but preserves a replacement', () => {
+    const keptPath = path.join(tempDir, 'start-nanoclaw.sh');
+    fs.writeFileSync(keptPath, '#!/bin/sh\n');
+    const keptIdentity = pathIdentity(keptPath);
+    const removed = executePlan(
+      [
+        {
+          kind: 'delete-path',
+          item: { what: 'Start script', where: keptPath, path: keptPath },
+          expectedIdentity: keptIdentity,
+          identityRequired: true,
+        },
+      ],
+      deps(),
+    );
+    expect(removed.results[0]?.outcome).toBe('removed');
+    expect(fs.existsSync(keptPath)).toBe(false);
+
+    const replacementPath = path.join(tempDir, 'replacement.txt');
+    fs.writeFileSync(replacementPath, 'approved');
+    const replacementIdentity = pathIdentity(replacementPath);
+    fs.writeFileSync(replacementPath, 'replacement');
+    const preserved = executePlan(
+      [
+        {
+          kind: 'delete-path',
+          item: { what: 'Replacement', where: replacementPath, path: replacementPath },
+          expectedIdentity: replacementIdentity,
+          identityRequired: true,
+        },
+      ],
+      deps(),
+    );
+    expect(preserved.results[0]?.outcome).toBe('untouched');
+    expect(fs.readFileSync(replacementPath, 'utf8')).toBe('replacement');
+  });
+
+  it('does not unlink a service unit replaced while the stop command is running', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    const dataPath = path.join(tempDir, 'data');
+    fs.writeFileSync(unitPath, 'approved');
+    fs.mkdirSync(dataPath);
+    const expectedIdentity = pathIdentity(unitPath);
+    const result = executePlan(
+      [
+        {
+          kind: 'unload-service',
+          flavor: 'launchd',
+          unitPath,
+          unitName: 'service',
+          expectedIdentity,
+          identityRequired: true,
+        },
+        { kind: 'delete-path', item: { what: 'Data', where: dataPath, path: dataPath } },
+      ],
+      deps({
+        runCommand: () => {
+          fs.writeFileSync(unitPath, 'replacement');
+          return { status: 0, stdout: '' };
+        },
+      }),
+    );
+
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        outcome: 'untouched',
+        error: expect.objectContaining({ code: 'identity_changed' }),
+      }),
+    );
+    expect(result.results[1]).toEqual(
+      expect.objectContaining({
+        outcome: 'untouched',
+        error: expect.objectContaining({ code: 'service_prerequisite_failed' }),
+      }),
+    );
+    expect(fs.readFileSync(unitPath, 'utf8')).toBe('replacement');
+    expect(fs.existsSync(dataPath)).toBe(true);
+  });
+
+  it('rechecks a checkout-owned directory root immediately before recursive deletion', () => {
+    const dir = path.join(tempDir, 'data');
+    fs.mkdirSync(dir);
+    const expectedRootIdentity = pathIdentity(dir);
+    fs.renameSync(dir, `${dir}.approved`);
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, 'replacement.txt'), 'keep');
+
+    const result = executePlan(
+      [
+        {
+          kind: 'delete-path',
+          item: { what: 'Data', where: dir, path: dir },
+          expectedRootIdentity,
+        },
+      ],
+      deps(),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(fs.readFileSync(path.join(dir, 'replacement.txt'), 'utf8')).toBe('keep');
+  });
+
+  it('does not signal a non-host pidfile target that mentions this checkout', () => {
+    const pidFile = path.join(tempDir, 'nanoclaw.pid');
+    const processPattern = `${tempDir}/dist/index.js`;
+    fs.writeFileSync(pidFile, '321');
+    const killed: number[] = [];
+    const result = executePlan(
+      [
+        {
+          kind: 'kill-pid',
+          pidFile,
+          processPattern,
+          expectedIdentity: pathIdentity(pidFile),
+          identityRequired: true,
+        },
+      ],
+      deps({
+        runCommand: () => ({ status: 0, stdout: `/usr/bin/vim ${processPattern}\n` }),
+        killProcess: (pid) => {
+          killed.push(pid);
+        },
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(killed).toEqual([]);
+    expect(fs.existsSync(pidFile)).toBe(true);
+  });
+
+  it('waits for an owned pidfile process to stop before satisfying the prerequisite', () => {
+    const pidFile = path.join(tempDir, 'nanoclaw.pid');
+    const processPattern = `${tempDir}/dist/index.js`;
+    fs.writeFileSync(pidFile, '321');
+    let checks = 0;
+    const result = executePlan(
+      [
+        {
+          kind: 'kill-pid',
+          pidFile,
+          processPattern,
+          expectedIdentity: pathIdentity(pidFile),
+          identityRequired: true,
+        },
+      ],
+      deps({
+        runCommand: () => ({ status: ++checks < 4 ? 0 : 1, stdout: `/usr/bin/node ${processPattern}\n` }),
+        killProcess: () => {},
+        sleep: () => {},
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('removed');
+    expect(checks).toBeGreaterThanOrEqual(4);
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  it('re-lists only the NanoClaw node argv shape, not editors or grep', () => {
+    const processPattern = `${tempDir}/dist/index.js`;
+    const killed: number[] = [];
+    let listings = 0;
+    const result = executePlan(
+      [{ kind: 'pkill-host', pattern: processPattern }],
+      deps({
+        runCommand: () => ({
+          status: 0,
+          stdout:
+            listings++ === 0
+              ? `321 /usr/bin/node ${processPattern}\n322 /usr/bin/vim ${processPattern}\n323 grep ${processPattern}\n`
+              : `322 /usr/bin/vim ${processPattern}\n323 grep ${processPattern}\n`,
+        }),
+        killProcess: (pid) => {
+          killed.push(pid);
+        },
+        sleep: () => {},
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('removed');
+    expect(killed).toEqual([321]);
+  });
+
+  it('rechecks the exact image identity immediately before removal', () => {
+    const calls: string[][] = [];
+    const result = executePlan(
+      [
+        {
+          kind: 'rmi',
+          runtime: 'docker',
+          image: 'img:latest',
+          expectedIdentity: '{"Id":"approved"}',
+          identityRequired: true,
+        },
+      ],
+      deps({
+        runCommand: (cmd, args) => {
+          calls.push([cmd, ...args]);
+          return { status: 0, stdout: '{"Id":"replacement"}' };
+        },
+      }),
+    );
+
+    expect(result.results[0]?.outcome).toBe('untouched');
+    expect(calls).toEqual([['docker', 'image', 'inspect', 'img:latest']]);
+  });
+
+  it('does not delete OneCLI agents after service failure', () => {
+    const unitPath = path.join(tempDir, 'service.plist');
+    const dataPath = path.join(tempDir, 'data');
+    fs.writeFileSync(unitPath, 'service');
+    fs.mkdirSync(dataPath);
+    const calls: string[][] = [];
+    const runCommand: RunCommand = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (cmd === 'launchctl') return { status: 1, stdout: '' };
+      return { status: 0, stdout: '' };
+    };
+    const result = executePlan(
+      [
+        { kind: 'unload-service', flavor: 'launchd', unitPath, unitName: 'service' },
+        { kind: 'delete-onecli-agent', agent: { uuid: 'u-1', identifier: 'ag-1', name: 'Agent' } },
+        { kind: 'delete-path', item: { what: 'Data', where: dataPath, path: dataPath } },
+      ],
+      deps({ runCommand }),
+    );
+
+    expect(result.results.map((entry) => entry.outcome)).toEqual(['failed', 'untouched', 'untouched']);
+    expect(calls.some((call) => call.join(' ') === 'onecli agents delete --id u-1')).toBe(false);
+    expect(fs.existsSync(dataPath)).toBe(true);
   });
 });

--- a/setup/uninstall/remove.ts
+++ b/setup/uninstall/remove.ts
@@ -8,81 +8,264 @@
  * the injected `log` callback.
  */
 import fs from 'fs';
+import { createHash } from 'node:crypto';
 import path from 'path';
 
-import type { RunCommand } from './onecli-agents.js';
+import { listVaultAgents, type RunCommand } from './onecli-agents.js';
 import type { RemovalAction } from './plan.js';
+import { checkoutHostProcesses, isNanoclawHostCommand, pathIdentity } from './scan.js';
+
+export type ActionOutcome = 'removed' | 'preserved' | 'failed' | 'untouched' | 'alreadyAbsent';
+
+export type UninstallActionResult = {
+  actionId: string;
+  artifactId: string;
+  outcome: ActionOutcome;
+  error?: { code: string; message: string };
+};
 
 export interface ExecDeps {
   runCommand: RunCommand;
   log: (line: string) => void;
   /** True when running as root — required to remove a system-level unit. */
   isRoot: boolean;
+  prerequisiteFailed?: boolean;
+  prerequisiteError?: { code: string; message: string };
+  onResult?: (result: UninstallActionResult) => void;
+  killProcess?: (pid: number) => void;
+  sleep?: (milliseconds: number) => void;
+  processStopTimeoutMs?: number;
 }
 
-export function executePlan(actions: RemovalAction[], deps: ExecDeps): { notes: string[] } {
-  const notes: string[] = [];
-  for (const action of actions) {
-    try {
-      runAction(action, deps, notes);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      notes.push(`${action.kind}: failed (${msg}) — re-run the uninstaller to retry.`);
-    }
+type IdentityResult = {
+  outcome: 'failed' | 'untouched' | 'alreadyAbsent';
+  error?: { code: string; message: string };
+};
+
+function missingExactPath(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return true;
+    throw new IdentityRevalidationError({
+      outcome: 'failed',
+      error: { code: 'identity_check_failed', message: 'The exact filesystem target could not be checked.' },
+    });
   }
-  return { notes };
+}
+
+class IdentityRevalidationError extends Error {
+  constructor(readonly result: IdentityResult) {
+    super(result.error?.message ?? 'The target identity changed during removal.');
+  }
+}
+
+export function executePlan(
+  actions: RemovalAction[],
+  deps: ExecDeps,
+): { notes: string[]; results: UninstallActionResult[]; prerequisiteFailed: boolean } {
+  const notes: string[] = [];
+  const results: UninstallActionResult[] = [];
+  let prerequisiteFailed = deps.prerequisiteFailed === true;
+  for (const action of actions) {
+    let outcome: ActionOutcome = 'failed';
+    let error: { code: string; message: string } | undefined;
+    try {
+      if (prerequisiteFailed && dependsOnStoppedService(action)) {
+        outcome = 'untouched';
+        error = deps.prerequisiteError ?? {
+          code: 'service_prerequisite_failed',
+          message: 'The service could not be stopped safely.',
+        };
+        notes.push(`${action.kind}: left untouched (${error.message})`);
+      } else {
+        const identity = verifyScopedRoot(action) ?? verifyExactIdentity(action, deps.runCommand);
+        if (identity) {
+          outcome = identity.outcome;
+          error = identity.error;
+        } else {
+          outcome = runAction(action, deps, notes);
+        }
+      }
+    } catch (err) {
+      if (err instanceof IdentityRevalidationError) {
+        outcome = err.result.outcome;
+        error = err.result.error;
+        notes.push(`${action.kind}: left untouched (${err.message}); re-run the uninstaller to rescan.`);
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        notes.push(`${action.kind}: failed (${msg}); re-run the uninstaller to retry.`);
+        error = { code: 'action_failed', message: msg };
+        outcome = 'failed';
+      }
+    }
+    if (stopsService(action) && (outcome === 'failed' || outcome === 'untouched')) {
+      prerequisiteFailed = true;
+    }
+    const result: UninstallActionResult = {
+      actionId: actionId(action),
+      artifactId: artifactId(action),
+      outcome,
+      ...(error ? { error } : {}),
+    };
+    results.push(result);
+    deps.onResult?.(result);
+  }
+  return { notes, results, prerequisiteFailed };
+}
+
+export function artifactId(action: RemovalAction): string {
+  return `artifact-${createHash('sha256').update(actionKey(action)).digest('hex').slice(0, 16)}`;
+}
+
+export function actionId(action: RemovalAction): string {
+  return `remove-${createHash('sha256').update(actionKey(action)).digest('hex').slice(0, 16)}`;
 }
 
 /**
  * Copy .env aside before deletion. Never clobbers an existing backup —
  * falls back to a timestamped name on collision. Returns the backup path.
  */
-export function backupEnv(envPath: string): string {
-  const dir = path.dirname(envPath);
-  let backup = path.join(dir, '.env.bak');
-  if (fs.existsSync(backup)) {
-    // Local time (system TZ) — the stamp is read by the human running the
-    // uninstall. sv-SE renders "YYYY-MM-DD HH:mm:ss".
-    const stamp = new Date()
-      .toLocaleString('sv-SE', { hour12: false })
-      .replace(/[-:]/g, '')
-      .replace(' ', '-')
-      .slice(0, 15);
-    backup = path.join(dir, `.env.bak.${stamp}`);
-  }
-  fs.copyFileSync(envPath, backup);
-  return backup;
+export function backupEnv(envPath: string, backupRoot: string, expectedIdentity?: string): string {
+  return backupEnvSecure(envPath, backupRoot, expectedIdentity);
 }
 
-function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void {
+/**
+ * Copy an approved .env without following a symlink. The production plan
+ * always supplies an external backupRoot. The root is explicit so no caller
+ * can accidentally advertise a checkout-local credential backup.
+ */
+function backupEnvSecure(envPath: string, backupRoot: string, expectedIdentity = pathIdentity(envPath)): string {
+  if (!expectedIdentity) throw new Error('credential backup source is unavailable');
+
+  const noFollow = (fs.constants as typeof fs.constants & { O_NOFOLLOW?: number }).O_NOFOLLOW;
+  if (noFollow === undefined) throw new Error('credential backup source could not be opened safely');
+  let sourceFd: number | undefined;
+  let contents: Buffer;
+  try {
+    sourceFd = fs.openSync(envPath, fs.constants.O_RDONLY | noFollow);
+    const stat = fs.fstatSync(sourceFd);
+    if (!stat.isFile()) throw new Error('credential backup source is not a regular file');
+    contents = fs.readFileSync(sourceFd);
+    const openedIdentity = `file:${stat.dev}:${stat.ino}:${createHash('sha256').update(contents).digest('hex')}`;
+    if (openedIdentity !== expectedIdentity) {
+      throw new IdentityRevalidationError({
+        outcome: 'untouched',
+        error: { code: 'identity_changed', message: 'The .env file changed before it could be backed up.' },
+      });
+    }
+  } catch (error) {
+    if (error instanceof IdentityRevalidationError) throw error;
+    throw new Error('credential backup source could not be opened safely');
+  } finally {
+    if (sourceFd !== undefined) fs.closeSync(sourceFd);
+  }
+
+  fs.mkdirSync(backupRoot, { recursive: true, mode: 0o700 });
+  const rootStat = fs.lstatSync(backupRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error('credential backup directory is not a private directory');
+  }
+  fs.chmodSync(backupRoot, 0o700);
+
+  const candidates = [
+    path.join(backupRoot, '.env.bak'),
+    ...Array.from({ length: 8 }, (_, index) => path.join(backupRoot, `.env.bak.${Date.now()}-${process.pid}-${index}`)),
+  ];
+  let backupPath: string | undefined;
+  let backupFd: number | undefined;
+  for (const candidate of candidates) {
+    try {
+      backupFd = fs.openSync(
+        candidate,
+        fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollow,
+        0o600,
+      );
+      backupPath = candidate;
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST')
+        throw new Error('credential backup could not be created safely');
+    }
+  }
+  if (!backupPath || backupFd === undefined) throw new Error('credential backup name is unavailable');
+  try {
+    fs.fchmodSync(backupFd, 0o600);
+    fs.writeFileSync(backupFd, contents);
+  } catch {
+    try {
+      fs.closeSync(backupFd);
+    } catch {
+      /* best effort cleanup */
+    }
+    try {
+      fs.unlinkSync(backupPath);
+    } catch {
+      /* preserve the original on cleanup failure */
+    }
+    throw new Error('credential backup could not be written safely');
+  }
+  fs.closeSync(backupFd);
+
+  // The source may have been replaced while the backup was being written.
+  // Leave both the replacement and the approved backup untouched in that case.
+  if (pathIdentity(envPath) !== expectedIdentity) {
+    throw new IdentityRevalidationError({
+      outcome: 'untouched',
+      error: { code: 'identity_changed', message: 'The .env file changed before it could be removed.' },
+    });
+  }
+  try {
+    fs.unlinkSync(envPath);
+  } catch {
+    throw new Error('credential source could not be removed after backup');
+  }
+  return backupPath;
+}
+
+function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): ActionOutcome {
   const { runCommand, log } = deps;
   switch (action.kind) {
     case 'unload-service':
       switch (action.flavor) {
         case 'launchd':
-          runCommand('launchctl', ['unload', action.unitPath]);
-          fs.rmSync(action.unitPath, { force: true });
+          {
+            const unloaded = runCommand('launchctl', ['unload', action.unitPath]);
+            const alreadyStopped = /could not find|not loaded|no such process/i.test(
+              `${unloaded.stdout}\n${unloaded.stderr ?? ''}`,
+            );
+            if (unloaded.status !== 0 && !alreadyStopped) {
+              throw new Error('launchctl unload failed');
+            }
+          }
+          removeApprovedServiceUnit(action, deps.runCommand);
           log('✓ background service removed');
-          break;
+          return 'removed';
         case 'systemd-user':
-          runCommand('systemctl', ['--user', 'disable', '--now', `${action.unitName}.service`]);
-          fs.rmSync(action.unitPath, { force: true });
-          runCommand('systemctl', ['--user', 'daemon-reload']);
+          requireSuccess(
+            runCommand('systemctl', ['--user', 'disable', '--now', `${action.unitName}.service`]),
+            'systemd user service stop failed',
+          );
+          removeApprovedServiceUnit(action, deps.runCommand);
+          requireSuccess(runCommand('systemctl', ['--user', 'daemon-reload']), 'systemd user daemon-reload failed');
           log('✓ background service removed');
-          break;
+          return 'removed';
         case 'systemd-system':
           if (!deps.isRoot) {
-            log('! system service needs root — left in place');
-            notes.push(`System service ${action.unitPath} — re-run with sudo to remove.`);
-            break;
+            log('! system service needs root; left in place');
+            notes.push(`System service ${action.unitPath}; re-run with sudo to remove.`);
+            throw new Error(`System service ${action.unitPath} needs root.`);
           }
-          runCommand('systemctl', ['disable', '--now', `${action.unitName}.service`]);
-          fs.rmSync(action.unitPath, { force: true });
-          runCommand('systemctl', ['daemon-reload']);
+          requireSuccess(
+            runCommand('systemctl', ['disable', '--now', `${action.unitName}.service`]),
+            'system service stop failed',
+          );
+          removeApprovedServiceUnit(action, deps.runCommand);
+          requireSuccess(runCommand('systemctl', ['daemon-reload']), 'system daemon-reload failed');
           log('✓ system service removed');
-          break;
+          return 'removed';
       }
-      break;
     case 'kill-pid': {
       let pid = NaN;
       try {
@@ -91,19 +274,41 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
         // pidfile already gone
       }
       if (Number.isInteger(pid) && pid > 0) {
-        try {
-          process.kill(pid);
-          log('✓ stopped host process');
-        } catch {
-          // not running
+        const current = processCommand(runCommand, pid);
+        if (!current.available) throw new Error('could not verify the host process');
+        if (current.command) {
+          if (!isNanoclawHostCommand(current.command, action.processPattern)) {
+            throw new Error('pidfile points to a process outside this checkout');
+          }
+          try {
+            (deps.killProcess ?? ((target) => process.kill(target)))(pid);
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+          }
+          waitForStopped(() => {
+            const state = processCommand(runCommand, pid);
+            if (!state.available) throw new Error('could not verify that the host stopped');
+            return !state.command;
+          }, deps);
         }
       }
-      break;
+      fs.rmSync(action.pidFile, { force: true });
+      log('✓ stopped host process');
+      return 'removed';
     }
-    case 'pkill-host':
-      // Exit 1 = no matching process — not a failure.
-      runCommand('pkill', ['-f', action.pattern]);
-      break;
+    case 'pkill-host': {
+      const matching = checkoutProcesses(runCommand, action.pattern);
+      if (matching.length === 0) return 'alreadyAbsent';
+      for (const pid of matching) {
+        try {
+          (deps.killProcess ?? ((target) => process.kill(target)))(pid);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+        }
+      }
+      waitForStopped(() => checkoutProcesses(runCommand, action.pattern).length === 0, deps);
+      return 'removed';
+    }
     case 'rm-containers': {
       // Re-list at removal time: the host was alive during the confirm
       // phase and may have spawned containers the scan never saw.
@@ -113,35 +318,37 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
           `Containers: '${action.runtime}' unavailable — remove later with: ` +
             `${action.runtime} ps -aq --filter label=${action.labelFilter} | xargs -r ${action.runtime} rm -f`,
         );
-        break;
+        throw new Error(`'${action.runtime}' unavailable while listing approved containers`);
       }
       const ids = ps.stdout
         .split('\n')
         .map((s) => s.trim())
         .filter(Boolean);
-      if (ids.length === 0) break;
-      runCommand(action.runtime, ['rm', '-f', ...ids]);
+      if (ids.length === 0) return 'alreadyAbsent';
+      requireSuccess(runCommand(action.runtime, ['rm', '-f', ...ids]), 'container removal failed');
       log(`✓ removed ${ids.length} container(s)`);
-      break;
+      return 'removed';
     }
     case 'rmi': {
       const res = runCommand(action.runtime, ['rmi', action.image]);
       if (res.status === 0) {
         log('✓ removed container image');
+        return 'removed';
       } else {
         log('! could not remove image (in use?)');
-        notes.push(`Image ${action.image}: not removed — retry with: ${action.runtime} rmi ${action.image}`);
+        notes.push(`Image ${action.image}: not removed; retry with: ${action.runtime} rmi ${action.image}`);
       }
-      break;
+      throw new Error(`container image ${action.image} was not removed`);
     }
     case 'rm-ncl-symlink':
       fs.rmSync(action.linkPath, { force: true });
       log('✓ removed ncl command');
-      break;
+      return 'removed';
     case 'delete-onecli-agent': {
       const res = runCommand('onecli', ['agents', 'delete', '--id', action.agent.uuid]);
       if (res.status === 0) {
         log(`✓ deleted OneCLI agent ${action.agent.name} (${action.agent.identifier})`);
+        return 'removed';
       } else if (res.status === null) {
         // spawn failure (binary gone since the scan), not a missing agent
         log(`! couldn't run onecli for ${action.agent.identifier}`);
@@ -149,23 +356,226 @@ function runAction(action: RemovalAction, deps: ExecDeps, notes: string[]): void
           `OneCLI agent ${action.agent.name} (${action.agent.identifier}): couldn't run onecli — ` +
             `delete manually with: onecli agents delete --id ${action.agent.uuid}`,
         );
-      } else {
-        log(`! OneCLI agent ${action.agent.identifier} already gone`);
+        throw new Error('onecli could not be started');
       }
-      break;
+      throw new Error(`OneCLI agent ${action.agent.identifier} was not deleted`);
     }
     case 'backup-env': {
+      let envStat: fs.Stats;
+      try {
+        envStat = fs.lstatSync(action.envPath);
+      } catch {
+        return 'alreadyAbsent';
+      }
+      if (!envStat.isFile()) {
+        throw new IdentityRevalidationError({
+          outcome: 'untouched',
+          error: { code: 'identity_changed', message: 'The .env path is no longer a regular file.' },
+        });
+      }
       // Backup and removal are one action so a failed backup (which throws
       // into executePlan's catch) can never be followed by the deletion.
-      const backup = backupEnv(action.envPath);
-      fs.rmSync(action.envPath, { force: true });
+      if (!action.backupRoot) throw new Error('credential backup destination is unavailable');
+      const backup = backupEnvSecure(action.envPath, action.backupRoot, action.expectedIdentity);
       log(`✓ removed .env (backup at ${backup})`);
-      break;
+      return 'removed';
     }
     case 'delete-path':
     case 'delete-runtime-path':
+      if (!fs.existsSync(action.item.path)) return 'alreadyAbsent';
       fs.rmSync(action.item.path, { recursive: true, force: true });
       log(`✓ removed ${action.item.what}`);
-      break;
+      return 'removed';
   }
+}
+
+function actionKey(action: RemovalAction): string {
+  switch (action.kind) {
+    case 'unload-service':
+      return `${action.kind}:${action.unitPath}`;
+    case 'kill-pid':
+      return `${action.kind}:${action.pidFile}:${action.processPattern}`;
+    case 'pkill-host':
+      return `${action.kind}:${action.pattern}`;
+    case 'rm-containers':
+      return `${action.kind}:${action.runtime}:${action.labelFilter}`;
+    case 'rmi':
+      return `${action.kind}:${action.runtime}:${action.image}`;
+    case 'rm-ncl-symlink':
+      return `${action.kind}:${action.linkPath}`;
+    case 'delete-onecli-agent':
+      return `${action.kind}:${action.agent.uuid}`;
+    case 'backup-env':
+      return `${action.kind}:${action.envPath}`;
+    case 'delete-path':
+    case 'delete-runtime-path':
+      return `${action.kind}:${action.item.path}`;
+  }
+}
+
+function stopsService(action: RemovalAction): boolean {
+  return (
+    action.kind === 'unload-service' ||
+    action.kind === 'kill-pid' ||
+    action.kind === 'pkill-host' ||
+    action.kind === 'rm-containers'
+  );
+}
+
+function dependsOnStoppedService(action: RemovalAction): boolean {
+  return ['rm-containers', 'rmi', 'backup-env', 'delete-onecli-agent', 'delete-path', 'delete-runtime-path'].includes(
+    action.kind,
+  );
+}
+
+function verifyExactIdentity(action: RemovalAction, runCommand: RunCommand): IdentityResult | undefined {
+  if (!('identityRequired' in action) || action.identityRequired !== true) return undefined;
+  const expected = action.expectedIdentity;
+  if (!expected) {
+    return {
+      outcome: 'untouched',
+      error: { code: 'identity_uninspectable', message: 'The exact target identity could not be proven.' },
+    };
+  }
+  if (action.kind === 'rmi') {
+    const current = runCommand(action.runtime, ['image', 'inspect', action.image]);
+    if (current.status === 1) return { outcome: 'alreadyAbsent' };
+    if (current.status !== 0) {
+      return {
+        outcome: 'failed',
+        error: { code: 'identity_check_failed', message: 'The container image identity could not be checked.' },
+      };
+    }
+    if (current.stdout.trim() !== expected) {
+      return {
+        outcome: 'untouched',
+        error: { code: 'identity_changed', message: 'The container image changed after approval.' },
+      };
+    }
+    return undefined;
+  }
+  if (action.kind === 'delete-onecli-agent') {
+    const current = listVaultAgents(runCommand);
+    if (!current.available) {
+      return {
+        outcome: 'failed',
+        error: { code: 'identity_check_failed', message: 'The OneCLI agent list could not be checked.' },
+      };
+    }
+    const agent = current.agents.find((candidate) => candidate.uuid === action.agent.uuid);
+    if (!agent) return { outcome: 'alreadyAbsent' };
+    if (JSON.stringify(agent) !== expected) {
+      return {
+        outcome: 'untouched',
+        error: { code: 'identity_changed', message: 'The OneCLI agent changed after approval.' },
+      };
+    }
+    return undefined;
+  }
+  const target =
+    action.kind === 'unload-service'
+      ? action.unitPath
+      : action.kind === 'kill-pid'
+        ? action.pidFile
+        : action.kind === 'backup-env'
+          ? action.envPath
+          : action.kind === 'delete-path' || action.kind === 'delete-runtime-path'
+            ? action.item.path
+            : action.linkPath;
+  const current = pathIdentity(target);
+  if (!current) {
+    if (missingExactPath(target)) return { outcome: 'alreadyAbsent' };
+    return {
+      outcome: 'failed',
+      error: { code: 'identity_check_failed', message: 'The exact filesystem target could not be checked.' },
+    };
+  }
+  if (current !== expected) {
+    return {
+      outcome: 'untouched',
+      error: { code: 'identity_changed', message: 'The exact filesystem target changed after approval.' },
+    };
+  }
+  if (action.kind === 'kill-pid') {
+    const pid = Number(fs.readFileSync(action.pidFile, 'utf8').trim());
+    if (Number.isInteger(pid) && pid > 0) {
+      const process = processCommand(runCommand, pid);
+      if (!process.available) {
+        return {
+          outcome: 'failed',
+          error: { code: 'identity_check_failed', message: 'The host process identity could not be checked.' },
+        };
+      }
+      if (process.command && !isNanoclawHostCommand(process.command, action.processPattern)) {
+        return {
+          outcome: 'untouched',
+          error: { code: 'identity_changed', message: 'The pidfile now points outside this checkout.' },
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+function removeApprovedServiceUnit(
+  action: Extract<RemovalAction, { kind: 'unload-service' }>,
+  runCommand: RunCommand,
+): void {
+  const identity = verifyExactIdentity(action, runCommand);
+  if (identity?.outcome === 'alreadyAbsent') return;
+  if (identity) throw new IdentityRevalidationError(identity);
+  fs.rmSync(action.unitPath, { force: true });
+}
+
+function verifyScopedRoot(
+  action: RemovalAction,
+): { outcome: 'untouched' | 'alreadyAbsent'; error?: { code: string; message: string } } | undefined {
+  if ((action.kind !== 'delete-path' && action.kind !== 'delete-runtime-path') || !action.expectedRootIdentity) {
+    return undefined;
+  }
+  const current = pathIdentity(action.item.path);
+  if (!current) {
+    if (missingExactPath(action.item.path)) return { outcome: 'alreadyAbsent' };
+    return {
+      outcome: 'untouched',
+      error: { code: 'identity_check_failed', message: 'The checkout-owned root could not be checked.' },
+    };
+  }
+  if (current !== action.expectedRootIdentity) {
+    return {
+      outcome: 'untouched',
+      error: { code: 'ownership_root_changed', message: 'The approved checkout-owned root changed before removal.' },
+    };
+  }
+  return undefined;
+}
+
+function processCommand(runCommand: RunCommand, pid: number): { available: boolean; command?: string } {
+  const result = runCommand('ps', ['-p', String(pid), '-o', 'command=']);
+  if (result.status === 0) return { available: true, command: result.stdout.trim() || undefined };
+  if (result.status === 1) return { available: true };
+  return { available: false };
+}
+
+function checkoutProcesses(runCommand: RunCommand, pattern: string): number[] {
+  const pids = checkoutHostProcesses(runCommand, pattern);
+  if (!pids) throw new Error('could not list host processes');
+  return pids;
+}
+
+function waitForStopped(check: () => boolean, deps: ExecDeps): void {
+  const timeout = deps.processStopTimeoutMs ?? 5_000;
+  const deadline = Date.now() + timeout;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('host process did not stop before the timeout');
+    (deps.sleep ?? sleepSync)(50);
+  }
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function requireSuccess(result: { status: number | null }, message: string): void {
+  if (result.status !== 0) throw new Error(message);
 }

--- a/setup/uninstall/scan.test.ts
+++ b/setup/uninstall/scan.test.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 
 import { getInstallSlug, getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
 import type { RunCommand } from './onecli-agents.js';
-import { detectExistingInstall, scanInstall, type ScanDeps } from './scan.js';
+import { credentialBackupRoot, detectExistingInstall, pathIdentity, scanInstall, type ScanDeps } from './scan.js';
 
 let root: string;
 let home: string;
@@ -32,13 +32,18 @@ function deps(overrides: Partial<ScanDeps> = {}): ScanDeps {
     projectRoot: root,
     home,
     platform: 'darwin',
-    runCommand: fakeRun({}),
+    runCommand: fakeRun({
+      ps: () => ({ status: 0, stdout: '' }),
+      onecli: () => ({ status: 0, stdout: '{"data":[]}' }),
+    }),
     ...overrides,
   };
 }
 
 const dockerUp = (containerIds: string[], hasImage: boolean) =>
   fakeRun({
+    ps: () => ({ status: 0, stdout: '' }),
+    onecli: () => ({ status: 0, stdout: '{"data":[]}' }),
     docker: (args) => {
       if (args[0] === 'ps') return { status: 0, stdout: containerIds.join('\n') + '\n' };
       if (args[0] === 'image') return { status: hasImage ? 0 : 1, stdout: '' };
@@ -47,6 +52,20 @@ const dockerUp = (containerIds: string[], hasImage: boolean) =>
   });
 
 describe('scanInstall path groups', () => {
+  it('uses the Linux state directory for credential backups', () => {
+    const previous = process.env.XDG_STATE_HOME;
+    const stateHome = path.join(home, 'state');
+    process.env.XDG_STATE_HOME = stateHome;
+    try {
+      expect(credentialBackupRoot(home, 'linux', 'install-slug')).toBe(
+        path.join(stateHome, 'nanoclaw', 'uninstall-backups', 'install-slug'),
+      );
+    } finally {
+      if (previous === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = previous;
+    }
+  });
+
   it('puts dist and node_modules in runtime, not data', () => {
     for (const dir of ['data', 'logs', 'dist', 'node_modules', 'groups', 'store']) {
       fs.mkdirSync(path.join(root, dir));
@@ -71,6 +90,27 @@ describe('scanInstall path groups', () => {
     expect(inv.user.map((i) => path.basename(i.path))).toEqual(['groups', 'store']);
   });
 
+  it('reports credential backups separately so receipts preserve them', () => {
+    const backupRoot = credentialBackupRoot(home, 'darwin', getInstallSlug(root));
+    fs.mkdirSync(backupRoot, { recursive: true });
+    fs.writeFileSync(path.join(backupRoot, '.env.bak'), 'KEY=old');
+    fs.writeFileSync(path.join(backupRoot, '.env.bak.20260101-120000'), 'KEY=older');
+
+    const inv = scanInstall(deps());
+
+    expect(inv.envBackups.map((item) => path.basename(item.path))).toEqual(['.env.bak', '.env.bak.20260101-120000']);
+    expect(inv.data).toEqual([]);
+  });
+
+  it('reports legacy in-checkout backups separately as unsafe residue', () => {
+    fs.writeFileSync(path.join(root, '.env.bak'), 'KEY=old');
+
+    const inv = scanInstall(deps());
+
+    expect(inv.envBackups).toEqual([]);
+    expect(inv.legacyEnvBackups?.map((item) => path.basename(item.path))).toEqual(['.env.bak']);
+  });
+
   it('finds nothing in an empty checkout', () => {
     const inv = scanInstall(deps());
     expect(inv.data).toEqual([]);
@@ -78,6 +118,17 @@ describe('scanInstall path groups', () => {
     expect(inv.user).toEqual([]);
     expect(inv.service.containerIds).toEqual([]);
     expect(inv.service.image).toBeUndefined();
+  });
+
+  it('inventories a dangling .env symlink without following it', () => {
+    const env = path.join(root, '.env');
+    fs.symlinkSync(path.join(root, 'missing-secret'), env);
+
+    const inv = scanInstall(deps());
+
+    expect(inv.data.map((item) => path.basename(item.path))).toContain('.env');
+    expect(inv.identity?.exactPaths[env]).toBe(pathIdentity(env));
+    expect(inv.identity?.exactPaths[env]).toMatch(/^symlink:/);
   });
 });
 
@@ -111,11 +162,50 @@ describe('scanInstall service artifacts', () => {
     expect(inv.notes).toEqual([]);
   });
 
+  it('inventories only an exact checkout host argv shape', () => {
+    const script = path.join(root, 'dist', 'index.js');
+    const inv = scanInstall(
+      deps({
+        runCommand: fakeRun({
+          ps: () => ({
+            status: 0,
+            stdout: `41 /usr/bin/node ${script}\n42 /usr/bin/vim ${script}\n43 node ${script} --extra\n`,
+          }),
+        }),
+      }),
+    );
+
+    expect(inv.service.hostProcessIds).toEqual([41]);
+  });
+
   it('degrades with a manual-cleanup note when docker is unavailable', () => {
     const inv = scanInstall(deps());
     expect(inv.service.containerIds).toEqual([]);
     expect(inv.service.image).toBeUndefined();
+    expect(inv.service.containerRuntimeAvailable).toBe(false);
     expect(inv.notes.some((n) => n.includes("'docker' unavailable"))).toBe(true);
+  });
+});
+
+describe('scanInstall ownership identity', () => {
+  it('snapshots the checkout, exact files, scoped roots, and container selector', () => {
+    const data = path.join(root, 'data');
+    const pid = path.join(root, 'nanoclaw.pid');
+    const env = path.join(root, '.env');
+    const start = path.join(root, 'start-nanoclaw.sh');
+    fs.mkdirSync(data);
+    fs.writeFileSync(pid, '123');
+    fs.writeFileSync(env, 'TOKEN=secret');
+    fs.writeFileSync(start, '#!/bin/sh');
+
+    const inv = scanInstall(deps({ platform: 'linux' }));
+
+    expect(inv.identity?.root).toBeTruthy();
+    expect(inv.identity?.exactPaths[pid]).toContain('file:');
+    expect(inv.identity?.exactPaths[env]).toContain('file:');
+    expect(inv.identity?.exactPaths[start]).toContain('file:');
+    expect(inv.identity?.scopedRoots[data]).toContain('node:');
+    expect(inv.identity?.containerSelector).toBe(`nanoclaw-install=${inv.slug}`);
   });
 });
 
@@ -147,7 +237,10 @@ describe('scanInstall OneCLI agents', () => {
       { id: 'u-2', identifier: 'ag-other', name: 'Other', isDefault: false },
     ],
   });
-  const onecliUp = fakeRun({ onecli: () => ({ status: 0, stdout: vault }) });
+  const onecliUp = fakeRun({
+    ps: () => ({ status: 0, stdout: '' }),
+    onecli: () => ({ status: 0, stdout: vault }),
+  });
 
   it('splits mine vs orphans against the central DB', () => {
     fs.mkdirSync(path.join(root, 'data'));
@@ -168,6 +261,16 @@ describe('scanInstall OneCLI agents', () => {
     expect(inv.onecli.mine).toEqual([]);
     expect(inv.onecli.orphans.map((a) => a.identifier)).toEqual(['ag-mine', 'ag-other']);
     expect(inv.notes.some((n) => n.includes("Couldn't read agent_groups"))).toBe(true);
+  });
+
+  it('reports an uninspectable artifact when OneCLI cannot be inventoried', () => {
+    const inv = scanInstall(
+      deps({
+        runCommand: fakeRun({ ps: () => ({ status: 0, stdout: '' }) }),
+      }),
+    );
+    expect(inv.onecli.available).toBe(false);
+    expect(inv.notes.some((n) => n.includes("Couldn't inspect OneCLI agents"))).toBe(true);
   });
 });
 

--- a/setup/uninstall/scan.ts
+++ b/setup/uninstall/scan.ts
@@ -15,6 +15,7 @@
  * Deliberately does NOT import src/config.ts (import-time side effects).
  */
 import fs from 'fs';
+import { createHash } from 'node:crypto';
 import os from 'os';
 import path from 'path';
 
@@ -41,14 +42,27 @@ export interface ServiceInventory {
   systemdUserUnit?: string;
   systemdSystemUnit?: string;
   pidFile?: string;
+  /** Exact checkout-owned host processes, or undefined when `ps` was unavailable. */
+  hostProcessIds?: number[];
+  containerRuntimeAvailable?: boolean;
   containerIds: string[];
   image?: string;
   nclSymlink?: string;
+  imageIdentity?: string;
+}
+
+export interface InventoryIdentity {
+  root: string;
+  exactPaths: Record<string, string>;
+  scopedRoots: Record<string, string>;
+  containerSelector: string;
 }
 
 export interface OnecliInventory {
   mine: VaultAgent[];
   orphans: VaultAgent[];
+  /** False when the OneCLI inventory could not be inspected at all. */
+  available: boolean;
   /** False when agent_groups couldn't be read — orphan labels are then unreliable. */
   idsKnown: boolean;
 }
@@ -67,8 +81,15 @@ export interface Inventory {
   runtime: PathItem[];
   /** Group 3: groups/ and store/ — user content, unrecoverable. */
   user: PathItem[];
+  /** Credential backups created by earlier/current uninstalls; never removed here. */
+  envBackups: PathItem[];
+  /** Legacy backups left inside the checkout; these block safe checkout removal. */
+  legacyEnvBackups?: PathItem[];
+  /** Secure external backup directory used by the removal plan. */
+  credentialBackupRoot?: string;
   onecli: OnecliInventory;
   notes: string[];
+  identity?: InventoryIdentity;
 }
 
 export interface ScanDeps {
@@ -78,24 +99,36 @@ export interface ScanDeps {
   runCommand: RunCommand;
 }
 
+/**
+ * Credential backups live outside the checkout so deleting the checkout cannot
+ * delete the only copy of the user's credentials.
+ */
+export function credentialBackupRoot(home: string, platform: NodeJS.Platform, slug: string): string {
+  const root =
+    platform === 'darwin'
+      ? path.join(home, 'Library', 'Application Support', 'NanoClaw', 'uninstall-backups')
+      : path.join(process.env.XDG_STATE_HOME || path.join(home, '.local', 'state'), 'nanoclaw', 'uninstall-backups');
+  return path.join(root, slug);
+}
+
 export function tilde(p: string, home: string): string {
   return p.startsWith(home) ? `~${p.slice(home.length)}` : p;
 }
 
 export function scanInstall(deps: ScanDeps): Inventory {
-  const { projectRoot, home, runCommand } = deps;
+  const { projectRoot, home, platform, runCommand } = deps;
   const slug = getInstallSlug(projectRoot);
   const containerRuntime = process.env.CONTAINER_RUNTIME ?? 'docker';
   const notes: string[] = [];
 
   const service = scanService(deps, slug, containerRuntime, notes);
+  const backupRoot = credentialBackupRoot(home, platform, slug);
 
   const data = existingItems(projectRoot, home, [
     { rel: 'data', what: 'Database & conversations' },
     { rel: 'logs', what: 'Logs' },
     { rel: '.env', what: 'Secrets / API keys (.env)', where: 'backed up before removal' },
     { rel: 'start-nanoclaw.sh', what: 'Start script', where: 'start-nanoclaw.sh' },
-    { rel: 'nanoclaw.pid', what: 'PID file', where: 'nanoclaw.pid' },
   ]);
   const updates = path.join(path.dirname(projectRoot), '.nanoclaw-updates', slug);
   if (fs.existsSync(updates)) {
@@ -115,6 +148,15 @@ export function scanInstall(deps: ScanDeps): Inventory {
     { rel: 'groups', what: 'Agent memory & files' },
     { rel: 'store', what: 'Migrated data store' },
   ]);
+  const envBackups = existingEnvBackups(backupRoot, home);
+  const legacyEnvBackups = existingEnvBackups(projectRoot, home).filter(
+    (item) => path.dirname(item.path) === projectRoot,
+  );
+  if (legacyEnvBackups.length > 0) {
+    notes.push(
+      `Legacy credential backup(s) remain inside the checkout: ${legacyEnvBackups.map((item) => item.path).join(', ')}.`,
+    );
+  }
 
   const onecli = scanOnecli(projectRoot, runCommand, notes);
 
@@ -126,9 +168,90 @@ export function scanInstall(deps: ScanDeps): Inventory {
     data,
     runtime,
     user,
+    envBackups,
+    legacyEnvBackups,
+    credentialBackupRoot: backupRoot,
     onecli,
     notes,
+    identity: {
+      root: pathIdentity(projectRoot) ?? '',
+      exactPaths: Object.fromEntries(
+        [
+          service.launchdPlist,
+          service.systemdUserUnit,
+          service.systemdSystemUnit,
+          service.pidFile,
+          service.nclSymlink,
+          ...[...data, ...runtime, ...user].map((item) => item.path),
+        ]
+          .filter((value): value is string => Boolean(value))
+          .map((value) => [value, pathIdentity(value) ?? '']),
+      ),
+      scopedRoots: Object.fromEntries(
+        [...data, ...runtime, ...user]
+          .filter((item) => {
+            try {
+              return fs.lstatSync(item.path).isDirectory();
+            } catch {
+              return false;
+            }
+          })
+          .map((item) => [item.path, pathIdentity(item.path) ?? '']),
+      ),
+      containerSelector: `nanoclaw-install=${slug}`,
+    },
   };
+}
+
+function existingEnvBackups(projectRoot: string, home: string): PathItem[] {
+  let names: string[] = [];
+  try {
+    names = fs.readdirSync(projectRoot).filter((name) => /^\.env\.bak(?:\.|$)/.test(name));
+  } catch {
+    return [];
+  }
+  return names.sort().map((name) => {
+    const backupPath = path.join(projectRoot, name);
+    return {
+      what: 'Credential backup',
+      where: tilde(backupPath, home),
+      path: backupPath,
+    };
+  });
+}
+
+/** Identity for exact filesystem artifacts; directories are ownership roots. */
+export function pathIdentity(target: string): string | undefined {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch {
+    return undefined;
+  }
+
+  if (stat.isSymbolicLink()) {
+    try {
+      return `symlink:${fs.readlinkSync(target)}`;
+    } catch {
+      return undefined;
+    }
+  }
+  if (!stat.isFile()) return `node:${stat.dev}:${stat.ino}:${stat.mode}`;
+
+  const noFollow = (fs.constants as typeof fs.constants & { O_NOFOLLOW?: number }).O_NOFOLLOW;
+  if (noFollow === undefined) return undefined;
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(target, fs.constants.O_RDONLY | noFollow);
+    const opened = fs.fstatSync(fd);
+    if (!opened.isFile() || opened.dev !== stat.dev || opened.ino !== stat.ino) return undefined;
+    const digest = createHash('sha256').update(fs.readFileSync(fd)).digest('hex');
+    return `file:${opened.dev}:${opened.ino}:${digest}`;
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
 }
 
 /**
@@ -155,17 +278,24 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
   const { projectRoot, home, platform, runCommand } = deps;
   const service: ServiceInventory = { containerIds: [] };
 
+  service.hostProcessIds = checkoutHostProcesses(runCommand, path.join(projectRoot, 'dist', 'index.js'));
+  if (!service.hostProcessIds) {
+    notes.push(
+      'Host processes: could not inspect the process list; no process will be signalled without a fresh exact match.',
+    );
+  }
+
   if (platform === 'darwin') {
     const plist = path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(projectRoot)}.plist`);
-    if (fs.existsSync(plist)) service.launchdPlist = plist;
+    if (knownPath(plist)) service.launchdPlist = plist;
   } else if (platform === 'linux') {
     const unit = getSystemdUnit(projectRoot);
     const userUnit = path.join(home, '.config', 'systemd', 'user', `${unit}.service`);
     const systemUnit = `/etc/systemd/system/${unit}.service`;
-    if (fs.existsSync(userUnit)) service.systemdUserUnit = userUnit;
-    if (fs.existsSync(systemUnit)) service.systemdSystemUnit = systemUnit;
+    if (knownPath(userUnit)) service.systemdUserUnit = userUnit;
+    if (knownPath(systemUnit)) service.systemdSystemUnit = systemUnit;
     const pidFile = path.join(projectRoot, 'nanoclaw.pid');
-    if (fs.existsSync(pidFile)) service.pidFile = pidFile;
+    if (knownPath(pidFile)) service.pidFile = pidFile;
   }
 
   // Container label matches what container-runner.ts stamps at spawn time.
@@ -188,7 +318,10 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
   if (runtimeOk) {
     try {
       const inspect = runCommand(containerRuntime, ['image', 'inspect', image]);
-      if (inspect.status === 0) service.image = image;
+      if (inspect.status === 0) {
+        service.image = image;
+        service.imageIdentity = inspect.stdout.trim() || undefined;
+      }
     } catch {
       runtimeOk = false;
     }
@@ -200,6 +333,7 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
         `${containerRuntime} rmi ${image}`,
     );
   }
+  service.containerRuntimeAvailable = runtimeOk;
 
   const link = path.join(home, '.local', 'bin', 'ncl');
   let linkStat: fs.Stats | null = null;
@@ -223,10 +357,37 @@ function scanService(deps: ScanDeps, slug: string, containerRuntime: string, not
   return service;
 }
 
+/** Exact host argv shape used both by inventory and immediately before signalling. */
+export function isNanoclawHostCommand(command: string, scriptPath: string): boolean {
+  const suffix = ` ${scriptPath}`;
+  if (!command.endsWith(suffix)) return false;
+  const executable = command.slice(0, -suffix.length);
+  return !/\s/.test(executable) && ['node', 'nodejs'].includes(path.basename(executable));
+}
+
+export function checkoutHostProcesses(runCommand: RunCommand, scriptPath: string): number[] | undefined {
+  const result = runCommand('ps', ['-axo', 'pid=,command=']);
+  if (result.status !== 0) return undefined;
+  const pids: number[] = [];
+  for (const line of result.stdout.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    if (!match || !isNanoclawHostCommand(match[2], scriptPath)) continue;
+    const pid = Number(match[1]);
+    if (Number.isInteger(pid) && pid > 0) pids.push(pid);
+  }
+  return pids;
+}
+
 function scanOnecli(projectRoot: string, runCommand: RunCommand, notes: string[]): OnecliInventory {
   const vault = listVaultAgents(runCommand);
-  if (!vault.available || vault.agents.length === 0) {
-    return { mine: [], orphans: [], idsKnown: false };
+  if (!vault.available) {
+    notes.push(
+      "Couldn't inspect OneCLI agents; agents registered by this copy may remain. Restore OneCLI and rerun uninstall before deleting the checkout.",
+    );
+    return { mine: [], orphans: [], available: false, idsKnown: false };
+  }
+  if (vault.agents.length === 0) {
+    return { mine: [], orphans: [], available: true, idsKnown: false };
   }
 
   const { ids, known } = readAgentGroupIds(path.join(projectRoot, 'data', 'v2.db'));
@@ -236,7 +397,7 @@ function scanOnecli(projectRoot: string, runCommand: RunCommand, notes: string[]
       "Couldn't read agent_groups from data/v2.db; OneCLI agents shown as 'orphan' may actually belong to this copy.",
     );
   }
-  return { mine, orphans, idsKnown: known };
+  return { mine, orphans, available: true, idsKnown: known };
 }
 
 function existingItems(
@@ -247,7 +408,7 @@ function existingItems(
   const items: PathItem[] = [];
   for (const spec of specs) {
     const p = path.join(projectRoot, spec.rel);
-    if (!fs.existsSync(p)) continue;
+    if (!knownPath(p)) continue;
     items.push({
       what: spec.what,
       where: spec.where ?? `${tilde(p, home)}/`,
@@ -255,4 +416,14 @@ function existingItems(
     });
   }
   return items;
+}
+
+/** Treat only a confirmed ENOENT as absence; permission and type errors are known residue. */
+function knownPath(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT';
+  }
 }

--- a/setup/verify.test.ts
+++ b/setup/verify.test.ts
@@ -6,6 +6,9 @@ const healthyBase = {
   service: 'running' as const,
   credentials: 'configured',
   registeredGroups: 1,
+  healthStatus: 'healthy' as const,
+  healthCheckoutMatches: true,
+  healthProcessMatches: true,
 };
 
 describe('determineVerifyStatus', () => {
@@ -13,13 +16,13 @@ describe('determineVerifyStatus', () => {
     expect(determineVerifyStatus(healthyBase)).toBe('success');
   });
 
-  it('fails when no agent groups are registered', () => {
+  it('accepts an explicit empty agent-group state', () => {
     expect(
       determineVerifyStatus({
         ...healthyBase,
         registeredGroups: 0,
       }),
-    ).toBe('failed');
+    ).toBe('success');
   });
 
   // Deferred wire (Teams): configured but zero groups is pending operator
@@ -69,5 +72,31 @@ describe('determineVerifyStatus', () => {
         credentials: 'missing',
       }),
     ).toBe('failed');
+  });
+
+  it('fails when structured health is unavailable or from another checkout', () => {
+    expect(determineVerifyStatus({ ...healthyBase, healthStatus: 'unhealthy', healthCheckoutMatches: false })).toBe(
+      'failed',
+    );
+    expect(determineVerifyStatus({ ...healthyBase, healthStatus: 'healthy', healthCheckoutMatches: false })).toBe(
+      'failed',
+    );
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        healthStatus: 'healthy',
+        healthCheckoutMatches: true,
+        healthProcessMatches: true,
+      }),
+    ).toBe('success');
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        healthStatus: 'healthy',
+        healthCheckoutMatches: true,
+        healthProcessMatches: false,
+      }),
+    ).toBe('failed');
+    expect(determineVerifyStatus({ ...healthyBase, healthStatus: undefined as never })).toBe('failed');
   });
 });

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -11,10 +11,10 @@ import path from 'path';
 
 import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
-import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { inspectCentralDb } from './central-db-inspection.js';
 import { inspectAgentImage, readImageSource } from './lib/registry-state.js';
-import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
+import { inspectService, queryHostHealth } from './lib/service-health.js';
+import { getPlatform } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -32,81 +32,16 @@ export async function run(_args: string[]): Promise<void> {
   // developers with multiple clones), nothing in this checkout is actually
   // wired up. Surface the mismatch directly so the user knows to point the
   // service at the right folder.
-  let service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' = 'not_found';
-  let runningFromPath: string | null = null;
-  const mgr = getServiceManager();
-
-  const launchdLabel = getLaunchdLabel(projectRoot);
-  const systemdUnit = getSystemdUnit(projectRoot);
-
-  if (mgr === 'launchd') {
-    try {
-      const output = execSync('launchctl list', { encoding: 'utf-8' });
-      const line = output.split('\n').find((l) => l.includes(launchdLabel));
-      if (line) {
-        const pidField = line.trim().split(/\s+/)[0];
-        if (pidField !== '-' && pidField) {
-          service = 'running';
-          const pid = Number(pidField);
-          if (Number.isInteger(pid) && pid > 0) {
-            runningFromPath = resolveBinaryScript(pid);
-          }
-        } else {
-          service = 'stopped';
-        }
-      }
-    } catch {
-      // launchctl not available
-    }
-  } else if (mgr === 'systemd') {
-    const prefix = isRoot() ? 'systemctl' : 'systemctl --user';
-    try {
-      execSync(`${prefix} is-active ${systemdUnit}`, { stdio: 'ignore' });
-      service = 'running';
-      try {
-        const pidStr = execSync(`${prefix} show ${systemdUnit} -p MainPID --value`, { encoding: 'utf-8' }).trim();
-        const pid = Number(pidStr);
-        if (Number.isInteger(pid) && pid > 0) {
-          runningFromPath = resolveBinaryScript(pid);
-        }
-      } catch {
-        // couldn't read MainPID; leave runningFromPath null
-      }
-    } catch {
-      try {
-        const output = execSync(`${prefix} list-unit-files`, {
-          encoding: 'utf-8',
-        });
-        if (output.includes(systemdUnit)) {
-          service = 'stopped';
-        }
-      } catch {
-        // systemctl not available
-      }
-    }
-  } else {
-    // Check for nohup PID file
-    const pidFile = path.join(projectRoot, 'nanoclaw.pid');
-    if (fs.existsSync(pidFile)) {
-      try {
-        const raw = fs.readFileSync(pidFile, 'utf-8').trim();
-        const pid = Number(raw);
-        if (raw && Number.isInteger(pid) && pid > 0) {
-          process.kill(pid, 0);
-          service = 'running';
-          runningFromPath = resolveBinaryScript(pid);
-        }
-      } catch {
-        service = 'stopped';
-      }
-    }
-  }
-
-  if (service === 'running' && runningFromPath && !isPathInside(runningFromPath, projectRoot)) {
-    service = 'running_other_checkout';
-  }
-
-  log.info('Service status', { service, runningFromPath });
+  const serviceCheck = inspectService(projectRoot);
+  const service = serviceCheck.state;
+  const health = await queryHostHealth(projectRoot);
+  log.info('Service status', {
+    service,
+    manager: serviceCheck.manager,
+    pid: serviceCheck.pid,
+    checkoutRoot: serviceCheck.checkoutRoot,
+    health: health?.status,
+  });
 
   // 2. Check container runtime
   let containerRuntime = 'none';
@@ -222,6 +157,9 @@ export async function run(_args: string[]): Promise<void> {
     credentials,
     registeredGroups,
     wiringPending,
+    healthStatus: health?.status,
+    healthCheckoutMatches: health?.checkoutRoot === projectRoot && health?.process.cwd === projectRoot,
+    healthProcessMatches: health?.process.pid === serviceCheck.pid,
   });
 
   log.info('Verification complete', {
@@ -241,6 +179,11 @@ export async function run(_args: string[]): Promise<void> {
   // (setup/auto.ts) at installs that are working exactly as designed.
   emitStatus('VERIFY', {
     SERVICE: service,
+    SERVICE_MANAGER: serviceCheck.manager,
+    SERVICE_CHECKOUT_ROOT: serviceCheck.checkoutRoot ?? '',
+    SERVICE_PID: serviceCheck.pid ?? '',
+    HEALTH_STATUS: health?.status ?? 'unavailable',
+    HEALTH_CHECKOUT_ROOT: health?.checkoutRoot ?? '',
     CONTAINER_RUNTIME: containerRuntime,
     CREDENTIALS: credentials,
     CONFIGURED_CHANNELS: configuredChannels.join(','),
@@ -271,41 +214,15 @@ export async function run(_args: string[]): Promise<void> {
 export const DEFER_WIRE_CHANNELS = new Set(['teams']);
 
 export function determineVerifyStatus(input: {
-  service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout';
+  service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' | 'identity_unknown';
   credentials: string;
   registeredGroups: number;
   /** Zero groups but every configured channel defers wiring to the first DM. */
   wiringPending?: boolean;
+  healthStatus: 'healthy' | 'unhealthy';
+  healthCheckoutMatches: boolean;
+  healthProcessMatches: boolean;
 }): 'success' | 'failed' {
-  return input.service === 'running' &&
-    input.credentials !== 'missing' &&
-    (input.registeredGroups > 0 || input.wiringPending === true)
-    ? 'success'
-    : 'failed';
-}
-
-/**
- * Given a PID, resolve the script path the process is executing (i.e. the
- * first `.js` / `.ts` / `.mjs` arg after `node`). Returns null on any
- * error — callers should treat null as "couldn't tell" and skip the
- * mismatch check rather than flag a false positive.
- */
-function resolveBinaryScript(pid: number): string | null {
-  try {
-    // BSD ps (macOS) and util-linux both honour `-o command=` (full argv,
-    // no header). Node argv: "node /path/to/dist/index.js ...".
-    const out = execSync(`ps -p ${pid} -o command=`, {
-      encoding: 'utf-8',
-    }).trim();
-    const tokens = out.split(/\s+/);
-    const script = tokens.find((t) => /\.(js|mjs|cjs|ts)$/.test(t));
-    return script ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function isPathInside(candidate: string, parent: string): boolean {
-  const rel = path.relative(parent, candidate);
-  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+  const healthOkay = input.healthStatus === 'healthy' && input.healthCheckoutMatches && input.healthProcessMatches;
+  return input.service === 'running' && input.credentials !== 'missing' && healthOkay ? 'success' : 'failed';
 }

--- a/src/cli/commands/health.test.ts
+++ b/src/cli/commands/health.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { dispatch } from '../dispatch.js';
+import './health.js';
+
+describe('ncl health command', () => {
+  it('is host-only and returns the structured resource model', async () => {
+    const response = await dispatch({ id: 'health-test', command: 'health', args: {} }, { caller: 'host' });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const data = response.data as { resources?: { groups?: unknown; policies?: unknown; skills?: unknown } };
+    expect(data.resources?.groups).toBeDefined();
+    expect(data.resources?.policies).toBeDefined();
+    expect(data.resources?.skills).toBeDefined();
+  });
+});

--- a/src/cli/commands/health.ts
+++ b/src/cli/commands/health.ts
@@ -1,0 +1,14 @@
+import { collectConfiguredHostHealth } from '../../health.js';
+import { register } from '../registry.js';
+
+register({
+  name: 'health',
+  description: 'Return the structured health and resource state for this NanoClaw host.',
+  access: 'open',
+  hostOnly: true,
+  parseArgs: (raw) => {
+    if (Object.keys(raw).length > 0) throw new Error('health does not accept arguments');
+    return {};
+  },
+  handler: async () => collectConfiguredHostHealth(),
+});

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -5,6 +5,7 @@
  * Help commands are registered after resources are loaded.
  */
 import '../resources/index.js';
+import './health.js';
 import { registerResourceHelpCommands } from './help.js';
 
 registerResourceHelpCommands();

--- a/src/cli/socket-client.ts
+++ b/src/cli/socket-client.ts
@@ -14,36 +14,58 @@ import type { Transport } from './transport.js';
 
 export const DEFAULT_SOCKET_PATH = path.join(DATA_DIR, 'ncl.sock');
 
+export type SocketRequestOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+};
+
 export class SocketTransport implements Transport {
   constructor(private readonly socketPath: string = DEFAULT_SOCKET_PATH) {}
 
-  async sendFrame(req: RequestFrame): Promise<ResponseFrame> {
+  async sendFrame(req: RequestFrame, options: SocketRequestOptions = {}): Promise<ResponseFrame> {
     return new Promise((resolve, reject) => {
       const client = net.createConnection(this.socketPath);
-      let buffer = '';
+      const timeoutMs = options.timeoutMs ?? 30_000;
+      const maxResponseBytes = options.maxResponseBytes ?? 1024 * 1024;
+      let buffer = Buffer.alloc(0);
       let settled = false;
+
+      const abort = (): void => settle('reject', new Error('host request aborted'));
+      const timer = setTimeout(
+        () => settle('reject', new Error(`host request timed out after ${timeoutMs} ms`)),
+        timeoutMs,
+      );
 
       const settle = (action: 'resolve' | 'reject', valueOrErr: ResponseFrame | Error): void => {
         if (settled) return;
         settled = true;
-        try {
-          client.end();
-        } catch (_e) {
-          // best-effort
-        }
+        clearTimeout(timer);
+        options.signal?.removeEventListener('abort', abort);
+        client.destroy();
         if (action === 'resolve') resolve(valueOrErr as ResponseFrame);
         else reject(valueOrErr as Error);
       };
+
+      options.signal?.addEventListener('abort', abort, { once: true });
+      if (options.signal?.aborted) {
+        abort();
+        return;
+      }
 
       client.on('connect', () => {
         client.write(JSON.stringify(req) + '\n');
       });
 
       client.on('data', (chunk) => {
-        buffer += chunk.toString('utf8');
-        const idx = buffer.indexOf('\n');
+        if (buffer.byteLength + chunk.byteLength > maxResponseBytes) {
+          settle('reject', new Error(`host response exceeded ${maxResponseBytes} bytes`));
+          return;
+        }
+        buffer = Buffer.concat([buffer, chunk]);
+        const idx = buffer.indexOf(0x0a);
         if (idx < 0) return;
-        const line = buffer.slice(0, idx);
+        const line = buffer.subarray(0, idx).toString('utf8');
         try {
           const frame = JSON.parse(line) as ResponseFrame;
           settle('resolve', frame);

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,0 +1,50 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { collectHostHealth } from './health.js';
+
+describe('collectHostHealth', () => {
+  it('reports zero groups and policies as explicit empty resources', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_message_policies (from_agent_group_id TEXT, to_agent_group_id TEXT, approver TEXT, created_at TEXT);
+    `);
+    const report = collectHostHealth(process.cwd(), db);
+    expect(report.status).toBe('healthy');
+    expect(report.resources.groups).toEqual({ state: 'empty', count: 0 });
+    expect(report.resources.policies).toEqual({ state: 'empty', count: 0 });
+    expect(report.process.pid).toBeGreaterThan(0);
+    db.close();
+  });
+
+  it('counts only skills loaded into per-group session stores', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-'));
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_message_policies (from_agent_group_id TEXT, to_agent_group_id TEXT, approver TEXT, created_at TEXT);
+    `);
+
+    try {
+      fs.mkdirSync(path.join(root, '.claude', 'skills', 'bundled'), {
+        recursive: true,
+      });
+      fs.writeFileSync(path.join(root, '.claude', 'skills', 'bundled', 'SKILL.md'), '# Bundled');
+      const installed = path.join(root, 'data', 'v2-sessions', 'agent-1', '.claude-shared', 'skills', 'installed');
+      fs.mkdirSync(installed, { recursive: true });
+      fs.writeFileSync(path.join(installed, 'SKILL.md'), '# Installed');
+
+      expect(collectHostHealth(root, db).resources.skills).toEqual({
+        state: 'loaded',
+        count: 1,
+      });
+    } finally {
+      db.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,130 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type HealthResource = {
+  state: 'loaded' | 'empty';
+  count: number;
+};
+
+export type HostHealth = {
+  status: 'healthy' | 'unhealthy';
+  checkoutRoot: string;
+  process: {
+    pid: number;
+    ppid: number;
+    executable: string;
+    script: string;
+    cwd: string;
+  };
+  resources: {
+    groups: HealthResource;
+    policies: HealthResource;
+    skills: HealthResource;
+  };
+};
+
+type CountRow = { count: number };
+
+/** Collect the host-owned health model used by both `ncl health` and setup. */
+export function collectHostHealth(projectRoot: string = process.cwd(), db?: Database.Database): HostHealth {
+  const checkoutRoot = path.resolve(projectRoot);
+  const processIdentity = {
+    pid: process.pid,
+    ppid: process.ppid,
+    executable: process.execPath,
+    script: process.argv[1] ? path.resolve(process.cwd(), process.argv[1]) : '',
+    cwd: process.cwd(),
+  };
+  let ownedDb: Database.Database | undefined;
+  let healthy = processIdentity.pid > 0 && processIdentity.cwd === checkoutRoot;
+  let groups = 0;
+  let policies = 0;
+  try {
+    const connection = db ?? (ownedDb = new Database(path.join(checkoutRoot, 'data', 'v2.db'), { readonly: true }));
+    if (!hasTable(connection, 'agent_groups')) {
+      healthy = false;
+    } else {
+      groups = count(connection, 'agent_groups');
+      if (hasTable(connection, 'agent_message_policies')) {
+        policies = count(connection, 'agent_message_policies');
+      } else {
+        healthy = false;
+      }
+    }
+  } catch {
+    healthy = false;
+  } finally {
+    ownedDb?.close();
+  }
+
+  const skills = countInstalledSkills(checkoutRoot);
+  return {
+    status: healthy ? 'healthy' : 'unhealthy',
+    checkoutRoot,
+    process: processIdentity,
+    resources: {
+      groups: resource(groups),
+      policies: resource(policies),
+      skills: resource(skills),
+    },
+  };
+}
+
+/** The default root is kept here for callers that already import src/config. */
+export function collectConfiguredHostHealth(db?: Database.Database): HostHealth {
+  return collectHostHealth(process.cwd(), db);
+}
+
+function resource(count: number): HealthResource {
+  return { state: count > 0 ? 'loaded' : 'empty', count };
+}
+
+function hasTable(db: Database.Database, name: string): boolean {
+  return db.prepare('SELECT 1 FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1').get('table', name) !== undefined;
+}
+
+function count(db: Database.Database, table: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as CountRow;
+  return Number.isInteger(row.count) && row.count >= 0 ? row.count : 0;
+}
+
+function countInstalledSkills(root: string): number {
+  let total = 0;
+  try {
+    for (const entry of fs.readdirSync(path.join(root, 'data', 'v2-sessions'), { withFileTypes: true })) {
+      if (!entry.isSymbolicLink() && entry.isDirectory()) {
+        total += countGroupSkills(path.join(root, 'data', 'v2-sessions', entry.name, '.claude-shared', 'skills'));
+      }
+    }
+  } catch {
+    // A checkout can legitimately have no group session directory yet.
+  }
+  return total;
+}
+
+function countGroupSkills(location: string): number {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(location, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const entry of entries) {
+    // Shared skills are container-resolving symlinks; template skills are real
+    // directories. Both forms are loaded entries in this per-group store.
+    if (entry.isSymbolicLink()) {
+      total++;
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    const child = path.join(location, entry.name);
+    try {
+      if (fs.statSync(path.join(child, 'SKILL.md')).isFile()) total++;
+    } catch {
+      // Ignore incomplete directories.
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [ ] **Fix**
- [ ] **Simplification**
- [ ] **Documentation**

No box fits: small opt-in engine feature in `setup/` plus one shell gate. Stating it rather than mis-ticking.

## Stacked PR

Built on #3475 (setup driver), which itself stacks on #3472, #3473, #3474. **Review only the last two commits**, `2e59df04` and `d2606fe3` (`git diff 263405a5 d2606fe3`: 10 files). Merge order: #3475 and its base PRs, then this.

## Description

**Problem.** A front end that pre-seeds setup (the macOS app's "essentials" form) has to know which flags exist and how each value is validated. Today that lives only in the flag parser and the terminal screen, so a second copy would drift.

**Change.**
- `nanoclaw.sh --catalog-preseeds` prints the existing flag+UI setup registry as JSON and exits, **before** bootstrap; it refuses extra arguments and creates no setup state (17 shell lines, guarded so it can never run the wizard).
- `setup/catalog-preseeds.ts` projects the registry; string validation is stored once as data and reused by the flag parser (`setup/lib/setup-config-parse.ts`), the terminal screen (`setup-config-screen.ts`) and the catalog. `setup/providers/registry.ts` gains `listSetupProviderChoices` so the provider list comes from one place (the hard-wired `INSTALLABLE_PROVIDERS` constant moves out of `auto.ts`).
- `d2606fe3`: the catalog contract test writes an empty provider barrel into its fixture instead of copying install-time wiring from the checkout, so it stays stable after a provider payload is materialized.

**Why it is safe.** The flag is opt-in and read-only. Existing setup flags and terminal validation keep their behavior (the parser and screen tests are unchanged in intent, only sourced from the shared data). No checked-in JSON snapshot, no second registry, no dependency.

**Scope** (`git diff --name-only 263405a5 d2606fe3`): `nanoclaw.sh`, `setup/auto.ts`, `setup/catalog-preseeds.ts` + test, `setup/lib/setup-config-parse.ts` + test, `setup/lib/setup-config-screen.ts`, `setup/lib/setup-config.ts`, `setup/providers/registry.ts` + test. Nothing else.

## Verification (on `d2606fe3`)

```
pnpm typecheck                                   # OK
bash -n nanoclaw.sh                              # OK
pnpm exec vitest run setup/catalog-preseeds.test.ts setup/lib/setup-config-parse.test.ts \
  setup/providers/registry.test.ts setup/setup-driver-parity.test.ts setup/lib/setup-config.test.ts
  Test Files  5 passed (5)     Tests  17 passed (17)
```
Full suite on the next commit up the stack (`feat/nanoclaw-tz` b3d7eda4, which changes none of the catalog behavior): 2123 passed, 4 failed (env note below). Leak-gate `--classify`: no payload or wiring rows.

Environment note: `scripts/update/transaction.e2e.test.ts` (4 tests) fails on this machine for every branch including a clean `upstream/main` checkout (`tag.gpgSign=true` locally; the test runs a bare `git tag`).

## For Skills

Not applicable: no skill files touched.
