### PR TITLE
fix(container): prevent system rows starving inbound queue

### DIFF
--- a/container/agent-runner/src/db/messages-in.test.ts
+++ b/container/agent-runner/src/db/messages-in.test.ts
@@ -52,6 +52,21 @@ function insertContextRow(id: string, seq: number, text: string): void {
 }
 
 describe('trigger=1 rows never crowded out', () => {
+  it('stale system rows do not consume the wake-message cap', () => {
+    for (let i = 1; i <= CAP; i++) {
+      insertMessage(`system-${i}`, i * 2, 'system', {
+        type: 'question_response',
+        questionId: `expired-${i}`,
+      });
+    }
+    insertMessage('chat-new', (CAP + 1) * 2, 'chat', { sender: 'A', text: 'real message' });
+
+    const batch = getPendingMessages();
+    expect(batch).toHaveLength(CAP);
+    const turnMessages = batch.filter((m) => m.kind !== 'system');
+    expect(turnMessages.map((m) => m.id)).toEqual(['chat-new']);
+  });
+
   it('a due task row survives 12 newer context rows at cap 10', () => {
     insertMessage('task-1', 2, 'task', { prompt: 'daily digest' });
     for (let i = 1; i <= 12; i++) {

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -61,10 +61,12 @@ function getMaxMessagesPerPrompt(): number {
  * Fetch pending messages that are due for processing.
  * Fetch pending messages while excluding work already claimed by this runner.
  *
- * Selection is two-phase so accumulated context can never crowd a wake row
- * out of the batch: all due trigger=1 rows come first (oldest-first, up to
- * `maxMessagesPerPrompt`), then remaining slots fill with the NEWEST due
- * trigger=0 rows. Without this, ≥cap accumulated context rows (e.g.
+ * Selection is priority-based so accumulated context can never crowd a wake row
+ * out of the batch: all due non-system trigger=1 rows come first
+ * (oldest-first, up to `maxMessagesPerPrompt`), then remaining slots fill with
+ * the NEWEST due trigger=0 rows. System control responses only use slots left
+ * after turn messages because the poll loop filters them before prompting.
+ * Without this, ≥cap accumulated context rows (e.g.
  * non-engaged group messages) newer than a due task row would push the task
  * itself out of the batch. The combined batch is returned in chronological
  * order (oldest first). Host's countDueMessages gates waking on trigger=1

--- a/container/agent-runner/src/mailbox/sqlite/operations.ts
+++ b/container/agent-runner/src/mailbox/sqlite/operations.ts
@@ -47,10 +47,16 @@ export function sqliteGetPendingMessages(isFirstPoll: boolean, limit: number): M
       ),
     );
     const unclaimed = pending.filter(({ id }) => !acked.has(id));
-    const wake = unclaimed.filter(({ trigger }) => trigger === 1).slice(0, limit);
-    const remaining = limit - wake.length;
-    const context = remaining > 0 ? unclaimed.filter(({ trigger }) => trigger === 0).slice(-remaining) : [];
-    return [...wake, ...context].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
+    // System rows are control responses consumed by dedicated lookups. Keep
+    // them visible for compatibility, but only in slots that turn messages do
+    // not need; the poll loop filters them before building the prompt.
+    const turn = unclaimed.filter(({ kind }) => kind !== 'system');
+    const wake = turn.filter(({ trigger }) => trigger === 1).slice(0, limit);
+    const contextSlots = limit - wake.length;
+    const context = contextSlots > 0 ? turn.filter(({ trigger }) => trigger === 0).slice(-contextSlots) : [];
+    const systemSlots = limit - wake.length - context.length;
+    const system = systemSlots > 0 ? unclaimed.filter(({ kind }) => kind === 'system').slice(0, systemSlots) : [];
+    return [...system, ...wake, ...context].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
   } finally {
     inbound.close();
   }


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3568.

Pending non-system messages now receive batch slots before system control responses. Wake messages keep their existing priority, context fills the remaining turn-message slots, and system rows use only any capacity left afterward. This preserves the configured batch cap and system-row visibility while preventing stale control responses from hiding real inbound work that the poll loop can process.

A regression test covers ten stale system rows followed by a real chat message and verifies the real message remains visible without exceeding the cap.

Tested with:

- `bun test src/db/messages-in.test.ts`
- Full agent-runner suite: 333 passed, 1 skipped
- Full host suite: 2062 passed
- Host and agent-runner TypeScript checks
- Repository formatting checks
