### PR TITLE
fix(db): backfill the missing own-chat destination for existing wirings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **Agents wired to a chat before destinations became explicit can reply again.** A wiring created after the `agent-destinations` migration ran, but before every wiring path provisioned its companion row, had no destination for its own chat — so the agent composed a correctly-addressed reply, found no name to address, and the block was dropped inside the container. At the default log level nothing surfaced on the host (the container's warning only appears under `LOG_LEVEL=debug`) and the message was still acknowledged as processed, so it read as the agent ignoring the chat. A migration now backfills the missing row for every such wiring; existing destinations and custom local names are untouched. Wirings that predate the `agent-destinations` backfill are deliberately left alone — that migration already gave them a row, so a missing one means it was revoked with `ncl destinations remove`, and restoring it would re-grant a permission an admin took away.
+
 ## [2.3.0] - 2026-08-24
 
 - [BREAKING] **A new Slack experience — per-agent provisioned Slack apps, agent spawning from Slack, and UX improvements — is available to classic single-bot Slack installs.** Classic Slack keeps working unchanged; this gate asks for a decision, not a forced migration. New installs and non-Slack installs are unaffected. **Migration:** run `/migrate-slack-agents` — it detects classic state (exits cleanly otherwise) and either walks the upgrade or records the choice to stay on classic; both outcomes satisfy this requirement.

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -440,6 +440,7 @@ Several early migrations were later renamed/retired and replaced by "module" fil
 | 20 | `container-config-timezone` | `020-container-config-timezone.ts` | `container_configs.timezone` — per-agent-group timezone override (NULL = install-global) |
 | 21 | `approval-question-render-metadata` | `021-approval-question.ts` | `question` card-body column on all three approval tables so terminal edits retain the original request |
 | 22 | `messaging-group-detached-at` | `022-messaging-group-detached.ts` | `messaging_groups.detached_at` — records when the bot left a channel without deleting its wiring |
+| 24 | `backfill-wiring-destinations` | `024-backfill-wiring-destinations.ts` | The missing `agent_destinations` channel row for wirings created after `agent-destinations` ran but before wiring creation provisioned one; existing destinations and custom names are left as they are |
 
 Numbers 5 and 6 are intentionally absent — migrations were renumbered during early development.
 

--- a/src/db/migrations/024-backfill-wiring-destinations.test.ts
+++ b/src/db/migrations/024-backfill-wiring-destinations.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initSqliteTestDb } from '../connection.js';
+import type { DbDriver } from '../driver.js';
+import { migration024 } from './024-backfill-wiring-destinations.js';
+import { migrations, runMigrations } from './index.js';
+
+/** When `agent-destinations` ran. Pinned so the cutoff is deterministic —
+ *  the real stamp is the wall clock of whenever the suite happens to run. */
+const BACKFILL_APPLIED = '2026-04-01T00:00:00.000Z';
+/** After the cutoff, so wirings stamped with it are eligible for repair. */
+const CREATED_AT = '2026-04-12T10:00:00.000Z';
+/** Before the cutoff — `agent-destinations` already covered these. */
+const BEFORE_BACKFILL = '2026-03-01T00:00:00.000Z';
+
+/** The barrel minus the migration under test — every other migration, not
+ *  only the ones ahead of it — so each case can seed the pre-repair state and
+ *  then run it deliberately. The name is spelled out because it is a
+ *  permanent applied identity: renaming it must fail here, not silently
+ *  re-run the migration on installs that already have it. */
+const before024 = migrations.filter((migration) => migration.name !== 'backfill-wiring-destinations');
+
+let db: DbDriver;
+
+async function seedAgent(id: string): Promise<void> {
+  await db.run(`INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)`, id, id, id, CREATED_AT);
+}
+
+async function seedMessagingGroup(id: string, name: string | null): Promise<void> {
+  await db.run(
+    `INSERT INTO messaging_groups (id, channel_type, instance, platform_id, name, is_group, created_at)
+     VALUES (?, 'whatsapp', 'whatsapp', ?, ?, 1, ?)`,
+    id,
+    `chat-${id}`,
+    name,
+    CREATED_AT,
+  );
+}
+
+/** Insert straight into the table: the helper that normally creates a wiring
+ *  provisions the destination too, which is the exact state we must not have. */
+async function seedWiringWithoutDestination(
+  id: string,
+  messagingGroupId: string,
+  agentGroupId = 'agent-main',
+  createdAt = CREATED_AT,
+): Promise<void> {
+  await db.run(
+    `INSERT INTO messaging_group_agents (
+       id, messaging_group_id, agent_group_id,
+       engage_mode, sender_scope, session_mode, priority, created_at
+     ) VALUES (?, ?, ?, 'mention', 'all', 'shared', 0, ?)`,
+    id,
+    messagingGroupId,
+    agentGroupId,
+    createdAt,
+  );
+}
+
+async function addDestination(
+  agentGroupId: string,
+  localName: string,
+  targetType: 'channel' | 'agent',
+  targetId: string,
+): Promise<void> {
+  await db.run(
+    `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    agentGroupId,
+    localName,
+    targetType,
+    targetId,
+    CREATED_AT,
+  );
+}
+
+function destinations(): Promise<Array<Record<string, unknown>>> {
+  return db.all(
+    `SELECT agent_group_id, local_name, target_type, target_id, created_at
+       FROM agent_destinations ORDER BY agent_group_id, local_name`,
+  );
+}
+
+describe('migration 024 — backfill wiring destinations', () => {
+  beforeEach(async () => {
+    db = await initSqliteTestDb();
+    await runMigrations(db, before024, { mode: 'migrate' });
+    await db.run('UPDATE schema_version SET applied = ? WHERE name = ?', BACKFILL_APPLIED, 'agent-destinations');
+    await seedAgent('agent-main');
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it('gives a wiring that has no destination one named after its chat', async () => {
+    await seedMessagingGroup('mg-family', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-family', 'mg-family');
+    expect(await destinations()).toEqual([]);
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat',
+        target_type: 'channel',
+        target_id: 'mg-family',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('leaves an existing destination alone, including a custom local name', async () => {
+    await seedMessagingGroup('mg-wired', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-wired', 'mg-wired');
+    await addDestination('agent-main', 'custom-name', 'channel', 'mg-wired');
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'custom-name',
+        target_type: 'channel',
+        target_id: 'mg-wired',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('suffixes around a name already taken by an agent destination', async () => {
+    await seedAgent('agent-peer');
+    await seedMessagingGroup('mg-family', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-family', 'mg-family');
+    await addDestination('agent-main', 'family-chat', 'agent', 'agent-peer');
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat',
+        target_type: 'agent',
+        target_id: 'agent-peer',
+        created_at: CREATED_AT,
+      },
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat-2',
+        target_type: 'channel',
+        target_id: 'mg-family',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('keeps each agent in its own namespace', async () => {
+    await seedAgent('agent-other');
+    await seedMessagingGroup('mg-shared', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-main', 'mg-shared', 'agent-main');
+    await seedWiringWithoutDestination('wiring-other', 'mg-shared', 'agent-other');
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat',
+        target_type: 'channel',
+        target_id: 'mg-shared',
+        created_at: CREATED_AT,
+      },
+      {
+        agent_group_id: 'agent-other',
+        local_name: 'family-chat',
+        target_type: 'channel',
+        target_id: 'mg-shared',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('falls back to channel and id when the chat has no name', async () => {
+    await seedMessagingGroup('mg-12345678-tail', null);
+    await seedWiringWithoutDestination('wiring-unnamed', 'mg-12345678-tail');
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'whatsapp-mg-12345',
+        target_type: 'channel',
+        target_id: 'mg-12345678-tail',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('names a chat whose title has no ascii left rather than skipping it', async () => {
+    await seedMessagingGroup('mg-jp', 'ディストピアトーキョー');
+    await seedWiringWithoutDestination('wiring-jp', 'mg-jp');
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'unnamed',
+        target_type: 'channel',
+        target_id: 'mg-jp',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('leaves a wiring that predates the backfill alone, so a revoked destination stays revoked', async () => {
+    await seedMessagingGroup('mg-revoked', 'Secret Ops');
+    await seedWiringWithoutDestination('wiring-revoked', 'mg-revoked', 'agent-main', BEFORE_BACKFILL);
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([]);
+  });
+
+  it('repairs a post-backfill wiring while leaving a pre-backfill one revoked', async () => {
+    await seedMessagingGroup('mg-revoked', 'Secret Ops');
+    await seedMessagingGroup('mg-gap', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-revoked', 'mg-revoked', 'agent-main', BEFORE_BACKFILL);
+    await seedWiringWithoutDestination('wiring-gap', 'mg-gap', 'agent-main', CREATED_AT);
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat',
+        target_type: 'channel',
+        target_id: 'mg-gap',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('does nothing when the backfill was never stamped', async () => {
+    await db.run('DELETE FROM schema_version WHERE name = ?', 'agent-destinations');
+    await seedMessagingGroup('mg-family', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-family', 'mg-family');
+
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual([]);
+  });
+
+  it('changes nothing when run again', async () => {
+    await seedMessagingGroup('mg-family', 'Family Chat');
+    await seedWiringWithoutDestination('wiring-family', 'mg-family');
+
+    await migration024.up(db);
+    const afterFirst = await destinations();
+    await migration024.up(db);
+
+    expect(await destinations()).toEqual(afterFirst);
+  });
+
+  it('dates each destination from its own wiring', async () => {
+    const later = '2026-07-04T11:14:18.092Z';
+    await seedMessagingGroup('mg-early', 'Early Chat');
+    await seedMessagingGroup('mg-late', 'Late Chat');
+    await seedWiringWithoutDestination('wiring-early', 'mg-early', 'agent-main', CREATED_AT);
+    await seedWiringWithoutDestination('wiring-late', 'mg-late', 'agent-main', later);
+
+    await migration024.up(db);
+
+    const rows = await destinations();
+    expect(rows.map((row) => [row.local_name, row.created_at])).toEqual([
+      ['early-chat', CREATED_AT],
+      ['late-chat', later],
+    ]);
+  });
+});

--- a/src/db/migrations/024-backfill-wiring-destinations.ts
+++ b/src/db/migrations/024-backfill-wiring-destinations.ts
@@ -1,0 +1,118 @@
+import type { PortableMigration } from './index.js';
+
+/**
+ * Backfill the `agent_destinations` channel row for wirings that never got
+ * one.
+ *
+ * The `agent-destinations` migration backfilled every wiring that existed
+ * when it ran, and each wiring-creation path now provisions the companion
+ * row at wiring time. Wirings created in between have neither: the agent is
+ * wired to the chat and receives from it, but the chat is absent from the
+ * agent's destination map.
+ *
+ * That gap is silent. Sending requires a named destination, so the agent
+ * composes a correctly-addressed reply, finds no name to address, and the
+ * block is dropped inside the container. The warning rides the attach stream
+ * to the host but only lands at debug level, so a default install
+ * (`LOG_LEVEL=info`) sees nothing and the message is still acknowledged as
+ * processed. From the chat it reads as the agent ignoring you.
+ *
+ * Only wirings created after `agent-destinations` ran are eligible. That
+ * migration left every older wiring with a row, so an older wiring missing
+ * one had it removed deliberately — `ncl destinations remove` is an
+ * approval-gated revocation, and this table's row *is* the ACL (no row =
+ * unauthorized). Restoring those would silently re-grant a permission a
+ * human took away.
+ *
+ * Existing destinations are authoritative: a wiring that already has a
+ * channel destination keeps it, custom local names are never rewritten, and
+ * collisions resolve with a numeric suffix inside the owning agent's
+ * namespace. Re-running changes nothing.
+ */
+export const migration024: PortableMigration = {
+  version: 24,
+  name: 'backfill-wiring-destinations',
+  async up(db) {
+    // The table belongs to the agent-to-agent module — without it there is
+    // nothing to repair.
+    if (!(await db.hasTable('agent_destinations'))) return;
+
+    // The cutoff. `agent-destinations` stamps this row when it backfills, so
+    // its timestamp is exactly the boundary between "was covered by that
+    // backfill" and "created afterwards". Without the stamp the checkout's
+    // history is unknown, and re-granting a revoked destination is worse than
+    // leaving a broken one — so do nothing.
+    const stamp = await db.get<{ applied: string }>(
+      'SELECT applied FROM schema_version WHERE name = ?',
+      'agent-destinations',
+    );
+    if (!stamp?.applied) return;
+
+    const taken = new Map<string, Set<string>>();
+    const existing = await db.all<{ agent_group_id: string; local_name: string }>(
+      'SELECT agent_group_id, local_name FROM agent_destinations',
+    );
+    for (const row of existing) {
+      const names = taken.get(row.agent_group_id) ?? new Set<string>();
+      names.add(row.local_name);
+      taken.set(row.agent_group_id, names);
+    }
+
+    // ORDER BY makes the generated suffixes deterministic when one agent is
+    // missing several destinations whose chats share a name.
+    const missing = await db.all<{
+      agent_group_id: string;
+      messaging_group_id: string;
+      created_at: string;
+      channel_type: string;
+      name: string | null;
+    }>(
+      `SELECT mga.agent_group_id, mga.messaging_group_id, mga.created_at, mg.channel_type, mg.name
+         FROM messaging_group_agents mga
+         JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+         LEFT JOIN agent_destinations ad
+           ON ad.agent_group_id = mga.agent_group_id
+          AND ad.target_type = 'channel'
+          AND ad.target_id = mga.messaging_group_id
+        WHERE ad.agent_group_id IS NULL
+          AND mga.created_at >= ?
+        ORDER BY mga.agent_group_id, mga.created_at, mga.id`,
+      stamp.applied,
+    );
+
+    for (const row of missing) {
+      const base = normalizeName(row.name || `${row.channel_type}-${row.messaging_group_id.slice(0, 8)}`);
+      const names = taken.get(row.agent_group_id) ?? new Set<string>();
+      let localName = base;
+      let suffix = 2;
+      while (names.has(localName)) {
+        localName = `${base}-${suffix}`;
+        suffix++;
+      }
+      names.add(localName);
+      taken.set(row.agent_group_id, names);
+
+      // The destination should have existed from the moment the wiring did,
+      // which is what the wiring-time path records too.
+      await db.run(
+        `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+         VALUES (?, ?, 'channel', ?, ?)`,
+        row.agent_group_id,
+        localName,
+        row.messaging_group_id,
+        row.created_at,
+      );
+    }
+  },
+};
+
+/** Kept local so a later change to the shared helper cannot alter the names
+ *  this migration already wrote. Mirrors `agent-destinations`. */
+function normalizeName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'unnamed'
+  );
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -24,6 +24,7 @@ import { migration020 } from './020-container-config-timezone.js';
 import { migration021 } from './021-approval-question.js';
 import { migration022 } from './022-messaging-group-detached.js';
 import { migration023 } from './023-approvals-instance.js';
+import { migration024 } from './024-backfill-wiring-destinations.js';
 
 interface MigrationBase {
   version: number;
@@ -89,6 +90,7 @@ export const migrations: Migration[] = [
   migration021,
   migration022,
   migration023,
+  migration024,
 ];
 
 /**


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3140.

A wiring created after the `agent-destinations` migration ran, but before every wiring-creation path provisioned its companion row, has no destination for its own chat. The agent receives from the chat but cannot address it.

The failure is silent in three layers at once, which is why it goes unnoticed for a long time:

- Sending requires a named destination, so the agent composes a correctly-addressed reply, finds no name to address, and the block is dropped **inside the container**.
- That warning does reach the host over the attach stream, but only at `log.debug` — a default install (`LOG_LEVEL=info`) sees nothing.
- The inbound message is still acknowledged as processed, so nothing anywhere records that a reply was lost.

From the chat it reads as the agent ignoring you. On the install where I hit this, the affected group had produced **zero** `messages_out` rows for over a month before anyone noticed.

### What this does

Migration 024 inserts the missing channel row for every eligible wiring, dating it from the wiring it should have accompanied (matching what `ensureAgentDestinationForWiring` records, so the result is byte-identical to the never-broken state).

**The eligible window starts at the `agent-destinations` stamp in `schema_version`.** That migration left every older wiring with a row, so an older wiring missing one had it revoked deliberately — `ncl destinations remove` is approval-gated, and a row in this table *is* the ACL (`no row = unauthorized`). Restoring those would silently re-grant a permission a human took away. If the stamp is absent the checkout's history is unknown and the migration does nothing.

Existing destinations are authoritative: a wiring that already has one keeps it, custom local names are never rewritten, and collisions resolve with a numeric suffix inside the owning agent's namespace. Re-running changes nothing. Installs without the agent-to-agent module have no table and are skipped.

### Relationship to #3145

#3145 proposed a fix for the same issue and is closed — not on the merits, but because the fork CI workflow stayed unapproved and it never entered review ("Closing this since the fork workflow has remained unapproved..."). I read that PR before writing this one and the shared shape is visible: the anti-join, the ordering, the local `normalizeName` copy, and the migration name are the same. Credit for the original approach belongs to @tlysanhuo.

This version differs in three ways:

- It is ported to the async `DbDriver` boundary introduced in 2.3.0 (#3145 predates it and uses the synchronous `better-sqlite3` API, so it no longer applies).
- It adds the `schema_version` cutoff described above, so an approval-gated revocation is not undone.
- It guards on `hasTable('agent_destinations')` for installs without the module.

The migration name is unchanged from #3145, so an install that already applied that version is a no-op here (the runner dedups on `name`).

## Test plan

- [x] `pnpm test` — 2012 passed. The 4 failures in `scripts/update/transaction.e2e.test.ts` reproduce on a clean `upstream/main` worktree and are unrelated to this change.
- [x] 11 new cases in `src/db/migrations/024-backfill-wiring-destinations.test.ts`: repair, existing-destination and custom-name preservation, suffix collisions, per-agent namespacing, the unnamed-chat fallback, wiring-derived `created_at`, re-run idempotence, and three cutoff cases (pre-backfill wiring left revoked, mixed pre/post, missing stamp = no-op).
- [x] `pnpm exec tsc --noEmit`, ESLint and Prettier on changed files.
- [x] Verified against a copy of a real affected database: the missing destination is restored with the wiring's own timestamp, pre-existing rows are untouched, and the cutoff is respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bdZAV1zGoMaU4JAzE9UMU