### PR TITLE
fix(mattermost): recover card thread after restart

### DIFF
--- a/src/channels/mattermost-adapter/adapter.test.ts
+++ b/src/channels/mattermost-adapter/adapter.test.ts
@@ -1,0 +1,137 @@
+import type { ChatInstance } from 'chat';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MattermostAdapter } from './adapter.js';
+
+const BOT_ID = '7g4f95dymtrjmqnoozdyi57xbw';
+const USER_ID = '7mx5jdcrnby18yrpnzont8ggwo';
+const CHANNEL_ID = 'tyzg1xpaeinqzypmh6h9j9ysyy';
+const POST_ID = 'mjhbignk4inf7kh9w5wi8snchw';
+const ROOT_ID = 'or6atyakftywuq6jjo44oytu7h';
+
+function response(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function callbackRequest(): Request {
+  return new Request('https://nanoclaw.example.com/webhook/mattermost', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      channel_id: CHANNEL_ID,
+      context: { action_id: 'ncq:q1:0', callback_token: 'callback-secret', value: '0' },
+      post_id: POST_ID,
+      user_id: USER_ID,
+      user_name: 'operator',
+    }),
+  });
+}
+
+describe('Mattermost action callbacks', () => {
+  it('recovers a card thread and props after a process restart', async () => {
+    const requests: { method: string; url: string }[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      requests.push({ method, url });
+      if (url.endsWith('/users/me')) {
+        return response({ id: BOT_ID, is_bot: true, username: 'nanoclaw-bot' });
+      }
+      if (url.endsWith(`/posts/${POST_ID}`) && method === 'GET') {
+        return response({
+          channel_id: CHANNEL_ID,
+          create_at: 1,
+          id: POST_ID,
+          message: '',
+          props: {
+            attachments: [{ actions: [{ id: 'ncq:q1:0' }] }],
+            from_bot: 'true',
+            plugin_data: { preserved: true },
+          },
+          root_id: ROOT_ID,
+          user_id: BOT_ID,
+        });
+      }
+      if (url.endsWith(`/posts/${POST_ID}/patch`) && method === 'PUT') {
+        return response({ channel_id: CHANNEL_ID, id: POST_ID });
+      }
+      return response({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+    const processAction = vi.fn();
+    const logger = {
+      child: () => logger,
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    const adapter = new MattermostAdapter({
+      callbackSecret: 'callback-secret',
+      callbackUrl: 'https://nanoclaw.example.com',
+      fetchImpl,
+      skipSocket: true,
+      token: 'bot-token',
+      url: 'https://mattermost.example.com',
+    });
+    await adapter.initialize({ getLogger: () => logger, processAction } as unknown as ChatInstance);
+
+    expect((await adapter.handleWebhook(callbackRequest())).status).toBe(200);
+    expect(processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: POST_ID,
+        threadId: `mattermost:${CHANNEL_ID}:${ROOT_ID}`,
+      }),
+      undefined,
+    );
+
+    await adapter.editMessage(`mattermost:${CHANNEL_ID}:${ROOT_ID}`, POST_ID, { markdown: 'Resolved' });
+    expect(
+      requests.filter((request) => request.method === 'GET' && request.url.endsWith(`/posts/${POST_ID}`)),
+    ).toHaveLength(1);
+    const patchCall = vi
+      .mocked(fetchImpl)
+      .mock.calls.find(([input, init]) => String(input).endsWith(`/posts/${POST_ID}/patch`) && init?.method === 'PUT');
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
+      message: 'Resolved',
+      props: { attachments: [], from_bot: 'true', plugin_data: { preserved: true } },
+    });
+  });
+
+  it('falls back to the callback channel when the post cannot be read', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) =>
+      String(input).endsWith('/users/me')
+        ? response({ id: BOT_ID, is_bot: true, username: 'nanoclaw-bot' })
+        : response({ message: 'not found' }, 404),
+    ) as unknown as typeof fetch;
+    const processAction = vi.fn();
+    const logger = {
+      child: () => logger,
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    const adapter = new MattermostAdapter({
+      callbackSecret: 'callback-secret',
+      callbackUrl: 'https://nanoclaw.example.com',
+      fetchImpl,
+      skipSocket: true,
+      token: 'bot-token',
+      url: 'https://mattermost.example.com',
+    });
+    await adapter.initialize({ getLogger: () => logger, processAction } as unknown as ChatInstance);
+
+    expect((await adapter.handleWebhook(callbackRequest())).status).toBe(200);
+    expect(processAction).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: `mattermost:${CHANNEL_ID}` }),
+      undefined,
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Mattermost action callback: could not recover posting thread',
+      expect.objectContaining({ postId: POST_ID }),
+    );
+  });
+});

