### PR TITLE
fix: detect Telegram replies to the current bot

### DIFF
--- a/src/channels/telegram-reply-context.test.ts
+++ b/src/channels/telegram-reply-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractTelegramReplyContext } from './telegram.js';
+
+describe('Telegram reply context', () => {
+  const replyRaw = (from: { is_bot?: boolean; username?: string; first_name?: string }) => ({
+    reply_to_message: {
+      text: 'Earlier bot answer',
+      from,
+    },
+  });
+
+  it('marks a reply to the current bot using a normalized exact username match', () => {
+    expect(
+      extractTelegramReplyContext(
+        replyRaw({ is_bot: true, username: 'Current_Bot', first_name: 'Current Bot' }),
+        '@current_bot',
+      ),
+    ).toMatchObject({
+      text: 'Earlier bot answer',
+      sender: 'Current Bot',
+      isReplyToBot: true,
+    });
+  });
+
+  it.each([
+    ['another bot', { is_bot: true, username: 'another_bot' }, 'current_bot'],
+    ['a human', { is_bot: false, username: 'person' }, 'current_bot'],
+    ['an unresolved identity', { is_bot: true, username: 'current_bot' }, null],
+  ])('fails closed for a reply to %s', (_label, from, botUsername) => {
+    expect(
+      (extractTelegramReplyContext(replyRaw(from), botUsername) as { isReplyToBot?: boolean } | null)?.isReplyToBot,
+    ).toBe(false);
+  });
+});

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -55,14 +55,25 @@ async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5
   throw lastErr;
 }
 
+function normalizeTelegramUsername(username: unknown): string | null {
+  if (typeof username !== 'string') return null;
+  const normalized = username.trim().replace(/^@/, '').toLowerCase();
+  return normalized || null;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
+export function extractTelegramReplyContext(raw: Record<string, any>, botUsername: string | null): ReplyContext | null {
   if (!raw.reply_to_message) return null;
   const reply = raw.reply_to_message;
-  return {
+  const from = reply.from;
+  const expectedUsername = normalizeTelegramUsername(botUsername);
+  const replyUsername = normalizeTelegramUsername(from?.username);
+  const context: ReplyContext & { isReplyToBot: boolean } = {
     text: reply.text || reply.caption || '',
-    sender: reply.from?.first_name || reply.from?.username || 'Unknown',
+    sender: from?.first_name || from?.username || 'Unknown',
+    isReplyToBot: from?.is_bot === true && expectedUsername !== null && replyUsername === expectedUsername,
   };
+  return context;
 }
 
 /** Look up the bot username via Telegram getMe. Cached after first call. */
@@ -379,11 +390,16 @@ export function createTelegramBridge(options: TelegramBridgeOptions = {}): Chann
     botToken: token,
     mode: 'polling',
   });
+  const identity: { username: string | null } = { username: null };
+  const botUsernamePromise = fetchBotUsername(token).then((username) => {
+    identity.username = username;
+    return username;
+  });
   const bridge = createChatSdkBridge({
     adapter: telegramAdapter,
     instance: options.instanceKey, // undefined ⇒ default instance (keyed by channelType)
     concurrency: 'concurrent',
-    extractReplyContext,
+    extractReplyContext: (raw) => extractTelegramReplyContext(raw, identity.username),
     supportsThreads: false,
     defaults: TELEGRAM_DEFAULTS,
     // No transformOutboundText: @chat-adapter/telegram >= 4.29 parses
@@ -393,8 +409,6 @@ export function createTelegramBridge(options: TelegramBridgeOptions = {}): Chann
     // adapter then parsed as emphasis and rendered as _italic_.
     maxTextLength: 4000,
   });
-
-  const botUsernamePromise = fetchBotUsername(token);
 
   const wrapped: ChannelAdapter = {
     ...bridge,
@@ -414,6 +428,10 @@ export function createTelegramBridge(options: TelegramBridgeOptions = {}): Chann
       }
     },
     async setup(hostConfig: ChannelSetup) {
+      // Resolve this bridge's identity before polling starts so even the
+      // first inbound reply is classified deterministically. getMe failures
+      // resolve to null and therefore fail closed without blocking setup.
+      await botUsernamePromise;
       const intercepted: ChannelSetup = {
         ...hostConfig,
         onInbound: createTelegramInboundInterceptor(botUsernamePromise, hostConfig.onInbound, token, instanceKey),


### PR DESCRIPTION
## What

- resolve the current Telegram bot username with getMe before polling begins
- mark reply context only when the quoted author is a bot and its normalized username exactly matches the current bot
- keep identity state local to each bridge instance
- fail closed when bot identity cannot be resolved

## Why

Telegram replies are explicit addressing, but the adapter currently provides only quoted text and sender. This supplies the platform-specific signal consumed by #3600.

Unlike the earlier approach in #2644, this does not use module-global identity state and does not temporarily treat every bot as the current bot. That keeps multiple Telegram instances isolated and prevents false wake-ups on replies to other bots.

Credit to @yairixStudio for the earlier investigation in #2643 and #2644.

## Dependency

Depends on #3600 for the ReplyContext contract and routing behavior. The local return type is intentionally structural so this branch remains type-compatible before that PR lands.

## Verification

- Telegram reply-context and registration tests: 2 files, 5 tests passed
- Prettier check on touched files: passed
- ESLint on touched files: no errors
- full branch test run: 2099 passed, 19 skipped, 10 existing unrelated channel-registration failures
- full branch build and lint are currently blocked by existing errors in untouched channels-branch modules

Draft until #3600 lands or the maintainers choose a coordinated merge order.