### PR TITLE
versions: repin to hardened-2026-08-23 and let benign lock drift through

### DIFF
--- a/container/pull.sh
+++ b/container/pull.sh
@@ -247,8 +247,27 @@ fi
 # Lock drift. /app/node_modules is baked in from container/agent-runner/bun.lock
 # while /app/src is bind-mounted from this checkout at every spawn. Pair an image
 # with a checkout whose lockfile moved and the agent dies on a missing module
-# inside a `--rm` container whose logs are discarded. Hard failure here, where
-# the operator is watching, beats silence at 3am.
+# inside a `--rm` container whose logs are discarded, so this is worth saying
+# loudly where the operator is watching rather than at 3am.
+#
+# TEMPORARY (2026-08-24): drift was a hard failure here. Every published
+# hardened image still carries the v2.2.0 lockfile, so once ea1dadd8 moved
+# bun.lock the refusal blocked every new hardened install outright, with no
+# override to reach for.
+#
+# The check is a coarse proxy — it fires on any lockfile change, including one
+# that cannot break anything. This drift is that kind: ea1dadd8 bumped
+# @anthropic-ai/claude-agent-sdk ^0.3.197 -> ^0.3.238 and nothing else. The
+# lockfile adds and removes no package (only version strings and integrity
+# hashes for the SDK and its platform binaries move, peer ranges included), and
+# the runner's entire SDK surface is one unchanged import of `query`,
+# `HookCallback` and `PreCompactHookInput`. The baked node_modules therefore
+# resolves everything the mounted /app/src imports.
+#
+# So: warn rather than refuse, and let operators take the patched image. This
+# trade is only sound while the drift stays benign, which no shell check can
+# tell. Restore `exit 1` as soon as an image built from the current lockfile is
+# published and pinned.
 IMAGE_LOCK="$(${CONTAINER_RUNTIME} image inspect --format '{{index .Config.Labels "dev.nanoclaw.agent-runner-lock-sha256"}}' "$REF")"
 if [ "$IMAGE_LOCK" = "<no value>" ]; then
     IMAGE_LOCK=""
@@ -275,18 +294,17 @@ elif [ -z "$IMAGE_LOCK" ]; then
     fi
 elif [ "$IMAGE_LOCK" != "$LOCAL_LOCK" ]; then
     echo "" >&2
-    echo "Agent-runner lock drift — refusing to tag this image." >&2
+    echo "Warning: agent-runner lock drift — tagging this image anyway." >&2
     echo "  image     ${IMAGE_LOCK}" >&2
     echo "  checkout  ${LOCAL_LOCK}  (container/agent-runner/bun.lock)" >&2
     echo "" >&2
     echo "The image bakes /app/node_modules from the lockfile it was built with," >&2
-    echo "while /app/src is mounted from this checkout at spawn time. Running them" >&2
-    echo "together fails as a missing module inside a --rm container whose logs are" >&2
-    echo "discarded." >&2
+    echo "while /app/src is mounted from this checkout at spawn time. If the agent" >&2
+    echo "goes quiet or dies on a missing module inside a --rm container, this is" >&2
+    echo "the first thing to rule out." >&2
     echo "" >&2
-    echo "Use the image published for this checkout, or build locally:" >&2
-    echo "  ./container/build.sh" >&2
-    exit 1
+    echo "To take the drift out of the picture, build locally instead:" >&2
+    echo "  ./container/build.sh build" >&2
 fi
 
 # The retag. From here on the image is indistinguishable, to every consumer,

