### PR TITLE
feat(channels): add Mattermost installation skill

### DIFF
--- a/.claude/skills/add-mattermost/LOCAL_SERVER.md
+++ b/.claude/skills/add-mattermost/LOCAL_SERVER.md
@@ -1,0 +1,82 @@
+# Local Mattermost server
+
+Read this only when discovering, repairing, or installing a local Mattermost.
+The bundled Compose setup is for evaluation and NanoClaw development, not a
+production deployment.
+
+## Discovery
+
+Probe configured and conventional URLs with Mattermost's health endpoint:
+
+```bash
+for url in "${MATTERMOST_BASE_URL:-}" http://localhost:8065 http://127.0.0.1:8065; do
+  test -n "$url" || continue
+  curl -fsS --max-time 2 "${url%/}/api/v4/system/ping"
+done
+```
+
+Also inspect `docker ps -a` for images or names containing `mattermost`. Do not
+assume every service on port 8065 is Mattermost. When localhost and 127.0.0.1
+reach the same container, they are aliases, not two choices.
+
+If a stopped installation is found, identify its Compose project or original
+startup mechanism and offer to start it with that mechanism. Recreating an
+unknown container can lose non-persisted configuration.
+
+## Optional evaluation installation
+
+Before proceeding, tell the user this creates a Mattermost Team Edition
+container, PostgreSQL container, named data volumes, a Docker network, and a
+host listener on port 8065. Confirm Docker and Compose are available and port
+8065 is free, then obtain approval.
+
+Copy the bundled template into a user-visible project directory so future
+configuration changes remain reproducible:
+
+```bash
+mkdir -p .nanoclaw/mattermost
+cp .claude/skills/add-mattermost/assets/compose.yml .nanoclaw/mattermost/compose.yml
+docker compose -f .nanoclaw/mattermost/compose.yml up -d
+```
+
+Wait for `http://localhost:8065/api/v4/system/ping` to become healthy. Stop
+after a bounded wait and report container logs on failure; do not loop forever.
+Then set:
+
+```bash
+MATTERMOST_BASE_URL=http://localhost:8065
+```
+
+Keep this hostname in Mattermost Desktop too. The template persists the
+canonical Site URL and allows both common loopback origins for WebSockets, so
+Desktop does not silently stop receiving live events if it normalizes the
+hostname. It also enables bot account creation and permits callbacks only to
+the Docker host name needed by a locally running NanoClaw.
+
+The first browser visit creates the administrator and team. Continue with the
+bot-account steps in `SKILL.md` after that initialization is complete.
+
+## Verification
+
+Health:
+
+```bash
+curl -fsS http://localhost:8065/api/v4/system/ping
+```
+
+WebSocket origin (a successful upgrade remains open, so use a timeout; seeing
+`101 Switching Protocols` is success even when curl later reports a timeout):
+
+```bash
+curl -i --http1.1 --max-time 3 \
+  -H 'Origin: http://localhost:8065' \
+  -H 'Connection: Upgrade' \
+  -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' \
+  -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  http://localhost:8065/api/v4/websocket
+```
+
+Use `docker compose -f .nanoclaw/mattermost/compose.yml down` to stop the lab
+without deleting data. Never add `-v` unless the user explicitly asks to erase
+the Mattermost database and uploaded data.

--- a/.claude/skills/add-mattermost/LOCAL_SERVER.md
+++ b/.claude/skills/add-mattermost/LOCAL_SERVER.md
@@ -36,8 +36,13 @@ configuration changes remain reproducible:
 ```bash
 mkdir -p .nanoclaw/mattermost
 cp .claude/skills/add-mattermost/assets/compose.yml .nanoclaw/mattermost/compose.yml
+umask 077
+test -f .nanoclaw/mattermost/.env || printf 'MATTERMOST_DB_PASSWORD=%s\n' "$(openssl rand -hex 24)" > .nanoclaw/mattermost/.env
 docker compose -f .nanoclaw/mattermost/compose.yml up -d
 ```
+
+The generated database credential is local to this evaluation stack and is
+stored mode-private beside its Compose file. Do not commit that `.env` file.
 
 Wait for `http://localhost:8065/api/v4/system/ping` to become healthy. Stop
 after a bounded wait and report container logs on failure; do not loop forever.

--- a/.claude/skills/add-mattermost/LOCAL_SERVER.md
+++ b/.claude/skills/add-mattermost/LOCAL_SERVER.md
@@ -58,8 +58,11 @@ Desktop does not silently stop receiving live events if it normalizes the
 hostname. It also enables bot account creation and permits callbacks only to
 the Docker host name needed by a locally running NanoClaw.
 
