### PR TITLE
refactor(sweep): extract per-session reconcile; make the recurrence re-arm atomic

### DIFF
--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -1,112 +1,28 @@
 /**
- * Host sweep — periodic maintenance of all session mailboxes.
+ * Host sweep — the periodic tick over all session mailboxes.
  *
- * Reads runner-owned processing/container state and maintains host-owned
- * inbound state through the registered mailbox.
- *
- * Stuck / idle detection (replaces the old IDLE_TIMEOUT setTimeout + 10-min
- * heartbeat threshold):
- *
- *   If the container isn't running and there are 'processing' rows left over
- *   (e.g. it crashed mid-turn) → reset them to pending with backoff +
- *   tries++. Existing retry machinery does the rest.
- *
- *   If the container IS running:
- *     1. Absolute ceiling: heartbeat age > max(30 min, current_bash_timeout)
- *        → kill. Covers the "alive but silent for 30 min" case. Extended
- *        only while Bash is declared as running longer, honouring the
- *        user's own timeout directive. Kill then resets processing rows.
- *        When no heartbeat file exists yet, falls back to the tracked
- *        container spawn time so a container that goes idle without ever
- *        reaching an SDK event —
- *        and so never writes a heartbeat — still ages out instead of
- *        living forever (see decideStuckAction's grace-period comment).
- *
- *     2. Message-scoped stuck: for each 'processing' row, tolerance =
- *        max(60s, current_bash_timeout_ms_if_Bash_running). If
- *        (claim_age > tolerance) AND (heartbeat_mtime <= status_changed)
- *        → kill + reset this message + tries++. Semantics: "container
- *        claimed a message and went quiet past tolerance since the claim."
+ * The per-session body lives in src/reconcile-session.ts (`reconcileSession`,
+ * the ReconcileFn shape from src/reconcile.ts); this module owns only the
+ * loop: the 60s cadence, the active-session iteration, and the once-per-tick
+ * duties that aren't per-session (egress re-heal, the reject-with-reason
+ * finalizer). The re-exports below keep the long-standing import surface of
+ * this module stable.
  */
-import fs from 'fs';
-
 import { ensureEgressNetwork } from './egress-lockdown.js';
-import { getActiveSessions, isTaskThread, updateSession } from './db/sessions.js';
-import { getAgentGroup } from './db/agent-groups.js';
+import { getActiveSessions } from './db/sessions.js';
 import { log } from './log.js';
