### PR TITLE
refactor(providers): implement the codex provider contract

### DIFF
--- a/.github/workflows/provider-contract.yml
+++ b/.github/workflows/provider-contract.yml
@@ -1,0 +1,126 @@
+name: Provider contract
+
+on:
+  pull_request:
+    branches: [providers]
+  push:
+    branches: [providers]
+
+permissions:
+  contents: read
+
+env:
+  # The core this payload is verified against. Until the provider-contract
+  # core stack merges to main, this pin must track the HEAD of that stack
+  # (currently refactor/provider-contract-setup); bump it whenever the stack is amended.
+  COMPATIBLE_CORE_SHA: 9d9d0df8deb5ca0e5c3278af7f1841152e54ac3f
+  COMPATIBLE_CHANNELS_SHA: 4bd51d583c5a8749d1d76c36f8d04ab6f1c7e2a8
+  # A pre-contract main commit that still carries /add-codex and /add-opencode:
+  # the old-core gate installs the pre-contract payloads there and refreshes
+  # them to this PR's head, proving the payload still lands on an old install.
+  OLD_CORE_SHA: 99283f3e274b2b1dae47b141ac4f11f56ad8eb2d
+
+jobs:
+  combined-providers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out provider PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          path: provider-payload
+      - name: Check out compatible core
+        uses: actions/checkout@v4
+        with:
+          repository: nanocoai/nanoclaw
+          ref: ${{ env.COMPATIBLE_CORE_SHA }}
+          path: core
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: core/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: core/pnpm-lock.yaml
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - id: provider
+        name: Pin provider payload head
+        run: |
+          sha=$(git -C provider-payload rev-parse HEAD)
+          git -C core fetch ../provider-payload "$sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      - run: pnpm install --frozen-lockfile
+        working-directory: core
+      - name: Install, refresh, and verify provider head
+        working-directory: core
+        env:
+          REGISTRY_CHANNELS_SHA: ${{ env.COMPATIBLE_CHANNELS_SHA }}
+          REGISTRY_PROVIDERS_SHA: ${{ steps.provider.outputs.sha }}
+        run: pnpm exec tsx scripts/test-registry-skills.ts --combined-providers
+      - name: Verify pre-contract providers on the exact current core
+        working-directory: core
+        run: pnpm exec tsx scripts/test-registry-skills.ts --pre-contract-providers
+      - name: Install legacy providers on the old core, then refresh them to provider head
+        working-directory: core
+        env:
+          REGISTRY_CHANNELS_SHA: ${{ env.COMPATIBLE_CHANNELS_SHA }}
+          REGISTRY_PROVIDERS_SHA: ${{ steps.provider.outputs.sha }}
+        run: pnpm exec tsx scripts/test-registry-skills.ts --old-provider-refresh "$OLD_CORE_SHA"
+
+  intermediate-cores:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - stage: runtime
+            core: c214a7e05ad51bbd5a2277584dd8f5160da1c734
+          - stage: host
+            core: bc383a2a16a6ecb35a3b1c6840757b59ea1b2f65
+          - stage: instructions
+            core: ff1d8091179c14850f506a6ded49ee2d657731f0
+          - stage: speed
+            core: 89cb2c6f15d4872782d6e8db10c1392a227d52ee
+    steps:
+      - name: Check out provider PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          path: provider-payload
+      - name: Check out composition verifier
+        uses: actions/checkout@v4
+        with:
+          repository: nanocoai/nanoclaw
+          ref: ${{ env.COMPATIBLE_CORE_SHA }}
+          path: core
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: core/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: core/pnpm-lock.yaml
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - id: provider
+        name: Pin provider payload head
+        run: |
+          sha=$(git -C provider-payload rev-parse HEAD)
+          git -C core fetch ../provider-payload "$sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      - run: pnpm install --frozen-lockfile
+        working-directory: core
+      - name: Verify the intermediate install and provider refresh
+        working-directory: core
+        env:
+          REGISTRY_CHANNELS_SHA: ${{ env.COMPATIBLE_CHANNELS_SHA }}
+          REGISTRY_PROVIDERS_SHA: ${{ steps.provider.outputs.sha }}
+          STAGE_CORE_SHA: ${{ matrix.core }}
+        run: pnpm exec tsx scripts/test-registry-skills.ts --old-provider-refresh "$STAGE_CORE_SHA"

--- a/container/agent-runner/src/provider-contracts/codex.ts
+++ b/container/agent-runner/src/provider-contracts/codex.ts
@@ -1,0 +1,65 @@
+import {
+  codexExecutionPolicySection,
+  codexInferenceSection,
+  codexMcpServersSection,
+  codexMemorySection,
+  codexRuntimeOwnership,
+  type CodexMemorySessionHook,
+  writeCodexConfigToml,
+} from '../providers/codex-app-server.js';
+import { archiveProviderExchange } from '../providers/exchange-archive.js';
+import { registerProviderContract } from '../providers/provider-registry.js';
+
+import {
+  type ProviderRuntimeContract,
+  type RuntimeAfterExchangeInput,
+  type RuntimeCallbackEffects,
+  type RuntimeConfigurationInputs,
+} from './registry.js';
+
+const provider = 'codex';
+// Pinned literal, not the core's constant: a core seam bump must fail this
+// payload's version check until the payload is refreshed to match.
+const RUNTIME_SEAM_VERSION = 1;
+
+// This module loading means core runs the contract's beforeQuery before every
+// query, so the provider's own direct write must stand down — otherwise the
+// files would be written twice per query.
+codexRuntimeOwnership.contractOwnsRuntimeFiles = true;
+
+export const codexRuntimeContract: ProviderRuntimeContract = {
+  seamVersion: RUNTIME_SEAM_VERSION,
+  configuration: {
+    executionPolicy: { constant: codexExecutionPolicySection() },
+    inference: codexInferenceSection,
+    // Codex's native memory stays off whatever hook core registers, so the
+    // section is a declared constant, not a function of the hook.
+    memory: { constant: codexMemorySection() },
+    mcpServers: codexMcpServersSection,
+  },
+  lifecycle: { beforeQuery: writeCodexRuntimeFiles },
+  history: { afterExchange: archiveCodexExchange },
+  textDelivery: 'result',
+  commands: { formatting: 'xml' },
+};
+
+// Two-step registration: providers/codex.ts registered the factory; this
+// attaches the contract. Order-independent, and neither file imports the other.
+registerProviderContract(provider, codexRuntimeContract);
+
+function writeCodexRuntimeFiles(inputs: Partial<RuntimeConfigurationInputs>): void {
+  const hook = inputs.memory as CodexMemorySessionHook | undefined;
+  if (!hook) throw new Error('Codex provider requires a registered memory hook before query');
+  writeCodexConfigToml(inputs.mcpServers ?? {}, hook, codexInferenceSection(inputs.inference ?? {}));
+}
+
+function archiveCodexExchange({ exchange }: RuntimeAfterExchangeInput, fx: RuntimeCallbackEffects): string | null {
+  return archiveProviderExchange({
+    provider,
+    prompt: exchange.prompt,
+    result: exchange.result,
+    continuation: exchange.continuation,
+    status: exchange.status,
+    timestamp: new Date(fx.now()),
+  });
+}

--- a/container/agent-runner/src/provider-contracts/opencode.ts
+++ b/container/agent-runner/src/provider-contracts/opencode.ts
@@ -1,0 +1,22 @@
+import { mcpServersToOpenCodeConfig } from '../providers/mcp-to-opencode.js';
+import { OPENCODE_PERMISSION_POLICY } from '../providers/opencode.js';
+import { registerProviderContract } from '../providers/provider-registry.js';
+import type { ProviderRuntimeContract } from './registry.js';
+
+// Pinned literal, not the core's constant: a core seam bump must fail this
+// payload's version check until the payload is refreshed to match.
+const RUNTIME_SEAM_VERSION = 1;
+
+export const opencodeRuntimeContract: ProviderRuntimeContract = {
+  seamVersion: RUNTIME_SEAM_VERSION,
+  configuration: {
+    executionPolicy: { constant: OPENCODE_PERMISSION_POLICY },
+    mcpServers: mcpServersToOpenCodeConfig,
+  },
+  textDelivery: 'result',
+  commands: { formatting: 'xml' },
+};
+
+// Two-step registration: providers/opencode.ts registered the factory; this
+// attaches the contract. Order-independent, and neither file imports the other.
+registerProviderContract('opencode', opencodeRuntimeContract);

