### PR TITLE
fix(teams): namespace colon-bearing user ids so card clicks and sender resolution match

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -21,6 +21,7 @@ import {
   type Message as ChatMessage,
 } from 'chat';
 import { log } from '../log.js';
+import { namespacedUserId } from '../platform-id.js';
 import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
@@ -528,7 +529,13 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     const author = serialized.author as { userId?: string; fullName?: string; userName?: string } | undefined;
     if (author) {
       const name = author.fullName ?? author.userName;
-      serialized.senderId = author.userId;
+      // Namespace here rather than leaving it to extractAndUpsertUser: that
+      // resolver treats any colon as "already namespaced", which is true for
+      // the ids most adapters emit but not for Teams ("29:xxx"). Left bare,
+      // a Teams sender resolves to a second user row carrying none of the
+      // roles granted to the namespaced one. Adapters whose ids have no colon
+      // are unaffected — they end up prefixed either way.
+      serialized.senderId = author.userId ? namespacedUserId(adapter.name, author.userId) : author.userId;
       serialized.sender = name;
       serialized.senderName = name;
     }

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -24,6 +24,7 @@ import {
 } from '../../db/sessions.js';
 import type { ResponsePayload } from '../../response-registry.js';
 import { log } from '../../log.js';
+import { namespacedUserId } from '../../platform-id.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { PendingApproval } from '../../types.js';
 import { hasAdminPrivilege, isGlobalAdmin, isOwner } from '../permissions/db/user-roles.js';
@@ -56,7 +57,7 @@ export async function handleApprovalsResponse(payload: ResponsePayload): Promise
     return true;
   }
 
-  await handleRegisteredApproval(approval, payload.value, namespacedUserId(payload) ?? '');
+  await handleRegisteredApproval(approval, payload.value, clickerUserId(payload) ?? '');
   return true;
 }
 
@@ -132,13 +133,13 @@ async function handleRegisteredApproval(
   await requestWake(session, 'approval-response');
 }
 