-The first browser visit creates the administrator and team. Continue with the
-bot-account steps in `SKILL.md` after that initialization is complete.
+The first browser visit creates the administrator and team; Mattermost always
+allows creating the first account even with open signup disabled. The template
+keeps open signup off, so anyone else who reaches the listener cannot
+self-register — add further users through System Console invitations. Continue
+with the bot-account steps in `SKILL.md` after that initialization is complete.
 
 ## Verification
 

--- a/.claude/skills/add-mattermost/REMOVE.md
+++ b/.claude/skills/add-mattermost/REMOVE.md
@@ -1,0 +1,41 @@
+# Remove Mattermost
+
+Every step is idempotent and safe to re-run.
+
+## 1. Remove the registration
+
+Delete `import './mattermost.js';` from `src/channels/index.ts`, skipping it if
+it is already absent.
+
+## 2. Remove the channel files
+
+```bash
+rm -f src/channels/mattermost.ts src/channels/mattermost-registration.test.ts
+rm -rf src/channels/mattermost-adapter
+```
+
+## 3. Remove credentials
+
+Remove `MATTERMOST_BASE_URL`, `MATTERMOST_BOT_TOKEN`,
+`MATTERMOST_CALLBACK_URL`, and `MATTERMOST_CALLBACK_SECRET` from `.env`.
+
+## 4. Remove direct dependencies
+
+If no other locally installed channel imports `ws`, remove the dependencies:
+
+```bash
+pnpm uninstall ws @types/ws
+```
+
+## 5. Optional local server
+
+The evaluation server is deliberately not removed automatically because its
+volumes contain Mattermost data. If it was created only for NanoClaw and the
+data is no longer needed, follow the teardown instructions in `LOCAL_SERVER.md`.
+
+## 6. Rebuild and restart
+
+```bash
+pnpm run build
+bash setup/lib/restart.sh
+```

--- a/.claude/skills/add-mattermost/REMOVE.md
+++ b/.claude/skills/add-mattermost/REMOVE.md
@@ -21,7 +21,14 @@ Remove `MATTERMOST_BASE_URL`, `MATTERMOST_BOT_TOKEN`,
 
 ## 4. Remove direct dependencies
 
-If no other locally installed channel imports `ws`, remove the dependencies:
+Check whether any remaining channel still imports `ws`:
+
+```bash
+grep -rl "require('ws')\|from 'ws'" src/channels
+```
+
+The adapter removed in step 2 was the only trunk consumer, so if the grep
+matches nothing, remove the dependencies:
 
 ```bash
 pnpm uninstall ws @types/ws
@@ -30,8 +37,15 @@ pnpm uninstall ws @types/ws
 ## 5. Optional local server
 
 The evaluation server is deliberately not removed automatically because its
-volumes contain Mattermost data. If it was created only for NanoClaw and the
-data is no longer needed, follow the teardown instructions in `LOCAL_SERVER.md`.
+volumes contain Mattermost data. Stopping it keeps that data:
+
+```bash
+docker compose -f .nanoclaw/mattermost/compose.yml down
+```
+
+Only when the operator explicitly confirms the Mattermost database and uploads
+should be erased, add `-v` to that command to delete the volumes as well. Also
+delete `.nanoclaw/mattermost/` afterwards if the stack is gone for good.
 
 ## 6. Rebuild and restart
 

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-mattermost
-description: Add a self-hosted or cloud Mattermost bot channel through the Chat SDK bridge.
+description: Add a self-hosted or cloud Mattermost bot channel through the Chat SDK bridge, reusing a local server when available and offering an evaluation server when none exists.
 ---
 
 # Add Mattermost Channel
@@ -8,6 +8,34 @@ description: Add a self-hosted or cloud Mattermost bot channel through the Chat 
 Adds Mattermost DMs, channels, threads, files, reactions, and interactive
 approval cards. Messages arrive over Mattermost's WebSocket; card clicks return
 to NanoClaw over an authenticated HTTP callback. Every step is safe to re-run.
+
+## Discover the server first
+
+Do this before installing the adapter or asking for a URL. The goal is to
+reuse a healthy Mattermost the user already has and establish one canonical
+base URL.
+
+1. Check an existing `MATTERMOST_BASE_URL` in the current environment and
+   NanoClaw env/config files. Do not print tokens or dump whole env files.
+2. Probe likely local URLs, at least `http://localhost:8065` and
+   `http://127.0.0.1:8065`, using `GET /api/v4/system/ping`. A listening port
+   alone is not evidence that the service is Mattermost.
+3. Inspect Docker/Compose for Mattermost containers. If a matching container
+   exists but is stopped, offer to start it; do not start or recreate it
+   without the user's approval.
+4. If one healthy server is found, tell the user and use it. If multiple
+   distinct servers are found, ask which one to use. Treat localhost and
+   127.0.0.1 endpoints for the same container as one server and prefer the
+   hostname in its configured Site URL; otherwise prefer `localhost`.
+5. If nothing local is found, ask whether the user has a remote Mattermost.
+   If not, offer the local evaluation installation in
+   [LOCAL_SERVER.md](LOCAL_SERVER.md). Read that file only for local server
+   discovery, repair, or installation.
+
+Set `MATTERMOST_BASE_URL` to the chosen canonical URL (scheme included, no
+trailing slash), then use that exact hostname in browser/Desktop setup. Do not
+silently install Mattermost: it runs containers, binds a port, and persists
+data, so show what will be created and get approval first.
 
 ## Apply
 
