### PR TITLE
setup: keep pasted auth secrets out of argv

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -71,6 +71,7 @@ import type { AgentGroup } from '../src/types.js';
 import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-claude.js';
 import * as setupLog from './logs.js';
 import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
+import { withSecretFile } from './lib/secret-file.js';
 import { emit as phEmit } from './lib/diagnostics.js';
 import {
   accentGreen,
@@ -1626,28 +1627,30 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
   );
   const token = (answer as string).replace(/\s+/g, '');
 
-  const res = await runQuietChild(
-    'auth',
-    'onecli',
-    [
-      'secrets',
-      'create',
-      '--name',
-      'Anthropic',
-      '--type',
-      'anthropic',
-      '--value',
-      token,
-      '--host-pattern',
-      'api.anthropic.com',
-    ],
-    {
-      running: `Saving your ${label} to your OneCLI vault…`,
-      done: 'Claude account connected.',
-    },
-    {
-      extraFields: { METHOD: method },
-    },
+  const res = await withSecretFile(token, (filePath) =>
+    runQuietChild(
+      'auth',
+      'onecli',
+      [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'anthropic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        'api.anthropic.com',
+      ],
+      {
+        running: `Saving your ${label} to your OneCLI vault…`,
+        done: 'Claude account connected.',
+      },
+      {
+        extraFields: { METHOD: method },
+      },
+    ),
   );
   if (!res.ok) {
     await fail(
@@ -1673,30 +1676,34 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
     return;
   }
 
-  const res = await runQuietChild(
-    'auth',
-    'onecli',
-    [
-      'secrets',
-      'create',
-      '--name',
-      'Anthropic',
-      '--type',
-      'generic',
-      '--value',
-      token,
-      '--host-pattern',
-      host,
-      '--header-name',
-      'Authorization',
-      '--value-format',
-      'Bearer {value}',
-    ],
-    {
-      running: `Saving your Anthropic auth token to your OneCLI vault…`,
-      done: 'Claude account connected.',
-    },
-    { extraFields: { METHOD: 'custom-endpoint', HOST: host } },
+  const res = await withSecretFile(token, (filePath) =>
+    runQuietChild(
+      'auth',
+      'onecli',
+      [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'generic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        host,
+        '--header-name',
+        'Authorization',
+        '--value-format',
+        'Bearer {value}',
+      ],
+      {
+        running: `Saving your Anthropic auth token to your OneCLI vault…`,
+        done: 'Claude account connected.',
+      },
+      {
+        extraFields: { METHOD: 'custom-endpoint', HOST: host },
+      },
+    ),
   );
   if (!res.ok) {
     await fail(

--- a/setup/lib/secret-file.test.ts
+++ b/setup/lib/secret-file.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { withSecretFile } from './secret-file.js';
+
+describe('withSecretFile', () => {
+  it('provides a private file and removes it after the operation', async () => {
+    const secret = 'machine-only-secret';
+    let secretPath = '';
+
+    await withSecretFile(secret, async (filePath) => {
+      secretPath = filePath;
+      expect(fs.readFileSync(filePath, 'utf8')).toBe(secret);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(path.dirname(filePath)).mode & 0o777).toBe(0o700);
+    });
+
+    expect(fs.existsSync(secretPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+
+  it('removes the file when the operation fails', async () => {
+    let secretPath = '';
+
+    await expect(
+      withSecretFile('secret', async (filePath) => {
+        secretPath = filePath;
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+
+    expect(fs.existsSync(secretPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+});

--- a/setup/lib/secret-file.ts
+++ b/setup/lib/secret-file.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** Run an operation with a private one-use secret file, then remove it. */
+export async function withSecretFile<T>(secret: string, operation: (filePath: string) => Promise<T>): Promise<T> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-secret-'));
+  const filePath = path.join(directory, 'value');
+  let fd: number | undefined;
+
+  try {
+    fs.chmodSync(directory, 0o700);
+    fd = fs.openSync(
+      filePath,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.writeFileSync(fd, secret, { encoding: 'utf8' });
+    fs.fchmodSync(fd, 0o600);
+    fs.closeSync(fd);
+    fd = undefined;
+    return await operation(filePath);
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+    fs.rmSync(filePath, { force: true });
+    fs.rmdirSync(directory);
+  }
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
When you paste an OAuth token or API key into the setup wizard, it went straight onto the command line of a child process: `onecli secrets create --name Anthropic --type anthropic --value <token> ...`. Command-line arguments are not private. Any other program on the machine can read them while that child process runs (on Linux `/proc/<pid>/cmdline` is readable by anyone; on macOS `ps` shows them to the same user or to root), and `spawnQuiet` in `setup/lib/runner.ts` writes the whole command line, arguments included, as the first line of the per-step raw log:

```ts
raw.write(`# ${[cmd, ...args].join(' ')} — ${new Date().toISOString()}\n\n`);
```

So the token also landed in plain text in `logs/setup-steps/NN-auth.log`, where it stayed until the next fresh run wiped the directory. That is the same log people are asked to attach when setup misbehaves.

This builds on #3483.

## Description

The two places where the wizard authenticates now hand OneCLI a short-lived file holding the token instead of the token itself. `onecli secrets create` already accepts `--file` as an alternative to `--value` (`Read secret value from a file`), so the vault entry that comes out is exactly the same.

| Where the token showed up | Before | After |
|---|---|---|
| The `onecli` command line, for as long as the call runs | the token | a path under the OS temp directory |
| `logs/setup-steps/NN-auth.log` header line | the token, kept until the next run's `reset()` wiped the directory | that same path, pointing at a file that has already been deleted |

New helper, `setup/lib/secret-file.ts`:

```ts
export async function withSecretFile<T>(secret: string, operation: (filePath: string) => Promise<T>): Promise<T>
```

It makes a fresh directory with `fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-secret-'))`, limits it to the current user with `chmodSync(directory, 0o700)`, and opens the file with `O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW` at mode `0o600`, then sets that mode again with `fchmodSync(fd, 0o600)` so the result does not depend on the process umask. `O_EXCL` makes the open fail if the name already exists, and `O_NOFOLLOW` makes it fail if the name is a symlink, so a file someone planted in the temp directory beforehand cannot redirect the write elsewhere. The file is written and closed *before* `operation` runs, so OneCLI opens a file that is already complete on disk and holds the token bytes and nothing else, with no trailing newline. A `finally` block deletes the file (`force: true`) and then the directory, whether the operation succeeded or threw.

### The two places in the wizard

Both are in `setup/auto.ts` and both change only `'--value', token` to `'--file', filePath`, wrapped in `withSecretFile`:

- `runPasteAuth` (`--type anthropic`, host pattern `api.anthropic.com`) covers the pasted OAuth token and API key.
- `runCustomEndpointAuth` (`--type generic`, `--header-name Authorization`, `--value-format 'Bearer {value}'`) covers a token supplied through `NANOCLAW_ANTHROPIC_AUTH_TOKEN` for a custom Anthropic-compatible endpoint.

Everything else about those calls, the spinner labels, the `extraFields` diagnostics, the `fail()` handling, is untouched. The rest of the `+53/-46` in `setup/auto.ts` is indentation: wrapping the argument array in a callback shifts those lines.

> [!NOTE]
> The secret now briefly touches disk in the OS temp directory instead of only living on the command line. That is the deliberate trade: a `0600` file inside a `0700` directory, deleted in `finally`, versus a value anyone can read off the command line and archived in plain text in a log file.

## Scope

Three files: `setup/auto.ts`, `setup/lib/secret-file.ts`, `setup/lib/secret-file.test.ts`.

Deliberately out of scope: `setup/auth.ts` (the non-interactive `--create --value <token>` step) and `setup/register-claude-token.sh` still pass `--value`. Those are separate entry points, not the wizard path, and are left for a follow-up.

## Verification

```
pnpm exec vitest run setup/lib/secret-file.test.ts
```

Two tests in `setup/lib/secret-file.test.ts`: the callback sees the exact secret at `filePath`, the file's permissions are `mode & 0o777 === 0o600` and the directory's are `0o700`, and both are gone once the call returns; and when the callback throws, the error comes back out unchanged and both are still removed.

Worth checking by hand on a real install: run the wizard's paste-auth path, then `grep` `logs/setup-steps/` for the start of the token (`sk-ant-oat` / `sk-ant-api`). It should match nothing.
