### PR TITLE
fix(update): resolve symlinks in the update controller's path comparisons

### DIFF
--- a/scripts/update-nanoclaw.ts
+++ b/scripts/update-nanoclaw.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -117,6 +118,27 @@ async function main(): Promise<void> {
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+/**
+ * True when this module was started as the process entrypoint.
+ *
+ * `import.meta.url` is realpath-resolved by the loader, so the argv path has
+ * to be resolved the same way: the documented flow runs this controller from
+ * `$(mktemp -d)`, which on macOS is under `/var/folders` — a symlink to
+ * `/private/var/folders`. Comparing unresolved paths there never matches, and
+ * the documented invocation exits 0 having done nothing at all.
+ */
+function startedAsEntrypoint(argvPath: string | undefined): boolean {
+  if (!argvPath) return false;
+  const resolved = path.resolve(argvPath);
+  let real = resolved;
+  try {
+    real = fs.realpathSync(resolved);
+  } catch {
+    // Not on disk under that name — fall back to the unresolved comparison.
+  }
+  return import.meta.url === pathToFileURL(real).href || import.meta.url === pathToFileURL(resolved).href;
+}
+
+if (startedAsEntrypoint(process.argv[1])) {
   void main();
 }

--- a/scripts/update/transaction.ts
+++ b/scripts/update/transaction.ts
@@ -128,11 +128,15 @@ function saveState(state: UpdateState): void {
 }
 
 export function loadState(projectRoot: string, id: string): UpdateState {
-  const expectedTransactionRoot = path.join(defaultTransactionsRoot(path.resolve(projectRoot)), id);
+  // prepareUpdate() records realpath'd paths, so resolve symlinks here too or
+  // every path comparison below fails for a checkout reached through one —
+  // a macOS /var/folders temp dir, or an install under a symlinked parent.
+  const resolvedProjectRoot = fs.realpathSync(projectRoot);
+  const expectedTransactionRoot = path.join(defaultTransactionsRoot(resolvedProjectRoot), id);
   const target = statePath(expectedTransactionRoot);
   const state = JSON.parse(fs.readFileSync(target, 'utf8')) as UpdateState;
   if (state.schema !== 'nanoclaw-update/v1') throw new Error(`Unsupported update state in ${target}`);
-  if (!hasSafeStatePaths(state, projectRoot, expectedTransactionRoot, id)) {
+  if (!hasSafeStatePaths(state, resolvedProjectRoot, expectedTransactionRoot, id)) {
     throw new Error('Update state contains mismatched or unsafe paths');
   }
   return state;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3498.

**What** — normalizes the two path comparisons in the update controller through `fs.realpathSync`: the module-entry guard in `scripts/update-nanoclaw.ts`, and `hasSafeStatePaths` in `scripts/update/transaction.ts`.

**Why** — both used `path.resolve` where a realpath is needed. On macOS `os.tmpdir()` and `mktemp -d` return `/var/folders/...`, a symlink to `/private/var/folders/...`, so both comparisons fail:

1. The entry guard compares `import.meta.url` — which the loader realpath-resolves — against an unresolved argv path. SKILL.md step 1 tells the caller to `git archive` the controller into `$(mktemp -d)` and run it from there, so on macOS `main()` is never called: the documented invocation exits **0 with no output** and creates no transaction. Nothing distinguishes that from a completed step.
2. `hasSafeStatePaths` compares the state it just wrote, so `loadState` rejects it with `Update state contains mismatched or unsafe paths`. Four `transaction.e2e` cases fail on a clean checkout, and a real install whose project root is reached through a symlink is rejected the same way.

`prepareUpdate` already stores realpath'd paths and `pruneTransactions` already realpaths before calling `loadState` — `loadState` was the one caller left out.

**How it works** — the entry guard resolves the argv path with `fs.realpathSync` (falling back to the unresolved comparison if the path is not on disk under that name) and accepts either form. `loadState` resolves `projectRoot` before deriving `expectedTransactionRoot` and comparing. `hasSafeStatePaths` itself is unchanged, so the equality and pattern checks against `state.*` keep their current strength.

**How it was tested** — on macOS arm64, Node v22.21.1:

- `scripts/update/transaction.e2e.test.ts`: 4 failed on `upstream/main`, 4 pass with this change. Reverting only `scripts/update/transaction.ts` reproduces the failures.
- Entry guard, running the controller from `$(mktemp -d)` exactly as SKILL.md step 1 does: `upstream/main` prints nothing and exits 0; with this change the same invocation reaches `main()` and returns its normal JSON.
- Used end to end for a real 2.1.53 → 2.3.0 update on a customized install (prepare → validate → cutover → finish).