### PR TITLE
docs(setup): document the setup driver protocol and design

### DIFF
--- a/docs/setup-driver-design.md
+++ b/docs/setup-driver-design.md
@@ -1,0 +1,124 @@
+# Structured setup driver: design
+
+## Outcome
+
+A desktop client or a future process proxy can drive NanoClaw setup and
+uninstall without parsing terminal prose or copying NanoClaw policy. NanoClaw
+still decides what happens and validates what actually happened. The client
+renders structured events and returns structured answers.
+
+The terminal stays the default. Machine mode is explicit and versioned:
+
+```text
+bash nanoclaw.sh --protocol nanoclaw.driver.v1
+bash nanoclaw.sh --uninstall --protocol nanoclaw.driver.v1
+```
+
+The exact contract is in
+[setup-driver-protocol.md](setup-driver-protocol.md).
+
+## Ownership boundary
+
+```text
+desktop / proxy
+  │  NDJSON events and commands
+  ▼
+SetupDriver adapter
+  │  same prompts, policy, ordering, and checks
+  ├──────── setup orchestration ─────── service + structured health
+  └──────── uninstall planner ───────── identity checks + exact receipt
+```
+
+| NanoClaw owns | Client owns |
+|---|---|
+| Step order and conditional branches | Layout and controls |
+| Prompt definitions and validation | Secure answer collection |
+| Side effects and postcondition checks | Declarative external-action attempts |
+| Health and service identity | Acquisition provenance |
+| Artifact discovery and uninstall safety | Deleting the checkout only when permitted |
+
+The client never predicts the next step, branches on a label, supplies an
+executable, or decides that an action succeeded. Only one item awaits input at a
+time, so NanoClaw remains the state machine.
+
+## Setup flow
+
+The shell recognizes the protocol before normal output or mutation. It can emit
+structured preflight and bootstrap progress before Node exists, then hands the
+same stream to the TypeScript driver. Unsupported provisioning or a provider
+without a machine adapter returns a typed error with safe recovery instead of
+a command for the client to execute.
+
+The TypeScript adapter exposes progress, prompts, displays, declarative external
+actions, errors, cancellation, and completion. External actions are limited to
+opening an HTTPS URL, starting a named application, or presenting system
+permission instructions. `attempted` is not trusted; NanoClaw rechecks the real
+postcondition.
+
+Completion means healthy, not merely finished. NanoClaw proves that the running
+service belongs to this checkout, queries the same structured host-health model
+used by `ncl health --json`, and reports groups, policies, and skills as loaded
+or explicitly empty. Only that receipt plus exit code `0` is success.
+
+## Secret boundary
+
+Machine secrets arrive only through protocol stdin. They do not enter the
+driver's arguments or environment. OneCLI receives a path to a no-follow,
+private temporary file. Secret-bearing curl effects receive a private curl
+configuration file, so the secret is absent from curl arguments and environment.
+Temporary files are removed in `finally`. Child output stays captured and
+redacted. Terminal setup keeps its existing credential path.
+
+Interactive provider CLIs use inherited stdio only in terminal mode. In machine
+mode a bounded private process seam pipes their bytes to the provider adapter;
+the adapter emits semantic URL, code, prompt, progress, and external-action
+events. Raw provider output never becomes protocol output.
+
+Teams device login follows the same boundary. Machine mode emits the Microsoft
+URL as an external action and the device code as sensitive display content,
+then clears both displays when the login process ends.
+
+Registry sign-in is not an interactive-provider child. Both renderers call one
+RFC 8628 implementation directly. It presents the verification URL, pairing
+code, progress, and cancellation through the selected driver.
+
+Sensitive display content, such as a pairing code, is allowed only in the
+marked display event. A client renders it without logging or persistence and
+clears it when instructed or when the process ends.
+
+## Uninstall flow
+
+Uninstall remains plan-first:
+
+```text
+scan (read only) → emit plan → receive category choices → rescan ownership
+→ execute approved actions → emit each result → emit receipt
+```
+
+Callers approve categories, not paths or process IDs. Exact files have
+`lstat`-based snapshots; checkout-owned directories use scoped root identity.
+Every exact target is revalidated before its action. A changed service blocks
+dependent deletion. A changed `.env`, symlink replacement, or uninspectable
+identity stays untouched, while unrelated approved work may continue.
+
+Credential backups live in a private NanoClaw state directory outside the
+checkout and are returned as external artifacts. Plan artifacts, action results,
+and remaining artifacts stream one item per event. The terminal receipt says
+whether the caller may safely delete the checkout:
+
+```ts
+checkoutRemoval: { safe: boolean; blockers: string[] }
+```
+
+NanoClaw never deletes the checkout.
+
+## Cancellation and compatibility
+
+Commands and presentation data are bounded. Closing stdin is disconnection, not
+success. Cancellation reaches the current bootstrap/setup child process tree;
+uninstall finishes the current atomic action and starts no new one. Exit codes
+remain `0` complete, `1` error or incomplete uninstall, and `2` cancelled.
+
+No protocol flag means the established terminal setup and uninstall behavior.
+V1 intentionally adds no daemon, HTTP or WebSocket transport, remote auth,
+persisted session, resume token, second setup engine, or new dependency.