@@ -181,6 +209,17 @@ changes are observed, but restarting NanoClaw forces a fresh subscription.
 **A new channel gets no immediate reply.** Check the owner's DM with the bot.
 NanoClaw holds the first message behind a channel-approval card and deduplicates
 later mentions until that card is resolved.
+
+**Desktop messages appear only after a manual refresh.** This is usually the
+Desktop client's WebSocket origin being rejected. Keep the Desktop server URL,
+`MATTERMOST_BASE_URL`, and Mattermost `ServiceSettings.SiteURL` on the same
+canonical hostname. Check server logs for `request origin not allowed`, and
+verify `/api/v4/websocket` returns `101 Switching Protocols` for that Origin.
+For a local server that genuinely needs both hostnames, persist a space-separated
+`ServiceSettings.AllowCorsFrom` containing `http://localhost:8065` and
+`http://127.0.0.1:8065`; do not use `*`. Preview images may regenerate
+`config.json` on restart, so make the setting part of container startup rather
+than relying on an in-container edit.
 
 **Cards render but clicks do nothing.** From the Mattermost server, POST to the
 callback URL. A `401` proves the path reaches NanoClaw; timeout or refusal means

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -64,6 +64,13 @@ Copy the canonical adapter and registration test from the `channels` branch.
 ```nc:copy from-branch:channels
 src/channels/mattermost.ts
 src/channels/mattermost-registration.test.ts
+src/channels/mattermost-adapter/adapter.ts
+src/channels/mattermost-adapter/format.ts
+src/channels/mattermost-adapter/index.ts
+src/channels/mattermost-adapter/rest.ts
+src/channels/mattermost-adapter/thread-id.ts
+src/channels/mattermost-adapter/types.ts
+src/channels/mattermost-adapter/websocket.ts
 ```
 
 Append the channel's single reach-in to the barrel, skipping it if present.
@@ -73,16 +80,18 @@ import './mattermost.js';
 ```
 
 Remove the conflicting unscoped adapter when it is installed. The channel uses
-only NanoCo's scoped package.
+the audited implementation copied from the `channels` branch.
 
 ```nc:run
 if node -e "const p=require('./package.json'); process.exit(p.dependencies?.['chat-adapter-mattermost'] ? 0 : 1)"; then pnpm remove chat-adapter-mattermost; fi
 ```
 
-Install NanoCo's audited adapter at the exact supported version.
+Install the vendored adapter's direct WebSocket dependencies at the exact
+supported versions.
 
 ```nc:dep
-@nanoco/chat-adapter-mattermost@0.1.0
+ws@8.21.3
+@types/ws@8.18.1
 ```
 
 ### 3. Create and authenticate the bot

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -79,8 +79,11 @@ Append the channel's single reach-in to the barrel, skipping it if present.
 import './mattermost.js';
 ```
 
