### PR TITLE
fix(container): bypass the gateway proxy for host-local addresses so HTTP MCP servers work

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -62,6 +62,24 @@ ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 # ~300MB Chromium. We've already installed the system one above.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
+# ---- Proxy bypass for host-local services ------------------------------------
+# A gateway provider (OneCLI) injects HTTP_PROXY/HTTPS_PROXY so all agent egress
+# is credential-injected. That proxy cannot serve a request aimed at the Docker
+# host: it accepts the connection and closes it. An MCP server published on
+# host.docker.internal therefore answers a direct request but returns an empty
+# reply through the proxy, so the SDK registers the server and loads none of its
+# tools -- with no error in the agent log.
+#
+# `ncl groups config add-mcp-server` explicitly permits plain HTTP for localhost
+# and host.docker.internal, so those URLs are a supported configuration that
+# could not work.
+#
+# no_proxy matches on the *target* host, so this exempts only host-local
+# traffic; external calls still route through the gateway and still get their
+# credentials injected.
+ENV no_proxy=host.docker.internal,localhost,127.0.0.1
+ENV NO_PROXY=host.docker.internal,localhost,127.0.0.1
+
 # ---- Bun runtime -------------------------------------------------------------
 # Install via the official script (handles multi-arch detection), then move
 # the binary to /usr/local/bin so the non-root `node` user can execute it.


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [x] **Fix**
- [ ] **Simplification**
- [ ] **Documentation**

## Description

With a gateway provider active, an HTTP MCP server on `host.docker.internal`
is unreachable from the agent — **and fails silently**.

The gateway injects `HTTP_PROXY`/`HTTPS_PROXY` so all agent egress is
credential-injected. That proxy cannot serve a request aimed at the Docker host
itself: it accepts the connection and closes it. The SDK's MCP handshake
therefore fails, the server is registered, and **none of its tools load** —
with no error in the agent log.

What that looks like in practice: the agent insists it has no access to tools
that `ncl groups config get` shows correctly configured, while a direct `curl`
to the same URL from the same container returns HTTP 200. The only difference
is the proxy env, which makes it easy to "rule out" with a probe that does not
reproduce the agent's environment.

```
# inside a live agent container
curl -X POST http://host.docker.internal:8001/mcp …
  → curl: (52) Empty reply from server

no_proxy=host.docker.internal curl -X POST http://host.docker.internal:8001/mcp …
  → HTTP 200
```

This matters because `ncl groups config add-mcp-server` **explicitly permits**
plain HTTP for `localhost` and `host.docker.internal` (`src/container-config.ts`
rejects plain HTTP for everything else), so those URLs are a documented
configuration that could not work while a gateway is active.

### Approach

Sets `no_proxy`/`NO_PROXY` to `host.docker.internal,localhost,127.0.0.1` in the
agent image. `no_proxy` matches on the **target** host, so this exempts only
host-local traffic; calls to `api.anthropic.com` and every other external host
still route through the gateway and still get their credentials injected. No
change to the egress model.

### Open question for reviewers

Baking this into the Dockerfile is the blunt fix. It may be cleaner for the
gateway provider to emit `NO_PROXY` alongside the proxy vars it already
contributes (`src/gateway-providers/onecli.ts`), so the bypass lives with the
thing that introduces the proxy and non-gateway installs are unaffected. Happy
to move it there — I went with the image because it is provider-agnostic, but I
do not have strong grounds to prefer it.

### Testing

Verified on a live install: before, four HTTP MCP servers registered and zero
tools loaded; after rebuilding the image, the agent calls them successfully.

## For Skills

n/a — container fix, no skill changes.
