### PR TITLE
refactor(providers): declare the setup provider contract and install verifier

### DIFF
--- a/.claude/skills/add-codex/REMOVE.md
+++ b/.claude/skills/add-codex/REMOVE.md
@@ -18,7 +18,9 @@ ncl groups restart --id <group-id>
 Delete (do not comment out) the `import './codex.js';` line from each of:
 
 - `src/providers/index.ts`
+- `src/provider-contracts/index.ts`
 - `container/agent-runner/src/providers/index.ts`
+- `container/agent-runner/src/provider-contracts/index.ts`
 - `setup/providers/index.ts`
 
 ## 3. Delete every copied file
@@ -29,6 +31,7 @@ rm -f src/providers/codex.ts \
       src/providers/codex-registration.test.ts \
       src/providers/codex-host-contribution.test.ts \
       src/providers/codex-agents-md.test.ts \
+      src/provider-contracts/codex.ts \
       container/agent-runner/src/providers/codex.ts \
       container/agent-runner/src/providers/codex-app-server.ts \
       container/agent-runner/src/providers/exchange-archive.ts \
@@ -37,7 +40,10 @@ rm -f src/providers/codex.ts \
       container/agent-runner/src/providers/codex.factory.test.ts \
       container/agent-runner/src/providers/codex.turns.test.ts \
       container/agent-runner/src/providers/codex-app-server.test.ts \
+      container/agent-runner/src/providers/codex-contract-parity.test.ts \
+      container/agent-runner/src/providers/codex.conformance.test.ts \
       container/agent-runner/src/providers/codex-cli-tools.test.ts \
+      container/agent-runner/src/provider-contracts/codex.ts \
       setup/providers/codex.ts \
       setup/providers/codex.test.ts \
       setup/providers/codex-registration.test.ts

--- a/.claude/skills/add-codex/SKILL.md
+++ b/.claude/skills/add-codex/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: add-codex
 description: Use Codex (OpenAI's codex app-server) as a full agent provider — planning, tool orchestration, MCP tools, server-side history, session resume — alongside or instead of Claude. ChatGPT subscription or OpenAI API key, vault-only via OneCLI. Per-group via `ncl groups config update --provider codex`. Distinct from using OpenAI as an MCP tool (where Claude remains the planner).
+metadata:
+  nanoclaw-provider: codex
+  nanoclaw-provider-label: Codex
+  nanoclaw-provider-hint: OpenAI — ChatGPT subscription or API key
+  nanoclaw-provider-offered: 'true'
+  nanoclaw-provider-image: local-required
 ---
 
 # Codex agent provider
@@ -24,8 +30,8 @@ Check whether the payload is already wired (a prior apply, or a trunk that still
 
 - `src/providers/codex.ts` and `src/providers/codex-agents-md.ts`
 - `container/agent-runner/src/providers/codex.ts` and `codex-app-server.ts`
-- `setup/providers/codex.ts`
-- `import './codex.js';` in `src/providers/index.ts`, `container/agent-runner/src/providers/index.ts`, and `setup/providers/index.ts`
+- `setup/providers/codex.ts` and both `provider-contracts/codex.ts` declarations (host and container)
+- `import './codex.js';` in the three provider barrels and both contract barrels
 - an `@openai/codex` entry in `container/cli-tools.json`
 
 ### 1. Fetch and copy the payload
@@ -38,6 +44,7 @@ src/providers/codex-agents-md.ts
 src/providers/codex-registration.test.ts
 src/providers/codex-host-contribution.test.ts
 src/providers/codex-agents-md.test.ts
+src/provider-contracts/codex.ts
 container/agent-runner/src/providers/codex.ts
 container/agent-runner/src/providers/codex-app-server.ts
 container/agent-runner/src/providers/exchange-archive.ts
@@ -46,7 +53,10 @@ container/agent-runner/src/providers/codex-registration.test.ts
 container/agent-runner/src/providers/codex.factory.test.ts
 container/agent-runner/src/providers/codex.turns.test.ts
 container/agent-runner/src/providers/codex-app-server.test.ts
+container/agent-runner/src/providers/codex-contract-parity.test.ts
+container/agent-runner/src/providers/codex.conformance.test.ts
 container/agent-runner/src/providers/codex-cli-tools.test.ts
+container/agent-runner/src/provider-contracts/codex.ts
 setup/providers/codex.ts
 setup/providers/codex.test.ts
 setup/providers/codex-registration.test.ts
@@ -55,14 +65,24 @@ container/AGENTS.md
 
 ### 2. Wire the barrels
 
-Append the self-registration import to each of the three provider barrels (skipped if the line is already present). Each barrel-registration test imports its real barrel and asserts `codex` is registered — they go red the moment a barrel line is missing or drifts.
+Append the self-registration import to each provider and contract barrel (skipped if already present).
 
 ```nc:append to:src/providers/index.ts
 import './codex.js';
 ```
+
+```nc:append to:src/provider-contracts/index.ts
+import './codex.js';
+```
+
+```nc:append to:container/agent-runner/src/provider-contracts/index.ts
+import './codex.js';
+```
+
 ```nc:append to:container/agent-runner/src/providers/index.ts
 import './codex.js';
 ```
+
 ```nc:append to:setup/providers/index.ts
 import './codex.js';
 ```
@@ -88,10 +108,7 @@ pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
 ### 5. Validate
 
 ```nc:run effect:test
-pnpm vitest run src/providers/codex-registration.test.ts src/providers/codex-host-contribution.test.ts src/providers/codex-agents-md.test.ts setup/providers/
-```
-```nc:run effect:test
-cd container/agent-runner && bun test src/providers/
+pnpm exec tsx scripts/provider-contract-verifier.ts --required-declared codex
 ```
 
 The registration tests import only the real barrels — they go red if a barrel line is missing, a barrel fails to evaluate, or the payload is broken.

--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: add-opencode
 description: Use OpenCode as an agent provider. OpenRouter, OpenAI, Google, DeepSeek, etc. via OpenCode config — not the Anthropic Agent SDK. Per group via `ncl groups config update --provider opencode`; host passes OPENCODE_* and XDG mount when spawning containers.
+metadata:
+  nanoclaw-provider: opencode
+  nanoclaw-provider-label: OpenCode
+  nanoclaw-provider-hint: Open-source provider router
+  nanoclaw-provider-offered: 'false'
+  nanoclaw-provider-image: local-required
 ---
 
 # OpenCode agent provider

--- a/.github/workflows/registry-skills.yml
+++ b/.github/workflows/registry-skills.yml
@@ -6,6 +6,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      core_sha:
+        description: Full core commit SHA to promote
+        required: true
+        type: string
+      providers_sha:
+        description: Full providers commit SHA to promote
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,10 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.skills.outputs.matrix }}
+      core: ${{ steps.refs.outputs.core }}
       channels: ${{ steps.refs.outputs.channels }}
       providers: ${{ steps.refs.outputs.providers }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.core_sha || github.sha }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -27,13 +39,37 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - id: skills
         run: |
-          matrix=$(pnpm exec tsx scripts/test-registry-skills.ts --list)
+          matrix=$(pnpm exec tsx scripts/test-registry-skills.ts --list-available)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - id: refs
+        # Dispatch inputs reach the shell through env, never by direct
+        # interpolation into the script, so a malformed value can only fail
+        # the hex check below — it can never become shell syntax.
+        env:
+          REQUESTED_CORE_SHA: ${{ inputs.core_sha }}
+          REQUESTED_PROVIDERS_SHA: ${{ inputs.providers_sha }}
         run: |
-          git fetch origin channels providers
+          core=$(git rev-parse HEAD)
+          test ${#core} -eq 40
+          requested_core="$REQUESTED_CORE_SHA"
+          if [ -n "$requested_core" ]; then
+            case "$requested_core" in *[!0-9a-fA-F]*|'') exit 1;; esac
+            test ${#requested_core} -eq 40
+          fi
+          providers="$REQUESTED_PROVIDERS_SHA"
+          if [ -n "$providers" ]; then
+            case "$providers" in *[!0-9a-fA-F]*|'') exit 1;; esac
+            test ${#providers} -eq 40
+            git fetch origin "$providers"
+            git cat-file -e "$providers^{commit}"
+          else
+            git fetch origin providers
+            providers=$(git rev-parse origin/providers)
+          fi
+          git fetch origin channels
+          echo "core=$core" >> "$GITHUB_OUTPUT"
           echo "channels=$(git rev-parse origin/channels)" >> "$GITHUB_OUTPUT"
-          echo "providers=$(git rev-parse origin/providers)" >> "$GITHUB_OUTPUT"
+          echo "providers=$providers" >> "$GITHUB_OUTPUT"
 
   test:
     needs: discover
@@ -45,6 +81,8 @@ jobs:
         include: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.discover.outputs.core }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -60,3 +98,78 @@ jobs:
           REGISTRY_CHANNELS_SHA: ${{ needs.discover.outputs.channels }}
           REGISTRY_PROVIDERS_SHA: ${{ needs.discover.outputs.providers }}
         run: pnpm exec tsx scripts/test-registry-skills.ts "${{ matrix.skill }}"
+
+  combined-providers:
+    needs: discover
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.discover.outputs.core }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - run: pnpm install --frozen-lockfile
+      - name: Install, refresh, and verify all providers
+        env:
+          REGISTRY_CHANNELS_SHA: ${{ needs.discover.outputs.channels }}
+          REGISTRY_PROVIDERS_SHA: ${{ needs.discover.outputs.providers }}
+        run: pnpm exec tsx scripts/test-registry-skills.ts --combined-providers
+
+  pre-contract-providers:
+    needs: discover
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.discover.outputs.core }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - run: pnpm install --frozen-lockfile
+      - name: Apply pre-contract Codex and OpenCode payloads to current core
+        run: pnpm exec tsx scripts/test-registry-skills.ts --pre-contract-providers
+
+  old-provider-refresh:
+    needs: discover
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.discover.outputs.core }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - run: pnpm install --frozen-lockfile
+      - name: Install legacy providers, then refresh them to the current payload
+        env:
+          REGISTRY_CHANNELS_SHA: ${{ needs.discover.outputs.channels }}
+          REGISTRY_PROVIDERS_SHA: ${{ needs.discover.outputs.providers }}
+        run: pnpm exec tsx scripts/test-registry-skills.ts --old-provider-refresh 99283f3e274b2b1dae47b141ac4f11f56ad8eb2d
+
+  provider-promotion:
+    if: always()
+    needs: [test, combined-providers, pre-contract-providers, old-provider-refresh]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every provider composition gate
+        run: |
+          test "${{ needs.test.result }}" = success
+          test "${{ needs.combined-providers.result }}" = success
+          test "${{ needs.pre-contract-providers.result }}" = success
+          test "${{ needs.old-provider-refresh.result }}" = success

