### PR TITLE
fix(mattermost): improve initial setup and SiteURL handling

### DIFF
--- a/.claude/skills/add-mattermost/LOCAL_SERVER.md
+++ b/.claude/skills/add-mattermost/LOCAL_SERVER.md
@@ -53,10 +53,11 @@ MATTERMOST_BASE_URL=http://localhost:8065
 ```
 
 Keep this hostname in Mattermost Desktop too. The template persists the
-canonical Site URL and allows both common loopback origins for WebSockets, so
-Desktop does not silently stop receiving live events if it normalizes the
-hostname. It also enables bot account creation and permits callbacks only to
-the Docker host name needed by a locally running NanoClaw.
+canonical Site URL so Desktop's WebSocket Origin matches the server setting.
+Use `http://localhost:8065` everywhere; do not substitute `127.0.0.1` in
+Desktop. `WebsocketURL` stays blank and the template does not broaden
+`AllowCorsFrom`. It also enables bot account creation and permits callbacks
+only to the Docker host name needed by a locally running NanoClaw.
 
 The first browser visit creates the administrator and team; Mattermost always
 allows creating the first account even with open signup disabled. The template
@@ -70,6 +71,14 @@ Health:
 
 ```bash
 curl -fsS http://localhost:8065/api/v4/system/ping
+```
+
+Advertised client configuration (the first value must be the canonical URL and
+the second should be empty):
+
+```bash
+curl -fsS 'http://localhost:8065/api/v4/config/client?format=old' |
+  jq -er '.SiteURL, (.WebsocketURL // "")'
 ```
 
 WebSocket origin (a successful upgrade remains open, so use a timeout; seeing

--- a/.claude/skills/add-mattermost/LOCAL_SERVER.md
+++ b/.claude/skills/add-mattermost/LOCAL_SERVER.md
@@ -52,12 +52,12 @@ Then set:
 MATTERMOST_BASE_URL=http://localhost:8065
 ```
 
-Keep this hostname in Mattermost Desktop too. The template persists the
-canonical Site URL so Desktop's WebSocket Origin matches the server setting.
-Use `http://localhost:8065` everywhere; do not substitute `127.0.0.1` in
-Desktop. `WebsocketURL` stays blank and the template does not broaden
-`AllowCorsFrom`. It also enables bot account creation and permits callbacks
-only to the Docker host name needed by a locally running NanoClaw.
+Use this host name in Mattermost Desktop. This keeps the Desktop app and the
+server on the same address. The template sets SiteURL for you. Use
+`http://localhost:8065` in all settings. Do not use `127.0.0.1` in Desktop.
+Keep `WebsocketURL` blank. The template does not change `AllowCorsFrom`. It
+enables bot account creation. It permits callbacks only to the Docker host name
+that a local NanoClaw installation uses.
 
 The first browser visit creates the administrator and team; Mattermost always
 allows creating the first account even with open signup disabled. The template
@@ -73,8 +73,8 @@ Health:
 curl -fsS http://localhost:8065/api/v4/system/ping
 ```
 
-Advertised client configuration (the first value must be the canonical URL and
-the second should be empty):
+Client configuration. The first value must be the SiteURL. The second value
+must be empty.
 
 ```bash
 curl -fsS 'http://localhost:8065/api/v4/config/client?format=old' |

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -288,7 +288,7 @@ Your Mattermost username, without `@`.
 
 Resolve that user and open the DM shared with the bot.
 
-```nc:run capture:owner_user_id=.id effect:fetch
+```nc:run capture:owner_user_id=.id,owner_handle=.id effect:fetch
 curl -sf "{{base_url}}/api/v4/users/username/{{owner_username}}" -H "Authorization: Bearer {{bot_token}}"
 ```
 
@@ -296,7 +296,7 @@ curl -sf "{{base_url}}/api/v4/users/username/{{owner_username}}" -H "Authorizati
 curl -sf -X POST "{{base_url}}/api/v4/channels/direct" -H "Authorization: Bearer {{bot_token}}" -H "Content-Type: application/json" -d '["{{owner_user_id}}","{{bot_user_id}}"]' | jq -er '"mattermost:" + .id'
 ```
 
-The resolved `platform_id` and `owner_username` are used by
+The resolved `platform_id`, `owner_handle`, and `owner_username` are used by
 `/init-first-agent`. If an owner exists, use `/manage-channels` instead.
 
 ### 7. Build, test, and restart

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -253,7 +253,15 @@ the server-only callback context.
 openssl rand -hex 32
 ```
 
-Store the channel configuration. Existing keys remain unchanged on a re-run.
+Update the selected canonical URL on every run so choosing another server
+corrects an existing installation. Keep existing credentials unchanged.
+
+```nc:run effect:external
+pnpm exec tsx setup/index.ts --step set-env -- --key MATTERMOST_BASE_URL --value "{{base_url}}"
+```
+
+Store the remaining channel configuration. Existing credential keys remain
+unchanged on a re-run.
 
 ```nc:env-set
 MATTERMOST_BASE_URL={{base_url}}

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -23,10 +23,10 @@ base URL.
 3. Inspect Docker/Compose for Mattermost containers. If a matching container
    exists but is stopped, offer to start it; do not start or recreate it
    without the user's approval.
-4. If a healthy server is found, show its URL and ask whether to use it, enter
-   another URL, or create the bundled local evaluation/development server.
-   Never select a detected server on the user's behalf. Treat localhost and
-   127.0.0.1 endpoints for the same container as one detection.
+4. If you find a healthy server, show its URL. Ask the user to use this server,
+   enter a different URL, or create the local evaluation server. Do not select a
+   server automatically. Treat the localhost and 127.0.0.1 endpoints for the
+   same container as one server.
 5. If nothing local is found, ask whether the user has a remote Mattermost.
    If not, offer the local evaluation installation in
    [LOCAL_SERVER.md](LOCAL_SERVER.md). Read that file only for local server
@@ -41,20 +41,19 @@ data, so show what will be created and get approval first.
 
 ### 1. Detect the server
 
-Probe a configured URL and the conventional local endpoints. Detection is only
-a suggestion: always let the operator confirm it, enter another URL, or create
-the bundled local evaluation/development server.
+Test the configured URL and the standard local URLs. A detected server is only
+a suggestion. The user must select the server.
 
 ```nc:run capture:discovery=.discovery,detected_url=.base_url,detected_config_access=.config_access,detected_container=.mattermost_container effect:fetch
 node .claude/skills/add-mattermost/scripts/discover-server.mjs
 ```
 
 ```nc:operator when:discovery=found
-A healthy Mattermost server was detected at {{detected_url}}. Confirm whether to use it; detection never selects a server on your behalf.
+NanoClaw found a healthy Mattermost server at {{detected_url}}. You can use this server, enter a different URL, or create a local evaluation server.
 ```
 
 ```nc:prompt server_choice when:discovery=found normalize:lower validate:^(use|enter|create)$
-Enter `use` for {{detected_url}}, `enter` to provide another Mattermost URL, or `create` for a new local evaluation/development server.
+Enter `use` to use {{detected_url}}. Enter `enter` to specify a different Mattermost URL. Enter `create` to create a local evaluation server.
 ```
 
 ```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:server_choice=use
@@ -62,7 +61,7 @@ node .claude/skills/add-mattermost/scripts/select-server.mjs use "{{detected_url
 ```
 
 ```nc:prompt entered_url when:server_choice=enter normalize:rstrip-slash validate:^https?://(?:[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%+-]+)*$
-Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
+Enter the Mattermost base URL. Include the scheme, for example `https://mattermost.example.com`.
 ```
 
 ```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:server_choice=enter
@@ -74,15 +73,15 @@ printf 'yes\n'
 ```
 
 ```nc:operator when:discovery=none
-No healthy configured or local Mattermost server was detected. Choose whether to enter an existing remote server URL or create the bundled local evaluation/development server.
+NanoClaw did not find a healthy Mattermost server. You can enter a server URL or create a local evaluation server.
 ```
 
 ```nc:prompt no_server_choice when:discovery=none normalize:lower validate:^(enter|create)$
-Enter `enter` to provide a Mattermost URL or `create` for a new local evaluation/development server.
+Enter `enter` to specify a Mattermost URL. Enter `create` to create a local evaluation server.
 ```
 
 ```nc:prompt entered_url_new when:no_server_choice=enter normalize:rstrip-slash validate:^https?://(?:[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%+-]+)*$
-Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
+Enter the Mattermost base URL. Include the scheme, for example `https://mattermost.example.com`.
 ```
 
 ```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:no_server_choice=enter
@@ -93,19 +92,19 @@ node .claude/skills/add-mattermost/scripts/select-server.mjs enter "{{entered_ur
 printf 'yes\n'
 ```
 
-Tell the operator exactly what local creation does, then obtain approval:
+Explain what the installation creates. Give the user time to review the details. Then get approval.
 
 ```nc:operator when:create_requested=yes
-Creating the local evaluation/development server will start Mattermost Team Edition and PostgreSQL containers, create a Docker network and named persistent volumes, write reproducible files under .nanoclaw/mattermost, and bind 127.0.0.1:8065. Docker and Compose must be available and port 8065 must be free. If another server uses that port, this installer will stop without changing it.
+The local evaluation server runs Mattermost Team Edition and PostgreSQL in containers. The installation creates a Docker network and named volumes. It saves configuration files in .nanoclaw/mattermost. It binds the server to 127.0.0.1:8065. You need Docker and Docker Compose. Port 8065 must be free. If the port is in use, the installation stops and makes no changes.
 ```
 
 ```nc:prompt local_install_approval when:create_requested=yes normalize:lower validate:^install$
-Enter `install` to approve creating and starting those local resources.
+Enter `install` to create and start these local resources.
 ```
 
-After approval, verify prerequisites, create the reproducible stack, and wait
-at most 60 seconds for Mattermost. On failure, show bounded service logs and
-stop; do not claim the server exists.
+After approval, verify the requirements and create the stack. Wait for a
+maximum of 60 seconds for Mattermost. If the operation fails, show the last
+100 service log lines and stop.
 
 ```nc:run effect:external when:local_install_approval=install
 docker info >/dev/null
@@ -125,17 +124,18 @@ exit 1
 node .claude/skills/add-mattermost/scripts/select-server.mjs create
 ```
 
-### 2. Align the server's canonical URL
+### 2. Set the server SiteURL
 
-Mattermost Desktop opens its WebSocket with the configured server URL as the
-Origin. Before installing the adapter, make `ServiceSettings.SiteURL` exactly
-match `{{base_url}}`. Keep `ServiceSettings.WebsocketURL` blank; it is not the
-fix for an origin mismatch. Do not broaden `ServiceSettings.AllowCorsFrom`.
+Mattermost Desktop sends its configured server URL as the WebSocket Origin.
+Before you install the adapter, set `ServiceSettings.SiteURL` to the same URL:
+`{{base_url}}`. Keep
+`ServiceSettings.WebsocketURL` blank. Do not change
+`ServiceSettings.AllowCorsFrom` to correct an Origin error.
 
 When discovery found host-local `mmctl`, ask before changing the server:
 
 ```nc:prompt site_url_action normalize:lower validate:^(set|already)$ when:config_access=host
-Enter `set` to set Mattermost's canonical SiteURL to {{base_url}} and keep WebsocketURL blank, or `already` only if those settings are already correct.
+Enter `set` to set SiteURL to {{base_url}} and clear WebsocketURL. Enter `already` if these values are already correct.
 ```
 
 ```nc:run effect:external when:site_url_action=set
@@ -147,7 +147,7 @@ When discovery found `mmctl` inside a local Mattermost container, ask before
 changing it there:
 
 ```nc:prompt site_url_action_docker normalize:lower validate:^(set|already)$ when:config_access=docker
-Enter `set` to configure {{mattermost_container}} with canonical SiteURL {{base_url}} and a blank WebsocketURL, or `already` only if those settings are already correct.
+Enter `set` to set SiteURL to {{base_url}} in {{mattermost_container}} and clear WebsocketURL. Enter `already` if these values are already correct.
 ```
 
 ```nc:run effect:external when:site_url_action_docker=set
@@ -158,15 +158,15 @@ docker exec "{{mattermost_container}}" mmctl config set ServiceSettings.Websocke
 If local configuration access is unavailable, tell the operator:
 
 ```nc:operator when:config_access=unavailable
-Set Mattermost ServiceSettings.SiteURL to exactly {{base_url}} and leave ServiceSettings.WebsocketURL blank before continuing. Either sign in as a System Admin with mmctl and run `mmctl config set ServiceSettings.SiteURL "{{base_url}}"` plus `mmctl config set ServiceSettings.WebsocketURL ""`, or use System Console → Environment → Web Server. Do not work around the mismatch with a broad ServiceSettings.AllowCorsFrom value.
+Set Mattermost ServiceSettings.SiteURL to {{base_url}}. Leave ServiceSettings.WebsocketURL blank. As a System Admin, run `mmctl config set ServiceSettings.SiteURL "{{base_url}}"`. Run `mmctl config set ServiceSettings.WebsocketURL ""`. You can also use System Console → Environment → Web Server. Do not change ServiceSettings.AllowCorsFrom to correct an Origin error.
 ```
 
 ```nc:prompt site_url_ready normalize:lower validate:^ready$ when:config_access=unavailable
-Enter `ready` after the Mattermost settings above are saved.
+Enter `ready` after you save these Mattermost settings.
 ```
 
-Verify the effective client configuration through Mattermost's public client
-config endpoint. This must print `{{base_url}}` followed by a blank line:
+Use the public client configuration endpoint to verify the settings. The
+command must print `{{base_url}}` and then a blank line.
 
 ```nc:run effect:fetch
 curl -fsS "{{base_url}}/api/v4/config/client?format=old" | jq -er --arg url "{{base_url}}" '(.SiteURL == $url and (.WebsocketURL // "") == "") as $ok | if $ok then .SiteURL, (.WebsocketURL // "") else error("Mattermost SiteURL/WebsocketURL mismatch") end'
@@ -219,12 +219,12 @@ ws@8.21.3
 Tell the operator:
 
 ```nc:operator
-Create a dedicated Mattermost bot:
-1. As a System Admin, open System Console → Integrations → Bot Accounts and turn on Enable Bot Account Creation if it is disabled. This setting only permits bot creation; it is not where bots are created.
-2. Return to the Mattermost workspace, open the Product menu → Integrations → Bot Accounts, select Add Bot Account, and create a bot such as `nanoclaw`.
-3. Copy the access token shown after creation.
-4. Add the bot to every team and channel where it should receive messages. Bots do not join teams or channels automatically.
-5. Keep the token private. If it is lost, create a new token and deactivate the obsolete one after replacement.
+Now create a Mattermost bot for NanoClaw:
+1. As a System Admin, open System Console → Integrations → Bot Accounts. Turn on Enable Bot Account Creation. This setting permits bot creation. You do not create the bot on this page.
+2. Return to the Mattermost workspace. Open Product menu → Integrations → Bot Accounts. Select Add Bot Account. Create a bot, for example `nanoclaw`.
+3. Copy the access token.
+4. Add the bot to each required team and channel. Mattermost does not add bots to teams or channels automatically.
+5. Keep the token secret. If you lose the token, create a replacement. Deactivate the old token after the replacement works.
 ```
 
 ```nc:prompt bot_token secret normalize:trim validate:^[A-Za-z0-9_-]{20,}$
@@ -255,15 +255,14 @@ the server-only callback context.
 openssl rand -hex 32
 ```
 
-Update the selected canonical URL on every run so choosing another server
-corrects an existing installation. Keep existing credentials unchanged.
+Update `MATTERMOST_BASE_URL` on each run. This update lets the user select a
+different server. Do not change existing credentials.
 
 ```nc:run effect:external
 pnpm exec tsx setup/index.ts --step set-env -- --key MATTERMOST_BASE_URL --value "{{base_url}}"
 ```
 
-Store the remaining channel configuration. Existing credential keys remain
-unchanged on a re-run.
+Store the other channel settings. Do not replace existing credentials.
 
 ```nc:env-set
 MATTERMOST_BASE_URL={{base_url}}
@@ -275,7 +274,7 @@ MATTERMOST_CALLBACK_SECRET={{callback_secret}}
 Tell the operator:
 
 ```nc:operator
-From the Mattermost server, verify the callback host is reachable. For a private host or Docker bridge name, add that hostname or IP under System Console → Environment → Developer → Allow untrusted internal connections. Use a publicly trusted HTTPS certificate in production.
+Make sure that the Mattermost server can reach the callback host. For a private host or Docker bridge name, add the host name or IP address in System Console → Environment → Developer → Allow untrusted internal connections. Use a publicly trusted HTTPS certificate in production.
 ```
 
 ### 6. Resolve the owner's DM
@@ -307,8 +306,8 @@ Build the composed host to guard the typed Chat SDK bridge call and dependency.
 pnpm run build
 ```
 
-Run the registration test through the real channel barrel and the focused
-adapter regressions installed beside the implementation.
+Run the registration test through the channel barrel. Also run the installed
+adapter regression tests.
 
 ```nc:run effect:test
 pnpm exec vitest run src/channels/mattermost-registration.test.ts src/channels/mattermost-adapter/adapter.test.ts src/channels/mattermost-adapter/websocket.test.ts
@@ -361,14 +360,13 @@ changes are observed, but restarting NanoClaw forces a fresh subscription.
 NanoClaw holds the first message behind a channel-approval card and deduplicates
 later mentions until that card is resolved.
 
-**Desktop messages appear only after a manual refresh.** This is usually the
-Desktop client's WebSocket origin being rejected. Keep the Desktop server URL,
-`MATTERMOST_BASE_URL`, and Mattermost `ServiceSettings.SiteURL` on the same
-canonical hostname. Leave `ServiceSettings.WebsocketURL` blank, verify the
-effective values through `/api/v4/config/client?format=old`, and check server
-logs for `request origin not allowed`. Do not mask a canonical-URL mismatch by
-broadening `ServiceSettings.AllowCorsFrom`. For Compose installations, persist
-SiteURL declaratively so container recreation does not discard the fix.
+**Desktop messages appear only after a manual refresh.** The server can reject
+the WebSocket Origin. Use the same host name in the Desktop server URL,
+`MATTERMOST_BASE_URL`, and `ServiceSettings.SiteURL`. Keep
+`ServiceSettings.WebsocketURL` blank. Verify the values through
+`/api/v4/config/client?format=old`. Check the server logs for `request origin
+not allowed`. Do not change `ServiceSettings.AllowCorsFrom` to correct this
+error. For a Compose installation, set SiteURL in the Compose configuration.
 
 **Cards render but clicks do nothing.** From the Mattermost server, POST to the
 callback URL. A `401` proves the path reaches NanoClaw; timeout or refusal means

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -107,17 +107,13 @@ maximum of 60 seconds for Mattermost. If the operation fails, show the last
 100 service log lines and stop.
 
 ```nc:run effect:external when:local_install_approval=install
-docker info >/dev/null
-docker compose version >/dev/null
+docker info >/dev/null && docker compose version >/dev/null
 node -e 'const net=require("node:net");const s=net.createServer();s.once("error",()=>process.exit(1));s.listen(8065,"127.0.0.1",()=>s.close())'
 mkdir -p .nanoclaw/mattermost
 cp .claude/skills/add-mattermost/assets/compose.yml .nanoclaw/mattermost/compose.yml
-umask 077
-test -f .nanoclaw/mattermost/.env || printf 'MATTERMOST_DB_PASSWORD=%s\n' "$(openssl rand -hex 24)" > .nanoclaw/mattermost/.env
+test -f .nanoclaw/mattermost/.env || { umask 077; printf 'MATTERMOST_DB_PASSWORD=%s\n' "$(openssl rand -hex 24)" > .nanoclaw/mattermost/.env; }
 docker compose -f .nanoclaw/mattermost/compose.yml up -d
-for attempt in $(seq 1 30); do curl -fsS --connect-timeout 1 --max-time 1 http://localhost:8065/api/v4/system/ping >/dev/null && exit 0; sleep 1; done
-docker compose -f .nanoclaw/mattermost/compose.yml logs --tail 100 mattermost
-exit 1
+for attempt in $(seq 1 30); do curl -fsS --connect-timeout 1 --max-time 1 http://localhost:8065/api/v4/system/ping >/dev/null && exit 0; sleep 1; done; docker compose -f .nanoclaw/mattermost/compose.yml logs --tail 100 mattermost; exit 1
 ```
 
 ```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:local_install_approval=install
@@ -131,6 +127,12 @@ Before you install the adapter, set `ServiceSettings.SiteURL` to the same URL:
 `{{base_url}}`. Keep
 `ServiceSettings.WebsocketURL` blank. Do not change
 `ServiceSettings.AllowCorsFrom` to correct an Origin error.
+
+For the evaluation server, the Compose configuration manages SiteURL:
+
+```nc:operator when:config_access=managed
+The evaluation server already sets SiteURL to {{base_url}} and keeps WebsocketURL blank. NanoClaw will verify these values before it continues.
+```
 
 When discovery found host-local `mmctl`, ask before changing the server:
 
@@ -258,14 +260,13 @@ openssl rand -hex 32
 Update `MATTERMOST_BASE_URL` on each run. This update lets the user select a
 different server. Do not change existing credentials.
 
-```nc:run effect:external
+```nc:run effect:external remove:.claude/skills/add-mattermost/scripts/remove-base-url.mjs
 pnpm exec tsx setup/index.ts --step set-env -- --key MATTERMOST_BASE_URL --value "{{base_url}}"
 ```
 
 Store the other channel settings. Do not replace existing credentials.
 
 ```nc:env-set
-MATTERMOST_BASE_URL={{base_url}}
 MATTERMOST_BOT_TOKEN={{bot_token}}
 MATTERMOST_CALLBACK_URL={{callback_url}}
 MATTERMOST_CALLBACK_SECRET={{callback_secret}}

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -45,7 +45,7 @@ Probe a configured URL and the conventional local endpoints. The detector
 always returns structured output: `found` binds `base_url`; `none` leaves it
 for the guarded prompt below.
 
-```nc:run capture:discovery=.discovery,base_url=.base_url effect:fetch
+```nc:run capture:discovery=.discovery,base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch
 node .claude/skills/add-mattermost/scripts/discover-server.mjs
 ```
 
@@ -53,11 +53,58 @@ node .claude/skills/add-mattermost/scripts/discover-server.mjs
 No healthy configured or local Mattermost server was detected. If you have a remote server, provide its URL next. Otherwise install the local evaluation server by following LOCAL_SERVER.md, then provide http://localhost:8065.
 ```
 
-```nc:prompt base_url when:discovery=none normalize:rstrip-slash validate:^https?://[A-Za-z0-9._~:%/?#\[\]@!&()*+,;=-]+$
+```nc:prompt base_url when:discovery=none normalize:rstrip-slash validate:^https?://(?:[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%+-]+)*$
 Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
 ```
 
-### 2. Copy and register the channel
+### 2. Align the server's canonical URL
+
+Mattermost Desktop opens its WebSocket with the configured server URL as the
+Origin. Before installing the adapter, make `ServiceSettings.SiteURL` exactly
+match `{{base_url}}`. Keep `ServiceSettings.WebsocketURL` blank; it is not the
+fix for an origin mismatch. Do not broaden `ServiceSettings.AllowCorsFrom`.
+
+When discovery found host-local `mmctl`, ask before changing the server:
+
+```nc:prompt site_url_action normalize:lower validate:^(set|already)$ when:config_access=host
+Enter `set` to set Mattermost's canonical SiteURL to {{base_url}} and keep WebsocketURL blank, or `already` only if those settings are already correct.
+```
+
+```nc:run effect:external when:site_url_action=set
+mmctl config set ServiceSettings.SiteURL "{{base_url}}" --local
+mmctl config set ServiceSettings.WebsocketURL "" --local
+```
+
+When discovery found `mmctl` inside a local Mattermost container, ask before
+changing it there:
+
+```nc:prompt site_url_action_docker normalize:lower validate:^(set|already)$ when:config_access=docker
+Enter `set` to configure {{mattermost_container}} with canonical SiteURL {{base_url}} and a blank WebsocketURL, or `already` only if those settings are already correct.
+```
+
+```nc:run effect:external when:site_url_action_docker=set
+docker exec "{{mattermost_container}}" mmctl config set ServiceSettings.SiteURL "{{base_url}}" --local
+docker exec "{{mattermost_container}}" mmctl config set ServiceSettings.WebsocketURL "" --local
+```
+
+If local configuration access is unavailable, tell the operator:
+
+```nc:operator when:config_access=unavailable
+Set Mattermost ServiceSettings.SiteURL to exactly {{base_url}} and leave ServiceSettings.WebsocketURL blank before continuing. Either sign in as a System Admin with mmctl and run `mmctl config set ServiceSettings.SiteURL "{{base_url}}"` plus `mmctl config set ServiceSettings.WebsocketURL ""`, or use System Console → Environment → Web Server. Do not work around the mismatch with a broad ServiceSettings.AllowCorsFrom value.
+```
+
+```nc:prompt site_url_ready normalize:lower validate:^ready$ when:config_access=unavailable
+Enter `ready` after the Mattermost settings above are saved.
+```
+
+Verify the effective client configuration through Mattermost's public client
+config endpoint. This must print `{{base_url}}` followed by a blank line:
+
+```nc:run effect:fetch
+curl -fsS "{{base_url}}/api/v4/config/client?format=old" | jq -er --arg url "{{base_url}}" '(.SiteURL == $url and (.WebsocketURL // "") == "") as $ok | if $ok then .SiteURL, (.WebsocketURL // "") else error("Mattermost SiteURL/WebsocketURL mismatch") end'
+```
+
+### 3. Copy and register the channel
 
 Copy the canonical adapter and registration test from the `channels` branch.
 
@@ -97,7 +144,7 @@ ws@8.21.3
 @types/ws@8.18.1
 ```
 
-### 3. Create and authenticate the bot
+### 4. Create and authenticate the bot
 
 Tell the operator:
 
@@ -121,7 +168,7 @@ token, or bot-account status is wrong.
 curl -sf "{{base_url}}/api/v4/users/me" -H "Authorization: Bearer {{bot_token}}"
 ```
 
-### 4. Configure authenticated card callbacks
+### 5. Configure authenticated card callbacks
 
 Approvals require Mattermost itself—not the browser—to reach NanoClaw. Ask for
 a URL routable from the Mattermost server. It may be NanoClaw's base URL or the
@@ -153,7 +200,7 @@ Tell the operator:
 From the Mattermost server, verify the callback host is reachable. For a private host or Docker bridge name, add that hostname or IP under System Console → Environment → Developer → Allow untrusted internal connections. Use a publicly trusted HTTPS certificate in production.
 ```
 
-### 5. Resolve the owner's DM
+### 6. Resolve the owner's DM
 
 Ask for the Mattermost username that will own this NanoClaw installation.
 
@@ -174,7 +221,7 @@ curl -sf -X POST "{{base_url}}/api/v4/channels/direct" -H "Authorization: Bearer
 The resolved `platform_id` and `owner_username` are used by
 `/init-first-agent`. If an owner exists, use `/manage-channels` instead.
 
-### 6. Build, test, and restart
+### 7. Build, test, and restart
 
 Build the composed host to guard the typed Chat SDK bridge call and dependency.
 
@@ -238,13 +285,11 @@ later mentions until that card is resolved.
 **Desktop messages appear only after a manual refresh.** This is usually the
 Desktop client's WebSocket origin being rejected. Keep the Desktop server URL,
 `MATTERMOST_BASE_URL`, and Mattermost `ServiceSettings.SiteURL` on the same
-canonical hostname. Check server logs for `request origin not allowed`, and
-verify `/api/v4/websocket` returns `101 Switching Protocols` for that Origin.
-For a local server that genuinely needs both hostnames, persist a space-separated
-`ServiceSettings.AllowCorsFrom` containing `http://localhost:8065` and
-`http://127.0.0.1:8065`; do not use `*`. Preview images may regenerate
-`config.json` on restart, so make the setting part of container startup rather
-than relying on an in-container edit.
+canonical hostname. Leave `ServiceSettings.WebsocketURL` blank, verify the
+effective values through `/api/v4/config/client?format=old`, and check server
+logs for `request origin not allowed`. Do not mask a canonical-URL mismatch by
+broadening `ServiceSettings.AllowCorsFrom`. For Compose installations, persist
+SiteURL declaratively so container recreation does not discard the fix.
 
 **Cards render but clicks do nothing.** From the Mattermost server, POST to the
 callback URL. A `401` proves the path reaches NanoClaw; timeout or refusal means

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -180,12 +180,14 @@ Copy the canonical adapter and registration test from the `channels` branch.
 src/channels/mattermost.ts
 src/channels/mattermost-registration.test.ts
 src/channels/mattermost-adapter/adapter.ts
+src/channels/mattermost-adapter/adapter.test.ts
 src/channels/mattermost-adapter/format.ts
 src/channels/mattermost-adapter/index.ts
 src/channels/mattermost-adapter/rest.ts
 src/channels/mattermost-adapter/thread-id.ts
 src/channels/mattermost-adapter/types.ts
 src/channels/mattermost-adapter/websocket.ts
+src/channels/mattermost-adapter/websocket.test.ts
 ```
 
 Append the channel's single reach-in to the barrel, skipping it if present.
@@ -305,10 +307,11 @@ Build the composed host to guard the typed Chat SDK bridge call and dependency.
 pnpm run build
 ```
 
-Run the registration test through the real channel barrel.
+Run the registration test through the real channel barrel and the focused
+adapter regressions installed beside the implementation.
 
 ```nc:run effect:test
-pnpm exec vitest run src/channels/mattermost-registration.test.ts
+pnpm exec vitest run src/channels/mattermost-registration.test.ts src/channels/mattermost-adapter/adapter.test.ts src/channels/mattermost-adapter/websocket.test.ts
 ```
 
 Restart NanoClaw so the channel and credentials load.

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -103,10 +103,11 @@ Tell the operator:
 
 ```nc:operator
 Create a dedicated Mattermost bot:
-1. As a System Admin, open System Console → Integrations → Bot Accounts and enable bot-account creation.
-2. Create a bot such as `nanoclaw`, then copy the access token shown after creation.
-3. Add the bot to every team and channel where it should receive messages. Bots do not join channels automatically.
-4. Keep the token private. If it is lost, create a new token and deactivate the obsolete one after replacement.
+1. As a System Admin, open System Console → Integrations → Bot Accounts and turn on Enable Bot Account Creation if it is disabled. This setting only permits bot creation; it is not where bots are created.
+2. Return to the Mattermost workspace, open the Product menu → Integrations → Bot Accounts, select Add Bot Account, and create a bot such as `nanoclaw`.
+3. Copy the access token shown after creation.
+4. Add the bot to every team and channel where it should receive messages. Bots do not join teams or channels automatically.
+5. Keep the token private. If it is lost, create a new token and deactivate the obsolete one after replacement.
 ```
 
 ```nc:prompt bot_token secret normalize:trim validate:^[A-Za-z0-9_-]{20,}$

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -23,10 +23,10 @@ base URL.
 3. Inspect Docker/Compose for Mattermost containers. If a matching container
    exists but is stopped, offer to start it; do not start or recreate it
    without the user's approval.
-4. If one healthy server is found, tell the user and use it. If multiple
-   distinct servers are found, ask which one to use. Treat localhost and
-   127.0.0.1 endpoints for the same container as one server and prefer the
-   hostname in its configured Site URL; otherwise prefer `localhost`.
+4. If a healthy server is found, show its URL and ask whether to use it, enter
+   another URL, or create the bundled local evaluation/development server.
+   Never select a detected server on the user's behalf. Treat localhost and
+   127.0.0.1 endpoints for the same container as one detection.
 5. If nothing local is found, ask whether the user has a remote Mattermost.
    If not, offer the local evaluation installation in
    [LOCAL_SERVER.md](LOCAL_SERVER.md). Read that file only for local server
@@ -41,20 +41,88 @@ data, so show what will be created and get approval first.
 
 ### 1. Detect the server
 
-Probe a configured URL and the conventional local endpoints. The detector
-always returns structured output: `found` binds `base_url`; `none` leaves it
-for the guarded prompt below.
+Probe a configured URL and the conventional local endpoints. Detection is only
+a suggestion: always let the operator confirm it, enter another URL, or create
+the bundled local evaluation/development server.
 
-```nc:run capture:discovery=.discovery,base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch
+```nc:run capture:discovery=.discovery,detected_url=.base_url,detected_config_access=.config_access,detected_container=.mattermost_container effect:fetch
 node .claude/skills/add-mattermost/scripts/discover-server.mjs
 ```
 
-```nc:operator when:discovery=none
-No healthy configured or local Mattermost server was detected. If you have a remote server, provide its URL next. Otherwise install the local evaluation server by following LOCAL_SERVER.md, then provide http://localhost:8065.
+```nc:operator when:discovery=found
+A healthy Mattermost server was detected at {{detected_url}}. Confirm whether to use it; detection never selects a server on your behalf.
 ```
 
-```nc:prompt base_url when:discovery=none normalize:rstrip-slash validate:^https?://(?:[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%+-]+)*$
+```nc:prompt server_choice when:discovery=found normalize:lower validate:^(use|enter|create)$
+Enter `use` for {{detected_url}}, `enter` to provide another Mattermost URL, or `create` for a new local evaluation/development server.
+```
+
+```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:server_choice=use
+node .claude/skills/add-mattermost/scripts/select-server.mjs use "{{detected_url}}" "{{detected_config_access}}" "{{detected_container}}"
+```
+
+```nc:prompt entered_url when:server_choice=enter normalize:rstrip-slash validate:^https?://(?:[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%+-]+)*$
 Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
+```
+
+```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:server_choice=enter
+node .claude/skills/add-mattermost/scripts/select-server.mjs enter "{{entered_url}}"
+```
+
+```nc:run capture:create_requested when:server_choice=create
+printf 'yes\n'
+```
+
+```nc:operator when:discovery=none
+No healthy configured or local Mattermost server was detected. Choose whether to enter an existing remote server URL or create the bundled local evaluation/development server.
+```
+
+```nc:prompt no_server_choice when:discovery=none normalize:lower validate:^(enter|create)$
+Enter `enter` to provide a Mattermost URL or `create` for a new local evaluation/development server.
+```
+
+```nc:prompt entered_url_new when:no_server_choice=enter normalize:rstrip-slash validate:^https?://(?:[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%+-]+)*$
+Mattermost base URL including the scheme, such as `https://mattermost.example.com`.
+```
+
+```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:no_server_choice=enter
+node .claude/skills/add-mattermost/scripts/select-server.mjs enter "{{entered_url_new}}"
+```
+
+```nc:run capture:create_requested when:no_server_choice=create
+printf 'yes\n'
+```
+
+Tell the operator exactly what local creation does, then obtain approval:
+
+```nc:operator when:create_requested=yes
+Creating the local evaluation/development server will start Mattermost Team Edition and PostgreSQL containers, create a Docker network and named persistent volumes, write reproducible files under .nanoclaw/mattermost, and bind 127.0.0.1:8065. Docker and Compose must be available and port 8065 must be free. If another server uses that port, this installer will stop without changing it.
+```
+
+```nc:prompt local_install_approval when:create_requested=yes normalize:lower validate:^install$
+Enter `install` to approve creating and starting those local resources.
+```
+
+After approval, verify prerequisites, create the reproducible stack, and wait
+at most 60 seconds for Mattermost. On failure, show bounded service logs and
+stop; do not claim the server exists.
+
+```nc:run effect:external when:local_install_approval=install
+docker info >/dev/null
+docker compose version >/dev/null
+node -e 'const net=require("node:net");const s=net.createServer();s.once("error",()=>process.exit(1));s.listen(8065,"127.0.0.1",()=>s.close())'
+mkdir -p .nanoclaw/mattermost
+cp .claude/skills/add-mattermost/assets/compose.yml .nanoclaw/mattermost/compose.yml
+umask 077
+test -f .nanoclaw/mattermost/.env || printf 'MATTERMOST_DB_PASSWORD=%s\n' "$(openssl rand -hex 24)" > .nanoclaw/mattermost/.env
+docker compose -f .nanoclaw/mattermost/compose.yml up -d
+for attempt in $(seq 1 30); do curl -fsS --connect-timeout 1 --max-time 1 http://localhost:8065/api/v4/system/ping >/dev/null && exit 0; sleep 1; done
+docker compose -f .nanoclaw/mattermost/compose.yml logs --tail 100 mattermost
+exit 1
+```
+
+```nc:run capture:base_url=.base_url,config_access=.config_access,mattermost_container=.mattermost_container effect:fetch when:local_install_approval=install
+node .claude/skills/add-mattermost/scripts/select-server.mjs create
 ```
 
 ### 2. Align the server's canonical URL

--- a/.claude/skills/add-mattermost/apply-fixtures.json
+++ b/.claude/skills/add-mattermost/apply-fixtures.json
@@ -4,7 +4,8 @@
     {
       "name": "self-hosted-bot",
       "inputs": {
-        "base_url": "https://mattermost.example.test/",
+        "no_server_choice": "enter",
+        "entered_url_new": "https://mattermost.example.test/",
         "site_url_ready": "ready",
         "bot_token": "fakeMattermostBotToken_123456",
         "callback_url": "http://host.docker.internal:3000/webhook/mattermost/",
@@ -13,7 +14,11 @@
       "exec": [
         {
           "match": "discover-server.mjs",
-          "stdout": "{\"discovery\":\"none\",\"base_url\":\"\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}"
+          "stdout": "{\"discovery\":\"none\",\"base_url\":\"none\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}"
+        },
+        {
+          "match": "select-server.mjs enter",
+          "stdout": "{\"base_url\":\"https://mattermost.example.test\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}"
         },
         { "match": "/api/v4/config/client?format=old", "stdout": "https://mattermost.example.test\n\n" },
         { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
@@ -26,8 +31,69 @@
       ]
     },
     {
+      "name": "detected-but-enter-another",
+      "inputs": {
+        "server_choice": "enter",
+        "entered_url": "https://other.example.test",
+        "site_url_ready": "ready",
+        "bot_token": "fakeMattermostBotToken_123456",
+        "callback_url": "https://nanoclaw.example.test",
+        "owner_username": "owner.test"
+      },
+      "exec": [
+        { "match": "discover-server.mjs", "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\",\"config_access\":\"host\",\"mattermost_container\":\"none\"}" },
+        { "match": "select-server.mjs enter", "stdout": "{\"base_url\":\"https://other.example.test\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}" },
+        { "match": "/api/v4/config/client?format=old", "stdout": "https://other.example.test\n\n" },
+        { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
+        { "match": "openssl rand -hex 32", "stdout": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" },
+        { "match": "/api/v4/users/username/owner.test", "stdout": "{\"id\":\"oooooooooooooooooooooooooo\"}" },
+        { "match": "/api/v4/channels/direct", "stdout": "mattermost:dddddddddddddddddddddddddd" }
+      ]
+    },
+    {
+      "name": "detected-but-create-local",
+      "inputs": {
+        "server_choice": "create",
+        "local_install_approval": "install",
+        "bot_token": "fakeMattermostBotToken_123456",
+        "callback_url": "http://host.docker.internal:3000/webhook/mattermost",
+        "owner_username": "owner.test"
+      },
+      "exec": [
+        { "match": "discover-server.mjs", "stdout": "{\"discovery\":\"found\",\"base_url\":\"https://detected.example.test\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}" },
+        { "match": "printf 'yes", "stdout": "yes" },
+        { "match": "select-server.mjs create", "stdout": "{\"base_url\":\"http://localhost:8065\",\"config_access\":\"managed\",\"mattermost_container\":\"nanoclaw-mattermost-mattermost-1\"}" },
+        { "match": "/api/v4/config/client?format=old", "stdout": "http://localhost:8065\n\n" },
+        { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
+        { "match": "openssl rand -hex 32", "stdout": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" },
+        { "match": "/api/v4/users/username/owner.test", "stdout": "{\"id\":\"oooooooooooooooooooooooooo\"}" },
+        { "match": "/api/v4/channels/direct", "stdout": "mattermost:dddddddddddddddddddddddddd" }
+      ]
+    },
+    {
+      "name": "no-server-create-local",
+      "inputs": {
+        "no_server_choice": "create",
+        "local_install_approval": "install",
+        "bot_token": "fakeMattermostBotToken_123456",
+        "callback_url": "http://host.docker.internal:3000/webhook/mattermost",
+        "owner_username": "owner.test"
+      },
+      "exec": [
+        { "match": "discover-server.mjs", "stdout": "{\"discovery\":\"none\",\"base_url\":\"none\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}" },
+        { "match": "printf 'yes", "stdout": "yes" },
+        { "match": "select-server.mjs create", "stdout": "{\"base_url\":\"http://localhost:8065\",\"config_access\":\"managed\",\"mattermost_container\":\"nanoclaw-mattermost-mattermost-1\"}" },
+        { "match": "/api/v4/config/client?format=old", "stdout": "http://localhost:8065\n\n" },
+        { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
+        { "match": "openssl rand -hex 32", "stdout": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" },
+        { "match": "/api/v4/users/username/owner.test", "stdout": "{\"id\":\"oooooooooooooooooooooooooo\"}" },
+        { "match": "/api/v4/channels/direct", "stdout": "mattermost:dddddddddddddddddddddddddd" }
+      ]
+    },
+    {
       "name": "detected-host-mmctl",
       "inputs": {
+        "server_choice": "use",
         "site_url_action": "set",
         "bot_token": "fakeMattermostBotToken_123456",
         "callback_url": "http://localhost:3000/webhook/mattermost/",
@@ -37,6 +103,10 @@
         {
           "match": "discover-server.mjs",
           "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\",\"config_access\":\"host\",\"mattermost_container\":\"none\"}"
+        },
+        {
+          "match": "select-server.mjs use",
+          "stdout": "{\"base_url\":\"http://localhost:8065\",\"config_access\":\"host\",\"mattermost_container\":\"none\"}"
         },
         { "match": "/api/v4/config/client?format=old", "stdout": "http://localhost:8065\n\n" },
         { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
@@ -51,6 +121,7 @@
     {
       "name": "detected-local-server",
       "inputs": {
+        "server_choice": "use",
         "site_url_action_docker": "set",
         "bot_token": "fakeMattermostBotToken_123456",
         "callback_url": "http://host.docker.internal:3000/webhook/mattermost/",
@@ -60,6 +131,10 @@
         {
           "match": "discover-server.mjs",
           "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\",\"config_access\":\"docker\",\"mattermost_container\":\"nanoclaw-mattermost-mattermost-1\"}"
+        },
+        {
+          "match": "select-server.mjs use",
+          "stdout": "{\"base_url\":\"http://localhost:8065\",\"config_access\":\"docker\",\"mattermost_container\":\"nanoclaw-mattermost-mattermost-1\"}"
         },
         { "match": "/api/v4/config/client?format=old", "stdout": "http://localhost:8065\n\n" },
         { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },

--- a/.claude/skills/add-mattermost/apply-fixtures.json
+++ b/.claude/skills/add-mattermost/apply-fixtures.json
@@ -5,6 +5,7 @@
       "name": "self-hosted-bot",
       "inputs": {
         "base_url": "https://mattermost.example.test/",
+        "site_url_ready": "ready",
         "bot_token": "fakeMattermostBotToken_123456",
         "callback_url": "http://host.docker.internal:3000/webhook/mattermost/",
         "owner_username": "owner.test"
@@ -12,8 +13,32 @@
       "exec": [
         {
           "match": "discover-server.mjs",
-          "stdout": "{\"discovery\":\"none\",\"base_url\":\"\"}"
+          "stdout": "{\"discovery\":\"none\",\"base_url\":\"\",\"config_access\":\"unavailable\",\"mattermost_container\":\"none\"}"
         },
+        { "match": "/api/v4/config/client?format=old", "stdout": "https://mattermost.example.test\n\n" },
+        { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
+        {
+          "match": "openssl rand -hex 32",
+          "stdout": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        },
+        { "match": "/api/v4/users/username/owner.test", "stdout": "{\"id\":\"oooooooooooooooooooooooooo\"}" },
+        { "match": "/api/v4/channels/direct", "stdout": "mattermost:dddddddddddddddddddddddddd" }
+      ]
+    },
+    {
+      "name": "detected-host-mmctl",
+      "inputs": {
+        "site_url_action": "set",
+        "bot_token": "fakeMattermostBotToken_123456",
+        "callback_url": "http://localhost:3000/webhook/mattermost/",
+        "owner_username": "owner.test"
+      },
+      "exec": [
+        {
+          "match": "discover-server.mjs",
+          "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\",\"config_access\":\"host\",\"mattermost_container\":\"none\"}"
+        },
+        { "match": "/api/v4/config/client?format=old", "stdout": "http://localhost:8065\n\n" },
         { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
         {
           "match": "openssl rand -hex 32",
@@ -26,6 +51,7 @@
     {
       "name": "detected-local-server",
       "inputs": {
+        "site_url_action_docker": "set",
         "bot_token": "fakeMattermostBotToken_123456",
         "callback_url": "http://host.docker.internal:3000/webhook/mattermost/",
         "owner_username": "owner.test"
@@ -33,8 +59,9 @@
       "exec": [
         {
           "match": "discover-server.mjs",
-          "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\"}"
+          "stdout": "{\"discovery\":\"found\",\"base_url\":\"http://localhost:8065\",\"config_access\":\"docker\",\"mattermost_container\":\"nanoclaw-mattermost-mattermost-1\"}"
         },
+        { "match": "/api/v4/config/client?format=old", "stdout": "http://localhost:8065\n\n" },
         { "match": "/api/v4/users/me", "stdout": "{\"id\":\"bbbbbbbbbbbbbbbbbbbbbbbbbb\",\"username\":\"nanoclaw\"}" },
         {
           "match": "openssl rand -hex 32",

--- a/.claude/skills/add-mattermost/assets/compose.yml
+++ b/.claude/skills/add-mattermost/assets/compose.yml
@@ -28,7 +28,6 @@ services:
       MM_SQLSETTINGS_DRIVERNAME: postgres
       MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:${MATTERMOST_DB_PASSWORD:?set MATTERMOST_DB_PASSWORD in .env}@postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
       MM_SERVICESETTINGS_SITEURL: "http://localhost:8065"
-      MM_SERVICESETTINGS_ALLOWCORSFROM: "http://localhost:8065 http://127.0.0.1:8065"
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
       # Open signup stays off: the first browser visit still creates the

--- a/.claude/skills/add-mattermost/scripts/discover-server.mjs
+++ b/.claude/skills/add-mattermost/scripts/discover-server.mjs
@@ -1,9 +1,19 @@
 import { readFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
 
 const PING_PATH = '/api/v4/system/ping';
 
 function normalize(value) {
-  return value?.trim().replace(/\/+$/, '') || '';
+  try {
+    const url = new URL(value?.trim() || '');
+    if (!['http:', 'https:'].includes(url.protocol)) return '';
+    if (url.username || url.password || url.search || url.hash) return '';
+    if (!/^\/(?:[A-Za-z0-9._~%+-]+\/)*[A-Za-z0-9._~%+-]*$/.test(url.pathname)) return '';
+    const path = url.pathname.replace(/\/+$/, '');
+    return `${url.origin}${path}`;
+  } catch {
+    return '';
+  }
 }
 
 async function configuredUrl() {
@@ -32,6 +42,56 @@ async function isMattermost(baseUrl) {
   }
 }
 
+function commandWorks(command, args) {
+  try {
+    execFileSync(command, args, { stdio: 'ignore', timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function localConfigAccess(baseUrl) {
+  let hostname = '';
+  let port = '';
+  try {
+    const parsed = new URL(baseUrl);
+    hostname = parsed.hostname;
+    port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
+  } catch {
+    return { config_access: 'unavailable', mattermost_container: 'none' };
+  }
+  if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1') {
+    // A canonical DNS name does not prove that an arbitrary host socket or
+    // container belongs to this server. Prefer manual authenticated guidance
+    // over risking a configuration change against the wrong local instance.
+    return { config_access: 'unavailable', mattermost_container: 'none' };
+  }
+
+  if (commandWorks('mmctl', ['config', 'get', 'ServiceSettings.SiteURL', '--local'])) {
+    return { config_access: 'host', mattermost_container: 'none' };
+  }
+
+  try {
+    const names = execFileSync('docker', ['ps', '--format', '{{.Names}}\t{{.Image}}\t{{.Ports}}'], {
+      encoding: 'utf8',
+      timeout: 3000,
+    });
+    for (const row of names.split(/\r?\n/)) {
+      const [name, image = '', ports = ''] = row.split('\t');
+      if (!name || !/mattermost/i.test(`${name} ${image}`)) continue;
+      if (!ports.split(',').some((mapping) => mapping.includes(`:${port}->`))) continue;
+      if (commandWorks('docker', ['exec', name, 'mmctl', 'config', 'get', 'ServiceSettings.SiteURL', '--local'])) {
+        return { config_access: 'docker', mattermost_container: name };
+      }
+    }
+  } catch {
+    // Docker is optional. Lack of access is handled by operator guidance.
+  }
+
+  return { config_access: 'unavailable', mattermost_container: 'none' };
+}
+
 try {
   const candidates = [...new Set([await configuredUrl(), 'http://localhost:8065', 'http://127.0.0.1:8065'])].filter(
     Boolean,
@@ -39,7 +99,9 @@ try {
 
   for (const baseUrl of candidates) {
     if (await isMattermost(baseUrl)) {
-      process.stdout.write(`${JSON.stringify({ discovery: 'found', base_url: baseUrl })}\n`);
+      process.stdout.write(
+        `${JSON.stringify({ discovery: 'found', base_url: baseUrl, ...localConfigAccess(baseUrl) })}\n`,
+      );
       process.exit(0);
     }
   }
@@ -47,4 +109,6 @@ try {
   // Fall through to the not-found result below.
 }
 
-process.stdout.write(`${JSON.stringify({ discovery: 'none', base_url: '' })}\n`);
+process.stdout.write(
+  `${JSON.stringify({ discovery: 'none', base_url: '', config_access: 'unavailable', mattermost_container: 'none' })}\n`,
+);

--- a/.claude/skills/add-mattermost/scripts/discover-server.mjs
+++ b/.claude/skills/add-mattermost/scripts/discover-server.mjs
@@ -110,5 +110,5 @@ try {
 }
 
 process.stdout.write(
-  `${JSON.stringify({ discovery: 'none', base_url: '', config_access: 'unavailable', mattermost_container: 'none' })}\n`,
+  `${JSON.stringify({ discovery: 'none', base_url: 'none', config_access: 'unavailable', mattermost_container: 'none' })}\n`,
 );

--- a/.claude/skills/add-mattermost/scripts/remove-base-url.mjs
+++ b/.claude/skills/add-mattermost/scripts/remove-base-url.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const envPath = join(process.cwd(), '.env');
+if (!existsSync(envPath)) process.exit(0);
+
+const content = readFileSync(envPath, 'utf8');
+writeFileSync(envPath, content.replace(/^MATTERMOST_BASE_URL=.*\n?/m, ''));

--- a/.claude/skills/add-mattermost/scripts/select-server.mjs
+++ b/.claude/skills/add-mattermost/scripts/select-server.mjs
@@ -1,0 +1,35 @@
+const [mode, baseUrl = '', configAccess = 'unavailable', container = 'none'] = process.argv.slice(2);
+
+function validUrl(value) {
+  try {
+    const url = new URL(value);
+    if (!['http:', 'https:'].includes(url.protocol)) return false;
+    if (url.username || url.password || url.search || url.hash) return false;
+    return /^\/(?:[A-Za-z0-9._~%+-]+\/)*[A-Za-z0-9._~%+-]*$/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+let selection;
+if (mode === 'create') {
+  selection = {
+    base_url: 'http://localhost:8065',
+    config_access: 'managed',
+    mattermost_container: 'nanoclaw-mattermost-mattermost-1',
+  };
+} else if (mode === 'enter' && validUrl(baseUrl)) {
+  selection = { base_url: baseUrl, config_access: 'unavailable', mattermost_container: 'none' };
+} else if (
+  mode === 'use' &&
+  validUrl(baseUrl) &&
+  ['host', 'docker', 'unavailable'].includes(configAccess) &&
+  /^(?:none|[A-Za-z0-9][A-Za-z0-9_.-]*)$/.test(container)
+) {
+  selection = { base_url: baseUrl, config_access: configAccess, mattermost_container: container };
+} else {
+  process.stderr.write('Invalid Mattermost server selection\n');
+  process.exit(1);
+}
+
+process.stdout.write(`${JSON.stringify(selection)}\n`);

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -37,6 +37,12 @@ import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 // extensions (setup/channels/companions.ts) before running its install skill
 // — the wizard itself stays free of channel-specific imports.
 import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
+import {
+  channelDmLabel,
+  initialChannelOptions,
+  runInitialChannel,
+  type ChannelChoice,
+} from './channels/initial-setup.js';
 import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
@@ -109,18 +115,6 @@ const REGISTRY_STEP = 'pnpm exec tsx setup/index.ts --step registry';
 
 /** `setup/registry-login.sh`'s "nothing was signed in, and that is fine" code. */
 const LOGIN_EXIT_SKIPPED = 2;
-
-type ChannelChoice =
-  | 'telegram'
-  | 'discord'
-  | 'whatsapp'
-  | 'signal'
-  | 'teams'
-  | 'slack'
-  | 'imessage'
-  | 'dial'
-  | 'other'
-  | 'skip';
 
 async function main(): Promise<void> {
   // Make sure ~/.local/bin is on PATH for every child process we spawn.
@@ -689,30 +683,9 @@ async function main(): Promise<void> {
         await resolveDisplayName();
       }
       let result: void | typeof BACK_TO_CHANNEL_SELECTION;
-      // Every channel now runs through the SKILL.md-driven flow — the whole
-      // connect+wire procedure lives in each add-<channel>/SKILL.md.
-      if (channelChoice === 'telegram') {
-        result = await runChannelSkillWithPreStep('telegram', displayName!, { offerBack: true });
-      } else if (channelChoice === 'discord') {
-        result = await runChannelSkillWithPreStep('discord', displayName!, { offerBack: true });
-      } else if (channelChoice === 'whatsapp') {
-        result = await runChannelSkillWithPreStep('whatsapp', displayName!, { offerBack: true });
-      } else if (channelChoice === 'signal') {
-        result = await runChannelSkillWithPreStep('signal', displayName!, { offerBack: true });
-      } else if (channelChoice === 'teams') {
-        // Fresh create resolves the owner DM proactively and wires inline (the
-        // welcome message reaches the human first); a drop-through re-run
-        // resolves nothing and falls back to the deferred-wire ending.
-        result = await runChannelSkillWithPreStep('teams', displayName!, { wireIfResolved: true, offerBack: true });
-      } else if (channelChoice === 'slack') {
-        result = await runChannelSkillWithPreStep('slack', displayName!, { offerBack: true });
-      } else if (channelChoice === 'imessage') {
-        result = await runChannelSkillWithPreStep('imessage', displayName!, { offerBack: true });
-      } else if (channelChoice === 'dial') {
-        result = await runChannelSkillWithPreStep('dial', displayName!, { offerBack: true });
-      } else if (channelChoice === 'other') {
+      if (channelChoice === 'other') {
         result = await askOtherChannelName();
-      } else {
+      } else if (channelChoice === 'skip') {
         p.log.info(
           brandBody(
             wrapForGutter(
@@ -721,6 +694,10 @@ async function main(): Promise<void> {
             ),
           ),
         );
+      } else {
+        // Every installable choice runs through the SKILL.md-driven flow. The
+        // mapping is executable and unit-tested in channels/initial-setup.ts.
+        result = await runInitialChannel(channelChoice, displayName!, runChannelSkillWithPreStep);
       }
       if (result === BACK_TO_CHANNEL_SELECTION) backed = true;
     }
@@ -832,29 +809,6 @@ async function main(): Promise<void> {
     p.outro(k.green("You're set."));
   } else {
     p.outro(k.green("You're ready! Chat with `pnpm run chat hi`."));
-  }
-}
-
-function channelDmLabel(choice: ChannelChoice): string | null {
-  switch (choice) {
-    case 'telegram':
-      return 'Telegram';
-    case 'discord':
-      return 'Discord DMs';
-    case 'whatsapp':
-      return 'WhatsApp';
-    case 'signal':
-      return 'Signal';
-    case 'teams':
-      return 'Teams';
-    case 'imessage':
-      return 'iMessage';
-    case 'slack':
-      return 'Slack DMs';
-    case 'dial':
-      return 'phone';
-    default:
-      return null;
   }
 }
 
@@ -1882,26 +1836,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
   const choice = ensureAnswer(
     await brightSelect<ChannelChoice>({
       message: 'Want to chat with your assistant from your phone?',
-      options: [
-        { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
-        { value: 'teams', label: 'Yes, connect Microsoft Teams' },
-        { value: 'telegram', label: 'Yes, connect Telegram' },
-        { value: 'discord', label: 'Yes, connect Discord' },
-        { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
-        { value: 'dial', label: 'Yes, connect Dial', hint: 'a dedicated phone number for your agent — place calls, SMS — worldwide' },
-        {
-          value: 'signal',
-          label: 'Yes, connect Signal',
-          hint: 'needs signal-cli installed',
-        },
-        {
-          value: 'imessage',
-          label: 'Yes, connect iMessage',
-          hint: 'local Mac or hosted iMessage (via photon.codes)',
-        },
-        { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
-        { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
-      ],
+      options: initialChannelOptions(),
     }),
   );
   setupLog.userInput('channel_choice', String(choice));

--- a/setup/channels/initial-setup.ts
+++ b/setup/channels/initial-setup.ts
@@ -1,0 +1,81 @@
+import type { BACK_TO_CHANNEL_SELECTION } from '../lib/back-nav.js';
+
+export type ChannelChoice =
+  | 'telegram'
+  | 'discord'
+  | 'whatsapp'
+  | 'signal'
+  | 'teams'
+  | 'slack'
+  | 'mattermost'
+  | 'imessage'
+  | 'dial'
+  | 'other'
+  | 'skip';
+
+type InstallableChannel = Exclude<ChannelChoice, 'other' | 'skip'>;
+type ChannelRunOptions = { offerBack: true; wireIfResolved?: true };
+type ChannelRunner = (
+  channel: string,
+  displayName: string,
+  options: ChannelRunOptions,
+) => Promise<void | typeof BACK_TO_CHANNEL_SELECTION>;
+
+export function initialChannelOptions(): { value: ChannelChoice; label: string; hint?: string }[] {
+  return [
+    { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
+    { value: 'mattermost', label: 'Yes, connect Mattermost', hint: 'self-hosted or cloud' },
+    { value: 'teams', label: 'Yes, connect Microsoft Teams' },
+    { value: 'telegram', label: 'Yes, connect Telegram' },
+    { value: 'discord', label: 'Yes, connect Discord' },
+    { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
+    {
+      value: 'dial',
+      label: 'Yes, connect Dial',
+      hint: 'a dedicated phone number for your agent — place calls, SMS — worldwide',
+    },
+    { value: 'signal', label: 'Yes, connect Signal', hint: 'needs signal-cli installed' },
+    {
+      value: 'imessage',
+      label: 'Yes, connect iMessage',
+      hint: 'local Mac or hosted iMessage (via photon.codes)',
+    },
+    { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
+    { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
+  ];
+}
+
+export function runInitialChannel(
+  choice: InstallableChannel,
+  displayName: string,
+  runner: ChannelRunner,
+): Promise<void | typeof BACK_TO_CHANNEL_SELECTION> {
+  const options: ChannelRunOptions =
+    choice === 'teams' ? { wireIfResolved: true, offerBack: true } : { offerBack: true };
+  return runner(choice, displayName, options);
+}
+
+export function channelDmLabel(choice: ChannelChoice): string | null {
+  switch (choice) {
+    case 'telegram':
+      return 'Telegram';
+    case 'discord':
+      return 'Discord DMs';
+    case 'whatsapp':
+      return 'WhatsApp';
+    case 'signal':
+      return 'Signal';
+    case 'teams':
+      return 'Teams';
+    case 'imessage':
+      return 'iMessage';
+    case 'slack':
+      return 'Slack DMs';
+    case 'mattermost':
+      return 'Mattermost DMs';
+    case 'dial':
+      return 'phone';
+    default:
+      return null;
+  }
+}

--- a/setup/channels/initial-setup.ts
+++ b/setup/channels/initial-setup.ts
@@ -24,7 +24,11 @@ type ChannelRunner = (
 export function initialChannelOptions(): { value: ChannelChoice; label: string; hint?: string }[] {
   return [
     { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
-    { value: 'mattermost', label: 'Yes, connect Mattermost', hint: 'self-hosted or cloud' },
+    {
+      value: 'mattermost',
+      label: 'Yes, connect Mattermost',
+      hint: 'use your server or create an evaluation server',
+    },
     { value: 'teams', label: 'Yes, connect Microsoft Teams' },
     { value: 'telegram', label: 'Yes, connect Telegram' },
     { value: 'discord', label: 'Yes, connect Discord' },

--- a/setup/channels/mattermost-discovery.test.ts
+++ b/setup/channels/mattermost-discovery.test.ts
@@ -1,0 +1,86 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const script = '.claude/skills/add-mattermost/scripts/discover-server.mjs';
+
+describe('Mattermost server discovery', () => {
+  const cleanups: (() => Promise<unknown>)[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  async function fakeCommand(directory: string, name: string, body: string) {
+    const path = join(directory, name);
+    await writeFile(path, `#!/bin/sh\n${body}\n`);
+    await chmod(path, 0o755);
+  }
+
+  async function discover(
+    commandSetup: (directory: string, port: number) => Promise<void>,
+    basePath = '',
+  ) {
+    const server = createServer((request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(request.url === `${basePath}/api/v4/system/ping` ? '{"status":"OK"}' : '{}');
+    });
+    cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('test server did not bind TCP');
+
+    const bin = await mkdtemp(join(tmpdir(), 'mattermost-discovery-'));
+    cleanups.push(() => rm(bin, { recursive: true, force: true }));
+    await commandSetup(bin, address.port);
+    const baseUrl = `http://127.0.0.1:${address.port}${basePath}`;
+    const { stdout } = await execFileAsync(process.execPath, [script], {
+      env: { ...process.env, PATH: bin, MATTERMOST_BASE_URL: baseUrl },
+    });
+    return { result: JSON.parse(stdout), baseUrl };
+  }
+
+  it('detects host-local mmctl without replacing the selected URL', async () => {
+    const { result, baseUrl } = await discover(
+      async (bin) => {
+        await fakeCommand(bin, 'mmctl', 'exit 0');
+      },
+      '/mattermost',
+    );
+    expect(result).toEqual({
+      discovery: 'found',
+      base_url: baseUrl,
+      config_access: 'host',
+      mattermost_container: 'none',
+    });
+  });
+
+  it('detects mmctl in a Mattermost container published on the selected port', async () => {
+    const { result } = await discover(async (bin, port) => {
+      await fakeCommand(bin, 'mmctl', 'exit 1');
+      await fakeCommand(
+        bin,
+        'docker',
+        `if [ "$1" = "ps" ]; then printf 'mattermost-lab\\tmattermost/mattermost-team-edition\\t127.0.0.1:${port}->8065/tcp\\n'; exit 0; fi\nexit 0`,
+      );
+    });
+    expect(result).toMatchObject({ config_access: 'docker', mattermost_container: 'mattermost-lab' });
+  });
+
+  it('does not associate a Mattermost container published on another port', async () => {
+    const { result } = await discover(async (bin) => {
+      await fakeCommand(bin, 'mmctl', 'exit 1');
+      await fakeCommand(
+        bin,
+        'docker',
+        `if [ "$1" = "ps" ]; then printf 'mattermost-lab\\tmattermost/mattermost-team-edition\\t127.0.0.1:9999->8065/tcp\\n'; exit 0; fi\nexit 0`,
+      );
+    });
+    expect(result).toMatchObject({ config_access: 'unavailable', mattermost_container: 'none' });
+  });
+});

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const skill = readFileSync('.claude/skills/add-mattermost/SKILL.md', 'utf8');
+
+describe('Mattermost bot setup guidance', () => {
+  it('distinguishes enabling bot creation from creating the bot', () => {
+    expect(skill).toContain(
+      'System Console → Integrations → Bot Accounts and turn on Enable Bot Account Creation',
+    );
+    expect(skill).toContain(
+      'Product menu → Integrations → Bot Accounts, select Add Bot Account',
+    );
+    expect(skill).toContain('This setting only permits bot creation; it is not where bots are created.');
+  });
+
+  it('requires both team and channel membership', () => {
+    expect(skill).toContain('Bots do not join teams or channels automatically.');
+  });
+});

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const skill = readFileSync('.claude/skills/add-mattermost/SKILL.md', 'utf8');
+const localServer = readFileSync('.claude/skills/add-mattermost/LOCAL_SERVER.md', 'utf8');
+const compose = readFileSync('.claude/skills/add-mattermost/assets/compose.yml', 'utf8');
 
 describe('Mattermost bot setup guidance', () => {
   it('distinguishes enabling bot creation from creating the bot', () => {
@@ -16,5 +18,20 @@ describe('Mattermost bot setup guidance', () => {
 
   it('requires both team and channel membership', () => {
     expect(skill).toContain('Bots do not join teams or channels automatically.');
+  });
+
+  it('configures and verifies the exact canonical SiteURL without weakening origin checks', () => {
+    expect(skill).toContain('mmctl config set ServiceSettings.SiteURL "{{base_url}}" --local');
+    expect(skill).toContain('/api/v4/config/client?format=old');
+    expect(skill).toContain('Do not broaden `ServiceSettings.AllowCorsFrom`');
+    expect(skill).toContain('System Console → Environment → Web Server');
+    expect(skill).toContain('config_access=docker');
+  });
+
+  it('keeps the evaluation server canonical and declarative', () => {
+    expect(compose).toContain('MM_SERVICESETTINGS_SITEURL: "http://localhost:8065"');
+    expect(compose).not.toContain('MM_SERVICESETTINGS_ALLOWCORSFROM');
+    expect(localServer).toContain('`WebsocketURL` stays blank');
+    expect(localServer).toContain('/api/v4/config/client?format=old');
   });
 });

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -1,14 +1,26 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { parseDirectives } from '../../scripts/skill-directives.js';
 import { upsertEnvVar } from '../set-env.js';
 import { channelDmLabel, initialChannelOptions, runInitialChannel } from './initial-setup.js';
 
 const skill = readFileSync('.claude/skills/add-mattermost/SKILL.md', 'utf8');
 const localServer = readFileSync('.claude/skills/add-mattermost/LOCAL_SERVER.md', 'utf8');
 const compose = readFileSync('.claude/skills/add-mattermost/assets/compose.yml', 'utf8');
+const directives = parseDirectives(skill);
 
 describe('Mattermost bot setup guidance', () => {
   it('distinguishes enabling bot creation from creating the bot', () => {
@@ -18,11 +30,10 @@ describe('Mattermost bot setup guidance', () => {
     expect(skill).toContain(
       'Open Product menu → Integrations → Bot Accounts. Select Add Bot Account',
     );
-    expect(skill).toContain('This setting permits bot creation. You do not create the bot on this page.');
   });
 
   it('requires both team and channel membership', () => {
-    expect(skill).toContain('Mattermost does not add bots to teams or channels automatically.');
+    expect(skill).toMatch(/Add the bot to each required team and channel\./);
   });
 
   it('offers and dispatches Mattermost as a first-class initial setup option', async () => {
@@ -48,26 +59,103 @@ describe('Mattermost bot setup guidance', () => {
   });
 
   it('requires the operator to choose how a detected server is used', () => {
-    expect(skill).toContain('The user must select the server');
-    expect(skill).toContain('validate:^(use|enter|create)$');
-    expect(skill).toContain('Enter `enter` to specify a different Mattermost URL');
-    expect(skill).toContain('Enter `create` to create a local evaluation server');
-    expect(skill).toContain('Do not select a');
-    expect(skill).toContain('server automatically');
-    expect(skill).toContain('Enter `install` to create and start these local resources');
-    expect(skill).toContain('Port 8065 must be free');
-    expect(skill).toContain('for attempt in $(seq 1 30)');
-    expect(skill).toContain('curl -fsS --connect-timeout 1 --max-time 1');
-    expect(skill).toContain('docker info >/dev/null');
-    expect(skill).toContain('logs --tail 100 mattermost');
+    const choice = directives.find(
+      (directive) => directive.kind === 'prompt' && directive.args.includes('server_choice'),
+    );
+    const install = directives.find(
+      (directive) => directive.kind === 'prompt' && directive.args.includes('local_install_approval'),
+    );
+    expect(choice?.attrs.validate).toBe('^(use|enter|create)$');
+    expect(install?.attrs.validate).toBe('^install$');
+  });
+
+  it('keeps every evaluation-server command self-contained and preserves shell control flow', () => {
+    const install = directives.find(
+      (directive) => directive.kind === 'run' && directive.body.some((line) => line.includes('for attempt in')),
+    );
+    expect(install?.body).toHaveLength(7);
+    expect(install?.body[0]).toContain('docker info >/dev/null && docker compose version >/dev/null');
+    expect(install?.body).not.toContain('umask 077');
+    expect(install?.body).not.toContain('exit 1');
+
+    const envCommand = install?.body.find((line) => line.includes('MATTERMOST_DB_PASSWORD'));
+    const retryCommand = install?.body.find((line) => line.includes('for attempt in'));
+    expect(envCommand).toContain('{ umask 077;');
+    expect(retryCommand).toContain('done; docker compose');
+    expect(retryCommand).toMatch(/; exit 1$/);
+
+    const root = mkdtempSync(join(tmpdir(), 'nanoclaw-mattermost-shell-'));
+    const bin = join(root, 'bin');
+    const log = join(root, 'docker.log');
+    mkdirSync(join(root, '.nanoclaw/mattermost'), { recursive: true });
+    mkdirSync(bin);
+    const fake = (name: string, body: string) => {
+      const path = join(bin, name);
+      writeFileSync(path, `#!/bin/sh\n${body}\n`);
+      chmodSync(path, 0o755);
+    };
+
+    try {
+      fake('openssl', "printf '0123456789abcdef0123456789abcdef0123456789abcdef'");
+      fake('seq', "printf '1\\n2\\n'");
+      fake('sleep', 'exit 0');
+      fake('docker', 'printf "logs\\n" >> "$MM_TEST_LOG"');
+      fake('curl', 'exit "${MM_CURL_EXIT:-0}"');
+      const env = { ...process.env, PATH: bin, MM_TEST_LOG: log };
+
+      execFileSync('/bin/sh', ['-c', envCommand!], { cwd: root, env });
+      expect(statSync(join(root, '.nanoclaw/mattermost/.env')).mode & 0o777).toBe(0o600);
+
+      execFileSync('/bin/sh', ['-c', retryCommand!], { cwd: root, env: { ...env, MM_CURL_EXIT: '0' } });
+      expect(existsSync(log)).toBe(false);
+
+      const failed = spawnSync('/bin/sh', ['-c', retryCommand!], {
+        cwd: root,
+        env: { ...env, MM_CURL_EXIT: '1' },
+      });
+      expect(failed.status).toBe(1);
+      expect(readFileSync(log, 'utf8')).toBe('logs\n');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('consumes the managed SiteURL state and journals removal for the refreshed base URL', () => {
+    const managed = directives.find(
+      (directive) => directive.kind === 'operator' && directive.attrs.when === 'config_access=managed',
+    );
+    const baseUrlUpdate = directives.find(
+      (directive) =>
+        directive.kind === 'run' && directive.body.some((line) => line.includes('--key MATTERMOST_BASE_URL')),
+    );
+    const envSet = directives.find((directive) => directive.kind === 'env-set');
+    expect(managed).toBeDefined();
+    expect(baseUrlUpdate?.attrs.remove).toBe(
+      '.claude/skills/add-mattermost/scripts/remove-base-url.mjs',
+    );
+    expect(envSet?.body.some((line) => line.startsWith('MATTERMOST_BASE_URL='))).toBe(false);
+
+    const root = mkdtempSync(join(tmpdir(), 'nanoclaw-mattermost-remove-'));
+    try {
+      writeFileSync(
+        join(root, '.env'),
+        'MATTERMOST_BASE_URL=http://localhost:8065\nMATTERMOST_BOT_TOKEN=keep-me\n',
+      );
+      execFileSync(
+        join(process.cwd(), '.claude/skills/add-mattermost/scripts/remove-base-url.mjs'),
+        { cwd: root },
+      );
+      expect(readFileSync(join(root, '.env'), 'utf8')).toBe('MATTERMOST_BOT_TOKEN=keep-me\n');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('configures and verifies the exact canonical SiteURL without weakening origin checks', () => {
     expect(skill).toContain('mmctl config set ServiceSettings.SiteURL "{{base_url}}" --local');
     expect(skill).toContain('/api/v4/config/client?format=old');
-    expect(skill).toContain('Do not change\n`ServiceSettings.AllowCorsFrom` to correct an Origin error');
-    expect(skill).toContain('System Console → Environment → Web Server');
-    expect(skill).toContain('config_access=docker');
+    expect(skill).toContain('ServiceSettings.AllowCorsFrom');
+    expect(directives.some((directive) => directive.attrs.when === 'config_access=docker')).toBe(true);
     expect(skill).toContain(
       'setup/index.ts --step set-env -- --key MATTERMOST_BASE_URL --value "{{base_url}}"',
     );

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { upsertEnvVar } from '../set-env.js';
+import { channelDmLabel, initialChannelOptions, runInitialChannel } from './initial-setup.js';
 
 const skill = readFileSync('.claude/skills/add-mattermost/SKILL.md', 'utf8');
 const localServer = readFileSync('.claude/skills/add-mattermost/LOCAL_SERVER.md', 'utf8');
@@ -22,6 +23,20 @@ describe('Mattermost bot setup guidance', () => {
 
   it('requires both team and channel membership', () => {
     expect(skill).toContain('Bots do not join teams or channels automatically.');
+  });
+
+  it('offers and dispatches Mattermost as a first-class initial setup option', async () => {
+    expect(initialChannelOptions()).toContainEqual({
+      value: 'mattermost',
+      label: 'Yes, connect Mattermost',
+      hint: 'self-hosted or cloud',
+    });
+    const calls: unknown[][] = [];
+    await runInitialChannel('mattermost', 'Ethan', async (...args) => {
+      calls.push(args);
+    });
+    expect(calls).toEqual([['mattermost', 'Ethan', { offerBack: true }]]);
+    expect(channelDmLabel('mattermost')).toBe('Mattermost DMs');
   });
 
   it('installs and runs focused adapter regressions with the registration test', () => {

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -161,6 +161,15 @@ describe('Mattermost bot setup guidance', () => {
     );
   });
 
+  it('binds the generic wizard owner handle to the resolved Mattermost user ID', () => {
+    const ownerLookup = directives.find(
+      (directive) =>
+        directive.kind === 'run' &&
+        directive.body.some((line) => line.includes('/api/v4/users/username/{{owner_username}}')),
+    );
+    expect(ownerLookup?.attrs.capture).toBe('owner_user_id=.id,owner_handle=.id');
+  });
+
   it('replaces a stale canonical URL without changing existing credentials', () => {
     const root = mkdtempSync(join(tmpdir(), 'nanoclaw-mattermost-rerun-'));
     const previousCwd = process.cwd();

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -13,23 +13,23 @@ const compose = readFileSync('.claude/skills/add-mattermost/assets/compose.yml',
 describe('Mattermost bot setup guidance', () => {
   it('distinguishes enabling bot creation from creating the bot', () => {
     expect(skill).toContain(
-      'System Console → Integrations → Bot Accounts and turn on Enable Bot Account Creation',
+      'System Console → Integrations → Bot Accounts. Turn on Enable Bot Account Creation',
     );
     expect(skill).toContain(
-      'Product menu → Integrations → Bot Accounts, select Add Bot Account',
+      'Open Product menu → Integrations → Bot Accounts. Select Add Bot Account',
     );
-    expect(skill).toContain('This setting only permits bot creation; it is not where bots are created.');
+    expect(skill).toContain('This setting permits bot creation. You do not create the bot on this page.');
   });
 
   it('requires both team and channel membership', () => {
-    expect(skill).toContain('Bots do not join teams or channels automatically.');
+    expect(skill).toContain('Mattermost does not add bots to teams or channels automatically.');
   });
 
   it('offers and dispatches Mattermost as a first-class initial setup option', async () => {
     expect(initialChannelOptions()).toContainEqual({
       value: 'mattermost',
       label: 'Yes, connect Mattermost',
-      hint: 'self-hosted or cloud',
+      hint: 'use your server or create an evaluation server',
     });
     const calls: unknown[][] = [];
     await runInitialChannel('mattermost', 'Ethan', async (...args) => {
@@ -48,13 +48,14 @@ describe('Mattermost bot setup guidance', () => {
   });
 
   it('requires the operator to choose how a detected server is used', () => {
-    expect(skill).toContain('detection never selects a server on your behalf');
+    expect(skill).toContain('The user must select the server');
     expect(skill).toContain('validate:^(use|enter|create)$');
-    expect(skill).toContain('`enter` to provide another Mattermost URL');
-    expect(skill).toContain('`create` for a new local evaluation/development server');
-    expect(skill).toContain('Never select a detected server on the user\'s behalf');
-    expect(skill).toContain('Enter `install` to approve creating and starting those local resources');
-    expect(skill).toContain('port 8065 must be free');
+    expect(skill).toContain('Enter `enter` to specify a different Mattermost URL');
+    expect(skill).toContain('Enter `create` to create a local evaluation server');
+    expect(skill).toContain('Do not select a');
+    expect(skill).toContain('server automatically');
+    expect(skill).toContain('Enter `install` to create and start these local resources');
+    expect(skill).toContain('Port 8065 must be free');
     expect(skill).toContain('for attempt in $(seq 1 30)');
     expect(skill).toContain('curl -fsS --connect-timeout 1 --max-time 1');
     expect(skill).toContain('docker info >/dev/null');
@@ -64,7 +65,7 @@ describe('Mattermost bot setup guidance', () => {
   it('configures and verifies the exact canonical SiteURL without weakening origin checks', () => {
     expect(skill).toContain('mmctl config set ServiceSettings.SiteURL "{{base_url}}" --local');
     expect(skill).toContain('/api/v4/config/client?format=old');
-    expect(skill).toContain('Do not broaden `ServiceSettings.AllowCorsFrom`');
+    expect(skill).toContain('Do not change\n`ServiceSettings.AllowCorsFrom` to correct an Origin error');
     expect(skill).toContain('System Console → Environment → Web Server');
     expect(skill).toContain('config_access=docker');
     expect(skill).toContain(
@@ -99,7 +100,7 @@ describe('Mattermost bot setup guidance', () => {
   it('keeps the evaluation server canonical and declarative', () => {
     expect(compose).toContain('MM_SERVICESETTINGS_SITEURL: "http://localhost:8065"');
     expect(compose).not.toContain('MM_SERVICESETTINGS_ALLOWCORSFROM');
-    expect(localServer).toContain('`WebsocketURL` stays blank');
+    expect(localServer).toContain('Keep `WebsocketURL` blank');
     expect(localServer).toContain('/api/v4/config/client?format=old');
   });
 });

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -20,6 +20,20 @@ describe('Mattermost bot setup guidance', () => {
     expect(skill).toContain('Bots do not join teams or channels automatically.');
   });
 
+  it('requires the operator to choose how a detected server is used', () => {
+    expect(skill).toContain('detection never selects a server on your behalf');
+    expect(skill).toContain('validate:^(use|enter|create)$');
+    expect(skill).toContain('`enter` to provide another Mattermost URL');
+    expect(skill).toContain('`create` for a new local evaluation/development server');
+    expect(skill).toContain('Never select a detected server on the user\'s behalf');
+    expect(skill).toContain('Enter `install` to approve creating and starting those local resources');
+    expect(skill).toContain('port 8065 must be free');
+    expect(skill).toContain('for attempt in $(seq 1 30)');
+    expect(skill).toContain('curl -fsS --connect-timeout 1 --max-time 1');
+    expect(skill).toContain('docker info >/dev/null');
+    expect(skill).toContain('logs --tail 100 mattermost');
+  });
+
   it('configures and verifies the exact canonical SiteURL without weakening origin checks', () => {
     expect(skill).toContain('mmctl config set ServiceSettings.SiteURL "{{base_url}}" --local');
     expect(skill).toContain('/api/v4/config/client?format=old');

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -1,5 +1,9 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+
+import { upsertEnvVar } from '../set-env.js';
 
 const skill = readFileSync('.claude/skills/add-mattermost/SKILL.md', 'utf8');
 const localServer = readFileSync('.claude/skills/add-mattermost/LOCAL_SERVER.md', 'utf8');
@@ -40,6 +44,33 @@ describe('Mattermost bot setup guidance', () => {
     expect(skill).toContain('Do not broaden `ServiceSettings.AllowCorsFrom`');
     expect(skill).toContain('System Console → Environment → Web Server');
     expect(skill).toContain('config_access=docker');
+    expect(skill).toContain(
+      'setup/index.ts --step set-env -- --key MATTERMOST_BASE_URL --value "{{base_url}}"',
+    );
+  });
+
+  it('replaces a stale canonical URL without changing existing credentials', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nanoclaw-mattermost-rerun-'));
+    const previousCwd = process.cwd();
+    const before = [
+      'MATTERMOST_BASE_URL=http://localhost:8065',
+      'MATTERMOST_BOT_TOKEN=existing-bot-token',
+      'MATTERMOST_CALLBACK_URL=http://host.docker.internal:3000/webhook/mattermost',
+      'MATTERMOST_CALLBACK_SECRET=existing-callback-secret',
+      '',
+    ].join('\n');
+
+    try {
+      writeFileSync(join(root, '.env'), before);
+      process.chdir(root);
+      expect(upsertEnvVar('MATTERMOST_BASE_URL', 'http://127.0.0.1:8065')).toEqual({ existed: true });
+      expect(readFileSync(join(root, '.env'), 'utf8')).toBe(
+        before.replace('http://localhost:8065', 'http://127.0.0.1:8065'),
+      );
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('keeps the evaluation server canonical and declarative', () => {

--- a/setup/channels/mattermost-guidance.test.ts
+++ b/setup/channels/mattermost-guidance.test.ts
@@ -24,6 +24,14 @@ describe('Mattermost bot setup guidance', () => {
     expect(skill).toContain('Bots do not join teams or channels automatically.');
   });
 
+  it('installs and runs focused adapter regressions with the registration test', () => {
+    expect(skill).toContain('src/channels/mattermost-adapter/adapter.test.ts');
+    expect(skill).toContain('src/channels/mattermost-adapter/websocket.test.ts');
+    expect(skill).toContain(
+      'pnpm exec vitest run src/channels/mattermost-registration.test.ts src/channels/mattermost-adapter/adapter.test.ts src/channels/mattermost-adapter/websocket.test.ts',
+    );
+  });
+
   it('requires the operator to choose how a detected server is used', () => {
     expect(skill).toContain('detection never selects a server on your behalf');
     expect(skill).toContain('validate:^(use|enter|create)$');


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

- offer Mattermost as a first-class option during initial setup
- correct the bot-creation path and use warmer Simplified Technical English
- align Mattermost SiteURL guidance with the selected server URL
- require confirmation before setup uses a discovered server
- refresh the selected URL when setup runs again
- add focused discovery, guidance, and installed-adapter regression coverage

The related Mattermost adapter fix was merged separately in #3556.

## Verification

- focused Mattermost tests: 11/11 passed
- skill conformance tests: 184/184 passed
- TypeScript build passed
- `git diff --check origin/main...HEAD` passed
- independent adversarial review completed with no remaining findings

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill with a disposable installed-adapter checkout