### PR TITLE
feat(db): durable host-coordination state and the seams that will consume it

### DIFF
--- a/container/agent-runner/src/heartbeat.test.ts
+++ b/container/agent-runner/src/heartbeat.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { heartbeatPath, touchHeartbeat } from './heartbeat.js';
+
+afterEach(() => {
+  delete process.env.NANOCLAW_HEARTBEAT_PATH;
+});
+
+describe('heartbeat path', () => {
+  it('defaults to the workspace heartbeat', () => {
+    expect(heartbeatPath()).toBe('/workspace/.heartbeat');
+  });
+
+  it('honors NANOCLAW_HEARTBEAT_PATH and touches that file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'heartbeat-'));
+    const override = path.join(dir, '.heartbeat');
+    process.env.NANOCLAW_HEARTBEAT_PATH = override;
+
+    expect(heartbeatPath()).toBe(override);
+    touchHeartbeat();
+    expect(fs.existsSync(override)).toBe(true);
+
+    // Second touch goes down the utimes path (file exists) and lands within
+    // clock tolerance — utimes stores whole ms while write stamps fractional.
+    const before = fs.statSync(override).mtimeMs;
+    touchHeartbeat();
+    expect(fs.statSync(override).mtimeMs).toBeGreaterThanOrEqual(before - 5);
+  });
+});

--- a/container/agent-runner/src/heartbeat.ts
+++ b/container/agent-runner/src/heartbeat.ts
@@ -1,14 +1,25 @@
 import fs from 'fs';
 
