### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/.claude/skills/gbr/SKILL.md
+++ b/.claude/skills/gbr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: gbr
+description: >
+  Pair a phone running Build Remote Agent to this NanoClaw host. Requires
+  gbr-agent run on the host (not inside an agent container). Attach via Bot API
+  127.0.0.1:8788 or gbr-mcp. Use when the user wants a mobile spectator / inject
+  into the desktop session, or says /gbr, "pair the phone", or "Build Remote Agent".
+compatibility: Requires gbr-agent ≥ 0.6.0 on the host. Loopback only. No mailbox keys in this file.
+metadata:
+  version: "0.6.1"
+  product: "Build Remote Agent"
+  website: "https://grokbuildremote.com/"
+---
+
+# Build Remote Agent — pairing device
+
+One adapter. Protocol `gbr/1`. No fourth pair protocol.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+This is an **instruction-only** host skill. Run `gbr-agent` on the Mac/PC that
+hosts NanoClaw. Do **not** install it inside an agent container. NanoClaw
+WhatsApp/Telegram/etc. channels are not `gbr/1`.
+
+## Pair (unchanged)
+
+1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
+2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
+3. Phone scans QR **or** types the 8-char code.
+4. PC: `gbr-agent run` (keep it running).
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Unpair on the phone before a new mailbox. Force-close is not enough.
+
+## Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+
+Phone is spectator + veto, not orchestrator.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+curl -sS -X POST http://127.0.0.1:8788/v1/inject \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id":"SESSION","text":"hello","submit":true}'
+```
+
+## MCP
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+Host `.mcp.json` (never put mailbox keys here):
+
+```json
+{
+  "mcpServers": {
+    "gbr": {
+      "command": "node",
+      "args": ["GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+    }
+  }
+}
+```
+
+Remote bots: phone **Settings → Bot API** copies relay URL + mailbox id + key. Never commit the key.
+
+## Loop
+
+diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
+
+Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md


### PR DESCRIPTION
## What

Adds a **Build Remote Agent** pairing-device adapter so a phone can spectate this desktop agent.

- Protocol: `gbr/1` (no fourth pair protocol)
- Install MIT `gbr-agent` v0.6.0+ → `gbr-agent pair` (QR **and** 8-char code) → `gbr-agent run`
- Attach **only** `http://127.0.0.1:8788` or stdio `gbr-mcp`
- Phone is spectator + veto, not orchestrator
- No mailbox keys, no `X-GBR-Key`, no `device.json` in this PR

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.

Website: https://grokbuildremote.com/
Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents

## How to use

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version          # v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

```bash
git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
node bin/gbr-mcp.js --diagnose
```

Unpair on the phone before a new mailbox. Force-close is not enough.

## Files

- `.claude/skills/gbr/SKILL.md` — instruction-only host skill (`/gbr`)

Run `gbr-agent` on the NanoClaw **host**, not inside an agent container. Messaging channels stay NanoClaw’s.