### PR TITLE
Install the Dial tool when the install has no agents yet

### DIFF
--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -392,7 +392,7 @@ and hand it down:
 ncl groups list --json | jq -r 'if (.data|length)==0 then "no" else "yes" end'
 ```
 ```nc:operator when:has_agents=no
-No agent groups exist yet, so there is nothing to grant Dial to — skipping the tool install. Run `/add-dial-tool` once your first agent exists; the channel below works either way.
+No agents exist yet — this install creates its first one in a moment, so there is nobody to choose between. Installing the tool for every agent; re-run `/add-dial-tool` any time to narrow that down.
 ```
 ```nc:run capture:agent_groups when:has_agents=yes effect:fetch
 ncl groups list --json | jq -r '[.data[] | "\(.id) (\(.name))"] | join(", ")'
@@ -405,6 +405,9 @@ Which agents may use Dial? Enter agent ids separated by commas with no spaces (t
 ```
 ```nc:run effect:step when:has_agents=yes
 pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/add-dial-tool --input 'dial_agents={{dial_agents}}'
+```
+```nc:run effect:step when:has_agents=no
+pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/add-dial-tool --input 'dial_agents=all'
 ```
 
 Then tell the sandboxed agent which line is its own. The container authenticates


### PR DESCRIPTION
A first-time install connects Dial, answers **yes** to "Install the Dial tool now?", and gets no tool: the agent created moments later has no `dial` on its PATH and no `dial-cli` skill, and tells its owner it cannot place calls.


## Cause

The wizard runs `/add-dial` at `auto.ts:712` and does not create the first agent until `init-first-agent`, so on a first-ever install `ncl groups list` is empty at that point. The no-agent-groups guard I added put `when:has_agents=yes` on the nested `/add-dial-tool` step as well as on the question, so the whole install was skipped rather than just the question.

Reproduced twice on a clean machine: `container/cli-tools.json` never gains `@getdial/cli` and `container/skills/dial-cli/SKILL.md` is never written. The step log shows the guard returning `no`, and the wizard step order confirms the ordering:

```
09-skill-add-dial.log
10-init-first-agent.log
```

## Fix

The guard belonged on the question alone. With no groups there is nobody to choose between, so the question stays skipped — but the install now runs with `all` implied. That is what the operator asked for by saying yes, and it is a no-op for scoping either way: the block-rule loop iterates the group list, which is empty. The CLI and the skill land in the image, and the first agent inherits them.

The operator message changes with it — the old one said the install was being skipped, which is no longer true.

## Checks

- typecheck clean
- `scripts/` suite 469 passing, including the `signed-in-no-agent-groups` fixture that now exercises the new branch
- conformance still requires a scenario per `when:` guard, so the added `when:has_agents=no` step is covered
