### PR TITLE
fix(mailbox): use INSERT OR IGNORE for retried message delivery (#3457)

### DIFF
--- a/src/mailbox/sqlite/session-db.ts
+++ b/src/mailbox/sqlite/session-db.ts
@@ -96,7 +96,7 @@ export function nextEvenSeq(db: Database.Database): number {
 export function insertMessage(db: Database.Database, message: InboundWrite, sequence = nextEvenSeq(db)): void {
   const record = createInboundRecord(message, sequence);
   db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
+    `INSERT OR IGNORE INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
      VALUES (@id, @sequence, @kind, @timestamp, @status, @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @seriesId, @trigger, @sourceSessionId, @onWake)`,
   ).run({
     ...record,


### PR DESCRIPTION
## What Problem This Solves

`insertMessage()` uses a plain `INSERT INTO messages_in` which throws `UNIQUE constraint failed` when a delivery is retried with a message id that already landed. The caller logs this as a delivery failure and retries again, creating an infinite crash loop.

## Why This Change Was Made

When a card's delivery confirmation times out but the row actually landed, the retry hits the UNIQUE constraint on `id` and throws. Same `id` means same message — the duplicate insert is a safe no-op.

## User Impact

Retried deliveries with duplicate message ids are now silently ignored instead of crashing. The original row (same content) is retained, and `seq`/ordering is unaffected.

## Evidence

- Issue: https://github.com/nanocoai/nanoclaw/issues/3457
- Root cause: `INSERT INTO` at `session-db.ts:99` throws on duplicate `id`
- Fix: changed to `INSERT OR IGNORE`
- 1 file changed, 1 insertion, 1 deletion
