### PR TITLE
feat(groups): add a core-owned speed inference property

### DIFF
--- a/container/agent-runner/src/config.test.ts
+++ b/container/agent-runner/src/config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+
+import { runnerConfigFromRaw } from './config.js';
+
+describe('runner config speed', () => {
+  it('reads speed from a host that writes it', () => {
+    expect(runnerConfigFromRaw({ speed: 'fast' }).speed).toBe('fast');
+    expect(runnerConfigFromRaw({ speed: 'standard' }).speed).toBe('standard');
+  });
+
+  it('reads the legacy fastMode key from a host older than speed', () => {
+    expect(runnerConfigFromRaw({ fastMode: true }).speed).toBe('fast');
+    expect(runnerConfigFromRaw({ fastMode: false }).speed).toBeUndefined();
+    expect(runnerConfigFromRaw({}).speed).toBeUndefined();
+  });
+
+  it('lets speed win over the legacy mirror and passes provider-declared tiers through', () => {
+    expect(runnerConfigFromRaw({ speed: 'standard', fastMode: true }).speed).toBe('standard');
+    // The vocabulary is the provider's; the host validated the name at write time.
+    expect(runnerConfigFromRaw({ speed: 'turbo' }).speed).toBe('turbo');
+    expect(runnerConfigFromRaw({ speed: '' }).speed).toBeUndefined();
+    expect(runnerConfigFromRaw({ speed: 7 }).speed).toBeUndefined();
+  });
+});

--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -7,7 +7,7 @@
  */
 import fs from 'fs';
 
-import type { McpServerConfig } from './providers/types.js';
+import type { McpServerConfig, ProviderSpeed } from './providers/types.js';
 
 const CONFIG_PATH = '/workspace/agent/container.json';
 
@@ -20,8 +20,7 @@ export interface RunnerConfig {
   mcpServers: Record<string, McpServerConfig>;
   model?: string;
   effort?: string;
-  /** API fast serving tier (host-configured; see the host's container-config). */
-  fastMode?: boolean;
+  speed?: ProviderSpeed;
 }
 
 const DEFAULT_MAX_MESSAGES = 10;
@@ -42,7 +41,14 @@ export function loadConfig(): RunnerConfig {
     console.error(`[config] Failed to read ${CONFIG_PATH}, using defaults`);
   }
 
-  _config = {
+  _config = runnerConfigFromRaw(raw);
+
+  return _config;
+}
+
+/** Build the runner config from a parsed container.json; missing fields take their defaults. */
+export function runnerConfigFromRaw(raw: Record<string, unknown>): RunnerConfig {
+  return {
     provider: (raw.provider as string) || 'claude',
     assistantName: (raw.assistantName as string) || '',
     groupName: (raw.groupName as string) || '',
@@ -51,10 +57,19 @@ export function loadConfig(): RunnerConfig {
     mcpServers: (raw.mcpServers as RunnerConfig['mcpServers']) || {},
     model: (raw.model as string) || undefined,
     effort: (raw.effort as string) || undefined,
-    fastMode: raw.fastMode === true || undefined,
+    speed: readSpeed(raw),
   };
+}
 
-  return _config;
+/**
+ * `speed` wins when present; the host already validated it against the
+ * provider's declared tiers, so any non-empty name passes through. A host from
+ * before `speed` existed wrote only `fastMode: true`, so that alone still
+ * means `fast`.
+ */
+function readSpeed(raw: Record<string, unknown>): ProviderSpeed | undefined {
+  if (typeof raw.speed === 'string' && raw.speed !== '') return raw.speed;
+  return raw.fastMode === true ? 'fast' : undefined;
 }
 
 /** Get the loaded config. Throws if loadConfig() hasn't been called. */

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -121,7 +121,7 @@ async function main(): Promise<void> {
     additionalDirectories: additionalDirectories.length > 0 ? additionalDirectories : undefined,
     model: config.model,
     effort: config.effort,
-    fastMode: config.fastMode,
+    speed: config.speed,
   });
   registerProviderMemorySessionHook(providerName, provider, MEMORY_SESSION_HOOK);
 

