### PR TITLE
fix: clear container_status drift at startup adoption

### DIFF
--- a/src/container-adoption.test.ts
+++ b/src/container-adoption.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Startup adoption — the reconciliation of DB `container_status` against what
+ * the session runtime actually still has.
+ *
+ * The case that matters here is the absent one: a container that died while no
+ * host was attached never appears in `listSessions`, so the adoption loop never
+ * visits its row. `container_status` is only ever cleared by the in-process
+ * exit handler, which that container outlived — so without a clearing pass the
+ * row reads 'running' forever.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { adoptRunningSessions } from './container-runner.js';
+import { getRunningSessions, getSession } from './db/sessions.js';
+import { getSessionDriver } from './drivers/index.js';
+import { markContainerRunning, markContainerStopped } from './session-manager.js';
+import type { Session } from './types.js';
+
+vi.mock('./log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+vi.mock('./db/sessions.js', () => ({ getSession: vi.fn(), getRunningSessions: vi.fn() }));
+vi.mock('./drivers/index.js', () => ({
+  getSessionDriver: vi.fn(),
+  isSessionEventsDriver: () => false,
+}));
+vi.mock('./session-manager.js', () => ({
+  markContainerRunning: vi.fn(),
+  markContainerStopped: vi.fn(),
+  heartbeatPath: vi.fn(),
+  sessionContextPath: vi.fn(),
+  sessionDir: vi.fn(),
+  writeSessionContext: vi.fn(),
+  writeSessionRouting: vi.fn(),
+}));
+
+function session(id: string): Session {
+  return {
+    id,
+    agent_group_id: 'ag-1',
+    messaging_group_id: 'mg-1',
+    thread_id: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: '2026-08-19T19:50:06.786Z',
+    created_at: '2026-08-19T19:50:06.786Z',
+  } as Session;
+}
+
+function snapshot(sessionId: string, phase: 'running' | 'terminal') {
+  return {
+    phase,
+    handle: {
+      name: `nanoclaw-${sessionId}`,
+      key: { installSlug: 'slug', agentGroupId: 'ag-1', sessionId },
+      stop: vi.fn().mockResolvedValue(undefined),
+      onTerminal: vi.fn(),
+    },
+  };
+}
+
+describe('adoptRunningSessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSession).mockImplementation(async (id: string) => session(id));
+    vi.mocked(getRunningSessions).mockResolvedValue([]);
+  });
+
+  it('clears container_status for a session the runtime no longer lists', async () => {
+    vi.mocked(getSessionDriver).mockReturnValue({
+      listSessions: vi.fn().mockResolvedValue([]),
+    } as never);
+    vi.mocked(getRunningSessions).mockResolvedValue([session('sess-gone')]);
+
+    const result = await adoptRunningSessions();
+
+    expect(result.cleared).toBe(1);
+    expect(markContainerStopped).toHaveBeenCalledWith('sess-gone');
+  });
+
+  it('leaves an adopted session marked running', async () => {
+    vi.mocked(getSessionDriver).mockReturnValue({
+      listSessions: vi.fn().mockResolvedValue([snapshot('sess-alive', 'running')]),
+    } as never);
+    // The DB still lists it as running — the clearing pass must skip it.
+    vi.mocked(getRunningSessions).mockResolvedValue([session('sess-alive')]);
+
+    const result = await adoptRunningSessions();
+
+    expect(result).toMatchObject({ adopted: 1, cleared: 0 });
+    expect(markContainerRunning).toHaveBeenCalledWith('sess-alive');
+    expect(markContainerStopped).not.toHaveBeenCalled();
+  });
+
+  it('clears a session whose listed container is already terminal', async () => {
+    vi.mocked(getSessionDriver).mockReturnValue({
+      listSessions: vi.fn().mockResolvedValue([snapshot('sess-dead', 'terminal')]),
+    } as never);
+    vi.mocked(getRunningSessions).mockResolvedValue([session('sess-dead')]);
+
+    const result = await adoptRunningSessions();
+
+    expect(result).toMatchObject({ adopted: 0, stopped: 1, cleared: 1 });
+    expect(markContainerStopped).toHaveBeenCalledWith('sess-dead');
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -30,7 +30,7 @@ import { CONTAINER_RUNTIME_BIN } from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
-import { getSession } from './db/sessions.js';
+import { getRunningSessions, getSession } from './db/sessions.js';
 import { getSessionDriver, isSessionEventsDriver } from './drivers/index.js';
 import type { SupervisedHandle, SupervisedSnapshot } from './drivers/session-events.js';
 import { GROUP_FOLDER_LABEL, labelValueLegal, specInvalid } from './drivers/types.js';
@@ -378,19 +378,24 @@ export function killContainer(sessionId: string, reason: string, onExit?: () => 
  * through the DB; now the host re-registers it and delivery resumes. The OneCLI
  * gateway resolves credentials per request on the host side, so an adopted
  * session's egress keeps working without any per-process state to rebuild.
+ *
+ * It is also the only place `container_status` drift gets corrected: a row is
+ * marked stopped by the in-process exit handler, so a container that died with
+ * no host attached leaves the row stuck on 'running'. See the clearing pass.
  */
-export async function adoptRunningSessions(): Promise<{ adopted: number; stopped: number }> {
+export async function adoptRunningSessions(): Promise<{ adopted: number; stopped: number; cleared: number }> {
   const driver = getSessionDriver();
   let snapshots: SupervisedSnapshot[];
   try {
     snapshots = await driver.listSessions(INSTALL_SLUG);
   } catch (err) {
     log.warn('Failed to list existing sessions for adoption', { err });
-    return { adopted: 0, stopped: 0 };
+    return { adopted: 0, stopped: 0, cleared: 0 };
   }
 
   let adopted = 0;
   let stopped = 0;
+  const adoptedIds = new Set<string>();
   for (const { handle, phase } of snapshots) {
     const session = handle.key.sessionId ? await getSession(handle.key.sessionId) : undefined;
     // The snapshot's phase is the listing's own truth: a corpse arrives as
@@ -408,8 +413,24 @@ export async function adoptRunningSessions(): Promise<{ adopted: number; stopped
       void finishAndResolve(session.id, failure);
     });
     await markContainerRunning(session.id);
+    adoptedIds.add(session.id);
     adopted += 1;
   }
+
+  // The snapshot listing only tells us about containers that still exist. A
+  // session whose container died while no host was listening is absent from it
+  // entirely, so the loop above never visits the row — and `container_status`
+  // is only ever cleared by the in-process exit handler, which that container
+  // outlived. Without this pass the row says 'running' for the rest of the
+  // install's life: `getRunningSessions()` keeps returning it, delivery keeps
+  // polling it, and the diagnostics heartbeat check flags it forever.
+  let cleared = 0;
+  for (const session of await getRunningSessions()) {
+    if (adoptedIds.has(session.id)) continue;
+    await markContainerStopped(session.id);
+    cleared += 1;
+  }
+  if (cleared > 0) log.info('Cleared stale running container status', { sessions: cleared });
 
   await driver.reapResidue?.(INSTALL_SLUG).catch?.(() => {});
   // Reconcile terminals the watch stream missed while no host was listening —
@@ -417,10 +438,10 @@ export async function adoptRunningSessions(): Promise<{ adopted: number; stopped
   // resync wires here rather than into new periodic machinery.
   if (isSessionEventsDriver(driver)) await driver.resync(INSTALL_SLUG).catch(() => {});
 
-  if (adopted > 0 || stopped > 0) {
-    log.info('Reconciled sessions at startup', { adopted, stopped });
+  if (adopted > 0 || stopped > 0 || cleared > 0) {
+    log.info('Reconciled sessions at startup', { adopted, stopped, cleared });
   }
-  return { adopted, stopped };
+  return { adopted, stopped, cleared };
 }
 
 /**


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — `adoptRunningSessions` now clears `sessions.container_status` for any session the runtime no longer lists, instead of leaving the row stuck on `running` forever.

**Why** — `container_status` is only ever reset to `stopped` by the in-process exit handler (`finish()` → `markContainerStopped`). A container that dies while no host is attached — any unclean host restart, a `docker kill`, an OOM — outlives that handler. Startup adoption iterates the *runtime's snapshot listing*, where a dead container does not appear at all, so those rows are never visited.

The drift is permanent for the life of the install: `getRunningSessions()` keeps returning the session, delivery keeps polling it, and the web diagnostics heartbeat check reports `N sessions marked running whose container has not beaten in 30 min` on every run.

This is the bug reported in #2533 (closed by its reporter as withdrawn, not fixed). Its "Expected Behavior" section describes this change: *"if a session is marked `running` or `idle` but no matching live container exists, mark it `stopped` … log the reconciliation with enough detail to diagnose stale state."*

**How it works** — the adoption loop records the session ids it adopted; a following pass walks `getRunningSessions()` and marks stopped everything not in that set, logging the count. Adoption is already the one place a full re-list is cheap, and it is the only point where the host's in-memory view is authoritative for "what survived" — so the reconciliation wires here rather than into new periodic machinery. The healthy path is unchanged: a live adopted container is in the set and is skipped. `stopped` (orphans reaped from the listing) and `cleared` (rows with no listing entry at all) are counted separately because they are different failures.

**How it was tested**

- New `src/container-adoption.test.ts` covers the three cases: a session absent from the listing is cleared; an adopted session stays `running`; a listed-but-terminal container is both stopped and cleared.
- Full suite green on this branch apart from 3 failures in `src/cli/stdin-json.test.ts` / `stdin-json.e2e.test.ts` that reproduce identically on pristine `main` with this commit absent — pre-existing and unrelated.
- Verified on a live install: startup logged `Cleared stale running container status sessions=4` / `Reconciled sessions at startup adopted=0 stopped=0 cleared=4`, and `SELECT ... WHERE container_status IN ('running','idle')` went from 4 rows (heartbeats 6 days stale) to none. The diagnostics warning cleared with it.
