### PR TITLE
fix(tasks): account errored task turns as FAILED runs instead of dropping them

### DIFF
--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -93,8 +93,9 @@ export function markScriptSkipped(skips: Array<{ id: string; reason: string }>):
   getAgentMailbox().operations.markScriptSkipped(skips);
 }
 
-export function markFailed(id: string): void {
-  getAgentMailbox().operations.markMessages([id], 'failed');
+/** Monotonic failed-demotion; see MailboxOperations.markFailed. */
+export function markFailed(id: string): boolean {
+  return getAgentMailbox().operations.markFailed(id);
 }
 
 export function getMessageIn(id: string): MessageInRow | undefined {

--- a/container/agent-runner/src/mailbox/sqlite/index.ts
+++ b/container/agent-runner/src/mailbox/sqlite/index.ts
@@ -126,6 +126,10 @@ export class SqliteAgentMailbox implements AgentMailbox {
     else sqliteMarkScriptSkipped(ids.map((id) => ({ id, reason: 'error' })));
   }
 
+  markFailed(id: string): boolean {
+    return sqliteMarkFailed(id);
+  }
+
   markScriptSkipped(skips: Array<{ id: string; reason: string }>): void {
     sqliteMarkScriptSkipped(skips);
   }

--- a/container/agent-runner/src/mailbox/sqlite/operations.ts
+++ b/container/agent-runner/src/mailbox/sqlite/operations.ts
@@ -70,12 +70,37 @@ export function sqliteMarkProcessing(ids: string[]): void {
   mark(ids, 'processing');
 }
 
+/**
+ * `failed` is terminal: a completed ack never resurrects a row an errored
+ * task turn already demoted (mirrors the host's settled-row-is-terminal
+ * rule in syncProcessingAcks).
+ */
 export function sqliteMarkCompleted(ids: string[]): void {
-  mark(ids, 'completed');
+  if (ids.length === 0) return;
+  const statement = getOutboundDb().prepare(
+    `INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, 'completed', ?)
+     ON CONFLICT(message_id) DO UPDATE SET status = 'completed', status_changed = excluded.status_changed
+       WHERE processing_ack.status != 'failed'`,
+  );
+  getOutboundDb().transaction(() => {
+    for (const id of ids) statement.run(id, new Date().toISOString());
+  })();
 }
 
-export function sqliteMarkFailed(id: string): void {
-  mark([id], 'failed');
+/**
+ * Monotonic: only demotes a live `processing` claim (markProcessing writes
+ * one at batch claim time), so a provider error arriving AFTER a result
+ * event settled the batch cannot flip a genuinely completed run to failed.
+ * Returns whether a row was demoted — callers use this to decide if the
+ * failure is real or post-run noise.
+ */
+export function sqliteMarkFailed(id: string): boolean {
+  const res = getOutboundDb()
+    .prepare(
+      "UPDATE processing_ack SET status = 'failed', status_changed = ? WHERE message_id = ? AND status = 'processing'",
+    )
+    .run(new Date().toISOString(), id);
+  return res.changes > 0;
 }
 
 export function sqliteMarkScriptSkipped(skips: Array<{ id: string; reason: string }>): void {

--- a/container/agent-runner/src/mailbox/types.ts
+++ b/container/agent-runner/src/mailbox/types.ts
@@ -45,6 +45,13 @@ export type StateValue = Omit<StateRecord, 'key'>;
 export interface MailboxOperations {
   getPendingMessages(limit: number, isFirstPoll: boolean): InboundMessage[];
   markMessages(ids: string[], status: ProcessingStatus): void;
+  /**
+   * Mark one message failed. Monotonic — only demotes a live `processing`
+   * claim; returns whether a row was actually demoted so callers can tell a
+   * real failure from post-run noise (a provider error after the batch
+   * already settled).
+   */
+  markFailed(id: string): boolean;
   markScriptSkipped(skips: Array<{ id: string; reason: string }>): void;
   getMessageIn(id: string): InboundMessage | undefined;
   findQuestionResponse(questionId: string): InboundMessage | undefined;

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './mailbox/sqlite/connection.js';
-import { getPendingMessages, markCompleted } from './db/messages-in.js';
+import { getPendingMessages, markCompleted, markFailed, markProcessing } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { processQuery } from './poll-loop.js';
+import { isCorruptionError, processQuery, handleTurnError } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -567,4 +567,120 @@ describe('task-run turn wiring (real processQuery)', () => {
     // slow runners the test died as a mute timeout instead of reaching the
     // diagnostic throw above (observed consistently on CI-hosted runners).
   }, 20_000);
+});
+
+// --- Errored-turn ack routing: task turns must not vanish ---
+// An errored TASK turn has no chat routing (platform/channel are null by
+// design), so the legacy error-chat write produced an unroutable row the host
+// dropped, and the clean `completed` ack hid the failure from run history.
+// handleTurnError is the extracted catch-path: task turns append the error to
+// the task run log and ack `failed`; chat turns keep the legacy behavior.
+
+describe('handleTurnError (errored-turn ack routing)', () => {
+  const CHAT_ROUTING = {
+    platformId: 'telegram:111',
+    channelType: 'telegram',
+    threadId: null,
+    inReplyTo: 'm1',
+    taskRun: false,
+  };
+
+  function ackRows(): Array<{ message_id: string; status: string }> {
+    return getOutboundDb()
+      .prepare('SELECT message_id, status FROM processing_ack ORDER BY message_id')
+      .all() as Array<{ message_id: string; status: string }>;
+  }
+
+  it('task turn: appends error to task run log, acks failed, writes no chat', async () => {
+    markProcessing(['t1']);
+    await handleTurnError(new Error('boom: model rejected'), TASK_ROUTING, ['t1']);
+
+    const logs = taskLogRows().map((l) => l.text);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain('Run FAILED');
+    expect(logs[0]).toContain('boom: model rejected');
+
+    expect(ackRows()).toEqual([{ message_id: 't1', status: 'failed' }]);
+
+    const chats = getUndeliveredMessages().filter((m) => m.kind === 'chat');
+    expect(chats).toHaveLength(0);
+  });
+
+  it('task turn: acks every message in the batch failed', async () => {
+    markProcessing(['t1', 't2']);
+    await handleTurnError(new Error('x'), TASK_ROUTING, ['t1', 't2']);
+    expect(ackRows()).toEqual([
+      { message_id: 't1', status: 'failed' },
+      { message_id: 't2', status: 'failed' },
+    ]);
+  });
+
+  it('late stream error after a completed run: no spurious FAILED line, ack stays completed', async () => {
+    // processQuery marks the batch completed at the first result event and
+    // keeps the stream open for follow-ups. A provider error AFTER that must
+    // not demote the settled ack or stamp "Run FAILED" on a run that
+    // succeeded (adversarial-review finding #1).
+    markProcessing(['t1']);
+    markCompleted(['t1']);
+
+    await handleTurnError(new Error('stream closed while idle'), TASK_ROUTING, ['t1']);
+
+    expect(ackRows()).toEqual([{ message_id: 't1', status: 'completed' }]);
+    expect(taskLogRows().map((l) => l.text).filter((t) => t.includes('Run FAILED'))).toHaveLength(0);
+  });
+
+  it('markFailed is monotonic and markCompleted cannot resurrect a failed ack', () => {
+    // Pins the ack lattice: processing → failed is terminal, so even if the
+    // loop's `continue` were removed, the fall-through markCompleted could
+    // not silently flip a failed run back to completed (finding #3).
+    markProcessing(['t1']);
+    expect(markFailed('t1')).toBe(true);
+    expect(markFailed('t1')).toBe(false); // already failed — no-op
+
+    markCompleted(['t1']);
+    expect(ackRows()).toEqual([{ message_id: 't1', status: 'failed' }]);
+  });
+
+  it('chat turn: writes routed error chat and leaves acks to the normal completed path', async () => {
+    await handleTurnError(new Error('boom: provider died'), CHAT_ROUTING, ['m1']);
+
+    const chats = getUndeliveredMessages().filter((m) => m.kind === 'chat');
+    expect(chats).toHaveLength(1);
+    expect(chats[0].platform_id).toBe('telegram:111');
+    expect(chats[0].channel_type).toBe('telegram');
+    expect(JSON.parse(chats[0].content).text).toBe('Error: boom: provider died');
+
+    // no ack written here — the loop's markCompleted still runs for chat turns
+    expect(ackRows()).toHaveLength(0);
+    expect(taskLogRows()).toHaveLength(0);
+  });
+
+  it('reports whether it handled the ack (task true, chat false)', async () => {
+    expect(await handleTurnError(new Error('x'), TASK_ROUTING, ['t1'])).toBe(true);
+    expect(await handleTurnError(new Error('x'), CHAT_ROUTING, ['m1'])).toBe(false);
+  });
+
+  it('task run with an error RESULT (isError, not a throw) acks failed and logs Run FAILED', async () => {
+    // Providers can surface non-retryable failures as a result event with
+    // isError (e.g. a 403 billing error) instead of throwing. A task run must
+    // account those as FAILED too, or accounting becomes provider-behavior-
+    // dependent (adversarial-review finding #2).
+    markProcessing(['t1']);
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'result', text: 'Error: 403 billing_error — upstream declined', isError: true };
+    }
+    const query: AgentQuery = { push: () => {}, end: () => {}, events: events(), abort: () => {} };
+
+    await processQuery(query, TASK_ROUTING, ['t1'], 'claude', undefined, 'prompt', undefined);
+
+    const acks = ackRows();
+    expect(acks).toEqual([{ message_id: 't1', status: 'failed' }]);
+    const logs = taskLogRows().map((l) => l.text);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain('Run FAILED');
+    expect(logs[0]).toContain('403 billing_error');
+    // one-door: still no chat delivery from a task session
+    expect(getUndeliveredMessages().filter((m) => m.kind === 'chat')).toHaveLength(0);
+  });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -3,6 +3,7 @@ import {
   getPendingMessages,
   markProcessing,
   markCompleted,
+  markFailed,
   markScriptSkipped,
   type MessageInRow,
 } from './db/messages-in.js';
@@ -271,15 +272,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         clearContinuation(config.providerName);
       }
 
-      // Write error response so the user knows something went wrong
-      await writeMessageOut({
-        id: generateId(),
-        kind: 'chat',
-        platform_id: routing.platformId,
-        channel_type: routing.channelType,
-        thread_id: routing.threadId,
-        content: JSON.stringify({ text: `Error: ${errMsg}` }),
-      });
+      if (await handleTurnError(err, routing, processingIds)) {
+        // Task turn: error is in the run log, batch acked failed (feeds the
+        // series' FAILED count and recurrence backoff). No redelivery; the
+        // finally below still clears in_reply_to on this path.
+        log(`Errored task run — ${processingIds.length} message(s) acked failed, error in run log`);
+        continue;
+      }
 
       // The batch is still acked completed below (no redelivery). Without
       // this line the only log trace of the errored turn is "Query error"
@@ -553,7 +552,17 @@ export async function processQuery(
         // follow-up pushes. The agent may have responded via MCP
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
-        markCompleted(initialBatchIds);
+        // Exception: a task run whose provider surfaced a non-retryable
+        // error as a result event (isError) is a FAILED run — ack it failed
+        // so the accounting matches the thrown-error path in the poll loop's
+        // catch (handleTurnError) instead of depending on how a provider
+        // happens to report failure.
+        const failedTaskRun = routing.taskRun && event.isError === true;
+        if (failedTaskRun) {
+          for (const id of initialBatchIds) markFailed(id);
+        } else {
+          markCompleted(initialBatchIds);
+        }
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = await dispatchResultText(event.text, routing, {
             midTurnSent,
@@ -576,7 +585,8 @@ export async function processQuery(
           // Errors included: a failed run's text belongs in its log, not chat.
           // A corrective retry handles delivery only; its result is not a
           // second run summary.
-          if (routing.taskRun && !taskBlockNudged) await autoAppendTaskLog(event.text);
+          if (routing.taskRun && !taskBlockNudged)
+            await autoAppendTaskLog(failedTaskRun ? `Run FAILED: ${event.text}` : event.text);
           if (resultBlocks === 0 && event.isError === true && !routing.taskRun) {
             // Non-retryable error turn (e.g. a 403 billing_error) with no
             // <message> envelope: deliver the notice instead of dropping it as
@@ -1129,6 +1139,50 @@ export async function autoAppendTaskLog(text: string): Promise<void> {
     content: JSON.stringify({ text: line }),
   });
   log('Task run log auto-appended from final text');
+}
+
+/**
+ * Errored-turn ack routing. A task turn has no chat routing (platform/channel
+ * are null by design — the agent picks delivery at fire time), so writing its
+ * error as a chat row produced an unroutable message the host dropped
+ * ("Message missing routing fields") while the clean `completed` ack hid the
+ * failure from the series' run history entirely. Instead: append the error to
+ * the task run log (the run's one durable artifact) and ack `failed`, which
+ * the host's ack sync records as a FAILED occurrence — surfacing in
+ * `ncl tasks list` and feeding the recurrence backoff streak. Chat turns keep
+ * the legacy behavior: a routed error chat, ack left to the loop's normal
+ * completed path. Returns true when it acked the batch itself (task turns).
+ */
+export async function handleTurnError(
+  err: unknown,
+  routing: RoutingContext,
+  processingIds: string[],
+): Promise<boolean> {
+  const errMsg = err instanceof Error ? err.message : String(err);
+  if (routing.taskRun) {
+    // markFailed is monotonic — it only demotes live `processing` claims. If
+    // nothing was demoted, the batch already settled (a result event landed
+    // before this error), so the run itself succeeded: log the late error
+    // for the operator but do NOT stamp "Run FAILED" on a completed run.
+    let demoted = 0;
+    for (const id of processingIds) if (markFailed(id)) demoted++;
+    if (demoted > 0) {
+      await autoAppendTaskLog(`Run FAILED: ${errMsg}`);
+    } else {
+      log(`Post-run provider error (batch already settled): ${errMsg}`);
+    }
+    return true;
+  }
+  // Write error response so the user knows something went wrong
+  await writeMessageOut({
+    id: generateId(),
+    kind: 'chat',
+    platform_id: routing.platformId,
+    channel_type: routing.channelType,
+    thread_id: routing.threadId,
+    content: JSON.stringify({ text: `Error: ${errMsg}` }),
+  });
+  return false;
 }
 
 async function sendToDestination(dest: DestinationEntry, body: string, routing: RoutingContext): Promise<void> {

--- a/src/mailbox/sqlite/session-db.test.ts
+++ b/src/mailbox/sqlite/session-db.test.ts
@@ -153,4 +153,17 @@ describe('syncProcessingAcks — script-skip counter', () => {
 
     expect(status(inDb, 't1')).toBe('completed');
   });
+
+  it("a 'failed' ack (errored task turn) lands the row as a FAILED run, not completed", () => {
+    // The runner's errored-task-turn path acks 'failed' (markFailed) so the
+    // failure shows in run history and feeds the recurrence backoff streak —
+    // mapping it to completed would hide the errored run entirely.
+    const { inDb, outDb } = freshPair();
+    seedTask(inDb, 't1', { prompt: 'p' });
+    ack(outDb, 't1', 'failed');
+
+    syncProcessingAcks(inDb, outDb);
+
+    expect(status(inDb, 't1')).toBe('failed');
+  });
 });

--- a/src/mailbox/sqlite/session-db.ts
+++ b/src/mailbox/sqlite/session-db.ts
@@ -146,9 +146,10 @@ export function syncProcessingAcks(inDb: Database.Database, outDb: Database.Data
 
   if (completed.length === 0) return;
 
-  // `script-skip:error` (pre-task script crashed) lands as a FAILED run —
-  // semantically true, and it lets recurrence derive the trailing failed
-  // streak from the occurrence rows themselves (no stored counter).
+  // `script-skip:error` (pre-task script crashed) and `failed` (errored task
+  // turn, runner's markFailed) land as FAILED runs — semantically true, and it
+  // lets recurrence derive the trailing failed streak from the occurrence rows
+  // themselves (no stored counter).
   const completeStmt = inDb.prepare(
     "UPDATE messages_in SET status = 'completed' WHERE id = ? AND status NOT IN ('completed', 'failed')",
   );
@@ -157,7 +158,7 @@ export function syncProcessingAcks(inDb: Database.Database, outDb: Database.Data
   );
   inDb.transaction(() => {
     for (const { message_id, status } of completed) {
-      (status === 'script-skip:error' ? failStmt : completeStmt).run(message_id);
+      (status === 'script-skip:error' || status === 'failed' ? failStmt : completeStmt).run(message_id);
     }
   })();
 }

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -238,7 +238,7 @@ describe('handleRecurrence — script-failure backoff (streak derived from faile
     const logFile = path.join(TEST_DIR, 'groups', 'g-test', 'tasks', 'task-s-0.md');
     expect(fs.existsSync(logFile)).toBe(true);
     const content = fs.readFileSync(logFile, 'utf8');
-    expect(content).toContain('auto-paused after 8 consecutive script failures');
+    expect(content).toContain('auto-paused after 8 consecutive failed runs');
     expect(content).toContain('ncl tasks resume task-s-0');
     expect(content).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} — /m); // appendRunLog's local-time stamp
   });

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -80,7 +80,7 @@ export async function handleRecurrence(inDb: InboundMailbox, session: Session): 
         await appendHostTaskNote(
           session.agent_group_id,
           msg.seriesId,
-          `auto-paused after ${scriptFails} consecutive script failures (host); fix the script, then \`ncl tasks resume ${msg.seriesId}\``,
+          `auto-paused after ${scriptFails} consecutive failed runs (host); check this run log for the error (script failure or errored agent turn), then \`ncl tasks resume ${msg.seriesId}\``,
         );
         log.warn('Task series auto-paused: script keeps failing', {
           seriesId: msg.seriesId,


### PR DESCRIPTION
## Type of change

- [x] **Fix** - bug fix or security fix to source code

## What

Fixes #3223. A scheduled task that errors is currently indistinguishable from one that ran and chose not to message anyone.

The turn's error is written as a `chat` message copying routing fields from the triggering message. Task messages carry no routing fields by design ("the agent chooses delivery destination at fire time"), so the error lands with `platform_id = channel_type = NULL`; `src/delivery.ts` logs `Message missing routing fields` and drops it, and the batch is acked `completed`. Nothing is delivered, nothing is retried, and the run history records no failure — so a recurring task that starts failing (expired credential, retired model, dead MCP server) fails forever, silently, at full cron cadence.

## The fixes

1. **Errored task turns become FAILED runs.** `handleTurnError` appends `Run FAILED: <err>` to the task run log (the mechanism already exists — successful final text is auto-appended) and acks `failed` instead of a clean `completed`. Chat turns are untouched: they still write the routed error chat the user sees.
2. **Accounting.** `syncProcessingAcks` maps a `failed` ack to a FAILED run alongside the existing `script-skip:error` mapping, so `ncl tasks list` surfaces chronic failures and the recurrence backoff / auto-pause streak reacts. The auto-pause note no longer says "script failures" — the streak can now come from an errored agent turn.
3. **Monotonic acks (adversarial-review hardening).** `MailboxOperations.markFailed(id)` only demotes a live `processing` claim and returns whether it demoted, so a provider error arriving *after* a result event settled the batch cannot relabel a genuinely completed run; `markCompleted` gains the mirror guard (`WHERE status != 'failed'`) so a completed ack cannot resurrect a demoted row. Error-`result` events (`isError`, e.g. a 403 billing error) account the same as throws, so accounting is not provider-behavior-dependent.

Not included: the optional host-side dead-letter (deliver unroutable task errors to an owner DM). That's a bigger call and #3223 lists it as a separate direction — happy to follow up if you want it.

## Tests

Every behavior is **red-proofed** — verified failing with only its own fix reverted:

| Revert | Fails |
|---|---|
| drop the `Run FAILED` write | `task turn: appends error to task run log, acks failed, writes no chat` |
| remove the `processing` guard in `markFailed` | `late stream error after a completed run…` + `markFailed is monotonic and markCompleted cannot resurrect a failed ack` |

| | |
|---|---|
| host | **2071** pass (162 files) |
| container | **340** pass |
| typecheck | clean, both trees |

## Provenance

Running in production on a multi-user departmental install since 2026-08-09. The accounting has caught real failures there — a retired model and gateway 401s — that would otherwise have been silent.

Assisted by Claude; reviewed and verified by a human before submission.