--- a/docs/setup-driver-protocol.md
+++ b/docs/setup-driver-protocol.md
@@ -1,0 +1,329 @@
+# NanoClaw setup driver protocol v1
+
+`nanoclaw.driver.v1` lets a client render setup or uninstall without parsing
+terminal output. NanoClaw remains the state machine and owns validation, side
+effects, and completion checks.
+
+## Starting a session
+
+```sh
+bash nanoclaw.sh --protocol nanoclaw.driver.v1
+bash nanoclaw.sh --uninstall --protocol nanoclaw.driver.v1
+```
+
+Without `--protocol`, behavior is unchanged. An unsupported protocol fails
+before setup output or mutation.
+
+The process writes one JSON object per line to stdout and reads one JSON object
+per line from stdin. Stderr is empty during a protocol session. Every object has
+this envelope:
+
+```ts
+type Envelope = {
+  protocol: 'nanoclaw.driver.v1';
+  operation: 'setup' | 'uninstall';
+};
+```
+
+The first event is `hello`. It is emitted once across the shell bootstrap and
+TypeScript handoff.
+
+```json
+{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"hello"}
+```
+
+Exit codes are `0` for complete, `1` for error or incomplete uninstall, and `2`
+for cancellation.
+
+## Renderer parity
+
+Terminal and protocol mode call the same setup flow. `auto.ts` defines ordering,
+choices, side effects, and postconditions through `SetupDriver`; each renderer
+only presents those operations. Parity tests run the production first-agent
+choice through both renderers and exercise production template stamping through
+the real socket contract. A parity lint prevents direct prompt primitives from
+returning to `auto.ts`.
+
+Transport still creates three intentional differences. Protocol mode requires
+structured healthy completion, transports secrets on stdin, and removes
+terminal-only back navigation because the app owns its preflight navigation.
+These differences do not create a second setup policy or runner.
+
+## Commands
+
+Only the current outstanding item accepts an answer. A command with a different
+ID, or a command sent when nothing is pending, is rejected as `stale_command`.
+There is no replay cache or command fingerprint protocol.
+
+```ts
+type Command = Envelope & (
+  | { type: 'answer'; promptId: string; value: boolean | string }
+  | {
+      type: 'externalActionCompleted';
+      actionId: string;
+      result: 'attempted' | 'declined' | 'unsupported';
+    }
+  | {
+      type: 'applyUninstall';
+      planId: string;
+      choices: Array<{
+        groupId: 'service' | 'data' | 'user' | 'onecli';
+        choice: 'preserve' | 'remove';
+      }>;
+    }
+  | { type: 'cancel'; reason?: string }
+);
+```
+
+Each command string is bounded to 64 KiB, arrays are bounded to 64 entries,
+and an input line is bounded to 1 MiB.
+
+## Common events
+
+### Progress
+
+```ts
+type ProgressEvent = Envelope & {
+  type: 'progress';
+  stepId: string;
+  state: 'pending' | 'running' | 'succeeded' | 'failed';
+  label?: string;
+};
+```
+
+A step that successfully falls back to another supported path is `succeeded`.
+There is no `skipped` wire state.
+
+### Prompt
+
+```ts
+type PromptEvent = Envelope & {
+  type: 'prompt';
+  prompt: {
+    id: string;
+    kind: 'confirm' | 'singleChoice' | 'text' | 'secret';
+    message: string;
+    sensitive: boolean;
+    choices?: Array<{ id: string; label: string }>;
+    default?: boolean | string;
+    validation?: {
+      required?: boolean;
+      minLength?: number;
+      maxLength?: number;
+      pattern?: string;
+    };
+  };
+};
+```
+
+The client answers with `answer`. A secret answer must arrive on protocol stdin.
+Secrets are forbidden in launch arguments and environment variables. A client
+must not log or persist a prompt marked `sensitive`.
+
+### Display
+
+```ts
+type Display =
+  | { id: string; kind: 'text' | 'code'; content: string; label?: string; sensitive: boolean }
+  | { id: string; kind: 'url'; url: string; label: string; sensitive: boolean }
+  | { id: string; kind: 'qr'; payload: string; label?: string; sensitive: boolean };
+
+type DisplayEvent = Envelope & { type: 'display'; display: Display };
+type ClearDisplayEvent = Envelope & { type: 'clearDisplay'; displayId: string };
+```
+
+Sensitive displays are the only events allowed to carry a pairing code or
+verification URL containing a code. Render them without persistence and clear
+them on `clearDisplay` or process exit.
+
+### External action
+
+```ts
+type ExternalActionEvent = Envelope & {
+  type: 'externalAction';
+  action:
+    | { id: string; kind: 'openURL'; title: string; url: string }
+    | { id: string; kind: 'startApplication'; title: string; application: string }
+    | { id: string; kind: 'systemPermission'; title: string; instructions: string[] };
+};
+```
+
+An `openURL` action always uses HTTPS. The client reports only whether it
+attempted, declined, or could not support the action. NanoClaw checks any
+required postcondition itself.
+
+### Rejected input
+
+```ts
+type InputRejectedEvent = Envelope & {
+  type: 'inputRejected';
+  itemId?: string;
+  code: string;
+  message: string;
+};
+```
+
+Rejection is nonterminal. The current item remains pending unless another valid
+command has already resolved it.
+
+### Error and cancellation
+
+```ts
+type Recovery =
+  | { kind: 'rerun'; args: string[] }
+  | { kind: 'manual'; title: string; instructions: string[] };
+
+type ErrorEvent = Envelope & {
+  type: 'error';
+  code: string;
+  stepId?: string;
+  message: string;
+  recovery: Recovery[];
+};
+
+type CancelledEvent = Envelope & {
+  type: 'cancelled';
+  lastStepId?: string;
+};
+```
+
+`error` and `cancelled` are terminal. Closing stdin requests cancellation. During
+uninstall, NanoClaw completes the current atomic action and starts no new action.
+
+## Setup completion
+
+```ts
+type SetupCompleteEvent = Envelope & {
+  type: 'complete';
+  receipt: {
+    version: 1;
+    service: {
+      state: 'running';
+      manager: 'launchd' | 'systemd-user' | 'systemd-system' | 'pidfile';
+      checkoutRoot: string;
+    };
+    health: { status: 'healthy' };
+    resources: {
+      groups: { state: 'loaded' | 'empty'; count: number };
+      policies: { state: 'loaded' | 'empty'; count: number };
+      skills: { state: 'loaded' | 'empty'; count: number };
+    };
+    completedAt: string;
+  };
+};
+```
+
+Setup completes only after service ownership and structured host health are
+verified.
+
+## Uninstall
+
+Uninstall is plan-first and defaults every group to preservation. NanoClaw emits
+each artifact as it is discovered, then emits the actionable plan header.
+
+```ts
+type Artifact = {
+  id: string;
+  kind: string;
+  label: string;
+  location: string;
+  disposition: 'owned' | 'shared' | 'external' | 'uninspectable' | 'alreadyAbsent';
+  decisionGroup?: 'service' | 'data' | 'user' | 'onecli';
+};
+
+type UninstallPlanItemEvent = Envelope & {
+  type: 'uninstallPlanItem';
+  planId: string;
+  artifact: Artifact;
+};
+
+type UninstallPlanEvent = Envelope & {
+  type: 'uninstallPlan';
+  plan: {
+    id: string;
+    groups: Array<{
+      id: 'service' | 'data' | 'user' | 'onecli';
+      label: string;
+      description: string;
+      default: 'preserve';
+      choices: ['preserve', 'remove'];
+    }>;
+  };
+};
+```
+
+The client must send exactly one choice for each group. NanoClaw rejects unsafe
+combinations, rescans ownership after approval, and executes only the accepted
+plan.
+
+Each result is streamed once:
+
+```ts
+type UninstallActionEvent = Envelope & {
+  type: 'uninstallAction';
+  result: {
+    actionId: string;
+    artifactId: string;
+    outcome: 'removed' | 'preserved' | 'failed' | 'untouched' | 'alreadyAbsent';
+    error?: { code: string; message: string };
+  };
+};
+```
+
+Remaining artifacts, including credential backups outside the checkout, are
+streamed before the terminal event:
+
+```ts
+type UninstallReceiptItemEvent = Envelope & {
+  type: 'uninstallReceiptItem';
+  section: 'remaining';
+  artifact: Artifact;
+};
+
+type UninstallCompleteEvent = Envelope & {
+  type: 'complete';
+  receipt: {
+    version: 1;
+    outcome: 'success' | 'incomplete';
+    checkoutRemoval: { safe: boolean; blockers: string[] };
+    completedAt: string;
+  };
+};
+```
+
+There are no pages and no pagination counters. The client may delete the source
+checkout only when exit code is `0`, the receipt outcome is `success`, and
+`checkoutRemoval.safe` is `true`. NanoClaw never deletes the checkout.
+
+## Minimal client loop
+
+```ts
+for await (const event of readNdjson(child.stdout)) {
+  switch (event.type) {
+    case 'prompt':
+      write({ ...envelope, type: 'answer', promptId: event.prompt.id, value: await renderPrompt(event.prompt) });
+      break;
+    case 'externalAction':
+      write({ ...envelope, type: 'externalActionCompleted', actionId: event.action.id, result: await attempt(event.action) });
+      break;
+    case 'uninstallPlanItem':
+      renderArtifact(event.artifact);
+      break;
+    case 'uninstallPlan':
+      write({ ...envelope, type: 'applyUninstall', planId: event.plan.id, choices: await approve(event.plan.groups) });
+      break;
+    case 'uninstallAction':
+    case 'uninstallReceiptItem':
+    case 'progress':
+    case 'display':
+    case 'clearDisplay':
+    case 'inputRejected':
+      render(event);
+      break;
+    case 'complete':
+    case 'error':
+    case 'cancelled':
+      return event;
+  }
+}
+```

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -121,13 +121,14 @@ On failure the completion block names the failing step and its error:
 ### Level 3: raw per-step logs
 
 `logs/setup-steps/NN-step-name.log` — one file per step, numbered in
