### PR TITLE
fix(setup): time out signal-cli probes instead of deadlocking on the daemon's config lock

### DIFF
--- a/setup/signal-auth.test.ts
+++ b/setup/signal-auth.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Pin the signal-cli probe timeout (#2582).
+ *
+ * signal-cli serializes access to its config directory with an exclusive
+ * file lock. When the NanoClaw service is running, its `signal-cli daemon`
+ * holds that lock indefinitely, and a bare `listAccounts` probe blocks
+ * forever ("Config file is in use by another instance, waiting…") — the
+ * setup wizard hung at the Signal step with no diagnostic. The probe must
+ * time out and report `timedOut` so the caller can name the real cause.
+ *
+ * The tests point SIGNAL_CLI_PATH at stub scripts that emulate the three
+ * relevant behaviors: normal JSON output, a hang (the daemon-lock state),
+ * and a non-zero exit.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { listAccounts } from './signal-auth.js';
+
+let tmpDir: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-signal-auth-'));
+  savedEnv.SIGNAL_CLI_PATH = process.env.SIGNAL_CLI_PATH;
+  savedEnv.NANOCLAW_SIGNAL_PROBE_TIMEOUT_MS = process.env.NANOCLAW_SIGNAL_PROBE_TIMEOUT_MS;
+  // Keep the hang test fast: the timeout only needs to be shorter than the
+  // stub's sleep to prove the kill fires.
+  process.env.NANOCLAW_SIGNAL_PROBE_TIMEOUT_MS = '500';
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function stubCli(body: string): string {
+  const file = path.join(tmpDir, 'signal-cli');
+  fs.writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+  process.env.SIGNAL_CLI_PATH = file;
+  return file;
+}
+
+describe('signal-auth listAccounts', () => {
+  it('parses registered accounts from JSON output', async () => {
+    stubCli(`echo '[{"number":"+15551234567","registered":true},{"number":"+15550000000","registered":false}]'`);
+    expect(listAccounts()).toEqual({ accounts: ['+15551234567'], timedOut: false });
+  });
+
+  it('returns timedOut when signal-cli hangs on the config lock — the #2582 state', async () => {
+    // Emulate "Config file is in use by another instance, waiting…": the
+    // daemon holds the lock and listAccounts never returns on its own.
+    stubCli('sleep 30');
+    const started = Date.now();
+    expect(listAccounts()).toEqual({ accounts: [], timedOut: true });
+    // Must return via the probe timeout, not the stub finishing.
+    expect(Date.now() - started).toBeLessThan(10_000);
+  });
+
+  it('reports a non-zero exit as no accounts, not a timeout', async () => {
+    stubCli('exit 3');
+    expect(listAccounts()).toEqual({ accounts: [], timedOut: false });
+  });
+
+  it('reports garbage output as no accounts', async () => {
+    stubCli('echo not-json');
+    expect(listAccounts()).toEqual({ accounts: [], timedOut: false });
+  });
+});

--- a/setup/signal-auth.ts
+++ b/setup/signal-auth.ts
@@ -52,24 +52,53 @@ function cliPath(): string {
 }
 
 /**
- * Query signal-cli for currently linked accounts. Empty array if none
- * configured, no binary, or the call fails for any other reason.
+ * How long the synchronous signal-cli probes may run. signal-cli serializes
+ * access to its config directory with an exclusive file lock; when the
+ * NanoClaw service is already running, its `signal-cli daemon` holds that
+ * lock indefinitely and a bare `listAccounts` blocks forever (it logs
+ * "Config file is in use by another instance, waiting…" and waits). Without
+ * a timeout the whole setup wizard hangs at the Signal step with no
+ * diagnostic (#2582). Overridable for tests.
  */
-function listAccounts(): string[] {
+function probeTimeoutMs(): number {
+  return Number(process.env.NANOCLAW_SIGNAL_PROBE_TIMEOUT_MS) || 15_000;
+}
+
+export interface ListAccountsResult {
+  accounts: string[];
+  /** True when the probe hit PROBE_TIMEOUT_MS — almost always the daemon lock. */
+  timedOut: boolean;
+}
+
+/**
+ * Query signal-cli for currently linked accounts. Empty account list if none
+ * configured, no binary, or the call fails for any other reason; `timedOut`
+ * distinguishes the config-lock deadlock so the caller can name the real
+ * cause instead of hanging.
+ */
+export function listAccounts(): ListAccountsResult {
   const cli = cliPath();
   try {
     const res = spawnSync(cli, ['-o', 'json', 'listAccounts'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: probeTimeoutMs(),
+      killSignal: 'SIGKILL',
     });
-    if (res.status !== 0) return [];
+    if (res.error && (res.error as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+      return { accounts: [], timedOut: true };
+    }
+    if (res.status !== 0) return { accounts: [], timedOut: false };
     const parsed = JSON.parse(res.stdout || '[]') as SignalAccount[];
-    return parsed
-      .filter((a) => a.registered !== false)
-      .map((a) => a.number ?? a.account ?? '')
-      .filter(Boolean);
+    return {
+      timedOut: false,
+      accounts: parsed
+        .filter((a) => a.registered !== false)
+        .map((a) => a.number ?? a.account ?? '')
+        .filter(Boolean),
+    };
   } catch {
-    return [];
+    return { accounts: [], timedOut: false };
   }
 }
 
@@ -107,6 +136,8 @@ export async function run(_args: string[]): Promise<void> {
   // The driver checks too, but this keeps the step honest when run alone.
   const probe = spawnSync(cli, ['--version'], {
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: probeTimeoutMs(),
+    killSignal: 'SIGKILL',
   });
   if (probe.error || probe.status !== 0) {
     emitStatus('SIGNAL_AUTH', {
@@ -117,10 +148,23 @@ export async function run(_args: string[]): Promise<void> {
   }
 
   const existing = listAccounts();
-  if (existing.length > 0) {
+  if (existing.timedOut) {
+    // The daemon-lock deadlock (#2582): the running NanoClaw service's
+    // signal-cli daemon holds the config-file lock, so any other signal-cli
+    // invocation waits on it forever. Fail with the actual remedy instead
+    // of hanging the wizard at "Starting Signal link…".
+    emitStatus('SIGNAL_AUTH', {
+      STATUS: 'failed',
+      ERROR:
+        'signal-cli is locked by another instance (the running NanoClaw service holds it). ' +
+        'Stop the NanoClaw service, re-run setup, then start the service again.',
+    });
+    return;
+  }
+  if (existing.accounts.length > 0) {
     emitStatus('SIGNAL_AUTH', {
       STATUS: 'skipped',
-      ACCOUNT: existing[0],
+      ACCOUNT: existing.accounts[0],
       REASON: 'already-authenticated',
     });
     return;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2582.

**What:** signal-cli serializes access to its config directory with an exclusive file lock. When the NanoClaw service is already running, its `signal-cli daemon` holds that lock indefinitely, and `setup/signal-auth.ts`'s `listAccounts` probe — `spawnSync` with no timeout — blocked forever (`Config file is in use by another instance, waiting…`). The wizard hung at the Signal step with no diagnostic, reproducibly on every setup re-run after an initial install, because `auto.ts` starts the service before the Signal step probes it.

**How it works:** Fix (1) from the issue — a short timeout on the probe with a clear error:

- Both synchronous probes (`listAccounts`, `--version`) get a 15 s timeout with `SIGKILL` (signal-cli sits in an interruptible lock wait; gentler signals aren't reliable there). Overridable via `NANOCLAW_SIGNAL_PROBE_TIMEOUT_MS`.
- `listAccounts` now returns `{ accounts, timedOut }`, so the caller can tell the lock deadlock apart from "no accounts configured".
- On `timedOut`, `run()` fails the step with the actual remedy — "signal-cli is locked by another instance (the running NanoClaw service holds it). Stop the NanoClaw service, re-run setup, then start it again." — instead of hanging, or worse, mis-reading the timeout as "not authenticated" and starting a pointless link flow against a locked config.

**How it was tested:** `setup/signal-auth.test.ts` points `SIGNAL_CLI_PATH` at stub scripts covering all shapes: JSON parse of registered accounts, the hang (returns via the timeout, asserted well under the stub's sleep), non-zero exit, and garbage output. Full suite: 2048 host + 332 container tests pass, format/typecheck clean, on Node 22 and 24.