-Remove the conflicting unscoped adapter when it is installed. The channel uses
-the audited implementation copied from the `channels` branch.
+Remove the unscoped `chat-adapter-mattermost` package when it is installed.
+Nothing in this repository imports it: it is typosquat-shaped against the
+scoped `@chat-adapter` family, so any copy in `package.json` is stale or
+mistaken and would sit beside the audited implementation copied from the
+`channels` branch.
 
 ```nc:run
 if node -e "const p=require('./package.json'); process.exit(p.dependencies?.['chat-adapter-mattermost'] ? 0 : 1)"; then pnpm remove chat-adapter-mattermost; fi

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -39,7 +39,25 @@ data, so show what will be created and get approval first.
 
 ## Apply
 
-### 1. Copy and register the channel
+### 1. Detect the server
+
+Probe a configured URL and the conventional local endpoints. The detector
+always returns structured output: `found` binds `base_url`; `none` leaves it
+for the guarded prompt below.
+
+```nc:run capture:discovery=.discovery,base_url=.base_url effect:fetch
+node .claude/skills/add-mattermost/scripts/discover-server.mjs
+```
+
+```nc:operator when:discovery=none
+No healthy configured or local Mattermost server was detected. If you have a remote server, provide its URL next. Otherwise install the local evaluation server by following LOCAL_SERVER.md, then provide http://localhost:8065.
+```
+
+```nc:prompt base_url when:discovery=none normalize:rstrip-slash validate:^https?://[A-Za-z0-9._~:%/?#\[\]@!&()*+,;=-]+$
+Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
+```
+
+### 2. Copy and register the channel
 
 Copy the canonical adapter and registration test from the `channels` branch.
 
@@ -67,7 +85,7 @@ Install NanoCo's audited adapter at the exact supported version.
 @nanoco/chat-adapter-mattermost@0.1.0
 ```
 
-### 2. Create and authenticate the bot
+### 3. Create and authenticate the bot
 
 Tell the operator:
 
@@ -77,12 +95,6 @@ Create a dedicated Mattermost bot:
 2. Create a bot such as `nanoclaw`, then copy the access token shown after creation.
 3. Add the bot to every team and channel where it should receive messages. Bots do not join channels automatically.
 4. Keep the token private. If it is lost, create a new token and deactivate the obsolete one after replacement.
-```
-
-Collect the server URL without a trailing slash and the bot token.
-
-```nc:prompt base_url normalize:rstrip-slash validate:^https?://.+
-Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
 ```
 
 ```nc:prompt bot_token secret normalize:trim validate:^[A-Za-z0-9_-]{20,}$
@@ -96,7 +108,7 @@ token, or bot-account status is wrong.
 curl -sf "{{base_url}}/api/v4/users/me" -H "Authorization: Bearer {{bot_token}}"
 ```
 
-### 3. Configure authenticated card callbacks
+### 4. Configure authenticated card callbacks
 
 Approvals require Mattermost itself—not the browser—to reach NanoClaw. Ask for
 a URL routable from the Mattermost server. It may be NanoClaw's base URL or the
@@ -128,7 +140,7 @@ Tell the operator:
 From the Mattermost server, verify the callback host is reachable. For a private host or Docker bridge name, add that hostname or IP under System Console → Environment → Developer → Allow untrusted internal connections. Use a publicly trusted HTTPS certificate in production.
 ```
 
-### 4. Resolve the owner's DM
+### 5. Resolve the owner's DM
 
 Ask for the Mattermost username that will own this NanoClaw installation.
 
@@ -149,7 +161,7 @@ curl -sf -X POST "{{base_url}}/api/v4/channels/direct" -H "Authorization: Bearer
 The resolved `platform_id` and `owner_username` are used by
 `/init-first-agent`. If an owner exists, use `/manage-channels` instead.
 
