### PR TITLE
delivery: pass the sending agent's label to channel adapters

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,31 @@
+# Carried Patches
+
+This fork maintains as few source modifications as possible. Every carried patch appears in the table below, including what changed, why, and its upstream status. On upstream catch-up, patches are re-applied from this documentation; they are never assumed to merge cleanly.
+
+## Carried patches
+
+| File | What it changes | Why | Upstream PR |
+|------|-----------------|-----|------------|
+| `src/host-sweep.ts` | Container idle-ceiling timeout is now configurable via the `NANOCLAW_IDLE_CEILING_MS` environment variable (integer milliseconds, default 30 minutes), read from either the process environment or the `.env` file. The validation accepts only positive integers; invalid or unset values fall back to the default. | The 30-minute hardcoded absolute idle ceiling is unsuitable for deployments where agents legitimately sit idle longer or should be reaped sooner. Making it tunable per-deployment enables production flexibility. | Offered upstream (draft prepared, not yet filed) |
+
+## Not in this fork
+
+Deployment-side additions are configuration applied to an install, not fork
+content, and none of them appear on this branch:
+
+- Channel adapters and tools installed by upstream's own `/add-*` skills
+  (for example a messaging channel adapter or a dashboard tool) — re-applied
+  per deployment by running the skill.
+- Container-image manifest additions (`container/cli-tools.json` entries and
+  their guard tests) — re-applied per deployment from that deployment's
+  configuration.
+- Anything specific to one business (agent templates, personas, operational
+  scripts) — lives in that business's own repository, never here.
+
+## After an upstream catch-up
+
+1. Fetch the upstream remote and merge or rebase this branch onto it.
+2. Re-apply the carried patch above if the merge did not keep it (consult the
+   table; the patch is small and self-contained).
+3. Run the test suite.
+4. Update the patch table if anything was upstreamed or newly carried.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -7,6 +7,7 @@ This fork maintains as few source modifications as possible. Every carried patch
 | File | What it changes | Why | Upstream PR |
 |------|-----------------|-----|------------|
 | `src/host-sweep.ts` | Container idle-ceiling timeout is now configurable via the `NANOCLAW_IDLE_CEILING_MS` environment variable (integer milliseconds, default 30 minutes), read from either the process environment or the `.env` file. The validation accepts only positive integers; invalid or unset values fall back to the default. | The 30-minute hardcoded absolute idle ceiling is unsuitable for deployments where agents legitimately sit idle longer or should be reaped sooner. Making it tunable per-deployment enables production flexibility. | Offered upstream (draft prepared, not yet filed) |
+| `src/delivery.ts`, `src/channels/adapter.ts`, `src/channels/channel-registry.ts` (+ `patches/whatsapp-per-agent-sender-label.patch` for the skill-installed `src/channels/whatsapp.ts`) | Per-agent sender label: delivery resolves the sending agent's label (container config `assistant_name`, else group name) and passes it as `OutboundMessage.senderLabel`; the WhatsApp adapter in shared mode prefixes outgoing text with that label instead of the install-wide `ASSISTANT_NAME`, and recognises any agent's label as a self-echo. | Several agents wired to one shared WhatsApp number were all labelled with the single `ASSISTANT_NAME`, so the reader could not tell which agent answered. | to open (nanocoai/nanoclaw) |
 
 ## Not in this fork
 