-import { heartbeatPath, withExistingMailboxSession } from './session-manager.js';
-import { getContainerStartedAtMs, isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
-import type { Session } from './types.js';
-import type { ContainerState, InboundMailbox, OutboundMailbox } from './mailbox/index.js';
+import { reconcileSession } from './reconcile-session.js';
+
+export {
+  ABSOLUTE_CEILING_MS,
+  CLAIM_STUCK_MS,
+  _resetStuckProcessingRowsForTesting,
+  decideStuckAction,
+  shouldCloseTaskSession,
+  type StuckDecision,
+} from './reconcile-session.js';
 
 const SWEEP_INTERVAL_MS = 60_000;
-// Absolute idle ceiling for a running container. If the heartbeat file hasn't
-// been touched in this long, the container is either stuck or doing genuinely
-// nothing — kill and restart on the next inbound.
-export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
-// Stuck tolerance window applied per 'processing' claim — "did we see any
-// signs of life since this message was claimed?"
-export const CLAIM_STUCK_MS = 60 * 1000;
-const MAX_TRIES = 5;
-const BACKOFF_BASE_MS = 5000;
-
-export type StuckDecision =
-  | { action: 'ok' }
-  | { action: 'kill-ceiling'; heartbeatAgeMs: number; ceilingMs: number }
-  | { action: 'kill-claim'; messageId: string; claimAgeMs: number; toleranceMs: number };
-
-/**
- * Pure decision for whether a running container should be killed this sweep
- * tick. Inputs are all deterministic; filesystem and mailbox reads happen in the
- * caller.
- */
-export function decideStuckAction(args: {
-  now: number;
-  heartbeatMtimeMs: number; // 0 when heartbeat file absent
-  containerStartedAtMs?: number; // fallback when heartbeat file absent
-  containerState: ContainerState | null;
-  claims: Array<{ messageId: string; statusChanged: string }>;
-}): StuckDecision {
-  const { now, heartbeatMtimeMs, containerStartedAtMs, containerState, claims } = args;
-  const declaredBashMs = bashTimeoutMs(containerState);
-
-  // Ceiling check prefers the heartbeat file's mtime. A freshly-spawned
-  // container hasn't had any SDK activity yet so no heartbeat file exists —
-  // if we treated that as infinitely stale we'd kill every container within
-  // seconds of spawn. But "no heartbeat file" isn't only a spawn-grace-period
-  // signal: a container can also finish its one turn (or find nothing to do)
-  // without its poll loop ever reaching an SDK event, in which case a
-  // heartbeat file is never created for the rest of that container's life,
-  // and it sits alive-but-idle forever, immune to this check. Falling back
-  // to the container's spawn timestamp gives fresh spawns the same grace
-  // period as before (age starts at ~0) while still aging out a
-  // container that never ticks. Genuinely-dead containers that never wrote a
-  // heartbeat AND have no session record are caught by the separate
-  // "container process not running" cleanup path, not here. If a fresh
-  // container is hanging at the gate (claimed a message but never did
-  // anything) the claim-stuck check below handles it independently of this
-  // fallback.
-  const effectiveHeartbeatMs = heartbeatMtimeMs !== 0 ? heartbeatMtimeMs : (containerStartedAtMs ?? 0);
-  if (effectiveHeartbeatMs !== 0) {
-    const heartbeatAge = now - effectiveHeartbeatMs;
-    const ceiling = Math.max(ABSOLUTE_CEILING_MS, declaredBashMs ?? 0);
-    if (heartbeatAge > ceiling) {
-      return { action: 'kill-ceiling', heartbeatAgeMs: heartbeatAge, ceilingMs: ceiling };
-    }
-  }
-
-  const tolerance = Math.max(CLAIM_STUCK_MS, declaredBashMs ?? 0);
-  for (const claim of claims) {
-    const claimedAt = Date.parse(claim.statusChanged);
-    if (Number.isNaN(claimedAt)) continue;
-    const claimAge = now - claimedAt;
-    if (claimAge <= tolerance) continue;
-    if (heartbeatMtimeMs > claimedAt) continue;
-    return { action: 'kill-claim', messageId: claim.messageId, claimAgeMs: claimAge, toleranceMs: tolerance };
-  }
-
-  return { action: 'ok' };
-}
 
 let running = false;
 
@@ -136,7 +52,7 @@ async function sweep(): Promise<void> {
   try {
     const sessions = await getActiveSessions();
     for (const session of sessions) {
-      await sweepSession(session);
+      await reconcileSession(session.id);
     }
   } catch (err) {
     log.error('Host sweep error', { err });
@@ -155,200 +71,4 @@ async function sweep(): Promise<void> {
   // MODULE-HOOK:approvals-reason-sweep:end
 
   setTimeout(() => void sweep(), SWEEP_INTERVAL_MS);
-}
-
-/** A per-task session with no live tasks and no running container is spent → close it. */
-export function shouldCloseTaskSession(
-  threadId: string | null,
-  containerRunning: boolean,
-  liveTaskCount: number,
-): boolean {
-  return isTaskThread(threadId) && !containerRunning && liveTaskCount === 0;
-}
-
-async function sweepSession(session: Session): Promise<void> {
-  const agentGroup = await getAgentGroup(session.agent_group_id);
-  if (!agentGroup) return;
-
-  try {
-    let dueCount = 0;
-    let shouldWake = false;
-    const exists = await withExistingMailboxSession(agentGroup.id, session.id, async (mailbox) => {
-      mailbox.applyProcessingAcks(mailbox.getTerminalProcessingAcks());
-      dueCount = mailbox.countDueMessages();
-      shouldWake = dueCount > 0 && !isContainerRunning(session.id);
-      if (!shouldWake) {
-        await maintainSessionMailbox(mailbox, session, agentGroup.id, false);
-      }
-      return true;
-    });
-    if (!exists) return;
-
-    if (!shouldWake) return;
-
-    // Waking refreshes routing through the mailbox. Keep it outside the
-    // session transaction so serialized implementations do not re-enter
-    // themselves while the sweep still owns the session.
-    log.info('Waking container for due messages', { sessionId: session.id, count: dueCount });
-    await wakeContainer(session);
-
-    await withExistingMailboxSession(agentGroup.id, session.id, async (mailbox) => {
-      await maintainSessionMailbox(mailbox, session, agentGroup.id, true);
-    });
-  } catch (err) {
-    log.error('Session mailbox sweep failed', {
-      agentGroupId: agentGroup.id,
-      sessionId: session.id,
-      err,
-    });
-  }
-}
-
-async function maintainSessionMailbox(
-  mailbox: InboundMailbox & OutboundMailbox,
-  session: Session,
-  agentGroupId: string,
-  justWoke: boolean,
-): Promise<void> {
-  const alive = isContainerRunning(session.id);
-  if (alive && !justWoke) {
-    enforceRunningContainerSla(mailbox, mailbox, session, agentGroupId);
-  }
-  if (!alive) {
-    resetStuckProcessingRows(mailbox, mailbox, session, 'container not running');
-  }
-
-  // MODULE-HOOK:scheduling-recurrence:start
-  const { handleRecurrence } = await import('./modules/scheduling/recurrence.js');
-  await handleRecurrence(mailbox, session);
-  // MODULE-HOOK:scheduling-recurrence:end
-
-  if (isTaskThread(session.thread_id)) {
-    const liveTasks = mailbox.countLiveTasks();
-    if (shouldCloseTaskSession(session.thread_id, isContainerRunning(session.id), liveTasks)) {
-      await updateSession(session.id, { status: 'closed' });
-      log.info('Closed spent task session', { sessionId: session.id, threadId: session.thread_id });
-    }
-  }
-
-  // MODULE-HOOK:cross-session-echo-prune:start
-  try {
-    const { pruneEchoBacklog } = await import('./modules/cross-session-context/index.js');
-    const pruned = pruneEchoBacklog(mailbox);
-    if (pruned > 0) log.info('Pruned session-echo backlog', { sessionId: session.id, pruned });
-  } catch (err) {
-    log.error('Echo backlog prune failed', { sessionId: session.id, err });
-  }
-  // MODULE-HOOK:cross-session-echo-prune:end
-}
-
-function heartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
-  const hbPath = heartbeatPath(agentGroupId, sessionId);
-  try {
-    return fs.statSync(hbPath).mtimeMs;
-  } catch {
-    return 0;
-  }
-}
-
-function bashTimeoutMs(state: ContainerState | null): number | null {
-  if (!state || state.currentTool !== 'Bash') return null;
-  return state.toolDeclaredTimeoutMs;
-}
-
-function enforceRunningContainerSla(
-  inDb: InboundMailbox,
-  outDb: OutboundMailbox,
-  session: Session,
-  agentGroupId: string,
-): void {
-  const decision = decideStuckAction({
-    now: Date.now(),
-    heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
-    containerStartedAtMs: getContainerStartedAtMs(session.id),
-    containerState: outDb.getContainerState(),
-    claims: outDb.getProcessingClaims(),
-  });
-
-  if (decision.action === 'ok') return;
-
-  if (decision.action === 'kill-ceiling') {
-    log.warn('Killing container past absolute ceiling', {
-      sessionId: session.id,
-      heartbeatAgeMs: decision.heartbeatAgeMs,
-      ceilingMs: decision.ceilingMs,
-    });
-    killContainer(session.id, 'absolute-ceiling');
-    resetStuckProcessingRows(inDb, outDb, session, 'absolute-ceiling');
-    return;
-  }
-
-  log.warn('Killing container — message claimed then silent', {
-    sessionId: session.id,
-    messageId: decision.messageId,
-    claimAgeMs: decision.claimAgeMs,
-    toleranceMs: decision.toleranceMs,
-  });
-  killContainer(session.id, 'claim-stuck');
-  resetStuckProcessingRows(inDb, outDb, session, 'claim-stuck');
-}
-
-export function _resetStuckProcessingRowsForTesting(
-  inDb: InboundMailbox,
-  outDb: OutboundMailbox,
-  session: Session,
-  reason: string,
-): void {
-  resetStuckProcessingRows(inDb, outDb, session, reason);
-}
-
-function resetStuckProcessingRows(
-  inDb: InboundMailbox,
-  outDb: OutboundMailbox,
-  session: Session,
-  reason: string,
-): void {
-  const claims = outDb.getProcessingClaims();
-  const now = Date.now();
-  for (const { messageId } of claims) {
-    const msg = inDb.getMessageForRetry(messageId, 'pending');
-    if (!msg) continue;
-
-    // Already rescheduled for a future retry — don't bump tries again. The
-    // wake path (sweep step 2) will fire when process_after elapses and a
-    // fresh container will clean the orphan claim on startup.
-    if (msg.processAfter && Date.parse(msg.processAfter) > now) continue;
-
-    if (msg.tries >= MAX_TRIES) {
-      inDb.markMessageFailed(msg.id);
-      log.warn('Message marked as failed after max retries', {
-        messageId: msg.id,
-        sessionId: session.id,
-        reason,
-      });
-    } else {
-      const backoffMs = BACKOFF_BASE_MS * Math.pow(2, msg.tries);
-      const backoffSec = Math.floor(backoffMs / 1000);
-      inDb.retryWithBackoff(msg.id, backoffSec);
-      log.info('Reset stale message with backoff', {
-        messageId: msg.id,
-        tries: msg.tries,
-        backoffMs,
-        reason,
-      });
-    }
-  }
-
-  // Drop the orphan 'processing' rows. Without this, the next sweep tick
-  // would re-read them, see the old status_changed timestamp, conclude the
-  // freshly respawned container is stuck, and SIGKILL it before its
-  // agent-runner has a chance to run clearStaleProcessingAcks() on startup.
-  try {
-    const cleared = outDb.deleteOrphanProcessingClaims();
-    if (cleared > 0) {
-      log.info('Cleared orphan processing claims', { sessionId: session.id, cleared, reason });
-    }
-  } catch (err) {
-    log.warn('Failed to clear orphan processing claims', { sessionId: session.id, err });
-  }
 }

--- a/src/mailbox/sqlite/arm-next-task.test.ts
+++ b/src/mailbox/sqlite/arm-next-task.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `armNextTask` atomicity — the re-arm of a recurring series is one durable
+ * step. The dangerous tear is a next occurrence inserted while the original
+ * still carries its recurrence (re-cloned on the following tick → duplicate
+ * runs); the fatal one is a cleared recurrence with no next occurrence (the
+ * series silently dies). A failure mid-pair must leave the original's
+ * recurrence fully intact so the next tick simply retries.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { ensureSchema, openInboundDb } from './session-db.js';
+import { insertTaskRow, getCompletedRecurring } from './tasks.js';
+import { wrapSqliteInbound } from './index.js';
+
+const TEST_DIR = '/tmp/nanoclaw-arm-next-task-test';
+const DB_PATH = path.join(TEST_DIR, 'inbound.db');
+
+function freshDb() {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  ensureSchema(DB_PATH, 'inbound');
+  return openInboundDb(DB_PATH);
+}
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+function completedRecurringOriginal(db: ReturnType<typeof openInboundDb>, id: string) {
+  insertTaskRow(db, {
+    id,
+    seriesId: id,
+    processAfter: new Date(Date.now() - 60_000).toISOString(),
+    recurrence: '0 9 * * *',
+    content: JSON.stringify({ prompt: 'noop' }),
+  });
+  db.prepare("UPDATE messages_in SET status = 'completed' WHERE id = ?").run(id);
+}
+
+describe('armNextTask', () => {
+  it('inserts the next occurrence and clears the recurrence in one step', async () => {
+    const db = freshDb();
+    completedRecurringOriginal(db, 'task-original');
+    const mailbox = wrapSqliteInbound(db);
+
+    await mailbox.armNextTask('task-original', {
+      id: 'task-next',
+      seriesId: 'task-original',
+      processAfter: new Date(Date.now() + 3_600_000).toISOString(),
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'noop' }),
+    });
+
+    expect(mailbox.getTask('task-next')?.id).toBe('task-next');
+    expect(getCompletedRecurring(db)).toHaveLength(0);
+  });
+
+  it('a failure mid-pair leaves the recurrence intact for a clean retry', async () => {
+    const db = freshDb();
+    completedRecurringOriginal(db, 'task-original');
+    const mailbox = wrapSqliteInbound(db);
+    // Occupy the next occurrence's id so the insert inside the pair throws.
+    insertTaskRow(db, {
+      id: 'task-next',
+      seriesId: 'unrelated',
+      processAfter: new Date().toISOString(),
+      recurrence: null,
+      content: JSON.stringify({ prompt: 'squatter' }),
+    });
+
+    await expect(
+      mailbox.armNextTask('task-original', {
+        id: 'task-next',
+        seriesId: 'task-original',
+        processAfter: new Date(Date.now() + 3_600_000).toISOString(),
+        recurrence: '0 9 * * *',
+        content: JSON.stringify({ prompt: 'noop' }),
+      }),
+    ).rejects.toThrow();
+
+    // The original is still armed — the series is retryable, not dead.
+    expect(getCompletedRecurring(db).map((row) => row.id)).toEqual(['task-original']);
+
+    // And the retry with a fresh id completes the pair.
+    await mailbox.armNextTask('task-original', {
+      id: 'task-next-retry',
+      seriesId: 'task-original',
+      processAfter: new Date(Date.now() + 3_600_000).toISOString(),
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'noop' }),
+    });
+    expect(getCompletedRecurring(db)).toHaveLength(0);
+    expect(mailbox.getTask('task-next-retry')?.id).toBe('task-next-retry');
+  });
+});