-execution order (zero-padded 2-digit prefix for natural sorting). Full
-verbatim stdout + stderr from the child process. Truncated and rewritten
-on each run (not appended).
+execution order (zero-padded 2-digit prefix for natural sorting). Full verbatim
+stdout + stderr from the child process. Truncated and rewritten on each run
+(not appended).
 
-Contents are whatever the step emits: apt output, docker build layers,
-pnpm install spam, `curl` bodies, etc. This is the evidence plane —
-"what did the shell actually see?" Nothing is filtered.
+Contents are whatever the step emits: apt output, docker build layers, pnpm
+install spam, `curl` bodies, etc. This is the evidence plane: "what did the shell
+actually see?" Nothing is filtered in terminal mode. Protocol mode keeps secret
+values and sensitive QR or pairing displays out of these logs.
 
 ## Contract for a new step
 
@@ -160,10 +161,10 @@ installer invoked from `auto.ts`), it must:
 The driver handles the rest: spinner in level 1, structured append to
 level 2, raw capture to level 3.
 
-## The Anthropic exception
+## The Anthropic terminal exception
 
-Anthropic credential registration (`setup/register-claude-token.sh`) is
-the **one** permitted break in the visual flow. Why:
+Anthropic credential registration (`setup/register-claude-token.sh`) is the
+**one** permitted break in the normal terminal visual flow. Why:
 
 - `claude setup-token` opens a browser, runs its own OAuth prompt, and
   prints the token. It owns the TTY via `script(1)`.