-### 5. Build, test, and restart
+### 6. Build, test, and restart
 
 Build the composed host to guard the typed Chat SDK bridge call and dependency.
 

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: add-mattermost
+description: Add a self-hosted or cloud Mattermost bot channel through the Chat SDK bridge.
+---
+
+# Add Mattermost Channel
+
+Adds Mattermost DMs, channels, threads, files, reactions, and interactive
+approval cards. Messages arrive over Mattermost's WebSocket; card clicks return
+to NanoClaw over an authenticated HTTP callback. Every step is safe to re-run.
+
+## Apply
+
+### 1. Copy and register the channel
+
+Copy the canonical adapter and registration test from the `channels` branch.
+
+```nc:copy from-branch:channels
+src/channels/mattermost.ts
+src/channels/mattermost-registration.test.ts
+```
+
+Append the channel's single reach-in to the barrel, skipping it if present.
+
+```nc:append to:src/channels/index.ts
+import './mattermost.js';
+```
+
+Remove the conflicting unscoped adapter when it is installed. The channel uses
+only NanoCo's scoped package.
+
+```nc:run
+if node -e "const p=require('./package.json'); process.exit(p.dependencies?.['chat-adapter-mattermost'] ? 0 : 1)"; then pnpm remove chat-adapter-mattermost; fi
+```
+
+Install NanoCo's audited adapter at the exact supported version.
+
+```nc:dep
+@nanoco/chat-adapter-mattermost@0.1.0
+```
+
+### 2. Create and authenticate the bot
+
+Tell the operator:
+
+```nc:operator
+Create a dedicated Mattermost bot:
+1. As a System Admin, open System Console → Integrations → Bot Accounts and enable bot-account creation.
+2. Create a bot such as `nanoclaw`, then copy the access token shown after creation.
+3. Add the bot to every team and channel where it should receive messages. Bots do not join channels automatically.
+4. Keep the token private. If it is lost, create a new token and deactivate the obsolete one after replacement.
+```
+
+Collect the server URL without a trailing slash and the bot token.
+
+```nc:prompt base_url normalize:rstrip-slash validate:^https?://.+
+Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
+```
+
+```nc:prompt bot_token secret normalize:trim validate:^[A-Za-z0-9_-]{20,}$
+Mattermost bot access token (20 or more letters, digits, underscores, or hyphens).
+```
+
+Confirm the credential and capture the bot identity. A failure means the URL,
+token, or bot-account status is wrong.
+
+```nc:run capture:bot_user_id=.id,bot_username=.username effect:fetch
+curl -sf "{{base_url}}/api/v4/users/me" -H "Authorization: Bearer {{bot_token}}"
+```
+
+### 3. Configure authenticated card callbacks
+
+Approvals require Mattermost itself—not the browser—to reach NanoClaw. Ask for
+a URL routable from the Mattermost server. It may be NanoClaw's base URL or the
+full `/webhook/mattermost` route; the adapter normalizes either form.
+
+```nc:prompt callback_url normalize:rstrip-slash validate:^https?://.+
+Callback URL reachable from Mattermost, such as `https://nanoclaw.example.com` or `http://host.docker.internal:3000/webhook/mattermost`.
+```
+
+Mattermost does not sign action callbacks. Generate a random shared secret for
+the server-only callback context.
+
+```nc:run capture:callback_secret effect:external validate:^[a-f0-9]{64}$
+openssl rand -hex 32
+```
+
+Store the channel configuration. Existing keys remain unchanged on a re-run.
+
+```nc:env-set
+MATTERMOST_BASE_URL={{base_url}}
+MATTERMOST_BOT_TOKEN={{bot_token}}
+MATTERMOST_CALLBACK_URL={{callback_url}}
+MATTERMOST_CALLBACK_SECRET={{callback_secret}}
+```
+
+Tell the operator:
+
+```nc:operator
+From the Mattermost server, verify the callback host is reachable. For a private host or Docker bridge name, add that hostname or IP under System Console → Environment → Developer → Allow untrusted internal connections. Use a publicly trusted HTTPS certificate in production.
+```
+
+### 4. Resolve the owner's DM
+
+Ask for the Mattermost username that will own this NanoClaw installation.
+
+```nc:prompt owner_username normalize:lower validate:^[a-z0-9][a-z0-9._-]{0,63}$
+Your Mattermost username, without `@`.
+```
+
+Resolve that user and open the DM shared with the bot.
+
+```nc:run capture:owner_user_id=.id effect:fetch
+curl -sf "{{base_url}}/api/v4/users/username/{{owner_username}}" -H "Authorization: Bearer {{bot_token}}"
+```
+
+```nc:run capture:platform_id effect:fetch validate:^mattermost:[a-z0-9]{26}$
+curl -sf -X POST "{{base_url}}/api/v4/channels/direct" -H "Authorization: Bearer {{bot_token}}" -H "Content-Type: application/json" -d '["{{owner_user_id}}","{{bot_user_id}}"]' | jq -er '"mattermost:" + .id'
+```
+
+The resolved `platform_id` and `owner_username` are used by
+`/init-first-agent`. If an owner exists, use `/manage-channels` instead.
+
+### 5. Build, test, and restart
+
+Build the composed host to guard the typed Chat SDK bridge call and dependency.
+
+```nc:run effect:build
+pnpm run build
+```
+
+Run the registration test through the real channel barrel.
+
+```nc:run effect:test
+pnpm exec vitest run src/channels/mattermost-registration.test.ts
+```
+
+Restart NanoClaw so the channel and credentials load.
+
+```nc:run effect:restart
+bash setup/lib/restart.sh
+```
+
+## Next steps
+
+For a first channel, continue with `/init-first-agent` using `mattermost`,
+`{{platform_id}}`, and `{{owner_username}}`. Otherwise run `/manage-channels`.
+
+Send the bot a DM and mention it in a joined channel. The first mention in an
+unwired channel sends an approval card to the owner's bot DM. Approve it there;
+NanoClaw replays the held message after creating the wiring.
+
+Click a real approval card to verify callbacks. Success replaces the buttons
+with the chosen result. An unsigned probe must return `401`:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
+  -H 'content-type: application/json' -d '{}' \
+  http://<nanoclaw-host>:3000/webhook/mattermost
+```
+
+## Channel information
+
+- **type:** `mattermost`
+- **platform ID:** `mattermost:<channel-id>` for channels and DMs
+- **threads:** channel posts use optional Mattermost reply roots
+- **group trigger:** mention-sticky, scoped per thread
+- **DM trigger:** every message
+- **unknown channels:** request owner approval
+- **transport:** WebSocket inbound, REST outbound, HTTP action callbacks
+
+## Troubleshooting
+
+**The token check returns 401.** The token is stale, belongs to a deactivated
+bot, or was pasted incorrectly. Create a replacement token and deactivate the
+old token after the replacement works.
+
+**The bot ignores a channel.** Add it to that team and channel. Membership
+changes are observed, but restarting NanoClaw forces a fresh subscription.
+
+**A new channel gets no immediate reply.** Check the owner's DM with the bot.
+NanoClaw holds the first message behind a channel-approval card and deduplicates
+later mentions until that card is resolved.
+
+**Cards render but clicks do nothing.** From the Mattermost server, POST to the
+callback URL. A `401` proves the path reaches NanoClaw; timeout or refusal means
+routing or firewall failure. Mattermost logs report blocked hosts and TLS errors.
+
+**The adapter repeatedly reconnects.** Confirm `/api/v4/websocket` supports
+WebSocket upgrades through every reverse proxy and that idle connections live
+longer than the adapter heartbeat.
+
+**Messages arrive but no agent runs.** Inspect `ncl dropped-messages list` and
+`ncl wirings list`. `no_agent_wired` means approval is pending or no wiring was
+created; it is not an adapter failure.