--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -78,6 +78,26 @@ For a fence-carrying skill, conformance means:
 - **The lint passes**: `pnpm exec tsx scripts/skill-directives.ts .claude/skills/<name>/SKILL.md`. Retired presentation attrs (`min:`/`error:`/`open:`/`gate`/`label:`/`on-fail:`) are errors; the reference floor — a `## Troubleshooting` section on any skill with a secret prompt or interactive step — is a warning worth honoring regardless of fences.
 - **Directives are idempotent** by construction (`copy` overwrites, `append` skips-if-present, `env-set` sets-if-absent, …) — which is the same re-runnable-apply rule every skill already has.
 
+### Provider skill frontmatter (`nanoclaw-provider-*`)
+
+A provider install skill (`/add-codex`, `/add-opencode`) also declares how the setup wizard should treat the provider. The declaration lives in the SKILL.md frontmatter under `metadata:` and is parsed by `setup/providers/skill-descriptor.ts`; nothing about the offer is hard-coded in setup. Every key is required once `nanoclaw-provider` is present, and every key is read by setup code:
+
+| Key | Allowed values | Read by |
+|-----|----------------|---------|
+| `nanoclaw-provider` | lowercase kebab-case provider name (`codex`) | descriptor identity; `setup/providers/install.ts` passes it to the contract verifier as the provider that must be declared |
+| `nanoclaw-provider-label` | display text | the provider picker in `setup/auto.ts` (`askAgentProviderChoice`) |
+| `nanoclaw-provider-hint` | display text | the picker's hint column (suffixed "— installs now") |
+| `nanoclaw-provider-offered` | `'true'` \| `'false'` (quoted strings) | `listInstallableProviderDescriptors` — only `'true'` reaches the picker's "installs now" list and `--step provider-auth <name>`. `'false'` marks a skill-only provider that never appears in setup (OpenCode today) |
+| `nanoclaw-provider-image` | `local-required` \| `hardened-compatible` | `providerImagePolicy` — whether picking the provider forces a locally built sandbox image instead of the pre-built one |
+
+The skill directory itself is the install skill setup applies in-process (`applyProviderSkill`); there is no key for it, and a leftover `nanoclaw-provider-install-skill` is rejected. `nanoclaw-provider-label` and `nanoclaw-provider-hint` must match the `label`/`hint` of the provider's `setup/providers/<name>.ts` entry once it is installed — the descriptor labels the offer before install, the entry labels it after, and `setup/providers/skill-descriptor.test.ts` fails on drift.
+
+A skill-only provider (`offered: 'false'`) must not copy a `setup/providers/<name>.ts` or append to the `setup/providers/index.ts` barrel — that barrel is the second way a provider reaches the picker.
+
+**Conformance test.** Every provider that declares a runtime contract proves it from its own `container/agent-runner/src/providers/<name>.conformance.test.ts`, calling `defineProviderConformance(name, contract, { probes? })` with the probe fixtures its resolves need — that knowledge is the provider's, so core runs no generic sweep over registered contracts, and Claude proves its own the same way. The file is part of the payload a provider skill copies; the install verifier (`scripts/provider-contract-verifier.ts`) runs it and fails when a declared provider ships none.
+
+**Merge order.** The provider payload branch must carry the files a provider skill copies (including the `provider-contracts/<name>.ts` declarations and the `<name>.conformance.test.ts`) before the trunk change that lists them lands, otherwise `/add-<name>` fails at its copy step; `scripts/test-registry-skills.ts --combined-providers` fails CI when trunk carries provider skills whose payload is not on the registry branch.
+
 ---
 
 ## Integration points

--- a/scripts/provider-contract-names.ts
+++ b/scripts/provider-contract-names.ts
@@ -1,0 +1,14 @@
+import '../setup/providers/index.js';
+import '../src/providers/index.js';
+import '../src/provider-contracts/index.js';
+import { listSetupProviders } from '../setup/providers/registry.js';
+import { listProviderContainerConfigNames } from '../src/providers/provider-container-registry.js';
+import { listProviderHostContractNames } from '../src/provider-contracts/registry.js';
+
+console.log(
+  JSON.stringify({
+    host: listProviderHostContractNames().sort(),
+    hostProviders: listProviderContainerConfigNames().sort(),
+    setupProviders: listSetupProviders().map((provider) => provider.value).sort(),
+  }),
+);

