### PR TITLE
fix(slack): add explicit room handoffs

### DIFF
--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -13,9 +13,10 @@ a workspace manager token), registers it as a `slack-<name>` instance,
 hot-starts the adapter in the running host, opens a DM between the new bot and
 the operator, opens a three-way MPIM (operator + originating bot + new bot)
 registered as an agent-to-agent room, and wires everything so both agents hear
-the room. The flow also adds two agent-facing room actions — `create_room`
+the room. The flow also adds three agent-facing room actions — `create_room`
 (one shared room with N agents at once, the team primitive) and `add_to_room`
-(grow a room by one agent) — and extends the base `create_agent` tool with the
+(grow a room by one agent), plus `handoff` (reliably engage one or several
+explicitly selected sibling agents in a room) — and extends the base `create_agent` tool with the
 flow's `purpose` / `allow_guests` / `room` parameters. Non-Slack sessions are
 untouched: `create_agent` from any other channel behaves exactly as upstream.
 
@@ -179,7 +180,7 @@ import './slack-agent-flow/index.js';
 ### 6. Register the container room tools
 
 Append the tool-module import to the container MCP-tools barrel (skipped if
-already present). The module registers `create_room` / `add_to_room` and
+already present). The module registers `create_room` / `add_to_room` / `handoff` and
 extends the base `create_agent` tool, so it must evaluate after the base
 agents module — import order follows document order, and appending at the end
 guarantees it:
@@ -229,9 +230,11 @@ bash setup/lib/restart.sh
   with the same guard action and precheck as the agent-to-agent module; only
   the hold question changes when the request originates from a Slack session
   (it names the Slack provisioning side effects — new app, operator DM,
-  shared room). The room actions get the same trust split: `global` cli_scope
-  groups act directly, everything else holds for the admin chain, and
-  approved replays re-enter the wrapped handlers automatically.
+  shared room). Room creation and membership changes get the same trust split:
+  `global` cli_scope groups act directly, everything else holds for the admin
+  chain, and approved replays re-enter the wrapped handlers automatically.
+  `handoff` needs no approval because it can only post through the caller's
+  existing room adapter after host-side destination and membership checks.
 - **Expected boot warning.** Because the barrel imports the flow module after
   the agent-to-agent module, every boot logs
   `Delivery action handler overwritten` for `create_agent`. That warning is
@@ -269,6 +272,11 @@ bash setup/lib/restart.sh
   `create_room` naming all of them. When a batch of creates arrives together,
   their avatar generations are prefetched in parallel, so N waits collapse to
   roughly one.
+- **Room handoffs are explicit.** `handoff({ to, text, room? })` resolves one
+  agent name or an explicit list through the caller's destinations, verifies
+  every target is wired to the same physical Slack room, then posts through
+  the caller's room adapter/thread with exactly one real mention per selected
+  agent. Room creation never chooses a responder or wakes everyone by default.
 - **A2A cache staleness.** The a2a room allowlist is re-read from `.env` on a
   ≤30s cache. The room id is appended before any intro is posted, but the
   originating agent's own bridge may still miss ingesting the intro inside

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
@@ -1,6 +1,6 @@
-## Shared rooms (`create_room`, `add_to_room`)
+## Shared rooms (`create_room`, `add_to_room`, `handoff`)
 
-A room is one Slack group conversation shared by the user and N agents, with a canvas tab carrying the room contract (purpose, members). `mcp__nanoclaw__create_room({ name, purpose, agents, include_me? })` opens one; `mcp__nanoclaw__add_to_room({ room, agent })` grows one.
+A room is one Slack group conversation shared by the user and N agents, with a canvas tab carrying the room contract (purpose, members). `mcp__nanoclaw__create_room({ name, purpose, agents, include_me? })` opens one; `mcp__nanoclaw__add_to_room({ room, agent })` grows one; `mcp__nanoclaw__handoff({ to, text, room? })` reliably engages exactly the named sibling agent or agents.
 
 ### The team pattern — one room, not N
 
