### PR TITLE
fix(cli): refuse to steal a live ncl socket; register a durable host-instance lease

### DIFF
--- a/src/cli/socket-server.test.ts
+++ b/src/cli/socket-server.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import net from 'net';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startCliServer, stopCliServer } from './socket-server.js';
+
+// Unix socket paths have a small OS limit — keep them short.
+function tmpSocketPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-'));
+  return path.join(dir, 's.sock');
+}
+
+afterEach(async () => {
+  await stopCliServer();
+});
+
+describe('startCliServer single-bind', () => {
+  it('refuses to take over a socket a live server is accepting on', async () => {
+    const socketPath = tmpSocketPath();
+    // Another host instance, simulated by a raw listener on the same path.
+    const other = net.createServer(() => {});
+    await new Promise<void>((resolve) => other.listen(socketPath, resolve));
+    try {
+      await expect(startCliServer(socketPath)).rejects.toThrow(/already serving ncl/);
+      // The live socket file must still be there — nothing was unlinked.
+      expect(fs.existsSync(socketPath)).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => other.close(() => resolve()));
+    }
+  });
+
+  it('cleans up a stale socket file nobody answers and binds', async () => {
+    const socketPath = tmpSocketPath();
+    // A crashed run's leftover: the file exists but no listener answers.
+    fs.writeFileSync(socketPath, '');
+    await startCliServer(socketPath);
+    // Bound and accepting: a client connect succeeds.
+    await new Promise<void>((resolve, reject) => {
+      const probe = net.createConnection(socketPath);
+      probe.once('connect', () => {
+        probe.destroy();
+        resolve();
+      });
+      probe.once('error', reject);
+    });
+  });
+
+  it('binds normally when no socket file exists', async () => {
+    const socketPath = tmpSocketPath();
+    await startCliServer(socketPath);
+    expect(fs.existsSync(socketPath)).toBe(true);
+  });
+});

--- a/src/cli/socket-server.ts
+++ b/src/cli/socket-server.ts
@@ -17,15 +17,48 @@ import { DEFAULT_SOCKET_PATH } from './socket-client.js';
 
 let server: net.Server | null = null;
 
