### PR TITLE
fix: wait for configured MCP startup

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -111,6 +111,7 @@ async function main(): Promise<void> {
   const provider = createProvider(providerName, {
     assistantName: config.assistantName || undefined,
     mcpServers,
+    startupMcpServerNames: Object.keys(config.mcpServers),
     env: { ...process.env },
     additionalDirectories: additionalDirectories.length > 0 ? additionalDirectories : undefined,
     model: config.model,

--- a/container/agent-runner/src/providers/claude.mcp-startup.test.ts
+++ b/container/agent-runner/src/providers/claude.mcp-startup.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type McpStatus = {
+  name: string;
+  status: 'connected' | 'failed' | 'needs-auth' | 'pending' | 'disabled';
+};
+
+type StatusResponse = Promise<McpStatus[]>;
+
+interface QueryCapture {
+  prompt: AsyncIterable<unknown>;
+  statusCalls: number;
+}
+
+const captures: QueryCapture[] = [];
+let statusResponses: StatusResponse[] = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: ({ prompt }: { prompt: AsyncIterable<unknown> }) => {
+    const capture: QueryCapture = { prompt, statusCalls: 0 };
+    captures.push(capture);
+    return {
+      async *[Symbol.asyncIterator]() {},
+      async mcpServerStatus(): Promise<McpStatus[]> {
+        const response = statusResponses[capture.statusCalls];
+        capture.statusCalls += 1;
+        return response ?? Promise.resolve([]);
+      },
+    };
+  },
+}));
+
+const { ClaudeProvider } = await import('./claude.js');
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  captures.length = 0;
+  statusResponses = [];
+});
+
+describe('Claude MCP startup ordering', () => {
+  test('holds the first prompt until configured MCP startup leaves pending', async () => {
+    const firstStatus = deferred<McpStatus[]>();
+    const secondStatus = deferred<McpStatus[]>();
+    statusResponses = [
+      firstStatus.promise,
+      secondStatus.promise,
+      Promise.resolve([{ name: 'memory', status: 'connected' }]),
+    ];
+
+    const provider = new ClaudeProvider({
+      mcpServers: {
+        nanoclaw: { command: 'bun', args: [], env: {} },
+        memory: { command: 'memory-server', args: [], env: {} },
+      },
+      startupMcpServerNames: ['memory'],
+    });
+    provider.query({ prompt: 'first prompt', cwd: '/workspace/agent' });
+
+    const iterator = captures[0].prompt[Symbol.asyncIterator]();
+    let firstPromptSettled = false;
+    const firstPrompt = iterator.next().then((result) => {
+      firstPromptSettled = true;
+      return result;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(firstPromptSettled).toBe(false);
+    expect(captures[0].statusCalls).toBe(1);
+
+    firstStatus.resolve([]);
+    await Bun.sleep(75);
+
+    expect(captures[0].statusCalls).toBe(2);
+    expect(firstPromptSettled).toBe(false);
+
+    secondStatus.resolve([{ name: 'memory', status: 'pending' }]);
+    await Bun.sleep(75);
+
+    expect(captures[0].statusCalls).toBe(3);
+    expect(await firstPrompt).toMatchObject({
+      done: false,
+      value: { message: { content: 'first prompt' } },
+    });
+  });
+
+  test('does not add a startup barrier without configured MCP servers', async () => {
+    const provider = new ClaudeProvider({
+      mcpServers: {
+        nanoclaw: { command: 'bun', args: [], env: {} },
+      },
+      startupMcpServerNames: [],
+    });
+    provider.query({ prompt: 'normal prompt', cwd: '/workspace/agent' });
+
+    const iterator = captures[0].prompt[Symbol.asyncIterator]();
+    expect(await iterator.next()).toMatchObject({
+      done: false,
+      value: { message: { content: 'normal prompt' } },
+    });
+    expect(captures[0].statusCalls).toBe(0);
+  });
+
+  test('releases the first prompt when startup status fails', async () => {
+    statusResponses = [Promise.reject(new Error('status unavailable'))];
+    const provider = new ClaudeProvider({
+      mcpServers: {
+        nanoclaw: { command: 'bun', args: [], env: {} },
+        memory: { command: 'memory-server', args: [], env: {} },
+      },
+      startupMcpServerNames: ['memory'],
+    });
+    provider.query({ prompt: 'first prompt', cwd: '/workspace/agent' });
+
+    const iterator = captures[0].prompt[Symbol.asyncIterator]();
+    expect(await iterator.next()).toMatchObject({ value: { message: { content: 'first prompt' } } });
+    expect(captures[0].statusCalls).toBe(1);
+  });
+
+  test('applies the barrier only to the first query', async () => {
+    statusResponses = [Promise.resolve([{ name: 'memory', status: 'connected' }])];
+    const provider = new ClaudeProvider({
+      mcpServers: {
+        nanoclaw: { command: 'bun', args: [], env: {} },
+        memory: { command: 'memory-server', args: [], env: {} },
+      },
+      startupMcpServerNames: ['memory'],
+    });
+
+    provider.query({ prompt: 'first prompt', cwd: '/workspace/agent' });
+    const firstIterator = captures[0].prompt[Symbol.asyncIterator]();
+    expect(await firstIterator.next()).toMatchObject({ value: { message: { content: 'first prompt' } } });
+    expect(captures[0].statusCalls).toBe(1);
+
+    provider.query({ prompt: 'later prompt', cwd: '/workspace/agent' });
+    const laterIterator = captures[1].prompt[Symbol.asyncIterator]();
+    expect(await laterIterator.next()).toMatchObject({ value: { message: { content: 'later prompt' } } });
+    expect(captures[1].statusCalls).toBe(0);
+  });
+});

--- a/container/agent-runner/src/providers/claude.mcp-startup.test.ts
+++ b/container/agent-runner/src/providers/claude.mcp-startup.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 type McpStatus = {
   name: string;
@@ -31,19 +34,43 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 }));
 
 const { ClaudeProvider } = await import('./claude.js');
