### PR TITLE
ci: handle branches without an old image pin

### DIFF
--- a/.github/workflows/verify-agent-image.yml
+++ b/.github/workflows/verify-agent-image.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           set -euo pipefail
           read_pin() {
+            # Older long-lived branches may predate versions.json. Treat that
+            # as an empty old pin so the new pin still gets fully verified.
+            if ! git cat-file -e "$1:versions.json" 2>/dev/null; then
+              return 0
+            fi
             # Single-reference form only. A per-platform object is deliberately
             # not auto-bumped: the entries must move together, and a bot that
             # bumps them independently can leave the architectures on bytes


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The agent-image workflow currently exits before its safety checks when a
long-lived base branch does not have `versions.json` yet.

This treats a missing old file as an empty old pin. The new digest still goes
through the existing shape, platform, provenance, size, and signature checks.

This unblocks the `main` into `providers` catch-up in #3523 without weakening
the image gate.

## Verified

- Reproduced with `origin/providers` as the old ref and `main` as the new ref.
- The old pin resolves to empty.
- The new pin resolves to the expected digest-pinned image.
- `git diff --check` is clean.

Assisted by Claude; reviewed and verified by a human before submission.
