### PR TITLE
fix(update): let forks keep local adapters through the skill refresh

### DIFF
--- a/scripts/update-skills.test.ts
+++ b/scripts/update-skills.test.ts
@@ -142,3 +142,56 @@ describe('registry refresh end to end', () => {
     expect(report.skills[0].errors.join('\n')).toContain('no structured apply directives');
   });
 });
+
+describe('fork-owned (local) adapters — #3529', () => {
+  it('treats a barrel import with no skill directory as local instead of failing the refresh', async () => {
+    // Case 1 from the issue: an adapter the fork wrote itself. There is no
+    // .claude/skills/add-<name>/ and never will be — the update must not
+    // block on it.
+    const root = temp('nanoclaw-skills-own-adapter-');
+    write(root, 'src/channels/index.ts', "import './cli.js';\nimport './foo.js';\n");
+    write(root, 'src/channels/foo.ts', 'export const local = true;\n');
+
+    const report = await refreshInstalledSkills(root);
+
+    expect(report.success).toBe(true);
+    expect(report.skills).toMatchObject([{ name: 'foo', status: 'local', errors: [] }]);
+  });
+
+  it('honors `refresh: local` frontmatter and never touches the payload', async () => {
+    // Case 2: a skill-installed adapter the fork replaced or patched. The
+    // opt-out must keep the refresh from swapping the registry copy back in.
+    const root = temp('nanoclaw-skills-optout-');
+    write(root, 'src/channels/index.ts', "import './cli.js';\nimport './matrix.js';\n");
+    write(root, 'src/channels/matrix.ts', 'export const replaced = "fork-native";\n');
+    write(
+      root,
+      '.claude/skills/add-matrix/SKILL.md',
+      ['---', 'name: add-matrix', 'refresh: local', '---', '', '# Add Matrix', 'Fork-owned adapter.', ''].join('\n'),
+    );
+
+    const report = await refreshInstalledSkills(root);
+
+    expect(report.success).toBe(true);
+    expect(report.skills).toMatchObject([{ name: 'matrix', status: 'local' }]);
+    expect(fs.readFileSync(path.join(root, 'src/channels/matrix.ts'), 'utf8')).toContain('fork-native');
+  });
+
+  it('only reads the flag from frontmatter, not from prose', async () => {
+    const root = temp('nanoclaw-skills-prose-mention-');
+    write(root, 'src/channels/index.ts', "import './cli.js';\nimport './demo.js';\n");
+    write(
+      root,
+      '.claude/skills/add-demo/SKILL.md',
+      ['---', 'name: add-demo', '---', '', 'Set `refresh: local` to opt out.', ''].join('\n'),
+    );
+
+    const report = await refreshInstalledSkills(root);
+
+    // No frontmatter flag and no directives -> still the structured failure,
+    // now pointing at the opt-out.
+    expect(report.success).toBe(false);
+    expect(report.skills[0]).toMatchObject({ name: 'demo', status: 'failed' });
+    expect(report.skills[0].errors.join('\n')).toContain('refresh: local');
+  });
+});

