### PR TITLE
fix(chat): fail fast with a wiring hint when cli/local has no agent

### DIFF
--- a/scripts/chat-wiring.test.ts
+++ b/scripts/chat-wiring.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `pnpm run chat` preflight (#2703): setup's recommended path leaves
+ * `cli/local` unwired while still advertising the command, and the old
+ * behavior was a 120s opaque timeout. The preflight must distinguish
+ * wired / unwired / no-messaging-group so the client can fail fast with
+ * the wiring hint instead.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, getDb, initSqliteTestDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { createAgentGroup } from '../src/db/agent-groups.js';
+import { createMessagingGroup, createMessagingGroupAgent } from '../src/db/messaging-groups.js';
+import { checkCliWiring, CLI_CHANNEL, CLI_PLATFORM_ID, WIRE_HINT } from './chat-wiring.js';
+
+beforeEach(async () => {
+  const db = await initSqliteTestDb();
+  await runMigrations(db);
+});
+
+afterEach(async () => {
+  await closeDb();
+});
+
+async function createCliMessagingGroup(): Promise<string> {
+  const id = `mg-cli-${Date.now()}`;
+  await createMessagingGroup({
+    id,
+    channel_type: CLI_CHANNEL,
+    platform_id: CLI_PLATFORM_ID,
+    instance: CLI_CHANNEL,
+    name: 'CLI',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: new Date().toISOString(),
+  });
+  return id;
+}
+
+describe('checkCliWiring', () => {
+  it('reports no-messaging-group on a fresh database', async () => {
+    expect(await checkCliWiring(getDb())).toBe('no-messaging-group');
+  });
+
+  it('reports unwired when cli/local exists but no agent is wired — the #2703 state', async () => {
+    // Setup's recommended path: the ping-test agent is deleted (cascading the
+    // wiring away) but the messaging group is deliberately left behind.
+    await createCliMessagingGroup();
+    expect(await checkCliWiring(getDb())).toBe('unwired');
+  });
+
+  it('reports wired when an agent handles cli/local', async () => {
+    const mgId = await createCliMessagingGroup();
+    await createAgentGroup({
+      id: 'ag-terminal',
+      name: "Test's Terminal",
+      folder: 'test-terminal',
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    });
+    await createMessagingGroupAgent({
+      id: `mga-${Date.now()}`,
+      messaging_group_id: mgId,
+      agent_group_id: 'ag-terminal',
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: new Date().toISOString(),
+    });
+    expect(await checkCliWiring(getDb())).toBe('wired');
+  });
+
+  it('ignores wirings of other messaging groups', async () => {
+    await createCliMessagingGroup();
+    await createMessagingGroup({
+      id: 'mg-telegram',
+      channel_type: 'telegram',
+      platform_id: 'telegram:42',
+      instance: 'telegram',
+      name: 'TG',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+    await createAgentGroup({
+      id: 'ag-tg',
+      name: 'TG Agent',
+      folder: 'tg-agent',
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    });
+    await createMessagingGroupAgent({
+      id: 'mga-tg',
+      messaging_group_id: 'mg-telegram',
+      agent_group_id: 'ag-tg',
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: new Date().toISOString(),
+    });
+    // The channel agent's wiring must not count as a terminal wiring.
+    expect(await checkCliWiring(getDb())).toBe('unwired');
+  });
+
+  it('exposes an actionable hint naming the wiring paths', () => {
+    expect(WIRE_HINT).toContain('cli/local');
+    expect(WIRE_HINT).toContain('init-first-agent');
+    expect(WIRE_HINT).toContain('init-cli-agent');
+  });
+});

--- a/scripts/chat-wiring.ts
+++ b/scripts/chat-wiring.ts
@@ -1,0 +1,42 @@
+/**
+ * Preflight for `pnpm run chat`: is the `cli/local` messaging group wired to
+ * an agent?
+ *
+ * Setup's recommended path deletes the ping-test agent (which cascades the
+ * wiring away) and never creates a terminal agent, yet the final panel
+ * advertises `pnpm run chat hi`. Without a wiring the message still routes
+ * and wakes a container, but the agent has no destination pointing back at
+ * `cli/local`, so the terminal waits out the full 120s timeout with no hint
+ * of the cause. This check turns that into an immediate, explained failure.
+ *
+ * Read-only and best-effort by design: chat must keep working when the check
+ * itself can't run (missing/locked DB, schema drift), so callers treat any
+ * thrown error as "proceed as before".
+ */
+import type { DbDriver } from '../src/db/driver.js';
+
+export const CLI_CHANNEL = 'cli';
+export const CLI_PLATFORM_ID = 'local';
+
+export type CliWiringStatus = 'wired' | 'no-messaging-group' | 'unwired';
+
+/** How to fix an unwired terminal, shown verbatim by the chat client. */
+export const WIRE_HINT =
+  'The terminal channel (cli/local) is not wired to an agent, so no reply can ever arrive.\n' +
+  'Wire it with your coding agent via /init-first-agent (or /manage-channels), or run:\n' +
+  '  pnpm exec tsx scripts/init-cli-agent.ts --display-name "<your name>" --agent-name "<name>\'s Terminal"';
+
+export async function checkCliWiring(db: DbDriver): Promise<CliWiringStatus> {
+  const mg = await db.get<{ id: string }>(
+    'SELECT id FROM messaging_groups WHERE channel_type = ? AND platform_id = ?',
+    CLI_CHANNEL,
+    CLI_PLATFORM_ID,
+  );
+  if (!mg) return 'no-messaging-group';
+
+  const wiring = await db.get<{ id: string }>(
+    'SELECT id FROM messaging_group_agents WHERE messaging_group_id = ? LIMIT 1',
+    mg.id,
+  );
+  return wiring ? 'wired' : 'unwired';
+}

--- a/scripts/chat.ts
+++ b/scripts/chat.ts
@@ -10,16 +10,45 @@
  * Preconditions: NanoClaw host service running, an agent group wired to
  * `cli/local` via `/init-first-agent` or `/manage-channels`.
  */
+import fs from 'fs';
 import net from 'net';
 import path from 'path';
 
-import { DATA_DIR } from '../src/config.js';
+import { CENTRAL_DB_PATH, DATA_DIR } from '../src/config.js';
+import { closeDb, initDb } from '../src/db/connection.js';
+import { checkCliWiring, WIRE_HINT } from './chat-wiring.js';
 
 const SILENCE_MS = 2000; // exit after this much quiet time following the first reply
 const TOTAL_TIMEOUT_MS = 120_000; // hard stop
 
 function socketPath(): string {
   return path.join(DATA_DIR, 'cli.sock');
+}
+
+/**
+ * Fail fast when `cli/local` has no agent wired: the message would route and
+ * wake a container, but no reply can ever come back to this terminal, so the
+ * old behavior was a 120s opaque timeout (#2703). Best-effort — any error in
+ * the check itself (missing DB, schema drift) falls through to the normal
+ * chat path, which still carries its own timeout.
+ */
+async function warnIfUnwired(): Promise<boolean> {
+  // Opening a missing DB would create it as a side effect; a fresh checkout
+  // has no wiring to check anyway, and the socket-connect error path already
+  // explains a not-running service better than the wiring hint would.
+  if (!fs.existsSync(CENTRAL_DB_PATH)) return false;
+  try {
+    const db = await initDb(CENTRAL_DB_PATH, { role: 'tool' });
+    const status = await checkCliWiring(db);
+    await closeDb();
+    if (status !== 'wired') {
+      console.error(WIRE_HINT);
+      return true;
+    }
+  } catch {
+    // Preflight is advisory only — never block chat on it.
+  }
+  return false;
 }
 
 function main(): void {
@@ -98,4 +127,9 @@ function main(): void {
   });
 }
 
+// Usage errors stay first and cost no DB open; the wiring preflight runs
+// only when there is actually a message to send.
+if (process.argv.length > 2 && (await warnIfUnwired())) {
+  process.exit(4);
+}
 main();


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2703 (the fail-gracefully half).

**What:** Setup's recommended path deletes the ping-test agent (cascading its `cli/local` wiring away), never creates a terminal agent, and still advertises `pnpm run chat hi` in the final panel and outro. Running it then hangs the full 120 s and exits `timeout: no reply` with no hint of the cause: the message routes and wakes a container, but the agent has no destination pointing back at `cli/local`, so no reply can ever reach the terminal.

**How it works:** This implements the issue's independent ask — "`scripts/chat.ts` should fail gracefully when `cli/local` is unwired — detect the missing wiring and print a one-line hint instead of a 120 s opaque timeout":

- New `scripts/chat-wiring.ts` exports `checkCliWiring()` (read-only: does the `cli/local` messaging group have any `messaging_group_agents` row?) and the wiring hint (`/init-first-agent`, `/manage-channels`, or `scripts/init-cli-agent.ts`)
- `scripts/chat.ts` runs the preflight before connecting; unwired → print the hint, exit 4 immediately
- Deliberately best-effort: a missing `data/v2.db` skips the check (opening would create the file as a side effect, and the socket-connect error path already explains a not-running service better), and any error inside the check falls through to the normal chat path — the 120 s timeout remains the backstop for every other failure mode

The setup-side question (which completion paths should wire a terminal agent) is a product decision left to the maintainers; this PR makes the advertised command diagnose itself either way.

**How it was tested:** `scripts/chat-wiring.test.ts` runs `checkCliWiring` against a real migrated sqlite DB — fresh DB, the exact #2703 state (messaging group present, wiring cascaded away), a wired terminal, and a wired non-cli channel that must not count. Manual smoke: fresh checkout (no DB) goes straight to the socket-error path and creates no DB file; a DB with unwired `cli/local` prints the hint and exits 4 instantly. Full suite: 2049 host + 333 container tests pass on Node 22 and 24.
