### PR TITLE
feat(sweep): event feeds — reconcile on driver terminal events and mail writes

### DIFF
--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -150,6 +150,16 @@ export function createSessionDriver(kind: DriverKind, overrides: Partial<MountPo
   return driver;
 }
 
+/**
+ * The already-selected driver, or null — never instantiates. For consumers
+ * that must arm only when a runtime is actually in use: the boot sequence
+ * selects the driver before the sweep starts, while a unit suite that never
+ * selected one sees null instead of triggering selection as a side effect.
+ */
+export function peekSessionDriver(): SessionEventsDriver | null {
+  return installed;
+}
+
 /** Test seam: drop the memoized driver so a suite can select another one. */
 export function resetSessionDriver(next: SessionDriver | null = null): void {
   // Tests may inject raw fakes; the probe (isSessionEventsDriver) guards resync,

--- a/src/host-sweep.feeds.test.ts
+++ b/src/host-sweep.feeds.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The event feeds: runtime terminal events and explicit enqueues land on the
+ * sweep's workqueue between ticks — behavior gets faster, never different.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./reconcile-session.js', () => ({
+  reconcileSession: vi.fn(),
+  // Re-exported surface host-sweep.ts forwards — inert stubs.
+  ABSOLUTE_CEILING_MS: 0,
+  CLAIM_STUCK_MS: 0,
+  _resetStuckProcessingRowsForTesting: vi.fn(),
+  decideStuckAction: vi.fn(),
+  shouldCloseTaskSession: vi.fn(),
+}));
+vi.mock('./db/sessions.js', () => ({ getActiveSessions: vi.fn() }));
+vi.mock('./egress-lockdown.js', () => ({ ensureEgressNetwork: vi.fn() }));
+vi.mock('./modules/approvals/index.js', () => ({ sweepAwaitingReasonRejects: vi.fn() }));
+vi.mock('./drivers/index.js', () => ({ peekSessionDriver: vi.fn(() => null) }));
+
+import { getActiveSessions } from './db/sessions.js';
+import { peekSessionDriver } from './drivers/index.js';
+import type { SessionEvent } from './drivers/types.js';
+import { startHostSweep, stopHostSweep } from './host-sweep.js';
+import { enqueueSessionReconcile } from './reconcile-feeds.js';
+import { reconcileSession } from './reconcile-session.js';
+
+const SWEEP_INTERVAL_MS = 60_000;
+const sweepCallbacks: Array<() => void> = [];
+const realSetTimeout = global.setTimeout;
+let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+let watchHandler: ((event: SessionEvent) => void) | null = null;
+const watchStop = vi.fn();
+
+function fakeWatchingDriver(): ReturnType<typeof peekSessionDriver> {
+  return {
+    watchSessions: (_slug: string, onEvent: (event: SessionEvent) => void) => {
+      watchHandler = onEvent;
+      return { stop: watchStop };
+    },
+  } as unknown as ReturnType<typeof peekSessionDriver>;
+}
+
+function terminalEvent(sessionId: string): SessionEvent {
+  return { kind: 'terminal', key: { installSlug: 'inst', agentGroupId: 'g-1', sessionId } };
+}
+
+async function startAndDrainFirstTick(): Promise<void> {
+  startHostSweep();
+  await vi.waitFor(() => {
+    expect(sweepCallbacks.length).toBe(1);
+  });
+}
+
+beforeEach(() => {
+  watchHandler = null;
+  watchStop.mockReset();
+  vi.mocked(peekSessionDriver).mockReset().mockReturnValue(null);
+  vi.mocked(reconcileSession).mockReset().mockResolvedValue(undefined);
+  vi.mocked(getActiveSessions).mockReset().mockResolvedValue([]);
+
+  sweepCallbacks.length = 0;
+  setTimeoutSpy = vi.spyOn(global, 'setTimeout').mockImplementation(((fn: () => void, ms?: number) => {
+    if (ms === SWEEP_INTERVAL_MS) {
+      sweepCallbacks.push(fn);
+      return 0 as unknown as NodeJS.Timeout;
+    }
+    return realSetTimeout(fn, ms);
+  }) as typeof setTimeout);
+});
+
+afterEach(() => {
+  stopHostSweep();
+  setTimeoutSpy.mockRestore();
+});
+
+describe('runtime terminal-event feed', () => {
+  it('a terminal event reconciles the session without waiting for a tick', async () => {
+    vi.mocked(peekSessionDriver).mockReturnValue(fakeWatchingDriver());
+    await startAndDrainFirstTick();
+    expect(watchHandler).not.toBeNull();
+    expect(reconcileSession).not.toHaveBeenCalled();
+
+    watchHandler!(terminalEvent('s-9'));
+    await vi.waitFor(() => {
+      expect(reconcileSession).toHaveBeenCalledWith('s-9');
+    });
+  });
+
+  it('ignores non-terminal events and keys without a session id', async () => {
+    vi.mocked(peekSessionDriver).mockReturnValue(fakeWatchingDriver());
+    await startAndDrainFirstTick();
+
+    watchHandler!({ kind: 'phase', key: { installSlug: 'inst', agentGroupId: 'g-1', sessionId: 's-9' } });
+    watchHandler!({ kind: 'terminal', key: { installSlug: 'inst', agentGroupId: 'g-1', sessionId: '' } });
+    await new Promise((resolve) => realSetTimeout(resolve, 20));
+    expect(reconcileSession).not.toHaveBeenCalled();
+  });
+
+  it('arms nothing when no driver has been selected', async () => {
+    await startAndDrainFirstTick();
+    expect(watchHandler).toBeNull();
+  });
+
+  it('stops the watch and drops feed enqueues once the sweep stops', async () => {
+    vi.mocked(peekSessionDriver).mockReturnValue(fakeWatchingDriver());
+    await startAndDrainFirstTick();
+    const handler = watchHandler!;
+
+    stopHostSweep();
+    expect(watchStop).toHaveBeenCalledTimes(1);
+
+    handler(terminalEvent('s-9'));
+    enqueueSessionReconcile('s-9');
+    await new Promise((resolve) => realSetTimeout(resolve, 20));
+    expect(reconcileSession).not.toHaveBeenCalled();
+  });
+
+  it('a burst of events for one session coalesces to at most one rerun', async () => {
+    vi.mocked(peekSessionDriver).mockReturnValue(fakeWatchingDriver());
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    vi.mocked(reconcileSession).mockImplementation(async () => gate);
+    await startAndDrainFirstTick();
+
+    for (let i = 0; i < 5; i += 1) watchHandler!(terminalEvent('s-9'));
+    await vi.waitFor(() => {
+      expect(reconcileSession).toHaveBeenCalledTimes(1);
+    });
+    release();
+    // The adds that landed mid-run collapse into a single dirty rerun.
+    await new Promise((resolve) => realSetTimeout(resolve, 30));
+    expect(vi.mocked(reconcileSession).mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('explicit enqueue feed', () => {
+  it('an enqueue between ticks reconciles the session promptly', async () => {
+    await startAndDrainFirstTick();
+    enqueueSessionReconcile('s-3');
+    await vi.waitFor(() => {
+      expect(reconcileSession).toHaveBeenCalledWith('s-3');
+    });
+  });
+});

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -10,9 +10,13 @@
  * can never be lost to a concurrent sweep. The re-exports below keep the
  * long-standing import surface of this module stable.
  */
+import { INSTALL_SLUG } from './config.js';
 import { ensureEgressNetwork } from './egress-lockdown.js';
 import { getActiveSessions } from './db/sessions.js';
+import { peekSessionDriver } from './drivers/index.js';
+import type { SessionWatch } from './drivers/types.js';
 import { log } from './log.js';
+import { registerReconcileEnqueue } from './reconcile-feeds.js';
 import { createReconcileQueue, type InProcessReconcileQueue } from './reconcile-queue.js';
 import { reconcileSession } from './reconcile-session.js';
 import { sessionKey } from './reconcile.js';
@@ -30,6 +34,37 @@ const SWEEP_INTERVAL_MS = 60_000;
 
 let running = false;
 let queue: InProcessReconcileQueue | null = null;
+let runtimeWatch: SessionWatch | null = null;
+
+/** Coalesced enqueue for the event feeds; drops harmlessly once stopped. */
+function feedEnqueue(sessionId: string): void {
+  const feedQueue = queue;
+  if (running && feedQueue) feedQueue.add(sessionKey(sessionId));
+}
+
+/**
+ * Reconcile promptly when the runtime reports a session ended: due mail on a
+ * dead session waits one queue turn instead of the next resync tick. Arms
+ * only against a driver that already exists — the sweep never instantiates
+ * one, so suites (and hosts) that never selected a runtime are untouched.
+ * Events are hints (they may drop, duplicate, or reference foreign keys);
+ * the enqueue re-reads truth, so all of that is safe by construction.
+ */
+function armRuntimeWatch(): void {
+  const driver = peekSessionDriver();
+  // Raw test fakes may lack watchSessions; never crash on them.
+  if (!driver || typeof driver.watchSessions !== 'function') return;
+  /* eslint-disable no-catch-all/no-catch-all -- a watch backend that cannot subscribe costs latency (the resync floor covers it), never the boot */
+  try {
+    runtimeWatch = driver.watchSessions(INSTALL_SLUG, (event) => {
+      if (event.kind !== 'terminal' || !event.key.sessionId) return;
+      feedEnqueue(event.key.sessionId);
+    });
+  } catch (err) {
+    log.warn('Runtime watch feed unavailable — the resync floor covers it', { err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}
 
 export function startHostSweep(): void {
   if (running) return;
@@ -64,11 +99,28 @@ export function startHostSweep(): void {
       // MODULE-HOOK:approvals-reason-sweep:end
     },
   });
+  // Event feeds — additive over the resync floor: mail writes and runtime
+  // terminal events land as coalesced enqueues, so behavior only gets
+  // faster, never different, and a lost event costs at most one tick.
+  registerReconcileEnqueue(feedEnqueue);
+  armRuntimeWatch();
   void sweep();
 }
 
 export function stopHostSweep(): void {
   running = false;
+  registerReconcileEnqueue(null);
+  const stoppingWatch = runtimeWatch;
+  runtimeWatch = null;
+  if (stoppingWatch) {
+    /* eslint-disable no-catch-all/no-catch-all -- a watch backend that is already gone must not block shutdown */
+    try {
+      stoppingWatch.stop();
+    } catch (err) {
+      log.warn('Runtime watch feed stop failed', { err });
+    }
+    /* eslint-enable no-catch-all/no-catch-all */
+  }
   const stopping = queue;
   queue = null;
   if (stopping) void stopping.shutdown();

--- a/src/reconcile-feeds.test.ts
+++ b/src/reconcile-feeds.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { enqueueSessionReconcile, registerReconcileEnqueue } from './reconcile-feeds.js';
+
+afterEach(() => {
+  registerReconcileEnqueue(null);
+});
+
+describe('reconcile enqueue feed', () => {
+  it('is a no-op while nothing is registered', () => {
+    expect(() => enqueueSessionReconcile('s-1')).not.toThrow();
+  });
+
+  it('delivers to the registered enqueue and stops after clearing', () => {
+    const enqueue = vi.fn();
+    registerReconcileEnqueue(enqueue);
+    enqueueSessionReconcile('s-1');
+    expect(enqueue).toHaveBeenCalledWith('s-1');
+
+    registerReconcileEnqueue(null);
+    enqueueSessionReconcile('s-2');
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('never lets a throwing enqueue reach the caller', () => {
+    registerReconcileEnqueue(() => {
+      throw new Error('queue gone');
+    });
+    expect(() => enqueueSessionReconcile('s-1')).not.toThrow();
+  });
+});

--- a/src/reconcile-feeds.ts
+++ b/src/reconcile-feeds.ts
@@ -1,0 +1,34 @@
+/**
+ * Reconcile enqueue feed — the narrow bridge between "something changed for
+ * this session" and the sweep's workqueue, with no import edge back into the
+ * sweep. Producers (the inbound mail writer, the runtime watch feed) call
+ * `enqueueSessionReconcile`; the sweep registers the real enqueue while it
+ * runs and clears it on stop, so producers are always safe to call — an
+ * unregistered feed is a no-op and the periodic resync still covers the
+ * change. Extra enqueues are free: the queue coalesces and the reconcile body
+ * is level-triggered, so a spurious call costs one no-op re-read, never a
+ * behavior change.
+ */
+import { log } from './log.js';
+
+let enqueue: ((sessionId: string) => void) | null = null;
+
+/** The sweep's hook. Last registration wins; null clears. */
+export function registerReconcileEnqueue(fn: ((sessionId: string) => void) | null): void {
+  enqueue = fn;
+}
+
+/**
+ * Ask for a prompt reconcile of one session. Fire-and-forget and never
+ * throws — a feed must never break the write path that called it.
+ */
+export function enqueueSessionReconcile(sessionId: string): void {
+  if (!enqueue) return;
+  /* eslint-disable no-catch-all/no-catch-all -- a failed enqueue costs latency (the resync floor covers it), never the caller's write */
+  try {
+    enqueue(sessionId);
+  } catch (err) {
+    log.warn('Reconcile enqueue failed', { sessionId, err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}

--- a/src/session-manager.feeds.test.ts
+++ b/src/session-manager.feeds.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The inbound write path asks for a prompt reconcile once the message is
+ * durable — through the feed, so nothing here imports the sweep.
+ */
+import fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-mail-feed' };
+});
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
+import { createSession } from './db/sessions.js';
+import { registerReconcileEnqueue } from './reconcile-feeds.js';
+import { initSessionFolder, writeSessionMessage } from './session-manager.js';
+import type { Session } from './types.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-mail-feed';
+const AG = 'ag-feed';
+const SESS = 'sess-feed';
+
+beforeEach(async () => {
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({
+    id: AG,
+    name: 'Feed',
+    folder: 'feed',
+    agent_provider: null,
+    created_at: new Date().toISOString(),
+  });
+  const sess: Session = {
+    id: SESS,
+    agent_group_id: AG,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: new Date().toISOString(),
+  };
+  await createSession(sess);
+  initSessionFolder(AG, SESS);
+});
+
+afterEach(async () => {
+  registerReconcileEnqueue(null);
+  await closeDb();
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('mail-written reconcile feed', () => {
+  it('enqueues the session after the message is durable', async () => {
+    const enqueue = vi.fn();
+    registerReconcileEnqueue(enqueue);
+
+    await writeSessionMessage(AG, SESS, {
+      id: 'm-1',
+      kind: 'chat',
+      timestamp: new Date().toISOString(),
+      content: JSON.stringify({ text: 'hello' }),
+    });
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledWith(SESS);
+  });
+
+  it('writes succeed unchanged when no feed is registered', async () => {
+    await expect(
+      writeSessionMessage(AG, SESS, {
+        id: 'm-2',
+        kind: 'chat',
+        timestamp: new Date().toISOString(),
+        content: JSON.stringify({ text: 'again' }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -24,6 +24,7 @@ import {
 } from './db/sessions.js';
 import { log } from './log.js';
 import { getAgentMailbox, type InboundMessage, type MailboxSession } from './mailbox/index.js';
+import { enqueueSessionReconcile } from './reconcile-feeds.js';
 import type { Session } from './types.js';
 
 /** Root directory for all session data. */
@@ -310,6 +311,10 @@ export async function writeSessionMessage(
     });
   });
   await updateSession(sessionId, { last_active: new Date().toISOString() });
+  // Ask for a prompt reconcile now that the message is durable: a wake that
+  // fails transiently is retried within the queue's cadence instead of
+  // waiting for the next resync tick. No-op when the sweep isn't running.
+  enqueueSessionReconcile(sessionId);
 }
 
 /**


### PR DESCRIPTION
Stacked on #3516. Purely additive (+362/0): two event feeds enqueue reconciles so sessions stop waiting for the 60s floor.

- **Driver terminal events:** the sweep arms a second `watchSessions` subscription on the already-selected driver and enqueues on terminal hints. No verification of the hint needed — the reconcile re-reads truth, so drops, duplicates, and foreign keys are safe by construction. New `peekSessionDriver()` (returns the memoized driver or null, never instantiates) keeps unit suites from spawning a real runtime watch.
- **Mail writes:** `writeSessionMessage` — the single funnel all fifteen inbound writers route through — enqueues after the message is durable, via a dependency-free registration seam (`reconcile-feeds.ts`) that breaks the import cycle; unregistered = no-op, and a throwing enqueue never reaches the write path.

## Test plan
11 new cases (terminal reconcile without a tick, burst coalescing via the dirty set, feed no-ops when stopped, write-path isolation). Zero existing-test edits; 176 tests across all touched surfaces pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)