--- a/docs/hardened-image.md
+++ b/docs/hardened-image.md
@@ -222,7 +222,7 @@ account-takeover bugs happen — and there is no way to merge them today. Pick o
 |---|---|
 | `./container/build.sh` exits 3 | Pinned install. `pull` to refresh, `build` to force local. |
 | Setup never offers the pull option | The option needs a Claude install and an `agent-image` pin in `versions.json`. Existing installs can follow [the migration above](#existing-installs-switch-to-the-hardened-image). |
-| Pull fails: lockfile mismatch | The image was built against a different `container/agent-runner/bun.lock`. Refresh the pin or build locally. |
+| Pull warns: lockfile mismatch | The image was built against a different `container/agent-runner/bun.lock`. The pull proceeds — temporarily, while no published image carries the current lockfile. If the agent then dies on a missing module, run `./container/build.sh build`. |
 | Pull fails: architecture mismatch | The reference names one architecture and it isn't this daemon's. Use a multi-arch index, or the reference for this architecture. |
 | "No agent-image reference for linux/…" | The pin is per-platform and has no entry for this machine. Build locally, or set `NANOCLAW_AGENT_IMAGE_REF`. |
 | Pull fails: auth | `--status` shows whether the credential helper is wired; `--force` re-runs sign-in. |

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "onecli-gateway": "1.41.0",
   "onecli-cli": "2.2.5",
-  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:ccde3d9c86fb655be66c93e07bc38a62faab2d951651a1fba345a7a47defeb85"
+  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:aac07700ef2406408c881e4f610e77f918f4f34a1ea9e138c926f0875abbd99f"
 }


### PR DESCRIPTION
**Stopgap while a release can't be cut.** Gets operators the patched image instead of a dead setup.

## The breakage

New hardened installs have failed setup since **2026-08-21 22:21 +0300** (ea1dadd8). `container/pull.sh` compares the image's `dev.nanoclaw.agent-runner-lock-sha256` label against the checkout's `container/agent-runner/bun.lock` and refused to retag on any difference:

```
Agent-runner lock drift — refusing to tag this image.
  image     5f499545…
  checkout  f9d63744…  (container/agent-runner/bun.lock)
```

Every published hardened tag — **all nine**, `hardened-2026-07-30` through `hardened-2026-08-23` — carries `5f499545…`, the v2.2.0 lockfile. So no value of the pin clears the refusal, and there is no override for a *mismatched* label (`NANOCLAW_ALLOW_UNLABELED_IMAGE` only covers a *missing* one). The only escapes were a local build or a release.

## Why letting this drift through is safe

The check is a coarse proxy — it fires on any lockfile change, including one that cannot break a spawn. This drift is that kind:

- ea1dadd8 bumped `@anthropic-ai/claude-agent-sdk` `^0.3.197` → `^0.3.238` **and nothing else** — three files, no source changes.
- The lockfile **adds and removes no package.** Every changed line is a version string or integrity hash for the SDK and its eight platform binaries. Peer ranges (`@anthropic-ai/sdk >=0.93.0`, `@modelcontextprotocol/sdk ^1.29.0`, `zod ^4.0.0`) are identical on both sides.
- The runner's entire SDK surface is one **unchanged** import: `query`, `HookCallback`, `PreCompactHookInput` — byte-identical at v2.2.0 and at `main`.

So the baked `/app/node_modules` at 0.3.197 resolves everything the mounted `/app/src` imports.

## What changes

| File | Change |
|---|---|
| `versions.json` | pin `ccde3d9c` (08-13) → `aac07700` (**hardened-2026-08-23**) — ten days of base and CVE patches |
| `container/pull.sh` | drift `exit 1` → warning, keeping the full diagnostic and pointing at `./container/build.sh build` |
| `docs/hardened-image.md` | troubleshooting row updated to match |

## Known gap in this PR

`verify-agent-image` mirrors the same assertion and is a **required, blocking** check that runs whenever the pin moves. It will go red on this PR for exactly the reason described above. Deliberately not touched here — relaxing a repo-wide CI gate is a separate decision. Needs either a companion change or an override to merge.

## Follow-up

Restore the hard failure in `pull.sh` (and re-tighten CI, if relaxed) as soon as an image built from the current lockfile is published and pinned. Ideally re-apply the SDK bump and the repin in one PR so the two can never drift apart again.

Separately worth closing: `verify-agent-image` only checks the lock label when the pin itself moves (`"The agent-image pin is unchanged — nothing to verify."`). It catches a new image that doesn't match the checkout, never a checkout that drifts away from the pinned image — which is why this sat unnoticed for three days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)