--- a/container/agent-runner/src/provider-contracts/registry.test.ts
+++ b/container/agent-runner/src/provider-contracts/registry.test.ts
@@ -93,10 +93,10 @@ describe('provider runtime contracts', () => {
     expect(policy.disallowedTools).toContain('AskUserQuestion');
 
     const inference = asFunction(contract.configuration.inference)(
-      { model: 'opus', effort: 'high', fastMode: true },
+      { model: 'opus', effort: 'high', speed: 'fast' },
       {},
     );
-    expect(inference).toEqual({ model: 'opus', effort: 'high', fastMode: true });
+    expect(inference).toEqual({ model: 'opus', effort: 'high', settings: { fastMode: true } });
 
     const mcp = asFunction(contract.configuration.mcpServers)({ nanoclaw: { command: 'bun' } }, {}) as {
       allowedTools: string[];

--- a/container/agent-runner/src/provider-contracts/registry.ts
+++ b/container/agent-runner/src/provider-contracts/registry.ts
@@ -9,7 +9,7 @@
  * probes live in verifier code, not in the startup registry path.
  */
 
-import type { McpServerConfig, ProviderExchange } from '../providers/types.js';
+import type { McpServerConfig, ProviderExchange, ProviderSpeed } from '../providers/types.js';
 
 export const PROVIDER_RUNTIME_CONTRACT_SEAM_VERSION = 1;
 
@@ -28,7 +28,7 @@ export interface RuntimeMemoryHookInput {
 export interface RuntimeInferenceInput {
   model?: string;
   effort?: string;
-  fastMode?: boolean;
+  speed?: ProviderSpeed;
 }
 
 /**

--- a/container/agent-runner/src/providers/claude-config.test.ts
+++ b/container/agent-runner/src/providers/claude-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resolveClaudeInference } from './claude-config.js';
+
+describe('resolveClaudeInference', () => {
+  it('passes model and effort through verbatim with no settings by default', () => {
+    const resolved = resolveClaudeInference({ model: 'opus', effort: 'high' }, {});
+    expect(resolved).toEqual({ model: 'opus', effort: 'high' });
+    expect(resolved.settings).toBeUndefined();
+  });
+
+  it("maps speed 'fast' to the SDK fastMode setting", () => {
+    expect(resolveClaudeInference({ speed: 'fast' }, {}).settings).toEqual({ fastMode: true });
+  });
+
+  it("maps speed 'standard' to the SDK default", () => {
+    expect(resolveClaudeInference({ speed: 'standard' }, {}).settings).toBeUndefined();
+  });
+
+  it('ignores unknown speed values instead of guessing', () => {
+    expect(resolveClaudeInference({ speed: 'ultrafast' }, {}).settings).toBeUndefined();
+  });
+});

--- a/container/agent-runner/src/providers/claude-config.ts
+++ b/container/agent-runner/src/providers/claude-config.ts
@@ -99,12 +99,20 @@ export function resolveClaudeExecutionPolicy(): {
   };
 }
 
-/** Model, reasoning effort, and fast mode pass through; the SDK owns defaults. */
+/**
+ * Model and reasoning effort pass to the SDK verbatim; the SDK owns defaults.
+ * `speed: 'fast'` maps to the SDK's `fastMode` settings key (the `/fast`
+ * toggle); `standard` keeps the SDK default. Unknown values are ignored.
+ */
 export function resolveClaudeInference(
   input: RuntimeInferenceInput,
   _environment: NodeJS.ProcessEnv,
-): { model?: string; effort?: string; fastMode?: boolean } {
-  return { model: input.model, effort: input.effort, fastMode: input.fastMode };
+): { model?: string; effort?: string; settings?: { fastMode: boolean } } {
+  return {
+    model: input.model,
+    effort: input.effort,
+    ...(input.speed === 'fast' ? { settings: { fastMode: true } } : {}),
+  };
 }
 
 /**

--- a/container/agent-runner/src/providers/claude.fast-mode.test.ts
+++ b/container/agent-runner/src/providers/claude.fast-mode.test.ts
@@ -57,7 +57,7 @@ async function drive(options: ProviderOptions): Promise<void> {
 
 describe('fast mode reaches the SDK through settings', () => {
   it('sends settings.fastMode when enabled', async () => {
-    await drive({ fastMode: true });
+    await drive({ speed: 'fast' });
     expect(lastOptions?.settings).toEqual({ fastMode: true });
   });
 
@@ -66,13 +66,13 @@ describe('fast mode reaches the SDK through settings', () => {
     expect(lastOptions && 'settings' in lastOptions).toBe(false);
   });
 
-  it('sends no settings key when explicitly false', async () => {
-    await drive({ fastMode: false });
+  it('sends no settings key for standard speed', async () => {
+    await drive({ speed: 'standard' });
     expect(lastOptions && 'settings' in lastOptions).toBe(false);
   });
 
   it('leaves the settingSources chain untouched either way', async () => {
-    await drive({ fastMode: true });
+    await drive({ speed: 'fast' });
     expect(lastOptions?.settingSources).toEqual(['project', 'user', 'local']);
     await drive({});
     expect(lastOptions?.settingSources).toEqual(['project', 'user', 'local']);

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -272,7 +272,7 @@ export class ClaudeProvider implements AgentProvider {
         // Only sent when enabled, so an install that never turns it on passes
         // exactly the options it always did. `fastMode` is a Settings member
         // rather than a query option, which is why it rides `settings`.
-        ...(this.inference.fastMode ? { settings: { fastMode: true } } : {}),
+        ...(this.inference.settings ? { settings: this.inference.settings } : {}),
         mcpServers: this.mcp.mcpServers,
         hooks: {
           PreToolUse: [{ hooks: [preToolUseHook] }],

--- a/container/agent-runner/src/providers/factory.ts
+++ b/container/agent-runner/src/providers/factory.ts
@@ -14,7 +14,7 @@ export function createProvider(name: string, options: ProviderOptions = {}): Age
   // The core-owned inputs for this instance: one object, owned here, closed
   // over by the render path below.
   const inputs: Partial<RuntimeConfigurationInputs> = {
-    inference: { model: options.model, effort: options.effort, fastMode: options.fastMode },
+    inference: { model: options.model, effort: options.effort, speed: options.speed },
     mcpServers: options.mcpServers ?? {},
   };
   // Core resolves the declared configuration and hands the result to the

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -1,5 +1,13 @@
 import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
 
+/**
+ * A speed tier name. The vocabulary is provider-declared (the host validates
+ * `--speed` against the provider's `inference.speedTiers`), so this is an
+ * opaque token here; a provider reacts to the names it declared and ignores
+ * the rest.
+ */
+export type ProviderSpeed = string;
+
 export interface AgentProvider {
   /**
    * Register shared memory through the provider's native session-start
@@ -79,10 +87,11 @@ export interface ProviderOptions {
    */
   effort?: string;
   /**
-   * API fast serving tier: faster output at a higher per-token price. Passed
-   * through to the underlying SDK. If omitted, the SDK default is used.
+   * Provider-declared speed tier (`standard` or `fast` for Claude). A provider
+   * maps `fast` onto its own fast serving tier when it has one; `standard`
+   * keeps the provider default; a tier it did not declare never reaches it.
    */
-  fastMode?: boolean;
+  speed?: ProviderSpeed;
 }
 
 export interface QueryInput {

--- a/src/backfill-container-configs.ts
+++ b/src/backfill-container-configs.ts
@@ -66,6 +66,7 @@ export async function backfillContainerConfigs(): Promise<void> {
       additional_mounts: JSON.stringify(legacy.additionalMounts ?? []),
       cli_scope: 'group',
       timezone: null,
+      speed: null,
       updated_at: new Date().toISOString(),
     };
 

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -38,11 +38,45 @@ import { createSession } from '../../db/sessions.js';
 import { dispatch } from '../dispatch.js';
 import { ensureContainerConfig, getContainerConfig } from '../../db/container-configs.js';
 import { restartAgentGroupContainers } from '../../container-restart.js';
+import { configFromDb } from '../../container-config.js';
+import type { ContainerConfig } from '../../container-config.js';
 // Side-effect import: registers the `groups-*` commands (including delete).
 import './groups.js';
+// Side-effect import: registers Claude's host contract (the `--speed` vocabulary source).
+import '../../provider-contracts/index.js';
+import {
+  PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  registerProviderHostContract,
+} from '../../provider-contracts/registry.js';
+
+/** A provider whose only speed tier is one Claude never declared. */
+const TURBO_PROVIDER = 'turbo-test-provider';
+registerProviderHostContract(TURBO_PROVIDER, {
+  seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  projectDocument: { fileName: 'AGENTS.md', containerPath: '/workspace/agent/AGENTS.md', mountClass: 'group-state' },
+  stateVolumes: [],
+  skillBackings: [],
+  skillViews: [],
+  files: [],
+  inference: { speedTiers: ['turbo'] },
+});
+/** A provider with a host contract but no inference declaration. */
+const TIERLESS_PROVIDER = 'tierless-test-provider';
+registerProviderHostContract(TIERLESS_PROVIDER, {
+  seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+  projectDocument: { fileName: 'AGENTS.md', containerPath: '/workspace/agent/AGENTS.md', mountClass: 'group-state' },
+  stateVolumes: [],
+  skillBackings: [],
+  skillViews: [],
+  files: [],
+});
 
 function now(): string {
   return new Date().toISOString();
+}
+
+function errorMessage(res: Awaited<ReturnType<typeof dispatch>>): string | undefined {
+  return res.ok ? undefined : res.error.message;
 }
 
 async function count(sql: string, ...params: unknown[]): Promise<number> {
@@ -267,7 +301,7 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
   });
 });
 
-describe('groups config add-mount / remove-mount (host-only)', () => {
+describe('groups config (host-only)', () => {
   beforeEach(async () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
     fs.mkdirSync(TEST_DIR, { recursive: true });
@@ -304,5 +338,103 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
     );
     expect(rm.ok).toBe(true);
     expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
+  });
+
+  describe("--speed validates against the tiers the group's provider declares", () => {
+    const GID = 'ag-speed';
+    const speedOf = async (): Promise<string | null> => (await getContainerConfig(GID))!.speed;
+    const setSpeed = (speed: string, extra: Record<string, unknown> = {}) =>
+      dispatch(
+        { id: `speed-${speed}`, command: 'groups-config-update', args: { id: GID, speed, ...extra } },
+        { caller: 'host' },
+      );
+
+    beforeEach(async () => {
+      await createAgentGroup({ id: GID, name: 's', folder: 's', agent_provider: null, created_at: now() });
+      await ensureContainerConfig(GID);
+    });
+
+    it('accepts each tier Claude declares for a group on the default provider', async () => {
+      for (const speed of ['standard', 'fast']) {
+        expect((await setSpeed(speed)).ok).toBe(true);
+        expect(await speedOf()).toBe(speed);
+      }
+    });
+
+    it('rejects an undeclared tier, names the provider and its tiers, and writes nothing', async () => {
+      await setSpeed('fast');
+      const rejected = await setSpeed('turbo');
+      expect(rejected.ok).toBe(false);
+      expect(errorMessage(rejected)).toBe(
+        '--speed "turbo" is not a speed tier of provider "claude" (declared: standard, fast)',
+      );
+      expect(await speedOf()).toBe('fast');
+    });
+
+    it('clears to NULL on "" for any provider', async () => {
+      await setSpeed('fast');
+      expect((await setSpeed('')).ok).toBe(true);
+      expect(await speedOf()).toBeNull();
+
+      await dispatch(
+        { id: 'p', command: 'groups-config-update', args: { id: GID, provider: TIERLESS_PROVIDER } },
+        { caller: 'host' },
+      );
+      expect((await setSpeed('')).ok).toBe(true);
+      expect(await speedOf()).toBeNull();
+    });
+
+    it('rejects every non-empty value for a provider with no host contract', async () => {
+      await dispatch(
+        { id: 'p', command: 'groups-config-update', args: { id: GID, provider: 'no-such-provider' } },
+        { caller: 'host' },
+      );
+      for (const speed of ['standard', 'fast', 'turbo']) {
+        const rejected = await setSpeed(speed);
+        expect(rejected.ok).toBe(false);
+        expect(errorMessage(rejected)).toBe(
+          'provider "no-such-provider" declares no speed tiers; --speed accepts only "" (clear)',
+        );
+      }
+      expect(await speedOf()).toBeNull();
+    });
+
+    it('rejects every non-empty value for a provider whose contract declares no inference', async () => {
+      await dispatch(
+        { id: 'p', command: 'groups-config-update', args: { id: GID, provider: TIERLESS_PROVIDER } },
+        { caller: 'host' },
+      );
+      const rejected = await setSpeed('fast');
+      expect(rejected.ok).toBe(false);
+      expect(errorMessage(rejected)).toBe(
+        `provider "${TIERLESS_PROVIDER}" declares no speed tiers; --speed accepts only "" (clear)`,
+      );
+      expect(await speedOf()).toBeNull();
+    });
+
+    it('validates --provider X --speed Y against X and passes a provider-specific tier through to container.json', async () => {
+      // Claude does not know `turbo`, so the new provider must be the one consulted.
+      const switched = await setSpeed('turbo', { provider: TURBO_PROVIDER });
+      expect(switched.ok).toBe(true);
+      const row = (await getContainerConfig(GID))!;
+      expect(row.provider).toBe(TURBO_PROVIDER);
+      expect(row.speed).toBe('turbo');
+
+      // Stored → materialized: the tier lands in container.json verbatim, and
+      // the legacy `fastMode` mirror is written only for `fast`.
+      const group = { id: GID, name: 's', folder: 's', agent_provider: null, created_at: now() };
+      const materialized = JSON.parse(JSON.stringify(configFromDb(row, group))) as ContainerConfig;
+      expect(materialized.speed).toBe('turbo');
+      expect(Object.keys(materialized)).not.toContain('fastMode');
+
+      // And the other direction: switching to Claude in the same command re-validates against Claude.
+      const back = await setSpeed('turbo', { provider: 'claude' });
+      expect(back.ok).toBe(false);
+      expect(errorMessage(back)).toBe(
+        '--speed "turbo" is not a speed tier of provider "claude" (declared: standard, fast)',
+      );
+      expect((await getContainerConfig(GID))!.provider).toBe(TURBO_PROVIDER);
+      expect(await speedOf()).toBe('turbo');
+    });
   });
 });

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -22,6 +22,8 @@ import {
 import { getSessionDriver } from '../../drivers/index.js';
 import { assertValidGroupFolder, groupFolderExistsOnDisk } from '../../group-folder.js';
 import { initGroupFilesystem } from '../../group-init.js';
+import { getProviderHostContract } from '../../provider-contracts/registry.js';
+import { resolveProviderName } from '../../providers/provider-name.js';
 import { createAgentFromTemplate } from '../../templates/create-agent.js';
 import {
   formatRestampResult,
@@ -52,6 +54,21 @@ function parseTimezoneFlag(value: unknown): string | null | undefined {
   return tz;
 }
 
+/**
+ * `--speed` vocabulary is provider-declared (`inference.speedTiers` on the host
+ * contract). Core only checks membership and stores the name; `""` (clear) is
+ * handled by the caller and never reaches here.
+ */
+function assertDeclaredSpeedTier(speed: string, provider: string): void {
+  const tiers = getProviderHostContract(provider)?.inference?.speedTiers;
+  if (tiers === undefined) {
+    throw new Error(`provider "${provider}" declares no speed tiers; --speed accepts only "" (clear)`);
+  }
+  if (!tiers.includes(speed)) {
+    throw new Error(`--speed "${speed}" is not a speed tier of provider "${provider}" (declared: ${tiers.join(', ')})`);
+  }
+}
+
 /** Deserialize JSON columns for display. */
 function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
   return {
@@ -59,6 +76,7 @@ function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
     provider: row.provider,
     model: row.model,
     effort: row.effort,
+    speed: row.speed,
     image_tag: row.image_tag,
     assistant_name: row.assistant_name,
     max_messages_per_prompt: row.max_messages_per_prompt,
@@ -371,7 +389,8 @@ registerResource({
       access: 'approval',
       description:
         'Update container config scalar fields. Changes are saved but do NOT take effect until you run `ncl groups restart`. ' +
-        'Use --id <group-id> and any of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, ' +
+        'Use --id <group-id> and any of: --provider, --model, --effort, --speed, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, ' +
+        '--speed must be one of the speed tiers the group\'s provider declares (Claude: "standard", "fast"), or "" to follow the install default; a provider that declares none accepts only "". ' +
         '--timezone (IANA id like "Europe/Lisbon"; "" clears back to the install default; scheduled-task times follow it immediately, message display after restart).',
       handler: async (args) => {
         const id = args.id as string;
@@ -385,6 +404,7 @@ registerResource({
             | 'provider'
             | 'model'
             | 'effort'
+            | 'speed'
             | 'image_tag'
             | 'assistant_name'
             | 'max_messages_per_prompt'
@@ -397,6 +417,14 @@ registerResource({
         if (timezone !== undefined) updates.timezone = timezone;
         if (args.model !== undefined) updates.model = args.model as string;
         if (args.effort !== undefined) updates.effort = args.effort as string;
+        if (args.speed !== undefined) {
+          const speed = args.speed as string;
+          // Validate against the provider the group will actually run on —
+          // the same rule spawn applies, with a `--provider` in this command
+          // taking precedence over the stored one.
+          if (speed !== '') assertDeclaredSpeedTier(speed, resolveProviderName(updates.provider, row.provider));
+          updates.speed = speed || null;
+        }
         if (args.image_tag !== undefined) updates.image_tag = args.image_tag as string;
         if (args.assistant_name !== undefined) updates.assistant_name = args.assistant_name as string;
         if (args.max_messages_per_prompt !== undefined)
@@ -411,7 +439,7 @@ registerResource({
 
         if (Object.keys(updates).length === 0) {
           throw new Error(
-            'Nothing to update — provide at least one of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, --timezone',
+            'Nothing to update — provide at least one of: --provider, --model, --effort, --speed, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, --timezone',
           );
         }
 

--- a/src/container-config-model-defaults.test.ts
+++ b/src/container-config-model-defaults.test.ts
@@ -10,12 +10,16 @@
  * graph with the environment it is testing rather than mocking the constants.
  * That exercises the real resolution chain.
  */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createAgentGroup } from './db/agent-groups.js';
 import { closeDb, initTestDb } from './db/connection.js';
 import { ensureContainerConfig, getContainerConfig, updateContainerConfigScalars } from './db/container-configs.js';
 import { runMigrations } from './db/migrations/index.js';
+import type { ContainerConfig } from './container-config.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
 const GROUP: AgentGroup = {
@@ -27,22 +31,23 @@ const GROUP: AgentGroup = {
 };
 
 /** Re-import container-config with a given environment and run configFromDb. */
-async function withEnv(
-  env: Record<string, string | undefined>,
-  row: ContainerConfigRow,
-): Promise<{ model?: string; fastMode?: boolean }> {
+async function withEnv(env: Record<string, string | undefined>, row: ContainerConfigRow): Promise<ContainerConfig> {
   const saved: Record<string, string | undefined> = {};
+  const savedCwd = process.cwd();
+  const emptyProject = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-model-defaults-'));
   for (const [k, v] of Object.entries(env)) {
     saved[k] = process.env[k];
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
   }
   try {
+    process.chdir(emptyProject);
     vi.resetModules();
     const { configFromDb } = await import('./container-config.js');
-    const cfg = configFromDb(row, GROUP);
-    return { model: cfg.model, fastMode: cfg.fastMode };
+    return configFromDb(row, GROUP);
   } finally {
+    process.chdir(savedCwd);
+    fs.rmSync(emptyProject, { recursive: true, force: true });
     for (const [k, v] of Object.entries(saved)) {
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;
@@ -70,7 +75,7 @@ describe('install-wide model defaults', () => {
   it('ships neither field when neither variable is set', async () => {
     const cfg = await withEnv(CLEAR, row);
     expect(cfg.model).toBeUndefined();
-    expect(cfg.fastMode).toBeUndefined();
+    expect(cfg.speed).toBeUndefined();
   });
 
   it('fills the model for a group that has none', async () => {
@@ -92,13 +97,66 @@ describe('install-wide model defaults', () => {
 
   it("enables fast mode on '1' and 'true', case-insensitively", async () => {
     for (const value of ['1', 'true', 'TRUE', 'True']) {
-      expect((await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: value }, row)).fastMode).toBe(true);
+      expect((await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: value }, row)).speed).toBe('fast');
     }
   });
 
   it('leaves fast mode off for anything else — a typo must not start charging', async () => {
     for (const value of ['0', 'false', 'yes', 'on', 'ture', '']) {
-      expect((await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: value }, row)).fastMode).toBeUndefined();
+      expect((await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: value }, row)).speed).toBeUndefined();
     }
+  });
+
+  it("keeps the group's fast speed when the install default is off", async () => {
+    await updateContainerConfigScalars(GROUP.id, { speed: 'fast' });
+    const withSpeed = (await getContainerConfig(GROUP.id))!;
+    expect((await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: 'false' }, withSpeed)).speed).toBe('fast');
+  });
+
+  it("lets the group's standard speed override the install-wide fast default", async () => {
+    await updateContainerConfigScalars(GROUP.id, { speed: 'standard' });
+    const withSpeed = (await getContainerConfig(GROUP.id))!;
+    expect((await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: 'true' }, withSpeed)).speed).toBe('standard');
+  });
+
+  // container.json is read by whatever agent image is installed. An image
+  // built before `speed` existed reads only `fastMode`, so the file must keep
+  // carrying it — and an install that sets nothing must keep getting the file
+  // it always got.
+  describe('container.json compatibility with agent images built before `speed`', () => {
+    const jsonKeys = (cfg: ContainerConfig): string[] => Object.keys(JSON.parse(JSON.stringify(cfg)));
+
+    it('writes neither speed nor fastMode when nothing is set', async () => {
+      const cfg = await withEnv(CLEAR, row);
+      expect(jsonKeys(cfg)).not.toContain('speed');
+      expect(jsonKeys(cfg)).not.toContain('fastMode');
+      expect(Object.keys(cfg)).not.toContain('fastMode');
+    });
+
+    it('writes the legacy fastMode key next to speed when fast comes from the install default', async () => {
+      const unset = jsonKeys(await withEnv(CLEAR, row));
+      const cfg = await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: 'true' }, row);
+      const keys = jsonKeys(cfg);
+      expect(cfg.fastMode).toBe(true);
+      expect(cfg.speed).toBe('fast');
+      // Same file as before, plus the two keys where `fastMode` always sat.
+      expect(keys.filter((key) => key !== 'fastMode' && key !== 'speed')).toEqual(unset);
+      expect(keys.indexOf('speed')).toBe(keys.indexOf('fastMode') + 1);
+      expect(keys.indexOf('fastMode')).toBeGreaterThan(keys.indexOf('maxMessagesPerPrompt'));
+    });
+
+    it('writes the legacy fastMode key when fast comes from the group', async () => {
+      await updateContainerConfigScalars(GROUP.id, { speed: 'fast' });
+      const cfg = await withEnv(CLEAR, (await getContainerConfig(GROUP.id))!);
+      expect(cfg.fastMode).toBe(true);
+      expect(cfg.speed).toBe('fast');
+    });
+
+    it('writes speed alone for standard, so an old image runs at its default', async () => {
+      await updateContainerConfigScalars(GROUP.id, { speed: 'standard' });
+      const cfg = await withEnv({ ...CLEAR, NANOCLAW_FAST_MODE: 'true' }, (await getContainerConfig(GROUP.id))!);
+      expect(cfg.speed).toBe('standard');
+      expect(jsonKeys(cfg)).not.toContain('fastMode');
+    });
   });
 });

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -16,7 +16,7 @@ import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { isValidTimezone } from './timezone.js';
 import { log } from './log.js';
-import type { AgentGroup, ContainerConfigRow } from './types.js';
+import type { AgentGroup, ContainerConfigRow, ContainerSpeed } from './types.js';
 
 /**
  * Container-side path where a group's stamped plugins are mounted read-only.
@@ -249,8 +249,13 @@ export interface ContainerConfig {
   maxMessagesPerPrompt?: number;
   model?: string;
   effort?: string;
-  /** API fast serving tier for this container; absent = the provider default. */
-  fastMode?: boolean;
+  /**
+   * Legacy mirror of `speed: 'fast'`, written exactly as the host did before
+   * `speed` existed so an agent image built then keeps fast mode working.
+   */
+  fastMode?: true;
+  /** Provider-declared speed tier (`standard` or `fast` for Claude); the group value overrides the install default. */
+  speed?: ContainerSpeed;
   timezone?: string;
   /** Session isolation tier for the group's containers; absent = the composer's default ('container'). */
   runtimeTier?: 'container' | 'vm';
@@ -374,10 +379,26 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
     // that have none. Both absent leaves the field out and the SDK decides.
     model: row.model ?? (DEFAULT_MODEL || undefined),
     effort: row.effort ?? undefined,
-    fastMode: FAST_MODE || undefined,
+    // A cleared group value falls back to the install-wide default.
+    ...speedFields(parseContainerSpeed(row.speed) ?? (FAST_MODE ? 'fast' : undefined)),
     timezone: row.timezone && isValidTimezone(row.timezone) ? row.timezone : undefined,
     runtimeTier: parseRuntimeTier(row.runtime_tier, group.name),
   };
+}
+
+/** The stored tier was validated against the provider's declaration when written; empty means unset. */
+function parseContainerSpeed(value: string | null): ContainerSpeed | undefined {
+  return value ? value : undefined;
+}
+
+/**
+ * Unset writes neither key, so an install that sets nothing produces the same
+ * file it always did. `fast` also writes the legacy `fastMode: true`, in the
+ * position it always had, for agent images that still read only that key.
+ */
+function speedFields(speed: ContainerSpeed | undefined): Pick<ContainerConfig, 'fastMode' | 'speed'> {
+  if (speed === undefined) return {};
+  return speed === 'fast' ? { fastMode: true, speed } : { speed };
 }
 
 /**

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -57,6 +57,7 @@ import { validateAdditionalMounts } from './modules/mount-security/index.js';
 // remains tied to src/providers/index.ts.
 import './provider-contracts/index.js';
 import { getProviderHostContract } from './provider-contracts/registry.js';
+import { resolveProviderName } from './providers/provider-name.js';
 import {
   providerStateVolumePath,
   realizeProviderSpawnSurfaces,
@@ -754,13 +755,12 @@ export async function honorPendingStopIntents(
  * Resolve the provider name for a session:
  *
  *   sessions.agent_provider → container_configs.provider → 'claude'
+ *
+ * The rule lives in providers/provider-name.ts so host commands that validate
+ * against the group's provider (e.g. `--speed`) share it; re-exported here for
+ * the spawn path's existing callers.
  */
-export function resolveProviderName(
-  sessionProvider: string | null | undefined,
-  containerConfigProvider: string | null | undefined,
-): string {
-  return (sessionProvider || containerConfigProvider || 'claude').toLowerCase();
-}
+export { resolveProviderName };
 
 export async function resolveProviderContribution(
   session: Session,

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -11,6 +11,7 @@ const SCALAR_COLUMNS = new Set([
   'max_messages_per_prompt',
   'cli_scope',
   'timezone',
+  'speed',
 ]);
 const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts']);
 
@@ -28,11 +29,11 @@ export async function createContainerConfig(config: ContainerConfigRow): Promise
     `INSERT INTO container_configs (
         agent_group_id, provider, model, effort, image_tag, assistant_name,
         max_messages_per_prompt, skills, mcp_servers, packages_apt, packages_npm,
-        additional_mounts, cli_scope, timezone, updated_at
+        additional_mounts, cli_scope, timezone, speed, updated_at
       ) VALUES (
         @agent_group_id, @provider, @model, @effort, @image_tag, @assistant_name,
         @max_messages_per_prompt, @skills, @mcp_servers, @packages_apt, @packages_npm,
-        @additional_mounts, @cli_scope, @timezone, @updated_at
+        @additional_mounts, @cli_scope, @timezone, @speed, @updated_at
       )`,
     config,
   );
@@ -86,6 +87,7 @@ export async function updateContainerConfigScalars(
       | 'max_messages_per_prompt'
       | 'cli_scope'
       | 'timezone'
+      | 'speed'
     >
   >,
 ): Promise<void> {

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -34,6 +34,8 @@ import {
   deletePendingQuestion,
   getContainerConfig,
   createContainerConfig,
+  ensureContainerConfig,
+  updateContainerConfigScalars,
 } from './index.js';
 
 function now() {
@@ -477,10 +479,22 @@ describe('container configs', () => {
       additional_mounts: '[]',
       cli_scope: 'global',
       timezone: null,
+      speed: null,
       updated_at: now(),
     });
     const row = await getContainerConfig('ag-full');
     expect(row).toBeDefined();
     expect(row!.cli_scope).toBe('global');
+  });
+
+  it('round-trips the speed scalar', async () => {
+    await createAgentGroup({ id: 'ag-speed', name: 'Speed', folder: 'speed', agent_provider: null, created_at: now() });
+    await ensureContainerConfig('ag-speed');
+    await updateContainerConfigScalars('ag-speed', { speed: 'fast' });
+    const row = await getContainerConfig('ag-speed');
+    expect(row!.speed).toBe('fast');
+    await updateContainerConfigScalars('ag-speed', { speed: null });
+    const cleared = await getContainerConfig('ag-speed');
+    expect(cleared!.speed).toBeNull();
   });
 });

--- a/src/db/migrations/025-container-config-speed.ts
+++ b/src/db/migrations/025-container-config-speed.ts
@@ -1,0 +1,15 @@
+import type { Migration } from './index.js';
+
+/**
+ * Per-agent-group `speed` on `container_configs`.
+ *
+ * NULL = the install/provider default — deliberately no backfill. Providers
+ * map `speed: "standard" | "fast"` onto their native serving tier.
+ */
+export const migration025: Migration = {
+  version: 25,
+  name: 'container-config-speed',
+  async up(db) {
+    await db.exec(`ALTER TABLE container_configs ADD COLUMN speed TEXT;`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -25,6 +25,7 @@ import { migration021 } from './021-approval-question.js';
 import { migration022 } from './022-messaging-group-detached.js';
 import { migration023 } from './023-approvals-instance.js';
 import { migration024 } from './024-host-coordination.js';
+import { migration025 } from './025-container-config-speed.js';
 
 interface MigrationBase {
   version: number;
@@ -91,6 +92,7 @@ export const migrations: Migration[] = [
   migration022,
   migration023,
   migration024,
+  migration025,
 ];
 
 /**

--- a/src/provider-contracts/claude.ts
+++ b/src/provider-contracts/claude.ts
@@ -62,4 +62,7 @@ registerProviderHostContract('claude', {
     nativeAdmin: ['/compact', '/context', '/cost', '/files'],
     nativeFiltered: ['/start', '/help', '/login', '/logout', '/doctor', '/config', '/remote-control'],
   },
+  // `fast` maps onto the SDK's fast serving tier; `standard` lets a group
+  // explicitly override an install-wide NANOCLAW_FAST_MODE=true.
+  inference: { speedTiers: ['standard', 'fast'] },
 });

--- a/src/provider-contracts/registry.test.ts
+++ b/src/provider-contracts/registry.test.ts
@@ -144,6 +144,42 @@ describe('provider host contracts', () => {
     expect(() => (stored.commands!.nativeAdmin as string[]).push('/later')).toThrow();
   });
 
+  describe('inference.speedTiers', () => {
+    it('is declared by Claude as standard and fast', () => {
+      expect(getProviderHostContract('claude')?.inference?.speedTiers).toEqual(['standard', 'fast']);
+    });
+
+    it('is optional — a provider that declares nothing has no tiers', () => {
+      const name = contractName('inference', 'absent');
+      registerProviderHostContract(name, emptyContract());
+      expect(getProviderHostContract(name)?.inference).toBeUndefined();
+    });
+
+    it('accepts provider-specific tier names and freezes them', () => {
+      const name = contractName('inference', 'custom');
+      registerProviderHostContract(name, { ...emptyContract(), inference: { speedTiers: ['eco', 'turbo-plus'] } });
+      const tiers = getProviderHostContract(name)!.inference!.speedTiers;
+      expect(tiers).toEqual(['eco', 'turbo-plus']);
+      expect(Object.isFrozen(tiers)).toBe(true);
+    });
+
+    it.each([
+      ['an empty list', [], /inference\.speedTiers must not be empty/],
+      ['a non-array', 'fast', /inference\.speedTiers must be an array/],
+      ['an uppercase tier', ['standard', 'Fast'], /inference\.speedTiers\[\] must be lowercase kebab-case/],
+      ['a spaced tier', ['very fast'], /inference\.speedTiers\[\] must be lowercase kebab-case/],
+      ['an empty tier', [''], /inference\.speedTiers\[\] must be lowercase kebab-case/],
+      ['a non-string tier', [1], /inference\.speedTiers\[\] must be lowercase kebab-case/],
+      ['a duplicate tier', ['fast', 'fast'], /inference\.speedTiers must be unique; duplicate 'fast'/],
+    ])('rejects %s at registration and stores nothing', (_label, speedTiers, expected) => {
+      const name = contractName(`inference-${_label}`, 'invalid');
+      expect(() => registerProviderHostContract(name, claudeContractWith('inference.speedTiers', speedTiers))).toThrow(
+        expected,
+      );
+      expect(hasDeclaredProviderContract(name)).toBe(false);
+    });
+  });
+
   it('requires a project document', () => {
     expect(() =>
       registerProviderHostContract(
@@ -292,6 +328,8 @@ describe('provider host contracts', () => {
     ['files.0.prepare.when', 'claude.files.claude-settings.prepare.when'],
     ['commands.nativeAdmin', 'claude.commands.nativeAdmin'],
     ['commands.nativeFiltered', 'claude.commands.nativeFiltered'],
+    ['inference', 'claude.inference'],
+    ['inference.speedTiers', 'claude.inference.speedTiers'],
   ])('rejects invalid %s at registration', (path, field) => {
     expect(() =>
       registerProviderHostContract(contractName(path, 'invalid'), claudeContractWith(path, 'invalid')),

--- a/src/provider-contracts/registry.ts
+++ b/src/provider-contracts/registry.ts
@@ -105,6 +105,17 @@ export interface ProviderPreparedFile {
   };
 }
 
+/**
+ * Inference vocabulary the provider accepts. Core validates
+ * `ncl groups config update --speed` against `speedTiers`, stores the tier,
+ * and passes it through unchanged; the provider owns the names and their
+ * meaning. A provider that declares nothing accepts no speed tier (only `""`
+ * to clear).
+ */
+export interface ProviderInferenceDeclaration {
+  speedTiers: readonly string[];
+}
+
 export interface ProviderHostContract {
   seamVersion: number;
   /** Core-composed project document carrying the provider's standing instructions. */
@@ -119,6 +130,8 @@ export interface ProviderHostContract {
     nativeAdmin?: readonly string[];
     nativeFiltered?: readonly string[];
   };
+  /** Provider-declared inference vocabulary; absent means no speed tier is accepted. */
+  inference?: ProviderInferenceDeclaration;
 }
 
 const registry = new Map<string, ProviderHostContract>();
@@ -188,6 +201,17 @@ export function assertProviderHostContractShape(provider: string, contract: Prov
   assertCommandArray(contract.commands?.nativeFiltered, `${provider}.commands.nativeFiltered`);
   unique(contract.commands?.nativeAdmin ?? [], `${provider}.commands.nativeAdmin`);
   unique(contract.commands?.nativeFiltered ?? [], `${provider}.commands.nativeFiltered`);
+  if (contract.inference !== undefined) {
+    if (contract.inference === null || typeof contract.inference !== 'object') {
+      throw new Error(`${provider}.inference must be an object`);
+    }
+    assertArray(contract.inference.speedTiers, `${provider}.inference.speedTiers`);
+    if (contract.inference.speedTiers.length === 0) {
+      throw new Error(`${provider}.inference.speedTiers must not be empty`);
+    }
+    for (const tier of contract.inference.speedTiers) assertName(tier, `${provider}.inference.speedTiers[]`);
+    unique(contract.inference.speedTiers, `${provider}.inference.speedTiers`);
+  }
 
   const volumeIds = unique(
     contract.stateVolumes.map((volume) => volume.id),

--- a/src/providers/provider-name.ts
+++ b/src/providers/provider-name.ts
@@ -1,0 +1,12 @@
+/**
+ * The one rule for which provider an agent group runs on: the session's
+ * pinned provider, else the group's container config, else Claude. Spawn
+ * resolves through this, and so does every host command that must validate
+ * against the group's actual provider (e.g. `--speed`).
+ */
+export function resolveProviderName(
+  sessionProvider: string | null | undefined,
+  containerConfigProvider: string | null | undefined,
+): string {
+  return (sessionProvider || containerConfigProvider || 'claude').toLowerCase();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,14 @@ export interface AgentGroup {
   created_at: string;
 }
 
+/**
+ * A provider-declared speed tier name (`inference.speedTiers` on the provider's
+ * host contract; `standard` | `fast` for Claude). Validated at `ncl groups
+ * config update --speed` time against the group's provider, then stored and
+ * passed through by core as an opaque token.
+ */
+export type ContainerSpeed = string;
+
 /** Per-agent-group container runtime config. Source of truth in the DB;
  *  materialized to `groups/<folder>/container.json` at spawn time. */
 export interface ContainerConfigRow {
@@ -26,6 +34,7 @@ export interface ContainerConfigRow {
   additional_mounts: string; // JSON: AdditionalMountConfig[]
   cli_scope: string; // 'disabled' | 'group' | 'global'
   timezone: string | null; // IANA id; NULL = follow the install-global timezone
+  speed: ContainerSpeed | null; // NULL = install/provider default
   /**
    * Session isolation tier ('container' | 'vm') — see SessionSpec.runtimeTier.
    * Optional on the TS type because the trunk schema does not carry the


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Adds `speed` as a core-owned per-agent-group property next to `model` and `effort`.

- **CLI**: `ncl groups config update --speed <tier>` (`""` clears). Approval-gated for agent callers, like `--timezone`.
- **Provider-declared vocabulary**: each provider declares the tiers it accepts in its host contract (`inference: ProviderInferenceDeclaration`, i.e. `speedTiers`, validated at registration); the CLI validates against the group's provider and names the accepted tiers on rejection. A provider that declares none accepts only `""`. Claude declares `standard` and `fast`.
- **Storage**: nullable column in `container_configs` (additive migration 025), materialized into `container.json`, passed through the provider inference contract.
- **Claude**: `fast` maps to the SDK's `settings.fastMode`. Other providers map their own tiers; OpenCode declares none.
- **Precedence**: group value wins over the install-wide fast-mode default; NULL preserves today's behavior byte-for-byte.
- **Old images keep working**: when fast mode is on, `container.json` carries both `speed` and the previous `fastMode` key, and the agent-runner reads either.

## Related work

On nanocoai/nanoclaw#3727. Providers-branch counterpart: the Codex declaration and speed tests in nanocoai/nanoclaw#3584. The installer in #3586 follows this PR so provider contracts can declare speed before installation. Merge order: #3584 → #3581 → #3585 → #3727 → #3592 → #3586. OpenCode (#3588 and #3722) and Cursor remain deferred.

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

Current reordered head passed provider install and refresh using the final Codex payload. The final core tree is unchanged. Earlier implementation checks:

- `pnpm run build` -> clean
- `pnpm test` -> 2,303 passed, 1 skipped
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` -> clean
- `cd container/agent-runner && bun test` -> 400 passed, 3 skipped
- `container.json` with speed unset rendered identical to `main`; with fast mode on, `main`'s file plus one `speed` line
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Per-group `speed` setting (`ncl groups config update --speed <tier>`) selects a serving tier the provider declares; Claude accepts `standard` and `fast` (fast mode).
```

## Security and trust boundaries

The setting is approval-gated for agent callers and validated against the provider's declared tiers before it is stored.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
