### PR TITLE
refactor(providers): implement the opencode provider contract

### DIFF
--- a/container/agent-runner/src/provider-contracts/opencode.ts
+++ b/container/agent-runner/src/provider-contracts/opencode.ts
@@ -1,8 +1,14 @@
-import { mcpServersToOpenCodeConfig } from '../providers/mcp-to-opencode.js';
-import { OPENCODE_PERMISSION_POLICY } from '../providers/opencode.js';
+import {
+  OPENCODE_EXECUTION_POLICY,
+  resolveOpenCodeInference,
+  resolveOpenCodeMcpServers,
+  resolveOpenCodeMemory,
+} from '../providers/opencode.js';
 import { registerProviderContract } from '../providers/provider-registry.js';
+
 import type { ProviderRuntimeContract } from './registry.js';
 
+const provider = 'opencode';
 // Pinned literal, not the core's constant: a core seam bump must fail this
 // payload's version check until the payload is refreshed to match.
 const RUNTIME_SEAM_VERSION = 1;
@@ -10,13 +16,30 @@ const RUNTIME_SEAM_VERSION = 1;
 export const opencodeRuntimeContract: ProviderRuntimeContract = {
   seamVersion: RUNTIME_SEAM_VERSION,
   configuration: {
-    executionPolicy: { constant: OPENCODE_PERMISSION_POLICY },
-    mcpServers: mcpServersToOpenCodeConfig,
+    // The stance is fixed — the container and the OneCLI allow-list are the
+    // boundary — so it is declared as the constant it is.
+    executionPolicy: { constant: OPENCODE_EXECUTION_POLICY },
+    // OpenCode selects its model through the OPENCODE_* environment the host
+    // provisions, so the core input's `model` and `speed` have no effect on
+    // it — only `effort` does, and only for a model the emitted config
+    // registers itself (any provider but `anthropic`). The conformance suite's
+    // default probes vary `model` alone, which this provider ignores, so
+    // providers/opencode.conformance.test.ts supplies fixtures that vary
+    // effort under an environment where it is observable.
+    inference: resolveOpenCodeInference,
+    // OpenCode has no native session-start hook file; the provider runs the
+    // hook command itself when a context window is built, so the capability
+    // derives how that run happens from the hook core registers.
+    memory: resolveOpenCodeMemory,
+    mcpServers: resolveOpenCodeMcpServers,
   },
+  // OpenCode persists and compacts its own session history under
+  // XDG_DATA_HOME: core writes no runtime files for it (the config travels in
+  // OPENCODE_CONFIG_CONTENT), archives nothing, and rotates nothing.
   textDelivery: 'result',
   commands: { formatting: 'xml' },
 };
 
 // Two-step registration: providers/opencode.ts registered the factory; this
 // attaches the contract. Order-independent, and neither file imports the other.
-registerProviderContract('opencode', opencodeRuntimeContract);
+registerProviderContract(provider, opencodeRuntimeContract);

--- a/container/agent-runner/src/providers/opencode.conformance.test.ts
+++ b/container/agent-runner/src/providers/opencode.conformance.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Runtime-contract conformance for the opencode payload, run through the
+ * core's own reusable suite (provider-contracts/testing/conformance.ts):
+ * registered contract identity, factory construction, contract shape, and
+ * live configuration probes.
+ *
+ * The suite exists only on the contract core. On the standalone providers
+ * branch and on a pre-contract install the file is absent, so this skips
+ * there. The contract modules are loaded dynamically for the same reason: a
+ * static import would fail to resolve where the core does not carry them.
+ */
+import fs from 'fs';
+import { describe, it } from 'bun:test';
+
+const CONFORMANCE_SUITE = '../provider-contracts/testing/conformance.ts';
+const hasContractCore = fs.existsSync(new URL(CONFORMANCE_SUITE, import.meta.url));
+
+if (hasContractCore) {
+  await import('./index.js');
+  await import('../provider-contracts/index.js');
+  const { opencodeRuntimeContract } = await import('../provider-contracts/opencode.js');
+  const { defineProviderConformance } = await import('../provider-contracts/testing/conformance.js');
+  defineProviderConformance('opencode', opencodeRuntimeContract, {
+    probes: {
+      // OpenCode selects its model through the OPENCODE_* environment the host
+      // provisions, so the suite's default probes (which vary `model` alone)
+      // cannot exercise the inference capability. Only `effort` responds to
+      // the core input, and only for a model the emitted config registers
+      // itself (any provider but `anthropic`), so probe under that environment.
+      inference: {
+        a: { effort: 'low' },
+        b: { effort: 'high' },
+        environment: { OPENCODE_PROVIDER: 'openai', OPENCODE_MODEL: 'openai/nanoclaw-probe-model' },
+      },
+    },
+  });
+} else {
+  describe.skip('runtime provider contract: opencode', () => {
+    it('needs the contract core', () => {});
+  });
+}

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -11,8 +11,15 @@ import { createOpencodeClient, type FilePartInput, type OpencodeClient } from '@
 import { createOpencodeClient as createOpencodeQuestionClient } from '@opencode-ai/sdk/v2';
 
 import { registerProvider } from './provider-registry.js';
