### PR TITLE
feat(db): shadow-write coordination state alongside the in-memory maps

### DIFF
--- a/src/container-restart-shadow.test.ts
+++ b/src/container-restart-shadow.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Restart shadow writes: a kill with a planned respawn records a durable
+ * `respawn_after_stop` intent before the kill and clears it once the respawn
+ * request has been made. The on_wake mechanism stays authoritative.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const killContainer = vi.fn();
+vi.mock('./container-runner.js', () => ({
+  isContainerRunning: vi.fn().mockReturnValue(true),
+  killContainer: (sessionId: string, reason: string, onExit?: () => void) => killContainer(sessionId, reason, onExit),
+}));
+
+const requestWake = vi.fn().mockResolvedValue(true);
+vi.mock('./request-wake.js', () => ({
+  requestWake: (session: unknown, reason: string) => requestWake(session, reason),
+}));
+
+vi.mock('./session-manager.js', () => ({
+  writeSessionMessage: vi.fn().mockResolvedValue(undefined),
+  withExistingMailboxSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { restartAgentGroupContainers } from './container-restart.js';
+import { getSessionClaim } from './db/coordination.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createSession } from './db/index.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+beforeEach(async () => {
+  killContainer.mockClear();
+  requestWake.mockClear();
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  await createSession({
+    id: 'sess-1',
+    agent_group_id: 'ag-1',
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: now(),
+    created_at: now(),
+  });
+});
+
+afterEach(async () => {
+  await closeDb();
+});
+
+describe('restart respawn intent', () => {
+  it('writes respawn_after_stop before the kill and clears it after the respawn request', async () => {
+    const restarted = await restartAgentGroupContainers('ag-1', 'test-restart', 'back online');
+    expect(restarted).toBe(1);
+
+    // The kill has happened but the (captured) exit callback has not fired:
+    // the durable intent must already be in place.
+    expect((await getSessionClaim('sess-1'))?.stop_intent).toBe('respawn_after_stop');
+    const [sessionId, , onExit] = killContainer.mock.calls[0] as [string, string, () => void];
+    expect(sessionId).toBe('sess-1');
+    expect(onExit).toBeTypeOf('function');
+
+    onExit();
+    await vi.waitFor(async () => {
+      expect(requestWake).toHaveBeenCalledWith(expect.objectContaining({ id: 'sess-1' }), 'container-restart');
+      expect((await getSessionClaim('sess-1'))?.stop_intent).toBeNull();
+    });
+  });
+
+  it('writes no intent when no respawn is planned', async () => {
+    const restarted = await restartAgentGroupContainers('ag-1', 'plain-stop');
+    expect(restarted).toBe(1);
+    expect(await getSessionClaim('sess-1')).toBeUndefined();
+    const [, , onExit] = killContainer.mock.calls[0] as [string, string, (() => void) | undefined];
+    expect(onExit).toBeUndefined();
+  });
+});

--- a/src/container-restart.ts
+++ b/src/container-restart.ts
@@ -6,6 +6,7 @@
  */
 import { isContainerRunning, killContainer } from './container-runner.js';
 import { requestWake } from './request-wake.js';
+import { setStopIntent, shadowWrite } from './db/coordination.js';
 import { getSession, getSessionsByAgentGroup } from './db/sessions.js';
 import { log } from './log.js';
 import { withExistingMailboxSession, writeSessionMessage } from './session-manager.js';
@@ -55,14 +56,21 @@ export async function restartAgentGroupContainers(
         session.id,
         (mailbox) => mailbox.countDueMessages() > 0,
       )) ?? false;
+    const willRespawn = Boolean(wakeMessage || hasPending);
+    // Shadow the respawn plan durably before the kill; the on_wake mechanism
+    // stays authoritative. Cleared once the respawn request has been made.
+    if (willRespawn) {
+      await shadowWrite('stop-intent', () => setStopIntent(session.id, 'respawn_after_stop', new Date().toISOString()));
+    }
     killContainer(
       session.id,
       reason,
-      wakeMessage || hasPending
+      willRespawn
         ? () => {
             void (async () => {
               const s = await getSession(session.id);
               if (s) await requestWake(s, 'container-restart');
+              await shadowWrite('stop-intent-clear', () => setStopIntent(session.id, null, new Date().toISOString()));
             })();
           }
         : undefined,

--- a/src/container-runner.claims.test.ts
+++ b/src/container-runner.claims.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Session-claim shadow writes through the real lifecycle: adoption claims a
+ * session (incarnation bump + CAS), finalization releases the claim. The
+ * in-memory registry stays authoritative throughout.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { SupervisedHandle, SupervisedSnapshot } from './drivers/session-events.js';
+
+const snapshots: SupervisedSnapshot[] = [];
+vi.mock('./drivers/index.js', () => ({
+  getSessionDriver: () => ({
+    listSessions: async () => snapshots,
+    capabilities: () => ({}),
+  }),
+  isSessionEventsDriver: () => false,
+}));
+
+import { adoptRunningSessions, isContainerRunning, killContainer } from './container-runner.js';
+import { getSessionClaim } from './db/coordination.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createSession } from './db/index.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function fakeHandle(sessionId: string, name: string): SupervisedHandle {
+  const terminalCallbacks: Array<(failure?: unknown) => void> = [];
+  return {
+    key: { installSlug: 'test-install', agentGroupId: 'ag-1', sessionId },
+    name,
+    async start() {},
+    async stop() {
+      for (const callback of terminalCallbacks) callback(undefined);
+    },
+    async status() {
+      return { phase: 'running' };
+    },
+    onTerminal(callback: (failure?: unknown) => void) {
+      terminalCallbacks.push(callback);
+    },
+  } as unknown as SupervisedHandle;
+}
+
+beforeEach(async () => {
+  snapshots.length = 0;
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  await createSession({
+    id: 'sess-1',
+    agent_group_id: 'ag-1',
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: now(),
+    created_at: now(),
+  });
+});
+
+afterEach(async () => {
+  // Drain any runtime left registered so cross-test state cannot leak.
+  if (isContainerRunning('sess-1')) {
+    killContainer('sess-1', 'test-teardown');
+    await vi.waitFor(() => expect(isContainerRunning('sess-1')).toBe(false));
+  }
+  await closeDb();
+});
+
+describe('session claim lifecycle', () => {
+  it('adoption shadow-claims the session and finalization releases it', async () => {
+    snapshots.push({ handle: fakeHandle('sess-1', 'container-a'), phase: 'running' } as SupervisedSnapshot);
+    const { adopted } = await adoptRunningSessions();
+    expect(adopted).toBe(1);
+
+    const claim = await getSessionClaim('sess-1');
+    expect(claim?.incarnation).toBe(1);
+    expect(claim?.claimed_by).toMatch(/:\d+$/);
+    expect(claim?.container_ref).toBe('container-a');
+
+    killContainer('sess-1', 'test-stop');
+    await vi.waitFor(async () => {
+      const released = await getSessionClaim('sess-1');
+      expect(released?.claimed_by).toBeNull();
+      expect(released?.incarnation).toBe(1);
+    });
+  });
+
+  it('a re-adopted session bumps the incarnation via CAS', async () => {
+    snapshots.push({ handle: fakeHandle('sess-1', 'container-a'), phase: 'running' } as SupervisedSnapshot);
+    await adoptRunningSessions();
+    killContainer('sess-1', 'test-stop');
+    await vi.waitFor(async () => expect((await getSessionClaim('sess-1'))?.claimed_by).toBeNull());
+
+    snapshots.length = 0;
+    snapshots.push({ handle: fakeHandle('sess-1', 'container-b'), phase: 'running' } as SupervisedSnapshot);
+    await adoptRunningSessions();
+    const claim = await getSessionClaim('sess-1');
+    expect(claim?.incarnation).toBe(2);
+    expect(claim?.container_ref).toBe('container-b');
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -9,6 +9,7 @@
  */
 import { exec } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
 
@@ -29,6 +30,7 @@ import { updateContainerConfigScalars } from './db/container-configs.js';
 import { CONTAINER_RUNTIME_BIN } from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
+import { getSessionClaim, releaseSessionClaim, shadowWrite, tryClaimSession } from './db/coordination.js';
 import { getDb, hasTable } from './db/connection.js';
 import { getSession } from './db/sessions.js';
 import { getSessionDriver, isSessionEventsDriver } from './drivers/index.js';
@@ -97,9 +99,39 @@ interface ActiveSessionRuntime {
   finishedPromise: Promise<void>;
   resolveFinished: () => void;
   stopReason?: string;
+  /** Incarnation this process shadow-claimed in session_claims, if the write landed. */
+  claimIncarnation?: number;
 }
 
 const activeContainers = new Map<string, ActiveSessionRuntime>();
+
+// Claimant identity for the shadow rows in session_claims. Process-scoped and
+// human-readable; the durable host-instance lease id takes over as claimant
+// when the rows become authoritative.
+const CLAIMANT_ID = `${os.hostname()}:${process.pid}`;
+
+/**
+ * Shadow-claim a session this process now runs (spawned or adopted). The
+ * in-memory registry stays authoritative — a lost CAS or failed write logs
+ * and changes nothing.
+ */
+async function shadowClaimSession(sessionId: string, runtime: ActiveSessionRuntime): Promise<void> {
+  await shadowWrite('session-claim', async () => {
+    const current = await getSessionClaim(sessionId);
+    const incarnation = await tryClaimSession({
+      sessionId,
+      instanceId: CLAIMANT_ID,
+      expectedIncarnation: current?.incarnation ?? 0,
+      containerRef: runtime.containerName,
+      now: new Date().toISOString(),
+    });
+    if (incarnation === null) {
+      log.warn('Session shadow claim lost the incarnation race', { sessionId, claimant: CLAIMANT_ID });
+      return;
+    }
+    runtime.claimIncarnation = incarnation;
+  });
+}
 
 /**
  * In-flight wake promises, keyed by session id. Deduplicates concurrent
@@ -253,6 +285,8 @@ async function spawnContainer(session: Session): Promise<void> {
     }
     throw err;
   }
+
+  await shadowClaimSession(session.id, runtime);
 }
 
 /**
@@ -336,6 +370,17 @@ async function finish(sessionId: string, runtime: ActiveSessionRuntime, failure?
   if (activeContainers.get(sessionId) === runtime) {
     activeContainers.delete(sessionId);
   }
+  if (runtime.claimIncarnation !== undefined) {
+    const incarnation = runtime.claimIncarnation;
+    await shadowWrite('session-claim-release', () =>
+      releaseSessionClaim({
+        sessionId,
+        instanceId: CLAIMANT_ID,
+        incarnation,
+        now: new Date().toISOString(),
+      }),
+    );
+  }
   for (const callback of runtime.exitCallbacks) {
     try {
       callback();
@@ -408,6 +453,7 @@ export async function adoptRunningSessions(): Promise<{ adopted: number; stopped
       void finishAndResolve(session.id, failure);
     });
     await markContainerRunning(session.id);
+    await shadowClaimSession(session.id, runtime);
     adopted += 1;
   }
 

--- a/src/db/coordination.ts
+++ b/src/db/coordination.ts
@@ -13,6 +13,21 @@
 import { randomUUID } from 'crypto';
 
 import { getDb } from './connection.js';
+import { log } from '../log.js';
+
+/**
+ * Run a shadow write. Failures log and are swallowed — shadow state must
+ * never affect the authoritative path, so no caller may see a throw.
+ */
+export async function shadowWrite(label: string, write: () => Promise<unknown>): Promise<void> {
+  /* eslint-disable no-catch-all/no-catch-all -- shadow writes must never affect the authoritative path */
+  try {
+    await write();
+  } catch (err) {
+    log.warn('Coordination shadow write failed', { label, err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}
 
 export interface HostInstanceRow {
   instance_id: string;

--- a/src/delivery-shadow.test.ts
+++ b/src/delivery-shadow.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Delivery shadow writes: the in-memory attempt map stays authoritative, and
+ * every transition it makes is mirrored into `delivery_attempts` rows.
+ */
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-delivery-shadow',
+    GROUPS_DIR: '/tmp/nanoclaw-test-delivery-shadow/groups',
+  };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-delivery-shadow';
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createMessagingGroup } from './db/index.js';
+import { getDeliveryAttempt } from './db/coordination.js';
+import { outboundDbPath } from './mailbox/sqlite/paths.js';
+import { resolveSession } from './session-manager.js';
+import { deliverSessionMessages, setDeliveryAdapter } from './delivery.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+async function seedAgentAndChannel(): Promise<void> {
+  await createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  await createMessagingGroup({
+    id: 'mg-1',
+    channel_type: 'telegram',
+    platform_id: 'telegram:123',
+    name: 'Test Chat',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+}
+
+function insertOutbound(agentGroupId: string, sessionId: string, msgId: string): void {
+  const db = new Database(outboundDbPath(agentGroupId, sessionId));
+  db.prepare(
+    `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+     VALUES (?, datetime('now'), 'chat', 'telegram:123', 'telegram', ?)`,
+  ).run(msgId, JSON.stringify({ text: 'hello' }));
+  db.close();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = await initTestDb();
+  await runMigrations(db);
+});
+
+afterEach(async () => {
+  await closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('delivery attempt shadow rows', () => {
+  it('records attempts with the error, and clears on eventual success', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'out-1');
+
+    let failuresLeft = 1;
+    setDeliveryAdapter({
+      async deliver() {
+        if (failuresLeft > 0) {
+          failuresLeft -= 1;
+          throw new Error('channel offline');
+        }
+        return 'plat-msg-1';
+      },
+    });
+
+    await deliverSessionMessages(session);
+    const afterFailure = await getDeliveryAttempt('out-1');
+    expect(afterFailure?.attempts).toBe(1);
+    expect(afterFailure?.session_id).toBe(session.id);
+    expect(afterFailure?.last_error).toContain('channel offline');
+
+    await deliverSessionMessages(session);
+    expect(await getDeliveryAttempt('out-1')).toBeUndefined();
+  });
+
+  it('clears the row when delivery gives up permanently', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'out-poison');
+
+    setDeliveryAdapter({
+      async deliver() {
+        throw new Error('always fails');
+      },
+    });
+
+    // MAX_DELIVERY_ATTEMPTS is 3: two failures leave the row counting…
+    await deliverSessionMessages(session);
+    await deliverSessionMessages(session);
+    expect((await getDeliveryAttempt('out-poison'))?.attempts).toBe(2);
+
+    // …the third marks the message failed mailbox-side and clears the row —
+    // the attempt bookkeeping's job is done.
+    await deliverSessionMessages(session);
+    expect(await getDeliveryAttempt('out-poison')).toBeUndefined();
+  });
+
+  it('never writes a row for a first-time success', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'out-clean');
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'plat-msg-2';
+      },
+    });
+
+    await deliverSessionMessages(session);
+    expect(await getDeliveryAttempt('out-clean')).toBeUndefined();
+  });
+});

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -18,6 +18,7 @@ import {
   getMessagingGroupByPlatform,
   getMessagingGroupForOwnDestination,
 } from './db/messaging-groups.js';
+import { clearDeliveryAttempt, recordDeliveryAttempt, shadowWrite } from './db/coordination.js';
 import { runGuarded, type DeliveryGuardSpec, type GuardedDeliveryHandler } from './delivery-guard.js';
 import { isUnguarded, type Unguarded } from './guard/index.js';
 import { fanOutboundMessage } from './modules/cross-session-context/index.js';
@@ -224,6 +225,7 @@ async function drainSession(session: Session): Promise<void> {
       const firstDelivery = delivered.size === 0;
       delivered.add(msg.id);
       deliveryAttempts.delete(msg.id);
+      await shadowWrite('delivery-attempt-clear', () => clearDeliveryAttempt(msg.id));
       if (msg.kind !== 'system' && msg.channelType !== 'agent') {
         pauseTypingRefreshAfterDelivery(session.id);
         if (msg.kind !== 'task_log') {
@@ -250,6 +252,17 @@ async function drainSession(session: Session): Promise<void> {
     } catch (err) {
       const attempts = (deliveryAttempts.get(msg.id) ?? 0) + 1;
       deliveryAttempts.set(msg.id, attempts);
+      // Shadow row mirrors the in-memory count; the map stays authoritative
+      // (no real backoff schedule exists in this path — retry is the next poll).
+      await shadowWrite('delivery-attempt', () =>
+        recordDeliveryAttempt({
+          messageId: msg.id,
+          sessionId: session.id,
+          now: new Date().toISOString(),
+          nextAttemptAt: null,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
       if (attempts >= MAX_DELIVERY_ATTEMPTS) {
         log.error('Message delivery failed permanently, giving up', {
           messageId: msg.id,
@@ -260,6 +273,7 @@ async function drainSession(session: Session): Promise<void> {
         try {
           await withExistingMailboxSession(agentGroup.id, session.id, (mailbox) => mailbox.markDeliveryFailed(msg.id));
           deliveryAttempts.delete(msg.id);
+          await shadowWrite('delivery-attempt-clear', () => clearDeliveryAttempt(msg.id));
         } catch (markErr) {
           log.error('Failed to record permanent delivery failure', {
             messageId: msg.id,

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -20,6 +20,7 @@ import {
 import { buildAgentGroupImage, killContainer } from '../../container-runner.js';
 import { requestWake } from '../../request-wake.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
+import { setStopIntent, shadowWrite } from '../../db/coordination.js';
 import { getContainerConfig, updateContainerConfigJson } from '../../db/container-configs.js';
 import { getSession } from '../../db/sessions.js';
 import { log } from '../../log.js';
@@ -30,6 +31,12 @@ import { notifyAgent } from '../approvals/index.js';
 async function wakeSessionById(sessionId: string): Promise<void> {
   const session = await getSession(sessionId);
   if (session) await requestWake(session, 'self-mod-apply');
+  await shadowWrite('stop-intent-clear', () => setStopIntent(sessionId, null, new Date().toISOString()));
+}
+
+/** Shadow the respawn plan durably before a kill-with-respawn; on_wake stays authoritative. */
+async function shadowRespawnIntent(sessionId: string): Promise<void> {
+  await shadowWrite('stop-intent', () => setStopIntent(sessionId, 'respawn_after_stop', new Date().toISOString()));
 }
 
 export async function applyInstallPackages(payload: Record<string, unknown>, session: Session): Promise<void> {
@@ -82,6 +89,7 @@ export async function applyInstallPackages(payload: Record<string, unknown>, ses
       }),
       onWake: true,
     });
+    await shadowRespawnIntent(session.id);
     killContainer(session.id, 'rebuild applied', () => {
       void wakeSessionById(session.id);
     });
@@ -155,6 +163,7 @@ export async function applyAddMcpServer(payload: Record<string, unknown>, sessio
     }),
     onWake: true,
   });
+  await shadowRespawnIntent(session.id);
   killContainer(session.id, 'mcp server added', () => {
     void wakeSessionById(session.id);
   });


### PR DESCRIPTION
Stacked on #3515 (chain: #3508 → #3514 → #3515 → this). Sibling of #3516; both retarget when the chain merges.

Every volatile coordination fact now dual-writes into the durable rows from #3508, behind a `shadowWrite` helper that never throws — the in-memory maps remain authoritative and nothing reads the rows to make decisions:

- delivery attempts: recorded with the failure, cleared on success or permanent give-up
- session claims: CAS-claimed on spawn *and* adoption (incarnation fencing), fenced release on finish
- stop/respawn intent: `respawn_after_stop` written before a kill-with-respawn, cleared once the respawn fires (on_wake stays authoritative)

Claimant id is `hostname:pid` for now; the durable host-instance lease id (#3513) takes over as claimant at the authority flip.

## Test plan
3 new test files (delivery attempt lifecycle via the real mailbox harness; restart-intent transitions with a captured onExit; claim lifecycle through real adopt/kill with a fake driver — incarnation bumps across re-adoption). Zero existing-test edits; adjacent suites re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)