### PR TITLE
docs(cli): describe group-scope auto-fill args as locked, not defaulted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Per-agent-group container runtime config (provider, model, packages, MCP servers
 | Value | Behavior |
 |-------|----------|
 | `disabled` | Agent never learns about ncl (instructions excluded from CLAUDE.md). Host dispatch rejects any `cli_request`. |
-| `group` (default) | Agent can access `groups`, `sessions`, `destinations`, `members`, `tasks` only, scoped to its own agent group. `--id` and group args are auto-filled. Cross-group access rejected. `cli_scope` changes blocked. |
+| `group` (default) | Agent can access `groups`, `sessions`, `destinations`, `members`, `tasks` only, scoped to its own agent group. `--id` and group args are locked to the caller's group (an explicitly passed different value is silently replaced, not honored). Cross-group access rejected — to act on another group, that group's agent must submit the request from its own CLI. `cli_scope` changes blocked. |
 | `global` | Unrestricted. Set automatically for owner agent groups via `init-first-agent`. |
 
 Key files: `src/db/container-configs.ts`, `src/container-config.ts`, `src/cli/dispatch.ts` (scope enforcement), `src/project-doc-compose.ts` (instructions exclusion).

--- a/container/agent-runner/src/mcp-tools/cli.instructions.md
+++ b/container/agent-runner/src/mcp-tools/cli.instructions.md
@@ -12,7 +12,7 @@ ncl help
 
 ### Scope
 
-Your CLI access may be scoped. Run `ncl help` to see which resources are available and whether args are auto-filled. Under `group` scope (the default), `--id` and group-related args are auto-filled to your agent group — you don't need to pass them.
+Your CLI access may be scoped. Run `ncl help` to see which resources are available and whether args are auto-filled. Under `group` scope (the default), `--agent-group-id`, `--group`, and `--id` (where it identifies a group-scoped resource, e.g. groups/destinations) are **locked** to your agent group, not just defaulted: passing a different value will silently use your own group's id — the provided value is dropped without warning. To act on another group, that group's agent must submit the request from its own CLI under its own scope; admin approval then routes the change to the right group.
 
 ### Resources
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2463.

**What:** The CLI scope docs said group-related args are "auto-filled … you don't need to pass them", which understates what `dispatch()` actually does: under `group` scope an explicitly passed `--agent-group-id`/`--group`/`--id` with a *different* value is silently replaced with the caller's own group id — the provided value is dropped without warning and the write lands on the caller's own group. An agent following the old wording could attempt a cross-group destination change and never learn why the approval card showed the wrong group.

**How it works:** Docs-only, both surfaces the issue names (adapted to where they live on current `main` — `.claude-fragments/module-cli.md` became `container/agent-runner/src/mcp-tools/cli.instructions.md` in the flat-CLAUDE.md refactor):

- `cli.instructions.md` Scope section: args are **locked**, a differing value is silently dropped, and cross-group changes must be submitted from the target group's own CLI (admin approval then routes them correctly) — essentially the issue's suggested wording
- `CLAUDE.md` `cli_scope` table: same clarification in the `group` row

No behavior change; the text now matches `src/cli/dispatch.ts` as it is. The companion stderr warning for the differing-value case is #2464, already addressed separately by PR #3448 — these compose (docs describe the lock; the warning surfaces it at call time).

**How it was tested:** Docs-only — full suite still passes (2044 host + 333 container tests), prettier/typecheck clean, on Node 22 and 24.
