### PR TITLE
fix(add-dial): add dial-status.test.ts to the nc:copy list

### DIFF
--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -33,6 +33,7 @@ src/channels/dial-user-agent.ts
 src/channels/dial-user-agent.test.ts
 src/channels/dial-registration.test.ts
 src/channels/dial-grant.test.ts
+src/channels/dial-status.test.ts
 ```
 
 The `dial-cli` container skill is deliberately **not** copied here.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #3579. One line: adds `src/channels/dial-status.test.ts` to the `nc:copy` fence in `.claude/skills/add-dial/SKILL.md`.

The file has been on the `channels` branch since #3041 (de9cbfe2), but the copy list never included it, so installs and channel refreshes copy the verdict-handling code without its 16 tests. Details and receipts in the issue.

How I verified it: on my install I copied the file in by hand and ran `pnpm exec vitest run src/channels/dial-status.test.ts` (16/16 pass); with this line in the list, a re-run of the skill's copy step picks the file up.

This covers part 1 of the issue only. The guard against the class recurring (manifest on the branch, or a CI diff of branch files vs copy list) is part 2 and stays open there.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

Not run on a fresh clone; tested the changed copy step on a live install as described above.

*Assisted by Claude; reviewed and verified by a human before submission.*