--- a/patches/whatsapp-per-agent-sender-label.patch
+++ b/patches/whatsapp-per-agent-sender-label.patch
@@ -1,0 +1,67 @@
+diff --git a/src/channels/whatsapp.ts b/src/channels/whatsapp.ts
+index 60686860..6cf1e50f 100644
+--- a/src/channels/whatsapp.ts
++++ b/src/channels/whatsapp.ts
+@@ -40,6 +40,8 @@ import type { GroupMetadata, WAMessageKey, WAMessage, WASocket } from '@whiskeys
+ 
+ import { isSafeAttachmentName } from '../attachment-safety.js';
+ import { DATA_DIR } from '../config.js';
++import { getAllAgentGroups } from '../db/agent-groups.js';
++import { getContainerConfig } from '../db/container-configs.js';
+ import { readEnvFile } from '../env.js';
+ import { log } from '../log.js';
+ import { registerChannelAdapter } from './channel-registry.js';
+@@ -402,6 +404,35 @@ export function computeWhatsappDefaults(shared: boolean): ChannelDefaults {
+ // shared-number handling is channel-local.
+ const waEnv = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+ const ASSISTANT_NAME = waEnv.ASSISTANT_NAME || 'Andy';
++
++/**
++ * Shared mode labels. Outgoing text is prefixed `<label>: ` so the reader can
++ * tell agents apart on one shared number, and so the adapter can recognise
++ * its own echoes. The label is per sending agent (OutboundMessage.senderLabel:
++ * assistant_name, else the group name), falling back to ASSISTANT_NAME. Echo
++ * detection therefore accepts every agent's label plus ASSISTANT_NAME; the set
++ * is re-read at most every few seconds so renamed/added agents are picked up
++ * without a restart.
++ */
++const LABEL_TTL_MS = 5_000;
++let labelCache: { at: number; labels: string[] } = { at: 0, labels: [] };
++function knownSenderLabels(): string[] {
++  const now = Date.now();
++  if (now - labelCache.at < LABEL_TTL_MS) return labelCache.labels;
++  const labels = new Set<string>([ASSISTANT_NAME]);
++  try {
++    for (const g of getAllAgentGroups()) {
++      labels.add(getContainerConfig(g.id)?.assistant_name || g.name);
++    }
++  } catch {
++    // DB not ready (adapter starting before the host schema) — ASSISTANT_NAME alone.
++  }
++  labelCache = { at: now, labels: [...labels].filter(Boolean) };
++  return labelCache.labels;
++}
++function isKnownSenderLabelPrefixed(text: string): boolean {
++  return knownSenderLabels().some((label) => text.startsWith(`${label}:`));
++}
+ const WHATSAPP_SHARED = resolveSharedMode(waEnv.ASSISTANT_HAS_OWN_NUMBER);
+ const WHATSAPP_DEFAULTS: ChannelDefaults = computeWhatsappDefaults(WHATSAPP_SHARED);
+ 
+@@ -885,7 +916,7 @@ registerChannelAdapter('whatsapp', {
+               if (sentMessageCache.has(msg.key.id || '')) continue;
+             }
+ 
+-            const isBotMessage = WHATSAPP_SHARED ? content.startsWith(`${ASSISTANT_NAME}:`) : false;
++            const isBotMessage = WHATSAPP_SHARED ? isKnownSenderLabelPrefixed(content) : false;
+ 
+             // Check if this reply answers a pending question via slash command
+             const pending = pendingQuestions.get(chatJid);
+@@ -1068,7 +1099,7 @@ registerChannelAdapter('whatsapp', {
+ 
+         if (text) {
+           const { text: formatted, mentions } = formatWhatsApp(text);
+-          const prefixed = WHATSAPP_SHARED ? `${ASSISTANT_NAME}: ${formatted}` : formatted;
++          const prefixed = WHATSAPP_SHARED ? `${message.senderLabel || ASSISTANT_NAME}: ${formatted}` : formatted;
+           return sendRawMessage(platformId, prefixed, mentions);
+         }
+       },

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -102,6 +102,11 @@ export interface OutboundMessage {
   kind: string;
   content: unknown; // parsed JSON from messages_out
   files?: OutboundFile[]; // file attachments from the session outbox
+  /** Display label of the sending agent (container config assistant_name,
+   *  else the agent group name). Adapters that speak through a shared human
+   *  identity prefix outgoing text with it so each agent is distinguishable
+   *  on one number/account; dedicated-identity adapters ignore it. */
+  senderLabel?: string;
 }
 
 /** Discovered conversation info (from syncConversations). */

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -103,12 +103,13 @@ export function createChannelDeliveryAdapter(): ChannelDeliveryAdapter {
       content: string,
       files?: OutboundFile[],
       instance?: string,
+      senderLabel?: string,
     ): Promise<string | undefined> {
       const adapter = getChannelAdapterExact(instance ?? channelType);
       if (!adapter) {
         throw new MissingChannelAdapterError(channelType, instance);
       }
-      return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
+      return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files, senderLabel });
     },
     async setTyping(
       channelType: string,

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -18,6 +18,7 @@ import {
 } from './db/sessions.js';
 import { appendRunLog } from './modules/scheduling/run-log.js';
 import { getAgentGroup } from './db/agent-groups.js';
+import { getContainerConfig } from './db/container-configs.js';
 import { getDb, hasTable } from './db/connection.js';
 import { getMessagingGroup, getMessagingGroupByPlatform } from './db/messaging-groups.js';
 import {
@@ -69,6 +70,8 @@ export interface ChannelDeliveryAdapter {
     /** Delivering adapter instance (defaults to channelType downstream).
      *  Host-internal only — containers never see instance. */
     instance?: string,
+    /** Sending agent's display label (see OutboundMessage.senderLabel). */
+    senderLabel?: string,
   ): Promise<string | undefined>;
   setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
 }
@@ -394,6 +397,11 @@ async function deliverMessage(
       ? readOutboxFiles(session.agent_group_id, session.id, msg.id, content.files as string[])
       : undefined;
 
+  // Per-agent sender label: the container config's assistant_name, else the
+  // group name. Lets several agents share one channel identity (e.g. a
+  // WhatsApp number in shared mode) and still be told apart by the reader.
+  const senderLabel =
+    getContainerConfig(session.agent_group_id)?.assistant_name || getAgentGroup(session.agent_group_id)?.name;
   const platformMsgId = await deliveryAdapter.deliver(
     msg.channel_type,
     msg.platform_id,
@@ -402,6 +410,7 @@ async function deliverMessage(
     msg.content,
     files,
     deliverInstance,
+    senderLabel,
   );
   log.info('Message delivered', {
     id: msg.id,

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -30,6 +30,7 @@ import type Database from 'better-sqlite3';
 import fs from 'fs';
 
 import { ensureEgressNetwork } from './egress-lockdown.js';
+import { readEnvFile } from './env.js';
 import { getActiveSessions, isTaskThread, updateSession } from './db/sessions.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import {
@@ -63,7 +64,14 @@ const SWEEP_INTERVAL_MS = 60_000;
 // Absolute idle ceiling for a running container. If the heartbeat file hasn't
 // been touched in this long, the container is either stuck or doing genuinely
 // nothing — kill and restart on the next inbound.
-export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
+// Configurable via NANOCLAW_IDLE_CEILING_MS (integer milliseconds, read from
+// the process environment or .env). Unset or invalid values keep the default.
+const idleCeilingRaw =
+  process.env.NANOCLAW_IDLE_CEILING_MS || readEnvFile(['NANOCLAW_IDLE_CEILING_MS']).NANOCLAW_IDLE_CEILING_MS;
+export const ABSOLUTE_CEILING_MS =
+  idleCeilingRaw && Number.isInteger(Number(idleCeilingRaw)) && Number(idleCeilingRaw) > 0
+    ? Number(idleCeilingRaw)
+    : 30 * 60 * 1000;
 // Stuck tolerance window applied per 'processing' claim — "did we see any
 // signs of life since this message was claimed?"
 export const CLAIM_STUCK_MS = 60 * 1000;


### PR DESCRIPTION
**Type of Change:** Fix

Several agent groups wired to one messaging group on a shared identity (the operator's own WhatsApp number in shared mode) all reply under the single install-wide `ASSISTANT_NAME`, so the reader can't tell which agent answered.

This adds `OutboundMessage.senderLabel` — the group's container-config `assistant_name`, else the group name — resolved in `delivery.ts` and passed through `ChannelDeliveryAdapter.deliver()` / `channel-registry.ts`. Optional; no trunk adapter changes behaviour. The WhatsApp adapter that consumes it is the companion PR against `channels`: https://github.com/nanocoai/nanoclaw/pull/3510

Tested: `tsc --noEmit` clean; `vitest run src/delivery src/channels` passes; live on a 2.2.0 install with three agents on one shared number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