--- a/.claude/skills/add-mattermost/apply-fixtures.json
+++ b/.claude/skills/add-mattermost/apply-fixtures.json
@@ -1,0 +1,23 @@
+{
+  "notes": "Fake values only. API responses and callback-secret generation are stubbed.",
+  "scenarios": [
+    {
+      "name": "self-hosted-bot",
+      "inputs": {
+        "base_url": "https://mattermost.example.test/",
+        "bot_token": "fakeMattermostBotToken_123456",
+        "callback_url": "http://host.docker.internal:3000/webhook/mattermost/",
+        "owner_username": "owner.test"
+      },
+      "exec": [
+        { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
+        {
+          "match": "openssl rand -hex 32",
+          "stdout": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        },
+        { "match": "/api/v4/users/username/owner.test", "stdout": "{\"id\":\"oooooooooooooooooooooooooo\"}" },
+        { "match": "/api/v4/channels/direct", "stdout": "mattermost:dddddddddddddddddddddddddd" }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/add-mattermost/apply-fixtures.json
+++ b/.claude/skills/add-mattermost/apply-fixtures.json
@@ -10,6 +10,31 @@
         "owner_username": "owner.test"
       },
       "exec": [
+        {
+          "match": "discover-server.mjs",
+          "stdout": "{\"discovery\":\"none\",\"base_url\":\"\"}"
+        },
+        { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
+        {
+          "match": "openssl rand -hex 32",
+          "stdout": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        },
+        { "match": "/api/v4/users/username/owner.test", "stdout": "{\"id\":\"oooooooooooooooooooooooooo\"}" },
+        { "match": "/api/v4/channels/direct", "stdout": "mattermost:dddddddddddddddddddddddddd" }
+      ]
+    },
+    {
+      "name": "detected-local-server",
+      "inputs": {
+        "bot_token": "fakeMattermostBotToken_123456",
+        "callback_url": "http://host.docker.internal:3000/webhook/mattermost/",
+        "owner_username": "owner.test"
+      },
+      "exec": [
+        {
+          "match": "discover-server.mjs",
+          "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\"}"
+        },
         { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
         {
           "match": "openssl rand -hex 32",

--- a/.claude/skills/add-mattermost/assets/compose.yml
+++ b/.claude/skills/add-mattermost/assets/compose.yml
@@ -1,0 +1,47 @@
+name: nanoclaw-mattermost
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: mmuser
+      POSTGRES_PASSWORD: local_mattermost_only
+      POSTGRES_DB: mattermost
+    volumes:
+      - database:/var/lib/postgresql/data
+
+  mattermost:
+    image: mattermost/mattermost-team-edition:latest
+    restart: unless-stopped
+    depends_on:
+      - postgres
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      MM_SQLSETTINGS_DRIVERNAME: postgres
+      MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:local_mattermost_only@postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
+      MM_SERVICESETTINGS_SITEURL: "http://localhost:8065"
+      MM_SERVICESETTINGS_ALLOWCORSFROM: "http://localhost:8065 http://127.0.0.1:8065"
+      MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
+      MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
+      MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
+      MM_SERVICESETTINGS_ALLOWEDUNTRUSTEDINTERNALCONNECTIONS: "host.docker.internal"
+    volumes:
+      - data:/mattermost/data
+      - config:/mattermost/config
+      - logs:/mattermost/logs
+      - plugins:/mattermost/plugins
+      - client-plugins:/mattermost/client/plugins
+      - bleve:/mattermost/bleve-indexes
+    ports:
+      - "8065:8065"
+
+volumes:
+  database:
+  data:
+  config:
+  logs:
+  plugins:
+  client-plugins:
+  bleve:

--- a/.claude/skills/add-mattermost/assets/compose.yml
+++ b/.claude/skills/add-mattermost/assets/compose.yml
@@ -31,7 +31,9 @@ services:
       MM_SERVICESETTINGS_ALLOWCORSFROM: "http://localhost:8065 http://127.0.0.1:8065"
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
-      MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
+      # Open signup stays off: the first browser visit still creates the
+      # System Admin, and further accounts are invited from the System Console.
+      MM_TEAMSETTINGS_ENABLEOPENSERVER: "false"
       MM_SERVICESETTINGS_ALLOWEDUNTRUSTEDINTERNALCONNECTIONS: "host.docker.internal"
     volumes:
       - data:/mattermost/data

--- a/.claude/skills/add-mattermost/assets/compose.yml
+++ b/.claude/skills/add-mattermost/assets/compose.yml
@@ -2,25 +2,31 @@ name: nanoclaw-mattermost
 
 services:
   postgres:
-    image: postgres:15-alpine
+    image: postgres:15.14-alpine
     restart: unless-stopped
     environment:
       POSTGRES_USER: mmuser
-      POSTGRES_PASSWORD: local_mattermost_only
+      POSTGRES_PASSWORD: "${MATTERMOST_DB_PASSWORD:?set MATTERMOST_DB_PASSWORD in .env}"
       POSTGRES_DB: mattermost
     volumes:
       - database:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mmuser -d mattermost"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   mattermost:
-    image: mattermost/mattermost-team-edition:latest
+    image: mattermost/mattermost-team-edition:11.10.0
     restart: unless-stopped
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       MM_SQLSETTINGS_DRIVERNAME: postgres
-      MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:local_mattermost_only@postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
+      MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:${MATTERMOST_DB_PASSWORD:?set MATTERMOST_DB_PASSWORD in .env}@postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
       MM_SERVICESETTINGS_SITEURL: "http://localhost:8065"
       MM_SERVICESETTINGS_ALLOWCORSFROM: "http://localhost:8065 http://127.0.0.1:8065"
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
@@ -35,7 +41,7 @@ services:
       - client-plugins:/mattermost/client/plugins
       - bleve:/mattermost/bleve-indexes
     ports:
-      - "8065:8065"
+      - "127.0.0.1:8065:8065"
 
 volumes:
   database:

--- a/.claude/skills/add-mattermost/scripts/discover-server.mjs
+++ b/.claude/skills/add-mattermost/scripts/discover-server.mjs
@@ -14,8 +14,9 @@ async function configuredUrl() {
       const match = line.match(/^\s*MATTERMOST_BASE_URL\s*=\s*(.*?)\s*$/);
       if (match?.[1]) return normalize(match[1].replace(/^(['"])(.*)\1$/, '$2'));
     }
-  } catch (error) {
-    if (error?.code !== 'ENOENT') throw error;
+  } catch {
+    // Any .env read failure means no configured URL; discovery must still
+    // resolve so the operator fallback prompt is offered.
   }
   return '';
 }
@@ -31,15 +32,19 @@ async function isMattermost(baseUrl) {
   }
 }
 
-const candidates = [...new Set([await configuredUrl(), 'http://localhost:8065', 'http://127.0.0.1:8065'])].filter(
-  Boolean,
-);
+try {
+  const candidates = [...new Set([await configuredUrl(), 'http://localhost:8065', 'http://127.0.0.1:8065'])].filter(
+    Boolean,
+  );
 
-for (const baseUrl of candidates) {
-  if (await isMattermost(baseUrl)) {
-    process.stdout.write(`${JSON.stringify({ discovery: 'found', base_url: baseUrl })}\n`);
-    process.exit(0);
+  for (const baseUrl of candidates) {
+    if (await isMattermost(baseUrl)) {
+      process.stdout.write(`${JSON.stringify({ discovery: 'found', base_url: baseUrl })}\n`);
+      process.exit(0);
+    }
   }
+} catch {
+  // Fall through to the not-found result below.
 }
 
 process.stdout.write(`${JSON.stringify({ discovery: 'none', base_url: '' })}\n`);

--- a/.claude/skills/add-mattermost/scripts/discover-server.mjs
+++ b/.claude/skills/add-mattermost/scripts/discover-server.mjs
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises';
+
+const PING_PATH = '/api/v4/system/ping';
+
+function normalize(value) {
+  return value?.trim().replace(/\/+$/, '') || '';
+}
+
+async function configuredUrl() {
+  if (process.env.MATTERMOST_BASE_URL) return normalize(process.env.MATTERMOST_BASE_URL);
+  try {
+    const text = await readFile('.env', 'utf8');
+    for (const line of text.split(/\r?\n/)) {
+      const match = line.match(/^\s*MATTERMOST_BASE_URL\s*=\s*(.*?)\s*$/);
+      if (match?.[1]) return normalize(match[1].replace(/^(['"])(.*)\1$/, '$2'));
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  return '';
+}
+
+async function isMattermost(baseUrl) {
+  try {
+    const response = await fetch(`${baseUrl}${PING_PATH}`, { signal: AbortSignal.timeout(2000) });
+    if (!response.ok) return false;
+    const body = await response.json();
+    return body?.status === 'OK';
+  } catch {
+    return false;
+  }
+}
+
+const candidates = [...new Set([await configuredUrl(), 'http://localhost:8065', 'http://127.0.0.1:8065'])].filter(
+  Boolean,
+);
+
+for (const baseUrl of candidates) {
+  if (await isMattermost(baseUrl)) {
+    process.stdout.write(`${JSON.stringify({ discovery: 'found', base_url: baseUrl })}\n`);
+    process.exit(0);
+  }
+}
+
+process.stdout.write(`${JSON.stringify({ discovery: 'none', base_url: '' })}\n`);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds the main-branch `/add-mattermost` skill while keeping channel runtime code on the `channels` branch. The skill copies the audited in-tree adapter from `origin/channels`; no separate Mattermost npm package is published or installed. It deterministically discovers and reuses a configured or healthy local Mattermost server before prompting and offers an optional persistent Team Edition + PostgreSQL evaluation stack.

The bundled local stack is hardened for development use: Mattermost binds only to loopback, container images are version-pinned, PostgreSQL gates startup on a health check, and setup generates a private database credential instead of committing a default password. The setup also verifies canonical SiteURL/WebSocket-origin behavior. `REMOVE.md` reverses the installed source, credentials, and direct dependencies while preserving local server data by default.

Validation completed:
- skill quick validation passes
- skill conformance suite passes (177 tests)
- executable discovery detects the running local Mattermost instance
- bundled Compose configuration parses successfully
- after #3502 merged into `channels`, a detached fresh `main` worktree copied the real payload from `origin/channels`, installed its dependencies, passed host TypeScript, and passed the real barrel registration test

## Why a vendored adapter

Every other channel installs a published adapter package plus a thin `src/channels/<name>.ts`. Mattermost currently has no compatible published adapter: the unscoped `chat-adapter-mattermost` on npm is third-party, stuck at 1.1.3 against the 4.x `@chat-adapter` family, and does not work with this bridge — [#3502](https://github.com/nanocoai/nanoclaw/pull/3502) replaced it for exactly that reason. Until a maintained package exists, the adapter lives in-tree on the `channels` branch with the rest of the channel runtime code, where it was reviewed in #3502; the skill copies it from `origin/channels`, so installs stay auditable and pinned to what maintainers cut. If a proper package lands later, the skill can switch to the standard install-a-package shape without changing the channel surface.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone

