### PR TITLE
Integration request from AIML API (providers branch)

### DIFF
--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -186,6 +186,44 @@ onecli secrets create --name "OpenRouter" --type generic \
   --header-name "Authorization" --value-format "Bearer {value}"
 ```
 
+#### Example: AI/ML API
+
+[AI/ML API](https://aimlapi.com) is OpenAI-compatible and has no dedicated
+OpenCode provider package, so it goes through the generic `openai` provider
+(same as any self-hosted OpenAI-compatible endpoint) rather than its own
+`OPENCODE_PROVIDER` id. Note the model id: config-building strips only the
+first `openai/` segment, and AI/ML API's own catalog ids are already
+vendor-prefixed (`openai/gpt-5.6-terra`, `anthropic/claude-opus-5`, …) — so
+the env var needs both prefixes, which is correct, not a typo. For Claude
+models specifically, prefer [`docs/aimlapi.md`](../../../docs/aimlapi.md)
+instead — AI/ML API also has a real Anthropic-compatible endpoint, so those
+work through the default `claude` provider with no OpenCode skill at all.
+
+```env
+OPENCODE_PROVIDER=openai
+OPENCODE_MODEL=openai/openai/gpt-5.6-terra
+OPENCODE_SMALL_MODEL=openai/openai/gpt-5.6-terra
+ANTHROPIC_BASE_URL=https://api.aimlapi.com/v1
+```
+
+Register the key, plus two optional non-secret "credentials" that ride the
+same request to attribute this traffic as coming from NanoClaw (the gateway
+applies every matching rule, not just one):
+
+```bash
+onecli secrets create --name "AI/ML API" --type generic \
+  --value YOUR_KEY --host-pattern "api.aimlapi.com" \
+  --header-name "Authorization" --value-format "Bearer {value}"
+
+onecli secrets create --name "AI/ML API Source" --type generic \
+  --value "agent/nanoclaw" --host-pattern "api.aimlapi.com" \
+  --header-name "X-AIMLAPI-Source" --value-format "{value}"
+
+onecli secrets create --name "AI/ML API Partner" --type generic \
+  --value "part_JVb2uUP2fkNTsmCLGT8ABaZy" --host-pattern "api.aimlapi.com" \
+  --header-name "X-AIMLAPI-Partner-ID" --value-format "{value}"
+```
+
 #### Example: Anthropic (no ANTHROPIC_BASE_URL needed)
 
 When `OPENCODE_PROVIDER` is `anthropic`, OpenCode uses normal Anthropic env inside the container — the proxy + placeholder key pattern is unchanged and `ANTHROPIC_BASE_URL` is not required.

--- a/docs/aimlapi.md
+++ b/docs/aimlapi.md
@@ -1,0 +1,79 @@
+# Running Agents on AI/ML API
+
+NanoClaw agents can be routed to [AI/ML API](https://aimlapi.com) instead of the Anthropic API — one key, 300+ models (Claude, GPT, Gemini, DeepSeek, and more), with automatic fallback between providers per model.
+
+## How It Works
+
+AI/ML API exposes an Anthropic-compatible `/v1/messages` endpoint alongside its OpenAI-compatible one. The Claude Code CLI (which runs inside agent containers) uses the Anthropic SDK, which reads `ANTHROPIC_BASE_URL` to find the API host. Pointing that variable at AI/ML API is all that's needed — no new provider code, no OneCLI bypass, no blocked hosts. This is the same trick as [Ollama](ollama.md), minus the local-proxy complications: AI/ML API is a normal remote host, so OneCLI's usual credential-proxy path (`ANTHROPIC_AUTH_TOKEN=placeholder` + a proxy-injected `Authorization` header) works unmodified — it's exactly the flow `src/providers/claude.ts` already implements for the real Anthropic API.
+
+```
+┌─────────────────────────────┐
+│  Agent container            │
+│                             │
+│  Claude Code CLI            │
+│    ↓ ANTHROPIC_BASE_URL     │      ┌──────────────────────┐
+│    https://api.aimlapi.com ─┼─────▶│  AI/ML API            │
+│    (via OneCLI proxy)       │      │  anthropic/claude-*   │
+└─────────────────────────────┘      └──────────────────────┘
+```
+
+Verified directly against the live API: both auth styles the Claude Agent SDK can send work —
+`x-api-key: <key>` and `Authorization: Bearer <key>` — so the standard OneCLI generic-secret
+setup (which injects the latter) needs no changes.
+
+## Setup
+
+`ANTHROPIC_BASE_URL` in `.env` alone does nothing: `src/providers/claude.ts` (the file that reads it) is only loaded when `src/providers/index.ts` contains `import './claude.js';`, and standard installs never add that line. Two ways to get there:
+
+**Fresh install** — run setup with the custom-endpoint variables. It creates the OneCLI secret, writes `ANTHROPIC_BASE_URL` to `.env` and appends the import for you:
+
+```bash
+NANOCLAW_ANTHROPIC_BASE_URL=https://api.aimlapi.com \
+NANOCLAW_ANTHROPIC_AUTH_TOKEN=YOUR_KEY \
+  pnpm run setup:auto
+```
+
+Setup skips this flow when OneCLI already holds an Anthropic secret, so on an existing install use the manual path instead.
+
+**Existing install** — three steps by hand:
+
+1. Register the key:
+
+```bash
+onecli secrets create --name "AI/ML API" --type generic \
+  --value YOUR_KEY --host-pattern "api.aimlapi.com" \
+  --header-name "Authorization" --value-format "Bearer {value}"
+```
+
+2. Add `ANTHROPIC_BASE_URL=https://api.aimlapi.com` to `.env`.
+3. Append `import './claude.js';` to `src/providers/index.ts` and restart NanoClaw.
+
+Optionally, attribute this traffic as coming from NanoClaw — a second, non-secret "credential" injecting a static header alongside the real key (the gateway applies every matching rule, not just one):
+
+```bash
+onecli secrets create --name "AI/ML API Source" --type generic \
+  --value "agent/nanoclaw" --host-pattern "api.aimlapi.com" \
+  --header-name "X-AIMLAPI-Source" --value-format "{value}"
+
+onecli secrets create --name "AI/ML API Partner" --type generic \
+  --value "part_JVb2uUP2fkNTsmCLGT8ABaZy" --host-pattern "api.aimlapi.com" \
+  --header-name "X-AIMLAPI-Partner-ID" --value-format "{value}"
+```
+
+Grant the agent access to all secret ids you created. `set-secrets` **replaces** the entire list, so read the current one first and merge in the new ids rather than overwriting it:
+
+```bash
+AGENT_ID=$(onecli agents list | jq -r '.data[] | select(.identifier=="<agentGroupId>") | .id')
+CURRENT=$(onecli agents secrets --id "$AGENT_ID" | jq -r '[.data[]] | join(",")')
+MERGED=$(printf '%s' "$CURRENT,<api-key-secret-id>,<source-secret-id>,<partner-secret-id>" | tr ',' '\n' | sort -u | paste -sd ',' -)
+onecli agents set-secrets --id "$AGENT_ID" --secret-ids "$MERGED"
+onecli agents secrets --id "$AGENT_ID"
+```
+
+## Model Selection
+
+Set `"model"` in the container's `~/.claude/settings.json` (bind-mounted from `data/v2-sessions/<agent-group-id>/.claude-shared/settings.json`) to an AI/ML API Claude model id, e.g. `anthropic/claude-opus-5`. Use the exact id from the [model catalog](https://docs.aimlapi.com) — ids are prefixed by vendor, not bare model names.
+
+## Other model families
+
+AI/ML API also serves GPT, Gemini, DeepSeek, and others via its OpenAI-compatible endpoint — route those through [`/add-opencode`](../.claude/skills/add-opencode/SKILL.md)'s `openai` provider example instead of this doc, which covers the Claude-compatible path only.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API, trusted by 400k+ users.

