### PR TITLE
fix: engage mention wirings on replies to bot

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -42,6 +42,8 @@ interface GatewayAdapter extends Adapter {
 export interface ReplyContext {
   text: string;
   sender: string;
+  /** True only when the quoted message was authored by this adapter's bot. */
+  isReplyToBot?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -619,6 +619,57 @@ describe('router', () => {
     expect(rows[0].trigger).toBe(0);
   });
 
+  it('treats a reply to this bot as a mention while other replies only accumulate', async () => {
+    const { routeInbound } = await import('./router.js');
+    const { wakeContainer } = await import('./container-runner.js');
+    const wake = wakeContainer as unknown as ReturnType<typeof vi.fn>;
+    wake.mockClear();
+
+    const { updateMessagingGroupAgent } = await import('./db/messaging-groups.js');
+    await updateMessagingGroupAgent('mga-1', {
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+    });
+
+    const reply = async (id: string, isReplyToBot: boolean) =>
+      routeInbound({
+        channelType: 'discord',
+        platformId: 'chan-123',
+        threadId: null,
+        message: {
+          id,
+          kind: 'chat',
+          content: JSON.stringify({
+            text: `follow-up ${id}`,
+            replyTo: { text: 'quoted message', sender: 'Quoted sender', isReplyToBot },
+          }),
+          timestamp: now(),
+          isMention: false,
+        },
+      });
+
+    await reply('msg-reply-own-bot', true);
+    await reply('msg-reply-human', false);
+    await reply('msg-reply-other-bot', false);
+
+    expect(wake).toHaveBeenCalledTimes(1);
+
+    const session = await findSession('mg-1', null);
+    expect(session).toBeDefined();
+    const db = new Database(inboundDbPath('ag-1', session!.id));
+    const rows = db.prepare('SELECT id, trigger FROM messages_in ORDER BY rowid').all() as Array<{
+      id: string;
+      trigger: number;
+    }>;
+    db.close();
+
+    expect(rows).toEqual([
+      { id: 'msg-reply-own-bot:ag-1', trigger: 1 },
+      { id: 'msg-reply-human:ag-1', trigger: 0 },
+      { id: 'msg-reply-other-bot:ag-1', trigger: 0 },
+    ]);
+  });
+
   it('drops silently when engage fails + ignored_message_policy=drop', async () => {
     const { routeInbound } = await import('./router.js');
     const { wakeContainer } = await import('./container-runner.js');

--- a/src/router.ts
+++ b/src/router.ts
@@ -200,7 +200,12 @@ function dispatchSessionCreated(event: SessionCreatedEvent): void {
   }
 }
 
-function safeParseContent(raw: string): { text?: string; sender?: string; senderId?: string } {
+function safeParseContent(raw: string): {
+  text?: string;
+  sender?: string;
+  senderId?: string;
+  replyTo?: { isReplyToBot?: boolean };
+} {
   try {
     return JSON.parse(raw);
   } catch {
@@ -358,6 +363,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   //    avoids the extra await).
   const parsed = safeParseContent(event.message.content);
   const messageText = parsed.text ?? '';
+  const isDirectlyAddressed = isMention || parsed.replyTo?.isReplyToBot === true;
 
   // Per-wiring thread policy inputs, resolved once per event. Each wiring's
   // threads override (NULL = inherit) resolves against the channel's declared
@@ -390,7 +396,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     );
     const effectiveThreadId = threadsEnabled ? event.threadId : null;
 
-    const engages = await evaluateEngage(agent, messageText, isMention, mg, effectiveThreadId);
+    const engages = await evaluateEngage(agent, messageText, isDirectlyAddressed, mg, effectiveThreadId);
 
     const accessOk = engages && (!accessGate || (await accessGate(event, userId, mg, agent.agent_group_id)).allowed);
     const scopeOk = engages && (!senderScopeGate || (await senderScopeGate(event, userId, mg, agent)).allowed);
@@ -458,9 +464,10 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
  * Decide whether a given wired agent should engage on this message.
  *
  *   'pattern'        — regex test on text; '.' = always
- *   'mention'        — bot must be mentioned on the platform. Resolved by
- *                      the adapter (SDK-level) and forwarded as
- *                      `event.message.isMention`. Agent display name
+ *   'mention'        — bot must be directly addressed by a platform mention
+ *                      or a reply to its own message. Resolved by the adapter
+ *                      and forwarded as `event.message.isMention` or
+ *                      serialized `replyTo.isReplyToBot`. Agent display name
  *                      (`agent_group.name`) is irrelevant — users address
  *                      the bot via its platform username (@botname on
  *                      Telegram, user-id mention on Slack/Discord), not
@@ -468,8 +475,8 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
  *                      user wants to disambiguate between multiple agents
  *                      wired to one chat, use engage_mode='pattern' with
  *                      the disambiguator as the regex.
- *   'mention-sticky' — platform mention OR an active per-thread session
- *                      already exists for this (agent, mg, thread). The
+ *   'mention-sticky' — direct address OR an active per-thread session already
+ *                      exists for this (agent, mg, thread). The
  *                      session existence IS our subscription state; once
  *                      a thread has engaged us once, follow-ups arrive
  *                      with no mention and should still fire.
@@ -477,7 +484,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
 async function evaluateEngage(
   agent: MessagingGroupAgent,
   text: string,
-  isMention: boolean,
+  isDirectlyAddressed: boolean,
   mg: MessagingGroup,
   threadId: string | null,
 ): Promise<boolean> {
@@ -493,9 +500,9 @@ async function evaluateEngage(
       }
     }
     case 'mention':
-      return isMention;
+      return isDirectlyAddressed;
     case 'mention-sticky': {
-      if (isMention) return true;
+      if (isDirectlyAddressed) return true;
       // Sticky follow-up: session already exists for this (agent, mg, thread)
       // — the thread was activated before, keep firing.
       if (mg.is_group === 0) return false; // DMs never use mention-sticky sensibly


### PR DESCRIPTION
## What

- add an optional reply-to-own-bot signal to ReplyContext
- treat that signal as direct addressing for mention and mention-sticky wirings
- keep pattern semantics unchanged

## Why

A platform reply to the bot is an explicit address, but routing currently wakes mention-mode agents only for a platform mention. Adapters already serialize reply context, so a narrowly scoped flag lets each adapter identify its own bot without teaching the router platform-specific rules.

Replies to humans or other bots remain non-triggering and still follow the configured ignored-message policy.

This is a smaller follow-up to the approach explored in #2643 and #2644. Credit to @yairixStudio for the earlier investigation and implementation direction.

## Verification

- pnpm test: 162 files, 2071 tests passed
- pnpm build: passed
- focused router suite: 42 tests passed
- Prettier check: passed
- ESLint on touched files: no errors

## Scope

This PR contains only the platform-agnostic contract and routing behavior. Telegram detection is proposed separately against the channels branch.