@@ -182,6 +183,13 @@ The level-2 log still gets an entry (`auth [interactive] → success`
 with the method — subscription / oauth / api). Level-3 captures
 are optional here; mirroring `script -q` output is tricky and the risk of
 leaking the token to disk outweighs the debugging value.
+
+Machine mode does not run this terminal script. It pipes `claude setup-token`
+through the private interactive-process seam, and the Claude adapter translates
+only the provider URL, authorization-code prompt, and progress into driver
+events. The returned token is registered as sensitive, passed to OneCLI through
+a one-use `0600` file, and removed with the isolated auth home in `finally`.
+Terminal users still take the inherited-stdio path above.
 
 ## Channel installs are skill-driven
 
@@ -205,6 +213,8 @@ convention — [skill-engine-seam.md](skill-engine-seam.md) §6).
 | `setup/logs.ts` | The logging primitives (`step`, `userInput`, `complete`, `stepRawLog`, `reset`). Single source of truth for level 2/3 formatting and file paths. |
 | `setup/<step>.ts` | Individual step implementations. Must emit one terminal status block; must not write directly to the terminal. |
 | `setup/register-claude-token.sh` | The Anthropic exception. Inherits stdio, prints its own UI, returns a status to the driver. |
+| `setup/lib/claude-subscription-auth.ts` | Machine-only Claude subscription adapter: provider output interpretation, semantic driver events, isolated credential capture, and vault handoff. |
+| `setup/lib/interactive-process.ts` | Provider-neutral private child boundary for terminal inheritance or bounded machine pipes, minimal environment, and process-group cancellation. |
 | `setup/lib/skill-driver.ts` | Generic skill runner: applies a SKILL.md's `nc:` directives via the engine (`scripts/skill-apply.ts`) and renders its events through clack — prompts via `resolveInput`, spinners for step events, operator notes with the gate/URL-offer policy from `scripts/skill-policy.ts`. Owns all prompting/gating presentation; the engine only declares and emits. |
 | `setup/channels/run-channel-skill.ts` | The generic channel-install entry: drives the channel's `/add-<channel>` SKILL.md through the skill driver, then owns the shared wire (agent name + operator role → `scripts/init-first-agent.ts`). One flow for every channel — no bespoke per-channel code. |
 | `setup/pair-telegram.ts` | Emits `PAIR_TELEGRAM_CODE` / `PAIR_TELEGRAM_ATTEMPT` / `PAIR_TELEGRAM` status blocks. Never prints UI. The driver renders it via clack notes. |