--- a/src/mailbox/sqlite/index.ts
+++ b/src/mailbox/sqlite/index.ts
@@ -217,6 +217,13 @@ export function wrapSqliteInbound(db: Database.Database, nextSequence = () => ne
     getInboundSourceSessionId: (messageId) => getInboundSourceSessionId(db, messageId),
     getMostRecentPeerSourceSessionId: (peerAgentGroupId) => getMostRecentPeerSourceSessionId(db, peerAgentGroupId),
     insertTask: async (task) => insertTaskRow(db, task, nextSequence()),
+    armNextTask: async (originalId, task) => {
+      const sequence = nextSequence();
+      db.transaction(() => {
+        insertTaskRow(db, task, sequence);
+        clearRecurrence(db, originalId);
+      })();
+    },
     cancelTask: (taskId) => (taskId === undefined ? cancelAllTasks(db) : cancelTask(db, taskId)),
     pauseTask: (taskId) => pauseTask(db, taskId),
     resumeTask: (taskId) => resumeTask(db, taskId),

--- a/src/mailbox/types.ts
+++ b/src/mailbox/types.ts
@@ -116,6 +116,15 @@ export interface InboundMailbox {
   getCompletedRecurring(): RecurringMessage[];
   trailingFailedRuns(seriesId: string): number;
   clearRecurrence(messageId: string): void;
+  /**
+   * Atomically insert a series' next occurrence and clear the recurrence on
+   * the completed original — one durable step. Split writes tear on a crash:
+   * an inserted next occurrence with the original's recurrence intact
+   * re-clones the series on the following tick (duplicate runs), while the
+   * reverse order silently kills the series. Durable when the promise
+   * resolves, like insertTask.
+   */
+  armNextTask(originalId: string, task: Task): Promise<void>;
   countLiveTasks(): number;
   prunePendingMessages(channelType: string, before: string, keep: number): number;
   getInboundHistory(limit: number): MailboxHistoryMessage[];

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -3,10 +3,12 @@
  *
  * Every sweep tick, find `messages_in` rows that are `completed` AND still
  * have a `recurrence` cron expression. For each, compute the next run via
- * cron-parser, insert a fresh pending row (copying series_id forward), then
- * clear the recurrence on the original so it isn't re-cloned next tick.
+ * cron-parser, then arm the next occurrence atomically (insert a fresh
+ * pending row copying series_id forward + clear the recurrence on the
+ * original, one durable step via `armNextTask`) so a crash between the two
+ * writes can never leave the series both armed and re-clonable.
  *
- * Called from `src/host-sweep.ts` inside `MODULE-HOOK:scheduling-recurrence`.
+ * Called from `src/reconcile-session.ts` inside `MODULE-HOOK:scheduling-recurrence`.
  * When scheduling ships inline (current state through PR #7), the hook is a
  * direct dynamic import. When scheduling moves to the modules branch in
  * PR #8, the install skill re-fills the marker on install.
@@ -68,7 +70,7 @@ export async function handleRecurrence(inDb: InboundMailbox, session: Session): 
       if (scriptFails >= SCRIPT_FAIL_PAUSE_CAP) {
         // Re-arm PAUSED at the cron time so `ncl tasks resume` revives the
         // series in place; leave the why in the run log.
-        await inDb.insertTask({
+        await inDb.armNextTask(msg.id, {
           id: newId,
           seriesId: msg.seriesId,
           processAfter: cronNext.toISOString(),
@@ -76,7 +78,6 @@ export async function handleRecurrence(inDb: InboundMailbox, session: Session): 
           content: msg.content,
           status: 'paused',
         });
-        inDb.clearRecurrence(msg.id);
         await appendHostTaskNote(
           session.agent_group_id,
           msg.seriesId,
@@ -93,14 +94,13 @@ export async function handleRecurrence(inDb: InboundMailbox, session: Session): 
       const backoffAt = scriptFails > 0 ? Date.now() + scriptBackoffMinutes(scriptFails) * 60_000 : 0;
       const nextRun = new Date(Math.max(cronNext.getTime(), backoffAt)).toISOString();
 
-      await inDb.insertTask({
+      await inDb.armNextTask(msg.id, {
         id: newId,
         seriesId: msg.seriesId,
         processAfter: nextRun,
         recurrence: msg.recurrence,
         content: msg.content,
       });
-      inDb.clearRecurrence(msg.id);
 
       log.info('Inserted next recurrence', {
         originalId: msg.id,

--- a/src/reconcile-session.ts
+++ b/src/reconcile-session.ts
@@ -1,0 +1,311 @@
+/**
+ * Per-session reconcile — one session's maintenance pass, extracted from the
+ * host sweep so it can run per key instead of only inside the global tick.
+ * `reconcileSession(sessionId)` is the `ReconcileFn` shape from
+ * src/reconcile.ts: level-triggered, reads current state, a missing or
+ * closed session is a clean no-op.
+ *
+ * Stuck / idle detection (replaces the old IDLE_TIMEOUT setTimeout + 10-min
+ * heartbeat threshold):
+ *
+ *   If the container isn't running and there are 'processing' rows left over
+ *   (e.g. it crashed mid-turn) → reset them to pending with backoff +
+ *   tries++. Existing retry machinery does the rest.
+ *
+ *   If the container IS running:
+ *     1. Absolute ceiling: heartbeat age > max(30 min, current_bash_timeout)
+ *        → kill. Covers the "alive but silent for 30 min" case. Extended
+ *        only while Bash is declared as running longer, honouring the
+ *        user's own timeout directive. Kill then resets processing rows.
+ *        When no heartbeat file exists yet, falls back to the tracked
+ *        container spawn time so a container that goes idle without ever
+ *        reaching an SDK event —
+ *        and so never writes a heartbeat — still ages out instead of
+ *        living forever (see decideStuckAction's grace-period comment).
+ *
+ *     2. Message-scoped stuck: for each 'processing' row, tolerance =
+ *        max(60s, current_bash_timeout_ms_if_Bash_running). If
+ *        (claim_age > tolerance) AND (heartbeat_mtime <= status_changed)
+ *        → kill + reset this message + tries++. Semantics: "container
+ *        claimed a message and went quiet past tolerance since the claim."
+ */
+import fs from 'fs';
+
+import { getSession, isTaskThread, updateSession } from './db/sessions.js';
+import { getAgentGroup } from './db/agent-groups.js';
+import { log } from './log.js';
+import { heartbeatPath, withExistingMailboxSession } from './session-manager.js';
+import { getContainerStartedAtMs, isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import type { Session } from './types.js';
+import type { ContainerState, InboundMailbox, OutboundMailbox } from './mailbox/index.js';
+
+// Absolute idle ceiling for a running container. If the heartbeat file hasn't
+// been touched in this long, the container is either stuck or doing genuinely
+// nothing — kill and restart on the next inbound.
+export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
+// Stuck tolerance window applied per 'processing' claim — "did we see any
+// signs of life since this message was claimed?"
+export const CLAIM_STUCK_MS = 60 * 1000;
+const MAX_TRIES = 5;
+const BACKOFF_BASE_MS = 5000;
+
+export type StuckDecision =
+  | { action: 'ok' }
+  | { action: 'kill-ceiling'; heartbeatAgeMs: number; ceilingMs: number }
+  | { action: 'kill-claim'; messageId: string; claimAgeMs: number; toleranceMs: number };
+
+/**
+ * Pure decision for whether a running container should be killed this sweep
+ * tick. Inputs are all deterministic; filesystem and mailbox reads happen in the
+ * caller.
+ */
+export function decideStuckAction(args: {
+  now: number;
+  heartbeatMtimeMs: number; // 0 when heartbeat file absent
+  containerStartedAtMs?: number; // fallback when heartbeat file absent
+  containerState: ContainerState | null;
+  claims: Array<{ messageId: string; statusChanged: string }>;
+}): StuckDecision {
+  const { now, heartbeatMtimeMs, containerStartedAtMs, containerState, claims } = args;
+  const declaredBashMs = bashTimeoutMs(containerState);
+
+  // Ceiling check prefers the heartbeat file's mtime. A freshly-spawned
+  // container hasn't had any SDK activity yet so no heartbeat file exists —
+  // if we treated that as infinitely stale we'd kill every container within
+  // seconds of spawn. But "no heartbeat file" isn't only a spawn-grace-period
+  // signal: a container can also finish its one turn (or find nothing to do)
+  // without its poll loop ever reaching an SDK event, in which case a
+  // heartbeat file is never created for the rest of that container's life,
+  // and it sits alive-but-idle forever, immune to this check. Falling back
+  // to the container's spawn timestamp gives fresh spawns the same grace
+  // period as before (age starts at ~0) while still aging out a
+  // container that never ticks. Genuinely-dead containers that never wrote a
+  // heartbeat AND have no session record are caught by the separate
+  // "container process not running" cleanup path, not here. If a fresh
+  // container is hanging at the gate (claimed a message but never did
+  // anything) the claim-stuck check below handles it independently of this
+  // fallback.
+  const effectiveHeartbeatMs = heartbeatMtimeMs !== 0 ? heartbeatMtimeMs : (containerStartedAtMs ?? 0);
+  if (effectiveHeartbeatMs !== 0) {
+    const heartbeatAge = now - effectiveHeartbeatMs;
+    const ceiling = Math.max(ABSOLUTE_CEILING_MS, declaredBashMs ?? 0);
+    if (heartbeatAge > ceiling) {
+      return { action: 'kill-ceiling', heartbeatAgeMs: heartbeatAge, ceilingMs: ceiling };
+    }
+  }
+
+  const tolerance = Math.max(CLAIM_STUCK_MS, declaredBashMs ?? 0);
+  for (const claim of claims) {
+    const claimedAt = Date.parse(claim.statusChanged);
+    if (Number.isNaN(claimedAt)) continue;
+    const claimAge = now - claimedAt;
+    if (claimAge <= tolerance) continue;
+    if (heartbeatMtimeMs > claimedAt) continue;
+    return { action: 'kill-claim', messageId: claim.messageId, claimAgeMs: claimAge, toleranceMs: tolerance };
+  }
+
+  return { action: 'ok' };
+}
+
+/** A per-task session with no live tasks and no running container is spent → close it. */
+export function shouldCloseTaskSession(
+  threadId: string | null,
+  containerRunning: boolean,
+  liveTaskCount: number,
+): boolean {
+  return isTaskThread(threadId) && !containerRunning && liveTaskCount === 0;
+}
+
+/** Reconcile one session against current state. Missing/closed sessions no-op. */
+export async function reconcileSession(sessionId: string): Promise<void> {
+  const session = await getSession(sessionId);
+  if (!session || session.status !== 'active') return;
+  await reconcileActiveSession(session);
+}
+
+async function reconcileActiveSession(session: Session): Promise<void> {
+  const agentGroup = await getAgentGroup(session.agent_group_id);
+  if (!agentGroup) return;
+
+  try {
+    let dueCount = 0;
+    let shouldWake = false;
+    const exists = await withExistingMailboxSession(agentGroup.id, session.id, async (mailbox) => {
+      mailbox.applyProcessingAcks(mailbox.getTerminalProcessingAcks());
+      dueCount = mailbox.countDueMessages();
+      shouldWake = dueCount > 0 && !isContainerRunning(session.id);
+      if (!shouldWake) {
+        await maintainSessionMailbox(mailbox, session, agentGroup.id, false);
+      }
+      return true;
+    });
+    if (!exists) return;
+
+    if (!shouldWake) return;
+
+    // Waking refreshes routing through the mailbox. Keep it outside the
+    // session transaction so serialized implementations do not re-enter
+    // themselves while the sweep still owns the session.
+    log.info('Waking container for due messages', { sessionId: session.id, count: dueCount });
+    await wakeContainer(session);
+
+    await withExistingMailboxSession(agentGroup.id, session.id, async (mailbox) => {
+      await maintainSessionMailbox(mailbox, session, agentGroup.id, true);
+    });
+  } catch (err) {
+    log.error('Session mailbox sweep failed', {
+      agentGroupId: agentGroup.id,
+      sessionId: session.id,
+      err,
+    });
+  }
+}
+
+async function maintainSessionMailbox(
+  mailbox: InboundMailbox & OutboundMailbox,
+  session: Session,
+  agentGroupId: string,
+  justWoke: boolean,
+): Promise<void> {
+  const alive = isContainerRunning(session.id);
+  if (alive && !justWoke) {
+    enforceRunningContainerSla(mailbox, mailbox, session, agentGroupId);
+  }
+  if (!alive) {
+    resetStuckProcessingRows(mailbox, mailbox, session, 'container not running');
+  }
+
+  // MODULE-HOOK:scheduling-recurrence:start
+  const { handleRecurrence } = await import('./modules/scheduling/recurrence.js');
+  await handleRecurrence(mailbox, session);
+  // MODULE-HOOK:scheduling-recurrence:end
+
+  if (isTaskThread(session.thread_id)) {
+    const liveTasks = mailbox.countLiveTasks();
+    if (shouldCloseTaskSession(session.thread_id, isContainerRunning(session.id), liveTasks)) {
+      await updateSession(session.id, { status: 'closed' });
+      log.info('Closed spent task session', { sessionId: session.id, threadId: session.thread_id });
+    }
+  }
+
+  // MODULE-HOOK:cross-session-echo-prune:start
+  try {
+    const { pruneEchoBacklog } = await import('./modules/cross-session-context/index.js');
+    const pruned = pruneEchoBacklog(mailbox);
+    if (pruned > 0) log.info('Pruned session-echo backlog', { sessionId: session.id, pruned });
+  } catch (err) {
+    log.error('Echo backlog prune failed', { sessionId: session.id, err });
+  }
+  // MODULE-HOOK:cross-session-echo-prune:end
+}
+
+function heartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
+  const hbPath = heartbeatPath(agentGroupId, sessionId);
+  try {
+    return fs.statSync(hbPath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function bashTimeoutMs(state: ContainerState | null): number | null {
+  if (!state || state.currentTool !== 'Bash') return null;
+  return state.toolDeclaredTimeoutMs;
+}
+
+function enforceRunningContainerSla(
+  inDb: InboundMailbox,
+  outDb: OutboundMailbox,
+  session: Session,
+  agentGroupId: string,
+): void {
+  const decision = decideStuckAction({
+    now: Date.now(),
+    heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
+    containerStartedAtMs: getContainerStartedAtMs(session.id),
+    containerState: outDb.getContainerState(),
+    claims: outDb.getProcessingClaims(),
+  });
+
+  if (decision.action === 'ok') return;
+
+  if (decision.action === 'kill-ceiling') {
+    log.warn('Killing container past absolute ceiling', {
+      sessionId: session.id,
+      heartbeatAgeMs: decision.heartbeatAgeMs,
+      ceilingMs: decision.ceilingMs,
+    });
+    killContainer(session.id, 'absolute-ceiling');
+    resetStuckProcessingRows(inDb, outDb, session, 'absolute-ceiling');
+    return;
+  }
+
+  log.warn('Killing container — message claimed then silent', {
+    sessionId: session.id,
+    messageId: decision.messageId,
+    claimAgeMs: decision.claimAgeMs,
+    toleranceMs: decision.toleranceMs,
+  });
+  killContainer(session.id, 'claim-stuck');
+  resetStuckProcessingRows(inDb, outDb, session, 'claim-stuck');
+}
+
+export function _resetStuckProcessingRowsForTesting(
+  inDb: InboundMailbox,
+  outDb: OutboundMailbox,
+  session: Session,
+  reason: string,
+): void {
+  resetStuckProcessingRows(inDb, outDb, session, reason);
+}
+
+function resetStuckProcessingRows(
+  inDb: InboundMailbox,
+  outDb: OutboundMailbox,
+  session: Session,
+  reason: string,
+): void {
+  const claims = outDb.getProcessingClaims();
+  const now = Date.now();
+  for (const { messageId } of claims) {
+    const msg = inDb.getMessageForRetry(messageId, 'pending');
+    if (!msg) continue;
+
+    // Already rescheduled for a future retry — don't bump tries again. The
+    // wake path (sweep step 2) will fire when process_after elapses and a
+    // fresh container will clean the orphan claim on startup.
+    if (msg.processAfter && Date.parse(msg.processAfter) > now) continue;
+
+    if (msg.tries >= MAX_TRIES) {
+      inDb.markMessageFailed(msg.id);
+      log.warn('Message marked as failed after max retries', {
+        messageId: msg.id,
+        sessionId: session.id,
+        reason,
+      });
+    } else {
+      const backoffMs = BACKOFF_BASE_MS * Math.pow(2, msg.tries);
+      const backoffSec = Math.floor(backoffMs / 1000);
+      inDb.retryWithBackoff(msg.id, backoffSec);
+      log.info('Reset stale message with backoff', {
+        messageId: msg.id,
+        tries: msg.tries,
+        backoffMs,
+        reason,
+      });
+    }
+  }
+
+  // Drop the orphan 'processing' rows. Without this, the next sweep tick
+  // would re-read them, see the old status_changed timestamp, conclude the
+  // freshly respawned container is stuck, and SIGKILL it before its
+  // agent-runner has a chance to run clearStaleProcessingAcks() on startup.
+  try {
+    const cleared = outDb.deleteOrphanProcessingClaims();
+    if (cleared > 0) {
+      log.info('Cleared orphan processing claims', { sessionId: session.id, cleared, reason });
+    }
+  } catch (err) {
+    log.warn('Failed to clear orphan processing claims', { sessionId: session.id, err });
+  }
+}


### PR DESCRIPTION
Stacked on #3508 (base: `feat/durable-host-coordination`). Code motion plus one durability fix; behavior otherwise byte-equivalent.

## The extraction

The per-session body of the host sweep (ack sync, due-message wake, stuck/idle enforcement, mailbox maintenance) moves verbatim from `host-sweep.ts` into `reconcile-session.ts` as `reconcileSession(sessionId)` — the `ReconcileFn` shape from `src/reconcile.ts`. Level-triggered: it loads current state, and a missing or closed session is a clean no-op. `host-sweep.ts` keeps the 60s loop, the active-session iteration, and the once-per-tick duties, and re-exports the moved public surface so every existing import resolves unchanged. **Zero existing test files edited** — the sweep suites pass untouched, which is the proof this is pure code motion.

## The recurrence tear

The recurring-task re-arm was two separate durable writes: insert the next occurrence, then clear the recurrence on the completed original. A crash between them re-clones the series on the following tick — duplicate runs. New `InboundMailbox.armNextTask(originalId, task)` does the pair as one transaction (the `applyProcessingAcks` idiom); both re-arm paths in `handleRecurrence` use it. A new test proves a mid-pair failure leaves the original armed — retryable, never dead, never duplicated.

Note for review: this adds one method to the host-side `InboundMailbox` interface (`src/mailbox/types.ts`); the runner-side mailbox surface is untouched.

## Test plan

Existing sweep/recurrence/mailbox suites pass unchanged (76 tests re-verified); new atomicity test; build green; full suite shows only the failures pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)