### PR TITLE
fix(approvals): survive restarts — row-keyed resolution via the gateway-provider seam

### DIFF
--- a/src/gateway-providers/gateway-provider-registry.ts
+++ b/src/gateway-providers/gateway-provider-registry.ts
@@ -50,6 +50,51 @@ export interface GatewayProviderInput {
   capabilities: DriverCapabilities;
 }
 
+/**
+ * A credentialed request held by the gateway awaiting a human decision, in
+ * provider-neutral vocabulary (the shape every credential-proxy gateway
+ * shares: what is being called, by which agent, until when).
+ */
+export interface GatewayApprovalRequest {
+  /** The gateway's own request id — the dedupe key across reconnects. */
+  id: string;
+  /** ISO-8601: when the gateway gives up waiting for a decision. */
+  expiresAt: string;
+  method: string;
+  host: string;
+  path: string;
+  bodyPreview?: string;
+  /** The requesting agent; `externalId` is the agent group id when set. */
+  agent: { externalId?: string; name: string };
+  /** Optional structured summary (action + labeled fields) for the card. */
+  summary?: { action?: string; details?: { label: string; value: string }[] };
+}
+
+export type GatewayApprovalDecision = 'approve' | 'deny';
+
+export interface GatewayApprovalSubscription {
+  stop(): void;
+}
+
+/**
+ * The manual-approvals capability of a gateway. `subscribe` is the one
+ * required member: the handler is invoked per held request and its resolved
+ * value is the decision. The optional members are capability flags —
+ * implement them only when the gateway genuinely supports the operation:
+ *
+ * - `listPending` — enumerate requests still held gateway-side, for
+ *   reconnect reconciliation. A gateway that does not redeliver un-decided
+ *   requests on reconnect and offers no enumeration omits it.
+ * - `decide` — deliver a decision outside the subscribe callback (a late
+ *   decision for a request whose original callback did not survive a
+ *   restart). Returns false when the gateway no longer holds the request.
+ */
+export interface GatewayApprovalSource {
+  subscribe(handler: (request: GatewayApprovalRequest) => Promise<GatewayApprovalDecision>): GatewayApprovalSubscription;
+  listPending?(): Promise<GatewayApprovalRequest[]>;
+  decide?(requestId: string, decision: GatewayApprovalDecision): Promise<boolean>;
+}
+
 export interface GatewayProvider {
   /** Identity, for logs and selection — never a branch above the seam. */
   readonly kind: string;
@@ -60,6 +105,12 @@ export interface GatewayProvider {
    * credentials, and it must not launch.
    */
   contribute(input: GatewayProviderInput): Promise<GatewayContribution>;
+  /**
+   * Manual-approvals capability. Absent when the gateway has no held-request
+   * approval flow; the approvals module consumes this seam and never imports
+   * a gateway SDK directly.
+   */
+  approvals?(): GatewayApprovalSource;
 }
 
 /** Not a union: overlays bring their own kinds (see `DriverKind`). */

--- a/src/gateway-providers/onecli.ts
+++ b/src/gateway-providers/onecli.ts
@@ -21,7 +21,12 @@ import { ONECLI_API_KEY, ONECLI_URL } from '../config.js';
 import type { MountSpec } from '../drivers/types.js';
 import { log } from '../log.js';
 
-import { registerGatewayProvider, type GatewayContribution } from './gateway-provider-registry.js';
+import {
+  registerGatewayProvider,
+  type GatewayApprovalRequest,
+  type GatewayApprovalSource,
+  type GatewayContribution,
+} from './gateway-provider-registry.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
@@ -57,8 +62,29 @@ export function contributionFromArgs(args: readonly string[], groupScope: string
   return { env, mounts };
 }
 
+/**
+ * OneCLI's approvals capability: the SDK's manual-approval long-poll, mapped
+ * to the neutral request shape. `listPending`/`decide` are deliberately
+ * absent — the gateway does not redeliver un-decided requests on reconnect
+ * and the SDK exposes no late-decision surface, so the capability flags
+ * honestly say so and the approvals module degrades accordingly.
+ */
+function onecliApprovalSource(): GatewayApprovalSource {
+  return {
+    subscribe(handler) {
+      const handle = onecli.configureManualApproval(async (request) =>
+        // The SDK's ApprovalRequest is structurally the neutral shape (the
+        // hosted gateway's `summary` rides as an extra field).
+        handler(request as unknown as GatewayApprovalRequest),
+      );
+      return { stop: () => handle.stop() };
+    },
+  };
+}
+
 registerGatewayProvider('onecli', () => ({
   kind: 'onecli',
+  approvals: onecliApprovalSource,
   async contribute({ key, groupName }) {
     // OneCLI agent identifier is always the agent group id — stable across
     // sessions and reversible via getAgentGroup() for approval routing.

--- a/src/modules/approvals/onecli-approvals.ts
+++ b/src/modules/approvals/onecli-approvals.ts
@@ -1,44 +1,53 @@
 /**
- * OneCLI manual-approval handler.
+ * Held-request (credential) approval handler.
  *
- * When the OneCLI gateway intercepts a credentialed request that needs human
- * approval, it holds the HTTP connection open and fires our `configureManualApproval`
- * callback. We:
+ * The gateway holds a credentialed request open awaiting a human decision and
+ * delivers it through the gateway provider's approvals capability
+ * (`GatewayProvider.approvals()` — this module never imports a gateway SDK
+ * directly). Per request we:
  *   1. Deliver an ask_question card to the admin channel (same routing as
- *      `requestApproval()` — global admin agent group's first messaging group).
- *   2. Persist a `pending_approvals` row (action='onecli_credential') so we can
- *      edit the card on expiry and sweep stale rows at startup.
+ *      `requestApproval()`).
+ *   2. Persist a `pending_approvals` row (action='onecli_credential') — the
+ *      durable, restart-surviving record of the decision being awaited.
  *   3. Wait on an in-memory Promise: resolved by the admin click
  *      (`resolveOneCLIApproval`) or by a local expiry timer.
- *   4. On expiry, retain the full card, replace its buttons with a timeout
- *      status, and return 'deny' — the gateway's HTTP side will have already
- *      closed, but we need to release the Promise so the SDK callback returns
- *      cleanly.
  *
- * Startup sweep marks leftover cards as timed out after a host restart and
- * drops the rows.
+ * Restart honesty: resolution is ROW-keyed, not map-keyed, so a card from a
+ * previous process stays clickable. At startup, surviving rows re-arm: still-
+ * open ones stay decidable (a late decision is delivered through the source's
+ * `decide` capability when the gateway supports it, and otherwise the card is
+ * told the truth — the original request died with the restart and the agent
+ * must retry); already-expired ones get an honest timeout edit. A periodic
+ * row-driven sweep expires overdue rows, so expiry survives the process that
+ * armed the timer. A gateway that redelivers a request we already carded is
+ * deduped by request id — never a duplicate card.
  */
-import { OneCLI, type ApprovalRequest, type ManualApprovalHandle } from '@onecli-sh/sdk';
-
 import { pickApprovalDelivery, pickApprover } from './primitive.js';
-import { ONECLI_API_KEY, ONECLI_URL } from '../../config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import {
   createPendingApproval,
   deletePendingApproval,
+  getPendingApproval,
   getPendingApprovalsByAction,
   transitionPendingApprovalStatus,
 } from '../../db/sessions.js';
 import type { ChannelDeliveryAdapter } from '../../delivery.js';
+import {
+  getGatewayProvider,
+  type GatewayApprovalDecision,
+  type GatewayApprovalRequest,
+  type GatewayApprovalSource,
+  type GatewayApprovalSubscription,
+} from '../../gateway-providers/index.js';
 import { log } from '../../log.js';
 import type { PendingApproval } from '../../types.js';
 
 export const ONECLI_ACTION = 'onecli_credential';
 
-type Decision = 'approve' | 'deny';
+type Decision = GatewayApprovalDecision;
 type ExpiryReason = 'no response' | 'host restarted';
 
-const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
+const EXPIRY_SWEEP_MS = 60_000;
 
 interface PendingState {
   resolve: (decision: Decision) => void;
@@ -46,30 +55,38 @@ interface PendingState {
 }
 
 const pending = new Map<string, PendingState>();
-let handle: ManualApprovalHandle | null = null;
+let subscription: GatewayApprovalSubscription | null = null;
+let approvalSource: GatewayApprovalSource | null = null;
+let expirySweep: NodeJS.Timeout | null = null;
 let adapterRef: ChannelDeliveryAdapter | null = null;
+let started = false;
 
 /**
  * Generate a short approval id for card buttons.
  *
- * OneCLI's native request.id is a UUID (36 bytes). When we put it into a card
- * button's action id as `ncq:<uuid>:Approve`, Chat SDK's Telegram adapter then
- * serializes both `id` and `value` into the Telegram `callback_data` field,
- * which has a hard 64-byte limit. UUIDs push past that limit.
+ * The gateway's native request.id is a UUID (36 bytes). When we put it into a
+ * card button's action id as `ncq:<uuid>:Approve`, Chat SDK's Telegram adapter
+ * then serializes both `id` and `value` into the Telegram `callback_data`
+ * field, which has a hard 64-byte limit. UUIDs push past that limit.
  *
  * Instead we generate a 10-byte id (`oa-` + 8 base36 chars) for the card, and
- * keep the OneCLI request.id in the persisted payload for audit. The pending
- * map, DB row, and button callback all use this short id; click handling
- * looks up the short id and resolves the Promise that was waiting on it.
+ * keep the gateway request.id on the row (`request_id`) for audit and
+ * reconnect dedupe. The pending map, DB row, and button callback all use this
+ * short id.
  */
 function shortApprovalId(): string {
   return `oa-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/** Called from the approvals response handler when a card button is clicked. */
+/**
+ * Called from the approvals response handler when a card button is clicked.
+ * Row-keyed: the click works whether or not this process armed the card. A
+ * live request resolves its waiting Promise; a re-armed card from a previous
+ * process takes the late-decision path.
+ */
 export async function resolveOneCLIApproval(approvalId: string, selectedOption: string): Promise<boolean> {
-  const state = pending.get(approvalId);
-  if (!state) return false;
+  const row = await getPendingApproval(approvalId);
+  if (!row || row.action !== ONECLI_ACTION) return false;
 
   const decision: Decision = selectedOption === 'approve' ? 'approve' : 'deny';
   const claimed = await transitionPendingApprovalStatus(
@@ -78,56 +95,137 @@ export async function resolveOneCLIApproval(approvalId: string, selectedOption: 
     decision === 'approve' ? 'approved' : 'rejected',
   );
   if (!claimed) return false;
-  pending.delete(approvalId);
-  clearTimeout(state.timer);
+  const state = pending.get(approvalId);
+  if (state) {
+    pending.delete(approvalId);
+    clearTimeout(state.timer);
+  }
   // Card is auto-edited to "✅ <option>" by chat-sdk-bridge's onAction handler,
-  // so we don't need to deliver an edit here.
+  // so the happy path needs no edit here.
   await deletePendingApproval(approvalId);
 
-  state.resolve(decision);
-  log.info('OneCLI approval resolved', { approvalId, decision });
+  if (state) {
+    state.resolve(decision);
+    log.info('Gateway approval resolved', { approvalId, decision });
+    return true;
+  }
+  await deliverLateDecision(row, decision);
   return true;
 }
 
-export function startOneCLIApprovalHandler(deliveryAdapter: ChannelDeliveryAdapter): void {
-  if (handle) return;
-  adapterRef = deliveryAdapter;
-
-  // Sweep any rows left over from a previous process.
-  sweepStaleApprovals().catch((err) => log.error('OneCLI approval sweep failed', { err }));
-
-  handle = onecli.configureManualApproval(async (request: ApprovalRequest): Promise<Decision> => {
+/**
+ * A decision for a request whose waiting callback died with a previous
+ * process. Deliver it through the gateway when it can accept one; otherwise
+ * an approval must tell the human the truth — the credentialed call is gone
+ * and the agent has to retry it.
+ */
+async function deliverLateDecision(row: PendingApproval, decision: Decision): Promise<void> {
+  let delivered = false;
+  if (approvalSource?.decide && row.request_id) {
     try {
-      return await handleRequest(request);
+      delivered = await approvalSource.decide(row.request_id, decision);
     } catch (err) {
-      log.error('OneCLI approval handler errored', { id: request.id, err });
-      return 'deny';
+      log.warn('Late approval decision not accepted by the gateway', { approvalId: row.approval_id, err });
     }
-  });
-  log.info('OneCLI approval handler started');
+  }
+  if (decision === 'approve' && !delivered) {
+    await editCardResolution(
+      row,
+      '✅ Approved — recorded, but the original request ended when the host restarted. Ask the agent to retry the action.',
+    );
+  }
+  log.info('Gateway approval resolved late', { approvalId: row.approval_id, decision, delivered });
+}
+
+export function startOneCLIApprovalHandler(deliveryAdapter: ChannelDeliveryAdapter): void {
+  if (started) return;
+  started = true;
+  adapterRef = deliveryAdapter;
+  approvalSource = getGatewayProvider().approvals?.() ?? null;
+
+  reattachSurvivingApprovals().catch((err) => log.error('Approval re-attach failed', { err }));
+
+  if (approvalSource) {
+    subscription = approvalSource.subscribe(async (request: GatewayApprovalRequest): Promise<Decision> => {
+      try {
+        return await handleRequest(request);
+      } catch (err) {
+        log.error('Gateway approval handler errored', { id: request.id, err });
+        return 'deny';
+      }
+    });
+    log.info('Gateway approval handler started');
+  } else {
+    log.info('Gateway provider exposes no approvals capability — held-request approvals disabled');
+  }
+
+  // Row-driven expiry: overdue rows expire on the sweep regardless of which
+  // process armed them — a timer that dies with its process is not the record.
+  expirySweep = setInterval(() => {
+    void expireOverdueApprovals();
+  }, EXPIRY_SWEEP_MS);
+  expirySweep.unref?.();
 }
 
 export function stopOneCLIApprovalHandler(): void {
-  handle?.stop();
-  handle = null;
+  subscription?.stop();
+  subscription = null;
+  approvalSource = null;
+  if (expirySweep) {
+    clearInterval(expirySweep);
+    expirySweep = null;
+  }
   for (const state of pending.values()) {
     clearTimeout(state.timer);
   }
   pending.clear();
   adapterRef = null;
+  started = false;
 }
 
-async function handleRequest(request: ApprovalRequest): Promise<Decision> {
+/** Arm the in-memory Promise for a live request, with its pre-TTL expiry timer. */
+function armPendingPromise(approvalId: string, expiresAt: string): Promise<Decision> {
+  // Expiry timer fires just before the gateway's own TTL so our decision lands
+  // in time to be recorded, even though the HTTP side will already be closing.
+  const timeoutMs = Math.max(1000, new Date(expiresAt).getTime() - Date.now() - 1000);
+  return new Promise<Decision>((resolve) => {
+    const timer = setTimeout(() => {
+      if (!pending.has(approvalId)) return;
+      pending.delete(approvalId);
+      expireApproval(approvalId, 'no response').catch((err) =>
+        log.error('Failed to mark approval expired', { approvalId, err }),
+      );
+      resolve('deny');
+    }, timeoutMs);
+
+    pending.set(approvalId, { resolve, timer });
+  });
+}
+
+async function handleRequest(request: GatewayApprovalRequest): Promise<Decision> {
   if (!adapterRef) return 'deny';
 
-  // Originating agent group is carried on the request via OneCLI's agent
+  // Reconnect dedupe: a gateway that redelivers a request we already carded
+  // gets the existing card re-armed — never a duplicate card.
+  const existing = (await getPendingApprovalsByAction(ONECLI_ACTION)).find(
+    (row) => row.request_id === request.id && row.status === 'pending',
+  );
+  if (existing && !pending.has(existing.approval_id)) {
+    log.info('Re-armed existing card for redelivered approval request', {
+      approvalId: existing.approval_id,
+      requestId: request.id,
+    });
+    return armPendingPromise(existing.approval_id, request.expiresAt);
+  }
+
+  // Originating agent group is carried on the request via the gateway's agent
   // identifier (set by container-runner.ts to agentGroup.id). Use it as
   // the scope for approver selection: admin @ group → global admin → owner.
   const originGroup = request.agent.externalId ? await getAgentGroup(request.agent.externalId) : undefined;
   const agentGroupId = originGroup?.id ?? null;
   const approvers = await pickApprover(agentGroupId);
   if (approvers.length === 0) {
-    log.warn('OneCLI approval auto-denied: no eligible approver', {
+    log.warn('Gateway approval auto-denied: no eligible approver', {
       id: request.id,
       host: request.host,
       agent: request.agent.externalId,
@@ -135,25 +233,22 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
     return 'deny';
   }
 
-  // No origin channel preference — OneCLI requests don't carry one. First
+  // No origin channel preference — held requests don't carry one. First
   // approver with a reachable DM wins.
   const target = await pickApprovalDelivery(approvers, '');
   if (!target) {
-    log.warn('OneCLI approval auto-denied: no DM channel for any approver', {
+    log.warn('Gateway approval auto-denied: no DM channel for any approver', {
       id: request.id,
       approvers,
     });
     return 'deny';
   }
 
-  // Use a short id for the card/button so Chat SDK's Telegram adapter can
-  // fit everything inside the 64-byte callback_data limit. The OneCLI
-  // request.id stays in the payload for audit.
   const approvalId = shortApprovalId();
   const question = buildQuestion(request, originGroup?.name ?? request.agent.name);
 
-  const onecliTitle = 'Credentials Request';
-  const onecliOptions = [
+  const cardTitle = 'Credentials Request';
+  const cardOptions = [
     { label: 'Approve', selectedLabel: '✅ Approved', value: 'approve', style: 'primary' as const },
     { label: 'Reject', selectedLabel: '❌ Rejected', value: 'reject', style: 'danger' as const },
   ];
@@ -167,9 +262,9 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
       JSON.stringify({
         type: 'ask_question',
         questionId: approvalId,
-        title: onecliTitle,
+        title: cardTitle,
         question,
-        options: onecliOptions,
+        options: cardOptions,
       }),
       undefined,
       // ensureUserDm may resolve the DM through a named instance (its registry
@@ -179,7 +274,7 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
       target.messagingGroup.instance,
     );
   } catch (err) {
-    log.error('Failed to deliver OneCLI approval card', { approvalId, oneCliRequestId: request.id, err });
+    log.error('Failed to deliver approval card', { approvalId, requestId: request.id, err });
     return 'deny';
   }
 
@@ -205,46 +300,89 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
     platform_message_id: platformMessageId ?? null,
     expires_at: request.expiresAt,
     status: 'pending',
-    title: onecliTitle,
+    title: cardTitle,
     question,
-    options_json: JSON.stringify(onecliOptions),
+    options_json: JSON.stringify(cardOptions),
+    // The DM'd approver is the one identity allowed to resolve this card.
+    approver_user_id: target.userId,
   });
 
-  // Expiry timer fires just before the gateway's own TTL so our decision lands
-  // in time to be recorded, even though the HTTP side will already be closing.
-  const expiresAtMs = new Date(request.expiresAt).getTime();
-  const timeoutMs = Math.max(1000, expiresAtMs - Date.now() - 1000);
-
-  return new Promise<Decision>((resolve) => {
-    const timer = setTimeout(() => {
-      if (!pending.has(approvalId)) return;
-      pending.delete(approvalId);
-      expireApproval(approvalId, 'no response').catch((err) =>
-        log.error('Failed to mark OneCLI approval expired', { approvalId, err }),
-      );
-      resolve('deny');
-    }, timeoutMs);
-
-    pending.set(approvalId, { resolve, timer });
-  });
+  return armPendingPromise(approvalId, request.expiresAt);
 }
 
 async function expireApproval(approvalId: string, reason: ExpiryReason): Promise<void> {
-  const rows = (await getPendingApprovalsByAction(ONECLI_ACTION)).filter((r) => r.approval_id === approvalId);
-  const row = rows[0];
-  if (!row) return;
+  const row = await getPendingApproval(approvalId);
+  if (!row || row.action !== ONECLI_ACTION) return;
 
   if (!(await transitionPendingApprovalStatus(approvalId, 'pending', 'expired'))) return;
   await editCardExpired(row, reason);
   await deletePendingApproval(approvalId);
-  log.info('OneCLI approval expired', { approvalId, reason });
+  log.info('Gateway approval expired', { approvalId, reason });
+}
+
+/**
+ * Re-attach surviving rows after a restart instead of blanket-expiring them:
+ * a still-open row stays decidable (resolution is row-keyed), an overdue one
+ * gets an honest timeout. When the gateway can enumerate its held requests,
+ * record whether each survivor is still live gateway-side.
+ */
+async function reattachSurvivingApprovals(): Promise<void> {
+  const rows = await getPendingApprovalsByAction(ONECLI_ACTION);
+  if (rows.length === 0) return;
+
+  let heldAtGateway: Set<string> | null = null;
+  if (approvalSource?.listPending) {
+    try {
+      heldAtGateway = new Set((await approvalSource.listPending()).map((request) => request.id));
+    } catch (err) {
+      log.warn('Gateway pending-approvals listing failed during re-attach', { err });
+    }
+  }
+
+  let rearmed = 0;
+  let expired = 0;
+  for (const row of rows) {
+    const stillOpen = row.expires_at !== null && new Date(row.expires_at).getTime() > Date.now();
+    if (!stillOpen) {
+      await expireApproval(row.approval_id, 'no response');
+      expired += 1;
+      continue;
+    }
+    rearmed += 1;
+    log.info('Re-armed approval from previous process', {
+      approvalId: row.approval_id,
+      heldAtGateway: heldAtGateway ? heldAtGateway.has(row.request_id ?? '') : null,
+    });
+  }
+  log.info('Approval re-attach complete', { rearmed, expired });
+}
+
+/** Row-driven expiry sweep: overdue rows expire regardless of which process armed them. */
+async function expireOverdueApprovals(): Promise<void> {
+  /* eslint-disable no-catch-all/no-catch-all -- the sweep must survive any single row's failure */
+  try {
+    const rows = await getPendingApprovalsByAction(ONECLI_ACTION);
+    for (const row of rows) {
+      if (row.expires_at !== null && new Date(row.expires_at).getTime() > Date.now()) continue;
+      // Live requests have their own pre-TTL timer; the sweep owns the rest.
+      if (pending.has(row.approval_id)) continue;
+      await expireApproval(row.approval_id, 'no response');
+    }
+  } catch (err) {
+    log.warn('Approval expiry sweep failed', { err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
 }
 
 /** Exported for tests — the sweep and the expiry timer are its only callers. */
 export async function editCardExpired(row: PendingApproval, reason: ExpiryReason): Promise<void> {
-  if (!adapterRef || !row.platform_message_id || !row.channel_type || !row.platform_id) return;
   const resolution =
     reason === 'no response' ? '⏱️ Timed out — no response' : '⏱️ Timed out — host restarted before resolution';
+  await editCardResolution(row, resolution);
+}
+
+async function editCardResolution(row: PendingApproval, resolution: string): Promise<void> {
+  if (!adapterRef || !row.platform_message_id || !row.channel_type || !row.platform_id) return;
   try {
     await adapterRef.deliver(
       row.channel_type,
@@ -272,34 +410,18 @@ export async function editCardExpired(row: PendingApproval, reason: ExpiryReason
     // Louder than a warn: the row is deleted straight after, so a swallowed
     // failure leaves a card showing live Approve/Reject buttons that resolve
     // nothing, with no other trace that it happened.
-    log.error('Failed to edit expired OneCLI approval card', { approvalId: row.approval_id, err });
+    log.error('Failed to edit resolved approval card', { approvalId: row.approval_id, err });
   }
 }
 
-async function sweepStaleApprovals(): Promise<void> {
-  const rows = await getPendingApprovalsByAction(ONECLI_ACTION);
-  if (rows.length === 0) return;
-  log.info('Sweeping stale OneCLI approvals from previous process', { count: rows.length });
-  for (const row of rows) {
-    await editCardExpired(row, 'host restarted');
-    await deletePendingApproval(row.approval_id);
-  }
-}
-
-/** The hosted gateway's structured request summary — not yet in the SDK's
- *  ApprovalRequest type (observed on api.onecli.sh, 2026-07): the action being
+/** The hosted gateway's structured request summary: the action being
  *  performed plus labeled fields (To / Subject / Body for email sends). */
-interface ApprovalSummary {
-  action?: string;
-  details?: { label: string; value: string }[];
-}
-
 const SUMMARY_VALUE_EXCERPT_CHARS = 900;
 
-function buildQuestion(request: ApprovalRequest, agentName: string): string {
+function buildQuestion(request: GatewayApprovalRequest, agentName: string): string {
   const lines = [`*Agent:* ${agentName}`];
 
-  const summary = (request as ApprovalRequest & { summary?: ApprovalSummary }).summary;
+  const summary = request.summary;
   if (summary?.details?.length) {
     if (summary.action) lines.push(`*Action:* ${summary.action}`);
     // A render bug here must never decide the request: handleRequest's catch

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -259,7 +259,9 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
     title,
     question,
     options_json: JSON.stringify(normalizedOptions),
-    approver_user_id: approverUserId ?? null,
+    // The DM'd approver is the identity this card was routed to; recording it
+    // makes resolution exact — only that user may decide the row.
+    approver_user_id: approverUserId ?? target.userId ?? null,
   });
 
   const adapter = getDeliveryAdapter();

--- a/src/modules/approvals/restart-honesty.test.ts
+++ b/src/modules/approvals/restart-honesty.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Approval restart honesty: rows survive the process, resolution is
+ * row-keyed, re-attach never duplicates a card, and expiry is row-driven.
+ * The gateway is consumed through the provider seam — these tests inject a
+ * fake provider and exercise every capability combination.
+ */
+import * as fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-restart-honesty' };
+});
+
+vi.mock('./primitive.js', () => ({
+  pickApprover: vi.fn().mockResolvedValue(['telegram:admin']),
+  pickApprovalDelivery: vi.fn().mockResolvedValue({
+    userId: 'telegram:admin',
+    messagingGroup: { channel_type: 'telegram', platform_id: 'D-1', instance: null },
+  }),
+}));
+
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { createPendingApproval, getPendingApproval } from '../../db/sessions.js';
+import type { ChannelDeliveryAdapter } from '../../delivery.js';
+import {
+  resetGatewayProvider,
+  type GatewayApprovalDecision,
+  type GatewayApprovalRequest,
+  type GatewayApprovalSource,
+  type GatewayProvider,
+} from '../../gateway-providers/index.js';
+import type { PendingApproval } from '../../types.js';
+import { ONECLI_ACTION, resolveOneCLIApproval, startOneCLIApprovalHandler, stopOneCLIApprovalHandler } from './onecli-approvals.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-restart-honesty';
+
+function iso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+interface DeliveredCall {
+  kind: string;
+  content: string;
+}
+const delivered: DeliveredCall[] = [];
+const captureAdapter: ChannelDeliveryAdapter = {
+  async deliver(_channelType, _platformId, _threadId, kind, content) {
+    delivered.push({ kind, content });
+    return 'pm-out';
+  },
+};
+
+let capturedHandler: ((request: GatewayApprovalRequest) => Promise<GatewayApprovalDecision>) | null = null;
+const source: GatewayApprovalSource & { decide?: ReturnType<typeof vi.fn>; listPending?: ReturnType<typeof vi.fn> } = {
+  subscribe(handler) {
+    capturedHandler = handler;
+    return { stop() {} };
+  },
+};
+
+const fakeProvider: GatewayProvider = {
+  kind: 'fake-for-tests',
+  async contribute() {
+    throw new Error('not under test');
+  },
+  approvals: () => source,
+};
+
+async function seedRow(overrides: Partial<PendingApproval> = {}): Promise<PendingApproval> {
+  const row: PendingApproval = {
+    approval_id: 'oa-test0001',
+    session_id: null,
+    request_id: 'req-1',
+    action: ONECLI_ACTION,
+    payload: JSON.stringify({ approver: 'telegram:admin' }),
+    created_at: iso(-60_000),
+    agent_group_id: 'ag-1',
+    channel_type: 'telegram',
+    platform_id: 'D-1',
+    instance: null,
+    platform_message_id: 'pm-1',
+    expires_at: iso(120_000),
+    status: 'pending',
+    title: 'Credentials Request',
+    question: 'Allow this request?',
+    options_json: '[]',
+    approver_user_id: 'telegram:admin',
+    ...overrides,
+  };
+  await createPendingApproval(row);
+  return row;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  delivered.length = 0;
+  capturedHandler = null;
+  delete source.decide;
+  delete source.listPending;
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: iso(0) });
+  resetGatewayProvider(fakeProvider);
+});
+
+afterEach(async () => {
+  stopOneCLIApprovalHandler();
+  resetGatewayProvider(null);
+  await closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('row-keyed resolution after a restart', () => {
+  it('a surviving still-open card is decidable; approve carries the retry caveat', async () => {
+    await seedRow();
+    startOneCLIApprovalHandler(captureAdapter);
+
+    // No in-memory state exists for this row — exactly the post-restart shape.
+    expect(await resolveOneCLIApproval('oa-test0001', 'approve')).toBe(true);
+    expect(await getPendingApproval('oa-test0001')).toBeUndefined();
+
+    const edit = delivered.find((call) => call.content.includes('retry'));
+    expect(edit, 'approve without a gateway decide path must tell the human to have the agent retry').toBeDefined();
+  });
+
+  it('a late reject needs no caveat edit — the auto-edited card is already honest', async () => {
+    await seedRow();
+    startOneCLIApprovalHandler(captureAdapter);
+
+    expect(await resolveOneCLIApproval('oa-test0001', 'reject')).toBe(true);
+    expect(await getPendingApproval('oa-test0001')).toBeUndefined();
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('a late decision rides the gateway decide capability when present', async () => {
+    source.decide = vi.fn().mockResolvedValue(true);
+    await seedRow();
+    startOneCLIApprovalHandler(captureAdapter);
+
+    expect(await resolveOneCLIApproval('oa-test0001', 'approve')).toBe(true);
+    expect(source.decide).toHaveBeenCalledWith('req-1', 'approve');
+    // Delivered to the gateway — no caveat follow-up needed.
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('a second click loses the row transition and reports unresolved', async () => {
+    await seedRow();
+    startOneCLIApprovalHandler(captureAdapter);
+    expect(await resolveOneCLIApproval('oa-test0001', 'approve')).toBe(true);
+    expect(await resolveOneCLIApproval('oa-test0001', 'reject')).toBe(false);
+  });
+});
+
+describe('re-attach at startup', () => {
+  it('expires overdue rows honestly and keeps still-open rows decidable', async () => {
+    await seedRow({ approval_id: 'oa-overdue1', request_id: 'req-old', expires_at: iso(-5_000), platform_message_id: 'pm-old' });
+    await seedRow({ approval_id: 'oa-alive001', request_id: 'req-new', expires_at: iso(120_000) });
+
+    startOneCLIApprovalHandler(captureAdapter);
+
+    await vi.waitFor(async () => {
+      expect(await getPendingApproval('oa-overdue1')).toBeUndefined();
+    });
+    const timeoutEdit = delivered.find((call) => call.content.includes('Timed out — no response'));
+    expect(timeoutEdit).toBeDefined();
+    expect(await getPendingApproval('oa-alive001')).toBeDefined();
+  });
+
+  it('consults listPending when the gateway can enumerate held requests', async () => {
+    source.listPending = vi.fn().mockResolvedValue([{ id: 'req-1' }]);
+    await seedRow();
+    startOneCLIApprovalHandler(captureAdapter);
+    await vi.waitFor(() => expect(source.listPending).toHaveBeenCalled());
+    expect(await getPendingApproval('oa-test0001')).toBeDefined();
+  });
+});
+
+describe('reconnect dedupe', () => {
+  it('a redelivered request re-arms the existing card — never a duplicate', async () => {
+    await seedRow({ request_id: 'req-9' });
+    startOneCLIApprovalHandler(captureAdapter);
+    expect(capturedHandler).not.toBeNull();
+
+    const decisionPromise = capturedHandler!({
+      id: 'req-9',
+      expiresAt: iso(120_000),
+      method: 'POST',
+      host: 'api.example.com',
+      path: '/send',
+      agent: { name: 'Agent' },
+    });
+    // Let handleRequest reach the dedupe check before clicking.
+    await vi.waitFor(async () => {
+      expect(await resolveOneCLIApproval('oa-test0001', 'approve')).toBe(true);
+    });
+    await expect(decisionPromise).resolves.toBe('approve');
+    // No ask_question card was delivered for the redelivery.
+    expect(delivered.filter((call) => call.content.includes('ask_question'))).toHaveLength(0);
+  });
+
+  it('a genuinely new request cards once and stamps the routed approver', async () => {
+    startOneCLIApprovalHandler(captureAdapter);
+    const decisionPromise = capturedHandler!({
+      id: 'req-fresh',
+      expiresAt: iso(120_000),
+      method: 'POST',
+      host: 'api.example.com',
+      path: '/send',
+      agent: { name: 'Agent', externalId: 'ag-1' },
+    });
+
+    let approvalId = '';
+    await vi.waitFor(() => {
+      const card = delivered.find((call) => call.content.includes('ask_question'));
+      expect(card).toBeDefined();
+      approvalId = (JSON.parse(card!.content) as { questionId: string }).questionId;
+    });
+    const row = await getPendingApproval(approvalId);
+    expect(row?.approver_user_id).toBe('telegram:admin');
+    expect(row?.request_id).toBe('req-fresh');
+
+    expect(await resolveOneCLIApproval(approvalId, 'reject')).toBe(true);
+    await expect(decisionPromise).resolves.toBe('deny');
+  });
+});


### PR DESCRIPTION
Stacked on the shadow-writes PR. Two things, deliberately together: the approvals module stops importing the gateway SDK directly, and approvals stop dying with the process.

## The seam
`GatewayProvider` grows an optional `approvals()` capability: `subscribe` (required) plus capability-flagged `listPending` and `decide` — implemented only when a gateway genuinely supports them. OneCLI registers subscribe-only, encoding the verified facts (no redelivery of un-decided requests on reconnect, no late-decision surface). `onecli-approvals.ts` keeps its filename and exports (zero import ripple) but now consumes the registry.

## Restart honesty
- Row-keyed resolution: a card from before a restart still resolves. With `decide` available the decision is delivered; a late approve without it gets an honest follow-up card; a late reject needs none.
- Boot re-attach replaces the blanket "host restarted" sweep: overdue rows expire as "no response", still-open rows stay armed, `listPending` consulted when available.
- Reconnect dedupe by request id — never a duplicate card.
- Row-driven expiry sweep (60s, unref'd) instead of in-memory timers that die with the process.
- `approver_user_id` populated by both producers, activating the existing exact-approver check in response-handler. (Release-note worthy: card clicks now authorize against the DM'd approver.)

## Test plan
New restart-honesty suite (8 cases via an injected fake provider: post-restart approve/reject, decide-capable path, double-click, re-attach expiry+keep, listPending reconciliation, dedupe, approver stamp). Zero existing-test edits; approvals + gateway + adjacent suites 101 tests re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)