### PR TITLE
refactor(providers): declare the host provider contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -967,6 +967,26 @@ Pre-scripts: if a task message has a `script` field, run it first. If `wakeAgent
 - PreCompact hook for transcript archiving (Claude provider)
 - Script execution for task-kind messages
 
+### Host Provider Contract
+
+Each agent provider tells the host, in plain data, what it needs on disk and in the container. This is the *host provider contract* (`src/provider-contracts/`). Claude's declaration is in `claude.ts`; a provider skill adds its own file and one import in `provider-contracts/index.ts`.
+
+A provider declares:
+
+- **Project document** — the file the host composes from every instruction source (for Claude, `CLAUDE.md`) and where it is mounted.
+- **State volumes** — provider-owned directories under `data/v2-sessions/<group>/` (group scope) or the session directory (session scope), with their container path and read/write mode.
+- **Skill backings and views** — where the provider's native skills directory lives and any extra bind mounts of it into the container. Core always keeps the shared-skill symlinks in every backing.
+- **Prepared files** — files core creates or reconciles inside a state volume (for Claude, `settings.json`). They are created with the process default mode; the contract does not pick one.
+
+Rules:
+
+- Contracts name only container paths and directory *names*; host paths are resolved by core. Every declared item is acted on — nothing is descriptive only.
+- The shape is validated when the contract registers, so a malformed provider skill fails when the host loads, not at first spawn.
+- A provider that also has a legacy host adapter (`src/providers/`) still gets that adapter's env passed through; its mounts are ignored because core now realizes the declared surfaces.
+- Mount order is fixed by core, not by the provider: state volumes, then skill views, then the project document.
+- The shipped base document (`container/CLAUDE.md`) is protected from operator mounts by core itself, not by any contract field.
+- A provider name with neither a contract nor an adapter spawns with the default (Claude) surfaces, plus a warning in the host log.
+
 ## Open Questions
 
 - **Approval routing** — how does the host find the admin's DM conversation? What if no DM channel exists? Is the approval list configurable per agent group or global?

--- a/src/command-gate.ts
+++ b/src/command-gate.ts
@@ -8,11 +8,19 @@
  * - Normal messages: pass through unchanged
  */
 import { hasAdminPrivilege } from './modules/permissions/db/user-roles.js';
+import './provider-contracts/index.js';
+import { listProviderHostContracts } from './provider-contracts/registry.js';
 
 export type GateResult = { action: 'pass' } | { action: 'filter' } | { action: 'deny'; command: string };
 
-const FILTERED_COMMANDS = new Set(['/start', '/help', '/login', '/logout', '/doctor', '/config', '/remote-control']);
-const ADMIN_COMMANDS = new Set(['/clear', '/compact', '/context', '/cost', '/files', '/upload-trace']);
+const FILTERED_COMMANDS = new Set(
+  listProviderHostContracts().flatMap((contract) => contract.commands?.nativeFiltered ?? []),
+);
+const ADMIN_COMMANDS = new Set([
+  '/clear',
+  '/upload-trace',
+  ...listProviderHostContracts().flatMap((contract) => contract.commands?.nativeAdmin ?? []),
+]);
 
 /**
  * Classify a message and decide whether it should reach the container.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -53,6 +53,16 @@ import { getAgentMailbox } from './mailbox/index.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { validateAdditionalMounts } from './modules/mount-security/index.js';
+// Provider contracts use a separate barrel so update-skills identity detection
+// remains tied to src/providers/index.ts.
+import './provider-contracts/index.js';
+import { getProviderHostContract } from './provider-contracts/registry.js';
+import {
+  providerStateVolumePath,
+  realizeProviderSpawnSurfaces,
+  syncSharedSkillLinks,
+  type ProviderSpawnRealization,
+} from './provider-contracts/realize.js';
 // Provider host-side config barrel — each provider that needs host-side
 // container setup self-registers on import.
 import './providers/index.js';
@@ -310,9 +320,9 @@ async function spawnContainer(session: Session): Promise<void> {
   // Resolve the effective provider + any host-side contribution it declares
   // (extra mounts, env passthrough). Computed once and threaded through both
   // buildMounts and buildContainerArgs so side effects (mkdir, etc.) fire once.
-  const { provider, contribution } = await resolveProviderContribution(session, agentGroup, containerConfig);
+  const { provider, contribution, surfaces } = await resolveProviderContribution(session, agentGroup, containerConfig);
 
-  const mounts = await buildMounts(agentGroup, session, containerConfig, provider, contribution);
+  const mounts = await buildMounts(agentGroup, session, containerConfig, provider, contribution, surfaces);
   const containerName = `nanoclaw-v2-${agentGroup.folder}-${Date.now()}`;
   const mailboxEnvironment = await mailbox.runnerEnvironment(mailboxKey);
 
@@ -752,23 +762,47 @@ export function resolveProviderName(
   return (sessionProvider || containerConfigProvider || 'claude').toLowerCase();
 }
 
-async function resolveProviderContribution(
+export async function resolveProviderContribution(
   session: Session,
   agentGroup: AgentGroup,
   containerConfig: import('./container-config.js').ContainerConfig,
-): Promise<{ provider: string; contribution: ProviderContainerContribution }> {
+): Promise<{ provider: string; contribution: ProviderContainerContribution; surfaces?: ProviderSpawnRealization }> {
   const provider = resolveProviderName(session.agent_provider, containerConfig.provider);
   const fn = getProviderContainerConfig(provider);
-  const contribution = fn
-    ? await fn({
-        sessionDir: sessionDir(agentGroup.id, session.id),
-        agentGroupId: agentGroup.id,
-        groupDir: path.resolve(GROUPS_DIR, agentGroup.folder),
-        selectedSkills: selectedSkillNames(containerConfig),
-        hostEnv: process.env,
-      })
-    : {};
-  return { provider, contribution };
+  const contract = getProviderHostContract(provider);
+  if (!contract && !fn) {
+    // Same as before contracts existed: the group spawns with the default
+    // (Claude) surfaces. Say so once per spawn so an operator can spot it.
+    log.warn('Provider has no registered host contract or adapter; spawning with default surfaces', {
+      provider,
+      agentGroupId: agentGroup.id,
+    });
+  }
+  const context = {
+    sessionDir: sessionDir(agentGroup.id, session.id),
+    agentGroupId: agentGroup.id,
+    groupDir: path.resolve(GROUPS_DIR, agentGroup.folder),
+    selectedSkills: selectedSkillNames(containerConfig),
+    hostEnv: process.env,
+  };
+  if (!contract) return { provider, contribution: fn ? await fn(context) : {} };
+  if (contract.legacyHostAdapter === 'required' && !fn) {
+    throw new Error(`Provider '${provider}' host contract requires a legacy host adapter`);
+  }
+
+  const surfaces = await realizeProviderSpawnSurfaces(
+    provider,
+    contract,
+    agentGroup.id,
+    context.groupDir,
+    context.sessionDir,
+    context.selectedSkills,
+    {
+      legacyOverlay: () => Promise.resolve(fn?.({ ...context, coreOwnsProviderSurfaces: true as const }) ?? {}),
+      composeProjectDocument: (spec) => composeGroupProjectDoc(agentGroup, context.groupDir, spec),
+    },
+  );
+  return { provider, contribution: surfaces.contribution, surfaces };
 }
 
 export async function buildMounts(
@@ -777,16 +811,38 @@ export async function buildMounts(
   containerConfig: import('./container-config.js').ContainerConfig,
   provider: string,
   providerContribution: ProviderContainerContribution,
+  providerSurfaces?: ProviderSpawnRealization,
 ): Promise<VolumeMount[]> {
   const projectRoot = process.cwd();
 
-  // Default agent surfaces (composed project doc, skill links, provider state
-  // dir) apply unless the provider's registration declares it provides its own.
-  const defaultSurfaces = !providerProvidesAgentSurfaces(provider);
+  const contract = getProviderHostContract(provider);
+  // Undeclared payloads stay on the legacy capability gate. Declared payloads
+  // are realized below from their contract.
+  const defaultSurfaces = !contract && !providerProvidesAgentSurfaces(provider);
 
   const groupDir = path.resolve(GROUPS_DIR, agentGroup.folder);
   const claudeDir = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, '.claude-shared');
-  if (defaultSurfaces) {
+  const sessDir = sessionDir(agentGroup.id, session.id);
+  const projectDocument = contract?.projectDocument;
+  let lateProjectDocumentMount: VolumeMount | undefined;
+  const lateStateVolumeMounts = new Map<string, VolumeMount>();
+  const lateSkillViewMounts = new Map<string, VolumeMount[]>();
+  let skillBackingPaths = new Map<string, string>();
+  if (contract) {
+    providerSurfaces ??= await realizeProviderSpawnSurfaces(
+      provider,
+      contract,
+      agentGroup.id,
+      groupDir,
+      sessDir,
+      selectedSkillNames(containerConfig),
+      {
+        legacyOverlay: async () => providerContribution,
+        composeProjectDocument: (spec) => composeGroupProjectDoc(agentGroup, groupDir, spec),
+      },
+    );
+    skillBackingPaths = providerSurfaces.skillBackingPaths;
+  } else if (defaultSurfaces) {
     syncSkillSymlinks(claudeDir, containerConfig);
 
     // Compose CLAUDE.md fresh every spawn: every instruction source inlined
@@ -795,7 +851,6 @@ export async function buildMounts(
   }
 
   const mounts: VolumeMount[] = [];
-  const sessDir = sessionDir(agentGroup.id, session.id);
   const scope = agentGroup.id;
 
   // Session workspace: mailbox-selected state plus outbox and heartbeat files.
@@ -853,20 +908,54 @@ export async function buildMounts(
   // The composed project document — one nested RO mount on top of the RW group
   // dir, holding the full text of every instruction source. `container/CLAUDE.md`
   // is read on the host at compose time, so nothing needs it inside the container.
-  const composedClaudeMd = path.join(groupDir, 'CLAUDE.md');
-  if (defaultSurfaces && fs.existsSync(composedClaudeMd)) {
-    mounts.push({
-      hostPath: composedClaudeMd,
-      containerPath: '/workspace/agent/CLAUDE.md',
+  const composedProjectDocument = path.join(groupDir, projectDocument?.fileName ?? DEFAULT_PROJECT_DOC.fileName);
+  if ((projectDocument || defaultSurfaces) && fs.existsSync(composedProjectDocument)) {
+    const mount = {
+      hostPath: composedProjectDocument,
+      containerPath: projectDocument?.containerPath ?? '/workspace/agent/CLAUDE.md',
       readonly: true,
-      mountClass: 'group-state',
+      mountClass: projectDocument?.mountClass ?? 'group-state',
       scope,
-    });
+    } satisfies VolumeMount;
+    if (mount.mountClass === 'allowlisted-extra') lateProjectDocumentMount = mount;
+    else mounts.push(mount);
   }
 
   // Per-group .claude-shared at /home/node/.claude (provider state, settings,
   // skill symlinks). Per agent group, not per session.
-  if (defaultSurfaces) {
+  if (contract) {
+    for (const volume of contract.stateVolumes) {
+      const hostPath = providerStateVolumePath(volume, agentGroup.id, sessDir);
+      const mount = {
+        hostPath,
+        containerPath: volume.containerPath,
+        readonly: volume.mode === 'ro',
+        mountClass: volume.mountClass,
+        scope,
+      } satisfies VolumeMount;
+      if (mount.mountClass === 'allowlisted-extra') lateStateVolumeMounts.set(volume.id, mount);
+      else mounts.push(mount);
+    }
+    for (const view of contract.skillViews) {
+      const hostPath = skillBackingPaths.get(view.backingId);
+      if (!hostPath)
+        throw new Error(`Provider '${provider}' skill view references unknown backing '${view.backingId}'`);
+      const mount = {
+        hostPath,
+        containerPath: view.containerPath,
+        readonly: view.mode === 'ro',
+        mountClass: view.mountClass,
+        scope,
+      } satisfies VolumeMount;
+      if (mount.mountClass === 'allowlisted-extra') {
+        const backingMounts = lateSkillViewMounts.get(view.backingId) ?? [];
+        backingMounts.push(mount);
+        lateSkillViewMounts.set(view.backingId, backingMounts);
+      } else {
+        mounts.push(mount);
+      }
+    }
+  } else if (defaultSurfaces) {
     mounts.push({
       hostPath: claudeDir,
       containerPath: '/home/node/.claude',
@@ -904,11 +993,24 @@ export async function buildMounts(
     mounts.push(...validated.map((m) => ({ ...m, mountClass: 'allowlisted-extra' as const, scope })));
   }
 
+  // Declared allowlisted-extra surfaces replace the old callback contribution
+  // at the same late slot, in the spawn order derived from resource kinds.
+  if (contract) {
+    for (const volume of contract.stateVolumes) {
+      const mount = lateStateVolumeMounts.get(volume.id);
+      if (mount) mounts.push(mount);
+    }
+    for (const backing of contract.skillBackings) {
+      mounts.push(...(lateSkillViewMounts.get(backing.id) ?? []));
+    }
+    if (lateProjectDocumentMount) mounts.push(lateProjectDocumentMount);
+  }
+
   // Provider-contributed mounts (e.g. opencode-xdg). Vetted upstream by the
   // in-tree provider registration, which is exactly the 'allowlisted-extra'
   // contract — classing them group-state would deny any provider whose state
   // root sits outside the group subtree.
-  if (providerContribution.mounts) {
+  if (!contract && providerContribution.mounts) {
     mounts.push(...providerContribution.mounts.map((m) => ({ ...m, mountClass: 'allowlisted-extra' as const, scope })));
   }
 
@@ -1112,48 +1214,11 @@ export function syncSkillSymlinks(
     fs.mkdirSync(skillsDir, { recursive: true });
   }
 
-  const desired = selectedSkillNames(containerConfig);
-  const desiredSet = new Set(desired);
-
-  // Remove symlinks not in the desired set
-  for (const entry of fs.readdirSync(skillsDir)) {
-    const entryPath = path.join(skillsDir, entry);
-    let isSymlink = false;
-    try {
-      isSymlink = fs.lstatSync(entryPath).isSymbolicLink();
-    } catch {
-      continue;
-    }
-    if (isSymlink && !desiredSet.has(entry)) {
-      fs.unlinkSync(entryPath);
-    }
-  }
-
-  // Create symlinks for desired skills (container path targets)
-  for (const skill of desired) {
-    const linkPath = path.join(skillsDir, skill);
-    let entry: fs.Stats | undefined;
-    try {
-      entry = fs.lstatSync(linkPath);
-    } catch {
-      /* missing */
-    }
-    if (!entry) {
-      fs.symlinkSync(`/app/skills/${skill}`, linkPath);
-    } else if (!entry.isSymbolicLink()) {
-      // A real entry here is either a template overlay (intentional; see
-      // src/group-skills.ts) or a stale pre-refactor skill copy that shadows
-      // the shared skill (#3001). No marker distinguishes them yet, so
-      // surface the skip instead of staying silent.
-      log.warn(
-        'Shared skill not symlinked: real entry occupies the path (template overlay or stale pre-refactor copy)',
-        {
-          skill,
-          path: linkPath,
-        },
-      );
-    }
-  }
+  // Same body as the declared-contract path; real (non-symlink) entries are
+  // either a template overlay (intentional; see src/group-skills.ts) or a stale
+  // pre-refactor skill copy that shadows the shared skill (#3001), so the
+  // skip is surfaced as a warning.
+  syncSharedSkillLinks(skillsDir, selectedSkillNames(containerConfig), true);
 }
 
 /**

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -43,6 +43,8 @@ import { DATA_DIR, GROUPS_DIR } from '../config.js';
 import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from '../egress-lockdown.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
+import '../provider-contracts/index.js';
+import { protectedProviderDocumentSourcePaths } from '../provider-contracts/realize.js';
 
 import { DockerSessionDriver, agentContainerName } from './docker-driver.js';
 import {
@@ -109,12 +111,10 @@ export function mountPolicy(env: NodeJS.ProcessEnv = process.env): MountPolicy {
     surfaceRoots: [
       path.join(projectRoot, 'container', 'agent-runner', 'src'),
       path.join(projectRoot, 'container', 'skills'),
-      // Not mounted any more — the composer reads it on the host. The root
-      // stays because it is what forces install-surface (and therefore
-      // read-only) on an operator additionalMount whose allowlisted root
-      // happens to cover the project tree. Without it the agent could get a
-      // writable mount of the base document inlined into its prompt.
-      path.join(projectRoot, 'container', 'CLAUDE.md'),
+      // Base documents are read by the host composer, not mounted. Declared
+      // protected sources stay here so an overlapping operator mount cannot
+      // make prompt-defining install content writable.
+      ...protectedProviderDocumentSourcePaths(projectRoot),
     ],
     // Must resolve to the same path an egress overlay's provisioner writes
     // material to, and a provisioner reads this key from `.env`. Reading it

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -5,34 +5,11 @@ import { DATA_DIR, DEFAULT_AGENT_PROVIDER, GROUPS_DIR } from './config.js';
 import { ensureContainerConfig } from './db/container-configs.js';
 import { stageGroupPersona } from './group-persona.js';
 import { log } from './log.js';
-import { migrateClaudeMemorySettings } from './migrate-claude-memory-settings.js';
+import { CLAUDE_DEFAULT_SETTINGS, migrateClaudeMemorySettings } from './migrate-claude-memory-settings.js';
+import { getProviderHostContract } from './provider-contracts/registry.js';
+import { initializeProviderGroupSurfaces } from './provider-contracts/realize.js';
 import { providerProvidesAgentSurfaces } from './providers/provider-container-registry.js';
 import type { AgentGroup } from './types.js';
-
-const DEFAULT_SETTINGS_JSON =
-  JSON.stringify(
-    {
-      autoMemoryEnabled: false,
-      env: {
-        CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
-      },
-      hooks: {
-        PreCompact: [
-          {
-            hooks: [
-              {
-                type: 'command',
-                command: 'bun /app/src/compact-instructions.ts',
-              },
-            ],
-          },
-        ],
-      },
-    },
-    null,
-    2,
-  ) + '\n';
 
 /**
  * Initialize the on-disk filesystem state for an agent group. Idempotent —
@@ -65,7 +42,8 @@ export async function initGroupFilesystem(
 
   // Default agent surfaces apply unless the provider declares (at registration)
   // that it provides its own.
-  const defaultSurfaces = !providerProvidesAgentSurfaces(providerHint);
+  const contract = getProviderHostContract(providerHint);
+  const defaultSurfaces = !contract && !providerProvidesAgentSurfaces(providerHint);
 
   // 1. groups/<folder>/ — group memory + working dir
   const groupDir = path.resolve(GROUPS_DIR, group.folder);
@@ -94,7 +72,9 @@ export async function initGroupFilesystem(
   initialized.push('container_configs');
 
   // 2. data/v2-sessions/<id>/.claude-shared/ — Claude state + per-group skills
-  if (defaultSurfaces) {
+  if (contract) {
+    initialized.push(...initializeProviderGroupSurfaces(providerHint, contract, group.id, groupDir));
+  } else if (defaultSurfaces) {
     const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
     if (!fs.existsSync(claudeDir)) {
       fs.mkdirSync(claudeDir, { recursive: true });
@@ -103,7 +83,7 @@ export async function initGroupFilesystem(
 
     const settingsFile = path.join(claudeDir, 'settings.json');
     if (!fs.existsSync(settingsFile)) {
-      fs.writeFileSync(settingsFile, DEFAULT_SETTINGS_JSON);
+      fs.writeFileSync(settingsFile, CLAUDE_DEFAULT_SETTINGS);
       initialized.push('settings.json');
     } else if (migrateClaudeMemorySettings(settingsFile)) {
       initialized.push('settings.json (reconciled Claude settings)');

--- a/src/host-lifecycle.test.ts
+++ b/src/host-lifecycle.test.ts
@@ -132,6 +132,12 @@ describe('host module lifecycle registry', () => {
 });
 
 describe('host lifecycle orchestration', () => {
+  it('does not validate provider host conformance during startup', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'index.ts'), 'utf8');
+
+    expect(source).not.toContain('assertProviderHostConformance()');
+  });
+
   it('starts after delivery is ready and before delivery polling', () => {
     const source = fs.readFileSync(path.join(process.cwd(), 'src', 'index.ts'), 'utf8');
     const deliveryReady = source.indexOf('setDeliveryAdapter(createChannelDeliveryAdapter())');

--- a/src/migrate-claude-memory-settings.ts
+++ b/src/migrate-claude-memory-settings.ts
@@ -1,17 +1,72 @@
 import fs from 'fs';
 
 import { log } from './log.js';
+import type { ProviderFileDiagnostic, ProviderFileTransformer } from './provider-contracts/registry.js';
 
 const PRE_COMPACT_COMMAND = 'bun /app/src/compact-instructions.ts';
 const LEGACY_MEMORY_SESSION_START_COMMAND = 'bun /app/src/memory-hook.ts';
 
+export const CLAUDE_DEFAULT_SETTINGS =
+  JSON.stringify(
+    {
+      autoMemoryEnabled: false,
+      env: {
+        CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      },
+      hooks: {
+        PreCompact: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: PRE_COMPACT_COMMAND,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    null,
+    2,
+  ) + '\n';
+
 /** Reconcile existing Claude settings with NanoClaw's shared memory system. */
 export function migrateClaudeMemorySettings(settingsFile: string): boolean {
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
+    const result = claudeSettingsTransformer.transform(fs.readFileSync(settingsFile, 'utf-8'), settingsFile);
+    emitDiagnostics(result.diagnostics);
+    if (result.kind === 'unchanged') return false;
+    writeAtomic(settingsFile, result.content);
+    return true;
+  } catch (err) {
+    emitDiagnostic(claudeSettingsTransformer.mapIoFailure(err, settingsFile));
+    return false;
+  }
+}
+
+export const claudeSettingsTransformer: ProviderFileTransformer = {
+  transform(current, settingsFile) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(current);
+    } catch (err) {
+      return {
+        kind: 'unchanged',
+        diagnostics: [failedDiagnostic(err, settingsFile)],
+      };
+    }
     if (!isRecord(parsed)) {
-      log.warn('Claude settings root is not an object; leaving it unchanged', { settingsFile });
-      return false;
+      return {
+        kind: 'unchanged',
+        diagnostics: [
+          {
+            level: 'warn',
+            message: 'Claude settings root is not an object; leaving it unchanged',
+            fields: { settingsFile },
+          },
+        ],
+      };
     }
 
     let changed = false;
@@ -52,16 +107,28 @@ export function migrateClaudeMemorySettings(settingsFile: string): boolean {
       changed = true;
     }
 
-    if (!changed) return false;
-    writeAtomic(settingsFile, JSON.stringify(parsed, null, 2) + '\n');
-    return true;
-  } catch (err) {
-    log.warn('Failed to reconcile Claude settings; leaving them unchanged', {
+    return changed ? { kind: 'replace', content: JSON.stringify(parsed, null, 2) + '\n' } : { kind: 'unchanged' };
+  },
+  mapIoFailure: failedDiagnostic,
+};
+
+function failedDiagnostic(err: unknown, settingsFile: string): ProviderFileDiagnostic {
+  return {
+    level: 'warn',
+    message: 'Failed to reconcile Claude settings; leaving them unchanged',
+    fields: {
       settingsFile,
       error: err instanceof Error ? err.message : String(err),
-    });
-    return false;
-  }
+    },
+  };
+}
+
+function emitDiagnostics(diagnostics: readonly ProviderFileDiagnostic[] | undefined): void {
+  for (const diagnostic of diagnostics ?? []) emitDiagnostic(diagnostic);
+}
+
+function emitDiagnostic(diagnostic: ProviderFileDiagnostic): void {
+  log[diagnostic.level](diagnostic.message, diagnostic.fields);
 }
 
 function removeLegacyNanoClawMemoryHook(value: unknown): unknown {
@@ -73,7 +140,8 @@ function removeLegacyNanoClawMemoryHook(value: unknown): unknown {
   return remaining.length > 0 ? { ...value, hooks: remaining } : undefined;
 }
 
-function writeAtomic(filePath: string, content: string): void {
+/** Write via a fresh temp file + rename so readers never see a partial file. */
+export function writeAtomic(filePath: string, content: string): void {
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   try {
     fs.writeFileSync(tmp, content, { flag: 'wx' });

--- a/src/provider-contracts/claude.ts
+++ b/src/provider-contracts/claude.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_PROJECT_DOC } from '../project-doc-compose.js';
+import { CLAUDE_DEFAULT_SETTINGS, claudeSettingsTransformer } from '../migrate-claude-memory-settings.js';
+
+import { registerProviderFileTransformer } from './file-transformers.js';
+import {
+  PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  registerProviderHostContract,
+  type ProviderHostContract,
+} from './registry.js';
+
+export const CLAUDE_COMPATIBLE_HOST_SURFACES = {
+  projectDocument: {
+    fileName: DEFAULT_PROJECT_DOC.fileName,
+    baseDocumentFile: 'CLAUDE.md',
+    maxBytes: DEFAULT_PROJECT_DOC.maxBytes,
+    containerPath: '/workspace/agent/CLAUDE.md',
+    mountClass: 'group-state',
+  },
+  stateVolumes: [
+    {
+      id: 'claude-home',
+      directory: '.claude-shared',
+      containerPath: '/home/node/.claude',
+      scope: 'group',
+      mode: 'rw',
+      mountClass: 'group-state',
+    },
+  ],
+  skillBackings: [
+    {
+      id: 'claude-skills',
+      location: { kind: 'state-volume', volumeId: 'claude-home', subdirectory: '' },
+      skillsSubdirectory: 'skills',
+      conflictDiagnostics: 'warn',
+      templateCopies: 'in-place',
+    },
+  ],
+  // The skills directory is already visible through the claude-home volume at
+  // /home/node/.claude/skills, so no separate view mount is declared.
+  skillViews: [],
+  files: [
+    {
+      id: 'claude-settings',
+      volumeId: 'claude-home',
+      relativePath: 'settings.json',
+      prepare: {
+        operation: 'create-if-missing',
+        when: 'group-init',
+        content: CLAUDE_DEFAULT_SETTINGS,
+      },
+      reconcile: { transformer: 'claude-settings' },
+    },
+  ],
+} satisfies Pick<ProviderHostContract, 'projectDocument' | 'stateVolumes' | 'skillBackings' | 'skillViews' | 'files'>;
+
+// The payload owns its transformer: core names no provider's implementation.
+registerProviderFileTransformer('claude-settings', claudeSettingsTransformer);
+
+registerProviderHostContract('claude', {
+  seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  ...CLAUDE_COMPATIBLE_HOST_SURFACES,
+  commands: {
+    nativeAdmin: ['/compact', '/context', '/cost', '/files'],
+    nativeFiltered: ['/start', '/help', '/login', '/logout', '/doctor', '/config', '/remote-control'],
+  },
+});

--- a/src/provider-contracts/conformance.test.ts
+++ b/src/provider-contracts/conformance.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import '../providers/index.js';
+import './index.js';
+import {
+  assertProviderHostConformance,
+  assertProviderHostContractShape,
+  getProviderHostContract,
+  listProviderHostContractNames,
+  registerProviderHostContract,
+  type ProviderHostContract,
+} from './registry.js';
+
+/** Deep clone that carries contract functions (transforms) by reference. */
+function cloneContract<T>(value: T): T {
+  if (Array.isArray(value)) return value.map((entry) => cloneContract(entry)) as T;
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, cloneContract(entry)])) as T;
+  }
+  return value;
+}
+
+describe('installed host provider contracts', () => {
+  it('match their compatibility adapters', () => {
+    for (const name of listProviderHostContractNames()) {
+      assertProviderHostContractShape(name, getProviderHostContract(name)!);
+    }
+    expect(() => assertProviderHostConformance()).not.toThrow();
+  });
+
+  it('rejects a declared provider whose required host adapter is missing', () => {
+    const contract: ProviderHostContract = {
+      ...cloneContract(getProviderHostContract('claude')!),
+      legacyHostAdapter: 'required',
+    };
+    registerProviderHostContract('missing-startup-adapter', contract);
+
+    expect(() => assertProviderHostConformance()).toThrow(
+      "Provider 'missing-startup-adapter' host contract requires a legacy host adapter",
+    );
+  });
+});

--- a/src/provider-contracts/file-transformers.test.ts
+++ b/src/provider-contracts/file-transformers.test.ts
@@ -1,0 +1,163 @@
+import fs from 'fs';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const TEST_ROOT = '/tmp/nanoclaw-provider-file-transformers-test';
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  DATA_DIR: '/tmp/nanoclaw-provider-file-transformers-test/data',
+  GROUPS_DIR: '/tmp/nanoclaw-provider-file-transformers-test/groups',
+}));
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import '../providers/index.js';
+import './index.js';
+import {
+  getProviderFileTransformer,
+  listProviderFileTransformerNames,
+  registerProviderFileTransformer,
+  type ProviderFileTransformer,
+} from './file-transformers.js';
+import { initializeProviderGroupSurfaces } from './realize.js';
+import {
+  PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  assertProviderHostConformance,
+  getProviderHostContract,
+  registerProviderHostContract,
+  type ProviderHostContract,
+} from './registry.js';
+
+/** A payload-owned transformer that has nothing to do with Claude. */
+const payloadTransformer: ProviderFileTransformer = {
+  transform(current) {
+    return current.includes('"reconciled"')
+      ? { kind: 'unchanged' }
+      : { kind: 'replace', content: '{"reconciled":true}\n' };
+  },
+  mapIoFailure(error) {
+    return { level: 'error', message: 'payload transformer failed', fields: { error: String(error) } };
+  },
+};
+
+/** Claude's registered document. */
+function baseProjectDocument(): ProviderHostContract['projectDocument'] {
+  return getProviderHostContract('claude')!.projectDocument;
+}
+
+function contractWithTransformer(transformer: string, directory: string): ProviderHostContract {
+  return {
+    seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+    // Derived from the registered Claude document rather than written out as a
+    // literal: the project-document shape is owned by other layers of this
+    // stack, and this suite is about transformers, not that shape.
+    projectDocument: {
+      ...baseProjectDocument(),
+      containerPath: '/workspace/agent/AGENTS.md',
+      mountClass: 'group-state',
+    },
+    stateVolumes: [
+      {
+        id: 'state',
+        directory,
+        containerPath: '/state',
+        scope: 'group',
+        mode: 'rw',
+        mountClass: 'group-state',
+      },
+    ],
+    skillBackings: [],
+    skillViews: [],
+    files: [
+      {
+        id: 'settings',
+        volumeId: 'state',
+        relativePath: 'settings.json',
+        prepare: {
+          operation: 'create-if-missing',
+          when: 'group-init',
+          content: '{"initial":true}\n',
+        },
+        reconcile: { transformer },
+      },
+    ],
+  };
+}
+
+beforeAll(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+});
+
+afterAll(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('provider file transformer registry', () => {
+  it('carries the transformer Claude registers for itself', () => {
+    expect(listProviderFileTransformerNames()).toContain('claude-settings');
+    expect(getProviderFileTransformer('claude-settings')).toBeDefined();
+    expect(getProviderFileTransformer('never-registered')).toBeUndefined();
+  });
+
+  it('rejects duplicate registration', () => {
+    registerProviderFileTransformer('duplicate-transformer', payloadTransformer);
+
+    expect(() => registerProviderFileTransformer('duplicate-transformer', payloadTransformer)).toThrow(
+      'Provider file transformer already registered: duplicate-transformer',
+    );
+  });
+
+  it('rejects a transformer name that is not lowercase kebab-case', () => {
+    expect(() => registerProviderFileTransformer('Not Kebab', payloadTransformer)).toThrow(
+      "Provider file transformer name must be lowercase kebab-case: 'Not Kebab'",
+    );
+  });
+
+  it('resolves and invokes a payload-registered transformer during realization', () => {
+    registerProviderFileTransformer('payload-settings', payloadTransformer);
+    const contract = contractWithTransformer('payload-settings', '.payload-state');
+    const settingsFile = path.join(
+      TEST_ROOT,
+      'data',
+      'v2-sessions',
+      'payload-group',
+      '.payload-state',
+      'settings.json',
+    );
+
+    expect(initializeProviderGroupSurfaces('payload', contract, 'payload-group', TEST_ROOT)).toContain('settings.json');
+    expect(fs.readFileSync(settingsFile, 'utf-8')).toBe('{"initial":true}\n');
+
+    expect(initializeProviderGroupSurfaces('payload', contract, 'payload-group', TEST_ROOT)).toContain(
+      'settings.json (reconciled Payload settings)',
+    );
+    expect(fs.readFileSync(settingsFile, 'utf-8')).toBe('{"reconciled":true}\n');
+  });
+
+  it('keeps Claude out of core: realization names no provider transformer', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'provider-contracts', 'realize.ts'), 'utf8');
+
+    expect(source).not.toContain('claudeSettingsTransformer');
+    expect(source).not.toContain('claude-settings');
+  });
+
+  // Registered last: it leaves an unresolvable contract in the module-global
+  // registry, so every later conformance call would fail on it.
+  it('rejects a contract naming an unregistered transformer at conformance', () => {
+    expect(() => assertProviderHostConformance()).not.toThrow();
+    registerProviderHostContract(
+      'unresolved-transformer-provider',
+      contractWithTransformer('never-registered', '.unresolved-state'),
+    );
+
+    const registered = listProviderFileTransformerNames();
+    expect(registered).toContain('claude-settings');
+    expect(() => assertProviderHostConformance()).toThrow(
+      `Provider 'unresolved-transformer-provider' file 'settings' names unregistered file transformer 'never-registered'; registered transformers: ${registered.join(', ')}`,
+    );
+  });
+});

--- a/src/provider-contracts/file-transformers.ts
+++ b/src/provider-contracts/file-transformers.ts
@@ -1,0 +1,59 @@
+/**
+ * Provider file-transformer registry.
+ *
+ * Host provider contracts are data-only: a contract that wants core to
+ * reconcile an existing file names its transformer as a string, and the
+ * payload that owns the transformer registers the implementation here at
+ * module scope. Core never names a payload's transformer, and a payload can
+ * reconcile its own settings file without editing core.
+ *
+ * Its own module, not part of `registry.ts`, for the same reason
+ * `gateway-provider-registry.ts` is separate from its barrel: the file an
+ * overlay appends an import to must not be the file that owns the map
+ * (temporal dead zone on the one path nobody exercises until an overlay is
+ * installed).
+ *
+ * Registration order between contract modules and transformer modules is not
+ * guaranteed, so contract registration only checks the *shape* of the name.
+ * That a named transformer actually exists is the conformance check
+ * (`assertProviderHostConformance`), which runs once every payload is loaded.
+ */
+
+export interface ProviderFileDiagnostic {
+  level: 'warn' | 'error';
+  message: string;
+  fields?: Record<string, unknown>;
+}
+
+export type ProviderFileTransformResult =
+  | { kind: 'unchanged'; diagnostics?: readonly ProviderFileDiagnostic[] }
+  | { kind: 'replace'; content: string; diagnostics?: readonly ProviderFileDiagnostic[] };
+
+export interface ProviderFileTransformer {
+  transform(current: string, filePath: string): ProviderFileTransformResult;
+  mapIoFailure(error: unknown, filePath: string): ProviderFileDiagnostic;
+}
+
+const transformers = new Map<string, ProviderFileTransformer>();
+
+export function registerProviderFileTransformer(name: string, transformer: ProviderFileTransformer): void {
+  if (typeof name !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    throw new Error(`Provider file transformer name must be lowercase kebab-case: '${String(name)}'`);
+  }
+  if (transformers.has(name)) throw new Error(`Provider file transformer already registered: ${name}`);
+  transformers.set(name, transformer);
+}
+
+export function getProviderFileTransformer(name: string): ProviderFileTransformer | undefined {
+  return transformers.get(name);
+}
+
+export function listProviderFileTransformerNames(): string[] {
+  return [...transformers.keys()];
+}
+
+/** Registered names for an error message; never the empty string. */
+export function describeRegisteredProviderFileTransformers(): string {
+  const names = listProviderFileTransformerNames();
+  return names.length ? names.join(', ') : '(none)';
+}

--- a/src/provider-contracts/index.ts
+++ b/src/provider-contracts/index.ts
@@ -1,0 +1,5 @@
+// Host provider-contract barrel. Optional provider skills append imports here;
+// provider identity detection continues to inspect src/providers/index.ts only.
+import './claude.js';
+
+export * from './registry.js';

--- a/src/provider-contracts/realize.ts
+++ b/src/provider-contracts/realize.ts
@@ -1,0 +1,321 @@
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from '../config.js';
+import { materializeTemplateSkills } from '../group-skills.js';
+import { log } from '../log.js';
+import { writeAtomic } from '../migrate-claude-memory-settings.js';
+import { DEFAULT_PROJECT_DOC, type ProjectDocSpec } from '../project-doc-compose.js';
+
+import {
+  describeRegisteredProviderFileTransformers,
+  getProviderFileTransformer,
+  type ProviderFileDiagnostic,
+  type ProviderFileTransformer,
+} from './file-transformers.js';
+import {
+  type ProviderFileTransformerId,
+  type ProviderHostContract,
+  type ProviderSkillBackingLocation,
+  type ProviderStateVolume,
+} from './registry.js';
+
+// Core-owned: the shipped base document is protected unconditionally; no
+// provider contract switches this on or off.
+export function protectedProviderDocumentSourcePaths(projectRoot: string): string[] {
+  return [path.resolve(projectRoot, DEFAULT_PROJECT_DOC.baseDocPath)];
+}
+
+export function providerProjectDocSpec(contract: ProviderHostContract): ProjectDocSpec | undefined {
+  if (contract.projectDocument === undefined) return undefined;
+  const { fileName, baseDocumentFile, extraSections, maxBytes } = contract.projectDocument;
+  resolveWithinRoot(path.resolve(process.cwd(), 'container'), baseDocumentFile);
+  return {
+    fileName,
+    baseDocPath: path.join('container', baseDocumentFile),
+    ...(extraSections ? { extraSections } : {}),
+    ...(maxBytes === undefined ? {} : { maxBytes }),
+  };
+}
+
+export function providerStateVolumePath(
+  volume: ProviderStateVolume,
+  agentGroupId: string,
+  sessionDirectory?: string,
+): string {
+  return resolveWithinRoot(providerStateVolumeRoot(volume, agentGroupId, sessionDirectory), volume.directory);
+}
+
+function providerStateVolumeRoot(volume: ProviderStateVolume, agentGroupId: string, sessionDirectory?: string): string {
+  if (volume.scope === 'session') {
+    if (!sessionDirectory) throw new Error(`Session directory required for provider state volume '${volume.id}'`);
+    return path.resolve(sessionDirectory);
+  }
+  return path.resolve(DATA_DIR, 'v2-sessions', agentGroupId);
+}
+
+/** Realize the group-lifetime portion of a declared provider contract. */
+export function initializeProviderGroupSurfaces(
+  provider: string,
+  contract: ProviderHostContract,
+  agentGroupId: string,
+  groupDir: string,
+): string[] {
+  const initialized: string[] = [];
+  const volumes = new Map(contract.stateVolumes.map((volume) => [volume.id, volume]));
+
+  for (const volume of contract.stateVolumes) {
+    if (volume.scope !== 'group') continue;
+    const hostPath = providerStateVolumePath(volume, agentGroupId);
+    const existed = fs.existsSync(hostPath);
+    ensureDirectoryWithinRoot(providerStateVolumeRoot(volume, agentGroupId), hostPath);
+    if (!existed) initialized.push(volume.directory);
+  }
+
+  for (const file of contract.files) {
+    if (file.prepare.when === 'group-init') initializeFile(provider, file, volumes, agentGroupId, initialized);
+  }
+
+  for (const backing of contract.skillBackings) {
+    if (backing.location.kind === 'state-volume') {
+      const volume = volumes.get(backing.location.volumeId);
+      if (!volume) throw new Error(`Provider skill backing references unknown volume '${backing.location.volumeId}'`);
+      if (volume.scope !== 'group') continue;
+    }
+    const skillsPath = providerSkillDirectory(backing, volumes, agentGroupId, groupDir);
+    const existed = fs.existsSync(skillsPath);
+    ensureDirectoryWithinRoot(
+      skillBackingContainmentRoot(backing.location, volumes, agentGroupId, groupDir),
+      skillsPath,
+    );
+    if (!existed) initialized.push(`${path.basename(skillsPath)}/`);
+  }
+
+  return initialized;
+}
+
+export interface ProviderSpawnRealization {
+  skillBackingPaths: Map<string, string>;
+  contribution: import('../providers/provider-container-registry.js').ProviderContainerContribution;
+}
+
+/** Realize every-spawn provider surfaces in the order derived from their resources. */
+export async function realizeProviderSpawnSurfaces(
+  _provider: string,
+  contract: ProviderHostContract,
+  agentGroupId: string,
+  groupDir: string,
+  sessionDirectory: string,
+  selectedSkills: readonly string[],
+  actions: {
+    legacyOverlay: () => Promise<import('../providers/provider-container-registry.js').ProviderContainerContribution>;
+    composeProjectDocument: (spec: ProjectDocSpec) => Promise<void>;
+  },
+): Promise<ProviderSpawnRealization> {
+  const volumes = new Map(contract.stateVolumes.map((volume) => [volume.id, volume]));
+  const paths = new Map<string, string>();
+  // A registered legacy adapter still contributes env exactly as before this
+  // contract existed; only its mounts are dropped, since core now realizes
+  // every declared surface. Nothing in the contract switches this on or off.
+  const overlay = await actions.legacyOverlay();
+  const contribution = overlay.env ? { env: overlay.env } : {};
+
+  for (const volume of contract.stateVolumes) {
+    const hostPath = providerStateVolumePath(volume, agentGroupId, sessionDirectory);
+    ensureDirectoryWithinRoot(providerStateVolumeRoot(volume, agentGroupId, sessionDirectory), hostPath);
+  }
+
+  for (const file of contract.files) {
+    if (file.prepare.when === 'every-spawn') prepareSpawnFile(file, volumes, agentGroupId, sessionDirectory);
+  }
+
+  for (const backing of contract.skillBackings) {
+    const backingRoot = skillBackingPath(backing.location, volumes, agentGroupId, groupDir, sessionDirectory);
+    const skillsPath = resolveWithinRoot(backingRoot, backing.skillsSubdirectory);
+    paths.set(backing.id, backingRoot);
+    ensureDirectoryWithinRoot(
+      skillBackingContainmentRoot(backing.location, volumes, agentGroupId, groupDir, sessionDirectory),
+      skillsPath,
+    );
+    syncSharedSkillLinks(skillsPath, selectedSkills, backing.conflictDiagnostics === 'warn');
+    if (backing.templateCopies === 'copy') {
+      materializeTemplateSkills(agentGroupId, skillsPath);
+    }
+  }
+
+  const spec = providerProjectDocSpec(contract);
+  if (spec) await actions.composeProjectDocument(spec);
+
+  return { skillBackingPaths: paths, contribution };
+}
+
+function initializeFile(
+  provider: string,
+  file: ProviderHostContract['files'][number],
+  volumes: ReadonlyMap<string, ProviderStateVolume>,
+  agentGroupId: string,
+  initialized: string[],
+): void {
+  const volume = volumes.get(file.volumeId);
+  if (!volume) throw new Error(`Provider prepared file references unknown volume '${file.volumeId}'`);
+  const volumePath = providerStateVolumePath(volume, agentGroupId);
+  const filePath = resolveWithinRoot(volumePath, file.relativePath);
+  if (!fs.existsSync(filePath)) {
+    if (file.prepare.operation !== 'create-if-missing') return;
+    fs.writeFileSync(filePath, file.prepare.content, { flag: 'wx' });
+    initialized.push(file.relativePath);
+    return;
+  }
+  // Reconciliation runs at the moment the file is prepared, so the prepare
+  // variant is the only schedule there is.
+  if (file.reconcile === undefined || file.prepare.when !== 'group-init') return;
+  const transformerProvider = file.reconcile.transformerProvider ?? provider;
+  const transformer = providerFileTransformer(file.reconcile.transformer);
+  try {
+    const result = transformer.transform(fs.readFileSync(filePath, 'utf-8'), filePath);
+    emitDiagnostics(result.diagnostics);
+    if (result.kind === 'replace') {
+      writeAtomic(filePath, result.content);
+      initialized.push(`${file.relativePath} (reconciled ${providerName(transformerProvider)} settings)`);
+    }
+  } catch (err) {
+    emitDiagnostic(transformer.mapIoFailure(err, filePath));
+  }
+}
+
+function providerFileTransformer(name: ProviderFileTransformerId): ProviderFileTransformer {
+  const transformer = getProviderFileTransformer(name);
+  if (transformer === undefined) {
+    throw new Error(
+      `Unknown provider file transformer '${name}'; registered transformers: ${describeRegisteredProviderFileTransformers()}`,
+    );
+  }
+  return transformer;
+}
+
+function prepareSpawnFile(
+  file: ProviderHostContract['files'][number],
+  volumes: ReadonlyMap<string, ProviderStateVolume>,
+  agentGroupId: string,
+  sessionDirectory: string,
+): void {
+  const volume = volumes.get(file.volumeId);
+  if (!volume) throw new Error(`Provider prepared file references unknown volume '${file.volumeId}'`);
+  const volumePath = providerStateVolumePath(volume, agentGroupId, sessionDirectory);
+  const filePath = resolveWithinRoot(volumePath, file.relativePath);
+  if (file.prepare.operation === 'append-open-close') {
+    const flags = fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW;
+    fs.closeSync(fs.openSync(filePath, flags));
+  }
+}
+
+function providerSkillDirectory(
+  backing: ProviderHostContract['skillBackings'][number],
+  volumes: ReadonlyMap<string, ProviderStateVolume>,
+  agentGroupId: string,
+  groupDir: string,
+): string {
+  return resolveWithinRoot(
+    skillBackingPath(backing.location, volumes, agentGroupId, groupDir),
+    backing.skillsSubdirectory,
+  );
+}
+
+function skillBackingPath(
+  location: ProviderSkillBackingLocation,
+  volumes: ReadonlyMap<string, ProviderStateVolume>,
+  agentGroupId: string,
+  groupDir: string,
+  sessionDirectory?: string,
+): string {
+  if (location.kind === 'group-directory') {
+    return resolveWithinRoot(groupDir, location.directory, location.subdirectory);
+  }
+  const volume = volumes.get(location.volumeId);
+  if (!volume) throw new Error(`Provider skill backing references unknown volume '${location.volumeId}'`);
+  return resolveWithinRoot(providerStateVolumePath(volume, agentGroupId, sessionDirectory), location.subdirectory);
+}
+
+function skillBackingContainmentRoot(
+  location: ProviderSkillBackingLocation,
+  volumes: ReadonlyMap<string, ProviderStateVolume>,
+  agentGroupId: string,
+  groupDir: string,
+  sessionDirectory?: string,
+): string {
+  if (location.kind === 'group-directory') return path.resolve(groupDir);
+  const volume = volumes.get(location.volumeId);
+  if (!volume) throw new Error(`Provider skill backing references unknown volume '${location.volumeId}'`);
+  return providerStateVolumePath(volume, agentGroupId, sessionDirectory);
+}
+
+/**
+ * Reconcile the shared-skill symlinks in one skills directory: drop links no
+ * longer selected, add missing ones pointing at the container's /app/skills.
+ * Also the body of the legacy Claude path (`syncSkillSymlinks` in
+ * container-runner.ts), which wraps it with mkdir + skill-selection lookup.
+ */
+export function syncSharedSkillLinks(
+  skillsDir: string,
+  desiredSkills: readonly string[],
+  warnOnConflict: boolean,
+): void {
+  const desired = new Set(desiredSkills);
+  for (const entry of fs.readdirSync(skillsDir)) {
+    const entryPath = path.join(skillsDir, entry);
+    let isSymlink = false;
+    try {
+      isSymlink = fs.lstatSync(entryPath).isSymbolicLink();
+    } catch {
+      continue;
+    }
+    if (isSymlink && !desired.has(entry)) fs.unlinkSync(entryPath);
+  }
+
+  for (const skill of desiredSkills) {
+    const linkPath = path.join(skillsDir, skill);
+    let entry: fs.Stats | undefined;
+    try {
+      entry = fs.lstatSync(linkPath);
+    } catch {
+      /* missing */
+    }
+    if (!entry) {
+      fs.symlinkSync(`/app/skills/${skill}`, linkPath);
+    } else if (!entry.isSymbolicLink() && warnOnConflict) {
+      log.warn(
+        'Shared skill not symlinked: real entry occupies the path (template overlay or stale pre-refactor copy)',
+        { skill, path: linkPath },
+      );
+    }
+  }
+}
+
+function resolveWithinRoot(root: string, ...segments: string[]): string {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...segments);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Provider contract path escapes its resolved root: '${segments.join('/')}'`);
+  }
+  return resolved;
+}
+
+function ensureDirectoryWithinRoot(root: string, directory: string): void {
+  // Lexical containment only: like the legacy path, symlinks placed by the
+  // operator (relocated state, shared skills) are followed, not rejected.
+  resolveWithinRoot(root, path.relative(path.resolve(root), path.resolve(directory)));
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+function emitDiagnostics(diagnostics: readonly ProviderFileDiagnostic[] | undefined): void {
+  for (const diagnostic of diagnostics ?? []) emitDiagnostic(diagnostic);
+}
+
+function emitDiagnostic(diagnostic: ProviderFileDiagnostic): void {
+  log[diagnostic.level](diagnostic.message, diagnostic.fields);
+}
+
+function providerName(provider: string): string {
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}

--- a/src/provider-contracts/registry.test.ts
+++ b/src/provider-contracts/registry.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it } from 'vitest';
+
+import './index.js';
+import {
+  PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  getProviderHostContract,
+  hasDeclaredProviderContract,
+  listProviderHostContractNames,
+  registerProviderHostContract,
+  type ProviderHostContract,
+} from './registry.js';
+
+function emptyContract(): ProviderHostContract {
+  return {
+    seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+    projectDocument: {
+      fileName: 'AGENTS.md',
+      baseDocumentFile: 'AGENTS.md',
+      containerPath: '/workspace/agent/AGENTS.md',
+      mountClass: 'group-state',
+    },
+    stateVolumes: [],
+    skillBackings: [],
+    skillViews: [],
+    files: [],
+    commands: { nativeAdmin: [], nativeFiltered: [] },
+  };
+}
+
+const missing = Symbol('missing');
+
+function cloneContract<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function claudeContractWith(path: string, value: unknown | typeof missing): ProviderHostContract {
+  const contract = cloneContract(getProviderHostContract('claude')!);
+  const parts = path.split('.');
+  let target = contract as unknown as Record<string, unknown>;
+  for (const part of parts.slice(0, -1)) target = target[part] as Record<string, unknown>;
+  const field = parts.at(-1)!;
+  if (value === missing) delete target[field];
+  else target[field] = value;
+  return contract;
+}
+
+function contractName(field: string, suffix: string): string {
+  return `invalid-${field}-${suffix}-${process.pid}`.replaceAll(/[^a-z0-9-]/g, '-');
+}
+
+/** Claude's contract plus one bind view of its skills backing, for view-field checks. */
+function viewContract(): ProviderHostContract {
+  const contract = cloneContract(getProviderHostContract('claude')!);
+  contract.skillViews = [
+    {
+      backingId: 'claude-skills',
+      containerPath: '/workspace/agent/.claude-skills',
+      mode: 'ro',
+      mountClass: 'group-state',
+    },
+  ];
+  return contract;
+}
+
+function viewContractWith(path: string, value: unknown): ProviderHostContract {
+  const contract = viewContract();
+  const parts = path.split('.');
+  let target = contract as unknown as Record<string, unknown>;
+  for (const part of parts.slice(0, -1)) target = target[part] as Record<string, unknown>;
+  target[parts.at(-1)!] = value;
+  return contract;
+}
+
+describe('provider host contracts', () => {
+  it('loads the complete Claude base declaration from the separate contract barrel', () => {
+    const contract = getProviderHostContract('claude');
+
+    expect(contract).toBeDefined();
+    expect(contract?.projectDocument).toMatchObject({
+      fileName: 'CLAUDE.md',
+      containerPath: '/workspace/agent/CLAUDE.md',
+    });
+    expect(contract?.stateVolumes).toEqual([
+      expect.objectContaining({ id: 'claude-home', directory: '.claude-shared', scope: 'group' }),
+    ]);
+    expect(contract?.skillBackings).toEqual([
+      expect.objectContaining({ id: 'claude-skills', templateCopies: 'in-place' }),
+    ]);
+    expect(contract?.files).toEqual([
+      expect.objectContaining({
+        id: 'claude-settings',
+        prepare: expect.objectContaining({ operation: 'create-if-missing', when: 'group-init' }),
+        reconcile: { transformer: 'claude-settings' },
+      }),
+    ]);
+    expect(contract?.legacyHostAdapter).toBeUndefined();
+    expect(contract?.seamVersion).toBe(PROVIDER_HOST_CONTRACT_SEAM_VERSION);
+    expect(contract?.commands?.nativeFiltered).toContain('/remote-control');
+  });
+
+  it('keeps installed contracts data-only', () => {
+    for (const name of listProviderHostContractNames()) {
+      const contract = getProviderHostContract(name)!;
+      expect(JSON.parse(JSON.stringify(contract))).toEqual(contract);
+    }
+  });
+
+  it('keeps provider lookup case-insensitive and unknown providers undeclared', () => {
+    expect(hasDeclaredProviderContract('CLAUDE')).toBe(true);
+    expect(hasDeclaredProviderContract('not-installed')).toBe(false);
+    expect(listProviderHostContractNames()).toContain('claude');
+  });
+
+  it('rejects duplicate declarations at registration', () => {
+    const name = `duplicate-contract-${process.pid}`;
+    const empty = emptyContract();
+    registerProviderHostContract(name, empty);
+    expect(() => registerProviderHostContract(name, empty)).toThrow(/already registered/);
+  });
+
+  it('rejects a malformed contract at registration and stores nothing', () => {
+    const name = contractName('malformed', 'container-path');
+    const contract = claudeContractWith('projectDocument.containerPath', 'workspace/agent/CLAUDE.md');
+
+    expect(() => registerProviderHostContract(name, contract)).toThrow(/canonical absolute container path/);
+    expect(hasDeclaredProviderContract(name)).toBe(false);
+    expect(listProviderHostContractNames()).not.toContain(name);
+  });
+
+  it('rejects mixed-version provider contracts with an operator fix', () => {
+    const contract = emptyContract();
+    contract.seamVersion = 0;
+    expect(() => registerProviderHostContract(contractName('seam-version', 'old'), contract)).toThrow(
+      /run \/update-skills/,
+    );
+  });
+
+  it('freezes the stored contract so later mutation attempts throw', () => {
+    const name = `immutable-contract-${process.pid}`;
+    registerProviderHostContract(name, emptyContract());
+
+    const stored = getProviderHostContract(name)!;
+    expect(Object.isFrozen(stored)).toBe(true);
+    expect(Object.isFrozen(stored.commands!.nativeAdmin)).toBe(true);
+    expect(() => (stored.commands!.nativeAdmin as string[]).push('/later')).toThrow();
+  });
+
+  it('requires a project document', () => {
+    expect(() =>
+      registerProviderHostContract(
+        contractName('project-document', 'missing'),
+        claudeContractWith('projectDocument', missing),
+      ),
+    ).toThrow(/projectDocument is required/);
+  });
+
+  it.each([
+    [
+      'host path',
+      () => ({
+        ...emptyContract(),
+        projectDocument: {
+          fileName: 'AGENTS.md',
+          baseDocumentFile: '/tmp/AGENTS.md',
+          containerPath: '/workspace/agent/AGENTS.md',
+          mountClass: 'group-state' as const,
+        },
+      }),
+      /one file or directory name/,
+    ],
+    [
+      'duplicate volume identity',
+      () => ({
+        ...emptyContract(),
+        stateVolumes: [
+          {
+            id: 'state',
+            directory: '.one',
+            containerPath: '/one',
+            scope: 'group' as const,
+            mode: 'rw' as const,
+            mountClass: 'group-state' as const,
+          },
+          {
+            id: 'state',
+            directory: '.two',
+            containerPath: '/two',
+            scope: 'session' as const,
+            mode: 'rw' as const,
+            mountClass: 'allowlisted-extra' as const,
+          },
+        ],
+      }),
+      /must be unique/,
+    ],
+    [
+      'missing backing volume',
+      () => ({
+        ...emptyContract(),
+        skillBackings: [
+          {
+            id: 'skills',
+            location: { kind: 'state-volume' as const, volumeId: 'missing', subdirectory: 'skills' },
+            skillsSubdirectory: 'skills',
+            conflictDiagnostics: 'silent' as const,
+            templateCopies: 'in-place' as const,
+          },
+        ],
+      }),
+      /references unknown/,
+    ],
+  ])('rejects %s at registration', (_label, makeContract, expected) => {
+    const name = `invalid-${_label.toLowerCase().replaceAll(' ', '-')}-${process.pid}`;
+    expect(() => registerProviderHostContract(name, makeContract())).toThrow(expected);
+  });
+
+  it.each([
+    ['not an array', {}, /projectDocument\.extraSections must be an array/],
+    ['missing name', [{ body: 'body' }], /extraSections\[0\]\.name must be a non-empty string/],
+    ['missing body', [{ name: 'name' }], /extraSections\[0\]\.body must be a non-empty string/],
+    ['blank name', [{ name: ' ', body: 'body' }], /extraSections\[0\]\.name must be a non-empty string/],
+    ['blank body', [{ name: 'name', body: ' ' }], /extraSections\[0\]\.body must be a non-empty string/],
+  ])('rejects malformed project-document extra sections: %s', (_label, value, expected) => {
+    expect(() =>
+      registerProviderHostContract(
+        contractName(`extra-sections-${_label}`, 'invalid'),
+        claudeContractWith('projectDocument.extraSections', value),
+      ),
+    ).toThrow(expected);
+  });
+
+  it.each(['stateVolumes', 'skillBackings', 'skillViews', 'files'])('requires top-level host array %s', (field) => {
+    expect(() =>
+      registerProviderHostContract(contractName(`array-${field}`, 'wrong'), claudeContractWith(field, {})),
+    ).toThrow(`.${field} must be an array`);
+    expect(() =>
+      registerProviderHostContract(contractName(`array-${field}`, 'missing'), claudeContractWith(field, missing)),
+    ).toThrow(`.${field} must be an array`);
+  });
+
+  it.each([
+    ['projectDocument.mountClass', 'claude.projectDocument.mountClass'],
+    ['stateVolumes.0.scope', 'claude.stateVolumes.claude-home.scope'],
+    ['stateVolumes.0.mode', 'claude.stateVolumes.claude-home.mode'],
+    ['stateVolumes.0.mountClass', 'claude.stateVolumes.claude-home.mountClass'],
+    ['skillBackings.0.location.kind', 'claude.skillBackings.claude-skills.location.kind'],
+    ['skillBackings.0.conflictDiagnostics', 'claude.skillBackings.claude-skills.conflictDiagnostics'],
+    ['skillBackings.0.templateCopies', 'claude.skillBackings.claude-skills.templateCopies'],
+    ['files.0.prepare.operation', 'claude.files.claude-settings.prepare.operation'],
+    ['files.0.prepare.when', 'claude.files.claude-settings.prepare.when'],
+    ['commands.nativeAdmin', 'claude.commands.nativeAdmin'],
+    ['commands.nativeFiltered', 'claude.commands.nativeFiltered'],
+  ])('rejects invalid %s at registration', (path, field) => {
+    expect(() =>
+      registerProviderHostContract(contractName(path, 'invalid'), claudeContractWith(path, 'invalid')),
+    ).toThrow(field.slice('claude'.length));
+  });
+
+  it.each([['legacyHostAdapter', 'claude.legacyHostAdapter']])('rejects invalid %s at registration', (path, field) => {
+    expect(() =>
+      registerProviderHostContract(contractName(path, 'invalid'), claudeContractWith(path, 'invalid')),
+    ).toThrow(field.slice('claude'.length));
+  });
+
+  it.each([
+    ['skillViews.0.mode', '.skillViews.claude-skills.mode'],
+    ['skillViews.0.mountClass', '.skillViews.claude-skills.mountClass'],
+    ['skillViews.0.containerPath', '.skillViews.claude-skills.containerPath'],
+  ])('rejects invalid %s at registration', (path, field) => {
+    expect(() =>
+      registerProviderHostContract(contractName(path, 'invalid'), viewContractWith(path, 'invalid')),
+    ).toThrow(field);
+  });
+
+  it('rejects a skill view whose container path collides with a state volume', () => {
+    expect(() =>
+      registerProviderHostContract(
+        contractName('view-destination', 'duplicate'),
+        viewContractWith('skillViews.0.containerPath', '/home/node/.claude'),
+      ),
+    ).toThrow(/container destinations must be unique/);
+  });
+
+  // Registration checks the shape of the transformer name only; that a name
+  // resolves to a registered implementation is `assertProviderHostConformance`,
+  // because contract and transformer modules load in no guaranteed order.
+  it('rejects malformed reconcile transformer names', () => {
+    expect(() =>
+      registerProviderHostContract(
+        contractName('reconcile-transform', 'invalid'),
+        claudeContractWith('files.0.reconcile.transformer', 'Not Kebab Case'),
+      ),
+    ).toThrow(/reconcile\.transformer must be lowercase kebab-case/);
+  });
+
+  it('accepts a well-formed transformer name core does not know', () => {
+    const name = contractName('reconcile-transform', 'unregistered');
+    registerProviderHostContract(
+      name,
+      claudeContractWith('files.0.reconcile.transformer', 'payload-owned-transformer'),
+    );
+
+    expect(getProviderHostContract(name)?.files[0].reconcile?.transformer).toBe('payload-owned-transformer');
+  });
+
+  it('rejects invalid prepared-file content and reconciliation', () => {
+    expect(() =>
+      registerProviderHostContract(
+        contractName('prepare-content', 'missing'),
+        claudeContractWith('files.0.prepare.content', missing),
+      ),
+    ).toThrow(/files\.claude-settings\.prepare\.content/);
+    // A gateway-owned file has nothing to reconcile: that rule is about the
+    // prepare variant, which is the only place ownership is stated now.
+    const appendReconcile = claudeContractWith('files.0.prepare', {
+      operation: 'append-open-close',
+      when: 'every-spawn',
+    });
+    expect(() => registerProviderHostContract(contractName('append-reconcile', 'kept'), appendReconcile)).toThrow(
+      /reconcile must be omitted for append-open-close/,
+    );
+  });
+
+  it('reconciles a prepared file on the schedule its prepare variant fixes', () => {
+    const contract = getProviderHostContract('claude')!;
+    // The reconciliation used to carry its own `when`, validated to equal this
+    // one. Deleting it cannot change the schedule.
+    expect(contract.files[0].prepare.when).toBe('group-init');
+    expect(contract.files[0].reconcile).toBeDefined();
+  });
+
+  // Both fields had exactly one legal value across every implementer, so the
+  // behavior they named is now core's: shared links are always synced and
+  // prepared files take the process default mode. A payload still declaring
+  // them is stale, and is told so rather than silently ignored.
+  it.each([
+    ['skillBackings.0.sharedLinks', true, /sharedLinks is no longer declared.*run \/update-skills/],
+    ['files.0.prepare.mode', 'process-default', /prepare\.mode is no longer declared.*run \/update-skills/],
+    ['files.0.prepare.mode', 0o600, /prepare\.mode is no longer declared.*run \/update-skills/],
+  ])('rejects the stale %s key with an operator fix', (path, value, expected) => {
+    expect(() =>
+      registerProviderHostContract(contractName(path, `stale-${String(value)}`), claudeContractWith(path, value)),
+    ).toThrow(expected);
+  });
+
+  it('rejects group-init prepared files in session volumes', () => {
+    const contract = claudeContractWith('stateVolumes', [
+      ...cloneContract(getProviderHostContract('claude')!.stateVolumes),
+      {
+        id: 'session-state',
+        directory: 'session-state',
+        containerPath: '/session-state',
+        scope: 'session',
+        mode: 'rw',
+        mountClass: 'allowlisted-extra',
+      },
+    ]);
+    contract.files = [
+      ...contract.files,
+      {
+        id: 'session-file',
+        volumeId: 'session-state',
+        relativePath: 'state.json',
+        prepare: { operation: 'create-if-missing', when: 'group-init', content: '{}\n' },
+      },
+    ];
+    expect(() => registerProviderHostContract(contractName('session-group-init-file', 'invalid'), contract)).toThrow(
+      /prepare cannot initialize session volume 'session-state'/,
+    );
+  });
+
+  it.each([
+    [
+      'container path alias',
+      'stateVolumes.0.containerPath',
+      '/home/node//.claude',
+      /canonical absolute container path/,
+    ],
+    ['relative dot alias', 'files.0.relativePath', './settings.json', /canonical relative path/],
+    ['relative parent alias', 'files.0.relativePath', 'config/../settings.json', /canonical relative path/],
+    ['leading relative parent', 'files.0.relativePath', '../settings.json', /canonical relative path/],
+    ['backing relative parent', 'skillBackings.0.location.subdirectory', '../skills', /canonical relative path/],
+    ['skills relative parent', 'skillBackings.0.skillsSubdirectory', '../skills', /canonical relative path/],
+    ['relative slash alias', 'files.0.relativePath', 'config//settings.json', /canonical relative path/],
+  ])('rejects noncanonical %s', (_label, field, value, expected) => {
+    expect(() =>
+      registerProviderHostContract(contractName(`path-${_label}`, 'invalid'), claudeContractWith(field, value)),
+    ).toThrow(expected);
+  });
+});

