### PR TITLE
fix(opencode): run the agent session in the agent workspace

### DIFF
--- a/container/agent-runner/src/providers/opencode.memory.test.ts
+++ b/container/agent-runner/src/providers/opencode.memory.test.ts
@@ -212,10 +212,13 @@ describe('buildOpenCodeConfig instructions', () => {
     expect(config.instructions).not.toContain('/workspace/agent/memory/system/definition.md');
   });
 
-  it('still loads the base and per-group instruction files', () => {
+  // The array named `/app/CLAUDE.md` and `.claude-fragments/*.md` until the
+  // host stopped mounting either and inlined every instruction source into the
+  // composed project document instead. OpenCode reads no other file at
+  // startup, so a stale entry here fails silently: the agent spawns with no
+  // capability instructions and nothing logs it.
+  it('loads the composed project document and the group memory file, and nothing that no longer exists', () => {
     const config = buildOpenCodeConfig({});
-    expect(config.instructions).toContain('/app/CLAUDE.md');
-    expect(config.instructions).toContain('/workspace/agent/.claude-fragments/*.md');
-    expect(config.instructions).toContain('/workspace/agent/CLAUDE.local.md');
+    expect(config.instructions).toEqual(['/workspace/agent/CLAUDE.md', '/workspace/agent/CLAUDE.local.md']);
   });
 });

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -27,6 +27,13 @@ const MODEL_INPUT_MODALITIES = ['text', 'audio', 'image', 'video', 'pdf'] as con
 
 const SESSION_STATUS_RETRY_ERROR_AFTER = 3;
 
+/**
+ * The agent workspace: the group directory the host mounts RW, holding the
+ * composed project document, the group's memory, and its working files. Both
+ * the server's cwd and every instruction path resolve here.
+ */
+const AGENT_DIR = '/workspace/agent';
+
 /** Stale / dead OpenCode session heuristics (complement Claude-centric host patterns). */
 const STALE_SESSION_RE =
   /no conversation found|ENOENT.*\.jsonl|session.*not found|NotFoundError|connection reset|ECONNRESET|404|event timeout/i;
