### PR TITLE
feat(sweep): drive per-session reconcile through a keyed workqueue with a resync floor

### DIFF
--- a/src/host-sweep.queue.test.ts
+++ b/src/host-sweep.queue.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The sweep drives the keyed workqueue: each tick enqueues the singleton
+ * duties and every active session, runs each exactly once in the loop's
+ * long-standing order, and re-arms only after the tick's work has drained.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./reconcile-session.js', () => ({
+  reconcileSession: vi.fn(),
+  // Re-exported surface host-sweep.ts forwards — inert stubs.
+  ABSOLUTE_CEILING_MS: 0,
+  CLAIM_STUCK_MS: 0,
+  _resetStuckProcessingRowsForTesting: vi.fn(),
+  decideStuckAction: vi.fn(),
+  shouldCloseTaskSession: vi.fn(),
+}));
+vi.mock('./db/sessions.js', () => ({ getActiveSessions: vi.fn() }));
+vi.mock('./egress-lockdown.js', () => ({ ensureEgressNetwork: vi.fn() }));
+vi.mock('./modules/approvals/index.js', () => ({ sweepAwaitingReasonRejects: vi.fn() }));
+
+import { getActiveSessions } from './db/sessions.js';
+import { ensureEgressNetwork } from './egress-lockdown.js';
+import { startHostSweep, stopHostSweep } from './host-sweep.js';
+import { sweepAwaitingReasonRejects } from './modules/approvals/index.js';
+import { reconcileSession } from './reconcile-session.js';
+
+const SWEEP_INTERVAL_MS = 60_000;
+const sweepCallbacks: Array<() => void> = [];
+const realSetTimeout = global.setTimeout;
+let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+let order: string[] = [];
+
+async function runSweepTick(): Promise<void> {
+  const before = sweepCallbacks.length;
+  if (before === 0) startHostSweep();
+  else sweepCallbacks[before - 1]();
+  await vi.waitFor(() => {
+    expect(sweepCallbacks.length).toBe(before + 1);
+  });
+}
+
+beforeEach(() => {
+  order = [];
+  vi.mocked(reconcileSession)
+    .mockReset()
+    .mockImplementation(async (id: string) => {
+      order.push(`session:${id}`);
+    });
+  vi.mocked(ensureEgressNetwork)
+    .mockReset()
+    .mockImplementation(() => {
+      order.push('egress');
+      return true;
+    });
+  vi.mocked(sweepAwaitingReasonRejects)
+    .mockReset()
+    .mockImplementation(async () => {
+      order.push('approvals');
+    });
+  vi.mocked(getActiveSessions)
+    .mockReset()
+    .mockResolvedValue([{ id: 's-1' }, { id: 's-2' }] as Awaited<ReturnType<typeof getActiveSessions>>);
+
+  sweepCallbacks.length = 0;
+  setTimeoutSpy = vi.spyOn(global, 'setTimeout').mockImplementation(((fn: () => void, ms?: number) => {
+    if (ms === SWEEP_INTERVAL_MS) {
+      sweepCallbacks.push(fn);
+      return 0 as unknown as NodeJS.Timeout;
+    }
+    return realSetTimeout(fn, ms);
+  }) as typeof setTimeout);
+});
+
+afterEach(() => {
+  stopHostSweep();
+  setTimeoutSpy.mockRestore();
+});
+
+describe('sweep over the workqueue', () => {
+  it('reconciles each active session exactly once per tick, in order, then re-arms', async () => {
+    await runSweepTick();
+
+    expect(reconcileSession).toHaveBeenCalledTimes(2);
+    expect(order).toEqual(['egress', 'session:s-1', 'session:s-2', 'approvals']);
+
+    await runSweepTick();
+    expect(reconcileSession).toHaveBeenCalledTimes(4);
+  });
+
+  it('a session listing failure still runs the singleton duties and re-arms', async () => {
+    vi.mocked(getActiveSessions).mockRejectedValueOnce(new Error('db down'));
+    await runSweepTick();
+
+    expect(reconcileSession).not.toHaveBeenCalled();
+    expect(ensureEgressNetwork).toHaveBeenCalledTimes(1);
+    expect(sweepAwaitingReasonRejects).toHaveBeenCalledTimes(1);
+
+    // Next tick recovers.
+    await runSweepTick();
+    expect(reconcileSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('a throwing per-session reconcile does not block the rest of the tick', async () => {
+    vi.mocked(reconcileSession).mockImplementation(async (id: string) => {
+      if (id === 's-1') throw new Error('boom');
+      order.push(`session:${id}`);
+    });
+
+    await runSweepTick();
+    // s-2 and the closing singleton still ran; the tick completed and re-armed.
+    expect(order).toEqual(['egress', 'session:s-2', 'approvals']);
+  });
+});

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -1,17 +1,21 @@
 /**
- * Host sweep — the periodic tick over all session mailboxes.
+ * Host sweep — the periodic resync over all session mailboxes.
  *
  * The per-session body lives in src/reconcile-session.ts (`reconcileSession`,
- * the ReconcileFn shape from src/reconcile.ts); this module owns only the
- * loop: the 60s cadence, the active-session iteration, and the once-per-tick
- * duties that aren't per-session (egress re-heal, the reject-with-reason
- * finalizer). The re-exports below keep the long-standing import surface of
- * this module stable.
+ * the ReconcileFn shape from src/reconcile.ts); execution runs through the
+ * keyed workqueue (src/reconcile-queue.ts). This module owns the resync
+ * floor: every 60s it enqueues the singleton duties and every active
+ * session, then re-arms once the tick's work has drained — so queue loss
+ * costs latency, never correctness, and an explicit enqueue between ticks
+ * can never be lost to a concurrent sweep. The re-exports below keep the
+ * long-standing import surface of this module stable.
  */
 import { ensureEgressNetwork } from './egress-lockdown.js';
 import { getActiveSessions } from './db/sessions.js';
 import { log } from './log.js';
+import { createReconcileQueue, type InProcessReconcileQueue } from './reconcile-queue.js';
 import { reconcileSession } from './reconcile-session.js';
+import { sessionKey } from './reconcile.js';
 
 export {
   ABSOLUTE_CEILING_MS,
@@ -25,50 +29,73 @@ export {
 const SWEEP_INTERVAL_MS = 60_000;
 
 let running = false;
+let queue: InProcessReconcileQueue | null = null;
 
 export function startHostSweep(): void {
   if (running) return;
   running = true;
+  queue = createReconcileQueue({
+    reconcile: reconcileSession,
+    singletons: {
+      // Re-heal the egress network so already-running agents keep their
+      // gateway hop if it was detached out-of-band. Best-effort: a heal
+      // failure isn't a leak (agents stay on the internal net), so log and
+      // continue — never surface a throw into queue backoff. No-op when
+      // lockdown is disabled.
+      'singleton:egress-reheal': async () => {
+        try {
+          ensureEgressNetwork();
+        } catch (err) {
+          log.error('Egress lockdown re-heal failed', { err });
+        }
+      },
+      // Finalize any "Reject with reason…" holds whose reply window elapsed
+      // (admin ghosted, or the host restarted mid-capture). Central-DB scan,
+      // once per tick — not per session.
+      // MODULE-HOOK:approvals-reason-sweep:start
+      'singleton:approvals-scan': async () => {
+        try {
+          const { sweepAwaitingReasonRejects } = await import('./modules/approvals/index.js');
+          await sweepAwaitingReasonRejects();
+        } catch (err) {
+          log.error('Reject-with-reason sweep failed', { err });
+        }
+      },
+      // MODULE-HOOK:approvals-reason-sweep:end
+    },
+  });
   void sweep();
 }
 
 export function stopHostSweep(): void {
   running = false;
+  const stopping = queue;
+  queue = null;
+  if (stopping) void stopping.shutdown();
 }
 
 async function sweep(): Promise<void> {
-  if (!running) return;
+  // Capture the queue for the whole tick: stopHostSweep nulls the module
+  // reference mid-flight, and a stopping queue drops adds harmlessly.
+  const tickQueue = queue;
+  if (!running || !tickQueue) return;
 
-  // Re-heal the egress network so already-running agents keep their gateway hop
-  // if it was detached out-of-band. Best-effort here: a heal failure isn't a
-  // leak (agents stay on the internal net), so log and continue. No-op when
-  // lockdown is disabled.
-  try {
-    ensureEgressNetwork();
-  } catch (err) {
-    log.error('Egress lockdown re-heal failed', { err });
-  }
-
+  // Tick order matches the loop this replaces: egress re-heal, then every
+  // active session, then the approvals scan — serial through the queue.
+  tickQueue.add('singleton:egress-reheal');
   try {
     const sessions = await getActiveSessions();
     for (const session of sessions) {
-      await reconcileSession(session.id);
+      tickQueue.add(sessionKey(session.id));
     }
   } catch (err) {
     log.error('Host sweep error', { err });
   }
+  tickQueue.add('singleton:approvals-scan');
 
-  // Finalize any "Reject with reason…" holds whose reply window elapsed (admin
-  // ghosted, or the host restarted mid-capture). Central-DB scan, once per tick
-  // — not per session.
-  // MODULE-HOOK:approvals-reason-sweep:start
-  try {
-    const { sweepAwaitingReasonRejects } = await import('./modules/approvals/index.js');
-    await sweepAwaitingReasonRejects();
-  } catch (err) {
-    log.error('Reject-with-reason sweep failed', { err });
-  }
-  // MODULE-HOOK:approvals-reason-sweep:end
-
+  // The tick ends — and the next one is armed — only after everything this
+  // tick enqueued has run. Delayed backoff retries don't hold the tick open.
+  await tickQueue.idle();
+  if (!running) return;
   setTimeout(() => void sweep(), SWEEP_INTERVAL_MS);
 }

--- a/src/reconcile-queue.test.ts
+++ b/src/reconcile-queue.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createReconcileQueue } from './reconcile-queue.js';
+import { sessionKey, type SingletonKey } from './reconcile.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void; reject: (err: Error) => void } {
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const noopSingletons: Record<SingletonKey, () => Promise<void>> = {
+  'singleton:egress-reheal': async () => {},
+  'singleton:approvals-scan': async () => {},
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('reconcile queue', () => {
+  it('coalesces adds for a waiting key into one run', async () => {
+    const runs: string[] = [];
+    const gate = deferred();
+    const queue = createReconcileQueue({
+      reconcile: async (id) => {
+        runs.push(id);
+        if (runs.length === 1) await gate.promise; // hold the first run so later adds land while s-2 waits
+      },
+      singletons: noopSingletons,
+    });
+
+    queue.add(sessionKey('s-1'));
+    queue.add(sessionKey('s-2'));
+    queue.add(sessionKey('s-2'));
+    queue.add(sessionKey('s-2'));
+    gate.resolve();
+    await queue.idle();
+
+    expect(runs).toEqual(['s-1', 's-2']);
+  });
+
+  it('re-runs a key that was re-added while it was running', async () => {
+    const runs: string[] = [];
+    const firstRun = deferred();
+    const queue: ReturnType<typeof createReconcileQueue> = createReconcileQueue({
+      reconcile: async (id) => {
+        runs.push(id);
+        if (runs.length === 1) {
+          queue.add(sessionKey('s-1')); // state changed mid-reconcile
+          firstRun.resolve();
+        }
+      },
+      singletons: noopSingletons,
+    });
+
+    queue.add(sessionKey('s-1'));
+    await firstRun.promise;
+    await queue.idle();
+
+    expect(runs).toEqual(['s-1', 's-1']);
+  });
+
+  it('addAfter keeps the earliest due time and is superseded by add', async () => {
+    const runs: string[] = [];
+    const queue = createReconcileQueue({
+      reconcile: async (id) => {
+        runs.push(id);
+      },
+      singletons: noopSingletons,
+    });
+
+    // Later reschedule must not push the due time back.
+    queue.addAfter(sessionKey('s-1'), 1_000);
+    queue.addAfter(sessionKey('s-1'), 10_000);
+    await vi.advanceTimersByTimeAsync(1_100);
+    await queue.idle();
+    expect(runs).toEqual(['s-1']);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(runs).toEqual(['s-1']); // the 10s schedule was coalesced away
+
+    // A plain add supersedes a pending delay entirely.
+    queue.addAfter(sessionKey('s-2'), 30_000);
+    queue.add(sessionKey('s-2'));
+    await queue.idle();
+    expect(runs).toEqual(['s-1', 's-2']);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runs).toEqual(['s-1', 's-2']);
+  });
+
+  it('backs off a throwing key without holding up others, and recovers', async () => {
+    const attempts: Record<string, number> = { 's-bad': 0, 's-good': 0 };
+    const queue = createReconcileQueue({
+      reconcile: async (id) => {
+        attempts[id]++;
+        if (id === 's-bad' && attempts[id] < 3) throw new Error('transient');
+      },
+      singletons: noopSingletons,
+    });
+
+    queue.add(sessionKey('s-bad'));
+    queue.add(sessionKey('s-good'));
+    await queue.idle();
+    // The failure never blocked the healthy key.
+    expect(attempts['s-good']).toBe(1);
+    expect(attempts['s-bad']).toBe(1);
+
+    // First retry at 5s, second at 10s; the third attempt succeeds.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await queue.idle();
+    expect(attempts['s-bad']).toBe(2);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await queue.idle();
+    expect(attempts['s-bad']).toBe(3);
+
+    // Recovered: no further retries pending.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(attempts['s-bad']).toBe(3);
+  });
+
+  it('runs keys serially at the default concurrency', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const queue = createReconcileQueue({
+      reconcile: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve();
+        inFlight--;
+      },
+      singletons: noopSingletons,
+    });
+
+    for (const id of ['a', 'b', 'c', 'd']) queue.add(sessionKey(id));
+    await queue.idle();
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('shutdown lets the in-flight run finish and drops everything pending', async () => {
+    const runs: string[] = [];
+    const gate = deferred();
+    const queue = createReconcileQueue({
+      reconcile: async (id) => {
+        runs.push(id);
+        if (id === 'slow') await gate.promise;
+      },
+      singletons: noopSingletons,
+    });
+
+    queue.add(sessionKey('slow'));
+    queue.add(sessionKey('pending'));
+    queue.addAfter(sessionKey('delayed'), 5_000);
+
+    const done = queue.shutdown();
+    gate.resolve();
+    await done;
+
+    expect(runs).toEqual(['slow']);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runs).toEqual(['slow']); // pending dropped, delayed timer cleared
+    queue.add(sessionKey('late'));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(runs).toEqual(['slow']); // adds after shutdown are inert
+  });
+
+  it('routes singleton keys to their handlers', async () => {
+    const calls: string[] = [];
+    const queue = createReconcileQueue({
+      reconcile: async () => {
+        calls.push('session');
+      },
+      singletons: {
+        'singleton:egress-reheal': async () => {
+          calls.push('egress');
+        },
+        'singleton:approvals-scan': async () => {
+          calls.push('approvals');
+        },
+      },
+    });
+
+    queue.add('singleton:egress-reheal');
+    queue.add(sessionKey('s-1'));
+    queue.add('singleton:approvals-scan');
+    await queue.idle();
+    expect(calls).toEqual(['egress', 'session', 'approvals']);
+  });
+});

--- a/src/reconcile-queue.ts
+++ b/src/reconcile-queue.ts
@@ -1,0 +1,166 @@
+/**
+ * In-process keyed workqueue for per-session reconciliation — the runtime
+ * behind the `ReconcileQueue` contract in src/reconcile.ts.
+ *
+ * Semantics (the contract, made concrete):
+ * - Level-triggered coalescing: an add for a key already waiting is a no-op;
+ *   an add for a key currently running marks it dirty so it runs once more
+ *   after — a change racing an in-flight reconcile is never lost until the
+ *   resync floor.
+ * - `addAfter` keeps the earliest due time per key and is superseded by a
+ *   plain `add`.
+ * - A thrown reconcile backs off per key (5s doubling, capped) without ever
+ *   holding up other keys. The cap stays under the sweep's resync interval —
+ *   past that point the resync re-add would fire first anyway.
+ * - Execution is serial by default (`concurrency: 1`) — the same profile as
+ *   the sweep loop this queue replaces. The knob exists so raising it later
+ *   is a config change, not a rewrite.
+ *
+ * `idle()` (beyond the contract) resolves when nothing is running and nothing
+ * is immediately ready; delayed retries don't count. The sweep uses it to end
+ * a tick only after the tick's work is done.
+ */
+import { log } from './log.js';
+import { sessionIdOf, type ReconcileFn, type ReconcileKey, type ReconcileQueue, type SingletonKey } from './reconcile.js';
+
+const INITIAL_BACKOFF_MS = 5_000;
+// Bounded under the 60s resync floor: a longer backoff would always be beaten
+// by the next tick's re-add, so it would only misreport the retry cadence.
+const MAX_BACKOFF_MS = 30_000;
+
+export interface ReconcileQueueOptions {
+  reconcile: ReconcileFn;
+  singletons: Record<SingletonKey, () => Promise<void>>;
+  /** Parallel reconciles. Default 1 — the serial profile of the sweep loop. */
+  concurrency?: number;
+}
+
+interface Delayed {
+  timer: NodeJS.Timeout;
+  dueAt: number;
+}
+
+class InProcessReconcileQueue implements ReconcileQueue {
+  private readonly reconcile: ReconcileFn;
+  private readonly singletons: Record<SingletonKey, () => Promise<void>>;
+  private readonly concurrency: number;
+
+  private readonly ready: ReconcileKey[] = [];
+  private readonly readySet = new Set<ReconcileKey>();
+  private readonly runningKeys = new Set<ReconcileKey>();
+  private readonly dirty = new Set<ReconcileKey>();
+  private readonly delayed = new Map<ReconcileKey, Delayed>();
+  private readonly failures = new Map<ReconcileKey, number>();
+  private active = 0;
+  private stopped = false;
+  private idleWaiters: Array<() => void> = [];
+
+  constructor(options: ReconcileQueueOptions) {
+    this.reconcile = options.reconcile;
+    this.singletons = options.singletons;
+    this.concurrency = options.concurrency ?? 1;
+  }
+
+  add(key: ReconcileKey): void {
+    if (this.stopped) return;
+    if (this.readySet.has(key)) return;
+    if (this.runningKeys.has(key)) {
+      this.dirty.add(key);
+      return;
+    }
+    // Running now supersedes a scheduled retry.
+    const pending = this.delayed.get(key);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.delayed.delete(key);
+    }
+    this.readySet.add(key);
+    this.ready.push(key);
+    this.pump();
+  }
+
+  addAfter(key: ReconcileKey, delayMs: number): void {
+    if (this.stopped) return;
+    if (this.readySet.has(key)) return; // already due sooner
+    const dueAt = Date.now() + delayMs;
+    const existing = this.delayed.get(key);
+    if (existing) {
+      if (existing.dueAt <= dueAt) return; // earliest due time wins
+      clearTimeout(existing.timer);
+    }
+    const timer = setTimeout(() => {
+      this.delayed.delete(key);
+      this.add(key);
+    }, delayMs);
+    this.delayed.set(key, { timer, dueAt });
+  }
+
+  /** Resolves when nothing is running or immediately ready. Delayed retries don't count. */
+  idle(): Promise<void> {
+    if (this.isIdle()) return Promise.resolve();
+    return new Promise((resolve) => this.idleWaiters.push(resolve));
+  }
+
+  async shutdown(): Promise<void> {
+    this.stopped = true;
+    for (const pending of this.delayed.values()) clearTimeout(pending.timer);
+    this.delayed.clear();
+    this.ready.length = 0;
+    this.readySet.clear();
+    this.dirty.clear();
+    await this.idle();
+  }
+
+  private isIdle(): boolean {
+    return this.active === 0 && this.ready.length === 0;
+  }
+
+  private pump(): void {
+    while (this.active < this.concurrency && this.ready.length > 0) {
+      const key = this.ready.shift() as ReconcileKey;
+      this.readySet.delete(key);
+      this.active++;
+      this.runningKeys.add(key);
+      void this.run(key);
+    }
+  }
+
+  private async run(key: ReconcileKey): Promise<void> {
+    let retryInMs = 0;
+    try {
+      await this.dispatch(key);
+      this.failures.delete(key);
+    } catch (err) {
+      const attempt = (this.failures.get(key) ?? 0) + 1;
+      this.failures.set(key, attempt);
+      retryInMs = Math.min(INITIAL_BACKOFF_MS * 2 ** (attempt - 1), MAX_BACKOFF_MS);
+      log.error('Reconcile failed — retrying with backoff', { key, attempt, retryInMs, err });
+    } finally {
+      this.runningKeys.delete(key);
+      this.active--;
+      // A dirty re-add signals fresh state — run again now, superseding backoff.
+      if (this.dirty.delete(key)) this.add(key);
+      else if (retryInMs > 0) this.addAfter(key, retryInMs);
+      this.pump();
+      if (this.isIdle()) {
+        const waiters = this.idleWaiters;
+        this.idleWaiters = [];
+        for (const resolve of waiters) resolve();
+      }
+    }
+  }
+
+  private dispatch(key: ReconcileKey): Promise<void> {
+    const sessionId = sessionIdOf(key);
+    if (sessionId !== null) return this.reconcile(sessionId);
+    const handler = this.singletons[key as SingletonKey];
+    if (!handler) return Promise.reject(new Error(`no handler registered for queue key '${key}'`));
+    return handler();
+  }
+}
+
+export function createReconcileQueue(options: ReconcileQueueOptions): InProcessReconcileQueue {
+  return new InProcessReconcileQueue(options);
+}
+
+export type { InProcessReconcileQueue };


### PR DESCRIPTION
Stacked on #3515 (chain: #3508 → #3514 → #3515 → this).

The 60s sweep becomes a resync floor over a keyed workqueue (`src/reconcile-queue.ts`, implementing the frozen contract from #3508): per-key coalescing with a dirty set (a change racing an in-flight reconcile is never lost), `addAfter` with earliest-due-wins, per-key backoff (5s→30s, deliberately under the resync floor), serial execution (concurrency knob defaulted to today's profile), clean shutdown. Each tick enqueues the singleton duties and every active session, then re-arms only after the queue drains — one reschedule per tick, fired after all tick work, exactly as the grace test pins.

Net behavior is equivalent; what changes is capability: an explicit enqueue between ticks can never be lost to a concurrent sweep, and queue loss costs latency, never correctness.

## Test plan
Zero existing-test edits (`host-sweep.ts` is the only modified existing file; all sweep suites pass unchanged). 7 new queue cases + 3 integration cases; 75 tests re-verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)