--- a/src/provider-contracts/registry.ts
+++ b/src/provider-contracts/registry.ts
@@ -1,0 +1,420 @@
+/**
+ * Host-side provider surface contracts.
+ *
+ * Provider payloads name container-visible files and directories. They never
+ * name host paths; the host realization resolves those from scope and group.
+ * Every declared surface is executed by the realization (group-init and
+ * spawn). Contracts are data-only; a contract names its file transformer as a
+ * string, and core resolves that name through the payload-populated registry
+ * in file-transformers.ts when realization runs.
+ *
+ * This registry is separate from src/providers/index.ts so contract imports do
+ * not change provider identity detection used by update-skills.
+ */
+
+import path from 'path';
+
+import { listProviderContainerConfigNames } from '../providers/provider-container-registry.js';
+
+import { describeRegisteredProviderFileTransformers, getProviderFileTransformer } from './file-transformers.js';
+
+export type {
+  ProviderFileDiagnostic,
+  ProviderFileTransformResult,
+  ProviderFileTransformer,
+} from './file-transformers.js';
+
+export const PROVIDER_HOST_CONTRACT_SEAM_VERSION = 1;
+
+export interface ProviderProjectDocument {
+  fileName: string;
+  /** Shipped filename under core's container document root; never a host path. */
+  baseDocumentFile: string;
+  extraSections?: { name: string; body: string }[];
+  maxBytes?: number;
+  /** Destination inside the agent container. */
+  containerPath: string;
+  /** Current effective admission class; declarations do not repair it. */
+  mountClass: 'group-state' | 'allowlisted-extra';
+}
+
+export interface ProviderStateVolume {
+  /** Stable identity used by files and skill backings. */
+  id: string;
+  /** Existing provider-owned directory name; never a host path. */
+  directory: string;
+  containerPath: string;
+  scope: 'group' | 'session';
+  mode: 'ro' | 'rw';
+  /** Current effective admission class; declarations do not repair it. */
+  mountClass: 'group-state' | 'allowlisted-extra';
+}
+
+export type ProviderSkillBackingLocation =
+  | { kind: 'state-volume'; volumeId: string; subdirectory: string }
+  | { kind: 'group-directory'; directory: string; subdirectory: string };
+
+export interface ProviderSkillBacking {
+  id: string;
+  /** Backing root mounted by every view. */
+  location: ProviderSkillBackingLocation;
+  /** Provider-native skills directory below the backing root. */
+  skillsSubdirectory: string;
+  conflictDiagnostics: 'warn' | 'silent';
+  templateCopies: 'in-place' | 'copy';
+}
+
+/** One bind mount of a skill backing into the container. */
+export interface ProviderSkillView {
+  backingId: string;
+  containerPath: string;
+  mode: 'ro' | 'rw';
+  mountClass: 'group-state' | 'allowlisted-extra';
+}
+
+/**
+ * Name of a file transformer, resolved through the transformer registry in
+ * `file-transformers.ts`. Core owns no list of transformer names: the payload
+ * that implements one registers it. Contract registration checks only that the
+ * name is lowercase kebab-case; that it resolves is a conformance check.
+ */
+export type ProviderFileTransformerId = string;
+
+export interface ProviderPreparedFile {
+  id: string;
+  volumeId: string;
+  relativePath: string;
+  /**
+   * The prepare variant fixes when the file is realized, and with it who owns
+   * its content: core writes initial content for `create-if-missing`, and only
+   * ensures the mountpoint for `append-open-close`, whose content belongs to
+   * whatever writes through it. Files are created with the process default
+   * mode; the contract does not choose one.
+   */
+  prepare:
+    | { operation: 'create-if-missing'; when: 'group-init'; content: string }
+    | { operation: 'append-open-close'; when: 'every-spawn' };
+  /** Present when core reconciles existing file content; absent for gateway-owned files. */
+  reconcile?: {
+    transformer: ProviderFileTransformerId;
+    /** Names whose settings the reconciliation log line reports; defaults to the contract's provider. */
+    transformerProvider?: string;
+  };
+}
+
+export interface ProviderHostContract {
+  seamVersion: number;
+  /** Core-composed project document carrying the provider's standing instructions. */
+  projectDocument: ProviderProjectDocument;
+  stateVolumes: readonly ProviderStateVolume[];
+  skillBackings: readonly ProviderSkillBacking[];
+  skillViews: readonly ProviderSkillView[];
+  files: readonly ProviderPreparedFile[];
+  /** Present only when the mixed-version compatibility adapter must be registered. */
+  legacyHostAdapter?: 'required';
+  commands?: {
+    nativeAdmin?: readonly string[];
+    nativeFiltered?: readonly string[];
+  };
+}
+
+const registry = new Map<string, ProviderHostContract>();
+
+export function registerProviderHostContract(name: string, contract: ProviderHostContract): void {
+  const key = name.toLowerCase();
+  if (name !== key || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    throw new Error(`Provider host contract name must be lowercase kebab-case: '${name}'`);
+  }
+  if (registry.has(key)) throw new Error(`Provider host contract already registered: ${key}`);
+  // Shape is checked before the contract is stored, so a malformed payload
+  // fails when its barrel import loads rather than at the first spawn.
+  assertProviderHostContractShape(key, contract);
+  registry.set(key, deepFreeze(contract));
+}
+
+export function getProviderHostContract(name: string | null | undefined): ProviderHostContract | undefined {
+  return name ? registry.get(name.toLowerCase()) : undefined;
+}
+
+export function hasDeclaredProviderContract(name: string | null | undefined): boolean {
+  return getProviderHostContract(name) !== undefined;
+}
+
+export function listProviderHostContractNames(): string[] {
+  return [...registry.keys()];
+}
+
+export function listProviderHostContracts(): readonly ProviderHostContract[] {
+  return [...registry.values()];
+}
+
+export function assertProviderHostConformance(): void {
+  const registered = new Set(listProviderContainerConfigNames());
+  for (const [provider, contract] of registry) {
+    if (contract.legacyHostAdapter === 'required' && !registered.has(provider)) {
+      throw new Error(`Provider '${provider}' host contract requires a legacy host adapter`);
+    }
+    // A declared implementation must exist. Checked here rather than at
+    // registration because contract modules and transformer modules load in no
+    // guaranteed order; by conformance time every payload has been imported.
+    for (const file of contract.files) {
+      const transformer = file.reconcile?.transformer;
+      if (transformer === undefined) continue;
+      if (getProviderFileTransformer(transformer) === undefined) {
+        throw new Error(
+          `Provider '${provider}' file '${file.id}' names unregistered file transformer '${transformer}'; registered transformers: ${describeRegisteredProviderFileTransformers()}`,
+        );
+      }
+    }
+  }
+}
+
+export function assertProviderHostContractShape(provider: string, contract: ProviderHostContract): void {
+  if (contract.seamVersion !== PROVIDER_HOST_CONTRACT_SEAM_VERSION) {
+    throw new Error(
+      `${provider}.seamVersion ${String(contract.seamVersion)} is incompatible with host seam ${PROVIDER_HOST_CONTRACT_SEAM_VERSION}; run /update-skills`,
+    );
+  }
+  for (const field of ['stateVolumes', 'skillBackings', 'skillViews', 'files'] as const) {
+    assertArray(contract[field], `${provider}.${field}`);
+  }
+  if (contract.legacyHostAdapter !== undefined) {
+    assertAllowed(contract.legacyHostAdapter, ['required'], `${provider}.legacyHostAdapter`);
+  }
+  assertCommandArray(contract.commands?.nativeAdmin, `${provider}.commands.nativeAdmin`);
+  assertCommandArray(contract.commands?.nativeFiltered, `${provider}.commands.nativeFiltered`);
+  unique(contract.commands?.nativeAdmin ?? [], `${provider}.commands.nativeAdmin`);
+  unique(contract.commands?.nativeFiltered ?? [], `${provider}.commands.nativeFiltered`);
+
+  const volumeIds = unique(
+    contract.stateVolumes.map((volume) => volume.id),
+    `${provider}.stateVolumes[].id`,
+  );
+  const backingIds = unique(
+    contract.skillBackings.map((backing) => backing.id),
+    `${provider}.skillBackings[].id`,
+  );
+  unique(
+    contract.files.map((file) => file.id),
+    `${provider}.files[].id`,
+  );
+
+  const destinations: string[] = [];
+  const doc = contract.projectDocument;
+  if (doc === undefined) throw new Error(`${provider}.projectDocument is required`);
+  if (doc === null || typeof doc !== 'object') throw new Error(`${provider}.projectDocument must be an object`);
+  assertFileName(doc.fileName, `${provider}.projectDocument.fileName`);
+  assertFileName(doc.baseDocumentFile, `${provider}.projectDocument.baseDocumentFile`);
+  assertContainerPath(doc.containerPath, `${provider}.projectDocument.containerPath`);
+  assertAllowed(doc.mountClass, ['group-state', 'allowlisted-extra'], `${provider}.projectDocument.mountClass`);
+  if (doc.extraSections !== undefined) {
+    if (!Array.isArray(doc.extraSections)) {
+      throw new Error(`${provider}.projectDocument.extraSections must be an array`);
+    }
+    for (const [index, section] of doc.extraSections.entries()) {
+      assertNonEmptyString(section?.name, `${provider}.projectDocument.extraSections[${index}].name`);
+      assertNonEmptyString(section?.body, `${provider}.projectDocument.extraSections[${index}].body`);
+    }
+  }
+  if (doc.maxBytes !== undefined && (!Number.isInteger(doc.maxBytes) || doc.maxBytes <= 0)) {
+    throw new Error(`${provider}.projectDocument.maxBytes must be a positive integer`);
+  }
+  destinations.push(doc.containerPath);
+
+  for (const volume of contract.stateVolumes) {
+    assertName(volume.id, `${provider}.stateVolumes.${volume.id}.id`);
+    assertFileName(volume.directory, `${provider}.stateVolumes.${volume.id}.directory`);
+    assertContainerPath(volume.containerPath, `${provider}.stateVolumes.${volume.id}.containerPath`);
+    assertAllowed(volume.scope, ['group', 'session'], `${provider}.stateVolumes.${volume.id}.scope`);
+    assertAllowed(volume.mode, ['ro', 'rw'], `${provider}.stateVolumes.${volume.id}.mode`);
+    assertAllowed(
+      volume.mountClass,
+      ['group-state', 'allowlisted-extra'],
+      `${provider}.stateVolumes.${volume.id}.mountClass`,
+    );
+    destinations.push(volume.containerPath);
+  }
+
+  for (const backing of contract.skillBackings) {
+    assertName(backing.id, `${provider}.skillBackings.${backing.id}.id`);
+    assertAllowed(
+      backing.location?.kind,
+      ['state-volume', 'group-directory'],
+      `${provider}.skillBackings.${backing.id}.location.kind`,
+    );
+    // Every backing gets shared-skill links; the field that once said so is a
+    // stale-payload marker, not a switch.
+    if ('sharedLinks' in backing) {
+      throw new Error(
+        `${provider}.skillBackings.${backing.id}.sharedLinks is no longer declared; shared skill links are always synced. Update the provider skill (run /update-skills)`,
+      );
+    }
+    assertAllowed(
+      backing.conflictDiagnostics,
+      ['warn', 'silent'],
+      `${provider}.skillBackings.${backing.id}.conflictDiagnostics`,
+    );
+    assertAllowed(
+      backing.templateCopies,
+      ['in-place', 'copy'],
+      `${provider}.skillBackings.${backing.id}.templateCopies`,
+    );
+    assertRelativePath(backing.location.subdirectory, `${provider}.skillBackings.${backing.id}.subdirectory`, true);
+    assertRelativePath(backing.skillsSubdirectory, `${provider}.skillBackings.${backing.id}.skillsSubdirectory`);
+    if (backing.location.kind === 'state-volume') {
+      assertReference(volumeIds, backing.location.volumeId, `${provider}.skillBackings.${backing.id}.volumeId`);
+    } else {
+      assertFileName(backing.location.directory, `${provider}.skillBackings.${backing.id}.directory`);
+    }
+  }
+
+  for (const view of contract.skillViews) {
+    assertReference(backingIds, view.backingId, `${provider}.skillViews[].backingId`);
+    assertContainerPath(view.containerPath, `${provider}.skillViews.${view.backingId}.containerPath`);
+    assertAllowed(view.mode, ['ro', 'rw'], `${provider}.skillViews.${view.backingId}.mode`);
+    assertAllowed(
+      view.mountClass,
+      ['group-state', 'allowlisted-extra'],
+      `${provider}.skillViews.${view.backingId}.mountClass`,
+    );
+    destinations.push(view.containerPath);
+  }
+
+  for (const file of contract.files) {
+    assertName(file.id, `${provider}.files.${file.id}.id`);
+    assertReference(volumeIds, file.volumeId, `${provider}.files.${file.id}.volumeId`);
+    const volume = contract.stateVolumes.find((candidate) => candidate.id === file.volumeId)!;
+    assertRelativePath(file.relativePath, `${provider}.files.${file.id}.relativePath`);
+    assertAllowed(
+      file.prepare?.operation,
+      ['create-if-missing', 'append-open-close'],
+      `${provider}.files.${file.id}.prepare.operation`,
+    );
+    assertAllowed(
+      file.prepare.when,
+      file.prepare.operation === 'create-if-missing' ? ['group-init'] : ['every-spawn'],
+      `${provider}.files.${file.id}.prepare.when`,
+    );
+    // Prepared files always take the process default mode; a declared mode is
+    // a stale-payload marker and must not be silently ignored.
+    if ('mode' in file.prepare) {
+      throw new Error(
+        `${provider}.files.${file.id}.prepare.mode is no longer declared; prepared files use the process default mode. Update the provider skill (run /update-skills)`,
+      );
+    }
+
+    if (file.prepare.operation === 'create-if-missing') {
+      if (typeof file.prepare.content !== 'string') {
+        throw new Error(`${provider}.files.${file.id}.prepare.content must be a string`);
+      }
+      if (volume.scope !== 'group') {
+        throw new Error(`${provider}.files.${file.id}.prepare cannot initialize session volume '${volume.id}'`);
+      }
+    } else {
+      if (file.reconcile !== undefined) {
+        throw new Error(`${provider}.files.${file.id}.reconcile must be omitted for append-open-close`);
+      }
+    }
+    if (file.reconcile !== undefined) {
+      // Shape only: whether the name resolves is `assertProviderHostConformance`.
+      assertName(file.reconcile.transformer, `${provider}.files.${file.id}.reconcile.transformer`);
+      if (file.reconcile.transformerProvider !== undefined) {
+        assertName(file.reconcile.transformerProvider, `${provider}.files.${file.id}.reconcile.transformerProvider`);
+      }
+    }
+  }
+
+  unique(destinations, `${provider} container destinations`);
+}
+
+function assertAllowed(value: unknown, allowed: readonly unknown[], field: string): void {
+  if (!allowed.includes(value)) {
+    throw new Error(`${field} must be one of ${allowed.map((entry) => `'${String(entry)}'`).join(', ')}`);
+  }
+}
+
+function assertArray(value: unknown, field: string): asserts value is readonly unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+}
+
+function unique(values: readonly string[], field: string): Set<string> {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) throw new Error(`${field} must be unique; duplicate '${value}'`);
+    seen.add(value);
+  }
+  return seen;
+}
+
+function assertReference(values: ReadonlySet<string>, value: string, field: string): void {
+  if (!values.has(value)) throw new Error(`${field} references unknown '${value}'`);
+}
+
+function assertName(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+    throw new Error(`${field} must be lowercase kebab-case`);
+  }
+}
+
+function assertFileName(value: unknown, field: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    value === '.' ||
+    value === '..' ||
+    value.includes('/') ||
+    value.includes('\\')
+  ) {
+    throw new Error(`${field} must be one file or directory name`);
+  }
+}
+
+function assertRelativePath(value: unknown, field: string, allowEmpty = false): asserts value is string {
+  if (allowEmpty && value === '') return;
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    value.includes('\\') ||
+    value.endsWith('/') ||
+    path.posix.isAbsolute(value) ||
+    value.split('/').includes('..') ||
+    path.posix.normalize(value) !== value ||
+    value === '.'
+  ) {
+    throw new Error(`${field} must be a canonical relative path`);
+  }
+}
+
+function assertContainerPath(value: unknown, field: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !path.posix.isAbsolute(value) ||
+    value.includes('\\') ||
+    (value.length > 1 && value.endsWith('/')) ||
+    path.posix.normalize(value) !== value
+  ) {
+    throw new Error(`${field} must be a canonical absolute container path`);
+  }
+}
+
+function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${field} must be a non-empty string`);
+}
+
+function assertCommandArray(value: unknown, field: string): asserts value is readonly string[] {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  for (const command of value) {
+    if (typeof command !== 'string' || !/^\/[a-z0-9-]+$/.test(command)) {
+      throw new Error(`${field} contains invalid command '${String(command)}'`);
+    }
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object') {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+}

--- a/src/provider-surfaces.test.ts
+++ b/src/provider-surfaces.test.ts
@@ -21,13 +21,32 @@ vi.mock('./log.js', () => ({
     fatal: vi.fn(),
   },
 }));
+vi.mock('./modules/mount-security/index.js', () => ({
+  validateAdditionalMounts: vi.fn((mounts) =>
+    mounts.map((mount: { hostPath: string; containerPath?: string; readonly?: boolean }) => ({
+      hostPath: mount.hostPath,
+      containerPath: `/workspace/extra/${mount.containerPath ?? path.basename(mount.hostPath)}`,
+      readonly: mount.readonly ?? true,
+    })),
+  ),
+}));
 
-import { buildMounts } from './container-runner.js';
+import { buildMounts, resolveProviderContribution } from './container-runner.js';
 import { closeDb, createAgentGroup, initTestDb, runMigrations } from './db/index.js';
 import { ensureContainerConfig } from './db/container-configs.js';
 import { initGroupFilesystem } from './group-init.js';
 import { PERSONA_PREPEND_FILE } from './group-persona.js';
 import { log } from './log.js';
+import {
+  initializeProviderGroupSurfaces,
+  protectedProviderDocumentSourcePaths,
+  realizeProviderSpawnSurfaces,
+} from './provider-contracts/realize.js';
+import {
+  PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  registerProviderHostContract,
+  type ProviderHostContract,
+} from './provider-contracts/registry.js';
 import { registerProviderContainerConfig } from './providers/provider-container-registry.js';
 import type { ContainerConfig } from './container-config.js';
 import type { AgentGroup, Session } from './types.js';
@@ -35,6 +54,75 @@ import type { AgentGroup, Session } from './types.js';
 // A provider that declares (at registration) that it owns its agent surfaces.
 // Registered once — the registry is module-global and rejects duplicates.
 registerProviderContainerConfig('surfaces-test-provider', () => ({}), { providesAgentSurfaces: true });
+const oldPayloadContribution = vi.fn(() => ({ env: { COMPAT: 'legacy' } }));
+registerProviderContainerConfig('old-payload-provider', oldPayloadContribution, { providesAgentSurfaces: true });
+const currentPayloadContribution = vi.fn((ctx: { groupDir: string }) => ({
+  env: { COMPAT: 'current' },
+  mounts: [{ hostPath: ctx.groupDir, containerPath: '/home/node/.codex', readonly: false }],
+}));
+registerProviderContainerConfig('ordered-mount-provider', currentPayloadContribution, {
+  providesAgentSurfaces: true,
+});
+registerProviderHostContract('ordered-mount-provider', {
+  seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  projectDocument: {
+    fileName: 'AGENTS.md',
+    baseDocumentFile: 'CLAUDE.md',
+    containerPath: '/workspace/agent/AGENTS.md',
+    mountClass: 'allowlisted-extra',
+  },
+  stateVolumes: [
+    {
+      id: 'ordered-state',
+      directory: '.ordered-state',
+      containerPath: '/home/node/.codex',
+      scope: 'group',
+      mode: 'rw',
+      mountClass: 'allowlisted-extra',
+    },
+  ],
+  skillBackings: [
+    {
+      id: 'ordered-skills',
+      location: { kind: 'state-volume', volumeId: 'ordered-state', subdirectory: '' },
+      skillsSubdirectory: 'skills',
+      conflictDiagnostics: 'silent',
+      templateCopies: 'in-place',
+    },
+  ],
+  skillViews: [
+    {
+      backingId: 'ordered-skills',
+      containerPath: '/workspace/agent/.agents',
+      mode: 'ro',
+      mountClass: 'allowlisted-extra',
+    },
+    {
+      backingId: 'ordered-skills',
+      containerPath: '/home/node/.agents',
+      mode: 'ro',
+      mountClass: 'allowlisted-extra',
+    },
+  ],
+  files: [],
+  commands: { nativeAdmin: [], nativeFiltered: [] },
+});
+
+registerProviderHostContract('partial-install-provider', {
+  seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  projectDocument: {
+    fileName: 'AGENTS.md',
+    baseDocumentFile: 'AGENTS.md',
+    containerPath: '/workspace/agent/AGENTS.md',
+    mountClass: 'group-state',
+  },
+  stateVolumes: [],
+  skillBackings: [],
+  skillViews: [],
+  files: [],
+  legacyHostAdapter: 'required',
+  commands: { nativeAdmin: [], nativeFiltered: [] },
+});
 
 function group(id: string, folder: string): AgentGroup {
   return { id, name: folder, folder, agent_provider: null, created_at: new Date().toISOString() } as AgentGroup;
@@ -185,7 +273,118 @@ describe('initGroupFilesystem legacy seed isolation', () => {
 });
 
 describe('buildMounts agent surfaces', () => {
-  it('mounts the default surfaces for an unregistered provider (today’s behavior)', async () => {
+  it('fails fast when a declared provider requires a missing legacy adapter', async () => {
+    const ag = group('ag-partial-install', 'partial-install');
+    await expect(
+      resolveProviderContribution(session('partial-session', ag.id), ag, {
+        ...containerConfig(),
+        provider: 'partial-install-provider',
+      }),
+    ).rejects.toThrow("Provider 'partial-install-provider' host contract requires a legacy host adapter");
+  });
+
+  it('runs an undeclared old payload exactly once on new core', async () => {
+    const ag = group('ag-old-payload', 'old-payload');
+    const sess = session('old-session', ag.id);
+    const resolved = await resolveProviderContribution(sess, ag, {
+      ...containerConfig(),
+      provider: 'old-payload-provider',
+    });
+
+    expect(oldPayloadContribution).toHaveBeenCalledOnce();
+    expect(resolved).toMatchObject({
+      provider: 'old-payload-provider',
+      contribution: { env: { COMPAT: 'legacy' } },
+    });
+    expect(resolved.surfaces).toBeUndefined();
+  });
+
+  it('realizes declared Claude surfaces identically to the legacy default path', async () => {
+    const declared = group('ag-declared-claude', 'declared-claude');
+    const legacy = group('ag-legacy-default', 'legacy-default');
+    await createAgentGroup(declared);
+    await createAgentGroup(legacy);
+    await ensureContainerConfig(declared.id);
+    await ensureContainerConfig(legacy.id);
+    await initGroupFilesystem(declared, { provider: 'claude' });
+    await initGroupFilesystem(legacy, { provider: 'not-registered' });
+
+    const config = { ...containerConfig(), skills: ['welcome'] };
+    const declaredMounts = await buildMounts(declared, session('declared-session', declared.id), config, 'claude', {});
+    const legacyMounts = await buildMounts(legacy, session('legacy-session', legacy.id), config, 'not-registered', {});
+    const normalize = (value: string): string =>
+      value
+        .replaceAll(declared.id, '<group>')
+        .replaceAll(legacy.id, '<group>')
+        .replaceAll(declared.folder, '<folder>')
+        .replaceAll(legacy.folder, '<folder>')
+        .replaceAll('declared-session', '<session>')
+        .replaceAll('legacy-session', '<session>');
+    const normalizeMounts = (mounts: typeof declaredMounts) =>
+      mounts.map((mount) => ({ ...mount, hostPath: normalize(mount.hostPath), scope: normalize(mount.scope ?? '') }));
+
+    expect(normalizeMounts(declaredMounts)).toEqual(normalizeMounts(legacyMounts));
+    expect(fs.readFileSync(path.join(GROUPS_DIR, declared.folder, 'CLAUDE.md'), 'utf-8')).toBe(
+      fs.readFileSync(path.join(GROUPS_DIR, legacy.folder, 'CLAUDE.md'), 'utf-8'),
+    );
+
+    for (const ag of [declared, legacy]) {
+      const state = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared');
+      expect(fs.readFileSync(path.join(state, 'settings.json'), 'utf-8')).toBe(
+        fs.readFileSync(path.join(DATA_DIR, 'v2-sessions', declared.id, '.claude-shared', 'settings.json'), 'utf-8'),
+      );
+      expect(fs.lstatSync(path.join(state, 'skills', 'welcome')).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(path.join(state, 'skills', 'welcome'))).toBe('/app/skills/welcome');
+    }
+  });
+
+  it('follows a symlinked .claude-shared/skills directory exactly as the legacy path does', async () => {
+    const declared = group('ag-declared-symlink', 'declared-symlink');
+    const legacy = group('ag-legacy-symlink', 'legacy-symlink');
+    await createAgentGroup(declared);
+    await createAgentGroup(legacy);
+    await ensureContainerConfig(declared.id);
+    await ensureContainerConfig(legacy.id);
+    await initGroupFilesystem(declared, { provider: 'claude' });
+    await initGroupFilesystem(legacy, { provider: 'not-registered' });
+
+    // Operator relocated the skills directory and left a symlink in its place.
+    const relocated = new Map<string, string>();
+    for (const ag of [declared, legacy]) {
+      const skills = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'skills');
+      const target = path.join(TEST_ROOT, 'relocated', ag.id, 'skills');
+      fs.rmSync(skills, { recursive: true, force: true });
+      fs.mkdirSync(target, { recursive: true });
+      fs.symlinkSync(target, skills);
+      relocated.set(ag.id, target);
+    }
+
+    const config = { ...containerConfig(), skills: ['welcome'] };
+    const declaredMounts = await buildMounts(declared, session('declared-session', declared.id), config, 'claude', {});
+    const legacyMounts = await buildMounts(legacy, session('legacy-session', legacy.id), config, 'not-registered', {});
+    const normalize = (value: string): string =>
+      value
+        .replaceAll(declared.id, '<group>')
+        .replaceAll(legacy.id, '<group>')
+        .replaceAll(declared.folder, '<folder>')
+        .replaceAll(legacy.folder, '<folder>')
+        .replaceAll('declared-session', '<session>')
+        .replaceAll('legacy-session', '<session>');
+    const normalizeMounts = (mounts: typeof declaredMounts) =>
+      mounts.map((mount) => ({ ...mount, hostPath: normalize(mount.hostPath), scope: normalize(mount.scope ?? '') }));
+
+    expect(normalizeMounts(declaredMounts)).toEqual(normalizeMounts(legacyMounts));
+    for (const ag of [declared, legacy]) {
+      const skills = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'skills');
+      expect(fs.lstatSync(skills).isSymbolicLink()).toBe(true);
+      // The link was written through the symlink into the relocated directory.
+      const link = path.join(relocated.get(ag.id)!, 'welcome');
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(link)).toBe('/app/skills/welcome');
+    }
+  });
+
+  it('materializes the Claude surface access contract', async () => {
     const ag = group('ag-mounts-default', 'mounts-default');
     await createAgentGroup(ag);
     await ensureContainerConfig(ag.id);
@@ -194,8 +393,19 @@ describe('buildMounts agent surfaces', () => {
     const mounts = await buildMounts(ag, session('s1', ag.id), containerConfig(), 'claude', {});
 
     const byContainerPath = new Map(mounts.map((m) => [m.containerPath, m]));
-    expect(byContainerPath.has('/home/node/.claude')).toBe(true);
-    expect(byContainerPath.has('/workspace/agent/CLAUDE.md')).toBe(true);
+    expect(byContainerPath.get('/workspace/agent/CLAUDE.md')).toMatchObject({
+      hostPath: path.join(GROUPS_DIR, ag.folder, 'CLAUDE.md'),
+      readonly: true,
+    });
+    expect(byContainerPath.get('/home/node/.claude')).toMatchObject({
+      hostPath: path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared'),
+      readonly: false,
+    });
+    expect(
+      mounts
+        .filter((mount) => ['/workspace/agent/CLAUDE.md', '/home/node/.claude'].includes(mount.containerPath))
+        .map((mount) => mount.containerPath),
+    ).toEqual(['/workspace/agent/CLAUDE.md', '/home/node/.claude']);
     // Composer ran: the generated project doc exists on disk.
     expect(fs.existsSync(path.join(GROUPS_DIR, ag.folder, 'CLAUDE.md'))).toBe(true);
   });
@@ -215,13 +425,9 @@ describe('buildMounts agent surfaces', () => {
         },
       ],
     };
-    const mounts = await buildMounts(
-      ag,
-      session('s2', ag.id),
-      containerConfig(),
-      'surfaces-test-provider',
-      contributed,
-    );
+    const config = containerConfig();
+    config.additionalMounts = [{ hostPath: path.join(GROUPS_DIR, ag.folder), containerPath: 'operator' }];
+    const mounts = await buildMounts(ag, session('s2', ag.id), config, 'surfaces-test-provider', contributed);
 
     const containerPaths = mounts.map((m) => m.containerPath);
     expect(containerPaths).not.toContain('/home/node/.claude');
@@ -233,5 +439,220 @@ describe('buildMounts agent surfaces', () => {
     expect(containerPaths).toContain('/workspace/agent');
     expect(containerPaths).toContain('/app/src');
     expect(containerPaths).toContain('/workspace/agent/OWN-DOC.md');
+    expect(containerPaths.slice(-2)).toEqual(['/workspace/extra/operator', '/workspace/agent/OWN-DOC.md']);
+  });
+
+  it('keeps declared allowlisted surfaces at the former provider slot in derived resource order', async () => {
+    const ag = group('ag-ordered-mounts', 'ordered-mounts');
+    await createAgentGroup(ag);
+    await initGroupFilesystem(ag, { provider: 'ordered-mount-provider' });
+
+    const config = containerConfig();
+    config.additionalMounts = [{ hostPath: path.join(GROUPS_DIR, ag.folder), containerPath: 'operator' }];
+    const sess = session('ordered-mount-session', ag.id);
+    const resolved = await resolveProviderContribution(sess, ag, {
+      ...config,
+      provider: 'ordered-mount-provider',
+    });
+    const mounts = await buildMounts(ag, sess, config, resolved.provider, resolved.contribution, resolved.surfaces);
+
+    const containerPaths = mounts.map((mount) => mount.containerPath);
+    expect(resolved.contribution).toEqual({ env: { COMPAT: 'current' } });
+    expect(currentPayloadContribution).toHaveBeenCalledWith(
+      expect.objectContaining({ coreOwnsProviderSurfaces: true }),
+    );
+    expect(new Set(containerPaths).size).toBe(containerPaths.length);
+    expect(containerPaths).toEqual([
+      '/workspace',
+      '/app/.nanoclaw-session.json',
+      '/workspace/agent',
+      '/workspace/agent/plugins',
+      '/app/src',
+      '/app/skills',
+      '/workspace/extra/operator',
+      '/home/node/.codex',
+      '/workspace/agent/.agents',
+      '/home/node/.agents',
+      '/workspace/agent/AGENTS.md',
+    ]);
+  });
+});
+
+describe('derived provider spawn surfaces', () => {
+  function backingContract(backing?: ProviderHostContract['skillBackings'][number]): ProviderHostContract {
+    return {
+      seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+      projectDocument: {
+        fileName: 'AGENTS.md',
+        baseDocumentFile: 'AGENTS.md',
+        containerPath: '/workspace/agent/AGENTS.md',
+        mountClass: 'group-state',
+      },
+      stateVolumes: [],
+      skillBackings: backing ? [backing] : [],
+      skillViews: [],
+      files: [],
+      commands: { nativeAdmin: [], nativeFiltered: [] },
+    };
+  }
+
+  it('derives spawn work before composing the project document', async () => {
+    const contract: ProviderHostContract = {
+      seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+      projectDocument: {
+        fileName: 'AGENTS.md',
+        baseDocumentFile: 'AGENTS.md',
+        containerPath: '/workspace/agent/AGENTS.md',
+        mountClass: 'group-state',
+      },
+      stateVolumes: [
+        {
+          id: 'state',
+          directory: '.state',
+          containerPath: '/state',
+          scope: 'session',
+          mode: 'rw',
+          mountClass: 'group-state',
+        },
+      ],
+      skillBackings: [
+        {
+          id: 'skills',
+          location: { kind: 'group-directory', directory: '.agents', subdirectory: '' },
+          skillsSubdirectory: 'skills',
+          conflictDiagnostics: 'silent',
+          templateCopies: 'in-place',
+        },
+      ],
+      skillViews: [],
+      files: [
+        {
+          id: 'auth',
+          volumeId: 'state',
+          relativePath: 'auth.json',
+          prepare: { operation: 'append-open-close', when: 'every-spawn' },
+        },
+      ],
+      legacyHostAdapter: 'required',
+      commands: { nativeAdmin: [], nativeFiltered: [] },
+    };
+    const groupDir = path.join(GROUPS_DIR, 'ordered-group');
+    const sessionDirectory = path.join(DATA_DIR, 'v2-sessions', 'ordered-session');
+    const legacyOverlay = vi.fn(async () => ({}));
+
+    await expect(
+      realizeProviderSpawnSurfaces('ordered', contract, 'ordered-group', groupDir, sessionDirectory, [], {
+        legacyOverlay,
+        composeProjectDocument: async () => {
+          throw new Error('compose failed');
+        },
+      }),
+    ).rejects.toThrow('compose failed');
+
+    expect(fs.existsSync(path.join(sessionDirectory, '.state', 'auth.json'))).toBe(true);
+    expect(fs.existsSync(path.join(groupDir, '.agents', 'skills'))).toBe(true);
+    expect(legacyOverlay).toHaveBeenCalledOnce();
+  });
+
+  it('ignores declared legacy callback mounts while retaining env', async () => {
+    const realized = await realizeProviderSpawnSurfaces(
+      'declared',
+      backingContract(),
+      'group',
+      GROUPS_DIR,
+      DATA_DIR,
+      [],
+      {
+        legacyOverlay: async () => ({
+          env: { COMPAT: 'yes' },
+          mounts: [{ hostPath: GROUPS_DIR, containerPath: '/legacy', readonly: true }],
+        }),
+        composeProjectDocument: async () => {},
+      },
+    );
+    expect(realized.contribution).toEqual({ env: { COMPAT: 'yes' } });
+  });
+
+  it('contains raw contract paths if registration validation is bypassed', async () => {
+    const contract = backingContract({
+      id: 'skills',
+      location: { kind: 'group-directory', directory: '.agents', subdirectory: '../../escape' },
+      skillsSubdirectory: 'skills',
+      conflictDiagnostics: 'silent',
+      templateCopies: 'in-place',
+    });
+
+    await expect(
+      realizeProviderSpawnSurfaces('raw', contract, 'group', path.join(TEST_ROOT, 'safe'), DATA_DIR, [], {
+        legacyOverlay: async () => ({}),
+        composeProjectDocument: async () => {},
+      }),
+    ).rejects.toThrow(/escapes its resolved root/);
+  });
+
+  it.each([
+    ['warn', true],
+    ['silent', false],
+  ] as const)('%s conflict diagnostics control shared-link warnings', async (policy, expectedWarning) => {
+    const groupDir = path.join(TEST_ROOT, `conflict-${policy}`);
+    fs.mkdirSync(path.join(groupDir, '.agents', 'skills', 'welcome'), { recursive: true });
+    const contract = backingContract({
+      id: 'skills',
+      location: { kind: 'group-directory', directory: '.agents', subdirectory: '' },
+      skillsSubdirectory: 'skills',
+      conflictDiagnostics: policy,
+      templateCopies: 'in-place',
+    });
+
+    await realizeProviderSpawnSurfaces('conflict', contract, 'group', groupDir, DATA_DIR, ['welcome'], {
+      legacyOverlay: async () => ({}),
+      composeProjectDocument: async () => {},
+    });
+
+    expect(log.warn).toHaveBeenCalledTimes(expectedWarning ? 1 : 0);
+    vi.mocked(log.warn).mockClear();
+  });
+
+  it('protects the shipped base document as a core fact, not a contract field', () => {
+    // Contracts registered in this file declare other documents (AGENTS.md)
+    // and none of them adds to or removes from the protected set.
+    expect(protectedProviderDocumentSourcePaths('/install')).toEqual([path.join('/install', 'container', 'CLAUDE.md')]);
+  });
+
+  it('labels reconciliation from the transformer provider', () => {
+    const contract: ProviderHostContract = {
+      ...backingContract(),
+      stateVolumes: [
+        {
+          id: 'state',
+          directory: '.diagnostic-state',
+          containerPath: '/state',
+          scope: 'group',
+          mode: 'rw',
+          mountClass: 'group-state',
+        },
+      ],
+      files: [
+        {
+          id: 'settings',
+          volumeId: 'state',
+          relativePath: 'settings.json',
+          prepare: {
+            operation: 'create-if-missing',
+            when: 'group-init',
+            content: '{"old":true}\n',
+          },
+          reconcile: {
+            transformer: 'claude-settings',
+            transformerProvider: 'diagnostic-source',
+          },
+        },
+      ],
+    };
+
+    initializeProviderGroupSurfaces('consumer', contract, 'diagnostic-group', GROUPS_DIR);
+    expect(initializeProviderGroupSurfaces('consumer', contract, 'diagnostic-group', GROUPS_DIR)).toContain(
+      'settings.json (reconciled Diagnostic-source settings)',
+    );
   });
 });

--- a/src/providers/legacy-payload-compat.test.ts
+++ b/src/providers/legacy-payload-compat.test.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_ROOT = '/tmp/nanoclaw-legacy-provider-compat-test';
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  DATA_DIR: '/tmp/nanoclaw-legacy-provider-compat-test/data',
+  GROUPS_DIR: '/tmp/nanoclaw-legacy-provider-compat-test/groups',
+}));
+
+import { resolveProviderContribution } from '../container-runner.js';
+import { getProviderHostContract } from '../provider-contracts/registry.js';
+import type { ContainerConfig } from '../container-config.js';
+import type { AgentGroup, Session } from '../types.js';
+import { listProviderContainerConfigNames } from './provider-container-registry.js';
+import './index.js';
+
+const installed = fs.existsSync(new URL('./opencode.ts', import.meta.url));
+const describeLegacy = installed && !getProviderHostContract('opencode') ? describe : describe.skip;
+const env = {
+  NO_PROXY: 'corp.local',
+  no_proxy: 'internal',
+  OPENCODE_PROVIDER: 'openrouter',
+  OPENCODE_MODEL: 'openrouter/model',
+  OPENCODE_SMALL_MODEL: 'openrouter/small',
+  ANTHROPIC_BASE_URL: 'https://openrouter.example/v1',
+  OPENCODE_MODEL_CONTEXT_LIMIT: '1000',
+  OPENCODE_MODEL_OUTPUT_LIMIT: '100',
+  OPENCODE_MODEL_INPUT_MODALITIES: 'text,image',
+} as const;
+const previous = new Map<string, string | undefined>();
+
+afterEach(() => {
+  for (const [key, value] of previous) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  previous.clear();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describeLegacy('pre-contract OpenCode payload on new host core', () => {
+  it('runs the real registered legacy contribution exactly once', async () => {
+    for (const [key, value] of Object.entries(env)) {
+      previous.set(key, process.env[key]);
+      process.env[key] = value;
+    }
+    expect(listProviderContainerConfigNames()).toContain('opencode');
+
+    const session = { id: 'session-1', agent_group_id: 'group-1', agent_provider: null } as Session;
+    const group = { id: 'group-1', folder: 'legacy-opencode' } as AgentGroup;
+    const config: ContainerConfig = {
+      provider: 'opencode',
+      mcpServers: {},
+      packages: { apt: [], npm: [] },
+      additionalMounts: [],
+      skills: [],
+    };
+    const opencodeDir = path.join(TEST_ROOT, 'data/v2-sessions/group-1/session-1/opencode-xdg');
+    const mkdir = vi.spyOn(fs, 'mkdirSync');
+
+    const resolved = await resolveProviderContribution(session, group, config);
+
+    expect(resolved.surfaces).toBeUndefined();
+    expect(resolved.contribution.mounts).toEqual([
+      { hostPath: opencodeDir, containerPath: '/opencode-xdg', readonly: false },
+    ]);
+    expect(resolved.contribution.env).toEqual({
+      XDG_DATA_HOME: '/opencode-xdg',
+      NO_PROXY: 'corp.local,127.0.0.1,localhost',
+      no_proxy: 'internal,127.0.0.1,localhost',
+      OPENCODE_PROVIDER: 'openrouter',
+      OPENCODE_MODEL: 'openrouter/model',
+      OPENCODE_SMALL_MODEL: 'openrouter/small',
+      ANTHROPIC_BASE_URL: 'https://openrouter.example/v1',
+      OPENCODE_MODEL_CONTEXT_LIMIT: '1000',
+      OPENCODE_MODEL_OUTPUT_LIMIT: '100',
+      OPENCODE_MODEL_INPUT_MODALITIES: 'text,image',
+    });
+    expect(mkdir.mock.calls.filter(([target]) => target === opencodeDir)).toHaveLength(1);
+  });
+});

--- a/src/providers/provider-container-registry.ts
+++ b/src/providers/provider-container-registry.ts
@@ -50,6 +50,13 @@ export interface ProviderContainerContext {
   selectedSkills: string[];
   /** `process.env` at spawn time — pull passthrough values from here. */
   hostEnv: NodeJS.ProcessEnv;
+  /**
+   * Mixed-version handshake. Present only when this host loaded a declaration
+   * and will realize its surfaces. Updated legacy callbacks keep returning env
+   * but suppress their old filesystem/mount work when this is true. Old hosts
+   * omit the field, so refreshed payloads retain their old behavior.
+   */
+  coreOwnsProviderSurfaces?: true;
 }
 
 export interface ProviderContainerContribution {


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Routes the host's provider spawn and group-init surfaces through a declared, registration-validated contract.

- **Problem**: the host materialized Claude's files and mounts with hard-coded logic; other providers had to reach around it with imperative callbacks.
- **Contract**: a provider declares its project document, state volumes, skill backings and views, and prepared files as data. Core realizes them at group-init and every spawn in a fixed order (state volumes → skill views → project document). Legacy adapters still contribute environment through an overlay.
- **Validated at registration**: wrong seam version, non-absolute container path, unsafe file name, or a view pointing at an undeclared backing throws as the barrel loads. The cross-registry check (a contract requiring a legacy adapter must have one) runs at spawn and in the install verifier.
- **Behavior preserved**: unknown provider names still spawn with default surfaces (with a warning), `--provider` is stored verbatim, symlinked state paths are followed.
- **File reconcilers are payload-registered**: a contract references a reconciler by name and the payload registers the function (`registerProviderFileTransformer`), so core imports no provider code and a provider can reconcile its own files without a core edit. Conformance rejects a name nothing registered.
- **Fewer knobs**: `sharedLinks` (every provider set it) and `prepare.mode` (every provider used the default) are gone and stale keys are rejected with an operator message; protecting the canonical instruction template is core-owned, not a per-provider flag.
- **Known limit**: mount order is fixed by core and not declarable.

## Related work

Middle layer of the provider-contract stack, on nanocoai/nanoclaw#3581. No issue; the provider-surfaces parity suite makes it safe to review directly.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm run build` -> clean
- `pnpm test` -> 2,244 passed, 1 skipped
- Declared Claude realization asserted mount-for-mount and byte-for-byte equal to the legacy default path, including a symlinked skills directory
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

## Security and trust boundaries

Declared paths are lexically contained within their volume root. Symlinks are followed exactly as before this PR; no new trust boundary.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