@@ -234,6 +244,3 @@ convention — [skill-engine-seam.md](skill-engine-seam.md) §6).
 - **Raw log rotation for multi-run installs.** Currently each run
   overwrites. Fine for now; revisit if support needs to compare
   successive attempts.
-- **Structured output from `register-claude-token.sh`.** The interactive
-  step emits no machine-readable status today. Future could add a
-  post-interaction status block with the method used.


### PR DESCRIPTION
## TL;DR

Proposed documentation-only change, the last of the 39 pull requests in this stack: it writes down the setup driver protocol that the previous 38 pull requests built, and refreshes the existing setup flow document to match. No code, no tests, no behaviour change.

## What problem it solves

The rest of this stack added a way for a program, rather than a person at a terminal, to run NanoClaw setup: NanoClaw prints one JSON object per line on stdout describing what it wants (a prompt, a progress step, a URL to open), and the program answers with one JSON object per line on stdin. That wire format, called `nanoclaw.driver.v1`, existed only in TypeScript types. Anyone writing a client (the native macOS app, for example) would have had to read the source to learn it. These documents state the contract in one place.

## How it works

Three files:

| File | What it is |
|---|---|
| `docs/setup-driver-protocol.md` (new, 329 lines) | The reference. How to start a session (`bash nanoclaw.sh --protocol nanoclaw.driver.v1`), the common envelope on every message, the `hello` handshake, the four commands a client may send, every event type (progress, prompt, display, external action, rejected input, error, cancellation), the setup completion receipt, the whole uninstall plan-then-approve exchange, and a minimal client loop to copy. |
| `docs/setup-driver-design.md` (new, 124 lines) | The rationale. Who owns what (NanoClaw owns step order, validation and postcondition checks; the client owns layout and collecting answers), why secrets travel on stdin and never in arguments or environment, what "complete" means (a proven-healthy service, not merely a finished run), and what v1 deliberately does not add: no daemon, no HTTP or WebSocket transport, no resume tokens, no new dependency. |
| `docs/setup-flow.md` (edited, +19/-12) | The pre-existing setup document, brought up to date: two new rows in its file map for `setup/lib/claude-subscription-auth.ts` and `setup/lib/interactive-process.ts`; a paragraph explaining that machine mode does not run the interactive `register-claude-token.sh` shell script but pipes `claude setup-token` through the bounded process seam instead; one sentence saying protocol mode keeps secret values and pairing or QR displays out of the raw per-step logs; and the deletion of a future-work bullet that this stack has now done. The remaining removed lines are prose rewrapping, including one em dash replaced by a colon. |

