### PR TITLE
fix(destinations): report wired chats the agent cannot address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **An agent that cannot address one of its wired chats now says so in the host log.** Sending is name-based, so a wired chat with no destination row is a chat the agent cannot address: its `<message to="…">` blocks are dropped inside the container, the turn is still acknowledged as processed, and from the chat it reads as the agent ignoring you. The container does report the drop, but it reaches the host at `debug` and a default `LOG_LEVEL=info` install never prints it. The host now checks the agent's wirings against its destination map on every wake and on every destination edit, and warns once with the chats it cannot address. It is a warning rather than an error because an absent row also means "not authorized" — the row is the ACL, and removing one is deliberate — so the report names the consequence without prescribing a fix.
+
 ## [2.3.0] - 2026-08-24
 
 - [BREAKING] **A new Slack experience — per-agent provisioned Slack apps, agent spawning from Slack, and UX improvements — is available to classic single-bot Slack installs.** Classic Slack keeps working unchanged; this gate asks for a decision, not a forced migration. New installs and non-Slack installs are unaffected. **Migration:** run `/migrate-slack-agents` — it detects classic state (exits cleanly otherwise) and either walks the upgrade or records the choice to stay on classic; both outcomes satisfy this requirement.

--- a/src/cli/crud.test.ts
+++ b/src/cli/crud.test.ts
@@ -27,6 +27,7 @@ vi.mock('../log.js', () => ({
 const writeDestinationsSpy = vi.fn();
 vi.mock('../modules/agent-to-agent/write-destinations.js', () => ({
   writeDestinations: (...args: unknown[]) => writeDestinationsSpy(...args),
+  reportUnreachableWiredChats: vi.fn(),
 }));
 
 import { initTestDb, closeDb, getDb, runMigrations, createAgentGroup, createMessagingGroup } from '../db/index.js';

--- a/src/cli/resources/destinations.ts
+++ b/src/cli/resources/destinations.ts
@@ -16,16 +16,30 @@ import { registerResource } from '../crud.js';
  * local_name silently drops with "unknown destination" until restart.
  * See the destination-projection invariant in
  * src/modules/agent-to-agent/db/agent-destinations.ts.
+ *
+ * Also reports, once per call, any wired chat the edit leaves the agent unable
+ * to address.
  */
 export async function projectDestinationsToSessions(agentGroupId: string): Promise<void> {
   if (!(await hasTable(getDb(), 'agent_destinations'))) return;
-  const { writeDestinations } = await import('../../modules/agent-to-agent/write-destinations.js');
+  const { writeDestinations, reportUnreachableWiredChats } =
+    await import('../../modules/agent-to-agent/write-destinations.js');
   for (const session of await getSessionsByAgentGroup(agentGroupId)) {
     try {
       await writeDestinations(agentGroupId, session.id);
     } catch (err) {
       log.warn('Failed to project destinations to session mailbox', { agentGroupId, sessionId: session.id, err });
     }
+  }
+  // Once for the agent group, not once per session — the routing this reports
+  // on is the same for every session, and an edit that leaves a wired chat
+  // unaddressable should say so once rather than once per open thread. The
+  // mutation is already committed by the time we get here, so a failure in the
+  // diagnostic must not surface to the operator as a failed command.
+  try {
+    await reportUnreachableWiredChats(agentGroupId);
+  } catch (err) {
+    log.debug('Wired-chat reachability check failed', { agentGroupId, err });
   }
 }
 

--- a/src/cli/resources/programmatic-wiring.test.ts
+++ b/src/cli/resources/programmatic-wiring.test.ts
@@ -48,7 +48,10 @@ vi.mock('../../group-init.js', async () => {
 
 // wirings' postCommit projects destinations into live session DBs — no
 // sessions run in this test, but the module must not open on-disk DB files.
-vi.mock('../../modules/agent-to-agent/write-destinations.js', () => ({ writeDestinations: vi.fn() }));
+vi.mock('../../modules/agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: vi.fn(),
+  reportUnreachableWiredChats: vi.fn(),
+}));
 
 const TEST_DIR = '/tmp/nanoclaw-test-cli-programmatic-wiring';
 

--- a/src/cli/resources/wirings.test.ts
+++ b/src/cli/resources/wirings.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../log.js', () => ({
 // sessions run in this test, but the module must not open on-disk DB files.
 vi.mock('../../modules/agent-to-agent/write-destinations.js', () => ({
   writeDestinations: vi.fn(),
+  reportUnreachableWiredChats: vi.fn(),
 }));
 
 import type { ChannelDefaults } from '../../channels/adapter.js';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -165,8 +165,17 @@ async function spawnContainer(session: Session): Promise<void> {
   // changes take effect on wake. Destinations come from the agent-to-agent
   // module — skip when the module isn't installed (table absent).
   if (await hasTable(getDb(), 'agent_destinations')) {
-    const { writeDestinations } = await import('./modules/agent-to-agent/write-destinations.js');
-    await writeDestinations(agentGroup.id, session.id);
+    const { writeDestinations, reportUnreachableWiredChats } =
+      await import('./modules/agent-to-agent/write-destinations.js');
+    const destinations = await writeDestinations(agentGroup.id, session.id);
+    // Wake is when a missing destination starts costing replies, so it is
+    // where the agent's routing gets checked against its wirings. Diagnostic
+    // only — a failure here must not keep the container from starting.
+    try {
+      await reportUnreachableWiredChats(agentGroup.id, destinations);
+    } catch (err) {
+      log.debug('Wired-chat reachability check failed', { agentGroupId: agentGroup.id, err });
+    }
   }
   await writeSessionRouting(agentGroup.id, session.id);
   const mailboxKey = { agentGroupId: agentGroup.id, sessionId: session.id };

--- a/src/modules/agent-to-agent/write-destinations.test.ts
+++ b/src/modules/agent-to-agent/write-destinations.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for reportUnreachableWiredChats.
+ *
+ * The failure class: an agent is wired to a chat but has no destination that
+ * addresses it, so the replies it composes for that chat are dropped inside
+ * the container and the turn is still acked. The container does log the drop,
+ * but it reaches the host at `debug`, which a default `LOG_LEVEL=info` install
+ * never prints.
+ *
+ * These pin the two properties that decide whether the report is worth
+ * printing: it fires on the shapes that actually lose replies, and it stays
+ * quiet on the shapes that never had a reply to lose. The unit under test is
+ * the wiring-to-destination comparison — no session is involved, which is the
+ * point: keying on any one session's `messaging_group_id` is what missed the
+ * `agent-shared` case.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentDestination, MessagingGroup } from '../../types.js';
+
+const { destinations, messagingGroups, wirings, agentGroups, logWarn } = vi.hoisted(() => ({
+  destinations: new Map<string, AgentDestination[]>(),
+  messagingGroups: new Map<string, MessagingGroup>(),
+  wirings: new Map<string, string[]>(),
+  agentGroups: new Map<string, { id: string; name: string }>(),
+  logWarn: vi.fn(),
+}));
+
+vi.mock('./db/agent-destinations.js', () => ({
+  getDestinations: async (agentGroupId: string) => destinations.get(agentGroupId) ?? [],
+}));
+vi.mock('../../db/messaging-groups.js', () => ({
+  getMessagingGroup: async (id: string) => messagingGroups.get(id),
+  getMessagingGroupsByAgentGroup: async (agentGroupId: string) =>
+    (wirings.get(agentGroupId) ?? []).map((id) => messagingGroups.get(id)).filter(Boolean),
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  getAgentGroup: async (id: string) => agentGroups.get(id),
+}));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: (...a: unknown[]) => logWarn(...a), error: vi.fn(), fatal: vi.fn() },
+}));
+vi.mock('../../session-manager.js', () => ({
+  withMailboxSession: async (_a: string, _s: string, fn: (db: unknown) => void) => fn({ replaceDestinations: vi.fn() }),
+}));
+
+import { reportUnreachableWiredChats } from './write-destinations.js';
+
+function messagingGroup(id: string, overrides: Partial<MessagingGroup> = {}): MessagingGroup {
+  return {
+    id,
+    channel_type: 'slack',
+    platform_id: `platform-${id}`,
+    instance: 'slack',
+    name: id,
+    is_group: 1,
+    unknown_sender_policy: 'ignore',
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as MessagingGroup;
+}
+
+function destinationRow(overrides: Partial<AgentDestination> = {}): AgentDestination {
+  return {
+    agent_group_id: 'ag-1',
+    local_name: 'group',
+    target_type: 'channel',
+    target_id: 'mg-a',
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * The chats named by the single warn call, sorted. `getMessagingGroupsByAgentGroup`
+ * is an unordered join, so only the set is a real guarantee.
+ */
+function reportedChatIds(): string[] {
+  const [, data] = logWarn.mock.calls[0] as [string, { chats: Array<{ messagingGroupId: string }> }];
+  return data.chats.map((c) => c.messagingGroupId).sort();
+}
+
+beforeEach(() => {
+  destinations.clear();
+  messagingGroups.clear();
+  wirings.clear();
+  agentGroups.clear();
+  logWarn.mockClear();
+  messagingGroups.set('mg-a', messagingGroup('mg-a'));
+  messagingGroups.set('mg-b', messagingGroup('mg-b'));
+  wirings.set('ag-1', ['mg-a']);
+});
+
+describe('reportUnreachableWiredChats', () => {
+  it('reports a wired chat when the agent has no destinations at all', async () => {
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const [message] = logWarn.mock.calls[0] as [string];
+    expect(message).toContain('no destination');
+    expect(reportedChatIds()).toEqual(['mg-a']);
+  });
+
+  it('reports an uncovered chat when a sibling wiring is covered', async () => {
+    // The shape a session-scoped check misses: under agent-shared one session
+    // serves both chats while staying pinned to whichever created it, so the
+    // covered chat would vouch for the uncovered one.
+    wirings.set('ag-1', ['mg-a', 'mg-b']);
+    destinations.set('ag-1', [destinationRow({ target_id: 'mg-a' })]);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(reportedChatIds()).toEqual(['mg-b']);
+  });
+
+  it('reports every uncovered chat in one call rather than one call each', async () => {
+    wirings.set('ag-1', ['mg-a', 'mg-b']);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(reportedChatIds()).toEqual(['mg-a', 'mg-b']);
+  });
+
+  it('reports a chat whose destination row points at a target that no longer resolves', async () => {
+    destinations.set('ag-1', [destinationRow({ target_id: 'mg-deleted' })]);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(reportedChatIds()).toEqual(['mg-a']);
+  });
+
+  it('stays quiet when every wired chat has a destination', async () => {
+    destinations.set('ag-1', [destinationRow({ target_id: 'mg-a' })]);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it('accepts a destination on a sibling messaging group with the same address', async () => {
+    // Migration 016 keyed uniqueness on `instance`, so two rows can name one
+    // chat. Delivery resolves on (channel_type, platform_id), so either reaches
+    // it — matching on messaging-group id would report a false failure here.
+    messagingGroups.set('mg-a2', messagingGroup('mg-a2', { platform_id: 'platform-mg-a', instance: 'slack-2' }));
+    destinations.set('ag-1', [destinationRow({ target_id: 'mg-a2' })]);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it('still reports a chat carrying a stale denied_at, which the router ignores once wired', async () => {
+    // `denied_at` only gates the router's no-wirings branch, and nothing clears
+    // it when a wiring is later added — so skipping on it here would silence a
+    // chat that does receive and does lose its replies.
+    messagingGroups.set('mg-a', messagingGroup('mg-a', { denied_at: '2026-01-02T00:00:00.000Z' }));
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(reportedChatIds()).toEqual(['mg-a']);
+  });
+
+  it('skips a detached chat', async () => {
+    messagingGroups.set('mg-a', messagingGroup('mg-a', { detached_at: '2026-01-02T00:00:00.000Z' }));
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for an agent with no wirings', async () => {
+    wirings.set('ag-1', []);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it('uses a caller-supplied projection instead of resolving again', async () => {
+    // The wake path hands over what it just wrote; the central rows are stale
+    // here only to prove the argument is what gets used.
+    destinations.set('ag-1', [destinationRow({ target_id: 'mg-a' })]);
+
+    await reportUnreachableWiredChats('ag-1', []);
+
+    expect(reportedChatIds()).toEqual(['mg-a']);
+  });
+
+  it('does not accept an agent-to-agent destination as covering a wired chat', async () => {
+    agentGroups.set('ag-peer', { id: 'ag-peer', name: 'Peer' });
+    destinations.set('ag-1', [destinationRow({ local_name: 'peer', target_type: 'agent', target_id: 'ag-peer' })]);
+
+    await reportUnreachableWiredChats('ag-1');
+
+    expect(reportedChatIds()).toEqual(['mg-a']);
+  });
+});

--- a/src/modules/agent-to-agent/write-destinations.ts
+++ b/src/modules/agent-to-agent/write-destinations.ts
@@ -8,13 +8,19 @@
  * installed, the central table doesn't exist and the projection is skipped.
  */
 import { getAgentGroup } from '../../db/agent-groups.js';
-import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { getMessagingGroup, getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
 import type { Destination } from '../../mailbox/index.js';
 import { log } from '../../log.js';
 import { withMailboxSession } from '../../session-manager.js';
 import { getDestinations } from './db/agent-destinations.js';
 
-export async function writeDestinations(agentGroupId: string, sessionId: string): Promise<void> {
+/**
+ * Resolve the agent's central destination rows against their targets. A row
+ * whose target no longer resolves is dropped — the projection carries the
+ * target's routing address, not just its local name, and there is none to
+ * carry.
+ */
+async function resolveDestinations(agentGroupId: string): Promise<Destination[]> {
   const rows = await getDestinations(agentGroupId);
   const resolved: Destination[] = [];
 
@@ -44,8 +50,97 @@ export async function writeDestinations(agentGroupId: string, sessionId: string)
     }
   }
 
+  return resolved;
+}
+
+export async function writeDestinations(agentGroupId: string, sessionId: string): Promise<Destination[]> {
+  const resolved = await resolveDestinations(agentGroupId);
   await withMailboxSession(agentGroupId, sessionId, (db) => {
     db.replaceDestinations(resolved);
   });
   log.debug('Destination map written', { sessionId, count: resolved.length });
+  return resolved;
+}
+
+/** A chat's routing address, as the projection and the delivery side see it. */
+function addressKey(channelType: string, platformId: string): string {
+  return `${channelType} ${platformId}`;
+}
+
+/**
+ * Report chats the agent is wired to but has no destination for.
+ *
+ * Everything the agent addresses is resolved by name against the projection
+ * and against nothing else (`findByName`), so a wired chat absent from the
+ * projection is a chat the agent cannot address: its `<message to="…">` blocks
+ * are dropped at `[poll-loop] Unknown destination …` and its `send_message` /
+ * `send_file` calls come back as tool errors. The turn is still acked as
+ * processed either way.
+ *
+ * Not everything the container writes goes through a name. `send_card`,
+ * `ask_user_question`, and the runner's own notices (`/clear`, `/upload-trace`,
+ * a failed turn) address the session's routing directly, and delivery lets an
+ * origin-chat send through without an ACL row (`isOriginChat`) — so those still
+ * land. What is lost is the agent's composed reply, which is the part a user
+ * is waiting on.
+ *
+ * A turn whose blocks all drop is nudged to retry with the names it does have,
+ * so the outcome is not always silence: the reply can end up in a different
+ * chat instead of the one it was meant for.
+ *
+ * That drop is not invisible, just quiet: the container writes it to stderr,
+ * the driver forwards every attached stderr line to the host, and the host
+ * logs it at `debug`. A default install runs at `LOG_LEVEL=info` and never
+ * sees it. This warning is the same failure, reported at a level the default
+ * install does see.
+ *
+ * Keyed on wirings rather than on any one session, because a session's
+ * `messaging_group_id` is not the set of chats it serves — an `agent-shared`
+ * session handles every chat wired to the agent while staying pinned to
+ * whichever one created it.
+ *
+ * Matched by `(channel_type, platform_id)` rather than messaging-group id,
+ * because that pair is what the projection carries and what delivery resolves
+ * against. Two messaging-group rows can share one address (migration 016 keyed
+ * uniqueness on `instance` as well), and a destination pointing at either of
+ * them gives the agent a name delivery will accept. Whether the send then
+ * lands is a separate question — delivery uses the resolved row's `instance`
+ * to pick the adapter, and a sibling instance need not be in the chat.
+ *
+ * `warn`, not `error`: an absent row also means "not authorized" — this table
+ * is the ACL, and removing a row is a deliberate act either way (approval-gated
+ * from an agent, immediate for an operator on the socket). A revoked
+ * destination looks identical from here, so this reports the consequence
+ * without asserting a misconfiguration or prescribing a fix.
+ *
+ * Detached chats are skipped: our bot has left them, and delivery refuses them
+ * outright, so no reply was reaching them regardless of the destination map.
+ * `denied_at` is deliberately *not* skipped — the router only consults it on a
+ * group with no wirings at all, which by construction is not in this set, so
+ * filtering on it would drop true positives and report nothing else.
+ *
+ * `resolved` is the projection this agent's sessions were just given; pass it
+ * to reuse that work. Omitting it resolves the destinations again.
+ */
+export async function reportUnreachableWiredChats(
+  agentGroupId: string,
+  resolved?: readonly Destination[],
+): Promise<void> {
+  resolved ??= await resolveDestinations(agentGroupId);
+  const reachable = new Set(
+    resolved
+      .filter((d) => d.type === 'channel' && d.channelType !== null && d.platformId !== null)
+      .map((d) => addressKey(d.channelType as string, d.platformId as string)),
+  );
+
+  const unreachable = (await getMessagingGroupsByAgentGroup(agentGroupId))
+    .filter((mg) => !mg.detached_at)
+    .filter((mg) => !reachable.has(addressKey(mg.channel_type, mg.platform_id)))
+    .map((mg) => ({ messagingGroupId: mg.id, channelType: mg.channel_type, name: mg.name }));
+
+  if (unreachable.length === 0) return;
+  log.warn('Wired chats have no destination — the agent cannot address them, so its replies there are dropped', {
+    agentGroupId,
+    chats: unreachable,
+  });
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Sending is name-based: the container resolves every destination by name against the per-session projection and against nothing else (`findByName`). A chat an agent is wired to but has no `agent_destinations` row for is therefore a chat the agent cannot address — its `<message to="...">` blocks are dropped inside the container, its `send_message` calls come back as tool errors, and the turn is still acknowledged as processed. From the chat it reads as the agent ignoring you.

The container does report the drop. It writes `[poll-loop] Unknown destination ...` to stderr, the driver forwards attached stderr to the host (`src/drivers/docker-driver.ts`), and the host logs it at `debug` — so a default `LOG_LEVEL=info` install never prints it. #3140 asked for this failure to be loud host-side; #3512 removes one cause of it, and this makes the state itself visible whatever the cause. Refs #3140 (not `Closes` — that issue's Expected is an either/or and #3512 covers the migration half).

**What it does.** `reportUnreachableWiredChats(agentGroupId)` compares the agent's wirings against its resolved destination map and warns once, listing every chat it cannot address. Called from `spawnContainer` after the projection is written, and once per `projectDestinationsToSessions` call (not once per session).

**Keyed on wirings, not on a session.** A session's `messaging_group_id` is not the set of chats it serves: an `agent-shared` session handles every chat wired to the agent while staying pinned to whichever one created it (`src/session-manager.ts`, `docs/isolation-model.md`). A session-scoped check would miss exactly the multi-chat case explicit destinations were introduced for.

**Matched on `(channel_type, platform_id)`, not messaging-group id.** That pair is what the projection carries and what delivery resolves against. Migration 016 keyed uniqueness on `instance` as well, so two rows can name one chat and a destination on either gives the agent a name delivery accepts — matching on id would report a false failure there.

**`warn`, and no suggested command.** An absent row also means "not authorized" — this table is the ACL, and removing a row is deliberate either way (approval-gated from an agent, immediate for an operator on the socket). A revoked destination looks identical from here, so the report names the consequence without asserting a misconfiguration or prescribing a fix that would undo someone's decision. `warn` still lands in `logs/nanoclaw.error.log` (`src/log.ts` sends `>= warn` to stderr), which is the file the troubleshooting table points at first.

**Exclusions.** Detached chats are skipped — delivery refuses them outright (`src/delivery.ts`), so no reply was reaching them regardless. `denied_at` is deliberately *not* skipped: the router only consults it on a group with no wirings at all (`src/router.ts`, inside `if (agentCount === 0)`), which by construction is not in this set, and nothing clears it when a wiring is later added — filtering on it would drop true positives and report nothing else.

Both call sites wrap the check: a diagnostic must not keep a container from starting, and must not make an already-committed `ncl` mutation look like it failed.

## Test plan

- [x] `src/modules/agent-to-agent/write-destinations.test.ts` — 11 cases covering no destinations, a partially-covered wiring set, one call for many chats, a destination whose target no longer resolves, the fully-covered case, a sibling-instance destination on the same address, a stale `denied_at`, a detached chat, no wirings, an agent-to-agent destination not counting as chat coverage, and the caller-supplied projection path
- [x] `pnpm test` — 2012 passing. The 4 failures in `scripts/update/transaction.e2e.test.ts` reproduce on pristine `upstream/main` and are unrelated to this change
- [x] `pnpm exec tsc --noEmit`, eslint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bdZAV1zGoMaU4JAzE9UMU