### PR TITLE
fix(tasks): stamp the series id into task_log rows so chat-session fires keep their run log

### DIFF
--- a/container/agent-runner/src/cross-session-echo.test.ts
+++ b/container/agent-runner/src/cross-session-echo.test.ts
@@ -184,6 +184,32 @@ describe('routing (extractRouting)', () => {
 
     expect(extractRouting(getPendingMessages()).taskRun).toBe(false);
   });
+
+  it('carries the task series id so the run log survives a chat-session fire (#3301)', () => {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, seq, kind, timestamp, status, "trigger", series_id, content)
+         VALUES ('t1', 2, 'task', datetime('now'), 'pending', 1, 'water-plants-9f3c', ?)`,
+      )
+      .run(JSON.stringify({ prompt: 'water the plants' }));
+
+    expect(extractRouting(getPendingMessages()).taskSeriesId).toBe('water-plants-9f3c');
+  });
+
+  it('taskSeriesId is null when the task row carries no series', () => {
+    // The host's own writers stamp series_id on every row, but the mailbox
+    // contract allows NULL — an absent series must stay absent, never be
+    // invented from the row id.
+    insertMessage('task-abc', 'task', { prompt: 'one-shot' }, { seq: 2 });
+
+    expect(extractRouting(getPendingMessages()).taskSeriesId).toBeNull();
+  });
+
+  it('taskSeriesId is null for non-task batches', () => {
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'hi' }, { seq: 2 });
+
+    expect(extractRouting(getPendingMessages()).taskSeriesId).toBeNull();
+  });
 });
 
 describe('command classification', () => {

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -117,6 +117,13 @@ export interface RoutingContext {
    *  delivers from a task session; final-text `<message to>` blocks are inert
    *  and the final text auto-appends to the series run log. */
   taskRun: boolean;
+  /** Series id of the triggering task row, stamped into task_log rows so the
+   *  host can append the run log even when the task fired outside a
+   *  system:tasks:<series> session (#3301). Null when the batch is not a
+   *  task run, or when the row carries no series — the host's writers stamp
+   *  one on every row, but the mailbox contract allows NULL, and an absent
+   *  series must stay absent, never invented from the row id. */
+  taskSeriesId: string | null;
 }
 
 /**
@@ -139,6 +146,11 @@ export function extractRouting(messages: MessageInRow[]): RoutingContext {
     taskRun:
       messages.some((m) => m.kind === 'task') &&
       messages.every((m) => m.kind === 'task' || isSessionEcho(m)),
+    // First task row's series wins. A chat-session batch can in principle
+    // carry rows from two legacy series; the single run summary cannot be
+    // split, so it lands in the first series' log — still better than the
+    // pre-stamp behavior of dropping it entirely.
+    taskSeriesId: messages.find((m) => m.kind === 'task')?.series_id ?? null,
   };
 }
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -576,7 +576,7 @@ export async function processQuery(
           // Errors included: a failed run's text belongs in its log, not chat.
           // A corrective retry handles delivery only; its result is not a
           // second run summary.
-          if (routing.taskRun && !taskBlockNudged) await autoAppendTaskLog(event.text);
+          if (routing.taskRun && !taskBlockNudged) await autoAppendTaskLog(event.text, routing.taskSeriesId);
           if (resultBlocks === 0 && event.isError === true && !routing.taskRun) {
             // Non-retryable error turn (e.g. a 403 billing_error) with no
             // <message> envelope: deliver the notice instead of dropping it as
@@ -1113,7 +1113,7 @@ function escapePromptXml(value: string): string {
  * `task_log` outbound row; the host appends it to the series' tasks/<id>.md
  * with its usual timestamp stamp. Never delivered to anyone.
  */
-export async function autoAppendTaskLog(text: string): Promise<void> {
+export async function autoAppendTaskLog(text: string, seriesId: string | null = null): Promise<void> {
   // Run-log hygiene: an inert <message to> block never belongs in the log as
   // raw XML — replace each with its inner text, marked undelivered, so the
   // log stays readable prose.
@@ -1123,10 +1123,13 @@ export async function autoAppendTaskLog(text: string): Promise<void> {
   );
   const line = stripInternalTags(prose).replace(/\s+/g, ' ').trim().slice(0, 500);
   if (!line) return;
+  // The series rides in the content so the host can attribute the log even
+  // when the row fired in a chat session, whose thread id carries no series
+  // (#3301). Series-less rows keep the exact `{ text }` shape.
   await writeMessageOut({
     id: generateId(),
     kind: 'task_log',
-    content: JSON.stringify({ text: line }),
+    content: JSON.stringify(seriesId ? { text: line, series: seriesId } : { text: line }),
   });
   log('Task run log auto-appended from final text');
 }

--- a/container/agent-runner/src/task-delivery.test.ts
+++ b/container/agent-runner/src/task-delivery.test.ts
@@ -39,6 +39,7 @@ const taskRouting: RoutingContext = {
   threadId: 'system:tasks:daily-digest-a1b2',
   inReplyTo: 'run-1',
   taskRun: true,
+  taskSeriesId: 'daily-digest-a1b2',
 };
 
 beforeEach(() => {
@@ -194,6 +195,24 @@ describe('automatic task run summary', () => {
     }[];
     expect(rows).toHaveLength(1);
     expect(JSON.parse(rows[0].content).text).toBe('Checked the feeds — nothing new.');
+  });
+
+  it('stamps the series into the row so a chat-session fire keeps its run log (#3301)', async () => {
+    await autoAppendTaskLog('Reminder sent.', 'water-plants-9f3c');
+
+    const row = getOutboundDb().prepare("SELECT content FROM messages_out WHERE kind = 'task_log'").get() as {
+      content: string;
+    };
+    expect(JSON.parse(row.content)).toEqual({ text: 'Reminder sent.', series: 'water-plants-9f3c' });
+  });
+
+  it('keeps the exact { text } shape when no series is known', async () => {
+    await autoAppendTaskLog('Done.', null);
+
+    const row = getOutboundDb().prepare("SELECT content FROM messages_out WHERE kind = 'task_log'").get() as {
+      content: string;
+    };
+    expect(JSON.parse(row.content)).toEqual({ text: 'Done.' });
   });
 
   it('marks legacy final-output blocks undelivered and never stores raw XML', async () => {

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -599,6 +599,134 @@ describe('deliverSessionMessages — task_log rows (one-door task delivery)', ()
     const delivered = await withMailboxSession('ag-1', session.id, (mailbox) => mailbox.getDeliveredIds());
     expect(delivered.has('log-1')).toBe(true);
   });
+
+  it('falls back to the runner-stamped series when the row fired in a chat session (#3301)', async () => {
+    // A legacy pre-2.1.48 series fires its task rows inside an ordinary chat
+    // session, whose thread id carries no series. The runner stamps `series`
+    // into the row content; the host must use it instead of dropping the log.
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-2', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'reminder sent', series: 'water-plants-9f3c' }));
+    db.close();
+
+    const calls: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_c, _p, _t, _k, content) {
+        calls.push(content);
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session);
+
+    expect(calls).toHaveLength(0); // a run-log line is still never a delivery
+    const logFile = `${TEST_DIR}/groups/test-agent/tasks/water-plants-9f3c.md`;
+    expect(fs.existsSync(logFile)).toBe(true);
+    expect(fs.readFileSync(logFile, 'utf8')).toContain('reminder sent');
+  });
+
+  it('still ignores a task_log row with neither a task session nor a series stamp', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-3', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'orphan line' }));
+    db.close();
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session);
+
+    const tasksDir = `${TEST_DIR}/groups/test-agent/tasks`;
+    const files = fs.existsSync(tasksDir) ? fs.readdirSync(tasksDir) : [];
+    expect(files.filter((f) => fs.readFileSync(`${tasksDir}/${f}`, 'utf8').includes('orphan line'))).toHaveLength(0);
+  });
+
+  it('rejects a series stamp that fails the filename charset guard', async () => {
+    // appendRunLog's charset guard is the security boundary: the stamp is
+    // container-authored, and a corrupt or malicious value must not write
+    // outside tasks/.
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-4', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'evil', series: '../../escape' }));
+    db.close();
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session); // must not throw
+
+    expect(fs.existsSync(`${TEST_DIR}/groups/escape.md`)).toBe(false);
+    expect(fs.existsSync(`${TEST_DIR}/escape.md`)).toBe(false);
+  });
+
+  it('falls through to the stamp in the legacy SHARED task session (bare system:tasks thread)', async () => {
+    // isTaskThread is true for the bare legacy thread, but slicing it yields
+    // '' — the resolver must fall through to the stamp instead of dropping a
+    // perfectly attributable log.
+    await seedAgentAndChannel();
+    const { session } = await resolveTaskSession('ag-1', 'daily-digest-a1b2');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-5', datetime('now'), 'task_log', ?)`,
+    ).run(JSON.stringify({ text: 'legacy shared fire', series: 'water-plants-9f3c' }));
+    db.close();
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages({ ...session, thread_id: 'system:tasks' });
+
+    const logFile = `${TEST_DIR}/groups/test-agent/tasks/water-plants-9f3c.md`;
+    expect(fs.existsSync(logFile)).toBe(true);
+    expect(fs.readFileSync(logFile, 'utf8')).toContain('legacy shared fire');
+  });
+
+  it('tolerates a task_log row whose content is JSON null (container-authored)', async () => {
+    // `content` is container-authored and may be any JSON value. A null must
+    // take the warn-ignore path and be marked delivered, never throw into
+    // the retry loop.
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, content)
+       VALUES ('log-6', datetime('now'), 'task_log', 'null')`,
+    ).run();
+    db.close();
+
+    setDeliveryAdapter({
+      async deliver() {
+        return 'pm';
+      },
+    });
+    await deliverSessionMessages(session); // must not throw
+
+    const delivered = await withMailboxSession('ag-1', session.id, (mailbox) => mailbox.getDeliveredIds());
+    expect(delivered.has('log-6')).toBe(true);
+  });
 });
 
 describe('deliverSessionMessages — batch preview hooks', () => {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -310,15 +310,33 @@ async function deliverMessage(
   // the only delivery path from a task session). Append to the series log,
   // never deliver. The caller marks it delivered so it isn't retried.
   if (msg.kind === 'task_log') {
-    if (session.messaging_group_id === null && isTaskThread(session.thread_id) && session.thread_id) {
-      const series = session.thread_id.slice(`${TASKS_SYSTEM_THREAD_ID}:`.length);
+    // Series resolution, in order of authority: the session's own
+    // system:tasks:<series> thread id, then the series the runner stamped
+    // into the row. A task that fired in a chat session (legacy pre-2.1.48
+    // series) has no task thread id, and dropping its log recorded runs as
+    // if they never happened (#3301). The stamp is container-authored, so it
+    // never overrides a per-series task session's thread id, and
+    // appendRunLog's charset guard keeps a corrupt stamp from writing
+    // outside tasks/. The legacy SHARED task thread (bare 'system:tasks')
+    // slices to '' — fall through to the stamp there too. `content` itself
+    // is container-authored and may be any JSON value, null included.
+    const threadSeries =
+      session.messaging_group_id === null && isTaskThread(session.thread_id) && session.thread_id
+        ? session.thread_id.slice(`${TASKS_SYSTEM_THREAD_ID}:`.length)
+        : '';
+    const stampedSeries = content && typeof content.series === 'string' ? content.series : '';
+    const series = threadSeries || stampedSeries || null;
+    if (series) {
       try {
         await appendRunLog(session.agent_group_id, series, typeof content.text === 'string' ? content.text : '');
       } catch (err) {
-        log.warn('Failed to append task run log', { id: msg.id, sessionId: session.id, err });
+        log.warn('Failed to append task run log', { id: msg.id, sessionId: session.id, series, err });
       }
     } else {
-      log.warn('task_log row outside a task session — ignoring', { id: msg.id, sessionId: session.id });
+      log.warn('task_log row with no resolvable series (no per-series thread, no stamp) — ignoring', {
+        id: msg.id,
+        sessionId: session.id,
+      });
     }
     return;
   }


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Refs #3301. This fixes one of its three symptoms: run logs get silently dropped when a task fires inside a chat session.

**The problem.** Old task series (from before 2.1.48) live in chat sessions. When one of them runs, the runner writes a `task_log` row. The host then asks: which series does this belong to? Today it has only one way to answer: read the session's `system:tasks:<series>` thread id. A chat session has no such id. So the host drops the log and the run leaves no trace. On the issue's live install, one series is at `completed_runs: 141` with `recent_log: []`.

**The fix.** Two small halves.

1. The runner now writes the task row's `series_id` into the `task_log` row.
2. The host tries the thread id first, like today. If that gives no series, it uses the stamp.

The fix also covers two edge cases:

- The old shared task thread is just `system:tasks`, with no series after it. The old code picked that empty answer and dropped the log. Now it falls through to the stamp.
- The row content comes from the container, so it can be any JSON, even `null`. The host now checks before reading `content.series`. Before, a `null` threw an error and sent the row into the retry loop.

**Is the stamp safe?** Yes. The stamp comes from the container, but it cannot cross into another agent group: `appendRunLog` is scoped by the session's own group. And its charset guard blocks path tricks like `../../escape`. A test pins that case.

**About #3564.** Same direction as that PR, and thanks for it: the working patch shaped this one. Three differences: the shared-thread fallthrough, the `null` guard, and no row-id fallback in the runner (a row with no series stays unlogged; the host already stamps `series_id` on every row it writes, so this only matters for other mailbox backends). One consequence to know about, on purpose: channel-onboarding writes carry a `series_id` too, so their runs now get a small `tasks/<row-id>.md` log instead of vanishing. The nicer long-term home for onboarding is the issue's related note (that write may not want `kind: 'task'` at all). That stays a separate decision.

The other two symptoms in #3301 (replies eaten, old series invisible to `tasks list`) need the legacy-session migration the issue calls direction 2. That is a breaking-change-class decision, so this PR keeps the issue open.

## How it was tested

- New runner tests: the stamp is copied from `series_id`; it is null when the row has no series; null for non-task batches; the row shape is `{ text, series }` with a stamp and exactly `{ text }` without one.
- New host tests: a chat-session row with a stamp lands in `tasks/<series>.md` with zero channel sends; the bare `system:tasks` session falls through to the stamp; JSON-`null` content is warn-ignored and marked delivered; a row with no resolvable series is still ignored; a `../../escape` stamp writes nothing outside `tasks/`.
- Red proof: with only the implementation reverted to main, the new host fallback test fails and the three new runner routing tests fail. The tests really pin the fix.
- Full suites on macOS, at the final commit: host `tsc` clean, delivery suite 23/23, full vitest 2072/2075 (the 3 failures are the known stdin-json environment baseline, identical on clean main `a4f609c6`). Runner `tsc` clean, 338 tests, 0 fail under `bun test`. `mailbox-model:check` and `stdin-json:check` clean.
- Two rounds of independent adversarial review. Round 1 caught the three sharpest problems above. Round 2 re-verified every fix and returned READY.

Review status: needs a colleague's review before merge.

Assisted by Claude; reviewed and verified by a human before submission.
