### PR TITLE
docs(add-telegram): add-another-bot path, instance-aware pairing and wiring

### DIFF
--- a/.claude/skills/add-telegram/REMOVE.md
+++ b/.claude/skills/add-telegram/REMOVE.md
@@ -16,7 +16,8 @@ Then delete the copied adapter, helpers, tests, registration test, and setup ste
 rm -f src/channels/telegram.ts src/channels/telegram-registration.test.ts \
   src/channels/telegram-pairing.ts src/channels/telegram-markdown-sanitize.ts \
   src/channels/telegram-pairing.test.ts src/channels/telegram-markdown-sanitize.test.ts \
-  setup/pair-telegram.ts
+  src/channels/telegram-instances-registration.test.ts src/channels/telegram-pairing-interceptor.test.ts \
+  src/channels/telegram-connect-group.test.ts setup/pair-telegram.ts
 ```
 
 ## 2. Remove the setup step
@@ -29,7 +30,7 @@ Delete this entry from the `STEPS` map in `setup/index.ts` (skip if already gone
 
 ## 3. Remove credentials
 
-Remove `TELEGRAM_BOT_TOKEN` from `.env`.
+Remove `TELEGRAM_BOT_TOKEN` from `.env`, and, if you added more bots, `TELEGRAM_INSTANCES` and every `TELEGRAM_BOT_TOKEN_<NAME>` line.
 
 ## 4. Remove the package
 

--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -15,6 +15,9 @@ reads the prose and applies them, and a parser can apply them deterministically
 from the same document. Every directive is idempotent, so the whole skill is
 safe to re-run; anything a parser can't apply falls back to the prose beside it.
 
+Re-running with a bot already configured can add a second one instead of
+re-pairing the first; see **Add another bot** under Credentials.
+
 ## Apply
 
 ### 1. Copy the adapter, helpers, and tests
@@ -29,6 +32,8 @@ src/channels/telegram-pairing.ts
 src/channels/telegram-pairing.test.ts
 src/channels/telegram-registration.test.ts
 src/channels/telegram-connect-group.test.ts
+src/channels/telegram-instances-registration.test.ts
+src/channels/telegram-pairing-interceptor.test.ts
 ```
 
 ### 2. Register the adapter
@@ -79,11 +84,35 @@ delivery against a real bot is verified manually once the service runs.
 
 ## Credentials
 
+An install that already holds `TELEGRAM_BOT_TOKEN` can add a second bot instead of
+re-pairing the first. Check which case this is; the answer steers the rest of the
+flow:
+
+```nc:run capture:has_default_bot
+grep -qsE '^TELEGRAM_BOT_TOKEN=.+' .env && echo yes || echo no
+```
+```nc:run capture:add_another
+[ "{{has_default_bot}}" = yes ] && echo ask || echo no
+```
+
+On a first install there is no bot to add another to, so `add_another` is `no` and
+the steps below create and configure the first bot. When a bot is already configured, ask the
+user whether to keep using it (`no`: the stored token stays as it is and the flow
+re-pairs that bot) or to add another one (`yes`: the first bot's steps are satisfied
+by the stored token and change nothing; the new bot is handled under **Add another
+bot**):
+
+```nc:prompt add_another validate:^(yes|no)$ normalize:lower when:add_another=ask
+A Telegram bot is already configured (TELEGRAM_BOT_TOKEN in .env). Add another bot (yes), or keep using the existing one (no)?
+```
+
 Bot creation in Telegram is human and interactive — no parser can click through
 BotFather. The adapter is installed and registered, but it can't receive a
-message until the bot exists. Tell the user:
+message until the bot exists. On a first install, tell the user (a bot that is
+already configured keeps its stored token below; a second one is created under
+**Add another bot**):
 
-```nc:operator
+```nc:operator when:has_default_bot=no
 Create the Telegram bot:
 1. Open Telegram and message @BotFather — Telegram's official bot for creating bots.
 2. Send /newbot and follow the prompts: a friendly name, then a username that must end in "bot".
