### PR TITLE
fix(host): notify the user when their message's container repeatedly fails to wake

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -41,6 +41,7 @@ import { getAgentMailbox } from './mailbox/index.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { validateAdditionalMounts } from './modules/mount-security/index.js';
+import { clearWakeFailures, notifyWakeFailure, recordWakeFailure } from './wake-failure-notify.js';
 // Provider host-side config barrel — each provider that needs host-side
 // container setup self-registers on import.
 import './providers/index.js';
@@ -142,9 +143,18 @@ export function wakeContainer(session: Session): Promise<boolean> {
     return existing;
   }
   const promise = spawnContainer(session)
-    .then(() => true)
+    .then(() => {
+      clearWakeFailures(session.id);
+      return true;
+    })
     .catch((err) => {
       log.warn('wakeContainer failed — host-sweep will retry', { sessionId: session.id, err });
+      // A persistent failure streak surfaces ONE rate-limited notice on the
+      // originating channel (#2902) — otherwise a broken gateway/runtime is
+      // indistinguishable from "the agent is ignoring me" for the user.
+      // Fire-and-forget: the notifier never throws, and the wake result
+      // must not wait on channel I/O.
+      if (recordWakeFailure(session.id)) void notifyWakeFailure(session);
       return false;
     })
     .finally(() => {

--- a/src/wake-failure-notify.test.ts
+++ b/src/wake-failure-notify.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Wake-failure notifier (#2902): a channel-accepted message whose container
+ * can never spawn used to fail into logs only — the user saw silence. The
+ * notifier must (1) stay quiet through transient blips, (2) send one
+ * rate-limited notice per session during a persistent outage, (3) re-arm
+ * after a successful wake, and (4) never throw into the wake path.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db/messaging-groups.js', () => ({
+  getMessagingGroup: vi.fn(),
+}));
+vi.mock('./delivery.js', () => ({
+  getDeliveryAdapter: vi.fn(),
+}));
+
+import { getMessagingGroup } from './db/messaging-groups.js';
+import { getDeliveryAdapter } from './delivery.js';
+import type { Session } from './types.js';
+import {
+  NOTIFY_AFTER_FAILURES,
+  RENOTIFY_INTERVAL_MS,
+  WAKE_FAILURE_NOTICE,
+  _resetWakeFailuresForTesting,
+  clearWakeFailures,
+  notifyWakeFailure,
+  recordWakeFailure,
+} from './wake-failure-notify.js';
+
+const session = {
+  id: 'sess-1',
+  agent_group_id: 'ag-1',
+  messaging_group_id: 'mg-1',
+  thread_id: null,
+} as Session;
+
+beforeEach(() => {
+  _resetWakeFailuresForTesting();
+  vi.mocked(getMessagingGroup).mockResolvedValue({
+    id: 'mg-1',
+    channel_type: 'telegram',
+    platform_id: 'telegram:42',
+    instance: 'telegram',
+    name: null,
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: '2026-01-01T00:00:00.000Z',
+  } as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('recordWakeFailure', () => {
+  const T0 = Date.parse('2026-08-01T00:00:00.000Z');
+
+  it('stays silent below the consecutive-failure threshold', () => {
+    for (let i = 1; i < NOTIFY_AFTER_FAILURES; i++) {
+      expect(recordWakeFailure('s1', T0 + i)).toBe(false);
+    }
+    expect(recordWakeFailure('s1', T0 + NOTIFY_AFTER_FAILURES)).toBe(true);
+  });
+
+  it('rate-limits: no second notice inside the renotify interval, one after it', () => {
+    for (let i = 0; i < NOTIFY_AFTER_FAILURES; i++) recordWakeFailure('s1', T0);
+    // Sweep keeps failing every minute — silent.
+    expect(recordWakeFailure('s1', T0 + 60_000)).toBe(false);
+    expect(recordWakeFailure('s1', T0 + RENOTIFY_INTERVAL_MS - 1)).toBe(false);
+    // Interval elapsed — one more notice.
+    expect(recordWakeFailure('s1', T0 + RENOTIFY_INTERVAL_MS + 1)).toBe(true);
+    expect(recordWakeFailure('s1', T0 + RENOTIFY_INTERVAL_MS + 2)).toBe(false);
+  });
+
+  it('a successful wake resets the streak and re-arms the notifier', () => {
+    for (let i = 0; i < NOTIFY_AFTER_FAILURES; i++) recordWakeFailure('s1', T0);
+    clearWakeFailures('s1');
+    // Fresh outage: threshold applies again from zero.
+    expect(recordWakeFailure('s1', T0 + 1)).toBe(false);
+    expect(recordWakeFailure('s1', T0 + 2)).toBe(false);
+    expect(recordWakeFailure('s1', T0 + 3)).toBe(true);
+  });
+
+  it('tracks sessions independently', () => {
+    for (let i = 0; i < NOTIFY_AFTER_FAILURES; i++) recordWakeFailure('s1', T0);
+    expect(recordWakeFailure('s2', T0)).toBe(false);
+  });
+});
+
+describe('notifyWakeFailure', () => {
+  it('delivers the notice to the originating channel', async () => {
+    const deliver = vi.fn().mockResolvedValue('pm-1');
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    await notifyWakeFailure(session);
+
+    expect(deliver).toHaveBeenCalledWith(
+      'telegram',
+      'telegram:42',
+      null,
+      'chat',
+      JSON.stringify({ text: WAKE_FAILURE_NOTICE }),
+      undefined,
+      'telegram',
+    );
+  });
+
+  it('skips sessions with no messaging group (task / agent-to-agent)', async () => {
+    const deliver = vi.fn();
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    await notifyWakeFailure({ ...session, messaging_group_id: null } as Session);
+
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it('never throws when delivery fails (the channel may share the outage)', async () => {
+    vi.mocked(getDeliveryAdapter).mockReturnValue({
+      deliver: vi.fn().mockRejectedValue(new Error('channel down too')),
+    } as never);
+
+    await expect(notifyWakeFailure(session)).resolves.toBeUndefined();
+  });
+
+  it('never throws before the delivery adapter is registered', async () => {
+    vi.mocked(getDeliveryAdapter).mockReturnValue(null);
+
+    await expect(notifyWakeFailure(session)).resolves.toBeUndefined();
+  });
+});

--- a/src/wake-failure-notify.ts
+++ b/src/wake-failure-notify.ts
@@ -1,0 +1,93 @@
+/**
+ * Wake-failure notifier (#2902).
+ *
+ * A message can be accepted on a channel (the user sees it delivered) and
+ * then never reach an agent: `wakeContainer` fails — OneCLI gateway down,
+ * runtime misconfigured — and host-sweep retries silently every tick,
+ * forever. The only trace was a WARN in logs/nanoclaw.error.log; from the
+ * user's side the install was indistinguishable from "just not responding".
+ *
+ * This module turns a *persistent* wake failure into one rate-limited notice
+ * on the originating channel. Design constraints:
+ *
+ * - Transient blips stay silent: nothing is sent before
+ *   `NOTIFY_AFTER_FAILURES` consecutive failures for a session, so the
+ *   normal fail→sweep-retry→succeed path never spams.
+ * - A persistent outage notifies once per `RENOTIFY_INTERVAL_MS` per
+ *   session, not once per retry.
+ * - Best-effort by contract: the notifier itself can fail (the channel may
+ *   be the broken part) — it must never throw into the wake path.
+ * - No new state tables: the failure ledger is in-memory. A host restart
+ *   resets it, which is correct — the restart is itself a fresh attempt.
+ */
+import { getMessagingGroup } from './db/messaging-groups.js';
+import { getDeliveryAdapter } from './delivery.js';
+import { log } from './log.js';
+import type { Session } from './types.js';
+
+/** Consecutive failures before the first notice. */
+export const NOTIFY_AFTER_FAILURES = 3;
+/** Minimum gap between notices for the same session. */
+export const RENOTIFY_INTERVAL_MS = 30 * 60 * 1000;
+
+export const WAKE_FAILURE_NOTICE =
+  '⚠️ Your message was received, but the assistant could not be started ' +
+  '(the host keeps retrying). If this persists, the operator should check logs/nanoclaw.error.log.';
+
+interface FailureEntry {
+  consecutive: number;
+  lastNotifiedAt: number | null;
+}
+
+const failures = new Map<string, FailureEntry>();
+
+/** Record a failed wake. Returns true when a notice should go out now. */
+export function recordWakeFailure(sessionId: string, now = Date.now()): boolean {
+  const entry = failures.get(sessionId) ?? { consecutive: 0, lastNotifiedAt: null };
+  entry.consecutive += 1;
+  failures.set(sessionId, entry);
+  if (entry.consecutive < NOTIFY_AFTER_FAILURES) return false;
+  if (entry.lastNotifiedAt !== null && now - entry.lastNotifiedAt < RENOTIFY_INTERVAL_MS) return false;
+  entry.lastNotifiedAt = now;
+  return true;
+}
+
+/** A successful wake ends the failure streak (and re-arms the notifier). */
+export function clearWakeFailures(sessionId: string): void {
+  failures.delete(sessionId);
+}
+
+/** Test seam. */
+export function _resetWakeFailuresForTesting(): void {
+  failures.clear();
+}
+
+/**
+ * Deliver the notice to the session's originating channel. Sessions without
+ * a messaging group (task sessions, agent-to-agent) have no user waiting on
+ * a channel — skip. Every failure mode degrades to a log line; the wake
+ * path's never-throws contract extends through here.
+ */
+export async function notifyWakeFailure(session: Session): Promise<void> {
+  try {
+    if (!session.messaging_group_id) return;
+    const adapter = getDeliveryAdapter();
+    if (!adapter) return;
+    const mg = await getMessagingGroup(session.messaging_group_id);
+    if (!mg) return;
+    await adapter.deliver(
+      mg.channel_type,
+      mg.platform_id,
+      session.thread_id,
+      'chat',
+      JSON.stringify({ text: WAKE_FAILURE_NOTICE }),
+      undefined,
+      mg.instance ?? mg.channel_type,
+    );
+    log.info('Wake-failure notice delivered', { sessionId: session.id, messagingGroupId: mg.id });
+  } catch (err) {
+    // The channel may be part of the same outage — a failed notice is
+    // expected there and must not disturb the retry loop.
+    log.warn('Wake-failure notice could not be delivered', { sessionId: session.id, err });
+  }
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2902.

**What:** A message accepted on a channel (the user sees the double check-mark) could then never reach an agent: `wakeContainer` fails — OneCLI gateway unreachable, runtime misconfigured — and host-sweep retries silently every tick, forever. The only trace was a WARN in `logs/nanoclaw.error.log`; from the user's side a broken install was indistinguishable from "the agent is ignoring me" (the issue's install ran that way for 24+ hours).

**How it works:** New `src/wake-failure-notify.ts` turns a *persistent* wake failure into one rate-limited notice on the originating channel — the issue's requested behavior, including the rate limit:

- Silent below **3 consecutive failures** per session, so the normal fail → sweep-retry → succeed path never emits anything.
- During a persistent outage, at most **one notice per session per 30 minutes**, not one per retry.
- A successful wake clears the streak and re-arms the notifier (a later, separate outage notifies again).
- Best-effort by contract: no delivery adapter yet, no messaging group (task / agent-to-agent sessions have no user waiting on a channel), or a channel that shares the outage all degrade to a log line. `wakeContainer`'s never-throws contract is preserved, and the notice is fire-and-forget, so the wake result never waits on channel I/O.
- In-memory ledger only — no new tables. A host restart resets it, which is correct: the restart is itself a fresh attempt.

The hook rides inside `wakeContainer`'s existing `.catch`, so every wake path (router, host-sweep, restart, scripts) is covered without touching the callers.

**How it was tested:** 8 new tests: the threshold, the rate limit (silent inside the interval, one notice after), re-arm after success, per-session independence, the exact delivery payload/routing (instance-aware, thread-preserving), and all three never-throws paths (missing adapter, missing messaging group, failing channel). Full suite: 2052 host + 332 container tests pass, format/typecheck clean, on Node 22 and 24.
