### PR TITLE
fix(mattermost): keep heartbeat defaults when options carry undefined keys

### DIFF
--- a/src/channels/mattermost-adapter/websocket.test.ts
+++ b/src/channels/mattermost-adapter/websocket.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type WebSocket from 'ws';
+
+import { MattermostSocket } from './websocket.js';
+
+const silentLogger = {
+  debug: () => {},
+  error: () => {},
+  info: () => {},
+  warn: () => {},
+};
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  readyState = 0;
+  pings = 0;
+  sent: string[] = [];
+  private listeners = new Map<string, Listener[]>();
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  on(event: string, listener: Listener): void {
+    const existing = this.listeners.get(event) ?? [];
+    existing.push(listener);
+    this.listeners.set(event, existing);
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+
+  send(raw: string): void {
+    this.sent.push(raw);
+  }
+
+  ping(): void {
+    this.pings += 1;
+  }
+
+  terminate(): void {
+    this.readyState = 3;
+    this.emit('close', 1006);
+  }
+}
+
+/** Connect a socket through the fake transport and complete the auth handshake. */
+async function connectSocket(overrides: { heartbeatIntervalMs?: number | undefined }): Promise<{
+  socket: MattermostSocket;
+  transport: FakeWebSocket;
+}> {
+  const socket = new MattermostSocket({
+    baseUrl: 'http://mattermost.test',
+    logger: silentLogger,
+    onEvent: () => {},
+    token: 'test-token',
+    webSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    ...overrides,
+  });
+  const connected = socket.connect();
+  const transport = FakeWebSocket.instances.at(-1)!;
+  transport.readyState = 1;
+  transport.emit('open');
+  const auth = JSON.parse(transport.sent.at(-1)!) as { seq: number };
+  transport.emit('message', JSON.stringify({ status: 'OK', seq_reply: auth.seq }));
+  await connected;
+  return { socket, transport };
+}
+
+describe('MattermostSocket heartbeat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the 30s default when heartbeatIntervalMs is passed as an explicit undefined', async () => {
+    // Regression: the adapter forwards its optional config verbatim, so the
+    // socket receives `heartbeatIntervalMs: undefined` as an own key. Before
+    // the constructor guarded its defaults, that clobbered the 30s interval
+    // and `setInterval(cb, undefined)` pinged the server every ~1ms.
+    const { socket, transport } = await connectSocket({ heartbeatIntervalMs: undefined });
+
+    vi.advanceTimersByTime(29_000);
+    expect(transport.pings).toBe(0);
+
+    vi.advanceTimersByTime(1_000);
+    expect(transport.pings).toBe(1);
+
+    await socket.disconnect();
+  });
+
+  it('honors an explicit heartbeat interval', async () => {
+    const { socket, transport } = await connectSocket({ heartbeatIntervalMs: 5_000 });
+
+    vi.advanceTimersByTime(4_999);
+    expect(transport.pings).toBe(0);
+
+    vi.advanceTimersByTime(1);
+    expect(transport.pings).toBe(1);
+
+    await socket.disconnect();
+  });
+
+  it('disables the heartbeat when the interval is 0', async () => {
+    const { socket, transport } = await connectSocket({ heartbeatIntervalMs: 0 });
+
+    vi.advanceTimersByTime(120_000);
+    expect(transport.pings).toBe(0);
+
+    await socket.disconnect();
+  });
+});

--- a/src/channels/mattermost-adapter/websocket.ts
+++ b/src/channels/mattermost-adapter/websocket.ts
@@ -108,13 +108,17 @@ export class MattermostSocket {
   private socket: WebSocket | undefined;
 
   constructor(options: MattermostSocketOptions) {
+    // The defaults must survive an own key holding `undefined` — callers pass
+    // optional config through verbatim (`heartbeatIntervalMs: maybeUndefined`),
+    // and a `...options` spread over defaults would replace 30s with
+    // `undefined`, which `setInterval` clamps to ~1ms.
     this.options = {
-      authTimeoutMs: 10_000,
-      heartbeatIntervalMs: 30_000,
-      heartbeatTimeoutMs: 10_000,
-      maxBackoffMs: 30_000,
-      minBackoffMs: 1_000,
       ...options,
+      authTimeoutMs: options.authTimeoutMs ?? 10_000,
+      heartbeatIntervalMs: options.heartbeatIntervalMs ?? 30_000,
+      heartbeatTimeoutMs: options.heartbeatTimeoutMs ?? 10_000,
+      maxBackoffMs: options.maxBackoffMs ?? 30_000,
+      minBackoffMs: options.minBackoffMs ?? 1_000,
     };
   }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes a bug where the Mattermost websocket pinged the server about 800 times per second. It should ping once every 30 seconds.

`buildMattermostAdapter` does not set `heartbeatIntervalMs`. The adapter still passes the key to `MattermostSocket`, with the value `undefined` (`adapter.ts:305`). The socket constructor spread the defaults first and the options after, so the `undefined` key replaced the 30 second default. `setInterval(cb, undefined)` runs about every 1ms. That is the ping flood.

The fix resolves each default with `??`. A key set to `undefined` now falls back to the default, same as a missing key. `0` still turns the heartbeat off. TypeScript did not catch this because the options field is typed `Required<Pick<...>>`, which hides the runtime `undefined`.

How I verified it:

- New unit tests for the socket (fake transport, fake timers). The regression test fails on the old code and passes with the fix.
- Live check against a real Mattermost server: 3,969 pings in 5 seconds before the fix, 0 after.
- The live lab suite still passes (`pnpm test:mattermost-live`, 15/15).

Needs a colleague's review before merge.

Assisted by Claude; reviewed and verified by a human before submission.
