### PR TITLE
fix(channels): bump chat core + adapters to 4.38.1 — Telegram drops URLs with odd underscore counts

### DIFF
--- a/.claude/skills/add-discord/SKILL.md
+++ b/.claude/skills/add-discord/SKILL.md
@@ -39,7 +39,7 @@ import './discord.js';
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/discord@4.29.0
+@chat-adapter/discord@4.38.1
 ```
 
 ### 4. Build and validate

--- a/.claude/skills/add-gchat/SKILL.md
+++ b/.claude/skills/add-gchat/SKILL.md
@@ -40,7 +40,7 @@ import './gchat.js';
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/gchat@4.29.0
+@chat-adapter/gchat@4.38.1
 ```
 
 ### 4. Build and validate

--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -44,7 +44,7 @@ import './github.js';
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/github@4.29.0
+@chat-adapter/github@4.38.1
 ```
 
 ### 4. Build and validate

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -60,7 +60,7 @@ import './linear.js';
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/linear@4.29.0
+@chat-adapter/linear@4.38.1
 ```
 
 ### 4. Build and validate

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -63,7 +63,7 @@ import './slack-a2a-guard.js';
 
 Pinned exactly — the supply-chain policy rejects ranges and `latest`:
 ```nc:dep
-@chat-adapter/slack@4.29.0
+@chat-adapter/slack@4.38.1
 ```
 
 ### 4. Build and validate

--- a/.claude/skills/add-teams/SKILL.md
+++ b/.claude/skills/add-teams/SKILL.md
@@ -49,7 +49,7 @@ import './teams.js';
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/teams@4.29.0
+@chat-adapter/teams@4.38.1
 ```
 
 ### 4. Build and validate

--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -61,7 +61,7 @@ clean-upstream rebuild). The pairing handshake below spawns this step:
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/telegram@4.29.0
+@chat-adapter/telegram@4.38.1
 ```
 
 ### 5. Build and validate

--- a/.claude/skills/add-whatsapp-cloud/SKILL.md
+++ b/.claude/skills/add-whatsapp-cloud/SKILL.md
@@ -40,7 +40,7 @@ import './whatsapp-cloud.js';
 Pinned to an exact version — the supply-chain policy rejects ranges and `latest`:
 
 ```nc:dep
-@chat-adapter/whatsapp@4.29.0
+@chat-adapter/whatsapp@4.38.1
 ```
 
 ### 4. Build and validate

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@clack/prompts": "^1.2.0",
     "@onecli-sh/sdk": "2.2.1",
     "better-sqlite3": "13.0.3",
-    "chat": "4.29.0",
+    "chat": "4.38.1",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
     "yaml": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 13.0.3
         version: 13.0.3
       chat:
-        specifier: 4.29.0
-        version: 4.29.0
+        specifier: 4.38.1
+        version: 4.38.1
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
@@ -601,14 +601,17 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
-  chat@4.29.0:
-    resolution: {integrity: sha512-KdPfzaie5ivYytyRICTERg5xT+LeCbYefokvNAqTHe92eqkFaoTMXXkSitikxJVWhZIb2YoXF1b9UZHyzSzKzw==}
+  chat@4.38.1:
+    resolution: {integrity: sha512-FD6vNLT8clXHKhN3I1m+3Bn2nz0rsB6/bmNPsJeh6Cr7kwWLg0MYl2uor9YaKBp38F77sBRVKdYKVA6ihUby3w==}
     engines: {node: '>=20'}
     peerDependencies:
-      ai: ^6.0.182
+      ai: ^6.0.182 || ^7.0.0
+      workflow: ^5.0.0-beta.35
       zod: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       ai:
+        optional: true
+      workflow:
         optional: true
       zod:
         optional: true
