### PR TITLE
fix(container): raise the Claude SDK output-token cap to the model's real ceiling

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -10,13 +10,14 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CONTAINER_CPU_LIMIT, CONTAINER_MEMORY_LIMIT } from './config.js';
 import type { ContainerConfig } from './container-config.js';
 import {
   armSessionLifecycle,
   composeSessionSpec,
+  maxOutputTokensFor,
   parseMemoryMb,
   parsePidsLimit,
   resolveProviderName,
@@ -154,6 +155,32 @@ describe('composeSessionSpec', () => {
 
   it('passes non-secret mailbox environment on the composed lane', () => {
     expect(compose().containers[0].env.NANOCLAW_MAILBOX_BACKEND).toBe('sqlite');
+  });
+
+  it('raises the Claude SDK output-token ceiling for the default (claude) provider', () => {
+    // Default model (unset) is a current Opus/Sonnet — full 128K ceiling.
+    expect(compose().containers[0].env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('128000');
+  });
+
+  it('caps the ceiling at 64K for Haiku-configured groups (overshooting is a 400)', () => {
+    const spec = compose({
+      containerConfig: { ...containerConfig, model: 'claude-haiku-4-5' } as ContainerConfig,
+    });
+    expect(spec.containers[0].env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('64000');
+  });
+
+  it('omits the variable entirely for non-claude providers', () => {
+    const spec = composeSessionSpec({
+      agentGroup,
+      session: { ...session, agent_provider: 'opencode' },
+      containerName: 'nanoclaw-v2-agent-one-1700000000000',
+      mounts,
+      containerConfig,
+      mailboxEnvironment: { NANOCLAW_MAILBOX_BACKEND: 'sqlite' },
+      contribution: {} as never,
+      gateway: {} as never,
+    });
+    expect(spec.containers[0].env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
   });
 
   it('the gateway contribution fills the contributed lane last and wins a collision', () => {
@@ -490,5 +517,41 @@ describe('syncSkillSymlinks', () => {
       expect.stringContaining('Shared skill not symlinked'),
       expect.objectContaining({ skill: 'welcome' }),
     );
+  });
+});
+
+describe('maxOutputTokensFor', () => {
+  afterEach(() => {
+    delete process.env.NANOCLAW_MAX_OUTPUT_TOKENS;
+  });
+
+  it('gives current Opus/Sonnet models (and the unset default) the 128K ceiling', () => {
+    expect(maxOutputTokensFor(null)).toBe(128_000);
+    expect(maxOutputTokensFor(undefined)).toBe(128_000);
+    expect(maxOutputTokensFor('claude-opus-4-6')).toBe(128_000);
+    expect(maxOutputTokensFor('claude-sonnet-4-6')).toBe(128_000);
+  });
+
+  it('gives Haiku models 64K (their real ceiling; higher is a 400)', () => {
+    expect(maxOutputTokensFor('claude-haiku-4-5')).toBe(64_000);
+  });
+
+  it('falls back to 64K for unknown/custom model strings instead of guessing high', () => {
+    expect(maxOutputTokensFor('deepseek/deepseek-v4-pro')).toBe(64_000);
+    expect(maxOutputTokensFor('my-custom-endpoint-model')).toBe(64_000);
+  });
+
+  it('honors a positive NANOCLAW_MAX_OUTPUT_TOKENS override', () => {
+    process.env.NANOCLAW_MAX_OUTPUT_TOKENS = '48000';
+    expect(maxOutputTokensFor('claude-opus-4-6')).toBe(48_000);
+  });
+
+  it('ignores non-numeric and non-positive overrides', () => {
+    process.env.NANOCLAW_MAX_OUTPUT_TOKENS = 'unlimited';
+    expect(maxOutputTokensFor(null)).toBe(128_000);
+    process.env.NANOCLAW_MAX_OUTPUT_TOKENS = '0';
+    expect(maxOutputTokensFor(null)).toBe(128_000);
+    process.env.NANOCLAW_MAX_OUTPUT_TOKENS = '-5';
+    expect(maxOutputTokensFor(null)).toBe(128_000);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -644,6 +644,28 @@ export function mergeMounts(composed: MountSpec[], contributed: MountSpec[]): Mo
  * with argv assembly removed: the host says what a session *is*, the driver
  * says how it is realized.
  */
+/**
+ * Output-token ceiling for the Claude Agent SDK. Unset, the SDK caps every
+ * turn at 32000 output tokens and destroys the turn when the model wants to
+ * write more ("Claude's response exceeded the 32000 output token maximum"),
+ * even though every current model's real ceiling is higher. Model-aware
+ * because the ceilings differ and asking above a model's ceiling is a 400:
+ * Haiku tops out at 64K while Opus/Sonnet take 128K. Unknown or custom model
+ * strings get 64K — the value every current model accepts — rather than
+ * guessing high and risking the 400. `NANOCLAW_MAX_OUTPUT_TOKENS` overrides
+ * the table for operators who want a tighter cap (e.g. to bound spend on a
+ * runaway agent). This is a ceiling, not a target: ordinary turns are
+ * unaffected, only turns that actually need the room use it.
+ */
+export function maxOutputTokensFor(model: string | null | undefined): number {
+  const override = Number(process.env.NANOCLAW_MAX_OUTPUT_TOKENS);
+  if (Number.isFinite(override) && override > 0) return Math.floor(override);
+  const m = (model ?? '').toLowerCase();
+  if (m.includes('haiku')) return 64_000;
+  if (!m || m.includes('opus') || m.includes('sonnet')) return 128_000;
+  return 64_000;
+}
+
 export function composeSessionSpec(input: ComposeSessionSpecInput): SessionSpec {
   const { agentGroup, session, containerName, mounts, containerConfig, contribution, gateway, mailboxEnvironment } =
     input;
@@ -652,6 +674,12 @@ export function composeSessionSpec(input: ComposeSessionSpecInput): SessionSpec 
     TZ: containerConfig.timezone ?? TIMEZONE,
     ...mailboxEnvironment,
   };
+  // Raise the SDK's 32000 output-token default to the model's real ceiling.
+  // Claude provider only — the variable is read by the Claude Agent SDK and
+  // means nothing to other providers, whose limits are configured elsewhere.
+  if (resolveProviderName(session.agent_provider, containerConfig.provider) === 'claude') {
+    env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = String(maxOutputTokensFor(containerConfig.model));
+  }
   // The contributed lane (ContainerSpec.contributedEnv): registry-sourced env,
   // exempt from the credential-NAME check and still refused credential VALUES.
   // The model provider's contribution fills first, the gateway's second — a


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #3023.

**What:** Nothing in the tree set `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, so every Claude agent ran at the Agent SDK's default 32000 output-token cap. A turn that wanted to write more (a large generated file, a long refactor) was killed partway with `Claude's response exceeded the 32000 output token maximum` — work lost, raw API error in chat — while every current model supports 2–4× that.

**How it works:** Implements the shape proposed in the issue, adapted to the current spec seam (the issue predates the driver refactor — env now goes through `composeSessionSpec`, not `buildContainerArgs`):

- `maxOutputTokensFor(model)`: Opus/Sonnet and the unset default → 128000; Haiku → 64000 (its real ceiling — asking higher is a 400); unknown/custom model strings → 64000, the value every current model accepts, rather than guessing high and risking the 400
- `NANOCLAW_MAX_OUTPUT_TOKENS` (positive integers) overrides the table for operators who want a tighter spend bound; non-numeric/non-positive values are ignored
- Set on the composed env lane only when the session's resolved provider is `claude` — the variable is SDK-specific and means nothing to opencode/ollama
- It is a ceiling, not a target: ordinary turns pay nothing, and the runner streams, so a high ceiling doesn't introduce a non-streaming HTTP-timeout problem

**How it was tested:** 8 new tests — the model table (Opus/Sonnet/Haiku/unknown/null), override handling (positive, non-numeric, zero, negative), and `composeSessionSpec` wiring (claude default gets 128000, haiku-configured group gets 64000, non-claude provider omits the variable). Full suite: 2052 host + 333 container tests pass, typecheck and prettier clean, on Node 22 and 24.