-import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
-import { mcpServersToOpenCodeConfig } from './mcp-to-opencode.js';
+import type {
+  AgentProvider,
+  AgentQuery,
+  McpServerConfig,
+  ProviderEvent,
+  ProviderOptions,
+  QueryInput,
+} from './types.js';
+import { mcpServersToOpenCodeConfig, type OpenCodeMcpEntry } from './mcp-to-opencode.js';
 import { getAllDestinations } from '../destinations.js';
 
 function log(msg: string): void {
@@ -266,16 +273,39 @@ function parseLimitEnv(varName: string, raw: string | undefined): number | undef
   return Number(trimmed);
 }
 
-export function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> {
-  const provider = process.env.OPENCODE_PROVIDER || 'anthropic';
-  const model = process.env.OPENCODE_MODEL;
-  const smallModel = process.env.OPENCODE_SMALL_MODEL;
-  // Reasoning effort from the group's container config (ncl groups config
-  // update --effort). OpenCode forwards a free-form per-model `options` object
-  // to the ai-sdk provider, which maps reasoningEffort onto reasoning_effort in
-  // the request body.
-  const effort = options.effort;
-  const proxyUrl = process.env.ANTHROPIC_BASE_URL;
+/** The inference-selection section of the OpenCode config (see resolveOpenCodeInference). */
+export interface OpenCodeInferenceConfig {
+  model?: string;
+  smallModel?: string;
+  enabledProviders: string[];
+  providerOptions: Record<string, unknown>;
+}
+
+/**
+ * Inference selection: which provider and model OpenCode talks to, and how
+ * hard it reasons. Pure — it reads only its arguments — so the runtime
+ * contract declares it as the `inference` capability and core runs it.
+ *
+ * Model identity comes from the OPENCODE_* environment the host provisions.
+ * The group's container config (`ncl groups config update --effort`, the core
+ * `inference` input) steers reasoning effort only: OpenCode forwards a
+ * free-form per-model `options` object to the ai-sdk provider, which maps
+ * reasoningEffort onto reasoning_effort in the request body.
+ *
+ * The core input's `model` and `speed` members have NO effect for OpenCode:
+ * the model is OPENCODE_MODEL, and OpenCode has no serving-tier switch to map
+ * `speed` onto. Only `effort` varies the output, and only for a model the
+ * emitted config registers itself (every provider except `anthropic`).
+ */
+export function resolveOpenCodeInference(
+  input: { model?: string; effort?: string; speed?: string },
+  environment: NodeJS.ProcessEnv,
+): OpenCodeInferenceConfig {
+  const provider = environment.OPENCODE_PROVIDER || 'anthropic';
+  const model = environment.OPENCODE_MODEL;
+  const smallModel = environment.OPENCODE_SMALL_MODEL;
+  const effort = input.effort;
+  const proxyUrl = environment.ANTHROPIC_BASE_URL;
 
   const providerModelId = model ? model.replace(new RegExp(`^${provider}/`), '') : undefined;
   const providerSmallModelId = smallModel ? smallModel.replace(new RegExp(`^${provider}/`), '') : undefined;
@@ -287,8 +317,8 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
   // Undeclared custom models resolve limit.context to 0, which silently disables
   // compaction and kills long sessions against a fixed-window backend (e.g. vLLM).
   // Absent these env vars, behavior is unchanged (no `limit` key emitted).
-  const contextLimitEnv = process.env.OPENCODE_MODEL_CONTEXT_LIMIT;
-  const outputLimitEnv = process.env.OPENCODE_MODEL_OUTPUT_LIMIT;
+  const contextLimitEnv = environment.OPENCODE_MODEL_CONTEXT_LIMIT;
+  const outputLimitEnv = environment.OPENCODE_MODEL_OUTPUT_LIMIT;
   const contextLimit = parseLimitEnv('OPENCODE_MODEL_CONTEXT_LIMIT', contextLimitEnv);
   const outputLimit = parseLimitEnv('OPENCODE_MODEL_OUTPUT_LIMIT', outputLimitEnv);
   if (outputLimitEnv !== undefined && contextLimit === undefined) {
@@ -311,7 +341,7 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
   // `attachment` is a registry/UI flag rather than a pipeline gate, but it is
   // set alongside so the entry stays internally consistent.
   // Absent this env var, behavior is unchanged (no capability keys emitted).
-  const modalityEnv = process.env.OPENCODE_MODEL_INPUT_MODALITIES;
+  const modalityEnv = environment.OPENCODE_MODEL_INPUT_MODALITIES;
   const requestedModalities = (modalityEnv ?? '')
     .split(',')
     .map((entry) => entry.trim().toLowerCase())
@@ -371,7 +401,62 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
           },
         };
 
-  const mcp = mcpServersToOpenCodeConfig(options.mcpServers);
+  return { model, smallModel, enabledProviders: [provider], providerOptions };
+}
+
+/**
+ * Execution policy: the container and the OneCLI allow-list are the security
+ * boundary, so every tool category OpenCode knows stays allowed — except the
+ * interactive `question` tool — and OpenCode's self-update and snapshot
+ * machinery stay off. A fixed stance, so the runtime contract states it as a
+ * value rather than a resolve of anything.
+ *
+ * A flat `permission: 'allow'` string leaves every category — including
+ * `question`, OpenCode's built-in interactive multi-choice tool — to
+ * whatever OpenCode's own default/merge resolves it to. Server logs from
+ * a live session showed that resolution land on BOTH `question -> deny *`
+ * and `question -> allow *` for the same session: internally
+ * contradictory, and whichever rule wins last, `allow` sometimes does —
+ * and a headless container has no human to answer an interactive
+ * question, so any path that lets it fire wedges the session forever
+ * (see OpenCodeProvider's question.asked handling below for the runtime
+ * belt-and-suspenders). Enumerate every known permission category
+ * explicitly instead of relying on the wildcard string, so `question`
+ * resolves to a single deterministic value — `deny` — that can never
+ * contradict itself, while every other category keeps the prior
+ * "allow everything" behavior.
+ * A category OpenCode adds after this list was written is absent from it,
+ * and so resolves to OpenCode's own default rather than to `allow`.
+ */
+export const OPENCODE_EXECUTION_POLICY = {
+  permission: OPENCODE_PERMISSION_POLICY,
+  autoupdate: false,
+  snapshot: false,
+} as const;
+
+export type OpenCodeExecutionPolicy = typeof OPENCODE_EXECUTION_POLICY;
+
+/** MCP wiring: NanoClaw's server map translated into OpenCode's local/remote `mcp` entries. */
+export function resolveOpenCodeMcpServers(
+  input: Record<string, McpServerConfig> | undefined,
+  _environment?: NodeJS.ProcessEnv,
+): Record<string, OpenCodeMcpEntry> {
+  return mcpServersToOpenCodeConfig(input);
+}
+
+/** The config sections the runtime contract declares, resolved. */
+export interface OpenCodeConfigSections {
+  inference: OpenCodeInferenceConfig;
+  executionPolicy: OpenCodeExecutionPolicy;
+  mcp: Record<string, OpenCodeMcpEntry>;
+}
+
+/**
+ * Assemble the OPENCODE_CONFIG_CONTENT document from its resolved sections.
+ * The key order and the conditional keys here ARE the emitted JSON's layout.
+ */
+export function assembleOpenCodeConfig(sections: OpenCodeConfigSections): Record<string, unknown> {
+  const { inference, executionPolicy, mcp } = sections;
 
   // Named explicitly rather than left to the cwd walk: OpenCode takes the
   // FIRST of AGENTS.md, CLAUDE.md, CONTEXT.md it finds and stops, so a stale
@@ -389,32 +474,36 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
   const instructions = [`${AGENT_DIR}/CLAUDE.md`, `${AGENT_DIR}/CLAUDE.local.md`];
 
   return {
-    ...(model ? { model } : {}),
-    ...(smallModel ? { small_model: smallModel } : {}),
-    enabled_providers: [provider],
-    // A flat `permission: 'allow'` string leaves every category — including
-    // `question`, OpenCode's built-in interactive multi-choice tool — to
-    // whatever OpenCode's own default/merge resolves it to. Server logs from
-    // a live session showed that resolution land on BOTH `question -> deny *`
-    // and `question -> allow *` for the same session: internally
-    // contradictory, and whichever rule wins last, `allow` sometimes does —
-    // and a headless container has no human to answer an interactive
-    // question, so any path that lets it fire wedges the session forever
-    // (see OpenCodeProvider's question.asked handling below for the runtime
-    // belt-and-suspenders). Enumerate every known permission category
-    // explicitly instead of relying on the wildcard string, so `question`
-    // resolves to a single deterministic value — `deny` — that can never
-    // contradict itself, while every other category keeps the prior
-    // "allow everything" behavior.
-    // A category OpenCode adds after this list was written is absent from it,
-    // and so resolves to OpenCode's own default rather than to `allow`.
-    permission: OPENCODE_PERMISSION_POLICY,
-    autoupdate: false,
-    snapshot: false,
-    provider: providerOptions,
+    ...(inference.model ? { model: inference.model } : {}),
+    ...(inference.smallModel ? { small_model: inference.smallModel } : {}),
+    enabled_providers: inference.enabledProviders,
+    permission: executionPolicy.permission,
+    autoupdate: executionPolicy.autoupdate,
+    snapshot: executionPolicy.snapshot,
+    provider: inference.providerOptions,
     instructions,
     mcp,
   };
+}
+
+/**
+ * Build the OpenCode config for one provider instance. `resolved` carries the
+ * sections a contract core already resolved through the runtime contract and
+ * handed to the factory — those are consumed as-is. Any section not handed
+ * over is resolved here from the very functions the contract declares, which
+ * is every section on a pre-contract core. Both paths land on the same bytes.
+ */
+export function buildOpenCodeConfig(
+  options: ProviderOptions,
+  environment: NodeJS.ProcessEnv = process.env,
+  resolved: Partial<OpenCodeConfigSections> = {},
+): Record<string, unknown> {
+  return assembleOpenCodeConfig({
+    inference:
+      resolved.inference ?? resolveOpenCodeInference({ model: options.model, effort: options.effort }, environment),
+    executionPolicy: resolved.executionPolicy ?? OPENCODE_EXECUTION_POLICY,
+    mcp: resolved.mcp ?? resolveOpenCodeMcpServers(options.mcpServers, environment),
+  });
 }
 
 type SharedRuntime = {
@@ -438,7 +527,10 @@ function runtimeConfigKey(options: ProviderOptions): string {
   });
 }
 