--- a/scripts/update-skills.ts
+++ b/scripts/update-skills.ts
@@ -18,7 +18,8 @@ export interface SkillRefreshResult {
   name: string;
   skillName: string;
   kind: InstalledSkillKind;
-  status: 'refreshed' | 'failed';
+  /** `local` = deliberately not registry-managed; the refresh touched nothing. */
+  status: 'refreshed' | 'failed' | 'local';
   applied: string[];
   skipped: string[];
   errors: string[];
@@ -79,6 +80,21 @@ function tryGit(root: string, args: string[]): string {
   } catch {
     return '';
   }
+}
+
+/**
+ * `refresh: local` in SKILL.md's YAML frontmatter marks the skill's payload
+ * as fork-owned: the operator replaced or patched the adapter deliberately,
+ * and the registry refresh must leave it alone instead of silently swapping
+ * the registry copy back in (#3529). Only the frontmatter block (between the
+ * leading `---` fences) is consulted, so prose mentioning the phrase can't
+ * trip it.
+ */
+export function isLocalSkill(skillMdPath: string): boolean {
+  const source = fs.readFileSync(skillMdPath, 'utf8');
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return false;
+  return /^refresh:\s*local\s*$/m.test(match[1]);
 }
 
 function readImports(file: string): string[] {
@@ -154,14 +170,30 @@ export async function refreshInstalledSkills(
 
   for (const skill of selected) {
     const skillDir = path.join(root, '.claude/skills', skill.skillName);
+    const skillMd = path.join(skillDir, 'SKILL.md');
     const errors: string[] = [];
-    if (!fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
-      errors.push(`Missing ${path.relative(root, path.join(skillDir, 'SKILL.md'))}`);
-    } else {
-      const directives = parseDirectives(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'));
-      if (directives.length === 0) {
-        errors.push('Skill has no structured apply directives and cannot be refreshed headlessly');
-      }
+    if (!fs.existsSync(skillMd)) {
+      // A barrel import with no skill directory is a LOCAL adapter — code the
+      // fork owns, not registry output that rotted. Treating it as a hard
+      // failure blocked the whole update for forks carrying their own
+      // adapters (#3529); the refresh has nothing to refresh, so report it
+      // and move on.
+      results.push({ ...skill, status: 'local', applied: [], skipped: [], errors: [] });
+      continue;
+    }
+    if (isLocalSkill(skillMd)) {
+      // Explicit opt-out (`refresh: local` frontmatter): the adapter files
+      // are deliberately fork-owned — a replaced upstream adapter, or local
+      // patches the operator wants to keep. Never overwrite them.
+      results.push({ ...skill, status: 'local', applied: [], skipped: [], errors: [] });
+      continue;
+    }
+    const directives = parseDirectives(fs.readFileSync(skillMd, 'utf8'));
+    if (directives.length === 0) {
+      errors.push(
+        'Skill has no structured apply directives and cannot be refreshed headlessly ' +
+          '(mark it `refresh: local` in SKILL.md frontmatter if it is deliberately fork-owned)',
+      );
     }
 
     if (errors.length > 0) {
@@ -209,7 +241,9 @@ export async function refreshInstalledSkills(
   return {
     schema: 'nanoclaw-skill-refresh/v1',
     schemaVersion: 1,
-    success: results.every((result) => result.status === 'refreshed'),
+    // `local` skills are a healthy outcome: deliberately not registry-managed,
+    // nothing was (or should be) refreshed. Only real refresh failures block.
+    success: results.every((result) => result.status !== 'failed'),
     selected: selected.map((skill) => skill.name),
     remotes,
     skills: results,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #3529.

**What:** The update's skill refresh assumed every import in the channel/provider barrels came from a registry skill. Two fork-hostile consequences: an adapter the fork wrote itself (no `.claude/skills/add-<name>/`) hard-failed the refresh and **blocked the whole update** at `validate`; and a deliberately replaced or patched adapter was **silently overwritten** with the registry copy — dependency re-adds included — inside the `refresh installed skill payloads` commit.

**How it works:** Both opt-out shapes suggested in the issue, as a contract instead of the marker-SKILL.md trick:

- An import with **no matching skill directory** now reports status `local` (deliberately fork-owned, nothing to refresh) instead of `failed` — a fork's own adapter no longer blocks updates (case 1).
- **`refresh: local`** in SKILL.md frontmatter marks a skill-installed payload as fork-owned; the refresh reports it `local` and touches nothing, so a replaced adapter stays replaced (case 2). Only the YAML frontmatter block is consulted — prose mentioning the phrase can't trip it.
- `report.success` now means "no refresh **failed**": `local` skills are a healthy outcome and don't block the update transaction (`transaction.ts`'s existing `if (!success) throw` needs no change).
- The zero-directive error message now points at the opt-out, instead of reading like local adapters are banned.

Genuinely broken skills (SKILL.md present, refreshable, refresh errors) still fail exactly as before. Complements #3451 (companion-import attribution), which deliberately kept the missing-skill failure for unclaimed imports — this PR is where that failure becomes a supported "local" outcome.

**How it was tested:** New tests: a fork-own adapter passes as `local` with `success: true`; a `refresh: local` payload survives byte-identical; the flag is frontmatter-only (a prose mention still fails, now with the opt-out hint in the error). The existing prose-only-failure and end-to-end registry refresh tests still pass, as do the update transaction e2e tests. Full suite: 2047 host + 332 container tests, format/typecheck clean, on Node 22 and 24.
