### PR TITLE
feat: expose structured host health

### DIFF
--- a/src/cli/commands/health.test.ts
+++ b/src/cli/commands/health.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { dispatch } from '../dispatch.js';
+import './health.js';
+
+describe('ncl health command', () => {
+  it('is host-only and returns the structured resource model', async () => {
+    const response = await dispatch({ id: 'health-test', command: 'health', args: {} }, { caller: 'host' });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const data = response.data as { resources?: { groups?: unknown; policies?: unknown; skills?: unknown } };
+    expect(data.resources?.groups).toBeDefined();
+    expect(data.resources?.policies).toBeDefined();
+    expect(data.resources?.skills).toBeDefined();
+  });
+});

--- a/src/cli/commands/health.ts
+++ b/src/cli/commands/health.ts
@@ -1,0 +1,14 @@
+import { collectConfiguredHostHealth } from '../../health.js';
+import { register } from '../registry.js';
+
+register({
+  name: 'health',
+  description: 'Return the structured health and resource state for this NanoClaw host.',
+  access: 'open',
+  hostOnly: true,
+  parseArgs: (raw) => {
+    if (Object.keys(raw).length > 0) throw new Error('health does not accept arguments');
+    return {};
+  },
+  handler: async () => collectConfiguredHostHealth(),
+});

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -5,6 +5,7 @@
  * Help commands are registered after resources are loaded.
  */
 import '../resources/index.js';