--- a/scripts/provider-contract-verifier.test.ts
+++ b/scripts/provider-contract-verifier.test.ts
@@ -1,0 +1,349 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  isPinnedBunVersion,
+  parseProviderContractVerifierArgs,
+  runtimeConformanceTestPath,
+  verifyProviderContracts,
+} from './provider-contract-verifier.js';
+
+const roots: string[] = [];
+
+/**
+ * A tree with the given providers' runtime conformance tests shipped. Claude
+ * is the bare trunk's only declared contract, so it ships by default.
+ */
+function fixture(conformanceTests: string[] = ['claude']): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-contract-verifier-'));
+  roots.push(root);
+  fs.mkdirSync(path.join(root, 'src/provider-contracts'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'container/agent-runner'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src/provider-contracts/index.ts'), '');
+  fs.writeFileSync(path.join(root, 'container/Dockerfile'), 'ARG BUN_VERSION=1.3.12\n');
+  for (const provider of conformanceTests) shipConformanceTest(root, provider);
+  return root;
+}
+
+function shipConformanceTest(root: string, provider: string): void {
+  const file = path.join(root, runtimeConformanceTestPath(provider));
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '');
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('provider contract verifier', () => {
+  it('accepts only the Bun version pinned by the container image', () => {
+    const root = fixture();
+    expect(isPinnedBunVersion(root, '1.3.12')).toBe(true);
+    expect(isPinnedBunVersion(root, '1.3.14')).toBe(false);
+  });
+
+  it('uses the pinned Bun fallback and compares every contract inventory', async () => {
+    const commands: string[] = [];
+    const result = await verifyProviderContracts(fixture(), {
+      commandAvailable: () => false,
+      exec: (command) => {
+        commands.push(command);
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude'],
+            hostProviders: [],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('passed');
+    expect(commands).toContain('pnpm --package=bun@1.3.12 dlx bun install --frozen-lockfile');
+    expect(commands).toContain(
+      'pnpm exec vitest run src/provider-contracts src/providers setup/provider-contract.test.ts setup/providers',
+    );
+    expect(commands).toContain('pnpm --package=bun@1.3.12 dlx bun test src/provider-contracts src/providers');
+    expect(result.checks.slice(-2)).toEqual(['runtime contract inventory', 'runtime conformance test files']);
+  });
+
+  it('passes when every declared runtime contract ships its conformance test', async () => {
+    const result = await verifyProviderContracts(fixture(['claude', 'opencode']), {
+      requiredDeclaredProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude', 'opencode'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude', 'opencode'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('passed');
+    expect(result.checks).toContain('runtime conformance test files');
+  });
+
+  it('rejects a declared runtime contract that ships no conformance test', async () => {
+    // Probe fixtures are provider knowledge, so there is no generic sweep to
+    // fall back on: a payload that forgot the file has an unproven contract.
+    const result = await verifyProviderContracts(fixture(['claude']), {
+      requiredDeclaredProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude', 'opencode'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude', 'opencode'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error:
+        "Provider 'opencode' declares a runtime contract but ships no container/agent-runner/src/providers/opencode.conformance.test.ts",
+    });
+    expect(result.checks).not.toContain('runtime conformance test files');
+  });
+
+  it('accepts only explicitly expected fully undeclared legacy providers', async () => {
+    const result = await verifyProviderContracts(fixture(), {
+      expectedLegacyProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('passed');
+  });
+
+  it.each([true, false])('requires Codex adoption alongside legacy OpenCode (declared=%s)', async (declared) => {
+    const contracts = declared ? ['claude', 'codex'] : ['claude'];
+    const result = await verifyProviderContracts(fixture(contracts), {
+      expectedLegacyProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: contracts,
+            hostProviders: ['codex', 'opencode'],
+            setupProviders: ['claude', 'codex'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts, providers: ['claude', 'codex', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe(declared ? 'passed' : 'failed');
+    if (!declared) expect(result.error).toContain('actual=["codex","opencode"]');
+  });
+
+  it('allows an undeclared legacy provider when another provider is required to declare', async () => {
+    const result = await verifyProviderContracts(fixture(['claude', 'codex']), {
+      requiredDeclaredProviders: ['codex'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude', 'codex'],
+            hostProviders: ['codex', 'opencode'],
+            setupProviders: ['claude', 'codex'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude', 'codex'], providers: ['claude', 'codex', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('passed');
+  });
+
+  it('passes a required provider that declares host + runtime contracts but registers no setup picker entry', async () => {
+    // A skill-only provider (kept out of the setup wizard on purpose) has no
+    // setup/providers/<name>.ts — setup registration is optional, not a contract.
+    const result = await verifyProviderContracts(fixture(['claude', 'opencode']), {
+      requiredDeclaredProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude', 'opencode'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude', 'opencode'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('passed');
+  });
+
+  it('requires every selected provider to declare its contract', async () => {
+    const result = await verifyProviderContracts(fixture(), {
+      requiredDeclaredProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result).toMatchObject({ status: 'failed', error: 'Required provider contracts missing: opencode' });
+  });
+
+  it('rejects a current provider with no contract', async () => {
+    const result = await verifyProviderContracts(fixture(), {
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: 'Undeclared legacy providers differ: expected=[], actual=["opencode"]',
+    });
+  });
+
+  it('rejects partial contract adoption', async () => {
+    const result = await verifyProviderContracts(fixture(), {
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude', 'opencode'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude', 'opencode'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('Provider contract inventories differ');
+  });
+
+  it('rejects a legacy provider missing a runtime surface', async () => {
+    const result = await verifyProviderContracts(fixture(), {
+      expectedLegacyProviders: ['opencode'],
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({
+            host: ['claude'],
+            hostProviders: ['opencode'],
+            setupProviders: ['claude'],
+          });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude'] });
+        }
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: 'Runtime provider surface differs: expected=["claude","opencode"], actual=["claude"]',
+    });
+  });
+
+  it('runs the OpenCode CLI pin guard when the skill installed it', async () => {
+    const root = fixture();
+    fs.writeFileSync(path.join(root, 'src/opencode-cli-tools.test.ts'), '');
+    const commands: string[] = [];
+
+    const result = await verifyProviderContracts(root, {
+      commandAvailable: () => true,
+      exec: (command) => {
+        commands.push(command);
+        if (command.includes('provider-contract-names.ts')) {
+          return JSON.stringify({ host: ['claude'], hostProviders: [], setupProviders: ['claude'] });
+        }
+        if (command.includes('src/provider-contracts/names.ts')) {
+          return JSON.stringify({ contracts: ['claude'], providers: ['claude'] });
+        }
+      },
+    });
+
+    expect(result.status).toBe('passed');
+    expect(commands).toContain(
+      'pnpm exec vitest run src/provider-contracts src/providers setup/provider-contract.test.ts setup/providers src/opencode-cli-tools.test.ts',
+    );
+  });
+
+  it('parses the provider required by an install skill', () => {
+    expect(parseProviderContractVerifierArgs(['--required-declared', 'Codex, opencode'])).toEqual({
+      requiredDeclaredProviders: ['codex', 'opencode'],
+    });
+    expect(() => parseProviderContractVerifierArgs(['--required-declared', ''])).toThrow(/at least one provider/);
+    expect(() => parseProviderContractVerifierArgs(['--unknown'])).toThrow(/Usage/);
+  });
+
+  it('returns a structured blocking failure', async () => {
+    const result = await verifyProviderContracts(fixture(), {
+      commandAvailable: () => true,
+      exec: (command) => {
+        if (command === 'pnpm run build') throw new Error('compile failed');
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      checks: ['host dependencies', 'runtime dependencies'],
+      error: 'compile failed',
+    });
+  });
+});

--- a/scripts/provider-contract-verifier.ts
+++ b/scripts/provider-contract-verifier.ts
@@ -1,0 +1,171 @@
+import { execFileSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export interface ProviderContractVerification {
+  status: 'passed' | 'failed' | 'skipped';
+  checks: string[];
+  error?: string;
+}
+
+export interface ProviderContractVerifierOptions {
+  commandAvailable?: (command: string, cwd: string) => boolean;
+  exec?: (command: string, cwd: string) => string | void | Promise<string | void>;
+  expectedLegacyProviders?: string[];
+  requiredDeclaredProviders?: string[];
+}
+
+function commandAvailable(command: string, cwd: string): boolean {
+  try {
+    const version = execFileSync(command, ['--version'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return command !== 'bun' || isPinnedBunVersion(cwd, version.trim());
+  } catch {
+    return false;
+  }
+}
+
+export function pinnedBunVersion(root: string): string {
+  const dockerfile = fs.readFileSync(path.join(root, 'container/Dockerfile'), 'utf8');
+  const match = dockerfile.match(/^ARG BUN_VERSION=([^\s#]+)$/m);
+  if (!match) throw new Error('container/Dockerfile does not declare an exact BUN_VERSION');
+  return match[1];
+}
+
+export function isPinnedBunVersion(root: string, version: string): boolean {
+  return version === pinnedBunVersion(root);
+}
+
+/** Where a provider's runtime conformance test lives, relative to the install root. */
+export function runtimeConformanceTestPath(provider: string): string {
+  return `container/agent-runner/src/providers/${provider}.conformance.test.ts`;
+}
+
+export async function verifyProviderContracts(
+  root: string,
+  options: ProviderContractVerifierOptions = {},
+): Promise<ProviderContractVerification> {
+  if (!fs.existsSync(path.join(root, 'src/provider-contracts/index.ts'))) {
+    return { status: 'skipped', checks: [] };
+  }
+
+  const checks: string[] = [];
+  const run = async (name: string, command: string, cwd = root): Promise<string> => {
+    const output = options.exec
+      ? await options.exec(command, cwd)
+      : execSync(command, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    checks.push(name);
+    return String(output ?? '').trim();
+  };
+
+  try {
+    const bun = (options.commandAvailable ?? commandAvailable)('bun', root)
+      ? 'bun'
+      : `pnpm --package=bun@${pinnedBunVersion(root)} dlx bun`;
+    const runnerRoot = path.join(root, 'container/agent-runner');
+
+    await run('host dependencies', 'pnpm install --frozen-lockfile');
+    await run('runtime dependencies', `${bun} install --frozen-lockfile`, runnerRoot);
+    await run('host build', 'pnpm run build');
+    const optionalHostTests = fs.existsSync(path.join(root, 'src/opencode-cli-tools.test.ts'))
+      ? ' src/opencode-cli-tools.test.ts'
+      : '';
+    await run(
+      'host provider contract tests',
+      `pnpm exec vitest run src/provider-contracts src/providers setup/provider-contract.test.ts setup/providers${optionalHostTests}`,
+    );
+    await run('runtime typecheck', 'pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit');
+    await run('runtime provider contract tests', `${bun} test src/provider-contracts src/providers`, runnerRoot);
+
+    const host = JSON.parse(
+      await run('host contract inventory', 'pnpm exec tsx scripts/provider-contract-names.ts'),
+    ) as {
+      host: string[];
+      hostProviders: string[];
+      setupProviders: string[];
+    };
+    const runtime = JSON.parse(
+      await run('runtime contract inventory', `${bun} src/provider-contracts/names.ts`, runnerRoot),
+    ) as { contracts: string[]; providers: string[] };
+    const expected = JSON.stringify(host.host);
+    if (JSON.stringify(runtime.contracts) !== expected) {
+      throw new Error(
+        `Provider contract inventories differ: host=${expected}, runtime=${JSON.stringify(runtime.contracts)}`,
+      );
+    }
+    // Every declared runtime contract proves itself from its own
+    // providers/<name>.conformance.test.ts — the probe fixtures a contract
+    // needs are provider knowledge, so core runs no generic sweep. The
+    // 'runtime provider contract tests' step above (`bun test
+    // src/provider-contracts src/providers`) already executed the file;
+    // this check is what makes a payload that forgot to ship it fail.
+    for (const provider of runtime.contracts) {
+      const relative = runtimeConformanceTestPath(provider);
+      if (!fs.existsSync(path.join(root, relative))) {
+        throw new Error(`Provider '${provider}' declares a runtime contract but ships no ${relative}`);
+      }
+    }
+    checks.push('runtime conformance test files');
+    const contracts = new Set(host.host);
+    const registered = new Set([...host.hostProviders, ...host.setupProviders, ...runtime.providers]);
+    const undeclared = [...registered].filter((provider) => !contracts.has(provider)).sort();
+    const requiredDeclared = [...new Set(options.requiredDeclaredProviders ?? [])].sort();
+    const missingRequired = requiredDeclared.filter((provider) => !contracts.has(provider));
+    if (missingRequired.length) {
+      throw new Error(`Required provider contracts missing: ${missingRequired.join(', ')}`);
+    }
+    const expectedLegacy = options.requiredDeclaredProviders
+      ? undeclared
+      : [...new Set(options.expectedLegacyProviders ?? [])].sort();
+    if (JSON.stringify(undeclared) !== JSON.stringify(expectedLegacy)) {
+      throw new Error(
+        `Undeclared legacy providers differ: expected=${JSON.stringify(expectedLegacy)}, actual=${JSON.stringify(undeclared)}`,
+      );
+    }
+
+    const expectedRuntime = [...new Set([...host.host, ...expectedLegacy])].sort();
+    if (JSON.stringify(runtime.providers) !== JSON.stringify(expectedRuntime)) {
+      throw new Error(
+        `Runtime provider surface differs: expected=${JSON.stringify(expectedRuntime)}, actual=${JSON.stringify(runtime.providers)}`,
+      );
+    }
+    const missingLegacyHost = expectedLegacy.filter((provider) => !host.hostProviders.includes(provider));
+    if (missingLegacyHost.length) {
+      throw new Error(`Legacy provider host surface missing: ${missingLegacyHost.join(', ')}`);
+    }
+
+    return { status: 'passed', checks };
+  } catch (error) {
+    return { status: 'failed', checks, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function parseProviderContractVerifierArgs(argv: string[]): ProviderContractVerifierOptions {
+  if (argv.length === 0) return {};
+  if (argv.length !== 2 || argv[0] !== '--required-declared') {
+    throw new Error('Usage: provider-contract-verifier [--required-declared <provider[,provider...]>]');
+  }
+  const requiredDeclaredProviders = argv[1]
+    .split(',')
+    .map((provider) => provider.trim().toLowerCase())
+    .filter(Boolean);
+  if (requiredDeclaredProviders.length === 0) throw new Error('--required-declared needs at least one provider');
+  return { requiredDeclaredProviders };
+}
+
+async function main(): Promise<void> {
+  const result = await verifyProviderContracts(process.cwd(), parseProviderContractVerifierArgs(process.argv.slice(2)));
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (result.status === 'failed') process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-registry-skills.test.ts
+++ b/scripts/test-registry-skills.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  formatUnavailable,
+  missingRegistrySources,
+  partitionRegistryAvailability,
+  selectCombinedProviders,
+  type RegistrySkill,
+} from './test-registry-skills.js';
+
+function skill(name: string, copy: string[], extra: Partial<RegistrySkill> = {}): RegistrySkill {
+  return {
+    skill: name,
+    branches: ['providers'],
+    bun: false,
+    executable: true,
+    dir: `.claude/skills/${name}`,
+    markdown: ['```nc:copy from-branch:providers', ...copy, '```', ''].join('\n'),
+    ...extra,
+  };
+}
+
+const registry = new Set(['providers:src/providers/codex.ts', 'providers:src/providers/opencode.ts']);
+const hasSource = (branch: string, path: string) => registry.has(`${branch}:${path}`);
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('registry availability filter', () => {
+  it('names every copy source the registry commit lacks', () => {
+    const meta = skill('add-codex', ['src/providers/codex.ts', 'src/provider-contracts/codex.ts -> src/x.ts']);
+    expect(missingRegistrySources(meta, hasSource)).toEqual(['providers:src/provider-contracts/codex.ts']);
+  });
+
+  it('splits skills into available and unavailable with a WARN line per skipped skill', () => {
+    const ok = skill('add-opencode', ['src/providers/opencode.ts']);
+    const stale = skill('add-codex', ['src/providers/codex.ts', 'src/provider-contracts/codex.ts']);
+    const { available, unavailable } = partitionRegistryAvailability([ok, stale], hasSource);
+    expect(available.map((s) => s.skill)).toEqual(['add-opencode']);
+    expect(unavailable.map(formatUnavailable)).toEqual([
+      'WARN: add-codex unavailable in registry (missing: providers:src/provider-contracts/codex.ts)',
+    ]);
+  });
+});
+
+describe('--combined-providers selection', () => {
+  it('fails loudly when trunk carries provider skills but none is available', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const codex = skill('add-codex', ['src/provider-contracts/codex.ts'], { provider: 'codex' });
+    const opencode = skill('add-opencode', ['src/provider-contracts/opencode.ts'], { provider: 'opencode' });
+    expect(() => selectCombinedProviders([codex, opencode], hasSource)).toThrow(
+      /FAIL: trunk carries provider skills \(add-codex, add-opencode\) but none is available/,
+    );
+    expect(warn.mock.calls.map(([line]) => String(line))).toEqual([
+      'WARN: add-codex unavailable in registry (missing: providers:src/provider-contracts/codex.ts)',
+      'WARN: add-opencode unavailable in registry (missing: providers:src/provider-contracts/opencode.ts)',
+    ]);
+  });
+
+  it('keeps the available provider skills and warns about the rest', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const codex = skill('add-codex', ['src/providers/codex.ts'], { provider: 'codex' });
+    const stale = skill('add-opencode', ['src/provider-contracts/opencode.ts'], { provider: 'opencode' });
+    expect(selectCombinedProviders([codex, stale], hasSource).map((s) => s.provider)).toEqual(['codex']);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a provider skill without nanoclaw-provider metadata', () => {
+    expect(() => selectCombinedProviders([skill('add-mystery', ['src/providers/codex.ts'])], hasSource)).toThrow(
+      /missing nanoclaw-provider metadata: add-mystery/,
+    );
+  });
+
+  it('selects nothing only when trunk ships no provider skill at all', () => {
+    const channel = skill('add-slack', ['src/channels/slack.ts'], { branches: ['channels'] });
+    expect(selectCombinedProviders([channel], hasSource)).toEqual([]);
+  });
+});

--- a/scripts/test-registry-skills.ts
+++ b/scripts/test-registry-skills.ts
@@ -4,11 +4,23 @@
 // its build/test directives. `--all` is the local equivalent of the CI matrix.
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-import { applySkill, fullyApplied } from './skill-apply.js';
+import { applySkill, fullyApplied, removeSkill } from './skill-apply.js';
 import {
   lintGateAmbiguity,
   lintReferenceFloor,
@@ -16,7 +28,9 @@ import {
   resolveChatCoreVersion,
   validate,
 } from './skill-directives.js';
-import { resolveRegistryRemote } from './update-skills.js';
+import { refreshInstalledSkills, resolveRegistryRemote } from './update-skills.js';
+import { verifyProviderContracts } from './provider-contract-verifier.js';
+import { parseProviderDescriptor } from '../setup/providers/skill-descriptor.js';
 
 const SOURCE_ROOT = process.cwd();
 const SKILLS_ROOT = join(SOURCE_ROOT, '.claude/skills');
@@ -24,14 +38,28 @@ const REGISTRY_MENTION = /(?:from-branch:|origin\/|git fetch\s+\S+\s+)(channels|
 const REGISTRY_BRANCHES = new Set(['channels', 'providers']);
 const STUBBED_EFFECTS = new Set(['check', 'external', 'fetch']);
 const SKIPPED_EFFECTS = ['restart', 'wire'];
+const LEGACY_PROVIDER_SKILLS = ['add-codex', 'add-opencode'];
+const PRE_CONTRACT_CORE_SHA = '99283f3e274b2b1dae47b141ac4f11f56ad8eb2d';
+// Immediate parent of the first providers-branch contract payload commit.
+const PRE_CONTRACT_PROVIDERS_SHA = 'f503f23ce3da61048a8725716397e68ea0c22a30';
 
-interface RegistrySkill {
+export interface RegistrySkill {
   skill: string;
   branches: string[];
+  provider?: string;
   bun: boolean;
   executable: boolean;
   dir: string;
   markdown: string;
+}
+
+/** `true` when `<branch>:<path>` exists on the resolved registry commit. */
+export type RegistrySourceCheck = (branch: string, path: string) => boolean;
+
+export interface UnavailableRegistrySkill {
+  skill: RegistrySkill;
+  /** `<branch>:<path>` for every copy source the registry commit lacks. */
+  missing: string[];
 }
 
 interface Fixture {
@@ -49,6 +77,61 @@ function git(args: string[], cwd = SOURCE_ROOT): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
+function ensureCommit(commit: string): void {
+  try {
+    git(['cat-file', '-e', `${commit}^{commit}`]);
+  } catch {
+    git(['fetch', 'origin', commit]);
+  }
+}
+
+function snapshot(root: string): Map<string, string> {
+  const files = execFileSync('git', ['ls-files', '-z', '--cached', '--others', '--exclude-standard'], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+    .split('\0')
+    .filter(Boolean)
+    .sort();
+  return new Map(
+    files.map((file) => {
+      const full = join(root, file);
+      if (!existsSync(full)) return [file, 'missing'];
+      const stat = lstatSync(full);
+      const content = stat.isSymbolicLink() ? readlinkSync(full) : readFileSync(full);
+      const hash = createHash('sha256').update(content).digest('hex');
+      return [file, `${stat.mode & 0o777}:${hash}`];
+    }),
+  );
+}
+
+function assertSnapshot(label: string, expected: Map<string, string>, actual: Map<string, string>): void {
+  const changed = [...new Set([...expected.keys(), ...actual.keys()])].filter(
+    (file) => expected.get(file) !== actual.get(file),
+  );
+  if (changed.length) throw new Error(`${label}: ${changed.slice(0, 20).join(', ')}`);
+}
+
+function materializeSkill(commit: string, skill: string, skillsRoot: string): RegistrySkill {
+  ensureCommit(commit);
+  const prefix = `.claude/skills/${skill}/`;
+  const files = execFileSync('git', ['ls-tree', '-r', '--name-only', '-z', commit, '--', prefix], {
+    cwd: SOURCE_ROOT,
+    encoding: 'utf8',
+  })
+    .split('\0')
+    .filter(Boolean);
+  if (!files.length) throw new Error(`${commit} has no ${skill} skill`);
+  for (const file of files) {
+    const dest = join(skillsRoot, file.slice('.claude/skills/'.length));
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, execFileSync('git', ['show', `${commit}:${file}`], { cwd: SOURCE_ROOT }));
+  }
+  const meta = discover(skillsRoot).find((candidate) => candidate.skill === skill);
+  if (!meta) throw new Error(`could not materialize ${skill} from ${commit}`);
+  return meta;
+}
+
 function command(cmd: string, cwd: string, quiet = false): string {
   if (!quiet) console.log(`  $ ${cmd}`);
   const result = spawnSync(cmd, { cwd, shell: true, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
@@ -60,11 +143,11 @@ function command(cmd: string, cwd: string, quiet = false): string {
   return result.stdout ?? '';
 }
 
-function discover(): RegistrySkill[] {
-  return readdirSync(SKILLS_ROOT)
+function discover(skillsRoot = SKILLS_ROOT): RegistrySkill[] {
+  return readdirSync(skillsRoot)
     .filter((name) => name.startsWith('add-'))
     .flatMap((skill) => {
-      const dir = join(SKILLS_ROOT, skill);
+      const dir = join(skillsRoot, skill);
       const path = join(dir, 'SKILL.md');
       if (!existsSync(path)) return [];
       const markdown = readFileSync(path, 'utf8');
@@ -82,6 +165,7 @@ function discover(): RegistrySkill[] {
         {
           skill,
           branches,
+          provider: parseProviderDescriptor(markdown, skill)?.value,
           bun: markdown.includes('container/agent-runner'),
           executable: branches.length > 0,
           dir,
@@ -121,6 +205,88 @@ function resolveRegistryRefs(): Record<string, string> {
   return refs;
 }
 
+function hasRegistrySource(refs: Record<string, string>, branch: string, path: string): boolean {
+  return (
+    spawnSync('git', ['cat-file', '-e', `${refs[branch]}:${path}`], {
+      cwd: SOURCE_ROOT,
+      stdio: 'ignore',
+    }).status === 0
+  );
+}
+
+/** Every `nc:copy from-branch:` source of the skill that the registry commit does not carry. */
+export function missingRegistrySources(meta: RegistrySkill, hasSource: RegistrySourceCheck): string[] {
+  const missing: string[] = [];
+  for (const directive of parseDirectives(meta.markdown)) {
+    if (directive.kind !== 'copy' || typeof directive.attrs['from-branch'] !== 'string') continue;
+    const branch = directive.attrs['from-branch'];
+    for (const line of directive.body) {
+      const source = line.includes('->') ? line.split('->')[0].trim() : line.trim();
+      if (!hasSource(branch, source)) missing.push(`${branch}:${source}`);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Split skills by whether the registry commit carries every file they copy.
+ * A skill whose payload has not been promoted yet cannot be applied, so the
+ * matrix skips it — but never silently: callers print `warnUnavailable`.
+ */
+export function partitionRegistryAvailability(
+  skills: RegistrySkill[],
+  hasSource: RegistrySourceCheck,
+): { available: RegistrySkill[]; unavailable: UnavailableRegistrySkill[] } {
+  const available: RegistrySkill[] = [];
+  const unavailable: UnavailableRegistrySkill[] = [];
+  for (const skill of skills) {
+    const missing = missingRegistrySources(skill, hasSource);
+    if (missing.length) unavailable.push({ skill, missing });
+    else available.push(skill);
+  }
+  return { available, unavailable };
+}
+
+export function formatUnavailable({ skill, missing }: UnavailableRegistrySkill): string {
+  return `WARN: ${skill.skill} unavailable in registry (missing: ${missing.join(', ')})`;
+}
+
+function warnUnavailable(unavailable: UnavailableRegistrySkill[]): void {
+  for (const entry of unavailable) console.error(formatUnavailable(entry));
+}
+
+function registrySourceCheck(refs: Record<string, string>): RegistrySourceCheck {
+  return (branch, path) => hasRegistrySource(refs, branch, path);
+}
+
+/**
+ * The provider skills `--combined-providers` must exercise. Trunk carrying
+ * provider skills whose payload is missing from the registry is a broken
+ * composition (`/add-<name>` would fail at its copy step), so "none available"
+ * is a failure — never a green "nothing to combine".
+ */
+export function selectCombinedProviders(
+  skills: RegistrySkill[],
+  hasSource: RegistrySourceCheck,
+): Array<RegistrySkill & { provider: string }> {
+  const providerSkills = skills.filter((skill) => skill.provider || skill.branches.includes('providers'));
+  const missingMetadata = providerSkills.filter((skill) => !skill.provider);
+  if (missingMetadata.length) {
+    throw new Error(`provider skills missing nanoclaw-provider metadata: ${missingMetadata.map(({ skill }) => skill)}`);
+  }
+  const { available, unavailable } = partitionRegistryAvailability(providerSkills, hasSource);
+  warnUnavailable(unavailable);
+  if (providerSkills.length && !available.length) {
+    throw new Error(
+      `FAIL: trunk carries provider skills (${providerSkills.map(({ skill }) => skill).join(', ')}) ` +
+        `but none is available in the providers registry:\n` +
+        unavailable.map((entry) => `  ${formatUnavailable(entry)}`).join('\n') +
+        `\nPromote the provider payloads to the providers branch (or pin REGISTRY_PROVIDERS_SHA to a commit that carries them) before this core lands.`,
+    );
+  }
+  return available as Array<RegistrySkill & { provider: string }>;
+}
+
 function pinRegistryRef(root: string, branch: string, commit: string): void {
   try {
     git(['cat-file', '-e', `${commit}^{commit}`], root);
@@ -135,6 +301,8 @@ async function testSkill(
   fixture: FixtureScenario,
   root: string,
   refs: Record<string, string>,
+  roundTrip: boolean,
+  skipEffects = SKIPPED_EFFECTS,
 ): Promise<void> {
   if (!meta.executable) {
     throw new Error(`${meta.skill} pulls registry code but has no nc:copy from-branch directive`);
@@ -152,24 +320,28 @@ async function testSkill(
   const byLine = new Map(directives.map((directive) => [directive.line, directive]));
   let current = directives[0];
 
-  const result = await applySkill(meta.dir, root, {
-    inputs: fixture.inputs ?? {},
-    skipEffects: SKIPPED_EFFECTS,
-    resolveRemote: () => 'skill-ci',
-    onEvent: (event) => {
-      if (event.type === 'step-start') current = byLine.get(event.line);
-    },
-    exec: (cmd) => {
-      if (/^git fetch skill-ci (channels|providers)$/.test(cmd)) return '';
-      const stub = fixture.exec?.find((candidate) => cmd.includes(candidate.match));
-      if (stub) return stub.stdout;
-      if (current?.kind === 'run' && STUBBED_EFFECTS.has(String(current.attrs.effect))) {
-        return '';
-      }
-      return command(cmd, root);
-    },
-    execStream: async () => ({ ok: true, fields: fixture.stepFields ?? {} }),
-  });
+  const apply = () =>
+    applySkill(meta.dir, root, {
+      inputs: fixture.inputs ?? {},
+      skipEffects,
+      resolveRemote: () => 'skill-ci',
+      onEvent: (event) => {
+        if (event.type === 'step-start') current = byLine.get(event.line);
+      },
+      exec: (cmd) => {
+        if (/^git fetch skill-ci (channels|providers)$/.test(cmd)) return '';
+        const stub = fixture.exec?.find((candidate) => cmd.includes(candidate.match));
+        if (stub) return stub.stdout;
+        if (current?.kind === 'run' && STUBBED_EFFECTS.has(String(current.attrs.effect))) {
+          return '';
+        }
+        return command(cmd, root);
+      },
+      execStream: async () => ({ ok: true, fields: fixture.stepFields ?? {} }),
+    });
+
+  const before = roundTrip && meta.branches.includes('providers') ? snapshot(root) : undefined;
+  const result = await apply();
 
   if (!fullyApplied(result)) {
     const failures = [
@@ -177,6 +349,159 @@ async function testSkill(
       ...result.agentTasks.map((task) => `line ${task.line}: ${task.reason}`),
     ];
     throw new Error(failures.join('\n'));
+  }
+  if (roundTrip) {
+    const installed = before ? snapshot(root) : undefined;
+    await removeSkill(root, result.journal, (cmd) => command(cmd, root));
+    if (before && installed) {
+      assertSnapshot('provider removal did not restore the exact checkout', before, snapshot(root));
+      const verification = await verifyProviderContracts(root, { exec: (cmd, cwd) => command(cmd, cwd) });
+      if (verification.status !== 'passed') {
+        throw new Error(`removed-state provider verification failed: ${verification.error ?? verification.status}`);
+      }
+      assertSnapshot('removed-state verification changed the checkout', before, snapshot(root));
+    }
+    const reapplied = await apply();
+    if (!fullyApplied(reapplied)) throw new Error('provider add → remove → add round trip failed');
+    if (installed)
+      assertSnapshot('provider reapply did not restore the exact installed checkout', installed, snapshot(root));
+  }
+}
+
+async function testCombinedProviders(skills: RegistrySkill[]): Promise<void> {
+  const refs = resolveRegistryRefs();
+  const selected = selectCombinedProviders(skills, registrySourceCheck(refs));
+  if (!selected.length) {
+    // Only reachable when trunk ships no provider skill at all.
+    console.log('\nPASS: trunk carries no provider skills to combine');
+    return;
+  }
+  const temp = mkdtempSync(join(tmpdir(), 'nanoclaw-provider-ci-'));
+  const root = join(temp, 'repo');
+  try {
+    git(['clone', '--quiet', '--shared', '--no-checkout', SOURCE_ROOT, root]);
+    git(['checkout', '--quiet', '--detach', git(['rev-parse', 'HEAD'])], root);
+    command('pnpm install --frozen-lockfile --prefer-offline', root);
+    command('bun install --frozen-lockfile', join(root, 'container/agent-runner'));
+
+    for (const meta of selected) {
+      console.log(`\n==> ${meta.skill}`);
+      await testSkill(meta, fixtureScenarios(meta)[0] ?? {}, root, refs, false, [...SKIPPED_EFFECTS, 'build', 'test']);
+    }
+
+    git(['update-ref', 'refs/heads/providers', refs.providers], root);
+    git(['remote', 'remove', 'origin'], root);
+    git(['remote', 'add', 'skill-ci', '.'], root);
+    const report = await refreshInstalledSkills(root, 'all', {
+      exec: (cmd, cwd) => command(cmd, cwd),
+    });
+    const expected = selected.map(({ provider }) => provider).sort();
+    if (JSON.stringify(report.selected) !== JSON.stringify(expected)) {
+      throw new Error(`update-skills detected ${report.selected.join(', ') || 'no providers'}`);
+    }
+    if (!report.success) {
+      throw new Error(`update-skills refresh failed: ${JSON.stringify(report)}`);
+    }
+    const verification = await verifyProviderContracts(root, {
+      // OpenCode retains its existing payload until its contract skill lands.
+      // Every other installed provider must already declare its contract.
+      expectedLegacyProviders: ['opencode'],
+      exec: (cmd, cwd) => command(cmd, cwd),
+    });
+    if (verification.status !== 'passed') {
+      throw new Error(`combined provider conformance failed: ${JSON.stringify(verification)}`);
+    }
+    console.log('\nPASS: combined providers install, refresh, and conformance');
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+async function testOldProviderRefresh(commit: string): Promise<void> {
+  if (!/^[0-9a-f]{40}$/i.test(commit)) throw new Error('old trunk must be a full commit SHA');
+
+  ensureCommit(commit);
+  const currentRefs = resolveRegistryRefs();
+  ensureCommit(PRE_CONTRACT_PROVIDERS_SHA);
+  const temp = mkdtempSync(join(tmpdir(), 'nanoclaw-old-provider-refresh-ci-'));
+  const root = join(temp, 'repo');
+  try {
+    git(['clone', '--quiet', '--shared', '--no-checkout', SOURCE_ROOT, root]);
+    git(['fetch', '--quiet', 'origin', commit], root);
+    git(['checkout', '--quiet', '--detach', commit], root);
+    command('pnpm install --frozen-lockfile --prefer-offline', root);
+    command('bun install --frozen-lockfile', join(root, 'container/agent-runner'));
+
+    const oldSkills = LEGACY_PROVIDER_SKILLS.map((name) =>
+      discover(join(root, '.claude/skills')).find(({ skill }) => skill === name),
+    );
+    if (oldSkills.some((skill) => !skill)) throw new Error('old trunk is missing a provider skill');
+
+    const legacyRefs = { providers: PRE_CONTRACT_PROVIDERS_SHA };
+    for (const meta of oldSkills as RegistrySkill[]) {
+      console.log(`\n==> install ${meta.skill} from ${PRE_CONTRACT_PROVIDERS_SHA}`);
+      await testSkill(meta, fixtureScenarios(meta)[0] ?? {}, root, legacyRefs, false, [
+        ...SKIPPED_EFFECTS,
+        'build',
+        'test',
+      ]);
+    }
+
+    git(['fetch', '--quiet', 'origin', currentRefs.providers], root);
+    git(['update-ref', 'refs/heads/providers', currentRefs.providers], root);
+    git(['remote', 'remove', 'origin'], root);
+    git(['remote', 'add', 'skill-ci', '.'], root);
+    const report = await refreshInstalledSkills(root, 'all', {
+      exec: (cmd, cwd) => command(cmd, cwd),
+    });
+    const expected = ['codex', 'opencode'];
+    if (JSON.stringify(report.selected) !== JSON.stringify(expected) || !report.success) {
+      throw new Error(`old-install provider refresh failed: ${JSON.stringify(report)}`);
+    }
+    if (!existsSync(join(root, 'src/opencode-cli-tools.test.ts'))) {
+      throw new Error('OpenCode refresh lost src/opencode-cli-tools.test.ts');
+    }
+
+    for (const meta of oldSkills as RegistrySkill[]) {
+      console.log(`\n==> validate refreshed ${meta.skill} with its old install checks`);
+      await testSkill(meta, fixtureScenarios(meta)[0] ?? {}, root, currentRefs, false);
+    }
+    console.log(
+      `\nPASS: providers installed from ${PRE_CONTRACT_PROVIDERS_SHA} and refreshed to ${currentRefs.providers} on ${commit}`,
+    );
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+async function testPreContractProviders(): Promise<void> {
+  ensureCommit(PRE_CONTRACT_PROVIDERS_SHA);
+  const temp = mkdtempSync(join(tmpdir(), 'nanoclaw-pre-contract-provider-ci-'));
+  const root = join(temp, 'repo');
+  const skillsRoot = join(temp, 'skills');
+  try {
+    git(['clone', '--quiet', '--shared', '--no-checkout', SOURCE_ROOT, root]);
+    git(['checkout', '--quiet', '--detach', git(['rev-parse', 'HEAD'])], root);
+    command('pnpm install --frozen-lockfile --prefer-offline', root);
+    command('bun install --frozen-lockfile', join(root, 'container/agent-runner'));
+
+    const refs = { providers: PRE_CONTRACT_PROVIDERS_SHA };
+    for (const name of LEGACY_PROVIDER_SKILLS) {
+      const meta = materializeSkill(PRE_CONTRACT_CORE_SHA, name, skillsRoot);
+      console.log(`\n==> ${name} from pre-contract providers ${PRE_CONTRACT_PROVIDERS_SHA}`);
+      await testSkill(meta, fixtureScenarios(meta)[0] ?? {}, root, refs, false, [...SKIPPED_EFFECTS, 'build', 'test']);
+    }
+
+    const verification = await verifyProviderContracts(root, {
+      expectedLegacyProviders: ['codex', 'opencode'],
+      exec: (cmd, cwd) => command(cmd, cwd),
+    });
+    if (verification.status !== 'passed') {
+      throw new Error(`pre-contract provider verification failed: ${verification.error ?? verification.status}`);
+    }
+    console.log(`\nPASS: new core with pre-contract provider payloads ${PRE_CONTRACT_PROVIDERS_SHA}`);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
   }
 }
 
@@ -205,7 +530,7 @@ async function testAll(skills: RegistrySkill[]): Promise<void> {
         const scenario = fixture.name ?? String(index + 1);
         if (scenarios.length > 1) console.log(`  scenario: ${scenario}`);
         try {
-          await testSkill(meta, fixture, root, refs);
+          await testSkill(meta, fixture, root, refs, index === 0 && meta.branches.includes('providers'));
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           throw new Error(`${scenario}: ${message}`);
@@ -225,22 +550,41 @@ async function testAll(skills: RegistrySkill[]): Promise<void> {
   console.log(`\n${skills.length}/${skills.length} registry skills passed.`);
 }
 
-const skills = discover();
-const arg = process.argv[2];
+async function main(): Promise<void> {
+  const skills = discover();
+  const arg = process.argv[2];
 
-if (arg === '--list') {
-  console.log(JSON.stringify(skills.map(({ skill, bun, executable }) => ({ skill, bun, executable }))));
-} else if (arg === '--all') {
-  const requested = process.argv.slice(3);
-  const selected = requested.length ? skills.filter(({ skill }) => requested.includes(skill)) : skills;
-  if (selected.length !== (requested.length || skills.length))
-    throw new Error('unknown registry skill in --all filter');
-  await testAll(selected);
-} else if (arg) {
-  const meta = skills.find((candidate) => candidate.skill === basename(arg));
-  if (!meta) throw new Error(`unknown registry skill: ${arg}`);
-  await testAll([meta]);
-} else {
-  console.error('usage: pnpm exec tsx scripts/test-registry-skills.ts --list|--all [skill...]|<skill>');
-  process.exitCode = 2;
+  if (arg === '--list') {
+    console.log(JSON.stringify(skills.map(({ skill, bun, executable }) => ({ skill, bun, executable }))));
+  } else if (arg === '--list-available') {
+    const refs = resolveRegistryRefs();
+    const { available, unavailable } = partitionRegistryAvailability(skills, registrySourceCheck(refs));
+    warnUnavailable(unavailable);
+    console.log(JSON.stringify(available.map(({ skill, bun, executable }) => ({ skill, bun, executable }))));
+  } else if (arg === '--all') {
+    const requested = process.argv.slice(3);
+    const selected = requested.length ? skills.filter(({ skill }) => requested.includes(skill)) : skills;
+    if (selected.length !== (requested.length || skills.length))
+      throw new Error('unknown registry skill in --all filter');
+    await testAll(selected);
+  } else if (arg === '--combined-providers') {
+    await testCombinedProviders(skills);
+  } else if (arg === '--old-provider-refresh') {
+    await testOldProviderRefresh(process.argv[3] ?? '');
+  } else if (arg === '--pre-contract-providers') {
+    await testPreContractProviders();
+  } else if (arg) {
+    const meta = skills.find((candidate) => candidate.skill === basename(arg));
+    if (!meta) throw new Error(`unknown registry skill: ${arg}`);
+    await testAll([meta]);
+  } else {
+    console.error(
+      'usage: pnpm exec tsx scripts/test-registry-skills.ts --list|--list-available|--all [skill...]|--combined-providers|--old-provider-refresh <sha>|--pre-contract-providers|<skill>',
+    );
+    process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main();
 }

--- a/scripts/update-skills.ts
+++ b/scripts/update-skills.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 
 import { applySkill, fullyApplied, type DependencyCommandRequest } from './skill-apply.js';
 import { parseDirectives } from './skill-directives.js';
+import { pinnedBunVersion } from './provider-contract-verifier.js';
 
 export type InstalledSkillKind = 'channel' | 'provider';
 
@@ -49,13 +50,6 @@ function commandAvailable(command: string, cwd: string): boolean {
   } catch {
     return false;
   }
-}
-
-function pinnedBunVersion(root: string): string {
-  const dockerfile = fs.readFileSync(path.join(root, 'container/Dockerfile'), 'utf8');
-  const match = dockerfile.match(/^ARG BUN_VERSION=([^\s#]+)$/m);
-  if (!match) throw new Error('container/Dockerfile does not declare an exact BUN_VERSION');
-  return match[1];
 }
 
 export function portableDependencyCommand(root: string, bunOnHost: boolean, request: DependencyCommandRequest): string {

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -47,6 +47,11 @@ import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
+import {
+  getInstallableProviderDescriptor,
+  listInstallableProviderDescriptors,
+  providerImagePolicy,
+} from './providers/skill-descriptor.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
 import { brightSelect } from './lib/bright-select.js';
@@ -428,7 +433,8 @@ async function main(): Promise<void> {
     // machine builds. Settle it here: buildContainerImage() below refuses on a
     // pinned install, and reaching that refusal aborts setup with no way out
     // short of re-running it.
-    if (agentProvider !== 'claude' && readImageSource() === 'hardened') {
+    const providerDescriptor = getInstallableProviderDescriptor(agentProvider);
+    if (providerImagePolicy(agentProvider) === 'local-required' && readImageSource() === 'hardened') {
       const leave = ensureAnswer(
         await p.confirm({
           message: `${agentProvider} needs a sandbox image built on this machine. Stop using the pre-built one?`,
@@ -448,14 +454,15 @@ async function main(): Promise<void> {
     }
 
     let providerEntry = getSetupProvider(agentProvider);
-    if (agentProvider !== 'claude' && !providerEntry) {
+    if (!providerEntry) {
       // A non-claude provider picked from the hard-wired list isn't wired in
       // this install yet — install it by applying its `/add-<name>` SKILL.md
       // in-process via the directive engine (channel style, idempotent:
       // self-skips if already installed), rebuild the image (the container step
       // already ran, the CLI manifest just changed), then load the payload's
       // setup module so it self-registers.
-      const skillDir = `.claude/skills/add-${agentProvider}`;
+      if (!providerDescriptor) throw new Error(`No install descriptor for provider '${agentProvider}'`);
+      const skillDir = providerDescriptor.skillDir;
       const s = p.spinner();
       s.start(`Installing ${agentProvider}…`);
       let blockers: string[];
@@ -921,15 +928,6 @@ function sendChatMessage(message: string): Promise<void> {
 
 // ─── auth step (select → branch) ────────────────────────────────────────
 
-// Providers offered for install are hard-wired in trunk — an audited control
-// surface (no branch enumeration that anyone with write access could extend).
-// Codex is the only one offered here; opencode/ollama install via their own
-// /add-* skills. Each is installed by applying its `/add-<name>` SKILL.md
-// in-process via the directive engine.
-const INSTALLABLE_PROVIDERS = [
-  { value: 'codex', label: 'Codex', hint: 'OpenAI — ChatGPT subscription or API key' },
-] as const;
-
 // `pickSavedByPreviousRun`: the .env bridge promoted a pick persisted by a
 // PREVIOUS run. That pick is a default to confirm, not a decision to replay:
 // the operator may be rerunning precisely to change it. In-process presets
@@ -1087,9 +1085,7 @@ async function chooseTemplate(templates: TemplateEntry[]): Promise<string | unde
 }
 
 type TemplateAgentOutcome = 'none' | 'channel-target' | 'restamped';
-type TemplateSetupOperation =
-  | TemplateOperation
-  | { kind: 'connect'; agentGroupId: string };
+type TemplateSetupOperation = TemplateOperation | { kind: 'connect'; agentGroupId: string };
 
 async function installSelectedTemplateAgent(provider?: string): Promise<TemplateAgentOutcome> {
   const ref = process.env.NANOCLAW_TEMPLATE_PATH?.trim();
@@ -1137,9 +1133,7 @@ async function installSelectedTemplateAgent(provider?: string): Promise<Template
     }
 
     const name =
-      operation.kind === 'create' && agents.length > 0
-        ? await askNewTemplateAgentName(agents, presetName)
-        : presetName;
+      operation.kind === 'create' && agents.length > 0 ? await askNewTemplateAgentName(agents, presetName) : presetName;
 
     p.log.step(
       brandBody(
@@ -1235,11 +1229,13 @@ async function chooseTemplateOperation(
   const options = agents.flatMap((agent) => [
     ...(agent.isWired
       ? []
-      : [{
-          value: { kind: 'connect', agentGroupId: agent.id } as const,
-          label: `Connect "${agent.name}" to a channel`,
-          hint: `groups/${agent.folder} · not connected`,
-        }]),
+      : [
+          {
+            value: { kind: 'connect', agentGroupId: agent.id } as const,
+            label: `Connect "${agent.name}" to a channel`,
+            hint: `groups/${agent.folder} · not connected`,
+          },
+        ]),
     {
       value: { kind: 'restamp', agentGroupId: agent.id } as const,
       label: `Update "${agent.name}" in place`,
@@ -1264,10 +1260,7 @@ async function chooseTemplateOperation(
   return choice.kind === 'cancel' ? undefined : choice;
 }
 
-async function askNewTemplateAgentName(
-  agents: readonly AgentGroup[],
-  initialValue?: string,
-): Promise<string> {
+async function askNewTemplateAgentName(agents: readonly AgentGroup[], initialValue?: string): Promise<string> {
   const answer = ensureAnswer(
     await p.text({
       message: 'Name the new agent',
@@ -1305,7 +1298,7 @@ async function chooseImageSource(): Promise<void> {
     DEFAULT_AGENT_PROVIDER ||
     'claude'
   ).toLowerCase();
-  if (plannedProvider !== 'claude') {
+  if (providerImagePolicy(plannedProvider) === 'local-required') {
     p.log.info(
       brandBody(
         `Building the sandbox here — the pre-built image is Claude-only, and ${plannedProvider} needs an image of its own.`,
@@ -1411,9 +1404,7 @@ async function chooseImageSource(): Promise<void> {
 async function askAgentProviderChoice(): Promise<string> {
   const installed = listSetupProviders();
   const installedNames = new Set(installed.map((entry) => entry.value));
-  // Offer the hard-wired installable providers this install hasn't wired yet —
-  // selecting one applies its `/add-<name>` SKILL.md in-process.
-  const available = INSTALLABLE_PROVIDERS.filter((prov) => !installedNames.has(prov.value));
+  const available = listInstallableProviderDescriptors().filter((prov) => !installedNames.has(prov.value));
   // On a pinned install every non-Claude runtime forces a local rebuild — the
   // image bakes /app/node_modules and the CLI manifest, and each changes one.
   // Say so on the option rather than only at the confirm two steps later, so
@@ -1421,7 +1412,9 @@ async function askAgentProviderChoice(): Promise<string> {
   // this install pulls; on a local-build install it is not a trade-off.
   const pinned = readImageSource() === 'hardened';
   const note = (value: string, hint: string): string =>
-    pinned && value !== 'claude' ? `${hint} — ⚠ not in the pre-built image; needs a local build` : hint;
+    pinned && providerImagePolicy(value) === 'local-required'
+      ? `${hint} — ⚠ not in the pre-built image; needs a local build`
+      : hint;
 
   const options = [
     ...installed.map(({ value, label, hint }) => ({ value, label, hint: note(value, hint) })),

--- a/setup/provider-auth.ts
+++ b/setup/provider-auth.ts
@@ -15,17 +15,9 @@
 import { buildContainerImage } from './lib/container-build.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
+import { getInstallableProviderDescriptor } from './providers/skill-descriptor.js';
 // Provider payloads self-register on import.
 import './providers/index.js';
-
-// Hard-wired install skills — the audited control surface (no branch
-// enumeration). Each `/add-<name>` SKILL.md is idempotent and self-skips when
-// the payload is already wired; it is applied in-process via the directive
-// engine (no shell-out to a drift-prone setup/add-<name>.sh). Codex is the only
-// manifest-style provider today.
-const INSTALL_SKILLS: Record<string, string> = {
-  codex: '.claude/skills/add-codex',
-};
 
 export async function run(args: string[]): Promise<void> {
   const name = args[0]?.trim().toLowerCase();
@@ -40,7 +32,7 @@ export async function run(args: string[]): Promise<void> {
   }
 
   let entry = getSetupProvider(name);
-  const skillDir = INSTALL_SKILLS[name];
+  const skillDir = getInstallableProviderDescriptor(name)?.skillDir;
   if (skillDir) {
     // Install OR refresh: the skill is idempotent and is also the upgrade path
     // — payload files resync and a bumped CLI-manifest pin replaces the local

--- a/setup/provider-contract.test.ts
+++ b/setup/provider-contract.test.ts
@@ -94,7 +94,8 @@ describe('codex installs from its hard-wired /add-codex skill in-process', () =>
   it('setup/auto.ts installs the picked provider in-process via applyProviderSkill', () => {
     const src = read('setup/auto.ts');
     expect(src).toContain('applyProviderSkill');
-    expect(src).toContain('.claude/skills/add-${agentProvider}');
+    expect(src).toContain('providerDescriptor.skillDir');
+    expect(src).toContain('listInstallableProviderDescriptors()');
     // No shell-out to a per-provider install script.
     expect(src).not.toContain('setup/add-${agentProvider}.sh');
     // The removed branch-enumeration machinery must not creep back in.
@@ -105,6 +106,18 @@ describe('codex installs from its hard-wired /add-codex skill in-process', () =>
   it('setup/provider-auth.ts installs the picked provider in-process via applyProviderSkill', () => {
     const src = read('setup/provider-auth.ts');
     expect(src).toContain('applyProviderSkill');
+    expect(src).toContain('getInstallableProviderDescriptor(name)?.skillDir');
     expect(src).not.toContain('setup/add-codex.sh');
+  });
+
+  it('setup owns the shared provider verifier instead of running the skill directive twice', () => {
+    const src = read('setup/providers/install.ts');
+    const flowOwned = src.slice(src.indexOf('function isFlowOwnedCommand'), src.indexOf('export interface'));
+    expect(flowOwned).toContain('/provider-contract-verifier/.test(cmd)');
+    expect(src).toContain('verifyProviderContracts');
+    expect(src).toContain("verification.status === 'failed'");
+    // The installed provider must declare its contract; unrelated pre-contract
+    // payloads already in the install must not abort setup.
+    expect(src).toContain('requiredDeclaredProviders: [installedProviderName(skillDir, projectRoot)]');
   });
 });

--- a/setup/providers/claude.ts
+++ b/setup/providers/claude.ts
@@ -1,0 +1,7 @@
+import { registerSetupProvider } from './registry.js';
+
+registerSetupProvider({
+  value: 'claude',
+  label: 'Claude',
+  hint: 'default — Anthropic subscription or API key',
+});

--- a/setup/providers/index.ts
+++ b/setup/providers/index.ts
@@ -1,3 +1,4 @@
 // Setup-side provider barrel. Provider payloads with their own setup surface
 // (picker entry, auth walk-through, install check) self-register on import.
 // Skills add a provider by appending one import line below.
+import './claude.js';

--- a/setup/providers/install.ts
+++ b/setup/providers/install.ts
@@ -28,8 +28,15 @@
  * failed: a provider install is fully deterministic with no prompts).
  */
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { applySkill, type ApplyResult } from '../../scripts/skill-apply.js';
+import {
+  verifyProviderContracts,
+  type ProviderContractVerification,
+} from '../../scripts/provider-contract-verifier.js';
+import { parseProviderDescriptor } from './skill-descriptor.js';
 
 /** Commands the directive engine emits that the surrounding setup flow owns. */
 function isFlowOwnedCommand(cmd: string): boolean {
@@ -39,6 +46,7 @@ function isFlowOwnedCommand(cmd: string): boolean {
     /container\/build\.sh/.test(cmd) ||
     /\bvitest\b/.test(cmd) ||
     /\bbun\s+test\b/.test(cmd) ||
+    /provider-contract-verifier/.test(cmd) ||
     // The skill's auth step re-invokes `--step provider-auth` — running it from
     // inside the install would recurse. The flow runs runAuth itself.
     /provider-auth/.test(cmd)
@@ -51,6 +59,7 @@ export interface ProviderInstallResult {
   changed: boolean;
   /** Non-deterministic leftovers — non-empty means the install did not fully apply. */
   blockers: string[];
+  verification: ProviderContractVerification;
 }
 
 export async function applyProviderSkill(skillDir: string, projectRoot: string): Promise<ProviderInstallResult> {
@@ -74,9 +83,31 @@ export async function applyProviderSkill(skillDir: string, projectRoot: string):
   });
 
   const blockers = [...result.agentTasks.map((t) => t.reason), ...result.deferred];
+  // Verify in "required-declared" mode: the provider this skill installs must
+  // declare its contract, while any OTHER provider already in this install
+  // that predates the contract (a pre-contract payload) is tolerated. Without
+  // the option the verifier expects zero undeclared providers and would abort
+  // an otherwise-good install over an unrelated legacy payload.
+  const verification =
+    blockers.length === 0
+      ? await verifyProviderContracts(projectRoot, {
+          requiredDeclaredProviders: [installedProviderName(skillDir, projectRoot)],
+        })
+      : { status: 'skipped' as const, checks: [] };
+  if (verification.status === 'failed') blockers.push(verification.error ?? 'Provider contract verification failed');
   return {
     apply: result,
     changed: result.applied.length > 0,
     blockers,
+    verification,
   };
+}
+
+/** The provider a `/add-<name>` skill installs, read from its `nanoclaw-provider` frontmatter. */
+export function installedProviderName(skillDir: string, projectRoot: string): string {
+  const directory = path.basename(skillDir);
+  const markdown = fs.readFileSync(path.join(projectRoot, skillDir, 'SKILL.md'), 'utf-8');
+  const descriptor = parseProviderDescriptor(markdown, directory);
+  if (!descriptor) throw new Error(`${directory}/SKILL.md has no nanoclaw-provider metadata`);
+  return descriptor.value;
 }

--- a/setup/providers/registry.ts
+++ b/setup/providers/registry.ts
@@ -4,7 +4,7 @@
  * flow (same capability-not-name rule as the host provider-container registry).
  *
  * `claude` is the built-in default: it has no `runAuth` of its own, which the
- * setup flow reads as "run the standard auth step". A provider payload adds
+ * setup flow reads as "run the standard auth step". Every provider adds
  * itself by shipping a `setup/providers/<name>.ts` with a top-level
  * `registerSetupProvider(...)` call and appending one import line to the
  * `setup/providers/index.ts` barrel — the same shape as the host and container
@@ -36,17 +36,13 @@ export interface SetupProviderEntry {
 
 const registry = new Map<string, SetupProviderEntry>();
 
-registry.set('claude', {
-  value: 'claude',
-  label: 'Claude',
-  hint: 'default — Anthropic subscription or API key',
-});
-
 export function registerSetupProvider(entry: SetupProviderEntry): void {
-  if (registry.has(entry.value)) {
-    throw new Error(`Setup provider already registered: ${entry.value}`);
+  const key = entry.value.toLowerCase();
+  if (entry.value !== key || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entry.value)) {
+    throw new Error(`Setup provider name must be lowercase kebab-case: '${entry.value}'`);
   }
-  registry.set(entry.value, entry);
+  if (registry.has(key)) throw new Error(`Setup provider already registered: ${key}`);
+  registry.set(key, entry);
 }
 
 export function getSetupProvider(name: string): SetupProviderEntry | undefined {

--- a/setup/providers/skill-descriptor.test.ts
+++ b/setup/providers/skill-descriptor.test.ts
@@ -1,0 +1,183 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { listSetupProviders } from './registry.js';
+import {
+  getInstallableProviderDescriptor,
+  getProviderDescriptor,
+  listInstallableProviderDescriptors,
+  listProviderDescriptors,
+  providerImagePolicy,
+} from './skill-descriptor.js';
+import './index.js'; // the real setup provider barrel — triggers self-registration
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('provider skill descriptors', () => {
+  it('derives the Codex setup offer and image policy from add-codex frontmatter', () => {
+    expect(getInstallableProviderDescriptor('CODEX')).toEqual({
+      value: 'codex',
+      label: 'Codex',
+      hint: 'OpenAI — ChatGPT subscription or API key',
+      installSkill: 'add-codex',
+      image: 'local-required',
+      offered: true,
+      skillDir: path.join('.claude', 'skills', 'add-codex'),
+    });
+    expect(listInstallableProviderDescriptors().map((entry) => entry.value)).toEqual(['codex']);
+    expect(providerImagePolicy('CODEX')).toBe('local-required');
+    expect(providerImagePolicy('claude')).toBe('hardened-compatible');
+    expect(providerImagePolicy('unknown-provider')).toBe('local-required');
+  });
+
+  it('offers exactly Codex on trunk and keeps OpenCode out of the setup picker', () => {
+    // The picker (setup/auto.ts askAgentProviderChoice) lists installed setup
+    // providers plus listInstallableProviderDescriptors(). OpenCode is a
+    // skill-only provider: hidden from the offer AND never registered with
+    // setup, so neither source can surface it.
+    expect(listInstallableProviderDescriptors().map((entry) => entry.value)).toEqual(['codex']);
+    const opencode = listProviderDescriptors().find((entry) => entry.value === 'opencode');
+    expect(opencode?.offered).toBe(false);
+    expect(getInstallableProviderDescriptor('opencode')).toBeUndefined();
+
+    const addOpencode = fs.readFileSync(path.join('.claude', 'skills', 'add-opencode', 'SKILL.md'), 'utf-8');
+    expect(addOpencode).not.toMatch(/^```nc:append to:setup\/providers\/index\.ts/m);
+    expect(addOpencode).not.toMatch(/^setup\/providers\/opencode\.ts$/m);
+  });
+
+  it('never surfaces a descriptor with offered false in the installable list', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-descriptor-'));
+    roots.push(root);
+    const dir = path.join(root, '.claude', 'skills', 'add-hidden');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      [
+        '---',
+        'name: add-hidden',
+        'description: hidden',
+        'metadata:',
+        '  nanoclaw-provider: hidden',
+        '  nanoclaw-provider-label: Hidden',
+        '  nanoclaw-provider-hint: skill-only',
+        "  nanoclaw-provider-offered: 'false'",
+        '  nanoclaw-provider-image: local-required',
+        '---',
+        '',
+      ].join('\n'),
+    );
+    expect(listProviderDescriptors(root).map((entry) => [entry.value, entry.offered])).toEqual([['hidden', false]]);
+    expect(listInstallableProviderDescriptors(root)).toEqual([]);
+    expect(getInstallableProviderDescriptor('hidden', root)).toBeUndefined();
+    // Hidden is not unknown: the image policy still comes from the descriptor.
+    expect(providerImagePolicy('hidden', root)).toBe('local-required');
+  });
+
+  it('rejects the retired install-skill key so stale frontmatter fails loudly', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-descriptor-'));
+    roots.push(root);
+    const dir = path.join(root, '.claude', 'skills', 'add-stale');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      [
+        '---',
+        'name: add-stale',
+        'description: stale',
+        'metadata:',
+        '  nanoclaw-provider: stale',
+        '  nanoclaw-provider-label: Stale',
+        '  nanoclaw-provider-hint: carries the retired key',
+        "  nanoclaw-provider-offered: 'true'",
+        '  nanoclaw-provider-install-skill: add-stale',
+        '  nanoclaw-provider-image: local-required',
+        '---',
+        '',
+      ].join('\n'),
+    );
+    expect(() => listProviderDescriptors(root)).toThrow(
+      'add-stale: nanoclaw-provider-install-skill is no longer read; remove it (the skill directory is the install skill)',
+    );
+  });
+
+  it('derives the install skill from the directory name, never from frontmatter', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-descriptor-'));
+    roots.push(root);
+    const dir = path.join(root, '.claude', 'skills', 'add-derived');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      [
+        '---',
+        'name: add-derived',
+        'description: derived',
+        'metadata:',
+        '  nanoclaw-provider: derived',
+        '  nanoclaw-provider-label: Derived',
+        '  nanoclaw-provider-hint: no install-skill key',
+        "  nanoclaw-provider-offered: 'true'",
+        '  nanoclaw-provider-image: hardened-compatible',
+        '---',
+        '',
+      ].join('\n'),
+    );
+    expect(getInstallableProviderDescriptor('derived', root)?.installSkill).toBe('add-derived');
+    expect(getInstallableProviderDescriptor('derived', root)?.skillDir).toBe(path.join('.claude', 'skills', 'add-derived'));
+  });
+
+  it('rejects incomplete provider metadata instead of offering a partial install', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-descriptor-'));
+    roots.push(root);
+    const dir = path.join(root, '.claude', 'skills', 'add-broken');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      '---\nname: add-broken\ndescription: broken\nmetadata:\n  nanoclaw-provider: broken\n---\n',
+    );
+    expect(() => listInstallableProviderDescriptors(root)).toThrow(/missing nanoclaw-provider-label/);
+  });
+
+  it('ignores malformed frontmatter that does not claim to describe a provider', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-descriptor-'));
+    roots.push(root);
+    const dir = path.join(root, '.claude', 'skills', 'unrelated');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: unrelated\ndescription: [broken\n');
+
+    expect(listInstallableProviderDescriptors(root)).toEqual([]);
+  });
+
+  it('still rejects malformed frontmatter that claims to describe a provider', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-descriptor-'));
+    roots.push(root);
+    const dir = path.join(root, '.claude', 'skills', 'add-broken');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nmetadata:\n  nanoclaw-provider: broken\n');
+
+    expect(() => listInstallableProviderDescriptors(root)).toThrow(/frontmatter is missing the closing/);
+  });
+});
+
+describe('setup entry and descriptor labels stay in sync', () => {
+  // A provider is labelled twice on purpose: the descriptor labels the offer
+  // before install (the entry does not exist yet), the registered
+  // SetupProviderEntry labels it after. Claude has no descriptor and an
+  // uninstalled provider has no entry, so on bare trunk no pair exists — the
+  // install-time verifier (scripts/provider-contract-verifier.ts) runs the
+  // setup/providers tests in the installed tree, where the pair exists and
+  // drift goes red.
+  it('every registered provider with a descriptor carries the same label and hint in both', () => {
+    for (const entry of listSetupProviders()) {
+      const descriptor = getProviderDescriptor(entry.value);
+      if (!descriptor) continue;
+      expect([entry.value, entry.label, entry.hint]).toEqual([entry.value, descriptor.label, descriptor.hint]);
+    }
+  });
+});

--- a/setup/providers/skill-descriptor.ts
+++ b/setup/providers/skill-descriptor.ts
@@ -1,0 +1,110 @@
+import fs from 'fs';
+import path from 'path';
+
+import { parse } from 'yaml';
+
+export interface InstallableProviderDescriptor {
+  value: string;
+  label: string;
+  hint: string;
+  installSkill: string;
+  image: 'local-required' | 'hardened-compatible';
+  offered: boolean;
+  skillDir: string;
+}
+
+const PREFIX = 'nanoclaw-provider-';
+
+/** Read setup offers from the audited provider skills already in this checkout. */
+export function listInstallableProviderDescriptors(projectRoot = process.cwd()): InstallableProviderDescriptor[] {
+  return listProviderDescriptors(projectRoot).filter((descriptor) => descriptor.offered);
+}
+
+/** Parse every provider descriptor, including intentionally hidden offers. */
+export function listProviderDescriptors(projectRoot = process.cwd()): InstallableProviderDescriptor[] {
+  const skillsRoot = path.join(projectRoot, '.claude', 'skills');
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(skillsRoot).sort();
+  } catch {
+    return [];
+  }
+
+  const descriptors: InstallableProviderDescriptor[] = [];
+  for (const entry of entries) {
+    const skillFile = path.join(skillsRoot, entry, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    const descriptor = parseProviderDescriptor(fs.readFileSync(skillFile, 'utf-8'), entry);
+    if (descriptor) descriptors.push({ ...descriptor, skillDir: path.join('.claude', 'skills', entry) });
+  }
+  return descriptors;
+}
+
+export function getInstallableProviderDescriptor(
+  provider: string,
+  projectRoot = process.cwd(),
+): InstallableProviderDescriptor | undefined {
+  return listInstallableProviderDescriptors(projectRoot).find((entry) => entry.value === provider.toLowerCase());
+}
+
+export function getProviderDescriptor(
+  provider: string,
+  projectRoot = process.cwd(),
+): InstallableProviderDescriptor | undefined {
+  return listProviderDescriptors(projectRoot).find((entry) => entry.value === provider.toLowerCase());
+}
+
+export function providerImagePolicy(
+  provider: string,
+  projectRoot = process.cwd(),
+): 'local-required' | 'hardened-compatible' {
+  const normalized = provider.toLowerCase();
+  return (
+    getProviderDescriptor(normalized, projectRoot)?.image ??
+    (normalized === 'claude' ? 'hardened-compatible' : 'local-required')
+  );
+}
+
+export function parseProviderDescriptor(
+  markdown: string,
+  directory: string,
+): Omit<InstallableProviderDescriptor, 'skillDir'> | undefined {
+  const lines = markdown.split('\n');
+  if (lines[0] !== '---') return undefined;
+  if (!/^\s*nanoclaw-provider\s*:/m.test(markdown)) return undefined;
+  const closing = lines.indexOf('---', 1);
+  if (closing === -1) throw new Error(`${directory}/SKILL.md frontmatter is missing the closing ---`);
+  const frontmatter = parse(lines.slice(1, closing).join('\n')) as { metadata?: Record<string, unknown> };
+  const metadata = frontmatter?.metadata;
+  const value = text(metadata?.[`${PREFIX.slice(0, -1)}`]);
+  if (!value) return undefined;
+
+  const label = required(metadata, 'label', directory);
+  const hint = required(metadata, 'hint', directory);
+  const offered = required(metadata, 'offered', directory);
+  const image = required(metadata, 'image', directory);
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) throw new Error(`${directory}: invalid provider '${value}'`);
+  if (offered !== 'true' && offered !== 'false') throw new Error(`${directory}: invalid offered value '${offered}'`);
+  // The install skill IS the directory the descriptor lives in — a separate key
+  // could only ever repeat it. Stale frontmatter fails loudly instead of being
+  // silently ignored.
+  if (metadata?.[`${PREFIX}install-skill`] !== undefined) {
+    throw new Error(
+      `${directory}: ${PREFIX}install-skill is no longer read; remove it (the skill directory is the install skill)`,
+    );
+  }
+  if (image !== 'local-required' && image !== 'hardened-compatible') {
+    throw new Error(`${directory}: invalid provider image policy '${image}'`);
+  }
+  return { value, label, hint, installSkill: directory, image, offered: offered === 'true' };
+}
+
+function required(metadata: Record<string, unknown> | undefined, key: string, directory: string): string {
+  const value = text(metadata?.[`${PREFIX}${key}`]);
+  if (!value) throw new Error(`${directory}: missing ${PREFIX}${key}`);
+  return value;
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Replace setup's hard-coded provider lists with skill-declared descriptors and add the install-time provider contract verifier. The verifier runs builds, typechecks, provider suites, conformance-file checks, and host/runtime inventory checks. Codex's install and removal skills adopt the new contract.

OpenCode keeps its existing install/removal payload and remains outside the setup picker. Its descriptor metadata is retained, but its contract adoption is deferred to #3722 (which requires #3588). Combined-provider CI requires exactly OpenCode to remain undeclared and rejects a missing Codex contract. This allows the core stack to land before OpenCode or Cursor.

Merge order: #3584 → #3581 → #3585 → #3727 → #3592 → #3586. OpenCode (#3588 and #3722) and Cursor remain deferred. This PR is based on #3592 and installs contracts only after the instruction and speed declarations exist. Registry-dependent checks must pass against the promoted Codex payload before merging.

Validation: exact core `9d9d0df8deb5ca0e5c3278af7f1841152e54ac3f` with Codex payload `43d693b0388e95fbe70e77ec848b9e03f2340a14` passed combined install/refresh, builds, typecheck, provider suites, conformance and inventory. The final core with pre-contract providers and provider refresh on the old core plus all four intermediate core commits also passed. The final core tree is unchanged by this reorder. Earlier install/remove/reinstall and focused tests remain applicable.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