--- a/src/channels/mattermost-adapter/adapter.ts
+++ b/src/channels/mattermost-adapter/adapter.ts
@@ -953,6 +953,7 @@ export class MattermostAdapter implements Adapter<MattermostThreadId, Mattermost
       });
       return new Response('Bad request', { status: 400 });
     }
+    event.threadId = (await this.actionThreadId(payload)) ?? event.threadId;
 
     const chat = this.chat;
     if (!chat) {
@@ -960,8 +961,8 @@ export class MattermostAdapter implements Adapter<MattermostThreadId, Mattermost
       return this.actionResponse();
     }
 
-    // Remember the clicked post as a card post even if this process never
-    // wrote it (restart mid-question), so the follow-up edit can clear it.
+    // A failed recovery still needs the old best-effort cache entry so the
+    // follow-up edit knows this was a card and can clear its actions.
     if (payload.post_id && !this.cardPosts.has(payload.post_id)) {
       this.cardPosts.set(payload.post_id, { props: {}, threadId: event.threadId });
     }
@@ -1012,6 +1013,36 @@ export class MattermostAdapter implements Adapter<MattermostThreadId, Mattermost
       user: this.projectAuthor(userId, { fallbackUserName: payload.user_name }),
       ...(rawValue === undefined ? {} : { value: String(rawValue) }),
     };
+  }
+
+  /**
+   * Recover a card's rooted thread after a process restart.
+   *
+   * Mattermost's callback body carries `channel_id` and `post_id`, but omits
+   * the post's `root_id`. The in-memory card cache handles clicks during one
+   * process lifetime; after restart, read the post once so the action reaches
+   * the same thread and preserve its non-card props for the terminal edit.
+   */
+  private async actionThreadId(payload: PostActionIntegrationRequest): Promise<string | undefined> {
+    if (!payload.post_id) {
+      return undefined;
+    }
+    const cached = this.cardPosts.get(payload.post_id);
+    if (cached) {
+      return cached.threadId;
+    }
+    try {
+      const post = await this.rest.getPost(payload.post_id);
+      const threadId = threadIdForPost(post);
+      this.rememberCardPost(post, threadId);
+      return threadId;
+    } catch (error) {
+      this.logger.debug('Mattermost action callback: could not recover posting thread', {
+        error,
+        postId: payload.post_id,
+      });
+      return undefined;
+    }
   }
 
   /** Empty `PostActionIntegrationResponse` — accept the click, change nothing. */


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Mattermost interactive-card routing previously depended on an in-memory post-to-thread cache populated when NanoClaw sent the card. After a host restart, clicking an existing approval card lost that cache and could fall back to channel-level routing instead of the original thread.

This change recovers a cold card callback by fetching the Mattermost post after callback-secret and payload-shape validation, deriving its root thread, and caching both the thread and original non-card props. If the read fails, the existing channel-level fallback remains unchanged.

The regression tests cover a cold callback after restart, rooted-thread recovery, one post fetch, preservation of arbitrary nested props, removal of card attachments, and the read-failure fallback.

## Validation

- Focused Mattermost adapter and WebSocket tests: 6/6 passed under Node 22
- Local composed NanoClaw build passed
- Live local Mattermost E2E: created an approval card, restarted the NanoClaw host to clear adapter memory, then approved the existing card; the approval was handled, the requested group restart completed, the session respawned, and the confirmation message was delivered
- Independent adversarial review found no blockers

## Scope

This PR targets the channels branch and changes only the vendored Mattermost adapter plus its focused regression test. Setup-wizard changes are intentionally separate.