@@ -14,8 +14,8 @@ For a SINGLE new agent, plain `create_agent` (default `room: 'own'`) is right �
 ### How it works
 
 - `agents` takes the same names you use with `send_message` — agents you created or can already message. Unknown names come back as an error note, nothing half-created.
-- Both tools are fire-and-forget and may require admin approval; the outcome arrives as a system note. When the room is live, the note tells you the destination to post to and whom to tag — post a brief intro in your own voice (1-2 lines, no mechanics, no member lists).
-- In rooms, agents engage when @-mentioned; everything else accumulates as ambient context. Tag an agent to bring it in.
+- Room creation and membership changes are fire-and-forget and may require admin approval; the outcome arrives as a system note. Creating a room never chooses responders or wakes everyone automatically.
+- In rooms, agents engage when @-mentioned; everything else accumulates as ambient context. Use `handoff` to bring in exactly the agent(s) whose response the user wants: one name for one responder, an explicit list for several. Omit `room` inside the room; after a `create_room` completion note, pass the room destination it provides. Never place raw Slack mention markup in `text`.
 
 ### Growing a room
 

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
@@ -1,5 +1,5 @@
 /**
- * Room MCP tool tests: create_room / add_to_room arg validation and
+ * Room MCP tool tests: create_room / add_to_room / handoff arg validation and
  * system-action row shape, plus the extendTool-based create_agent extension
  * (schema/description growth + purpose/allow_guests/room payload
  * passthrough) — all fire-and-forget writes to messages_out (authorization
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
 import { createAgent } from './agents.js';
-import { addToRoom, createRoom } from './rooms.js';
+import { addToRoom, createRoom, handoff } from './rooms.js';
 
 function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
   return (
@@ -95,6 +95,42 @@ describe('add_to_room', () => {
     expect(rows[0].kind).toBe('system');
     expect(rows[0].content).toMatchObject({ action: 'add_to_room', room: 'Website Team', agent: 'Devin' });
     expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+});
+
+describe('handoff', () => {
+  it('accepts one target or several and writes explicit recipient lists', async () => {
+    await handoff.handler({ to: ' Pixel ', text: ' Please review. ' });
+    await handoff.handler({ room: ' Website Team ', to: ['Pixel', 'Devin'], text: 'Please both review.' });
+
+    const rows = outboundActions();
+    expect(rows[0].content).toMatchObject({
+      action: 'handoff',
+      to: ['Pixel'],
+      text: 'Please review.',
+    });
+    expect(rows[0].content.room).toBeUndefined();
+    expect(rows[1].content).toMatchObject({
+      action: 'handoff',
+      room: 'Website Team',
+      to: ['Pixel', 'Devin'],
+      text: 'Please both review.',
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+    expect(rows[1].content.requestId).toBe(rows[1].id);
+  });
+
+  it('rejects missing recipients, missing text, and raw Slack mentions', async () => {
+    for (const args of [
+      { to: [], text: 'Review.' },
+      { to: ['  '], text: 'Review.' },
+      { to: ['Pixel'], text: '  ' },
+      { to: ['Pixel'], text: 'Review this <@U0OTHER>.' },
+      { to: ['Pixel'], text: 'Attention <!here>.' },
+    ]) {
+      expect((await handoff.handler(args)).isError).toBe(true);
+    }
+    expect(outboundActions()).toHaveLength(0);
   });
 });
 

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
@@ -1,17 +1,18 @@
 /**
- * Room management MCP tools: create_room, add_to_room.
+ * Slack room MCP tools: create_room, add_to_room, handoff.
  *
  * A "room" is one Slack group conversation shared by the user and N agents.
  * create_room is the team primitive — the multi-agent pattern is N
  * create_agent calls with room:'none', then ONE create_room naming all of
- * them. Both tools are fire-and-forget (create_agent pattern): they write an
- * outbound system row and return; the host resolves names, opens the
- * conversation, wires everyone, and reports back as a system note.
+ * them. The management tools are fire-and-forget (create_agent pattern):
+ * they write an outbound system row and return; the host resolves names,
+ * opens the conversation, wires everyone, and reports back as a system note.
+ * handoff uses the same system-action path to resolve real bot mentions and
+ * deliver through the caller's room adapter/thread.
  *
- * Authorization is enforced host-side by the guard (same trust split as
- * create_agent: trusted global-scope groups act directly, confined groups
- * hold for admin approval) — the container is untrusted and cannot be relied
- * on to gate itself.
+ * Authorization is host-side: create_room/add_to_room use the create_agent
+ * guard split; handoff needs no approval but re-validates destinations,
+ * same-room wiring, and content because the container is untrusted.
  *
  * This module also extends the base `create_agent` tool (see the extendTool
  * call at the bottom): the Slack flow adds `purpose` / `allow_guests` /
@@ -126,7 +127,57 @@ export const addToRoom: McpToolDefinition = {
   },
 };
 
-registerTools([createRoom, addToRoom]);
+export const handoff: McpToolDefinition = {
+  tool: {
+    name: 'handoff',
+    description:
+      'Post one Slack room message that reliably engages exactly the named sibling agent(s). Use one name for one responder or a list for several; never write raw <@...> mentions yourself. By default this targets the current Slack room/thread. From another session (for example immediately after create_room), pass the room destination name. Fire-and-forget: host-side validation rejects self, unknown agents, agents outside the room, duplicates, and embedded Slack mentions.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        to: {
+          oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' }, minItems: 1 }],
+          description: 'One agent destination name, or an explicit list of agent destination names.',
+        },
+        text: { type: 'string', description: 'The message for the selected agents, without raw Slack mentions.' },
+        room: {
+          type: 'string',
+          description:
+            'Optional room destination name. Omit inside the room; provide it when handing off from another session.',
+        },
+      },
+      required: ['to', 'text'],
+    },
+  },
+  async handler(args) {
+    const to = typeof args.to === 'string' ? [args.to] : Array.isArray(args.to) ? args.to : [];
+    if (to.length === 0 || !to.every((name) => typeof name === 'string' && name.trim())) {
+      return err('to must be one agent name or a non-empty list of agent names');
+    }
+    const text = typeof args.text === 'string' ? args.text.trim() : '';
+    if (!text) return err('text is required');
+    if (/<(?:@|!)[^>]+>/.test(text)) return err('text must not contain raw Slack mention markup');
+    const room = typeof args.room === 'string' ? args.room.trim() : '';
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'handoff',
+        requestId,
+        to: to.map((name) => (name as string).trim()),
+        text,
+        ...(room ? { room } : {}),
+      }),
+    });
+
+    log(`handoff: ${requestId} → ${to.length} agent(s)`);
+    return ok(`Handing off to ${to.length} agent${to.length === 1 ? '' : 's'}.`);
+  },
+};
+
+registerTools([createRoom, addToRoom, handoff]);
 
 // ── create_agent extension (Slack agent flow) ──
 //

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
@@ -18,6 +18,12 @@ for the sibling half:
   voice: say what the new agent is for and tag them with their `<@bot-user-id>` mention
   (send it literally; it renders as a mention). No mechanics, no member lists — the room's
   canvas tab already holds that.
+- **Choose responders explicitly.** For ordinary room coordination, use
+  `handoff({ to, text, room? })` instead of writing agent names or raw Slack mentions.
+  `to` may name one sibling or list several; select exactly the agents whose response the
+  user wants. Omit `room` while already in the room, or pass the room destination from a
+  `create_room` completion note. Room creation never chooses a first speaker or wakes
+  everyone automatically.
 - **Bot-to-bot hop budget.** The platform may cap consecutive bot-to-bot messages (~6)
   until a human speaks again, but do not rely on it — self-limit. Don't ping-pong with
   siblings: do the work, converge, hand back to the human.

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -15,7 +15,9 @@
  * Also registers the agent-facing room actions: `create_room` (one
  * MPIM with N bots + the operator over ensureAgentRoom) and `add_to_room`
  * (superset re-open — MPIM fork), each guard-wrapped with the same
- * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
+ * cli_scope trust split as create_agent, plus unguarded `handoff`, whose
+ * recipients and same-room authority are validated in the host handler
+ * before delivery through the caller's own adapter.
  *
  * The handler never touches inbound DBs (guarded handlers replay without
  * one); all requester notifications go through the approvals module's
@@ -25,6 +27,7 @@ import { SlackApiError } from '../../channels/slack-lib.js';
 import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { unguarded } from '../../guard/index.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
@@ -36,6 +39,7 @@ import { dedupeSlug, deriveInstanceSlug, runSlackAgentFlow } from './orchestrate
 import {
   handleAddToRoom,
   handleCreateRoom,
+  handleHandoff,
   requestAddToRoomHold,
   requestCreateRoomHold,
   validateAddToRoom,
@@ -254,7 +258,7 @@ registerDeliveryAction('create_agent', slackAwareCreateAgent, {
   onDeny: (_content, session, reason) => notifyAgent(session, `create_agent denied: ${reason}`),
 });
 
-// Agent-facing room actions — guard-wrapped like create_agent:
+// Room creation/membership actions — guard-wrapped like create_agent:
 // global-scope groups act directly, everything else holds for the admin
 // chain, and the approval continuation re-enters the same wrapped entry with
 // the approval row as its grant.
@@ -273,3 +277,11 @@ registerDeliveryAction('add_to_room', handleAddToRoom, {
   onDeny: (_content, session, reason) => notifyAgent(session, `add_to_room denied: ${reason}`),
 });
 registerApprovalHandler('add_to_room', reenterGuardedDeliveryAction('add_to_room'));
+
+registerDeliveryAction(
+  'handoff',
+  handleHandoff,
+  unguarded(
+    "same-room message through the caller's own Slack adapter; recipients are host-validated destinations and room members",
+  ),
+);

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for the agent-facing room actions: create_room and
- * add_to_room, driven through the REAL guard-wrapped delivery entries
+ * Tests for the agent-facing room actions: create_room, add_to_room, and
+ * handoff, driven through the real registered delivery entries
  * (getDeliveryAction) over a real in-memory central DB. Slack traffic is a
  * recorded fetch stub (auth.test + conversations.open only — room actions
  * never provision apps); the canvas leg is mocked like orchestrate.test.ts.
@@ -18,14 +18,21 @@ const ANDY_BOT_TOKEN = 'xoxb-andy-secret-token';
 const PIXEL_BOT_TOKEN = 'xoxb-pixel-secret-token';
 const DEVIN_BOT_TOKEN = 'xoxb-devin-secret-token';
 
-const { mockNotifyWrite, mockRequestApproval, mockWriteDestinations, mockCreateRoomCanvas, mockWireCanvasComments } =
-  vi.hoisted(() => ({
-    mockNotifyWrite: vi.fn(),
-    mockRequestApproval: vi.fn().mockResolvedValue(undefined),
-    mockWriteDestinations: vi.fn(),
-    mockCreateRoomCanvas: vi.fn(),
-    mockWireCanvasComments: vi.fn(),
-  }));
+const {
+  mockNotifyWrite,
+  mockRequestApproval,
+  mockWriteDestinations,
+  mockCreateRoomCanvas,
+  mockWireCanvasComments,
+  mockDeliver,
+} = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+  mockWriteDestinations: vi.fn(),
+  mockCreateRoomCanvas: vi.fn(),
+  mockWireCanvasComments: vi.fn(),
+  mockDeliver: vi.fn().mockResolvedValue('slack-message-1'),
+}));
 
 // Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
 vi.mock('./room-canvas.js', () => ({
@@ -65,11 +72,11 @@ vi.mock('../approvals/index.js', async () => {
   };
 });
 
-// Registers the create_room / add_to_room delivery actions — the path under
+// Registers the create_room / add_to_room / handoff delivery actions — the path under
 // test. Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays
 // unloaded.
 import './index.js';
-import { getDeliveryAction } from '../../delivery.js';
+import { getDeliveryAction, setDeliveryAdapter } from '../../delivery.js';
 import { listGuardedActions } from '../../guard/index.js';
 import { log } from '../../log.js';
 import { registerChannelAdapter } from '../../channels/channel-registry.js';
@@ -230,6 +237,8 @@ async function seedSubAgent(name: string, groupId: string, instanceKey: string):
 beforeEach(async () => {
   vi.clearAllMocks();
   mockCreateRoomCanvas.mockResolvedValue(undefined);
+  mockDeliver.mockResolvedValue('slack-message-1');
+  setDeliveryAdapter({ deliver: (...args) => mockDeliver(...args) });
   fetchCalls = [];
   // Faithful default: the source room holds exactly the operator + its bots.
   sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT'];
@@ -289,12 +298,13 @@ afterEach(async () => {
 });
 
 describe('guard wiring', () => {
-  it('both room actions are in the guard catalog and their entries are guard-wrapped', () => {
+  it('privileged room actions are guarded and the host-validated handoff entry is registered', () => {
     const actions = new Set(listGuardedActions().map((s) => s.action));
     expect(actions.has('rooms.create')).toBe(true);
     expect(actions.has('rooms.add_agent')).toBe(true);
     expect(getDeliveryAction('create_room')).toBeDefined();
     expect(getDeliveryAction('add_to_room')).toBeDefined();
+    expect(getDeliveryAction('handoff')).toBeDefined();
   });
 
   it('confined (group-scope) caller: create_room holds for approval, nothing runs', async () => {
@@ -367,16 +377,14 @@ describe('create_room', () => {
       agentNames: ['Andy', 'Pixel', 'Devin'],
     });
 
-    // Allowlisted for a2a; success notify tells the CALLER to author the
-    // intro via its projected room destination, tagging both bots.
+    // Allowlisted for a2a; success notify keeps recipient choice explicit
+    // and never manufactures a mention-all kickoff.
     expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0TEAM/m);
     const success = notifyTexts().at(-1)!;
     expect(success).toContain('Room "Website Team" is live (G0TEAM)');
-    expect(success).toContain('send_message({ to: "website-team"');
-    expect(success).toContain('<@U0PIXELBOT>');
-    expect(success).toContain('<@U0DEVINBOT>');
-    expect(success).not.toContain('<@U0ANDYBOT>');
-    expect(success).toContain('no mechanics, no member lists');
+    expect(success).toContain('No agent was engaged automatically');
+    expect(success).toContain('handoff({ room: "website-team"');
+    expect(success).not.toContain('<@');
 
     assertNoTokenLeak();
   });
@@ -423,6 +431,87 @@ describe('create_room', () => {
 
     expect(mockRequestApproval).not.toHaveBeenCalled();
     expect(notifyTexts().at(-1)).toContain('agents must be a non-empty list');
+  });
+});
+
+describe('handoff', () => {
+  async function openRoom(agentNames: string[]): Promise<Session> {
+    await runAction('create_room', { name: 'Website Team', agents: agentNames });
+    const room = await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack');
+    expect(room).toBeDefined();
+    mockNotifyWrite.mockClear();
+    mockDeliver.mockClear();
+    fetchCalls = [];
+    return {
+      ...SLACK_SESSION,
+      id: 'sess-room',
+      messaging_group_id: room!.id,
+      thread_id: 'slack:G0TEAM:1700000000.000001',
+    };
+  }
+
+  it('from the room session, posts one mention through the caller instance/thread and wakes only that agent', async () => {
+    const session = await openRoom(['Pixel', 'Devin']);
+
+    await runAction('handoff', { to: 'Pixel', text: 'Please review the API contract.' }, session);
+
+    expect(mockDeliver).toHaveBeenCalledTimes(1);
+    const [channelType, platformId, threadId, kind, rawContent, files, instance] = mockDeliver.mock.calls[0]!;
+    expect({ channelType, platformId, threadId, kind, files, instance }).toEqual({
+      channelType: 'slack',
+      platformId: 'slack:G0TEAM',
+      threadId: 'slack:G0TEAM:1700000000.000001',
+      kind: 'chat',
+      files: undefined,
+      instance: 'slack',
+    });
+    const delivered = JSON.parse(rawContent as string) as { text: string };
+    expect(delivered.text).toBe('Please review the API contract.\n<@U0PIXELBOT>');
+    expect(delivered.text.match(/<@[^>]+>/g)).toEqual(['<@U0PIXELBOT>']);
+    expect(delivered.text).not.toContain('U0DEVINBOT');
+  });
+
+  it('from the creation session, an explicit room and recipient list engages exactly those agents', async () => {
+    await openRoom(['Pixel', 'Devin']);
+
+    await runAction('handoff', {
+      room: 'website-team',
+      to: ['Pixel', 'Devin'],
+      text: 'Please both review the API contract.',
+    });
+
+    expect(mockDeliver).toHaveBeenCalledTimes(1);
+    const [, platformId, threadId, , rawContent, , instance] = mockDeliver.mock.calls[0]!;
+    expect({ platformId, threadId, instance }).toEqual({
+      platformId: 'slack:G0TEAM',
+      threadId: null,
+      instance: 'slack',
+    });
+    expect(JSON.parse(rawContent as string)).toEqual({
+      text: 'Please both review the API contract.\n<@U0PIXELBOT> <@U0DEVINBOT>',
+    });
+  });
+
+  it('rejects self, outsider, unknown, duplicate, and raw-mention requests host-side', async () => {
+    const session = await openRoom(['Pixel']);
+    const cases: Array<{ content: Record<string, unknown>; failure: string }> = [
+      { content: { to: 'Andy', text: 'Review.' }, failure: 'cannot hand off to yourself' },
+      { content: { to: 'Devin', text: 'Review.' }, failure: 'agent "Devin" is not wired to room' },
+      { content: { to: 'Ghost', text: 'Review.' }, failure: 'unknown agent "Ghost"' },
+      { content: { to: ['Pixel', 'pixel'], text: 'Review.' }, failure: 'duplicate handoff target' },
+      {
+        content: { to: 'Pixel', text: 'Review <@U0OTHER>.' },
+        failure: 'text must not contain raw Slack mention markup',
+      },
+    ];
+
+    for (const testCase of cases) {
+      mockNotifyWrite.mockClear();
+      await runAction('handoff', testCase.content, session);
+      expect(mockDeliver).not.toHaveBeenCalled();
+      expect(notifyTexts().at(-1)).toContain(`handoff failed: ${testCase.failure}`);
+    }
+    assertNoTokenLeak();
   });
 });
 

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
@@ -1,5 +1,5 @@
 /**
- * Agent-facing room actions: `create_room` and `add_to_room`
+ * Agent-facing room actions: `create_room`, `add_to_room`, and `handoff`
  * delivery-action bodies over the already-N-capable ensureAgentRoom.
  *
  * `create_room` is the "team room" primitive — the multi-agent pattern is N
@@ -40,6 +40,7 @@ import {
   normalizeName,
 } from '../agent-to-agent/db/agent-destinations.js';
 import { botTokenKeyForInstance, slackAuthTest, slackConversationsMembers } from '../../channels/slack-lib.js';
+import { getDeliveryAdapter } from '../../delivery.js';
 import { notifyAgent, requestApproval } from '../approvals/index.js';
 import { readEnvValue } from './env-file.js';
 import { ensureAgentRoom, publicPurpose, resolveOperatorSlackUserId, type RoomParticipant } from './orchestrate.js';
@@ -151,14 +152,6 @@ async function callerRoomDestination(
   const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, callerInstanceKey);
   const dest = roomMg ? await getDestinationByTarget(callerGroupId, 'channel', roomMg.id) : undefined;
   return dest?.local_name ?? normalizeName(roomName);
-}
-
-/** `<@U…>, <@U…>` mention tags for every participant except the caller. */
-function mentionTags(participants: RoomParticipant[], excludeGroupId: string): string {
-  return participants
-    .filter((p) => p.agentGroupId !== excludeGroupId)
-    .map((p) => `<@${p.botUserId}>`)
-    .join(', ');
 }
 
 // ── create_room ──
