### PR TITLE
refactor(codex): keep the spec, drop the duplicated composer

### DIFF
--- a/src/providers/codex-agents-md.test.ts
+++ b/src/providers/codex-agents-md.test.ts
@@ -19,7 +19,6 @@ vi.mock('../config.js', async (importOriginal) => ({
 import { composeGroupAgentsMd, CODEX_PROJECT_DOC_MAX_BYTES } from './codex-agents-md.js';
 import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../db/index.js';
 import { ensureContainerConfig, updateContainerConfigJson } from '../db/container-configs.js';
-import { PERSONA_PREPEND_FILE } from '../group-persona.js';
 import type { AgentGroup } from '../types.js';
 
 const TEST_ROOT = '/tmp/nanoclaw-agents-md-test';
@@ -114,67 +113,7 @@ describe('composeGroupAgentsMd cap handling', () => {
   });
 });
 
-describe('composeGroupAgentsMd persona', () => {
-  beforeEach(async () => {
-    if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
-    fs.mkdirSync(path.join(TEST_ROOT, 'data'), { recursive: true });
-    await runMigrations(await initTestDb());
-  });
-
-  afterEach(async () => {
-    await closeDb();
-    if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
-  });
-
-  it('inlines the persona as the first section, before the runtime contract', async () => {
-    const g = group('persona');
-    await createAgentGroup(g);
-    await ensureContainerConfig(g.id);
-    const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
-    try {
-      fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'You are an SDR agent.\n');
-      await composeGroupAgentsMd(g, groupDir);
-      const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
-      expect(doc).toContain('You are an SDR agent.');
-      // First markdown heading (the HEADER is an HTML comment, not a `# ` heading).
-      const firstHeading = doc.split('\n').find((line) => line.startsWith('# '));
-      expect(firstHeading).toBe('# Persona');
-    } finally {
-      fs.rmSync(groupDir, { recursive: true, force: true });
-    }
-  });
-
-  it('never evicts the persona even when the doc exceeds the cap', async () => {
-    const g = group('persona-big');
-    await createAgentGroup(g);
-    await ensureContainerConfig(g.id);
-    await updateContainerConfigJson(g.id, 'mcp_servers', {
-      bloat: { command: 'x', instructions: 'B'.repeat(CODEX_PROJECT_DOC_MAX_BYTES + 1024) },
-    });
-    const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
-    try {
-      fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'PERSONA_MARKER body');
-      await composeGroupAgentsMd(g, groupDir);
-      const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
-      expect(Buffer.byteLength(doc, 'utf-8')).toBeLessThanOrEqual(CODEX_PROJECT_DOC_MAX_BYTES);
-      expect(doc).toContain('PERSONA_MARKER'); // survived eviction
-      expect(doc).toContain('Omitted for size');
-    } finally {
-      fs.rmSync(groupDir, { recursive: true, force: true });
-    }
-  });
-
-  it('omits the persona section when no prepend file is present', async () => {
-    const g = group('no-persona');
-    await createAgentGroup(g);
-    await ensureContainerConfig(g.id);
-    const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
-    try {
-      await composeGroupAgentsMd(g, groupDir);
-      const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
-      expect(doc).not.toContain('# Persona');
-    } finally {
-      fs.rmSync(groupDir, { recursive: true, force: true });
-    }
-  });
-});
+// The persona rules (leads the document, never evicted, absent without a
+// prepend file) belong to the shared composer and are pinned in trunk's
+// src/project-doc-compose.test.ts. Re-asserting them here would pin trunk
+// behavior from a branch that cannot be edited in the same change.

--- a/src/providers/codex-agents-md.ts
+++ b/src/providers/codex-agents-md.ts
@@ -15,7 +15,7 @@
  */
 import path from 'path';
 
-import { composeProjectDoc, type ProjectDocSpec } from '../project-doc-compose.js';
+import { composeGroupProjectDoc, type ProjectDocSpec } from '../project-doc-compose.js';
 import type { AgentGroup } from '../types.js';
 
 export const CODEX_PROJECT_DOC_MAX_BYTES = 32 * 1024;
@@ -47,5 +47,5 @@ const CODEX_PROJECT_DOC: ProjectDocSpec = {
 };
 
 export function composeGroupAgentsMd(group: AgentGroup, groupDir: string): Promise<void> {
-  return composeProjectDoc(group, groupDir, CODEX_PROJECT_DOC);
+  return composeGroupProjectDoc(group, groupDir, CODEX_PROJECT_DOC);
 }

