### PR TITLE
test(codex): pin speed → service_tier rendering

### DIFF
--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -9,6 +9,7 @@ import {
   attachCodexAutoApproval,
   buildCodexConfigPlan,
   buildCodexProcessEnv,
+  codexInferenceSection,
   renderCodexConfigToml,
   startOrResumeCodexThread,
   tomlBasicString,
@@ -89,6 +90,38 @@ describe('Codex config TOML', () => {
         '',
       ].join('\n'),
     );
+  });
+
+  // Core's speed property → Codex's service tier. `fast` is the only value
+  // with a Codex rendering; `standard` (the core default) and anything else
+  // emit no tier line, so Codex's own default serving tier stays in force.
+  it('renders service_tier = "fast" only for speed fast', () => {
+    const fast = renderCodexConfigToml({
+      ...buildCodexConfigPlan({}, {}),
+      inference: codexInferenceSection({ speed: 'fast' }),
+    });
+    expect(fast).toContain('service_tier = "fast"');
+    // The tier is a plain top-level key: no feature flag rides along with it.
+    expect(fast).not.toContain('fast_mode');
+
+    const standard = renderCodexConfigToml({
+      ...buildCodexConfigPlan({}, {}),
+      inference: codexInferenceSection({ speed: 'standard' }),
+    });
+    expect(standard).not.toContain('service_tier');
+
+    const unset = renderCodexConfigToml(buildCodexConfigPlan({}, {}));
+    expect(unset).not.toContain('service_tier');
+  });
+
+  it('treats speed as a fast-or-default flag — other tier names are dropped, not passed through', () => {
+    expect(codexInferenceSection({ speed: 'ultrafast' }).fastMode).toBeUndefined();
+    const rendered = renderCodexConfigToml({
+      ...buildCodexConfigPlan({}, {}),
+      inference: codexInferenceSection({ speed: 'ultrafast' }),
+    });
+    expect(rendered).not.toContain('service_tier');
+    expect(rendered).not.toContain('ultrafast');
   });
 
   it('escapes basic strings', () => {


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Pins how the Codex payload renders the core-owned `speed` property.

- **Context**: nanocoai/nanoclaw#3584 already renders `speed: fast` as `service_tier = "fast"` in `config.toml`.
- **Tests**: `fast` emits the tier line; `standard` and unknown values emit nothing; no feature flag is written. With `speed` unset the TOML is byte-identical to today (existing golden test).
- **No code change**: tests only.

## Related work

Providers-branch counterpart of nanocoai/nanoclaw#3592, on nanocoai/nanoclaw#3588. Tests only, safe to review directly.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `cd container/agent-runner && bun test src/providers/codex-app-server.test.ts` -> passes, including the two new cases
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

## Security and trust boundaries

None.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
