### PR TITLE
feat(host): exactly one active host per shared central DB — leader election on host_instances

### DIFF
--- a/src/db/coordination.ts
+++ b/src/db/coordination.ts
@@ -127,6 +127,72 @@ export async function listLiveHostInstances(now: string): Promise<HostInstanceRo
   );
 }
 
+// ── host_leadership ──
+
+export interface HostLeadershipRow {
+  install_id: string;
+  leader_instance_id: string;
+  acquired_at: string;
+  lease_expires_at: string;
+}
+
+/**
+ * CAS-acquire the install's leader row. Succeeds when the row is absent, when
+ * the incumbent's lease has lapsed as of `now`, or when the incumbent is the
+ * caller (re-acquire after a missed renewal). A live incumbent wins.
+ */
+export async function tryAcquireHostLeadership(args: {
+  installId: string;
+  instanceId: string;
+  now: string;
+  leaseExpiresAt: string;
+}): Promise<boolean> {
+  const result = await getDb().run(
+    `INSERT INTO host_leadership (install_id, leader_instance_id, acquired_at, lease_expires_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT (install_id) DO UPDATE SET
+       leader_instance_id = excluded.leader_instance_id,
+       acquired_at = excluded.acquired_at,
+       lease_expires_at = excluded.lease_expires_at
+     WHERE host_leadership.lease_expires_at <= excluded.acquired_at
+        OR host_leadership.leader_instance_id = excluded.leader_instance_id`,
+    args.installId,
+    args.instanceId,
+    args.now,
+    args.leaseExpiresAt,
+  );
+  return result.changes > 0;
+}
+
+/** Renew only while still the leader. False means leadership was lost. */
+export async function renewHostLeadership(
+  installId: string,
+  instanceId: string,
+  leaseExpiresAt: string,
+): Promise<boolean> {
+  const result = await getDb().run(
+    'UPDATE host_leadership SET lease_expires_at = ? WHERE install_id = ? AND leader_instance_id = ?',
+    leaseExpiresAt,
+    installId,
+    instanceId,
+  );
+  return result.changes > 0;
+}
+
+/** Release only if the caller still holds the row — a prompt handoff on graceful shutdown. */
+export async function releaseHostLeadership(installId: string, instanceId: string): Promise<boolean> {
+  const result = await getDb().run(
+    'DELETE FROM host_leadership WHERE install_id = ? AND leader_instance_id = ?',
+    installId,
+    instanceId,
+  );
+  return result.changes > 0;
+}
+
+export async function getHostLeadership(installId: string): Promise<HostLeadershipRow | undefined> {
+  return getDb().get<HostLeadershipRow>('SELECT * FROM host_leadership WHERE install_id = ?', installId);
+}
+
 // ── session_claims ──
 
 export async function getSessionClaim(sessionId: string): Promise<SessionClaimRow | undefined> {

--- a/src/db/migrations/025-host-leadership.ts
+++ b/src/db/migrations/025-host-leadership.ts
@@ -1,0 +1,30 @@
+import type { Migration } from './index.js';
+
+/**
+ * Single-active-host leadership (one row per install).
+ *
+ * With the central DB on a network backend, two host processes on different
+ * machines can point at the same database — and the only thing preventing a
+ * second active host today is the node-local ncl-socket guard, which cannot
+ * see across machines. This table is the coarse gate: exactly one instance
+ * holds the leader row per `install_id`, CAS-acquired and lease-renewed like
+ * the rest of the coordination tables (ISO-8601 strings, caller clocks). The
+ * per-session claim fencing remains the fine-grained safety net underneath.
+ *
+ * On a SQLite central DB the election short-circuits host-side (same box by
+ * construction) and this table stays empty.
+ */
+export const migration025: Migration = {
+  version: 25,
+  name: 'host-leadership',
+  async up(db) {
+    await db.exec(`
+      CREATE TABLE host_leadership (
+        install_id TEXT PRIMARY KEY,
+        leader_instance_id TEXT NOT NULL,
+        acquired_at TEXT NOT NULL,
+        lease_expires_at TEXT NOT NULL
+      );
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -25,6 +25,7 @@ import { migration021 } from './021-approval-question.js';
 import { migration022 } from './022-messaging-group-detached.js';
 import { migration023 } from './023-approvals-instance.js';
 import { migration024 } from './024-host-coordination.js';
+import { migration025 } from './025-host-leadership.js';
 
 interface MigrationBase {
   version: number;
@@ -91,6 +92,7 @@ export const migrations: Migration[] = [
   migration022,
   migration023,
   migration024,
+  migration025,
 ];
 
 /**

--- a/src/host-instance.ts
+++ b/src/host-instance.ts
@@ -1,17 +1,36 @@
 /**
- * Durable host-instance lease.
+ * Durable host-instance lease + single-active-host leadership.
  *
  * The host registers itself in `host_instances` at startup and renews its
  * lease on an interval, so restarts and overlapping instances become
- * observable durable facts instead of invisible process state (today the
- * only trace of "which host is running" is the process itself). Write-only
- * shadow state: nothing may read these rows to make decisions yet.
+ * observable durable facts instead of invisible process state. Session-claim
+ * fencing reads the instance rows to refuse taking over a live host's
+ * sessions.
+ *
+ * Leadership is the coarse gate on top: with the central DB on a network
+ * backend, two host processes on different machines can point at the same
+ * database, and the node-local ncl-socket guard cannot see across machines.
+ * `awaitHostLeadership` guarantees exactly one active host per shared
+ * central DB — a non-leader waits in standby and takes over when the
+ * leader's lease lapses (boot then proceeds normally; adoption doubles as
+ * the takeover resync). On a SQLite central DB the election short-circuits
+ * to leader: same box by construction, byte-identical behavior for existing
+ * installs. The per-session claim fencing stays the fine-grained safety net
+ * underneath either way.
  */
 import { randomUUID } from 'crypto';
 import os from 'os';
 
 import { INSTALL_SLUG } from './config.js';
-import { markHostInstanceStopped, registerHostInstance, renewHostInstanceLease } from './db/coordination.js';
+import { getDb } from './db/connection.js';
+import {
+  markHostInstanceStopped,
+  registerHostInstance,
+  releaseHostLeadership,
+  renewHostInstanceLease,
+  renewHostLeadership,
+  tryAcquireHostLeadership,
+} from './db/coordination.js';
 import { log } from './log.js';
 
 const RENEW_INTERVAL_MS = 30_000;
@@ -80,6 +99,150 @@ export async function stopHostInstanceLease(): Promise<void> {
     await markHostInstanceStopped(id, new Date().toISOString());
   } catch (err) {
     log.warn('Failed to mark host instance stopped', { instanceId: id, err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}
+
+// ── leadership ──
+
+const LEADER_RETRY_INTERVAL_MS = 5_000;
+
+type LeadershipState = 'none' | 'short-circuit' | 'elected';
+
+let leadership: LeadershipState = 'none';
+let leaderRenewTimer: NodeJS.Timeout | null = null;
+
+/** True once this process is the active host (elected or short-circuited). */
+export function isHostLeader(): boolean {
+  return leadership !== 'none';
+}
+
+export interface HostLeadershipOptions {
+  /** Standby poll cadence while another host holds leadership. */
+  retryIntervalMs?: number;
+  /** Leadership renewal cadence — same philosophy as the instance lease. */
+  renewIntervalMs?: number;
+  leaseTtlMs?: number;
+  /**
+   * 'auto' short-circuits on a SQLite central DB (same box by construction —
+   * the ncl-socket guard is the same-box protection, and behavior stays
+   * byte-identical for existing installs). 'always' runs the election
+   * regardless of dialect; tests use it to exercise the machinery.
+   */
+  electionMode?: 'auto' | 'always';
+  /**
+   * Called when leadership is lost at runtime (renewal finds another leader —
+   * impossible unless our lease lapsed under us). A half-leader is worse than
+   * a restart, so the default exits nonzero and the supervisor restarts us
+   * into standby.
+   */
+  onLeadershipLost?: (code: number) => void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve only as the active host. Requires the instance lease to be started
+ * (the leadership claim is held under the instance id).
+ */
+export async function awaitHostLeadership(options: HostLeadershipOptions = {}): Promise<void> {
+  const id = instanceId;
+  if (!id) throw new Error('host leadership requires the instance lease to be started first');
+  if (leadership !== 'none') throw new Error('host leadership already established');
+
+  const mode = options.electionMode ?? 'auto';
+  if (mode === 'auto' && getDb().dialect === 'sqlite') {
+    leadership = 'short-circuit';
+    return;
+  }
+
+  const retryIntervalMs = options.retryIntervalMs ?? LEADER_RETRY_INTERVAL_MS;
+  const renewIntervalMs = options.renewIntervalMs ?? RENEW_INTERVAL_MS;
+  const leaseTtlMs = options.leaseTtlMs ?? LEASE_TTL_MS;
+  const onLost = options.onLeadershipLost ?? ((code: number) => process.exit(code));
+
+  let announcedStandby = false;
+  for (;;) {
+    const acquired = await tryAcquireHostLeadership({
+      installId: INSTALL_SLUG,
+      instanceId: id,
+      now: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + leaseTtlMs).toISOString(),
+    });
+    if (acquired) break;
+    if (!announcedStandby) {
+      log.info('standby: another host holds leadership for this install — waiting for its lease to lapse', {
+        installId: INSTALL_SLUG,
+        instanceId: id,
+        retryIntervalMs,
+      });
+      announcedStandby = true;
+    }
+    await sleep(retryIntervalMs);
+  }
+
+  leadership = 'elected';
+  if (announcedStandby) log.info('standby host took over leadership', { installId: INSTALL_SLUG, instanceId: id });
+  else log.info('acquired active-host leadership', { installId: INSTALL_SLUG, instanceId: id });
+
+  leaderRenewTimer = setInterval(() => {
+    void renewLeadership(id, leaseTtlMs, onLost);
+  }, renewIntervalMs);
+  // Never keep an otherwise-finished process alive for a renewal tick.
+  leaderRenewTimer.unref?.();
+}
+
+async function renewLeadership(id: string, leaseTtlMs: number, onLost: (code: number) => void): Promise<void> {
+  /* eslint-disable no-catch-all/no-catch-all -- a transient renewal error must not kill the host; the lease TTL gives 3× headroom */
+  try {
+    const renewed = await renewHostLeadership(INSTALL_SLUG, id, new Date(Date.now() + leaseTtlMs).toISOString());
+    if (renewed) return;
+    // Row gone or taken. Re-acquire covers our own lapsed-but-unclaimed lease;
+    // a live usurper means two hosts believed they were active — stop being one.
+    const reacquired = await tryAcquireHostLeadership({
+      installId: INSTALL_SLUG,
+      instanceId: id,
+      now: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + leaseTtlMs).toISOString(),
+    });
+    if (reacquired) {
+      log.warn('Leadership lease had lapsed unclaimed — re-acquired', { installId: INSTALL_SLUG, instanceId: id });
+      return;
+    }
+    log.error('Lost active-host leadership — another host has taken over; exiting so the supervisor restarts us into standby', {
+      installId: INSTALL_SLUG,
+      instanceId: id,
+    });
+    if (leaderRenewTimer) {
+      clearInterval(leaderRenewTimer);
+      leaderRenewTimer = null;
+    }
+    leadership = 'none';
+    onLost(1);
+  } catch (err) {
+    log.warn('Leadership renewal failed', { installId: INSTALL_SLUG, instanceId: id, err });
+  }
+  /* eslint-enable no-catch-all/no-catch-all */
+}
+
+/** Release leadership (prompt handoff): standby hosts acquire on their next retry. */
+export async function stopHostLeadership(): Promise<void> {
+  if (leaderRenewTimer) {
+    clearInterval(leaderRenewTimer);
+    leaderRenewTimer = null;
+  }
+  const state = leadership;
+  leadership = 'none';
+  if (state !== 'elected') return;
+  const id = instanceId;
+  if (!id) return;
+  /* eslint-disable no-catch-all/no-catch-all -- graceful shutdown must proceed even if the release cannot be written; the lease lapses on its own */
+  try {
+    await releaseHostLeadership(INSTALL_SLUG, id);
+  } catch (err) {
+    log.warn('Failed to release host leadership', { installId: INSTALL_SLUG, instanceId: id, err });
   }
   /* eslint-enable no-catch-all/no-catch-all */
 }

--- a/src/host-leadership.test.ts
+++ b/src/host-leadership.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { INSTALL_SLUG } from './config.js';
+import { initSqliteTestDb, closeDb, runMigrations } from './db/index.js';
+import { getHostLeadership, tryAcquireHostLeadership } from './db/coordination.js';
+import {
+  awaitHostLeadership,
+  getHostInstanceId,
+  isHostLeader,
+  startHostInstanceLease,
+  stopHostInstanceLease,
+  stopHostLeadership,
+} from './host-instance.js';
+
+function iso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeEach(async () => {
+  const db = await initSqliteTestDb();
+  await runMigrations(db);
+});
+
+afterEach(async () => {
+  await stopHostLeadership();
+  await stopHostInstanceLease();
+  await closeDb();
+});
+
+describe('host leadership', () => {
+  it('short-circuits on a sqlite central DB — leader immediately, no election rows', async () => {
+    await startHostInstanceLease();
+    expect(isHostLeader()).toBe(false);
+    await awaitHostLeadership();
+    expect(isHostLeader()).toBe(true);
+    expect(await getHostLeadership(INSTALL_SLUG)).toBeUndefined();
+  });
+
+  it('requires the instance lease first', async () => {
+    await expect(awaitHostLeadership()).rejects.toThrow(/instance lease/);
+  });
+
+  it('acquires, renews on the interval, and releases the row on stop', async () => {
+    await startHostInstanceLease();
+    await awaitHostLeadership({ electionMode: 'always', renewIntervalMs: 25, leaseTtlMs: 500 });
+    expect(isHostLeader()).toBe(true);
+
+    const initial = await getHostLeadership(INSTALL_SLUG);
+    expect(initial?.leader_instance_id).toBe(getHostInstanceId());
+
+    await sleep(80);
+    const renewed = await getHostLeadership(INSTALL_SLUG);
+    expect(renewed?.lease_expires_at ?? '').not.toBe('');
+    expect(renewed!.lease_expires_at > initial!.lease_expires_at).toBe(true);
+
+    await stopHostLeadership();
+    expect(isHostLeader()).toBe(false);
+    expect(await getHostLeadership(INSTALL_SLUG)).toBeUndefined();
+  });
+
+  it('waits in standby behind a live leader and takes over when its lease lapses', async () => {
+    // Another host holds leadership with a lease about to lapse.
+    await tryAcquireHostLeadership({
+      installId: INSTALL_SLUG,
+      instanceId: 'i-other',
+      now: iso(),
+      leaseExpiresAt: iso(120),
+    });
+    await startHostInstanceLease();
+
+    const started = Date.now();
+    await awaitHostLeadership({ electionMode: 'always', retryIntervalMs: 20, renewIntervalMs: 60_000 });
+    // Could not have won before the incumbent's lease lapsed.
+    expect(Date.now() - started).toBeGreaterThanOrEqual(100);
+    expect((await getHostLeadership(INSTALL_SLUG))?.leader_instance_id).toBe(getHostInstanceId());
+  });
+
+  it('a graceful release hands leadership to the next claimant immediately', async () => {
+    await startHostInstanceLease();
+    await awaitHostLeadership({ electionMode: 'always', renewIntervalMs: 60_000 });
+    await stopHostLeadership();
+    // A standby's very next retry succeeds — no lease lapse to wait for.
+    expect(
+      await tryAcquireHostLeadership({
+        installId: INSTALL_SLUG,
+        instanceId: 'i-standby',
+        now: iso(),
+        leaseExpiresAt: iso(60_000),
+      }),
+    ).toBe(true);
+  });
+
+  it('losing leadership at runtime calls the lost hook instead of limping on', async () => {
+    await startHostInstanceLease();
+    const lost: number[] = [];
+    await awaitHostLeadership({
+      electionMode: 'always',
+      renewIntervalMs: 20,
+      leaseTtlMs: 500,
+      onLeadershipLost: (code) => lost.push(code),
+    });
+
+    // Simulate a usurper: overwrite the row with a live foreign lease. The
+    // CAS accessor refuses live incumbents, so force it at the SQL level —
+    // this models the "our lease lapsed under us and another host won" state.
+    const { getDb } = await import('./db/connection.js');
+    await getDb().run(
+      'UPDATE host_leadership SET leader_instance_id = ?, lease_expires_at = ? WHERE install_id = ?',
+      'i-usurper',
+      iso(60_000),
+      INSTALL_SLUG,
+    );
+
+    await sleep(100);
+    expect(lost).toEqual([1]);
+    expect(isHostLeader()).toBe(false);
+    // The usurper's row is untouched — we backed off, not fought.
+    expect((await getHostLeadership(INSTALL_SLUG))?.leader_instance_id).toBe('i-usurper');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { closeDb, initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
 import { getSessionDriver } from './drivers/index.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
-import { startHostInstanceLease, stopHostInstanceLease } from './host-instance.js';
+import { awaitHostLeadership, startHostInstanceLease, stopHostInstanceLease, stopHostLeadership } from './host-instance.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { startHostModules, stopHostModules } from './host-lifecycle.js';
 import { routeInbound } from './router.js';
@@ -79,6 +79,17 @@ async function main(): Promise<void> {
   // Idempotent — skips groups that already have a config row.
   if (db.dialect === 'sqlite') await backfillContainerConfigs();
   else log.info('Skipping local container.json backfill for non-local central DB');
+
+  // 1c. Register this host process in durable state and keep its lease fresh;
+  // claim fencing reads the instance rows to protect a live host's sessions.
+  await startHostInstanceLease();
+
+  // 1d. Exactly one active host per shared central DB. On SQLite this
+  // short-circuits (same box by construction — the ncl-socket guard already
+  // protects it); on a network backend a second host waits here in standby
+  // and takes over when the leader's lease lapses. Everything below runs as
+  // the active host only, and adoption doubles as the takeover resync.
+  await awaitHostLeadership();
 
   // 2. Session runtime: prove it is reachable, then reconcile what survived a
   // restart. Adoption replaces the old reap-everything cleanup — a session that
@@ -154,10 +165,6 @@ async function main(): Promise<void> {
   // actual work begins here, after DB + delivery are ready and before polls.
   await startHostModules({ db, signal: hostAbortController.signal });
 
-  // 5b. Register this host process in durable state and keep its lease fresh
-  // (shadow state — observability across restarts, no behavior reads it).
-  await startHostInstanceLease();
-
   // 6. Start delivery polls
   startActiveDeliveryPoll();
   startSweepDeliveryPoll();
@@ -178,7 +185,9 @@ async function shutdown(signal: string): Promise<void> {
   log.info('Shutdown signal received', { signal });
   hostAbortController.abort();
   await stopHostModules();
-  // Stamp the durable stop before the DB closes below.
+  // Hand leadership off promptly (a standby acquires on its next retry),
+  // then stamp the durable stop — both before the DB closes below.
+  await stopHostLeadership();
   await stopHostInstanceLease();
   stopDeliveryPolls();
   stopHostSweep();


### PR DESCRIPTION
Stacked on #3528. With the central DB on a network backend, two host processes on different machines can point at the same database — and the only guard today is the node-local ncl socket, which cannot see across machines. This lands **exactly one active host per shared central DB**.

- `host_leadership` (migration 025): one row per install — CAS-acquired in a single portable statement (absent row, lapsed lease, or self wins; a live incumbent wins the conflict), lease-renewed alongside the instance lease, released on graceful shutdown for prompt handoff.
- **SQLite installs short-circuit to leader** — no rows, no timers, byte-identical behavior for every existing install; the socket guard remains the same-box protection.
- Standby hosts wait with a clear log line and take over automatically: within lease TTL + retry on leader death (90s + 5s defaults), on the next retry (≤5s) after graceful shutdown. Runtime leadership loss fails fast via an injectable hook (default exit-nonzero) — a half-leader is worse than a restart.
- Boot integration: instance lease + leadership acquire moved before adoption, so everything below the gate runs only as the active host, adoption doubles as the takeover resync — and session claims now carry the lease id from the very first adoption pass.
- The per-session claim fencing (#3521/#3528) stays as the fine-grained net underneath; election is the coarse gate.

## Test plan
6 new cases including timing-asserted takeover-on-lapse and immediate handoff after graceful release. Zero existing-test edits; migration passes the portability gate; 337 union tests re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)