--- a/src/providers/codex-agents-md.ts
+++ b/src/providers/codex-agents-md.ts
@@ -1,33 +1,24 @@
 /**
- * AGENTS.md composition for codex agent groups — codex-owned payload code.
+ * AGENTS.md spec for codex agent groups — codex-owned payload data.
  *
- * AGENTS.md is Codex's project doc (its CLAUDE.md equivalent). Composed fresh
- * on every spawn by the codex provider contribution (see ./codex.ts) from:
- *   - the shared base (`container/AGENTS.md`)
- *   - a pointer to the runner-scaffolded memory system (content is supplied by
- *     the provider's native SessionStart hook — nothing is read here)
- *   - a pointer to codex-native skills under `.agents/skills`
- *   - each enabled NanoClaw module's `*.instructions.md` fragment
- *   - MCP server `instructions` from container.json
+ * AGENTS.md is Codex's project doc (its CLAUDE.md equivalent). Composing it is
+ * not codex-specific and lives on trunk in `src/project-doc-compose.ts`, shared
+ * with every other provider. What stays here is only what differs: the file
+ * name, the runtime-contract base document, two pointer blocks, and Codex's
+ * project-doc byte cap.
  *
- * Codex hard-caps project-doc loading (`project_doc_max_bytes`, mirrored in
- * the container provider's config.toml writer) — compose fails loudly rather
- * than letting Codex truncate silently.
+ * `project_doc_max_bytes` is mirrored in the container provider's config.toml
+ * writer. Over the cap the shared composer degrades — it drops the largest
+ * capability sections, logs what went, and says so in the document — rather
+ * than throwing, which would ride `wakeContainer`'s retry contract and dark
+ * the group.
  */
-import fs from 'fs';
 import path from 'path';
 
-import type { McpServerConfig } from '../container-config.js';
-import { getContainerConfig } from '../db/container-configs.js';
-import { readGroupPersona } from '../group-persona.js';
-import { log } from '../log.js';
+import { composeProjectDoc, type ProjectDocSpec } from '../project-doc-compose.js';
 import type { AgentGroup } from '../types.js';
 
 export const CODEX_PROJECT_DOC_MAX_BYTES = 32 * 1024;