@@ -1850,7 +1853,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat@4.29.0:
+  chat@4.38.1:
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -96,7 +96,7 @@ describe('skill-directives parser, on the converted add-slack', () => {
 
   it('reads the dependency pinned exactly', () => {
     const dep = directives.find((d) => d.kind === 'dep')!;
-    expect(dep.body).toEqual(['@chat-adapter/slack@4.29.0']);
+    expect(dep.body).toEqual(['@chat-adapter/slack@4.38.1']);
   });
 
   it('tags the runs with their effects', () => {

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -37,7 +37,7 @@ if ! grep -q "import './github.js';" src/channels/index.ts; then
 fi
 
 echo "STEP: pnpm-install"
-pnpm install @chat-adapter/github@4.29.0
+pnpm install @chat-adapter/github@4.38.1
 
 echo "STEP: pnpm-build"
 pnpm run build

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -104,7 +104,7 @@ function appContextKey(instance: string, channelId: string, userId: string): str
 
 /**
  * Derive ordered entities from an SDK assistant event. The installed chat
- * core (4.29.0) parses assistant_thread_started / app_context_changed into a
+ * core (4.38.1) parses assistant_thread_started / app_context_changed into a
  * `context` object (channelId/teamId/threadEntryPoint — the legacy assistant
  * context shape) with no entities array; prefer a real `entities` array
  * whenever a future SDK forwards the platform's ordered agent-context
@@ -214,7 +214,7 @@ export type ReplyContextExtractor = (raw: Record<string, any>) => ReplyContext |
  * A member joined (or left) a channel/group conversation one of our bridge
  * instances is in. Forwarded from the Chat SDK's member_joined_channel
  * dispatch; `left` is reserved for member_left_channel, which the installed
- * chat core (4.29.0) does NOT dispatch — see the TODO at the
+ * chat core (4.38.1) does NOT dispatch — see the TODO at the
  * onMemberJoinedChannel registration in setup().
  */
 export interface MembershipEvent {
@@ -607,7 +607,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       });
 
       // Agent-mode assistant context: cache the latest "what the user is
-      // viewing" per (channel, user). The installed chat core (4.29.0)
+      // viewing" per (channel, user). The installed chat core (4.38.1)
       // dispatches both the legacy assistant_thread_started and the
       // agent_view app_context_changed events into these handlers.
       const rememberAppContext = (event: AssistantThreadStartedEvent | AssistantContextChangedEvent): void => {
@@ -623,7 +623,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // channel type (setMembershipHandler); no-op when none is registered.
       // The chat core dispatches only member_joined_channel;
       // member_left_channel arrives at the adapter but has no SDK handler
-      // in 4.29.0.
+      // in 4.38.1.
       // TODO(member-left): when the chat core grows an onMemberLeftChannel
       // dispatch, register it here and forward with { left: true } — the
       // MembershipEvent type and dispatchMembership already carry it.


### PR DESCRIPTION
Fixes #3569.

## What this fixes

`@chat-adapter/telegram@4.29.0` permanently fails to deliver any message whose whole-message count of unescaped MarkdownV2 markers (`_ * ~ \``) is **odd**. The most visible symptom is that **OneCLI connect links never arrive on Telegram** — they always carry exactly one underscore (`&agent_name=`).

`escapeLinkUrl` escapes only `)` and `\` in a link target, so a raw `_` in a URL survives into the rendered MarkdownV2. `trimToMarkdownV2SafeBoundary` then counts unescaped markers across the entire message, reads the odd count as an unpaired entity, and truncates there — destroying the link's closing `)`. Telegram rejects the send with `can't parse entities: Can't find end of a URL`.

Upstream fixed this in **4.32.0** (`findUnescapedPositionsOutsideCode` now skips `](...)` targets). Confirmed by bisect: 4.30.0/4.31.0 buggy, 4.32.0 onward fixed.

## Why this bumps everything, not just Telegram

Adapters pin `chat` exactly, and `scripts/skill-conformance.test.ts` already enforces the lockstep:

> `@chat-adapter/slack pinned 4.29.0 but our chat core is 4.38.1 — a @chat-adapter/* adapter must match the chat package`

Bumping Telegram alone fails that test and yields two copies of `chat` in the store. So this moves the chat core and all eight adapter pins together, plus two other hardcoded `4.29.0` pins that would otherwise drift (`setup/install-github.sh`, the `skill-directives` fixture).

## Verification

Same repro through the real adapter send path with a stubbed `fetch`, before and after:

```
before (4.29.0)                     after (4.38.1)
BREAK  ?utm_source=newsletter       OK  ?utm_source=newsletter
BREAK  /foo/my_repo                 OK  /foo/my_repo
BREAK  ...&agent_name=Nano          OK  ...&agent_name=Nano
```

Test suite: `4 failed | 2058 passed`. The 4 failures are `scripts/update/transaction.e2e.test.ts`, which fail **identically on pristine `origin/main`** in the same environment — pre-existing and unrelated to this change. Everything else, including `skill-conformance` and `skill-directives`, is green. `pnpm run build` clean. The `pnpm-lock.yaml` delta is `chat` only.

## Two things reviewers should know

1. **The `4.29.0`-keyed workaround comments in `src/channels/chat-sdk-bridge.ts` were re-verified against 4.38.1**, not blindly renumbered. The chat core still does not dispatch `member_left_channel` and still exposes no `entities` array on assistant events, so both workarounds remain correct and only their version references changed. The `TODO(member-left)` stays open.

2. **New surface in 4.32.0+:** a `sendRichMessage` path is attempted before `sendMessage`. It is a one-shot probe — on failure the adapter sets `richMessagesAvailable = false` and falls back permanently — so it is not per-message overhead, but it is worth a look. It arrives with the fix and cannot be avoided by picking 4.32.0 instead.

## Note on the underlying pattern

Exact version pins in `SKILL.md` mean a published adapter fix never reaches users automatically — this one sat available for six releases. Might be worth a periodic pin-refresh check, but that is out of scope here.

Only Telegram was runtime-verified, as that is the adapter installed locally; the other seven pins are lockstep-consistency changes covered by the conformance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
