### PR TITLE
fix(tasks): stamp the series id into task_log rows so chat-session fires keep their run log

### DIFF
--- a/container/agent-runner/src/cross-session-echo.test.ts
+++ b/container/agent-runner/src/cross-session-echo.test.ts
@@ -184,6 +184,29 @@ describe('routing (extractRouting)', () => {
 
     expect(extractRouting(getPendingMessages()).taskRun).toBe(false);
   });
+
+  it('carries the task series id so the run log survives a chat-session fire (#3301)', () => {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, seq, kind, timestamp, status, "trigger", series_id, content)
+         VALUES ('t1', 2, 'task', datetime('now'), 'pending', 1, 'water-plants-9f3c', ?)`,
+      )
+      .run(JSON.stringify({ prompt: 'water the plants' }));
+
+    expect(extractRouting(getPendingMessages()).taskSeriesId).toBe('water-plants-9f3c');
+  });
+
+  it('falls back to the task row id when series_id is NULL (brand-new series)', () => {
+    insertMessage('task-abc', 'task', { prompt: 'one-shot' }, { seq: 2 });
+
+    expect(extractRouting(getPendingMessages()).taskSeriesId).toBe('task-abc');
+  });
+
+  it('taskSeriesId is null for non-task batches', () => {
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'hi' }, { seq: 2 });
+
+    expect(extractRouting(getPendingMessages()).taskSeriesId).toBeNull();
+  });
 });
 
 describe('command classification', () => {

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -117,6 +117,11 @@ export interface RoutingContext {
    *  delivers from a task session; final-text `<message to>` blocks are inert
    *  and the final text auto-appends to the series run log. */
   taskRun: boolean;
+  /** Series join key of the triggering task row (series_id, falling back to
+   *  the row id for a brand-new series). Stamped into task_log rows so the
+   *  host can append the run log even when the task fired outside a
+   *  system:tasks:<series> session (#3301). Null for non-task batches. */
+  taskSeriesId: string | null;
 }
 
 /**
@@ -129,6 +134,7 @@ export interface RoutingContext {
  */
 export function extractRouting(messages: MessageInRow[]): RoutingContext {
   const first = messages.find((m) => !isSessionEcho(m)) ?? messages[0];
+  const firstTask = messages.find((m) => m.kind === 'task');
   return {
     platformId: first?.platform_id ?? null,
     channelType: first?.channel_type ?? null,
@@ -139,6 +145,13 @@ export function extractRouting(messages: MessageInRow[]): RoutingContext {
     taskRun:
       messages.some((m) => m.kind === 'task') &&
       messages.every((m) => m.kind === 'task' || isSessionEcho(m)),
+    // Series join key for the run log. A task row fired in a CHAT session
+    // (legacy pre-2.1.54 series, or register's onboarding write) has no
+    // system:tasks:<series> thread id for the host to recover the series
+    // from — stamping it here keeps the run log reaching tasks/<id>.md
+    // regardless of where the row fired (#3301). series_id equals the row id
+    // for a brand-new series, so the fallback covers first fires too.
+    taskSeriesId: firstTask ? (firstTask.series_id ?? firstTask.id) : null,
   };
 }
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -576,7 +576,7 @@ export async function processQuery(
           // Errors included: a failed run's text belongs in its log, not chat.
           // A corrective retry handles delivery only; its result is not a
           // second run summary.
-          if (routing.taskRun && !taskBlockNudged) await autoAppendTaskLog(event.text);
+          if (routing.taskRun && !taskBlockNudged) await autoAppendTaskLog(event.text, routing.taskSeriesId);
           if (resultBlocks === 0 && event.isError === true && !routing.taskRun) {
             // Non-retryable error turn (e.g. a 403 billing_error) with no
             // <message> envelope: deliver the notice instead of dropping it as
@@ -1113,7 +1113,7 @@ function escapePromptXml(value: string): string {
  * `task_log` outbound row; the host appends it to the series' tasks/<id>.md
  * with its usual timestamp stamp. Never delivered to anyone.
  */
-export async function autoAppendTaskLog(text: string): Promise<void> {
+export async function autoAppendTaskLog(text: string, seriesId: string | null = null): Promise<void> {
   // Run-log hygiene: an inert <message to> block never belongs in the log as
   // raw XML — replace each with its inner text, marked undelivered, so the
   // log stays readable prose.
@@ -1123,10 +1123,13 @@ export async function autoAppendTaskLog(text: string): Promise<void> {
   );
   const line = stripInternalTags(prose).replace(/\s+/g, ' ').trim().slice(0, 500);
   if (!line) return;
+  // The series id rides in the content so the host can append the run log
+  // even when the row lands in a chat session (legacy series, onboarding
+  // task writes) whose thread id carries no series (#3301).
   await writeMessageOut({
     id: generateId(),
     kind: 'task_log',
-    content: JSON.stringify({ text: line }),
+    content: JSON.stringify(seriesId ? { text: line, series: seriesId } : { text: line }),
   });
   log('Task run log auto-appended from final text');
 }

--- a/container/agent-runner/src/task-delivery.test.ts
+++ b/container/agent-runner/src/task-delivery.test.ts
@@ -39,6 +39,7 @@ const taskRouting: RoutingContext = {
   threadId: 'system:tasks:daily-digest-a1b2',
   inReplyTo: 'run-1',
   taskRun: true,
+  taskSeriesId: 'daily-digest-a1b2',
 };
 
 beforeEach(() => {
@@ -194,6 +195,24 @@ describe('automatic task run summary', () => {
     }[];
     expect(rows).toHaveLength(1);
     expect(JSON.parse(rows[0].content).text).toBe('Checked the feeds — nothing new.');
+  });
+
+  it('stamps the series id into the row so the host can log runs fired outside task sessions (#3301)', async () => {
+    await autoAppendTaskLog('Reminder sent.', 'water-plants-9f3c');
+
+    const row = getOutboundDb().prepare("SELECT content FROM messages_out WHERE kind = 'task_log'").get() as {
+      content: string;
+    };
+    expect(JSON.parse(row.content)).toEqual({ text: 'Reminder sent.', series: 'water-plants-9f3c' });
+  });
+
+  it('omits the series field when no series is known (shape unchanged for legacy consumers)', async () => {
+    await autoAppendTaskLog('Done.', null);
+
+    const row = getOutboundDb().prepare("SELECT content FROM messages_out WHERE kind = 'task_log'").get() as {
+      content: string;
+    };
+    expect(JSON.parse(row.content)).toEqual({ text: 'Done.' });
   });
 
   it('marks legacy final-output blocks undelivered and never stores raw XML', async () => {

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -599,6 +599,83 @@ describe('deliverSessionMessages — task_log rows (one-door task delivery)', ()
     const delivered = await withMailboxSession('ag-1', session.id, (mailbox) => mailbox.getDeliveredIds());
     expect(delivered.has('log-1')).toBe(true);
   });
+
+  it('falls back to the runner-stamped series when the row fired in a chat session (#3301)', async () => {
+    // Legacy pre-2.1.54 series (and register's onboarding write) fire task
+    // rows inside ordinary chat sessions, whose thread id carries no series.
+    // The runner stamps `series` into the row content; the host must use it
+    // instead of dropping the log.
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-2', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'reminder sent', series: 'water-plants-9f3c' }));
+    db.close();
+
+    const calls: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_c, _p, _t, _k, content) {
+        calls.push(content);
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session);
+
+    expect(calls).toHaveLength(0); // still never a channel delivery
+    const logFile = `${TEST_DIR}/groups/test-agent/tasks/water-plants-9f3c.md`;
+    expect(fs.existsSync(logFile)).toBe(true);
+    expect(fs.readFileSync(logFile, 'utf8')).toContain('reminder sent');
+  });
+
+  it('still ignores a task_log row with neither a task session nor a series stamp', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-3', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'orphan line' }));
+    db.close();
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session);
+
+    const tasksDir = `${TEST_DIR}/groups/test-agent/tasks`;
+    const files = fs.existsSync(tasksDir) ? fs.readdirSync(tasksDir) : [];
+    expect(files.filter((f) => fs.readFileSync(`${tasksDir}/${f}`, 'utf8').includes('orphan line'))).toHaveLength(0);
+  });
+
+  it('rejects a series stamp that fails the filename charset guard', async () => {
+    // appendRunLog's charset guard is the security boundary (path traversal);
+    // a malicious or corrupt stamp must not write outside tasks/.
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-4', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'evil', series: '../../escape' }));
+    db.close();
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session); // must not throw
+
+    expect(fs.existsSync(`${TEST_DIR}/groups/escape.md`)).toBe(false);
+    expect(fs.existsSync(`${TEST_DIR}/escape.md`)).toBe(false);
+  });
 });
 
 describe('deliverSessionMessages — batch preview hooks', () => {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -310,15 +310,28 @@ async function deliverMessage(
   // the only delivery path from a task session). Append to the series log,
   // never deliver. The caller marks it delivered so it isn't retried.
   if (msg.kind === 'task_log') {
-    if (session.messaging_group_id === null && isTaskThread(session.thread_id) && session.thread_id) {
-      const series = session.thread_id.slice(`${TASKS_SYSTEM_THREAD_ID}:`.length);
+    // Series resolution, in order of authority: the session's own
+    // system:tasks:<series> thread id, then the series the runner stamped
+    // into the row (a task that fired in a CHAT session — legacy pre-2.1.54
+    // series, or register's onboarding write — has no task thread id, and
+    // dropping its log recorded runs as if they never happened, #3301).
+    const series =
+      session.messaging_group_id === null && isTaskThread(session.thread_id) && session.thread_id
+        ? session.thread_id.slice(`${TASKS_SYSTEM_THREAD_ID}:`.length)
+        : typeof content.series === 'string' && content.series
+          ? content.series
+          : null;
+    if (series) {
       try {
         await appendRunLog(session.agent_group_id, series, typeof content.text === 'string' ? content.text : '');
       } catch (err) {
-        log.warn('Failed to append task run log', { id: msg.id, sessionId: session.id, err });
+        log.warn('Failed to append task run log', { id: msg.id, sessionId: session.id, series, err });
       }
     } else {
-      log.warn('task_log row outside a task session — ignoring', { id: msg.id, sessionId: session.id });
+      log.warn('task_log row outside a task session and without a series stamp — ignoring', {
+        id: msg.id,
+        sessionId: session.id,
+      });
     }
     return;
   }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #3301 (direction 1 — the small, cross-boundary half).

**What:** Since one-door task delivery, a `kind='task'` row that fires inside a **chat** session — every legacy pre-2.1.54 series, plus `register`'s onboarding write on each first wiring — produces a `task_log` row the host cannot attribute: series recovery relied solely on the session's `system:tasks:<series>` thread id, which a chat session doesn't have. `delivery.ts` warned `task_log row outside a task session — ignoring` and dropped the log, so runs recorded nothing (the issue's live install: `completed_runs: 141`, `recent_log: []`).

**How it works:** Exactly the issue's suggested fix 1 — stamp the series id into the `task_log` row:

- **Runner:** `extractRouting` now carries `taskSeriesId` (the triggering task row's `series_id`, falling back to the row id for a brand-new series — `insertTask` sets `series_id = id` there, so the fallback also covers first fires). `autoAppendTaskLog` writes it into the row content. Rows with no known series keep the exact old `{ text }` shape.
- **Host:** `delivery.ts` resolves the series from the task-session thread id first (unchanged authority), then falls back to the stamped series. `appendRunLog`'s charset guard still applies, so a corrupt or malicious stamp cannot write outside `tasks/` (covered by a test).

Direction 2 (migrating legacy armed rows into per-series sessions) is a `[BREAKING]`-class migration left to the maintainers; as the issue notes, direction 1 independently keeps the invariant from silently failing if a task row ever lands in a chat session again — and un-breaks run logs for legacy series and fresh-install onboarding without any migration.

**How it was tested:** Runner — series stamped, shape unchanged without one, `extractRouting` stamped/fallback/null cases against a real inbound DB. Host — chat-session fallback appends to `tasks/<series>.md` with zero channel deliveries, stamp-less rows still ignored, and a `../../escape` stamp rejected by the charset guard (nothing written outside `tasks/`). Full suite: 2047 host + 337 container tests pass on Node 22 and 24; `mailbox-model:check` and `stdin-json:check` clean.