+const PROBE_TIMEOUT_MS = 1000;
+
+/**
+ * Is a live server accepting on this socket path? Used before stale-socket
+ * cleanup so a second host started in the same checkout refuses to take over
+ * a running host's socket instead of silently unlinking it (after which every
+ * `ncl` call would route to the newcomer while the original keeps running).
+ * No verdict within the timeout counts as live — when unsure, never steal.
+ */
+function probeLiveServer(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = net.createConnection(socketPath);
+    const done = (live: boolean): void => {
+      probe.destroy();
+      resolve(live);
+    };
+    probe.once('connect', () => done(true));
+    probe.once('error', () => done(false));
+    probe.setTimeout(PROBE_TIMEOUT_MS, () => done(true));
+  });
+}
+
 export async function startCliServer(socketPath: string = DEFAULT_SOCKET_PATH): Promise<void> {
   // Stale-socket cleanup — a previous run that crashed may have left the
   // file behind, and net.createServer refuses to bind to an existing path.
-  try {
-    fs.unlinkSync(socketPath);
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException;
-    if (e.code !== 'ENOENT') {
-      log.warn('Failed to unlink stale ncl socket (will try to bind anyway)', { socketPath, err });
+  // Only a socket nobody answers is stale: a live listener means another
+  // host instance owns this path, and startup must fail rather than steal it.
+  if (fs.existsSync(socketPath)) {
+    if (await probeLiveServer(socketPath)) {
+      throw new Error(
+        `another host instance is already serving ncl at ${socketPath} — ` +
+          `refusing to take over its socket. Stop the other instance ` +
+          `(or remove the file if you are certain none is running) and restart.`,
+      );
+    }
+    try {
+      fs.unlinkSync(socketPath);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code !== 'ENOENT') {
+        log.warn('Failed to unlink stale ncl socket (will try to bind anyway)', { socketPath, err });
+      }
     }
   }
 

--- a/src/host-instance.test.ts
+++ b/src/host-instance.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getDb, initSqliteTestDb, closeDb, runMigrations } from './db/index.js';
+import type { HostInstanceRow } from './db/coordination.js';
+import { getHostInstanceId, startHostInstanceLease, stopHostInstanceLease } from './host-instance.js';
+
+async function row(instanceId: string): Promise<HostInstanceRow | undefined> {
+  return getDb().get<HostInstanceRow>('SELECT * FROM host_instances WHERE instance_id = ?', instanceId);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeEach(async () => {
+  const db = await initSqliteTestDb();
+  await runMigrations(db);
+});
+
+afterEach(async () => {
+  await stopHostInstanceLease();
+  await closeDb();
+});
+
+describe('host instance lease', () => {
+  it('registers on start, renews on the interval, stamps stop on shutdown', async () => {
+    const id = await startHostInstanceLease({ renewIntervalMs: 25, leaseTtlMs: 200 });
+    expect(getHostInstanceId()).toBe(id);
+
+    const registered = await row(id);
+    expect(registered).toBeDefined();
+    expect(registered?.pid).toBe(process.pid);
+    expect(registered?.stopped_at).toBeNull();
+
+    // At least one renewal fires and pushes the lease expiry forward.
+    const before = registered!.lease_expires_at;
+    await sleep(80);
+    const renewed = await row(id);
+    expect(renewed!.lease_expires_at > before).toBe(true);
+
+    await stopHostInstanceLease();
+    expect(getHostInstanceId()).toBeNull();
+    expect((await row(id))?.stopped_at).not.toBeNull();
+  });
+
+  it('refuses a second concurrent start', async () => {
+    await startHostInstanceLease({ renewIntervalMs: 1_000 });
+    await expect(startHostInstanceLease()).rejects.toThrow(/already started/);
+  });
+
+  it('can start again after a stop (restart shape)', async () => {
+    const first = await startHostInstanceLease({ renewIntervalMs: 1_000 });
+    await stopHostInstanceLease();
+    const second = await startHostInstanceLease({ renewIntervalMs: 1_000 });
+    expect(second).not.toBe(first);
+    expect((await row(second))?.stopped_at).toBeNull();
+  });
+});

--- a/src/host-instance.ts
+++ b/src/host-instance.ts
@@ -1,0 +1,85 @@
+/**
+ * Durable host-instance lease.
+ *
+ * The host registers itself in `host_instances` at startup and renews its
+ * lease on an interval, so restarts and overlapping instances become
+ * observable durable facts instead of invisible process state (today the
+ * only trace of "which host is running" is the process itself). Write-only
+ * shadow state: nothing may read these rows to make decisions yet.
+ */
+import { randomUUID } from 'crypto';
+import os from 'os';
+
+import { INSTALL_SLUG } from './config.js';
+import { markHostInstanceStopped, registerHostInstance, renewHostInstanceLease } from './db/coordination.js';
+import { log } from './log.js';
+
+const RENEW_INTERVAL_MS = 30_000;
+// TTL is 3× the renewal interval: two consecutive renewals can fail (slow
+// disk, transient DB contention) before the row reads as expired.
+const LEASE_TTL_MS = 90_000;
+
+let instanceId: string | null = null;
+let renewTimer: NodeJS.Timeout | null = null;
+
+/** The running host's instance id, or null before start / after stop. */
+export function getHostInstanceId(): string | null {
+  return instanceId;
+}
+
+export interface HostInstanceLeaseOptions {
+  renewIntervalMs?: number;
+  leaseTtlMs?: number;
+}
+
+export async function startHostInstanceLease(options: HostInstanceLeaseOptions = {}): Promise<string> {
+  if (instanceId) throw new Error('host instance lease already started');
+  const renewIntervalMs = options.renewIntervalMs ?? RENEW_INTERVAL_MS;
+  const leaseTtlMs = options.leaseTtlMs ?? LEASE_TTL_MS;
+
+  const id = randomUUID();
+  await registerHostInstance({
+    instanceId: id,
+    installId: INSTALL_SLUG,
+    hostname: os.hostname(),
+    pid: process.pid,
+    now: new Date().toISOString(),
+    leaseExpiresAt: new Date(Date.now() + leaseTtlMs).toISOString(),
+  });
+  instanceId = id;
+
+  renewTimer = setInterval(() => {
+    void renewLease(id, leaseTtlMs);
+  }, renewIntervalMs);
+  // The renewal timer must never keep an otherwise-finished process alive.
+  renewTimer.unref?.();
+  return id;
+}
+
+async function renewLease(id: string, leaseTtlMs: number): Promise<void> {
+  /* eslint-disable no-catch-all/no-catch-all -- lease writes are shadow state; a failed renewal must never affect the host */
+  try {
+    const renewed = await renewHostInstanceLease(id, new Date(Date.now() + leaseTtlMs).toISOString());
+    if (!renewed) log.warn('Host instance lease row missing on renewal', { instanceId: id });
+  } catch (err) {
+    log.warn('Host instance lease renewal failed', { instanceId: id, err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}
+
+export async function stopHostInstanceLease(): Promise<void> {
+  if (renewTimer) {
+    clearInterval(renewTimer);
+    renewTimer = null;
+  }
+  const id = instanceId;
+  instanceId = null;
+  if (!id) return;
+  /* eslint-disable no-catch-all/no-catch-all -- graceful shutdown must proceed even if the stop stamp cannot be written */
+  try {
+    await markHostInstanceStopped(id, new Date().toISOString());
+  } catch (err) {
+    log.warn('Failed to mark host instance stopped', { instanceId: id, err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { closeDb, initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
 import { getSessionDriver } from './drivers/index.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
+import { startHostInstanceLease, stopHostInstanceLease } from './host-instance.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { startHostModules, stopHostModules } from './host-lifecycle.js';
 import { routeInbound } from './router.js';
@@ -153,6 +154,10 @@ async function main(): Promise<void> {
   // actual work begins here, after DB + delivery are ready and before polls.
   await startHostModules({ db, signal: hostAbortController.signal });
 
+  // 5b. Register this host process in durable state and keep its lease fresh
+  // (shadow state — observability across restarts, no behavior reads it).
+  await startHostInstanceLease();
+
   // 6. Start delivery polls
   startActiveDeliveryPoll();
   startSweepDeliveryPoll();
@@ -173,6 +178,8 @@ async function shutdown(signal: string): Promise<void> {
   log.info('Shutdown signal received', { signal });
   hostAbortController.abort();
   await stopHostModules();
+  // Stamp the durable stop before the DB closes below.
+  await stopHostInstanceLease();
   stopDeliveryPolls();
   stopHostSweep();
   await stopCliServer();


### PR DESCRIPTION
Stacked on #3508 (base: `feat/durable-host-coordination`). Two restart-safety fixes that make overlapping host instances safe and observable.

## The socket steal

`startCliServer` unconditionally `unlinkSync`'d `data/ncl.sock` before binding — labeled stale-socket cleanup, but with no liveness check. A second host started in the same checkout silently took over the socket of a running first: every `ncl` call then routed to the newcomer while the original kept running. Now an existing socket is probed first: a live listener fails startup with a clear conflict error (nothing unlinked); only a socket nobody answers is treated as stale. No verdict within the probe timeout counts as live — when unsure, never steal.

## The host-instance lease

The host registers itself in `host_instances` (from #3508) at startup, renews the lease every 30s (TTL 90s — two consecutive failed renewals tolerated; failures log and never affect the host), and stamps `stopped_at` on graceful shutdown. Which host processes exist becomes a durable fact instead of invisible process state. Write-only shadow state: nothing reads these rows to make decisions.

## Test plan

New: 3 socket cases (live-listener refusal with the file left intact, stale-file cleanup-and-bind, no-file bind) + 3 lease lifecycle cases. Full `src/cli` suite 206/206; build + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)