### PR TITLE
feat(drivers): Apple Container session driver — first overlay for the driver seam

### DIFF
--- a/.claude/skills/add-apple-container/REMOVE.md
+++ b/.claude/skills/add-apple-container/REMOVE.md
@@ -1,0 +1,51 @@
+# Remove Apple Container Driver
+
+Reverses every change `/add-apple-container` made. Docker becomes the session
+driver again on the next service start.
+
+## 1. Deselect the driver
+
+Remove from `.env` (or set back to your previous values):
+
+```
+NANOCLAW_RUNTIME_DRIVER=container
+CONTAINER_RUNTIME=container
+```
+
+With `NANOCLAW_RUNTIME_DRIVER` unset, selection falls back to `docker`.
+
+## 2. Remove the barrel registration
+
+Delete this line from `src/drivers/installed.ts`:
+
+```
+import './apple-container-registration.js';
+```
+
+## 3. Delete the driver payload
+
+```
+rm src/drivers/apple-container-driver.ts
+rm src/drivers/apple-container-registration.ts
+rm src/drivers/apple-container-driver.test.ts
+```
+
+Restore the trunk conformance suite (drops the apple harness):
+
+```
+git checkout origin/main -- src/drivers/conformance.test.ts
+```
+
+## 4. Rebuild and restart
+
+```
+pnpm run build
+```
+
+Restart the NanoClaw service. The boot log's `Session runtime driver selected`
+line must report `driver="docker"`.
+
+Note: sessions that were running under Apple Container are not adopted by the
+docker driver (different runtime, different store). Let them exit or stop them
+with `container stop` before switching; agent images must exist in Docker's
+store (`./container/build.sh` with `CONTAINER_RUNTIME` unset rebuilds there).

