### PR TITLE
refactor(wake): route every wake call site through the requestWake seam

### DIFF
--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -7,7 +7,8 @@ import {
   type AdditionalMountConfig,
   type McpServerConfig,
 } from '../../container-config.js';
-import { buildAgentGroupImage, killContainer, wakeContainer } from '../../container-runner.js';
+import { buildAgentGroupImage, killContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { restartAgentGroupContainers } from '../../container-restart.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
 import { getDb, hasTable } from '../../db/connection.js';
@@ -342,7 +343,7 @@ registerResource({
               ? () => {
                   void (async () => {
                     const s = await getSession(ctx.sessionId);
-                    if (s) await wakeContainer(s);
+                    if (s) await requestWake(s, 'cli');
                   })();
                 }
               : undefined,

--- a/src/container-restart.ts
+++ b/src/container-restart.ts
@@ -4,7 +4,8 @@
  * Writes an on_wake message to each session, kills the container, then
  * wakes a fresh container via the onExit callback — race-free.
  */
-import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { isContainerRunning, killContainer } from './container-runner.js';
+import { requestWake } from './request-wake.js';
 import { getSession, getSessionsByAgentGroup } from './db/sessions.js';
 import { log } from './log.js';
 import { withExistingMailboxSession, writeSessionMessage } from './session-manager.js';
@@ -15,7 +16,7 @@ import { withExistingMailboxSession, writeSessionMessage } from './session-manag
  * Only targets sessions that actually have a running container.
  * If `wakeMessage` is provided, each session gets an on_wake message
  * (picked up only by the fresh container's first poll) and a
- * wakeContainer call on exit. Without it, containers are killed and
+ * wake request on exit. Without it, containers are killed and
  * only come back on the next real user message.
  */
 export async function restartAgentGroupContainers(
@@ -61,7 +62,7 @@ export async function restartAgentGroupContainers(
         ? () => {
             void (async () => {
               const s = await getSession(session.id);
-              if (s) await wakeContainer(s);
+              if (s) await requestWake(s, 'container-restart');
             })();
           }
         : undefined,

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -25,7 +25,7 @@ import { isSafeAttachmentName } from '../../attachment-safety.js';
 import { ensureContainedInboxDir, isPathInside } from '../../inbox-safety.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getSession } from '../../db/sessions.js';
-import { wakeContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { GuardDenyError, guard } from '../../guard/index.js';
 import { log } from '../../log.js';
 import { resolveSession, sessionDir, withExistingMailboxSession, writeSessionMessage } from '../../session-manager.js';
@@ -355,7 +355,7 @@ async function performAgentRoute(
     forwardedFileCount: countForwardedFiles(forwardedContent),
   });
   const fresh = await getSession(targetSession.id);
-  if (fresh) await wakeContainer(fresh);
+  if (fresh) await requestWake(fresh, 'inbound-message');
 }
 
 /**

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -20,7 +20,7 @@ import { GROUPS_DIR } from '../../config.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
 import { getContainerConfig } from '../../db/container-configs.js';
 import { getSession } from '../../db/sessions.js';
-import { wakeContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { groupFolderExistsOnDisk } from '../../group-folder.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { log } from '../../log.js';
@@ -41,7 +41,7 @@ async function notifyAgent(session: Session, text: string): Promise<void> {
     content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
   });
   const fresh = await getSession(session.id);
-  if (fresh) await wakeContainer(fresh);
+  if (fresh) await requestWake(fresh, 'agent-created');
 }
 
 /** Guard precheck: malformed requests are answered without ever creating a hold. */

--- a/src/modules/approvals/finalize.ts
+++ b/src/modules/approvals/finalize.ts
@@ -10,7 +10,7 @@
  * Kept in its own leaf file so both response-handler.ts and reason-capture.ts
  * can import it without an import cycle (finalize → primitive only).
  */
-import { wakeContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { deletePendingApproval, transitionPendingApprovalStatus } from '../../db/sessions.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
@@ -58,6 +58,6 @@ export async function finalizeReject(
 
   await deletePendingApproval(approval.approval_id);
   await notifyApprovalResolved({ approval, session, outcome: 'reject', userId });
-  await wakeContainer(session);
+  await requestWake(session, 'approval-response');
   return true;
 }

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -25,7 +25,7 @@ import { normalizeOptions, type RawOption } from '../../channels/ask-question.js
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { createPendingApproval, deletePendingApproval, getSession } from '../../db/sessions.js';
 import { getDeliveryAdapter } from '../../delivery.js';
-import { wakeContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { MessagingGroup, PendingApproval, Session } from '../../types.js';
@@ -200,7 +200,7 @@ export async function notifyAgent(session: Session, text: string): Promise<void>
     content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
   });
   const fresh = await getSession(session.id);
-  if (fresh) await wakeContainer(fresh);
+  if (fresh) await requestWake(fresh, 'inbound-message');
 }
 
 export interface RequestApprovalOptions {

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -15,7 +15,7 @@
  * The response handler is registered via core's `registerResponseHandler`;
  * core iterates handlers and the first one to return `true` claims the response.
  */
-import { wakeContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import {
   deletePendingApproval,
   getPendingApproval,
@@ -112,7 +112,7 @@ async function handleRegisteredApproval(
     await notify(`Your ${approval.action} was approved, but no handler is installed to apply it.`);
     await deletePendingApproval(approval.approval_id);
     await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
-    await wakeContainer(session);
+    await requestWake(session, 'approval-response');
     return;
   }
 
@@ -129,7 +129,7 @@ async function handleRegisteredApproval(
 
   await deletePendingApproval(approval.approval_id);
   await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
-  await wakeContainer(session);
+  await requestWake(session, 'approval-response');
 }
 
 function namespacedUserId(payload: ResponsePayload): string | null {

--- a/src/modules/interactive/index.ts
+++ b/src/modules/interactive/index.ts
@@ -12,7 +12,7 @@
  */
 import { getDb, hasTable } from '../../db/connection.js';
 import { deletePendingQuestion, getPendingQuestion, getSession } from '../../db/sessions.js';
-import { wakeContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { registerResponseHandler, type ResponsePayload } from '../../response-registry.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
@@ -52,7 +52,7 @@ async function handleInteractiveResponse(payload: ResponsePayload): Promise<bool
     sessionId: session.id,
   });
 
-  await wakeContainer(session);
+  await requestWake(session, 'interactive');
   return true;
 }
 

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -17,7 +17,8 @@ import {
   validateMcpServerName,
   type McpServerConfig,
 } from '../../container-config.js';
-import { buildAgentGroupImage, killContainer, wakeContainer } from '../../container-runner.js';
+import { buildAgentGroupImage, killContainer } from '../../container-runner.js';
+import { requestWake } from '../../request-wake.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getContainerConfig, updateContainerConfigJson } from '../../db/container-configs.js';
 import { getSession } from '../../db/sessions.js';
@@ -28,7 +29,7 @@ import { notifyAgent } from '../approvals/index.js';
 
 async function wakeSessionById(sessionId: string): Promise<void> {
   const session = await getSession(sessionId);
-  if (session) await wakeContainer(session);
+  if (session) await requestWake(session, 'self-mod-apply');
 }
 
 export async function applyInstallPackages(payload: Record<string, unknown>, session: Session): Promise<void> {

--- a/src/reconcile-session.ts
+++ b/src/reconcile-session.ts
@@ -35,7 +35,8 @@ import { getSession, isTaskThread, updateSession } from './db/sessions.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { log } from './log.js';
 import { heartbeatPath, withExistingMailboxSession } from './session-manager.js';
-import { getContainerStartedAtMs, isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { getContainerStartedAtMs, isContainerRunning, killContainer } from './container-runner.js';
+import { requestWake } from './request-wake.js';
 import type { Session } from './types.js';
 import type { ContainerState, InboundMailbox, OutboundMailbox } from './mailbox/index.js';
 
@@ -147,7 +148,7 @@ async function reconcileActiveSession(session: Session): Promise<void> {
     // session transaction so serialized implementations do not re-enter
     // themselves while the sweep still owns the session.
     log.info('Waking container for due messages', { sessionId: session.id, count: dueCount });
-    await wakeContainer(session);
+    await requestWake(session, 'due-message');
 
     await withExistingMailboxSession(agentGroup.id, session.id, async (mailbox) => {
       await maintainSessionMailbox(mailbox, session, agentGroup.id, true);

--- a/src/router.ts
+++ b/src/router.ts
@@ -32,7 +32,7 @@ import { backfillNewSession, fanInboundMessage } from './modules/cross-session-c
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
-import { wakeContainer } from './container-runner.js';
+import { requestWake } from './request-wake.js';
 import { getSession } from './db/sessions.js';
 import type { AgentGroup, MessagingGroup, MessagingGroupAgent, Session } from './types.js';
 import type { InboundEvent } from './channels/adapter.js';
@@ -656,8 +656,8 @@ async function deliverToAgent(
     );
     const freshSession = await getSession(session.id);
     if (freshSession) {
-      const woke = await wakeContainer(freshSession);
-      // wakeContainer never throws — it returns false on transient spawn
+      const woke = await requestWake(freshSession, 'inbound-message');
+      // requestWake never throws — it returns false on transient spawn
       // failure (host-sweep retries). Stop the typing indicator we just
       // started so it doesn't leak; the inbound row stays pending.
       if (!woke) stopTypingRefresh(freshSession.id);


### PR DESCRIPTION
Stacked on #3514 (base: `refactor/per-session-reconcile`; chain: #3508 → #3514 → this). Mechanical, byte-equivalent by construction.

Every "make this session's container run" call site outside `container-runner.ts` now goes through the `requestWake` seam (from #3508) instead of importing `wakeContainer` directly — 12 sites across 11 files, each stamped with why the session should be running (`inbound-message`, `due-message`, `container-restart`, `cli`, `self-mod-apply`, `agent-created`, `interactive`, `approval-response`). Sites that write mail and then wake carry `inbound-message` — the mail is the reason.

`requestWake` itself is untouched: still a pure delegation to `wakeContainer`, so behavior is identical. The chokepoint is what later lets wake intent be recorded durably and served event-driven.

## Test plan

Zero edits to existing tests — all touched-module suites pass unchanged (138 tests; `vi.mock('./container-runner.js')` mocks intercept through the delegation). Build + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)