+import './health.js';
 import { registerResourceHelpCommands } from './help.js';
 
 registerResourceHelpCommands();

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,0 +1,50 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { collectHostHealth } from './health.js';
+
+describe('collectHostHealth', () => {
+  it('reports zero groups and policies as explicit empty resources', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_message_policies (from_agent_group_id TEXT, to_agent_group_id TEXT, approver TEXT, created_at TEXT);
+    `);
+    const report = collectHostHealth(process.cwd(), db);
+    expect(report.status).toBe('healthy');
+    expect(report.resources.groups).toEqual({ state: 'empty', count: 0 });
+    expect(report.resources.policies).toEqual({ state: 'empty', count: 0 });
+    expect(report.process.pid).toBeGreaterThan(0);
+    db.close();
+  });
+
+  it('counts only skills loaded into per-group session stores', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-'));
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE agent_groups (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_message_policies (from_agent_group_id TEXT, to_agent_group_id TEXT, approver TEXT, created_at TEXT);
+    `);
+
+    try {
+      fs.mkdirSync(path.join(root, '.claude', 'skills', 'bundled'), {
+        recursive: true,
+      });
+      fs.writeFileSync(path.join(root, '.claude', 'skills', 'bundled', 'SKILL.md'), '# Bundled');
+      const installed = path.join(root, 'data', 'v2-sessions', 'agent-1', '.claude-shared', 'skills', 'installed');
+      fs.mkdirSync(installed, { recursive: true });
+      fs.writeFileSync(path.join(installed, 'SKILL.md'), '# Installed');
+
+      expect(collectHostHealth(root, db).resources.skills).toEqual({
+        state: 'loaded',
+        count: 1,
+      });
+    } finally {
+      db.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,130 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type HealthResource = {
+  state: 'loaded' | 'empty';
+  count: number;
+};
+
+export type HostHealth = {
+  status: 'healthy' | 'unhealthy';
+  checkoutRoot: string;
+  process: {
+    pid: number;
+    ppid: number;
+    executable: string;
+    script: string;
+    cwd: string;
+  };
+  resources: {
+    groups: HealthResource;
+    policies: HealthResource;
+    skills: HealthResource;
+  };
+};
+
+type CountRow = { count: number };
+
+/** Collect the host-owned health model used by both `ncl health` and setup. */
+export function collectHostHealth(projectRoot: string = process.cwd(), db?: Database.Database): HostHealth {
+  const checkoutRoot = path.resolve(projectRoot);
+  const processIdentity = {
+    pid: process.pid,
+    ppid: process.ppid,
+    executable: process.execPath,
+    script: process.argv[1] ? path.resolve(process.cwd(), process.argv[1]) : '',
+    cwd: process.cwd(),
+  };
+  let ownedDb: Database.Database | undefined;
+  let healthy = processIdentity.pid > 0 && processIdentity.cwd === checkoutRoot;
+  let groups = 0;
+  let policies = 0;
+  try {
+    const connection = db ?? (ownedDb = new Database(path.join(checkoutRoot, 'data', 'v2.db'), { readonly: true }));
+    if (!hasTable(connection, 'agent_groups')) {
+      healthy = false;
+    } else {
+      groups = count(connection, 'agent_groups');
+      if (hasTable(connection, 'agent_message_policies')) {
+        policies = count(connection, 'agent_message_policies');
+      } else {
+        healthy = false;
+      }
+    }
+  } catch {
+    healthy = false;
+  } finally {
+    ownedDb?.close();
+  }
+
+  const skills = countInstalledSkills(checkoutRoot);
+  return {
+    status: healthy ? 'healthy' : 'unhealthy',
+    checkoutRoot,
+    process: processIdentity,
+    resources: {
+      groups: resource(groups),
+      policies: resource(policies),
+      skills: resource(skills),
+    },
+  };
+}
+
+/** The default root is kept here for callers that already import src/config. */
+export function collectConfiguredHostHealth(db?: Database.Database): HostHealth {
+  return collectHostHealth(process.cwd(), db);
+}
+
+function resource(count: number): HealthResource {
+  return { state: count > 0 ? 'loaded' : 'empty', count };
+}
+
+function hasTable(db: Database.Database, name: string): boolean {
+  return db.prepare('SELECT 1 FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1').get('table', name) !== undefined;
+}
+
+function count(db: Database.Database, table: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as CountRow;
+  return Number.isInteger(row.count) && row.count >= 0 ? row.count : 0;
+}
+
+function countInstalledSkills(root: string): number {
+  let total = 0;
+  try {
+    for (const entry of fs.readdirSync(path.join(root, 'data', 'v2-sessions'), { withFileTypes: true })) {
+      if (!entry.isSymbolicLink() && entry.isDirectory()) {
+        total += countGroupSkills(path.join(root, 'data', 'v2-sessions', entry.name, '.claude-shared', 'skills'));
+      }
+    }
+  } catch {
+    // A checkout can legitimately have no group session directory yet.
+  }
+  return total;
+}
+
+function countGroupSkills(location: string): number {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(location, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const entry of entries) {
+    // Shared skills are container-resolving symlinks; template skills are real
+    // directories. Both forms are loaded entries in this per-group store.
+    if (entry.isSymbolicLink()) {
+      total++;
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    const child = path.join(location, entry.name);
+    try {
+      if (fs.statSync(path.join(child, 'SKILL.md')).isFile()) total++;
+    } catch {
+      // Ignore incomplete directories.
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
Nothing in the host CLI can answer "is this install actually up, and what is in it" in a single read-only call. Today, a tool that wants to tell a fresh, empty install apart from a broken one has to open the central database itself, find the host process, and look through each group's skill folders by hand. This adds `ncl health`, one operator-only command that returns that whole picture as a structured object.

## What ships

| File | What it does |
|---|---|
| `src/health.ts` | `collectHostHealth(projectRoot, db?)` builds the `HostHealth` object; `collectConfiguredHostHealth(db?)` is the no-argument wrapper the command calls |
| `src/cli/commands/health.ts` | Registers the `health` command: `access: 'open'`, `hostOnly: true`, rejects any argument |
| `src/cli/commands/index.ts` | One import so the command is in the registry before the CLI socket server accepts connections |
| `src/health.test.ts`, `src/cli/commands/health.test.ts` | Tests |

No schema change, no migration, no new dependency, no saved state, no restart. The command only reads.

## The shape it returns

Verbatim from `src/health.ts`:

```ts
export type HealthResource = {
  state: 'loaded' | 'empty';
  count: number;
};

export type HostHealth = {
  status: 'healthy' | 'unhealthy';
  checkoutRoot: string;
  process: { pid: number; ppid: number; executable: string; script: string; cwd: string };
  resources: {
    groups: HealthResource;
    policies: HealthResource;
    skills: HealthResource;
  };
};
```

```mermaid
flowchart LR
  AG["an agent in a container"] -. refused .-> G["dispatch guard"]
  OP["ncl health (operator)"] --> G --> H["collectHostHealth()"]
  H -->|reads| P["process: pid, ppid, execPath, argv[1], cwd"]
  H -->|opens read-only| DB["data/v2.db: COUNT agent_groups, COUNT agent_message_policies"]
  H -->|scans| S["data/v2-sessions/*/.claude-shared/skills"]
  P & DB & S --> R["HostHealth"]
```

The database is opened read-only and closed in a `finally`, and the whole database block is wrapped in a `try`, so a missing or unreadable `data/v2.db`, or a missing `agent_groups` or `agent_message_policies` table, reports `status: 'unhealthy'` instead of crashing.

`health` registers no `formatHuman`, so both `ncl health` and `ncl health --json` print the object as pretty JSON. Any flag other than `--json` (which the client removes before the command runs) is rejected by `parseArgs` with `health does not accept arguments`.

## What trips people up

**Empty is healthy.** A brand new install with zero groups reports `status: 'healthy'` and `groups: { state: 'empty', count: 0 }`. Telling those two apart, empty versus broken, is the point of the command. `state` is only computed from the count: `count > 0 ? 'loaded' : 'empty'`.

**The skills count adds up every group's skills, so one skill can be counted several times.** `countInstalledSkills` walks every non-symlink directory under `data/v2-sessions/`, then counts entries in that group's `.claude-shared/skills/`. Both ways a skill can be stored are counted: symlinks (the shared container skills the runner syncs in) and real directories that contain a `SKILL.md` (the ones added when an agent is created from a template). A skill present in three groups therefore contributes 3. Skills that ship with the repository are deliberately not counted, so `.claude/skills/` in the checkout contributes nothing.

**`hostOnly` cannot be overridden.** It is enforced in `commandDecide` in `src/cli/guard.ts`, which refuses a `hostOnly` command to any agent caller whatever its `cli_scope` is, `global` included, and no approval can unlock it.

## Verification

```
pnpm exec vitest run src/health.test.ts src/cli/commands/health.test.ts
pnpm typecheck
```

Covered: resources reported as empty when the database has zero rows, telling installed skills apart from the ones that ship with the repository, and host dispatch returning the `resources.groups` / `resources.policies` / `resources.skills` shape.

## Notes for review

> [!NOTE]
> `src/health.ts` opens `data/v2.db` directly with `better-sqlite3`, instead of going through `DbDriver`, the async layer host modules normally use to reach the database. Outside `src/db/` and `src/mailbox/`, it is the first host module to do so. That is what lets `collectHostHealth` stay synchronous, and it is worth a deliberate decision on whether health is allowed to skip that layer.

- No test checks that `health` itself is refused inside a container. `src/cli/commands/health.test.ts` covers the host caller only; the `hostOnly` refusal is covered in general in `src/cli/dispatch.test.ts` through a `host-only-cmd` fixture.
- `collectConfiguredHostHealth(db)` is exactly `collectHostHealth(process.cwd(), db)`, and its comment mentions `src/config`, which the module does not import. Both `data/v2.db` and `data/v2-sessions` are joined onto `checkoutRoot` locally instead of using `CENTRAL_DB_PATH` / `DATA_DIR`. Those point at the same paths today, since `config.ts` also builds them from `process.cwd()`.
