### PR TITLE
feat(setup): expose the build-time preseed catalog (--catalog-preseeds)

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -25,6 +25,22 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
+# --catalog-preseeds is a read-only build-time contract. Never bootstrap or
+# create setup state just to inspect it.
+for arg in "$@"; do
+  if [ "$arg" = "--catalog-preseeds" ]; then
+    if [ "$#" -ne 1 ]; then
+      echo "--catalog-preseeds does not accept other arguments" >&2
+      exit 2
+    fi
+    if ! command -v node >/dev/null 2>&1 || [ ! -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; then
+      echo "Cannot print the preseed catalog: run pnpm install first." >&2
+      exit 1
+    fi
+    exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/catalog-preseeds.ts"
+  fi
+done
+
 # ─── --slack-agents: former testing flag, accepted and ignored ─────────
 # The managed Slack experience is simply the default; the flag that once
 # enabled it is swallowed so older invocations keep working.
@@ -165,6 +181,7 @@ for arg in "$@"; do
     fi
     echo "Usage: bash nanoclaw.sh [options]"
     echo ""
+    echo "  --catalog-preseeds    Print the build-time preseed contract as JSON"
     echo "  --template-path <ref>  Create or update an agent from templates/<ref>"
     echo "  --uninstall            Uninstall this NanoClaw copy"
     echo "  --help, -h             Show this help without installing dependencies"

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -40,7 +40,7 @@ import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
 import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
-import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './providers/registry.js';
+import { getSetupProvider, listSetupProviderChoices, runSetupProviderAuth } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
@@ -1312,15 +1312,6 @@ function sendChatMessage(driver: SetupDriver, message: string): Promise<void> {
 
 // ─── auth step (select → branch) ────────────────────────────────────────
 
-// Providers offered for install are hard-wired in trunk — an audited control
-// surface (no branch enumeration that anyone with write access could extend).
-// Codex is the only one offered here; opencode/ollama install via their own
-// /add-* skills. Each is installed by applying its `/add-<name>` SKILL.md
-// in-process via the directive engine.
-const INSTALLABLE_PROVIDERS = [
-  { value: 'codex', label: 'Codex', hint: 'OpenAI — ChatGPT subscription or API key' },
-] as const;
-
 // `pickSavedByPreviousRun`: the .env bridge promoted a pick persisted by a
 // PREVIOUS run. That pick is a default to confirm, not a decision to replay:
 // the operator may be rerunning precisely to change it. In-process presets
@@ -1831,11 +1822,6 @@ function finishRegistryLogin(driver: SetupDriver, durationMs: number, method?: s
 }
 
 async function askAgentProviderChoice(driver: SetupDriver): Promise<string> {
-  const installed = listSetupProviders();
-  const installedNames = new Set(installed.map((entry) => entry.value));
-  // Offer the hard-wired installable providers this install hasn't wired yet —
-  // selecting one applies its `/add-<name>` SKILL.md in-process.
-  const available = INSTALLABLE_PROVIDERS.filter((prov) => !installedNames.has(prov.value));
   // On a pinned install every non-Claude runtime forces a local rebuild — the
   // image bakes /app/node_modules and the CLI manifest, and each changes one.
   // Say so on the option rather than only at the confirm two steps later, so
@@ -1845,14 +1831,11 @@ async function askAgentProviderChoice(driver: SetupDriver): Promise<string> {
   const note = (value: string, hint: string): string =>
     pinned && value !== 'claude' ? `${hint} — ⚠ not in the pre-built image; needs a local build` : hint;
 
-  const options = [
-    ...installed.map(({ value, label, hint }) => ({ value, label, hint: note(value, hint) })),
-    ...available.map((prov) => ({
-      value: prov.value,
-      label: prov.label,
-      hint: note(prov.value, `${prov.hint} — installs now`),
-    })),
-  ];
+  const options = listSetupProviderChoices().map(({ value, label, hint }) => ({
+    value,
+    label,
+    hint: note(value, hint),
+  }));
   const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
   if (preset) {
     if (!options.some((option) => option.value === preset)) {

--- a/setup/catalog-preseeds.test.ts
+++ b/setup/catalog-preseeds.test.ts
@@ -14,12 +14,12 @@ describe('--catalog-preseeds', () => {
         'nanoclaw.sh',
         'setup/catalog-preseeds.ts',
         'setup/lib/setup-config.ts',
-        'setup/providers/index.ts',
         'setup/providers/registry.ts',
       ]) {
         fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
         fs.copyFileSync(path.join(process.cwd(), file), path.join(root, file));
       }
+      fs.writeFileSync(path.join(root, 'setup', 'providers', 'index.ts'), '');
       fs.symlinkSync(path.join(process.cwd(), 'node_modules'), path.join(root, 'node_modules'));
 
       const result = spawnSync('bash', ['nanoclaw.sh', '--catalog-preseeds'], {

--- a/setup/catalog-preseeds.test.ts
+++ b/setup/catalog-preseeds.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import { describe, expect, it } from 'vitest';
+
+describe('--catalog-preseeds', () => {
+  it('prints the UI preseed contract before setup can mutate the checkout', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-preseeds-'));
+    try {
+      fs.mkdirSync(path.join(root, 'setup', 'lib'), { recursive: true });
+      for (const file of [
+        'nanoclaw.sh',
+        'setup/catalog-preseeds.ts',
+        'setup/lib/setup-config.ts',
+        'setup/providers/index.ts',
+        'setup/providers/registry.ts',
+      ]) {
+        fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+        fs.copyFileSync(path.join(process.cwd(), file), path.join(root, file));
+      }
+      fs.symlinkSync(path.join(process.cwd(), 'node_modules'), path.join(root, 'node_modules'));
+
+      const result = spawnSync('bash', ['nanoclaw.sh', '--catalog-preseeds'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      const catalog = JSON.parse(result.stdout) as {
+        preseeds: Array<{
+          key: string;
+          kind: string;
+          default: unknown;
+          options: Array<unknown>;
+          validation: unknown;
+        }>;
+      };
+      expect(catalog.preseeds.map((entry) => entry.key).sort()).toEqual(
+        [
+          'agentName',
+          'agentProvider',
+          'anthropicAuthToken',
+          'anthropicBaseUrl',
+          'displayName',
+          'hardenedImage',
+          'onecliApiHost',
+          'onecliApiToken',
+          'skip',
+          'templatePath',
+        ].sort(),
+      );
+      expect(catalog.preseeds.every((entry) => entry.kind && Array.isArray(entry.options))).toBe(true);
+      expect(
+        catalog.preseeds
+          .find((entry) => entry.key === 'agentProvider')
+          ?.options.map((option) => (option as { value: string }).value),
+      ).toEqual(['claude', 'codex']);
+      expect(catalog.preseeds.find((entry) => entry.key === 'hardenedImage')?.options).toEqual([true, false]);
+      expect(catalog.preseeds.find((entry) => entry.key === 'onecliApiHost')?.default).toBeNull();
+      expect(catalog.preseeds.find((entry) => entry.key === 'onecliApiHost')?.validation).toEqual({
+        kind: 'httpUrl',
+        message: 'Must be http(s)://…',
+      });
+      expect(fs.existsSync(path.join(root, 'logs'))).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/catalog-preseeds.ts
+++ b/setup/catalog-preseeds.ts
@@ -1,0 +1,39 @@
+import { CONFIG, envVarFor, flagFor, type Entry } from './lib/setup-config.js';
+import './providers/index.js';
+import { listSetupProviderChoices } from './providers/registry.js';
+
+function catalogEntry(entry: Entry) {
+  return {
+    key: entry.key,
+    envVar: envVarFor(entry),
+    flag: flagFor(entry),
+    kind: entry.type,
+    label: entry.label,
+    help: entry.help,
+    group: entry.group ?? null,
+    secret: entry.secret ?? false,
+    default: entry.default ?? null,
+    options:
+      entry.key === 'agentProvider'
+        ? listSetupProviderChoices()
+        : entry.type === 'enum'
+          ? entry.options
+          : entry.type === 'boolean'
+            ? [true, false]
+            : [],
+    validation:
+      entry.type === 'string' || entry.type === 'url'
+        ? (entry.validation ?? null)
+        : entry.type === 'integer'
+          ? { min: entry.min ?? null, max: entry.max ?? null }
+          : null,
+  };
+}
+
+process.stdout.write(
+  `${JSON.stringify(
+    { preseeds: CONFIG.filter((entry) => entry.surface === 'flag+ui' || entry.preseed).map(catalogEntry) },
+    null,
+    2,
+  )}\n`,
+);

--- a/setup/lib/setup-config-parse.test.ts
+++ b/setup/lib/setup-config-parse.test.ts
@@ -38,4 +38,10 @@ describe('public setup flags', () => {
       errors: [],
     });
   });
+
+  it('uses the cataloged validation rules when parsing flags', () => {
+    expect(parseFlags(['--onecli-api-host', 'not-a-url']).errors).toEqual(['--onecli-api-host: Must be http(s)://…']);
+    expect(parseFlags(['--onecli-api-token', 'wrong']).errors).toEqual(['--onecli-api-token: Must start with oc_']);
+    expect(parseFlags(['--onecli-api-host', 'https://api.onecli.sh']).errors).toEqual([]);
+  });
 });

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -13,7 +13,7 @@
  *   --key            booleans only (sets true)
  *   --no-key         booleans only (sets false)
  */
-import { CONFIG, envVarFor, flagFor, findByFlag, type Entry } from './setup-config.js';
+import { CONFIG, envVarFor, flagFor, findByFlag, validateEntry, type Entry } from './setup-config.js';
 
 export type ConfigValues = Record<string, string | boolean | number>;
 
@@ -40,7 +40,7 @@ export function readFromEnv(env: NodeJS.ProcessEnv = process.env): ConfigValues 
     const raw = env[envVarFor(e)];
     if (raw === undefined || raw === '') continue;
     const v = coerce(e, raw);
-    if ((e.type === 'string' || e.type === 'url') && e.validate?.(raw)) continue;
+    if ((e.type === 'string' || e.type === 'url') && validateEntry(e, raw)) continue;
     if (v !== undefined) out[e.key] = v;
   }
   return out;
@@ -115,7 +115,7 @@ export function parseFlags(argv: string[]): FlagParseResult {
       continue;
     }
     if (entry.type === 'string' || entry.type === 'url') {
-      const err = entry.validate?.(raw);
+      const err = validateEntry(entry, raw);
       if (err) {
         errors.push(`${name}: ${err}`);
         continue;

--- a/setup/lib/setup-config-screen.ts
+++ b/setup/lib/setup-config-screen.ts
@@ -14,7 +14,7 @@ import * as p from '@clack/prompts';
 
 import { brightSelect } from './bright-select.js';
 import { ensureAnswer } from './runner.js';
-import { CONFIG, type Entry } from './setup-config.js';
+import { CONFIG, validateEntry, type Entry } from './setup-config.js';
 import type { ConfigValues } from './setup-config-parse.js';
 import type { SetupDriver } from './setup-driver.js';
 
@@ -138,7 +138,7 @@ async function promptOne(e: Entry, values: ConfigValues, driver?: SetupDriver): 
   const validate = (v: string | undefined): string | undefined => {
     const s = (v ?? '').trim();
     if (!s) return undefined;
-    return e.validate?.(s);
+    return validateEntry(e, s);
   };
   const ans = driver
     ? await driver.prompt({

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -30,13 +30,18 @@ interface BaseEntry {
   group?: string;
   /** Mask in UI, redact in logs. */
   secret?: boolean;
+  /** Expose this flag-only setting to app setup preflight. */
+  preseed?: boolean;
 }
 
 interface StringEntry extends BaseEntry {
   type: 'string' | 'url';
   default?: string;
   placeholder?: string;
-  validate?: (v: string) => string | undefined;
+  validation?:
+    | { kind: 'httpUrl'; message: string }
+    | { kind: 'prefix'; value: string; message: string }
+    | { kind: 'nonEmpty'; message: string };
 }
 
 interface EnumEntry extends BaseEntry {
@@ -77,9 +82,8 @@ export const CONFIG: Entry[] = [
     surface: 'flag+ui',
     group: 'OneCLI',
     type: 'url',
-    default: 'https://api.onecli.sh',
     placeholder: 'https://api.onecli.sh',
-    validate: validateHttpUrl,
+    validation: { kind: 'httpUrl', message: 'Must be http(s)://…' },
   },
   {
     key: 'onecliApiToken',
@@ -90,7 +94,7 @@ export const CONFIG: Entry[] = [
     type: 'string',
     secret: true,
     placeholder: 'oc_…',
-    validate: (v) => (v.startsWith('oc_') ? undefined : 'Must start with oc_'),
+    validation: { kind: 'prefix', value: 'oc_', message: 'Must start with oc_' },
   },
   {
     key: 'anthropicBaseUrl',
@@ -100,7 +104,7 @@ export const CONFIG: Entry[] = [
     group: 'Anthropic',
     type: 'url',
     placeholder: 'https://api.anthropic.com',
-    validate: validateHttpUrl,
+    validation: { kind: 'httpUrl', message: 'Must be http(s)://…' },
   },
   {
     key: 'anthropicAuthToken',
@@ -110,7 +114,7 @@ export const CONFIG: Entry[] = [
     group: 'Anthropic',
     type: 'string',
     secret: true,
-    validate: (v) => (v.trim() ? undefined : 'Required'),
+    validation: { kind: 'nonEmpty', message: 'Required' },
   },
   {
     key: 'templatePath',
@@ -129,6 +133,7 @@ export const CONFIG: Entry[] = [
     label: 'Skip steps',
     help: 'Comma-separated step names to skip (debugging only).',
     surface: 'flag',
+    preseed: true,
     type: 'string',
   },
   {
@@ -137,6 +142,7 @@ export const CONFIG: Entry[] = [
     label: 'Display name',
     help: 'Skip the "what should your assistant call you?" prompt.',
     surface: 'flag',
+    preseed: true,
     type: 'string',
   },
   {
@@ -145,7 +151,26 @@ export const CONFIG: Entry[] = [
     label: 'Agent provider',
     help: 'Preselect the setup provider and skip the provider picker.',
     surface: 'flag',
+    preseed: true,
     type: 'string',
+  },
+  {
+    key: 'agentName',
+    envVar: 'NANOCLAW_AGENT_NAME',
+    label: 'Agent name',
+    help: 'Name the first messaging-channel agent.',
+    surface: 'flag',
+    preseed: true,
+    type: 'string',
+  },
+  {
+    key: 'hardenedImage',
+    envVar: 'NANOCLAW_HARDENED_IMAGE',
+    label: 'Use pre-built image',
+    help: 'Use the hardened pre-built image instead of building locally.',
+    surface: 'flag',
+    preseed: true,
+    type: 'boolean',
   },
   {
     key: 'assistMode',
@@ -198,4 +223,19 @@ export function flagFor(e: Entry): string {
 
 export function findByFlag(flag: string): Entry | null {
   return CONFIG.find((e) => flagFor(e) === flag) ?? null;
+}
+
+export function validateEntry(entry: Entry, value: string): string | undefined {
+  if (entry.type !== 'string' && entry.type !== 'url') return undefined;
+  const rule = entry.validation;
+  if (!rule) return undefined;
+
+  switch (rule.kind) {
+    case 'httpUrl':
+      return validateHttpUrl(value);
+    case 'prefix':
+      return value.startsWith(rule.value) ? undefined : rule.message;
+    case 'nonEmpty':
+      return value.trim() ? undefined : rule.message;
+  }
 }

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -122,9 +122,9 @@ describe('setup provider registry', () => {
 });
 
 describe('setup flow consumes the registry (structural)', () => {
-  it('the picker renders options from listSetupProviders', () => {
+  it('the picker renders the shared provider choices', () => {
     const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'auto.ts'), 'utf-8');
-    expect(src).toContain('listSetupProviders()');
+    expect(src).toContain('listSetupProviderChoices()');
     expect(src).toContain("import './providers/index.js'");
     expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
     // The capability-keyed branch — a provider's own auth runs iff it declares one.

--- a/setup/providers/registry.ts
+++ b/setup/providers/registry.ts
@@ -39,6 +39,12 @@ export interface SetupProviderEntry {
 
 const registry = new Map<string, SetupProviderEntry>();
 
+// Audited providers offered for installation when their payload is not
+// already present. Provider branches register themselves in the map above.
+const INSTALLABLE_PROVIDERS = [
+  { value: 'codex', label: 'Codex', hint: 'OpenAI - ChatGPT subscription or API key' },
+] as const;
+
 registry.set('claude', {
   value: 'claude',
   label: 'Claude',
@@ -80,4 +86,17 @@ export async function runSetupProviderAuth(entry: SetupProviderEntry, driver: Se
 /** Claude (the default) first, then the rest in registration order. */
 export function listSetupProviders(): SetupProviderEntry[] {
   return [...registry.values()];
+}
+
+/** The shared picker/catalog choices, including provider payloads installable from trunk. */
+export function listSetupProviderChoices(): Array<{ value: string; label: string; hint: string }> {
+  const installed = listSetupProviders();
+  const installedNames = new Set(installed.map((entry) => entry.value));
+  return [
+    ...installed.map(({ value, label, hint }) => ({ value, label, hint })),
+    ...INSTALLABLE_PROVIDERS.filter(({ value }) => !installedNames.has(value)).map((provider) => ({
+      ...provider,
+      hint: `${provider.hint} - installs now`,
+    })),
+  ];
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
Anything that wants to fill in a NanoClaw install's settings before handing off to the wizard has to know three things: which setup settings exist, what each one accepts, and what makes a value invalid. Today only the running wizard knows. The settings live in `CONFIG` in `setup/lib/setup-config.ts`, but the rules that check a value are small functions written inline on each entry (`validate: (v) => v.startsWith('oc_') ? undefined : 'Must start with oc_'`), and nothing outside that process can read them. The provider list is a constant written directly into `setup/auto.ts`. Any front end that wants the same knowledge has to copy it by hand, and that copy goes stale the first time a flag is added or a rule changes.

This PR turns that knowledge into one read-only list, generated from the code itself rather than kept as a second copy: `bash nanoclaw.sh --catalog-preseeds` prints the list as JSON and exits, without bootstrapping anything.

Built on top of #3485 (base branch `feat/setup-driver-v1`); the diff here is only this PR's own two commits.

## How it works

```mermaid
flowchart TD
  GATE{"first argument check in nanoclaw.sh"} -->|"exec tsx"| CAT["setup/catalog-preseeds.ts"]
  GATE -.->|"never reached"| BOOT["diagnostics, logs/, setup state, wizard"]
  CFG["setup-config.ts CONFIG + validateEntry"] --> CAT
  CFG --> PARSE["setup-config-parse.ts"]
  CFG --> SCREEN["setup-config-screen.ts"]
  REG["providers/registry.ts listSetupProviderChoices()"] --> CAT
  REG --> PICK["provider picker in setup/auto.ts"]
```

**The check in the shell script** (`nanoclaw.sh`, 17 lines) is the very first argument scan in the script, ahead of the `--slack-agents` filter, ahead of `--help` and `--uninstall`, and ahead of the `source setup/lib/diagnostics.sh` that emits `setup_launched`, so printing the list sends no telemetry event. `--catalog-preseeds` with any other argument exits 2; a missing `node` or `tsx` exits 1 with `Cannot print the preseed catalog: run pnpm install first.` rather than installing anything.

**Validation rules become data.** `StringEntry.validate?: (v: string) => string | undefined` becomes `validation?: { kind: 'httpUrl' | 'prefix' | 'nonEmpty', … }` plus one shared `validateEntry(entry, value)` in `setup/lib/setup-config.ts`, called from `parseFlags` and `readFromEnv` as well as the terminal screen. The printed list carries that same rule object.

**One provider list.** `INSTALLABLE_PROVIDERS` (currently just Codex) moves out of `setup/auto.ts` into `setup/providers/registry.ts`, behind a new `listSetupProviderChoices()` that merges the providers already installed in this checkout (they register themselves) with the reviewed installable ones, and appends the `installs now` hint.

### What the list contains

`CONFIG.filter((entry) => entry.surface === 'flag+ui' || entry.preseed)`, ten entries today:

| Included | Why |
|---|---|
| `onecliApiHost`, `onecliApiToken`, `anthropicBaseUrl`, `anthropicAuthToken`, `templatePath` | already `surface: 'flag+ui'` |
| `skip`, `displayName`, `agentProvider`, `agentName`, `hardenedImage` | flag-only, newly marked `preseed: true` |

`assistMode`, `uninstall`, `dryRun` and `yes` stay out: an entry has to be marked `preseed` to be included, so debug and lifecycle flags are not published as settings a front end should offer.

Each entry is printed in a fixed shape (`key`, `envVar`, `flag`, `kind`, `label`, `help`, `group`, `secret`, `default`, `options`, `validation`), for example `onecliApiHost`:

```json
{
  "key": "onecliApiHost",
  "envVar": "NANOCLAW_ONECLI_API_HOST",
  "flag": "--onecli-api-host",
  "validation": { "kind": "httpUrl", "message": "Must be http(s)://…" }
}
```

`options` is filled in for the kinds that have one: `agentProvider` gets `listSetupProviderChoices()` (`claude`, `codex` on a plain checkout of `main`), `enum` entries get their own options, booleans get `[true, false]`, everything else `[]`.

`agentName` and `hardenedImage` are new `CONFIG` rows, so `--agent-name` and `--hardened-image` / `--no-hardened-image` become real flags on env vars setup already reads (`NANOCLAW_AGENT_NAME` in the channel-agent naming step, `NANOCLAW_HARDENED_IMAGE` for the pre-built image path). They also appear in `printHelp`, which lists every `CONFIG` entry.

## What to watch for

> [!NOTE]
> `onecliApiHost` loses `default: 'https://api.onecli.sh'`. Nothing in the wizard changes: `default` is only ever read as a UI placeholder (`placeholder: e.placeholder ?? e.default`) and that entry already carries the identical `placeholder`. What changes is the printed list, which now reports `default: null` instead of offering a remote vault URL as a pre-filled value when the local vault is the normal case.

- Adding a new validation kind means extending the `validation` union **and** the `switch` in `validateEntry`. An inline function on an entry no longer does anything.
- `--catalog-preseeds` needs `node_modules/` to exist. It deliberately will not bootstrap to satisfy itself.
- The test that guards this builds a temp checkout, copies in `nanoclaw.sh`, `setup/catalog-preseeds.ts`, `setup/lib/setup-config.ts` and `setup/providers/registry.ts`, and writes an **empty** `setup/providers/index.ts` rather than copying the checkout's own barrel (second commit). Without that, an install that had copied a provider's code in would change the expected `agentProvider` options and the test would fail on a developer machine but not in CI. It also asserts `logs/` was never created.

## Scope

`nanoclaw.sh`, `setup/auto.ts`, `setup/catalog-preseeds.ts` + test, `setup/lib/setup-config.ts`, `setup/lib/setup-config-parse.ts` + test, `setup/lib/setup-config-screen.ts`, `setup/providers/registry.ts` + test. No checked-in JSON copy, no second registry, no new dependency, no runtime form renderer.

## Verification

```
pnpm typecheck
bash -n nanoclaw.sh
pnpm exec vitest run setup/catalog-preseeds.test.ts setup/lib/setup-config-parse.test.ts \
  setup/providers/registry.test.ts setup/setup-driver-parity.test.ts setup/lib/setup-config.test.ts
```

Full suite was run one commit up the stack (which changes none of this behavior); the only failures are in `scripts/update/transaction.e2e.test.ts`, which fails identically on a clean `upstream/main` checkout on the author's machine because `tag.gpgSign=true` is set globally and the test runs a bare `git tag`. Leak gate (`--classify`): no channel or provider code, no wiring rows.