+const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+let tmp: string;
+let previousHome: string | undefined;
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 beforeEach(() => {
   captures.length = 0;
   statusResponses = [];
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-mcp-startup-'));
+  previousHome = process.env.HOME;
+  process.env.HOME = tmp;
 });
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function prepare(provider: InstanceType<typeof ClaudeProvider>): InstanceType<typeof ClaudeProvider> {
+  provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+  return provider;
+}
 
 describe('Claude MCP startup ordering', () => {
   test('holds the first prompt until configured MCP startup leaves pending', async () => {
@@ -55,13 +82,15 @@ describe('Claude MCP startup ordering', () => {
       Promise.resolve([{ name: 'memory', status: 'connected' }]),
     ];
 
-    const provider = new ClaudeProvider({
-      mcpServers: {
-        nanoclaw: { command: 'bun', args: [], env: {} },
-        memory: { command: 'memory-server', args: [], env: {} },
-      },
-      startupMcpServerNames: ['memory'],
-    });
+    const provider = prepare(
+      new ClaudeProvider({
+        mcpServers: {
+          nanoclaw: { command: 'bun', args: [], env: {} },
+          memory: { command: 'memory-server', args: [], env: {} },
+        },
+        startupMcpServerNames: ['memory'],
+      }),
+    );
     provider.query({ prompt: 'first prompt', cwd: '/workspace/agent' });
 
     const iterator = captures[0].prompt[Symbol.asyncIterator]();
@@ -92,12 +121,14 @@ describe('Claude MCP startup ordering', () => {
   });
 
   test('does not add a startup barrier without configured MCP servers', async () => {
-    const provider = new ClaudeProvider({
-      mcpServers: {
-        nanoclaw: { command: 'bun', args: [], env: {} },
-      },
-      startupMcpServerNames: [],
-    });
+    const provider = prepare(
+      new ClaudeProvider({
+        mcpServers: {
+          nanoclaw: { command: 'bun', args: [], env: {} },
+        },
+        startupMcpServerNames: [],
+      }),
+    );
     provider.query({ prompt: 'normal prompt', cwd: '/workspace/agent' });
 
     const iterator = captures[0].prompt[Symbol.asyncIterator]();
@@ -109,30 +140,37 @@ describe('Claude MCP startup ordering', () => {
   });
 
   test('releases the first prompt when startup status fails', async () => {
-    statusResponses = [Promise.reject(new Error('status unavailable'))];
-    const provider = new ClaudeProvider({
-      mcpServers: {
-        nanoclaw: { command: 'bun', args: [], env: {} },
-        memory: { command: 'memory-server', args: [], env: {} },
-      },
-      startupMcpServerNames: ['memory'],
-    });
+    const failedStatus = deferred<McpStatus[]>();
+    statusResponses = [failedStatus.promise];
+    const provider = prepare(
+      new ClaudeProvider({
+        mcpServers: {
+          nanoclaw: { command: 'bun', args: [], env: {} },
+          memory: { command: 'memory-server', args: [], env: {} },
+        },
+        startupMcpServerNames: ['memory'],
+      }),
+    );
     provider.query({ prompt: 'first prompt', cwd: '/workspace/agent' });
 
     const iterator = captures[0].prompt[Symbol.asyncIterator]();
-    expect(await iterator.next()).toMatchObject({ value: { message: { content: 'first prompt' } } });
+    const firstPrompt = iterator.next();
+    failedStatus.reject(new Error('status unavailable'));
+    expect(await firstPrompt).toMatchObject({ value: { message: { content: 'first prompt' } } });
     expect(captures[0].statusCalls).toBe(1);
   });
 
   test('applies the barrier only to the first query', async () => {
     statusResponses = [Promise.resolve([{ name: 'memory', status: 'connected' }])];
-    const provider = new ClaudeProvider({
-      mcpServers: {
-        nanoclaw: { command: 'bun', args: [], env: {} },
-        memory: { command: 'memory-server', args: [], env: {} },
-      },
-      startupMcpServerNames: ['memory'],
-    });
+    const provider = prepare(
+      new ClaudeProvider({
+        mcpServers: {
+          nanoclaw: { command: 'bun', args: [], env: {} },
+          memory: { command: 'memory-server', args: [], env: {} },
+        },
+        startupMcpServerNames: ['memory'],
+      }),
+    );
 
     provider.query({ prompt: 'first prompt', cwd: '/workspace/agent' });
     const firstIterator = captures[0].prompt[Symbol.asyncIterator]();

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -2,7 +2,12 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query as sdkQuery,
+  type HookCallback,
+  type PreCompactHookInput,
+  type Query,
+} from '@anthropic-ai/claude-agent-sdk';
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/container-state.js';
 import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
@@ -452,6 +457,8 @@ function transcriptStartMs(transcriptPath: string): number | null {
  * with a 1M-context model variant or when emergency-tuning a deployment.
  */
 const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '165000';
+const MCP_STARTUP_POLL_MS = 50;
+const MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 /**
  * Stale-session detection. Matches Claude Code's error text when a
@@ -459,6 +466,38 @@ const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WIN
  * session ID, etc.
  */
 const STALE_SESSION_RE = /no conversation found|ENOENT.*\.jsonl|session.*not found/i;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`MCP startup timed out after ${MCP_STARTUP_TIMEOUT_MS}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+async function waitForMcpStartup(query: Pick<Query, 'mcpServerStatus'>, serverNames: string[]): Promise<void> {
+  const deadline = Date.now() + MCP_STARTUP_TIMEOUT_MS;
+  while (true) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw new Error(`MCP startup timed out after ${MCP_STARTUP_TIMEOUT_MS}ms`);
+    const statuses = await withTimeout(query.mcpServerStatus(), remainingMs);
+    const byName = new Map(statuses.map((server) => [server.name, server.status]));
+    const waiting = serverNames.some((name) => !byName.has(name) || byName.get(name) === 'pending');
+    if (!waiting) return;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(MCP_STARTUP_POLL_MS, remainingMs)));
+  }
+}
 
 export class ClaudeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = true;
@@ -480,6 +519,8 @@ export class ClaudeProvider implements AgentProvider {
 
   private assistantName?: string;
   private mcpServers: Record<string, McpServerConfig>;
+  private startupMcpServerNames: string[];
+  private startupBarrierUsed = false;
   private env: Record<string, string | undefined>;
   private additionalDirectories?: string[];
   private model?: string;
@@ -491,6 +532,7 @@ export class ClaudeProvider implements AgentProvider {
     this.mcpServers = Object.fromEntries(
       Object.entries(options.mcpServers ?? {}).map(([name, server]) => [name, shimCwd(server)]),
     );
+    this.startupMcpServerNames = options.startupMcpServerNames ?? [];
     this.additionalDirectories = options.additionalDirectories;
     this.model = options.model;
     this.effort = options.effort;
@@ -549,7 +591,12 @@ export class ClaudeProvider implements AgentProvider {
   query(input: QueryInput): AgentQuery {
     if (!this.memorySessionHook) throw new Error('Claude memory session hook was not registered');
     const stream = new MessageStream();
-    stream.push(input.prompt);
+    const waitForStartup = !this.startupBarrierUsed && this.startupMcpServerNames.length > 0;
+    if (waitForStartup) {
+      this.startupBarrierUsed = true;
+    } else {
+      stream.push(input.prompt);
+    }
 
     const instructions = input.systemContext?.instructions;
 
@@ -581,6 +628,17 @@ export class ClaudeProvider implements AgentProvider {
         },
       },
     });
+
+    if (waitForStartup) {
+      void (async () => {
+        try {
+          await waitForMcpStartup(sdkResult, this.startupMcpServerNames);
+        } catch (err) {
+          log(`MCP startup wait failed; continuing: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        stream.push(input.prompt);
+      })();
+    }
 
     let aborted = false;
 

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -81,6 +81,12 @@ export interface ProviderExchange {
 export interface ProviderOptions {
   assistantName?: string;
   mcpServers?: Record<string, McpServerConfig>;
+  /**
+   * Configured external MCP servers whose first startup must finish before
+   * the provider accepts the initial prompt. The built-in NanoClaw server is
+   * intentionally excluded by the caller.
+   */
+  startupMcpServerNames?: string[];
   env?: Record<string, string | undefined>;
   additionalDirectories?: string[];
   /**


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Configured external MCP servers could still be pending when Claude consumed the first prompt. That creates a first-message warm-up gap for integrations that perform startup preparation before serving requests.

This starts the SDK query first, waits only for configured external MCP servers to leave `pending`, and then releases the initial prompt. The barrier is one-shot, bounded to 30 seconds, and fail-open; built-in-only groups and follow-up prompts keep the existing path.

Tested with:
- focused MCP startup ordering: 4/4
- agent-runner typecheck
- current pinned-SDK delayed stdio MCP probe: server reached `connected` while the first prompt remained withheld
- host suite: 2,001/2,005; the same four updater worktree-path failures reproduce unchanged on `main`
