### PR TITLE
feat(setup): accept a client timezone preseed (--tz)

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -14,6 +14,7 @@
  *                          "Terminal Agent".
  *   NANOCLAW_AGENT_PROVIDER preselect the setup provider and skip the picker
  *                          (for packaged flows). Example: claude.
+ *   NANOCLAW_TZ            preselect an IANA timezone and skip timezone prompts
  *   NANOCLAW_SKIP          comma-separated step names to skip
  *                          (environment|container|onecli|auth|mounts|
  *                           service|cli-agent|timezone|channel|
@@ -228,6 +229,11 @@ async function main(driver: SetupDriver): Promise<void> {
     if (typeof value === 'string') registerSensitiveValue(value);
   }
   applyToEnv(configValues);
+  const configuredTz = process.env.NANOCLAW_TZ?.trim() ?? '';
+  if (configuredTz && !isValidTimezone(configuredTz)) {
+    console.error('error: NANOCLAW_TZ must be an IANA timezone such as Europe/Lisbon');
+    process.exit(1);
+  }
 
   // --uninstall routes to the uninstall flow before any setup side effects —
   // in particular before initProgressionLog(), so an uninstall never resets
@@ -2155,18 +2161,20 @@ function appendProviderImport(modulePath: string): void {
  * a headless `claude -p` pass to resolve them to a real IANA zone.
  */
 async function runTimezoneStep(driver: SetupDriver): Promise<void> {
+  const preseedTz = process.env.NANOCLAW_TZ?.trim();
   const res = await runQuietStep(
     'timezone',
     {
       running: 'Checking your timezone…',
       done: 'Timezone set.',
     },
-    [],
+    preseedTz ? ['--tz', preseedTz] : [],
     driver,
   );
   if (!res.ok && res.terminal?.fields.NEEDS_USER_INPUT !== 'true') {
     await fail('timezone', "Couldn't determine your timezone.", undefined, undefined, driver);
   }
+  if (preseedTz && res.ok) return;
 
   const fields = res.terminal?.fields ?? {};
   const resolvedTz = fields.RESOLVED_TZ;

--- a/setup/catalog-preseeds.test.ts
+++ b/setup/catalog-preseeds.test.ts
@@ -15,6 +15,7 @@ describe('--catalog-preseeds', () => {
         'setup/catalog-preseeds.ts',
         'setup/lib/setup-config.ts',
         'setup/providers/registry.ts',
+        'src/timezone.ts',
       ]) {
         fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
         fs.copyFileSync(path.join(process.cwd(), file), path.join(root, file));
@@ -49,6 +50,7 @@ describe('--catalog-preseeds', () => {
           'onecliApiToken',
           'skip',
           'templatePath',
+          'tz',
         ].sort(),
       );
       expect(catalog.preseeds.every((entry) => entry.kind && Array.isArray(entry.options))).toBe(true);
@@ -62,6 +64,10 @@ describe('--catalog-preseeds', () => {
       expect(catalog.preseeds.find((entry) => entry.key === 'onecliApiHost')?.validation).toEqual({
         kind: 'httpUrl',
         message: 'Must be http(s)://…',
+      });
+      expect(catalog.preseeds.find((entry) => entry.key === 'tz')?.validation).toEqual({
+        kind: 'ianaTimezone',
+        message: 'Must be an IANA timezone such as Europe/Lisbon',
       });
       expect(fs.existsSync(path.join(root, 'logs'))).toBe(false);
     } finally {

--- a/setup/lib/setup-config-parse.test.ts
+++ b/setup/lib/setup-config-parse.test.ts
@@ -38,6 +38,10 @@ describe('public setup flags', () => {
       errors: [],
     });
   });
+  it('accepts a valid --tz preseed and rejects a non-IANA value', () => {
+    expect(parseFlags(['--tz', 'Asia/Jerusalem']).errors).toEqual([]);
+    expect(parseFlags(['--tz', 'local']).errors).toEqual(['--tz: Must be an IANA timezone such as Europe/Lisbon']);
+  });
 
   it('uses the cataloged validation rules when parsing flags', () => {
     expect(parseFlags(['--onecli-api-host', 'not-a-url']).errors).toEqual(['--onecli-api-host: Must be http(s)://…']);

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -14,6 +14,8 @@
  *   'flag+ui'  — also shown in the advanced-settings screen
  */
 
+import { isValidTimezone } from '../../src/timezone.js';
+
 export type EntrySurface = 'flag' | 'flag+ui';
 
 interface BaseEntry {
@@ -41,7 +43,8 @@ interface StringEntry extends BaseEntry {
   validation?:
     | { kind: 'httpUrl'; message: string }
     | { kind: 'prefix'; value: string; message: string }
-    | { kind: 'nonEmpty'; message: string };
+    | { kind: 'nonEmpty'; message: string }
+    | { kind: 'ianaTimezone'; message: string };
 }
 
 interface EnumEntry extends BaseEntry {
@@ -155,6 +158,20 @@ export const CONFIG: Entry[] = [
     type: 'string',
   },
   {
+    key: 'tz',
+    envVar: 'NANOCLAW_TZ',
+    flag: '--tz',
+    label: 'Timezone',
+    help: 'Use an IANA timezone and skip timezone prompts.',
+    surface: 'flag',
+    preseed: true,
+    type: 'string',
+    validation: {
+      kind: 'ianaTimezone',
+      message: 'Must be an IANA timezone such as Europe/Lisbon',
+    },
+  },
+  {
     key: 'agentName',
     envVar: 'NANOCLAW_AGENT_NAME',
     label: 'Agent name',
@@ -237,5 +254,7 @@ export function validateEntry(entry: Entry, value: string): string | undefined {
       return value.startsWith(rule.value) ? undefined : rule.message;
     case 'nonEmpty':
       return value.trim() ? undefined : rule.message;
+    case 'ianaTimezone':
+      return isValidTimezone(value) ? undefined : rule.message;
   }
 }

--- a/setup/timezone.test.ts
+++ b/setup/timezone.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { run } from './timezone.js';
+
+const originalCwd = process.cwd();
+const originalTz = process.env.TZ;
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalTz === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTz;
+});
+
+describe('timezone preseed', () => {
+  it('persists --tz ahead of the host timezone', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-tz-'));
+    try {
+      process.chdir(root);
+      process.env.TZ = 'UTC';
+
+      await run(['--tz', 'Asia/Jerusalem']);
+
+      expect(fs.readFileSync(path.join(root, '.env'), 'utf8')).toBe('TZ=Asia/Jerusalem\n');
+      const autoSource = fs.readFileSync(path.join(originalCwd, 'setup', 'auto.ts'), 'utf8');
+      expect(autoSource).toContain("preseedTz ? ['--tz', preseedTz] : []");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an invalid environment preseed before setup starts', () => {
+    const result = spawnSync(
+      path.join(originalCwd, 'node_modules', '.bin', 'tsx'),
+      [path.join(originalCwd, 'setup', 'auto.ts')],
+      {
+        cwd: originalCwd,
+        encoding: 'utf8',
+        env: { ...process.env, NANOCLAW_TZ: 'local' },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('NANOCLAW_TZ must be an IANA timezone such as Europe/Lisbon');
+  });
+});


### PR DESCRIPTION
Setup's timezone step detects a zone on its own and then asks the person at the terminal about it: it confirms the zone it found, offers "keep UTC" when the system reports UTC, and otherwise falls back to a free-text "where are you?" question, which a background `claude -p` call turns into a standard IANA timezone name such as `Europe/Lisbon`. That is right for a person at a terminal. A front end that already knows the user's timezone has no way to hand it over, so it has to show and answer a question it could have skipped. This PR adds the one input that lets it skip: `--tz` / `NANOCLAW_TZ`.

Stacked on #3486, which is where the catalog of values a caller can supply up front (a "preseed") lands. Everything below is only this PR's commit: 5 files, 32 production lines.

## What changes

`setup/lib/setup-config.ts` gets one new entry in the shared list of settings that already produces the CLI flags, the env-var reader and `--help`:

| Field | Value |
|---|---|
| `key` | `tz` |
| `flag` | `--tz` |
| `envVar` | `NANOCLAW_TZ` |
| `surface` | `flag` |
| `preseed` | `true` |
| `validation` | `{ kind: 'ianaTimezone', message: 'Must be an IANA timezone such as Europe/Lisbon' }` |

`ianaTimezone` is a new kind of check for the string entries in that list. `validateEntry` runs it through `isValidTimezone` from `src/timezone.ts`, which builds an `Intl.DateTimeFormat` for the zone and counts it valid if that does not throw. That adds a new import, `setup/lib/setup-config.ts` → `../../src/timezone.js`, which is why the `--catalog-preseeds` fixture copies `src/timezone.ts` into its temp root. Because the entry is `preseed: true`, `--catalog-preseeds` from the base PR now lists `tz` along with its validation rule, so a front end can check the value before it ever launches setup.

`runTimezoneStep` in `setup/auto.ts` reads `process.env.NANOCLAW_TZ`, passes it to the step as `['--tz', preseedTz]`, and returns as soon as the step succeeds:

```ts
const preseedTz = process.env.NANOCLAW_TZ?.trim();
const res = await runQuietStep('timezone', { … }, preseedTz ? ['--tz', preseedTz] : [], driver);
…
if (preseedTz && res.ok) return;
```

```mermaid
flowchart TD
    Check{"NANOCLAW_TZ set?"} -->|"no"| Prompt["detect a zone, then confirm / choose / type a city"]
    Check -->|"set, not an IANA name"| Fail["exit 1, before setup changes anything"]
    Check -->|"set and valid"| Pass["step runs with --tz, no question asked"]
    Prompt --> Env["TZ= written to .env"]
    Pass --> Env
```

The step itself is untouched: `setup/timezone.ts` already accepted `--tz` and already puts it first in its order of preference, `userTz > envFileTz > envTz > systemTz`. The early return is what keeps `timezone-detected-confirm`, `timezone-choice` and `timezone-location` from being shown, along with the `claude -p` call behind them; with nothing supplied, `runQuietStep` gets the same empty argument list as before.

## The second check, and why it exists

`--tz local` is rejected by the flag parser, which reports `--tz: Must be an IANA timezone such as Europe/Lisbon`. `NANOCLAW_TZ=local` in the environment is not rejected: `readFromEnv` **skips** any entry whose value fails validation, so the bad zone would simply disappear from the parsed config, `runTimezoneStep` would read the raw env var anyway, the step would reject it while working through its order of preference, and setup would quietly carry on with the system zone. A caller that thought it had fixed the timezone would get a different one and never be told.

So `setup/auto.ts` checks the env var again itself, right after `applyToEnv`, and stops with an error before it decides whether this is an `--uninstall` run:

```
error: NANOCLAW_TZ must be an IANA timezone such as Europe/Lisbon
```

> [!NOTE]
> A valid value overrides an existing `TZ=` line in `.env`, because the step ranks `--tz` above the `.env` value. That is what supplying a value up front is for, but it means re-running setup with `--tz` is how you change an already-saved zone without prompts, rather than doing nothing.

## Files

| File | +/- | What |
|---|---|---|
| `setup/lib/setup-config.ts` | +20/-1 | The `tz` entry, the `ianaTimezone` check, its `validateEntry` case |
| `setup/auto.ts` | +9/-1 | Env-var guard, `--tz` pass-through, early return, `--help` header line |
| `setup/timezone.test.ts` | +50 | New: a supplied zone beats the machine's own zone; an invalid `NANOCLAW_TZ` exits 1 |
| `setup/catalog-preseeds.test.ts` | +6 | `tz` in the emitted key set with its validation rule; fixture copies `src/timezone.ts` |
| `setup/lib/setup-config-parse.test.ts` | +4 | `--tz Asia/Jerusalem` parses without error, `--tz local` errors |

## Verification

`pnpm exec vitest run setup/timezone.test.ts setup/catalog-preseeds.test.ts setup/lib/setup-config-parse.test.ts`, plus `pnpm typecheck`. Those cover the real step writing `TZ=Asia/Jerusalem` into `.env` from a temp working directory under `TZ=UTC`, a separately launched `setup/auto.ts` under `NANOCLAW_TZ=local` exiting 1 with the error above, both flag outcomes, and what `--catalog-preseeds` emits.