## What trips people up

- **Docs land last on purpose.** Documenting a wire format before the format settles produces a stale document. Every type described here was fixed early in the stack and untouched afterwards, so the text is written against declarations that are already merged below it. The trade-off is that reviewers of the earlier pull requests had no specification to read; that was accepted.
- **The `setup-flow.md` bullet deletion is a claim, not just tidying.** The removed future-work item said structured output from the Anthropic credential step did not exist yet. It exists now, which is only true with the whole stack applied, so the deletion belongs in this final pull request and nowhere earlier.
- **Zero production and zero test lines.** That is the entire change; there is nothing dormant here waiting to be switched on by a later pull request, because this is the last one.

## What to review

Read the two new documents against the merged declarations, mainly `setup/lib/setup-driver.ts`: `DriverPrompt`, `DriverDisplay`, `ExternalAction`, `UninstallPlan`, `UninstallReceipt` and `SetupReceipt`, plus the bound constants (`MAX_INPUT_LINE_BYTES` 1 MiB, `MAX_COMMAND_STRING_BYTES` 64 KiB, `MAX_COMMAND_ARRAY_LENGTH` 64) and the `stale_command` rejection. Those all matched when this description was written. The claim about a parity lint keeping direct prompt primitives out of `auto.ts` corresponds to the third case in `setup/setup-driver-parity.test.ts`, added by the previous pull request in the stack.

Because this is the tip of the stack, it is also where the whole split is proved: with all 39 applied, the tree is byte-identical to the single upstream commit they replace, confirmed by an empty `git diff` between the two.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box is ticked. This is documentation only, but the "Documentation" box is scoped to docs, README or CONTRIBUTING changes, and the closest honest reading is that these are developer specification documents shipped as part of a feature stack rather than a standalone docs change. Reviewers who read that box more broadly may consider it the intended one.

## For Skills

Not a skill, so the skill checklist does not apply.

## Verification

Documentation only, so nothing to run. For the record, this commit passes the same gates as the rest of the stack: the setup-inclusive TypeScript check and `bash -n nanoclaw.sh`. Across the stack the full test run goes from 2038 passed / 4 failed at the base to 2150 passed / 4 failed here; the 4 are a pre-existing git tag-signing problem on the author's machine that also fails on a clean upstream checkout. Note that `tsconfig.json` covers only `src/**/*`, so CI does not typecheck `setup/` or `scripts/`.