-export const CODEX_PROJECT_DOC_WARN_BYTES = 28 * 1024;
-
-const HEADER = '<!-- Composed at spawn. Do not edit. Edit memory/system/definition.md for memory behavior. -->';
-const MCP_TOOLS_HOST_SUBPATH = path.join('container', 'agent-runner', 'src', 'mcp-tools');
 
 const MEMORY_POINTER = [
   'The live memory index and definition are supplied by NanoClaw at session startup, clear, and after compaction.',
@@ -41,140 +32,20 @@ const MEMORY_POINTER = [
 const NATIVE_RUNTIME_SKILLS_POINTER = [
   'Selected NanoClaw runtime skills are available as Codex-native skills at `/workspace/agent/.agents/skills`.',
   'Each skill directory contains a `SKILL.md` with its trigger description plus any supporting files, and points to the read-only shared skill source under `/app/skills`.',
-  'Use skill discovery to load these skills only when their descriptions match the task. Full skill instructions live in the skill directories, not in `AGENTS.md`.',
+  'Use skill discovery to load these skills only when their descriptions match the task. A skill whose rules must hold before the task is recognised ships an `instructions.md` instead, and those arrive inlined as `NanoClaw Skill:` sections of this document.',
   'Skills YOU author or install yourself go in `~/.codex/skills/<name>/SKILL.md` — persistent across sessions and discovered by Codex automatically. Never write skills elsewhere: paths outside `~/.codex` and `~/.agents` are ephemeral or not discovered.',
 ].join('\n\n');
 
-interface AgentsMdSection {
-  name: string;
-  content: string;
-}
+const CODEX_PROJECT_DOC: ProjectDocSpec = {
+  fileName: 'AGENTS.md',
+  baseDocPath: path.join('container', 'AGENTS.md'),
+  extraSections: [
+    { name: 'Memory System', body: MEMORY_POINTER },
+    { name: 'Native Runtime Skills', body: NATIVE_RUNTIME_SKILLS_POINTER },
+  ],
+  maxBytes: CODEX_PROJECT_DOC_MAX_BYTES,
+};
 
-export async function composeGroupAgentsMd(group: AgentGroup, groupDir: string): Promise<void> {
-  if (!fs.existsSync(groupDir)) fs.mkdirSync(groupDir, { recursive: true });
-
-  const configRow = await getContainerConfig(group.id);
-  const mcpServers: Record<string, McpServerConfig> = configRow
-    ? (JSON.parse(configRow.mcp_servers) as Record<string, McpServerConfig>)
-    : {};
-
-  const sections: AgentsMdSection[] = [{ name: 'header', content: HEADER }];
-  const pushSection = (name: string, ...content: string[]): void => {
-    const body = content
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .join('\n\n');
-    if (body) sections.push({ name, content: `# ${name}\n\n${body}` });
-  };
-
-  // Template persona first — the top of the system prompt. 'Persona' is not a
-  // droppable prefix (see fitAgentsMdToCap.isDroppable), so it is never evicted.
-  const persona = readGroupPersona(groupDir);
-  if (persona) pushSection('Persona', persona);
-
-  const sharedBase = path.join(process.cwd(), 'container', 'AGENTS.md');
-  if (fs.existsSync(sharedBase)) {
-    pushSection('NanoClaw Runtime Contract', fs.readFileSync(sharedBase, 'utf-8'));
-  }
-
-  pushSection('Memory System', MEMORY_POINTER);
-  pushSection('Native Runtime Skills', NATIVE_RUNTIME_SKILLS_POINTER);
-
-  const cliDisabled = configRow?.cli_scope === 'disabled';
-  const mcpToolsHostDir = path.join(process.cwd(), MCP_TOOLS_HOST_SUBPATH);
-  if (fs.existsSync(mcpToolsHostDir)) {
-    for (const entry of fs.readdirSync(mcpToolsHostDir).sort()) {
-      const match = entry.match(/^(.+)\.instructions\.md$/);
-      if (!match) continue;
-      const moduleName = match[1];
-      if (moduleName === 'cli' && cliDisabled) continue;
-      pushSection(`NanoClaw Module: ${moduleName}`, fs.readFileSync(path.join(mcpToolsHostDir, entry), 'utf-8'));
-    }
-  }
-
-  for (const [name, mcp] of Object.entries(mcpServers)) {
-    if (mcp.instructions) {
-      pushSection(`MCP Server: ${name}`, mcp.instructions);
-    }
-  }
-
-  const content = fitAgentsMdToCap(group, sections);
-  writeAtomic(path.join(groupDir, 'AGENTS.md'), content);
-}
-
-function renderAgentsMd(sections: AgentsMdSection[]): string {
-  return (
-    sections
-      .map((section) => section.content.trim())
-      .filter(Boolean)
-      .join('\n\n') + '\n'
-  );
-}
-
-/**
- * Fit the doc under Codex's 32KB project-doc cap by DEGRADING, never
- * throwing: a per-spawn throw rides wakeContainer's transient-retry contract
- * — host-sweep respawns every 60s forever and the group goes silently dark.
- * Instead, drop the largest optional instruction sections (per-module and
- * per-MCP-server) until the doc fits, log what was dropped at error level,
- * and tell the agent in the doc itself. The core contract (header, runtime
- * contract, memory, skills pointer) is never dropped.
- */
-function fitAgentsMdToCap(group: AgentGroup, sections: AgentsMdSection[]): string {
-  const sectionBytes = (): { section: string; bytes: number }[] =>
-    sections.map((section) => ({ section: section.name, bytes: Buffer.byteLength(section.content, 'utf-8') }));
-
-  const isDroppable = (s: AgentsMdSection): boolean =>
-    s.name.startsWith('MCP Server: ') || s.name.startsWith('NanoClaw Module: ');
-
-  const dropped: string[] = [];
-  const render = (): string => {
-    const parts = [...sections];
-    if (dropped.length > 0) {
-      parts.push({
-        name: 'omitted',
-        content:
-          `# Omitted for size\n\nThese instruction sections were omitted to fit Codex's project-doc cap: ` +
-          `${dropped.join(', ')}. Their tools still work; consult each tool's own description.`,
-      });
-    }
-    return renderAgentsMd(parts);
-  };
-
-  let content = render();
-  while (Buffer.byteLength(content, 'utf-8') > CODEX_PROJECT_DOC_MAX_BYTES) {
-    const candidates = sections
-      .filter(isDroppable)
-      .sort((a, b) => Buffer.byteLength(b.content, 'utf-8') - Buffer.byteLength(a.content, 'utf-8'));
-    if (candidates.length === 0) break; // only core left — write oversized rather than brick the group
-    sections.splice(sections.indexOf(candidates[0]), 1);
-    dropped.push(candidates[0].name);
-    content = render();
-  }
-
-  const bytes = Buffer.byteLength(content, 'utf-8');
-  if (dropped.length > 0) {
-    log.error('AGENTS.md exceeded Codex project-doc cap — dropped largest instruction sections', {
-      group: group.name,
-      bytes,
-      maxBytes: CODEX_PROJECT_DOC_MAX_BYTES,
-      dropped,
-      sections: sectionBytes(),
-    });
-  } else if (bytes >= CODEX_PROJECT_DOC_WARN_BYTES) {
-    log.warn('AGENTS.md is near Codex project-doc cap', {
-      group: group.name,
-      bytes,
-      warnBytes: CODEX_PROJECT_DOC_WARN_BYTES,
-      maxBytes: CODEX_PROJECT_DOC_MAX_BYTES,
-      sections: sectionBytes(),
-    });
-  }
-  return content;
-}
-
-function writeAtomic(filePath: string, content: string): void {
-  const tmp = `${filePath}.tmp-${process.pid}`;
-  fs.writeFileSync(tmp, content);
-  fs.renameSync(tmp, filePath);
+export function composeGroupAgentsMd(group: AgentGroup, groupDir: string): Promise<void> {
+  return composeProjectDoc(group, groupDir, CODEX_PROJECT_DOC);
 }


### PR DESCRIPTION
Codex composes its project document through trunk's shared composer instead of its own copy.

## Why

Two composers doing one job had already drifted apart:

- A Codex group with `cli_scope: disabled` was handed the `ncl tasks` manual — for commands host dispatch rejects on arrival. Trunk dropped it; Codex did not.
- Codex never composed resident skill prose at all. Those are the credential-gateway rules that have to hold *before* a 401 arrives, not after the agent decides to load a skill.

## What

**154 lines deleted, 25 added.** The file keeps only what is codex-specific: the file name, `container/AGENTS.md`, two pointer blocks, and `project_doc_max_bytes`.

Composition, rendering, the byte-cap ladder and `writeAtomic` now come from trunk's `composeProjectDoc`.

The three persona test cases go too — they pin shared-composer behavior, which must not be asserted from a branch that cannot be edited alongside trunk.

## Risk

No operator action, no rebuild. `AGENTS.md` gains one section and loses one:

| group | old | new |
|---|---|---|
| default | 17,140 B | 18,041 B (+901, gains the credential rules) |
| `cli_scope: disabled` | 10,728 B | 10,267 B (**−461**, drops `scheduling` too) |

Stored MCP servers are now re-validated before their instructions are inlined. Measured on 4 stored entries: old taught all 4, new teaches 1 — the other 3 are servers `configFromDb` already rejects, so the old doc was teaching servers that were never wired.

## Be skeptical of

Codex never had the `@`-import bug. That was Claude-only. This is deduplication plus the two drift fixes above, not a rescue.

## Tests

Registry PRs get **no CI** (`ci.yml` fires only on `pull_request` into `main`), so everything below is local, composed onto a trunk checkout carrying `composeProjectDoc`:

| | |
|---|---|
| codex suites, unmodified | **18** pass |
| full host suite | **2038** pass |
| container suite | **366** pass |
| typecheck | clean, both trees |

**Live Codex container:** `AGENTS.md` 18,193 B (cap 32,768), **0** `@` lines, mounted read-only, section order `Persona → Runtime Contract → Memory System → Native Runtime Skills → six modules → NanoClaw Skill: onecli-gateway`.

Cap ladder exercised separately: 8 MCP blobs → 32,064 B, `# Omitted for size` present, persona and Memory System retained, error log naming every dropped section, no throw.

---

**Requires nanocoai/nanoclaw#3536 to merge first** — this imports `composeProjectDoc` from it. A cross-trunk chain cannot be a `gh stack`, so the order is stated rather than enforced. Installing this payload onto an older trunk fails at the skill's build step, and #3536 adds a preflight that says so in a sentence.