@@ -66,6 +73,13 @@ function spawnOpencodeServer(config: Record<string, unknown>, timeoutMs = 10_000
     const hostname = '127.0.0.1';
     const port = 4096;
     const proc = spawn('opencode', ['serve', `--hostname=${hostname}`, `--port=${port}`], {
+      // `opencode serve` has no --directory flag: the server's project
+      // directory IS its cwd, and both native project-doc discovery and the
+      // root that read/glob/grep/bash resolve against follow from it.
+      // Inherited, that was the image WORKDIR (/workspace/group) — a sibling
+      // of the agent workspace, so the tools ran in an empty directory.
+      // Codex passes the same directory explicitly; OpenCode had no equivalent.
+      cwd: AGENT_DIR,
       env: {
         ...process.env,
         OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
@@ -334,10 +348,12 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
 
   const mcp = mcpServersToOpenCodeConfig(options.mcpServers);
 
-  // Load the shared base + per-group fragments through OpenCode's native
-  // instructions pipeline (session/instruction.ts). Absolute paths with
-  // globs are supported. Files are read raw — `@./...` includes are NOT expanded
-  // by OpenCode, so point at the concrete files, not at composed CLAUDE.md.
+  // Named explicitly rather than left to the cwd walk: OpenCode takes the
+  // FIRST of AGENTS.md, CLAUDE.md, CONTEXT.md it finds and stops, so a stale
+  // AGENTS.md from a group that once ran codex would shadow the document the
+  // host just composed. Listed here it loads either way (resolved paths
+  // dedupe against the walk). CLAUDE.local.md is in no walk target list, so
+  // this array is the group memory file's only channel.
   //
   // Memory deliberately does NOT ride this array. OpenCode's instruction
   // pipeline calls instruction.system() on every model request and rereads
@@ -345,11 +361,7 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
   // unrendered) on every request instead of following the shared
   // startup/clear/compact lifecycle. Memory is delivered by the registered
   // memory session hook instead — see createMemoryLifecycle below.
-  const instructions = [
-    '/app/CLAUDE.md',
-    '/workspace/agent/.claude-fragments/*.md',
-    '/workspace/agent/CLAUDE.local.md',
-  ];
+  const instructions = [`${AGENT_DIR}/CLAUDE.md`, `${AGENT_DIR}/CLAUDE.local.md`];
 
   return {
     ...(model ? { model } : {}),


### PR DESCRIPTION
OpenCode agents read the composed project document, from the directory they actually work in.

## Why

`opencode serve` inherited the runner's cwd — the image `WORKDIR`, `/workspace/group`. That is a **sibling** of the agent workspace, not a parent, so OpenCode's project-document walk could never reach `/workspace/agent`, and `read` / `glob` / `grep` / `bash` resolved against an empty directory. Codex passes the directory explicitly (`cwd: params.cwd`); OpenCode had no equivalent.

The instructions array compensated by naming two files directly: `/app/CLAUDE.md` and `/workspace/agent/.claude-fragments/*.md`. #3536 inlines every instruction source into one composed document and deletes both. OpenCode reads nothing else at startup, so once that lands:

| group | today | with #3536, without this |
|---|---|---|
| upgraded | base doc + fragments | frozen fragments no spawn regenerates, base doc gone |
| fresh | base doc + fragments | **nothing** |

Silent either way — no error, no log line. The same failure #3536 fixes for Claude, arriving through a different door.

## What

`spawnOpencodeServer` passes `cwd: AGENT_DIR`, and `buildOpenCodeConfig` names the composed document plus the group memory file. One file, 25 production lines, ~15 of them the comments explaining the two decisions.

The document is named explicitly rather than left to the walk: OpenCode takes the **first** of `AGENTS.md`, `CLAUDE.md`, `CONTEXT.md` it finds and stops, so a stale `AGENTS.md` from a group that once ran codex would shadow it. `CLAUDE.local.md` is in no walk target list, so the array is the group memory file's only channel regardless.

## Risk

Image rebuild and restart. No migration, no operator action.

Sessions are **not** keyed to the project directory — verified against the pinned CLI: a session created under one cwd resolves by id under the other, and back again. Conversation continuity survives the move.

## Verification

Composed onto a trunk carrying `project-doc-compose.ts` (#3536) with the codex payload of #3539:

| | |
|---|---|
| container `bun test` | **457** pass, 0 fail |
| host `pnpm test` | **2036** pass, 4 fail |
| `pnpm run build` / container `tsc --noEmit` | clean / clean |

The 4 red are `scripts/update/transaction.e2e.test.ts`, which needs unannotated `git tag` and fails under a global `tag.gpgsign` — identical at the base with zero changes.

**Live**, pinned CLI (`opencode-ai@1.4.17`) and pinned SDK, driven through the real `buildOpenCodeConfig`, container directory layout reproduced, model request body recorded off the wire:

| scenario | composed document | group memory |
|---|---|---|
| before: cwd `…/group`, old instruction paths | **ABSENT** | present |
| after: cwd `…/agent`, composed document | **PRESENT** | present |
| after + stale `AGENTS.md` in the workspace | **PRESENT** | present |

## Be skeptical of

- **7 test lines against 21 production.** The array is asserted exactly (`toEqual`), and it is the load-bearing half. The spawn cwd carries no unit test: asserting it needs a live process, and `/workspace/agent` cannot be created on a dev host. The live table is its cover; a container-level guard is the same deferred work #3536 names.
- **The composed file is still `CLAUDE.md`, not `AGENTS.md`.** Renaming it means declaring `providesAgentSurfaces`, which also drops `/home/node/.claude` and the skill links core supplies today — re-adding those here would duplicate core's default-surface block, the exact drift #3539 deletes. The walk finds `CLAUDE.md` either way.

---

Stacked on #3539. Both layers target `providers`; this one is written against that tree.