We'd love to be available as a verified provider option inside NanoClaw — so we went ahead and did all the technical work on our side.

To build our partnership, we offer a 50/50 revenue share on all traffic from this integration. (P.S.: tracking starts as soon as this release goes live, so no earnings will be lost during setup)

If you have any questions - happy to answer.

My contacts: hugo@aimlapi.com (email / Slack), Telegram: @hug0the

---

Companion to #3573 (same change against `main`), rebased onto the `providers` registry branch.

### Why

`providers` keeps its own `docs/` and its own copy of `.claude/skills/add-opencode/SKILL.md`. Without this, users who install from the registry branch don't get the AI/ML API docs, and the OpenCode example drifts apart from `main`.

### What

- `docs/aimlapi.md` — same file as in #3573: `ANTHROPIC_BASE_URL=https://api.aimlapi.com` + OneCLI generic secret, optional `X-AIMLAPI-Source` / `X-AIMLAPI-Partner-ID` attribution, model selection.
- `.claude/skills/add-opencode/SKILL.md` — same "Example: AI/ML API" section, placed after the OpenRouter example.
- Docs only, no source changes.

### How it was tested

Same as #3573; the OpenCode model-id note was checked against `container/agent-runner/src/providers/opencode.ts` on this branch.

### Notes

If you prefer to sync docs onto `providers` yourselves from #3573, feel free to close this one.
