### PR TITLE
fix(setup): put ~/.local/bin on PATH before the onecli guard in register-claude-token.sh

### DIFF
--- a/setup/register-claude-token-path.test.ts
+++ b/setup/register-claude-token-path.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pin the PATH-before-guard ordering in setup/register-claude-token.sh
+ * (#3354 bug 2).
+ *
+ * onecli installs into ~/.local/bin, which a non-login shell (headless ssh
+ * command) does not have on PATH. The script's `command -v onecli` guard
+ * used to run before any PATH fix — the fix lived only inside the
+ * claude-not-found branch further down — so a good install failed with
+ * "onecli not found" whenever setup ran non-interactively.
+ *
+ * The test runs the real script under bash with HOME pointed at a fixture
+ * whose ~/.local/bin holds a stub `onecli`, and a PATH that deliberately
+ * lacks it. Passing the guard proves the PATH fix now precedes it; the
+ * script is then allowed to stop at the next dependency probe.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const setupDir = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(setupDir, 'register-claude-token.sh');
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-register-token-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function runScript(opts: { onecliInLocalBin: boolean }): { status: number | null; stderr: string } {
+  const home = path.join(tmpDir, 'home');
+  const localBin = path.join(home, '.local', 'bin');
+  const sysBin = path.join(tmpDir, 'sysbin');
+  fs.mkdirSync(localBin, { recursive: true });
+  fs.mkdirSync(sysBin, { recursive: true });
+
+  // Minimal system PATH: bash internals need coreutils; symlink the ones the
+  // preamble uses so ~/.local/bin is the ONLY place onecli can come from.
+  for (const tool of ['bash', 'dirname', 'uname', 'mktemp', 'rm', 'cp', 'grep', 'cat']) {
+    const real = spawnSync('which', [tool], { encoding: 'utf8' }).stdout.trim();
+    if (real) fs.symlinkSync(real, path.join(sysBin, tool));
+  }
+
+  if (opts.onecliInLocalBin) {
+    fs.writeFileSync(path.join(localBin, 'onecli'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+  }
+  // No `script` binary on PATH: with the onecli guard passed and claude
+  // "present", the run stops deterministically at the PTY-capture probe.
+  fs.writeFileSync(path.join(localBin, 'claude'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+
+  const res = spawnSync('bash', [scriptPath], {
+    encoding: 'utf8',
+    env: { HOME: home, PATH: sysBin },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { status: res.status, stderr: res.stderr ?? '' };
+}
+
+describe('register-claude-token.sh non-login PATH (#3354 bug 2)', () => {
+  it('finds onecli in ~/.local/bin even when PATH lacks it', () => {
+    const { stderr } = runScript({ onecliInLocalBin: true });
+    // The old bug: exit 1 with "onecli not found" before any PATH fix ran.
+    expect(stderr).not.toContain('onecli not found');
+    // Guard passed; the run stops at the next dependency (script(1)),
+    // proving execution got past the previously failing point.
+    expect(stderr).toContain('script(1) is required');
+  });
+
+  it('still fails cleanly when onecli is genuinely absent', () => {
+    const { status, stderr } = runScript({ onecliInLocalBin: false });
+    expect(status).toBe(1);
+    expect(stderr).toContain('onecli not found');
+  });
+});

--- a/setup/register-claude-token.sh
+++ b/setup/register-claude-token.sh
@@ -24,6 +24,16 @@ set -euo pipefail
 SECRET_NAME="${SECRET_NAME:-Anthropic}"
 HOST_PATTERN="${HOST_PATTERN:-api.anthropic.com}"
 
+# ~/.local/bin joins PATH FIRST: onecli (and often claude) install there, and
+# a non-login shell — headless ssh command, systemd unit — doesn't have it on
+# PATH. The guard below used to run before any PATH fix, so a perfectly good
+# install failed with "onecli not found" whenever setup ran non-interactively
+# (#3354 bug 2). The later claude-branch copy of this fix stays for the
+# freshly-installed-binary case (hash -r matters there).
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
 command -v onecli >/dev/null \
   || { echo "onecli not found. Install it first (see /setup §4)." >&2; exit 1; }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes bug 2 of #3354 (bug 1 is addressed separately by #3441 — the two are independent in mechanism and files, and compose cleanly).

**What:** `setup/register-claude-token.sh` guards on `command -v onecli` at the top, but its `~/.local/bin` PATH fix lived only inside the claude-not-found branch further down. onecli installs into `~/.local/bin`, and a non-login shell — a headless ssh command, exactly how remote installs run setup — does not have that on PATH. Result: a perfectly good install died at the guard with `onecli not found` before ever reaching the line that would have fixed it, and a Claude token could not be registered headlessly.

**How it works:** The issue's suggested fix, verbatim: add `~/.local/bin` to PATH once at the top of the script, before the onecli guard (same idempotent `[[ ":$PATH:" != *…* ]]` shape the script already used). The claude-branch copy of the fix stays — it matters for the freshly-installed-binary case where the `hash -r` is needed.

**How it was tested:** `setup/register-claude-token-path.test.ts` runs the **real script** under bash with `HOME` pointed at a fixture whose `~/.local/bin` holds a stub `onecli`, and a PATH that deliberately lacks it: the guard now passes and the run provably proceeds to the next dependency probe (`script(1) is required`), while a genuinely missing onecli still fails with the same clean error. `bash -n` clean. Full suite: 2046 host + 332 container tests pass, format/typecheck clean, on Node 22 and 24.