-const HEARTBEAT_PATH = '/workspace/.heartbeat';
+const DEFAULT_HEARTBEAT_PATH = '/workspace/.heartbeat';
+
+/**
+ * The heartbeat location is deployment-configurable via
+ * NANOCLAW_HEARTBEAT_PATH for setups that relocate the workspace heartbeat.
+ * Unset = today's path, byte-identical. Read per call so the container env,
+ * not import order, decides.
+ */
+export function heartbeatPath(): string {
+  return process.env.NANOCLAW_HEARTBEAT_PATH || DEFAULT_HEARTBEAT_PATH;
+}
 
 export function touchHeartbeat(): void {
+  const heartbeat = heartbeatPath();
   const now = new Date();
   try {
-    fs.utimesSync(HEARTBEAT_PATH, now, now);
+    fs.utimesSync(heartbeat, now, now);
   } catch {
     try {
-      fs.writeFileSync(HEARTBEAT_PATH, '');
+      fs.writeFileSync(heartbeat, '');
     } catch {
       // Parent may not exist in tests.
     }

--- a/src/db/coordination.test.ts
+++ b/src/db/coordination.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { initSqliteTestDb, closeDb, runMigrations } from './index.js';
+import {
+  registerHostInstance,
+  renewHostInstanceLease,
+  markHostInstanceStopped,
+  listLiveHostInstances,
+  getSessionClaim,
+  tryClaimSession,
+  releaseSessionClaim,
+  setStopIntent,
+  recordDeliveryAttempt,
+  getDeliveryAttempt,
+  clearDeliveryAttempt,
+  writeWakeSignal,
+  takeWakeSignals,
+} from './coordination.js';
+
+function iso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+beforeEach(async () => {
+  const db = await initSqliteTestDb();
+  await runMigrations(db);
+});
+
+afterEach(async () => {
+  await closeDb();
+});
+
+describe('host_instances', () => {
+  it('registers, renews, and expires leases', async () => {
+    await registerHostInstance({
+      instanceId: 'i-1',
+      installId: 'ab12cd34',
+      now: iso(),
+      leaseExpiresAt: iso(30_000),
+    });
+    expect(await listLiveHostInstances(iso())).toHaveLength(1);
+    // Lease behind `now` → not live.
+    expect(await listLiveHostInstances(iso(60_000))).toHaveLength(0);
+    expect(await renewHostInstanceLease('i-1', iso(120_000))).toBe(true);
+    expect(await listLiveHostInstances(iso(60_000))).toHaveLength(1);
+    await markHostInstanceStopped('i-1', iso());
+    expect(await listLiveHostInstances(iso())).toHaveLength(0);
+    expect(await renewHostInstanceLease('i-1', iso(240_000))).toBe(false);
+  });
+
+  it('re-registering the same instance clears stopped_at', async () => {
+    await registerHostInstance({ instanceId: 'i-1', installId: 'x', now: iso(), leaseExpiresAt: iso(30_000) });
+    await markHostInstanceStopped('i-1', iso());
+    await registerHostInstance({ instanceId: 'i-1', installId: 'x', now: iso(), leaseExpiresAt: iso(30_000) });
+    expect(await listLiveHostInstances(iso())).toHaveLength(1);
+  });
+});
+
+describe('session_claims', () => {
+  it('first claim creates the row at incarnation 1', async () => {
+    const inc = await tryClaimSession({ sessionId: 's-1', instanceId: 'i-1', expectedIncarnation: 0, now: iso() });
+    expect(inc).toBe(1);
+    const claim = await getSessionClaim('s-1');
+    expect(claim?.incarnation).toBe(1);
+    expect(claim?.claimed_by).toBe('i-1');
+  });
+
+  it('CAS on a stale incarnation loses', async () => {
+    await tryClaimSession({ sessionId: 's-1', instanceId: 'i-1', expectedIncarnation: 0, now: iso() });
+    // A second claimant that still believes incarnation 0 must lose.
+    expect(
+      await tryClaimSession({ sessionId: 's-1', instanceId: 'i-2', expectedIncarnation: 0, now: iso() }),
+    ).toBeNull();
+    // A claimant with the current view wins and fences the previous one.
+    expect(await tryClaimSession({ sessionId: 's-1', instanceId: 'i-2', expectedIncarnation: 1, now: iso() })).toBe(2);
+  });
+
+  it('release is fenced by holder and incarnation', async () => {
+    await tryClaimSession({ sessionId: 's-1', instanceId: 'i-1', expectedIncarnation: 0, now: iso() });
+    expect(await releaseSessionClaim({ sessionId: 's-1', instanceId: 'i-2', incarnation: 1, now: iso() })).toBe(false);
+    expect(await releaseSessionClaim({ sessionId: 's-1', instanceId: 'i-1', incarnation: 1, now: iso() })).toBe(true);
+    expect((await getSessionClaim('s-1'))?.claimed_by).toBeNull();
+  });
+
+  it('stop intent persists on a row that has never been claimed', async () => {
+    await setStopIntent('s-9', 'respawn_after_stop', iso());
+    expect((await getSessionClaim('s-9'))?.stop_intent).toBe('respawn_after_stop');
+    await setStopIntent('s-9', null, iso());
+    expect((await getSessionClaim('s-9'))?.stop_intent).toBeNull();
+  });
+});
+
+describe('delivery_attempts', () => {
+  it('counts attempts and clears on success', async () => {
+    expect(
+      await recordDeliveryAttempt({ messageId: 'm-1', sessionId: 's-1', now: iso(), nextAttemptAt: iso(5_000) }),
+    ).toBe(1);
+    expect(
+      await recordDeliveryAttempt({ messageId: 'm-1', sessionId: 's-1', now: iso(), nextAttemptAt: null, error: 'x' }),
+    ).toBe(2);
+    expect((await getDeliveryAttempt('m-1'))?.last_error).toBe('x');
+    await clearDeliveryAttempt('m-1');
+    expect(await getDeliveryAttempt('m-1')).toBeUndefined();
+  });
+});
+
+describe('wake_signals', () => {
+  it('each signal is consumed exactly once', async () => {
+    await writeWakeSignal('s-1', 'inbound-message', iso());
+    await writeWakeSignal('s-1', 'due-message', iso());
+    await writeWakeSignal('s-2', 'inbound-message', iso());
+
+    const taken = await takeWakeSignals({ consumerId: 'i-1', now: iso(), sessionId: 's-1' });
+    // Same-ms created_at stamps make relative order unspecified — compare as a set.
+    expect(taken.map((signal) => signal.reason).sort()).toEqual(['due-message', 'inbound-message']);
+
+    // Already-consumed signals are not re-delivered; s-2 remains.
+    const rest = await takeWakeSignals({ consumerId: 'i-2', now: iso() });
+    expect(rest).toHaveLength(1);
+    expect(rest[0].session_id).toBe('s-2');
+    expect(await takeWakeSignals({ consumerId: 'i-3', now: iso() })).toHaveLength(0);
+  });
+});

--- a/src/db/coordination.ts
+++ b/src/db/coordination.ts
@@ -1,0 +1,269 @@
+/**
+ * Typed accessors over the host-coordination tables (migration 024) — the
+ * only sanctioned readers/writers of `host_instances`, `session_claims`,
+ * `delivery_attempts`, and `wake_signals`. Until the authority flip these
+ * tables are SHADOW state — callers may dual-write but the in-memory maps in
+ * container-runner/delivery remain authoritative, and nothing may change
+ * behavior based on a read from here.
+ *
+ * Timestamps are ISO-8601 UTC strings and are compared lexicographically
+ * (the repo-wide rule — no `datetime()` in central SQL). Callers pass `now`
+ * so the functions stay clock-free and portable across DB backends.
+ */
+import { randomUUID } from 'crypto';
+
+import { getDb } from './connection.js';
+
+export interface HostInstanceRow {
+  instance_id: string;
+  install_id: string;
+  hostname: string | null;
+  pid: number | null;
+  started_at: string;
+  lease_expires_at: string;
+  stopped_at: string | null;
+}
+
+export interface SessionClaimRow {
+  session_id: string;
+  incarnation: number;
+  claimed_by: string | null;
+  claimed_at: string | null;
+  container_ref: string | null;
+  stop_intent: 'stop' | 'respawn_after_stop' | null;
+  updated_at: string;
+}
+
+export interface DeliveryAttemptRow {
+  message_id: string;
+  session_id: string;
+  attempts: number;
+  last_attempt_at: string | null;
+  next_attempt_at: string | null;
+  last_error: string | null;
+}
+
+export interface WakeSignalRow {
+  id: string;
+  session_id: string;
+  reason: string;
+  created_at: string;
+  consumed_at: string | null;
+  consumed_by: string | null;
+}
+
+// ── host_instances ──
+
+export async function registerHostInstance(args: {
+  instanceId: string;
+  installId: string;
+  hostname?: string;
+  pid?: number;
+  now: string;
+  leaseExpiresAt: string;
+}): Promise<void> {
+  await getDb().run(
+    `INSERT INTO host_instances (instance_id, install_id, hostname, pid, started_at, lease_expires_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT (instance_id) DO UPDATE SET
+       lease_expires_at = excluded.lease_expires_at, stopped_at = NULL`,
+    args.instanceId,
+    args.installId,
+    args.hostname ?? null,
+    args.pid ?? null,
+    args.now,
+    args.leaseExpiresAt,
+  );
+}
+
+/** Renew the lease. Returns false when the row no longer exists. */
+export async function renewHostInstanceLease(instanceId: string, leaseExpiresAt: string): Promise<boolean> {
+  const result = await getDb().run(
+    'UPDATE host_instances SET lease_expires_at = ? WHERE instance_id = ? AND stopped_at IS NULL',
+    leaseExpiresAt,
+    instanceId,
+  );
+  return result.changes > 0;
+}
+
+export async function markHostInstanceStopped(instanceId: string, now: string): Promise<void> {
+  await getDb().run('UPDATE host_instances SET stopped_at = ? WHERE instance_id = ?', now, instanceId);
+}
+
+/** Instances whose lease is still ahead of `now` and not gracefully stopped. */
+export async function listLiveHostInstances(now: string): Promise<HostInstanceRow[]> {
+  return getDb().all<HostInstanceRow>(
+    'SELECT * FROM host_instances WHERE stopped_at IS NULL AND lease_expires_at > ? ORDER BY started_at',
+    now,
+  );
+}
+
+// ── session_claims ──
+
+export async function getSessionClaim(sessionId: string): Promise<SessionClaimRow | undefined> {
+  return getDb().get<SessionClaimRow>('SELECT * FROM session_claims WHERE session_id = ?', sessionId);
+}
+
+/**
+ * The fencing primitive. Bumps the incarnation and takes the claim only when
+ * the caller's view of the current incarnation is still true — a stale host
+ * (or a stale `finish()` racing a fresh spawn) loses the CAS and must reload.
+ * Creating the row (first spawn ever) is the `expectedIncarnation: 0` case.
+ * Returns the new incarnation on success, null when the CAS lost.
+ */
+export async function tryClaimSession(args: {
+  sessionId: string;
+  instanceId: string;
+  expectedIncarnation: number;
+  containerRef?: string;
+  now: string;
+}): Promise<number | null> {
+  const db = getDb();
+  const next = args.expectedIncarnation + 1;
+  if (args.expectedIncarnation === 0) {
+    const inserted = await db.run(
+      `INSERT INTO session_claims (session_id, incarnation, claimed_by, claimed_at, container_ref, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (session_id) DO NOTHING`,
+      args.sessionId,
+      next,
+      args.instanceId,
+      args.now,
+      args.containerRef ?? null,
+      args.now,
+    );
+    if (inserted.changes > 0) return next;
+  }
+  const updated = await db.run(
+    `UPDATE session_claims
+     SET incarnation = ?, claimed_by = ?, claimed_at = ?, container_ref = ?, updated_at = ?
+     WHERE session_id = ? AND incarnation = ?`,
+    next,
+    args.instanceId,
+    args.now,
+    args.containerRef ?? null,
+    args.now,
+    args.sessionId,
+    args.expectedIncarnation,
+  );
+  return updated.changes > 0 ? next : null;
+}
+
+/** Release only if this instance still holds the claim at this incarnation. */
+export async function releaseSessionClaim(args: {
+  sessionId: string;
+  instanceId: string;
+  incarnation: number;
+  now: string;
+}): Promise<boolean> {
+  const result = await getDb().run(
+    `UPDATE session_claims SET claimed_by = NULL, claimed_at = NULL, container_ref = NULL, updated_at = ?
+     WHERE session_id = ? AND claimed_by = ? AND incarnation = ?`,
+    args.now,
+    args.sessionId,
+    args.instanceId,
+    args.incarnation,
+  );
+  return result.changes > 0;
+}
+
+/** Durable stop intent — survives a host restart, unlike the on-wake promise. */
+export async function setStopIntent(
+  sessionId: string,
+  intent: 'stop' | 'respawn_after_stop' | null,
+  now: string,
+): Promise<void> {
+  await getDb().run(
+    `INSERT INTO session_claims (session_id, incarnation, stop_intent, updated_at)
+     VALUES (?, 0, ?, ?)
+     ON CONFLICT (session_id) DO UPDATE SET stop_intent = excluded.stop_intent, updated_at = excluded.updated_at`,
+    sessionId,
+    intent,
+    now,
+  );
+}
+
+// ── delivery_attempts ──
+
+/** Record one attempt; returns the new attempt count. */
+export async function recordDeliveryAttempt(args: {
+  messageId: string;
+  sessionId: string;
+  now: string;
+  nextAttemptAt: string | null;
+  error?: string;
+}): Promise<number> {
+  const db = getDb();
+  await db.run(
+    `INSERT INTO delivery_attempts (message_id, session_id, attempts, last_attempt_at, next_attempt_at, last_error)
+     VALUES (?, ?, 1, ?, ?, ?)
+     ON CONFLICT (message_id) DO UPDATE SET
+       attempts = delivery_attempts.attempts + 1,
+       last_attempt_at = excluded.last_attempt_at,
+       next_attempt_at = excluded.next_attempt_at,
+       last_error = excluded.last_error`,
+    args.messageId,
+    args.sessionId,
+    args.now,
+    args.nextAttemptAt,
+    args.error ?? null,
+  );
+  const row = await db.get<{ attempts: number }>(
+    'SELECT attempts FROM delivery_attempts WHERE message_id = ?',
+    args.messageId,
+  );
+  return row?.attempts ?? 1;
+}
+
+export async function getDeliveryAttempt(messageId: string): Promise<DeliveryAttemptRow | undefined> {
+  return getDb().get<DeliveryAttemptRow>('SELECT * FROM delivery_attempts WHERE message_id = ?', messageId);
+}
+
+/** Delivered or terminally failed — the row's job is done. */
+export async function clearDeliveryAttempt(messageId: string): Promise<void> {
+  await getDb().run('DELETE FROM delivery_attempts WHERE message_id = ?', messageId);
+}
+
+// ── wake_signals (the wake-signal outbox) ──
+
+export async function writeWakeSignal(sessionId: string, reason: string, now: string): Promise<string> {
+  const id = randomUUID();
+  await getDb().run(
+    'INSERT INTO wake_signals (id, session_id, reason, created_at) VALUES (?, ?, ?, ?)',
+    id,
+    sessionId,
+    reason,
+    now,
+  );
+  return id;
+}
+
+/**
+ * Consume pending signals for one session (or all sessions when omitted).
+ * Marks them consumed and returns what was taken — each signal is delivered
+ * to exactly one consumer.
+ */
+export async function takeWakeSignals(args: {
+  consumerId: string;
+  now: string;
+  sessionId?: string;
+}): Promise<WakeSignalRow[]> {
+  const db = getDb();
+  const pending = args.sessionId
+    ? await db.all<WakeSignalRow>(
+        'SELECT * FROM wake_signals WHERE session_id = ? AND consumed_at IS NULL ORDER BY created_at',
+        args.sessionId,
+      )
+    : await db.all<WakeSignalRow>('SELECT * FROM wake_signals WHERE consumed_at IS NULL ORDER BY created_at');
+  const taken: WakeSignalRow[] = [];
+  for (const signal of pending) {
+    const result = await db.run(
+      'UPDATE wake_signals SET consumed_at = ?, consumed_by = ? WHERE id = ? AND consumed_at IS NULL',
+      args.now,
+      args.consumerId,
+      signal.id,
+    );
+    if (result.changes > 0) taken.push({ ...signal, consumed_at: args.now, consumed_by: args.consumerId });
+  }
+  return taken;
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,22 @@
 export { initDb, initTestDb, initSqliteTestDb, getDb, closeDb } from './connection.js';
 export type { DbConfig, DbDriver, DbDialect, DbInitOptions, DbRole, RunResult } from './driver.js';
 export { runMigrations } from './migrations/index.js';
+
+export {
+  registerHostInstance,
+  renewHostInstanceLease,
+  markHostInstanceStopped,
+  listLiveHostInstances,
+  getSessionClaim,
+  tryClaimSession,
+  releaseSessionClaim,
+  setStopIntent,
+  recordDeliveryAttempt,
+  getDeliveryAttempt,
+  clearDeliveryAttempt,
+  writeWakeSignal,
+  takeWakeSignals,
+} from './coordination.js';
 export type { MigrationMode, MigrationRunOptions } from './migrations/index.js';
 export {
   createAgentGroup,

--- a/src/db/migrations/024-host-coordination.ts
+++ b/src/db/migrations/024-host-coordination.ts
@@ -1,0 +1,72 @@
+import type { Migration } from './index.js';
+
+/**
+ * Durable host-coordination state (schema only — no writers yet). Every
+ * coordination fact the host holds in process memory today is lost on
+ * restart: delivery retry counts reset (a poison message retries forever
+ * across a crash loop), stop/respawn intent vanishes after "rebuild
+ * applied", and a stale `finish()` can stomp a fresh container. These
+ * tables give each fact a durable home; the in-memory maps stay
+ * authoritative until a follow-up flips authority to the rows, so this is
+ * shadow surface for now.
+ *
+ * - `host_instances` — one row per live host process (lease). Lease expiry is
+ *   compared as ISO-8601 strings; renewal is the host's heartbeat.
+ * - `session_claims` — per-session incarnation fencing + durable stop intent.
+ *   `incarnation` increments per container start; a compare-and-set on it is
+ *   the spawn-dedup / stale-`finish()` fence. `stop_intent` outlives a host
+ *   restart (`respawn_after_stop` replaces the volatile on-wake promise).
+ * - `delivery_attempts` — outbound retry counts + backoff schedule, keyed by
+ *   mailbox message id. `delivered` stays mailbox-side; only attempt
+ *   bookkeeping lives here.
+ * - `wake_signals` — durable "session has reason to wake" rows, written where
+ *   mail is written and consumed by the wake path. Text ids (uuid) — no
+ *   AUTOINCREMENT, the schema stays portable.
+ */
+export const migration024: Migration = {
+  version: 24,
+  name: 'host-coordination',
+  async up(db) {
+    await db.exec(`
+      CREATE TABLE host_instances (
+        instance_id TEXT PRIMARY KEY,
+        install_id TEXT NOT NULL,
+        hostname TEXT,
+        pid INTEGER,
+        started_at TEXT NOT NULL,
+        lease_expires_at TEXT NOT NULL,
+        stopped_at TEXT
+      );
+
+      CREATE TABLE session_claims (
+        session_id TEXT PRIMARY KEY,
+        incarnation INTEGER NOT NULL DEFAULT 0,
+        claimed_by TEXT,
+        claimed_at TEXT,
+        container_ref TEXT,
+        stop_intent TEXT,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE delivery_attempts (
+        message_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_attempt_at TEXT,
+        next_attempt_at TEXT,
+        last_error TEXT
+      );
+      CREATE INDEX idx_delivery_attempts_session ON delivery_attempts(session_id);
+
+      CREATE TABLE wake_signals (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        consumed_at TEXT,
+        consumed_by TEXT
+      );
+      CREATE INDEX idx_wake_signals_session_pending ON wake_signals(session_id, consumed_at);
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -24,6 +24,7 @@ import { migration020 } from './020-container-config-timezone.js';
 import { migration021 } from './021-approval-question.js';
 import { migration022 } from './022-messaging-group-detached.js';
 import { migration023 } from './023-approvals-instance.js';
+import { migration024 } from './024-host-coordination.js';
 
 interface MigrationBase {
   version: number;
@@ -89,6 +90,7 @@ export const migrations: Migration[] = [
   migration021,
   migration022,
   migration023,
+  migration024,
 ];
 
 /**

--- a/src/install-slug.test.ts
+++ b/src/install-slug.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getInstallSlug } from './install-slug.js';
+
+afterEach(() => {
+  delete process.env.NANOCLAW_INSTALL_ID;
+});
+
+describe('getInstallSlug', () => {
+  it('derives from the project root when NANOCLAW_INSTALL_ID is unset', () => {
+    const slug = getInstallSlug('/some/checkout');
+    expect(slug).toMatch(/^[0-9a-f]{8}$/);
+    expect(getInstallSlug('/some/checkout')).toBe(slug);
+    expect(getInstallSlug('/other/checkout')).not.toBe(slug);
+  });
+
+  it('honors a valid NANOCLAW_INSTALL_ID override', () => {
+    process.env.NANOCLAW_INSTALL_ID = 'prod-eks_1';
+    expect(getInstallSlug('/some/checkout')).toBe('prod-eks_1');
+  });
+
+  it('rejects label-unsafe overrides', () => {
+    for (const bad of ['UPPER', '-leading', 'has space', 'a'.repeat(33), 'dot.dot']) {
+      process.env.NANOCLAW_INSTALL_ID = bad;
+      expect(() => getInstallSlug('/some/checkout'), bad).toThrow(/NANOCLAW_INSTALL_ID/);
+    }
+  });
+});

--- a/src/install-slug.ts
+++ b/src/install-slug.ts
@@ -5,10 +5,25 @@
  *
  * Slug is sha1(projectRoot)[:8] — deterministic per checkout path, stable
  * across re-runs, unique enough across installs.
+ *
+ * NANOCLAW_INSTALL_ID overrides the cwd derivation for deployments where
+ * the checkout path is not a stable identity (copied or ephemeral trees), so
+ * identity can come from the environment instead. The value flows into
+ * docker labels, image names, and service unit names — hence the
+ * conservative charset. Unset = today's behavior, byte-identical.
  */
 import { createHash } from 'crypto';
 
+const INSTALL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
 export function getInstallSlug(projectRoot: string = process.cwd()): string {
+  const override = process.env.NANOCLAW_INSTALL_ID;
+  if (override) {
+    if (!INSTALL_ID_PATTERN.test(override)) {
+      throw new Error(`NANOCLAW_INSTALL_ID must be 1-32 chars of [a-z0-9_-] starting alphanumeric (got '${override}')`);
+    }
+    return override;
+  }
   return createHash('sha1').update(projectRoot).digest('hex').slice(0, 8);
 }
 

--- a/src/liveness.test.ts
+++ b/src/liveness.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+import { createHeartbeatFileLivenessSource } from './liveness.js';
+
+describe('heartbeat-file liveness source', () => {
+  it('reports the heartbeat mtime, and null when the file is absent', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'liveness-'));
+    const hb = path.join(dir, '.heartbeat');
+    const source = createHeartbeatFileLivenessSource(() => hb);
+    const session = { id: 's-1', agent_group_id: 'g-1' };
+
+    expect(await source.lastActivityMs(session)).toBeNull();
+
+    fs.writeFileSync(hb, '');
+    const stamp = new Date(Date.now() - 60_000);
+    fs.utimesSync(hb, stamp, stamp);
+    const observed = await source.lastActivityMs(session);
+    expect(observed).not.toBeNull();
+    expect(Math.abs((observed as number) - stamp.getTime())).toBeLessThan(1_000);
+  });
+});

--- a/src/liveness.ts
+++ b/src/liveness.ts
@@ -1,0 +1,38 @@
+/**
+ * LivenessSource — the single seam for "when did this session's agent last
+ * show activity". One seam, never a second mechanism: every consumer (stuck
+ * detection, typing freshness) reads activity through it, so an alternative
+ * source (e.g. driver-reported events) can replace the file stat without
+ * touching consumers.
+ *
+ * The default implementation is today's heartbeat-file stat, verbatim.
+ * The source reports observations only. Fallbacks for "nothing observed yet"
+ * (e.g. container start time) belong to the consumer — `decideStuckAction`
+ * keeps its zero-sentinel semantics.
+ */
+import fs from 'fs';
+
+import { heartbeatPath } from './session-manager.js';
+
+export interface LivenessSource {
+  /**
+   * Epoch ms of the last observed agent activity for this session, or null
+   * when nothing has been observed (no heartbeat yet).
+   */
+  lastActivityMs(session: { id: string; agent_group_id: string }): Promise<number | null>;
+}
+
+/** Today's behavior, extracted: heartbeat-file mtime, null when absent. */
+export function createHeartbeatFileLivenessSource(
+  pathFor: (agentGroupId: string, sessionId: string) => string = heartbeatPath,
+): LivenessSource {
+  return {
+    async lastActivityMs(session) {
+      try {
+        return fs.statSync(pathFor(session.agent_group_id, session.id)).mtimeMs;
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -1,0 +1,51 @@
+/**
+ * Reconciler contract (types only — no runtime yet).
+ *
+ * The 60s host sweep becomes per-key reconciliation: `sweepSession`'s
+ * responsibilities (ack sync, due-message wake, mailbox maintenance / stale
+ * detection / recurrence — host-sweep.ts stays the source of truth for the
+ * ported logic) move into `reconcileSession(sessionId)` driven by a keyed
+ * workqueue. Per-session reconcile with event-driven requeue beats the
+ * global tick — faster wakes, no full sweep on every beat — and a host
+ * restart becomes a resync instead of an adoption ceremony. This module
+ * freezes the surface so the queue implementation, the sweep port, and the
+ * wake path can land independently.
+ *
+ * Queue semantics the implementation must honor:
+ * - Coalescing: adding a key already queued is a no-op (level-triggered — the
+ *   reconcile reads current state, so one run covers many adds).
+ * - `addAfter` schedules a retry/backoff without blocking the queue.
+ * - Per-key backoff on reconcile failure; other keys are never held up.
+ * - A periodic full resync (the 60s ticker) re-adds every active session key
+ *   as the loss floor: queue loss costs latency, never correctness.
+ */
+
+/** Reconcile one session against desired state. Idempotent; reads current state. */
+export type ReconcileFn = (sessionId: string) => Promise<void>;
+
+/**
+ * Singleton work that today rides the global sweep tick rather than any one
+ * session. Each becomes its own coalesced queue key.
+ */
+export const SINGLETON_KEYS = ['singleton:egress-reheal', 'singleton:approvals-scan'] as const;
+export type SingletonKey = (typeof SINGLETON_KEYS)[number];
+
+export type ReconcileKey = `session:${string}` | SingletonKey;
+
+export function sessionKey(sessionId: string): ReconcileKey {
+  return `session:${sessionId}`;
+}
+
+/** Extract the session id from a session key; null for singleton keys. */
+export function sessionIdOf(key: ReconcileKey): string | null {
+  return key.startsWith('session:') ? key.slice('session:'.length) : null;
+}
+
+export interface ReconcileQueue {
+  /** Enqueue now. Coalesces with an already-pending add of the same key. */
+  add(key: ReconcileKey): void;
+  /** Enqueue after a delay (retry/backoff). Coalesces to the earliest due time. */
+  addAfter(key: ReconcileKey, delayMs: number): void;
+  /** Stop the queue; in-flight reconciles finish, pending adds are dropped. */
+  shutdown(): Promise<void>;
+}

--- a/src/request-wake.test.ts
+++ b/src/request-wake.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import type { Session } from './types.js';
+
+const wakeContainer = vi.fn();
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: (session: Session) => wakeContainer(session),
+}));
+
+import { requestWake } from './request-wake.js';
+
+const session = { id: 's-1', agent_group_id: 'g-1' } as Session;
+
+describe('requestWake', () => {
+  it('is a pure delegation to wakeContainer (role=all byte-equivalence)', async () => {
+    wakeContainer.mockResolvedValueOnce(true);
+    expect(await requestWake(session, 'inbound-message')).toBe(true);
+    expect(wakeContainer).toHaveBeenCalledWith(session);
+
+    wakeContainer.mockResolvedValueOnce(false);
+    expect(await requestWake(session, 'due-message')).toBe(false);
+  });
+});

--- a/src/request-wake.ts
+++ b/src/request-wake.ts
@@ -1,0 +1,32 @@
+/**
+ * The wake seam.
+ *
+ * Every "make this session's container run" call site migrates from
+ * importing `wakeContainer` directly to `requestWake`, giving wake intent a
+ * single chokepoint so it can later be recorded durably (`wake_signals` in
+ * src/db/coordination.ts) and served event-driven. The implementation below
+ * is a pure delegation — byte-equivalent to calling `wakeContainer` — and
+ * MUST stay that way until the durable rows become authoritative: no
+ * logging, no signal writes, no behavior.
+ */
+import { wakeContainer } from './container-runner.js';
+import type { Session } from './types.js';
+
+/**
+ * Why the session should be running. Later recorded on the wake-signal row;
+ * extend the union as call sites migrate.
+ */
+export type WakeReason =
+  | 'inbound-message'
+  | 'due-message'
+  | 'container-restart'
+  | 'self-mod-apply'
+  | 'agent-created'
+  | 'interactive'
+  | 'cli'
+  | 'approval-response'
+  | 'adoption';
+
+export async function requestWake(session: Session, _reason: WakeReason): Promise<boolean> {
+  return wakeContainer(session);
+}

--- a/src/workspace-contract.ts
+++ b/src/workspace-contract.ts
@@ -1,0 +1,30 @@
+/**
+ * Workspace composition contract.
+ *
+ * Today the host composes a group's workspace at spawn time by writing files
+ * (CLAUDE.md via claude-md-compose.ts, scaffold + skill links via
+ * group-init.ts, container.json materialized from the `container_configs`
+ * row). This type freezes what a composer implementation may need: data
+ * reachable through the central DB alone. Nothing here may ever require
+ * reading the host's filesystem — keeping composition portable to wherever
+ * the session's workspace is materialized, with the composition functions
+ * themselves carrying unchanged.
+ */
+import type { AgentGroup, ContainerConfigRow } from './types.js';
+
+export interface WorkspaceComposeInputs {
+  /** The agent group row — identity, folder, personality, memory settings. */
+  group: AgentGroup;
+  /** DB-authoritative container config (source of the container.json projection). */
+  containerConfig: ContainerConfigRow;
+  /** Resolved group timezone (group override → install global). */
+  timezone: string;
+}
+
+export interface WorkspaceComposer {
+  /**
+   * Materialize the workspace under `workspaceRoot` (the group folder).
+   * Idempotent — safe to re-run on every session start.
+   */
+  compose(inputs: WorkspaceComposeInputs, workspaceRoot: string): Promise<void>;
+}


### PR DESCRIPTION
Dormant groundwork for making host restarts safe. Today every coordination fact lives in process memory, so a restart kills approval waiters, resets delivery retry counts (a poison message retries forever across a crash loop), loses stop/respawn intent after "rebuild applied", and lets a stale finish() stomp a fresh container. This lands the durable homes and the seams, all inert — no behavior changes anywhere.

## What's in here

- **Migration 024 + `src/db/coordination.ts`** — durable homes for the host's in-memory coordination state: `host_instances` (process lease), `session_claims` (incarnation CAS fencing + durable `respawn_after_stop` stop intent), `delivery_attempts` (backoff bookkeeping; `delivered` stays mailbox-side), `wake_signals` (durable wake intent). Shadow state — no writers yet; portable SQL, caller-supplied ISO clocks.
- **`src/reconcile.ts`** — the contract for per-session reconciliation replacing the global 60s sweep tick: `reconcileSession` + `ReconcileQueue` (keyed, coalescing, `addAfter`, resync loss floor). Types only.
- **`src/request-wake.ts`** — one chokepoint for wake intent; pure delegation to `wakeContainer`, byte-equivalent until the durable rows become authoritative.
- **`src/liveness.ts`** — `LivenessSource`, the single activity seam; default impl is today's heartbeat-file stat extracted verbatim.
- **`src/workspace-contract.ts`** — workspace-composer inputs contract: data reachable through the central DB only, never the host's filesystem.
- **`NANOCLAW_INSTALL_ID`** — env identity override for installs whose checkout path is not a stable identity; label-safe charset; unset = sha1(cwd), byte-identical.
- **Runner: `NANOCLAW_HEARTBEAT_PATH`** — deployment-configurable heartbeat location, read per call; unset = today's path.

## Test plan

- New: coordination accessor suite (lease lifecycle, CAS fencing, attempt counting, consume-once wake signals), wake-seam delegation, liveness source, install-id validation, runner heartbeat override (bun:test).
- Migration passes the portability + registry gates; `pnpm run build`, container typecheck, and the full suite are green (the update-transaction e2e failures are pre-existing on main; two script tests are load-flaky and pass solo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)