-async function ensureSharedRuntime(options: ProviderOptions): Promise<SharedRuntime> {
+async function ensureSharedRuntime(
+  options: ProviderOptions,
+  resolved: Partial<OpenCodeConfigSections> = {},
+): Promise<SharedRuntime> {
   const key = runtimeConfigKey(options);
   if (sharedRuntime && sharedConfigKey === key) return sharedRuntime;
 
@@ -448,7 +540,7 @@ async function ensureSharedRuntime(options: ProviderOptions): Promise<SharedRunt
     if (sharedRuntime) {
       destroySharedRuntime();
     }
-    const config = buildOpenCodeConfig(options);
+    const config = buildOpenCodeConfig(options, process.env, resolved);
     const { url, proc } = await spawnOpencodeServer(config);
     const client = createOpencodeClient({ baseUrl: url });
     const questionClient = createOpencodeQuestionClient({ baseUrl: url });
@@ -593,6 +685,32 @@ export type OpenCodeMemorySource = 'startup' | 'compact';
 const MEMORY_HOOK_TIMEOUT_MS = 10_000;
 
 /**
+ * How the registered memory session hook is run: the command, the lifecycle
+ * sources it serves, and the per-run timeout. This is the `memory` capability
+ * the runtime contract declares. OpenCode has no native session-start hook
+ * file to write the command into (Claude's settings.json, Codex's hooks.json),
+ * so the provider executes this itself at the moments a context window is
+ * built — see createMemoryLifecycle. Pure: derived from the registration alone.
+ */
+export interface OpenCodeMemoryHookRun {
+  readonly command: string;
+  readonly sources: readonly string[];
+  readonly timeoutMs: number;
+}
+
+export function resolveOpenCodeMemory(
+  hook: OpenCodeMemorySessionHook,
+  _environment?: NodeJS.ProcessEnv,
+): OpenCodeMemoryHookRun {
+  return { command: hook.command, sources: hook.sources, timeoutMs: MEMORY_HOOK_TIMEOUT_MS };
+}
+
+/** A contract core hands over the resolved run; a bare registration resolves here. */
+function memoryHookRun(hook: OpenCodeMemorySessionHook | OpenCodeMemoryHookRun): OpenCodeMemoryHookRun {
+  return 'timeoutMs' in hook ? hook : resolveOpenCodeMemory(hook, process.env);
+}
+
+/**
  * Run the registered memory session hook and return what it printed.
  *
  * The hook reads a Claude-style SessionStart payload on stdin and prints the
@@ -605,24 +723,25 @@ const MEMORY_HOOK_TIMEOUT_MS = 10_000;
  * one log line, no injection, never a thrown turn.
  */
 export function runMemorySessionHook(
-  hook: OpenCodeMemorySessionHook | undefined,
+  hook: OpenCodeMemorySessionHook | OpenCodeMemoryHookRun | undefined,
   source: OpenCodeMemorySource,
 ): string | undefined {
   if (!hook) {
     log(`No memory session hook registered; skipping ${source} memory injection`);
     return undefined;
   }
-  if (!hook.sources.includes(source)) {
+  const run = memoryHookRun(hook);
+  if (!run.sources.includes(source)) {
     log(`Memory session hook does not declare source ${source}; skipping injection`);
     return undefined;
   }
 
   try {
-    const res = spawnSync(hook.command, {
+    const res = spawnSync(run.command, {
       shell: true,
       input: JSON.stringify({ hook_event_name: 'SessionStart', source }),
       encoding: 'utf-8',
-      timeout: MEMORY_HOOK_TIMEOUT_MS,
+      timeout: run.timeoutMs,
     });
     if (res.error || res.status !== 0) {
       const why = res.error ? res.error.message : `exit ${String(res.status)}`;
@@ -658,7 +777,7 @@ export function runMemorySessionHook(
  * memory rides the same exactly-once next-prompt slot as the routing reminder.
  */
 export function createMemoryLifecycle(
-  hook: OpenCodeMemorySessionHook | undefined,
+  hook: OpenCodeMemorySessionHook | OpenCodeMemoryHookRun | undefined,
   isResume: boolean,
 ): {
   openingInstructions(systemInstructions?: string): string | undefined;
@@ -840,25 +959,59 @@ export async function drainPendingQuestions(
   }
 }
 
+/**
+ * Structural mirror of the contract core's `ResolvedRuntimeConfiguration` —
+ * what `createProvider` hands the factory after running the contract's
+ * configuration resolves. Mirrored, not imported: the type lives in
+ * `provider-contracts/registry.ts`, which a pre-contract core does not have.
+ */
+export interface OpenCodeResolvedConfiguration {
+  executionPolicy?: unknown;
+  inference?: unknown;
+  mcpServers?: unknown;
+}
+
 export class OpenCodeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
   private readonly options: ProviderOptions;
   private readonly runtime?: OpenCodeRuntimeDeps;
+  /** Config sections a contract core resolved for this instance; empty on a pre-contract core. */
+  private readonly resolved: Partial<OpenCodeConfigSections>;
   private activeSessionId: string | undefined;
-  private memorySessionHook?: OpenCodeMemorySessionHook;
+  private memorySessionHook?: OpenCodeMemoryHookRun;
 
-  constructor(options: ProviderOptions = {}, runtime?: OpenCodeRuntimeDeps) {
+  /**
+   * `configuration` is present on a contract core: core has already run the
+   * contract's resolves and hands the results over, so they are consumed
+   * as-is. Without it (a pre-contract core) buildOpenCodeConfig derives the
+   * same sections itself, exactly as it always did.
+   */
+  constructor(
+    options: ProviderOptions = {},
+    runtime?: OpenCodeRuntimeDeps,
+    configuration?: OpenCodeResolvedConfiguration,
+  ) {
     this.options = options;
     this.runtime = runtime;
+    this.resolved = configuration
+      ? {
+          inference: configuration.inference as OpenCodeInferenceConfig | undefined,
+          executionPolicy: configuration.executionPolicy as OpenCodeExecutionPolicy | undefined,
+          mcp: configuration.mcpServers as Record<string, OpenCodeMcpEntry> | undefined,
+        }
+      : {};
   }
 
   // OpenCode has no native session-start hook mechanism to hand the command to
   // (as the Claude Agent SDK's settings.json and Codex's hooks.json have), so
-  // the provider stores the registration and runs the command itself at the
-  // lifecycle points OpenCode does expose — see createMemoryLifecycle.
-  registerMemorySessionHook(hook: OpenCodeMemorySessionHook): void {
-    this.memorySessionHook = hook;
+  // the provider stores how the hook runs and runs the command itself at the
+  // lifecycle points OpenCode does expose — see createMemoryLifecycle. A
+  // contract core resolves that (`memory`) through the runtime contract and
+  // passes it as the second argument; a pre-contract core passes only the
+  // registration, which resolves to the same run here.
+  registerMemorySessionHook(hook: OpenCodeMemorySessionHook, memory?: unknown): void {
+    this.memorySessionHook = (memory as OpenCodeMemoryHookRun | undefined) ?? resolveOpenCodeMemory(hook, process.env);
   }
 
   isSessionInvalid(err: unknown): boolean {
@@ -921,7 +1074,9 @@ export class OpenCodeProvider implements AgentProvider {
 
     async function* gen(): AsyncGenerator<ProviderEvent> {
       let initYielded = false;
-      const rt = self.runtime ? await self.runtime.getRuntime(self.options) : await ensureSharedRuntime(self.options);
+      const rt = self.runtime
+        ? await self.runtime.getRuntime(self.options)
+        : await ensureSharedRuntime(self.options, self.resolved);
       const { client, stream, questionClient } = rt;
 
       while (!aborted) {
@@ -1187,5 +1342,10 @@ export class OpenCodeProvider implements AgentProvider {
 }
 
 // Function-form registration only; the runtime contract attaches itself from
-// provider-contracts/opencode.ts, so this module compiles on either core.
-registerProvider('opencode', (opts) => new OpenCodeProvider(opts));
+// provider-contracts/opencode.ts, so this module compiles on either core. A
+// contract core passes the resolved configuration as the second argument; a
+// pre-contract core calls with the options alone.
+registerProvider(
+  'opencode',
+  (opts, configuration?: OpenCodeResolvedConfiguration) => new OpenCodeProvider(opts, undefined, configuration),
+);

--- a/src/provider-contracts/opencode.ts
+++ b/src/provider-contracts/opencode.ts
@@ -1,10 +1,41 @@
 import { CLAUDE_COMPATIBLE_HOST_SURFACES } from './claude.js';
 import { registerProviderHostContract } from './registry.js';
 
+// Pinned literal, not the core's constant: a core seam bump must fail this
+// payload's version check until the payload is refreshed to match.
 const HOST_SEAM_VERSION = 1;
 
+// OpenCode reads the Claude document plane exactly as the legacy path mounted
+// it: the composed CLAUDE.md (canonical instructions, no provider facts), the
+// group's .claude-shared home with its skills and settings.json, all under the
+// same container paths.
 registerProviderHostContract('opencode', {
   seamVersion: HOST_SEAM_VERSION,
-  ...CLAUDE_COMPATIBLE_HOST_SURFACES,
+  projectDocument: CLAUDE_COMPATIBLE_HOST_SURFACES.projectDocument,
+  stateVolumes: [
+    ...CLAUDE_COMPATIBLE_HOST_SURFACES.stateVolumes,
+    // `opencode serve` keeps its state under XDG_DATA_HOME, pinned by the
+    // legacy adapter's env to /opencode-xdg — the per-session directory the
+    // adapter used to mkdir and mount itself.
+    {
+      id: 'opencode-xdg',
+      directory: 'opencode-xdg',
+      containerPath: '/opencode-xdg',
+      scope: 'session',
+      mode: 'rw',
+      mountClass: 'allowlisted-extra',
+    },
+  ],
+  skillBackings: CLAUDE_COMPATIBLE_HOST_SURFACES.skillBackings,
+  skillViews: CLAUDE_COMPATIBLE_HOST_SURFACES.skillViews,
+  // The inherited settings.json is Claude's file, so its reconciliation keeps
+  // reporting as Claude settings — the same log line the legacy path wrote.
+  files: CLAUDE_COMPATIBLE_HOST_SURFACES.files.map((file) => ({
+    ...file,
+    ...(file.reconcile === undefined ? {} : { reconcile: { ...file.reconcile, transformerProvider: 'claude' } }),
+  })),
+  // The adapter in src/providers/opencode.ts still contributes the env
+  // (XDG_DATA_HOME, NO_PROXY, the OPENCODE_* passthrough); core realizes the
+  // volume above and tells the adapter so through coreOwnsProviderSurfaces.
   legacyHostAdapter: 'required',
 });

--- a/src/providers/opencode-registration.test.ts
+++ b/src/providers/opencode-registration.test.ts
@@ -14,14 +14,145 @@
  * A provider is a MULTI-POINT integration: this guards the HOST barrel; the CONTAINER
  * barrel is guarded by the sibling bun test; the SDK/CLI dependency + Dockerfile install
  * are guarded by the build/container legs (see the skill's validate step).
+ *
+ * The contribution tests below drive the REAL registered adapter against the real
+ * buildMounts on either core generation: on a pre-contract core the adapter creates and
+ * mounts the per-session XDG directory itself; on the contract core it hands over only
+ * env and core realizes the declared surfaces — the same paths, once.
  */
-import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { listProviderContainerConfigNames } from './provider-container-registry.js';
+const TEST_ROOT = '/tmp/nanoclaw-opencode-host-contribution-test';
+const DATA_DIR = path.join(TEST_ROOT, 'data');
+const GROUPS_DIR = path.join(TEST_ROOT, 'groups');
+const newCoreIt = fs.existsSync(path.join(process.cwd(), 'src/provider-contracts/realize.ts')) ? it : it.skip;
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  DATA_DIR: '/tmp/nanoclaw-opencode-host-contribution-test/data',
+  GROUPS_DIR: '/tmp/nanoclaw-opencode-host-contribution-test/groups',
+}));
+
+import { buildMounts } from '../container-runner.js';
+import type { ContainerConfig } from '../container-config.js';
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../db/index.js';
+import { ensureContainerConfig } from '../db/container-configs.js';
+import { initGroupFilesystem } from '../group-init.js';
+import type { AgentGroup, Session } from '../types.js';
+import { getProviderContainerConfig, listProviderContainerConfigNames } from './provider-container-registry.js';
 import './index.js'; // the real host provider barrel — triggers each provider's self-registration
 
+function group(): AgentGroup {
+  return {
+    id: 'ag-opencode',
+    name: 'OpenCode',
+    folder: 'opencode-group',
+    agent_provider: null,
+    created_at: new Date().toISOString(),
+  } as AgentGroup;
+}
+
+const CONFIG: ContainerConfig = {
+  provider: 'opencode',
+  mcpServers: {},
+  packages: { apt: [], npm: [] },
+  additionalMounts: [],
+  skills: [],
+};
+
+const SURFACE_PATHS = ['/workspace/agent/CLAUDE.md', '/home/node/.claude', '/opencode-xdg'];
+
 describe('opencode provider host registration', () => {
+  beforeEach(async () => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.mkdirSync(GROUPS_DIR, { recursive: true });
+    await runMigrations(await initTestDb());
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
   it('registers opencode host container-config via the barrel', () => {
     expect(listProviderContainerConfigNames()).toContain('opencode');
+  });
+
+  it('creates and mounts the XDG dir itself, unless core says it owns the surfaces', async () => {
+    const adapter = getProviderContainerConfig('opencode')!;
+    const sessionDir = path.join(DATA_DIR, 'v2-sessions', 'group-1', 'session-1');
+    const base = {
+      sessionDir,
+      agentGroupId: 'group-1',
+      groupDir: path.join(GROUPS_DIR, 'group'),
+      selectedSkills: [],
+      hostEnv: {},
+    };
+
+    const legacy = await adapter(base);
+    expect(legacy.mounts).toEqual([
+      { hostPath: path.join(sessionDir, 'opencode-xdg'), containerPath: '/opencode-xdg', readonly: false },
+    ]);
+    expect(fs.existsSync(path.join(sessionDir, 'opencode-xdg'))).toBe(true);
+    expect(legacy.env).toMatchObject({ XDG_DATA_HOME: '/opencode-xdg' });
+
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+    // Built as a variable, not an inline literal: a pre-contract core's context
+    // type has no coreOwnsProviderSurfaces member, and this file compiles there too.
+    const declaredContext = { ...base, coreOwnsProviderSurfaces: true as const };
+    const declared = await adapter(declaredContext);
+    expect(declared.mounts).toEqual([]);
+    expect(declared.env).toEqual(legacy.env);
+    expect(fs.existsSync(path.join(sessionDir, 'opencode-xdg'))).toBe(false);
+  });
+
+  newCoreIt('lets the contract core realize the Claude document plane plus the XDG volume', async () => {
+    const ag = group();
+    const groupDir = path.join(GROUPS_DIR, ag.folder);
+    const session = { id: 'session-1', agent_group_id: ag.id } as Session;
+    const sessionDir = path.join(DATA_DIR, 'v2-sessions', ag.id, session.id);
+    await createAgentGroup(ag);
+    await ensureContainerConfig(ag.id, 'opencode');
+    await initGroupFilesystem(ag, { provider: 'opencode' });
+
+    // What resolveProviderContribution hands the adapter on a contract core.
+    const declaredContext = {
+      sessionDir,
+      agentGroupId: ag.id,
+      groupDir,
+      selectedSkills: [],
+      hostEnv: {},
+      coreOwnsProviderSurfaces: true as const,
+    };
+    const contribution = await getProviderContainerConfig('opencode')!(declaredContext);
+    expect(contribution.mounts ?? []).toEqual([]);
+    expect(fs.existsSync(path.join(sessionDir, 'opencode-xdg'))).toBe(false);
+
+    const mounts = await buildMounts(ag, session, CONFIG, 'opencode', contribution);
+
+    expect(
+      mounts
+        .filter((mount) => SURFACE_PATHS.includes(mount.containerPath))
+        .map(({ containerPath, hostPath, readonly }) => ({ containerPath, hostPath, readonly })),
+    ).toEqual([
+      { containerPath: '/workspace/agent/CLAUDE.md', hostPath: path.join(groupDir, 'CLAUDE.md'), readonly: true },
+      {
+        containerPath: '/home/node/.claude',
+        hostPath: path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared'),
+        readonly: false,
+      },
+      { containerPath: '/opencode-xdg', hostPath: path.join(sessionDir, 'opencode-xdg'), readonly: false },
+    ]);
+    // Core created the volume the adapter no longer creates.
+    expect(fs.existsSync(path.join(sessionDir, 'opencode-xdg'))).toBe(true);
+    expect(fs.existsSync(path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'settings.json'))).toBe(true);
+    expect(contribution.env).toMatchObject({
+      XDG_DATA_HOME: '/opencode-xdg',
+      NO_PROXY: '127.0.0.1,localhost',
+      no_proxy: '127.0.0.1,localhost',
+    });
   });
 });

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -40,8 +40,9 @@ function mergeNoProxy(current: string | undefined, additions: string): string {
 }
 
 registerProviderContainerConfig('opencode', (ctx) => {
+  const coreOwnsProviderSurfaces = (ctx as typeof ctx & { coreOwnsProviderSurfaces?: true }).coreOwnsProviderSurfaces;
   const opencodeDir = path.join(ctx.sessionDir, 'opencode-xdg');
-  fs.mkdirSync(opencodeDir, { recursive: true });
+  if (!coreOwnsProviderSurfaces) fs.mkdirSync(opencodeDir, { recursive: true });
 
   const env: Record<string, string> = {
     XDG_DATA_HOME: '/opencode-xdg',
@@ -60,7 +61,9 @@ registerProviderContainerConfig('opencode', (ctx) => {
   }
 
   return {
-    mounts: [{ hostPath: opencodeDir, containerPath: '/opencode-xdg', readonly: false }],
+    mounts: coreOwnsProviderSurfaces
+      ? []
+      : [{ hostPath: opencodeDir, containerPath: '/opencode-xdg', readonly: false }],
     env,
   };
 });


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Binds the OpenCode payload to the enforced provider contracts with byte-identical output.

- **Runtime contract**: pure resolvers for execution policy (constant), inference, MCP servers, and the memory session-hook run; `buildOpenCodeConfig` is assembled from exactly those, so the contract declares the functions the live path uses. Core-resolved values are consumed when present; the pre-contract path computes the same values.
- **Inference probe**: model selection is environment-provisioned, so the probe varies reasoning effort under a fixed environment. Those fixtures are passed to `defineProviderConformance` in `opencode.conformance.test.ts`, not carried on the contract; the contract states that core's `model` and `speed` inputs have no effect for OpenCode.
- **Two-step registration**: `provider-contracts/opencode.ts` registers the contract; the provider module registers only its factory.
- **Host contract**: Claude document plane (canonical instructions) plus the per-session `opencode-xdg` volume; the legacy adapter still contributes environment and skips its own mkdir/mount when core owns the surfaces.
- **Setup**: nothing registered — OpenCode stays skill-only with no wizard offer.
- **Self-verification**: `opencode.conformance.test.ts` runs the exported conformance suite (skipped where absent).

## Related work

Top layer of the payload stack, on nanocoai/nanoclaw#3584. Deferred: #3584 can merge independently. Merge this PR only when the OpenCode work is ready, before its install skill in #3722. This amendment only restacks the unchanged OpenCode patch.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

Installed together with the Codex payload on the core stack head:
- `pnpm run build`, host and container typecheck -> clean
- `pnpm test` -> 2,319 passed, 4 skipped
- `cd container/agent-runner && bun test` -> 551 passed, 1 skipped
- `provider-contract-verifier.ts --required-declared codex,opencode` -> passed, including `runtime conformance test files`
- `scripts/test-registry-skills.ts --combined-providers` -> PASS

Installed on `main`: build and container typecheck clean; `vitest run src/providers` -> 8 passed, 3 skipped; `bun test src/providers` -> 165 passed.

Parity vs the previous payload: emitted config JSON for Anthropic, OpenAI, OpenRouter, DeepSeek, and Zen shapes, the XDG path, mounts, environment, and the memory-hook command -> identical bytes.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

## Security and trust boundaries

None new. No dependency changes.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
