### PR TITLE
docs(onecli): catch a hardcoded gateway image tag during upgrade

### DIFF
--- a/docs/onecli-upgrades.md
+++ b/docs/onecli-upgrades.md
@@ -22,6 +22,24 @@ Why gateways fall behind: the OneCLI installer's docker-compose tracks the `late
 
 The gateway runs as a Docker service in `~/.onecli`. Upgrade just that container to the pinned `onecli-gateway` version — vault data lives in named Docker volumes and survives. This upgrades only the gateway; the CLI binary is pinned separately (see below).
 
+**First, confirm the compose file actually reads `ONECLI_VERSION`.** Installers
+from older lines wrote the tag as a literal (`image: ghcr.io/onecli/onecli:1.36.0`)
+rather than a variable, and `docker compose` has no reason to complain: the
+command below then re-pulls the *old* tag and prints `Pulled` / `Running`, so the
+upgrade reads as successful while the gateway stays exactly where it was.
+
+```bash
+cd ~/.onecli && ONECLI_VERSION=<onecli-gateway pin from versions.json> docker compose config | grep 'image: ghcr.io/onecli'
+```
+
+If that does not print the pinned version, edit `~/.onecli/docker-compose.yml`
+and parameterize the tag once, so this upgrade and every later one work as
+documented:
+
+```yaml
+    image: ghcr.io/onecli/onecli:${ONECLI_VERSION:-<onecli-gateway pin from versions.json>}
+```
+
 **Local gateway (the common case):**
 
 ```bash
@@ -37,6 +55,22 @@ Host-side health is necessary but **not sufficient**:
 ```bash
 curl -s http://127.0.0.1:10254/v1/health     # must return {"status":"ok",...}
 ```
+
+**Confirm the pinned version is the one now running.** Liveness alone cannot
+tell an upgraded gateway from one that never moved — a gateway that already
+served `/v1` answered `200` before the upgrade too. Upgraded gateways report
+their version in that payload, so read it; on the gateway's own host the
+container tag is the direct check (match the container exactly — `--filter
+name=onecli` is a substring match that also catches `onecli-postgres-1`):
+
+```bash
+curl -s http://127.0.0.1:10254/v1/health | grep -o '"version":"[^"]*"'
+cd ~/.onecli && docker compose ps onecli --format '{{.Image}}'   # gateway host only
+```
+
+Both must show the `onecli-gateway` pin. For a remote gateway, run the
+container check on that host; from the NanoClaw host only the `/v1/health`
+payload is available.
 
 **Verify the bind interface (container reachability).** Agent containers reach the gateway over the docker bridge (`host.docker.internal` → e.g. `172.17.0.1`), so a server bound only to `127.0.0.1` boots clean host-side while every credentialed call from containers dies at the proxy:
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — adds a pre-upgrade check to `docs/onecli-upgrades.md` for a compose file that hardcodes the gateway image tag, and makes the verify step confirm the pinned version is the one running.

**Why** — the documented upgrade is

```bash
cd ~/.onecli && ONECLI_VERSION=<pin> docker compose pull onecli && ONECLI_VERSION=<pin> docker compose up -d
```

which assumes the compose file reads `ONECLI_VERSION`. Installers from older lines wrote the tag as a literal instead:

```yaml
    image: ghcr.io/onecli/onecli:1.36.0
```

`docker compose` has no reason to complain — it re-pulls the *old* tag and prints `Pulled` / `Running`. The upgrade reads as successful while the gateway stays exactly where it was. Verbatim output from following the doc on such an install:

```
 Image ghcr.io/onecli/onecli:1.36.0 Pulling
 Image ghcr.io/onecli/onecli:1.36.0 Pulled
 Container onecli Running
```

The existing verify step cannot catch it: `curl -s http://127.0.0.1:10254/v1/health` answered `200` before the upgrade too.

**How it works** — one `docker compose config | grep` before the upgrade, with the one-line `${ONECLI_VERSION:-<pin>}` edit to apply when the tag is literal, so this upgrade and every later one work as documented. The verify step then reads the version rather than liveness alone: the `/v1/health` payload from the NanoClaw host, and the container tag on the gateway's own host. `docker ps --filter name=onecli` is not used — it is a substring match that also catches `onecli-postgres-1`.

**How it was tested** — ran every added command against a live OneCLI gateway (1.41.0, compose v5.1.2) and against a real 1.36.0-era compose file kept from before the upgrade:

- literal tag → `image: ghcr.io/onecli/onecli:1.36.0` (the diagnostic fires)
- parameterized → `image: ghcr.io/onecli/onecli:1.41.0`
- `curl ... /v1/health | grep -o '"version":"[^"]*"'` → `"version":"1.41.0"`
- `docker compose ps onecli --format '{{.Image}}'` → `ghcr.io/onecli/onecli:1.41.0`
- confirmed `docker ps --filter name=onecli` does list `onecli-postgres-1` alongside the gateway

Found while following this doc during a real `/update-nanoclaw` run, where the 1.36.0 → 1.41.0 pin move silently did nothing.