--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -7,7 +7,10 @@ import {
   type AppServer,
   CODEX_APP_SERVER_ARGS,
   attachCodexAutoApproval,
+  buildCodexConfigPlan,
   buildCodexProcessEnv,
+  codexInferenceSection,
+  renderCodexConfigToml,
   startOrResumeCodexThread,
   tomlBasicString,
   writeCodexConfigToml,
@@ -31,6 +34,96 @@ afterEach(() => {
 });
 
 describe('Codex config TOML', () => {
+  it('builds every declared configuration capability before rendering', () => {
+    const mcpServers = { nanoclaw: { command: 'bun', args: ['run', 'server.ts'] } };
+    const plan = buildCodexConfigPlan(mcpServers, { model: 'gpt-5', effort: 'medium', fastMode: true });
+
+    expect(plan).toEqual({
+      executionPolicy: {
+        sandboxMode: 'danger-full-access',
+        approvalPolicy: 'never',
+        projectDocumentMaxBytes: 32768,
+      },
+      inference: { model: 'gpt-5', effort: 'medium', fastMode: true },
+      memory: { memories: false, useMemories: false, generateMemories: false },
+      mcpServers,
+    });
+    expect(renderCodexConfigToml(plan)).toContain('[mcp_servers.nanoclaw]');
+  });
+
+  it('renders the exact bytes, pinning line order and the trailing newline', () => {
+    const content = renderCodexConfigToml(
+      buildCodexConfigPlan(
+        {
+          nanoclaw: { command: 'bun', args: ['run', '/app/src/mcp-tools/index.ts'], env: { FOO: 'bar' } },
+          docs: { type: 'http', url: 'https://mcp.example.com/mcp', headers: { 'X-Api-Version': '2024-06' } },
+        },
+        { model: 'gpt-5', effort: 'medium', fastMode: true },
+      ),
+    );
+    expect(content).toBe(
+      [
+        'sandbox_mode = "danger-full-access"',
+        'approval_policy = "never"',
+        'project_doc_max_bytes = 32768',
+        'model = "gpt-5"',
+        'model_reasoning_effort = "medium"',
+        'service_tier = "fast"',
+        '',
+        '[features]',
+        'memories = false',
+        '',
+        '[memories]',
+        'use_memories = false',
+        'generate_memories = false',
+        '',
+        '[mcp_servers.nanoclaw]',
+        'command = "bun"',
+        'args = ["run", "/app/src/mcp-tools/index.ts"]',
+        '[mcp_servers.nanoclaw.env]',
+        'FOO = "bar"',
+        '',
+        '[mcp_servers.docs]',
+        'url = "https://mcp.example.com/mcp"',
+        '[mcp_servers.docs.http_headers]',
+        '"X-Api-Version" = "2024-06"',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  // Core's speed property → Codex's service tier. `fast` is the only value
+  // with a Codex rendering; `standard` (the core default) and anything else
+  // emit no tier line, so Codex's own default serving tier stays in force.
+  it('renders service_tier = "fast" only for speed fast', () => {
+    const fast = renderCodexConfigToml({
+      ...buildCodexConfigPlan({}, {}),
+      inference: codexInferenceSection({ speed: 'fast' }),
+    });
+    expect(fast).toContain('service_tier = "fast"');
+    // The tier is a plain top-level key: no feature flag rides along with it.
+    expect(fast).not.toContain('fast_mode');
+
+    const standard = renderCodexConfigToml({
+      ...buildCodexConfigPlan({}, {}),
+      inference: codexInferenceSection({ speed: 'standard' }),
+    });
+    expect(standard).not.toContain('service_tier');
+
+    const unset = renderCodexConfigToml(buildCodexConfigPlan({}, {}));
+    expect(unset).not.toContain('service_tier');
+  });
+
+  it('treats speed as a fast-or-default flag — other tier names are dropped, not passed through', () => {
+    expect(codexInferenceSection({ speed: 'ultrafast' }).fastMode).toBeUndefined();
+    const rendered = renderCodexConfigToml({
+      ...buildCodexConfigPlan({}, {}),
+      inference: codexInferenceSection({ speed: 'ultrafast' }),
+    });
+    expect(rendered).not.toContain('service_tier');
+    expect(rendered).not.toContain('ultrafast');
+  });
+
   it('escapes basic strings', () => {
     expect(tomlBasicString('a "quoted" \\\\ value')).toBe('"a \\"quoted\\" \\\\\\\\ value"');
   });
@@ -43,7 +136,7 @@ describe('Codex config TOML', () => {
     expect(() => tomlBasicString('bad\nvalue')).toThrow(/newline/);
   });
 
-  it('hardcodes danger-full-access + never and writes model, effort, and MCP servers', () => {
+  it('hardcodes danger-full-access + never and writes model, effort, fast mode, and MCP servers', () => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
     process.env.HOME = tmpHome;
 
@@ -61,7 +154,7 @@ describe('Codex config TOML', () => {
         },
       },
       MEMORY_SESSION_HOOK,
-      { model: 'gpt-5', effort: 'medium' },
+      { model: 'gpt-5', effort: 'medium', fastMode: true },
     );
 
     const content = fs.readFileSync(path.join(tmpHome, '.codex', 'config.toml'), 'utf-8');
@@ -70,6 +163,7 @@ describe('Codex config TOML', () => {
     expect(content).toContain('project_doc_max_bytes = 32768');
     expect(content).toContain('model = "gpt-5"');
     expect(content).toContain('model_reasoning_effort = "medium"');
+    expect(content).toContain('service_tier = "fast"');
     expect(content).toContain('[features]\nmemories = false');
     expect(content).toContain('[memories]\nuse_memories = false\ngenerate_memories = false');
     expect(content).not.toContain('[sandbox_workspace_write]');
@@ -204,6 +298,38 @@ describe('Codex config TOML', () => {
       },
     ]);
   });
+
+  it('replaces config.toml before malformed hooks.json fails', () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+    process.env.HOME = tmpHome;
+    const codexDir = path.join(tmpHome, '.codex');
+    const configPath = path.join(codexDir, 'config.toml');
+    const hooksPath = path.join(codexDir, 'hooks.json');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(configPath, 'stale config');
+    fs.writeFileSync(hooksPath, '{');
+
+    expect(() => writeCodexConfigToml({}, MEMORY_SESSION_HOOK, { model: 'gpt-5' })).toThrow();
+    expect(fs.readFileSync(configPath, 'utf-8')).toContain('model = "gpt-5"');
+    expect(fs.readFileSync(configPath, 'utf-8')).not.toContain('stale config');
+    expect(fs.readFileSync(hooksPath, 'utf-8')).toBe('{');
+  });
+
+  it('replaces config.toml before an existing empty hooks.json fails', () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+    process.env.HOME = tmpHome;
+    const codexDir = path.join(tmpHome, '.codex');
+    const configPath = path.join(codexDir, 'config.toml');
+    const hooksPath = path.join(codexDir, 'hooks.json');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(configPath, 'stale config');
+    fs.writeFileSync(hooksPath, '');
+
+    expect(() => writeCodexConfigToml({}, MEMORY_SESSION_HOOK, { model: 'gpt-5' })).toThrow();
+    expect(fs.readFileSync(configPath, 'utf-8')).toContain('model = "gpt-5"');
+    expect(fs.readFileSync(configPath, 'utf-8')).not.toContain('stale config');
+    expect(fs.readFileSync(hooksPath, 'utf-8')).toBe('');
+  });
 });
 
 describe('Codex thread SessionStart source', () => {
@@ -213,6 +339,7 @@ describe('Codex thread SessionStart source', () => {
     await startOrResumeCodexThread(server, undefined, { cwd: '/workspace/agent' });
 
     expect(requests[0].method).toBe('thread/start');
+    expect(requests[0].params.config).toEqual({ bypass_hook_trust: true });
     expect(requests[0].params.sessionStartSource).toBe('startup');
   });
 
@@ -222,6 +349,7 @@ describe('Codex thread SessionStart source', () => {
     await startOrResumeCodexThread(server, 'thread-existing', { cwd: '/workspace/agent' });
 
     expect(requests[0].method).toBe('thread/resume');
+    expect(requests[0].params.config).toEqual({ bypass_hook_trust: true });
     expect(requests[0].params.sessionStartSource).toBeUndefined();
   });
 });

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -67,6 +67,17 @@ export interface AppServer {
 
 export type CodexReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
+const SUPPORTED_EFFORTS = new Set<CodexReasoningEffort>(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']);
+
+export function normalizeCodexEffort(effort: string | undefined): CodexReasoningEffort | undefined {
+  const normalized = effort?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (!SUPPORTED_EFFORTS.has(normalized as CodexReasoningEffort)) {
+    throw new Error(`Unsupported Codex reasoning effort: ${effort}`);
+  }
+  return normalized as CodexReasoningEffort;
+}
+
 // Codex runs unrestricted inside the container. NanoClaw's container isolation and
 // the OneCLI allow-list are the security boundary — not Codex's own sandbox/approval
 // primitives (which can't run here anyway: workspace-write/read-only need user
@@ -272,6 +283,8 @@ export async function startOrResumeCodexThread(
     cwd: params.cwd,
     approvalPolicy: CODEX_APPROVAL_POLICY,
     sandbox: CODEX_SANDBOX_MODE,
+    // App-server ignores the CLI hook-trust flag; apply it to every thread.
+    config: { bypass_hook_trust: true },
     baseInstructions: params.baseInstructions,
     developerInstructions: params.developerInstructions,
     personality: 'friendly',
@@ -376,37 +389,119 @@ export function attachCodexAutoApproval(server: AppServer): void {
   });
 }
 
+/**
+ * Who writes config.toml / hooks.json before a query. The provider's own
+ * direct write (in CodexProvider.query) runs only while this is false. The
+ * runtime contract module (provider-contracts/codex.ts) flips it to true when
+ * it loads, because on that core the contract's beforeQuery performs the
+ * write — so each query writes the files exactly once on either core.
+ */
+export const codexRuntimeOwnership = { contractOwnsRuntimeFiles: false };
+
 export function writeCodexConfigToml(
   servers: Record<string, McpServerConfig>,
   memorySessionHook: CodexMemorySessionHook,
-  opts: { model?: string; effort?: string } = {},
+  opts: { model?: string; effort?: string; fastMode?: boolean } = {},
 ): void {
   const codexConfigDir = path.join(process.env.HOME || '/home/node', '.codex');
   fs.mkdirSync(codexConfigDir, { recursive: true });
   const configTomlPath = path.join(codexConfigDir, 'config.toml');
   const hooksJsonPath = path.join(codexConfigDir, 'hooks.json');
+  fs.writeFileSync(configTomlPath, renderCodexConfigToml(buildCodexConfigPlan(servers, opts)));
+  const hooksExist = fs.existsSync(hooksJsonPath);
+  fs.writeFileSync(
+    hooksJsonPath,
+    reconcileCodexHooksJson(
+      hooksExist ? fs.readFileSync(hooksJsonPath, 'utf-8') : '',
+      memorySessionHook,
+      hooksJsonPath,
+      hooksExist,
+    ),
+  );
+}
 
+export interface CodexConfigPlan {
+  executionPolicy: {
+    sandboxMode: string;
+    approvalPolicy: string;
+    projectDocumentMaxBytes: number;
+  };
+  inference: { model?: string; effort?: string; fastMode?: boolean };
+  memory: { memories: false; useMemories: false; generateMemories: false };
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+// Per-capability plan functions. The runtime contract probes these same
+// functions, and the lifecycle callback uses the direct writer below.
+
+export function codexExecutionPolicySection(): CodexConfigPlan['executionPolicy'] {
+  return {
+    sandboxMode: CODEX_SANDBOX_MODE,
+    approvalPolicy: CODEX_APPROVAL_POLICY,
+    projectDocumentMaxBytes: CODEX_PROJECT_DOC_MAX_BYTES,
+  };
+}
+
+/**
+ * The contract path receives the raw core input and normalizes here; the
+ * legacy provider path normalizes in its constructor and passes the result
+ * through `buildCodexConfigPlan` untouched — both land on the same bytes.
+ */
+export function codexInferenceSection(input: {
+  model?: string;
+  effort?: string;
+  speed?: string;
+}): CodexConfigPlan['inference'] {
+  return {
+    model: input.model,
+    effort: normalizeCodexEffort(input.effort),
+    fastMode: input.speed === 'fast' || undefined,
+  };
+}
+
+export function codexMemorySection(): CodexConfigPlan['memory'] {
+  return { memories: false, useMemories: false, generateMemories: false };
+}
+
+export function codexMcpServersSection(input: Record<string, McpServerConfig>): CodexConfigPlan['mcpServers'] {
+  return input;
+}
+
+export function buildCodexConfigPlan(
+  servers: Record<string, McpServerConfig>,
+  opts: { model?: string; effort?: string; fastMode?: boolean } = {},
+): CodexConfigPlan {
+  return {
+    executionPolicy: codexExecutionPolicySection(),
+    inference: opts,
+    memory: codexMemorySection(),
+    mcpServers: codexMcpServersSection(servers),
+  };
+}
+
+export function renderCodexConfigToml(plan: CodexConfigPlan): string {
   // Instance-level defaults the app-server reads on startup; threads/turns inherit them.
   const lines: string[] = [
-    `sandbox_mode = ${tomlBasicString(CODEX_SANDBOX_MODE)}`,
-    `approval_policy = ${tomlBasicString(CODEX_APPROVAL_POLICY)}`,
-    `project_doc_max_bytes = ${CODEX_PROJECT_DOC_MAX_BYTES}`,
+    `sandbox_mode = ${tomlBasicString(plan.executionPolicy.sandboxMode)}`,
+    `approval_policy = ${tomlBasicString(plan.executionPolicy.approvalPolicy)}`,
+    `project_doc_max_bytes = ${plan.executionPolicy.projectDocumentMaxBytes}`,
   ];
-  if (opts.model) lines.push(`model = ${tomlBasicString(opts.model)}`);
-  if (opts.effort) lines.push(`model_reasoning_effort = ${tomlBasicString(opts.effort)}`);
+  if (plan.inference.model) lines.push(`model = ${tomlBasicString(plan.inference.model)}`);
+  if (plan.inference.effort) lines.push(`model_reasoning_effort = ${tomlBasicString(plan.inference.effort)}`);
+  if (plan.inference.fastMode) lines.push('service_tier = "fast"');
   lines.push('');
 
   // NanoClaw owns persistent memory across providers. Keep Codex's native
   // memory disabled even if its defaults or a user-level config change.
   lines.push('[features]');
-  lines.push('memories = false');
+  lines.push(`memories = ${plan.memory.memories}`);
   lines.push('');
   lines.push('[memories]');
-  lines.push('use_memories = false');
-  lines.push('generate_memories = false');
+  lines.push(`use_memories = ${plan.memory.useMemories}`);
+  lines.push(`generate_memories = ${plan.memory.generateMemories}`);
   lines.push('');
 
-  for (const [name, config] of Object.entries(servers)) {
+  for (const [name, config] of Object.entries(plan.mcpServers)) {
     const tomlName = tomlKey(name);
     lines.push(`[mcp_servers.${tomlName}]`);
     if (config.type === 'http') {
@@ -441,8 +536,18 @@ export function writeCodexConfigToml(
     lines.push('');
   }
 
-  fs.writeFileSync(configTomlPath, lines.join('\n'));
-  const hooksConfig = readHooksConfig(hooksJsonPath);
+  return lines.join('\n');
+}
+
+export function reconcileCodexHooksJson(
+  current: string,
+  memorySessionHook: CodexMemorySessionHook,
+  filePath = 'Codex hooks config',
+  exists = Boolean(current),
+): string {
+  const parsed: unknown = exists ? JSON.parse(current) : {};
+  if (!isRecord(parsed)) throw new Error(`${filePath} must contain a JSON object`);
+  const hooksConfig = parsed;
   const hooks = objectProperty(hooksConfig, 'hooks');
   const sessionStart = arrayProperty(hooks, 'SessionStart');
 
@@ -455,16 +560,7 @@ export function writeCodexConfigToml(
     hooks: [{ type: 'command', command: memorySessionHook.command, timeout: 10 }],
   });
   hooks.SessionStart = nextSessionStart;
-  fs.writeFileSync(hooksJsonPath, JSON.stringify(hooksConfig, null, 2) + '\n');
-}
-
-function readHooksConfig(filePath: string): Record<string, unknown> {
-  if (!fs.existsSync(filePath)) return {};
-  const parsed: unknown = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  if (!isRecord(parsed)) {
-    throw new Error(`${filePath} must contain a JSON object`);
-  }
-  return parsed;
+  return JSON.stringify(hooksConfig, null, 2) + '\n';
 }
 
 function objectProperty(parent: Record<string, unknown>, key: string): Record<string, unknown> {

--- a/container/agent-runner/src/providers/codex-contract-parity.test.ts
+++ b/container/agent-runner/src/providers/codex-contract-parity.test.ts
@@ -1,0 +1,170 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, spyOn } from 'bun:test';
+
+import { type AppServer, writeCodexConfigToml, type CodexMemorySessionHook } from './codex-app-server.js';
+import { defaultCodexRuntimeDeps } from './codex.js';
+import type { McpServerConfig } from './types.js';
+
+// These tests need the runtime-contract core (registry + realize + factory
+// wiring). On the standalone providers branch that core is absent — the
+// payload is only ever executed inside an install — so they skip there, the
+// same way legacy-payload-compat.test.ts skips absent payloads on core.
+const hasContractCore = fs.existsSync(new URL('../provider-contracts/realize.ts', import.meta.url));
+
+const SERVERS: Record<string, McpServerConfig> = {
+  nanoclaw: {
+    command: 'bun',
+    args: ['run', '/app/src/mcp-tools/index.ts'],
+    env: { FOO: 'bar' },
+  },
+  docs: {
+    type: 'http',
+    url: 'https://mcp.example.com/mcp',
+    headers: { 'X-Api-Version': '2024-06' },
+  },
+};
+
+const HOOK: CodexMemorySessionHook = {
+  command: 'bun /app/src/memory/hook.ts',
+  legacyCommands: ['bun /app/src/memory-hook.ts'],
+  sources: ['startup', 'clear', 'compact'],
+};
+
+const EXISTING_HOOKS_JSON = JSON.stringify(
+  {
+    hooks: {
+      Stop: [{ hooks: [{ type: 'command', command: 'custom-stop' }] }],
+      SessionStart: [{ matcher: 'resume', hooks: [{ type: 'command', command: 'custom-resume' }] }],
+    },
+  },
+  null,
+  2,
+);
+
+function seedHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-parity-'));
+  const codexDir = path.join(home, '.codex');
+  fs.mkdirSync(codexDir, { recursive: true });
+  fs.writeFileSync(path.join(codexDir, 'hooks.json'), EXISTING_HOOKS_JSON);
+  return home;
+}
+
+function readCodexFiles(home: string): { configToml: string; hooksJson: string } {
+  return {
+    configToml: fs.readFileSync(path.join(home, '.codex', 'config.toml'), 'utf-8'),
+    hooksJson: fs.readFileSync(path.join(home, '.codex', 'hooks.json'), 'utf-8'),
+  };
+}
+
+(hasContractCore ? describe : describe.skip)('codex contract write-path parity', () => {
+  it('produces byte-identical config.toml and hooks.json through the contract path and the legacy writer', async () => {
+    // Two-step registration: the providers barrel registers the factory, the
+    // contracts barrel attaches the contract whose beforeQuery writes the files.
+    await import('./index.js');
+    await import('../provider-contracts/index.js');
+    const { createProvider } = await import('./factory.js');
+    const { registerProviderMemorySessionHook, runProviderBeforeQuery } =
+      await import('../provider-contracts/realize.js');
+
+    const previousHome = process.env.HOME;
+    const legacyHome = seedHome();
+    const contractHome = seedHome();
+    try {
+      // Legacy path: the provider normalizes effort in its constructor, then
+      // hands the direct writer the normalized value.
+      process.env.HOME = legacyHome;
+      writeCodexConfigToml(SERVERS, HOOK, { model: 'gpt-5', effort: 'high' });
+      const legacy = readCodexFiles(legacyHome);
+
+      // Contract path: core hands the raw construction inputs to the provider
+      // lifecycle callback (effort arrives un-normalized).
+      process.env.HOME = contractHome;
+      const provider = createProvider('codex', { mcpServers: SERVERS, model: 'gpt-5', effort: 'HIGH' });
+      registerProviderMemorySessionHook('codex', provider, {
+        command: HOOK.command,
+        legacyCommands: [...HOOK.legacyCommands],
+        sources: ['startup', 'clear', 'compact'],
+      });
+      runProviderBeforeQuery('codex', {
+        inference: { model: 'gpt-5', effort: 'HIGH' },
+        memory: HOOK,
+        mcpServers: SERVERS,
+      });
+      const contract = readCodexFiles(contractHome);
+
+      expect(contract.configToml).toBe(legacy.configToml);
+      expect(contract.hooksJson).toBe(legacy.hooksJson);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(legacyHome, { recursive: true, force: true });
+      fs.rmSync(contractHome, { recursive: true, force: true });
+    }
+  });
+
+  it('writes config.toml and hooks.json exactly once per query through the factory-wrapped provider', async () => {
+    await import('./index.js');
+    await import('../provider-contracts/index.js');
+    const { createProvider } = await import('./factory.js');
+    const { registerProviderMemorySessionHook } = await import('../provider-contracts/realize.js');
+
+    const previousHome = process.env.HOME;
+    const home = seedHome();
+    // The contract's beforeQuery writes through the real writer; the
+    // provider's own direct write goes through its runtime deps. Count the
+    // real file writes and the deps writer separately, and keep the query
+    // from reaching a codex binary by failing the app-server handshake.
+    const originalDeps = { ...defaultCodexRuntimeDeps };
+    let legacyWrites = 0;
+    const writeSpy = spyOn(fs, 'writeFileSync');
+    Object.assign(defaultCodexRuntimeDeps, {
+      writeCodexConfigToml: (...args: Parameters<typeof writeCodexConfigToml>) => {
+        legacyWrites += 1;
+        originalDeps.writeCodexConfigToml(...args);
+      },
+      spawnCodexAppServer: () => fakeAppServer(),
+      attachCodexAutoApproval: () => {},
+      initializeCodexAppServer: async () => {
+        throw new Error('handshake stopped by test');
+      },
+      killCodexAppServer: () => {},
+    });
+    try {
+      process.env.HOME = home;
+      const provider = createProvider('codex', { mcpServers: SERVERS, model: 'gpt-5', effort: 'high' });
+      registerProviderMemorySessionHook('codex', provider, {
+        command: HOOK.command,
+        legacyCommands: [...HOOK.legacyCommands],
+        sources: ['startup', 'clear', 'compact'],
+      });
+
+      const query = provider.query({ prompt: 'hello', cwd: '/workspace/agent' });
+      await expect(query.events.next()).rejects.toThrow('handshake stopped by test');
+
+      const written = writeSpy.mock.calls.map((call) => path.basename(String(call[0])));
+      expect(written.filter((name) => name === 'config.toml')).toHaveLength(1);
+      expect(written.filter((name) => name === 'hooks.json')).toHaveLength(1);
+      expect(legacyWrites).toBe(0);
+      expect(readCodexFiles(home).configToml).toContain('model = "gpt-5"');
+    } finally {
+      writeSpy.mockRestore();
+      Object.assign(defaultCodexRuntimeDeps, originalDeps);
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+function fakeAppServer(): AppServer {
+  return {
+    process: { stdin: { write: () => true } },
+    readline: { close: () => {} },
+    pending: new Map(),
+    notificationHandlers: [],
+    exitHandlers: [],
+    serverRequestHandlers: [],
+  } as unknown as AppServer;
+}

--- a/container/agent-runner/src/providers/codex.conformance.test.ts
+++ b/container/agent-runner/src/providers/codex.conformance.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Runtime-contract conformance for the codex payload, run through the core's
+ * own reusable suite (provider-contracts/testing/conformance.ts): registered
+ * contract identity, factory construction, contract shape, and live
+ * configuration probes.
+ *
+ * The suite exists only on the contract core. On the standalone providers
+ * branch and on a pre-contract install the file is absent, so this skips
+ * there — the same core detection codex-contract-parity.test.ts uses. The
+ * contract modules are loaded dynamically for the same reason: a static
+ * import would fail to resolve where the core does not carry them.
+ */
+import fs from 'fs';
+import { describe, it } from 'bun:test';
+
+const CONFORMANCE_SUITE = '../provider-contracts/testing/conformance.ts';
+const hasContractCore = fs.existsSync(new URL(CONFORMANCE_SUITE, import.meta.url));
+
+if (hasContractCore) {
+  await import('./index.js');
+  await import('../provider-contracts/index.js');
+  const { codexRuntimeContract } = await import('../provider-contracts/codex.js');
+  const { defineProviderConformance } = await import('../provider-contracts/testing/conformance.js');
+  defineProviderConformance('codex', codexRuntimeContract);
+} else {
+  describe.skip('runtime provider contract: codex', () => {
+    it('needs the contract core', () => {});
+  });
+}

--- a/container/agent-runner/src/providers/codex.factory.test.ts
+++ b/container/agent-runner/src/providers/codex.factory.test.ts
@@ -1,6 +1,47 @@
 import { describe, expect, it } from 'bun:test';
 
-import { CodexProvider } from './codex.js';
+import { type AppServer, codexRuntimeOwnership, type writeCodexConfigToml } from './codex-app-server.js';
+import { CodexProvider, type CodexRuntimeDeps } from './codex.js';
+
+const MEMORY_HOOK = { command: 'bun /app/src/memory/hook.ts', legacyCommands: [], sources: ['startup'] };
+
+/**
+ * Runtime deps that record config writes and stop the query at the app-server
+ * handshake, so no codex binary is ever spawned.
+ */
+function recordingRuntime(): { runtime: CodexRuntimeDeps; writes: Parameters<typeof writeCodexConfigToml>[] } {
+  const writes: Parameters<typeof writeCodexConfigToml>[] = [];
+  const runtime: CodexRuntimeDeps = {
+    writeCodexConfigToml: (...args) => {
+      writes.push(args);
+    },
+    spawnCodexAppServer: () =>
+      ({
+        process: { stdin: { write: () => true } },
+        readline: { close: () => {} },
+        pending: new Map(),
+        notificationHandlers: [],
+        exitHandlers: [],
+        serverRequestHandlers: [],
+      }) as unknown as AppServer,
+    attachCodexAutoApproval: () => {},
+    initializeCodexAppServer: async () => {
+      throw new Error('handshake stopped by test');
+    },
+    startOrResumeCodexThread: async () => 'thread-unreached',
+    startCodexTurn: async () => 'turn-unreached',
+    steerCodexTurn: async () => {},
+    interruptCodexTurn: async () => {},
+    killCodexAppServer: () => {},
+  };
+  return { runtime, writes };
+}
+
+async function runQueryToHandshake(provider: CodexProvider): Promise<void> {
+  provider.registerMemorySessionHook(MEMORY_HOOK);
+  const query = provider.query({ prompt: 'hello', cwd: '/workspace/agent' });
+  await expect(query.events.next()).rejects.toThrow('handshake stopped by test');
+}
 
 describe('CodexProvider', () => {
   it('rejects unsupported reasoning effort values', () => {
@@ -17,5 +58,57 @@ describe('CodexProvider', () => {
 
   it('requires the shared memory hook before starting a query', () => {
     expect(() => new CodexProvider({}).query({ prompt: 'hello', cwd: '/workspace/agent' })).toThrow(/not registered/);
+  });
+
+  it('writes the runtime files exactly once per query when no contract owns them', async () => {
+    const previous = codexRuntimeOwnership.contractOwnsRuntimeFiles;
+    codexRuntimeOwnership.contractOwnsRuntimeFiles = false;
+    try {
+      const { runtime, writes } = recordingRuntime();
+      const servers = { nanoclaw: { command: 'bun' } };
+      await runQueryToHandshake(
+        new CodexProvider({ mcpServers: servers, model: 'gpt-5', effort: 'HIGH', speed: 'fast' }, runtime),
+      );
+      expect(writes).toHaveLength(1);
+      const [mcpServers, hook, inference] = writes[0];
+      expect(mcpServers).toEqual(servers);
+      expect(hook).toEqual(MEMORY_HOOK);
+      // The same normalized values the contract path renders from.
+      expect(inference).toEqual({ model: 'gpt-5', effort: 'high', fastMode: true });
+    } finally {
+      codexRuntimeOwnership.contractOwnsRuntimeFiles = previous;
+    }
+  });
+
+  it('leaves the runtime files to the contract when its module owns them', async () => {
+    const previous = codexRuntimeOwnership.contractOwnsRuntimeFiles;
+    codexRuntimeOwnership.contractOwnsRuntimeFiles = true;
+    try {
+      const { runtime, writes } = recordingRuntime();
+      await runQueryToHandshake(new CodexProvider({ model: 'gpt-5' }, runtime));
+      expect(writes).toHaveLength(0);
+    } finally {
+      codexRuntimeOwnership.contractOwnsRuntimeFiles = previous;
+    }
+  });
+
+  it('consumes core-resolved configuration instead of re-deriving it', async () => {
+    const previous = codexRuntimeOwnership.contractOwnsRuntimeFiles;
+    codexRuntimeOwnership.contractOwnsRuntimeFiles = false;
+    try {
+      const { runtime, writes } = recordingRuntime();
+      const resolvedServers = { resolved: { command: 'resolved-bin' } };
+      const provider = new CodexProvider({ mcpServers: { ignored: { command: 'x' } }, model: 'ignored' }, runtime, {
+        executionPolicy: {},
+        inference: { model: 'gpt-5', effort: 'high', fastMode: undefined },
+        mcpServers: resolvedServers,
+      });
+      await runQueryToHandshake(provider);
+      const [mcpServers, , inference] = writes[0];
+      expect(mcpServers).toEqual(resolvedServers);
+      expect(inference).toEqual({ model: 'gpt-5', effort: 'high', fastMode: undefined });
+    } finally {
+      codexRuntimeOwnership.contractOwnsRuntimeFiles = previous;
+    }
   });
 });

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 
+// This module never imports the runtime contract (provider-contracts/codex.ts):
+// registration is two-step, so it compiles and runs on a core that predates the
+// contract seam. The contract attaches itself through registerProviderContract.
 import { registerProvider } from './provider-registry.js';
 import type {
   AgentProvider,
@@ -11,14 +14,16 @@ import type {
   ProviderOptions,
   QueryInput,
 } from './types.js';
-import { archiveProviderExchange } from './exchange-archive.js';
+import { archiveProviderExchange as archiveProviderExchangeLegacy } from './exchange-archive.js';
 import {
   type AppServer,
+  type CodexConfigPlan,
   type CodexMemorySessionHook,
-  type CodexReasoningEffort,
   type JsonRpcNotification,
   STALE_THREAD_RE,
   attachCodexAutoApproval,
+  codexInferenceSection,
+  codexRuntimeOwnership,
   initializeCodexAppServer,
   interruptCodexTurn,
   killCodexAppServer,
@@ -30,7 +35,6 @@ import {
 } from './codex-app-server.js';
 
 const TURN_TIMEOUT_MS = 10 * 60 * 1000;
-const SUPPORTED_EFFORTS = new Set<CodexReasoningEffort>(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']);
 
 export interface CodexRuntimeDeps {
   writeCodexConfigToml: typeof writeCodexConfigToml;
@@ -44,7 +48,25 @@ export interface CodexRuntimeDeps {
   killCodexAppServer: typeof killCodexAppServer;
 }
 
-const defaultCodexRuntimeDeps: CodexRuntimeDeps = {
+/**
+ * Structural mirror of the contract core's `ResolvedRuntimeConfiguration` —
+ * what `createProvider` hands the factory after running the contract's
+ * configuration resolves. Mirrored, not imported: the type lives in
+ * `provider-contracts/registry.ts`, which a pre-contract core does not have.
+ */
+export interface CodexResolvedConfiguration {
+  executionPolicy?: unknown;
+  inference?: unknown;
+  mcpServers?: unknown;
+}
+
+/**
+ * The production runtime deps. Exported as one mutable object so a test can
+ * swap in fakes for a provider that core constructs (createProvider gives the
+ * test no constructor access); every instance built without explicit deps
+ * reads through this object.
+ */
+export const defaultCodexRuntimeDeps: CodexRuntimeDeps = {
   writeCodexConfigToml,
   spawnCodexAppServer,
   attachCodexAutoApproval,
@@ -64,23 +86,14 @@ function classifyError(message: string): string | undefined {
   return undefined;
 }
 
-function normalizeEffort(effort: string | undefined): CodexReasoningEffort | undefined {
-  const normalized = effort?.trim().toLowerCase();
-  if (!normalized) return undefined;
-  if (!SUPPORTED_EFFORTS.has(normalized as CodexReasoningEffort)) {
-    throw new Error(`Unsupported Codex reasoning effort: ${effort}`);
-  }
-  return normalized as CodexReasoningEffort;
-}
-
 export class CodexProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
   // The app-server keeps history server-side; there is no on-disk transcript,
-  // so the provider persists each exchange itself into `conversations/`
-  // (see exchange-archive.ts). The poll-loop reports exchanges through this
-  // hook and does nothing else — archiving is payload code, not runner code.
+  // so each exchange is persisted into `conversations/`. A contract core
+  // replaces this fallback with the contract's afterExchange at the factory
+  // boundary; a pre-contract core calls it directly.
   onExchangeComplete(exchange: ProviderExchange): void {
-    archiveProviderExchange({
+    archiveProviderExchangeLegacy({
       provider: 'codex',
       prompt: exchange.prompt,
       result: exchange.result,
@@ -90,16 +103,32 @@ export class CodexProvider implements AgentProvider {
   }
 
   private readonly mcpServers: Record<string, McpServerConfig>;
-  private readonly model?: string;
-  private readonly effort?: CodexReasoningEffort;
+  private readonly inference: CodexConfigPlan['inference'];
   private readonly runtime: CodexRuntimeDeps;
   private memorySessionHook?: CodexMemorySessionHook;
 
-  constructor(options: ProviderOptions = {}, runtime: CodexRuntimeDeps = defaultCodexRuntimeDeps) {
-    this.mcpServers = options.mcpServers ?? {};
-    this.model = options.model;
+  /**
+   * `configuration` is present on a contract core: core has already run the
+   * contract's inference and MCP resolves and hands the results over, so
+   * they are consumed as-is. Without it (a pre-contract core) the provider
+   * derives the same values itself, exactly as it always did.
+   */
+  constructor(
+    options: ProviderOptions = {},
+    runtime: CodexRuntimeDeps = defaultCodexRuntimeDeps,
+    configuration?: CodexResolvedConfiguration,
+  ) {
     this.runtime = runtime;
-    this.effort = normalizeEffort(options.effort);
+    if (configuration) {
+      this.inference = configuration.inference as CodexConfigPlan['inference'];
+      this.mcpServers = configuration.mcpServers as Record<string, McpServerConfig>;
+    } else {
+      this.mcpServers = options.mcpServers ?? {};
+      // `speed` exists on ProviderOptions only from the contract core on; read
+      // it structurally so this compiles against the older options type too.
+      const { speed } = options as ProviderOptions & { speed?: string };
+      this.inference = codexInferenceSection({ model: options.model, effort: options.effort, speed });
+    }
   }
 
   registerMemorySessionHook(hook: CodexMemorySessionHook): void {
@@ -143,10 +172,12 @@ export class CodexProvider implements AgentProvider {
     const self = this;
 
     async function* gen(): AsyncGenerator<ProviderEvent> {
-      self.runtime.writeCodexConfigToml(self.mcpServers, memorySessionHook, {
-        model: self.model,
-        effort: self.effort,
-      });
+      // On a contract core the contract's beforeQuery has already written
+      // config.toml and hooks.json for this query (see codexRuntimeOwnership);
+      // this direct write is the pre-contract core's path only.
+      if (!codexRuntimeOwnership.contractOwnsRuntimeFiles) {
+        self.runtime.writeCodexConfigToml(self.mcpServers, memorySessionHook, self.inference);
+      }
       const server = self.runtime.spawnCodexAppServer();
       activeServer = server;
       self.runtime.attachCodexAutoApproval(server);
@@ -157,7 +188,7 @@ export class CodexProvider implements AgentProvider {
       try {
         await self.runtime.initializeCodexAppServer(server);
         threadId = await self.runtime.startOrResumeCodexThread(server, threadId, {
-          model: self.model,
+          model: self.inference.model,
           cwd: input.cwd,
           baseInstructions: input.systemContext?.instructions,
         });
@@ -177,8 +208,8 @@ export class CodexProvider implements AgentProvider {
             server,
             threadId,
             text,
-            self.model,
-            self.effort,
+            self.inference.model,
+            self.inference.effort,
             input.cwd,
             (turnId) => {
               activeTurnId = turnId;
@@ -424,4 +455,10 @@ function listGeneratedImages(threadId: string): Set<string> {
   }
 }
 
-registerProvider('codex', (opts) => new CodexProvider(opts));
+// Function-form registration only — the one shape both core generations
+// accept. A contract core passes the resolved configuration as the second
+// argument; a pre-contract core passes nothing there.
+registerProvider(
+  'codex',
+  (opts, configuration?: CodexResolvedConfiguration) => new CodexProvider(opts, defaultCodexRuntimeDeps, configuration),
+);

--- a/container/agent-runner/src/providers/exchange-archive.test.ts
+++ b/container/agent-runner/src/providers/exchange-archive.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { archiveProviderExchange } from './exchange-archive.js';
+import { archiveProviderExchange, planProviderExchangeArchive } from './exchange-archive.js';
 
 let tmpDir: string | null = null;
 
@@ -132,5 +132,84 @@ describe('provider exchange archive', () => {
 
     expect(filename).toBeNull();
     expect(fs.readdirSync(conversationsDir)).toHaveLength(0);
+  });
+
+  it('skips empty results before touching an absent or unreadable conversations path', () => {
+    const root = makeTmpDir();
+    const empty = {
+      provider: 'codex',
+      prompt: 'hello',
+      result: '   ',
+      continuation: 'thread-123',
+      status: 'completed',
+    };
+    const absent = path.join(root, 'absent');
+    expect(archiveProviderExchange({ ...empty, conversationsDir: absent })).toBeNull();
+    expect(fs.existsSync(absent)).toBe(false);
+
+    const unreadable = path.join(root, 'not-a-directory');
+    fs.writeFileSync(unreadable, 'blocked');
+    expect(archiveProviderExchange({ ...empty, conversationsDir: unreadable })).toBeNull();
+    expect(fs.readFileSync(unreadable, 'utf-8')).toBe('blocked');
+  });
+
+  it('skips empty results before resolving the default timestamp', () => {
+    const conversationsDir = makeTmpDir();
+    let timestampReads = 0;
+    const options = {
+      conversationsDir,
+      provider: 'codex',
+      prompt: 'hello',
+      result: '   ',
+      continuation: 'thread-123',
+      status: 'completed',
+      get timestamp(): Date {
+        timestampReads++;
+        throw new Error('timestamp must not be read');
+      },
+    };
+
+    expect(archiveProviderExchange(options)).toBeNull();
+    expect(timestampReads).toBe(0);
+    expect(fs.readdirSync(conversationsDir)).toHaveLength(0);
+  });
+
+  it('hands back the thread header separately from the appended exchange', () => {
+    const filename = '2026-06-03-codex-thread-123.md';
+    const plan = planProviderExchangeArchive({
+      provider: 'codex',
+      prompt: 'hello',
+      result: 'world',
+      continuation: 'thread-123',
+      status: 'completed',
+      timestamp: new Date('2026-06-05T12:34:56.789Z'),
+      entries: [filename],
+    });
+
+    // The plan continues the existing thread file and never asks whether that
+    // file is still there: the writer decides whether the header is due.
+    expect(plan?.relativePath).toBe(filename);
+    expect(plan?.headerIfNew).toStartWith('# Codex Conversation\n');
+    expect(plan?.content).not.toContain('# Codex Conversation');
+  });
+
+  it('writes the header through a dangling selected-target symlink', () => {
+    const conversationsDir = makeTmpDir();
+    const filename = '2026-06-03-codex-thread-123.md';
+    const target = path.join(conversationsDir, 'restored.md');
+    fs.symlinkSync('restored.md', path.join(conversationsDir, filename));
+
+    expect(
+      archiveProviderExchange({
+        conversationsDir,
+        provider: 'codex',
+        prompt: 'hello',
+        result: 'world',
+        continuation: 'thread-123',
+        status: 'completed',
+        timestamp: new Date('2026-06-05T12:34:56.789Z'),
+      }),
+    ).toBe(filename);
+    expect(fs.readFileSync(target, 'utf-8')).toStartWith('# Codex Conversation\n');
   });
 });

--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -4,10 +4,9 @@ import path from 'path';
 import { TIMEZONE, formatLocalStamp } from '../timezone.js';
 
 /**
- * Per-thread conversation archive for providers with no on-disk transcript —
- * payload code, shipped with the provider that needs it. The provider's
- * `onExchangeComplete` hook (see types.ts) calls this with each completed
- * exchange; the runner never archives on a provider's behalf.
+ * Per-thread conversation archive for providers with no on-disk transcript.
+ * The pure plan is shared by provider writers, so callback wiring cannot
+ * change the archive format.
  *
  * One file per thread (keyed on the continuation id), named
  * `<date>-<provider>-<thread>.md` and appended to as exchanges complete —
@@ -29,6 +28,24 @@ export interface ProviderExchangeArchiveOptions {
   conversationsDir?: string;
 }
 
+export interface ProviderExchangeArchivePlan {
+  relativePath: string;
+  content: string;
+  write: 'append';
+  /** Thread-level header, written once by whoever creates the file. */
+  headerIfNew?: string;
+}
+
+export interface ProviderExchangeArchivePlanInput {
+  provider: string;
+  prompt: string;
+  result: string | null | undefined;
+  continuation?: string;
+  status: string;
+  timestamp: Date;
+  entries: readonly string[];
+}
+
 /**
  * Append a single prompt/result exchange to its thread's conversation file,
  * writing the thread-level header once when the file is first created. Returns
@@ -36,47 +53,63 @@ export interface ProviderExchangeArchiveOptions {
  * (empty result).
  */
 export function archiveProviderExchange(options: ProviderExchangeArchiveOptions): string | null {
-  const result = options.result?.trim();
-  if (!result) return null;
-
+  if (!options.result?.trim()) return null;
   const timestamp = options.timestamp ?? new Date();
   const conversationsDir =
     options.conversationsDir || process.env.NANOCLAW_CONVERSATIONS_DIR || DEFAULT_CONVERSATIONS_DIR;
-  fs.mkdirSync(conversationsDir, { recursive: true });
+  let entries: readonly string[] = [];
+  try {
+    entries = fs.readdirSync(conversationsDir);
+  } catch {
+    // First archive for this workspace: nothing to continue.
+  }
+  const plan = planProviderExchangeArchive({ ...options, timestamp, entries });
+  if (!plan) return null;
 
-  const filename = threadArchiveFilename(conversationsDir, options.provider, options.continuation, timestamp);
-  const filePath = path.join(conversationsDir, filename);
+  fs.mkdirSync(conversationsDir, { recursive: true });
+  const filePath = path.join(conversationsDir, plan.relativePath);
+  const header = plan.headerIfNew && !fs.existsSync(filePath) ? plan.headerIfNew : '';
+  fs.appendFileSync(filePath, `${header}${plan.content}`);
+  return plan.relativePath;
+}
+
+export function planProviderExchangeArchive(
+  options: ProviderExchangeArchivePlanInput,
+): ProviderExchangeArchivePlan | null {
+  const result = options.result?.trim();
+  if (!result) return null;
+
+  const filename = threadArchiveFilename(options.entries, options.provider, options.continuation, options.timestamp);
 
   // Thread-level metadata (provider, thread id) belongs in the header, written
   // once. Per-exchange metadata (timestamp, status) rides in each appended
   // block. Each block leads with a blank line + `---` so the separator renders
   // as a thematic break, not a setext heading underline on the prior line.
+  // The header is handed back separately: whoever writes the file knows
+  // whether it is creating it, so the plan never has to ask the filesystem.
+  const headerIfNew = [
+    `# ${titleCase(options.provider)} Conversation`,
+    '',
+    `Provider: ${options.provider}`,
+    `Continuation/thread id: ${options.continuation || '(none)'}`,
+  ].join('\n');
   const parts: string[] = [];
-  if (!fs.existsSync(filePath)) {
-    parts.push(
-      `# ${titleCase(options.provider)} Conversation`,
-      '',
-      `Provider: ${options.provider}`,
-      `Continuation/thread id: ${options.continuation || '(none)'}`,
-    );
-  }
   parts.push(
     '',
     '---',
     '',
-    `Archived: ${formatLocalStamp(timestamp, TIMEZONE)} · Status: ${options.status}`,
+    `Archived: ${formatLocalStamp(options.timestamp, TIMEZONE)} · Status: ${options.status}`,
     '',
     `**User**: ${truncate(options.prompt)}`,
     '',
     `**Assistant**: ${truncate(result)}`,
     '',
   );
-  fs.appendFileSync(filePath, parts.join('\n'));
-  return filename;
+  return { relativePath: filename, content: parts.join('\n'), write: 'append', headerIfNew };
 }
 
 function threadArchiveFilename(
-  dir: string,
+  entries: readonly string[],
   provider: string,
   continuation: string | undefined,
   timestamp: Date,
@@ -86,7 +119,7 @@ function threadArchiveFilename(
   // Reuse this thread's existing file whatever day it was created; only stamp a
   // new date when none exists. Match on the suffix after the date prefix.
   const dated = /^\d{4}-\d{2}-\d{2}-/;
-  const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.replace(dated, '') === suffix);
+  const existing = entries.find((file) => dated.test(file) && file.replace(dated, '') === suffix);
   if (existing) return existing;
   // Local calendar day — the agent navigates conversations/ by these
   // date-sortable names, and evening sessions west of UTC would otherwise

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -27,6 +27,30 @@ const MODEL_INPUT_MODALITIES = ['text', 'audio', 'image', 'video', 'pdf'] as con
 
 const SESSION_STATUS_RETRY_ERROR_AFTER = 3;
 
+// OpenCode's permission stance inside the NanoClaw container: the container
+// and the OneCLI allow-list are the boundary, so every category OpenCode knows
+// today is allowed except the interactive `question` tool. Declared here (the
+// provider's own config module) and exported so the runtime contract can
+// state it as its execution policy without this module importing the contract.
+export const OPENCODE_PERMISSION_POLICY = {
+  read: 'allow',
+  edit: 'allow',
+  glob: 'allow',
+  grep: 'allow',
+  list: 'allow',
+  bash: 'allow',
+  task: 'allow',
+  external_directory: 'allow',
+  todowrite: 'allow',
+  question: 'deny',
+  webfetch: 'allow',
+  websearch: 'allow',
+  codesearch: 'allow',
+  lsp: 'allow',
+  doom_loop: 'allow',
+  skill: 'allow',
+} as const;
+
 /**
  * The agent workspace: the group directory the host mounts RW, holding the
  * composed project document, the group's memory, and its working files. Both
@@ -68,7 +92,10 @@ function killProcessTree(proc: ChildProcess): void {
   }
 }
 
-function spawnOpencodeServer(config: Record<string, unknown>, timeoutMs = 10_000): Promise<{ url: string; proc: ChildProcess }> {
+function spawnOpencodeServer(
+  config: Record<string, unknown>,
+  timeoutMs = 10_000,
+): Promise<{ url: string; proc: ChildProcess }> {
   return new Promise((resolve, reject) => {
     const hostname = '127.0.0.1';
     const port = 4096;
@@ -297,9 +324,7 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
     })
     .filter((entry) => entry !== 'text');
   const modelModalities =
-    requestedModalities.length > 0
-      ? { input: ['text', ...requestedModalities], output: ['text'] }
-      : undefined;
+    requestedModalities.length > 0 ? { input: ['text', ...requestedModalities], output: ['text'] } : undefined;
 
   const providerOptions: Record<string, unknown> =
     provider === 'anthropic'
@@ -383,24 +408,7 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
     // "allow everything" behavior.
     // A category OpenCode adds after this list was written is absent from it,
     // and so resolves to OpenCode's own default rather than to `allow`.
-    permission: {
-      read: 'allow',
-      edit: 'allow',
-      glob: 'allow',
-      grep: 'allow',
-      list: 'allow',
-      bash: 'allow',
-      task: 'allow',
-      external_directory: 'allow',
-      todowrite: 'allow',
-      question: 'deny',
-      webfetch: 'allow',
-      websearch: 'allow',
-      codesearch: 'allow',
-      lsp: 'allow',
-      doom_loop: 'allow',
-      skill: 'allow',
-    },
+    permission: OPENCODE_PERMISSION_POLICY,
     autoupdate: false,
     snapshot: false,
     provider: providerOptions,
@@ -1178,4 +1186,6 @@ export class OpenCodeProvider implements AgentProvider {
   }
 }
 
+// Function-form registration only; the runtime contract attaches itself from
+// provider-contracts/opencode.ts, so this module compiles on either core.
 registerProvider('opencode', (opts) => new OpenCodeProvider(opts));

--- a/setup/providers/codex.test.ts
+++ b/setup/providers/codex.test.ts
@@ -20,7 +20,7 @@ vi.mock('child_process', () => ({
 // Keep the auth flow's structured logging out of logs/setup.log.
 vi.mock('../logs.js', () => ({ step: vi.fn(), userInput: vi.fn() }));
 
-import { buildCodexFailurePrompt, runCodexLoginAuth, verifyCodexInstall } from './codex.js';
+import { buildCodexFailurePrompt, runCodexInstallCheck, runCodexLoginAuth, verifyCodexInstall } from './codex.js';
 
 // Structural guard for the codex payload wiring: provider files, both barrel
 // imports, and the pinned Dockerfile install. Goes red if any of them is
@@ -30,6 +30,15 @@ describe('verifyCodexInstall', () => {
     const { ok, problems } = verifyCodexInstall();
     expect(problems).toEqual([]);
     expect(ok).toBe(true);
+  });
+
+  it('blocks setup when the payload is incomplete', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-install-check-'));
+    try {
+      await expect(runCodexInstallCheck(root)).rejects.toThrow(/Codex provider is not fully installed/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/setup/providers/codex.ts
+++ b/setup/providers/codex.ts
@@ -379,9 +379,8 @@ export async function offerCodexFailureAssist(ctx: AssistContext, projectRoot: s
  * the payload moves to the providers branch, a failed check means the install
  * step should run (or the user finishes via /add-codex).
  */
-export function verifyCodexInstall(): { ok: boolean; problems: string[] } {
+export function verifyCodexInstall(root = process.cwd()): { ok: boolean; problems: string[] } {
   const problems: string[] = [];
-  const root = process.cwd();
 
   const requiredFiles = [
     'src/providers/codex.ts',
@@ -417,9 +416,9 @@ export function verifyCodexInstall(): { ok: boolean; problems: string[] } {
   return { ok: problems.length === 0, problems };
 }
 
-export async function runCodexInstallCheck(): Promise<void> {
+export async function runCodexInstallCheck(root = process.cwd()): Promise<void> {
   p.log.step(brandBody('Checking the Codex provider install…'));
-  const { ok, problems } = verifyCodexInstall();
+  const { ok, problems } = verifyCodexInstall(root);
   if (ok) {
     setupLog.step('codex-install', 'success', 0, {});
     p.log.success(brandBody('Codex installed properly.'));
@@ -431,9 +430,10 @@ export async function runCodexInstallCheck(): Promise<void> {
   for (const problem of problems) console.log(k.dim(`   • ${problem}`));
   p.log.warn(
     brandBody(
-      'Finish it with your coding agent of choice: open Codex CLI or Claude Code in this repo and run the /add-codex skill. Setup will continue — Codex groups will work once the install completes.',
+      'Finish it with your coding agent of choice: open Codex CLI or Claude Code in this repo and run the /add-codex skill.',
     ),
   );
+  throw new Error(`Codex provider is not fully installed: ${problems.join('; ')}`);
 }
 
 // Self-registration: the setup picker and the standalone `provider-auth` step

--- a/src/provider-contracts/codex.ts
+++ b/src/provider-contracts/codex.ts
@@ -1,0 +1,72 @@
+import { CODEX_PROJECT_DOC_MAX_BYTES } from '../providers/codex-agents-md.js';
+
+import { registerProviderHostContract } from './registry.js';
+
+const HOST_SEAM_VERSION = 1;
+
+registerProviderHostContract('codex', {
+  seamVersion: HOST_SEAM_VERSION,
+  projectDocument: {
+    fileName: 'AGENTS.md',
+    maxBytes: CODEX_PROJECT_DOC_MAX_BYTES,
+    containerPath: '/workspace/agent/AGENTS.md',
+    mountClass: 'allowlisted-extra',
+    // Instruction prose is core-owned canon; Codex declares only the facts
+    // rendered into it.
+    instructions: {
+      nativeOverrideFiles: ['AGENTS.local.md', 'AGENTS.override.md'],
+      nativeSkills: {
+        discoveryPath: '/workspace/agent/.agents/skills',
+        sharedSource: '/app/skills',
+        selfAuthoredHome: '~/.codex/skills',
+        persistentRoots: ['~/.codex', '~/.agents'],
+        ruleBearingInlined: true,
+      },
+    },
+  },
+  stateVolumes: [
+    {
+      id: 'codex-home',
+      directory: '.codex-shared',
+      containerPath: '/home/node/.codex',
+      scope: 'group',
+      mode: 'rw',
+      mountClass: 'allowlisted-extra',
+    },
+  ],
+  skillBackings: [
+    {
+      id: 'codex-skills',
+      location: { kind: 'group-directory', directory: '.agents', subdirectory: '' },
+      skillsSubdirectory: 'skills',
+      conflictDiagnostics: 'silent',
+      templateCopies: 'copy',
+    },
+  ],
+  skillViews: [
+    {
+      backingId: 'codex-skills',
+      containerPath: '/workspace/agent/.agents',
+      mode: 'ro',
+      mountClass: 'allowlisted-extra',
+    },
+    {
+      backingId: 'codex-skills',
+      containerPath: '/home/node/.agents',
+      mode: 'ro',
+      mountClass: 'allowlisted-extra',
+    },
+  ],
+  files: [
+    {
+      id: 'codex-auth-stub',
+      volumeId: 'codex-home',
+      relativePath: 'auth.json',
+      prepare: { operation: 'append-open-close', when: 'every-spawn' },
+    },
+  ],
+  // Core validates `--speed` against these names; the runtime payload renders
+  // only `fast` (as `service_tier = "fast"`), `standard` keeps Codex's default.
+  inference: { speedTiers: ['standard', 'fast'] },
+  legacyHostAdapter: 'required',
+});

--- a/src/provider-contracts/opencode.ts
+++ b/src/provider-contracts/opencode.ts
@@ -1,0 +1,10 @@
+import { CLAUDE_COMPATIBLE_HOST_SURFACES } from './claude.js';
+import { registerProviderHostContract } from './registry.js';
+
+const HOST_SEAM_VERSION = 1;
+
+registerProviderHostContract('opencode', {
+  seamVersion: HOST_SEAM_VERSION,
+  ...CLAUDE_COMPATIBLE_HOST_SURFACES,
+  legacyHostAdapter: 'required',
+});

--- a/src/providers/codex-agents-md.test.ts
+++ b/src/providers/codex-agents-md.test.ts
@@ -23,6 +23,11 @@ import type { AgentGroup } from '../types.js';
 
 const TEST_ROOT = '/tmp/nanoclaw-agents-md-test';
 
+// This module is the pre-contract compatibility path: on a contract core the
+// canonical template composes AGENTS.md and this spec is never consulted, so
+// its cap-handling guards only apply where the legacy path is live.
+const legacyIt = fs.existsSync(path.join(process.cwd(), 'src/provider-contracts/realize.ts')) ? it.skip : it;
+
 function group(folder: string): AgentGroup {
   return {
     id: `ag-${folder}`,
@@ -46,7 +51,7 @@ describe('composeGroupAgentsMd cap handling', () => {
     if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
   });
 
-  it('writes the doc untouched when under the cap', async () => {
+  legacyIt('writes the doc untouched when under the cap', async () => {
     const g = group('small');
     await createAgentGroup(g);
     await ensureContainerConfig(g.id);
@@ -67,7 +72,7 @@ describe('composeGroupAgentsMd cap handling', () => {
     }
   });
 
-  it('never reads or inlines the host memory index', async () => {
+  legacyIt('never reads or inlines the host memory index', async () => {
     const g = group('with-memory');
     await createAgentGroup(g);
     await ensureContainerConfig(g.id);
@@ -88,7 +93,7 @@ describe('composeGroupAgentsMd cap handling', () => {
     }
   });
 
-  it('degrades instead of throwing when MCP instructions push the doc over the cap', async () => {
+  legacyIt('degrades instead of throwing when MCP instructions push the doc over the cap', async () => {
     const g = group('oversized');
     await createAgentGroup(g);
     await ensureContainerConfig(g.id);

--- a/src/providers/codex-agents-md.ts
+++ b/src/providers/codex-agents-md.ts
@@ -1,11 +1,15 @@
 /**
- * AGENTS.md spec for codex agent groups — codex-owned payload data.
+ * AGENTS.md spec for codex agent groups — the MIXED-VERSION COMPATIBILITY path.
  *
- * AGENTS.md is Codex's project doc (its CLAUDE.md equivalent). Composing it is
- * not codex-specific and lives on trunk in `src/project-doc-compose.ts`, shared
- * with every other provider. What stays here is only what differs: the file
- * name, the runtime-contract base document, two pointer blocks, and Codex's
- * project-doc byte cap.
+ * On a core with the provider contracts, AGENTS.md instructions come from the
+ * core-owned canonical template rendered with the instruction facts the codex
+ * host contract declares (`src/provider-contracts/codex.ts`); this module is
+ * never reached there. On a core that predates the contracts, the legacy host
+ * adapter composes AGENTS.md through this spec, whose extra sections and base
+ * document (`container/AGENTS.md`) preserve the exact document those cores
+ * always produced. Both core generations still type `baseDocPath` and
+ * `extraSections` on `ProjectDocSpec` (deprecated on the contract core), so
+ * the spec is typed directly.
  *
  * `project_doc_max_bytes` is mirrored in the container provider's config.toml
  * writer. Over the cap the shared composer degrades — it drops the largest
@@ -20,32 +24,38 @@ import type { AgentGroup } from '../types.js';
 
 export const CODEX_PROJECT_DOC_MAX_BYTES = 32 * 1024;
 
-const MEMORY_POINTER = [
-  'The live memory index and definition are supplied by NanoClaw at session startup, clear, and after compaction.',
-  'Editable memory-system definition: `/workspace/agent/memory/system/definition.md`.',
-  'Top memory index: `/workspace/agent/memory/index.md`.',
-  'Read the definition and index, then use linked memory files and conversation archives when relevant.',
-  'Stored user preferences are binding: read any linked memory file relevant to the user or the request, and apply it without being asked.',
-  'Do not use `AGENTS.local.md` or `AGENTS.override.md` for memory.',
-].join('\n\n');
-
-const NATIVE_RUNTIME_SKILLS_POINTER = [
-  'Selected NanoClaw runtime skills are available as Codex-native skills at `/workspace/agent/.agents/skills`.',
-  'Each skill directory contains a `SKILL.md` with its trigger description plus any supporting files, and points to the read-only shared skill source under `/app/skills`.',
-  'Use skill discovery to load these skills only when their descriptions match the task. A skill whose rules must hold before the task is recognised ships an `instructions.md` instead, and those arrive inlined as `NanoClaw Skill:` sections of this document.',
-  'Skills YOU author or install yourself go in `~/.codex/skills/<name>/SKILL.md` — persistent across sessions and discovered by Codex automatically. Never write skills elsewhere: paths outside `~/.codex` and `~/.agents` are ephemeral or not discovered.',
-].join('\n\n');
+export const CODEX_PROJECT_DOC_EXTRA_SECTIONS = [
+  {
+    name: 'Memory System',
+    body: [
+      'The live memory index and definition are supplied by NanoClaw at session startup, clear, and after compaction.',
+      'Editable memory-system definition: `/workspace/agent/memory/system/definition.md`.',
+      'Top memory index: `/workspace/agent/memory/index.md`.',
+      'Read the definition and index, then use linked memory files and conversation archives when relevant.',
+      'Stored user preferences are binding: read any linked memory file relevant to the user or the request, and apply it without being asked.',
+      'Do not use `AGENTS.local.md` or `AGENTS.override.md` for memory.',
+    ].join('\n\n'),
+  },
+  {
+    name: 'Native Runtime Skills',
+    body: [
+      'Selected NanoClaw runtime skills are available as Codex-native skills at `/workspace/agent/.agents/skills`.',
+      'Each skill directory contains a `SKILL.md` with its trigger description plus any supporting files, and points to the read-only shared skill source under `/app/skills`.',
+      'Use skill discovery to load these skills only when their descriptions match the task. A skill whose rules must hold before the task is recognised ships an `instructions.md` instead, and those arrive inlined as `NanoClaw Skill:` sections of this document.',
+      'Skills YOU author or install yourself go in `~/.codex/skills/<name>/SKILL.md` — persistent across sessions and discovered by Codex automatically. Never write skills elsewhere: paths outside `~/.codex` and `~/.agents` are ephemeral or not discovered.',
+    ].join('\n\n'),
+  },
+];
 
 const CODEX_PROJECT_DOC: ProjectDocSpec = {
   fileName: 'AGENTS.md',
   baseDocPath: path.join('container', 'AGENTS.md'),
-  extraSections: [
-    { name: 'Memory System', body: MEMORY_POINTER },
-    { name: 'Native Runtime Skills', body: NATIVE_RUNTIME_SKILLS_POINTER },
-  ],
+  extraSections: CODEX_PROJECT_DOC_EXTRA_SECTIONS,
   maxBytes: CODEX_PROJECT_DOC_MAX_BYTES,
 };
 
 export function composeGroupAgentsMd(group: AgentGroup, groupDir: string): Promise<void> {
+  // Pre-contract cores read baseDocPath/extraSections; contract cores ignore
+  // them (and never call this path for surfaces).
   return composeGroupProjectDoc(group, groupDir, CODEX_PROJECT_DOC);
 }

--- a/src/providers/codex-host-contribution.test.ts
+++ b/src/providers/codex-host-contribution.test.ts
@@ -20,6 +20,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const TEST_ROOT = '/tmp/nanoclaw-codex-host-contribution-test';
 const DATA_DIR = path.join(TEST_ROOT, 'data');
 const GROUPS_DIR = path.join(TEST_ROOT, 'groups');
+// An old install skill may run on a new core without installing Codex's contract.
+const newCoreIt = fs.existsSync(path.join(process.cwd(), 'src/provider-contracts/codex.ts')) ? it : it.skip;
 
 vi.mock('../config.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../config.js')>()),
@@ -37,6 +39,35 @@ import type { AgentGroup, Session } from '../types.js';
 
 function group(id: string, folder: string): AgentGroup {
   return { id, name: folder, folder, agent_provider: null, created_at: new Date().toISOString() } as AgentGroup;
+}
+
+type MountShape = { containerPath: string; hostPath: string; readonly: boolean };
+
+const CODEX_CONTAINER_PATHS = [
+  '/home/node/.codex',
+  '/workspace/agent/AGENTS.md',
+  '/workspace/agent/.agents',
+  '/home/node/.agents',
+];
+
+function codexMounts(mounts: readonly MountShape[]): MountShape[] {
+  return mounts
+    .filter((mount) => CODEX_CONTAINER_PATHS.includes(mount.containerPath))
+    .map(({ containerPath, hostPath, readonly }) => ({ containerPath, hostPath, readonly }));
+}
+
+function expectedCodexMounts(groupDir: string, codexShared: string): MountShape[] {
+  const agentsDir = path.join(groupDir, '.agents');
+  return [
+    { containerPath: '/home/node/.codex', hostPath: codexShared, readonly: false },
+    { containerPath: '/workspace/agent/.agents', hostPath: agentsDir, readonly: true },
+    { containerPath: '/home/node/.agents', hostPath: agentsDir, readonly: true },
+    { containerPath: '/workspace/agent/AGENTS.md', hostPath: path.join(groupDir, 'AGENTS.md'), readonly: true },
+  ];
+}
+
+function byContainerPath(mounts: readonly MountShape[]): MountShape[] {
+  return [...mounts].sort((left, right) => left.containerPath.localeCompare(right.containerPath));
 }
 
 describe('codex host contribution against real core', () => {
@@ -96,9 +127,35 @@ describe('codex host contribution against real core', () => {
     };
     const mounts = await buildMounts(ag, session, config, 'codex', contribution);
     const containerPaths = mounts.map((m) => m.containerPath);
-    expect(containerPaths).toContain('/home/node/.codex');
-    expect(containerPaths.some((p) => p.endsWith('AGENTS.md'))).toBe(true);
+    // The same four codex mounts on either core generation; only their order
+    // differs (the contract core realizes declared surfaces first), so the set
+    // is asserted here and the order in the contract-core test below.
+    expect(byContainerPath(codexMounts(mounts))).toEqual(byContainerPath(expectedCodexMounts(groupDir, codexShared)));
     expect(containerPaths).not.toContain('/home/node/.claude');
+  });
+
+  newCoreIt('orders the declared codex surfaces ahead of the composed AGENTS.md', async () => {
+    const ag = group('ag-codex-order', 'codex-order-group');
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id);
+    const groupDir = path.join(GROUPS_DIR, ag.folder);
+    const contribution = await getProviderContainerConfig('codex')!({
+      sessionDir: path.join(DATA_DIR, 'v2-sessions', ag.id, 'session-1'),
+      agentGroupId: ag.id,
+      groupDir,
+      selectedSkills: [],
+      hostEnv: process.env,
+    });
+    const session = { id: 'session-1', agent_group_id: ag.id } as Session;
+    const config: ContainerConfig = {
+      mcpServers: {},
+      packages: { apt: [], npm: [] },
+      additionalMounts: [],
+      skills: [],
+    };
+    const mounts = await buildMounts(ag, session, config, 'codex', contribution);
+    const codexShared = path.join(DATA_DIR, 'v2-sessions', ag.id, '.codex-shared');
+    expect(codexMounts(mounts)).toEqual(expectedCodexMounts(groupDir, codexShared));
   });
 
   it('mirrors per-group template skills from the Claude plane into .agents/skills', async () => {
@@ -124,5 +181,41 @@ describe('codex host contribution against real core', () => {
     expect(fs.existsSync(path.join(mirrored, 'SKILL.md'))).toBe(true);
     // A real dir, not a symlink — so it survives syncCodexSkillLinks' symlink-only prune.
     expect(fs.lstatSync(mirrored).isSymbolicLink()).toBe(false);
+  });
+
+  newCoreIt('lets new core realize declared surfaces without legacy duplicates', async () => {
+    const ag = group('ag-codex-contract', 'codex-contract-group');
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id);
+    const groupDir = path.join(GROUPS_DIR, ag.folder);
+    const session = { id: 'session-contract', agent_group_id: ag.id } as Session;
+    const config: ContainerConfig = {
+      mcpServers: {},
+      packages: { apt: [], npm: [] },
+      additionalMounts: [],
+      skills: [],
+    };
+    const context = {
+      sessionDir: path.join(DATA_DIR, 'v2-sessions', ag.id, session.id),
+      agentGroupId: ag.id,
+      groupDir,
+      selectedSkills: [],
+      hostEnv: process.env,
+      coreOwnsProviderSurfaces: true as const,
+    };
+
+    const contribution = await getProviderContainerConfig('codex')!(context);
+    expect(contribution).toEqual({});
+
+    const mounts = await buildMounts(ag, session, config, 'codex', contribution);
+    expect(mounts.filter((mount) => mount.containerPath === '/home/node/.codex')).toHaveLength(1);
+    expect(mounts.filter((mount) => mount.containerPath === '/workspace/agent/AGENTS.md')).toHaveLength(1);
+    for (const destination of ['/workspace/agent/.agents', '/home/node/.agents']) {
+      expect(mounts.find((mount) => mount.containerPath === destination)?.hostPath).toBe(
+        path.join(groupDir, '.agents'),
+      );
+    }
+    expect(fs.existsSync(path.join(groupDir, '.agents', 'skills'))).toBe(true);
+    expect(fs.existsSync(path.join(DATA_DIR, 'v2-sessions', ag.id, '.codex-shared', 'auth.json'))).toBe(true);
   });
 });

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -23,8 +23,8 @@
  *
  * Memory and exchange archiving are NOT handled here either. The shared
  * runner scaffolds memory, while the container-side provider registers its
- * native SessionStart hook and persists exchanges through
- * `onExchangeComplete`.
+ * native SessionStart hook and reports completed exchanges for the declared
+ * archive plan.
  */
 import fs from 'fs';
 import path from 'path';
@@ -38,6 +38,9 @@ import { registerProviderContainerConfig } from './provider-container-registry.j
 registerProviderContainerConfig(
   'codex',
   async (ctx) => {
+    const coreOwnsProviderSurfaces = (ctx as typeof ctx & { coreOwnsProviderSurfaces?: true }).coreOwnsProviderSurfaces;
+    if (coreOwnsProviderSurfaces) return {};
+
     // Per-group codex state (config.toml, thread metadata).
     const codexDir = path.join(DATA_DIR, 'v2-sessions', ctx.agentGroupId, '.codex-shared');
     fs.mkdirSync(codexDir, { recursive: true });


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Binds the Codex payload to the enforced provider contracts while keeping it loadable on cores that predate them.

- **Runtime contract**: the four configuration responsibilities are `config.toml` sections (execution policy, inference incl. `speed: fast` → `service_tier`, native-memory-off, MCP servers) plus the `hooks.json` memory hook. Execution policy and memory are declared `{ constant }`; inference and MCP servers are functions of the core-owned input. On a contract core, core resolves them and the before-query hook writes both files; on a pre-contract core the provider's own writer runs. Exactly one write per query on either path (tested).
- **Two-step registration**: `provider-contracts/codex.ts` registers the contract; the provider module registers only its factory, so the same files compile and run on current `main`.
- **Host contract**: typed instruction facts only (native override files, skill-discovery paths) plus the declared speed tiers (`standard`, `fast`); the AGENTS.md base document plus extra sections survive only as the pre-contract path.
- **OpenCode stubs** ride along so the add-opencode copy list resolves; OpenCode registers nothing in setup.
- **Self-verification**: `codex.conformance.test.ts` runs the exported runtime conformance suite (skipped where the harness is absent); every provider proves conformance through its own test file of this shape, and the install verifier requires one per declared provider. The workflow pins the core stack head (`COMPATIBLE_CORE_SHA`, tracked until the stack merges) and checks the pre-contract core via `--old-provider-refresh`.

## Related work

Merge order: #3584 → #3581 → #3585 → #3727 → #3592 → #3586. OpenCode (#3588 and #3722) and Cursor remain deferred. The final core is #3586 (`9d9d0df8deb5ca0e5c3278af7f1841152e54ac3f`); CI pins that exact commit.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

Current payload `43d693b0388e95fbe70e77ec848b9e03f2340a14` passed all seven registry checks:
- Exact final core: combined provider install, refresh, build, typecheck, provider suites, conformance and inventory.
- Exact final core with pre-contract providers.
- Old-core provider install and refresh on `99283f3e274b2b1dae47b141ac4f11f56ad8eb2d`.
- Install and refresh at each intermediate core: runtime #3581, host #3585, instructions #3727, and speed #3592.

The workflow now runs these cases. Contract-only host tests run when the Codex contract is installed; legacy host tests still run on every core. The final installer requires the Codex contract, so missing contract files cannot silently skip final verification.

Codex thread start/resume passes `bypass_hook_trust: true` for the pinned CLI. Regression assertions passed, and live startup, MCP, shell, resume, restart, clear, and history checks passed in the earlier integrated verification. This amendment changes CI and test gating only.

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Codex agents now read the same canonical instruction text as Claude agents (paths substituted); config files and mounts are unchanged.
```

## Security and trust boundaries

None new. No dependency changes; the workflow runs no PR-supplied code beyond the existing registry-skills harness.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