@@ -274,10 +267,9 @@ export async function handleCreateRoom(content: Record<string, unknown>, session
       await notifyAgent(
         session,
         `Room "${name}" is live (${roomChannelId}) with you, the operator, and ${memberNames}. ` +
-          `Post a brief introduction there now via send_message({ to: "${roomDest}", ... }): ` +
-          `1-2 lines in your own voice on what this room is for, tagging each agent literally ` +
-          `(${mentionTags(participants, session.agent_group_id)}) — the tags render as mentions and are how you ` +
-          `engage them there. Just the intro — no mechanics, no member lists.`,
+          `No agent was engaged automatically. If a response is wanted now, post a brief introduction with ` +
+          `handoff({ room: "${roomDest}", to: ["agent-name"], text: "..." }), listing exactly the agent or ` +
+          `agents the user wants to respond. One or several names are both valid; never write raw Slack mentions.`,
       );
     }
     log.info('create_room completed', { roomChannelId, created, participantCount: participants.length });
@@ -285,6 +277,112 @@ export async function handleCreateRoom(content: Record<string, unknown>, session
     const message = err instanceof Error ? err.message : String(err);
     await notifyAgent(session, `create_room failed: ${message}`);
     log.error('create_room failed', { name, err: message });
+  }
+}
+
+// ── handoff ──
+
+/** Resolve the caller's current room, or an explicitly named room destination. */
+async function resolveHandoffRoom(
+  content: Record<string, unknown>,
+  session: Session,
+): Promise<{ room: MessagingGroup; threadId: string | null }> {
+  const current = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  const roomName = typeof content.room === 'string' ? content.room.trim() : '';
+  let room = current;
+
+  if (roomName) {
+    const dest = await getDestinationByName(session.agent_group_id, normalizeName(roomName));
+    if (!dest || dest.target_type !== 'channel') {
+      throw new RoomActionError(`unknown room destination "${roomName}"`);
+    }
+    room = await getMessagingGroup(dest.target_id);
+  }
+
+  if (!room) throw new RoomActionError('handoff needs a current Slack room or an explicit room destination');
+  if (room.channel_type !== 'slack' || room.is_group !== 1) {
+    throw new RoomActionError(`handoff needs a shared Slack room ("${room.name ?? room.platform_id}" is not one)`);
+  }
+  if (room.denied_at || room.detached_at) {
+    throw new RoomActionError(`room "${room.name ?? room.platform_id}" is no longer active`);
+  }
+  const callerWired = (await getMessagingGroupAgents(room.id)).some(
+    (wiring) => wiring.agent_group_id === session.agent_group_id,
+  );
+  if (!callerWired) throw new RoomActionError(`you are not wired to room "${room.name ?? room.platform_id}"`);
+
+  return { room, threadId: current?.id === room.id ? session.thread_id : null };
+}
+
+/**
+ * Deliver one room message with exactly one real Slack mention per selected
+ * sibling. The container supplies intent; every authority/room check is
+ * repeated here because the container is untrusted.
+ */
+export async function handleHandoff(content: Record<string, unknown>, session: Session): Promise<void> {
+  const targetNames = typeof content.to === 'string' ? [content.to] : Array.isArray(content.to) ? content.to : [];
+  const text = typeof content.text === 'string' ? content.text.trim() : '';
+
+  try {
+    if (targetNames.length === 0 || !targetNames.every((name) => typeof name === 'string' && name.trim())) {
+      throw new RoomActionError('to must be one agent name or a non-empty list of agent names');
+    }
+    if (!text) throw new RoomActionError('text is required');
+    if (/<(?:@|!)[^>]+>/.test(text)) {
+      throw new RoomActionError('text must not contain raw Slack mention markup');
+    }
+
+    const caller = await getAgentGroup(session.agent_group_id);
+    if (!caller) throw new RoomActionError('source agent group not found');
+    const { room, threadId } = await resolveHandoffRoom(content, session);
+    const recipients: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+
+    for (const rawName of targetNames) {
+      const name = (rawName as string).trim();
+      if (normalizeName(name) === normalizeName(caller.name)) {
+        throw new RoomActionError(`cannot hand off to yourself ("${name}")`);
+      }
+      const group = await resolveAgentByName(session.agent_group_id, name);
+      if (group.id === session.agent_group_id) throw new RoomActionError(`cannot hand off to yourself ("${name}")`);
+      if (seen.has(group.id)) throw new RoomActionError(`duplicate handoff target "${name}"`);
+      seen.add(group.id);
+
+      const targetRoom = (await getMessagingGroupsByAgentGroup(group.id)).find(
+        (mg) =>
+          mg.channel_type === 'slack' &&
+          mg.platform_id === room.platform_id &&
+          mg.is_group === 1 &&
+          !mg.denied_at &&
+          !mg.detached_at,
+      );
+      if (!targetRoom) {
+        throw new RoomActionError(`agent "${group.name}" is not wired to room "${room.name ?? room.platform_id}"`);
+      }
+      recipients.push(await participantForInstance(group, targetRoom.instance ?? 'slack', process.cwd()));
+    }
+
+    const adapter = getDeliveryAdapter();
+    if (!adapter) throw new RoomActionError('channel delivery adapter is not ready');
+    const message = `${text}\n${recipients.map((recipient) => `<@${recipient.botUserId}>`).join(' ')}`;
+    await adapter.deliver(
+      'slack',
+      room.platform_id,
+      threadId,
+      'chat',
+      JSON.stringify({ text: message }),
+      undefined,
+      room.instance ?? 'slack',
+    );
+    log.info('handoff completed', {
+      roomPlatformId: room.platform_id,
+      recipientCount: recipients.length,
+      agentGroupId: session.agent_group_id,
+    });
+  } catch (err) {
+    if (!(err instanceof RoomActionError)) throw err;
+    await notifyAgent(session, `handoff failed: ${err.message}`);
+    log.warn('handoff rejected', { agentGroupId: session.agent_group_id, err: err.message });
   }
 }
 


### PR DESCRIPTION
## Summary

- add an explicit Slack room handoff tool for one or multiple selected agents
- resolve real Slack bot mentions host-side and validate self, unknown, duplicate, outsider, and raw-mention inputs
- stop room creation from automatically mentioning every participant
- preserve delivery through the caller Slack instance and current thread when applicable

## Testing

- host build and container typecheck
- Slack agent-flow regression: 216 passed, 2 skipped
- container room and canvas tests: 19 passed
- formatting, skill-directive, and diff checks

## Context

Bot-to-bot handoff stalls when names are not real Slack mentions.

Canonical report: https://team-metabase.tailc2ca02.ts.net/htmlit/p/engineering/bugs/slack-multi-agent/mention-handoff