### PR TITLE
fix(setup): non-interactive apt in the Linux installers (needrestart hang)

### DIFF
--- a/setup/install-docker.sh
+++ b/setup/install-docker.sh
@@ -30,6 +30,13 @@ case "$(uname -s)" in
     brew install --cask docker
     ;;
   Linux)
+    # Non-interactive apt: setup pipes this script's output to a log, so an
+    # interactive prompt is invisible and hangs the whole run. get.docker.com
+    # drives apt underneath, and needrestart's post-install whiptail dialog
+    # blocks on stdin even when nobody can see it (#2514) —
+    # NEEDRESTART_SUSPEND defers it; DEBIAN_FRONTEND silences the rest.
+    export DEBIAN_FRONTEND=noninteractive
+    export NEEDRESTART_SUSPEND=1
     echo "STEP: docker-get-script"
     curl -fsSL https://get.docker.com | sh
     echo "STEP: usermod-docker-group"

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -44,10 +44,17 @@ else
       export PATH="$(brew --prefix node@22)/bin:$PATH"
       ;;
     Linux)
+      # Non-interactive apt: setup pipes this script's output to a log, so an
+      # interactive prompt is invisible and hangs the whole run. needrestart's
+      # post-install whiptail dialog ("Which services should be restarted?")
+      # is the one that actually bit (#2514) — DEBIAN_FRONTEND alone does not
+      # suppress it; NEEDRESTART_SUSPEND makes it defer instead of prompt.
+      export DEBIAN_FRONTEND=noninteractive
+      export NEEDRESTART_SUSPEND=1
       echo "STEP: nodesource-setup"
       curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
       echo "STEP: apt-install-nodejs"
-      sudo apt-get install -y nodejs
+      sudo -E apt-get install -y nodejs
       ;;
     *)
       echo "STATUS: failed"

--- a/setup/noninteractive-apt.test.ts
+++ b/setup/noninteractive-apt.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Pin the non-interactive apt posture of the Linux setup helpers (#2514).
+ *
+ * Setup pipes these scripts' output to a log file, so any interactive prompt
+ * is invisible and blocks the whole run on stdin. The observed hang is
+ * needrestart's post-install whiptail dialog, which DEBIAN_FRONTEND alone
+ * does not suppress — NEEDRESTART_SUSPEND is required. Both installers must
+ * export both, before the command that drives apt, in a way that survives
+ * the sudo they use (nodesource pipes into `sudo -E bash -`, get.docker.com
+ * escalates via `sudo -E sh -c`, and the direct apt-get call carries `-E`).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const setupDir = path.dirname(fileURLToPath(import.meta.url));
+
+function linuxBranch(script: string): string {
+  const source = fs.readFileSync(path.join(setupDir, script), 'utf8');
+  const start = source.indexOf('Linux)');
+  expect(start, `Linux branch not found in ${script}`).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(';;', start);
+  expect(end, `unterminated Linux branch in ${script}`).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe.each(['install-node.sh', 'install-docker.sh'])('%s Linux branch', (script) => {
+  it('exports DEBIAN_FRONTEND=noninteractive and NEEDRESTART_SUSPEND before driving apt', () => {
+    const branch = linuxBranch(script);
+    const frontier = branch.indexOf('curl ');
+    expect(frontier, 'no curl call found').toBeGreaterThanOrEqual(0);
+    const preamble = branch.slice(0, frontier);
+    expect(preamble).toContain('export DEBIAN_FRONTEND=noninteractive');
+    expect(preamble).toContain('export NEEDRESTART_SUSPEND=1');
+  });
+
+  it('preserves the exported environment across sudo (sudo -E)', () => {
+    const branch = linuxBranch(script);
+    // Every sudo that (directly or via a piped installer script) reaches
+    // apt must carry -E, or the exports die at the privilege boundary.
+    // usermod does not touch apt and is exempt.
+    const sudoCalls = branch.match(/sudo(?: -\S+)* [a-z-]+/g) ?? [];
+    for (const call of sudoCalls) {
+      if (call.includes('usermod')) continue;
+      expect(call, `"${call}" drops the exported env — use sudo -E`).toContain('-E');
+    }
+  });
+});


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2514.

**What:** On Ubuntu servers with `needrestart` installed, setup could hang indefinitely. `install-node.sh` and `install-docker.sh` drive apt (directly, and via the nodesource / get.docker.com scripts), setup pipes their output to a log file, and needrestart's post-install whiptail dialog ("Which services should be restarted?") blocks on stdin where nobody can see it — exactly the process tree in the issue's screenshots.

**How it works:** The issue's own suggestion ("force non-interactive frontend?"), applied where apt is actually driven. Both Linux branches export, before any apt-driving command:

- `DEBIAN_FRONTEND=noninteractive` — silences debconf prompts
- `NEEDRESTART_SUSPEND=1` — needrestart prompts *regardless* of DEBIAN_FRONTEND; this makes it defer (list, don't ask) instead

The exports survive the privilege boundary: nodesource already runs under `sudo -E bash -`, get.docker.com escalates internally via `sudo -E sh -c` (verified against the current script), and the direct `apt-get install` call gains `-E`. macOS branches are untouched.

**How it was tested:** `setup/noninteractive-apt.test.ts` pins both invariants on both scripts — the exports appear before the first apt-driving command, and every sudo on the apt path carries `-E` (so a future edit that drops either fails CI). `bash -n` clean on both scripts. Full suite: 2048 host + 333 container tests pass on Node 22 and 24.