--- a/.claude/skills/add-apple-container/SKILL.md
+++ b/.claude/skills/add-apple-container/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: add-apple-container
+description: Run agent sessions on Apple Container (macOS microVMs) — a session-driver overlay for the driver seam. Each session gets its own lightweight VM with a stronger isolation boundary than a shared-kernel namespace. macOS 15+ on Apple Silicon with the `container` CLI installed.
+---
+
+# Add Apple Container Driver
+
+Runs NanoClaw agent sessions on [Apple Container](https://github.com/apple/container)
+instead of Docker: each session is its own microVM. The driver is a session-driver
+overlay (`src/drivers/`, kind `container`) — it self-registers through
+`installed.ts` and is selected per-install with `NANOCLAW_RUNTIME_DRIVER=container`.
+Docker installs are untouched; the docker driver remains the default.
+
+The driver passes the full driver conformance suite unchanged (its harness rides
+`src/drivers/conformance.test.ts`), and carries the Apple-runtime knowledge the
+seam cannot: which hardening flags the CLI rejects, the
+`host.docker.internal` rewrite (the runtime has no `--add-host` and VMs cannot
+resolve that name), the nested-file-mount collapse
+([apple/container#2148](https://github.com/apple/container/issues/2148)), JSON
+list/inspect parsing across both historical `status` shapes, and
+`container system start` recovery on a cold or stale runtime.
+
+## Requirements
+
+- macOS 15+ on Apple Silicon
+- The `container` CLI installed and on `PATH` (`brew install container`), 1.2.x or newer
+
+Verify before installing:
+
+```nc:run effect:check
+container --version
+```
+
+## Install
+
+### 1. Driver payload
+
+Fetch the driver, its registration module, and its tests from the registry
+branch (additive fetch, never a merge):
+
+```nc:copy from-branch:drivers
+src/drivers/apple-container-driver.ts
+src/drivers/apple-container-registration.ts
+src/drivers/apple-container-driver.test.ts
+src/drivers/conformance.test.ts
+```
+
+The `conformance.test.ts` copy is the trunk file plus this driver's harness —
+the suite is designed for exactly that addition, and the registry branch keeps
+it in sync with `main`.
+
+### 2. Barrel registration
+
+Append the self-registration import to the drivers barrel (skipped if the line
+is already present):
+
+```nc:append to:src/drivers/installed.ts
+import './apple-container-registration.js';
+```
+
+### 3. Select the driver
+
+```nc:env-set NANOCLAW_RUNTIME_DRIVER
+container
+```
+
+`CONTAINER_RUNTIME=container` should also be set in `.env` so the non-session
+shell-outs (per-group image builds, `container/build.sh`) target the same
+runtime the sessions run on:
+
+```nc:env-set CONTAINER_RUNTIME
+container
+```
+
+### 4. Build and verify
+
+```nc:run effect:build
+pnpm run build
+```
+
+```nc:run effect:test
+pnpm vitest run src/drivers/
+```
+
+The conformance suite now runs every case against both the docker and
+apple-container harnesses; the driver-specific file covers the Apple-only
+behavior (hardening arg shape, gateway env rewrite, nested-file-mount drop,
+system-start recovery, label-scoped listing and reaping).
+
+### 5. Restart
+
+Restart the NanoClaw service. The boot log's `Session runtime driver selected`
+line must report `driver="container"` — that log line is the discriminator for
+a mis-selected driver (see `src/drivers/index.ts`).
+
+## How it differs from the docker realization
+
+Two deliberate deviations, both declared in the driver header:
+
+- **Nested file mounts are dropped, loudly.** A single-file bind whose
+  destination sits inside another share REPLACES the parent share in the guest
+  (apple/container#2148). Refusing such specs would brick stock composition
+  (the `container.json` nested-RO mount is unconditional), and mounting anyway
+  destroys the parent share silently — strictly worse. The driver drops the
+  nested file mount with one warning per spawn; the real file stays visible
+  through the parent share. The cost is that mount's read-only protection,
+  bounded by per-spawn host-side re-materialization.
+- **`host.docker.internal` is rewritten to the bridge gateway IP in env
+  values.** The runtime has no `--add-host` and its VMs cannot resolve the
+  name, so a byte-identical pass-through ships a value that can never work.
+  Resolution order: `CONTAINER_HOST_GATEWAY` override, then
+  `container network inspect default`, then a bridge interface scan — never a
+  hardcoded constant.
+
+Also: `--security-opt` and `--pids-limit` are rejected by this CLI (exit 64);
+the pids cap is realized as `--ulimit nproc=N`, which in a single-VM session is
+the same bound. `no-new-privileges` has no equivalent — each session being its
+own kernel is the stronger boundary.
+
+## Troubleshooting
+
+- **Image build dies with `cannot allocate memory` / `Killed`.** Every bare
+  `container build` re-creates the builder VM at a 2 GiB default — a builder
+  started separately with more memory does not survive the next bare
+  invocation. `container/build.sh` passes `-m` (default `8G`, override with
+  `CONTAINER_BUILDER_MEM`) whenever `CONTAINER_RUNTIME=container`.
+- **Container egress black-holes after a host reboot or runtime update.**
+  Stale vmnet state ([apple/container#2051](https://github.com/apple/container/issues/2051)
+  is the likely mechanism): short requests may still work while long-lived
+  connections fail. `container system stop && container system start`
+  reinitializes it; the driver's `ensureReady` starts a stopped runtime but
+  cannot detect this degraded state.
+- **Credentialed calls fail with connection-refused inside sessions.** The
+  gateway rewrite could not resolve a bridge IP. Set `CONTAINER_HOST_GATEWAY`
+  in `.env` as the escape hatch and check
+  `container network inspect default` reports an `ipv4Gateway`.
+- **A group's shared files seem to vanish inside the container.** Check the
+  host error log for `Dropping nested file mount` lines — if a mount you added
+  via `additionalMounts` is a FILE nested inside another mount, it was dropped
+  (see apple/container#2148); mount the parent directory instead.

--- a/container/build.sh
+++ b/container/build.sh
@@ -131,6 +131,13 @@ if [ -z "${INSTALL_CJK_FONTS:-}" ] && [ -f "../.env" ]; then
 fi
 
 BUILD_ARGS=()
+# Apple Container re-creates its builder VM at a 2 GiB default on every bare
+# `container build`, which OOMs ("Killed ... cannot allocate memory") on the
+# cli-tools layer — and a builder started separately with more memory does not
+# survive the next bare invocation. Pass the memory explicitly every time.
+if [ "$CONTAINER_RUNTIME" = "container" ]; then
+    BUILD_ARGS+=(-m "${CONTAINER_BUILDER_MEM:-8G}")
+fi
 if [ "${INSTALL_CJK_FONTS:-false}" = "true" ]; then
     if [ "$PULL" = "true" ]; then
         # A pulled image ships whatever font set its publisher baked in; this

--- a/scripts/update/service.ts
+++ b/scripts/update/service.ts
@@ -172,14 +172,44 @@ export async function drainContainers(
   timeoutMs = 300_000,
 ): Promise<void> {
   const runtime = process.env.CONTAINER_RUNTIME ?? 'docker';
-  const label = `nanoclaw-install=${getInstallSlug(projectRoot)}`;
+  const slug = getInstallSlug(projectRoot);
+  const label = `nanoclaw-install=${slug}`;
+  /**
+   * Apple Container's CLI has no `ps` alias and no `--filter`; list JSON and
+   * filter by label client-side. Docker keeps the native filter. Same split
+   * the session drivers make.
+   */
+  const listActive = (): { ok: boolean; ids: string[] } => {
+    if (runtime === 'container') {
+      const res = env.runner.tryRun(runtime, ['list', '--format', 'json']);
+      if (!res.ok) return { ok: false, ids: [] };
+      try {
+        const entries = JSON.parse(res.stdout || '[]') as Array<{
+          status: string | { state?: string };
+          configuration: { id: string; labels?: Record<string, string> };
+        }>;
+        const stateOf = (e: (typeof entries)[number]): string | undefined =>
+          typeof e.status === 'string' ? e.status : e.status?.state;
+        return {
+          ok: true,
+          ids: entries
+            .filter((e) => stateOf(e) === 'running' && e.configuration.labels?.['nanoclaw-install'] === slug)
+            .map((e) => e.configuration.id),
+        };
+      } catch {
+        return { ok: false, ids: [] };
+      }
+    }
+    const res = env.runner.tryRun(runtime, ['ps', '-q', '--filter', `label=${label}`]);
+    return { ok: res.ok, ids: res.stdout ? res.stdout.split('\n').filter(Boolean) : [] };
+  };
   const started = Date.now();
   while (true) {
-    const listed = env.runner.tryRun(runtime, ['ps', '-q', '--filter', `label=${label}`]);
+    const listed = listActive();
     if (!listed.ok) throw new Error(`Cannot inspect active NanoClaw containers with ${runtime}`);
-    if (!listed.stdout) return;
+    if (listed.ids.length === 0) return;
     if (Date.now() - started >= timeoutMs) {
-      throw new Error(`Timed out waiting for active NanoClaw containers: ${listed.stdout.split('\n').join(', ')}`);
+      throw new Error(`Timed out waiting for active NanoClaw containers: ${listed.ids.join(', ')}`);
     }
     await env.sleep(1_000);
   }

--- a/src/drivers/apple-container-driver.test.ts
+++ b/src/drivers/apple-container-driver.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Apple Container driver tests — the fixture spec through the real driver
+ * against a fake `container` CLI. Replaces the pre-seam
+ * `container-runtime-apple.test.ts`: every behavioral pin from that file that
+ * still has a home lives here (hardening arg shape, gateway env rewrite,
+ * nested-file-mount drop, system-start ensureReady, label-scoped reaping).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import {
+  AppleContainerSessionDriver,
+  appleHardeningArgs,
+  dropClobberingFileMounts,
+  ensureAppleContainerRunning,
+  rewriteHostDockerInternalEnv,
+} from './apple-container-driver.js';
+import { FakeCli } from './fake-cli.js';
+import { FIXTURE_POLICY, fixtureSpec } from './spec-fixture.js';
+import { LABELS, type MountSpec } from './types.js';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+// The driver re-checks mount sources exist; fixture paths are not real files.
+vi.mock('fs', () => ({ default: { existsSync: vi.fn(() => true), statSync: vi.fn(() => ({ isFile: () => false })) } }));
+
+// Gateway resolution shells the real `container` binary; pin it via the
+// operator override so tests never touch the host runtime.
+process.env.CONTAINER_HOST_GATEWAY = '192.168.64.1';
+
+let cli: FakeCli;
+
+function driver(): AppleContainerSessionDriver {
+  return new AppleContainerSessionDriver({ ...FIXTURE_POLICY, cli });
+}
+
+beforeEach(() => {
+  cli = new FakeCli('container');
+  // prepare() probes for an existing session by name; default to "not found".
+  cli.responses = [{ match: /^inspect /, throws: 'no such container' }];
+});
+
+describe('appleHardeningArgs', () => {
+  it('never emits --security-opt or --pids-limit (rejected with exit 64 on this runtime)', () => {
+    const args = appleHardeningArgs(fixtureSpec({ resources: { pidsLimit: 256 } }));
+    expect(args).not.toContain('--security-opt');
+    expect(args.join(' ')).not.toContain('--pids-limit');
+    expect(args).toContain('--cap-drop=ALL');
+    expect(args).toContain('--init');
+    expect(args.join(' ')).toContain('--ulimit nproc=256');
+  });
+
+  it('omits the nproc cap when pidsLimit is unset or nonpositive', () => {
+    expect(appleHardeningArgs(fixtureSpec({ resources: {} })).join(' ')).not.toContain('nproc');
+    expect(appleHardeningArgs(fixtureSpec({ resources: { pidsLimit: 0 } })).join(' ')).not.toContain('nproc');
+  });
+});
+
+describe('rewriteHostDockerInternalEnv', () => {
+  it('rewrites the hostname inside env values (VMs cannot resolve it; no --add-host exists)', () => {
+    const out = rewriteHostDockerInternalEnv(
+      { HTTPS_PROXY: 'http://user@host.docker.internal:10255', OTHER: 'untouched' },
+      '192.168.64.1',
+    );
+    expect(out.HTTPS_PROXY).toBe('http://user@192.168.64.1:10255');
+    expect(out.OTHER).toBe('untouched');
+  });
+});
+
+describe('dropClobberingFileMounts', () => {
+  const dir = (containerPath: string): MountSpec => ({
+    class: 'group-state',
+    hostPath: `/host${containerPath}`,
+    containerPath,
+    mode: 'rw',
+    groupScope: 'g1',
+  });
+  const file = (containerPath: string, mode: 'ro' | 'rw' = 'ro'): MountSpec => ({
+    class: 'install-surface',
+    hostPath: `/host${containerPath}`,
+    containerPath,
+    mode,
+    groupScope: 'g1',
+  });
+
+  it('drops a FILE mount nested inside a directory share (apple/container#2148) in either mode', () => {
+    const isFile = (p: string): boolean => p.endsWith('.json');
+    const mounts = [dir('/workspace/agent'), file('/workspace/agent/container.json'), file('/tmp/ca.pem')];
+    const kept = dropClobberingFileMounts(
+      mounts.map((m) => (m.containerPath.endsWith('.json') ? { ...m, hostPath: m.hostPath } : m)),
+      isFile,
+    );
+    expect(kept.map((m) => m.containerPath)).toEqual(['/workspace/agent', '/tmp/ca.pem']);
+  });
+
+  it('keeps nested DIRECTORY mounts — only file shares replace the parent', () => {
+    const isFile = (): boolean => false;
+    const mounts = [dir('/workspace'), dir('/workspace/agent')];
+    expect(dropClobberingFileMounts(mounts, isFile)).toHaveLength(2);
+  });
+});
+
+describe('ensureAppleContainerRunning', () => {
+  it('does nothing when system status succeeds', () => {
+    const fake = new FakeCli('container');
+    ensureAppleContainerRunning(fake);
+    expect(fake.calls.map((c) => c.args.join(' '))).toEqual(['system status']);
+  });
+
+  it('starts the runtime when status fails (cold boot / stale vmnet is routine)', () => {
+    const fake = new FakeCli('container');
+    fake.responses = [{ match: /^system status/, throws: 'not running' }];
+    ensureAppleContainerRunning(fake);
+    expect(fake.calls.map((c) => c.args.join(' '))).toEqual(['system status', 'system start']);
+  });
+
+  it('throws when start also fails', () => {
+    const fake = new FakeCli('container');
+    fake.responses = [
+      { match: /^system status/, throws: 'not running' },
+      { match: /^system start/, throws: 'no' },
+    ];
+    expect(() => ensureAppleContainerRunning(fake)).toThrow(/failed to start/i);
+  });
+});
+
+describe('prepare', () => {
+  it('creates with apple-safe args: labels, hardening, mounts, entrypoint split', async () => {
+    await driver().prepare(fixtureSpec({ resources: { pidsLimit: 128 } }));
+    const create = cli.calls.find((c) => c.args[0] === 'create');
+    expect(create).toBeDefined();
+    const joined = create!.args.join(' ');
+    expect(joined).toContain('--rm');
+    expect(joined).toContain(`--label ${LABELS.install}=spike`);
+    expect(joined).toContain(`--label ${LABELS.role}=agent`);
+    expect(joined).not.toContain('--security-opt');
+    expect(joined).toContain('--ulimit nproc=128');
+    expect(joined).toContain('--entrypoint bash');
+    expect(joined).toContain('-v /install/data/v2-sessions/g1/s1:/workspace');
+  });
+
+  it('rewrites host.docker.internal in env before the container sees it', async () => {
+    const spec = fixtureSpec();
+    spec.containers[0] = {
+      ...spec.containers[0],
+      contributedEnv: { HTTPS_PROXY: 'http://token@host.docker.internal:10255' },
+    };
+    await driver().prepare(spec);
+    const create = cli.calls.find((c) => c.args[0] === 'create')!;
+    const joined = create.args.join(' ');
+    expect(joined).toContain('HTTPS_PROXY=http://token@192.168.64.1:10255');
+    expect(joined).not.toContain('host.docker.internal');
+  });
+
+  it('refuses auxiliary containers (capabilities().auxiliaryContainers is false)', async () => {
+    const spec = fixtureSpec();
+    spec.containers = [...spec.containers, { ...spec.containers[0], role: 'egress-proxy' }];
+    await expect(driver().prepare(spec)).rejects.toThrow(/auxiliary/i);
+  });
+});
+
+describe('listSessions / reapResidue', () => {
+  const entry = (
+    id: string,
+    state: string,
+    labels: Record<string, string>,
+  ): { status: { state: string }; configuration: { id: string; labels: Record<string, string> } } => ({
+    status: { state },
+    configuration: { id, labels },
+  });
+
+  it('filters by install + role labels client-side (no --filter on this CLI)', async () => {
+    cli.responses = [
+      {
+        match: /^list /,
+        output: JSON.stringify([
+          entry('ours-1', 'running', {
+            [LABELS.install]: 'spike',
+            [LABELS.role]: 'agent',
+            [LABELS.group]: 'g1',
+            [LABELS.session]: 's1',
+          }),
+          entry('peer', 'running', {
+            [LABELS.install]: 'other-install',
+            [LABELS.role]: 'agent',
+            [LABELS.group]: 'gx',
+            [LABELS.session]: 'sx',
+          }),
+        ]),
+      },
+    ];
+    const sessions = await driver().listSessions('spike');
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].handle.name).toBe('ours-1');
+    expect(sessions[0].phase).toBe('running');
+  });
+
+  it('accepts both status shapes (plain string through 0.12.x, {state} from 1.0.0)', async () => {
+    cli.responses = [
+      {
+        match: /^list /,
+        output: JSON.stringify([
+          {
+            status: 'running',
+            configuration: {
+              id: 'legacy',
+              labels: {
+                [LABELS.install]: 'spike',
+                [LABELS.role]: 'agent',
+                [LABELS.group]: 'g1',
+                [LABELS.session]: 's1',
+              },
+            },
+          },
+        ]),
+      },
+    ];
+    const sessions = await driver().listSessions('spike');
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].phase).toBe('running');
+  });
+
+  it('reaps only this install: deletes stale entries, stops pre-seam runners, spares peers', async () => {
+    cli.responses = [
+      {
+        match: /^list /,
+        output: JSON.stringify([
+          entry('stale-ours', 'stopped', { [LABELS.install]: 'spike' }),
+          entry('preseam-ours', 'running', { [LABELS.install]: 'spike' }),
+          entry('peer-stale', 'stopped', { [LABELS.install]: 'other' }),
+        ]),
+      },
+    ];
+    await driver().reapResidue('spike');
+    const cmds = cli.calls.map((c) => c.args.join(' '));
+    expect(cmds).toContain('rm --force stale-ours');
+    expect(cmds).toContain('stop preseam-ours');
+    expect(cmds.join('\n')).not.toContain('peer-stale');
+  });
+});

--- a/src/drivers/apple-container-driver.ts
+++ b/src/drivers/apple-container-driver.ts
@@ -1,0 +1,615 @@
+/**
+ * Apple Container driver — the macOS microVM realization (kind 'container').
+ *
+ * Port of this install's pre-seam Apple Container support (the
+ * `CONTAINER_RUNTIME=container` branches that lived in `container-runtime.ts`
+ * and `container-runner.ts`) onto the session-driver seam. Selected via
+ * `NANOCLAW_RUNTIME_DRIVER=container` in `.env`; registered from
+ * `installed.ts` like any overlay driver.
+ *
+ * Where the grammar matches Docker's, this driver reuses the docker driver's
+ * exported arg builders. The Apple-specific knowledge it adds:
+ *
+ * - `--security-opt` and `--pids-limit` are rejected (exit 64, EX_USAGE);
+ *   `--ulimit nproc=` carries the pids-cap intent. Each container is its own
+ *   microVM, so the isolation boundary is stronger by default anyway.
+ * - VMs cannot resolve `host.docker.internal` and there is no `--add-host`:
+ *   env values carrying that hostname (OneCLI's injected proxy URL) are
+ *   rewritten to the bridge gateway IP, resolved from
+ *   `container network inspect default` (version-agnostic) with a
+ *   `CONTAINER_HOST_GATEWAY` override escape hatch.
+ * - A single-FILE bind whose destination sits INSIDE another share does not
+ *   layer — it REPLACES the parent share in the guest (apple/container#2148).
+ *   Nested file mounts are dropped; the real file is visible through the
+ *   parent share. Nested DIRECTORY mounts layer fine.
+ *
+ *   DECLARED DEVIATION from "realizes every declared mount": dropping is the
+ *   only viable realization on this runtime today. Refusing (the
+ *   auxiliary-container rule's shape) would brick stock composition, whose
+ *   container.json nested-RO mount is unconditional; faking (mounting and
+ *   letting the share collapse) silently destroys the parent mount, which is
+ *   strictly worse. The drop is loud (one warn per dropped mount, every
+ *   spawn), the file stays readable through the parent share, and the only
+ *   loss is the nested mount's RO protection — bounded by per-spawn host-side
+ *   re-materialization. Revisit when apple/container#2148 is fixed.
+ *
+ *   The host.docker.internal env rewrite is the same class of deviation from
+ *   "declared env passes through byte-identical": the hostname is
+ *   UNRESOLVABLE in this runtime (no --add-host exists), so a byte-identical
+ *   pass-through ships a value that can never work (upstream nanoclaw#2589).
+ *   The rewrite preserves the value's meaning — reach the host — the way a
+ *   resolver would, touches only values that carry the hostname, and runs on
+ *   both env lanes.
+ * - `list`/`inspect` have no `--filter` or go-template `--format`; listing
+ *   parses `--format json` and filters by label client-side. The `status`
+ *   field was a plain string through 0.12.x and became `{ state }` in 1.0.0 —
+ *   both shapes are accepted.
+ * - There is no `events` stream (the plugin is not installed by default), so
+ *   `watchSessions` is realized as a driver-level poll: one interval per
+ *   install, diffing listed phases and emitting terminal hints. Events are
+ *   best-effort hints by contract; supervision of self-started sessions rides
+ *   the `start --attach` exit like the docker driver.
+ * - `ensureReady` runs `container system status` and starts the runtime when
+ *   it is down — the runtime black-holes egress when its vmnet state is stale
+ *   (apple/container#2051), and a cold start after reboot is routine.
+ */
+import fs from 'fs';
+import os from 'os';
+
+import { log } from '../log.js';
+
+import { realCli, validateRuntimeName, type Cli, type SupervisedProcess } from './cli.js';
+import {
+  agentContainerName,
+  assertMountSourcesExist,
+  envArgs,
+  labelArgs,
+  resourceArgs,
+  userArgs,
+} from './docker-driver.js';
+import {
+  LABELS,
+  asFailureError,
+  labelsForKey,
+  specInvalid,
+  validateSpec,
+  type DriverCapabilities,
+  type MountPolicy,
+  type MountSpec,
+  type SessionDriver,
+  type SessionEvent,
+  type SessionExecSpec,
+  type SessionFailure,
+  type SessionHandle,
+  type SessionKey,
+  type SessionPhase,
+  type SessionSnapshot,
+  type SessionSpec,
+  type SessionStatus,
+  type SessionWatch,
+} from './types.js';
+
+export interface AppleContainerDriverOptions extends MountPolicy {
+  cli?: Cli;
+}
+
+/** Shape of one entry in `container list --format json` / `container inspect`. */
+interface AppleContainerEntry {
+  status: string | { state?: string };
+  configuration: { id: string; labels?: Record<string, string> };
+}
+
+function stateOf(entry: AppleContainerEntry): string | undefined {
+  return typeof entry.status === 'string' ? entry.status : entry.status?.state;
+}
+
+function applePhase(state: string | undefined): SessionPhase {
+  if (state === 'running') return 'running';
+  if (state === 'created') return 'starting';
+  return 'terminal';
+}
+
+/** Poll cadence for the events-substitute watch. */
+const WATCH_POLL_MS = 15_000;
+
+function isIPv4(addr: string): boolean {
+  const parts = addr.split('.');
+  return parts.length === 4 && parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) <= 255);
+}
+
+/**
+ * IP address containers use to reach the host machine. Resolved through the
+ * driver's `Cli` seam (never an ad-hoc child_process call) and only when an
+ * env value actually needs the rewrite. Precedence, each step logged so a
+ * future breakage is visible:
+ *   1. `CONTAINER_HOST_GATEWAY` override — operator escape hatch.
+ *   2. `container network inspect default` → `[0].status.ipv4Gateway`
+ *      (authoritative and VERSION-AGNOSTIC across bridge-subnet moves).
+ *   3. bridge100/bridge0 interface scan — back-compat with 0.12.x.
+ *   4. Throw. Deliberately NO hardcoded fallback: a plausible-but-stale
+ *      constant hands every container a dead gateway and produces a silent,
+ *      total outage with no error anywhere.
+ */
+export function resolveAppleHostGateway(cli: Cli, env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.CONTAINER_HOST_GATEWAY?.trim();
+  if (override) {
+    log.info('Host gateway resolved from CONTAINER_HOST_GATEWAY override', { gateway: override });
+    return override;
+  }
+  try {
+    const output = cli.run(['network', 'inspect', 'default'], { timeoutMs: 5000 });
+    const parsed = JSON.parse(String(output)) as Array<{ status?: { ipv4Gateway?: string } }>;
+    const gateway = parsed?.[0]?.status?.ipv4Gateway;
+    if (typeof gateway === 'string' && isIPv4(gateway)) {
+      log.debug('Host gateway resolved via `network inspect default`', { gateway });
+      return gateway;
+    }
+    log.warn('`network inspect default` returned no usable ipv4Gateway, falling back', { parsed });
+  } catch (err) {
+    log.debug('`network inspect default` failed, falling back to interface scan', { err });
+  }
+  const ifaces = os.networkInterfaces();
+  const bridge = ifaces['bridge100'] || ifaces['bridge0'];
+  const ipv4 = bridge?.find((a) => a.family === 'IPv4');
+  if (ipv4) {
+    log.debug('Host gateway resolved via bridge interface scan', { gateway: ipv4.address });
+    return ipv4.address;
+  }
+  const message =
+    'Could not detect the container host gateway: no CONTAINER_HOST_GATEWAY override, ' +
+    '`network inspect default` returned no usable ipv4Gateway, and no bridge100/bridge0 ' +
+    'interface with an IPv4 address was found. Set CONTAINER_HOST_GATEWAY as an escape hatch.';
+  log.error(message);
+  throw new Error(message);
+}
+
+/**
+ * Rewrite `host.docker.internal` to the bridge gateway IP in env values.
+ * Apple Container VMs cannot resolve that hostname and the runtime has no
+ * `--add-host`, so the proxy URL OneCLI injects would be unreachable and
+ * every credentialed call would fail silently (upstream nanoclaw#2589).
+ * Scoped to env values on purpose — never mount paths or names.
+ */
+export function rewriteHostDockerInternalEnv(env: Record<string, string>, gateway: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    out[k] = v.includes('host.docker.internal') ? v.replaceAll('host.docker.internal', gateway) : v;
+  }
+  return out;
+}
+
+/**
+ * Apple Container: a single-FILE share nested INSIDE another share REPLACES
+ * the parent share in the guest (apple/container#2148, observed and minimally
+ * reproduced 2026-08-14; re-verified on 1.2.2 2026-08-23). Drop nested file
+ * mounts — the real file is visible through the parent share. The cost is the
+ * RO protection those file mounts carried; per-spawn re-materialization and
+ * host-side authority (DB config, command gates) bound the tamper impact.
+ */
+export function dropClobberingFileMounts(
+  mounts: readonly MountSpec[],
+  isFile: (p: string) => boolean = defaultIsFile,
+): MountSpec[] {
+  const shareRoots = mounts.filter((m) => !isFile(m.hostPath)).map((m) => m.containerPath.replace(/\/+$/, ''));
+  return mounts.filter((mount) => {
+    if (!isFile(mount.hostPath)) return true;
+    const dest = mount.containerPath;
+    const clobbers = shareRoots.some((root) => root !== dest && dest.startsWith(`${root}/`));
+    if (clobbers) {
+      log.warn('Dropping nested file mount — Apple Container file shares replace the parent share', {
+        hostPath: mount.hostPath,
+        containerPath: dest,
+      });
+    }
+    return !clobbers;
+  });
+}
+
+function defaultIsFile(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hardening for the Apple runtime. `--security-opt` and `--pids-limit` are
+ * rejected as unknown options (exit 64) before the agent starts — verified
+ * against 1.1.0. `--ulimit nproc` carries the pids-cap intent;
+ * no-new-privileges has no equivalent, but each container is its own microVM,
+ * so the isolation boundary is stronger by default than a shared-kernel
+ * namespace. `--init` is not optional: the entrypoint override defeats the
+ * image's tini, leaving bun as PID 1 with no signal handler.
+ */
+export function appleHardeningArgs(spec: SessionSpec): string[] {
+  const args = ['--cap-drop=ALL', '--init'];
+  const pids = spec.resources.pidsLimit;
+  if (typeof pids === 'number' && Number.isFinite(pids) && pids > 0) {
+    args.push('--ulimit', `nproc=${Math.floor(pids)}`);
+  }
+  return args;
+}
+
+/** Ensure the runtime is up, starting it when down — a cold start after reboot is routine. */
+export function ensureAppleContainerRunning(cli: Cli = realCli('container')): void {
+  try {
+    cli.run(['system', 'status'], { timeoutMs: 10_000 });
+    log.debug('Apple Container runtime already running');
+  } catch {
+    log.info('Starting Apple Container runtime');
+    try {
+      cli.run(['system', 'start'], { timeoutMs: 30_000 });
+    } catch (err) {
+      log.error('Failed to start Apple Container', { err });
+      throw new Error('Container runtime is required but failed to start', { cause: err });
+    }
+  }
+}
+
+function normalizeAppleError(error: unknown): Error & SessionFailure {
+  const msg = error instanceof Error ? error.message : String(error);
+  const failure: SessionFailure = /not found|no such image|manifest/i.test(msg)
+    ? { kind: 'image-unavailable', retryable: true }
+    : /system services are not running|XPC connection|connection refused/i.test(msg)
+      ? { kind: 'runtime-unavailable', retryable: true }
+      : /no space left|cannot allocate memory/i.test(msg)
+        ? { kind: 'resources-exhausted', retryable: true }
+        : { kind: 'unknown', retryable: false, opaqueRef: `apple-container-${Date.now()}` };
+  return asFailureError(failure);
+}
+
+interface InstallPollWatch {
+  subscribers: Set<(event: SessionEvent) => void>;
+  timer: ReturnType<typeof setInterval>;
+  /** Last observed phase per keyId — terminal transitions are edges in this map. */
+  lastPhases: Map<string, { key: SessionKey; phase: SessionPhase }>;
+}
+
+function keyId(key: SessionKey): string {
+  return `${key.installSlug} ${key.agentGroupId} ${key.sessionId}`;
+}
+
+export class AppleContainerSessionDriver implements SessionDriver {
+  readonly kind = 'container' as const;
+  readonly #cli: Cli;
+  readonly #policy: MountPolicy;
+  readonly #watches = new Map<string, InstallPollWatch>();
+  #gateway: string | undefined;
+
+  /** Handle-observed transitions (the `start --attach` exit) ride the same stream as poll hints. */
+  readonly #emit = (event: SessionEvent): void => {
+    const watch = this.#watches.get(event.key.installSlug);
+    if (!watch) return;
+    for (const subscriber of watch.subscribers) subscriber(event);
+  };
+
+  /** Lazily resolved and instance-cached: only a spec whose env actually
+   *  carries `host.docker.internal` pays for the lookup. */
+  #hostGateway(): string {
+    if (this.#gateway === undefined) this.#gateway = resolveAppleHostGateway(this.#cli);
+    return this.#gateway;
+  }
+
+  constructor(opts: AppleContainerDriverOptions) {
+    this.#cli = opts.cli ?? realCli('container');
+    this.#policy = opts;
+  }
+
+  capabilities(): DriverCapabilities {
+    return {
+      isolationTiers: ['container'],
+      admissionEnforced: false,
+      networkPolicy: 'topology',
+      encryptedVolumes: false,
+      unrealized: [],
+      // Each session is a microVM with its own kernel; nothing shares a netns.
+      sharedNetworkNamespace: false,
+      auxiliaryContainers: false,
+      // `container build` targets the same store sessions run from.
+      imageBuild: true,
+    };
+  }
+
+  async ensureReady(): Promise<void> {
+    ensureAppleContainerRunning(this.#cli);
+  }
+
+  async prepare(spec: SessionSpec): Promise<SessionHandle> {
+    validateSpec(spec, this.#policy, this.capabilities());
+    const extra = spec.containers.filter((c) => c.role !== 'agent');
+    if (extra.length > 0) {
+      throw specInvalid(
+        `apple-container driver does not manage container role '${extra[0].role}'; ` +
+          `auxiliary containers require a driver with capabilities().auxiliaryContainers`,
+      );
+    }
+    const agent = spec.containers.find((c) => c.role === 'agent')!;
+    const name = validateRuntimeName(agentContainerName(spec), 'container');
+
+    if (this.#existingSession(name, spec.key)) {
+      return new AppleHandle(spec.key, name, this.#cli, null, this.#emit);
+    }
+
+    const mounts = dropClobberingFileMounts(agent.mounts);
+    assertMountSourcesExist(mounts);
+
+    const composedEnv = agent.env;
+    const contributedEnv = agent.contributedEnv ?? {};
+    const needsGateway = [...Object.values(composedEnv), ...Object.values(contributedEnv)].some((v) =>
+      v.includes('host.docker.internal'),
+    );
+    const gateway = needsGateway ? this.#hostGateway() : '';
+    const args = ['create', '--rm', '--name', name];
+    args.push(...labelArgs(labelsForKey(spec.key, 'agent', { ...spec.labels, ...(agent.labels ?? {}) })));
+    args.push(...resourceArgs(spec));
+    args.push(...appleHardeningArgs(spec));
+    args.push(...userArgs(spec));
+    // Composed env first, contributed env second — same override lane order as
+    // the docker driver. Both lanes get the host.docker.internal rewrite; the
+    // gateway proxy URL rides the contributed lane.
+    args.push(...envArgs(needsGateway ? rewriteHostDockerInternalEnv(composedEnv, gateway) : composedEnv));
+    args.push(...envArgs(needsGateway ? rewriteHostDockerInternalEnv(contributedEnv, gateway) : contributedEnv));
+    for (const m of mounts) {
+      args.push('-v', m.mode === 'ro' ? `${m.hostPath}:${m.containerPath}:ro` : `${m.hostPath}:${m.containerPath}`);
+    }
+    if (agent.command && agent.command.length > 0) {
+      args.push('--entrypoint', agent.command[0]);
+      args.push(agent.image, ...agent.command.slice(1), ...(agent.args ?? []));
+    } else {
+      args.push(agent.image, ...(agent.args ?? []));
+    }
+
+    try {
+      this.#cli.run(args, { timeoutMs: 120_000 });
+    } catch (error) {
+      try {
+        this.#cli.run(['rm', '--force', name]);
+      } catch {
+        /* prepare is atomic: allocate all or leave nothing */
+      }
+      throw normalizeAppleError(error);
+    }
+    return new AppleHandle(spec.key, name, this.#cli, spec, this.#emit);
+  }
+
+  async listSessions(installSlug: string): Promise<SessionSnapshot[]> {
+    return this.#list(installSlug).map(({ entry, key }) => ({
+      handle: new AppleHandle(key, entry.configuration.id, this.#cli, null, this.#emit),
+      phase: applePhase(stateOf(entry)),
+    }));
+  }
+
+  #list(installSlug: string): Array<{ entry: AppleContainerEntry; key: SessionKey }> {
+    let out: string;
+    try {
+      out = this.#cli.run(['list', '--all', '--format', 'json']);
+    } catch (error) {
+      throw normalizeAppleError(error);
+    }
+    const entries: AppleContainerEntry[] = JSON.parse(out.trim() || '[]');
+    const result: Array<{ entry: AppleContainerEntry; key: SessionKey }> = [];
+    for (const entry of entries) {
+      const labels = entry.configuration.labels ?? {};
+      if (labels[LABELS.install] !== installSlug) continue;
+      if (labels[LABELS.role] !== 'agent') continue;
+      const agentGroupId = labels[LABELS.group];
+      const sessionId = labels[LABELS.session];
+      if (!agentGroupId || !sessionId) continue;
+      result.push({ entry, key: { installSlug, agentGroupId, sessionId } });
+    }
+    return result;
+  }
+
+  /**
+   * Events substitute: Apple Container ships no `events` stream, so the one
+   * driver-level subscription is a poll that emits terminal hints on observed
+   * edges. Self-started sessions get exact supervision from `start --attach`;
+   * this covers adopted sessions and externally-killed containers.
+   */
+  watchSessions(installSlug: string, onEvent: (event: SessionEvent) => void): SessionWatch {
+    let watch = this.#watches.get(installSlug);
+    if (!watch) {
+      const created: InstallPollWatch = {
+        subscribers: new Set(),
+        lastPhases: new Map(),
+        timer: setInterval(() => this.#poll(installSlug, created), WATCH_POLL_MS),
+      };
+      created.timer.unref?.();
+      this.#watches.set(installSlug, created);
+      watch = created;
+    }
+    watch.subscribers.add(onEvent);
+    return {
+      stop: () => {
+        watch.subscribers.delete(onEvent);
+        if (watch.subscribers.size === 0) {
+          clearInterval(watch.timer);
+          this.#watches.delete(installSlug);
+        }
+      },
+    };
+  }
+
+  #poll(installSlug: string, watch: InstallPollWatch): void {
+    let current: Map<string, { key: SessionKey; phase: SessionPhase }>;
+    try {
+      current = new Map(
+        this.#list(installSlug).map(({ entry, key }) => [keyId(key), { key, phase: applePhase(stateOf(entry)) }]),
+      );
+    } catch {
+      return; // transient runtime hiccup; next tick retries
+    }
+    for (const [id, prev] of watch.lastPhases) {
+      const now = current.get(id);
+      if (prev.phase !== 'terminal' && (!now || now.phase === 'terminal')) {
+        for (const subscriber of watch.subscribers) subscriber({ key: prev.key, kind: 'terminal' });
+      }
+    }
+    watch.lastPhases = current;
+  }
+
+  async reapResidue(installSlug: string): Promise<void> {
+    try {
+      let out = '';
+      try {
+        out = this.#cli.run(['list', '--all', '--format', 'json']);
+      } catch (error) {
+        throw normalizeAppleError(error);
+      }
+      const entries: AppleContainerEntry[] = JSON.parse(out.trim() || '[]');
+      const stale = entries.filter(
+        (e) => e.configuration.labels?.[LABELS.install] === installSlug && stateOf(e) !== 'running',
+      );
+      for (const e of stale) {
+        try {
+          this.#cli.run(['rm', '--force', validateRuntimeName(e.configuration.id, 'container')]);
+        } catch {
+          /* already gone */
+        }
+      }
+      if (stale.length > 0) {
+        log.info('Removed orphaned containers', { count: stale.length, names: stale.map((e) => e.configuration.id) });
+      }
+      // Pre-seam residue: running containers with the install label but no
+      // session label can be neither adopted nor matched — stop them, exactly
+      // what the old cleanupOrphans() did on every start.
+      const preSeam = entries.filter(
+        (e) =>
+          e.configuration.labels?.[LABELS.install] === installSlug &&
+          stateOf(e) === 'running' &&
+          !e.configuration.labels?.[LABELS.session],
+      );
+      for (const e of preSeam) {
+        try {
+          this.#cli.run(['stop', validateRuntimeName(e.configuration.id, 'container')], { timeoutMs: 60_000 });
+        } catch {
+          /* already stopped */
+        }
+      }
+      if (preSeam.length > 0) {
+        log.info('Stopped pre-seam containers', {
+          count: preSeam.length,
+          names: preSeam.map((e) => e.configuration.id),
+        });
+      }
+    } catch (err) {
+      log.warn('Failed to clean up orphaned containers', { err });
+    }
+  }
+
+  /** Same adoption safety as the docker driver: labels verified, collision refuses loudly. */
+  #existingSession(name: string, key: SessionKey): boolean {
+    let out: string;
+    try {
+      out = this.#cli.run(['inspect', name]);
+    } catch {
+      return false;
+    }
+    let entries: AppleContainerEntry[];
+    try {
+      entries = JSON.parse(out.trim() || '[]');
+    } catch {
+      return false;
+    }
+    const labels = entries[0]?.configuration?.labels ?? {};
+    if (
+      labels[LABELS.install] === key.installSlug &&
+      labels[LABELS.group] === key.agentGroupId &&
+      labels[LABELS.session] === key.sessionId
+    ) {
+      return true;
+    }
+    log.warn('Container name collision: existing container is not this session', {
+      containerName: name,
+      wanted: key,
+      found: labels,
+    });
+    throw asFailureError({ kind: 'unknown', retryable: false, opaqueRef: `name-collision-${name}` });
+  }
+}
+
+class AppleHandle implements SessionHandle {
+  #proc: SupervisedProcess | null = null;
+  #stopping = false;
+  #attachExitCode: number | null | undefined;
+  readonly #stderrTail: string[] = [];
+
+  constructor(
+    readonly key: SessionKey,
+    readonly name: string,
+    private readonly cli: Cli,
+    private readonly pendingSpec: SessionSpec | null,
+    private readonly emit: (event: SessionEvent) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.#proc) return; // idempotent
+    const proc = this.cli.start(['start', '--attach', this.name]);
+    this.#proc = proc;
+    proc.onStderr((line) => {
+      log.debug(line, { container: this.name });
+      this.#stderrTail.push(line);
+      if (this.#stderrTail.length > 10) this.#stderrTail.shift();
+    });
+    proc.onExit((code) => {
+      this.#attachExitCode = code;
+      if (!this.#stopping && code !== 0 && code !== null && this.#stderrTail.length > 0) {
+        log.warn('Container exited non-zero', { containerName: this.name, code, stderrTail: this.#stderrTail });
+      }
+      // Every observed terminal transition rides the driver-level stream —
+      // even ends the host requested. Intent filtering is the hub's job.
+      this.emit({ key: this.key, kind: 'terminal' });
+    });
+  }
+
+  async status(): Promise<SessionStatus> {
+    let state: string | undefined;
+    try {
+      const out = this.cli.run(['inspect', this.name]);
+      const entries: AppleContainerEntry[] = JSON.parse(out.trim() || '[]');
+      if (entries.length === 0) throw new Error('not found');
+      state = stateOf(entries[0]);
+    } catch {
+      // `--rm` means an exited container is already gone; the attach exit code
+      // is the only record of how it ended.
+      if (!this.#stopping && typeof this.#attachExitCode === 'number' && this.#attachExitCode !== 0) {
+        return {
+          phase: 'failed',
+          failure: { kind: 'started-then-died', retryable: false, exitCode: this.#attachExitCode },
+        };
+      }
+      if (!this.#stopping && this.#proc && this.#attachExitCode === undefined) {
+        return { phase: 'running' };
+      }
+      return this.pendingSpec && !this.#proc ? { phase: 'ready' } : { phase: 'stopped' };
+    }
+    if (state === 'running') return { phase: 'running' };
+    if (state === 'created') return { phase: 'ready' };
+    return { phase: 'stopped' };
+  }
+
+  async stop(reason: string): Promise<void> {
+    this.#stopping = true;
+    log.info('Stopping session container', { containerName: this.name, reason });
+    const grace = String(this.pendingSpec?.stopGraceSeconds ?? 1);
+    try {
+      this.cli.run(['stop', '-t', grace, this.name], { timeoutMs: 60_000 });
+    } catch {
+      this.#proc?.kill();
+    }
+    try {
+      this.cli.run(['rm', '--force', this.name]);
+    } catch {
+      /* `--rm` usually got there first */
+    }
+  }
+
+  execSpec(command: string[]): SessionExecSpec {
+    return {
+      bin: 'container',
+      argsTty: ['exec', '-it', this.name, ...command],
+      argsPlain: ['exec', '-i', this.name, ...command],
+    };
+  }
+}

--- a/src/drivers/apple-container-registration.ts
+++ b/src/drivers/apple-container-registration.ts
@@ -1,0 +1,9 @@
+/**
+ * Self-registration for the Apple Container driver (kind 'container').
+ * Reached via the `installed.ts` barrel; select with
+ * `NANOCLAW_RUNTIME_DRIVER=container` in `.env`.
+ */
+import { AppleContainerSessionDriver } from './apple-container-driver.js';
+import { registerSessionDriver } from './driver-registry.js';
+
+registerSessionDriver('container', (policy) => new AppleContainerSessionDriver(policy));

--- a/src/drivers/conformance.test.ts
+++ b/src/drivers/conformance.test.ts
@@ -16,6 +16,8 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AppleContainerSessionDriver } from './apple-container-driver.js';
+import type { Cli } from './cli.js';
 import { DockerSessionDriver } from './docker-driver.js';
 import { FakeCli } from './fake-cli.js';
 import { withSessionEvents, type SessionEventsDriver } from './session-events.js';
@@ -100,10 +102,121 @@ function dockerHarness(): Harness {
   };
 }
 
+/**
+ * Apple Container harness — the same cases, realized by the `container` CLI.
+ *
+ * The cases program `h.cli` in Docker's stub grammar (`inspect` pipe rows,
+ * `ps -a` pipe rows) because that grammar IS the suite's neutral fixture
+ * vocabulary. This harness owns the translation the suite's header promises
+ * ("the translation layer that lets one assertion cover every driver"): a
+ * `Cli` wrapper hands the Apple driver's list/inspect queries to the same
+ * programmed stubs and re-shapes their answers into the JSON the real
+ * `container` CLI produces. Assertions on issued argv still see every real
+ * call (`create`, `rm --force`, `start --attach`) verbatim.
+ */
+function appleContainerHarness(): Harness {
+  const cli = new FakeCli('container');
+  cli.responses = [{ match: /^inspect /, throws: new Error('no such container') }];
+
+  const appleEntry = (name: string, state: string, group: string, session: string): unknown => ({
+    status: { state },
+    configuration: {
+      id: name,
+      labels: {
+        [LABELS.install]: 'spike',
+        [LABELS.role]: 'agent',
+        [LABELS.group]: group,
+        [LABELS.session]: session,
+      },
+    },
+  });
+
+  const translating: Cli = {
+    bin: 'container',
+    run(args, opts) {
+      if (args[0] === 'list') {
+        // Real CLI: `list --all --format json`. The stubs speak `ps -a` pipe
+        // rows (name|state|group|session); re-shape them.
+        const rows = cli.run(['ps', '-a'], opts);
+        const entries = rows
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((row) => {
+            const [name, state, group, session] = row.split('|');
+            return appleEntry(name, state, group, session);
+          });
+        return JSON.stringify(entries);
+      }
+      if (args[0] === 'inspect') {
+        // Real CLI: JSON array. The stubs speak `install|group|session`.
+        const out = cli.run(['inspect', args[1]], opts);
+        const [install, group, session] = out.trim().split('|');
+        return JSON.stringify([
+          {
+            status: { state: 'running' },
+            configuration: {
+              id: args[1],
+              labels: { [LABELS.install]: install, [LABELS.group]: group, [LABELS.session]: session },
+            },
+          },
+        ]);
+      }
+      return cli.run(args, opts);
+    },
+    start(args) {
+      return cli.start(args);
+    },
+  };
+
+  const driver = withSessionEvents(new AppleContainerSessionDriver({ ...FIXTURE_POLICY, cli: translating }));
+  return {
+    name: 'apple-container',
+    driver,
+    cli,
+    async realize(spec) {
+      await driver.prepare(spec);
+      const create = cli.callMatching(/^create /)!.args;
+      const env: Record<string, string> = {};
+      const mounts: Realized['containers'][number]['mounts'] = [];
+      const labels: Record<string, string> = {};
+      for (let i = 0; i < create.length; i++) {
+        if (create[i] === '-e') {
+          const eq = create[i + 1].indexOf('=');
+          env[create[i + 1].slice(0, eq)] = create[i + 1].slice(eq + 1);
+        }
+        if (create[i] === '-v') {
+          const parts = create[i + 1].split(':');
+          mounts.push({ hostPath: parts[0], containerPath: parts[1], ro: parts[2] === 'ro' });
+        }
+        if (create[i] === '--label') {
+          const eq = create[i + 1].indexOf('=');
+          labels[create[i + 1].slice(0, eq)] = create[i + 1].slice(eq + 1);
+        }
+      }
+      const agent = spec.containers.find((c) => c.role === 'agent')!;
+      return { containers: [{ role: 'agent', image: agent.image, env, mounts }], labels };
+    },
+    failWith(message) {
+      // Each runtime fails in its own words; the case names the failure CLASS
+      // through Docker's canonical message, and the harness realizes that
+      // class in this runtime's real vocabulary.
+      const appleMessage =
+        message === 'Cannot connect to the Docker daemon'
+          ? 'XPC connection error: Connection refused - if system services are not running, start them'
+          : message;
+      cli.responses = [
+        { match: /^inspect /, throws: new Error('no such container') },
+        { match: /^create /, throws: new Error(appleMessage) },
+      ];
+    },
+  };
+}
+
 let harnesses: Harness[];
 beforeEach(() => {
   vi.clearAllMocks();
-  harnesses = [dockerHarness()];
+  harnesses = [dockerHarness(), appleContainerHarness()];
 });
 
 /**

--- a/src/drivers/installed.ts
+++ b/src/drivers/installed.ts
@@ -6,3 +6,4 @@
 // on purpose: an overlay that instead rewrote the construction expression in
 // `index.ts` would own a patch of this tree's internals, and every later edit
 // to selection would silently invalidate it.
+import './apple-container-registration.js';


### PR DESCRIPTION
## Type of change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

## What

Apple Container (macOS microVMs) as a session-driver overlay — kind `container`, self-registered via `installed.ts`, selected with `NANOCLAW_RUNTIME_DRIVER=container`. Ships as `/add-apple-container` (SKILL.md + REMOVE.md). Docker installs are untouched; docker stays the default.

## Why

- **No Docker Desktop dependency on macOS.** Docker Desktop requires a paid subscription for commercial use in larger organizations, and the common alternatives are third-party stacks with their own commercial terms. Apple Container is first-party and Apache-2.0.
- **Stronger isolation for agent workloads.** Each session gets its own VM with its own kernel — a real hardening upgrade for prompt-injectable agents holding credentials, over shared-kernel namespaces inside one shared VM.
- **Footprint that scales with sessions, not a VM reservation.** No multi-GB always-on VM: an idle install holds no VM memory, and a bursty multi-user install pays only for live sessions, with no shared-VM memory ceiling to tune under concurrency.
- **Measured cost:** ~0.35s additional spawn latency per session versus a warm docker engine on the same host (565ms vs 208ms round-trip, n=8) — negligible against an agent turn.
- **First overlay for the driver seam** — exercises the extension point with a runtime that genuinely differs (CLI grammar, isolation model, no events stream), and supersedes the stale `skill/apple-container` branch. Closes #2574.

## How it works

The driver reuses the docker driver's arg builders where the grammar matches and carries the Apple-specific knowledge the seam cannot: the CLI rejects `--security-opt`/`--pids-limit` (pids cap realized as `--ulimit nproc`), there is no events stream (`watchSessions` is a driver-level poll; self-started sessions get exact supervision from the `start --attach` exit), `list`/`inspect` have no `--filter` or go-template format (JSON parsed, label-filtered client-side, both historical `status` shapes accepted), and `ensureReady` runs `container system start` on a cold runtime.

Two deliberate deviations, declared in the driver header and SKILL.md rather than discovered:

- **Nested file mounts are dropped, loudly** — a single-file bind nested inside another share REPLACES the parent share in the guest (apple/container#2148). Refusing would brick stock composition (the `container.json` nested-RO mount is unconditional); mounting anyway destroys the parent share silently. One warn per dropped mount per spawn; the file stays visible through the parent share.
- **`host.docker.internal` is rewritten to the bridge gateway IP in env values** — the runtime has no `--add-host` and its VMs cannot resolve the name (#2589), so a byte-identical pass-through ships a value that can never work. Resolution: `CONTAINER_HOST_GATEWAY` override → `container network inspect default` → bridge scan; never a hardcoded constant.

`container/build.sh` gains a guarded `-m` arg (default 8G, `CONTAINER_BUILDER_MEM` override): every bare `container build` re-creates the builder VM at a 2 GiB default, which OOMs on the cli-tools layer, so `capabilities().imageBuild = true` is only honest with it.

## How it was tested

- The driver's harness rides the conformance suite: **every case unchanged, 56/56** across both harnesses. The harness owns the stub-grammar translation (the suite's "translation layer" role); harness execution was canary-verified.
- 14 driver-specific tests (hardening shape, gateway rewrite, nested-mount drop, system-start recovery, label-scoped listing/reaping, both `status` shapes).
- **In production on our departmental multi-user install since 2026-08-08** — the same runtime support ran pre-seam (as `CONTAINER_RUNTIME` branches) through ~2.5 weeks of real traffic, image builds, and incident debugging; ported onto the driver seam 2026-08-24 and verified live there (respawn + full agent turns through OneCLI-injected credentials and MCP, on async-DB trunk).

## Usage

`/add-apple-container`, then set `NANOCLAW_RUNTIME_DRIVER=container` (the skill walks it). Requirements: macOS on Apple Silicon, `container` CLI 1.2.x+.

**Note for maintainers:** the SKILL.md references a `drivers` registry branch that does not exist yet — happy to reshape to whatever distribution you prefer (new registry branch, or in-tree beside docker). Draft until that question settles.

**Update (drain fix folded in):** `scripts/update/service.ts` drain now speaks this runtime's grammar (`list --format json` + client-side label filter — the CLI has no `ps` and no `--filter`). Only reachable with this driver selected; without it, `/update-nanoclaw` cutover refuses on Apple-runtime installs. Same driver-completing rationale as the build.sh change.