### PR TITLE
refactor(providers): declare the runtime provider contract

### DIFF
--- a/container/agent-runner/src/cross-session-echo.test.ts
+++ b/container/agent-runner/src/cross-session-echo.test.ts
@@ -192,7 +192,7 @@ describe('command classification', () => {
 
     const [msg] = getPendingMessages();
     expect(isSessionEcho(msg)).toBe(true);
-    expect(categorizeMessage(msg).category).toBe('none');
+    expect(categorizeMessage(msg, 'claude').category).toBe('none');
   });
 
   it('echoed /clear and /compact are never runner commands', () => {
@@ -201,7 +201,7 @@ describe('command classification', () => {
 
     const messages = getPendingMessages();
     expect(messages.some((m) => isClearCommand(m))).toBe(false);
-    expect(messages.some((m) => isRunnerCommand(m))).toBe(false);
+    expect(messages.some((m) => isRunnerCommand(m, 'claude'))).toBe(false);
   });
 
   it('a real /clear in the same batch still classifies normally', () => {

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -1,6 +1,9 @@
 import { findByRouting } from './destinations.js';
 import type { MessageInRow } from './db/messages-in.js';
 import { TIMEZONE, formatLocalTime, formatLocalStamp } from './timezone.js';
+import './providers/index.js';
+import './provider-contracts/index.js';
+import { getProviderRuntimeContract } from './providers/provider-registry.js';
 
 /**
  * channel_type marking cross-session context copies (accumulate fan-out from
@@ -23,8 +26,41 @@ export function isSessionEcho(msg: MessageInRow): boolean {
  */
 export type CommandCategory = 'admin' | 'filtered' | 'passthrough' | 'none';
 
-const ADMIN_COMMANDS = new Set(['/remote-control', '/clear', '/compact', '/context', '/cost', '/files', '/upload-trace']);
-const FILTERED_COMMANDS = new Set(['/help', '/login', '/logout', '/doctor', '/config', '/start']);
+/** Commands the runner itself handles, whatever provider is active. */
+const RUNNER_ADMIN_COMMANDS = ['/clear', '/upload-trace'];
+
+interface CommandSets {
+  admin: ReadonlySet<string>;
+  filtered: ReadonlySet<string>;
+}
+
+const commandSetsByProvider = new Map<string, CommandSets>();
+
+/**
+ * The command lists for the ACTIVE provider: the runner's own commands plus
+ * the native admin/filtered commands its contract declares. Another
+ * registered contract's lists are never consulted — a session runs exactly
+ * one provider. A provider without a contract contributes nothing.
+ */
+// What the formatter applied to every provider before runtime contracts
+// existed. Only the contractless fallback reads these; a declared contract
+// supplies its own lists.
+const LEGACY_NATIVE_ADMIN_COMMANDS = ['/remote-control', '/compact', '/context', '/cost', '/files'];
+const LEGACY_NATIVE_FILTERED_COMMANDS = ['/help', '/login', '/logout', '/doctor', '/config', '/start'];
+
+function commandSets(providerName: string): CommandSets {
+  const cached = commandSetsByProvider.get(providerName);
+  if (cached) return cached;
+  const contract = getProviderRuntimeContract(providerName);
+  const sets: CommandSets = {
+    // A provider with no contract keeps the lists the formatter hard-coded
+    // before contracts existed, so a pre-contract payload sees no change.
+    admin: new Set([...RUNNER_ADMIN_COMMANDS, ...(contract?.commands.nativeAdmin ?? LEGACY_NATIVE_ADMIN_COMMANDS)]),
+    filtered: new Set(contract?.commands.nativeFiltered ?? LEGACY_NATIVE_FILTERED_COMMANDS),
+  };
+  commandSetsByProvider.set(providerName, sets);
+  return sets;
+}
 
 export interface CommandInfo {
   category: CommandCategory;
@@ -35,7 +71,8 @@ export interface CommandInfo {
 
 /**
  * Categorize a message as a command or not.
- * Only applies to chat/chat-sdk messages.
+ * Only applies to chat/chat-sdk messages. `providerName` is the active
+ * provider whose contract supplies the native command lists.
  *
  * The extracted `senderId` is compared against `NANOCLAW_ADMIN_USER_IDS`
  * which stores ids in the namespaced form `<channel_type>:<raw>` (see
@@ -44,7 +81,7 @@ export interface CommandInfo {
  * contains a `:` we assume it's pre-namespaced (non-chat-sdk adapters
  * that populate `senderId` directly) and leave it alone.
  */
-export function categorizeMessage(msg: MessageInRow): CommandInfo {
+export function categorizeMessage(msg: MessageInRow, providerName: string): CommandInfo {
   const content = parseContent(msg.content);
   const text = (content.text || '').trim();
   const senderId = extractSenderId(msg, content);
@@ -58,11 +95,12 @@ export function categorizeMessage(msg: MessageInRow): CommandInfo {
   // Extract the command name (e.g., '/clear' from '/clear some args')
   const command = text.split(/\s/)[0].toLowerCase();
 
-  if (ADMIN_COMMANDS.has(command)) {
+  const commands = commandSets(providerName);
+  if (commands.admin.has(command)) {
     return { category: 'admin', command, text, senderId };
   }
 
-  if (FILTERED_COMMANDS.has(command)) {
+  if (commands.filtered.has(command)) {
     return { category: 'filtered', command, text, senderId };
   }
 
@@ -87,9 +125,9 @@ export function isClearCommand(msg: MessageInRow): boolean {
  * a query's first input. Used by the follow-up poller to bail out and let
  * the outer loop reopen the query.
  */
-export function isRunnerCommand(msg: MessageInRow): boolean {
+export function isRunnerCommand(msg: MessageInRow, providerName: string): boolean {
   if (msg.kind !== 'chat' && msg.kind !== 'chat-sdk') return false;
-  const cat = categorizeMessage(msg).category;
+  const cat = categorizeMessage(msg, providerName).category;
   return cat === 'admin' || cat === 'passthrough';
 }
 
@@ -136,9 +174,7 @@ export function extractRouting(messages: MessageInRow[]): RoutingContext {
     inReplyTo: first?.id ?? null,
     // Echo rows riding along with a task must not disable one-door delivery:
     // taskRun as long as at least one task row and no non-task/non-echo row.
-    taskRun:
-      messages.some((m) => m.kind === 'task') &&
-      messages.every((m) => m.kind === 'task' || isSessionEcho(m)),
+    taskRun: messages.some((m) => m.kind === 'task') && messages.every((m) => m.kind === 'task' || isSessionEcho(m)),
   };
 }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -34,8 +34,14 @@ import { getAgentMailbox, readMailboxContext } from './mailbox/index.js';
 // Providers barrel — each enabled provider self-registers on import.
 // Provider skills append imports to providers/index.ts.
 import './providers/index.js';
-import { createProvider, type ProviderName } from './providers/factory.js';
+// Provider-contracts barrel — each provider's runtime contract attaches to its
+// registration on import. Provider skills append imports to
+// provider-contracts/index.ts alongside the providers barrel line.
+import './provider-contracts/index.js';
+import { createProvider } from './providers/factory.js';
+import { getProviderRuntimeContract, requireProviderName } from './providers/provider-registry.js';
 import { resolvePluginServer } from './plugin-mcp.js';
+import { registerProviderMemorySessionHook } from './provider-contracts/realize.js';
 import type { McpServerConfig } from './providers/types.js';
 import { runPollLoop } from './poll-loop.js';
 
@@ -47,7 +53,7 @@ const CWD = '/workspace/agent';
 
 async function main(): Promise<void> {
   const config = loadConfig();
-  const providerName = config.provider.toLowerCase() as ProviderName;
+  const providerName = requireProviderName(config.provider);
   const mailbox = getAgentMailbox();
   await mailbox.start(await readMailboxContext());
 
@@ -117,11 +123,12 @@ async function main(): Promise<void> {
     effort: config.effort,
     fastMode: config.fastMode,
   });
-  provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+  registerProviderMemorySessionHook(providerName, provider, MEMORY_SESSION_HOOK);
 
   try {
     await runPollLoop({
       provider,
+      providerContract: getProviderRuntimeContract(providerName),
       providerName,
       cwd: CWD,
       systemContext: { instructions },

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -9,6 +9,11 @@ import { MockProvider } from './providers/mock.js';
 import type { ProviderExchange } from './providers/types.js';
 import { runPollLoop } from './poll-loop.js';
 
+const MOCK_PROVIDER_CONTRACT = {
+  textDelivery: 'mid-turn-complete',
+  commands: { formatting: 'xml' },
+} as const;
+
 beforeEach(() => {
   initTestSessionDb();
   // Seed a destination so output parsing can resolve "discord-test" → routing
@@ -311,6 +316,7 @@ async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSigna
   return Promise.race([
     runPollLoop({
       provider,
+      providerContract: MOCK_PROVIDER_CONTRACT,
       providerName: 'mock',
       cwd: '/tmp',
       signal,
@@ -505,7 +511,6 @@ describe('poll loop — /clear command', () => {
  * Provider that throws on every query, simulating API failures.
  */
 class ThrowingProvider {
-  readonly supportsNativeSlashCommands = false;
   private errorMessage: string;
 
   constructor(errorMessage: string) {
@@ -534,8 +539,6 @@ class ThrowingProvider {
  * First emits an init event (setting continuation), then throws.
  */
 class InvalidSessionProvider {
-  readonly supportsNativeSlashCommands = false;
-
   isSessionInvalid(): boolean {
     return true;
   }
@@ -600,7 +603,6 @@ describe('poll loop — slash command during active query', () => {
  * the loop interrupts an active stream.
  */
 class BlockingProvider {
-  readonly supportsNativeSlashCommands = false;
   queries = 0;
   aborts = 0;
   ends = 0;

--- a/container/agent-runner/src/memory/session-hook.wiring.test.ts
+++ b/container/agent-runner/src/memory/session-hook.wiring.test.ts
@@ -11,8 +11,10 @@ describe('Claude memory hook wiring', () => {
   );
 
   it('passes the shared hook to Claude without a second SDK hook path', () => {
-    expect(runnerSource).toMatch(/provider\.registerMemorySessionHook\(MEMORY_SESSION_HOOK\)/);
-    expect(providerSource).toMatch(/registerMemorySessionHook\(hook: MemorySessionHookRegistration\)/);
+    expect(runnerSource).toMatch(/registerProviderMemorySessionHook\(providerName, provider, MEMORY_SESSION_HOOK\)/);
+    expect(providerSource).toMatch(
+      /registerMemorySessionHook\(hook: MemorySessionHookRegistration, memory\?: unknown\)/,
+    );
     expect(providerSource).not.toContain('memorySessionStartHook');
     expect(providerSource).not.toContain('providesMemorySessionHook');
     expect(groupInitSource).not.toContain('MEMORY_SESSION_START_MATCHER');

--- a/container/agent-runner/src/poll-loop.harness-tag-strip.test.ts
+++ b/container/agent-runner/src/poll-loop.harness-tag-strip.test.ts
@@ -91,7 +91,7 @@ describe('stripHarnessTagArtifacts', () => {
 
 // Wiring guards: the sanitizer must be applied at BOTH delivery seams inside
 // the real processQuery path — the <message> block extraction in
-// dispatchResultText (exercised here without emitsMidTurnText, where the
+// dispatchResultText (exercised here without mid-turn delivery, where the
 // result is the delivery door; the mid-turn seam has its own sanitization
 // test in poll-loop.midturn.test.ts), and the bare error-result delivery.
 // Removing either call site (not just the helper) goes red here.

--- a/container/agent-runner/src/poll-loop.legacy-flags.test.ts
+++ b/container/agent-runner/src/poll-loop.legacy-flags.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { closeSessionDb, getInboundDb, initTestSessionDb } from './mailbox/sqlite/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { runPollLoop } from './poll-loop.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, QueryInput } from './providers/types.js';
+
+// A provider with no runtime contract (a payload built against a core that
+// predates the seam) still declares its behavior through the legacy instance
+// flags. The poll-loop must honor those, not silently default them to false.
+
+class LegacyProvider implements AgentProvider {
+  supportsNativeSlashCommands?: boolean;
+  prompts: string[] = [];
+
+  constructor(flags: { supportsNativeSlashCommands?: boolean } = {}) {
+    this.supportsNativeSlashCommands = flags.supportsNativeSlashCommands;
+  }
+
+  registerMemorySessionHook(): void {}
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query(input: QueryInput): AgentQuery {
+    this.prompts.push(input.prompt);
+    let end: (() => void) | undefined;
+    const ended = new Promise<void>((resolve) => {
+      end = resolve;
+    });
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'init', continuation: 'legacy-session' };
+        yield { type: 'result', text: '<message to="discord-test">seen</message>' };
+        await ended;
+      },
+    };
+    return { push() {}, end: () => end?.(), events, abort: () => end?.() };
+  }
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES ('discord-test', 'Discord Test', 'channel', 'discord', 'chan-1', NULL)`,
+    )
+    .run();
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, content)
+       VALUES ('m-cmd', 'chat', datetime('now'), 'pending', 'chan-1', 'discord', ?)`,
+    )
+    .run(JSON.stringify({ sender: 'Alice', text: '/mycmd hello' }));
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+async function runUntilReply(provider: LegacyProvider): Promise<void> {
+  const controller = new AbortController();
+  const loop = runPollLoop({ provider, providerName: 'legacy', cwd: '/tmp', signal: controller.signal }).catch(
+    () => {},
+  );
+  const start = Date.now();
+  while (getUndeliveredMessages().length === 0 && Date.now() - start < 3000) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  controller.abort();
+  await loop;
+}
+
+describe('contractless provider legacy flags', () => {
+  it('passes slash commands raw when the instance declares supportsNativeSlashCommands', async () => {
+    const provider = new LegacyProvider({ supportsNativeSlashCommands: true });
+    await runUntilReply(provider);
+    expect(provider.prompts).toEqual(['/mycmd hello']);
+  });
+
+  it('wraps slash commands like chat when the instance declares nothing', async () => {
+    const provider = new LegacyProvider();
+    await runUntilReply(provider);
+    expect(provider.prompts).toHaveLength(1);
+    expect(provider.prompts[0]).not.toBe('/mycmd hello');
+    expect(provider.prompts[0]).toContain('/mycmd hello');
+    expect(provider.prompts[0]).toContain('<');
+  });
+});

--- a/container/agent-runner/src/poll-loop.midturn-recovery.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-recovery.test.ts
@@ -203,7 +203,7 @@ describe('mid-turn recovery when the final result is empty', () => {
 });
 
 // The result door is still a live delivery path for providers that do NOT
-// declare emitsMidTurnText — these run without the capability so the final
+// declare mid-turn delivery — these run without the capability so the final
 // text actually delivers, and the <internal> exclusion must hold there too.
 describe('final-text <internal> exclusion (the result-door half of the guarantee)', () => {
   it('never delivers a block wrapped in <internal> in the FINAL result text', async () => {

--- a/container/agent-runner/src/poll-loop.midturn-resultdoor.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn-resultdoor.test.ts
@@ -5,7 +5,7 @@ import { getUndeliveredMessages } from './db/messages-out.js';
 import { processQuery } from './poll-loop.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
-// Adversarial verification of the one-door contract for emitsMidTurnText
+// Adversarial verification of the one-door contract for mid-turn delivery
 // providers: mid-turn streaming is the SINGLE content door. The result door
 // NEVER writes content to messages_out (error results excepted) — its only
 // other job is the nudge decision: a turn that delivered nothing (no door

--- a/container/agent-runner/src/poll-loop.midturn.test.ts
+++ b/container/agent-runner/src/poll-loop.midturn.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 
 // --- Mid-turn <message> block delivery ---
 // The SDK's final result carries only the LAST assistant text. For providers
-// declaring emitsMidTurnText, a wrapped reply composed between tool calls is
+// declaring `textDelivery: 'mid-turn-complete'`, a wrapped reply composed between tool calls is
 // delivered from the 'text' event stream at parse time; the final result
 // structurally STRIPS complete blocks (they already streamed, so they were
 // already delivered — no runtime record consulted), and a bare final text
@@ -325,11 +325,11 @@ describe('mid-turn <message> block delivery', () => {
   });
 });
 
-// Providers that do NOT declare emitsMidTurnText keep the old single-door
+// Providers that do NOT declare mid-turn delivery keep the old single-door
 // behavior: text events are delivery-inert and <message> blocks deliver from
 // the final result. The capability is a static fact of the provider, threaded
 // into processQuery by runPollLoop — never inferred from runtime events.
-describe('provider without emitsMidTurnText: result door unchanged', () => {
+describe('provider without mid-turn delivery: result door unchanged', () => {
   it('ignores text events and delivers the result block exactly once', async () => {
     seedDest();
     const block = '<message to="discord-main">The answer is 4.</message>';
@@ -358,7 +358,7 @@ describe('provider without emitsMidTurnText: result door unchanged', () => {
     const block = '<message to="discord-main">Result-door delivery.</message>';
     // A real MockProvider stream (text segment, then a result repeating the
     // block), but driven the way runPollLoop drives a provider that does not
-    // declare emitsMidTurnText.
+    // declare mid-turn delivery.
     const provider = new MockProvider(
       {},
       () => block,
@@ -376,10 +376,6 @@ describe('provider without emitsMidTurnText: result door unchanged', () => {
 });
 
 describe('mock provider mid-turn text events', () => {
-  it('declares the emitsMidTurnText capability', () => {
-    expect(new MockProvider().emitsMidTurnText).toBe(true);
-  });
-
   it('emits configured text events before each result', async () => {
     const provider = new MockProvider(
       {},
@@ -412,8 +408,7 @@ describe('mock provider mid-turn text events', () => {
       events.push(event);
     }
     // The real SDK's result only repeats the final assistant text, which
-    // already streamed — a mock declaring emitsMidTurnText must match that,
-    // or the result-door strip would remove blocks that never delivered.
+    // already streamed.
     const texts = events.filter((e) => e.type === 'text');
     expect(texts).toHaveLength(1);
     expect(texts[0].text).toBe('ok');

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -298,8 +298,7 @@ describe('mock provider', () => {
     const typed = events.filter((e) => e.type !== 'activity');
     expect(typed.length).toBeGreaterThanOrEqual(3);
     expect(typed[0].type).toBe('init');
-    // The mock declares emitsMidTurnText, so the turn's text streams as a
-    // text event before the result repeats it.
+    // The mock streams text before the result repeats it.
     expect(typed[1].type).toBe('text');
     expect(typed[2].type).toBe('result');
     expect((typed[2] as { text: string }).text).toBe('Echo: Hello');

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -30,6 +30,7 @@ import {
 import { stripHarnessTagArtifacts } from './harness-tag-strip.js';
 import { isUploadTraceCommand, uploadTrace } from './upload-trace.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderExchange } from './providers/types.js';
+import type { ProviderRuntimeContract } from './provider-contracts/registry.js';
 
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
@@ -47,6 +48,8 @@ function generateId(): string {
 
 export interface PollLoopConfig {
   provider: AgentProvider;
+  /** Declared provider runtime behavior. Contractless providers keep legacy defaults. */
+  providerContract?: Pick<ProviderRuntimeContract, 'textDelivery' | 'commands'>;
   /**
    * Name of the provider (e.g. "claude", "codex", "opencode"). Used to key
    * the stored continuation per-provider so flipping providers doesn't
@@ -76,6 +79,16 @@ export interface PollLoopConfig {
  * 6. Loop
  */
 export async function runPollLoop(config: PollLoopConfig): Promise<void> {
+  // Contract providers declare these; a contractless (legacy payload)
+  // provider keeps declaring them as instance flags, exactly as before.
+  const legacy = config.provider as { supportsNativeSlashCommands?: boolean; emitsMidTurnText?: boolean };
+  const nativeSlashCommands = config.providerContract
+    ? config.providerContract.commands.formatting === 'native'
+    : (legacy.supportsNativeSlashCommands ?? false);
+  const midTurnCompleteDelivery = config.providerContract
+    ? config.providerContract.textDelivery === 'mid-turn-complete'
+    : (legacy.emitsMidTurnText ?? false);
+
   // Resume the agent's prior session from a previous container run if one
   // was persisted. The continuation is opaque to the poll-loop — the
   // provider decides how to use it (Claude resumes a .jsonl transcript,
@@ -173,7 +186,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
           platform_id: routing.platformId,
           channel_type: routing.channelType,
           thread_id: routing.threadId,
-          content: JSON.stringify({ text: uploadTrace() }),
+          content: JSON.stringify({ text: uploadTrace(config.providerName) }),
         });
         commandIds.push(msg.id);
         continue;
@@ -217,7 +230,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     // Format messages: passthrough commands get raw text (only if the
     // provider natively handles slash commands), others get XML.
-    const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
+    const prompt = formatMessagesWithCommands(keep, nativeSlashCommands, config.providerName);
 
     log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
 
@@ -252,7 +265,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         config.provider.onExchangeComplete?.bind(config.provider),
         prompt,
         continuation,
-        config.provider.emitsMidTurnText === true,
+        midTurnCompleteDelivery,
       );
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
@@ -303,13 +316,17 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
  * passthrough commands are sent raw (no XML wrapping) so the SDK can
  * dispatch them. Otherwise they fall through to standard XML formatting.
  */
-function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommands: boolean): string {
+function formatMessagesWithCommands(
+  messages: MessageInRow[],
+  nativeSlashCommands: boolean,
+  providerName: string,
+): string {
   const parts: string[] = [];
   const normalBatch: MessageInRow[] = [];
 
   for (const msg of messages) {
     if (nativeSlashCommands && (msg.kind === 'chat' || msg.kind === 'chat-sdk')) {
-      const cmdInfo = categorizeMessage(msg);
+      const cmdInfo = categorizeMessage(msg, providerName);
       if (cmdInfo.category === 'passthrough' || cmdInfo.category === 'admin') {
         // Flush normal batch first
         if (normalBatch.length > 0) {
@@ -344,15 +361,15 @@ export async function processQuery(
   initialPrompt: string,
   initialContinuation: string | undefined,
   /**
-   * The provider's declared `emitsMidTurnText` capability (see
-   * providers/types.ts). True → mid-turn streaming is the single content
+   * The provider contract's `textDelivery: 'mid-turn-complete'`. True →
+   * mid-turn streaming is the single content
    * door: complete <message> blocks deliver exactly once, at parse time from
    * streamed 'text' events (with cross-segment assembly of split blocks),
    * and the final result never delivers content — it only surfaces error
    * results and decides the wrap-nudge. False → text events are
    * delivery-inert and the final result stays the single delivery door.
    */
-  emitsMidTurnText = false,
+  midTurnCompleteDelivery = false,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
@@ -361,7 +378,7 @@ export async function processQuery(
   // nudge — mirrors unwrappedNudged for chat turns.
   let taskBlockNudged = false;
   // How many <message> blocks were delivered from 'text' events this turn
-  // (chat runs, emitsMidTurnText providers only). A frame-local count, never
+  // (chat runs, mid-turn delivery providers only). A frame-local count, never
   // keyed by content: it feeds the result door's nudge decision ("did this
   // turn deliver anything?"). Reset at the turn boundary (the 'result'
   // event) — NOT at the follow-up push seam: query.push() does not end the
@@ -426,7 +443,7 @@ export async function processQuery(
         // not end: end() lets an in-flight turn run to completion, which
         // can block the command (e.g. /clear during a long task) for as
         // long as the turn takes.
-        if (pending.some((m) => isRunnerCommand(m))) {
+        if (pending.some((m) => isRunnerCommand(m, providerName))) {
           log('Pending slash command — aborting active stream so outer loop can process');
           endedForCommand = true;
           query.abort();
@@ -538,10 +555,10 @@ export async function processQuery(
         // final result only carries the LAST assistant text, so complete
         // <message> blocks composed here would otherwise be lost — deliver
         // them now (chat runs only; task runs stay one-door). Gated on the
-        // provider's static capability: for a provider that does not declare
-        // emitsMidTurnText the result stays the only delivery door, so a
-        // stray text event must not open a second one.
-        if (emitsMidTurnText) {
+        // provider contract: for a provider that does not declare mid-turn
+        // delivery the result stays the only delivery door, so a stray text
+        // event must not open a second one.
+        if (midTurnCompleteDelivery) {
           const scan = await deliverMidTurnBlocks(event.text, routing, turnStartSeq, midTurnTail);
           midTurnSent += scan.delivered;
           midTurnTail = scan.tail;
@@ -557,18 +574,18 @@ export async function processQuery(
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = await dispatchResultText(event.text, routing, {
             midTurnSent,
-            // For emitsMidTurnText providers the result door NEVER delivers
+            // For mid-turn delivery providers the result door NEVER delivers
             // content (error results excepted, below): mid-turn streaming is
             // the single content door. The result door's remaining job is
             // the nudge decision — see turnDelivered.
-            suppressDelivery: emitsMidTurnText,
+            suppressDelivery: midTurnCompleteDelivery,
             // "Did anything user-visible go out this turn?" — door
             // deliveries (midTurnSent) plus any chat row written since the
             // turn boundary (which also sees MCP send_message calls the
             // frame-local count can't). When false and the result still
             // carries content, the wrap-nudge fires so the model re-sends
             // and the retry streams through the mid-turn door.
-            turnDelivered: emitsMidTurnText ? midTurnSent > 0 || chatRowWrittenSince(turnStartSeq) : undefined,
+            turnDelivered: midTurnCompleteDelivery ? midTurnSent > 0 || chatRowWrittenSince(turnStartSeq) : undefined,
           });
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
@@ -733,7 +750,7 @@ export interface ResultDispatchOptions {
    */
   midTurnSent?: number;
   /**
-   * Providers declaring `emitsMidTurnText`: the result door NEVER delivers
+   * Providers declaring `textDelivery: 'mid-turn-complete'`: the result door NEVER delivers
    * content. Mid-turn streaming (parse-time block delivery plus cross-
    * segment assembly) is the single content door; a complete <message>
    * block in the result text is at best a repeat of a mid-turn delivery and
@@ -1029,7 +1046,7 @@ export async function dispatchResultText(
       scratchpadParts.push(`[not delivered — empty after sanitization; to="${toName}"]`);
       continue;
     }
-    // One content door: with an emitsMidTurnText provider the result door
+    // One content door: with a mid-turn delivery provider the result door
     // never sends. A deliverable block here is either a repeat of a mid-turn
     // delivery (turnDelivered — keep it out of the scratchpad so it does not
     // read as an undelivered reply) or content the streaming door missed —

--- a/container/agent-runner/src/provider-contracts/active-provider.test.ts
+++ b/container/agent-runner/src/provider-contracts/active-provider.test.ts
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, spyOn } from 'bun:test';
+
+import type { MessageInRow } from '../db/messages-in.js';
+import { categorizeMessage, isRunnerCommand } from '../formatter.js';
+import { registerProvider } from '../providers/provider-registry.js';
+import { uploadTrace } from '../upload-trace.js';
+import { readProviderTrace } from './realize.js';
+import { PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION, type ProviderRuntimeContract } from './registry.js';
+
+// A session runs exactly one provider. The formatter's command lists and the
+// /upload-trace lookup come from THAT provider's contract; a second registered
+// contract (another installed payload) must never leak into a Claude session.
+
+const OTHER = `other-native-${process.pid}`;
+const OTHER_TRACE = `/nonexistent/${OTHER}/trace.jsonl`;
+
+const otherContract: ProviderRuntimeContract = {
+  seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  configuration: { executionPolicy: { constant: { boundary: 'container' } } },
+  history: { readTrace: () => OTHER_TRACE },
+  textDelivery: 'result',
+  commands: { formatting: 'native', nativeAdmin: ['/other-admin'], nativeFiltered: ['/other-filtered'] },
+};
+
+registerProvider(OTHER, {
+  create: () => ({
+    registerMemorySessionHook: () => {},
+    query: () => {
+      throw new Error('unused');
+    },
+    isSessionInvalid: () => false,
+  }),
+  contract: otherContract,
+});
+
+function chat(text: string): MessageInRow {
+  return {
+    id: `m-${text}`,
+    kind: 'chat',
+    channel_type: 'discord',
+    platform_id: 'chan-1',
+    content: JSON.stringify({ sender: 'Alice', text }),
+  } as unknown as MessageInRow;
+}
+
+describe('command lists come from the active provider only', () => {
+  it('keeps the pre-contract lists for a provider with no contract', () => {
+    // Before contracts existed the formatter hard-coded these for every
+    // provider; a contractless payload must see exactly that, not nothing.
+    const legacy = `no-contract-${process.pid}`;
+    expect(categorizeMessage(chat('/compact'), legacy).category).toBe('admin');
+    expect(categorizeMessage(chat('/context'), legacy).category).toBe('admin');
+    expect(categorizeMessage(chat('/help'), legacy).category).toBe('filtered');
+    expect(categorizeMessage(chat('/clear'), legacy).category).toBe('admin');
+    expect(categorizeMessage(chat('/other-admin'), legacy).category).toBe('passthrough');
+  });
+
+  it("keeps Claude's own native commands for a Claude session", () => {
+    expect(categorizeMessage(chat('/compact'), 'claude').category).toBe('admin');
+    expect(categorizeMessage(chat('/help'), 'claude').category).toBe('filtered');
+    expect(categorizeMessage(chat('/clear'), 'claude').category).toBe('admin');
+    expect(categorizeMessage(chat('/upload-trace'), 'claude').category).toBe('admin');
+  });
+
+  it("does not pick up another registered contract's lists for a Claude session", () => {
+    expect(categorizeMessage(chat('/other-admin'), 'claude').category).toBe('passthrough');
+    expect(categorizeMessage(chat('/other-filtered'), 'claude').category).toBe('passthrough');
+    // ...while the other provider's own session sees them.
+    expect(categorizeMessage(chat('/other-admin'), OTHER).category).toBe('admin');
+    expect(categorizeMessage(chat('/other-filtered'), OTHER).category).toBe('filtered');
+    expect(categorizeMessage(chat('/compact'), OTHER).category).toBe('passthrough');
+  });
+
+  it('isRunnerCommand follows the same per-provider lists', () => {
+    // Filtered commands are not runner commands; passthrough ones are.
+    expect(isRunnerCommand(chat('/other-filtered'), OTHER)).toBe(false);
+    expect(isRunnerCommand(chat('/other-filtered'), 'claude')).toBe(true);
+  });
+});
+
+describe('/upload-trace reads the active provider trace only', () => {
+  it("does not pick up another registered contract's trace for a Claude session", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `active-provider-trace-${process.pid}-`));
+    const homedirSpy = spyOn(os, 'homedir').mockReturnValue(root); // no Claude transcripts here
+    try {
+      expect(readProviderTrace(OTHER)).toBe(OTHER_TRACE);
+      expect(readProviderTrace('claude')).toBeNull();
+      expect(uploadTrace('claude')).toBe('No transcript to upload for this session yet.');
+    } finally {
+      homedirSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/container/agent-runner/src/provider-contracts/claude.ts
+++ b/container/agent-runner/src/provider-contracts/claude.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  resolveClaudeExecutionPolicy,
+  resolveClaudeInference,
+  resolveClaudeMcpServers,
+  resolveClaudeMemoryRuntime,
+} from '../providers/claude-config.js';
+import { claudeConfigDirectory, newestClaudeTranscript } from '../providers/claude-history.js';
+
+import { registerProviderContract } from '../providers/provider-registry.js';
+import {
+  PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  type ProviderRuntimeContract,
+  type RuntimeMemoryHookInput,
+} from './registry.js';
+
+const provider = 'claude';
+
+export const claudeRuntimeContract: ProviderRuntimeContract = {
+  seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  configuration: {
+    // Claude's stance is fixed — the container and the OneCLI allow-list are
+    // the boundary — so it is declared as the constant it is.
+    executionPolicy: { constant: resolveClaudeExecutionPolicy() },
+    inference: resolveClaudeInference,
+    // The memory runtime env is likewise fixed: auto-memory stays off whatever
+    // hook core registers, so it is a constant, not a function of the hook.
+    memory: { constant: resolveClaudeMemoryRuntime() },
+    mcpServers: resolveClaudeMcpServers,
+  },
+  lifecycle: { memorySessionHookRegistration: writeMemorySessionHook },
+  // Pre-compact archiving and continuation rotation are provider-internal
+  // (providers/claude-history.ts); core only needs the trace lookup.
+  history: { readTrace: newestClaudeTranscript },
+  textDelivery: 'mid-turn-complete',
+  commands: {
+    formatting: 'native',
+    nativeAdmin: ['/remote-control', '/compact', '/context', '/cost', '/files'],
+    nativeFiltered: ['/help', '/login', '/logout', '/doctor', '/config', '/start'],
+  },
+};
+
+registerProviderContract(provider, claudeRuntimeContract);
+
+function writeMemorySessionHook(hook: RuntimeMemoryHookInput): void {
+  const filePath = path.join(claudeConfigDirectory(), 'settings.json');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const exists = fs.existsSync(filePath);
+  const parsed: unknown = exists ? JSON.parse(fs.readFileSync(filePath, 'utf-8')) : {};
+  if (!isRecord(parsed)) throw new Error(`${filePath} must contain a JSON object`);
+
+  const hooks = parsed.hooks === undefined ? {} : parsed.hooks;
+  if (!isRecord(hooks)) throw new Error(`${filePath} hooks must be a JSON object`);
+
+  const sessionStart = hooks.SessionStart === undefined ? [] : hooks.SessionStart;
+  if (!Array.isArray(sessionStart)) throw new Error(`${filePath} hooks.SessionStart must be an array`);
+
+  const memoryCommands = new Set([hook.command, ...hook.legacyCommands]);
+  const nextSessionStart = sessionStart
+    .map((entry) => removeMemoryCommands(entry, memoryCommands))
+    .filter((entry) => entry !== undefined);
+  nextSessionStart.push({
+    matcher: hook.sources.join('|'),
+    hooks: [{ type: 'command', command: hook.command, timeout: 10 }],
+  });
+
+  hooks.SessionStart = nextSessionStart;
+  parsed.hooks = hooks;
+  fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n');
+}
+
+function removeMemoryCommands(value: unknown, commands: ReadonlySet<string>): unknown {
+  if (!isRecord(value) || !Array.isArray(value.hooks)) return value;
+  const hooks = value.hooks.filter((hook) => {
+    if (!isRecord(hook)) return true;
+    return typeof hook.command !== 'string' || !commands.has(hook.command);
+  });
+  return hooks.length > 0 ? { ...value, hooks } : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/container/agent-runner/src/provider-contracts/index.ts
+++ b/container/agent-runner/src/provider-contracts/index.ts
@@ -1,0 +1,9 @@
+// Provider runtime-contract barrel.
+// Each import attaches a provider's runtime contract to its registration via
+// registerProviderContract() at top level (order-independent with the
+// providers barrel). Skills add a new provider's contract by appending one
+// import line below, next to the line they add in providers/index.ts.
+// The test-double `mock` provider is not in either production barrel; its
+// contract (./mock.ts) is imported by the tests that register the mock.
+
+import './claude.js';

--- a/container/agent-runner/src/provider-contracts/mock.ts
+++ b/container/agent-runner/src/provider-contracts/mock.ts
@@ -1,0 +1,25 @@
+import { registerProviderContract } from '../providers/provider-registry.js';
+import { PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION, type ProviderRuntimeContract } from './registry.js';
+
+/**
+ * Runtime contract for the test-double provider (providers/mock.ts). It goes
+ * through the same two-step registration as every real provider, proves its
+ * contract from providers/mock.conformance.test.ts like every other provider,
+ * and the poll-loop sees the mock the way it sees Claude.
+ *
+ * The mock streams every text segment before the turn's result (mirroring the
+ * SDK's assistant-message -> result ordering), so it declares mid-turn
+ * delivery. It formats commands as XML and has no inference, memory, or MCP
+ * surface, so those capabilities are omitted.
+ */
+export const mockRuntimeContract: ProviderRuntimeContract = {
+  seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  configuration: {
+    // Nothing runs: the mock never leaves the process.
+    executionPolicy: { constant: { sandbox: 'none' } },
+  },
+  textDelivery: 'mid-turn-complete',
+  commands: { formatting: 'xml' },
+};
+
+registerProviderContract('mock', mockRuntimeContract);

--- a/container/agent-runner/src/provider-contracts/names.ts
+++ b/container/agent-runner/src/provider-contracts/names.ts
@@ -1,0 +1,15 @@
+import '../providers/index.js';
+import './index.js';
+import { listProviderNames, listProviderRuntimeContractNames } from '../providers/provider-registry.js';
+
+/** Lists registered providers and contracts. Prints only when run directly (`bun src/provider-contracts/names.ts`). */
+export function providerRuntimeNames(): { contracts: string[]; providers: string[] } {
+  return {
+    contracts: listProviderRuntimeContractNames().sort(),
+    providers: listProviderNames().sort(),
+  };
+}
+
+if (import.meta.main) {
+  console.log(JSON.stringify(providerRuntimeNames()));
+}

--- a/container/agent-runner/src/provider-contracts/realize.ts
+++ b/container/agent-runner/src/provider-contracts/realize.ts
@@ -1,0 +1,87 @@
+import {
+  type Capability,
+  type ProviderRuntimeContract,
+  type ResolvedRuntimeConfiguration,
+  type RuntimeCallbackEffects,
+  type RuntimeConfigurationInputs,
+} from './registry.js';
+import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
+import { getProviderRuntimeContract } from '../providers/provider-registry.js';
+import type { AgentProvider, ProviderExchange } from '../providers/types.js';
+
+/** The production clock handed to history callbacks; tests pass a fake. */
+const REAL_CLOCK: RuntimeCallbackEffects = { now: () => Date.now() };
+
+/**
+ * The configuration inputs are one object per provider instance, created in
+ * the factory from the construction options. The render path closes over that
+ * object directly, so nothing is looked up while a file is being written.
+ *
+ * This map exists for exactly one caller: the memory-session-hook
+ * registration, which reaches the seam after construction holding nothing but
+ * the instance. That one cannot be a closure without changing what
+ * `createProvider` returns, so it stays an explicit, single lookup.
+ */
+const providerInputs = new WeakMap<AgentProvider, Partial<RuntimeConfigurationInputs>>();
+
+export function bindProviderRuntimeInputs(instance: AgentProvider, inputs: Partial<RuntimeConfigurationInputs>): void {
+  providerInputs.set(instance, inputs);
+}
+
+/** The one way core reads a capability: call it with its input, or take the declared constant. */
+function resolveCapability<I>(capability: Capability<I>, input: I, environment: NodeJS.ProcessEnv): unknown {
+  return typeof capability === 'function' ? capability(input, environment) : capability.constant;
+}
+
+/**
+ * Core resolves the contract's configuration capabilities and hands the
+ * results to the provider — the provider never calls its own capabilities.
+ * `memory` is not resolved here: its input is the memory session hook, which
+ * core registers after construction (see registerProviderMemorySessionHook).
+ */
+export function resolveRuntimeConfiguration(
+  contract: ProviderRuntimeContract,
+  inputs: Partial<RuntimeConfigurationInputs>,
+  environment: NodeJS.ProcessEnv = process.env,
+): ResolvedRuntimeConfiguration {
+  const { executionPolicy, inference, mcpServers } = contract.configuration;
+  return {
+    executionPolicy: resolveCapability(executionPolicy, undefined, environment),
+    inference: inference ? resolveCapability(inference, inputs.inference ?? {}, environment) : undefined,
+    mcpServers: mcpServers ? resolveCapability(mcpServers, inputs.mcpServers ?? {}, environment) : undefined,
+  };
+}
+
+export function runProviderBeforeQuery(
+  provider: string,
+  inputs: Partial<RuntimeConfigurationInputs>,
+  context: unknown = undefined,
+): void {
+  getProviderRuntimeContract(provider)?.lifecycle?.beforeQuery?.(inputs, context);
+}
+
+export function registerProviderMemorySessionHook(
+  providerName: string,
+  provider: AgentProvider,
+  hook: MemorySessionHookRegistration,
+): void {
+  const inputs = providerInputs.get(provider) ?? {};
+  inputs.memory = hook;
+  providerInputs.set(provider, inputs);
+  const contract = getProviderRuntimeContract(providerName);
+  contract?.lifecycle?.memorySessionHookRegistration?.(hook);
+  // The memory capability's input is the hook itself, so it is resolved here
+  // — the one moment core has it — and handed to the provider alongside.
+  const memoryCapability = contract?.configuration.memory;
+  const memory = memoryCapability ? resolveCapability(memoryCapability, hook, process.env) : undefined;
+  provider.registerMemorySessionHook(hook, memory);
+}
+
+/** The active provider's newest trace, for `/upload-trace`. */
+export function readProviderTrace(provider: string): string | null {
+  return getProviderRuntimeContract(provider)?.history?.readTrace?.() ?? null;
+}
+
+export function runProviderAfterExchange(provider: string, exchange: ProviderExchange): string | null {
+  return getProviderRuntimeContract(provider)?.history?.afterExchange?.({ exchange }, REAL_CLOCK) ?? null;
+}

--- a/container/agent-runner/src/provider-contracts/registry.test.ts
+++ b/container/agent-runner/src/provider-contracts/registry.test.ts
@@ -1,0 +1,321 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, spyOn } from 'bun:test';
+
+import { registerProvider } from '../providers/provider-registry.js';
+import { readProviderTrace, runProviderAfterExchange, runProviderBeforeQuery } from './realize.js';
+import {
+  PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  type Capability,
+  type ProviderRuntimeContract,
+  type RuntimeInferenceInput,
+} from './registry.js';
+import { getProviderRuntimeContract, hasDeclaredProviderRuntimeContract } from '../providers/provider-registry.js';
+import {
+  assertProviderRuntimeContractShape,
+  probeProviderRuntimeConfiguration,
+  type ProbeFixtures,
+} from './verifier.js';
+
+function registerCheckedProvider(name: string, contract: ProviderRuntimeContract, probes?: ProbeFixtures): void {
+  assertProviderRuntimeContractShape(name, contract);
+  probeProviderRuntimeConfiguration(name, contract, probes);
+  registerProvider(name, {
+    create: () => ({
+      registerMemorySessionHook: () => {},
+      query: () => {
+        throw new Error('unused');
+      },
+      isSessionInvalid: () => false,
+    }),
+    contract,
+  });
+}
+
+function emptyContract(): ProviderRuntimeContract {
+  return {
+    seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+    configuration: {
+      executionPolicy: () => ({ boundary: 'container' }),
+      inference: (input) => ({ model: input.model, effort: input.effort }),
+      memory: (input) => ({ command: input.command }),
+      mcpServers: (input) => ({ servers: Object.keys(input) }),
+    },
+    textDelivery: 'result',
+    commands: { formatting: 'xml', nativeAdmin: [], nativeFiltered: [] },
+  };
+}
+
+function contractName(field: string, suffix: string): string {
+  return `runtime-${field}-${suffix}-${process.pid}`.replaceAll(/[^a-z0-9-]/g, '-');
+}
+
+/** Narrow a capability to its function form (the test knows which form the contract declared). */
+function asFunction<I>(capability: Capability<I> | undefined): (input: I, environment: NodeJS.ProcessEnv) => unknown {
+  if (typeof capability !== 'function') throw new Error('expected a function capability');
+  return capability;
+}
+
+function asConstant<I>(capability: Capability<I> | undefined): unknown {
+  if (typeof capability !== 'object') throw new Error('expected a constant capability');
+  return capability.constant;
+}
+
+describe('provider runtime contracts', () => {
+  it('loads the complete Claude implementation from the provider registration', () => {
+    const contract = getProviderRuntimeContract('claude');
+    expect(contract).toBeDefined();
+
+    expect(typeof contract?.configuration.executionPolicy).toBe('object');
+    expect(asConstant(contract?.configuration.executionPolicy)).toBeDefined();
+    expect(typeof contract?.configuration.inference).toBe('function');
+    expect(typeof contract?.configuration.mcpServers).toBe('function');
+    expect(typeof contract?.configuration.memory).toBe('object');
+    expect(asConstant(contract?.configuration.memory)).toEqual({ CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' });
+    expect(typeof contract?.lifecycle?.memorySessionHookRegistration).toBe('function');
+    expect(typeof contract?.history?.readTrace).toBe('function');
+    expect(contract?.history?.afterExchange).toBeUndefined();
+    expect(contract?.textDelivery).toBe('mid-turn-complete');
+    expect(contract?.commands.formatting).toBe('native');
+    expect(contract?.seamVersion).toBe(PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION);
+    expect(hasDeclaredProviderRuntimeContract('CLAUDE')).toBe(true);
+    expect(hasDeclaredProviderRuntimeContract('legacy')).toBe(false);
+  });
+
+  it('resolves Claude execution policy, inference, and MCP config through the contract functions', () => {
+    const contract = getProviderRuntimeContract('claude')!;
+    const policy = asConstant(contract.configuration.executionPolicy) as {
+      permissionMode: string;
+      disallowedTools: string[];
+    };
+    expect(policy.permissionMode).toBe('bypassPermissions');
+    expect(policy.disallowedTools).toContain('AskUserQuestion');
+
+    const inference = asFunction(contract.configuration.inference)(
+      { model: 'opus', effort: 'high', fastMode: true },
+      {},
+    );
+    expect(inference).toEqual({ model: 'opus', effort: 'high', fastMode: true });
+
+    const mcp = asFunction(contract.configuration.mcpServers)({ nanoclaw: { command: 'bun' } }, {}) as {
+      allowedTools: string[];
+    };
+    expect(mcp.allowedTools).toContain('mcp__nanoclaw__*');
+  });
+
+  it('rejects duplicate registrations', () => {
+    const name = `runtime-contract-${process.pid}`;
+    registerCheckedProvider(name, emptyContract());
+    expect(() => registerCheckedProvider(name, emptyContract())).toThrow(/already registered/);
+  });
+
+  it('rejects non-kebab-case provider names', () => {
+    expect(() => registerCheckedProvider('Runtime Bad Name', emptyContract())).toThrow(/kebab-case/);
+  });
+
+  it('rejects mixed-version provider contracts with an operator fix', () => {
+    const contract = emptyContract();
+    contract.seamVersion = 0;
+    expect(() => registerCheckedProvider(contractName('seam-version', 'old'), contract)).toThrow(/run \/update-skills/);
+  });
+
+  it('freezes the stored contract so later mutation attempts throw', () => {
+    const name = `runtime-immutable-${process.pid}`;
+    registerCheckedProvider(name, emptyContract());
+    const stored = getProviderRuntimeContract(name)!;
+    expect(Object.isFrozen(stored)).toBe(true);
+    expect(Object.isFrozen(stored.commands.nativeAdmin!)).toBe(true);
+    expect(() => (stored.commands.nativeAdmin as string[]).push('/later')).toThrow();
+  });
+
+  it('allows omitted and constant optional capabilities', () => {
+    const contract = emptyContract();
+    delete contract.configuration.memory;
+    contract.configuration.mcpServers = { constant: {} };
+    registerCheckedProvider(contractName('configuration-optional', 'valid'), contract);
+  });
+
+  it('rejects declared capabilities that are neither a function nor a constant', () => {
+    const contract = emptyContract();
+    contract.configuration.inference = {} as unknown as Capability<RuntimeInferenceInput>;
+    expect(() => registerCheckedProvider(contractName('configuration-empty', 'invalid'), contract)).toThrow(
+      /configuration\.inference must be a function or \{ constant \}/,
+    );
+  });
+
+  it('rejects a missing execution policy', () => {
+    const contract = emptyContract();
+    delete (contract.configuration as { executionPolicy?: unknown }).executionPolicy;
+    expect(() => registerCheckedProvider(contractName('execution-policy', 'missing'), contract)).toThrow(
+      /configuration\.executionPolicy is required/,
+    );
+  });
+
+  it('rejects a missing configuration block', () => {
+    const missingBlock = emptyContract() as unknown as { configuration?: unknown };
+    delete missingBlock.configuration;
+    expect(() =>
+      registerCheckedProvider(contractName('configuration-block', 'missing'), missingBlock as ProviderRuntimeContract),
+    ).toThrow(/configuration is required/);
+  });
+
+  it('rejects invalid lifecycle and history declarations', () => {
+    expect(() =>
+      registerCheckedProvider(contractName('lifecycle-before-query', 'invalid'), {
+        ...emptyContract(),
+        lifecycle: {
+          beforeQuery: 'bad' as unknown as NonNullable<ProviderRuntimeContract['lifecycle']>['beforeQuery'],
+        },
+      }),
+    ).toThrow(/lifecycle\.beforeQuery must be a function/);
+
+    expect(() =>
+      registerCheckedProvider(contractName('history-after-exchange', 'invalid'), {
+        ...emptyContract(),
+        history: {
+          afterExchange: 'bad' as unknown as NonNullable<ProviderRuntimeContract['history']>['afterExchange'],
+        },
+      }),
+    ).toThrow(/history\.afterExchange must be a function/);
+
+    expect(() =>
+      registerCheckedProvider(contractName('history-read-trace', 'invalid'), {
+        ...emptyContract(),
+        history: {
+          readTrace: 'bad' as unknown as NonNullable<ProviderRuntimeContract['history']>['readTrace'],
+        },
+      }),
+    ).toThrow(/history\.readTrace must be a function/);
+  });
+
+  it('rejects invalid text delivery and command declarations', () => {
+    expect(() =>
+      registerCheckedProvider(contractName('text-delivery', 'invalid'), {
+        ...emptyContract(),
+        textDelivery: 'invalid' as ProviderRuntimeContract['textDelivery'],
+      }),
+    ).toThrow(/textDelivery/);
+
+    expect(() =>
+      registerCheckedProvider(contractName('commands-formatting', 'invalid'), {
+        ...emptyContract(),
+        commands: { formatting: 'invalid' as 'xml', nativeAdmin: [], nativeFiltered: [] },
+      }),
+    ).toThrow(/commands\.formatting/);
+
+    expect(() =>
+      registerCheckedProvider(contractName('commands-native', 'invalid'), {
+        ...emptyContract(),
+        commands: { formatting: 'xml', nativeAdmin: ['bad command'], nativeFiltered: [] },
+      }),
+    ).toThrow(/commands\.nativeAdmin/);
+  });
+
+  describe('configuration probes', () => {
+    it('rejects a function capability that ignores its configuration input', () => {
+      const contract = emptyContract();
+      contract.configuration.inference = () => ({ fixed: true });
+      expect(() => registerCheckedProvider(contractName('probe-insensitive', 'invalid'), contract)).toThrow(
+        /configuration\.inference does not respond to its configuration input/,
+      );
+    });
+
+    it('rejects a function capability that produces no value', () => {
+      const contract = emptyContract();
+      contract.configuration.executionPolicy = () => undefined;
+      expect(() => registerCheckedProvider(contractName('probe-undefined', 'invalid'), contract)).toThrow(
+        /configuration\.executionPolicy must produce a value/,
+      );
+    });
+
+    it('rejects a constant capability with no value', () => {
+      const contract = emptyContract();
+      contract.configuration.inference = { constant: undefined };
+      expect(() => registerCheckedProvider(contractName('constant-undefined', 'invalid'), contract)).toThrow(
+        /configuration\.inference\.constant must be a value/,
+      );
+    });
+
+    it('does not probe a constant capability', () => {
+      const contract = emptyContract();
+      contract.configuration.inference = { constant: { fixed: true } };
+      registerCheckedProvider(contractName('constant-unprobed', 'valid'), contract);
+    });
+
+    it('honors probe fixtures and probe environments passed by the caller', () => {
+      const seenEnvironments: Array<Record<string, string | undefined>> = [];
+      const effortOnly = (input: RuntimeInferenceInput, environment: NodeJS.ProcessEnv): unknown => {
+        seenEnvironments.push({ ...environment });
+        return { effort: input.effort ?? 'none' };
+      };
+
+      const withoutProbes = emptyContract();
+      withoutProbes.configuration.inference = effortOnly;
+      expect(() => registerCheckedProvider(contractName('probe-defaults-miss', 'invalid'), withoutProbes)).toThrow(
+        /configuration\.inference does not respond/,
+      );
+
+      const withProbes = emptyContract();
+      withProbes.configuration.inference = effortOnly;
+      registerCheckedProvider(contractName('probe-defaults-hit', 'valid'), withProbes, {
+        inference: { a: { effort: 'low' }, b: { effort: 'high' }, environment: { NANOCLAW_PROBE: 'set' } },
+      });
+      expect(seenEnvironments.at(-1)?.NANOCLAW_PROBE).toBe('set');
+    });
+  });
+
+  it('runs provider-owned before-query lifecycle callbacks', () => {
+    const name = `runtime-before-query-${process.pid}`;
+    const calls: unknown[] = [];
+    registerCheckedProvider(name, {
+      ...emptyContract(),
+      lifecycle: { beforeQuery: (inputs, context) => calls.push({ inputs, context }) },
+    });
+    const inputs = { inference: { model: 'opus' } };
+    runProviderBeforeQuery(name, inputs, { turn: 1 });
+    expect(calls).toEqual([{ inputs, context: { turn: 1 } }]);
+  });
+
+  it('runs provider-owned after-exchange callbacks', () => {
+    const name = `runtime-after-exchange-${process.pid}`;
+    const calls: unknown[] = [];
+    registerCheckedProvider(name, {
+      ...emptyContract(),
+      history: {
+        afterExchange: (input, fx) => {
+          calls.push({ input, now: fx.now() });
+          return 'exchange.md';
+        },
+      },
+    });
+    expect(runProviderAfterExchange(name, { prompt: 'hello', result: 'world', status: 'completed' })).toBe(
+      'exchange.md',
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  it('reads Claude traces through the provider-owned history callback', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `runtime-trace-home-${process.pid}-`));
+    const home = path.join(root, 'home');
+    const config = path.join(root, 'config');
+    const homeTrace = path.join(home, '.claude', 'projects', 'home-project', 'home.jsonl');
+    const configTrace = path.join(config, 'projects', 'config-project', 'config.jsonl');
+    fs.mkdirSync(path.dirname(homeTrace), { recursive: true });
+    fs.mkdirSync(path.dirname(configTrace), { recursive: true });
+    fs.writeFileSync(homeTrace, '{}\n');
+    fs.writeFileSync(configTrace, '{}\n');
+    const previousConfig = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = config;
+    const homedirSpy = spyOn(os, 'homedir').mockReturnValue(home);
+
+    try {
+      expect(readProviderTrace('claude')).toBe(homeTrace);
+    } finally {
+      homedirSpy.mockRestore();
+      if (previousConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = previousConfig;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/container/agent-runner/src/provider-contracts/registry.ts
+++ b/container/agent-runner/src/provider-contracts/registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Container-runtime provider contracts.
+ *
+ * A contract is an implementation object, not a description: every declared
+ * capability carries the function that implements it, and core calls those
+ * functions at the declared moments.
+ *
+ * Registration itself is a map write. The optional shape checks and behavioral
+ * probes live in verifier code, not in the startup registry path.
+ */
+
+import type { McpServerConfig, ProviderExchange } from '../providers/types.js';
+
+export const PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION = 1;
+
+/** Shared shape of the memory session-hook registration (structural mirror of memory/session-hook.ts). */
+export interface RuntimeMemoryHookInput {
+  readonly command: string;
+  readonly legacyCommands: readonly string[];
+  readonly sources: readonly string[];
+}
+
+/**
+ * The core-owned inference input every provider's inference capability
+ * receives. Core fills it from the group's container config; a provider maps
+ * the fields onto its own SDK options and owns the defaults for any it omits.
+ */
+export interface RuntimeInferenceInput {
+  model?: string;
+  effort?: string;
+  fastMode?: boolean;
+}
+
+/**
+ * Core-owned inputs for each configuration capability that has one.
+ * `executionPolicy` is absent by design: it is a stance, not a function of
+ * anything core varies, so its input is `void`.
+ */
+export interface RuntimeConfigurationInputs {
+  inference: RuntimeInferenceInput;
+  memory: RuntimeMemoryHookInput;
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+/** One shape for every configuration answer: derived from the core-owned input, or a declared constant. */
+export type Capability<I> = ((input: I, environment: NodeJS.ProcessEnv) => unknown) | { constant: unknown };
+
+export interface ProviderRuntimeConfiguration {
+  /** The provider's sandbox/permission stance. Mandatory: it is a fact every provider has. */
+  executionPolicy: Capability<void>;
+  inference?: Capability<RuntimeConfigurationInputs['inference']>;
+  memory?: Capability<RuntimeConfigurationInputs['memory']>;
+  mcpServers?: Capability<RuntimeConfigurationInputs['mcpServers']>;
+}
+
+/**
+ * What core hands a provider after resolving its declared configuration:
+ * core calls each function capability with its input (or takes the declared
+ * constant) at construction time and passes the results to the provider
+ * factory. The fields are `unknown` here because their shape is
+ * provider-private — the provider casts each one to its own return type.
+ * `memory` is absent: it is resolved later, when core registers the memory
+ * session hook, and handed to `registerMemorySessionHook` as its second
+ * argument.
+ */
+export interface ResolvedRuntimeConfiguration {
+  executionPolicy: unknown;
+  inference?: unknown;
+  mcpServers?: unknown;
+}
+
+export interface RuntimeLifecycleCallbacks {
+  /** Provider-owned setup after core registers the shared memory hook. */
+  memorySessionHookRegistration?(hook: RuntimeMemoryHookInput): void;
+  /** Provider-owned setup immediately before starting a query. */
+  beforeQuery?(inputs: Partial<RuntimeConfigurationInputs>, context: unknown): void;
+}
+
+/**
+ * Effects a provider callback is handed instead of reaching for them. Tests
+ * pass a fake clock; production passes the real one.
+ */
+export interface RuntimeCallbackEffects {
+  now(): number;
+}
+
+export interface RuntimeAfterExchangeInput {
+  exchange: ProviderExchange;
+}
+
+export interface RuntimeHistoryCallbacks {
+  /** Provider-owned work after core observes a completed exchange. */
+  afterExchange?(input: RuntimeAfterExchangeInput, fx: RuntimeCallbackEffects): string | null;
+  /** Provider-owned trace lookup for diagnostics (`/upload-trace`). */
+  readTrace?(): string | null;
+}
+
+export interface ProviderRuntimeContract {
+  seamVersion: number;
+  /** Provider-declared configuration surfaces. */
+  configuration: ProviderRuntimeConfiguration;
+  /** Provider-owned lifecycle effects. */
+  lifecycle?: RuntimeLifecycleCallbacks;
+  /** Provider-owned history hooks; core only decides when to invoke them. */
+  history?: RuntimeHistoryCallbacks;
+  textDelivery: 'mid-turn-complete' | 'result';
+  commands: {
+    formatting: 'native' | 'xml';
+    nativeAdmin?: readonly string[];
+    nativeFiltered?: readonly string[];
+  };
+}

--- a/container/agent-runner/src/provider-contracts/testing/conformance.ts
+++ b/container/agent-runner/src/provider-contracts/testing/conformance.ts
@@ -1,0 +1,58 @@
+/**
+ * Reusable runtime-contract conformance suite.
+ *
+ * Every provider — Claude and the test-double mock included — proves its
+ * contract from its own `providers/<name>.conformance.test.ts`:
+ *
+ *   import './index.js';
+ *   import { codexRuntimeContract } from '../provider-contracts/codex.js';
+ *   import { defineProviderConformance } from '../provider-contracts/testing/conformance.js';
+ *   defineProviderConformance('codex', codexRuntimeContract);
+ *
+ * Pass `options.probes` when the default probe fixtures cannot exercise a
+ * function capability (for example an env-gated resolve, or an inference
+ * resolve that ignores `model`). Probe fixtures are provider knowledge and a
+ * test concern, so they travel with the provider's test file and never on the
+ * production contract — which is why core runs no generic sweep over the
+ * registered contracts: it could not know which fixtures a payload needs.
+ * The install-time verifier requires the file for every declared provider.
+ * Mirrors the host's `src/db/testing/driver-conformance.ts` pattern.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { createProvider } from '../../providers/factory.js';
+import { getProviderRuntimeContract } from '../../providers/provider-registry.js';
+import type { ProviderRuntimeContract } from '../registry.js';
+import {
+  assertProviderRuntimeContractShape,
+  probeProviderRuntimeConfiguration,
+  type ProbeFixtures,
+} from '../verifier.js';
+
+export interface ProviderConformanceOptions {
+  probes?: ProbeFixtures;
+}
+
+export function defineProviderConformance(
+  name: string,
+  contract: ProviderRuntimeContract,
+  options: ProviderConformanceOptions = {},
+): void {
+  describe(`runtime provider contract: ${name}`, () => {
+    it('is the contract registered for its provider', () => {
+      expect(getProviderRuntimeContract(name)).toBe(contract);
+    });
+
+    it('matches its provider implementation', () => {
+      expect(() => createProvider(name)).not.toThrow();
+    });
+
+    it('satisfies the contract shape', () => {
+      expect(() => assertProviderRuntimeContractShape(name, contract)).not.toThrow();
+    });
+
+    it('has live configuration capabilities', () => {
+      expect(() => probeProviderRuntimeConfiguration(name, contract, options.probes)).not.toThrow();
+    });
+  });
+}

--- a/container/agent-runner/src/provider-contracts/verifier.ts
+++ b/container/agent-runner/src/provider-contracts/verifier.ts
@@ -1,0 +1,192 @@
+import {
+  PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  type Capability,
+  type ProviderRuntimeContract,
+  type RuntimeConfigurationInputs,
+} from './registry.js';
+
+const INPUT_CAPABILITY_NAMES = ['inference', 'memory', 'mcpServers'] as const;
+type InputCapabilityName = (typeof INPUT_CAPABILITY_NAMES)[number];
+
+/** Two inputs a function capability must answer differently, plus the environment it is probed under. */
+export type ProbeFixture<K extends InputCapabilityName> = {
+  a: RuntimeConfigurationInputs[K];
+  b: RuntimeConfigurationInputs[K];
+  environment?: NodeJS.ProcessEnv;
+};
+
+/** Per-capability probe fixtures; anything omitted falls back to the defaults below. */
+export type ProbeFixtures = { [K in InputCapabilityName]?: ProbeFixture<K> };
+
+/** Default probe fixtures for the input-sensitivity checks. */
+const DEFAULT_PROBES: { [K in InputCapabilityName]: ProbeFixture<K> } = {
+  inference: { a: { model: 'nanoclaw-probe-model-a' }, b: { model: 'nanoclaw-probe-model-b' } },
+  memory: {
+    a: { command: 'nanoclaw-probe-hook-a', legacyCommands: [], sources: ['startup'] },
+    b: { command: 'nanoclaw-probe-hook-b', legacyCommands: [], sources: ['startup'] },
+  },
+  mcpServers: {
+    a: {},
+    b: { 'nanoclaw-probe-server': { command: 'nanoclaw-probe-command' } },
+  },
+};
+
+/** Shape check for one contract. Run by tests and install-time verification, not startup. */
+export function assertProviderRuntimeContractShape(name: string, contract: ProviderRuntimeContract): void {
+  validateContract(providerKey(name), contract);
+}
+
+/**
+ * Behavioral probes for one contract. Run by tests and install-time
+ * verification, not startup. `probes` replaces the default fixtures for the
+ * capabilities it names (e.g. when a resolve is env-gated and the defaults
+ * cannot exercise it).
+ */
+export function probeProviderRuntimeConfiguration(
+  name: string,
+  contract: ProviderRuntimeContract,
+  probes: ProbeFixtures = {},
+): void {
+  probeConfiguration(providerKey(name), contract, probes);
+}
+
+function validateContract(provider: string, contract: ProviderRuntimeContract): void {
+  if (contract.seamVersion !== PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION) {
+    throw new Error(
+      `${provider}.seamVersion ${String(contract.seamVersion)} is incompatible with runtime seam ${PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION}; run /update-skills`,
+    );
+  }
+  if (contract.configuration === null || typeof contract.configuration !== 'object') {
+    throw new Error(`${provider}.configuration is required`);
+  }
+  const policyField = `${provider}.configuration.executionPolicy`;
+  if (contract.configuration.executionPolicy === undefined) throw new Error(`${policyField} is required`);
+  assertCapability(contract.configuration.executionPolicy, policyField);
+
+  for (const capability of INPUT_CAPABILITY_NAMES) {
+    const implementation = contract.configuration[capability];
+    if (implementation === undefined) continue;
+    assertCapability(implementation, `${provider}.configuration.${capability}`);
+  }
+
+  if (contract.lifecycle !== undefined) {
+    if (contract.lifecycle === null || typeof contract.lifecycle !== 'object') {
+      throw new Error(`${provider}.lifecycle must be an object`);
+    }
+    if (contract.lifecycle.memorySessionHookRegistration !== undefined) {
+      requireFunction(
+        contract.lifecycle.memorySessionHookRegistration,
+        `${provider}.lifecycle.memorySessionHookRegistration`,
+      );
+    }
+    if (contract.lifecycle.beforeQuery !== undefined) {
+      requireFunction(contract.lifecycle.beforeQuery, `${provider}.lifecycle.beforeQuery`);
+    }
+  }
+
+  if (contract.history !== undefined) {
+    if (contract.history === null || typeof contract.history !== 'object') {
+      throw new Error(`${provider}.history must be an object`);
+    }
+    if (contract.history.afterExchange !== undefined) {
+      requireFunction(contract.history.afterExchange, `${provider}.history.afterExchange`);
+    }
+    if (contract.history.readTrace !== undefined) {
+      requireFunction(contract.history.readTrace, `${provider}.history.readTrace`);
+    }
+  }
+
+  assertAllowed(contract.textDelivery, ['mid-turn-complete', 'result'], `${provider}.textDelivery`);
+  assertAllowed(contract.commands?.formatting, ['native', 'xml'], `${provider}.commands.formatting`);
+  assertCommandArray(contract.commands?.nativeAdmin, `${provider}.commands.nativeAdmin`);
+  assertCommandArray(contract.commands?.nativeFiltered, `${provider}.commands.nativeFiltered`);
+  unique(contract.commands?.nativeAdmin ?? [], `${provider}.commands.nativeAdmin`);
+  unique(contract.commands?.nativeFiltered ?? [], `${provider}.commands.nativeFiltered`);
+}
+
+/** A capability is a function of its input or a `{ constant }` — nothing else. */
+function assertCapability(value: unknown, field: string): void {
+  if (typeof value === 'function') return;
+  if (value === null || typeof value !== 'object' || !('constant' in value)) {
+    throw new Error(`${field} must be a function or { constant }`);
+  }
+  if ((value as { constant: unknown }).constant === undefined) {
+    throw new Error(`${field}.constant must be a value`);
+  }
+}
+
+function probeConfiguration(provider: string, contract: ProviderRuntimeContract, probes: ProbeFixtures): void {
+  const policy = contract.configuration.executionPolicy;
+  const policyField = `${provider}.configuration.executionPolicy`;
+  if (typeof policy === 'function' && policy(undefined, {}) === undefined) {
+    throw new Error(`${policyField} must produce a value`);
+  }
+
+  for (const capability of INPUT_CAPABILITY_NAMES) {
+    const field = `${provider}.configuration.${capability}`;
+    const implementation = contract.configuration[capability] as
+      | Capability<RuntimeConfigurationInputs[typeof capability]>
+      | undefined;
+    // A declared constant has nothing to respond to; only functions are probed.
+    if (implementation === undefined || typeof implementation !== 'function') continue;
+    const fixture = (probes[capability] ?? DEFAULT_PROBES[capability]) as ProbeFixture<typeof capability>;
+    const environment = fixture.environment ?? {};
+    const resolvedA = implementation(fixture.a as never, environment);
+    if (resolvedA === undefined) {
+      throw new Error(`${field} must produce a value for the probe input`);
+    }
+
+    const resolvedB = implementation(fixture.b as never, environment);
+    if (stableStringify(resolvedA) === stableStringify(resolvedB)) {
+      throw new Error(`${field} does not respond to its configuration input`);
+    }
+  }
+}
+
+function providerKey(name: string): string {
+  const key = name.toLowerCase();
+  if (name !== key || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    throw new Error(`Provider runtime contract name must be lowercase kebab-case: '${name}'`);
+  }
+  return key;
+}
+
+function requireFunction(value: unknown, field: string): void {
+  if (typeof value !== 'function') throw new Error(`${field} must be a function`);
+}
+
+function assertAllowed(value: unknown, allowed: readonly unknown[], field: string): void {
+  if (!allowed.includes(value)) {
+    throw new Error(`${field} must be one of ${allowed.map((entry) => `'${String(entry)}'`).join(', ')}`);
+  }
+}
+
+function unique(values: readonly string[], field: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) throw new Error(`${field} must be unique; duplicate '${value}'`);
+    seen.add(value);
+  }
+}
+
+function assertCommandArray(value: unknown, field: string): asserts value is readonly string[] {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  for (const command of value) {
+    if (typeof command !== 'string' || !/^\/[a-z0-9-]+$/.test(command)) {
+      throw new Error(`${field} contains invalid command '${String(command)}'`);
+    }
+  }
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, entry) => {
+    if (typeof entry === 'function') return '[function]';
+    if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+      return Object.fromEntries(
+        Object.entries(entry).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
+      );
+    }
+    return entry;
+  });
+}

--- a/container/agent-runner/src/providers/claude-config.ts
+++ b/container/agent-runner/src/providers/claude-config.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure configuration derivations for the Claude provider. These are the
+ * provider-runtime implementations the runtime contract declares for the
+ * executionPolicy / inference / mcpServers / memory capabilities — and the
+ * exact functions the live query path consumes, so the contract's probe
+ * exercises the real wiring, not a parallel description of it.
+ */
+
+import type { RuntimeInferenceInput } from '../provider-contracts/registry.js';
+import { shimCwd } from './cwd-shim.js';
+import type { McpServerConfig } from './types.js';
+
+// Deferred SDK builtins that either sidestep nanoclaw's own scheduling or
+// don't fit our async message-passing model (they're designed for Claude
+// Code's interactive UI and would hang here).
+//
+// - CronCreate / CronDelete / CronList / ScheduleWakeup: we have durable
+//   scheduling via `ncl tasks`.
+// - AskUserQuestion: SDK returns a placeholder instead of blocking on a
+//   real answer — we have mcp__nanoclaw__ask_user_question that persists
+//   the question and blocks on the real reply.
+// - SendMessage: addresses Claude Code's own in-session subagents, which are
+//   unrelated to NanoClaw agent groups — but the name reads as the obvious
+//   way to message another agent, so an agent that just called
+//   mcp__nanoclaw__create_agent reaches for it and gets "No agent named 'x'
+//   is currently addressable". mcp__nanoclaw__send_message is the real
+//   agent-to-agent path (it resolves the destination map in inbound.db).
+// - EnterPlanMode / ExitPlanMode / EnterWorktree / ExitWorktree: Claude
+//   Code UI affordances; in a headless container they'd appear stuck.
+// - DesignSync: desktop design-tool integration — nothing to sync with in a
+//   headless container (~9.3KB/turn schema).
+// - ReportFindings: code-review-reporting UI affordance with no headless
+//   host surface to receive it (~1.9KB/turn schema).
+export const SDK_DISALLOWED_TOOLS = [
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'ScheduleWakeup',
+  'AskUserQuestion',
+  'SendMessage',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'EnterWorktree',
+  'ExitWorktree',
+  'DesignSync',
+  'ReportFindings',
+];
+
+// Tool allowlist for NanoClaw agent containers. MCP-tool entries are derived
+// from the registered `mcpServers` map so that any server added via
+// `add_mcp_server` (or wired in container.json directly) is reachable to the
+// agent — without this, the SDK's allowedTools filter silently drops every
+// MCP namespace not listed here.
+export const TOOL_ALLOWLIST = [
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+  'Task',
+  'TaskOutput',
+  'TaskStop',
+  'TeamCreate',
+  'TeamDelete',
+  'TodoWrite',
+  'ToolSearch',
+  'Skill',
+  'NotebookEdit',
+];
+
+// MCP server names are sanitized by the SDK when forming tool prefixes:
+// any character outside [A-Za-z0-9_-] becomes '_'. Mirror that here so our
+// allowlist patterns match what the SDK actually exposes.
+export function mcpAllowPattern(serverName: string): string {
+  return `mcp__${serverName.replace(/[^a-zA-Z0-9_-]/g, '_')}__*`;
+}
+
+/**
+ * Claude runs unrestricted inside the container: NanoClaw's container
+ * isolation and the OneCLI allow-list are the security boundary, not the
+ * SDK's own permission prompts. The disallowed builtins are policy too —
+ * they are the SDK surfaces that would bypass nanoclaw's scheduling or hang
+ * a headless session.
+ */
+export function resolveClaudeExecutionPolicy(): {
+  permissionMode: 'bypassPermissions';
+  allowDangerouslySkipPermissions: true;
+  disallowedTools: string[];
+} {
+  return {
+    permissionMode: 'bypassPermissions',
+    allowDangerouslySkipPermissions: true,
+    // A copy: the contract value is deep-frozen on registration, and the
+    // exported constant must stay a plain mutable array.
+    disallowedTools: [...SDK_DISALLOWED_TOOLS],
+  };
+}
+
+/** Model, reasoning effort, and fast mode pass through; the SDK owns defaults. */
+export function resolveClaudeInference(
+  input: RuntimeInferenceInput,
+  _environment: NodeJS.ProcessEnv,
+): { model?: string; effort?: string; fastMode?: boolean } {
+  return { model: input.model, effort: input.effort, fastMode: input.fastMode };
+}
+
+/**
+ * The SDK's stdio server config has no cwd field, so stdio servers with a
+ * cwd are wrapped through the shell shim; the allowlist gains one pattern
+ * per server so the SDK's tool filter doesn't drop their namespaces.
+ */
+export function resolveClaudeMcpServers(
+  input: Record<string, McpServerConfig>,
+  _environment: NodeJS.ProcessEnv,
+): { mcpServers: Record<string, McpServerConfig>; allowedTools: string[] } {
+  const mcpServers = Object.fromEntries(Object.entries(input).map(([name, server]) => [name, shimCwd(server)]));
+  return {
+    mcpServers,
+    allowedTools: [...TOOL_ALLOWLIST, ...Object.keys(mcpServers).map(mcpAllowPattern)],
+  };
+}
+
+/**
+ * NanoClaw owns persistent memory across providers: the session hook injects
+ * the shared memory tree, and the SDK's own auto-memory stays disabled so the
+ * two never diverge. The hook itself is file-carried (settings.json); this is
+ * the runtime half of the same capability.
+ */
+export function resolveClaudeMemoryRuntime(): { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' } {
+  return { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' };
+}

--- a/container/agent-runner/src/providers/claude-history.test.ts
+++ b/container/agent-runner/src/providers/claude-history.test.ts
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'bun:test';
+
+import { TIMEZONE, formatLocalStamp } from '../timezone.js';
+import { archiveClaudeTranscript, type ClaudeHistoryClock } from './claude-history.js';
+
+// The pre-compact archive is Claude-internal: the PreCompact hook calls it
+// with the real clock. These pin what a reader can observe — the archive
+// name, its local date, and the log lines — under a fixed clock.
+
+const REAL_CLOCK: ClaudeHistoryClock = { now: () => Date.now() };
+
+function fixedClock(ms: number): ClaudeHistoryClock {
+  return { now: () => ms };
+}
+
+describe('archiveClaudeTranscript', () => {
+  it('archives a transcript into the conversations directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `runtime-transcript-${process.pid}-`));
+    const transcriptPath = path.join(root, 'transcript.jsonl');
+    const conversationsDir = path.join(root, 'conversations');
+    const previous = process.env.NANOCLAW_CONVERSATIONS_DIR;
+    process.env.NANOCLAW_CONVERSATIONS_DIR = conversationsDir;
+    fs.writeFileSync(transcriptPath, '{"type":"user","message":{"content":"hello"}}\n');
+
+    try {
+      const clockMs = Date.parse('2027-02-03T23:59:59.900Z');
+      const clockDate = new Date(clockMs);
+      const logs: string[] = [];
+      expect(
+        archiveClaudeTranscript(
+          { transcriptPath, sessionId: 'session', assistantName: 'Claude', log: (line) => logs.push(line) },
+          fixedClock(clockMs),
+        ),
+      ).toBe(true);
+      const [archive] = fs.readdirSync(conversationsDir);
+      const time = `${clockDate.getHours().toString().padStart(2, '0')}${clockDate
+        .getMinutes()
+        .toString()
+        .padStart(2, '0')}`;
+      expect(archive).toBe(`${formatLocalStamp(clockDate, TIMEZONE).slice(0, 10)}-conversation-${time}.md`);
+      expect(fs.readFileSync(path.join(conversationsDir, archive), 'utf-8')).toContain('**User**: hello');
+      expect(logs[0]).toContain('Archived conversation to');
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_CONVERSATIONS_DIR;
+      else process.env.NANOCLAW_CONVERSATIONS_DIR = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps empty transcripts a no-op before reading the optional sessions index', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `runtime-transcript-noop-${process.pid}-`));
+    const transcriptPath = path.join(root, 'empty.jsonl');
+    const conversationsDir = path.join(root, 'conversations');
+    const previous = process.env.NANOCLAW_CONVERSATIONS_DIR;
+    process.env.NANOCLAW_CONVERSATIONS_DIR = conversationsDir;
+    fs.writeFileSync(transcriptPath, '');
+
+    try {
+      fs.mkdirSync(path.join(root, 'sessions-index.json'));
+      const logs: string[] = [];
+      expect(
+        archiveClaudeTranscript({ transcriptPath, sessionId: 'empty', log: (line) => logs.push(line) }, REAL_CLOCK),
+      ).toBe(false);
+      expect(logs).toEqual([]);
+      expect(fs.existsSync(conversationsDir)).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_CONVERSATIONS_DIR;
+      else process.env.NANOCLAW_CONVERSATIONS_DIR = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a failed archive write instead of throwing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `runtime-transcript-blocked-${process.pid}-`));
+    const transcriptPath = path.join(root, 'transcript.jsonl');
+    const conversationsDir = path.join(root, 'not-a-directory');
+    const previous = process.env.NANOCLAW_CONVERSATIONS_DIR;
+    process.env.NANOCLAW_CONVERSATIONS_DIR = conversationsDir;
+    fs.writeFileSync(transcriptPath, '{"type":"user","message":{"content":"hello"}}\n');
+    fs.writeFileSync(conversationsDir, 'blocked');
+
+    try {
+      const logs: string[] = [];
+      expect(
+        archiveClaudeTranscript({ transcriptPath, sessionId: 'session', log: (line) => logs.push(line) }, REAL_CLOCK),
+      ).toBe(false);
+      expect(logs[0]).toContain('Failed to archive transcript:');
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_CONVERSATIONS_DIR;
+      else process.env.NANOCLAW_CONVERSATIONS_DIR = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/container/agent-runner/src/providers/claude-history.ts
+++ b/container/agent-runner/src/providers/claude-history.ts
@@ -1,0 +1,330 @@
+/**
+ * Claude-owned transcript history: the pre-compact archive, continuation
+ * rotation, and the newest-trace lookup. All of it reads the Claude Agent
+ * SDK's on-disk `.jsonl` transcripts, so it belongs to this provider and is
+ * not part of the runtime contract — ClaudeProvider calls the archive from its
+ * PreCompact hook and the rotation from `maybeRotateContinuation`; only
+ * `newestClaudeTranscript` is declared on the contract (`history.readTrace`).
+ *
+ * The functions take a clock instead of reading `Date.now()` themselves so
+ * tests can pin the archive name and header.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { TIMEZONE, formatLocalStamp } from '../timezone.js';
+
+export interface ClaudeHistoryClock {
+  now(): number;
+}
+
+export interface ClaudeArchiveInput {
+  transcriptPath?: string;
+  sessionId?: string;
+  assistantName?: string;
+  log(message: string): void;
+}
+
+export interface ClaudeContinuationRotationInput {
+  continuation: string;
+  assistantName?: string;
+  log(message: string): void;
+}
+
+interface ClaudeArchivePlan {
+  relativePath: string;
+  content: string;
+  write: 'replace' | 'append';
+  headerIfNew?: string;
+}
+
+interface ClaudeContinuationRotationDecision {
+  reason?: string;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** `CLAUDE_CONFIG_DIR` or `~/.claude`: where the SDK keeps settings.json and project transcripts. */
+export function claudeConfigDirectory(): string {
+  return process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME || os.homedir(), '.claude');
+}
+
+/** The newest SDK transcript under `~/.claude/projects`, for `/upload-trace`. */
+export function newestClaudeTranscript(): string | null {
+  const projects = path.join(os.homedir(), '.claude', 'projects');
+  let best: { path: string; mtimeMs: number } | null = null;
+  let dirs: string[];
+  try {
+    dirs = fs.readdirSync(projects);
+  } catch {
+    return null;
+  }
+  for (const dir of dirs) {
+    let files: string[];
+    try {
+      files = fs.readdirSync(path.join(projects, dir));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const candidate = path.join(projects, dir, file);
+      const mtimeMs = fs.statSync(candidate).mtimeMs;
+      if (!best || mtimeMs > best.mtimeMs) best = { path: candidate, mtimeMs };
+    }
+  }
+  return best?.path ?? null;
+}
+
+/** Archive a transcript as markdown into the conversations directory. Never throws. */
+export function archiveClaudeTranscript(input: ClaudeArchiveInput, fx: ClaudeHistoryClock): boolean {
+  if (!input.transcriptPath || !fs.existsSync(input.transcriptPath)) {
+    input.log('No transcript found for archiving');
+    return false;
+  }
+
+  try {
+    const transcriptContent = fs.readFileSync(input.transcriptPath, 'utf-8');
+    const indexPath = path.join(path.dirname(input.transcriptPath), 'sessions-index.json');
+    let sessionsIndexContent: string | undefined;
+    if (fs.existsSync(indexPath)) {
+      try {
+        sessionsIndexContent = fs.readFileSync(indexPath, 'utf-8');
+      } catch {
+        // Existing behavior ignores unreadable session indexes.
+      }
+    }
+    const plan = planTranscriptArchive(
+      { transcriptContent, sessionsIndexContent, sessionId: input.sessionId, assistantName: input.assistantName },
+      fx,
+    );
+    if (!plan) return false;
+
+    const conversationsDir = process.env.NANOCLAW_CONVERSATIONS_DIR || '/workspace/agent/conversations';
+    const target = resolveContainedPath(conversationsDir, plan.relativePath, 'Archive planner returned unsafe path');
+    fs.mkdirSync(conversationsDir, { recursive: true });
+    writeArchivePlan(target, plan);
+    input.log(`Archived conversation to ${plan.relativePath}`);
+    return true;
+  } catch (error) {
+    input.log(`Failed to archive transcript: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+
+function planTranscriptArchive(
+  input: {
+    transcriptContent: string;
+    sessionsIndexContent?: string;
+    sessionId?: string;
+    assistantName?: string;
+  },
+  fx: ClaudeHistoryClock,
+): ClaudeArchivePlan | null {
+  const messages = parseTranscript(input.transcriptContent);
+  if (messages.length === 0) return null;
+
+  let summary: string | undefined;
+  if (input.sessionsIndexContent) {
+    try {
+      const index = JSON.parse(input.sessionsIndexContent);
+      summary = index.entries?.find(
+        (entry: { sessionId: string; summary?: string }) => entry.sessionId === input.sessionId,
+      )?.summary;
+    } catch {
+      // Existing behavior ignores malformed session indexes.
+    }
+  }
+
+  const name = summary
+    ? summary
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 50)
+    : `conversation-${new Date(fx.now()).getHours().toString().padStart(2, '0')}${new Date(fx.now())
+        .getMinutes()
+        .toString()
+        .padStart(2, '0')}`;
+  const filenameDate = new Date(fx.now());
+  const headerDate = new Date(fx.now());
+  return {
+    relativePath: `${formatLocalStamp(filenameDate, TIMEZONE).slice(0, 10)}-${name}.md`,
+    content: formatTranscriptMarkdown(messages, summary, input.assistantName, headerDate),
+    write: 'replace',
+  };
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content.map((part: { text?: string }) => part.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const text = entry.message.content
+          .filter((part: { type: string }) => part.type === 'text')
+          .map((part: { text: string }) => part.text)
+          .join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+      // Existing behavior skips malformed transcript lines.
+    }
+  }
+  return messages;
+}
+
+function formatTranscriptMarkdown(
+  messages: ParsedMessage[],
+  title: string | undefined,
+  assistantName: string | undefined,
+  now: Date,
+): string {
+  const date = now.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  const lines = [`# ${title || 'Conversation'}`, '', `Archived: ${date}`, '', '---', ''];
+  for (const message of messages) {
+    const sender = message.role === 'user' ? 'User' : assistantName || 'Assistant';
+    const content = message.content.length > 2000 ? `${message.content.slice(0, 2000)}...` : message.content;
+    lines.push(`**${sender}**: ${content}`, '');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Before resuming, drop a transcript that has grown too large or too old to
+ * cold-resume within the host's idle ceiling. Archives what it can, moves the
+ * `.jsonl` aside, and returns the reason; null keeps resuming.
+ */
+export function rotateClaudeContinuation(
+  input: ClaudeContinuationRotationInput,
+  fx: ClaudeHistoryClock,
+): string | null {
+  const transcriptPath = findContinuationFile(
+    path.join(claudeConfigDirectory(), 'projects'),
+    `${input.continuation}.jsonl`,
+  );
+  if (!transcriptPath) return null;
+
+  try {
+    const size = fs.statSync(transcriptPath).size;
+    let firstLine = '';
+    try {
+      firstLine = readFirstLine(transcriptPath);
+    } catch {
+      // Size-only rotation must survive an unreadable first entry.
+    }
+    const decision = decideContinuationRotation({ size, firstLine }, fx);
+    if (!decision?.reason) return null;
+
+    archiveClaudeTranscript(
+      {
+        transcriptPath,
+        sessionId: input.continuation,
+        assistantName: input.assistantName,
+        log: input.log,
+      },
+      fx,
+    );
+    try {
+      fs.renameSync(transcriptPath, `${transcriptPath}.rotated-${fx.now()}`);
+    } catch (error) {
+      input.log(`Failed to move rotated transcript aside: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    return decision.reason;
+  } catch {
+    return null;
+  }
+}
+
+function decideContinuationRotation(
+  input: { size: number; firstLine: string },
+  fx: ClaudeHistoryClock,
+): ClaudeContinuationRotationDecision | null {
+  const maxBytes = Number(process.env.CLAUDE_TRANSCRIPT_ROTATE_BYTES) || 12 * 1024 * 1024;
+  const rawDays = process.env.CLAUDE_TRANSCRIPT_ROTATE_AGE_DAYS;
+  const days = rawDays === undefined || rawDays.trim() === '' ? 14 : Number(rawDays);
+  const maxAgeMs = !Number.isFinite(days) ? 14 * 86_400_000 : days > 0 ? days * 86_400_000 : Infinity;
+  let startMs: number | null = null;
+  try {
+    const timestamp = JSON.parse(input.firstLine)?.timestamp;
+    const parsed = timestamp ? Date.parse(timestamp) : NaN;
+    if (!Number.isNaN(parsed)) startMs = parsed;
+  } catch {
+    // Existing behavior ignores unreadable first entries.
+  }
+
+  const ageMs = startMs === null ? 0 : fx.now() - startMs;
+  if (input.size > maxBytes) {
+    return {
+      reason: `transcript ${(input.size / 1_048_576).toFixed(1)}MB > ${(maxBytes / 1_048_576).toFixed(0)}MB cap`,
+    };
+  }
+  if (startMs !== null && ageMs > maxAgeMs) {
+    return {
+      reason: `transcript ${(ageMs / 86_400_000).toFixed(1)}d old > ${(maxAgeMs / 86_400_000).toFixed(0)}d cap`,
+    };
+  }
+  return null;
+}
+
+function findContinuationFile(root: string, fileName: string): string | null {
+  let directories: string[];
+  try {
+    directories = fs.readdirSync(root);
+  } catch {
+    return null;
+  }
+  for (const directory of directories) {
+    const candidate = path.join(root, directory, fileName);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function readFirstLine(filePath: string): string {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(4096);
+    const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.toString('utf-8', 0, bytes).split('\n', 1)[0];
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function writeArchivePlan(filePath: string, plan: ClaudeArchivePlan): void {
+  if (plan.write === 'replace') {
+    fs.writeFileSync(filePath, plan.content);
+    return;
+  }
+  const header = plan.headerIfNew && !fs.existsSync(filePath) ? plan.headerIfNew : '';
+  fs.appendFileSync(filePath, `${header}${plan.content}`);
+}
+
+function resolveContainedPath(root: string, relativePath: string, errorPrefix: string): string {
+  const resolvedRoot = path.resolve(root);
+  const target = path.resolve(resolvedRoot, relativePath);
+  const relative = path.relative(resolvedRoot, target);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${errorPrefix} '${relativePath}'`);
+  }
+  return target;
+}

--- a/container/agent-runner/src/providers/claude.allowed-tools.test.ts
+++ b/container/agent-runner/src/providers/claude.allowed-tools.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+const allowedToolsCalls: string[][] = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: ({ options }: { options: { allowedTools: string[] } }) => {
+    allowedToolsCalls.push(options.allowedTools);
+    return (async function* () {
+      yield { type: 'result', subtype: 'success', result: 'ok' };
+    })();
+  },
+}));
+
+const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
+await import('./index.js');
+await import('../provider-contracts/index.js');
+const { createProvider } = await import('./factory.js');
+
+describe('Claude allowed tools', () => {
+  it('passes a fresh array to every SDK query', () => {
+    allowedToolsCalls.length = 0;
+    const provider = createProvider('claude', {
+      mcpServers: { 'custom.server': { command: 'custom-server' } },
+    });
+    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+
+    provider.query({ prompt: 'first', cwd: '/workspace/agent' });
+    allowedToolsCalls[0]!.push('mutated-by-sdk');
+    provider.query({ prompt: 'second', cwd: '/workspace/agent' });
+
+    expect(allowedToolsCalls).toHaveLength(2);
+    expect(allowedToolsCalls[1]).not.toBe(allowedToolsCalls[0]);
+    expect(allowedToolsCalls[1]).not.toContain('mutated-by-sdk');
+    expect(allowedToolsCalls[1]).toContain('mcp__custom_server__*');
+  });
+});

--- a/container/agent-runner/src/providers/claude.compact-boundary.test.ts
+++ b/container/agent-runner/src/providers/claude.compact-boundary.test.ts
@@ -19,7 +19,9 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
     })(),
 }));
 
-const { ClaudeProvider } = await import('./claude.js');
+await import('./index.js');
+await import('../provider-contracts/index.js');
+const { createProvider } = await import('./factory.js');
 const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
 
 let tmp: string;
@@ -46,7 +48,7 @@ describe('compact_boundary translation', () => {
       { type: 'result', subtype: 'success', result: '<message to="user">hello</message>' },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 

--- a/container/agent-runner/src/providers/claude.conformance.test.ts
+++ b/container/agent-runner/src/providers/claude.conformance.test.ts
@@ -1,0 +1,9 @@
+// Conformance for the Claude runtime contract. Every provider proves its
+// contract from its own `providers/<name>.conformance.test.ts` — the probe
+// fixtures a contract needs are provider knowledge, so core runs no generic
+// sweep over registered contracts. Claude uses the default probes.
+import './index.js';
+import { claudeRuntimeContract } from '../provider-contracts/claude.js';
+import { defineProviderConformance } from '../provider-contracts/testing/conformance.js';
+
+defineProviderConformance('claude', claudeRuntimeContract);

--- a/container/agent-runner/src/providers/claude.fast-mode.test.ts
+++ b/container/agent-runner/src/providers/claude.fast-mode.test.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import type { ProviderOptions } from './types.js';
+
 // `fastMode` is a Settings member, not a query option, so the provider has to
 // hand it to the SDK through `options.settings`. The failure this pins is the
 // quiet one: passing it as a bare option typechecks nowhere and would simply
@@ -23,7 +25,9 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
   },
 }));
 
-const { ClaudeProvider } = await import('./claude.js');
+await import('./index.js');
+await import('../provider-contracts/index.js');
+const { createProvider } = await import('./factory.js');
 const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
 
 let tmp: string;
@@ -42,8 +46,8 @@ afterEach(() => {
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-async function drive(options: ConstructorParameters<typeof ClaudeProvider>[0]): Promise<void> {
-  const provider = new ClaudeProvider(options);
+async function drive(options: ProviderOptions): Promise<void> {
+  const provider = createProvider('claude', options);
   provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
   const q = provider.query({ prompt: 'hi', cwd: tmp });
   for await (const _ of q.events) {

--- a/container/agent-runner/src/providers/claude.memory-hook.test.ts
+++ b/container/agent-runner/src/providers/claude.memory-hook.test.ts
@@ -4,7 +4,10 @@ import os from 'os';
 import path from 'path';
 
 import { MEMORY_SESSION_HOOK } from '../memory/session-hook.js';
-import { ClaudeProvider } from './claude.js';
+import './index.js';
+import '../provider-contracts/index.js';
+import { registerProviderMemorySessionHook } from '../provider-contracts/realize.js';
+import { createProvider } from './factory.js';
 
 let configDir: string;
 let previousConfigDir: string | undefined;
@@ -44,9 +47,9 @@ describe('Claude memory SessionStart registration', () => {
       }),
     );
 
-    const provider = new ClaudeProvider();
-    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
-    provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+    const provider = createProvider('claude');
+    registerProviderMemorySessionHook('claude', provider, MEMORY_SESSION_HOOK);
+    registerProviderMemorySessionHook('claude', provider, MEMORY_SESSION_HOOK);
 
     const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
     expect(settings.customValue).toBe('preserved');

--- a/container/agent-runner/src/providers/claude.midturn-text.test.ts
+++ b/container/agent-runner/src/providers/claude.midturn-text.test.ts
@@ -19,7 +19,10 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
     })(),
 }));
 
-const { ClaudeProvider } = await import('./claude.js');
+await import('./index.js');
+await import('../provider-contracts/index.js');
+const { createProvider } = await import('./factory.js');
+const { claudeRuntimeContract } = await import('../provider-contracts/claude.js');
 const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
 
 let tmp: string;
@@ -38,8 +41,8 @@ afterEach(() => {
 });
 
 describe('assistant text block surfacing', () => {
-  it('declares the emitsMidTurnText capability the poll-loop keys one-door delivery on', () => {
-    expect(new ClaudeProvider({}).emitsMidTurnText).toBe(true);
+  it('declares mid-turn delivery in the runtime contract', () => {
+    expect(claudeRuntimeContract.textDelivery).toBe('mid-turn-complete');
   });
 
   it('yields one text event per assistant message with text, before the result', async () => {
@@ -60,7 +63,7 @@ describe('assistant text block surfacing', () => {
       { type: 'result', subtype: 'success', result: 'final text' },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 
@@ -85,7 +88,7 @@ describe('assistant text block surfacing', () => {
       { type: 'result', subtype: 'success', result: 'done' },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 
@@ -115,7 +118,7 @@ describe('assistant text block surfacing', () => {
       { type: 'result', subtype: 'success', result: '<message to="user">The answer is 4.</message>' },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 
@@ -136,7 +139,7 @@ describe('assistant text block surfacing', () => {
       { type: 'result', subtype: 'success', result: 'closed here</message>' },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 
@@ -163,7 +166,7 @@ describe('result text is an independent SDK field (divergence surface)', () => {
       { type: 'result', subtype: 'success', result: '<message to="user">only in the result field</message>' },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 
@@ -183,7 +186,7 @@ describe('result text is an independent SDK field (divergence surface)', () => {
       { type: 'result', subtype: 'error_during_execution', is_error: true, errors: ['billing hard-stop'] },
     );
 
-    const provider = new ClaudeProvider({});
+    const provider = createProvider('claude');
     provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
     const q = provider.query({ prompt: 'hi', cwd: tmp });
 

--- a/container/agent-runner/src/providers/claude.recorded.test.ts
+++ b/container/agent-runner/src/providers/claude.recorded.test.ts
@@ -31,7 +31,9 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
     })(),
 }));
 
-const { ClaudeProvider } = await import('./claude.js');
+await import('./index.js');
+await import('../provider-contracts/index.js');
+const { createProvider } = await import('./factory.js');
 const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
 
 type Fixture = { gist: string; messages: unknown[] };
@@ -80,7 +82,7 @@ function load(id: string): void {
 
 async function providerEvents(id: string): Promise<Array<{ type: string; text?: string | null }>> {
   load(id);
-  const provider = new ClaudeProvider({});
+  const provider = createProvider('claude');
   provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
   const q = provider.query({ prompt: 'hi', cwd: tmp });
   const events: Array<{ type: string; text?: string | null }> = [];
@@ -90,7 +92,7 @@ async function providerEvents(id: string): Promise<Array<{ type: string; text?: 
 
 async function runThroughPollLoop(id: string): Promise<{ delivered: string[]; pushes: string[] }> {
   load(id);
-  const provider = new ClaudeProvider({});
+  const provider = createProvider('claude');
   provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
   const query = provider.query({ prompt: 'hi', cwd: tmp });
   const pushes: string[] = [];

--- a/container/agent-runner/src/providers/claude.rotate.test.ts
+++ b/container/agent-runner/src/providers/claude.rotate.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { ClaudeProvider } from './claude.js';
+import './index.js';
+import '../provider-contracts/index.js';
+import { createProvider } from './factory.js';
 
 // maybeRotateContinuation guards the cold-resume failure mode: a long-lived
 // session whose on-disk transcript has grown so large (or old) that the SDK
@@ -45,7 +47,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  const restore = (k: string, v: string | undefined) => (v === undefined ? delete process.env[k] : (process.env[k] = v));
+  const restore = (k: string, v: string | undefined) =>
+    v === undefined ? delete process.env[k] : (process.env[k] = v);
   restore('HOME', prevHome);
   restore('NANOCLAW_CONVERSATIONS_DIR', prevConv);
   restore('CLAUDE_TRANSCRIPT_ROTATE_BYTES', prevBytes);
@@ -53,24 +56,66 @@ afterEach(() => {
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-describe('ClaudeProvider.maybeRotateContinuation', () => {
+describe('claude maybeRotateContinuation', () => {
   it('keeps a small, recent transcript (returns null, leaves file in place)', () => {
     process.env.CLAUDE_TRANSCRIPT_ROTATE_BYTES = String(1024 * 1024);
     const p = writeTranscript('sess-small', 4096);
-    const provider = new ClaudeProvider();
-    expect(provider.maybeRotateContinuation('sess-small', CWD)).toBeNull();
+    const provider = createProvider('claude');
+    expect(provider.maybeRotateContinuation!('sess-small', CWD)).toBeNull();
     expect(fs.existsSync(p)).toBe(true);
   });
 
   it('rotates an oversized transcript (returns reason, moves the .jsonl aside)', () => {
     process.env.CLAUDE_TRANSCRIPT_ROTATE_BYTES = String(64 * 1024);
     const p = writeTranscript('sess-big', 200 * 1024);
-    const provider = new ClaudeProvider();
-    const reason = provider.maybeRotateContinuation('sess-big', CWD);
+    const provider = createProvider('claude');
+    const reason = provider.maybeRotateContinuation!('sess-big', CWD);
     expect(reason).toContain('MB');
     expect(fs.existsSync(p)).toBe(false); // original moved out of the resume path
     const dir = path.dirname(p);
     expect(fs.readdirSync(dir).some((f) => f.startsWith('sess-big.jsonl.rotated-'))).toBe(true);
+  });
+
+  it('rotates by size when the first line and archive read both fail', () => {
+    process.env.CLAUDE_TRANSCRIPT_ROTATE_BYTES = String(64 * 1024);
+    const p = writeTranscript('sess-unreadable', 200 * 1024);
+    let firstLineReadAttempted = false;
+    let archiveReadAttempted = false;
+    let archiveFailureLogged = false;
+    const openSpy = spyOn(fs, 'openSync').mockImplementation(() => {
+      firstLineReadAttempted = true;
+      throw new Error('first line unreadable');
+    });
+    const readSpy = spyOn(fs, 'readFileSync').mockImplementation(() => {
+      archiveReadAttempted = true;
+      throw new Error('archive unreadable');
+    });
+    const errorSpy = spyOn(console, 'error').mockImplementation((line) => {
+      if (String(line).includes('Failed to archive transcript')) archiveFailureLogged = true;
+    });
+    const renameClock = 1_234_567_890;
+    let clockReads = 0;
+    const nowSpy = spyOn(Date, 'now').mockImplementation(() => {
+      clockReads++;
+      return renameClock;
+    });
+    let reason: string | null;
+    try {
+      reason = createProvider('claude').maybeRotateContinuation!('sess-unreadable', CWD);
+    } finally {
+      openSpy.mockRestore();
+      readSpy.mockRestore();
+      errorSpy.mockRestore();
+      nowSpy.mockRestore();
+    }
+
+    expect(reason!).toContain('MB');
+    expect(firstLineReadAttempted).toBe(true);
+    expect(archiveReadAttempted).toBe(true);
+    expect(archiveFailureLogged).toBe(true);
+    expect(clockReads).toBe(1);
+    expect(fs.existsSync(p)).toBe(false);
+    expect(fs.readdirSync(path.dirname(p))).toContain(`sess-unreadable.jsonl.rotated-${renameClock}`);
   });
 
   it('rotates an aged transcript even when small', () => {
@@ -78,12 +123,12 @@ describe('ClaudeProvider.maybeRotateContinuation', () => {
     process.env.CLAUDE_TRANSCRIPT_ROTATE_AGE_DAYS = '7';
     const old = new Date(Date.now() - 10 * 86400_000).toISOString();
     writeTranscript('sess-old', 2048, old);
-    const provider = new ClaudeProvider();
-    expect(provider.maybeRotateContinuation('sess-old', CWD)).toContain('d');
+    const provider = createProvider('claude');
+    expect(provider.maybeRotateContinuation!('sess-old', CWD)).toContain('d');
   });
 
   it('returns null for an unknown session id', () => {
-    const provider = new ClaudeProvider();
-    expect(provider.maybeRotateContinuation('does-not-exist', CWD)).toBeNull();
+    const provider = createProvider('claude');
+    expect(provider.maybeRotateContinuation!('does-not-exist', CWD)).toBeNull();
   });
 });

--- a/container/agent-runner/src/providers/claude.tool-collisions.test.ts
+++ b/container/agent-runner/src/providers/claude.tool-collisions.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 
+import './index.js';
+import '../provider-contracts/index.js';
 import { SDK_DISALLOWED_TOOLS, TOOL_ALLOWLIST } from './claude.js';
 
 // Built-in Claude Code tools whose NAME reads as the obvious way to do
@@ -24,6 +26,10 @@ describe('built-in tools that collide with NanoClaw MCP tools', () => {
       expect(TOOL_ALLOWLIST).not.toContain(builtin);
     });
   }
+
+  it('the exported constant is not frozen by contract registration', () => {
+    expect(Object.isFrozen(SDK_DISALLOWED_TOOLS)).toBe(false);
+  });
 
   it('no tool is both allowlisted and disallowed', () => {
     const overlap = TOOL_ALLOWLIST.filter((t) => SDK_DISALLOWED_TOOLS.includes(t));

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -1,22 +1,25 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-
 import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/container-state.js';
 import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
-import { TIMEZONE, formatLocalStamp } from '../timezone.js';
-import { shimCwd } from './cwd-shim.js';
+import type { ResolvedRuntimeConfiguration } from '../provider-contracts/registry.js';
+// The execution-policy, inference, MCP, and memory derivations live in
+// claude-config.ts. The runtime contract (provider-contracts/claude.ts)
+// declares them; core calls them and hands the results to this provider's
+// constructor and registerMemorySessionHook. This module never imports the
+// contract — registration is two-step so it compiles on a core without one.
+import {
+  SDK_DISALLOWED_TOOLS,
+  type resolveClaudeExecutionPolicy,
+  type resolveClaudeInference,
+  type resolveClaudeMcpServers,
+  type resolveClaudeMemoryRuntime,
+} from './claude-config.js';
+// Transcript archiving and rotation are this provider's own concern: both
+// read the SDK's on-disk .jsonl, which no other provider has.
+import { archiveClaudeTranscript, rotateClaudeContinuation } from './claude-history.js';
 import { registerProvider } from './provider-registry.js';
-import type {
-  AgentProvider,
-  AgentQuery,
-  McpServerConfig,
-  ProviderEvent,
-  ProviderOptions,
-  QueryInput,
-} from './types.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 
 function log(msg: string): void {
   console.error(`[claude-provider] ${msg}`);
@@ -65,73 +68,7 @@ export function classifyRateLimitEvent(
   };
 }
 
-// Deferred SDK builtins that either sidestep nanoclaw's own scheduling or
-// don't fit our async message-passing model (they're designed for Claude
-// Code's interactive UI and would hang here).
-//
-// - CronCreate / CronDelete / CronList / ScheduleWakeup: we have durable
-//   scheduling via `ncl tasks`.
-// - AskUserQuestion: SDK returns a placeholder instead of blocking on a
-//   real answer — we have mcp__nanoclaw__ask_user_question that persists
-//   the question and blocks on the real reply.
-// - SendMessage: addresses Claude Code's own in-session subagents, which are
-//   unrelated to NanoClaw agent groups — but the name reads as the obvious
-//   way to message another agent, so an agent that just called
-//   mcp__nanoclaw__create_agent reaches for it and gets "No agent named 'x'
-//   is currently addressable". mcp__nanoclaw__send_message is the real
-//   agent-to-agent path (it resolves the destination map in inbound.db).
-// - EnterPlanMode / ExitPlanMode / EnterWorktree / ExitWorktree: Claude
-//   Code UI affordances; in a headless container they'd appear stuck.
-// - DesignSync: desktop design-tool integration — nothing to sync with in a
-//   headless container (~9.3KB/turn schema).
-// - ReportFindings: code-review-reporting UI affordance with no headless
-//   host surface to receive it (~1.9KB/turn schema).
-export const SDK_DISALLOWED_TOOLS = [
-  'CronCreate',
-  'CronDelete',
-  'CronList',
-  'ScheduleWakeup',
-  'AskUserQuestion',
-  'SendMessage',
-  'EnterPlanMode',
-  'ExitPlanMode',
-  'EnterWorktree',
-  'ExitWorktree',
-  'DesignSync',
-  'ReportFindings',
-];
-
-// Tool allowlist for NanoClaw agent containers. MCP-tool entries are derived
-// at the call site from the registered `mcpServers` map so that any server
-// added via `add_mcp_server` (or wired in container.json directly) is
-// reachable to the agent — without this, the SDK's allowedTools filter
-// silently drops every MCP namespace not listed here.
-export const TOOL_ALLOWLIST = [
-  'Bash',
-  'Read',
-  'Write',
-  'Edit',
-  'Glob',
-  'Grep',
-  'WebSearch',
-  'WebFetch',
-  'Task',
-  'TaskOutput',
-  'TaskStop',
-  'TeamCreate',
-  'TeamDelete',
-  'TodoWrite',
-  'ToolSearch',
-  'Skill',
-  'NotebookEdit',
-];
-
-// MCP server names are sanitized by the SDK when forming tool prefixes:
-// any character outside [A-Za-z0-9_-] becomes '_'. Mirror that here so our
-// allowlist patterns match what the SDK actually exposes.
-function mcpAllowPattern(serverName: string): string {
-  return `mcp__${serverName.replace(/[^a-zA-Z0-9_-]/g, '_')}__*`;
-}
+export { SDK_DISALLOWED_TOOLS, TOOL_ALLOWLIST } from './claude-config.js';
 
 interface SDKUserMessage {
   type: 'user';
@@ -177,57 +114,6 @@ class MessageStream {
   }
 }
 
-// ── Transcript archiving (PreCompact hook) ──
-
-interface ParsedMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
-
-function parseTranscript(content: string): ParsedMessage[] {
-  const messages: ParsedMessage[] = [];
-  for (const line of content.split('\n')) {
-    if (!line.trim()) continue;
-    try {
-      const entry = JSON.parse(line);
-      if (entry.type === 'user' && entry.message?.content) {
-        const text =
-          typeof entry.message.content === 'string'
-            ? entry.message.content
-            : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
-        if (text) messages.push({ role: 'user', content: text });
-      } else if (entry.type === 'assistant' && entry.message?.content) {
-        const textParts = entry.message.content
-          .filter((c: { type: string }) => c.type === 'text')
-          .map((c: { text: string }) => c.text);
-        const text = textParts.join('');
-        if (text) messages.push({ role: 'assistant', content: text });
-      }
-    } catch {
-      /* skip unparseable lines */
-    }
-  }
-  return messages;
-}
-
-function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
-  const now = new Date();
-  const dateStr = now.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-  const lines = [`# ${title || 'Conversation'}`, '', `Archived: ${dateStr}`, '', '---', ''];
-  for (const msg of messages) {
-    const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
-    const content = msg.content.length > 2000 ? msg.content.slice(0, 2000) + '...' : msg.content;
-    lines.push(`**${sender}**: ${content}`, '');
-  }
-  return lines.join('\n');
-}
-
 /**
  * PreToolUse hook: record the current tool + its declared timeout so the host
  * sweep can widen its stuck tolerance while Bash is running a long-declared
@@ -265,180 +151,25 @@ const postToolUseHook: HookCallback = async () => {
   return { continue: true };
 };
 
-/**
- * Read a Claude transcript .jsonl, render a markdown summary, and drop it into
- * the agent's `conversations/` folder so context survives a compaction or a
- * session rotation. Best-effort: returns false (and logs) on any failure.
- */
-function archiveTranscriptFile(
-  transcriptPath: string | undefined,
-  sessionId: string | undefined,
-  assistantName?: string,
-): boolean {
-  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
-    log('No transcript found for archiving');
-    return false;
-  }
+/** The real clock for archive names and rotation stamps; tests hand the history functions a fixed one. */
+const REAL_CLOCK = { now: () => Date.now() };
 
-  try {
-    const content = fs.readFileSync(transcriptPath, 'utf-8');
-    const messages = parseTranscript(content);
-    if (messages.length === 0) return false;
-
-    // Try to get summary from sessions index
-    let summary: string | undefined;
-    const indexPath = path.join(path.dirname(transcriptPath), 'sessions-index.json');
-    if (fs.existsSync(indexPath)) {
-      try {
-        const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-        summary = index.entries?.find(
-          (e: { sessionId: string; summary?: string }) => e.sessionId === sessionId,
-        )?.summary;
-      } catch {
-        /* ignore */
-      }
-    }
-
-    const name = summary
-      ? summary
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-+|-+$/g, '')
-          .slice(0, 50)
-      : `conversation-${new Date().getHours().toString().padStart(2, '0')}${new Date().getMinutes().toString().padStart(2, '0')}`;
-
-    const conversationsDir = process.env.NANOCLAW_CONVERSATIONS_DIR || '/workspace/agent/conversations';
-    fs.mkdirSync(conversationsDir, { recursive: true });
-    // Local calendar date — the fallback `name` above already uses local
-    // hours, and the agent navigates conversations/ by these date prefixes.
-    const filename = `${formatLocalStamp(new Date(), TIMEZONE).slice(0, 10)}-${name}.md`;
-    fs.writeFileSync(path.join(conversationsDir, filename), formatTranscriptMarkdown(messages, summary, assistantName));
-    log(`Archived conversation to ${filename}`);
-    return true;
-  } catch (err) {
-    log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
-    return false;
-  }
-}
-
+// The PreCompact hook is provider-originated: the SDK raises it from inside
+// the query, and the archive it triggers reads the SDK's own transcript.
 function createPreCompactHook(assistantName?: string): HookCallback {
   return async (input) => {
     const preCompact = input as PreCompactHookInput;
-    archiveTranscriptFile(preCompact.transcript_path, preCompact.session_id, assistantName);
+    archiveClaudeTranscript(
+      {
+        transcriptPath: preCompact.transcript_path,
+        sessionId: preCompact.session_id,
+        assistantName,
+        log,
+      },
+      REAL_CLOCK,
+    );
     return {};
   };
-}
-
-// ── Continuation rotation (cold-resume guard) ──
-
-/**
- * Resume cost is dominated by transcript size. Past this many bytes a fresh
- * cold container can't reload the .jsonl before the host's 30-min idle ceiling
- * fires, so the session is dropped and started clean. Operator-overridable.
- */
-function transcriptRotateBytes(): number {
-  return Number(process.env.CLAUDE_TRANSCRIPT_ROTATE_BYTES) || 12 * 1024 * 1024;
-}
-
-/**
- * Secondary age trigger, measured from the transcript's first entry. 0 (or a
- * non-positive value) disables the age check; size alone then governs.
- */
-function transcriptRotateAgeMs(): number {
-  const raw = process.env.CLAUDE_TRANSCRIPT_ROTATE_AGE_DAYS;
-  if (raw === undefined || raw.trim() === '') return 14 * 86_400_000;
-  const days = Number(raw);
-  if (!Number.isFinite(days)) return 14 * 86_400_000;
-  // Explicit non-positive override disables the age check; size alone governs.
-  return days > 0 ? days * 86_400_000 : Infinity;
-}
-
-function claudeProjectsDir(): string {
-  return path.join(claudeConfigDir(), 'projects');
-}
-
-function claudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME || os.homedir(), '.claude');
-}
-
-function writeMemorySessionHook(hook: MemorySessionHookRegistration): void {
-  const configDir = claudeConfigDir();
-  const settingsFile = path.join(configDir, 'settings.json');
-  fs.mkdirSync(configDir, { recursive: true });
-
-  const parsed: unknown = fs.existsSync(settingsFile) ? JSON.parse(fs.readFileSync(settingsFile, 'utf-8')) : {};
-  if (!isRecord(parsed)) throw new Error(`${settingsFile} must contain a JSON object`);
-
-  const hooks = parsed.hooks === undefined ? {} : parsed.hooks;
-  if (!isRecord(hooks)) throw new Error(`${settingsFile} hooks must be a JSON object`);
-
-  const sessionStart = hooks.SessionStart === undefined ? [] : hooks.SessionStart;
-  if (!Array.isArray(sessionStart)) throw new Error(`${settingsFile} hooks.SessionStart must be an array`);
-
-  const memoryCommands = new Set([hook.command, ...hook.legacyCommands]);
-  const nextSessionStart = sessionStart
-    .map((entry) => removeMemoryCommands(entry, memoryCommands))
-    .filter((entry) => entry !== undefined);
-  nextSessionStart.push({
-    matcher: hook.sources.join('|'),
-    hooks: [{ type: 'command', command: hook.command, timeout: 10 }],
-  });
-
-  hooks.SessionStart = nextSessionStart;
-  parsed.hooks = hooks;
-  fs.writeFileSync(settingsFile, JSON.stringify(parsed, null, 2) + '\n');
-}
-
-function removeMemoryCommands(value: unknown, commands: ReadonlySet<string>): unknown {
-  if (!isRecord(value) || !Array.isArray(value.hooks)) return value;
-  const hooks = value.hooks.filter((hook) => {
-    if (!isRecord(hook)) return true;
-    return typeof hook.command !== 'string' || !commands.has(hook.command);
-  });
-  return hooks.length > 0 ? { ...value, hooks } : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-/**
- * Locate the .jsonl backing a session id. The SDK names project dirs by a
- * mangled cwd; rather than reproduce that convention we scan project dirs for
- * `<sessionId>.jsonl` (session ids are UUIDs, so this is unambiguous).
- */
-function findTranscriptPath(sessionId: string): string | null {
-  const projects = claudeProjectsDir();
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(projects);
-  } catch {
-    return null;
-  }
-  for (const dir of dirs) {
-    const candidate = path.join(projects, dir, `${sessionId}.jsonl`);
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-/** Epoch-ms of the first transcript entry, or null if unreadable. */
-function transcriptStartMs(transcriptPath: string): number | null {
-  try {
-    const fd = fs.openSync(transcriptPath, 'r');
-    try {
-      const buf = Buffer.alloc(4096);
-      const n = fs.readSync(fd, buf, 0, buf.length, 0);
-      const firstLine = buf.toString('utf-8', 0, n).split('\n', 1)[0];
-      const ts = JSON.parse(firstLine)?.timestamp;
-      const ms = ts ? Date.parse(ts) : NaN;
-      return Number.isNaN(ms) ? null : ms;
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return null;
-  }
 }
 
 // ── Provider ──
@@ -461,51 +192,42 @@ const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WIN
 const STALE_SESSION_RE = /no conversation found|ENOENT.*\.jsonl|session.*not found/i;
 
 export class ClaudeProvider implements AgentProvider {
-  readonly supportsNativeSlashCommands = true;
-  /**
-   * Static capability, not runtime state: this provider yields a `text`
-   * event for every assistant message that carries non-empty text (see the
-   * assistant-message branch in query() — one event per message, text blocks
-   * joined). The SDK's result text repeats the final assistant message's
-   * text, so the final result is expected to repeat an already-streamed
-   * segment. NOTE this containment is an SDK premise, not something this
-   * provider enforces: the result event's text is taken verbatim from the
-   * SDK's own `result` / `errors[]` fields, which the provider cannot prove
-   * equal to streamed content. The poll-loop keys its one-door mid-turn
-   * delivery on this flag; the result door never delivers content — if the
-   * streaming door missed everything (premise violation), the poll-loop
-   * fires the wrap-nudge so the model re-sends through the mid-turn door.
-   */
-  readonly emitsMidTurnText = true;
-
   private assistantName?: string;
-  private mcpServers: Record<string, McpServerConfig>;
+  private mcp: ReturnType<typeof resolveClaudeMcpServers>;
+  private inference: ReturnType<typeof resolveClaudeInference>;
+  private executionPolicy: ReturnType<typeof resolveClaudeExecutionPolicy>;
   private env: Record<string, string | undefined>;
   private additionalDirectories?: string[];
-  private model?: string;
-  private effort?: string;
-  private fastMode?: boolean;
   private memorySessionHook?: MemorySessionHookRegistration;
 
-  constructor(options: ProviderOptions = {}) {
+  /**
+   * `configuration` is the contract's configuration as resolved by core
+   * (createProvider): execution policy, inference, and MCP servers. This
+   * provider does not call the resolves itself.
+   */
+  constructor(options: ProviderOptions, configuration: ResolvedRuntimeConfiguration) {
     this.assistantName = options.assistantName;
-    this.mcpServers = Object.fromEntries(
-      Object.entries(options.mcpServers ?? {}).map(([name, server]) => [name, shimCwd(server)]),
-    );
+    this.mcp = configuration.mcpServers as ReturnType<typeof resolveClaudeMcpServers>;
     this.additionalDirectories = options.additionalDirectories;
-    this.model = options.model;
-    this.effort = options.effort;
-    this.fastMode = options.fastMode;
+    this.inference = configuration.inference as ReturnType<typeof resolveClaudeInference>;
+    this.executionPolicy = configuration.executionPolicy as ReturnType<typeof resolveClaudeExecutionPolicy>;
     this.env = {
       ...(options.env ?? {}),
       CLAUDE_CODE_AUTO_COMPACT_WINDOW,
-      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
     };
   }
 
-  registerMemorySessionHook(hook: MemorySessionHookRegistration): void {
-    writeMemorySessionHook(hook);
+  /**
+   * `memory` is the contract's resolved memory capability (the runtime env
+   * that keeps the SDK's own auto-memory off). Core registers the hook before
+   * any query, so the SDK sees the same env it always did.
+   */
+  registerMemorySessionHook(hook: MemorySessionHookRegistration, memory?: unknown): void {
     this.memorySessionHook = hook;
+    this.env = {
+      ...this.env,
+      ...((memory as ReturnType<typeof resolveClaudeMemoryRuntime> | undefined) ?? {}),
+    };
   }
 
   isSessionInvalid(err: unknown): boolean {
@@ -513,39 +235,12 @@ export class ClaudeProvider implements AgentProvider {
     return STALE_SESSION_RE.test(msg);
   }
 
-  maybeRotateContinuation(continuation: string): string | null {
-    const transcriptPath = findTranscriptPath(continuation);
-    if (!transcriptPath) return null;
-
-    let size: number;
-    try {
-      size = fs.statSync(transcriptPath).size;
-    } catch {
-      return null;
-    }
-
-    const maxBytes = transcriptRotateBytes();
-    const startMs = transcriptStartMs(transcriptPath);
-    const ageMs = startMs === null ? 0 : Date.now() - startMs;
-    const maxAgeMs = transcriptRotateAgeMs();
-
-    let reason: string | null = null;
-    if (size > maxBytes) {
-      reason = `transcript ${(size / 1_048_576).toFixed(1)}MB > ${(maxBytes / 1_048_576).toFixed(0)}MB cap`;
-    } else if (startMs !== null && ageMs > maxAgeMs) {
-      reason = `transcript ${(ageMs / 86_400_000).toFixed(1)}d old > ${(maxAgeMs / 86_400_000).toFixed(0)}d cap`;
-    }
-    if (!reason) return null;
-
-    // Preserve a readable summary, then move the heavy .jsonl out of the
-    // resume path so the SDK starts a fresh session and the disk is reclaimed.
-    archiveTranscriptFile(transcriptPath, continuation, this.assistantName);
-    try {
-      fs.renameSync(transcriptPath, `${transcriptPath}.rotated-${Date.now()}`);
-    } catch (err) {
-      log(`Failed to move rotated transcript aside: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    return reason;
+  /**
+   * Pre-resume maintenance: drop a transcript too large or too old to
+   * cold-resume within the host's idle ceiling (see claude-history.ts).
+   */
+  maybeRotateContinuation(continuation: string, _cwd: string): string | null {
+    return rotateClaudeContinuation({ continuation, assistantName: this.assistantName, log }, REAL_CLOCK);
   }
 
   query(input: QueryInput): AgentQuery {
@@ -565,20 +260,20 @@ export class ClaudeProvider implements AgentProvider {
         systemPrompt: instructions
           ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions }
           : undefined,
-        allowedTools: [...TOOL_ALLOWLIST, ...Object.keys(this.mcpServers).map(mcpAllowPattern)],
-        disallowedTools: SDK_DISALLOWED_TOOLS,
+        allowedTools: [...this.mcp.allowedTools],
+        disallowedTools: [...this.executionPolicy.disallowedTools],
         env: this.env,
-        model: this.model,
+        model: this.inference.model,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        effort: this.effort as any,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
+        effort: this.inference.effort as any,
+        permissionMode: this.executionPolicy.permissionMode,
+        allowDangerouslySkipPermissions: this.executionPolicy.allowDangerouslySkipPermissions,
         settingSources: ['project', 'user', 'local'],
         // Only sent when enabled, so an install that never turns it on passes
         // exactly the options it always did. `fastMode` is a Settings member
         // rather than a query option, which is why it rides `settings`.
-        ...(this.fastMode ? { settings: { fastMode: true } } : {}),
-        mcpServers: this.mcpServers,
+        ...(this.inference.fastMode ? { settings: { fastMode: true } } : {}),
+        mcpServers: this.mcp.mcpServers,
         hooks: {
           PreToolUse: [{ hooks: [preToolUseHook] }],
           PostToolUse: [{ hooks: [postToolUseHook] }],
@@ -694,4 +389,12 @@ export class ClaudeProvider implements AgentProvider {
   }
 }
 
-registerProvider('claude', (opts) => new ClaudeProvider(opts));
+// Function-form registration only; the runtime contract attaches itself from
+// provider-contracts/claude.ts through the same two-step path any
+// skill-installed provider uses.
+registerProvider('claude', (opts, configuration) => {
+  if (!configuration) {
+    throw new Error('Claude provider requires its runtime contract; construct it through createProvider');
+  }
+  return new ClaudeProvider(opts, configuration);
+});

--- a/container/agent-runner/src/providers/factory.test.ts
+++ b/container/agent-runner/src/providers/factory.test.ts
@@ -1,8 +1,45 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { describe, it, expect } from 'bun:test';
 
-import { createProvider, type ProviderName } from './factory.js';
+import { createProvider } from './factory.js';
 import { ClaudeProvider } from './claude.js';
 import { MockProvider } from './mock.js';
+import './index.js';
+import '../provider-contracts/index.js';
+import {
+  getProviderRuntimeContract,
+  registerProvider,
+  registerProviderContract,
+  requireProviderName,
+} from './provider-registry.js';
+import {
+  PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+  type ProviderRuntimeContract,
+  type ResolvedRuntimeConfiguration,
+} from '../provider-contracts/registry.js';
+import { registerProviderMemorySessionHook } from '../provider-contracts/realize.js';
+import type { AgentProvider, ProviderOptions } from './types.js';
+
+function stubProvider(): AgentProvider {
+  return {
+    registerMemorySessionHook: () => {},
+    query: () => {
+      throw new Error('unused');
+    },
+    isSessionInvalid: () => false,
+  };
+}
+
+function minimalContract(): ProviderRuntimeContract {
+  return {
+    seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+    configuration: { executionPolicy: { constant: { boundary: 'container' } } },
+    textDelivery: 'result',
+    commands: { formatting: 'xml' },
+  };
+}
 
 describe('createProvider', () => {
   it('returns ClaudeProvider for claude', () => {
@@ -14,6 +51,157 @@ describe('createProvider', () => {
   });
 
   it('throws for unknown name', () => {
-    expect(() => createProvider('bogus' as ProviderName)).toThrow(/Unknown provider/);
+    expect(() => createProvider('bogus')).toThrow(/Unknown provider/);
+  });
+
+  it('attaches a contract registered before its provider', () => {
+    const name = `two-step-contract-first-${process.pid}`;
+    const contract = minimalContract();
+    registerProviderContract(name, contract);
+    expect(getProviderRuntimeContract(name)).toBeUndefined();
+    registerProvider(name, () => stubProvider());
+    expect(getProviderRuntimeContract(name)).toBe(contract);
+  });
+
+  it('attaches a contract registered after its provider', () => {
+    const name = `two-step-provider-first-${process.pid}`;
+    const contract = minimalContract();
+    registerProvider(name, () => stubProvider());
+    expect(getProviderRuntimeContract(name)).toBeUndefined();
+    registerProviderContract(name, contract);
+    expect(getProviderRuntimeContract(name)).toBe(contract);
+  });
+
+  it('rejects a second contract for the same provider in either order', () => {
+    const attached = `two-step-duplicate-attached-${process.pid}`;
+    registerProvider(attached, { create: () => stubProvider(), contract: minimalContract() });
+    expect(() => registerProviderContract(attached, minimalContract())).toThrow(/contract already registered/);
+
+    const pending = `two-step-duplicate-pending-${process.pid}`;
+    registerProviderContract(pending, minimalContract());
+    expect(() => registerProviderContract(pending, minimalContract())).toThrow(/contract already registered/);
+    expect(() => registerProvider(pending, { create: () => stubProvider(), contract: minimalContract() })).toThrow(
+      /contract already registered/,
+    );
+  });
+
+  it('resolves the declared configuration itself and hands it to the provider factory', () => {
+    const name = `factory-configuration-${process.pid}`;
+    const seen: Array<{ options: ProviderOptions; configuration?: ResolvedRuntimeConfiguration }> = [];
+    const memorySeen: unknown[] = [];
+    registerProvider(name, {
+      create: (options, configuration) => {
+        seen.push({ options, configuration });
+        return { ...stubProvider(), registerMemorySessionHook: (_hook, memory) => memorySeen.push(memory) };
+      },
+      contract: {
+        seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+        configuration: {
+          executionPolicy: (_input, environment) => ({ home: environment.HOME ?? null }),
+          inference: (input) => ({ chosen: input.model ?? 'default' }),
+          memory: (hook) => ({ hookCommand: hook.command }),
+          mcpServers: { constant: { fixed: true } },
+        },
+        textDelivery: 'result',
+        commands: { formatting: 'xml' },
+      },
+    });
+
+    const provider = createProvider(name, { model: 'opus', mcpServers: { ignored: { command: 'x' } } });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.configuration).toEqual({
+      executionPolicy: { home: process.env.HOME ?? null },
+      inference: { chosen: 'opus' },
+      mcpServers: { fixed: true },
+    });
+
+    // memory resolves when core registers the hook, with the hook as input.
+    registerProviderMemorySessionHook(name, provider, {
+      command: 'run-hook',
+      legacyCommands: [],
+      sources: ['startup'],
+    });
+    expect(memorySeen).toEqual([{ hookCommand: 'run-hook' }]);
+  });
+
+  it('hands Claude the core-resolved configuration (no provider-side resolve)', () => {
+    const provider = createProvider('claude', {
+      mcpServers: { 'custom.server': { command: 'custom-server' } },
+    }) as unknown as {
+      mcp: { allowedTools: string[] };
+      executionPolicy: { permissionMode: string };
+    };
+    expect(provider.mcp.allowedTools).toContain('mcp__custom_server__*');
+    expect(provider.executionPolicy.permissionMode).toBe('bypassPermissions');
+  });
+
+  it('normalizes and validates the selected provider before startup', () => {
+    expect(requireProviderName('CLAUDE')).toBe('claude');
+    expect(() => requireProviderName('bogus')).toThrow(/Unknown provider/);
+  });
+
+  it('dispatches provider-owned contract callbacks without calling provider fallbacks', () => {
+    const name = `factory-core-owner-${process.pid}`;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+    const conversations = path.join(root, 'conversations');
+    const previous = process.env.NANOCLAW_CONVERSATIONS_DIR;
+    process.env.NANOCLAW_CONVERSATIONS_DIR = conversations;
+    let fallbackCalls = 0;
+    let exchangePlannerCalls = 0;
+    let beforeQueryCalls = 0;
+
+    registerProvider(name, {
+      create: () => ({
+        registerMemorySessionHook: () => {},
+        onExchangeComplete: () => fallbackCalls++,
+        // Continuation rotation is provider-internal, so the instance method
+        // is the only implementation; the factory does not wrap it.
+        maybeRotateContinuation: () => 'rotate',
+        query: () => {
+          throw new Error('unused');
+        },
+        isSessionInvalid: () => false,
+      }),
+      contract: {
+        seamVersion: PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION,
+        configuration: {
+          executionPolicy: { constant: { boundary: 'container' } },
+          inference: (input) => ({ model: input.model }),
+          memory: (input) => ({ command: input.command }),
+          mcpServers: (input) => ({ servers: Object.keys(input) }),
+        },
+        lifecycle: {
+          beforeQuery: () => {
+            beforeQueryCalls++;
+          },
+        },
+        history: {
+          afterExchange: () => {
+            exchangePlannerCalls++;
+            fs.mkdirSync(conversations, { recursive: true });
+            fs.writeFileSync(path.join(conversations, 'exchange.md'), 'archived\n');
+            return 'exchange.md';
+          },
+        },
+        textDelivery: 'result',
+        commands: { formatting: 'xml', nativeAdmin: [], nativeFiltered: [] },
+      },
+    });
+
+    try {
+      const provider = createProvider(name);
+      provider.onExchangeComplete?.({ prompt: 'hello', result: 'world', status: 'completed' });
+      const archiveCalls = exchangePlannerCalls;
+      expect(provider.maybeRotateContinuation?.('session', '/unused')).toBe('rotate');
+      expect(() => provider.query({ prompt: 'hello', cwd: '/workspace/agent' })).toThrow(/unused/);
+      expect(fs.readFileSync(path.join(conversations, 'exchange.md'), 'utf8')).toBe('archived\n');
+      expect(exchangePlannerCalls).toBe(archiveCalls);
+      expect(fallbackCalls).toBe(0);
+      expect(beforeQueryCalls).toBe(1);
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_CONVERSATIONS_DIR;
+      else process.env.NANOCLAW_CONVERSATIONS_DIR = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/container/agent-runner/src/providers/factory.ts
+++ b/container/agent-runner/src/providers/factory.ts
@@ -1,13 +1,42 @@
 import type { AgentProvider, ProviderOptions } from './types.js';
 import { getProviderFactory } from './provider-registry.js';
+import { getProviderRuntimeContract } from './provider-registry.js';
+import {
+  bindProviderRuntimeInputs,
+  resolveRuntimeConfiguration,
+  runProviderAfterExchange,
+  runProviderBeforeQuery,
+} from '../provider-contracts/realize.js';
+import type { RuntimeConfigurationInputs } from '../provider-contracts/registry.js';
 
-/**
- * Any registered provider name. Kept as a named alias for readability; the
- * set of valid names is open and determined at runtime by whichever provider
- * modules the `providers/index.ts` barrel imports.
- */
-export type ProviderName = string;
+export function createProvider(name: string, options: ProviderOptions = {}): AgentProvider {
+  const contract = getProviderRuntimeContract(name);
+  // The core-owned inputs for this instance: one object, owned here, closed
+  // over by the render path below.
+  const inputs: Partial<RuntimeConfigurationInputs> = {
+    inference: { model: options.model, effort: options.effort, fastMode: options.fastMode },
+    mcpServers: options.mcpServers ?? {},
+  };
+  // Core resolves the declared configuration and hands the result to the
+  // provider; the provider does not call its own capabilities.
+  const configuration = contract ? resolveRuntimeConfiguration(contract, inputs) : undefined;
+  const provider = getProviderFactory(name)(options, configuration);
+  if (contract) {
+    bindProviderRuntimeInputs(provider, inputs);
 
-export function createProvider(name: ProviderName, options: ProviderOptions = {}): AgentProvider {
-  return getProviderFactory(name)(options);
+    if (contract.lifecycle?.beforeQuery) {
+      const query = provider.query.bind(provider);
+      provider.query = (input) => {
+        runProviderBeforeQuery(name, inputs);
+        return query(input);
+      };
+    }
+
+    if (contract.history?.afterExchange) {
+      provider.onExchangeComplete = (exchange) => {
+        runProviderAfterExchange(name, exchange);
+      };
+    }
+  }
+  return provider;
 }

--- a/container/agent-runner/src/providers/legacy-payload-compat.test.ts
+++ b/container/agent-runner/src/providers/legacy-payload-compat.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { createProvider } from './factory.js';
+import { listProviderNames } from './provider-registry.js';
+import './index.js';
+
+const hasCodex = fs.existsSync(new URL('./codex.ts', import.meta.url));
+const hasOpenCode = fs.existsSync(new URL('./opencode.ts', import.meta.url));
+let temp: string | undefined;
+
+afterEach(() => {
+  if (temp) fs.rmSync(temp, { recursive: true, force: true });
+  temp = undefined;
+  delete process.env.NANOCLAW_CONVERSATIONS_DIR;
+});
+
+(hasCodex ? describe : describe.skip)('Codex payload compatibility through new runtime core', () => {
+  it('registers, constructs, and archives one exchange exactly once', () => {
+    expect(listProviderNames()).toContain('codex');
+    temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-codex-compat-'));
+    process.env.NANOCLAW_CONVERSATIONS_DIR = temp;
+    const provider = createProvider('codex');
+
+    provider.onExchangeComplete?.({
+      prompt: 'hello',
+      result: 'world',
+      continuation: 'thread-1',
+      status: 'completed',
+    });
+
+    const files = fs.readdirSync(temp);
+    expect(files).toHaveLength(1);
+    const content = fs.readFileSync(path.join(temp, files[0]), 'utf8');
+    expect(content.match(/# Codex Conversation/g)).toHaveLength(1);
+    expect(content.match(/Status: completed/g)).toHaveLength(1);
+  });
+});
+
+(hasOpenCode ? describe : describe.skip)('OpenCode payload compatibility through new runtime core', () => {
+  it('registers, constructs, and enters the real query path', () => {
+    expect(listProviderNames()).toContain('opencode');
+    const provider = createProvider('opencode');
+    provider.registerMemorySessionHook({
+      command: 'true',
+      legacyCommands: [],
+      sources: ['startup', 'clear', 'compact'],
+    });
+
+    const query = provider.query({ prompt: 'hello', cwd: '/workspace/agent' });
+    query.abort();
+
+    expect(query.events[Symbol.asyncIterator]).toBeFunction();
+    expect(provider.isSessionInvalid(new Error('session not found'))).toBe(true);
+  });
+});

--- a/container/agent-runner/src/providers/mock.conformance.test.ts
+++ b/container/agent-runner/src/providers/mock.conformance.test.ts
@@ -1,0 +1,9 @@
+// Conformance for the test-double provider's runtime contract. The mock
+// provider and its contract are test-only and sit outside both production
+// barrels, so this file imports the pair directly — the same two-step
+// registration a skill wires through the barrels for a real provider.
+import './mock.js';
+import { mockRuntimeContract } from '../provider-contracts/mock.js';
+import { defineProviderConformance } from '../provider-contracts/testing/conformance.js';
+
+defineProviderConformance('mock', mockRuntimeContract);

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -5,16 +5,12 @@ import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryIn
 /**
  * Mock provider for testing. Returns canned responses.
  * Supports push() — queued messages produce additional results.
+ *
+ * Its runtime contract lives in provider-contracts/mock.ts and attaches via
+ * registerProviderContract, the same two-step path every provider uses; this
+ * module does not import it.
  */
 export class MockProvider implements AgentProvider {
-  readonly supportsNativeSlashCommands = false;
-  /**
-   * Mirrors ClaudeProvider: turnEvents() emits every configured text segment
-   * before the turn's result, so the mock exercises the same one-door
-   * mid-turn delivery path as the real SDK.
-   */
-  readonly emitsMidTurnText = true;
-
   private responseFactory: (prompt: string) => string;
   private textFactory: ((prompt: string) => string[]) | undefined;
 
@@ -48,8 +44,7 @@ export class MockProvider implements AgentProvider {
     // Mid-turn text segments (if configured) followed by the turn's result —
     // mirrors the SDK's assistant-message → result ordering. The result text
     // itself streams as the LAST text event first: the real SDK's result only
-    // repeats the final assistant text, which already streamed — that is the
-    // emitsMidTurnText contract this mock declares.
+    // repeats the final assistant text, which already streamed.
     function* turnEvents(prompt: string): Generator<ProviderEvent> {
       for (const text of textFactory?.(prompt) ?? []) {
         yield { type: 'text', text };

--- a/container/agent-runner/src/providers/provider-registry.ts
+++ b/container/agent-runner/src/providers/provider-registry.ts
@@ -5,29 +5,118 @@
  * calls `registerProvider()` at top level; the barrel (`providers/index.ts`)
  * imports every provider module for its side effect so registrations fire
  * before `createProvider()` is called.
+ *
+ * Registration is two-step and order-independent: the provider module
+ * registers its factory (`registerProvider`), and the contract module
+ * attaches the runtime contract (`registerProviderContract`). The two files
+ * never import each other, so a payload's provider module still compiles on a
+ * core that predates the contract seam — the contract file simply has nothing
+ * to attach to there and is not imported. Every provider, Claude included,
+ * goes through exactly this path.
  */
 import type { AgentProvider, ProviderOptions } from './types.js';
+import type { ProviderRuntimeContract, ResolvedRuntimeConfiguration } from '../provider-contracts/registry.js';
 
-export type ProviderFactory = (options: ProviderOptions) => AgentProvider;
+/**
+ * Builds a provider instance. `configuration` is present whenever the provider
+ * has a registered contract: core has already called the contract's
+ * configuration resolves and hands the results over here.
+ */
+export type ProviderFactory = (options: ProviderOptions, configuration?: ResolvedRuntimeConfiguration) => AgentProvider;
 
-const registry = new Map<string, ProviderFactory>();
+export interface ProviderRegistration {
+  create: ProviderFactory;
+  contract?: ProviderRuntimeContract;
+}
 
-export function registerProvider(name: string, factory: ProviderFactory): void {
-  if (registry.has(name)) {
-    throw new Error(`Provider already registered: ${name}`);
+const registry = new Map<string, ProviderRegistration>();
+/** Contracts registered before their provider factory arrived. */
+const pendingContracts = new Map<string, ProviderRuntimeContract>();
+
+export function registerProvider(name: string, registration: ProviderFactory | ProviderRegistration): void {
+  const key = providerKey(name);
+  if (registry.has(key)) {
+    throw new Error(`Provider already registered: ${key}`);
   }
-  registry.set(name, factory);
+  const entry: ProviderRegistration =
+    typeof registration === 'function' ? { create: registration } : { create: registration.create };
+  registry.set(key, entry);
+
+  const pending = pendingContracts.get(key);
+  if (typeof registration !== 'function' && registration.contract) {
+    if (pending) throw new Error(`Provider runtime contract already registered: ${key}`);
+    attachContract(entry, registration.contract);
+  } else if (pending) {
+    pendingContracts.delete(key);
+    attachContract(entry, pending);
+  }
+}
+
+/**
+ * Attach a runtime contract to a provider. Works before or after the
+ * provider's own `registerProvider` call; a second contract for the same
+ * provider is an error.
+ */
+export function registerProviderContract(name: string, contract: ProviderRuntimeContract): void {
+  const key = providerKey(name);
+  const entry = registry.get(key);
+  if (entry) {
+    if (entry.contract) throw new Error(`Provider runtime contract already registered: ${key}`);
+    attachContract(entry, contract);
+    return;
+  }
+  if (pendingContracts.has(key)) throw new Error(`Provider runtime contract already registered: ${key}`);
+  pendingContracts.set(key, deepFreeze(contract));
+}
+
+function attachContract(entry: ProviderRegistration, contract: ProviderRuntimeContract): void {
+  entry.contract = deepFreeze(contract);
 }
 
 export function getProviderFactory(name: string): ProviderFactory {
-  const factory = registry.get(name);
-  if (!factory) {
+  const registration = registry.get(name);
+  if (!registration) {
     const known = [...registry.keys()].join(', ') || '(none)';
     throw new Error(`Unknown provider: ${name}. Registered: ${known}`);
   }
-  return factory;
+  return registration.create;
+}
+
+export function getProviderRuntimeContract(name: string | null | undefined): ProviderRuntimeContract | undefined {
+  return name ? registry.get(name.toLowerCase())?.contract : undefined;
+}
+
+export function hasDeclaredProviderRuntimeContract(name: string | null | undefined): boolean {
+  return getProviderRuntimeContract(name) !== undefined;
+}
+
+export function listProviderRuntimeContractNames(): string[] {
+  return [...registry.entries()].filter(([, registration]) => registration.contract).map(([name]) => name);
+}
+
+/** Normalize and validate a provider selected from config before startup work begins. */
+export function requireProviderName(name: string): string {
+  const normalized = name.toLowerCase();
+  getProviderFactory(normalized);
+  return normalized;
 }
 
 export function listProviderNames(): string[] {
   return [...registry.keys()];
+}
+
+function providerKey(name: string): string {
+  const key = name.toLowerCase();
+  if (name !== key || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    throw new Error(`Provider name must be lowercase kebab-case: '${name}'`);
+  }
+  return key;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object') {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
 }

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -2,31 +2,13 @@ import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
 
 export interface AgentProvider {
   /**
-   * True if the provider's underlying SDK handles slash commands natively and
-   * wants them passed through as raw text. When false, the poll-loop formats
-   * slash commands like any other chat message.
+   * Register shared memory through the provider's native session-start
+   * mechanism. `memory` is the contract's resolved memory capability (core
+   * calls the contract's `memory` function with the hook, or takes its
+   * declared constant, and passes the result); absent for providers without
+   * a contract or without a memory capability.
    */
-  readonly supportsNativeSlashCommands: boolean;
-
-  /**
-   * Optional capability: true when the provider surfaces EVERY assistant text
-   * segment as a streamed `text` event before the turn's `result` — so the
-   * result text is always a repeat of a segment that already streamed
-   * (empirically: the SDK result is exactly the last streamed segment). When
-   * declared, mid-turn streaming becomes the SINGLE content door: the
-   * poll-loop delivers complete <message> blocks at parse time from the
-   * streamed events (assembling blocks split across segments), and the
-   * final-result handler never delivers content — error results are
-   * surfaced, and a turn that delivered nothing while its result still
-   * carries content gets the wrap-nudge so the retry streams through the
-   * mid-turn door. Providers that omit this (or set false) keep the single
-   * result-door delivery path: text events are delivery-inert and blocks in
-   * the final result text are delivered from there.
-   */
-  readonly emitsMidTurnText?: boolean;
-
-  /** Register shared memory through the provider's native session-start mechanism. */
-  registerMemorySessionHook(hook: MemorySessionHookRegistration): void;
+  registerMemorySessionHook(hook: MemorySessionHookRegistration, memory?: unknown): void;
 
   /**
    * Optional. Called by the poll-loop after each completed exchange (a
@@ -35,7 +17,9 @@ export interface AgentProvider {
    * markdown into the agent's `conversations/` dir); providers that persist
    * and archive their own transcript (e.g. the Claude Agent SDK's `.jsonl`)
    * omit it. Best-effort: the loop catches and logs anything it throws. The
-   * implementation lives with the provider, never in the runner.
+   * Contractless providers implement this directly. For a declared
+   * core-owned archive, the factory replaces it with the core executor while
+   * the provider implementation remains an old-core compatibility fallback.
    */
   onExchangeComplete?(exchange: ProviderExchange): void;
 
@@ -55,7 +39,8 @@ export interface AgentProvider {
    * the continuation and start a fresh session (the provider archives any
    * recoverable summary first); return null to keep resuming.
    *
-   * Guards the cold-resume failure mode: a long-lived hub session accumulates
+   * Provider-internal: only the provider knows its transcript format. This
+   * guards the cold-resume failure mode: a long-lived hub session accumulates
    * days of history — including base64 image blocks the agent Read — and the
    * SDK reloads the whole .jsonl on every resume. Past a threshold the first
    * turn alone can exceed the host's idle ceiling, so the container is killed
@@ -173,7 +158,7 @@ export type ProviderEvent =
    * The SDK's final `result` carries only the LAST assistant text, so a
    * complete <message to="..."> block composed before a trailing tool call
    * never reaches the result event. For providers declaring
-   * `emitsMidTurnText`, the poll-loop scans these segments for closed
+   * `textDelivery: 'mid-turn-complete'`, the poll-loop scans these segments for closed
    * message blocks and delivers them as they are emitted (chat runs only,
    * with cross-segment assembly of split blocks); the final result never
    * delivers content — repeats are inert there, and an undelivered turn

--- a/container/agent-runner/src/upload-trace.ts
+++ b/container/agent-runner/src/upload-trace.ts
@@ -1,16 +1,19 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import type { MessageInRow } from './db/messages-in.js';
+import './providers/index.js';
+import './provider-contracts/index.js';
+import { readProviderTrace } from './provider-contracts/realize.js';
 
 /**
- * `/upload-trace` command: upload this session's Claude Code transcript to the user's
+ * `/upload-trace` command: upload this session's transcript to the user's
  * own private `{hf_user}/nanoclaw-traces` dataset, browsable in the HF Agent
- * Trace Viewer. The transcript the Claude provider keeps under
- * `~/.claude/projects/<dir>/<sessionId>.jsonl` is already in the format the
- * viewer auto-detects, so this just locates the newest one and pushes it.
+ * Trace Viewer. The active provider's contract locates the trace
+ * (`history.readTrace`); for Claude that is the newest
+ * `~/.claude/projects/<dir>/<sessionId>.jsonl`, already in the format the
+ * viewer auto-detects, so this just pushes it.
  *
  * Auth is the OneCLI gateway's job: curl goes out through the injected
  * HTTPS_PROXY, which adds the user's HF token. We never see the raw token, and
@@ -29,33 +32,6 @@ export function isUploadTraceCommand(msg: MessageInRow): boolean {
     return false; // non-JSON content is never a command
   }
   return text.toLowerCase().startsWith('/upload-trace');
-}
-
-/** Newest Claude Code transcript jsonl (the current session). */
-function newestTranscript(): string | null {
-  const projects = path.join(os.homedir(), '.claude', 'projects');
-  let best: { p: string; m: number } | null = null;
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(projects);
-  } catch {
-    return null;
-  }
-  for (const dir of dirs) {
-    let files: string[];
-    try {
-      files = fs.readdirSync(path.join(projects, dir));
-    } catch {
-      continue;
-    }
-    for (const f of files) {
-      if (!f.endsWith('.jsonl')) continue;
-      const p = path.join(projects, dir, f);
-      const m = fs.statSync(p).mtimeMs;
-      if (!best || m > best.m) best = { p, m };
-    }
-  }
-  return best?.p ?? null;
 }
 
 function curl(args: string[], input?: string): { ok: boolean; out: string } {
@@ -101,9 +77,9 @@ function notSignedInMessage(body: string): string {
   return lines.join('\n');
 }
 
-/** Returns a user-facing status line. Never throws. */
-export function uploadTrace(): string {
-  const file = newestTranscript();
+/** Returns a user-facing status line. Never throws. `providerName` is the session's active provider. */
+export function uploadTrace(providerName: string): string {
+  const file = readProviderTrace(providerName);
   if (!file) return 'No transcript to upload for this session yet.';
 
   // whoami, capturing the body + HTTP status (no -f, so the gateway's error

--- a/docs/agent-runner-details.md
+++ b/docs/agent-runner-details.md
@@ -21,10 +21,6 @@ continuation token to resume, the working directory, and system context to injec
 
 ```typescript
 interface AgentProvider {
-  /** True if the SDK handles slash commands natively and wants them passed
-   *  through raw. When false, the poll-loop formats them like any chat message. */
-  readonly supportsNativeSlashCommands: boolean;
-
   /** Register shared memory through the provider's native session-start mechanism. */
   registerMemorySessionHook(hook: MemorySessionHookRegistration): void;
 
@@ -113,6 +109,61 @@ type ProviderEvent =
 - **`progress`** — optional, for logging. The agent-runner logs these but doesn't act on them.
 - **`activity`** — a liveness signal. Providers MUST yield it on every underlying SDK event (tool call, thinking, partial message) so the poll-loop's idle timer stays honest during long tool runs.
 
+## Runtime provider contract
+
+Besides implementing `AgentProvider`, every provider declares a **runtime contract**
+(`container/agent-runner/src/provider-contracts/`). The contract is not a description
+core reads once and forgets — each field is consumed by core at a specific moment.
+
+What a provider declares:
+
+- `configuration` — `executionPolicy` (mandatory), and optionally `inference`, `memory`,
+  `mcpServers`. All four share one shape, `Capability<I>`: either a function
+  `(input, env) => answer` of the core-owned input, or a declared constant
+  `{ constant: answer }`. **Core calls the functions, not the provider.** `createProvider`
+  resolves `executionPolicy`, `inference` and `mcpServers` and passes the result to the
+  provider factory as its second argument; `memory` is resolved when core registers the
+  memory session hook and passed as the second argument of `registerMemorySessionHook`.
+  The core-owned inputs are named types in `provider-contracts/registry.ts` —
+  `RuntimeInferenceInput` for `inference`, `RuntimeMemoryHookInput` for `memory`, the
+  `McpServerConfig` map for `mcpServers` — and a provider's resolve names them rather
+  than restating the shape, so a field core adds reaches every provider through the type.
+- `lifecycle` — `memorySessionHookRegistration` (runs when core registers the memory hook)
+  and `beforeQuery` (runs before each query).
+- `history` — `afterExchange` (the factory wraps `onExchangeComplete` with it) and
+  `readTrace` (what `/upload-trace` uploads). Anything else a provider does with its own
+  transcript — Claude's pre-compact archive and continuation rotation, for example — is
+  provider-internal code (`providers/claude-history.ts`), not a contract field.
+- `textDelivery`, `commands` — read by the poll-loop and formatter. The formatter's
+  native command lists and `/upload-trace` read the **active** provider's contract only;
+  other registered contracts are never consulted.
+
+Registration is **two-step** and order-independent. The provider module calls
+`registerProvider(name, factory)`; the contract module calls
+`registerProviderContract(name, contract)`. Neither file imports the other, so a
+skill-installed provider still compiles on a core that predates the contract seam (the
+contract file is simply not imported there). Barrels: `providers/index.ts` and
+`provider-contracts/index.ts` — a skill appends one import line to each. Claude and the
+test-double `mock` register exactly this way; no provider is special-cased.
+
+A provider without a contract keeps working: the poll-loop falls back to the legacy
+instance flags (`supportsNativeSlashCommands`, `emitsMidTurnText`).
+
+Conformance: `provider-contracts/testing/conformance.ts` exports
+`defineProviderConformance(name, contract, options?)`, which registers the shape checks and
+the "does each function capability respond to its input" probes as `bun:test` cases.
+Constants are not probed. When the default probe inputs cannot exercise a function (an
+env-gated resolve, say), pass `options.probes` — e.g.
+`{ inference: { a, b, environment? } }`. Probe fixtures live with the tests, never on the
+contract. Every provider ships `providers/<name>.conformance.test.ts` calling
+`defineProviderConformance` for its own contract — Claude and the test-double `mock`
+included; no provider is special-cased. Core runs no generic sweep over the registered
+contracts: which probe fixtures a contract needs is provider knowledge (a provider whose
+inference is environment-provisioned does not vary on `model`, say), so only the provider's
+own test file can supply them. The install-time verifier requires the file for every
+declared provider. `bun src/provider-contracts/names.ts` lists registered providers and
+contracts.
+
 ## Provider Implementations
 
 Only the `claude` provider ships in trunk. The Codex and OpenCode sections below document the provider interface for reference and for skills that install additional providers — they are not baked into the core image.
@@ -127,7 +178,6 @@ only reads the per-turn `QueryInput`.
 
 ```typescript
 class ClaudeProvider implements AgentProvider {
-  readonly supportsNativeSlashCommands = true;
   // ...constructor stores options.mcpServers, .env, .additionalDirectories,
   //    .model, .effort, .assistantName...
 

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -70,6 +70,8 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'src/channels/slack-lib.test.ts',
       'src/channels/slack-a2a-guard.ts',
       'src/channels/slack-a2a-guard.test.ts',
+      'src/channels/slack-raw-text.ts',
+      'src/channels/slack-raw-text.test.ts',
       'src/channels/slack-registration.test.ts',
       'src/channels/slack-instances-registration.test.ts',
       'src/provisioning/slack-app.ts',


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Turns the container runtime provider seam into an executable contract that core actually calls.

- **Problem**: provider behavior lived in flags and Claude-specific helpers; nothing proved a provider implemented what it claimed.
- **Contract**: each provider registers four configuration capabilities (execution policy, inference, memory, MCP servers), lifecycle hooks, two history hooks (after-exchange, trace), text-delivery mode, and slash-command handling. A capability is one shape: a function of the core-owned input, or `{ constant }`. Inputs are named seam types (`RuntimeInferenceInput`, `RuntimeMemoryHookInput`), so a payload binds its resolver against the type rather than restating it. Test probe fixtures are passed to the conformance harness, not carried in the contract.
- **Core consumes it**: the factory resolves configuration and hands the result to the provider; memory is resolved when the shared hook is registered. Claude no longer calls its own resolvers.
- **Two-step registration, same for every provider**: the provider module registers its factory, the contract file registers its contract (`registerProviderContract`), loaded by a new `provider-contracts/index.ts` barrel. A skill-installed contract file can attach without the provider module importing it, so one payload loads on cores with and without the contract.
- **Verification, not startup**: shape checks and behavioral probes (a function that ignores its input is rejected; constants are not probed) live in `verifier.ts` and run in the conformance test and the install-time verifier — a startup throw would kill a `--rm` container. `defineProviderConformance(name, contract, { probes? })` is exported so payload branches and out-of-tree providers run the same suite; trunk ships `providers/claude.conformance.test.ts` and `providers/mock.conformance.test.ts`; there is no generic sweep, because a provider's probe fixtures are provider knowledge.
- **Provider-internal stays internal**: transcript archiving on pre-compact and continuation rotation are Claude housekeeping and live in the Claude provider, not on the seam. The unread `compaction` flag is gone.
- **Active provider only**: slash-command lists and the trace lookup come from the running provider's contract, not a union across every registered one. A provider with no contract keeps the lists the formatter always applied.
- **Legacy path kept**: providers without a contract keep their own `supportsNativeSlashCommands` / `emitsMidTurnText` flags.
- **Out of scope**: host and setup seams (next two PRs in the stack).

## Related work

Bottom layer of the provider-contract stack; nanocoai/nanoclaw#3585 and nanocoai/nanoclaw#3586 build on it. No issue; parity suites make it safe to review directly.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm run build` -> clean
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` -> clean
- `cd container/agent-runner && bun test` -> 390 passed, 3 skipped, 0 failed
- SDK options, settings.json, archive, rotation, and fast-mode parity suites pass with unchanged expectations
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

## Security and trust boundaries

None. Contract values are deep-frozen at registration; the shared `SDK_DISALLOWED_TOOLS` constant is copied so it is not frozen globally.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
