### PR TITLE
feat(runner): lease-id claimants, restart-overlap protection, and the incarnation gate

### DIFF
--- a/src/claimant-liveness.test.ts
+++ b/src/claimant-liveness.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Claimant liveness: a session claim held by a LIVE peer host (unexpired,
+ * unstopped host_instances lease) is refused; claims held by stopped,
+ * expired, or unknown claimants stay takeover-able — a crashed claimant must
+ * never wedge a session. Also pins the claimant identity: the durable lease
+ * instance id when the lease is running, the process-scoped fallback
+ * otherwise.
+ */
+import os from 'os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { SupervisedHandle, SupervisedSnapshot } from './drivers/session-events.js';
+
+const snapshots: SupervisedSnapshot[] = [];
+vi.mock('./drivers/index.js', () => ({
+  getSessionDriver: () => ({
+    listSessions: async () => snapshots,
+    capabilities: () => ({}),
+  }),
+  peekSessionDriver: () => null,
+  isSessionEventsDriver: () => false,
+}));
+
+import { adoptRunningSessions, isContainerRunning, killContainer } from './container-runner.js';
+import { getSessionClaim, registerHostInstance, tryClaimSession } from './db/coordination.js';
+import { startHostInstanceLease, stopHostInstanceLease } from './host-instance.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createSession } from './db/index.js';
+
+function now(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function fakeRunningHandle(sessionId: string, name: string): SupervisedSnapshot {
+  const handle = {
+    key: { installSlug: 'test-install', agentGroupId: 'ag-1', sessionId },
+    name,
+    async start() {},
+    async stop() {},
+    async status() {
+      return { phase: 'running' };
+    },
+    onTerminal() {},
+  } as unknown as SupervisedHandle;
+  return { handle, phase: 'running' } as SupervisedSnapshot;
+}
+
+const FALLBACK_ID = `${os.hostname()}:${process.pid}`;
+
+beforeEach(async () => {
+  snapshots.length = 0;
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  await createSession({
+    id: 'sess-1',
+    agent_group_id: 'ag-1',
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: now(),
+    created_at: now(),
+  });
+});
+
+afterEach(async () => {
+  await stopHostInstanceLease();
+  if (isContainerRunning('sess-1')) {
+    killContainer('sess-1', 'test-teardown');
+    await vi.waitFor(() => expect(isContainerRunning('sess-1')).toBe(false));
+  }
+  await closeDb();
+});
+
+describe('claimant liveness', () => {
+  it('refuses to take over a claim held by a live peer host', async () => {
+    await registerHostInstance({ instanceId: 'peer-live', installId: 'x', now: now(), leaseExpiresAt: now(90_000) });
+    await tryClaimSession({ sessionId: 'sess-1', instanceId: 'peer-live', expectedIncarnation: 0, now: now() });
+
+    snapshots.push(fakeRunningHandle('sess-1', 'container-theirs'));
+    const { adopted, stopped } = await adoptRunningSessions();
+
+    expect(adopted).toBe(0);
+    expect(stopped).toBe(0);
+    expect(isContainerRunning('sess-1')).toBe(false);
+    const claim = await getSessionClaim('sess-1');
+    expect(claim?.claimed_by).toBe('peer-live');
+    expect(claim?.incarnation).toBe(1);
+  });
+
+  it('takes over when the holder lease is expired', async () => {
+    await registerHostInstance({ instanceId: 'peer-dead', installId: 'x', now: now(-120_000), leaseExpiresAt: now(-30_000) });
+    await tryClaimSession({ sessionId: 'sess-1', instanceId: 'peer-dead', expectedIncarnation: 0, now: now() });
+
+    snapshots.push(fakeRunningHandle('sess-1', 'container-orphaned'));
+    const { adopted } = await adoptRunningSessions();
+
+    expect(adopted).toBe(1);
+    const claim = await getSessionClaim('sess-1');
+    expect(claim?.incarnation).toBe(2);
+    expect(claim?.claimed_by).toBe(FALLBACK_ID);
+  });
+
+  it('takes over when the claimant id is unknown to host_instances', async () => {
+    await tryClaimSession({ sessionId: 'sess-1', instanceId: 'legacy-host:42', expectedIncarnation: 0, now: now() });
+
+    snapshots.push(fakeRunningHandle('sess-1', 'container-legacy'));
+    const { adopted } = await adoptRunningSessions();
+
+    expect(adopted).toBe(1);
+    expect((await getSessionClaim('sess-1'))?.incarnation).toBe(2);
+  });
+
+  it('re-claims its own held claim without a liveness refusal', async () => {
+    // Our own fallback id, registered live — self re-claim must not be
+    // refused even though the holder is a live instance.
+    await registerHostInstance({ instanceId: FALLBACK_ID, installId: 'x', now: now(), leaseExpiresAt: now(90_000) });
+    await tryClaimSession({ sessionId: 'sess-1', instanceId: FALLBACK_ID, expectedIncarnation: 0, now: now() });
+
+    snapshots.push(fakeRunningHandle('sess-1', 'container-ours'));
+    const { adopted } = await adoptRunningSessions();
+
+    expect(adopted).toBe(1);
+    const claim = await getSessionClaim('sess-1');
+    expect(claim?.incarnation).toBe(2);
+    expect(claim?.claimed_by).toBe(FALLBACK_ID);
+  });
+
+  it('claims as the lease instance id while the host lease is running', async () => {
+    const leaseId = await startHostInstanceLease();
+
+    snapshots.push(fakeRunningHandle('sess-1', 'container-leased'));
+    const { adopted } = await adoptRunningSessions();
+
+    expect(adopted).toBe(1);
+    expect((await getSessionClaim('sess-1'))?.claimed_by).toBe(leaseId);
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -31,6 +31,7 @@ import { CONTAINER_RUNTIME_BIN } from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import {
+  getLiveHostInstance,
   getSessionClaim,
   listSessionsWithStopIntent,
   releaseSessionClaim,
@@ -39,6 +40,7 @@ import {
   tryClaimSession,
   type SessionClaimRow,
 } from './db/coordination.js';
+import { getHostInstanceId } from './host-instance.js';
 import { getDb, hasTable } from './db/connection.js';
 import { getSession } from './db/sessions.js';
 import { getSessionDriver, isSessionEventsDriver } from './drivers/index.js';
@@ -113,10 +115,13 @@ interface ActiveSessionRuntime {
 
 const activeContainers = new Map<string, ActiveSessionRuntime>();
 
-// Claimant identity for the shadow rows in session_claims. Process-scoped and
-// human-readable; the durable host-instance lease id takes over as claimant
-// when the rows become authoritative.
-const CLAIMANT_ID = `${os.hostname()}:${process.pid}`;
+// Claimant identity for the session_claims rows: the host's durable lease
+// instance id when the lease is running, else a process-scoped fallback
+// (tests, tools). The lease id is what makes claims answerable against
+// host_instances liveness below.
+function claimantId(): string {
+  return getHostInstanceId() ?? `${os.hostname()}:${process.pid}`;
+}
 
 /**
  * Claim a session this process is about to run (spawn or adopt). The
@@ -125,12 +130,30 @@ const CLAIMANT_ID = `${os.hostname()}:${process.pid}`;
  * first, and the caller must not start or adopt a container for it. Returns
  * the claimed incarnation, or null when the claim was lost. Throws on a
  * failed write — a claim that cannot be recorded is a claim not held.
+ *
+ * A claim held by a LIVE peer host (a host_instances row that is not stopped
+ * and whose lease is unexpired) is refused outright — two live hosts must
+ * never trade a session back and forth. A claim whose holder is stopped,
+ * lease-expired, or unknown (older claimant-id schemes) stays takeover-able:
+ * a crashed claimant must never wedge a session.
  */
 async function claimSessionRun(sessionId: string, containerRef: string): Promise<number | null> {
   const current = await getSessionClaim(sessionId);
+  const self = claimantId();
+  if (current?.claimed_by && current.claimed_by !== self) {
+    const holder = await getLiveHostInstance(current.claimed_by, new Date().toISOString());
+    if (holder) {
+      log.warn('Refusing session claim held by a live peer host', {
+        sessionId,
+        holder: current.claimed_by,
+        claimant: self,
+      });
+      return null;
+    }
+  }
   return tryClaimSession({
     sessionId,
-    instanceId: CLAIMANT_ID,
+    instanceId: self,
     expectedIncarnation: current?.incarnation ?? 0,
     containerRef,
     now: new Date().toISOString(),
@@ -143,7 +166,7 @@ async function releaseClaimQuietly(sessionId: string, incarnation: number): Prom
   await shadowWrite('session-claim-release', () =>
     releaseSessionClaim({
       sessionId,
-      instanceId: CLAIMANT_ID,
+      instanceId: claimantId(),
       incarnation,
       now: new Date().toISOString(),
     }),

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -111,6 +111,8 @@ interface ActiveSessionRuntime {
   stopReason?: string;
   /** Incarnation this process shadow-claimed in session_claims, if the write landed. */
   claimIncarnation?: number;
+  /** A deferred fenced finalization is already queued for this runtime. */
+  deferredFinishScheduled?: boolean;
 }
 
 const activeContainers = new Map<string, ActiveSessionRuntime>();
@@ -195,6 +197,52 @@ export function getContainerStartedAtMs(sessionId: string): number | undefined {
 }
 
 /**
+ * Sessions whose running container could not be claim-fenced at adoption (the
+ * store was unreachable). They are deliberately NOT in the registry — nothing
+ * supervises them yet — but they are alive, so the wake path must reclaim them
+ * instead of spawning a duplicate. Cleared on a successful retry, on
+ * discovering the container gone, or on losing the claim to another live host.
+ */
+const pendingAdoptions = new Set<string>();
+
+export function _resetAdoptionRetryStateForTesting(): void {
+  pendingAdoptions.clear();
+}
+
+/**
+ * Retry the claim-fenced adoption of a container that survived a failed claim
+ * write. Re-lists from the driver (fresher truth than any cached handle):
+ * container gone → false, a fresh spawn is correct; claim lost to a live
+ * host → throws, no spawn either; store still down → throws, wake retries.
+ */
+async function retryPendingAdoption(session: Session): Promise<boolean> {
+  const driver = getSessionDriver();
+  const snapshots = await driver.listSessions(INSTALL_SLUG);
+  const snapshot = snapshots.find(({ handle, phase }) => handle.key.sessionId === session.id && phase === 'running');
+  if (!snapshot) {
+    pendingAdoptions.delete(session.id);
+    return false;
+  }
+  const claimIncarnation = await claimSessionRun(session.id, snapshot.handle.name);
+  if (claimIncarnation === null) {
+    pendingAdoptions.delete(session.id);
+    throw new Error(
+      `session ${session.id} is claimed by another live host process — not adopting or spawning a duplicate`,
+    );
+  }
+  const runtime = registerRuntime(session.id, snapshot.handle, snapshot.handle.name, true);
+  runtime.claimIncarnation = claimIncarnation;
+  runtime.stopReason = undefined;
+  snapshot.handle.onTerminal((failure) => {
+    void finishAndResolve(session.id, runtime, failure);
+  });
+  await markContainerRunning(session.id);
+  pendingAdoptions.delete(session.id);
+  log.info('Adopted surviving container on retry after a failed claim write', { sessionId: session.id });
+  return true;
+}
+
+/**
  * Wake up a container for a session. If already running or mid-spawn, no-op
  * (the in-flight wake promise is reused).
  *
@@ -227,6 +275,12 @@ export function wakeContainer(session: Session): Promise<boolean> {
 }
 
 async function spawnContainer(session: Session): Promise<void> {
+  if (pendingAdoptions.has(session.id)) {
+    // A running container is waiting to be re-fenced after a failed adoption
+    // claim. Reclaim it rather than spawning a duplicate; its poll loop picks
+    // up any pending mail the moment it is ours again.
+    if (await retryPendingAdoption(session)) return;
+  }
   const agentGroup = await getAgentGroup(session.agent_group_id);
   if (!agentGroup) {
     log.error('Agent group not found', { agentGroupId: session.agent_group_id });
@@ -412,6 +466,31 @@ async function finishAndResolve(sessionId: string, runtime: ActiveSessionRuntime
   }
 }
 
+// Fence-read schedule: brief in-line retries (~30s), then the whole
+// finalization defers to the resync cadence. A store outage never forces a
+// choice between clobbering a newer incarnation and leaking the runtime.
+let fenceRetryDelaysMs = [5_000, 10_000, 15_000];
+let deferredFinishDelayMs = 60_000;
+export function _setFinishFenceScheduleForTesting(retryDelaysMs?: number[], deferDelayMs?: number): void {
+  fenceRetryDelaysMs = retryDelaysMs ?? [5_000, 10_000, 15_000];
+  deferredFinishDelayMs = deferDelayMs ?? 60_000;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms).unref?.());
+
+/** Re-run finalization once the store may be back. One timer per runtime. */
+function scheduleDeferredFinish(sessionId: string, runtime: ActiveSessionRuntime, failure?: SessionFailure): void {
+  if (runtime.deferredFinishScheduled) return;
+  runtime.deferredFinishScheduled = true;
+  const timer = setTimeout(() => {
+    runtime.deferredFinishScheduled = false;
+    finish(sessionId, runtime, failure).catch((err: unknown) => {
+      log.error('Deferred finalization failed', { sessionId, err });
+    });
+  }, deferredFinishDelayMs);
+  timer.unref?.();
+}
+
 async function finish(sessionId: string, runtime: ActiveSessionRuntime, failure?: SessionFailure): Promise<void> {
   const { containerName } = runtime;
 
@@ -421,15 +500,35 @@ async function finish(sessionId: string, runtime: ActiveSessionRuntime, failure?
   // write, the exit callbacks, the claim release are all skipped; only this
   // runtime's own registry entry is dropped).
   if (runtime.claimIncarnation !== undefined) {
-    let fenced = false;
-    /* eslint-disable no-catch-all/no-catch-all -- an unreadable fence must not leak the runtime forever; proceed with finalization */
-    try {
-      const claim = await getSessionClaim(sessionId);
-      fenced = claim !== undefined && claim.incarnation !== runtime.claimIncarnation;
-    } catch (err) {
-      log.warn('Claim fence check failed — proceeding with finalization', { sessionId, err });
+    let fenced: boolean | 'unreadable' = 'unreadable';
+    /* eslint-disable no-catch-all/no-catch-all -- an unreadable fence defers finalization; it never licenses unfenced writes */
+    for (let attempt = 0; attempt <= fenceRetryDelaysMs.length; attempt++) {
+      if (attempt > 0) await sleep(fenceRetryDelaysMs[attempt - 1]);
+      try {
+        const claim = await getSessionClaim(sessionId);
+        fenced = claim !== undefined && claim.incarnation !== runtime.claimIncarnation;
+        break;
+      } catch (err) {
+        log.warn('Claim fence check failed', { sessionId, attempt: attempt + 1, err });
+      }
     }
     /* eslint-enable no-catch-all/no-catch-all */
+    if (fenced === 'unreadable') {
+      // Fail closed: no status write, no claim release, no exit callbacks —
+      // none of it may happen unfenced. The registry entry stays, so wakes
+      // see the session as occupied and nothing double-spawns; an unref'd
+      // timer re-runs finalization at the resync cadence until the store
+      // answers. Exit callbacks are deferred, not dropped — and a pending
+      // respawn is carried by its durable stop-intent row even if this
+      // process dies first.
+      log.warn('Claim fence unreadable — deferring finalization until the store answers', {
+        sessionId,
+        containerName,
+        incarnation: runtime.claimIncarnation,
+      });
+      scheduleDeferredFinish(sessionId, runtime, failure);
+      return;
+    }
     if (fenced) {
       log.warn('Ignoring stale session finish — a newer incarnation holds the claim', {
         sessionId,
@@ -538,21 +637,29 @@ export async function adoptRunningSessions(): Promise<{ adopted: number; stopped
     }
     // Claim before adopting: a lost CAS means another live process already
     // owns this session — leave its container strictly alone. A failed claim
-    // WRITE degrades to unfenced adoption (refusing to adopt over a transient
-    // write failure would orphan a healthy session).
-    let claimIncarnation: number | null | undefined;
-    /* eslint-disable no-catch-all/no-catch-all -- degrade to unfenced adoption rather than orphan a healthy session */
+    // WRITE also fails closed: an unfenced adoption could stomp a newer
+    // claimant's session, while an unadopted-but-running container is safe to
+    // leave — the spawn path is claim-first fail-closed too, so nothing can
+    // start a duplicate while the store is down, and the wake path reclaims
+    // the container (`retryPendingAdoption`) once the store answers.
+    let claimIncarnation: number | null;
+    /* eslint-disable no-catch-all/no-catch-all -- fail closed: leave the container unadopted and let the wake path retry, never adopt unfenced */
     try {
       claimIncarnation = await claimSessionRun(session.id, handle.name);
     } catch (err) {
-      log.error('Session claim write failed during adoption — adopting unfenced', { sessionId: session.id, err });
-      claimIncarnation = undefined;
+      log.error('Session claim write failed during adoption — leaving the container unadopted for retry', {
+        sessionId: session.id,
+        err,
+      });
+      pendingAdoptions.add(session.id);
+      continue;
     }
     /* eslint-enable no-catch-all/no-catch-all */
     if (claimIncarnation === null) {
       log.warn('Session adoption skipped — another live host process holds the claim', { sessionId: session.id });
       continue;
     }
+    pendingAdoptions.delete(session.id);
     const runtime = registerRuntime(session.id, handle, handle.name, true);
     runtime.claimIncarnation = claimIncarnation;
     runtime.stopReason = undefined;
@@ -600,6 +707,13 @@ export async function honorPendingStopIntents(
   }
   for (const intent of intents) {
     if (intent.stop_intent !== 'respawn_after_stop') continue;
+    if (pendingAdoptions.has(intent.session_id)) {
+      // The session's container is alive but not yet re-fenced; acting on the
+      // intent now could kill or respawn the wrong incarnation. The row stays
+      // for the next recovery pass.
+      log.warn('Deferring stop intent — session awaits claim-fenced adoption', { sessionId: intent.session_id });
+      continue;
+    }
     const session = await getSession(intent.session_id);
     if (!session || session.status !== 'active') {
       await shadowWrite('stop-intent-clear', () => setStopIntent(intent.session_id, null, new Date().toISOString()));

--- a/src/db/coordination.ts
+++ b/src/db/coordination.ts
@@ -105,6 +105,20 @@ export async function markHostInstanceStopped(instanceId: string, now: string): 
   await getDb().run('UPDATE host_instances SET stopped_at = ? WHERE instance_id = ?', now, instanceId);
 }
 
+/**
+ * One instance, only if live: not gracefully stopped and lease still ahead of
+ * `now`. Undefined for unknown ids (rows from older claimant-id schemes
+ * included) — an unknown claimant reads as not-live, which is what lets a
+ * claim it holds be taken over.
+ */
+export async function getLiveHostInstance(instanceId: string, now: string): Promise<HostInstanceRow | undefined> {
+  return getDb().get<HostInstanceRow>(
+    'SELECT * FROM host_instances WHERE instance_id = ? AND stopped_at IS NULL AND lease_expires_at > ?',
+    instanceId,
+    now,
+  );
+}
+
 /** Instances whose lease is still ahead of `now` and not gracefully stopped. */
 export async function listLiveHostInstances(now: string): Promise<HostInstanceRow[]> {
   return getDb().all<HostInstanceRow>(

--- a/src/host-sweep-grace.test.ts
+++ b/src/host-sweep-grace.test.ts
@@ -4,12 +4,14 @@
  * Drives the real sweep loop (startHostSweep) against a real central DB and
  * real on-disk session DBs, mocking only the container runner. Scenario: a
  * session has a due inbound message AND a stale processing_ack claim left
- * over from a crashed container. The sweep tick that wakes a fresh container
- * must NOT kill it in the same tick — the freshly-woken container hasn't had
- * a chance to clear the stale claim yet (clearStaleProcessingAcks runs on
- * agent-runner startup). A later tick where the claim is still stale must
- * kill (claim-stuck). Goes red if the justWoke grace gate
- * (`if (alive && outDb && !justWoke)`) is removed.
+ * over from a crashed container. Evidence that predates the fresh
+ * container's durable claim time must not kill it — the freshly-woken
+ * container hasn't had a chance to clear the stale claim yet
+ * (clearStaleProcessingAcks runs on agent-runner startup), so the inherited
+ * claim's age is measured from the incarnation's start, giving it the full
+ * tolerance window. Once that window elapses with no sign of life, a later
+ * tick must kill (claim-stuck). Goes red if the incarnation gate in
+ * enforceRunningContainerSla stops reading the session_claims row.
  */
 import fs from 'fs';
 import Database from 'better-sqlite3';
@@ -87,8 +89,18 @@ beforeEach(async () => {
   vi.mocked(killContainer).mockReset();
   vi.mocked(wakeContainer)
     .mockReset()
-    // Simulate a successful spawn: after wake, the container reports running.
+    // Simulate a successful spawn honoring the runner's claim-first contract:
+    // a wake claims the session at a fresh incarnation (claimed_at = now),
+    // then the container reports running.
     .mockImplementation(async () => {
+      const { getSessionClaim, tryClaimSession } = await import('./db/coordination.js');
+      const current = await getSessionClaim(SESS);
+      await tryClaimSession({
+        sessionId: SESS,
+        instanceId: 'sweep-test-host',
+        expectedIncarnation: current?.incarnation ?? 0,
+        now: new Date().toISOString(),
+      });
       vi.mocked(isContainerRunning).mockReturnValue(true);
       return true;
     });
@@ -134,7 +146,7 @@ afterEach(async () => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
-describe('host sweep justWoke grace period', () => {
+describe('host sweep incarnation-gated grace period', () => {
   it('uses one mailbox session when no wake is needed', async () => {
     vi.mocked(isContainerRunning).mockReturnValue(true);
     const sessionSpy = vi.spyOn(getAgentMailbox(), 'session');
@@ -170,17 +182,30 @@ describe('host sweep justWoke grace period', () => {
     }
   });
 
-  it('does not kill the container on the tick that woke it, kills on a later tick if the claim is still stale', async () => {
-    // Tick 1: due message + no running container → wake. The stale claim is
-    // still in outbound.db, but the grace period must skip the SLA check.
+  it('gives a fresh container its tolerance window against inherited stale claims, then kills', async () => {
+    // Tick 1: due message + no running container → wake. The 2h-old claim is
+    // still in outbound.db, but it predates the fresh incarnation's claim
+    // time — not evidence against this container.
     await runSweepTick();
     expect(wakeContainer).toHaveBeenCalledTimes(1);
     expect(killContainer).not.toHaveBeenCalled();
 
-    // Tick 2: container is running (no fresh wake → no grace), the claim is
-    // still stale because our simulated container never cleared it → kill.
+    // Tick 2, moments later: the inherited claim's age is measured from the
+    // incarnation start, so it is still inside the tolerance window — no kill.
     await runSweepTick();
     expect(wakeContainer).toHaveBeenCalledTimes(1); // no second wake
+    expect(killContainer).not.toHaveBeenCalled();
+
+    // The tolerance window elapses (backdate the incarnation's claim time)
+    // with no sign of life — now the stale claim is this container's own
+    // silence → kill.
+    const { getDb } = await import('./db/index.js');
+    await getDb().run(
+      'UPDATE session_claims SET claimed_at = ? WHERE session_id = ?',
+      new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+      SESS,
+    );
+    await runSweepTick();
     expect(killContainer).toHaveBeenCalledTimes(1);
     expect(killContainer).toHaveBeenCalledWith(SESS, 'claim-stuck');
   });

--- a/src/reconcile-session.ts
+++ b/src/reconcile-session.ts
@@ -31,6 +31,7 @@
  */
 import fs from 'fs';
 
+import { getSessionClaim } from './db/coordination.js';
 import { getSession, isTaskThread, updateSession } from './db/sessions.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { log } from './log.js';
@@ -136,7 +137,7 @@ async function reconcileActiveSession(session: Session): Promise<void> {
       dueCount = mailbox.countDueMessages();
       shouldWake = dueCount > 0 && !isContainerRunning(session.id);
       if (!shouldWake) {
-        await maintainSessionMailbox(mailbox, session, agentGroup.id, false);
+        await maintainSessionMailbox(mailbox, session, agentGroup.id);
       }
       return true;
     });
@@ -151,7 +152,7 @@ async function reconcileActiveSession(session: Session): Promise<void> {
     await requestWake(session, 'due-message');
 
     await withExistingMailboxSession(agentGroup.id, session.id, async (mailbox) => {
-      await maintainSessionMailbox(mailbox, session, agentGroup.id, true);
+      await maintainSessionMailbox(mailbox, session, agentGroup.id);
     });
   } catch (err) {
     log.error('Session mailbox sweep failed', {
@@ -166,11 +167,10 @@ async function maintainSessionMailbox(
   mailbox: InboundMailbox & OutboundMailbox,
   session: Session,
   agentGroupId: string,
-  justWoke: boolean,
 ): Promise<void> {
   const alive = isContainerRunning(session.id);
-  if (alive && !justWoke) {
-    enforceRunningContainerSla(mailbox, mailbox, session, agentGroupId);
+  if (alive) {
+    await enforceRunningContainerSla(mailbox, mailbox, session, agentGroupId);
   }
   if (!alive) {
     resetStuckProcessingRows(mailbox, mailbox, session, 'container not running');
@@ -214,18 +214,46 @@ function bashTimeoutMs(state: ContainerState | null): number | null {
   return state.toolDeclaredTimeoutMs;
 }
 
-function enforceRunningContainerSla(
+/**
+ * The incarnation gate: evidence that predates the current incarnation's
+ * durable claim time is not evidence against this container. A heartbeat
+ * mtime older than the claim is the previous incarnation's file — treated as
+ * absent, so the spawn-time fallback gives the fresh container its grace. A
+ * processing claim older than the claim time was inherited from a crashed
+ * predecessor — its age is measured from this incarnation's start, so the
+ * fresh container gets a full tolerance window to clear it before it can
+ * kill. Replaces the old wake-tick grace flag: the fence is a durable fact
+ * about when this incarnation began, not volatile "we just woke it"
+ * bookkeeping — it survives restarts and applies on every pass, not only the
+ * one that issued the wake.
+ */
+async function enforceRunningContainerSla(
   inDb: InboundMailbox,
   outDb: OutboundMailbox,
   session: Session,
   agentGroupId: string,
-): void {
+): Promise<void> {
+  let incarnationStartMs = 0;
+  const claimRow = await getSessionClaim(session.id);
+  if (claimRow?.claimed_at) {
+    const parsed = Date.parse(claimRow.claimed_at);
+    if (!Number.isNaN(parsed)) incarnationStartMs = parsed;
+  }
+
+  const rawHeartbeatMs = heartbeatMtimeMs(agentGroupId, session.id);
+  const gatedHeartbeatMs = rawHeartbeatMs >= incarnationStartMs ? rawHeartbeatMs : 0;
+  const gatedClaims = outDb.getProcessingClaims().map((claim) => {
+    const claimedAt = Date.parse(claim.statusChanged);
+    if (Number.isNaN(claimedAt) || claimedAt >= incarnationStartMs) return claim;
+    return { ...claim, statusChanged: new Date(incarnationStartMs).toISOString() };
+  });
+
   const decision = decideStuckAction({
     now: Date.now(),
-    heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
+    heartbeatMtimeMs: gatedHeartbeatMs,
     containerStartedAtMs: getContainerStartedAtMs(session.id),
     containerState: outDb.getContainerState(),
-    claims: outDb.getProcessingClaims(),
+    claims: gatedClaims,
   });
 
   if (decision.action === 'ok') return;

--- a/src/repo-hygiene.test.ts
+++ b/src/repo-hygiene.test.ts
@@ -1,0 +1,22 @@
+import { execFileSync } from 'child_process';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The tracked tree carries no symlinks beyond the two the repo owns. A
+ * worktree convenience link (a `node_modules` pointing at some absolute local
+ * path) that slips into a commit breaks every fresh checkout — install tools
+ * hit a self-referencing link before they can run.
+ */
+const ALLOWED_SYMLINKS = new Set(['AGENTS.md', '.agents/skills']);
+
+describe('repo hygiene', () => {
+  it('tracks no symlinks outside the allowlist', () => {
+    const listing = execFileSync('git', ['ls-files', '-s'], { encoding: 'utf8' });
+    const symlinks = listing
+      .split('\n')
+      .filter((line) => line.startsWith('120000'))
+      .map((line) => line.split('\t')[1]);
+    expect(symlinks.filter((path) => !ALLOWED_SYMLINKS.has(path))).toEqual([]);
+  });
+});

--- a/src/session-claim-fencing.test.ts
+++ b/src/session-claim-fencing.test.ts
@@ -17,7 +17,15 @@ vi.mock('./drivers/index.js', () => ({
   isSessionEventsDriver: () => false,
 }));
 
-import { adoptRunningSessions, honorPendingStopIntents, isContainerRunning, killContainer } from './container-runner.js';
+import {
+  _resetAdoptionRetryStateForTesting,
+  _setFinishFenceScheduleForTesting,
+  adoptRunningSessions,
+  honorPendingStopIntents,
+  isContainerRunning,
+  killContainer,
+  wakeContainer,
+} from './container-runner.js';
 import { getSessionClaim, setStopIntent, tryClaimSession } from './db/coordination.js';
 import { initTestDb, closeDb, runMigrations, createAgentGroup, createSession, getSession } from './db/index.js';
 import type { Session } from './types.js';
@@ -75,6 +83,8 @@ async function seedSession(id = 'sess-1'): Promise<void> {
 
 beforeEach(async () => {
   snapshots.length = 0;
+  _resetAdoptionRetryStateForTesting();
+  _setFinishFenceScheduleForTesting();
   const db = await initTestDb();
   await runMigrations(db);
   await createAgentGroup({
@@ -224,5 +234,96 @@ describe('durable respawn intent', () => {
     await honorPendingStopIntents(wake);
     expect(wake).not.toHaveBeenCalled();
     expect((await getSessionClaim('sess-closed'))?.stop_intent).toBeNull();
+  });
+});
+
+describe('fail-closed adoption', () => {
+  it('a claim write failure leaves the container unadopted and untouched; the wake path reclaims it', async () => {
+    const coordination = await import('./db/coordination.js');
+    const casSpy = vi.spyOn(coordination, 'tryClaimSession').mockRejectedValueOnce(new Error('store down'));
+
+    const controls = fakeHandle('sess-1', 'container-alive');
+    snapshots.push({ handle: controls.handle, phase: 'running' } as SupervisedSnapshot);
+
+    const { adopted, stopped } = await adoptRunningSessions();
+    expect(adopted).toBe(0);
+    expect(stopped).toBe(0);
+    // Untouched: no registry entry, no stop, no unfenced claim.
+    expect(isContainerRunning('sess-1')).toBe(false);
+    expect(controls.stopped).toHaveLength(0);
+    expect(await getSessionClaim('sess-1')).toBeUndefined();
+
+    // Store is back: the wake path reclaims the surviving container instead of
+    // spawning a duplicate — and the adoption is fenced this time.
+    const woke = await wakeContainer((await getSession('sess-1'))!);
+    expect(woke).toBe(true);
+    expect(isContainerRunning('sess-1')).toBe(true);
+    const claim = await getSessionClaim('sess-1');
+    expect(claim?.incarnation).toBe(1);
+    casSpy.mockRestore();
+  });
+
+  it('the wake path spawns nothing while the store is still down', async () => {
+    const coordination = await import('./db/coordination.js');
+    const casSpy = vi.spyOn(coordination, 'tryClaimSession').mockRejectedValue(new Error('store down'));
+
+    const controls = fakeHandle('sess-1', 'container-alive');
+    snapshots.push({ handle: controls.handle, phase: 'running' } as SupervisedSnapshot);
+    await adoptRunningSessions();
+
+    const woke = await wakeContainer((await getSession('sess-1'))!);
+    expect(woke).toBe(false);
+    expect(isContainerRunning('sess-1')).toBe(false);
+    expect(controls.stopped).toHaveLength(0);
+    casSpy.mockRestore();
+  });
+
+  it('a pending stop intent is deferred while the session awaits fenced adoption', async () => {
+    await setStopIntent('sess-1', 'respawn_after_stop', now());
+    const coordination = await import('./db/coordination.js');
+    const casSpy = vi.spyOn(coordination, 'tryClaimSession').mockRejectedValueOnce(new Error('store down'));
+    const controls = fakeHandle('sess-1', 'container-alive');
+    snapshots.push({ handle: controls.handle, phase: 'running' } as SupervisedSnapshot);
+    await adoptRunningSessions();
+    casSpy.mockRestore();
+
+    const wake = vi.fn().mockResolvedValue(true);
+    await honorPendingStopIntents(wake);
+    expect(wake).not.toHaveBeenCalled();
+    // The intent row survives for the pass that runs after fenced adoption.
+    expect((await getSessionClaim('sess-1'))?.stop_intent).toBe('respawn_after_stop');
+  });
+});
+
+describe('fail-closed finish', () => {
+  it('an unreadable fence defers finalization — zero writes — then finishes fenced when the store answers', async () => {
+    _setFinishFenceScheduleForTesting([], 250);
+
+    const controls = fakeHandle('sess-1', 'container-adopted');
+    snapshots.push({ handle: controls.handle, phase: 'running' } as SupervisedSnapshot);
+    await adoptRunningSessions();
+    expect(isContainerRunning('sess-1')).toBe(true);
+
+    const coordination = await import('./db/coordination.js');
+    const fenceSpy = vi.spyOn(coordination, 'getSessionClaim').mockRejectedValueOnce(new Error('store down'));
+    controls.fireTerminal();
+    await vi.waitFor(() => expect(fenceSpy).toHaveBeenCalled());
+
+    // Fail closed while the store is down: still registered, status untouched,
+    // claim intact — no durable write happened unfenced.
+    expect(isContainerRunning('sess-1')).toBe(true);
+    expect((await getSession('sess-1'))?.container_status).toBe('running');
+    expect((await getSessionClaim('sess-1'))?.claimed_by).not.toBeNull();
+
+    // The deferred pass finds the store healthy and finalizes, fenced.
+    await vi.waitFor(
+      () => {
+        expect(isContainerRunning('sess-1')).toBe(false);
+      },
+      { timeout: 3_000 },
+    );
+    expect((await getSession('sess-1'))?.container_status).toBe('stopped');
+    expect((await getSessionClaim('sess-1'))?.claimed_by).toBeNull();
+    fenceSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Base is `feat/durable-host-integration` — the zero-conflict convergence of the three sibling lines (#3513 · #3520/#3521 · #3522), proven healthy at 425/425 before this work stacked on it. The integration branch carries no work of its own; merge it trivially once the parents land.

With all three histories together, the follow-ups both lanes named become possible:

- **Claimant = lease id.** Session claims are recorded under the host-instance lease id (`hostname:pid` fallback when the lease isn't running — tests/tools).
- **Restart-overlap protection.** During a restart, the previous host process can still be draining sessions while its replacement boots — the ncl-socket guard binds too late in boot to cover that window. A claim whose holder's lease is still current is therefore refused (same abort contract as a CAS loss); once the previous process's lease lapses or it stops gracefully, its sessions are taken over normally. A crashed process never wedges a session.
- **The incarnation gate replaces `justWoke`.** Evidence older than the claim row's `claimed_at` is discounted in `enforceRunningContainerSla`: pre-incarnation heartbeats read as absent (spawn-time fallback grants grace), inherited processing claims age from incarnation start. `decideStuckAction` untouched — only its evidence source changed. Deliberate semantic upgrade: the fresh container's protection is durable (survives restarts) instead of a one-pass volatile skip.
- Kept with reasons, not deleted: `wakePromises` (promise coalescing — rows can't hand an in-flight result to a concurrent caller), the runtime handle registry, `inflightDeliveries`.

## Test plan
New claimant-liveness suite (5 cases). One sanctioned existing-test rewrite: the grace test pinned the replaced mechanism by name; now pins the new semantics with the same goes-red-if-removed intent, and its wake mock honors the claim-first contract. 430/430 across the 45-file union re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)