### PR TITLE
versions: repin the agent image to hardened-2026-08-24

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "onecli-gateway": "1.41.0",
   "onecli-cli": "2.2.5",
-  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:aac07700ef2406408c881e4f610e77f918f4f34a1ea9e138c926f0875abbd99f"
+  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:79ac5063af36c1a77560a8aff66bc5efec8295b004fef32855a1df93fec3ea1a"
 }


### PR DESCRIPTION
Repins the agent image to `hardened-2026-08-24`, the first published image built from the current agent-runner lockfile.

```
797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:79ac5063af36c1a77560a8aff66bc5efec8295b004fef32855a1df93fec3ea1a
```

**Why:** every hardened tag through `hardened-2026-08-23` carried the v2.2.0 lockfile (`5f499545`), while the checkout has been on `f9d63744` since ea1dadd8 bumped the agent SDK to 0.3.238. That mismatch broke hardened installs outright from 2026-08-21, forced the `pull.sh` refusal down to a warning in #3496, and left `verify-agent-image` red on that merge. This image carries `f9d63744`, so the drift is gone rather than tolerated.

**What:** one line in `versions.json`. No source change.

**Risk:** operators re-run `container/pull.sh` to pick it up; nothing under `src/` or `container/agent-runner/src/` moves. The `pull.sh` warning-instead-of-refusal stopgap from #3496 is deliberately left in place here and reverts in a follow-up, so this diff stays pin-only for `approve-agent-image`.

**Verification:** checked from the registry before pulling, then end to end in a scratch worktree on this branch:

- registry labels on both platform manifests: `agent-runner-lock-sha256 = f9d63744…` (matches the checkout exactly), `image-source = hardened`, index covers `linux/amd64` + `linux/arm64`
- `container/pull.sh` exit 0, no lock-drift warning, no arch mismatch
- `container/build.sh` on a pull install took the overlay path instead of the `exit 3` refusal, build completed clean, labels survive the overlay
- `bun build` of the mounted `/app/src` inside the image: every import resolves against the baked `node_modules`
- runner boots to `[agent-runner] Starting v2 agent-runner (provider: claude)` and then fails only on the absent session DBs, so no module is missing
- baked versions match the checkout: agent SDK 0.3.238, claude-code 2.1.238

**Opened by hand.** `refresh-agent-image` produced this branch and commit correctly (run 32847651131) but could not create the PR: "GitHub Actions is not permitted to create or approve pull requests". That setting needs turning back on, or the step needs a token; separately, the AWS worker has not fired its dispatch since 2026-08-13, so six hardened images came and went without a bump PR. Both are tracked outside this change.

No publisher signature exists for this digest, so `approve-agent-image` will decline and auto-merge stays off. A human merges.
