### PR TITLE
fix(setup): bootstrap an unloaded launchd plist in restart.sh instead of a silent kickstart no-op

### DIFF
--- a/setup/lib/restart-darwin.test.ts
+++ b/setup/lib/restart-darwin.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pin setup/lib/restart.sh's macOS branch (#2583): `launchctl kickstart` only
+ * operates on loaded services, so an unloaded plist made the old one-liner
+ * silently no-op — the script reported a restart that never happened and the
+ * next wiring step died on a dead CLI socket.
+ *
+ * The real restart_darwin() is extracted from the script and run under bash
+ * with a stub `launchctl` on PATH that records its argv and scripts the
+ * `print` probe's exit code, so all three states are exercised: loaded,
+ * unloaded-but-installed, and never-installed.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const libDir = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(libDir, 'restart.sh');
+
+function extractRestartDarwin(): string {
+  const source = fs.readFileSync(scriptPath, 'utf8');
+  const start = source.indexOf('restart_darwin() {');
+  expect(start, 'restart_darwin() not found in restart.sh').toBeGreaterThanOrEqual(0);
+  const end = source.indexOf('\n}', start);
+  expect(end, 'unterminated restart_darwin()').toBeGreaterThan(start);
+  return source.slice(start, end + 2);
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-restart-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Run restart_darwin with a stubbed launchctl.
+ * @param printExit exit code of `launchctl print` (0 = service loaded)
+ * @param plistInstalled whether the plist file exists on disk
+ */
+function runRestartDarwin(printExit: number, plistInstalled: boolean): string[] {
+  const binDir = path.join(tmpDir, 'bin');
+  const home = path.join(tmpDir, 'home');
+  const callLog = path.join(tmpDir, 'calls.log');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(path.join(home, 'Library', 'LaunchAgents'), { recursive: true });
+
+  const label = 'com.nanoclaw-v2-testslug';
+  if (plistInstalled) {
+    fs.writeFileSync(path.join(home, 'Library', 'LaunchAgents', `${label}.plist`), '<plist/>');
+  }
+
+  const stub = `#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(callLog)}
+if [ "$1" = "print" ]; then exit ${printExit}; fi
+exit 0
+`;
+  fs.writeFileSync(path.join(binDir, 'launchctl'), stub, { mode: 0o755 });
+
+  const script = `
+    set -u
+    launchd_label() { printf '%s' ${JSON.stringify(label)}; }
+    ${extractRestartDarwin()}
+    restart_darwin
+  `;
+  execFileSync('bash', ['-c', script], {
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, HOME: home },
+    stdio: 'ignore',
+  });
+
+  return fs.existsSync(callLog) ? fs.readFileSync(callLog, 'utf8').trim().split('\n') : [];
+}
+
+describe('restart.sh restart_darwin', () => {
+  it('kickstarts -k when the service is loaded (previous behavior preserved)', () => {
+    const calls = runRestartDarwin(0, true);
+    expect(calls[0]).toMatch(/^print gui\//);
+    expect(calls[1]).toMatch(/^kickstart -k gui\/.*com\.nanoclaw-v2-testslug$/);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('bootstraps the plist then kickstarts when unloaded but installed — the #2583 state', () => {
+    const calls = runRestartDarwin(113, true);
+    expect(calls[0]).toMatch(/^print gui\//);
+    expect(calls[1]).toMatch(/^bootstrap gui\/\d+ .*com\.nanoclaw-v2-testslug\.plist$/);
+    expect(calls[2]).toMatch(/^kickstart gui\/.*com\.nanoclaw-v2-testslug$/);
+    // The bare (non--k) kickstart: bootstrap already started RunAtLoad jobs,
+    // kickstart only demand-starts a job launchd left pended.
+    expect(calls[2]).not.toContain('-k');
+  });
+
+  it('does nothing beyond the probe when the service was never installed', () => {
+    const calls = runRestartDarwin(113, false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatch(/^print gui\//);
+  });
+});

--- a/setup/lib/restart.sh
+++ b/setup/lib/restart.sh
@@ -10,8 +10,32 @@ root="$(cd "$here/../.." && pwd)"
 # shellcheck source=/dev/null
 source "$here/install-slug.sh"
 
+# macOS: `launchctl kickstart` only operates on services that are currently
+# LOADED. If the plist was unloaded (by the user, or by peer cleanup), a bare
+# kickstart returns non-zero, the `|| true` swallows it, and this script
+# reports a restart that never happened — the host stays down and the next
+# wiring step fails on a dead CLI socket (#2583). Probe the loaded state
+# first and bootstrap the plist when it isn't.
+restart_darwin() {
+  local label domain plist
+  label="$(launchd_label)"
+  domain="gui/$(id -u)"
+  plist="$HOME/Library/LaunchAgents/${label}.plist"
+
+  if launchctl print "$domain/$label" >/dev/null 2>&1; then
+    launchctl kickstart -k "$domain/$label" 2>/dev/null || true
+  elif [ -f "$plist" ]; then
+    # Not loaded but installed — load it (bootstrap starts RunAtLoad jobs;
+    # kickstart demand-starts in case launchd leaves the job pended).
+    launchctl bootstrap "$domain" "$plist" 2>/dev/null || true
+    launchctl kickstart "$domain/$label" 2>/dev/null || true
+  fi
+  # Neither loaded nor installed: fresh setup before the service step —
+  # nothing to restart, and the socket wait below stays a fast no-op signal.
+}
+
 case "$(uname -s)" in
-  Darwin) launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" 2>/dev/null || true ;;
+  Darwin) restart_darwin ;;
   Linux) systemctl --user restart "$(systemd_unit)" 2>/dev/null \
     || sudo systemctl restart "$(systemd_unit)" 2>/dev/null || true ;;
 esac


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2583.

**What:** `launchctl kickstart` only operates on services that are currently *loaded*. `setup/lib/restart.sh` — the shared `effect:restart` helper every channel skill calls (the code the issue reported in `setup/channels/signal.ts`/`whatsapp.ts` and the add-channel scripts now lives here) — issued a bare `kickstart -k … || true`. With an unloaded plist (user `launchctl unload`, peer cleanup), the restart silently did nothing: the script reported success, the host never started, and the next wiring step failed on a dead CLI socket with an error pointing at the socket instead of the unloaded service.

**How it works:** Exactly the probe-then-bootstrap the issue suggests:

- **loaded** (probe `launchctl print gui/<uid>/<label>` exits 0) → `kickstart -k`, precisely the previous behavior
- **unloaded but installed** (plist file exists) → `launchctl bootstrap gui/<uid> <plist>` then a bare `kickstart` — the same pairing `setup/service.ts` and `scripts/update/service.ts` already use (bootstrap starts RunAtLoad jobs; kickstart demand-starts a job launchd leaves pended)
- **never installed** → no-op, preserving the script's documented best-effort contract for fresh setups where the service step hasn't run yet

The Linux branch and the existing "wait for the ncl socket" tail (which also covers the issue's re-check suggestion — a socket that never appears is reported to stderr) are unchanged.

**How it was tested:** `setup/lib/restart-darwin.test.ts` extracts the real `restart_darwin()` from the script and runs it under bash with a stubbed `launchctl` on PATH that records argv and scripts the probe's exit code — pinning all three states, including that the unloaded path uses `bootstrap` + bare `kickstart` (no `-k`). `bash -n` clean; the skill-conformance suite (which inspects restart handling) still passes. Full suite: 2047 host + 333 container tests on Node 22 and 24.