@@ -109,6 +138,69 @@ right chat just before pairing:
 curl -sf https://api.telegram.org/bot{{bot_token}}/getMe | jq -er '.result.username'
 ```
 
+### Add another bot
+
+Only when `add_another` is `yes`. The second bot is a named adapter instance: its
+short name becomes the registry key `telegram-<name>` and, uppercased with dashes as
+underscores, the token key suffix (`gh-bot` stores `TELEGRAM_BOT_TOKEN_GH_BOT`). A
+name whose `TELEGRAM_BOT_TOKEN_<NAME>` key is already set is taken (storing under it
+would overwrite that bot's token), so it is refused:
+
+```nc:prompt bot_name validate:^[a-z0-9][a-z0-9-]*$ when:add_another=yes
+Short name for the new bot (lowercase letters, digits, dashes; e.g. `mega`). Pick one whose token key is not already set in .env.
+```
+```nc:run capture:bot_name_env when:add_another=yes
+echo {{bot_name}} | tr 'a-z-' 'A-Z_'
+```
+```nc:run effect:check when:add_another=yes
+! grep -qs '^TELEGRAM_BOT_TOKEN_{{bot_name_env}}=.' .env
+```
+
+To pair an already-configured named bot again instead (its token is stored and the
+service restarted, but pairing failed or was cancelled), run
+`pnpm exec tsx setup/index.ts --step pair-telegram -- --intent main --instance telegram-<name>`,
+then `/init-first-agent` with `--instance telegram-<name>` if it was never wired.
+
+The second bot is created with @BotFather exactly like the first. Tell the user:
+
+```nc:operator when:add_another=yes
+Create the second Telegram bot: message @BotFather, send /newbot and follow the prompts (its own friendly name, then a username that must end in "bot"), and copy the token it gives you. It must be a different bot from the one already configured. Planning to use it in group chats? Send /mybots → that bot → Bot Settings → Group Privacy → Turn off.
+```
+
+Then confirm its token with `getMe` as above:
+
+```nc:prompt bot_token_2 secret validate:^[0-9]+:[A-Za-z0-9_-]{35,}$ when:add_another=yes
+Paste the second bot's token from BotFather (looks like `123456:ABC-DEF...`). It must belong to a different bot than the one already configured.
+```
+```nc:run capture:bot_username_2 effect:fetch when:add_another=yes
+curl -sf https://api.telegram.org/bot{{bot_token_2}}/getMe | jq -er '.result.username'
+```
+
+A second token that resolves to the same bot as the first (its handle matches) is
+refused here, before anything is written: it would only start a second poller on
+that bot, which the adapter refuses at startup anyway.
+
+```nc:run effect:check when:add_another=yes
+[ "{{bot_username_2}}" != "{{bot_username}}" ]
+```
+
+Store the token under its suffixed key and list the name in `TELEGRAM_INSTANCES`,
+merged with the names already there. Both writes go through the `set-env` step,
+which updates an existing key and logs the key, never the value:
+
+```nc:run effect:step when:add_another=yes
+pnpm exec tsx setup/index.ts --step set-env -- --key TELEGRAM_BOT_TOKEN_{{bot_name_env}} --value {{bot_token_2}}
+```
+```nc:run effect:step when:add_another=yes
+pnpm exec tsx setup/index.ts --step set-env -- --key TELEGRAM_INSTANCES --value "$({ sed -n 's/^TELEGRAM_INSTANCES=//p' .env; echo {{bot_name}}; } | tr ',' '\n' | grep . | sort -u | paste -sd, -)"
+```
+
+The registry key is how pairing and wiring address the new bot:
+
+```nc:run capture:instance when:add_another=yes
+echo telegram-{{bot_name}}
+```
+
 ## Restart
 
 Restart the service so it loads the Telegram adapter and the token you just
@@ -127,7 +219,7 @@ digits to the bot from the chat you want to register, and the live adapter
 matches them. Open the bot first so you're on the right screen when the code
 appears. Tell the user:
 
-```nc:operator
+```nc:operator when:add_another=no
 Open @{{bot_username}} (https://telegram.me/{{bot_username}}) in Telegram now and keep it on screen — a 6-digit pairing code is about to appear in this terminal. When it does, send just those 6 digits to the bot as a message (in a group chat with Group Privacy on, prefix them with @{{bot_username}}). A wrong guess is rejected and a fresh code is issued automatically.
 ```
 
