### PR TITLE
test(cli): keep stdin-json stderr assertions exact on Node 25+

### DIFF
--- a/src/cli/stdin-json.e2e.test.ts
+++ b/src/cli/stdin-json.e2e.test.ts
@@ -8,6 +8,7 @@ import { expect, it } from 'vitest';
 import type { ResponseFrame } from './frame.js';
 import { register } from './registry.js';
 import { startCliServer, stopCliServer } from './socket-server.js';
+import { stripNodeWarnings } from './stdin-json.test-utils.js';
 
 type PrintArgs = {
   'argv-value': string;
@@ -138,7 +139,11 @@ function runCli(
     });
     child.once('close', (code, signal) => {
       clearTimeout(timeout);
-      resolve({ code, signal, stdout, stderr });
+      // Node versions newer than the CI matrix print loader deprecation
+      // warnings on the child's stderr (tsx trips DEP0205 on Node 25+).
+      // Those are environmental noise, not CLI output — drop exactly them
+      // so the `stderr: ''` assertions stay meaningful everywhere.
+      resolve({ code, signal, stdout, stderr: stripNodeWarnings(stderr) });
     });
   });
 }

--- a/src/cli/stdin-json.test-utils.ts
+++ b/src/cli/stdin-json.test-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Strip Node.js process warnings from a spawned child's captured stderr.
+ *
+ * The stdin-json tests spawn the real CLI through the tsx loader and assert
+ * the child's stderr exactly. Node versions newer than the CI matrix emit
+ * loader deprecation warnings on that same stream (e.g. Node 25+ prints
+ * `[DEP0205] DeprecationWarning` because tsx still uses module.register()),
+ * which are environmental noise, not CLI output. Remove exactly those
+ * warning lines — `(node:<pid>) …Warning: …` plus Node's follow-up
+ * "(Use `node --trace-…`)" hint — so the assertions stay byte-exact on
+ * everything the CLI itself writes.
+ */
+const NODE_WARNING_RE =
+  /^\(node:\d+\) (?:\[\w+\] )?\w*Warning: .*(?:\r?\n|$)(?:\(Use `node --trace-\S+ \.\.\.` to show where the warning was created\)(?:\r?\n|$))?/gm;
+
+export function stripNodeWarnings(stderr: string): string {
+  return stderr.replace(NODE_WARNING_RE, '');
+}

--- a/src/cli/stdin-json.test.ts
+++ b/src/cli/stdin-json.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 
 import { parseArgv } from './parse-argv.js';
+import { stripNodeWarnings } from './stdin-json.test-utils.js';
 import { MAX_STDIN_JSON_BYTES, readStdinJsonArgs, type StdinJsonStream } from './stdin-json.js';
 
 async function* stream(...chunks: Array<string | Uint8Array>): StdinJsonStream {
@@ -87,6 +88,34 @@ describe('bounded stdin JSON', () => {
   });
 });
 
+describe('stripNodeWarnings', () => {
+  it('removes a deprecation warning and its trace hint, keeping CLI output', () => {
+    const stderr =
+      '(node:2826860) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n' +
+      '(Use `node --trace-deprecation ...` to show where the warning was created)\n' +
+      'ncl: --stdin-json input is not valid JSON\n';
+    expect(stripNodeWarnings(stderr)).toBe('ncl: --stdin-json input is not valid JSON\n');
+  });
+
+  it('removes multiple warnings of different categories', () => {
+    const stderr =
+      '(node:1) [DEP0205] DeprecationWarning: `module.register()` is deprecated.\n' +
+      '(node:1) ExperimentalWarning: something experimental\n' +
+      '(Use `node --trace-warnings ...` to show where the warning was created)\n';
+    expect(stripNodeWarnings(stderr)).toBe('');
+  });
+
+  it('returns real CLI stderr untouched', () => {
+    expect(stripNodeWarnings('ncl: --stdin-json input is empty\n')).toBe('ncl: --stdin-json input is empty\n');
+    expect(stripNodeWarnings('')).toBe('');
+  });
+
+  it('does not eat lines that merely mention Warning mid-text', () => {
+    const stderr = 'ncl: Warning: something the CLI itself said\n';
+    expect(stripNodeWarnings(stderr)).toBe(stderr);
+  });
+});
+
 describe('host CLI flags', () => {
   it('keeps --json as output mode while excluding --stdin-json from request args', () => {
     expect(parseArgv(['groups', 'update', '--stdin-json', '--json', '--force'])).toEqual({
@@ -110,6 +139,6 @@ describe('host CLI flags', () => {
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe('');
-    expect(result.stderr).toBe('ncl: --stdin-json input is not valid JSON\n');
+    expect(stripNodeWarnings(result.stderr)).toBe('ncl: --stdin-json input is not valid JSON\n');
   });
 });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #3453.

**What:** `src/cli/stdin-json.test.ts` and `stdin-json.e2e.test.ts` spawn the real CLI through the tsx loader and assert the child's stderr byte-exactly. On Node 25+ tsx trips `DEP0205` (`module.register()` deprecation), Node prints the warning on that same stderr, and three tests fail on a runtime that is inside the supported `engines` range but outside the CI matrix (22, 24).

**How it works:** This takes option (2) from the issue — filter warning lines out of the captured stderr before asserting — implemented so the assertions stay *exact* rather than loose:

- New `src/cli/stdin-json.test-utils.ts` exports `stripNodeWarnings()`, which removes exactly Node's process-warning shape — `(node:<pid>) …Warning: …` plus the ``(Use `node --trace-…`)`` follow-up hint — and nothing else.
- The direct spawn test wraps its stderr assertion in it; the e2e helper strips in `runCli` so both `stderr: ''` assertions keep meaning "the CLI wrote nothing".

Chose this over `--no-deprecation` (option 1) because warnings stay visible in local output instead of being suppressed in the child, and the regex is anchored to Node's exact warning format so real CLI stderr — including CLI lines that merely contain the word "Warning" — still fails the assertion.

**How it was tested:**
- Node v26.8.0: 24/24 stdin-json tests pass (previously 3 failed with the DEP0205 output shown in the issue)
- Node v22.19.0: 24/24 pass — behavior on the CI matrix is unchanged
- 4 new unit tests on `stripNodeWarnings` itself: single warning + hint, multiple warning categories, untouched real CLI stderr, and a CLI line containing "Warning:" mid-text that must NOT be eaten
- `pnpm run stdin-json:check` passes (the synced container copy is untouched — its Bun test doesn't assert spawned-child stderr the same way)
- Full suite: 2048 host tests + 333 container tests pass; typecheck and prettier clean