-function namespacedUserId(payload: ResponsePayload): string | null {
+function clickerUserId(payload: ResponsePayload): string | null {
   if (!payload.userId) return null;
-  return payload.userId.includes(':') ? payload.userId : `${payload.channelType}:${payload.userId}`;
+  return namespacedUserId(payload.channelType, payload.userId);
 }
 
 async function isAuthorizedApprovalClick(approval: PendingApproval, payload: ResponsePayload): Promise<boolean> {
-  const userId = namespacedUserId(payload);
+  const userId = clickerUserId(payload);
   if (!userId) return false;
 
   // An approval may name a specific approver; only that exact user may resolve it.

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -32,6 +32,7 @@ import type { InboundEvent } from '../../channels/adapter.js';
 import { registerResponseHandler, type ResponsePayload } from '../../response-registry.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { log } from '../../log.js';
+import { namespacedUserId } from '../../platform-id.js';
 import type { MessagingGroup, MessagingGroupAgent } from '../../types.js';
 import { guard } from '../../guard/index.js';
 import { channelsRegister, sendersAdmit } from './guard.js';
@@ -272,15 +273,9 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
   const row = await getPendingSenderApproval(payload.questionId);
   if (!row) return false;
 
-  // payload.userId is the raw platform userId (e.g. "6037840640"); namespace it
-  // with the channel type so it matches users(id) format. Some platforms
-  // (e.g. Teams "29:xxx") already include a colon — mirror resolveOrCreateUser
-  // logic and only prefix when the raw id has no colon.
-  const clickerId = payload.userId
-    ? payload.userId.includes(':')
-      ? payload.userId
-      : `${payload.channelType}:${payload.userId}`
-    : null;
+  // payload.userId is the raw platform userId (e.g. "6037840640" or Teams
+  // "29:xxx"); namespace it with the channel type so it matches users(id).
+  const clickerId = payload.userId ? namespacedUserId(payload.channelType, payload.userId) : null;
   const isAuthorized =
     clickerId !== null &&
     (clickerId === row.approver_user_id || (await hasAdminPrivilege(clickerId, row.agent_group_id)));
@@ -458,11 +453,7 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
 
   // Click authorization is the guard's channels.register decision (./guard.ts):
   // the delivered approver, or an admin of the pending row's anchor agent group.
-  const clickerId = payload.userId
-    ? payload.userId.includes(':')
-      ? payload.userId
-      : `${payload.channelType}:${payload.userId}`
-    : null;
+  const clickerId = payload.userId ? namespacedUserId(payload.channelType, payload.userId) : null;
   const decision = await guard(channelsRegister, {
     actor: { kind: 'human', userId: clickerId ?? '' },
     payload: { questionId: payload.questionId },

--- a/src/platform-id.ts
+++ b/src/platform-id.ts
@@ -23,3 +23,19 @@ export function namespacedPlatformId(channel: string, raw: string): string {
   if (channel === 'deltachat') return raw;
   return `${channel}:${raw}`;
 }
+
+/**
+ * Namespace a raw platform user ID with its channel type to match users(id).
+ *
+ * Distinct from namespacedPlatformId: user IDs get no '@'/'+' escapes, so
+ * WhatsApp JIDs and Signal numbers keep the prefix they are stored with.
+ *
+ * The prefix test is startsWith(`${channel}:`), not includes(':'): Teams user
+ * IDs are natively colon-bearing ("29:1Eiqnrl..."), so an includes(':') test
+ * reads them as already-namespaced and leaves them bare — they then never
+ * match the stored "teams:29:1Eiqnrl..." and every card click is rejected as
+ * an unauthorized clicker.
+ */
+export function namespacedUserId(channel: string, raw: string): string {
+  return raw.startsWith(`${channel}:`) ? raw : `${channel}:${raw}`;
+}


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [x] **Fix**
- [ ] **Simplification**
- [ ] **Documentation**

## Description

Card-click authorization and Chat SDK sender resolution both decide whether a
platform user id is "already namespaced" with `payload.userId.includes(':')`.
That holds for the ids most adapters emit, but **Teams user ids natively
contain a colon** (`29:1Eiqnrl…`). They are read as already-prefixed and left
bare, so they never match the stored `teams:29:1Eiqnrl…`.

Two observable consequences on any Teams install:

1. **No Teams user can approve anything.** Every card click is rejected as an
   unauthorized clicker — channel registration, unknown-sender approval, and
   the generic approval path. The log shows the mismatch plainly:

   ```
   Channel registration click rejected — unauthorized clicker
     clickerId="29:1Eiqnrl…"  expectedApprover="teams:29:1Eiqnrl…"
   ```

2. **A duplicate user row accumulates.** The Chat SDK bridge projects
   `author.userId` raw into `senderId`, so an inbound Teams sender resolves to
   a bare `29:…` row rather than the `teams:29:…` one holding their roles. The
   owner arrives unprivileged; messaging still works when `sender_scope=all`,
   which is what makes it easy to miss.

### Approach

Adds `namespacedUserId(channel, raw)` in `src/platform-id.ts`, testing
`startsWith(`${channel}:`)` instead of `includes(':')`, and uses it at the
three click-authorization sites plus the bridge's sender projection.

Two deliberate choices:

- **Not reusing `namespacedPlatformId`.** Its `@`/`+` escapes would stop
  prefixing WhatsApp JIDs and Signal phone numbers, silently changing those
  channels. The new helper has no escapes, so the only ids whose treatment
  changes are colon-bearing ones without a channel prefix.
- **Fixing the bridge rather than `extractAndUpsertUser`.** Changing the
  resolver would alter how *every* channel treats colon-bearing handles, and
  its own tests pin the current semantics (`senderId: 'tg:stranger'` asserting
  it stays bare). Namespacing at the projection leaves that contract intact:
  adapters whose ids carry no colon were prefixed by the resolver before and
  are prefixed here now, reaching the same id.

### Testing

Full host suite passes. Verified end to end against a live Teams install:
card clicks now authorize, and the sender resolves to the namespaced identity
holding the `owner` role instead of creating a second row.

## For Skills

n/a — source fix, no skill changes.