@@ -135,13 +227,27 @@ Run the pairing handshake. It prints the code, streams "waiting…" and wrong-co
 feedback while it watches for your message, and resolves your chat address
 `telegram:<chatId>` plus your Telegram user id once the code matches:
 
-```nc:run effect:step capture:platform_id=PLATFORM_ID,owner_handle=ADMIN_USER_ID
+```nc:run effect:step capture:platform_id=PLATFORM_ID,owner_handle=ADMIN_USER_ID when:add_another=no
 pnpm exec tsx setup/index.ts --step pair-telegram -- --intent main
+```
+
+A second bot pairs through its own instance key: the code is bound to
+`telegram-<name>`, the first bot ignores it, and the paired chat gets its own
+messaging-group row for that instance (a bot cannot message a user who never opened
+it, so the chat id known from the first bot is not reused). Tell the user:
+
+```nc:operator when:add_another=yes
+Open @{{bot_username_2}} (https://telegram.me/{{bot_username_2}}) in Telegram now and keep it on screen: a pairing code is about to appear in this terminal. Send just those digits to this new bot, not to the first one. A wrong guess is rejected and a fresh code is issued automatically.
+```
+```nc:run effect:step capture:platform_id=PLATFORM_ID,owner_handle=ADMIN_USER_ID when:add_another=yes
+pnpm exec tsx setup/index.ts --step pair-telegram -- --intent main --instance {{instance}}
 ```
 
 `owner_handle` (your Telegram user id) and `platform_id` (`telegram:<chatId>`)
 are what the owner-wiring step needs. The greeting goes out over the same chat as
-soon as pairing completes.
+soon as pairing completes. For a second bot, `instance` (`telegram-<name>`) comes
+along too: pass it as `--instance` to `scripts/init-first-agent.ts` so the DM row,
+the wiring and the welcome all target that bot (see `/init-first-agent`).
 
 ## Next Steps
 
@@ -180,6 +286,7 @@ the group and keeps the approval card in the loop.
 - **terminology**: Telegram calls them "groups" and "chats." A "group" has multiple members; a "chat" is a 1:1 conversation with the bot.
 - **platform-id-format**: `telegram:{chatId}` (e.g. `telegram:123456789` for a DM, `telegram:-1001234567890` for a group — negative chat IDs are groups/channels).
 - **how-to-find-id**: Do NOT ask the user for a chat ID. Pair the first DM with `pnpm exec tsx setup/index.ts --step pair-telegram -- --intent main`. For another group, have an owner/global admin send `/connect_group` in that paired DM, choose the group, and approve the resulting channel-registration card. The service must be running — the polling adapter observes both flows.
+- **instances**: `TELEGRAM_BOT_TOKEN` is the default instance `telegram`; `TELEGRAM_INSTANCES=<name>,...` plus `TELEGRAM_BOT_TOKEN_<NAME>` adds `telegram-<name>` (reference: `.claude/skills/telegram-multi-instance/SKILL.md` on the `channels` branch).
 - **supports-threads**: no
 - **typical-use**: Interactive chat — direct messages or small groups
 - **default-isolation**: Same agent group if you're the only participant across multiple chats. Separate agent group if different people are in different groups.
@@ -197,5 +304,7 @@ the group and keeps the approval card in the loop.
 **`/connect_group` is denied.** The Telegram sender is not a NanoClaw owner or global admin. The command never grants privileges; inspect them with `ncl roles list` and grant the intended role explicitly if appropriate.
 
 **The group was chosen but no approval card arrived.** Confirm the service is running and post `/start@{{bot_username}} connect` in the group. The card is delivered to an eligible owner/admin DM, not to the group.
+
+**The second bot never comes online.** `TELEGRAM_INSTANCES` and `TELEGRAM_BOT_TOKEN_<NAME>` are read once at start, so restart after adding a bot. A name whose token equals one already in use is skipped with a warning in `logs/nanoclaw.error.log` (Telegram allows one poller per token): give each bot its own BotFather token. A pairing code issued for `telegram-<name>` is ignored by the first bot; send it to the new one.
 
 **Everything green but no replies.** Run `pnpm exec vitest run src/channels/telegram-registration.test.ts` — red means the barrel import or the `@chat-adapter/telegram` install drifted, so re-run the Apply steps. If green, restart again (`bash setup/lib/restart.sh`) and check `logs/nanoclaw.error.log` for token errors.

--- a/.claude/skills/add-telegram/apply-fixtures.json
+++ b/.claude/skills/add-telegram/apply-fixtures.json
@@ -1,5 +1,9 @@
 {
-  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — shaped fake values only, never real credentials. The getMe stub answers the bot_username capture (the operator block after the restart renders it); stepFields feed the pairing step's terminal block (capture:platform_id=PLATFORM_ID,owner_handle=ADMIN_USER_ID).",
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts: shaped fake values only, never real credentials. Two scenarios: a first install (the TELEGRAM_BOT_TOKEN probe answers 'no', add_another derives to 'no', the first-bot steps run, the default pairing step runs) and a rerun that adds a second bot (the probe answers 'yes', add_another derives to 'ask' and the prompt answers yes, name mega, a second token; the getMe stubs answer both bot_username captures with different usernames so the same-bot check passes, the tr/echo stubs answer bot_name_env and instance, the set-env writes are effect:step and need no stdout). stepFields feed every effect:step's terminal block (the pairing step's capture:platform_id=PLATFORM_ID,owner_handle=ADMIN_USER_ID).",
+  "coverageExclude": [
+    "add_another=ask"
+  ],
+  "coverageExcludeReason": "add_another=ask is the probe's rerun answer that only gates the add_another prompt, which re-binds the same var to yes or no before the run ends, so no scenario can finish with vars.add_another='ask'. The add-another scenario exercises the guard at runtime (its prompt only runs under it).",
   "scenarios": [
     {
       "name": "pairing",
@@ -7,9 +11,29 @@
         "bot_token": "123456789:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
       },
       "exec": [
+        { "match": "^TELEGRAM_BOT_TOKEN=.+' .env", "stdout": "no" },
+        { "match": "echo ask || echo no", "stdout": "no" },
         { "match": "getMe", "stdout": "nanoclaw_bot" }
       ],
       "stepFields": { "PLATFORM_ID": "telegram:123456789", "ADMIN_USER_ID": "987654321" }
+    },
+    {
+      "name": "add-another",
+      "inputs": {
+        "bot_token": "123456789:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "add_another": "yes",
+        "bot_name": "mega",
+        "bot_token_2": "987654321:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+      },
+      "exec": [
+        { "match": "^TELEGRAM_BOT_TOKEN=.+' .env", "stdout": "yes" },
+        { "match": "echo ask || echo no", "stdout": "ask" },
+        { "match": "bot123456789:AAAA", "stdout": "nanoclaw_bot" },
+        { "match": "bot987654321:BBBB", "stdout": "mega_bot" },
+        { "match": "tr 'a-z-' 'A-Z_'", "stdout": "MEGA" },
+        { "match": "echo telegram-", "stdout": "telegram-mega" }
+      ],
+      "stepFields": { "PLATFORM_ID": "telegram:123456789", "ADMIN_USER_ID": "987654321", "INSTANCE": "telegram-mega" }
     }
   ]
 }

--- a/scripts/skill-policy.test.ts
+++ b/scripts/skill-policy.test.ts
@@ -45,10 +45,14 @@ describe('gatePolicy — §5.1 parity table (real skills)', () => {
     expect(d[3].flavor).toBe('completed');
   });
 
-  it('telegram: the pairing operator gains a readiness pause before the effect:step', () => {
+  it('telegram: each pairing operator gains a readiness pause before its own effect:step', () => {
     const d = decisions(loadSkill('telegram'));
-    expect(d.map((g) => g.needsConfirm)).toEqual([false, true]); // BotFather → prompt; pairing → step
-    expect(d[1].flavor).toBe('readiness'); // "a 6-digit code is about to appear"
+    // BotFather → prompt; second-bot BotFather → its own prompt; default-bot
+    // pairing → its step (the second-bot operator and step are guard-incompatible,
+    // when:add_another=yes, and skipped); second-bot pairing → its own --instance step.
+    expect(d.map((g) => g.needsConfirm)).toEqual([false, false, true, true]);
+    expect(d[2].flavor).toBe('readiness'); // "a pairing code is about to appear"
+    expect(d[3].flavor).toBe('readiness');
   });
 
   it('signal: readiness pause before the QR device-link step', () => {

--- a/setup/channels/telegram-flow.test.ts
+++ b/setup/channels/telegram-flow.test.ts
@@ -1,0 +1,168 @@
+// The add-another-bot path, asserted against the add-telegram SKILL.md itself.
+// Kill conditions: drop `when:add_another=no` from the default pairing fence
+// (the first bot would be re-paired on the add path), stop the TELEGRAM_BOT_TOKEN
+// probe from answering `yes` (the question is never asked on a rerun), drop
+// `when:has_default_bot=no` from the first-bot BotFather walkthrough (a rerun that
+// keeps the bot would tell the operator to create one), change the
+// TELEGRAM_BOT_TOKEN_<NAME> / TELEGRAM_INSTANCES writes, the name-collision check
+// or the same-bot check (a second token that getMe resolves to the bot already
+// configured would be stored as a second instance), and a case below goes red.
+// The document is driven end-to-end with pre-supplied answers against a scratch
+// .env: local shell (the probe, tr, the sed/sort/paste merge, echo, both checks)
+// runs for real; git, pnpm, the restart and the getMe curl are recorded and
+// answered by stubs.
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { applySkill, fullyApplied, type ApplyResult } from '../../scripts/skill-apply.js';
+import { parseDirectives } from '../../scripts/skill-directives.js';
+
+const SKILL_DIR = path.join(process.cwd(), '.claude/skills/add-telegram');
+const OLD_TOKEN = '123456789:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const NEW_TOKEN = '987654321:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const PAIR_DEFAULT = 'pnpm exec tsx setup/index.ts --step pair-telegram -- --intent main';
+
+// How many fences each branch guards, read from the document so the skip
+// assertions below track the skill instead of a hardcoded count.
+const guarded = (value: string): number =>
+  parseDirectives(fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf-8')).filter(
+    (d) => d.attrs.when === `add_another=${value}`,
+  ).length;
+
+interface Recorded {
+  res: ApplyResult;
+  execs: string[];
+  steps: string[]; // effect:step commands: the set-env writes and the pairing step
+  envValues: string[]; // each set-env `--value "$(...)"` merge pipeline, evaluated for real
+  envAfter: string;
+}
+
+async function run(
+  envBefore: string,
+  inputs: Record<string, string>,
+  // What the stubbed getMe answers per curl: by default each token resolves to its own bot.
+  getMe: (cmd: string) => string = (cmd) => (cmd.includes(NEW_TOKEN) ? 'mega_bot' : 'nanoclaw_bot'),
+): Promise<Recorded> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-tg-flow-'));
+  fs.mkdirSync(path.join(root, 'src/channels'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'setup'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src/channels/index.ts'), '');
+  // The pair-telegram loader appends inside setup/index.ts's dormant marker region.
+  fs.writeFileSync(
+    path.join(root, 'setup/index.ts'),
+    ['const STEPS = {', '  // >>> nanoclaw:setup-steps', '  // <<< nanoclaw:setup-steps', '};', ''].join('\n'),
+  );
+  fs.writeFileSync(path.join(root, '.env'), envBefore);
+  const execs: string[] = [];
+  const steps: string[] = [];
+  const envValues: string[] = [];
+  const res = await applySkill(SKILL_DIR, root, {
+    inputs,
+    exec: (cmd) => {
+      execs.push(cmd);
+      if (/^(git|pnpm|bash)\b/.test(cmd)) return '';
+      if (cmd.startsWith('curl')) return getMe(cmd);
+      return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
+    },
+    execStream: async (cmd) => {
+      steps.push(cmd);
+      // set-env itself is trunk code (setup/set-env.ts); only its value
+      // pipeline is the skill's own, so that is what runs here.
+      const m = cmd.match(/--value "(\$\(.*\))"$/);
+      if (m) envValues.push(execFileSync('bash', ['-c', `printf %s "${m[1]}"`], { cwd: root, encoding: 'utf-8' }));
+      return { ok: true, fields: { PLATFORM_ID: 'telegram:555', ADMIN_USER_ID: '555' } };
+    },
+    resolveRemote: () => 'origin',
+  });
+  const envAfter = fs.readFileSync(path.join(root, '.env'), 'utf-8');
+  fs.rmSync(root, { recursive: true, force: true });
+  return { res, execs, steps, envValues, envAfter };
+}
+
+describe('Telegram add-another-bot path (add-telegram SKILL.md)', () => {
+  it('first install: add_another is no without asking, the first bot is stored and paired, every add fence skips', async () => {
+    const r = await run('', { bot_token: OLD_TOKEN });
+    expect(fullyApplied(r.res)).toBe(true);
+    expect(r.res.vars).toMatchObject({ has_default_bot: 'no', add_another: 'no' });
+    expect(r.res.vars.instance).toBeUndefined();
+    expect(r.res.operatorMessages).toEqual([
+      expect.stringMatching(/^Create the Telegram bot:/),
+      expect.stringMatching(/^Open @nanoclaw_bot /),
+    ]);
+    expect(r.envAfter).toBe(`TELEGRAM_BOT_TOKEN=${OLD_TOKEN}\n`);
+    expect(r.steps).toEqual([PAIR_DEFAULT]);
+    expect(r.res.skipped).toContain('prompt: when add_another=ask not met');
+    expect(r.res.skipped.filter((s) => s.endsWith('when add_another=yes not met'))).toHaveLength(guarded('yes'));
+    expect(guarded('yes')).toBeGreaterThan(0);
+  });
+
+  it('rerun, keep the existing bot: the stored token is untouched and the first bot is re-paired', async () => {
+    const env = `TELEGRAM_BOT_TOKEN=${OLD_TOKEN}\n`;
+    const r = await run(env, { bot_token: OLD_TOKEN, add_another: 'no' });
+    expect(fullyApplied(r.res)).toBe(true);
+    expect(r.res.vars).toMatchObject({ has_default_bot: 'yes', add_another: 'no' });
+    // The bot exists: no BotFather walkthrough, straight to its pairing note.
+    expect(r.res.operatorMessages).toEqual([expect.stringMatching(/^Open @nanoclaw_bot /)]);
+    expect(r.envAfter).toBe(env);
+    expect(r.steps).toEqual([PAIR_DEFAULT]);
+    expect(r.res.skipped).toContain('env-set: TELEGRAM_BOT_TOKEN already set');
+  });
+
+  it('rerun, add another bot: suffixed token key, merged TELEGRAM_INSTANCES, instance-bound pairing, first bot untouched', async () => {
+    const env = `TELEGRAM_BOT_TOKEN=${OLD_TOKEN}\nTELEGRAM_INSTANCES=mega\n`;
+    const r = await run(env, { bot_token: OLD_TOKEN, add_another: 'yes', bot_name: 'gh-bot', bot_token_2: NEW_TOKEN });
+    expect(fullyApplied(r.res)).toBe(true);
+    expect(r.res.vars).toMatchObject({
+      add_another: 'yes',
+      bot_name: 'gh-bot',
+      bot_name_env: 'GH_BOT',
+      bot_username_2: 'mega_bot',
+      instance: 'telegram-gh-bot',
+      platform_id: 'telegram:555',
+      owner_handle: '555',
+    });
+    expect(r.steps).toEqual([
+      `pnpm exec tsx setup/index.ts --step set-env -- --key TELEGRAM_BOT_TOKEN_GH_BOT --value ${NEW_TOKEN}`,
+      expect.stringContaining('--step set-env -- --key TELEGRAM_INSTANCES --value "$('),
+      `${PAIR_DEFAULT} --instance telegram-gh-bot`,
+    ]);
+    expect(r.envValues).toEqual(['gh-bot,mega']); // existing names kept, new one merged, no duplicates
+    expect(r.res.operatorMessages).toEqual([
+      expect.stringMatching(/^Create the second Telegram bot/),
+      expect.stringMatching(/^Open @mega_bot /),
+    ]);
+    expect(r.envAfter).toBe(env); // the first bot's fences are no-ops here: env-set never overwrites
+    expect(r.res.skipped.filter((s) => s.endsWith('when add_another=no not met'))).toHaveLength(guarded('no'));
+    expect(r.execs.filter((c) => /restart\.sh/.test(c))).toHaveLength(1);
+  });
+
+  it('rerun, add another bot under a taken name: the collision check refuses before any write, restart or pairing', async () => {
+    const env = `TELEGRAM_BOT_TOKEN=${OLD_TOKEN}\nTELEGRAM_INSTANCES=mega\nTELEGRAM_BOT_TOKEN_MEGA=${NEW_TOKEN}\n`;
+    const r = await run(env, { bot_token: OLD_TOKEN, add_another: 'yes', bot_name: 'mega', bot_token_2: NEW_TOKEN });
+    expect(fullyApplied(r.res)).toBe(false);
+    expect(r.res.agentTasks[0]).toMatchObject({ kind: 'run', prose: expect.stringContaining('Add another bot') });
+    expect(r.steps).toEqual([]);
+    expect(r.execs.some((c) => /restart\.sh/.test(c))).toBe(false);
+    expect(r.envAfter).toBe(env);
+  });
+
+  it('rerun, add another bot with a token for the bot already configured: the same-bot check refuses before any write, restart or pairing', async () => {
+    const env = `TELEGRAM_BOT_TOKEN=${OLD_TOKEN}\n`;
+    // A different token string (a BotFather /token regeneration) that getMe resolves to the first bot.
+    const r = await run(
+      env,
+      { bot_token: OLD_TOKEN, add_another: 'yes', bot_name: 'mega', bot_token_2: NEW_TOKEN },
+      () => 'nanoclaw_bot',
+    );
+    expect(fullyApplied(r.res)).toBe(false);
+    expect(r.res.vars).toMatchObject({ bot_username: 'nanoclaw_bot', bot_username_2: 'nanoclaw_bot' });
+    expect(r.res.agentTasks[0]).toMatchObject({ kind: 'run', prose: expect.stringContaining('same bot') });
+    expect(r.steps).toEqual([]);
+    expect(r.execs.some((c) => /restart\.sh/.test(c))).toBe(false);
+    expect(r.envAfter).toBe(env);
+  });
+});


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

(Closest box: SKILL.md, its fixtures, and a test that drives the document; no engine code.)

## Description

Re-running `/add-telegram` on an install that already has a bot now offers "add another bot". First install unchanged.

**Why.** The skill only knew the first-bot flow; a rerun re-paired the same bot. The skill engine branches on a prompt variable in document order (`when:` guards), so the second-bot path fits in the same document and setup, the agent and `ncl` produce one install.

**What changed** (`.claude/skills/add-telegram/SKILL.md`).
- A probe captures `has_default_bot`; on a rerun a prompt asks `add_another` (yes/no). The "create the bot" note is skipped on reruns. Everything else on the first-bot path is untouched.
- `when:add_another=yes`: name (`^[a-z0-9][a-z0-9-]*$`), refuse a name whose token key is already set, second token (its own prompt, never offered the first token), `getMe`, refuse a token that is the same bot, write `TELEGRAM_BOT_TOKEN_<NAME>` and merge `TELEGRAM_INSTANCES` via `set-env`, one restart, `pair-telegram --instance telegram-<name>`.
- Copy list gains the two new payload tests; `REMOVE.md` covers the new keys; links the `telegram-multi-instance` reference.

**Risk.** None. Prose and fences; first run byte-identical. Known, pre-existing: the `getMe` curl is teed into the step log like the first bot's (a driver-level fix, not this PR).

**Verification.**
- Skill lint: `problems: [], warnings: []`. Plan mode: 28 steps.
- `setup/channels/telegram-flow.test.ts` 5 (first install, rerun keep, rerun add with a real `TELEGRAM_INSTANCES` merge and `--instance` pairing, taken name refused, same-bot token refused); with conformance + policy suites: 187 passed. Removing the guard, the probe or either check turns a test red. Build clean.
- [ ] Live rerun on the agent path (the wizard path was smoked in the setup PR).

**Train.** Native stack: based on `feat/setup-telegram-instance` (#3478), so this diff shows only its own commit. Merge after #3436 on `channels` (the copy list names two test files that exist only once it lands; the Registry-skills CI job here stays red until then; expected). #3431 is already merged and this branch is rebased over it. The wizard PR stacks on top.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone (fresh install in a clean worktree, then the rerun add-another path with a second real bot through the wizard, 2026-08-21)

---
Replaces #3437: same branch and content, moved from the fork into this repository for the native stack.
