### PR TITLE
Canvas and rooms MCP tools, Slack construct/A2A skills, module updates

### DIFF
--- a/.claude/skills/slack-a2a-rooms/SKILL.md
+++ b/.claude/skills/slack-a2a-rooms/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: slack-a2a-rooms
+description: Agent-to-agent Slack rooms — a group DM (MPIM) holding a human plus two or more NanoClaw sibling bots, where each bot hears the room over its own Socket Mode connection. Registers the admission policy on the Slack channel's bot-inbound guard so bot-authored inbound is admitted only for rooms allowlisted in SLACK_A2A_ROOMS (re-attributed as slack:bot:<bot_id>, hop-limited via SLACK_A2A_MAX_HOPS), plus scripts/open-a2a-room.ts to open a room and register it.
+---
+
+# Slack agent-to-agent rooms (SLACK_A2A_ROOMS)
+
+Lets two or more NanoClaw Slack bots talk to each other — and to a human — in
+a shared group DM (MPIM). Empirically established against live Slack:
+`conversations.open` with `users=[<human>, <other bot user id>…]` works from a
+bot token holding `mpim:write` and returns an `is_mpim` channel, and bots
+receive each other's messages over their own Socket Mode connections as plain
+`message` events with `channel_type: "mpim"`, `bot_id` set, and `subtype`
+null.
+
+**Where sibling-bot messages die today.** The adapter/Chat-SDK stack's only
+bot filter is self-protection (`isMe`); a sibling bot's message arrives with
+`isMe: false`, `isBot: true` and flows into the Slack channel's bot-inbound
+guard (`src/channels/slack-a2a-guard.ts`, installed with `/add-slack`), which
+drops all bot-authored inbound at the bridge boundary by default — before the
+router, before any sender-approval flow. The guard exposes a single admission
+seam, `setBotInboundPolicy`; this skill registers the policy that opens it up
+selectively:
+
+- Rooms listed in `SLACK_A2A_ROOMS`: bot-authored inbound passes, attributed
+  to the user id `slack:bot:<bot_id>`, under a consecutive-hop limit.
+- Everywhere else: bot-authored inbound stays dropped at the bridge, exactly
+  as the guard's default already does.
+
+**Loop safety.** After N consecutive bot-authored inbound messages in an A2A
+room without a human message (N = `SLACK_A2A_MAX_HOPS`, default 6), further
+bot messages are dropped with a log line until a human speaks. The counter is
+per bot identity and per room; any human message resets it.
+
+**Requires:**
+
+- The Slack channel installed (`/add-slack`), current enough to ship the
+  bot-inbound guard (`src/channels/slack-a2a-guard.ts` with the
+  `setBotInboundPolicy` seam). The default drop arrives with that payload;
+  this skill only adds the allowlisted-room admission on top.
+- At least two Slack bot identities on this host (or sibling bots on other
+  hosts sharing the workspace). Named identities are registered natively by
+  the adapter from `SLACK_INSTANCES` — see the `slack-multi-instance` skill
+  for the env-key format. `scripts/open-a2a-room.ts` reads tokens by that
+  convention (`SLACK_BOT_TOKEN_<NAME>`; `default` → `SLACK_BOT_TOKEN`).
+- Every participating app's manifest must carry the MPIM scopes and event:
+  `mpim:write` (open the room), `mpim:history` + `mpim:read` (see it), and
+  the `message.mpim` bot event (hear it). Apps provisioned through the
+  managed flow (`apps.manifest.create` + `apps.managedInstall`) already
+  include all of these.
+
+## Apply
+
+### 1. Verify the installed Slack channel ships the bot-inbound guard
+
+The policy module copied next imports `setBotInboundPolicy` from the installed
+`src/channels/slack-a2a-guard.ts`. On a Slack payload that predates the guard,
+that import takes down the channel barrel — and with it **every** adapter — so
+verify the seam first. If the check fails, **stop**: re-run `/add-slack` from a
+channels branch that ships the guard, then re-apply this skill.
+
+```nc:run effect:check
+grep -sq 'export function setBotInboundPolicy' src/channels/slack-a2a-guard.ts || { echo 'slack-a2a-rooms: src/channels/slack-a2a-guard.ts is missing or does not export setBotInboundPolicy. Installing anyway would break the channel barrel and take down every channel adapter. Update the installed Slack channel first (re-run /add-slack from a channels branch that ships the bot-inbound guard), then re-apply this skill.' >&2; exit 1; }
+```
+
+### 2. Copy the policy module, its guard test, and the room-opener script
+
+This skill ships three files alongside this document; copy them into the tree
+at the same relative paths (overwrite; the skill's copies are canonical):
+
+```nc:copy
+src/channels/slack-a2a.ts
+src/channels/slack-a2a.test.ts
+scripts/open-a2a-room.ts
+```
+
+- `slack-a2a.ts` — the admission policy: `SLACK_A2A_ROOMS` /
+  `SLACK_A2A_MAX_HOPS` parsing (re-read with a ~30s cache so a freshly opened
+  room needs no restart), the per-room, per-identity consecutive-hop counter
+  with human reset, and the `slack:bot:<bot_id>` re-attribution. The module
+  registers itself onto the guard's admission seam on import.
+- `slack-a2a.test.ts` — the guard: drives the real channel barrel and the
+  real bot-inbound guard end-to-end (see step 4 for what it pins).
+- `open-a2a-room.ts` — operator CLI to open a room (see Configuration).
+
+### 3. Register the policy module
+
+Append the self-registration import to the channel barrel (skipped if the
+line is already present). Appending at the end keeps it after the Slack
+channel's own imports:
+
+```nc:append to:src/channels/index.ts
+import './slack-a2a.js';
+```
+
+### 4. Build and validate
+
+Build first — it guards the typed `setBotInboundPolicy` call against guard
+drift. The test imports the real channel barrel (a deleted or broken barrel
+line goes red) and asserts the policy end-to-end: allowlisted-room admission
+with `slack:bot:<bot_id>` re-attribution, non-listed-room drop, the hop limit
+with human reset, per-room/per-identity budgets, and that a downstream throw
+consumes no hop budget:
+
+```nc:run effect:build
+pnpm run build
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/channels/slack-a2a.test.ts
+```
+
+## Configuration
+
+`.env` keys (both re-read with a ~30s cache — no restart needed after edits):
+
+- `SLACK_A2A_ROOMS` — comma-separated raw Slack channel ids (the MPIM ids the
+  opener script prints, e.g. `G0AAAAAAA` — note MPIM ids may start with `G`
+  or `C` depending on workspace vintage). Only these rooms admit bot-authored
+  inbound.
+- `SLACK_A2A_MAX_HOPS` — consecutive bot-authored inbound messages allowed in
+  an A2A room without a human message before further bot messages are dropped.
+  Default `6`.
+
+### Opening a room
+
+```bash
+pnpm exec tsx scripts/open-a2a-room.ts --instances dana,eli --user U0AAAAAAA
+```
+
+The first listed instance opens the conversation (via `conversations.open`
+with the human + the other bots' user ids, resolved through `auth.test` per
+token) and posts an intro message. The script prints the channel id and
+appends it to `SLACK_A2A_ROOMS` in `.env`. Without `--user` you get a
+bots-only room, which needs at least three instances (Slack collapses a
+two-party open into a 1:1 IM).
+
+### Letting bot senders through the access gate
+
+The room allowlist gets bot messages *to* the router; the permissions module
+still gates them like any sender. Bot senders arrive as user id
+`slack:bot:<bot_id>`, which starts unknown. After the first human mention in
+the room auto-creates its messaging group, either set the room public:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:<channel id>'"
+```
+
+or keep `request_approval` and approve each `slack:bot:<bot_id>` sender once
+(or add them as members of the agent group). A private A2A room with known
+humans is a reasonable place for `public`.
+
+## Engagement: A2A conversation is mention-driven
+
+An MPIM is a *group* context in NanoClaw's channel-defaults model (Slack DMs
+are only `D…` channels), so the Slack group defaults apply:
+`engage_mode: mention-sticky`, per-thread stickiness. That means a bot
+replies when it is @-mentioned (then stays engaged in that thread) — it does
+not answer every room message. Bot-to-bot conversation is therefore
+**mention-driven by design**: bot A's reply reaches bot B's agent when it
+@-mentions bot B, and the chain continues only as long as each reply
+mentions the next speaker. Slack does not emit `app_mention` for
+bot-authored messages, but mention detection still works: the Chat SDK's
+text-level detector matches the bot's own `<@U…>` token, which the adapter
+deliberately leaves unresolved in the text. This is the intended loop
+governor alongside the hop limit — prompt the agents (group CLAUDE.md /
+personality) to @-mention the sibling they want an answer from, and to stop
+mentioning anyone when the exchange has converged.
+
+## Remove
+
+1. Delete the three copied files: `src/channels/slack-a2a.ts`,
+   `src/channels/slack-a2a.test.ts`, `scripts/open-a2a-room.ts`.
+2. Delete the `import './slack-a2a.js';` line from `src/channels/index.ts`.
+3. Remove `SLACK_A2A_ROOMS` and `SLACK_A2A_MAX_HOPS` from `.env`.
+4. Optionally re-tighten any messaging groups you set to
+   `unknown_sender_policy='public'`, and archive/leave the MPIMs from Slack
+   (the rooms themselves are ordinary Slack conversations; NanoClaw holds no
+   other state for them beyond the usual messaging-group/session rows).
+5. Rebuild (`pnpm run build`).
+
+With the skill removed, the channel guard's default applies everywhere again:
+bot-authored inbound is dropped in every room.
+
+## Notes
+
+- **Bot senders outside A2A rooms**: the Slack channel's bot-inbound guard
+  drops bot-authored messages in rooms not listed in `SLACK_A2A_ROOMS` at the
+  bridge — before the router and before any sender-approval flow — with or
+  without this skill applied. If an install relies on a bot sender (another
+  workspace app posting into a channel the agent watches), add that room to
+  `SLACK_A2A_ROOMS`. Human messages are never affected.
+- **Access-gate story is manual.** The recipe deliberately leaves letting
+  `slack:bot:<bot_id>` senders through the gate as an operator step (public
+  policy or per-bot approval). Should `open-a2a-room.ts` instead pre-create
+  the messaging group + wirings + members via `ncl` so a room works with zero
+  extra steps? That needs the host running and a choice of agent group per
+  bot — deferred.
+- **Hop-counter scope.** The counter counts bot-authored *inbound* per bot
+  identity (bridge instance). A bot's own outbound is invisible to it (`isMe`
+  dropped upstream), so with two bots the effective conversation length is
+  roughly `2×maxHops` messages; with k bots each message increments k−1
+  counters. If per-room total (not per-identity) semantics are wanted, the
+  counter needs to live host-side (router/session), not in the channel layer.
+- **Cross-host rooms.** For sibling bots on *different* NanoClaw hosts, each
+  host needs this skill (its own allowlist entry). The opener script only
+  handles co-hosted tokens; opening a cross-host room means running it where
+  the first bot's token lives and adding the room id to the other host's
+  `.env` manually.
+- **`message_changed` / edited bot messages** are not admitted (the adapter
+  only forwards unfurl data for edits) — fine for v1.
+- **Attribution name.** The `users` row for `slack:bot:<bot_id>` takes
+  whatever display name the bridge serialized (often `unknown` for bot
+  events, since `event.username` is frequently absent and `event.user` is
+  unset). A nicety would be resolving the bot's profile name via
+  `bots.info` — deferred.
+- **MPIM id prefix.** Older workspaces mint MPIM ids starting with `G`,
+  newer ones with `C`. The allowlist matches exact ids so both work, but the
+  adapter's `getChannelVisibility` calls `C…` ids "workspace"-visible —
+  cosmetic only, nothing here branches on it.

--- a/.claude/skills/slack-a2a-rooms/scripts/open-a2a-room.ts
+++ b/.claude/skills/slack-a2a-rooms/scripts/open-a2a-room.ts
@@ -1,0 +1,203 @@
+/**
+ * scripts/open-a2a-room.ts — open a Slack agent-to-agent (A2A) room.
+ *
+ * Creates a group DM (MPIM) holding a human plus two or more NanoClaw sibling
+ * bots, posts an intro message from the first bot, prints the channel id, and
+ * appends it to SLACK_A2A_ROOMS in .env so the slack-a2a-rooms bridge filter
+ * starts admitting bot-authored messages there (picked up within ~30s — no
+ * service restart required).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]
+ *
+ * Instance names follow the slack-multi-instance convention: each name reads
+ * its bot token from SLACK_BOT_TOKEN_<NAME> (uppercased, dashes →
+ * underscores); the special name `default` reads SLACK_BOT_TOKEN. The first
+ * listed instance is the caller — it opens the conversation and posts the
+ * intro. Bot user ids are resolved via auth.test per token.
+ *
+ * Requires the `mpim:write` scope on every listed app (see the skill's
+ * prerequisites). Without --user the room holds bots only, which needs at
+ * least three instances (Slack turns a two-party open into a 1:1 IM).
+ *
+ * Token values are never printed.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from '../src/env.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+interface SlackAuth {
+  name: string;
+  envKey: string;
+  token: string;
+  userId: string; // U… bot user id (auth.test user_id)
+  botId: string | null; // B… bot id (auth.test bot_id)
+}
+
+function fail(msg: string): never {
+  console.error(`open-a2a-room: ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): { instances: string[]; user?: string } {
+  let instances: string[] = [];
+  let user: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--instances') {
+      instances = (argv[++i] ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (argv[i] === '--user') {
+      user = argv[++i];
+    } else {
+      fail(
+        `unknown argument: ${argv[i]}\nUsage: pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]`,
+      );
+    }
+  }
+  if (instances.length < 2) fail('--instances needs at least two comma-separated instance names');
+  if (!user && instances.length < 3) {
+    fail(
+      'without --user the room holds bots only, which needs at least three instances (a two-party open becomes a 1:1 IM)',
+    );
+  }
+  if (user && !/^[UW][A-Z0-9]+$/.test(user)) {
+    fail(`--user must be a Slack user id (U…/W…), got: ${user}`);
+  }
+  return { instances, user };
+}
+
+function tokenEnvKey(name: string): string {
+  if (name === 'default') return 'SLACK_BOT_TOKEN';
+  return `SLACK_BOT_TOKEN_${name.toUpperCase().replace(/-/g, '_')}`;
+}
+
+async function slackCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (json.ok !== true) {
+    throw new Error(`${method} failed: ${String(json.error ?? `HTTP ${res.status}`)}`);
+  }
+  return json;
+}
+
+async function resolveAuth(name: string): Promise<SlackAuth> {
+  const envKey = tokenEnvKey(name);
+  const env = readEnvFile([envKey]);
+  const token = env[envKey];
+  if (!token) fail(`missing ${envKey} in .env (slack-multi-instance token convention)`);
+  const auth = await slackCall(token, 'auth.test', {});
+  const userId = typeof auth.user_id === 'string' ? auth.user_id : null;
+  if (!userId) fail(`auth.test for instance "${name}" returned no user_id`);
+  return {
+    name,
+    envKey,
+    token,
+    userId,
+    botId: typeof auth.bot_id === 'string' ? auth.bot_id : null,
+  };
+}
+
+/** Append the room to SLACK_A2A_ROOMS in .env (create the key if absent,
+ * no-op if the id is already listed). */
+function appendRoomToEnv(roomId: string): 'appended' | 'already-present' | 'created' {
+  const envPath = path.join(process.cwd(), '.env');
+  let content = '';
+  try {
+    content = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    // no .env — create one with just this key
+  }
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.trim().startsWith('SLACK_A2A_ROOMS='));
+  if (idx === -1) {
+    const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+    fs.writeFileSync(envPath, `${content}${suffix}SLACK_A2A_ROOMS=${roomId}\n`);
+    return 'created';
+  }
+  const existing = lines[idx].slice(lines[idx].indexOf('=') + 1).trim();
+  const rooms = existing
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (rooms.includes(roomId)) return 'already-present';
+  rooms.push(roomId);
+  lines[idx] = `SLACK_A2A_ROOMS=${rooms.join(',')}`;
+  fs.writeFileSync(envPath, lines.join('\n'));
+  return 'appended';
+}
+
+async function main(): Promise<void> {
+  const { instances, user } = parseArgs(process.argv.slice(2));
+
+  console.log(`Resolving bot identities for: ${instances.join(', ')}`);
+  const auths: SlackAuth[] = [];
+  for (const name of instances) {
+    const auth = await resolveAuth(name);
+    console.log(`  ${name}: bot user ${auth.userId}${auth.botId ? ` (bot id ${auth.botId})` : ''}`);
+    auths.push(auth);
+  }
+
+  const caller = auths[0];
+  const otherBotUserIds = auths.slice(1).map((a) => a.userId);
+  const members = [...(user ? [user] : []), ...otherBotUserIds];
+
+  console.log(`Opening group DM as "${caller.name}" with: ${members.join(', ')}`);
+  const opened = await slackCall(caller.token, 'conversations.open', {
+    users: members.join(','),
+  });
+  const channel = opened.channel as Record<string, unknown> | undefined;
+  const channelId = typeof channel?.id === 'string' ? channel.id : null;
+  if (!channelId) fail('conversations.open returned no channel id');
+  if (channel?.is_mpim !== true) {
+    console.warn(
+      `warning: opened conversation ${channelId} is not an MPIM (is_mpim=${String(channel?.is_mpim)}) — with fewer than three members Slack returns a 1:1 IM`,
+    );
+  }
+
+  const botMentions = otherBotUserIds.map((id) => `<@${id}>`).join(' ');
+  const introText =
+    `:robot_face: Agent-to-agent room opened by "${caller.name}". ` +
+    `${botMentions}${user ? ` <@${user}>` : ''} — bots in this room can hear each other. ` +
+    `Conversation is mention-driven: @-mention a bot to get its reply, and it can @-mention the next one. ` +
+    `After too many consecutive bot messages the room pauses until a human speaks.`;
+  await slackCall(caller.token, 'chat.postMessage', {
+    channel: channelId,
+    text: introText,
+  });
+
+  const envResult = appendRoomToEnv(channelId);
+  console.log('');
+  console.log(`A2A room channel id: ${channelId}`);
+  console.log(
+    envResult === 'already-present'
+      ? 'SLACK_A2A_ROOMS already lists this room — .env unchanged.'
+      : `SLACK_A2A_ROOMS ${envResult === 'created' ? 'created' : 'updated'} in .env — the bridge filter picks it up within ~30s (no restart needed).`,
+  );
+  console.log('');
+  console.log('Next steps (once per room):');
+  console.log(`  - Mention a bot in the room once so the host auto-creates the messaging group,`);
+  console.log(`    then allow bot senders through the access gate, e.g.:`);
+  console.log(
+    `      pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:${channelId}'"`,
+  );
+  console.log(`    (or approve / add the slack:bot:<bot_id> users as members instead of going public).`);
+  console.log(`  - Wire the room to each bot's agent group (ncl messaging-groups / wirings) if not auto-wired.`);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.test.ts
+++ b/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Guard for the slack-a2a-rooms admission policy and its registration.
+ *
+ * The skill's one reach-in is the barrel line `import './slack-a2a.js';` in
+ * src/channels/index.ts: importing the module installs the A2A room policy on
+ * the Slack channel layer's bot-inbound guard (setBotInboundPolicy). This
+ * file drives that wiring end-to-end through the REAL guard: it imports the
+ * real channel barrel — never ./slack-a2a.js directly, see the note at the
+ * env-parsing describe — and sends bridge-shaped inbound through
+ * wrapSlackBotGuard, asserting the policy's semantics:
+ *
+ *   - allowlisted rooms admit bot messages re-attributed as slack:bot:<bot_id>
+ *   - non-listed rooms stay dropped; humans pass everywhere, untouched
+ *   - the consecutive-hop limit drops bot messages until a human speaks
+ *   - budgets are tracked per room and per bot identity (bridge instance)
+ *   - a downstream throw does not consume hop budget
+ *
+ * If the barrel line is deleted (or the barrel fails to evaluate), no policy
+ * is installed, the guard's default drop applies, and the admit test goes
+ * red — exactly the composed-install failure this file guards. The guard's
+ * own mechanics (default drop, human byte-identical pass-through, fail-closed
+ * policy errors, non-Slack adapters untouched) are pinned by the channel
+ * payload's slack-a2a-guard.test.ts, not here.
+ *
+ * Config is read from .env (SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS) at first
+ * decision, so the test chdirs into a temp dir carrying a crafted .env BEFORE
+ * importing the barrel. Vitest's per-file process isolation keeps the chdir
+ * and the module cache local to this file. No DB, no Slack.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import { wrapSlackBotGuard } from './slack-a2a-guard.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'slack-a2a-'));
+  writeFileSync(
+    join(dir, '.env'),
+    'SLACK_A2A_ROOMS=G0ALLOW,G0HOPS,G0ROOMA,G0ROOMB,G0INST,G0THROW\nSLACK_A2A_MAX_HOPS=2\n',
+  );
+  process.chdir(dir);
+  await import('./index.js'); // the real barrel — installs the policy via the skill's barrel line
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+interface InboundCall {
+  platformId: string;
+  message: InboundMessage;
+}
+
+function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const setup: ChannelSetup = {
+    onInbound:
+      onInbound ??
+      ((platformId, _threadId, message) => {
+        calls.push({ platformId, message });
+      }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { setup, calls };
+}
+
+let nextMessageId = 0;
+
+/** Bridge-shaped inbound fixture (see chat-sdk-bridge.ts messageToInbound). */
+function makeInbound(author: Record<string, unknown>, text: string): InboundMessage {
+  const id = `msg-${++nextMessageId}`;
+  return {
+    id,
+    kind: 'chat-sdk',
+    content: { id, text, author, senderId: author.userId },
+    timestamp: new Date().toISOString(),
+    isGroup: true,
+  };
+}
+
+function humanMsg(): InboundMessage {
+  return makeInbound({ userId: 'U111', isBot: false, isMe: false }, 'hello');
+}
+
+function botMsg(botId = 'B999'): InboundMessage {
+  return makeInbound({ userId: botId, isBot: true, isMe: false }, 'from a sibling bot');
+}
+
+describe('slack-a2a room policy (registered via the channel barrel)', () => {
+  it('admits allowlisted bot messages re-attributed as slack:bot:<bot_id>', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const msg = botMsg('B42');
+
+    await wrapped.onInbound('slack:G0ALLOW', 'slack:G0ALLOW:171.1', msg);
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('slack:bot:B42');
+  });
+
+  it('drops bot messages for rooms not in SLACK_A2A_ROOMS', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:C0OTHER', null, botMsg());
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes human messages through unchanged — allowlisted room or not', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    const inRoom = humanMsg();
+    await wrapped.onInbound('slack:G0ALLOW', null, inRoom);
+    const outsideRoom = humanMsg();
+    await wrapped.onInbound('slack:C0OTHER', null, outsideRoom);
+
+    expect(calls).toHaveLength(2);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('U111');
+    expect((calls[1].message.content as Record<string, unknown>).senderId).toBe('U111');
+  });
+
+  it('enforces the consecutive-hop limit (SLACK_A2A_MAX_HOPS) and resets on a human message', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0HOPS';
+
+    await wrapped.onInbound(pid, null, botMsg('b1'));
+    await wrapped.onInbound(pid, null, botMsg('b2'));
+    expect(calls).toHaveLength(2);
+
+    // Third consecutive bot message exceeds maxHops=2 — dropped.
+    await wrapped.onInbound(pid, null, botMsg('b3'));
+    expect(calls).toHaveLength(2);
+
+    // A human message passes and resets the counter…
+    await wrapped.onInbound(pid, null, humanMsg());
+    expect(calls).toHaveLength(3);
+
+    // …so bot messages flow again.
+    await wrapped.onInbound(pid, null, botMsg('b4'));
+    expect(calls).toHaveLength(4);
+  });
+
+  it('tracks the hop budget per room', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a1'));
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a2'));
+    expect(calls).toHaveLength(2); // G0ROOMA at its limit (maxHops=2)
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a3'));
+    expect(calls).toHaveLength(2);
+
+    // A different room has its own budget.
+    await wrapped.onInbound('slack:G0ROOMB', null, botMsg('b1'));
+    expect(calls).toHaveLength(3);
+  });
+
+  it('tracks the hop budget per bot identity (bridge instance)', async () => {
+    const a = makeSetup();
+    const b = makeSetup();
+    const wrappedA = wrapSlackBotGuard(a.setup, 'slack');
+    const wrappedB = wrapSlackBotGuard(b.setup, 'slack-dana');
+    const pid = 'slack:G0INST';
+
+    await wrappedA.onInbound(pid, null, botMsg('a1'));
+    await wrappedA.onInbound(pid, null, botMsg('a2'));
+    await wrappedA.onInbound(pid, null, botMsg('a3'));
+    expect(a.calls).toHaveLength(2); // identity A exhausted its budget
+
+    // Identity B in the same room still has a full budget.
+    await wrappedB.onInbound(pid, null, botMsg('b1'));
+    expect(b.calls).toHaveLength(1);
+  });
+
+  it('does not consume hop budget when downstream throws', async () => {
+    let failNext = true;
+    const calls: InboundCall[] = [];
+    const { setup } = makeSetup(async (platformId, _threadId, message) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('router exploded');
+      }
+      calls.push({ platformId, message });
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0THROW';
+
+    // Admitted, but downstream throws — the message never reached a session,
+    // so the budget (maxHops=2) must be untouched.
+    await expect(wrapped.onInbound(pid, null, botMsg('t1'))).rejects.toThrow('router exploded');
+
+    // The full budget of two is still available…
+    await wrapped.onInbound(pid, null, botMsg('t2'));
+    await wrapped.onInbound(pid, null, botMsg('t3'));
+    expect(calls).toHaveLength(2);
+
+    // …and accounting still works: the third accepted hop is over the limit.
+    await wrapped.onInbound(pid, null, botMsg('t4'));
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('env parsing', () => {
+  // Imported dynamically, and only in this describe, which runs AFTER the
+  // behavior tests above: a static (or earlier) import of ./slack-a2a.js
+  // would install the policy as a side effect of this test file itself and
+  // mask a deleted barrel line. Via the barrel the module is already in the
+  // cache, so this import is a no-op read.
+  it('parseRooms splits, trims, and drops empties', async () => {
+    const { parseRooms } = await import('./slack-a2a.js');
+    expect([...parseRooms(' G0A , C0B ,,')]).toEqual(['G0A', 'C0B']);
+    expect(parseRooms(undefined).size).toBe(0);
+  });
+
+  it('parseMaxHops falls back to the default on junk', async () => {
+    const { parseMaxHops, DEFAULT_MAX_HOPS } = await import('./slack-a2a.js');
+    expect(parseMaxHops('4')).toBe(4);
+    expect(parseMaxHops('0')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('-2')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('six')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops(undefined)).toBe(DEFAULT_MAX_HOPS);
+  });
+});

--- a/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.ts
+++ b/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.ts
@@ -1,0 +1,135 @@
+/**
+ * Slack agent-to-agent (A2A) rooms — the admission policy for bot-authored
+ * inbound: room allowlist + consecutive-hop limit + `slack:bot:<bot_id>`
+ * re-attribution.
+ *
+ * The Slack channel layer's bot-inbound guard (src/channels/slack-a2a-guard.ts,
+ * installed with the Slack channel) drops every bot-authored inbound message
+ * at the bridge boundary by default — sibling and foreign bots never reach the
+ * router, so they can neither spam unknown-sender approval cards nor feed each
+ * other into loops. The guard exposes a single admission seam
+ * (`setBotInboundPolicy`); this module is that policy:
+ *
+ *   - Rooms allowlisted in `SLACK_A2A_ROOMS` (comma-separated Slack channel
+ *     ids, e.g. the MPIM ids printed by scripts/open-a2a-room.ts): bot-authored
+ *     inbound is admitted, re-attributed with sender id `slack:bot:<bot_id>`,
+ *     under a consecutive-hop limit (`SLACK_A2A_MAX_HOPS`, default 6) that any
+ *     human message in the room resets.
+ *   - Every other room: bot-authored inbound stays dropped (the guard logs the
+ *     drop with this policy's reason).
+ *
+ * Human-authored messages are structurally outside this policy's power: the
+ * guard passes them through untouched and only lets the policy observe them
+ * (for the hop-counter reset).
+ */
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { setBotInboundPolicy, type SlackBotInboundPolicy } from './slack-a2a-guard.js';
+
+export const DEFAULT_MAX_HOPS = 6;
+
+/** How long a read of SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS is cached.
+ * Short enough that a room appended to .env by scripts/open-a2a-room.ts is
+ * picked up without a service restart. */
+const CONFIG_TTL_MS = 30_000;
+
+export interface A2aConfig {
+  /** Raw Slack channel ids (C…/G…) allowed to carry bot-authored inbound. */
+  rooms: Set<string>;
+  /** Consecutive bot-authored inbound messages allowed without a human one. */
+  maxHops: number;
+}
+
+export function parseRooms(raw: string | undefined): Set<string> {
+  return new Set(
+    (raw ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+export function parseMaxHops(raw: string | undefined): number {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_MAX_HOPS;
+}
+
+let cached: { at: number; config: A2aConfig } | null = null;
+
+function readA2aConfig(): A2aConfig {
+  const now = Date.now();
+  if (cached && now - cached.at < CONFIG_TTL_MS) return cached.config;
+  const env = readEnvFile(['SLACK_A2A_ROOMS', 'SLACK_A2A_MAX_HOPS']);
+  cached = {
+    at: now,
+    config: {
+      rooms: parseRooms(env.SLACK_A2A_ROOMS),
+      maxHops: parseMaxHops(env.SLACK_A2A_MAX_HOPS),
+    },
+  };
+  return cached.config;
+}
+
+/** The guard reports the adapter's channel id (`slack:C0…`); the allowlist
+ * holds raw Slack channel ids. */
+function roomFromPlatformId(platformId: string): string {
+  const idx = platformId.indexOf(':');
+  return idx === -1 ? platformId : platformId.slice(idx + 1);
+}
+
+/**
+ * Build the A2A room policy. The hop counter is per bot identity and per room
+ * — keyed on the guard's instanceKey, since each bridge instance is one bot
+ * identity, and a bot's own outbound never arrives here (the SDK drops `isMe`
+ * upstream). With two bots the effective conversation length is therefore
+ * roughly 2×maxHops messages. Any human message in a room resets that room's
+ * counter for the identity that heard it; every co-hosted identity hears the
+ * same human message over its own connection, so the budgets reset together.
+ *
+ * `getConfig` is injectable for tests; production reads .env with a short TTL
+ * cache.
+ */
+export function createA2aRoomPolicy(getConfig: () => A2aConfig = readA2aConfig): SlackBotInboundPolicy {
+  /** Consecutive accepted bot hops, keyed `<instanceKey>:<room>`. */
+  const hops = new Map<string, number>();
+
+  return {
+    decideBotInbound(ctx) {
+      const room = roomFromPlatformId(ctx.platformId);
+      const { rooms, maxHops } = getConfig();
+      if (!rooms.has(room)) {
+        return { action: 'drop', reason: 'room not in SLACK_A2A_ROOMS' };
+      }
+      const key = `${ctx.instanceKey}:${room}`;
+      const count = hops.get(key) ?? 0;
+      if (count >= maxHops) {
+        log.info('slack-a2a: hop limit reached — dropping bot messages until a human speaks', {
+          room,
+          botId: ctx.botId,
+          maxHops,
+        });
+        return { action: 'drop', reason: 'hop limit reached' };
+      }
+      return {
+        action: 'admit',
+        // The permissions module uses a senderId that already contains a ':'
+        // verbatim (see extractAndUpsertUser), so the users row becomes
+        // `slack:bot:<bot_id>` — distinguishable from human `slack:U…` ids.
+        senderId: `slack:bot:${ctx.botId}`,
+        // The guard fires this only after downstream accepted the message —
+        // a throw in the host's onInbound must not consume budget for a
+        // message that never reached a session.
+        onAccepted: () => hops.set(key, count + 1),
+      };
+    },
+    onHumanInbound(ctx) {
+      // Human message — reset this identity's hop counter for the room.
+      hops.delete(`${ctx.instanceKey}:${roomFromPlatformId(ctx.platformId)}`);
+    },
+  };
+}
+
+// Install the policy on the channel layer's guard (single provider — the
+// guard warns if another policy was already installed). Runs on barrel
+// import, like every channel module's self-registration.
+setBotInboundPolicy(createA2aRoomPolicy());

--- a/.claude/skills/slack-agent-flow/REMOVE.md
+++ b/.claude/skills/slack-agent-flow/REMOVE.md
@@ -1,0 +1,45 @@
+# Remove slack-agent-flow
+
+Reverses everything Apply added. Runtime data the flow created (agent groups,
+messaging groups, wirings, `.env` token/instance/room lines, provisioned Slack
+apps) is user data and is deliberately left alone — for per-agent teardown of
+a provisioned bot, follow the slack-managed-agents skill's teardown section.
+
+1. Delete the barrel registration lines (delete, don't comment out):
+   - `import './slack-agent-flow/index.js';`, `import './slack-room-membership/index.js';`,
+     `import './canvas-actions/index.js';`, and `import './slack-onboarding/index.js';`
+     from `src/modules/index.ts`
+   - `import './rooms.js';` and `import './canvas.js';` from
+     `container/agent-runner/src/mcp-tools/index.ts`
+
+2. Delete the copied payload files (the flow's own plus the shared feature
+   payload it copies from the channels branch):
+
+   ```bash
+   rm -rf src/modules/slack-agent-flow src/modules/slack-room-membership \
+          src/modules/canvas-actions src/modules/slack-onboarding
+   rm -f src/env-file.ts src/env-file.test.ts
+   rm -f scripts/slack-agent-flow-finish.ts
+   rm -f container/agent-runner/src/mcp-tools/rooms.ts \
+         container/agent-runner/src/mcp-tools/rooms.test.ts \
+         container/agent-runner/src/mcp-tools/rooms.instructions.md \
+         container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md \
+         container/agent-runner/src/mcp-tools/canvas.ts \
+         container/agent-runner/src/mcp-tools/canvas.instructions.md \
+         container/agent-runner/src/mcp-tools/canvas.test.ts
+   rm -rf container/skills/slack-construct-agents container/skills/slack-construct \
+          container/skills/canvas-work
+   rm -f container/skills/welcome/addenda/teams-tour.md \
+         container/skills/welcome/addenda/slack.md
+   ```
+
+3. Rebuild and restart:
+
+   ```bash
+   pnpm run build
+   bash setup/lib/restart.sh
+   ```
+
+Composed group CLAUDE.md files regenerate on the next container spawn, so the
+dropped instructions fragment and welcome addendum disappear from agents
+without any manual cleanup.

--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: slack-agent-flow
+description: Let an existing Slack agent create new agents that arrive as their own Slack bots — provisioned app, operator DM, and a shared three-way room, hot-started without a host restart.
+---
+
+# Slack agent flow (create_agent → provisioned Slack bot)
+
+Composes the Slack extension skills into one conversational flow: a user tells
+an existing Slack-wired agent "create an agent called Research", and the new
+agent doesn't just exist as a `send_message` destination — it arrives in Slack
+as **its own bot**. The host provisions a Slack app for it (managed broker, or
+a workspace manager token), registers it as a `slack-<name>` instance,
+hot-starts the adapter in the running host, opens a DM between the new bot and
+the operator, opens a three-way MPIM (operator + originating bot + new bot)
+registered as an agent-to-agent room, and wires everything so both agents hear
+the room. The flow also adds two agent-facing room actions — `create_room`
+(one shared room with N agents at once, the team primitive) and `add_to_room`
+(grow a room by one agent) — and extends the base `create_agent` tool with the
+flow's `purpose` / `allow_guests` / `room` parameters. Non-Slack sessions are
+untouched: `create_agent` from any other channel behaves exactly as upstream.
+
+## Prerequisites
+
+All prose below assumes these are already in place, in this order:
+
+1. **`add-slack`** — the Slack channel install (`src/channels/slack.ts` and
+   the shared channel-layer lib `src/channels/slack-lib.ts` present, with
+   `slack.ts` exporting its `SLACK_DEFAULTS` declaration and the
+   multi-instance factory `slackInstanceBridgeFactory` — the adapter owns
+   `SLACK_INSTANCES` registration natively, and the flow writes each new
+   agent's tokens under that env-key scheme).
+2. **`slack-a2a-rooms`** — the bot-sender room policy
+   (`src/channels/slack-a2a.ts` present), so shared rooms admit the sibling
+   bots' posts.
+3. **A provisioning credential in `.env`** — `NANOCLAW_INSTALL_TOKEN` (managed
+   broker) or `SLACK_MANAGER_TOKEN` (direct workspace-level app creation).
+   Without one, agent creation still works but the Slack leg reports
+   `no-credentials` and points at the finish script.
+4. **At least one Slack owner/admin in `user_roles`** — the flow resolves "the
+   operator" from the approver chain (scoped admins → global admins → owners)
+   and needs a `slack:U…` identity there to open the DM and the room.
+
+## Apply
+
+### 1. Check the Slack payloads are installed
+
+The flow imports the skill-installed Slack channel modules; verify they are in
+the tree before copying anything. If `slack-lib.ts`, the `SLACK_DEFAULTS`
+export, or the `slackInstanceBridgeFactory` export is missing, the installed
+Slack channel payload predates this flow — re-apply the two skills above (or
+`/update-skills`) first:
+
+```nc:run effect:check
+test -f src/channels/slack.ts && test -f src/channels/slack-lib.ts && test -f src/channels/slack-a2a.ts && grep -q "export const SLACK_DEFAULTS" src/channels/slack.ts && grep -q "export function slackInstanceBridgeFactory" src/channels/slack.ts
+```
+
+### 2. Check the trunk extension seams
+
+Everything this flow plugs into is standard trunk API — the adapter hot-start
+entry, the delivery batch preview, the mailbox delivery/session helpers, the
+create-agent notify option, the decline-and-notify overrides, the container
+tool-extension hook, and the setup wizard's channel registries. This is a
+trunk **version requirement, not an edit**: if the check below fails, the
+NanoClaw trunk is too old for this skill — bring the install up to date
+(`/update-nanoclaw`) instead of patching any of these files by hand:
+
+```nc:run effect:check
+grep -q "export async function startChannelAdapter" src/channels/channel-registry.ts && grep -q "export function registerDeliveryBatchPreview" src/delivery.ts && grep -q "session: Session) => Promise<void>" src/delivery.ts && grep -q "trigger?: boolean" src/session-manager.ts && grep -q "findCliResponse" container/agent-runner/src/db/messages-in.ts && grep -q "Promise<number>" container/agent-runner/src/db/messages-out.ts && grep -q "suppressCreatedNotify" src/modules/agent-to-agent/create-agent.ts && grep -q "dedupeKey?: string" src/modules/permissions/sender-approval.ts && grep -q "declineText?: string" src/modules/permissions/sender-approval.ts && grep -q "fyiText?: string" src/modules/permissions/sender-approval.ts && grep -q "export function extendTool" container/agent-runner/src/mcp-tools/server.ts && grep -q "export function registerChannelPreStep" setup/channels/companions.ts && grep -q "instructions.md" src/claude-md-compose.ts && grep -q "await action.decide" src/guard/guard.ts
+```
+
+The last term requires an async-capable guard seam: the flow's `create_agent`
+and room-action guards read container config asynchronously, and on a trunk
+whose `guard()` does not await `decide` a returned Promise would be treated
+as an allow — the check turns that silent fail-open into a fail-fast here.
+
+### 3. Copy the shared feature payload from the channels branch
+
+The agents experience needs more than the base adapter: the room-membership
+module (invite-to-room adoption, group-DM fork carry-over, detach on removal,
+owner-presence access rule), canvas actions + the container `canvas` tool +
+the `canvas-work` skill (section-scoped canvas edits/reads via the session's
+own bot identity), DM onboarding (get-started prompts, per-thread DM titles),
+and their `env-file.ts` dotenv plumbing. They live on the `channels` branch;
+fetch and copy them into place (overwrite — the branch is canonical):
+
+```nc:copy from-branch:channels
+src/env-file.ts
+src/env-file.test.ts
+src/modules/slack-room-membership/index.ts
+src/modules/slack-room-membership/membership.ts
+src/modules/slack-room-membership/membership.test.ts
+src/modules/slack-room-membership/env-file.ts
+src/modules/slack-room-membership/env-file.test.ts
+src/modules/canvas-actions/index.ts
+src/modules/canvas-actions/handlers.ts
+src/modules/canvas-actions/canvas-api.ts
+src/modules/canvas-actions/canvas-actions.test.ts
+src/modules/slack-onboarding/index.ts
+src/modules/slack-onboarding/onboarding.test.ts
+src/modules/slack-onboarding/thread-title.test.ts
+container/agent-runner/src/mcp-tools/canvas.ts
+container/agent-runner/src/mcp-tools/canvas.instructions.md
+container/agent-runner/src/mcp-tools/canvas.test.ts
+container/skills/slack-construct/SKILL.md
+container/skills/slack-construct/instructions.md
+container/skills/canvas-work/SKILL.md
+container/skills/welcome/addenda/slack.md
+```
+
+The welcome addendum rides with the agents feature deliberately: its tour
+content describes rooms, canvases, suggested-prompt DMs, and the agents
+access model — none of which exist on a base `/add-slack` install.
+
+Register the three host modules in the modules barrel and the canvas tool in
+the container tool barrel (each append is skipped if already present; these
+must precede the flow module's own barrel line, which the fence order here
+guarantees):
+
+```nc:append to:src/modules/index.ts
+import './slack-room-membership/index.js';
+import './canvas-actions/index.js';
+import './slack-onboarding/index.js';
+```
+
+```nc:append to:container/agent-runner/src/mcp-tools/index.ts
+import './canvas.js';
+```
+
+### 4. Copy the flow payload
+
+This skill ships its payload alongside this document; copy the files into the
+tree at the same relative paths (overwrite; the skill's copies are canonical).
+The host module carries the wrapped `create_agent` handler and the room
+actions; the container files carry the room tools, the `create_agent`
+extension, the sibling-agent standing-context skill, and the welcome-tour
+addendum. The two `mcp-tools/*.instructions.md` fragments and the
+`slack-construct-agents` skill's `instructions.md` are picked up by the
+CLAUDE.md compose scan; the welcome addendum is consumed by the host's
+channel-matched addenda mechanism (inert on hosts that predate it) — so
+copying the files is the whole install:
+
+```nc:copy
+src/modules/slack-agent-flow/types.ts
+src/modules/slack-agent-flow/env-file.ts
+src/modules/slack-agent-flow/provision.ts
+src/modules/slack-agent-flow/slack-deps.ts
+src/modules/slack-agent-flow/orchestrate.ts
+src/modules/slack-agent-flow/guard.ts
+src/modules/slack-agent-flow/room-actions.ts
+src/modules/slack-agent-flow/room-canvas.ts
+src/modules/slack-agent-flow/index.ts
+src/modules/slack-agent-flow/env-file.test.ts
+src/modules/slack-agent-flow/provision.congruence.test.ts
+src/modules/slack-agent-flow/provision.prefetch.test.ts
+src/modules/slack-agent-flow/orchestrate.test.ts
+src/modules/slack-agent-flow/room-actions.test.ts
+src/modules/slack-agent-flow/room-canvas.test.ts
+scripts/slack-agent-flow-finish.ts
+container/agent-runner/src/mcp-tools/rooms.ts
+container/agent-runner/src/mcp-tools/rooms.test.ts
+container/agent-runner/src/mcp-tools/rooms.instructions.md
+container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+container/skills/slack-construct-agents/SKILL.md
+container/skills/slack-construct-agents/instructions.md
+container/skills/welcome/addenda/teams-tour.md
+```
+
+### 5. Register the host module
+
+Append the self-registration import to the module barrel (skipped if the line
+is already present). It must evaluate after the agent-to-agent module's own
+registration, which appending at the end guarantees — the flow's `create_agent`
+handler re-registers over upstream's:
+
+```nc:append to:src/modules/index.ts
+import './slack-agent-flow/index.js';
+```
+
+### 6. Register the container room tools
+
+Append the tool-module import to the container MCP-tools barrel (skipped if
+already present). The module registers `create_room` / `add_to_room` and
+extends the base `create_agent` tool, so it must evaluate after the base
+agents module — import order follows document order, and appending at the end
+guarantees it:
+
+```nc:append to:container/agent-runner/src/mcp-tools/index.ts
+import './rooms.js';
+```
+
+### 7. Build
+
+The build guards every typed call the flow makes into trunk (delivery
+registration, DB helpers, channel defaults, the shared Slack lib) against
+drift:
+
+```nc:run effect:build
+pnpm run build
+```
+
+### 8. Validate
+
+The flow's own tests, the shared feature payload's module tests, and the trunk
+hot-start seam's test run on the host. The room-tool tests run through the
+already-built agent image, so setup does not require Bun on the host; they also
+pin the `create_agent` extension:
+
+```nc:run effect:test
+pnpm exec vitest run src/modules/slack-agent-flow src/modules/slack-room-membership src/modules/canvas-actions src/modules/slack-onboarding src/env-file.test.ts src/channels/adapter-hot-start.test.ts
+```
+
+```nc:run effect:test
+source "$PWD/setup/lib/install-slug.sh" && "${CONTAINER_RUNTIME:-docker}" run --rm --entrypoint bun --workdir /app --volume "$PWD/container/agent-runner/src:/app/src:ro" "$(container_image_base):latest" test --preload /app/src/modules/index.ts src/mcp-tools/rooms.test.ts src/mcp-tools/canvas.test.ts
+```
+
+### 9. Restart the host
+
+The flow module registers at boot, and container mounts are read-only at
+runtime — restart so the running host picks everything up (new sessions see
+the container-side files; no image rebuild):
+
+```nc:run effect:restart
+bash setup/lib/restart.sh
+```
+
+## How it behaves
+
+- **Guard/approval flow is upstream's.** The flow re-registers `create_agent`
+  with the same guard action and precheck as the agent-to-agent module; only
+  the hold question changes when the request originates from a Slack session
+  (it names the Slack provisioning side effects — new app, operator DM,
+  shared room). The room actions get the same trust split: `global` cli_scope
+  groups act directly, everything else holds for the admin chain, and
+  approved replays re-enter the wrapped handlers automatically.
+- **Expected boot warning.** Because the barrel imports the flow module after
+  the agent-to-agent module, every boot logs
+  `Delivery action handler overwritten` for `create_agent`. That warning is
+  the intended signal that the wrapper won the registry — its absence means
+  the barrel line is missing or ordered wrong.
+- **What a successful run does.** Provisions (or reuses) the app — agent-mode
+  by default; `allow_guests: true` selects the plain, guest-accessible
+  variant — writes `SLACK_BOT_TOKEN_<NAME>` / `SLACK_APP_TOKEN_<NAME>` and
+  unions the slug into `SLACK_INSTANCES`, hot-starts `slack-<name>`, opens
+  the operator DM and wires it to the new agent group (agent-mode DMs get
+  thread-per-conversation sessions straight from the channel declaration),
+  opens the three-way MPIM with the new bot's token, appends the room's
+  channel id to `SLACK_A2A_ROOMS`, creates one room messaging group per
+  instance (both mention-gated), creates the room's canvas-tab contract, then
+  posts the DM intro and nudges the originating agent to introduce the new
+  one in the room. The new bot typically answers within ~10 seconds; if it
+  stays silent for a minute, an operator can run `bash setup/lib/restart.sh`
+  as the fallback.
+- **Workspaces that gate installs.** Where an admin must approve every app
+  install, the workspace refuses the automatic one and the managed service
+  answers with an install link instead of a bot token. The flow does not fall
+  back to hand-building an app: it posts one line into the conversation the
+  create came from — as the ORIGINATING bot, since the origin agent's own
+  reply cannot be delivered while the handler is still running — naming the
+  link to approve, then polls the service (5s, up to 5 minutes) for the bot
+  token the completed install releases. On arrival the rest of the flow runs
+  exactly as if the install had been automatic. On timeout the app parks:
+  `SLACK_APP_TOKEN_<NAME>`, `SLACK_APP_ID_<NAME>` and
+  `SLACK_INSTALL_URL_<NAME>` stay in `.env`, and asking the same agent for the
+  same name again resumes THAT app — it never provisions a second one.
+  `SLACK_INSTALL_WAIT_MS=0` skips the inline wait for installs that always go
+  through a slow approval queue; `SLACK_INSTALL_POLL_MS` moves the cadence.
+- **Teams get one room.** `create_agent({ ..., room: 'none' })` skips the
+  shared room; the multi-agent pattern is N such creates followed by ONE
+  `create_room` naming all of them. When a batch of creates arrives together,
+  their avatar generations are prefetched in parallel, so N waits collapse to
+  roughly one.
+- **A2A cache staleness.** The a2a room allowlist is re-read from `.env` on a
+  ≤30s cache. The room id is appended before any intro is posted, but the
+  originating agent's own bridge may still miss ingesting the intro inside
+  that window — harmless; the intro is for the human, and the originating
+  session is told the room id and wirings directly in its success message.
+- **Failures are resumable.** Any Slack-leg failure leaves the agent group
+  fully working via `send_message`, reports the exact step that failed, and
+  names the retry command. The finish script re-runs the whole leg
+  idempotently (tokens are reused from `.env`, rows are get-before-create,
+  intro posts fire only for newly created rows):
+
+  ```bash
+  pnpm exec tsx scripts/slack-agent-flow-finish.ts --group <newAgentGroupId> --name <slug> --source-group <sourceGroupId> [--origin-instance <key>] [--room none] [--allow-guests] [--restart]
+  ```
+
+  It runs outside the host process, so it cannot hot-start the adapter:
+  `--restart` runs `bash setup/lib/restart.sh` for you, otherwise it prints
+  the restart instruction.
+
+- **Setup-wizard leg.** On a trunk new enough for step 2's check, running
+  `bash nanoclaw.sh --slack-agents` does the whole install: the flag registers
+  the managed-provisioning pre-step and the companion list
+  (`slack-a2a-rooms`, then this skill) at wizard boot
+  (`setup/channels/slack-auto-register.ts` → `setup/channels/companions.ts`),
+  so the wizard provisions the first app, applies `/add-slack`, then applies
+  both feature skills with one deferred restart. Without the flag, setup
+  installs the base Slack experience only. That leg ships with trunk, and
+  this skill does not touch it.
+
+Everything the flow creates at runtime is user data, not skill payload: agent
+groups, messaging groups, and wirings stay in the central DB; token lines,
+`SLACK_INSTANCES` entries, and `SLACK_A2A_ROOMS` entries stay in `.env`;
+provisioned Slack apps stay in the workspace. Removal (see REMOVE.md) never
+touches any of it — for per-agent teardown of a provisioned bot, follow the
+slack-managed-agents skill's teardown section.

--- a/.claude/skills/slack-agent-flow/apply-fixtures.json
+++ b/.claude/skills/slack-agent-flow/apply-fixtures.json
@@ -1,0 +1,9 @@
+{
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — this skill declares no prompts and captures nothing, so one default scenario with no inputs covers the whole document (the two effect:check gates and the build/test/restart runs are exec-stubbed).",
+  "scenarios": [
+    {
+      "name": "default",
+      "inputs": {}
+    }
+  ]
+}

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
@@ -1,0 +1,9 @@
+## create_agent on Slack: acknowledge in the same turn (creation takes ~1 minute)
+
+On this install, every agent you create also gets its own Slack bot. Creation is not instant: a unique avatar is generated and a dedicated Slack app is provisioned, which takes about a minute. From the user's side that is silence — so ALWAYS acknowledge in the SAME turn as the `create_agent` call (before or alongside it), set the expectation, and say what happens next. Example: "On it — creating Pixel now. It takes about a minute; it'll introduce itself in a DM and open a shared room for the three of us."
+
+- What the user will see: roughly a minute of quiet, then an intro DM from the new agent plus a shared three-way room (you, the user, the new agent) — unless you passed `room: 'none'`, which skips the room (the team pattern: several agents with `room:'none'`, then one `create_room` with all of them — see the rooms tools).
+- Give each create a short PUBLIC `purpose` line (under 80 chars) — it appears in the room intro and on the room canvas; never put private detail from the instructions there.
+- In rooms, keep the acknowledgment brief — one short line, no play-by-play.
+- Some workspaces require an admin to approve every app install. When that happens the user gets a link to approve and setup finishes by itself once they do — so if they say the approval went through, or they ask you to finish setting that agent up, just call `create_agent` again with the SAME name. That resumes the app already waiting; it does not create a second one, and it is not a name collision.
+- You'll be notified when the agent is live (or get a failure notice with a fix-it command). Relay completion only when that arrives — never report "done" early.

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
@@ -1,0 +1,22 @@
+## Shared rooms (`create_room`, `add_to_room`)
+
+A room is one Slack group conversation shared by the user and N agents, with a canvas tab carrying the room contract (purpose, members). `mcp__nanoclaw__create_room({ name, purpose, agents, include_me? })` opens one; `mcp__nanoclaw__add_to_room({ room, agent })` grows one.
+
+### The team pattern — one room, not N
+
+When the user asks for a TEAM (several agents for one project), never let each `create_agent` open its own room — that yields N separate three-way rooms nobody wants:
+
+1. Create each agent with `room: 'none'` (they still get their operator DM).
+2. When all are live, call `create_room` ONCE with all their names and a short public `purpose`.
+
+For a SINGLE new agent, plain `create_agent` (default `room: 'own'`) is right — don't follow up with `create_room`.
+
+### How it works
+
+- `agents` takes the same names you use with `send_message` — agents you created or can already message. Unknown names come back as an error note, nothing half-created.
+- Both tools are fire-and-forget and may require admin approval; the outcome arrives as a system note. When the room is live, the note tells you the destination to post to and whom to tag — post a brief intro in your own voice (1-2 lines, no mechanics, no member lists).
+- In rooms, agents engage when @-mentioned; everything else accumulates as ambient context. Tag an agent to bring it in.
+
+### Growing a room
+
+`add_to_room` works, but Slack group conversations never grow in place — the room MOVES to a new conversation (everyone re-wired automatically; the old conversation keeps working). Prefer creating rooms complete: if you know the team needs four agents, create all four first, then one `create_room`.

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Room MCP tool tests: create_room / add_to_room arg validation and
+ * system-action row shape, plus the extendTool-based create_agent extension
+ * (schema/description growth + purpose/allow_guests/room payload
+ * passthrough) — all fire-and-forget writes to messages_out (authorization
+ * is host-side). Importing ./rooms.js applies the extension, so these tests
+ * exercise the same wiring the barrel produces.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
+import { createAgent } from './agents.js';
+import { addToRoom, createRoom } from './rooms.js';
+
+function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
+  return (
+    getOutboundDb().prepare('SELECT id, kind, content FROM messages_out ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, content: JSON.parse(r.content) }));
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+describe('create_room — arg validation', () => {
+  it('requires name', async () => {
+    const r = await createRoom.handler({ agents: ['Pixel'] });
+    expect(r.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('requires a non-empty agents list of names', async () => {
+    for (const agents of [undefined, [], ['  '], 'Pixel']) {
+      const r = await createRoom.handler({ name: 'Website Team', agents });
+      expect(r.isError).toBe(true);
+    }
+    expect(outboundActions()).toHaveLength(0);
+  });
+});
+
+describe('create_room — submission', () => {
+  it('writes a create_room system action with the full agent list', async () => {
+    const r = await createRoom.handler({
+      name: '  Website Team ',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toContain('Creating room "Website Team"');
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({
+      action: 'create_room',
+      name: 'Website Team',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+    // include_me travels only when explicitly false (host default is true).
+    expect(rows[0].content.include_me).toBeUndefined();
+  });
+
+  it('carries include_me:false only when explicitly set', async () => {
+    await createRoom.handler({ name: 'Duo', agents: ['Pixel'], include_me: false });
+    expect(outboundActions()[0].content).toMatchObject({ action: 'create_room', include_me: false });
+  });
+});
+
+describe('add_to_room', () => {
+  it('requires room and agent', async () => {
+    const r1 = await addToRoom.handler({ agent: 'Devin' });
+    expect(r1.isError).toBe(true);
+    const r2 = await addToRoom.handler({ room: 'Website Team' });
+    expect(r2.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('writes an add_to_room system action', async () => {
+    const r = await addToRoom.handler({ room: 'Website Team', agent: 'Devin' });
+    expect(r.isError).toBeUndefined();
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({ action: 'add_to_room', room: 'Website Team', agent: 'Devin' });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+});
+
+describe('create_agent — Slack extension (extendTool)', () => {
+  it('extends the base tool schema and description without editing agents.ts', () => {
+    const props = (createAgent.tool.inputSchema as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['name', 'instructions', 'purpose', 'allow_guests', 'room']),
+    );
+    expect(createAgent.tool.description).toContain('acknowledge the user in this SAME turn');
+  });
+
+  it('passes the registered keys through into the written system payload', async () => {
+    await createAgent.handler({ name: 'Pixel', room: 'none', purpose: 'design things' });
+    await createAgent.handler({ name: 'Solo' });
+    await createAgent.handler({ name: 'Own', room: 'own' });
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].content).toMatchObject({
+      action: 'create_agent',
+      name: 'Pixel',
+      room: 'none',
+      purpose: 'design things',
+    });
+    // No extension args → the payload stays byte-identical to the base tool's.
+    expect(rows[1].content.room).toBeUndefined();
+    expect(rows[1].content.purpose).toBeUndefined();
+    // The passthrough copies provided values verbatim; the host reads an
+    // explicit 'own' exactly as an absent room (both mean the default
+    // own-room policy), so nothing normalizes it away container-side.
+    expect(rows[2].content.room).toBe('own');
+  });
+});

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
@@ -1,0 +1,162 @@
+/**
+ * Room management MCP tools: create_room, add_to_room.
+ *
+ * A "room" is one Slack group conversation shared by the user and N agents.
+ * create_room is the team primitive — the multi-agent pattern is N
+ * create_agent calls with room:'none', then ONE create_room naming all of
+ * them. Both tools are fire-and-forget (create_agent pattern): they write an
+ * outbound system row and return; the host resolves names, opens the
+ * conversation, wires everyone, and reports back as a system note.
+ *
+ * Authorization is enforced host-side by the guard (same trust split as
+ * create_agent: trusted global-scope groups act directly, confined groups
+ * hold for admin approval) — the container is untrusted and cannot be relied
+ * on to gate itself.
+ *
+ * This module also extends the base `create_agent` tool (see the extendTool
+ * call at the bottom): the Slack flow adds `purpose` / `allow_guests` /
+ * `room` params and the acknowledge-now guidance without touching the base
+ * tool's source. The barrel imports this module after the base agents
+ * module, which is what makes the extension legal.
+ */
+import { writeMessageOut } from '../db/messages-out.js';
+import { extendTool, registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+export const createRoom: McpToolDefinition = {
+  tool: {
+    name: 'create_room',
+    description:
+      "Open ONE shared Slack room (group conversation) with the user and several agents at once — the team primitive. Use after creating the agents (create_agent with room:'none' for teams): one room with ALL of them, never one room per agent. May require admin approval. Fire-and-forget: the call returns immediately; you will get a system note when the room is live, telling you how to post the intro there.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string', description: 'Room name (also names the Slack conversation and its canvas)' },
+        purpose: {
+          type: 'string',
+          description:
+            'One short PUBLIC line (under 80 chars) saying what the room is for — shown on the room canvas. Never include private details.',
+        },
+        agents: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Agent names to include — the same names you use with send_message (agents you created or can already message).',
+        },
+        include_me: {
+          type: 'boolean',
+          description: 'Include yourself in the room. Default true — keep it unless the user explicitly excludes you.',
+        },
+      },
+      required: ['name', 'agents'],
+    },
+  },
+  async handler(args) {
+    const name = typeof args.name === 'string' ? args.name.trim() : '';
+    if (!name) return err('name is required');
+    const agents = Array.isArray(args.agents) ? args.agents.filter((a) => typeof a === 'string' && a.trim()) : [];
+    if (agents.length === 0) return err('agents must list at least one agent name');
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'create_room',
+        requestId,
+        name,
+        agents,
+        ...(typeof args.purpose === 'string' && args.purpose.trim()
+          ? { purpose: (args.purpose as string).trim() }
+          : {}),
+        ...(args.include_me === false ? { include_me: false } : {}),
+      }),
+    });
+
+    log(`create_room: ${requestId} → "${name}" (${agents.length} agents)`);
+    return ok(`Creating room "${name}". You will be notified when it is live.`);
+  },
+};
+
+export const addToRoom: McpToolDefinition = {
+  tool: {
+    name: 'add_to_room',
+    description:
+      'Add one agent to an existing shared room. Slack group conversations never grow in place — this moves the room to a NEW conversation containing everyone plus the new agent (the old one keeps working). For a planned team, prefer creating the room once, complete, via create_room. May require admin approval. Fire-and-forget: a system note reports the outcome.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        room: { type: 'string', description: 'Room name (as the room was created/named)' },
+        agent: { type: 'string', description: 'Agent name to add — the same name you use with send_message' },
+      },
+      required: ['room', 'agent'],
+    },
+  },
+  async handler(args) {
+    const room = typeof args.room === 'string' ? args.room.trim() : '';
+    const agent = typeof args.agent === 'string' ? args.agent.trim() : '';
+    if (!room) return err('room is required');
+    if (!agent) return err('agent is required');
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({ action: 'add_to_room', requestId, room, agent }),
+    });
+
+    log(`add_to_room: ${requestId} → "${agent}" into "${room}"`);
+    return ok(`Adding "${agent}" to room "${room}". You will be notified when it is done.`);
+  },
+};
+
+registerTools([createRoom, addToRoom]);
+
+// ── create_agent extension (Slack agent flow) ──
+//
+// Additive extension of the base create_agent tool: on a Slack-wired install
+// each created agent also gets a dedicated Slack bot, so the tool grows the
+// flow's three params and the acknowledge-now guidance. The registered
+// passthrough keys are copied verbatim into the system-action payload the
+// base handler writes — the host reads them exactly as it reads name and
+// instructions (room:'own' and allow_guests:false travel explicitly and read
+// as the defaults host-side).
+extendTool('create_agent', {
+  properties: {
+    purpose: {
+      type: 'string',
+      description:
+        'One short PUBLIC line (under 80 chars) saying what this agent is for — shown to everyone in the shared room intro and canvas. ALWAYS provide it. Never include private details from the instructions; without it the room states no purpose at all.',
+    },
+    allow_guests: {
+      type: 'boolean',
+      description:
+        'Set true ONLY if Slack workspace guests must be able to DM this agent — guests cannot access agent-mode bots, so this provisions a plain bot without the agent DM experience. Default false.',
+    },
+    room: {
+      type: 'string',
+      enum: ['own', 'none'],
+      description:
+        "Shared-room policy. 'own' (default) opens a room with you, the user, and the new agent — right for a single create. 'none' skips the room (the agent still gets its DM) — REQUIRED when creating several agents for one team: create each with room:'none', then call create_room ONCE with all of them. Never open per-agent rooms for a team.",
+    },
+  },
+  passthroughKeys: ['purpose', 'allow_guests', 'room'],
+  descriptionSuffix:
+    'The call returns immediately. Creation takes about a minute (a unique avatar is generated and a dedicated Slack bot is provisioned); when ready, the new agent introduces itself via DM and a shared room. You MUST acknowledge the user in this SAME turn, before or alongside this call — say you are on it, set the ~1-minute expectation, and mention the agent will introduce itself.',
+});

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/SKILL.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: slack-construct-agents
+description: Standing context for Slack sibling agents — one room per team, creator-posted introductions, bot-to-bot hop discipline. Ships as instructions.md composed into the group's CLAUDE.md at spawn; there is no workflow to invoke.
+---
+
+# Slack construct — sibling agents
+
+This skill is a carrier for standing context, not an on-demand workflow. Its
+payload is `instructions.md` in this directory: the rules an agent needs when
+it shares Slack with sibling agents it can create (`create_agent`) and room
+with (`create_room` / `add_to_room`) — team-room shape, who posts the
+introduction, and the bot-to-bot self-limit.
+
+The host composes every container skill's `instructions.md` into each group's
+CLAUDE.md at spawn (`src/claude-md-compose.ts`), so if you are reading this
+from inside a session, those rules are already part of your standing
+instructions. There is nothing further to load or run here.
+
+The room-and-canvas half of the Slack standing context (mention engagement,
+canvas discipline, access rules) ships separately with the Slack channel
+payload as the `slack-construct` skill; this fragment layers the
+sibling-agent rules on top and arrives with the slack-agent-flow skill.

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
@@ -1,0 +1,26 @@
+## Your Slack sibling agents
+
+You may be part of a construct of agents on Slack: sibling agents (each with its own bot,
+DM, and workspace) plus shared rooms where humans, you, and siblings talk. Standing rules
+for the sibling half:
+
+- **Teams get ONE room.** When the user asks for several agents for one project ("build me
+  a team"), create each agent with `create_agent({ ..., room: 'none' })` — they still get
+  their operator DM — then open a single shared room with
+  `create_room({ name, purpose, agents: [all of them] })`. Never let each create open its
+  own room: that yields N separate three-way rooms nobody wants. `add_to_room` works for
+  later growth, but Slack group DMs never grow in place — the room MOVES to a new
+  conversation (everyone is re-wired automatically; the old one keeps working), so prefer
+  creating rooms complete.
+- **You introduce agents you create.** When a shared room comes with an agent you created,
+  YOU post the introduction in the room — the host posts nothing there. You'll get a
+  system nudge telling you which destination to use. Keep it to 1-2 lines in your own
+  voice: say what the new agent is for and tag them with their `<@bot-user-id>` mention
+  (send it literally; it renders as a mention). No mechanics, no member lists — the room's
+  canvas tab already holds that.
+- **Bot-to-bot hop budget.** The platform may cap consecutive bot-to-bot messages (~6)
+  until a human speaks again, but do not rely on it — self-limit. Don't ping-pong with
+  siblings: do the work, converge, hand back to the human.
+- **Persist durable facts.** Conversations are per-session; rooms and DMs don't share
+  history. Anything worth keeping (decisions, preferences, ongoing state) goes in your
+  memory directory, not just the chat transcript.

--- a/.claude/skills/slack-agent-flow/container/skills/welcome/addenda/teams-tour.md
+++ b/.claude/skills/slack-agent-flow/container/skills/welcome/addenda/teams-tour.md
@@ -1,0 +1,17 @@
+---
+channel: slack
+---
+
+# Teams tour item (Slack agent flow)
+
+When the tour runs on Slack, also reveal this — same drip-feed rule as the base
+tour, one item at a time, 2-4 sentences:
+
+### Teams
+
+Want a whole team? Ask your agent to build one — e.g. "create a designer, a
+builder, and a reviewer for my new site, in one shared room." It will create
+the agents first and then open a single room with all of them (plus you). You
+can grow a room later by asking to add an agent, but Slack moves the
+conversation to a new group DM when members change — the old thread keeps
+working, and everything is rewired automatically.

--- a/.claude/skills/slack-agent-flow/scripts/slack-agent-flow-finish.ts
+++ b/.claude/skills/slack-agent-flow/scripts/slack-agent-flow-finish.ts
@@ -1,0 +1,178 @@
+/**
+ * Finish (or retry) the Slack leg of an agent created via create_agent.
+ *
+ * The in-host slack-agent-flow wrapper points here when the Slack leg fails
+ * partway: re-runs S1–S13 idempotently (provision reuses .env tokens, every
+ * DB row is get-before-create, conversations.open is idempotent on Slack's
+ * side, intro posts are gated on newly-created rows) EXCEPT the S5 hot-add —
+ * a separate process cannot start an adapter inside the live host, so the
+ * new instance comes online via a service restart instead (--restart runs it,
+ * otherwise the command is printed).
+ *
+ * Runs alongside the service the way scripts/init-first-agent.ts does
+ * (WAL-mode sqlite; no channel adapters are connected — the channels barrel
+ * import is registration-only, so declared defaults resolve here).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/slack-agent-flow-finish.ts \
+ *     --group <newAgentGroupId> \
+ *     --name <slug> \
+ *     --source-group <sourceAgentGroupId> \
+ *     [--origin-instance <key>] \   # default: slack
+ *     [--room none] \               # original create used room:'none' — skip the shared room
+ *     [--restart]
+ *
+ * Never prints token values — only key names and ids.
+ */
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+// Registration-only barrel import: channel modules call
+// registerChannelAdapter() at module scope (factories are NOT invoked, no
+// adapter connects), so declared channel defaults resolve here without live
+// adapters.
+import '../src/channels/index.js';
+import { SlackApiError } from '../src/channels/slack-lib.js';
+import { DATA_DIR } from '../src/config.js';
+import { getAgentGroup } from '../src/db/agent-groups.js';
+import { initDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { finishSlackAgentFlow } from '../src/modules/slack-agent-flow/orchestrate.js';
+import { SlackFlowError } from '../src/modules/slack-agent-flow/types.js';
+
+interface Args {
+  group: string;
+  name: string;
+  sourceGroup: string;
+  originInstance: string;
+  restart: boolean;
+  allowGuests: boolean;
+  room?: 'own' | 'none';
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Partial<Args> = {};
+  let restart = false;
+  let allowGuests = false;
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    switch (key) {
+      case '--group':
+        out.group = val;
+        i++;
+        break;
+      case '--name':
+        out.name = val;
+        i++;
+        break;
+      case '--source-group':
+        out.sourceGroup = val;
+        i++;
+        break;
+      case '--origin-instance':
+        out.originInstance = val;
+        i++;
+        break;
+      case '--room': {
+        if (val !== 'own' && val !== 'none') {
+          console.error(`--room must be 'own' or 'none', got "${val}"`);
+          process.exit(2);
+        }
+        out.room = val;
+        i++;
+        break;
+      }
+      case '--restart':
+        restart = true;
+        break;
+      case '--allow-guests':
+        allowGuests = true;
+        break;
+      default:
+        console.error(`Unknown flag: ${key}`);
+        process.exit(2);
+    }
+  }
+  const missing = (['group', 'name', 'sourceGroup'] as const).filter((k) => !out[k]);
+  if (missing.length) {
+    console.error(
+      `Missing required args: ${missing.map((k) => `--${k.replace(/([A-Z])/g, '-$1').toLowerCase()}`).join(', ')}`,
+    );
+    console.error('See scripts/slack-agent-flow-finish.ts header for usage.');
+    process.exit(2);
+  }
+  return {
+    group: out.group!,
+    name: out.name!,
+    sourceGroup: out.sourceGroup!,
+    originInstance: out.originInstance ?? 'slack',
+    restart,
+    allowGuests,
+    room: out.room,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const root = process.cwd();
+
+  const db = await initDb(path.join(DATA_DIR, 'v2.db'));
+  await runMigrations(db); // idempotent
+
+  const newGroup = await getAgentGroup(args.group);
+  if (!newGroup) throw new Error(`agent group ${args.group} not found (--group)`);
+  if (!(await getAgentGroup(args.sourceGroup))) {
+    throw new Error(`agent group ${args.sourceGroup} not found (--source-group)`);
+  }
+
+  const result = await finishSlackAgentFlow({
+    slug: args.name,
+    sourceGroupId: args.sourceGroup,
+    newAgentGroupId: args.group,
+    originInstanceKey: args.originInstance,
+    rootDir: root,
+    allowGuests: args.allowGuests,
+    room: args.room,
+    // A workspace install approval can hold this for minutes; say so rather
+    // than letting the script look hung.
+    onInstallPending: (text) => {
+      console.log('');
+      console.log(text);
+      console.log('Waiting…');
+    },
+  });
+
+  console.log('');
+  console.log('Slack leg complete:');
+  console.log(`  agent     ${newGroup.name} [${args.group}]`);
+  console.log(
+    `  instance  slack-${result.slug} (SLACK_INSTANCES + SLACK_*_TOKEN_${result.slug.toUpperCase().replace(/-/g, '_')})`,
+  );
+  console.log(`  bot       ${result.newBotUserId}`);
+  console.log(`  DM        ${result.dmChannelId} (operator ${result.operatorUserId})`);
+  console.log(
+    result.roomChannelId
+      ? `  room      ${result.roomChannelId} (SLACK_A2A_ROOMS)`
+      : `  room      (skipped — room:'none')`,
+  );
+  console.log('');
+
+  // S5 replacement: the new adapter instance connects on the next service
+  // start — this process cannot hot-add into the live host.
+  if (args.restart) {
+    console.log('Restarting the service so the new instance connects…');
+    execFileSync('bash', [path.join(root, 'setup', 'lib', 'restart.sh')], { cwd: root, stdio: 'inherit' });
+  } else {
+    console.log('Restart the service so the new instance connects: bash setup/lib/restart.sh');
+  }
+}
+
+main().catch((err: unknown) => {
+  if (err instanceof SlackFlowError || err instanceof SlackApiError) {
+    console.error(`slack-agent-flow-finish failed at step '${err.step}': ${err.message}`);
+  } else {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+  process.exit(1);
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.test.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+
+describe('slack-agent-flow env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'SAF_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'SAF_PLAIN=value1',
+          '  SAF_INDENTED = spaced ',
+          'SAF_DQUOTED="double quoted"',
+          "SAF_SQUOTED='single quoted'",
+          'SAF_EMPTY=',
+          '# SAF_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'SAF_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'SAF_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'SAF_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'SAF_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'SAF_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('SAF_PREFERS=file-value\n');
+      vi.stubEnv('SAF_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'SAF_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('SAF_BLANK_ENV=file-value\n');
+      vi.stubEnv('SAF_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'SAF_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('second');
+    });
+  });
+
+  describe('upsertEnvKey', () => {
+    it('creates .env when absent', () => {
+      upsertEnvKey(rootDir, 'SAF_NEW', 'v1');
+      expect(read()).toBe('SAF_NEW=v1\n');
+      expect(readEnvValue(rootDir, 'SAF_NEW')).toBe('v1');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      upsertEnvKey(rootDir, 'SAF_APPENDED', 'v2');
+      expect(read()).toBe('EXISTING=x\nSAF_APPENDED=v2\n');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nSAF_TARGET=old\nLAST=9\n');
+      upsertEnvKey(rootDir, 'SAF_TARGET', 'new');
+      expect(read()).toBe('# keep me\nFIRST=1\nSAF_TARGET=new\nLAST=9\n');
+    });
+
+    it('does not touch keys that merely share a prefix', () => {
+      write('SAF_KEY=keep\nSAF_KEY_LONGER=keep-too\n');
+      upsertEnvKey(rootDir, 'SAF_KEY', 'changed');
+      expect(read()).toBe('SAF_KEY=changed\nSAF_KEY_LONGER=keep-too\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      upsertEnvKey(rootDir, 'SAF_DUP', 'final');
+      expect(read()).toBe('SAF_DUP=final\nSAF_DUP=final\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('final');
+    });
+
+    it('replaces an indented assignment (readable lines are writable lines)', () => {
+      write('  SAF_INDENTED=old\n');
+      upsertEnvKey(rootDir, 'SAF_INDENTED', 'new');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('new');
+      expect(read()).not.toContain('old');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates the key and reports the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'alpha')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('SAF_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('SAF_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys (the adapter's SLACK_INSTANCES loop) parse .env
+      // only, so the union must be based on the file, not a stale
+      // process.env copy.
+      write('SAF_LIST=alpha\n');
+      vi.stubEnv('SAF_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('SAF_LIST=alpha,beta');
+    });
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.ts
@@ -1,0 +1,96 @@
+/**
+ * .env read/write helpers for the slack-agent-flow leg.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — the adapter's SLACK_INSTANCES loop
+ * (src/channels/slack.ts) reads back everything written here through that
+ * parser. Write conventions mirror upsertEnvLine /
+ * appendSlackInstance in .claude/skills/slack-managed-agents/scripts/
+ * slack-create-agent.ts: replace the key's line in place, preserve every
+ * other line (comments and blanks included), append with a clean trailing
+ * newline.
+ *
+ * Values written here include live Slack tokens: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value.
+ */
+export function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/guard.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/guard.ts
@@ -1,0 +1,60 @@
+/**
+ * Slack-agent-flow guard adapter — the module's catalog entries for the
+ * agent-facing room actions, composed at the module edge (imported
+ * by ./index.ts), mirroring agent-to-agent/guard.ts.
+ *
+ * rooms.create / rooms.add_agent — same trust split as agents.create:
+ * `global` cli_scope acts directly (room wiring is the intended primitive for
+ * trusted owner agent groups); anything else — the default `group` scope, and
+ * unknown/missing config, fail-closed — holds for the requesting group's
+ * admin chain. Both actions write central-DB state (messaging groups,
+ * wirings, a2a destinations) and open Slack conversations with the operator,
+ * so a confined container must never reach the handler unheld.
+ */
+import { getContainerConfig } from '../../db/container-configs.js';
+import { ALLOW, DENY, HOLD, defineGuardedAction, type GuardedAction } from '../../guard/index.js';
+import type { GuardDecision, GuardInput } from '../../guard/index.js';
+
+/** The agents.create trust split, reused verbatim for the room actions. */
+async function decideByCliScope(input: GuardInput, action: string): Promise<GuardDecision> {
+  if (input.actor.kind !== 'agent') return DENY(`${action} is a container-originated action.`);
+  const cliScope = (await getContainerConfig(input.actor.agentGroupId))?.cli_scope ?? 'group';
+  if (cliScope === 'global') {
+    // Trusted owner agent group — an approval tap on every room change would
+    // be needless friction.
+    return ALLOW('trusted global-scope agent group');
+  }
+  // The realistic prompt-injection victim (default `group` scope) — and any
+  // unknown config value, fail-closed — requires an admin before any
+  // central-DB write or MPIM open.
+  return HOLD(`agent-initiated ${action} requires admin approval`);
+}
+
+export const roomsCreate: GuardedAction = defineGuardedAction({
+  action: 'rooms.create',
+  grantActionName: 'create_room',
+  // Bind a create_room grant to the room name that was approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      return (JSON.parse(grant.payload) as { name?: string }).name === input.payload.name;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'create_room'),
+});
+
+export const roomsAddAgent: GuardedAction = defineGuardedAction({
+  action: 'rooms.add_agent',
+  grantActionName: 'add_to_room',
+  // Bind an add_to_room grant to the exact (room, agent) pair approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      const p = JSON.parse(grant.payload) as { room?: string; agent?: string };
+      return p.room === input.payload.room && p.agent === input.payload.agent;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'add_to_room'),
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -1,0 +1,275 @@
+/**
+ * slack-agent-flow module — guarded re-registration of `create_agent`.
+ *
+ * Re-registers the delivery action with the SAME guard pieces as upstream
+ * (agents.create decision, validateCreateAgent precheck) and a handler that
+ * first runs the upstream `createAgent()` (with its premature success notify
+ * suppressed on the Slack path — see slackAwareCreateAgent), then — only when
+ * the request originated from a Slack session — provisions a dedicated Slack
+ * bot for the new group (orchestrate.ts). The barrel imports this module AFTER
+ * agent-to-agent's registration, so this entry wins; the expected boot log is
+ * `Delivery action handler overwritten`. Approved replays re-enter this
+ * wrapper automatically — reenterGuardedDeliveryAction resolves the entry at
+ * call time, so no approval-handler re-registration is needed.
+ *
+ * Also registers the agent-facing room actions: `create_room` (one
+ * MPIM with N bots + the operator over ensureAgentRoom) and `add_to_room`
+ * (superset re-open — MPIM fork), each guard-wrapped with the same
+ * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
+ *
+ * The handler never touches inbound DBs (guarded handlers replay without
+ * one); all requester notifications go through the approvals module's
+ * notifyAgent. Token values never appear in notify texts or logs.
+ */
+import { SlackApiError } from '../../channels/slack-lib.js';
+import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
+import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
+import { agentsCreate } from '../agent-to-agent/guard.js';
+import { notifyAgent, registerApprovalHandler, requestApproval } from '../approvals/index.js';
+import { roomsAddAgent, roomsCreate } from './guard.js';
+import { dedupeSlug, deriveInstanceSlug, runSlackAgentFlow } from './orchestrate.js';
+import {
+  handleAddToRoom,
+  handleCreateRoom,
+  requestAddToRoomHold,
+  requestCreateRoomHold,
+  validateAddToRoom,
+  validateCreateRoom,
+} from './room-actions.js';
+import { pendingInstall, prefetchAvatar, resolveProvisioningCredential } from './provision.js';
+import { SlackFlowError } from './types.js';
+
+/** The Slack gate: the request came in through a Slack-channel session. */
+async function isSlackOriginSession(session: Session): Promise<boolean> {
+  if (!session.messaging_group_id) return false;
+  return (await getMessagingGroup(session.messaging_group_id))?.channel_type === 'slack';
+}
+
+// Avatar prefetch for multi-agent creates ("build me a team"): the batch
+// preview sees every create_agent row in the session's outbound batch before
+// they are processed sequentially, and starts all their avatar generations in
+// parallel — each is an independent async Lambda on the broker, so N waits
+// collapse to ~one (~23s). Gated on ≥2 creates: a single create starts its
+// flow immediately anyway, and skipping the single case means a guard-HELD
+// lone request never generates an avatar it might not get approval for.
+// The (displayName, description) derivation MUST mirror runSlackAgentFlow /
+// orchestrate exactly — a mismatch is harmless (fresh request) but wastes the
+// prefetch.
+registerDeliveryBatchPreview(async (batch, session) => {
+  if (!(await isSlackOriginSession(session))) return;
+  const creates = batch
+    .filter((m) => m.kind === 'system')
+    .map((m) => {
+      try {
+        return JSON.parse(m.content) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (c): c is Record<string, unknown> =>
+        c !== null && c.action === 'create_agent' && typeof c.name === 'string' && c.name !== '',
+    );
+  if (creates.length < 2) return;
+  const credential = resolveProvisioningCredential(process.cwd());
+  if (credential?.mode !== 'broker') return;
+  for (const c of creates) {
+    prefetchAvatar(
+      credential.baseUrl,
+      credential.installToken,
+      c.name as string,
+      typeof c.instructions === 'string' ? c.instructions.slice(0, 300) : undefined,
+    );
+  }
+  log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
+});
+
+function successText(name: string, roomChannelId: string | undefined, deferredInstall = false): string {
+  // The user already knows they were waiting on their workspace — name what
+  // unblocked it so the relay reads as an ending, not a fresh announcement.
+  const installed = deferredInstall ? ' The workspace approved the install, which is what the wait was for.' : '';
+  // room:'none': no shared room was opened — the multi-create
+  // pattern finishes with one create_room naming every agent.
+  if (roomChannelId === undefined) {
+    return (
+      `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
+      `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
+      `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+      installed
+    );
+  }
+  return (
+    `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
+    `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
+    `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+    installed
+  );
+}
+
+function failureText(
+  name: string,
+  localName: string,
+  step: string,
+  message: string,
+  newAgentGroupId: string,
+  slug: string,
+  sourceGroupId: string,
+  roomNone: boolean,
+): string {
+  // room:'none' must survive into the printed finish command too — omitting
+  // it would make the retry grow a room the multi-create pattern skipped.
+  return (
+    `Agent "${name}" was created and is reachable via send_message({ to: "${localName}", ... }), ` +
+    `but its Slack setup failed at step '${step}': ${message}. An operator can finish it with: ` +
+    `pnpm exec tsx scripts/slack-agent-flow-finish.ts --group ${newAgentGroupId} --name ${slug} ` +
+    `--source-group ${sourceGroupId}${roomNone ? ' --room none' : ''} [--origin-instance <key>] [--restart]`
+  );
+}
+
+/** Run the Slack leg for an already-created agent group and report the outcome. */
+async function runSlackLeg(
+  content: Record<string, unknown>,
+  session: Session,
+  args: {
+    name: string;
+    localName: string;
+    newAgentGroupId: string;
+    slug: string;
+  },
+): Promise<void> {
+  const { name, localName, newAgentGroupId, slug } = args;
+  try {
+    const r = await runSlackAgentFlow({ content, session, newAgentGroupId, slug });
+    await notifyAgent(session, successText(name, r.roomChannelId, r.deferredInstall));
+  } catch (err) {
+    // SlackApiError carries the flow step id its call site passed to the
+    // shared Slack lib — surface it like a typed flow step.
+    const step = err instanceof SlackFlowError || err instanceof SlackApiError ? err.step : 'unknown';
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(
+      session,
+      failureText(
+        name,
+        localName,
+        step,
+        message,
+        newAgentGroupId,
+        slug,
+        session.agent_group_id,
+        content.room === 'none',
+      ),
+    );
+    log.error('slack-agent-flow failed', { step });
+  }
+}
+
+async function slackAwareCreateAgent(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = typeof content.name === 'string' ? content.name : '';
+  const localName = normalizeName(name);
+  const before = await getDestinationByName(session.agent_group_id, localName);
+  const slackOrigin = await isSlackOriginSession(session);
+
+  // Resume, not collide: the agent group exists and its Slack app exists, but
+  // the workspace never approved the install, so the flow parked. Asking for
+  // the same agent again is how a user says "finish that" — take them back to
+  // waiting on the app they already have rather than reporting a name clash
+  // (upstream's answer) or provisioning a second one.
+  if (slackOrigin && before?.target_type === 'agent' && name) {
+    const slug = await dedupeSlug(deriveInstanceSlug(name), before.target_id);
+    if (pendingInstall(process.cwd(), slug)) {
+      await runSlackLeg(content, session, { name, localName, newAgentGroupId: before.target_id, slug });
+      return;
+    }
+  }
+
+  // Upstream behavior byte-for-byte on non-Slack sessions. On the Slack path
+  // the upstream "created — you can now message it" success notify is
+  // suppressed: it fires BEFORE Slack provisioning, so relaying it would
+  // report "done" ~a minute early — this wrapper's successText/failureText
+  // is the only completion signal. Upstream error notifies (collision,
+  // invalid path) still fire either way.
+  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+
+  const after = await getDestinationByName(session.agent_group_id, localName);
+  // Creation bailed or collided — upstream already answered the requester.
+  if (!after || after.target_type !== 'agent' || before) return;
+  // Non-Slack sessions (and task/a2a sessions with no messaging group) behave exactly as upstream.
+  if (!slackOrigin) return;
+
+  await runSlackLeg(content, session, {
+    name,
+    localName,
+    newAgentGroupId: after.target_id,
+    slug: await dedupeSlug(deriveInstanceSlug(name), after.target_id),
+  });
+}
+
+/**
+ * Slack-aware hold: same payload shape as upstream ({ name, instructions })
+ * so the approved replay re-enters this wrapper unchanged; only the card text
+ * differs, telling the admin a Slack bot comes with the sub-agent.
+ */
+async function requestSlackCreateAgentHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  if (!(await isSlackOriginSession(session))) {
+    await requestCreateAgentHold(content, session);
+    return;
+  }
+  const name = typeof content.name === 'string' ? content.name : '';
+  const instructions = typeof content.instructions === 'string' ? content.instructions : null;
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_agent',
+    // allow_guests must survive the hold: the approved replay re-enters the
+    // wrapper with this payload, and dropping it would silently upgrade a
+    // guest-accessible request to the agent-view variant.
+    payload: {
+      name,
+      instructions,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.allow_guests === true ? { allow_guests: true } : {}),
+      // room:'none' must survive the hold too — dropping it would grow a
+      // room the multi-create pattern deliberately skipped.
+      ...(content.room === 'none' ? { room: 'none' } : {}),
+    },
+    title: `Create agent: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
+  });
+}
+
+registerDeliveryAction('create_agent', slackAwareCreateAgent, {
+  guardAction: agentsCreate,
+  precheck: validateCreateAgent,
+  requestHold: requestSlackCreateAgentHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_agent denied: ${reason}`),
+});
+
+// Agent-facing room actions — guard-wrapped like create_agent:
+// global-scope groups act directly, everything else holds for the admin
+// chain, and the approval continuation re-enters the same wrapped entry with
+// the approval row as its grant.
+registerDeliveryAction('create_room', handleCreateRoom, {
+  guardAction: roomsCreate,
+  precheck: validateCreateRoom,
+  requestHold: requestCreateRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_room denied: ${reason}`),
+});
+registerApprovalHandler('create_room', reenterGuardedDeliveryAction('create_room'));
+
+registerDeliveryAction('add_to_room', handleAddToRoom, {
+  guardAction: roomsAddAgent,
+  precheck: validateAddToRoom,
+  requestHold: requestAddToRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `add_to_room denied: ${reason}`),
+});
+registerApprovalHandler('add_to_room', reenterGuardedDeliveryAction('add_to_room'));

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -1,0 +1,930 @@
+/**
+ * End-to-end tests for the slack-agent-flow wrapped create_agent action.
+ *
+ * Drives the REAL guard-wrapped delivery entry (getDeliveryAction) over a real
+ * in-memory central DB; Slack/broker traffic is a recorded fetch stub and the
+ * optional-module seam (slack-deps.js) is a recorded fake — no network, no
+ * skill-installed channel files. rootDir is process.cwd(), so each test runs
+ * chdir'd into its own tmpdir (vitest's default forks pool allows chdir).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ORIGIN_BOT_TOKEN = 'xoxb-origin-secret-token';
+const NEW_BOT_TOKEN = 'xoxb-new-bot-secret-token';
+const NEW_APP_TOKEN = 'xapp-new-app-secret-token';
+const REGISTRY_TOKEN = 'nct-registry-secret-token';
+
+// vi.hoisted: the module import below runs before this file's const
+// initializers, and the mock factories close over this state.
+const {
+  mockNotifyWrite,
+  mockRequestApproval,
+  mockInitGroupFilesystem,
+  mockWriteDestinations,
+  mockCreateRoomCanvas,
+  mockWireCanvasComments,
+  mockAssertSlackInstancesModuleInstalled,
+  fakeDeps,
+} = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+  mockInitGroupFilesystem: vi.fn(),
+  mockWriteDestinations: vi.fn(),
+  mockCreateRoomCanvas: vi.fn(),
+  mockWireCanvasComments: vi.fn(),
+  mockAssertSlackInstancesModuleInstalled: vi.fn().mockResolvedValue(undefined),
+  fakeDeps: {
+    slackInstanceBridgeFactory: vi.fn().mockReturnValue(null),
+    SLACK_DEFAULTS: undefined as unknown, // assigned in beforeEach (TEST_SLACK_DEFAULTS)
+    registerChannelAdapter: vi.fn(),
+    startChannelAdapter: vi.fn().mockResolvedValue('started'),
+  },
+}));
+
+// The optional-module seam — the only door to skill-installed channel files.
+vi.mock('./slack-deps.js', () => ({
+  loadSlackChannelDeps: async () => fakeDeps,
+  assertSlackInstancesModuleInstalled: (...a: unknown[]) => mockAssertSlackInstancesModuleInstalled(...a),
+}));
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+// wireCanvasComments (shadow-channel wiring) rides in the same module.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+// delivery.ts pulls more session-manager exports at import time.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({
+  initGroupFilesystem: (...a: unknown[]) => mockInitGroupFilesystem(...a),
+}));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// wrapper only needs these three. notifyAgent stays REAL (from primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the wrapped create_agent delivery action — the path under test.
+// Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
+import './index.js';
+import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
+import { SlackFlowError } from './types.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+// Mirrors the shape the Slack adapter declares (SLACK_DEFAULTS): the dm
+// context carries the B7 agent-DM declaration (sessionMode 'per-thread';
+// resolveWiringDefaults derives the threads=1 stamp from it) — S8 stamps
+// whatever the declaration resolves, so the per-thread/threads:1 pins below
+// exercise the declaration-driven path, not a hardcode.
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: {
+    engageMode: 'pattern',
+    engagePattern: '.',
+    threads: true,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'strict',
+  },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+/** .env content snapshotted at each chat.postMessage — proves S10 ran before S13. */
+let postMessageEnvSnapshots: string[] = [];
+let brokerStatus = 200;
+let tmpDir = '';
+/** null → the workspace refused auto-install; POST /v1/apps answers with a link instead. */
+let brokerBotToken: string | null = NEW_BOT_TOKEN;
+let brokerInstallUrl = '';
+/** Successive GET /v1/apps/{id} answers; the last one repeats. `http` overrides the status code. */
+let appStateQueue: Array<{ status?: string; bot_token?: string; http?: number }> = [];
+let appStateReads = 0;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const auth = String(init?.headers?.Authorization ?? '');
+  const token = auth.replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.endsWith('/v1/avatars')) {
+    // Pre-create avatar job: dispatched...
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'pending' }, 202));
+  }
+  if (url.includes('/v1/avatars/')) {
+    // ...and ready on the first poll, so the bot is born wearing its face.
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'ready' }));
+  }
+  if (url.includes('/v1/apps/')) {
+    const state = appStateQueue[Math.min(appStateReads, appStateQueue.length - 1)];
+    appStateReads++;
+    if (!state) return Promise.resolve(jsonResponse({ error: 'not_found' }, 404));
+    return Promise.resolve(jsonResponse(state, state.http ?? 200));
+  }
+  if (url.endsWith('/v1/apps')) {
+    if (brokerStatus !== 200) return Promise.resolve(jsonResponse({ message: 'boom' }, brokerStatus));
+    return Promise.resolve(
+      jsonResponse({
+        appId: 'A0TEST',
+        appToken: NEW_APP_TOKEN,
+        ...(brokerBotToken ? { botToken: brokerBotToken } : {}),
+        ...(brokerInstallUrl ? { installUrl: brokerInstallUrl } : {}),
+      }),
+    );
+  }
+  if (url.includes('/api/auth.test')) {
+    const userId = token === ORIGIN_BOT_TOKEN ? 'U0ORIGINBOT' : 'U0NEWBOT';
+    return Promise.resolve(
+      jsonResponse({
+        ok: true,
+        user_id: userId,
+        team_id: 'T0TEST',
+        team: 'NanoCo Test',
+        url: 'https://nanoco-test.slack.com/',
+      }),
+    );
+  }
+  if (url.includes('/api/conversations.open')) {
+    const users = String((JSON.parse(body) as { users?: string }).users ?? '');
+    return Promise.resolve(jsonResponse({ ok: true, channel: { id: users.includes(',') ? 'G0ROOM' : 'D0NEWDM' } }));
+  }
+  if (url.includes('/api/chat.postMessage')) {
+    const envPath = path.join(tmpDir, '.env');
+    postMessageEnvSnapshots.push(fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : '');
+    return Promise.resolve(jsonResponse({ ok: true }));
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+async function runCreateAgent(content: Record<string, unknown>, session: Session = SLACK_SESSION): Promise<void> {
+  const wrapped = getDeliveryAction('create_agent');
+  expect(wrapped).toBeDefined();
+  await wrapped!(content, session);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ORIGIN_BOT_TOKEN, NEW_BOT_TOKEN, NEW_APP_TOKEN, REGISTRY_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  fakeDeps.SLACK_DEFAULTS = TEST_SLACK_DEFAULTS;
+  fakeDeps.startChannelAdapter.mockResolvedValue('started');
+  // Degraded default (free workspace / canvases off): C2 returns undefined —
+  // the flow must tolerate it (no canvas, no link line). Canvas tests opt in.
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  postMessageEnvSnapshots = [];
+  brokerStatus = 200;
+  brokerBotToken = NEW_BOT_TOKEN;
+  brokerInstallUrl = '';
+  appStateQueue = [];
+  appStateReads = 0;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-agent-flow-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ORIGIN_BOT_TOKEN}\n`);
+  process.env.NANOCLAW_REGISTRY_TOKEN = REGISTRY_TOKEN; // broker mode, no account.json / .env lookup
+
+  const db = await initTestDb();
+  await runMigrations(db);
+
+  const now = new Date().toISOString();
+  await createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  await ensureContainerConfig(SRC_GROUP);
+  await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  await upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  await grantRole({
+    user_id: 'slack:U0OPERATOR',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createSession(SLACK_SESSION);
+  // Declared platform defaults so resolveWiringDefaults / validate see slack's
+  // real shape (group: mention-sticky + threads) for the dead named instance.
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  delete process.env.NANOCLAW_REGISTRY_TOKEN;
+  delete process.env.SLACK_INSTALL_WAIT_MS;
+  delete process.env.SLACK_INSTALL_POLL_MS;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slack-aware create_agent — happy path (Slack-origin session)', () => {
+  it('creates the group, provisions the bot, wires DM + room, posts intros in order', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // Upstream leg: group + scaffold + bidirectional a2a destinations.
+    const newGroup = await getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(mockInitGroupFilesystem).toHaveBeenCalledTimes(1);
+    const dest = await getDestinationByName(SRC_GROUP, 'research');
+    expect(dest).toMatchObject({ target_type: 'agent', target_id: newGroup!.id });
+    expect(await getDestinationByName(newGroup!.id, 'parent')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+
+    // Env keys (values themselves never asserted into messages/logs).
+    const env = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    expect(env).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(env).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // Hot-add through the seam.
+    expect(fakeDeps.registerChannelAdapter).toHaveBeenCalledWith(
+      'slack-research',
+      expect.objectContaining({ defaults: TEST_SLACK_DEFAULTS }),
+    );
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+
+    // DM row + wiring on the NEW instance. Agent-view is the default variant
+    // so the DM gets thread-per-conversation sessions:
+    // session_mode 'per-thread' + explicit threads:1.
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(dmMg).toMatchObject({ is_group: 0, unknown_sender_policy: 'strict', name: 'Research DM' });
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'per-thread',
+      threads: 1,
+      priority: 0,
+    });
+
+    // Room: one row PER instance, policy 'public', mention/accumulate wirings
+    // (D4 — flow-created rooms only; mention-sticky is gone from the flow).
+    const roomOrigin = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack');
+    const roomNew = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack-research');
+    expect(roomOrigin).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(roomNew).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(await getMessagingGroupAgentByPair(roomOrigin!.id, SRC_GROUP)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+    expect(await getMessagingGroupAgentByPair(roomNew!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+
+    // Projections pushed into the live source session.
+    expect(mockWriteDestinations).toHaveBeenCalledWith(SRC_GROUP, 'sess-1');
+
+    // No room-contract post: the only chat.postMessage is the DM intro,
+    // and SLACK_A2A_ROOMS was in .env before it.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(posts[0]!.token).toBe(NEW_BOT_TOKEN);
+    expect(postMessageEnvSnapshots).toHaveLength(1);
+    expect(postMessageEnvSnapshots[0]).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // The ORIGIN agent authors the room intro — exactly one
+    // instruction-shaped nudge written into the origin session, tagging the
+    // new bot and addressing the room by its projected destination name.
+    const nudges = notifyTexts().filter((t) => t.includes('introduction'));
+    expect(nudges).toHaveLength(1);
+    const nudgeCall = mockNotifyWrite.mock.calls.find((c) =>
+      String((c[2] as { content: string }).content).includes('introduction'),
+    )!;
+    expect(nudgeCall[0]).toBe(SRC_GROUP);
+    expect(nudgeCall[1]).toBe('sess-1');
+    // notifyAgent leaves `trigger` unset — writeSessionMessage defaults it
+    // to 1, so the nudge wakes the origin agent.
+    expect((nudgeCall[2] as { trigger?: number }).trigger).toBeUndefined();
+    expect(nudges[0]).toContain('<@U0NEWBOT>');
+    expect(nudges[0]).toContain('send_message({ to: "research-room"');
+    expect(nudges[0]).toContain('no mechanics, no member lists');
+    // No explicit purpose was provided — the creation prompt must NOT leak
+    // into the nudge (no fallback — creation prompts are private).
+    expect(nudges[0]).not.toContain('dig deep');
+    // No canvas id → no shadow channel to wire.
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+
+    // MPIM opened as the new bot with operator + origin bot.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(2);
+    expect(JSON.parse(opens[1]!.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT' });
+    expect(opens[1]!.token).toBe(NEW_BOT_TOKEN);
+
+    // Requester heard ONLY the Slack success notify — the upstream "created —
+    // you can now message it" text is suppressed on the Slack path (it fires
+    // before provisioning and would report "done" ~a minute early).
+    const texts = notifyTexts();
+    expect(texts.some((t) => t.includes('Agent "research" created'))).toBe(false);
+    expect(texts.at(-1)).toContain('is live on Slack');
+    expect(texts.at(-1)).toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+});
+
+describe('slack-aware create_agent — manifest variants', () => {
+  it('allow_guests: broker gets allow_guests:true, DM wiring keeps the plain defaults', async () => {
+    await runCreateAgent({ name: 'Guesty', instructions: 'help the guests', allow_guests: true });
+
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBe(true);
+
+    const newGroup = await getAgentGroupByFolder('guesty');
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-guesty');
+    const dmWiring = (await getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id))!;
+    expect(dmWiring).toMatchObject({ session_mode: 'shared' });
+    expect(dmWiring.threads ?? null).toBeNull();
+  });
+
+  it('default (agent-view): broker body carries no allow_guests flag', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBeUndefined();
+  });
+});
+
+describe("slack-aware create_agent — room:'none'", () => {
+  it('skips the room half entirely: DM only, no MPIM, no a2a entry, no canvas, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    expect(await getAgentGroupByFolder('research')).toBeDefined();
+    // Only the operator-DM conversations.open — no MPIM.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(1);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR' });
+    // No room rows on any instance, no a2a allowlist, no canvas, no shadow wiring.
+    expect((await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:G0ROOM')).toHaveLength(0);
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).not.toContain('SLACK_A2A_ROOMS');
+    expect(mockCreateRoomCanvas).not.toHaveBeenCalled();
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+    // The DM intro still posts; the origin agent gets NO intro nudge.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(0);
+    // Success text is the no-room variant pointing at create_room.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain("room:'none'");
+    expect(success).toContain('create_room');
+    expect(success).not.toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+
+  it("hold payload carries room:'none' through to the approved replay (confined group)", async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    // Held — nothing created yet; the replay payload must preserve room:'none'.
+    expect(await getAgentGroupByFolder('research')).toBeUndefined();
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_agent');
+    expect(opts.payload).toMatchObject({ name: 'Research', room: 'none' });
+  });
+});
+
+describe('slack-aware create_agent — room canvas contract', () => {
+  it('canvas available: called with the contract data (plain agent names), all participants wired', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The canvas carries the room contract: purpose, creator, members. Agent
+    // members travel as PLAIN NAMES — never bot user ids (the de-mention rule).
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Research room',
+      purpose: 'Research room',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Research'],
+    });
+    // Shadow-channel wiring rides on canvas success: EVERY participant —
+    // creator identified separately from the full list.
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledWith(
+      'F0CANVAS',
+      expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      [
+        expect.objectContaining({ instanceKey: 'slack', agentGroupId: SRC_GROUP }),
+        expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      ],
+      'Research room',
+    );
+    // Still no room post: the canvas tab IS the pinned surface — no link
+    // message either.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+  });
+});
+
+describe('ensureAgentRoom — N-bot rooms', () => {
+  it('opens the MPIM with every participating bot, wires each instance, and makes destinations pairwise', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    await createAgentGroup({ id: 'ag-third', name: 'Devin', folder: 'devin', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-devin', botUserId: 'U0THIRD', agentGroupId: 'ag-third', agentGroupName: 'Devin' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+
+    const result = await ensureAgentRoom({
+      creator: participants[2]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      rootDir: tmpDir,
+    });
+    expect(result).toMatchObject({ roomChannelId: 'G0ROOM', created: true });
+
+    // MPIM opened as the creator with operator + every OTHER participating bot.
+    const open = fetchCalls.find((c) => c.url.includes('conversations.open'))!;
+    expect(open.token).toBe(NEW_BOT_TOKEN);
+    expect(JSON.parse(open.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT,U0THIRD' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const p of participants) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', p.instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, p.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Destinations symmetry: every distinct agent-group pair, both directions.
+    expect(await getDestinationByName(SRC_GROUP, 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-third',
+    });
+    expect(await getDestinationByName(SRC_GROUP, 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-new',
+    });
+    expect(await getDestinationByName('ag-third', 'andy')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+    expect(await getDestinationByName('ag-third', 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-new',
+    });
+    expect(await getDestinationByName('ag-new', 'andy')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+    expect(await getDestinationByName('ag-new', 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-third',
+    });
+
+    // Allowlisted for a2a. No room-contract post: ensureAgentRoom
+    // itself posts nothing — the origin agent authors the intro, and
+    // the contract data lives on the canvas.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    // The canvas gets the contract data — every agent by plain name.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Devin', 'Pixel'],
+    });
+  });
+
+  it('is idempotent: a second call creates nothing new and grows no second canvas', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+    const args = {
+      creator: participants[1]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      rootDir: tmpDir,
+    };
+
+    await ensureAgentRoom(args);
+    const mgCountAfterFirst = (await getAllMessagingGroups()).length;
+
+    const second = await ensureAgentRoom(args);
+    expect(second).toMatchObject({ roomChannelId: 'G0ROOM', created: false });
+    expect((await getAllMessagingGroups()).length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-aware create_agent — non-Slack parity', () => {
+  it('non-slack session: behaves exactly as upstream, zero Slack side effects', async () => {
+    await createMessagingGroup({
+      id: 'mg-tg',
+      channel_type: 'telegram',
+      platform_id: 'tg:123',
+      name: 'TG DM',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+    const tgSession: Session = { ...SLACK_SESSION, id: 'sess-tg', messaging_group_id: 'mg-tg' };
+    await createSession(tgSession);
+    const envBefore = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    const mgCountBefore = (await getAllMessagingGroups()).length;
+
+    await runCreateAgent({ name: 'Helper' }, tgSession);
+
+    expect(await getAgentGroupByFolder('helper')).toBeDefined(); // upstream leg ran
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toBe(envBefore);
+    expect((await getAllMessagingGroups()).length).toBe(mgCountBefore);
+  });
+
+  it('null messaging_group_id (task/a2a session): skips the Slack leg', async () => {
+    const bareSession: Session = { ...SLACK_SESSION, id: 'sess-bare', messaging_group_id: null };
+    await createSession(bareSession);
+
+    await runCreateAgent({ name: 'Helper' }, bareSession);
+
+    expect(await getAgentGroupByFolder('helper')).toBeDefined();
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack-aware create_agent — failure and retry', () => {
+  it('broker failure: group still exists, failure notify carries the finish command', async () => {
+    brokerStatus = 500;
+
+    await runCreateAgent({ name: 'Research' });
+
+    const newGroup = await getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('scripts/slack-agent-flow-finish.ts');
+    expect(failure).toContain(`--group ${newGroup!.id}`);
+    expect(failure).toContain('--name research');
+    expect(failure).toContain(`--source-group ${SRC_GROUP}`);
+    expect(failure).toContain('send_message({ to: "research", ... })');
+
+    assertNoTokenLeak();
+  });
+
+  it('double invocation: upstream collision short-circuits — no duplicate rows, apps, posts, or nudges', async () => {
+    await runCreateAgent({ name: 'Research' });
+    const fetchCountAfterFirst = fetchCalls.length;
+    const mgCountAfterFirst = (await getAllMessagingGroups()).length;
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(fetchCalls.length).toBe(fetchCountAfterFirst);
+    expect((await getAllMessagingGroups()).length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(1);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+    expect(notifyTexts().at(-1)).toContain('already have a destination named "research"');
+  });
+
+  it('finish-path retry after success: rows exist, so no second canvas, no posts, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const postCountAfterFirst = fetchCalls.filter((c) => c.url.includes('chat.postMessage')).length;
+    const notifyCountAfterFirst = mockNotifyWrite.mock.calls.length;
+
+    // Operator re-runs the finish script — the S8/S11 created-gates hold.
+    await finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id });
+
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(postCountAfterFirst);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockNotifyWrite.mock.calls.length).toBe(notifyCountAfterFirst);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+  });
+
+  it('finish path aborts before wiring DB rows if the multi-instance module is missing', async () => {
+    // Group exists (S1-S4 already ran) but the Slack leg never completed —
+    // same starting state as the "broker failure" case above.
+    brokerStatus = 500;
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    brokerStatus = 200; // retry succeeds at the broker step this time
+    const mgCountBefore = (await getAllMessagingGroups()).length;
+
+    mockAssertSlackInstancesModuleInstalled.mockRejectedValueOnce(
+      new SlackFlowError(
+        'adapter-start',
+        'Slack channel payloads not installed — apply add-slack and slack-multi-instance first',
+      ),
+    );
+
+    await expect(
+      finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id }),
+    ).rejects.toThrow(/multi-instance/);
+
+    // S6-S8 must not have run: no DM messaging group got wired for an
+    // instance the runtime still can't start.
+    expect((await getAllMessagingGroups()).length).toBe(mgCountBefore);
+  });
+});
+
+describe('slack-aware create_agent — workspace install approval', () => {
+  const INSTALL_URL = 'https://slack.com/oauth/v2/authorize?client_id=1.2&state=signed-state';
+
+  /** Auto-install refused: the app is real, but the workspace must approve it. */
+  function refuseAutoInstall(): void {
+    brokerBotToken = null;
+    brokerInstallUrl = INSTALL_URL;
+    process.env.SLACK_INSTALL_POLL_MS = '1';
+    process.env.SLACK_INSTALL_WAIT_MS = '120';
+  }
+
+  function env(): string {
+    return fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+  }
+
+  function postedTexts(): string[] {
+    return fetchCalls
+      .filter((c) => c.url.includes('chat.postMessage'))
+      .map((c) => (JSON.parse(c.body) as { text: string }).text);
+  }
+
+  it('tells the operator what to approve, then finishes the flow on the token the approval releases', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }, { status: 'installed', bot_token: NEW_BOT_TOKEN }];
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The heads-up goes out as the ORIGIN bot, in the conversation the create
+    // was asked for — the origin agent's own reply could not be delivered
+    // while this handler still holds the session.
+    const notice = postedTexts()[0];
+    expect(notice).toContain('needs an admin to approve');
+    expect(notice).toContain(INSTALL_URL);
+    const noticeCall = fetchCalls.find((c) => c.url.includes('chat.postMessage'))!;
+    expect(noticeCall.token).toBe(ORIGIN_BOT_TOKEN);
+    expect((JSON.parse(noticeCall.body) as { channel: string }).channel).toBe('D0OPDM');
+
+    // From the token onward the flow is the ordinary one: adapter hot-add,
+    // DM row + wiring, room, welcome DM.
+    expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env()).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup.id)).toBeDefined();
+    expect(postedTexts().some((t) => t.includes("I'm Research, your new agent"))).toBe(true);
+
+    // Exactly one app, and the consumed install link is retired.
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(env()).toMatch(/^SLACK_INSTALL_URL_RESEARCH=$/m);
+
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('is live on Slack');
+    expect(success).toContain('approved the install');
+    assertNoTokenLeak();
+  });
+
+  it('parks the app when the approval never lands, keeping every part of it for a resume', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    // Nothing to re-create: app token, app id and the link are all on record.
+    expect(env()).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env()).toMatch(/^SLACK_APP_ID_RESEARCH=A0TEST$/m);
+    expect(env()).toContain(`SLACK_INSTALL_URL_RESEARCH=${INSTALL_URL}`);
+    expect(env()).not.toMatch(/^SLACK_BOT_TOKEN_RESEARCH=./m);
+    // The wait really ran rather than falling straight through.
+    expect(appStateReads).toBeGreaterThan(1);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'install-wait'");
+    expect(failure).toContain('still waiting on a workspace install approval');
+    expect(failure).toContain('nothing needs re-creating');
+    expect(failure).toContain('finish setting up Research');
+    assertNoTokenLeak();
+  });
+
+  it('asking again after a park resumes the parked app instead of provisioning a second one', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }];
+    await runCreateAgent({ name: 'Research' });
+    const groupCountAfterPark = (await getAgentGroupByFolder('research'))!.id;
+    const postsAfterPark = postedTexts().length;
+
+    // The operator approves the install, then asks for the same agent again.
+    appStateQueue = [{ status: 'installed', bot_token: NEW_BOT_TOKEN }];
+    appStateReads = 0;
+    await runCreateAgent({ name: 'Research' });
+
+    // One Slack app, one agent group — the second ask finished the first.
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect((await getAgentGroupByFolder('research'))!.id).toBe(groupCountAfterPark);
+    expect(await getAgentGroupByFolder('research-2')).toBeUndefined();
+    // Upstream's name-collision answer must not be what the user hears.
+    expect(notifyTexts().at(-1)).not.toContain('already have a destination');
+    expect(notifyTexts().at(-1)).toContain('is live on Slack');
+
+    // A resume checks before it sleeps, so the standing approval is picked up
+    // on the first read.
+    expect(appStateReads).toBe(1);
+    expect(postedTexts()[postsAfterPark]).toContain('Still waiting on your workspace');
+    expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research')).toBeDefined();
+  });
+
+  it('SLACK_INSTALL_WAIT_MS=0 parks immediately — a slow approval queue need not hold delivery open', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '0';
+    appStateQueue = [{ status: 'pending_install' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(0);
+    // The operator still gets the link — the flow declines to wait, not to ask.
+    expect(postedTexts()[0]).toContain(INSTALL_URL);
+    expect(notifyTexts().at(-1)).toContain("failed at step 'install-wait'");
+    expect(env()).toMatch(/^SLACK_APP_ID_RESEARCH=A0TEST$/m);
+  });
+
+  it('a refusal with no install link keeps the hand-finish instructions — there is nothing to wait for', async () => {
+    brokerBotToken = null;
+    brokerInstallUrl = '';
+    process.env.SLACK_INSTALL_POLL_MS = '1';
+    process.env.SLACK_INSTALL_WAIT_MS = '120';
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(0);
+    expect(postedTexts()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('SLACK_BOT_TOKEN_RESEARCH');
+  });
+
+  it('polls through a service hiccup instead of treating it as a refusal', async () => {
+    refuseAutoInstall();
+    appStateQueue = [
+      { http: 502, status: 'bad_gateway' },
+      { status: 'installed', bot_token: NEW_BOT_TOKEN },
+    ];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(2);
+    expect(notifyTexts().at(-1)).toContain('is live on Slack');
+  });
+
+  it('stops on a credential the service refuses — no later poll can change that answer', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '5000'; // never reached
+    appStateQueue = [{ http: 401, status: 'unauthorized' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(1);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'install-wait'");
+    expect(failure).toContain('refused this install');
+    assertNoTokenLeak();
+  });
+
+  it('a token released to someone else stops the wait rather than burning the whole budget', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '5000'; // never reached
+    appStateQueue = [{ status: 'installed' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(1);
+    expect(notifyTexts().at(-1)).toContain("failed at step 'install-wait'");
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -1,0 +1,731 @@
+/**
+ * The Slack leg of create_agent — steps S1–S13 (one typed step id each).
+ *
+ * Ordering is load-bearing:
+ *  - S1/S2 are local/cheap prechecks — nothing external is created until the
+ *    operator identity and the origin bot token both resolve.
+ *  - S10 (SLACK_A2A_ROOMS append) runs strictly BEFORE the origin agent is
+ *    nudged to post the room intro, so every sibling instance's a2a
+ *    bridge admits the bot-authored intro instead of dropping it as a bot
+ *    sender.
+ *  - S13's DM intro and the origin intro nudge are gated on rows newly
+ *    created in S8/S11 — a retry (finish script) never double-posts or
+ *    double-nudges.
+ * Every step is idempotent: provision reuses .env tokens, messaging groups
+ * and wirings are get-before-create, conversations.open is idempotent on
+ * Slack's side.
+ *
+ * Slack HTTP plumbing comes from the shared channel-layer lib
+ * (src/channels/slack-lib.ts, installed with the Slack channel payload);
+ * access to the skill-installed adapter modules goes through
+ * loadSlackChannelDeps() so a partial install fails as a typed step error.
+ */
+import {
+  resolveUnknownSenderPolicy,
+  resolveWiringDefaults,
+  validateEngageAgainstChannel,
+} from '../../channels/channel-defaults.js';
+import {
+  SlackApiError,
+  botTokenKeyForInstance,
+  slackAuthTest,
+  slackConversationsOpen,
+  slackPostMessage,
+} from '../../channels/slack-lib.js';
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { MessagingGroup, MessagingGroupAgent, Session } from '../../types.js';
+import {
+  createDestination,
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { notifyAgent, pickApprover } from '../approvals/primitive.js';
+import { appendToEnvList, readEnvValue } from './env-file.js';
+import { provisionSlackApp } from './provision.js';
+import { createRoomCanvas, wireCanvasComments } from './room-canvas.js';
+import { assertSlackInstancesModuleInstalled, loadSlackChannelDeps } from './slack-deps.js';
+import { SlackFlowError, type OrchestrateSuccess, type SlackFlowStep } from './types.js';
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function envSuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/** Wrap a non-typed failure with the step it happened in. Never carries token
+ *  values. A SlackApiError keeps its own step — the shared Slack lib
+ *  (src/channels/slack-lib.ts) tags each call with the flow step id the call
+ *  site passed, which is more precise than the enclosing wrapper's step. */
+function asFlowError(err: unknown, step: SlackFlowStep): SlackFlowError {
+  if (err instanceof SlackFlowError) return err;
+  if (err instanceof SlackApiError) return new SlackFlowError(err.step as SlackFlowStep, err.message);
+  return new SlackFlowError(step, err instanceof Error ? err.message : String(err));
+}
+
+/** One canonical slugger — the same normalizeName the a2a destination namespace uses. */
+export function deriveInstanceSlug(name: string): string {
+  return normalizeName(name);
+}
+
+/**
+ * First approver with a Slack identity, 'slack:' prefix stripped. pickApprover
+ * order (scoped admins → global admins → owners) picks who gets the DM.
+ */
+export async function resolveOperatorSlackUserId(sourceAgentGroupId: string): Promise<string | null> {
+  const hit = (await pickApprover(sourceAgentGroupId)).find((id) => /^slack:U/i.test(id));
+  return hit ? hit.slice('slack:'.length) : null;
+}
+
+/**
+ * A slug conflicts when its .env footprint is already claimed (token key set
+ * or slug listed in SLACK_INSTANCES) AND its `slack-<slug>` instance is wired
+ * to a DIFFERENT agent group. Claimed-but-wired-to-this-group (or to nothing)
+ * is the retry path — reuse.
+ */
+async function slugConflicts(slug: string, newAgentGroupId: string, rootDir: string): Promise<boolean> {
+  const tokenExists = readEnvValue(rootDir, `SLACK_BOT_TOKEN_${envSuffix(slug)}`) !== undefined;
+  const instances = (readEnvValue(rootDir, 'SLACK_INSTANCES') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!tokenExists && !instances.includes(slug)) return false;
+
+  const instanceKey = `slack-${slug}`;
+  for (const mg of await getAllMessagingGroups()) {
+    if (mg.instance !== instanceKey) continue;
+    for (const wiring of await getMessagingGroupAgents(mg.id)) {
+      if (wiring.agent_group_id !== newAgentGroupId) return true;
+    }
+  }
+  return false;
+}
+
+export async function dedupeSlug(
+  base: string,
+  newAgentGroupId: string,
+  rootDir: string = process.cwd(),
+): Promise<string> {
+  let slug = base;
+  for (let n = 2; await slugConflicts(slug, newAgentGroupId, rootDir); n++) slug = `${base}-${n}`;
+  return slug;
+}
+
+async function ensureMessagingGroupRow(spec: {
+  platformId: string;
+  instance: string;
+  name: string;
+  isGroup: boolean;
+  unknownSenderPolicy: MessagingGroup['unknown_sender_policy'];
+}): Promise<{ mg: MessagingGroup; created: boolean }> {
+  const existing = await getMessagingGroupByPlatform('slack', spec.platformId, spec.instance);
+  if (existing) return { mg: existing, created: false };
+  const mg: MessagingGroup = {
+    id: generateId('mg'),
+    channel_type: 'slack',
+    platform_id: spec.platformId,
+    instance: spec.instance,
+    name: spec.name,
+    is_group: spec.isGroup ? 1 : 0,
+    unknown_sender_policy: spec.unknownSenderPolicy,
+    created_at: new Date().toISOString(),
+  };
+  await createMessagingGroup(mg);
+  return { mg, created: true };
+}
+
+/** Flow-chosen deviations from the channel-declared wiring defaults. */
+interface WiringOverrides {
+  /** Set together with engage_pattern to bypass resolveWiringDefaults. */
+  engage_mode?: MessagingGroupAgent['engage_mode'];
+  engage_pattern?: string | null;
+  ignored_message_policy?: MessagingGroupAgent['ignored_message_policy'];
+  session_mode?: MessagingGroupAgent['session_mode'];
+  /** 1/0 explicit stamp; null = explicitly leave the column NULL (inherit the
+   *  channel declaration at fanout time); omitted = follow the derived
+   *  creation-time stamp (resolveWiringDefaults stamps threads=1 when the
+   *  declared sessionMode is 'per-thread', else null). */
+  threads?: number | null;
+}
+
+/** Get-before-create wiring with channel-declared defaults (engage fields,
+ *  plus the B7 session-mode/threads creation-time stamps) unless overridden.
+ *  True iff newly created. */
+async function ensureWiring(
+  mg: MessagingGroup,
+  agentGroupId: string,
+  agentGroupName: string,
+  overrides: WiringOverrides = {},
+): Promise<boolean> {
+  if (await getMessagingGroupAgentByPair(mg.id, agentGroupId)) return false;
+  const channelKey = mg.instance ?? mg.channel_type;
+  // Overriding engage_mode bypasses the declaration entirely (flow-owned
+  // room semantics, D4); declaration-resolved wirings take the declared
+  // session_mode / threads stamps too (B7).
+  const resolved =
+    overrides.engage_mode !== undefined
+      ? undefined
+      : resolveWiringDefaults(channelKey, mg.is_group === 1, agentGroupName, mg.channel_type);
+  const engage = resolved ?? { engage_mode: overrides.engage_mode!, engage_pattern: overrides.engage_pattern ?? null };
+  const threads = overrides.threads !== undefined ? overrides.threads : (resolved?.threads ?? null);
+  const wiring: MessagingGroupAgent = {
+    id: generateId('mga'),
+    messaging_group_id: mg.id,
+    agent_group_id: agentGroupId,
+    engage_mode: engage.engage_mode,
+    engage_pattern: engage.engage_pattern,
+    sender_scope: 'all',
+    ignored_message_policy: overrides.ignored_message_policy ?? 'drop',
+    session_mode: overrides.session_mode ?? resolved?.session_mode ?? 'shared',
+    priority: 0,
+    ...(threads !== null ? { threads } : {}),
+    created_at: new Date().toISOString(),
+  };
+  validateEngageAgainstChannel(wiring, mg);
+  // createMessagingGroupAgent persists an explicit `threads` value itself
+  // (follow-up UPDATE in src/db/messaging-groups.ts) — the declared threads:1 stamp lands.
+  await createMessagingGroupAgent(wiring);
+  return true;
+}
+
+/**
+ * Room-wiring semantics for flow-created rooms (D4): each bot speaks only
+ * when @-mentioned; everything else accumulates as ambient context delivered
+ * with the next mention. Deliberately NOT the channel group default —
+ * flow-created rooms only.
+ */
+const ROOM_WIRING_OVERRIDES: WiringOverrides = {
+  engage_mode: 'mention',
+  engage_pattern: null,
+  ignored_message_policy: 'accumulate',
+};
+
+/** One bot in a shared room: its adapter instance and the agent group behind it. */
+export interface RoomParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  botUserId: string;
+  agentGroupId: string;
+  agentGroupName: string;
+}
+
+/**
+ * Idempotent agent→agent destination (= ACL grant + local name). No-op when
+ * a destination for the target already exists under any name (upstream
+ * create_agent's parent/child rows count). Name collisions get a numeric
+ * suffix, mirroring ensureAgentDestinationForWiring.
+ */
+async function ensureAgentDestination(fromGroupId: string, toGroupId: string, toName: string): Promise<void> {
+  if (fromGroupId === toGroupId) return;
+  if (await getDestinationByTarget(fromGroupId, 'agent', toGroupId)) return;
+  const base = normalizeName(toName) || toGroupId.slice(0, 8);
+  let localName = base;
+  let suffix = 2;
+  while (await getDestinationByName(fromGroupId, localName)) {
+    localName = `${base}-${suffix}`;
+    suffix++;
+  }
+  await createDestination({
+    agent_group_id: fromGroupId,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: toGroupId,
+    created_at: new Date().toISOString(),
+  });
+}
+
+/** Full pairwise a2a destination symmetry between every distinct agent group
+ *  in the room — "ask Devin" must be actionable from any participant. */
+async function ensurePairwiseAgentDestinations(participants: RoomParticipant[]): Promise<void> {
+  for (const a of participants) {
+    for (const b of participants) {
+      if (a.agentGroupId === b.agentGroupId) continue;
+      await ensureAgentDestination(a.agentGroupId, b.agentGroupId, b.agentGroupName);
+    }
+  }
+}
+
+/**
+ * Public purpose: ONLY the explicitly provided line (capped 80). No fallback
+ * from the instructions — the creation prompt is the agent's private persona
+ * and never appears on shared surfaces. No purpose = the intro simply
+ * doesn't state one.
+ */
+export function publicPurpose(explicit: string | undefined): string | undefined {
+  const cleaned = explicit?.trim();
+  if (!cleaned) return undefined;
+  return cleaned.length <= 80 ? cleaned : `${cleaned.slice(0, 80)}…`;
+}
+
+/**
+ * The ORIGIN agent — not a host template — introduces the new agent
+ * in the shared room. This is the instruction the origin session wakes to;
+ * the intro itself stays in the agent's own voice, and the room-contract
+ * data (purpose, members, created date) lives on the canvas, not in chat.
+ */
+function roomIntroNudgeText(args: {
+  newAgentName: string;
+  newBotUserId: string;
+  roomName: string;
+  /** The origin agent's local destination name for the room. */
+  roomDestination: string;
+  purpose?: string;
+}): string {
+  return (
+    `A shared Slack room "${args.roomName}" was just opened with you, the operator, and your new agent ${args.newAgentName}` +
+    `${args.purpose ? ` (${args.purpose})` : ''}. ` +
+    `Post a brief introduction of ${args.newAgentName} there now via send_message({ to: "${args.roomDestination}", ... }): ` +
+    `1-2 lines in your own voice saying what they're for, tagging them with <@${args.newBotUserId}> ` +
+    `(include that literally — it renders as a mention). Just the intro — no mechanics, no member lists.`
+  );
+}
+
+/**
+ * N-bot-capable room step (S9–S13's room half): open the MPIM as `creator`
+ * with the operator + every participating bot, allowlist it for a2a, create
+ * one mg row + mention/accumulate wiring PER participating instance, ensure
+ * pairwise a2a destinations, then (only when rows were newly created) create
+ * the room canvas — the room's pinned contract surface (no contract
+ * message, no link post; the channel canvas is already the room's canvas
+ * tab) — and wire its comment shadow channel for every participant. The
+ * conversational create_agent flow calls this with the 3-way default; any
+ * caller may pass a larger participant list.
+ */
+export async function ensureAgentRoom(args: {
+  /** Bot that opens the MPIM and creates the canvas. Must be one of `participants`. */
+  creator: RoomParticipant;
+  creatorBotToken: string;
+  operatorUserId: string;
+  /** All bots in the room, creator included. */
+  participants: RoomParticipant[];
+  /** Additional member user ids beyond the operator + participating bots —
+   *  e.g. Slack-UI-added humans carried over when add_to_room forks a room.
+   *  Members only; they get no mg rows or wirings. */
+  extraMemberUserIds?: string[];
+  roomName: string;
+  /** Creation prompt (room purpose) — the canvas contract excerpt. */
+  purpose?: string;
+  rootDir: string;
+}): Promise<{ roomChannelId: string; created: boolean }> {
+  const { creator, creatorBotToken, operatorUserId, participants, rootDir } = args;
+
+  // S9 mpim-open — operator + carried extra members + every other
+  // participating bot, opened AS the creator.
+  const otherBotIds = participants.filter((p) => p.botUserId !== creator.botUserId).map((p) => p.botUserId);
+  const roomChannelId = await slackConversationsOpen(
+    creatorBotToken,
+    [operatorUserId, ...(args.extraMemberUserIds ?? []), ...otherBotIds],
+    'mpim-open',
+  );
+
+  // S10 a2a-env — strictly before the origin agent can be nudged to post its
+  // intro: every sibling instance's a2a bridge must already allow the room
+  // or it drops bot-authored posts.
+  try {
+    appendToEnvList(rootDir, 'SLACK_A2A_ROOMS', roomChannelId);
+  } catch (err) {
+    throw asFlowError(err, 'a2a-env');
+  }
+
+  // S11 room-wire — one row PER participating instance (router lookup is
+  // exact-on-instance). unknown_sender_policy 'public' explicitly: sibling
+  // bridges' access gates must never approval-spam admitted bot messages.
+  // Wirings are mention/accumulate (D4 — flow-created rooms only).
+  let created = false;
+  try {
+    for (const p of participants) {
+      const row = await ensureMessagingGroupRow({
+        platformId: `slack:${roomChannelId}`,
+        instance: p.instanceKey,
+        name: args.roomName,
+        isGroup: true,
+        unknownSenderPolicy: 'public',
+      });
+      await ensureWiring(row.mg, p.agentGroupId, p.agentGroupName, ROOM_WIRING_OVERRIDES);
+      created = row.created || created;
+    }
+    await ensurePairwiseAgentDestinations(participants);
+  } catch (err) {
+    throw asFlowError(err, 'room-wire');
+  }
+
+  // S12 projections — in-host-process, so already-running containers see the
+  // auto-created destinations without waiting for the next spawn.
+  for (const groupId of new Set(participants.map((p) => p.agentGroupId))) {
+    await projectDestinationsToSessions(groupId);
+  }
+
+  // S13 room half — gated on newly created rows so a retry never grows a
+  // second canvas. No room-contract message: the canvas tab is the
+  // pinned surface and carries the contract data; the intro is authored by
+  // the ORIGIN agent (nudged by runFlow). Canvas failure is non-fatal
+  // (C2: createRoomCanvas never throws) — no canvas, no shadow channel.
+  if (created) {
+    const canvasId = await createRoomCanvas(creatorBotToken, roomChannelId, {
+      roomName: args.roomName,
+      purpose: args.purpose ?? args.roomName,
+      creatorUserId: operatorUserId,
+      agentNames: participants.map((p) => p.agentGroupName),
+    });
+    // Canvas comments arrive in a Slackbot-owned shadow channel (canvas id
+    // with F→C) — wire EVERY participating instance: creator as the
+    // pattern-engage default responder, siblings mention/accumulate.
+    // Non-throwing; no canvas id, nothing to wire.
+    if (canvasId) await wireCanvasComments(canvasId, creator, participants, args.roomName);
+  }
+
+  return { roomChannelId, created };
+}
+
+/**
+ * How long the flow waits inline for a workspace install approval, and how
+ * often it checks. The default is five minutes at a five-second cadence —
+ * long enough for someone already at their desk, short enough that the app
+ * parks (and stays resumable) rather than holding this session's delivery
+ * open indefinitely.
+ *
+ * `SLACK_INSTALL_WAIT_MS=0` skips the wait entirely: installs that always go
+ * through a slow approval queue are better served by parking immediately and
+ * finishing on a later ask. `SLACK_INSTALL_POLL_MS` moves the cadence.
+ */
+function resolveInstallWait(rootDir: string): { intervalMs?: number; timeoutMs?: number } | undefined {
+  const num = (key: string): number | undefined => {
+    const raw = readEnvValue(rootDir, key);
+    if (raw === undefined) return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  };
+  const timeoutMs = num('SLACK_INSTALL_WAIT_MS');
+  const intervalMs = num('SLACK_INSTALL_POLL_MS');
+  if (timeoutMs === undefined && intervalMs === undefined) return undefined;
+  return { ...(timeoutMs !== undefined ? { timeoutMs } : {}), ...(intervalMs !== undefined ? { intervalMs } : {}) };
+}
+
+/**
+ * The one line the human gets while the flow waits on a workspace install
+ * approval. Short on purpose: the link is the only actionable part, and the
+ * flow says nothing else until it either finishes or parks.
+ */
+export function installPendingText(displayName: string, info: { installUrl?: string; resumed: boolean }): string {
+  const where = info.installUrl ? ` Approve it here: ${info.installUrl}` : '';
+  return info.resumed
+    ? `Still waiting on your workspace to approve installing ${displayName}.${where} — I'll finish setting it up as soon as that lands.`
+    : `${displayName} is created, but your workspace needs an admin to approve installing it.${where} — I'll finish the setup automatically once it's approved.`;
+}
+
+interface FlowArgs {
+  slug: string;
+  displayName: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey: string;
+  /** Slack channel the create was asked for in — where the flow talks back
+   *  while it waits. Absent on the out-of-process finish path, which prints
+   *  to the operator's terminal instead. */
+  originChannelId?: string;
+  rootDir: string;
+  /** false on the out-of-process finish path — S5 needs the live host's registry. */
+  hotStart: boolean;
+  /** Agent instructions excerpt — drives the broker-generated avatar. */
+  description?: string;
+  /** Short PUBLIC line for the room contract + canvas ("what this agent is
+   *  for"). Falls back to a first-sentence excerpt of the instructions —
+   *  never the full creation prompt (it may carry private detail). */
+  purpose?: string;
+  /** true → plain manifest variant (guest-visible); false/absent → agent_view. */
+  allowGuests?: boolean;
+  /** The session whose create_agent call started the flow — receives the
+   *  room-intro nudge. Absent on the out-of-process finish path. */
+  originSession?: Session;
+  /**
+   * Room policy: 'own' (default) opens the shared origin+operator
+   * room; 'none' skips the room half entirely — the multi-create pattern is
+   * N creates with room:'none' followed by one create_room with all of them.
+   */
+  room?: 'own' | 'none';
+  /** Wait budget for a deferred workspace install. Tests shorten it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+  /** Extra sink for the pending-install line — the finish script prints it to
+   *  the operator's terminal, which has no Slack conversation to post into. */
+  onInstallPending?: (text: string) => void;
+}
+
+async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
+  const { slug, displayName, sourceGroupId, newAgentGroupId, originInstanceKey, rootDir } = args;
+  const instanceKey = `slack-${slug}`;
+
+  // S1 operator-identity
+  const operatorUserId = await resolveOperatorSlackUserId(sourceGroupId);
+  if (!operatorUserId) {
+    throw new SlackFlowError(
+      'operator-identity',
+      'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+    );
+  }
+
+  // S2 origin-auth — prove the origin instance's token before provisioning anything.
+  const originTokenKey = botTokenKeyForInstance(originInstanceKey);
+  const originBotToken = readEnvValue(rootDir, originTokenKey);
+  if (!originBotToken) {
+    throw new SlackFlowError(
+      'origin-auth',
+      `missing ${originTokenKey} in .env for origin instance '${originInstanceKey}'`,
+    );
+  }
+  const originAuth = await slackAuthTest(originBotToken, 'origin-auth');
+  const originBotUserId = originAuth.userId;
+
+  // S3/S4 provision. A workspace that requires an admin to approve installs
+  // refuses auto-install, and provisionSlackApp then waits for the human to
+  // finish it in the browser. That wait is silent from the outside, so it
+  // announces itself HERE, as the origin bot, in the conversation the create
+  // was asked for — the origin agent cannot relay it, since its own replies
+  // cannot be delivered while this handler is still running. A failed
+  // announcement is not worth abandoning the wait for.
+  const app = await provisionSlackApp({
+    slug,
+    displayName,
+    rootDir,
+    teamId: originAuth.teamId,
+    description: args.description,
+    allowGuests: args.allowGuests,
+    requestedBy: operatorUserId,
+    installWait: args.installWait ?? resolveInstallWait(rootDir),
+    onInstallPending: async (info) => {
+      const text = installPendingText(displayName, info);
+      log.info('Waiting on a Slack workspace install approval', { step: 'install-wait', appId: info.appId });
+      args.onInstallPending?.(text);
+      if (!args.originChannelId) return;
+      try {
+        await slackPostMessage(originBotToken, args.originChannelId, text, 'install-wait');
+      } catch (err) {
+        log.warn('Could not announce the pending Slack install', {
+          step: 'install-wait',
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  });
+
+  // S5 adapter-start. The multi-instance module must be installed regardless
+  // of hotStart: S6-S8 below wire DB rows to an instance name the runtime
+  // needs to be able to start after a restart, so the out-of-process finish
+  // path (hotStart: false) checks this too instead of silently skipping
+  // straight to DB writes for an instance nothing can ever connect.
+  await assertSlackInstancesModuleInstalled();
+  if (args.hotStart) {
+    // Hot-add the new instance into the live registry.
+    const deps = await loadSlackChannelDeps();
+    deps.registerChannelAdapter(instanceKey, {
+      factory: () => deps.slackInstanceBridgeFactory(slug),
+      defaults: deps.SLACK_DEFAULTS,
+    });
+    let started: 'started' | 'already-active' | 'no-credentials';
+    try {
+      started = await deps.startChannelAdapter(instanceKey);
+    } catch (err) {
+      throw asFlowError(err, 'adapter-start');
+    }
+    // 'already-active' is the retry path — the instance survived a previous attempt.
+    if (started === 'no-credentials') {
+      throw new SlackFlowError(
+        'adapter-start',
+        `adapter '${instanceKey}' found no credentials in .env (SLACK_BOT_TOKEN_${app.envSuffix} / SLACK_APP_TOKEN_${app.envSuffix})`,
+      );
+    }
+  }
+
+  // S6 new-bot identity (auth.test gates the DM open — same step id).
+  const newBotUserId = (await slackAuthTest(app.botToken, 'dm-open')).userId;
+
+  // S7 dm-open — the operator DM, opened AS the new bot.
+  const dmChannelId = await slackConversationsOpen(app.botToken, [operatorUserId], 'dm-open');
+
+  // S8 dm-wire. Agent-view apps (the default variant, allowGuests !== true)
+  // get thread-per-conversation DMs from the CHANNEL DECLARATION: the
+  // Slack adapter's SLACK_DEFAULTS declares dm.sessionMode 'per-thread',
+  // resolveWiringDefaults derives the threads=1 stamp from it (per-thread
+  // sessions structurally require honored thread ids), and ensureWiring
+  // stamps whatever it resolves — nothing is hardcoded here. The plain
+  // (allow_guests) variant has no agent-mode DM surface, so it pins
+  // session_mode 'shared' and leaves the threads column NULL explicitly.
+  let dmCreated = false;
+  try {
+    const dmRow = await ensureMessagingGroupRow({
+      platformId: `slack:${dmChannelId}`,
+      instance: instanceKey,
+      name: `${displayName} DM`,
+      isGroup: false,
+      unknownSenderPolicy: resolveUnknownSenderPolicy(instanceKey, false, 'slack'),
+    });
+    dmCreated = dmRow.created;
+    const agentView = args.allowGuests !== true;
+    await ensureWiring(
+      dmRow.mg,
+      newAgentGroupId,
+      displayName,
+      agentView ? {} : { session_mode: 'shared', threads: null },
+    );
+  } catch (err) {
+    throw asFlowError(err, 'dm-wire');
+  }
+
+  // S9–S13 room half: MPIM + allowlist + per-instance mention/accumulate
+  // wirings + pairwise destinations + canvas + room-contract intro. The
+  // conversational flow's 3-way default; ensureAgentRoom itself is N-capable.
+  // room:'none' skips the whole half — the DM is the entire surface
+  // and the caller composes a shared room later via create_room.
+  let roomChannelId: string | undefined;
+  if (args.room !== 'none') {
+    const sourceGroupName = (await getAgentGroup(sourceGroupId))?.name ?? sourceGroupId;
+    const newParticipant: RoomParticipant = {
+      instanceKey,
+      botUserId: newBotUserId,
+      agentGroupId: newAgentGroupId,
+      agentGroupName: displayName,
+    };
+    const roomName = `${displayName} room`;
+    const roomPurpose = publicPurpose(args.purpose);
+    const room = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: app.botToken,
+      operatorUserId,
+      participants: [
+        {
+          instanceKey: originInstanceKey,
+          botUserId: originBotUserId,
+          agentGroupId: sourceGroupId,
+          agentGroupName: sourceGroupName,
+        },
+        newParticipant,
+      ],
+      roomName,
+      purpose: roomPurpose,
+      rootDir,
+    });
+    roomChannelId = room.roomChannelId;
+
+    // The ORIGIN agent authors the room intro — an instruction-shaped
+    // system nudge (trigger=1 wake via notifyAgent) into the origin session,
+    // gated on the S13 created-gate so a flow retry never double-nudges. The
+    // wizard first-agent path never reaches here (it opens no room); the
+    // out-of-process finish path has no origin session to nudge. The room
+    // destination was projected into the live session in S12.
+    if (room.created && args.originSession) {
+      const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, originInstanceKey);
+      const roomDest = roomMg ? await getDestinationByTarget(sourceGroupId, 'channel', roomMg.id) : undefined;
+      await notifyAgent(
+        args.originSession,
+        roomIntroNudgeText({
+          newAgentName: displayName,
+          newBotUserId,
+          roomName,
+          roomDestination: roomDest?.local_name ?? normalizeName(roomName),
+          purpose: roomPurpose,
+        }),
+      );
+    }
+  }
+
+  // S13 DM half — gated on the row newly created in S8.
+  if (dmCreated) {
+    await slackPostMessage(
+      app.botToken,
+      dmChannelId,
+      `Hi <@${operatorUserId}> — I'm ${displayName}, your new agent. This DM is already wired up; just reply here to start.`,
+      'intro-post',
+    );
+  }
+
+  return {
+    slug,
+    newBotUserId,
+    operatorUserId,
+    dmChannelId,
+    roomChannelId,
+    ...(app.deferredInstall ? { deferredInstall: true } : {}),
+  };
+}
+
+/** In-host entry — the wrapped create_agent handler's Slack leg (hot-add active). */
+export async function runSlackAgentFlow(args: {
+  content: Record<string, unknown>;
+  session: Session;
+  newAgentGroupId: string;
+  slug: string;
+  /** Wait budget for a deferred workspace install. Tests shorten it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+}): Promise<OrchestrateSuccess> {
+  const { content, session, newAgentGroupId, slug } = args;
+  const displayName =
+    typeof content.name === 'string' && content.name
+      ? content.name
+      : ((await getAgentGroup(newAgentGroupId))?.name ?? slug);
+  const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  return runFlow({
+    slug,
+    displayName,
+    sourceGroupId: session.agent_group_id,
+    newAgentGroupId,
+    originInstanceKey: originMg?.instance ?? 'slack',
+    // messaging_groups store 'slack:<channelId>'; the Web API wants the bare id.
+    originChannelId: originMg?.platform_id?.replace(/^slack:/, ''),
+    installWait: args.installWait,
+    rootDir: process.cwd(),
+    hotStart: true,
+    description: typeof content.instructions === 'string' ? content.instructions.slice(0, 300) : undefined,
+    purpose: typeof content.purpose === 'string' ? content.purpose : undefined,
+    allowGuests: content.allow_guests === true,
+    originSession: session,
+    room: content.room === 'none' ? 'none' : 'own',
+  });
+}
+
+/**
+ * Out-of-process finish/retry entry (scripts/slack-agent-flow-finish.ts):
+ * S1–S13 minus the S5 hot-add — a separate process cannot start an adapter
+ * inside the live host, so the script restarts the service (or says how).
+ */
+export async function finishSlackAgentFlow(args: {
+  slug: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey?: string;
+  rootDir?: string;
+  /** Pass true when the original create used allow_guests (plain variant) —
+   *  keeps the finish path's DM wiring congruent with the provisioned app. */
+  allowGuests?: boolean;
+  /** Pass 'none' when the original create used room:'none' — keeps the
+   *  finish path from growing a room the caller deliberately skipped. */
+  room?: 'own' | 'none';
+  /** Called with the pending-install line when the app is waiting on a
+   *  workspace install approval — the script prints it so a five-minute wait
+   *  does not read as a hang. */
+  onInstallPending?: (text: string) => void;
+}): Promise<OrchestrateSuccess> {
+  return runFlow({
+    slug: args.slug,
+    displayName: (await getAgentGroup(args.newAgentGroupId))?.name ?? args.slug,
+    sourceGroupId: args.sourceGroupId,
+    newAgentGroupId: args.newAgentGroupId,
+    originInstanceKey: args.originInstanceKey ?? 'slack',
+    rootDir: args.rootDir ?? process.cwd(),
+    hotStart: false,
+    allowGuests: args.allowGuests,
+    room: args.room,
+    onInstallPending: args.onInstallPending,
+  });
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Congruence pins for provision.ts, which deliberately duplicates its broker
+ * protocol and manifest out of the trunk provisioning module
+ * src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts.
+ *
+ * ALL transports carry the same
+ * template: BASE + canvas scopes, BASE + membership events, and the
+ * agent-mode (agent_view) variant pair — matching the broker's BOT_SCOPES /
+ * BOT_EVENTS / AGENT_BOT_* in nanocoai/infra: modules/nanoclaw-slack lambda
+ * service/index.mjs. The pins here hold the mirrors (read as source text —
+ * they are not importable from src/) equal to provision.ts's own sets, and
+ * provision.ts equal to the documented BASE + additions.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_BROKER_BASE,
+  MANAGED_AGENT_BOT_EVENTS,
+  MANAGED_AGENT_BOT_SCOPES,
+  MANAGED_APP_DESCRIPTION,
+  MANAGED_BOT_EVENTS,
+  MANAGED_BOT_SCOPES,
+  buildManagedAppManifest,
+  provisionSlackApp,
+  resolveProvisioningCredential,
+} from './provision.js';
+
+const CREATE_AGENT_SCRIPT = path.resolve(
+  process.cwd(),
+  '.claude/skills/slack-managed-agents/scripts/slack-create-agent.ts',
+);
+const SLACK_PROVISION = path.resolve(process.cwd(), 'src/provisioning/slack-app.ts');
+
+/**
+ * The base managed-app sets, before the additions below. Kept literal so
+ * drift in either direction is loud.
+ */
+const BASE_BOT_SCOPES = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+];
+const BASE_BOT_EVENTS = ['message.channels', 'message.groups', 'message.im', 'message.mpim', 'app_mention'];
+
+/** Additions over the base set (room canvas + read-back; membership events). */
+const CANVAS_SCOPES = ['canvases:read', 'canvases:write', 'files:read'];
+const MEMBERSHIP_EVENTS = ['member_joined_channel', 'member_left_channel'];
+
+/** send_file: files.upload needs files:write, distinct from the canvas read-back path. */
+const SEND_FILE_SCOPES = ['files:write'];
+
+/** All single-quoted strings inside `export const <name> = […]`, comments stripped. */
+function extractStringArray(src: string, name: string): string[] {
+  const m = src.match(new RegExp(`export const ${name}[^=]*= \\[([\\s\\S]*?)\\];`));
+  expect(m, `export const ${name} = […] not found in mirror source`).toBeTruthy();
+  const body = m![1].replace(/\/\/.*$/gm, '');
+  return [...body.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+// The slack-managed-agents skill is optional (its install leg is coupled to
+// the managed-app provisioning service) — the mirror pins run wherever its
+// skill directory is present and skip cleanly where it is not. When present
+// it MUST match; the path is pinned literally, so a moved script fails loudly.
+describe.skipIf(!fs.existsSync(CREATE_AGENT_SCRIPT))('provision.ts congruence with slack-create-agent.ts', () => {
+  it("the mirror's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(extractStringArray(src, 'MANAGED_BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the mirror's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+    expect(src).toContain('--allow-guests');
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts sets', () => {
+  it("the trunk provisioning module's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(extractStringArray(src, 'BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the trunk provisioning module's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+  });
+});
+
+describe('provision.ts manifest shape (broker-congruent, both variants)', () => {
+  it('MANAGED_BOT_SCOPES = base + canvas scopes + send_file scope, bot scopes only', () => {
+    expect([...MANAGED_BOT_SCOPES]).toEqual([...BASE_BOT_SCOPES, ...CANVAS_SCOPES, ...SEND_FILE_SCOPES]);
+  });
+
+  it('MANAGED_BOT_EVENTS = base + membership events', () => {
+    expect([...MANAGED_BOT_EVENTS]).toEqual([...BASE_BOT_EVENTS, ...MEMBERSHIP_EVENTS]);
+  });
+
+  it('agent-mode additions are exactly assistant:write + the two agent events', () => {
+    expect([...MANAGED_AGENT_BOT_SCOPES]).toEqual(['assistant:write']);
+    expect([...MANAGED_AGENT_BOT_EVENTS]).toEqual(['app_home_opened', 'app_context_changed']);
+  });
+
+  interface ManifestShape {
+    display_information: { name: string; description: string };
+    features: {
+      bot_user: { display_name: string; always_online: boolean };
+      agent_view?: { agent_description: string };
+    };
+    oauth_config: { scopes: { bot: string[]; user?: string[] } };
+    settings: {
+      event_subscriptions: { bot_events: string[] };
+      socket_mode_enabled: boolean;
+      interactivity: { is_enabled: boolean };
+    };
+  }
+
+  it('default variant is agent-mode: agent_view + assistant:write + agent events', () => {
+    const manifest = buildManagedAppManifest('Research') as unknown as ManifestShape;
+    expect(manifest.display_information.name).toBe('Research');
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+    expect(manifest.features.bot_user).toEqual({ display_name: 'Research', always_online: true });
+    // The agent_description doubles as the attribution line (≤300-char field).
+    expect(manifest.features.agent_view).toEqual({ agent_description: MANAGED_APP_DESCRIPTION });
+    expect(MANAGED_APP_DESCRIPTION.length).toBeLessThanOrEqual(300);
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES]);
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([
+      ...MANAGED_BOT_EVENTS,
+      ...MANAGED_AGENT_BOT_EVENTS,
+    ]);
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    expect(manifest.settings.interactivity.is_enabled).toBe(false);
+  });
+
+  it('plain variant (agentView:false) omits agent_view, assistant:write, and the agent events', () => {
+    const manifest = buildManagedAppManifest('Research', { agentView: false }) as unknown as ManifestShape;
+    expect(manifest.features.agent_view).toBeUndefined();
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write');
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([...MANAGED_BOT_EVENTS]);
+    for (const ev of MANAGED_AGENT_BOT_EVENTS) {
+      expect(manifest.settings.event_subscriptions.bot_events).not.toContain(ev);
+    }
+    // Both still carry the always-on additions.
+    for (const scope of CANVAS_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const scope of SEND_FILE_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const ev of MEMBERSHIP_EVENTS) expect(manifest.settings.event_subscriptions.bot_events).toContain(ev);
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+  });
+
+  it('both variants stay bot-scopes-only (apps.managedInstall eligibility)', () => {
+    for (const agentView of [true, false]) {
+      const manifest = buildManagedAppManifest('Research', { agentView }) as unknown as ManifestShape;
+      expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
+    }
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts', () => {
+  it('broker base + override key + endpoint match the trunk provisioning module', () => {
+    expect(fs.existsSync(SLACK_PROVISION), `${SLACK_PROVISION} not found — the trunk provisioning module moved?`).toBe(
+      true,
+    );
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    const base = src.match(/export const DEFAULT_SLACK_SERVICE_BASE = '([^']+)'/);
+    expect(base?.[1]).toBe(DEFAULT_BROKER_BASE);
+    expect(src).toContain("'SLACK_SERVICE_BASE'");
+    expect(src).toContain("'/v1/apps'");
+  });
+});
+
+describe('provisionSlackApp broker body (allow_guests threading)', () => {
+  let rootDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-broker-'));
+    fs.writeFileSync(path.join(rootDir, '.env'), 'NANOCLAW_INSTALL_TOKEN=install-token-1\n');
+    for (const key of ['NANOCLAW_REGISTRY_TOKEN', 'SLACK_MANAGER_TOKEN', 'SLACK_SERVICE_BASE']) {
+      vi.stubEnv(key, '');
+    }
+    fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith('/v1/avatars')) {
+        // Generation unavailable → no avatar poll loop, no avatar_id in the create body.
+        return new Response(JSON.stringify({ avatar_id: null, status: 'unavailable' }), { status: 200 });
+      }
+      if (u.endsWith('/v1/apps')) {
+        return new Response(JSON.stringify({ app_id: 'A123', app_token: 'xapp-test', bot_token: 'xoxb-test' }), {
+          status: 201,
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  const createBody = (): Record<string, unknown> => {
+    const call = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/v1/apps'));
+    expect(call, 'POST /v1/apps was never called').toBeTruthy();
+    return JSON.parse((call![1] as RequestInit).body as string) as Record<string, unknown>;
+  };
+
+  it('omits allow_guests by default (broker provisions the agent-mode variant)', async () => {
+    const result = await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1' });
+    expect(result.reused).toBe(false);
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel' });
+  });
+
+  it('threads allowGuests:true into the body as allow_guests (plain variant)', async () => {
+    await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1', allowGuests: true });
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel', allow_guests: true });
+  });
+});
+
+describe('resolveProvisioningCredential', () => {
+  let rootDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-root-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-home-'));
+    // Neutralize the real environment — every key this resolver consults.
+    for (const key of [
+      'NANOCLAW_REGISTRY_TOKEN',
+      'NANOCLAW_INSTALL_TOKEN',
+      'SLACK_MANAGER_TOKEN',
+      'SLACK_SERVICE_BASE',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const writeEnv = (lines: string[]): void => fs.writeFileSync(path.join(rootDir, '.env'), lines.join('\n') + '\n');
+  const writeAccount = (content: string): void => {
+    const dir = path.join(homeDir, '.config', 'nanoclaw');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'account.json'), content);
+  };
+  const resolve = (): ReturnType<typeof resolveProvisioningCredential> =>
+    resolveProvisioningCredential(rootDir, { homeDir });
+
+  it('returns null when no credential exists anywhere', () => {
+    expect(resolve()).toBeNull();
+  });
+
+  it('process.env NANOCLAW_REGISTRY_TOKEN wins over every other source', () => {
+    vi.stubEnv('NANOCLAW_REGISTRY_TOKEN', 'registry-token-from-env');
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'registry-token-from-env',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('.env NANOCLAW_INSTALL_TOKEN beats account.json and the manager token', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('falls back to ~/.config/nanoclaw/account.json before direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({ mode: 'broker', installToken: 'account-token', baseUrl: DEFAULT_BROKER_BASE });
+  });
+
+  it('malformed account.json reads as not-enrolled, not an error', () => {
+    writeAccount('{not json');
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('account.json without a usable token field reads as not-enrolled', () => {
+    writeAccount(JSON.stringify({ token: '   ' }));
+    expect(resolve()).toBeNull();
+  });
+
+  it('SLACK_MANAGER_TOKEN alone selects direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('SLACK_SERVICE_BASE overrides the broker base, trailing slashes stripped', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_SERVICE_BASE=https://broker.example.test///']);
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: 'https://broker.example.test',
+    });
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.prefetch.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.prefetch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Avatar prefetch (multi-agent creates): prefetchAvatar starts the broker job
+ * in the background; the flow's later requestAvatar with the same
+ * (displayName, description) consumes that in-flight job instead of starting
+ * a second generation. A key miss or an already-consumed entry falls back to
+ * a fresh request.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAvatarPrefetches, prefetchAvatar, requestAvatar } from './provision.js';
+
+const fetchMock = vi.fn();
+
+function avatarBrokerResponses(id: string): void {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.endsWith('/v1/avatars')) {
+      return Promise.resolve(new Response(JSON.stringify({ avatar_id: id }), { status: 200 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ status: 'ready' }), { status: 200 }));
+  });
+}
+
+function postCount(): number {
+  return fetchMock.mock.calls.filter((c) => (c as [string])[0].endsWith('/v1/avatars')).length;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  clearAvatarPrefetches();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearAvatarPrefetches();
+});
+
+describe('avatar prefetch', () => {
+  it('requestAvatar consumes a pending prefetch — exactly one generation job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBe('av-1');
+    expect(postCount()).toBe(1);
+  });
+
+  it('a prefetch is consumed once — the next same-key request goes fresh', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('different (name, description) keys never share a job', async () => {
+    avatarBrokerResponses('av-x');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'designer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('duplicate prefetches for one key start one job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(1);
+  });
+
+  it('a failed prefetch resolves undefined without throwing into the flow', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBeUndefined();
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
@@ -1,0 +1,797 @@
+/**
+ * Managed Slack app provisioning for the slack-agent-flow leg.
+ *
+ * CONGRUENCE — this file deliberately duplicates:
+ * - src/provisioning/slack-app.ts (trunk provisioning module) — broker
+ *   protocol (install token from
+ *   ~/.config/nanoclaw/account.json or NANOCLAW_REGISTRY_TOKEN, base
+ *   SLACK_SERVICE_BASE else https://slack.nanoclaw.dev, POST /v1/apps) and the
+ *   direct apps.manifest.create + apps.managedInstall pair.
+ * - .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts —
+ *   MANAGED_BOT_SCOPES / MANAGED_BOT_EVENTS / buildManagedAppManifest,
+ *   credential resolution order, and the crash-safe persist-before-return
+ *   .env write (its step 1/3).
+ * This file, both mirrors, and the broker's server template all carry the
+ * SAME sets: base + canvas scopes, membership events, and the agent_view
+ * variant pair.
+ * provision.congruence.test.ts pins the mirrors against this file's sets and
+ * this file against the broker contract.
+ *
+ * The manager/install token is read, used as a Bearer header, and forgotten.
+ * Only the derived per-app bot/app tokens persist (to .env). No token value
+ * is ever logged or embedded in an error message.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+import { SlackFlowError, type ProvisionInput, type ProvisionResult } from './types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** The deployed managed-Slack broker. Overridable via SLACK_SERVICE_BASE. */
+export const DEFAULT_BROKER_BASE = 'https://slack.nanoclaw.dev';
+
+/**
+ * The managed-apps bot scope set — bot scopes only, no user scopes (that is
+ * the apps.managedInstall eligibility rule). Superset of MANAGED_BOT_SCOPES
+ * in slack-create-agent.ts (the base set) plus the canvas scopes; must stay
+ * identical to the broker's server-side BOT_SCOPES — apps provisioned via
+ * either transport must be scope-identical (pinned by
+ * provision.congruence.test.ts). im:write is what lets the new bot open the
+ * operator DM; mpim:* is what lets it open the three-way room; canvases:* +
+ * files:read is the room-canvas surface (files:read is the read-back path —
+ * canvases are files, the HTML download carries section ids).
+ */
+export const MANAGED_BOT_SCOPES: readonly string[] = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+  'canvases:read',
+  'canvases:write',
+  'files:read',
+  // send_file: agents deliver files they produce (charts, documents,
+  // generated artifacts) via files upload — live-verified missing_scope
+  // failure without it (filesUploadV2 needs files:write).
+  'files:write',
+];
+
+// member_joined/left_channel ride on the channels/groups/mpim:read scopes
+// already present (join-time adopt flow + membership bookkeeping).
+export const MANAGED_BOT_EVENTS: readonly string[] = [
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'app_mention',
+  'member_joined_channel',
+  'member_left_channel',
+];
+
+/**
+ * Agent-mode (features.agent_view) additions — the default variant. Slack
+ * auto-adds assistant:write when agent_view is enabled; declared explicitly
+ * so the manifest states what the app holds. Guests are hard-blocked from
+ * agent-enabled apps, so allowGuests selects the plain variant instead.
+ */
+export const MANAGED_AGENT_BOT_SCOPES: readonly string[] = ['assistant:write'];
+
+export const MANAGED_AGENT_BOT_EVENTS: readonly string[] = ['app_home_opened', 'app_context_changed'];
+
+/**
+ * Fixed attribution line: admins see this, never the creation prompt. Also
+ * the agent_view.agent_description (≤300 chars) on the agent-mode variant.
+ */
+export const MANAGED_APP_DESCRIPTION =
+  'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
+
+/**
+ * Socket-Mode-only managed-app manifest (see the congruence note above).
+ * Two variants, chosen at provision time — agent_view is a one-way door:
+ * agent-mode (default; free workspaces degrade to a plain DM) and plain
+ * (agentView:false, for workspaces that need guest access).
+ */
+export function buildManagedAppManifest(
+  displayName: string,
+  opts: { agentView?: boolean } = {},
+): Record<string, unknown> {
+  const agentView = opts.agentView ?? true;
+  return {
+    display_information: {
+      name: displayName,
+      description: MANAGED_APP_DESCRIPTION,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: displayName,
+        always_online: true,
+      },
+      ...(agentView ? { agent_view: { agent_description: MANAGED_APP_DESCRIPTION } } : {}),
+    },
+    oauth_config: {
+      scopes: { bot: agentView ? [...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES] : [...MANAGED_BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: agentView ? [...MANAGED_BOT_EVENTS, ...MANAGED_AGENT_BOT_EVENTS] : [...MANAGED_BOT_EVENTS],
+      },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+/**
+ * Which provisioning credential this install holds, in the decisive order:
+ * process.env.NANOCLAW_REGISTRY_TOKEN → .env NANOCLAW_INSTALL_TOKEN →
+ * ~/.config/nanoclaw/account.json (broker mode; base = SLACK_SERVICE_BASE
+ * else DEFAULT_BROKER_BASE) → .env SLACK_MANAGER_TOKEN (direct mode) → null.
+ *
+ * `opts.homeDir` overrides os.homedir() for tests only — the account.json
+ * credential is deliberately per-user, not per-checkout.
+ */
+export function resolveProvisioningCredential(
+  rootDir: string,
+  opts: { homeDir?: string } = {},
+): { mode: 'broker'; installToken: string; baseUrl: string } | { mode: 'direct'; managerToken: string } | null {
+  const baseUrl = (readEnvValue(rootDir, 'SLACK_SERVICE_BASE') ?? DEFAULT_BROKER_BASE).replace(/\/+$/, '');
+
+  const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
+  if (fromEnv) return { mode: 'broker', installToken: fromEnv, baseUrl };
+
+  const installToken = readEnvValue(rootDir, 'NANOCLAW_INSTALL_TOKEN');
+  if (installToken) return { mode: 'broker', installToken, baseUrl };
+
+  // Enrollment persists the install token at ~/.config/nanoclaw/account.json
+  // ({ token: "…" }). Malformed or missing reads as "not enrolled".
+  try {
+    const accountPath = path.join(opts.homeDir ?? os.homedir(), '.config', 'nanoclaw', 'account.json');
+    const parsed: unknown = JSON.parse(fs.readFileSync(accountPath, 'utf-8'));
+    const token = (parsed as { token?: unknown } | null)?.token;
+    if (typeof token === 'string' && token.trim()) {
+      return { mode: 'broker', installToken: token.trim(), baseUrl };
+    }
+  } catch {
+    // fall through to direct mode
+  }
+
+  const managerToken = readEnvValue(rootDir, 'SLACK_MANAGER_TOKEN');
+  if (managerToken) return { mode: 'direct', managerToken };
+
+  return null;
+}
+
+interface RawProvisioned {
+  appId: string;
+  appToken: string;
+  botToken?: string;
+  installUrl?: string;
+  installError?: string;
+}
+
+/**
+ * Optional request-origin metadata on the broker's POST /v1/apps body
+ * (requested_by / parent_app_id / template / client_version on the wire).
+ * Sent only when defined; a broker that predates them ignores unknown body
+ * fields. Names and no-value-no-key behavior are pinned across every
+ * provisioning home by provision.congruence.test.ts. The direct transport has
+ * nowhere to record them and never forwards them.
+ */
+interface ProvisionAttribution {
+  requestedBy?: string;
+  parentAppId?: string;
+  template?: string;
+  clientVersion?: string;
+}
+
+/**
+ * The installing host's package.json version — the client_version metadata
+ * field. Optional-shaped: unreadable/absent → undefined and the field is
+ * simply omitted (never a placeholder value).
+ */
+function readClientVersion(rootDir: string): string | undefined {
+  try {
+    const pkg: unknown = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
+    const version = (pkg as { version?: unknown } | null)?.version;
+    return typeof version === 'string' && version.trim() ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Broker mode: POST /v1/apps with the install token; 60s budget. */
+/** Poll cap for the pre-create avatar job — beyond it the bot is born with the mascot. */
+const AVATAR_WAIT_MS = 75_000;
+// Generation measures ~20-23s at the broker's floor settings (quality 'low',
+// 1024px is the model's minimum) — a 2s poll wastes at most ~2s of that,
+// where the old 4s poll wasted up to 4.
+const AVATAR_POLL_MS = 2_000;
+
+// ── Avatar prefetch (multi-agent creates) ──
+//
+// Each generation is an independent async Lambda on the broker, so N avatars
+// CAN run concurrently — the serialization was ours: flows run one at a time,
+// each paying the full ~23s avatar wait. The delivery batch preview
+// (index.ts) starts a prefetch for every create_agent in the batch in
+// parallel; requestAvatar consumes the matching prefetch instead of starting
+// a fresh job, collapsing N waits to ~one. Keyed by the exact
+// (displayName, description) derivation the flow uses, so a miss just means
+// a normal fresh request.
+const avatarPrefetches = new Map<string, { promise: Promise<string | undefined>; at: number }>();
+const AVATAR_PREFETCH_TTL_MS = 10 * 60_000;
+
+function avatarKey(displayName: string, description: string | undefined): string {
+  return `${displayName}\u0000${description ?? ''}`;
+}
+
+/** Start an avatar generation in the background for a create that is about to
+ *  be processed. Fire-and-forget; never throws. Deduped per key. */
+export function prefetchAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): void {
+  const key = avatarKey(displayName, description);
+  const existing = avatarPrefetches.get(key);
+  if (existing && Date.now() - existing.at < AVATAR_PREFETCH_TTL_MS) return;
+  avatarPrefetches.set(key, {
+    promise: requestAvatarFresh(baseUrl, installToken, displayName, description).catch(() => undefined),
+    at: Date.now(),
+  });
+}
+
+/** Test seam: drop all pending prefetches. */
+export function clearAvatarPrefetches(): void {
+  avatarPrefetches.clear();
+}
+
+/**
+ * Ask the broker to generate the agent's avatar BEFORE the app exists, so the
+ * bot's very first workspace appearance wears its face — the mascot default
+ * never shows on the happy path. Consumes a matching prefetch when one is
+ * pending (multi-agent creates start them in parallel). Returns undefined
+ * when generation is unavailable, failed, or over the wait cap (degraded
+ * path: mascot).
+ */
+export async function requestAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  const key = avatarKey(displayName, description);
+  const hit = avatarPrefetches.get(key);
+  if (hit) {
+    avatarPrefetches.delete(key);
+    if (Date.now() - hit.at < AVATAR_PREFETCH_TTL_MS) return hit.promise;
+  }
+  return requestAvatarFresh(baseUrl, installToken, displayName, description);
+}
+
+async function requestAvatarFresh(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  let avatarId: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/v1/avatars`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${installToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: displayName, ...(description ? { description } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = (await res.json()) as { avatar_id?: string | null };
+    avatarId = data.avatar_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+  if (!avatarId) return undefined;
+  const deadline = Date.now() + AVATAR_WAIT_MS;
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) await new Promise((r) => setTimeout(r, AVATAR_POLL_MS));
+    try {
+      const res = await fetch(`${baseUrl}/v1/avatars/${avatarId}`, {
+        headers: { Authorization: `Bearer ${installToken}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'ready') return avatarId;
+      if (data.status && data.status !== 'pending') return undefined;
+    } catch {
+      // Transient — bounded by the deadline.
+    }
+  }
+  return undefined;
+}
+
+async function provisionViaBroker(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  teamId: string | undefined,
+  description: string | undefined,
+  allowGuests = false,
+  attribution: ProvisionAttribution = {},
+): Promise<RawProvisioned> {
+  if (!teamId) {
+    throw new SlackFlowError(
+      'broker',
+      'broker mode needs the origin workspace team_id (origin auth.test returned none)',
+    );
+  }
+  const avatarId = await requestAvatar(baseUrl, installToken, displayName, description);
+  let res: Response;
+  let text: string;
+  try {
+    res = await fetch(`${baseUrl}/v1/apps`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${installToken}`,
+        'Content-Type': 'application/json',
+      },
+      // The deployed broker's contract (POST /v1/apps): it builds the manifest
+      // server-side (agent-mode variant unless allow_guests) and generates
+      // the per-agent avatar from the description.
+      body: JSON.stringify({
+        team_id: teamId,
+        name: displayName,
+        ...(avatarId ? { avatar_id: avatarId } : {}),
+        ...(allowGuests ? { allow_guests: true } : {}),
+        // Request-origin metadata — optional both ways: omitted when
+        // unknown, ignored by a broker that predates the fields.
+        ...(attribution.requestedBy ? { requested_by: attribution.requestedBy } : {}),
+        ...(attribution.parentAppId ? { parent_app_id: attribution.parentAppId } : {}),
+        ...(attribution.template ? { template: attribution.template } : {}),
+        ...(attribution.clientVersion ? { client_version: attribution.clientVersion } : {}),
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    text = await res.text();
+  } catch (err) {
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let data: Record<string, unknown>;
+  try {
+    data = (text ? JSON.parse(text) : {}) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('broker', `broker POST /v1/apps failed: HTTP ${res.status}, non-JSON body`);
+  }
+  if (!res.ok) {
+    // message is the human sentence, error the machine code — show the human one.
+    const detail = (data as { message?: string; error?: string }).message ?? (data as { error?: string }).error;
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: HTTP ${res.status}${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+  // Contract shape is camelCase; the deployed broker speaks snake_case
+  // (BrokerAppResponse in src/provisioning/slack-app.ts) — accept both.
+  const pick = (a: unknown, b: unknown): string | undefined =>
+    typeof a === 'string' && a ? a : typeof b === 'string' && b ? b : undefined;
+  const appId = pick(data.appId, data.app_id);
+  const appToken = pick(data.appToken, data.app_token);
+  if (!appId || !appToken) {
+    throw new SlackFlowError('broker', 'broker POST /v1/apps failed: response missing app id or app token');
+  }
+  return {
+    appId,
+    appToken,
+    botToken: pick(data.botToken, data.bot_token),
+    installUrl: pick(data.installUrl, data.install_url),
+    installError: pick(data.installError, data.install_error),
+  };
+}
+
+// ── Deferred install completion (broker transport) ──
+//
+// A workspace with an admin-approval policy refuses auto-install: POST
+// /v1/apps answers with an install_url and no bot token. That URL carries its
+// own signed state and stays valid for days, so the app is not lost — it sits
+// at pending_install until a human completes the install in the browser, and
+// GET /v1/apps/{app_id} then releases the bot token exactly once. Mirrors
+// waitForInstall in src/provisioning/slack-app.ts.
+
+/** Poll cadence while a workspace install approval is outstanding. */
+export const INSTALL_POLL_INTERVAL_MS = 5_000;
+/** How long the flow waits inline before parking the app for a later resume. */
+export const INSTALL_POLL_TIMEOUT_MS = 5 * 60_000;
+
+type AppStatus = 'installed' | 'pending_install' | 'deleted';
+
+interface AppState {
+  status: AppStatus;
+  botToken?: string;
+}
+
+/**
+ * One app's state, or undefined when the service does not know it (404) —
+ * which for every caller here means the same as "stop waiting". Transport
+ * failures throw so the poll loop can decide whether they are worth retrying.
+ */
+async function fetchAppState(baseUrl: string, installToken: string, appId: string): Promise<AppState | undefined> {
+  const res = await fetch(`${baseUrl}/v1/apps/${encodeURIComponent(appId)}`, {
+    headers: { Authorization: `Bearer ${installToken}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (res.status === 404) return undefined;
+  if (res.status === 401 || res.status === 403) {
+    throw new SlackFlowError(
+      'install-wait',
+      `the Slack service refused this install's credentials (HTTP ${res.status})`,
+    );
+  }
+  if (!res.ok) throw new Error(`GET /v1/apps/${appId}: HTTP ${res.status}`);
+  const data = (await res.json()) as { status?: string; bot_token?: string | null; botToken?: string | null };
+  const status = data.status;
+  if (status !== 'installed' && status !== 'pending_install' && status !== 'deleted') {
+    throw new Error(`GET /v1/apps/${appId}: unrecognized status '${String(status)}'`);
+  }
+  // Contract shape is snake_case; accept camelCase the way the create call does.
+  const botToken = data.bot_token ?? data.botToken ?? undefined;
+  return { status, ...(botToken ? { botToken } : {}) };
+}
+
+/**
+ * Wait out a pending install and return the one-time bot token.
+ *
+ * Undefined means "stop waiting and park the app": the deadline passed, the
+ * service does not know the app, it was deleted, or it reads as installed with
+ * no token left to give (someone else already took it — no further poll
+ * recovers it). A credential refusal is the one failure worth surfacing, since
+ * the next poll cannot change that answer.
+ */
+export async function waitForInstall(
+  baseUrl: string,
+  installToken: string,
+  appId: string,
+  opts: { intervalMs?: number; timeoutMs?: number; checkImmediately?: boolean } = {},
+): Promise<string | undefined> {
+  const intervalMs = opts.intervalMs ?? INSTALL_POLL_INTERVAL_MS;
+  const deadline = Date.now() + (opts.timeoutMs ?? INSTALL_POLL_TIMEOUT_MS);
+  // A resume checks straight away — the approval may have landed while nobody
+  // was waiting, and that is worth one call even when the budget is zero. A
+  // fresh refusal sleeps first: nothing can have changed in the instant since
+  // the service said no.
+  let due = opts.checkImmediately === true;
+  while (due || Date.now() < deadline) {
+    if (!due) await new Promise((r) => setTimeout(r, intervalMs));
+    due = false;
+    let state: AppState | undefined;
+    try {
+      state = await fetchAppState(baseUrl, installToken, appId);
+    } catch (err) {
+      if (err instanceof SlackFlowError) throw err;
+      continue; // transient — the deadline already bounds this
+    }
+    if (!state || state.status === 'deleted') return undefined;
+    if (state.status === 'installed') return state.botToken;
+  }
+  return undefined;
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+async function slackApi<T extends SlackApiResponse>(
+  method: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API}/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(params).toString(),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new SlackFlowError('direct-create', `${method} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok && res.status !== 200) throw new SlackFlowError('direct-create', `${method}: HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+/** Direct mode: apps.manifest.create + apps.managedInstall with the manager token. */
+async function provisionDirect(
+  managerToken: string,
+  displayName: string,
+  allowGuests = false,
+): Promise<RawProvisioned> {
+  const created = await slackApi<
+    SlackApiResponse & { app_id?: string; app_token?: string; oauth_authorize_url?: string }
+  >('apps.manifest.create', managerToken, {
+    manifest: JSON.stringify(buildManagedAppManifest(displayName, { agentView: !allowGuests })),
+    generate_app_token: 'true',
+  });
+  if (!created.ok || !created.app_id) {
+    throw new SlackFlowError(
+      'direct-create',
+      `apps.manifest.create failed: ${created.error ?? 'no app_id in response'}`,
+    );
+  }
+  if (!created.app_token) {
+    throw new SlackFlowError(
+      'direct-create',
+      'apps.manifest.create returned no app-level token (generate_app_token unsupported?)',
+    );
+  }
+  const result: RawProvisioned = {
+    appId: created.app_id,
+    appToken: created.app_token,
+    installUrl: created.oauth_authorize_url ?? '',
+  };
+  const installed = await slackApi<SlackApiResponse & { api_access_tokens?: { bot_access_token?: string } }>(
+    'apps.managedInstall',
+    managerToken,
+    { app_id: created.app_id },
+  );
+  if (installed.ok && installed.api_access_tokens?.bot_access_token) {
+    result.botToken = installed.api_access_tokens.bot_access_token;
+  } else {
+    result.installError = installed.error ?? 'no bot token in response';
+  }
+  return result;
+}
+
+/** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix shape. */
+export function envKeySuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * The .env keys one provisioned instance owns. The app id and install URL are
+ * the resume state for an app whose workspace has not approved the install
+ * yet: without them a retry has nothing to poll and can only create a second
+ * Slack app for the same agent.
+ */
+export function envKeysForSlug(slug: string): {
+  botKey: string;
+  appKey: string;
+  appIdKey: string;
+  installUrlKey: string;
+} {
+  const suffix = envKeySuffix(slug);
+  return {
+    botKey: `SLACK_BOT_TOKEN_${suffix}`,
+    appKey: `SLACK_APP_TOKEN_${suffix}`,
+    appIdKey: `SLACK_APP_ID_${suffix}`,
+    installUrlKey: `SLACK_INSTALL_URL_${suffix}`,
+  };
+}
+
+/**
+ * The app this slug has parked awaiting a workspace install approval, if any:
+ * an app token and an app id on record, no bot token yet. Callers use it to
+ * tell "finish what you started" apart from "start something new".
+ */
+export function pendingInstall(rootDir: string, slug: string): { appId: string; installUrl?: string } | undefined {
+  const { botKey, appKey, appIdKey, installUrlKey } = envKeysForSlug(slug);
+  if (readEnvValue(rootDir, botKey)) return undefined;
+  if (!readEnvValue(rootDir, appKey)) return undefined;
+  const appId = readEnvValue(rootDir, appIdKey);
+  if (!appId) return undefined;
+  return { appId, installUrl: readEnvValue(rootDir, installUrlKey) };
+}
+
+/** Best-effort: a caller's notification must never take the flow down with it. */
+async function announcePending(
+  input: ProvisionInput,
+  info: { appId: string; installUrl?: string; resumed: boolean },
+): Promise<void> {
+  try {
+    await input.onInstallPending?.(info);
+  } catch {
+    // The wait is the point; the announcement is a courtesy.
+  }
+}
+
+/** What the human is told when the wait runs out and the app stays parked. */
+function parkedError(displayName: string, appId: string, installUrl: string | undefined): SlackFlowError {
+  return new SlackFlowError(
+    'install-wait',
+    `Slack app ${appId} for "${displayName}" is still waiting on a workspace install approval. ` +
+      `Nothing was lost and nothing needs re-creating — the app is saved. ` +
+      `${installUrl ? `Approve the install at ${installUrl}, then ask` : 'Once the install is approved, ask'} ` +
+      `to finish setting up ${displayName} and it picks up from here.`,
+  );
+}
+
+/**
+ * Provision (or reuse, or finish) the named instance's Slack app and persist
+ * its tokens.
+ *
+ * Three entries, decided by what .env already holds:
+ *  - both tokens → reuse, no network.
+ *  - app token + app id, no bot token → an app parked awaiting a workspace
+ *    install approval: poll for it rather than provision a second one.
+ *  - nothing → provision. A refused auto-install is not the end of the road:
+ *    the app is real and its install URL stays valid, so the flow announces
+ *    the approval and waits inline for the install to land.
+ *
+ * .env is the resume state, so everything derivable is written the moment it
+ * exists (mirrors slack-create-agent.ts) — a failure after that point never
+ * re-provisions a duplicate Slack app on retry.
+ */
+export async function provisionSlackApp(input: ProvisionInput): Promise<ProvisionResult> {
+  const { slug, displayName, rootDir } = input;
+  const envSuffix = envKeySuffix(slug);
+  const { botKey, appKey, appIdKey, installUrlKey } = envKeysForSlug(slug);
+
+  const existingBot = readEnvValue(rootDir, botKey);
+  const existingApp = readEnvValue(rootDir, appKey);
+  if (existingBot && existingApp) {
+    return {
+      slug,
+      envSuffix,
+      botToken: existingBot,
+      appToken: existingApp,
+      // Recorded since the deferred-install work; older installs have no row,
+      // and nothing downstream of provisioning needs the id.
+      appId: readEnvValue(rootDir, appIdKey) ?? '',
+      reused: true,
+    };
+  }
+  if (existingBot && !existingApp) {
+    throw new SlackFlowError(
+      'no-credentials',
+      `${botKey} is set but ${appKey} is missing — add the app-level xapp-… token to .env as ${appKey} and retry.`,
+    );
+  }
+
+  const credential = resolveProvisioningCredential(rootDir);
+
+  if (existingApp && !existingBot) {
+    const parked = pendingInstall(rootDir, slug);
+    // No app id on record (or no broker to ask) leaves the hand-finish
+    // instructions as the only honest answer.
+    if (!parked || credential?.mode !== 'broker') {
+      throw new SlackFlowError(
+        'no-credentials',
+        `${appKey} is set but ${botKey} is missing — the app exists but was never installed. ` +
+          `Finish the install from the app's page in Slack, put the xoxb-… token in .env as ${botKey}, and retry.`,
+      );
+    }
+    await announcePending(input, { appId: parked.appId, installUrl: parked.installUrl, resumed: true });
+    const botToken = await waitForInstall(credential.baseUrl, credential.installToken, parked.appId, {
+      ...input.installWait,
+      checkImmediately: true,
+    });
+    if (!botToken) throw parkedError(displayName, parked.appId, parked.installUrl);
+    persistInstalled(rootDir, slug, botToken);
+    return {
+      slug,
+      envSuffix,
+      botToken,
+      appToken: existingApp,
+      appId: parked.appId,
+      reused: false,
+      deferredInstall: true,
+    };
+  }
+
+  if (!credential) {
+    throw new SlackFlowError(
+      'no-credentials',
+      'no Slack provisioning credential: set NANOCLAW_INSTALL_TOKEN (managed service) or ' +
+        'SLACK_MANAGER_TOKEN (direct) in .env, or enroll this install with the registry.',
+    );
+  }
+
+  const allowGuests = input.allowGuests ?? false;
+  const app =
+    credential.mode === 'broker'
+      ? await provisionViaBroker(
+          credential.baseUrl,
+          credential.installToken,
+          displayName,
+          input.teamId,
+          input.description,
+          allowGuests,
+          {
+            requestedBy: input.requestedBy,
+            parentAppId: input.parentAppId,
+            template: input.template,
+            clientVersion: readClientVersion(rootDir),
+          },
+        )
+      : await provisionDirect(credential.managerToken, displayName, allowGuests);
+
+  // Persist what we have before anything else can fail. App token, app id and
+  // instance slug land even when auto-install was refused, so a later run can
+  // finish this app instead of creating another.
+  try {
+    upsertEnvKey(rootDir, appKey, app.appToken);
+    if (app.appId) upsertEnvKey(rootDir, appIdKey, app.appId);
+    if (app.botToken) upsertEnvKey(rootDir, botKey, app.botToken);
+    else if (app.installUrl) upsertEnvKey(rootDir, installUrlKey, app.installUrl);
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${appKey}/${botKey}/SLACK_INSTANCES to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!app.botToken) {
+    // Usually a workspace admin-approval policy refusing auto-install. On the
+    // broker transport that is a wait, not a dead end — the install URL is
+    // signed and long-lived, and the service releases the bot token once the
+    // install lands. The direct transport has no such read-back.
+    if (credential.mode === 'broker' && app.installUrl) {
+      await announcePending(input, { appId: app.appId, installUrl: app.installUrl, resumed: false });
+      const botToken = await waitForInstall(
+        credential.baseUrl,
+        credential.installToken,
+        app.appId,
+        input.installWait ?? {},
+      );
+      if (!botToken) throw parkedError(displayName, app.appId, app.installUrl);
+      persistInstalled(rootDir, slug, botToken);
+      return {
+        slug,
+        envSuffix,
+        botToken,
+        appToken: app.appToken,
+        appId: app.appId,
+        reused: false,
+        deferredInstall: true,
+      };
+    }
+    throw new SlackFlowError(
+      credential.mode === 'broker' ? 'broker' : 'direct-create',
+      `Slack refused to auto-install app ${app.appId} (${app.installError ?? 'unknown reason'}). ` +
+        `Install it by hand${app.installUrl ? ` from ${app.installUrl}` : " from the app's page at api.slack.com/apps"}, ` +
+        `put the xoxb-… token in .env as ${botKey}, and retry — the app token is already saved.`,
+    );
+  }
+
+  return { slug, envSuffix, botToken: app.botToken, appToken: app.appToken, appId: app.appId, reused: false };
+}
+
+/**
+ * Record a bot token that arrived after the wait, and retire the install URL
+ * that produced it — a consumed link left on disk reads as work still to do.
+ */
+function persistInstalled(rootDir: string, slug: string, botToken: string): void {
+  const { botKey, installUrlKey } = envKeysForSlug(slug);
+  try {
+    upsertEnvKey(rootDir, botKey, botToken);
+    upsertEnvKey(rootDir, installUrlKey, '');
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${botKey} to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Tests for the agent-facing room actions: create_room and
+ * add_to_room, driven through the REAL guard-wrapped delivery entries
+ * (getDeliveryAction) over a real in-memory central DB. Slack traffic is a
+ * recorded fetch stub (auth.test + conversations.open only — room actions
+ * never provision apps); the canvas leg is mocked like orchestrate.test.ts.
+ * rootDir is process.cwd(), so each test runs chdir'd into its own tmpdir.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ANDY_BOT_TOKEN = 'xoxb-andy-secret-token';
+const PIXEL_BOT_TOKEN = 'xoxb-pixel-secret-token';
+const DEVIN_BOT_TOKEN = 'xoxb-devin-secret-token';
+
+const { mockNotifyWrite, mockRequestApproval, mockWriteDestinations, mockCreateRoomCanvas, mockWireCanvasComments } =
+  vi.hoisted(() => ({
+    mockNotifyWrite: vi.fn(),
+    mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+    mockWriteDestinations: vi.fn(),
+    mockCreateRoomCanvas: vi.fn(),
+    mockWireCanvasComments: vi.fn(),
+  }));
+
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({ initGroupFilesystem: vi.fn() }));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// room actions only need these three. notifyAgent stays REAL (primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the create_room / add_to_room delivery actions — the path under
+// test. Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays
+// unloaded.
+import './index.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { listGuardedActions } from '../../guard/index.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { createDestination, getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'strict' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+let tmpDir = '';
+// conversations.members response for the add_to_room source-room read.
+let sourceRoomMembers: string[] = [];
+let membersFail = false;
+
+const BOT_IDS: Record<string, string> = {
+  [ANDY_BOT_TOKEN]: 'U0ANDYBOT',
+  [PIXEL_BOT_TOKEN]: 'U0PIXELBOT',
+  [DEVIN_BOT_TOKEN]: 'U0DEVINBOT',
+};
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const token = String(init?.headers?.Authorization ?? '').replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.includes('/api/auth.test')) {
+    const userId = BOT_IDS[token];
+    if (!userId) return Promise.resolve(jsonResponse({ ok: false, error: 'invalid_auth' }));
+    return Promise.resolve(jsonResponse({ ok: true, user_id: userId, team_id: 'T0TEST' }));
+  }
+  if (url.includes('/api/conversations.members')) {
+    if (membersFail) return Promise.resolve(jsonResponse({ ok: false, error: 'fetch_members_failed' }));
+    return Promise.resolve(jsonResponse({ ok: true, members: sourceRoomMembers }));
+  }
+  if (url.includes('/api/conversations.open')) {
+    // add_to_room opens the superset AS the newly added agent (Devin in
+    // these tests) — that open forks; every other open is the original room.
+    return Promise.resolve(
+      jsonResponse({ ok: true, channel: { id: token === DEVIN_BOT_TOKEN ? 'G0FORK' : 'G0TEAM' } }),
+    );
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+function roomOpens(): RecordedFetch[] {
+  return fetchCalls.filter((c) => c.url.includes('conversations.open'));
+}
+
+async function runAction(
+  action: string,
+  content: Record<string, unknown>,
+  session: Session = SLACK_SESSION,
+): Promise<void> {
+  const wrapped = getDeliveryAction(action);
+  expect(wrapped).toBeDefined();
+  await wrapped!({ action, ...content }, session);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ANDY_BOT_TOKEN, PIXEL_BOT_TOKEN, DEVIN_BOT_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+/** A provisioned sub-agent: group + DM wiring on its own instance + the
+ *  caller's a2a destination for it (what create_agent leaves behind). */
+async function seedSubAgent(name: string, groupId: string, instanceKey: string): Promise<void> {
+  const now = new Date().toISOString();
+  const localName = name.toLowerCase();
+  await createAgentGroup({ id: groupId, name, folder: localName, agent_provider: null, created_at: now });
+  const dmMgId = `mg-${localName}-dm`;
+  await createMessagingGroup({
+    id: dmMgId,
+    channel_type: 'slack',
+    platform_id: `slack:D0${name.toUpperCase()}DM`,
+    instance: instanceKey,
+    name: `${name} DM`,
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createMessagingGroupAgent({
+    id: `mga-${localName}-dm`,
+    messaging_group_id: dmMgId,
+    agent_group_id: groupId,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+  await createDestination({
+    agent_group_id: SRC_GROUP,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: groupId,
+    created_at: now,
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  // Faithful default: the source room holds exactly the operator + its bots.
+  sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT'];
+  membersFail = false;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-room-actions-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(
+    path.join(tmpDir, '.env'),
+    `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\nSLACK_BOT_TOKEN_PIXEL=${PIXEL_BOT_TOKEN}\nSLACK_BOT_TOKEN_DEVIN=${DEVIN_BOT_TOKEN}\n`,
+  );
+
+  const db = await initTestDb();
+  await runMigrations(db);
+
+  const now = new Date().toISOString();
+  await createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  await ensureContainerConfig(SRC_GROUP);
+  await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  await upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  await grantRole({
+    user_id: 'slack:U0OPERATOR',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createSession(SLACK_SESSION);
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+
+  await seedSubAgent('Pixel', 'ag-pixel', 'slack-pixel');
+  await seedSubAgent('Devin', 'ag-devin', 'slack-devin');
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('guard wiring', () => {
+  it('both room actions are in the guard catalog and their entries are guard-wrapped', () => {
+    const actions = new Set(listGuardedActions().map((s) => s.action));
+    expect(actions.has('rooms.create')).toBe(true);
+    expect(actions.has('rooms.add_agent')).toBe(true);
+    expect(getDeliveryAction('create_room')).toBeDefined();
+    expect(getDeliveryAction('add_to_room')).toBeDefined();
+  });
+
+  it('confined (group-scope) caller: create_room holds for approval, nothing runs', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel', 'Devin'] });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_room');
+    expect(opts.payload).toMatchObject({ name: 'Website Team', agents: ['Pixel', 'Devin'] });
+  });
+
+  it('confined (group-scope) caller: add_to_room holds for approval with the (room, agent) payload', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('add_to_room');
+    expect(opts.payload).toEqual({ room: 'Website Team', agent: 'Devin' });
+  });
+});
+
+describe('create_room', () => {
+  it('resolves names and hands ensureAgentRoom the full participant list (caller included)', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runAction('create_room', { name: 'Website Team', purpose: 'ship the new site', agents: ['Pixel', 'Devin'] });
+
+    // MPIM opened AS the caller with the operator + every other bot.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(ANDY_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0PIXELBOT,U0DEVINBOT' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Pairwise a2a destinations between the sub-agents (caller already had both).
+    expect(await getDestinationByName('ag-pixel', 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-devin',
+    });
+    expect(await getDestinationByName('ag-devin', 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-pixel',
+    });
+
+    // Canvas gets the contract data — every agent by plain name, caller first.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(ANDY_BOT_TOKEN, 'G0TEAM', {
+      roomName: 'Website Team',
+      purpose: 'ship the new site',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Pixel', 'Devin'],
+    });
+
+    // Allowlisted for a2a; success notify tells the CALLER to author the
+    // intro via its projected room destination, tagging both bots.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0TEAM/m);
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Room "Website Team" is live (G0TEAM)');
+    expect(success).toContain('send_message({ to: "website-team"');
+    expect(success).toContain('<@U0PIXELBOT>');
+    expect(success).toContain('<@U0DEVINBOT>');
+    expect(success).not.toContain('<@U0ANDYBOT>');
+    expect(success).toContain('no mechanics, no member lists');
+
+    assertNoTokenLeak();
+  });
+
+  it('include_me:false — first listed agent becomes creator, caller stays out', async () => {
+    await runAction('create_room', { name: 'Duo', agents: ['Pixel', 'Devin'], include_me: false });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(PIXEL_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0DEVINBOT' });
+
+    // No caller-instance row, no caller wiring.
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeUndefined();
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('You are not a member');
+    expect(success).not.toContain('send_message');
+  });
+
+  it('unknown agent name surfaces as a failure notify before anything is opened', async () => {
+    await runAction('create_room', { name: 'Website Team', agents: ['Ghost'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect((await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:G0TEAM')).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('create_room failed: unknown agent "Ghost"');
+  });
+
+  it('missing bot token surfaces as a failure notify naming the key, never the value', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\n`);
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain('create_room failed: no bot token in .env for agent "Pixel"');
+    expect(failure).toContain('SLACK_BOT_TOKEN_PIXEL');
+    assertNoTokenLeak();
+  });
+
+  it('malformed request (no agents) is answered by the precheck without a hold', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: [] });
+
+    expect(mockRequestApproval).not.toHaveBeenCalled();
+    expect(notifyTexts().at(-1)).toContain('agents must be a non-empty list');
+  });
+});
+
+describe('add_to_room', () => {
+  beforeEach(async () => {
+    // An existing room: Andy + Pixel (+ operator), created through the real
+    // primitive so the wiring shape matches production.
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+    mockNotifyWrite.mockClear();
+    fetchCalls = [];
+  });
+
+  it('opens the superset MPIM as the new agent and wires everyone onto the forked channel', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    // Superset open AS Devin: operator + both existing bots → fork id.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(DEVIN_BOT_TOKEN);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(3);
+    expect(users).toContain('U0OPERATOR');
+    expect(users).toContain('U0ANDYBOT');
+    expect(users).toContain('U0PIXELBOT');
+
+    // Every participant wired onto the NEW channel; the old room untouched.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0FORK', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        ignored_message_policy: 'accumulate',
+      });
+    }
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeDefined();
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack-devin')).toBeUndefined();
+
+    // The caller is a room member — the notify explains the fork and asks
+    // for an intro of the new agent in the NEW conversation.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Devin was added to room "Website Team"');
+    expect(success).toContain('moved to a new conversation (G0FORK)');
+    expect(success).toContain('<@U0DEVINBOT>');
+
+    assertNoTokenLeak();
+  });
+
+  it('carries Slack-UI-added humans from the source room into the forked superset', async () => {
+    // A colleague was added to the room via the Slack UI — they exist only
+    // in the platform member list, never in wiring rows.
+    sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT', 'U0COLLEAGUE'];
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(4);
+    expect(users).toContain('U0COLLEAGUE');
+    expect(notifyTexts().at(-1)).toContain('moved to a new conversation (G0FORK)');
+  });
+
+  it('source-room member read failure fails the action — never a fork that silently drops members', async () => {
+    membersFail = true;
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed');
+  });
+
+  it('agent already in the room: says so, opens nothing', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Pixel' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('already in room "Website Team"');
+  });
+
+  it('unknown room surfaces as a failure notify', async () => {
+    await runAction('add_to_room', { room: 'Nope', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed: no wired Slack room named "Nope"');
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
@@ -1,0 +1,467 @@
+/**
+ * Agent-facing room actions: `create_room` and `add_to_room`
+ * delivery-action bodies over the already-N-capable ensureAgentRoom.
+ *
+ * `create_room` is the "team room" primitive — the multi-agent pattern is N
+ * `create_agent` calls with room:'none' followed by ONE create_room naming
+ * all of them. Agent names resolve through the CALLER's a2a destination
+ * namespace (the same names send_message uses), so an agent can only room
+ * with agents it can already message. Each resolved agent group maps to its
+ * Slack adapter instance via its wired messaging groups; bot identities come
+ * from auth.test on the instance's .env token (botTokenKeyForInstance) —
+ * token values never appear in notify texts or logs.
+ *
+ * `add_to_room` grows an existing room by one agent. Slack platform fact:
+ * MPIMs NEVER grow in place — opening the superset member list FORKS a new
+ * conversation id. ensureAgentRoom wires every participant onto the new id
+ * directly, and the source room's actual member list is read first so
+ * Slack-UI-added humans carry into the fork; the slack-room-membership
+ * MPIM-fork carry-over (membership.ts) remains the path for Slack-UI adds
+ * and stays silent here because the rows
+ * already exist when its join-recheck fires. The old room is left untouched
+ * (both conversations stay alive). For planned teams, prefer one complete
+ * create_room over add_to_room chains.
+ *
+ * Failures surface to the requesting agent via notifyAgent — never silent.
+ */
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  getMessagingGroupsByAgentGroup,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
+import {
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { botTokenKeyForInstance, slackAuthTest, slackConversationsMembers } from '../../channels/slack-lib.js';
+import { notifyAgent, requestApproval } from '../approvals/index.js';
+import { readEnvValue } from './env-file.js';
+import { ensureAgentRoom, publicPurpose, resolveOperatorSlackUserId, type RoomParticipant } from './orchestrate.js';
+
+/** Domain failure with an agent-presentable message (no token values, ever). */
+class RoomActionError extends Error {}
+
+/** A room participant plus the bot token that proves it — token stays local. */
+interface ResolvedParticipant extends RoomParticipant {
+  botToken: string;
+}
+
+// ── Participant resolution ──
+
+/**
+ * An agent name → its agent group, through the CALLER's destination
+ * namespace (normalizeName'd, same as send_message targets).
+ */
+async function resolveAgentByName(callerGroupId: string, name: string): Promise<AgentGroup> {
+  const localName = normalizeName(name);
+  const dest = await getDestinationByName(callerGroupId, localName);
+  if (!dest || dest.target_type !== 'agent') {
+    throw new RoomActionError(
+      `unknown agent "${name}" — you have no agent destination named "${localName}". ` +
+        `Use the names your send_message destinations use.`,
+    );
+  }
+  const group = await getAgentGroup(dest.target_id);
+  if (!group) throw new RoomActionError(`agent group behind destination "${localName}" no longer exists`);
+  return group;
+}
+
+/** Bot token + auth.test identity for one adapter instance. */
+async function identityForInstance(
+  instanceKey: string,
+  agentGroupName: string,
+  rootDir: string,
+): Promise<{ botToken: string; botUserId: string }> {
+  const tokenKey = botTokenKeyForInstance(instanceKey);
+  const botToken = readEnvValue(rootDir, tokenKey);
+  if (!botToken) {
+    throw new RoomActionError(`missing ${tokenKey} in .env for agent "${agentGroupName}" (instance '${instanceKey}')`);
+  }
+  const botUserId = (await slackAuthTest(botToken, 'room-resolve')).userId;
+  return { botToken, botUserId };
+}
+
+/** Build the participant for a known (group, instance) pair. */
+async function participantForInstance(
+  group: AgentGroup,
+  instanceKey: string,
+  rootDir: string,
+): Promise<ResolvedParticipant> {
+  const { botToken, botUserId } = await identityForInstance(instanceKey, group.name, rootDir);
+  return { instanceKey, botUserId, agentGroupId: group.id, agentGroupName: group.name, botToken };
+}
+
+/**
+ * Build the participant for an agent group by finding its Slack adapter
+ * instance among its wired messaging groups (a provisioned agent's DM and
+ * rooms all live on its dedicated `slack-<slug>` instance; the origin agent
+ * lives on its origin instance). Multiple distinct instances is a
+ * pathological state — the first (sorted) with a token in .env wins.
+ */
+async function participantForAgentGroup(group: AgentGroup, rootDir: string): Promise<ResolvedParticipant> {
+  const instances = [
+    ...new Set(
+      (await getMessagingGroupsByAgentGroup(group.id))
+        .filter((mg) => mg.channel_type === 'slack')
+        .map((mg) => mg.instance ?? 'slack'),
+    ),
+  ].sort();
+  if (instances.length === 0) {
+    throw new RoomActionError(
+      `agent "${group.name}" has no Slack presence (no Slack wiring found) — was its Slack bot provisioned?`,
+    );
+  }
+  const withToken = instances.find((key) => readEnvValue(rootDir, botTokenKeyForInstance(key)) !== undefined);
+  if (!withToken) {
+    throw new RoomActionError(
+      `no bot token in .env for agent "${group.name}" (looked for ${instances.map(botTokenKeyForInstance).join(', ')})`,
+    );
+  }
+  return participantForInstance(group, withToken, rootDir);
+}
+
+/**
+ * The CALLING agent as a participant — its instance is the session's origin
+ * instance when the request came in through Slack (mirrors runSlackAgentFlow),
+ * else resolved from its wired messaging groups (task/a2a sessions).
+ */
+async function callerParticipant(session: Session, rootDir: string): Promise<ResolvedParticipant> {
+  const group = await getAgentGroup(session.agent_group_id);
+  if (!group) throw new RoomActionError('source agent group not found');
+  const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  if (originMg?.channel_type === 'slack') {
+    return participantForInstance(group, originMg.instance ?? 'slack', rootDir);
+  }
+  return participantForAgentGroup(group, rootDir);
+}
+
+/** The caller's local destination name for a room channel on its instance. */
+async function callerRoomDestination(
+  callerGroupId: string,
+  callerInstanceKey: string,
+  roomChannelId: string,
+  roomName: string,
+): Promise<string> {
+  const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, callerInstanceKey);
+  const dest = roomMg ? await getDestinationByTarget(callerGroupId, 'channel', roomMg.id) : undefined;
+  return dest?.local_name ?? normalizeName(roomName);
+}
+
+/** `<@U…>, <@U…>` mention tags for every participant except the caller. */
+function mentionTags(participants: RoomParticipant[], excludeGroupId: string): string {
+  return participants
+    .filter((p) => p.agentGroupId !== excludeGroupId)
+    .map((p) => `<@${p.botUserId}>`)
+    .join(', ');
+}
+
+// ── create_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export async function validateCreateRoom(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  if (!name) {
+    await notifyAgent(session, 'create_room failed: name is required.');
+    return false;
+  }
+  const agents = Array.isArray(content.agents) ? content.agents : [];
+  if (agents.length === 0 || !agents.every((a) => typeof a === 'string' && a.trim())) {
+    await notifyAgent(session, 'create_room failed: agents must be a non-empty list of agent names.');
+    return false;
+  }
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'create_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestCreateRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  const agents = (Array.isArray(content.agents) ? content.agents : []).filter(
+    (a): a is string => typeof a === 'string',
+  );
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_room',
+    // Same payload shape as the tool call — the approved replay re-enters
+    // the wrapped action unchanged.
+    payload: {
+      name,
+      agents,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.include_me === false ? { include_me: false } : {}),
+    },
+    title: `Create room: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to open a shared Slack room "${name}" with you and ` +
+      `${agents.join(', ')}${content.include_me === false ? ' (without itself)' : ''}. Approve?`,
+  });
+}
+
+/**
+ * Guard allow body: resolve every named agent (+ the caller unless
+ * include_me:false), then hand the full participant list to ensureAgentRoom
+ * — one MPIM with ALL bots + the operator, one canvas, mention/accumulate
+ * wirings per instance, pairwise a2a destinations. The success notify tells
+ * the CALLER to author the room intro (no host-templated intro).
+ */
+export async function handleCreateRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = (content.name as string).trim();
+  const agentNames = (content.agents as string[]).map((a) => a.trim());
+  const includeMe = content.include_me !== false;
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = await resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    // Caller first when included — it becomes the creator (opens the MPIM,
+    // creates the canvas); otherwise the first listed agent does.
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    if (includeMe) {
+      const caller = await callerParticipant(session, rootDir);
+      seen.add(caller.agentGroupId);
+      participants.push(caller);
+    }
+    for (const agentName of agentNames) {
+      const group = await resolveAgentByName(session.agent_group_id, agentName);
+      if (seen.has(group.id)) continue;
+      seen.add(group.id);
+      participants.push(await participantForAgentGroup(group, rootDir));
+    }
+    if (participants.length === 0) throw new RoomActionError('no agents resolved');
+    const creator = participants[0]!;
+
+    const { roomChannelId, created } = await ensureAgentRoom({
+      creator,
+      creatorBotToken: creator.botToken,
+      operatorUserId,
+      participants,
+      roomName: name,
+      purpose: publicPurpose(typeof content.purpose === 'string' ? content.purpose : undefined),
+      rootDir,
+    });
+
+    const memberNames = participants.map((p) => p.agentGroupName).join(', ');
+    if (!includeMe) {
+      await notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with the operator and ${memberNames}. ` +
+          `You are not a member (include_me was false), so you cannot post there.`,
+      );
+    } else if (!created) {
+      await notifyAgent(session, `Room "${name}" already existed (${roomChannelId}) — nothing new was created.`);
+    } else {
+      // The calling agent authors the intro, in its own voice.
+      const roomDest = await callerRoomDestination(session.agent_group_id, creator.instanceKey, roomChannelId, name);
+      await notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with you, the operator, and ${memberNames}. ` +
+          `Post a brief introduction there now via send_message({ to: "${roomDest}", ... }): ` +
+          `1-2 lines in your own voice on what this room is for, tagging each agent literally ` +
+          `(${mentionTags(participants, session.agent_group_id)}) — the tags render as mentions and are how you ` +
+          `engage them there. Just the intro — no mechanics, no member lists.`,
+      );
+    }
+    log.info('create_room completed', { roomChannelId, created, participantCount: participants.length });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(session, `create_room failed: ${message}`);
+    log.error('create_room failed', { name, err: message });
+  }
+}
+
+// ── add_to_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export async function validateAddToRoom(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  if (typeof content.room !== 'string' || !content.room.trim()) {
+    await notifyAgent(session, 'add_to_room failed: room is required.');
+    return false;
+  }
+  if (typeof content.agent !== 'string' || !content.agent.trim()) {
+    await notifyAgent(session, 'add_to_room failed: agent is required.');
+    return false;
+  }
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'add_to_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestAddToRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const room = typeof content.room === 'string' ? content.room.trim() : '';
+  const agent = typeof content.agent === 'string' ? content.agent.trim() : '';
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'add_to_room',
+    payload: { room, agent },
+    title: `Add ${agent} to room: ${room}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to add agent "${agent}" to the shared Slack room "${room}" ` +
+      `(this opens a new group conversation with everyone plus "${agent}"). Approve?`,
+  });
+}
+
+/**
+ * The room named by an add_to_room call: wired Slack group rooms whose
+ * messaging-group name matches (case-insensitive). Shadow channels never
+ * match — their names carry a "canvas comments" suffix. When several rooms
+ * share the name (e.g. earlier add_to_room forks keep the old room alive
+ * under the same name), the NEWEST family wins — "the room" means its latest
+ * incarnation.
+ */
+async function resolveRoomFamily(roomName: string): Promise<{ family: MessagingGroup[]; name: string }> {
+  const wanted = roomName.trim().toLowerCase();
+  const matches: MessagingGroup[] = [];
+  for (const m of await getAllMessagingGroups()) {
+    if (
+      m.channel_type === 'slack' &&
+      m.is_group === 1 &&
+      !m.denied_at &&
+      m.platform_id.startsWith('slack:') &&
+      (m.name ?? '').trim().toLowerCase() === wanted &&
+      (await getMessagingGroupAgents(m.id)).length > 0
+    ) {
+      matches.push(m);
+    }
+  }
+  if (matches.length === 0) throw new RoomActionError(`no wired Slack room named "${roomName}" found`);
+  const newestFirst = [...new Set(matches.map((m) => m.platform_id))]
+    .map((pid) => ({
+      pid,
+      createdAt: matches
+        .filter((m) => m.platform_id === pid)
+        .map((m) => m.created_at)
+        .sort()[0]!,
+    }))
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  const family = matches.filter((m) => m.platform_id === newestFirst[0]!.pid);
+  return { family, name: family[0]!.name ?? roomName };
+}
+
+/**
+ * Guard allow body: resolve the room's current participants from its wiring
+ * rows, resolve the named agent, and re-run ensureAgentRoom with the
+ * superset. The conversations.open on the superset member list FORKS a new
+ * MPIM (Slack never grows one in place); ensureAgentRoom wires everyone onto
+ * the new id, and the old room stays untouched — same shape the
+ * slack-room-membership fork carry-over produces for Slack-UI adds.
+ */
+export async function handleAddToRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const roomArg = (content.room as string).trim();
+  const agentArg = (content.agent as string).trim();
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = await resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    const { family, name: roomName } = await resolveRoomFamily(roomArg);
+
+    // Current participants — one per wired agent group, on the room row's
+    // own instance (router lookup is exact-on-instance, so the row is the
+    // authoritative instance mapping).
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    for (const mg of family) {
+      for (const wiring of await getMessagingGroupAgents(mg.id)) {
+        if (seen.has(wiring.agent_group_id)) continue;
+        seen.add(wiring.agent_group_id);
+        const group = await getAgentGroup(wiring.agent_group_id);
+        if (!group) continue;
+        participants.push(await participantForInstance(group, mg.instance ?? 'slack', rootDir));
+      }
+    }
+
+    const newGroup = await resolveAgentByName(session.agent_group_id, agentArg);
+    if (seen.has(newGroup.id)) {
+      await notifyAgent(session, `add_to_room: agent "${newGroup.name}" is already in room "${roomName}".`);
+      return;
+    }
+    const newParticipant = await participantForAgentGroup(newGroup, rootDir);
+
+    // Members added via the Slack UI (extra humans, foreign bots) exist only
+    // on the platform — wiring rows carry agents alone. Read the source
+    // room's actual member list so the forked superset carries them instead
+    // of silently dropping them (the membership fork carry-over preserves
+    // members for UI adds; this path must too). A failed read fails the
+    // action (outer catch) — never a fork that quietly excludes someone.
+    let extraMemberUserIds: string[] = [];
+    if (participants.length > 0) {
+      const sourceChannelId = family[0]!.platform_id.slice('slack:'.length);
+      const knownIds = new Set([operatorUserId, newParticipant.botUserId, ...participants.map((p) => p.botUserId)]);
+      const sourceMembers = await slackConversationsMembers(participants[0]!.botToken, sourceChannelId, 'room-resolve');
+      extraMemberUserIds = sourceMembers.filter((id) => !knownIds.has(id));
+    }
+
+    // The NEW agent opens the superset MPIM (mirrors the create flow, where
+    // the newly arriving bot is the opener/canvas creator).
+    const { roomChannelId } = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: newParticipant.botToken,
+      operatorUserId,
+      participants: [...participants, newParticipant],
+      extraMemberUserIds,
+      roomName,
+      rootDir,
+    });
+
+    const callerInRoom = seen.has(session.agent_group_id);
+    let callerMg: MessagingGroup | undefined;
+    for (const mg of family) {
+      if ((await getMessagingGroupAgents(mg.id)).some((w) => w.agent_group_id === session.agent_group_id)) {
+        callerMg = mg;
+        break;
+      }
+    }
+    const roomDestination = callerMg
+      ? await callerRoomDestination(session.agent_group_id, callerMg.instance ?? 'slack', roomChannelId, roomName)
+      : undefined;
+    const intro =
+      callerInRoom && callerMg
+        ? ` Post a brief introduction of ${newParticipant.agentGroupName} there now via send_message({ to: ` +
+          `"${roomDestination}", ... }): ` +
+          `1-2 lines in your own voice, tagging them with <@${newParticipant.botUserId}> (include that literally — ` +
+          `it renders as a mention). Just the intro — no mechanics, no member lists.`
+        : '';
+    await notifyAgent(
+      session,
+      `${newParticipant.agentGroupName} was added to room "${roomName}". Slack group DMs never grow in place, ` +
+        `so the room moved to a new conversation (${roomChannelId}) — everyone is wired there and the old ` +
+        `conversation keeps working.${intro}`,
+    );
+    log.info('add_to_room completed', { roomChannelId, agentGroupId: newGroup.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(session, `add_to_room failed: ${message}`);
+    log.error('add_to_room failed', { room: roomArg, agent: agentArg, err: message });
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Room canvas creation tests (contract C2): template shape (the canvas IS the
+ * room contract; no bot mentions in the body), the
+ * conversations.canvases.create call, and the non-throwing failure paths.
+ * Plus the canvas-comments shadow-channel wiring (F→C derivation, one mg row
+ * + wiring per participating instance, idempotence, non-throwing).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TIMEZONE } from '../../config.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { formatLocalTime } from '../../timezone.js';
+import {
+  createRoomCanvas,
+  deriveCanvasShadowChannelId,
+  roomCanvasMarkdown,
+  wireCanvasComments,
+} from './room-canvas.js';
+
+const OPTS = {
+  roomName: 'Pixel room',
+  purpose: 'Design work between Gavriel, Pixel, and Mark.\nSecond purpose line.',
+  creatorUserId: 'U0CREATOR',
+  agentNames: ['Pixel', 'Mark', 'Pixel'],
+  createdAt: '2026-08-01T12:00:00.000Z',
+};
+
+describe('roomCanvasMarkdown', () => {
+  const md = roomCanvasMarkdown(OPTS);
+
+  it('leads with the blockquoted purpose — no body H1 (the create-call `title` param renders the document title; a body heading duplicated it, live-observed)', () => {
+    expect(md.startsWith('> Design work between Gavriel, Pixel, and Mark.')).toBe(true);
+    expect(md).not.toContain('# Pixel room');
+    expect(md).toContain('> Second purpose line.');
+  });
+
+  it('carries the room-contract data: creator card, created date, Members table', () => {
+    expect(md).toContain(`Created by ![](@U0CREATOR) on ${formatLocalTime(OPTS.createdAt, TIMEZONE)}.`);
+    expect(md).toContain('## Members');
+    expect(md).toContain('| ![](@U0CREATOR) | creator |');
+  });
+
+  it('lists agents by PLAIN NAME, deduped — never as user cards', () => {
+    expect(md).toContain('| Pixel | agent |');
+    expect(md).toContain('| Mark | agent |');
+    expect(md.match(/\| Pixel \| agent \|/g)).toHaveLength(1);
+  });
+
+  it('never @-mentions a bot: the only user card is the human creator', () => {
+    const cards = md.match(/!\[\]\(@\w+\)/g) ?? [];
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) expect(card).toBe('![](@U0CREATOR)');
+    expect(md).not.toContain('<@');
+  });
+
+  it('carries the Tasks checklist and the Decisions / Notes sections', () => {
+    expect(md).toContain('## Tasks');
+    expect(md).toContain('- [ ] ');
+    expect(md).toContain('## Decisions');
+    expect(md).toContain('## Notes');
+  });
+});
+
+describe('createRoomCanvas', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the template to conversations.canvases.create and returns the canvas id', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true, canvas_id: 'F0CANVAS1' }), { status: 200 }),
+    );
+
+    const id = await createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS);
+
+    expect(id).toBe('F0CANVAS1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/conversations.canvases.create');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-test-token');
+    const body = JSON.parse(init.body as string);
+    expect(body.channel_id).toBe('C0ROOM');
+    expect(body.document_content).toEqual({ type: 'markdown', markdown: roomCanvasMarkdown(OPTS) });
+  });
+
+  it('returns undefined on a Slack error instead of throwing', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, error: 'free_team_not_allowed' }), { status: 200 }),
+    );
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when fetch itself rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when ok:true carries no canvas_id', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+});
+
+describe('deriveCanvasShadowChannelId', () => {
+  it('swaps the leading F for C on a canvas-shaped id', () => {
+    expect(deriveCanvasShadowChannelId('F0BME4DL401')).toBe('C0BME4DL401');
+    expect(deriveCanvasShadowChannelId('F1')).toBe('C1');
+  });
+
+  it('returns undefined for anything not canvas-id shaped', () => {
+    for (const bad of ['C0BME4DL401', 'F', '', 'F0bme4dl401', 'F0BME-4DL401', 'X0BME4DL401', ' F0BME4DL401']) {
+      expect(deriveCanvasShadowChannelId(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe('wireCanvasComments', () => {
+  const CREATOR = { instanceKey: 'slack-pixel', agentGroupId: 'ag-pixel' };
+  // Creator deliberately ALSO present in the list — must not double-wire.
+  const PARTICIPANTS = [
+    { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+    { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    CREATOR,
+  ];
+
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    const now = new Date().toISOString();
+    for (const [id, name, folder] of [
+      ['ag-pixel', 'Pixel', 'pixel'],
+      ['ag-andy', 'Andy', 'andy'],
+      ['ag-mark', 'Mark', 'mark'],
+    ] as const) {
+      await createAgentGroup({ id, name, folder, agent_provider: null, created_at: now });
+    }
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it('wires EVERY participating instance: creator pattern-engage, siblings mention/accumulate', async () => {
+    const shadowId = await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(shadowId).toBe('C0CANVAS1');
+    // One mg row PER instance (router lookup is exact-on-instance), all public.
+    const all = (await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:C0CANVAS1');
+    expect(all).toHaveLength(3);
+    for (const p of PARTICIPANTS) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', p.instanceKey);
+      expect(mg).toMatchObject({
+        channel_type: 'slack',
+        instance: p.instanceKey,
+        name: 'Pixel room canvas comments (canvas F0CANVAS1)',
+        is_group: 1,
+        unknown_sender_policy: 'public',
+      });
+      expect(await getMessagingGroupAgents(mg!.id)).toHaveLength(1);
+    }
+    // Creator = default responder for anchored comments.
+    const creatorMg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel'))!;
+    expect(await getMessagingGroupAgentByPair(creatorMg.id, 'ag-pixel')).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+    });
+    // Siblings = room semantics: mention to trigger, everything else context.
+    for (const sibling of [
+      { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+      { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    ]) {
+      const mg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', sibling.instanceKey))!;
+      expect(await getMessagingGroupAgentByPair(mg.id, sibling.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        sender_scope: 'all',
+        ignored_message_policy: 'accumulate',
+        session_mode: 'shared',
+        priority: 0,
+      });
+    }
+  });
+
+  it('is idempotent: a second call creates no new rows', async () => {
+    await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+    const mgCount = (await getAllMessagingGroups()).length;
+    const mg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel'))!;
+    const wiringId = (await getMessagingGroupAgentByPair(mg.id, 'ag-pixel'))!.id;
+
+    const second = await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(second).toBe('C0CANVAS1');
+    expect((await getAllMessagingGroups()).length).toBe(mgCount);
+    expect(await getMessagingGroupAgents(mg.id)).toHaveLength(1);
+    expect((await getMessagingGroupAgentByPair(mg.id, 'ag-pixel'))!.id).toBe(wiringId);
+  });
+
+  it('returns undefined and writes nothing on an invalid canvas id shape', async () => {
+    const before = (await getAllMessagingGroups()).length;
+    expect(await wireCanvasComments('not-a-canvas', CREATOR, PARTICIPANTS, 'Pixel room')).toBeUndefined();
+    expect((await getAllMessagingGroups()).length).toBe(before);
+  });
+
+  it('never throws: a DB failure (unknown agent group breaks the FK) returns undefined', async () => {
+    expect(
+      await wireCanvasComments('F0CANVAS2', { instanceKey: 'slack', agentGroupId: 'ag-missing' }, [], 'X'),
+    ).toBeUndefined();
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.ts
@@ -1,0 +1,274 @@
+/**
+ * Room canvas creation — the room-contract template, written to the room's
+ * channel-tab canvas at room-creation time.
+ *
+ * Contract C2: `createRoomCanvas` is NON-THROWING — any failure (network,
+ * Slack error, malformed response) logs a warning and returns undefined. Room
+ * creation must never fail because the canvas leg did; the caller tolerates
+ * undefined and simply ships a room without a canvas.
+ *
+ * The Slack call is implemented locally (plain fetch, the shared slack-lib
+ * JSON-body conventions) — this file deliberately does not go through the
+ * lib's throwing helpers: canvas creation is contractually NON-THROWING (C2).
+ * Tokens travel only in the Authorization header and are never interpolated
+ * into messages or logs.
+ *
+ * Live-validated facts this leans on: `conversations.canvases.create`
+ * works on MPIMs and DMs (undocumented but confirmed); every markdown
+ * element in the template — checkboxes, tables with user cards, blockquote —
+ * is accepted; section headings are the later edit-addressing scheme
+ * (`canvases.sections.lookup` by contains_text), so heading text is part of
+ * the template's contract with the canvas-actions module.
+ */
+import { TIMEZONE } from '../../config.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import { formatLocalTime } from '../../timezone.js';
+import type { MessagingGroup } from '../../types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export interface RoomCanvasOpts {
+  roomName: string;
+  purpose: string;
+  /** The human operator who created the room — the ONLY member the template
+   *  may reference by user card. Bot user cards render as @-mentions, and a
+   *  creation-time mention is what triggered every sibling instance and
+   *  generated the approval-card spam. */
+  creatorUserId: string;
+  /** Agent members by display name — rendered as PLAIN TEXT, never mentioned. */
+  agentNames: string[];
+  /** ISO creation timestamp; defaults to now. Rendered install-local. */
+  createdAt?: string;
+}
+
+/** `![](@U…)` — Slack renders this image syntax as an inline user card.
+ *  Humans only: a bot's user card delivers a mention to that bot's instance. */
+function userCard(userId: string): string {
+  return `![](@${userId})`;
+}
+
+/** Blockquote-prefix every line so a multi-line purpose stays one quote block. */
+function asBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+/**
+ * The room-contract template (modeled on a live-verified room-canvas
+ * example). With the room-contract MESSAGE retired, this canvas IS the room
+ * contract: purpose, creator, member list, created date — the canvas tab is
+ * the room's pinned surface. Heading texts ("Tasks", "Decisions", "Notes")
+ * are load-bearing: agents address sections by contains_text lookup, and the
+ * canvas instructions reference them by name.
+ *
+ * The body must never @-mention a BOT — agent members appear by plain
+ * name. Only the (human) creator gets a user card.
+ */
+export function roomCanvasMarkdown(opts: RoomCanvasOpts): string {
+  const memberRows = [
+    `| ${userCard(opts.creatorUserId)} | creator |`,
+    ...opts.agentNames.filter((name, i, arr) => arr.indexOf(name) === i).map((name) => `| ${name} | agent |`),
+  ];
+
+  // No `# <roomName>` heading here: the `title` param on
+  // conversations.canvases.create already renders the canvas title as the
+  // document's H1 — a body heading would duplicate it (live-observed).
+  return [
+    asBlockquote(opts.purpose),
+    '',
+    `Created by ${userCard(opts.creatorUserId)} on ${formatLocalTime(opts.createdAt ?? new Date().toISOString(), TIMEZONE)}.`,
+    '',
+    '## Members',
+    '',
+    '| Who | Role |',
+    '|---|---|',
+    ...memberRows,
+    '',
+    '## Tasks',
+    '',
+    '- [ ] Add the room’s first task',
+    '',
+    '## Decisions',
+    '',
+    '_No decisions recorded yet — quote them here as they land._',
+    '',
+    '## Notes',
+    '',
+    '_Working notes and links — anything worth keeping that isn’t a task or a decision._',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Create the room's channel-tab canvas from the room-contract template.
+ * Returns the canvas id, or undefined on ANY failure (never throws).
+ */
+export async function createRoomCanvas(
+  botToken: string,
+  channelId: string,
+  opts: RoomCanvasOpts,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${SLACK_API}/conversations.canvases.create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        channel_id: channelId,
+        // Undocumented but live-verified: conversations.canvases.create
+        // accepts `title` (otherwise the canvas lists as "Untitled").
+        title: opts.roomName,
+        document_content: { type: 'markdown', markdown: roomCanvasMarkdown(opts) },
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (json.ok !== true) {
+      log.warn('Room canvas create failed', {
+        channelId,
+        error: String(json.error ?? `HTTP ${res.status}`),
+      });
+      return undefined;
+    }
+    const canvasId = typeof json.canvas_id === 'string' ? json.canvas_id : undefined;
+    if (!canvasId) {
+      log.warn('Room canvas create returned no canvas_id', { channelId });
+      return undefined;
+    }
+    log.info('Room canvas created', { channelId, canvasId });
+    return canvasId;
+  } catch (err) {
+    log.warn('Room canvas create failed', {
+      channelId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+// ── Canvas comments (shadow channel) ──
+
+/** Canvas ids are `F` + the base-36-ish Slack id body. */
+const CANVAS_ID_RE = /^F[A-Z0-9]+$/;
+
+/**
+ * Live-probed platform fact: creating ANY canvas makes Slack materialize
+ * a hidden private "shadow channel" owned by USLACKBOT whose id is the canvas
+ * id with the leading `F` swapped for `C` (canvas F0BME4DL401 → channel
+ * C0BME4DL401). Canvas comments live there as threads; members of the canvas
+ * are members of the shadow channel and bots receive its messages as ordinary
+ * message.groups events. Returns undefined for anything not canvas-id shaped.
+ */
+export function deriveCanvasShadowChannelId(canvasId: string): string | undefined {
+  return CANVAS_ID_RE.test(canvasId) ? `C${canvasId.slice(1)}` : undefined;
+}
+
+/** One room bot's instance/group pair, for shadow-channel wiring. The flow's
+ *  RoomParticipant satisfies this structurally. */
+export interface CanvasCommentsParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  agentGroupId: string;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Wire the canvas's shadow channel for EVERY participating instance — the
+ * shadow channel is the room's comment stream, so it gets room semantics for
+ * all room agents, not creator-only. Creator-only wiring is what turned
+ * every sibling's canvas events into unknown-channel approval-card spam.
+ *
+ * Per participant: one messaging-group row on ITS instance (router lookup is
+ * exact-on-instance) plus one wiring to its agent group. The CREATOR is the
+ * default responder — pattern `'.'` (always engage): a comment on the shared
+ * canvas is always addressed to the room's agents, unlike ambient room chat.
+ * Every SIBLING gets mention/accumulate — comments flow to all room agents
+ * as context, and tagging an agent in a comment actually triggers it with
+ * the anchor context. `unknown_sender_policy: 'public'` keeps access gates
+ * from approval-spamming on commenters.
+ *
+ * Idempotent (get-before-create on every row) and NON-THROWING — like
+ * createRoomCanvas, a failure here must never fail room creation. Returns the
+ * shadow channel id, or undefined on invalid canvas-id shape or any error.
+ */
+export async function wireCanvasComments(
+  canvasId: string,
+  creator: CanvasCommentsParticipant,
+  participants: CanvasCommentsParticipant[],
+  roomName: string,
+): Promise<string | undefined> {
+  try {
+    const shadowChannelId = deriveCanvasShadowChannelId(canvasId);
+    if (!shadowChannelId) {
+      log.warn('Canvas comments: unexpected canvas id shape — shadow channel not wired', { canvasId });
+      return undefined;
+    }
+    const platformId = `slack:${shadowChannelId}`;
+
+    // Creator first (its wiring must win even if it also appears in the list).
+    const isCreator = (p: CanvasCommentsParticipant): boolean =>
+      p.instanceKey === creator.instanceKey && p.agentGroupId === creator.agentGroupId;
+    const everyone = [creator, ...participants.filter((p) => !isCreator(p))];
+
+    for (const p of everyone) {
+      let mg = await getMessagingGroupByPlatform('slack', platformId, p.instanceKey);
+      if (!mg) {
+        const row: MessagingGroup = {
+          id: generateId('mg'),
+          channel_type: 'slack',
+          platform_id: platformId,
+          instance: p.instanceKey,
+          name: `${roomName} canvas comments (canvas ${canvasId})`,
+          is_group: 1,
+          unknown_sender_policy: 'public',
+          created_at: new Date().toISOString(),
+        };
+        await createMessagingGroup(row);
+        mg = row;
+      }
+
+      if (!(await getMessagingGroupAgentByPair(mg.id, p.agentGroupId))) {
+        const creatorRow = isCreator(p);
+        await createMessagingGroupAgent({
+          id: generateId('mga'),
+          messaging_group_id: mg.id,
+          agent_group_id: p.agentGroupId,
+          engage_mode: creatorRow ? 'pattern' : 'mention',
+          engage_pattern: creatorRow ? '.' : null,
+          sender_scope: 'all',
+          ignored_message_policy: creatorRow ? 'drop' : 'accumulate',
+          session_mode: 'shared',
+          priority: 0,
+          created_at: new Date().toISOString(),
+        });
+      }
+    }
+
+    log.info('Canvas comments shadow channel wired', {
+      canvasId,
+      shadowChannelId,
+      creatorInstance: creator.instanceKey,
+      participantCount: everyone.length,
+    });
+    return shadowChannelId;
+  } catch (err) {
+    log.warn('Canvas comments shadow-channel wiring failed', {
+      canvasId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/slack-deps.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/slack-deps.ts
@@ -1,0 +1,70 @@
+/**
+ * Optional-module seam — the ONLY file in the slack-agent-flow payload that
+ * touches the skill-installed Slack channel module (src/channels/slack.ts
+ * arrives via the add-slack skill) dynamically. The computed-specifier import
+ * keeps tsc from resolving a file that may not be in the tree, so a missing
+ * or outdated channel payload surfaces at runtime as a typed, actionable
+ * SlackFlowError instead of a crash. The hot-start entry
+ * (startChannelAdapter) is trunk registry API and is imported statically like
+ * registerChannelAdapter.
+ */
+import type { ChannelAdapter, ChannelDefaults } from '../../channels/adapter.js';
+import { registerChannelAdapter, startChannelAdapter } from '../../channels/channel-registry.js';
+import { SlackFlowError } from './types.js';
+
+export interface SlackChannelDeps {
+  slackInstanceBridgeFactory: (name: string) => ChannelAdapter | null;
+  SLACK_DEFAULTS: ChannelDefaults;
+  registerChannelAdapter: (
+    name: string,
+    registration: { factory: () => ChannelAdapter | null; defaults?: ChannelDefaults },
+  ) => void;
+  startChannelAdapter: (key: string) => Promise<'started' | 'already-active' | 'no-credentials'>;
+}
+
+const NOT_INSTALLED =
+  'Slack channel payload not installed or too old — apply add-slack first (multi-instance registration ships with the adapter)';
+
+/**
+ * Fails fast if the installed Slack adapter doesn't carry the multi-instance
+ * factory — checked regardless of hotStart. The adapter owns SLACK_INSTANCES
+ * natively (slackInstanceBridgeFactory + the import-time registration loop
+ * live in slack.ts); an older installed copy without that export would let
+ * S6-S8 wire DB rows to an instance name the runtime could never start, even
+ * after a restart. The out-of-process finish path (hotStart: false) needs
+ * this check just as much as the hot-add branch below.
+ */
+export async function assertSlackInstancesModuleInstalled(): Promise<void> {
+  try {
+    const slackSpec = '../../channels/slack.js';
+    const slackMod = (await import(slackSpec)) as Record<string, unknown>;
+    if (typeof slackMod.slackInstanceBridgeFactory !== 'function' || !slackMod.SLACK_DEFAULTS) {
+      throw new Error('missing exports');
+    }
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+}
+
+export async function loadSlackChannelDeps(): Promise<SlackChannelDeps> {
+  let slackMod: Record<string, unknown>;
+  try {
+    const slackSpec = '../../channels/slack.js';
+    slackMod = (await import(slackSpec)) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  const slackInstanceBridgeFactory = slackMod.slackInstanceBridgeFactory;
+  const SLACK_DEFAULTS = slackMod.SLACK_DEFAULTS;
+  if (typeof slackInstanceBridgeFactory !== 'function' || !SLACK_DEFAULTS) {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  return {
+    slackInstanceBridgeFactory: slackInstanceBridgeFactory as (name: string) => ChannelAdapter | null,
+    SLACK_DEFAULTS: SLACK_DEFAULTS as ChannelDefaults,
+    registerChannelAdapter,
+    startChannelAdapter,
+  };
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
@@ -1,0 +1,109 @@
+/**
+ * slack-agent-flow shared types.
+ * Congruence: env-key shapes mirror the adapter's native SLACK_INSTANCES
+ * conventions (src/channels/slack.ts, instanceEnvKeySuffix);
+ * broker protocol mirrors src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts. Pinned by
+ * provision.congruence.test.ts.
+ */
+
+export type SlackFlowStep =
+  | 'operator-identity'
+  | 'origin-auth'
+  | 'no-credentials'
+  | 'broker'
+  | 'direct-create'
+  /** Waiting out a workspace install approval before the bot token exists. */
+  | 'install-wait'
+  | 'env-write'
+  | 'adapter-start'
+  | 'dm-open'
+  | 'dm-wire'
+  | 'mpim-open'
+  | 'a2a-env'
+  | 'room-wire'
+  | 'intro-post'
+  /** room-actions module — create_room / add_to_room participant resolution. */
+  | 'room-resolve'
+  /** slack-room-membership module — join/left handling, not a create_agent flow step. */
+  | 'membership';
+
+/** Typed failure for the Slack leg. `message` MUST never contain a token value. */
+export class SlackFlowError extends Error {
+  constructor(
+    readonly step: SlackFlowStep,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SlackFlowError';
+  }
+}
+
+export interface ProvisionInput {
+  /** Instance slug: output of normalizeName(), post-dedupe. */
+  slug: string;
+  /** Display name for the Slack app/bot (the raw agent name). */
+  displayName: string;
+  /** Repo root; .env lives at `${rootDir}/.env`. */
+  rootDir: string;
+  /** Slack workspace the app is provisioned into (broker mode requires it). */
+  teamId?: string;
+  /** Agent description/instructions — drives the broker's generated avatar. */
+  description?: string;
+  /**
+   * true → plain manifest variant (no agent_view): workspace guests are
+   * hard-blocked from agent-enabled apps. Default false → agent mode, the
+   * default variant — a one-way door decided at provision time.
+   */
+  allowGuests?: boolean;
+  /**
+   * Request-origin metadata, all optional — sent on the broker's
+   * POST /v1/apps body only when defined (requested_by / parent_app_id /
+   * template on the wire; a broker that predates them ignores unknown body
+   * fields). client_version is derived from rootDir's package.json inside
+   * provisionSlackApp, not supplied here.
+   */
+  /** Slack user id (U…/W…) of the human who asked for this agent. */
+  requestedBy?: string;
+  /** The creating agent's own Slack app id (A…) when an agent created this one. */
+  parentAppId?: string;
+  /** Template name, when the agent was stamped from one. */
+  template?: string;
+  /**
+   * Called once when the workspace has not approved the app's install and the
+   * flow is about to wait for it — `resumed` distinguishes a fresh refusal
+   * from picking a parked app back up. Exceptions are swallowed: telling the
+   * human is best-effort, the wait happens either way.
+   */
+  onInstallPending?: (info: { appId: string; installUrl?: string; resumed: boolean }) => void | Promise<void>;
+  /** Wait budget for a deferred install. Tests shorten it; callers rarely set it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+}
+
+export interface ProvisionResult {
+  slug: string;
+  /** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix. */
+  envSuffix: string;
+  botToken: string; // xoxb-… NEVER log
+  appToken: string; // xapp-… NEVER log
+  appId: string;
+  /** True when tokens were already in .env and no provisioning call was made. */
+  reused: boolean;
+  /**
+   * True when the bot token arrived only after waiting out a workspace install
+   * approval (auto-install was refused). Everything downstream is identical —
+   * the flag exists so the completion message can say what happened.
+   */
+  deferredInstall?: boolean;
+}
+
+export interface OrchestrateSuccess {
+  slug: string;
+  newBotUserId: string;
+  operatorUserId: string;
+  dmChannelId: string;
+  /** Absent when the create ran with room:'none' — no shared room. */
+  roomChannelId?: string;
+  /** True when the bot only came online after a workspace install approval. */
+  deferredInstall?: boolean;
+}

--- a/container/agent-runner/src/mcp-tools/canvas.instructions.md
+++ b/container/agent-runner/src/mcp-tools/canvas.instructions.md
@@ -1,0 +1,36 @@
+## Canvases
+
+Slack canvases are shared documents that live alongside a conversation. The **room canvas** is the room's shared working surface: chat is for coordination, the canvas is for state. It has named sections — **Members**, **Tasks** (a checklist), **Decisions**, and **Notes** — and both humans and agents edit it. The canvas id (`F…`) for a room is in your destinations list — the `<room> canvas comments (canvas F0…)` destination carries it (canvas ids are uppercase, starting `F`). If you can't find it, ask in the room — never guess an id.
+
+Two tools:
+
+- `mcp__nanoclaw__canvas_update({ canvas_id, op, markdown, section_text? })` — fire-and-forget edit. `op` is `append` (at document end), `replace_section`, or `insert_after_section`; the last two need `section_text` — the target section's **exact heading text**. Outcomes: a FAILED edit wakes you with a system note saying why — fix and retry from a fresh read. A successful edit's note is silent (it rides along on your next wake), so verify structural changes with `canvas_read`.
+- `mcp__nanoclaw__canvas_read({ canvas_id, timeout? })` — blocking read; `timeout` is in **seconds** (default 20 — never pass milliseconds). Returns the canvas as readable text, checkboxes rendered as `[ ]` / `[x]`, truncated at ~8000 chars — a `…[truncated at N chars]` suffix marks the cut, and sections may exist below it, so never conclude a section is absent from a truncated read. A "timed out" error can occur even when the host read succeeded — retry once, with a larger `timeout` on slow canvases.
+
+Section targeting: `section_text` must be the exact heading text (matching is case-insensitive and trimmed; exact match beats contains; ties go to the first matching heading in document order). If it matches only body text — or the host's pre-read transiently fails — the op silently degrades to a **single-block** edit that can corrupt the section. Full mechanics live in the `canvas-work` skill; follow it for every edit.
+
+Working rules:
+
+- **Keep Tasks and Decisions current.** When work is agreed, ADD it under Tasks with `insert_after_section` (markdown = just the new `- [ ]` line — existing items and their ticks stay intact). Checkbox tick state is **UI-only**: the API ignores `- [x]` and a section rewrite resets every ticked box, so mark completion by editing the item's own text (see the `canvas-work` skill) and leave box-ticking to humans. When a decision lands in chat, record it under Decisions — quote the ask, name who decided.
+- **Section-scoped edits only.** Always target one section (`replace_section` / `insert_after_section`) or append. Never try to rewrite the whole document — whole-document replace is destructive to everyone else's edits and the tools will not do it.
+- **Read before your edits, read after structural ones.** Human edits fire no events, so your memory of the canvas is stale by default. One fresh `canvas_read` covers all the edits you compose in the same turn; after adding or reordering sections, `canvas_read` again to confirm. Humans may also tick checkboxes — re-reading is how you notice.
+- **Batch small edits.** Each bot edit posts a (debounced, but real) "updated the canvas" notice in the conversation. Compose one edit per section per work burst, not one edit per line.
+- Rich content that works well in canvas markdown: checklists, tables, user cards `![](@U…)`, message permalinks (paste the link — it becomes a card), code blocks, and blockquotes for decisions.
+
+### Canvas comments
+
+Comments people leave on a canvas reach the room's agents as ordinary messages in a separate channel named `<room> canvas comments` — one per canvas, wired to EVERY agent in the room. If you created the canvas, you are its default responder: every comment engages you. Otherwise comments reach you as ambient context only, and you respond when @-mentioned in one. A comment that @-mentions a sibling wakes BOTH that sibling and the creator — creator: when a comment tags someone else, let them answer; stay silent unless you're needed.
+
+- Comments arrive as **threads**. The thread's ROOT message is from **USLACKBOT** and its text is the exact canvas text the person commented on (e.g. the checklist line) — that is your anchor context for what the comment is about. The human comments are the replies under it.
+- **Reply in the same thread** to answer a comment. Your reply may appear to the commenter as a native canvas comment reply — treat the thread as the comment conversation.
+- **Never reply to messages authored by USLACKBOT itself.** The anchor roots and the `<@…> was mentioned in a canvas` notices are system noise. If you are the creator, one of these can itself be the message that WOKE you — being woken by it is not a request to answer it. Read it for context (e.g. `canvas_read` on a mention notice), reply only to human messages that need one, and if nothing does, ending your turn with no message is the correct outcome.
+- When woken in a comments channel without any @-mention (creator), your prompt is the **newest human comment** in the batch.
+- After addressing feedback: update the relevant canvas section (via `canvas_update`), then reply briefly in the comment thread so the commenter knows it's done.
+
+## Mention notices and finding context
+
+- The comments channel name carries the canvas id: `<room> canvas comments (canvas F0…)`.
+- When a "<@…> was mentioned in a canvas" notice arrives (or a comment lacks enough
+  anchor context), do NOT ask the user what they mean first — call `canvas_read` with
+  that canvas id, find the mention or the referenced section yourself, then respond
+  with the context in hand. Only ask if the canvas genuinely doesn't disambiguate.

--- a/container/agent-runner/src/mcp-tools/canvas.test.ts
+++ b/container/agent-runner/src/mcp-tools/canvas.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Canvas MCP tool tests: canvas_update arg validation + system-action row
+ * shape, and canvas_read's blocking poll round trip against a host-written
+ * canvas_response row (the ncl / ask_user_question pattern).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
+import { canvasRead, canvasUpdate } from './canvas.js';
+
+function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
+  return (
+    getOutboundDb().prepare('SELECT id, kind, content FROM messages_out ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, content: JSON.parse(r.content) }));
+}
+
+function seedCanvasResponse(requestId: string, body: Record<string, unknown>): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, content)
+       VALUES ($id, $seq, 'system', $timestamp, 'pending', $content)`,
+    )
+    .run({
+      $id: `canvas-resp-${requestId}`,
+      $seq: 2,
+      $timestamp: new Date().toISOString(),
+      $content: JSON.stringify({ type: 'canvas_response', requestId, action: 'canvas_read', ...body }),
+    });
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+describe('canvas_update — arg validation', () => {
+  it('requires canvas_id and markdown', async () => {
+    const r1 = await canvasUpdate.handler({ op: 'append', markdown: 'x' });
+    expect(r1.isError).toBe(true);
+    const r2 = await canvasUpdate.handler({ canvas_id: 'F1', op: 'append' });
+    expect(r2.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('rejects unknown ops', async () => {
+    const r = await canvasUpdate.handler({ canvas_id: 'F1', op: 'replace', markdown: 'x' });
+    expect(r.isError).toBe(true);
+    expect((r.content[0] as { text: string }).text).toContain('op must be one of');
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('rejects section ops without section_text — nothing is submitted', async () => {
+    for (const op of ['replace_section', 'insert_after_section']) {
+      const r = await canvasUpdate.handler({ canvas_id: 'F1', op, markdown: 'x' });
+      expect(r.isError).toBe(true);
+      expect((r.content[0] as { text: string }).text).toContain('section_text');
+    }
+    expect(outboundActions()).toHaveLength(0);
+  });
+});
+
+describe('canvas_update — submission', () => {
+  it('writes a canvas_edit system action and returns fire-and-forget text', async () => {
+    const r = await canvasUpdate.handler({
+      canvas_id: 'F1',
+      op: 'replace_section',
+      section_text: 'Tasks',
+      markdown: '## Tasks\n\n- [x] done',
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toBe(
+      'Edit submitted. If it fails you will be woken with a system note saying why; verify structural changes with canvas_read.',
+    );
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({
+      action: 'canvas_edit',
+      canvas_id: 'F1',
+      op: 'replace_section',
+      section_text: 'Tasks',
+      markdown: '## Tasks\n\n- [x] done',
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+
+  it('append needs no section_text', async () => {
+    const r = await canvasUpdate.handler({ canvas_id: 'F1', op: 'append', markdown: '- [ ] new' });
+    expect(r.isError).toBeUndefined();
+    const rows = outboundActions();
+    expect(rows[0].content).toMatchObject({ action: 'canvas_edit', op: 'append' });
+    expect(rows[0].content.section_text).toBeUndefined();
+  });
+});
+
+describe('canvas_read — blocking round trip', () => {
+  it('requires canvas_id', async () => {
+    const r = await canvasRead.handler({});
+    expect(r.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('submits canvas_read, polls, and returns the host-fetched text', async () => {
+    const pending = canvasRead.handler({ canvas_id: 'F1', timeout: 5 });
+
+    // Let the tool write its request row, then answer it like the host would.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toMatchObject({ action: 'canvas_read', canvas_id: 'F1' });
+    const requestId = rows[0].content.requestId as string;
+    seedCanvasResponse(requestId, { status: 'ok', result: { canvas_id: 'F1', text: '# Room\n\n- [x] done' } });
+
+    const r = await pending;
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toBe('# Room\n\n- [x] done');
+
+    // The response row is acked so the poll loop won't re-deliver it.
+    const acked = getOutboundDb()
+      .prepare('SELECT status FROM processing_ack WHERE message_id = ?')
+      .get(`canvas-resp-${requestId}`) as { status: string } | null;
+    expect(acked?.status).toBe('completed');
+  });
+
+  it('surfaces host-side errors as tool errors', async () => {
+    const pending = canvasRead.handler({ canvas_id: 'F1', timeout: 5 });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const requestId = outboundActions()[0].content.requestId as string;
+    seedCanvasResponse(requestId, { status: 'error', result: { error: 'canvas_not_found' } });
+
+    const r = await pending;
+    expect(r.isError).toBe(true);
+    expect((r.content[0] as { text: string }).text).toContain('canvas_not_found');
+  });
+
+  it('times out when no response arrives', async () => {
+    const r = await canvasRead.handler({ canvas_id: 'F1', timeout: 1 });
+    expect(r.isError).toBe(true);
+    expect((r.content[0] as { text: string }).text).toContain('timed out');
+  });
+});

--- a/container/agent-runner/src/mcp-tools/canvas.ts
+++ b/container/agent-runner/src/mcp-tools/canvas.ts
@@ -1,0 +1,156 @@
+/**
+ * Canvas MCP tools: canvas_update, canvas_read.
+ *
+ * canvas_update is fire-and-forget (self-mod.ts pattern): it writes a
+ * `canvas_edit` system action and returns immediately — the host applies the
+ * edit as this session's bot identity and the outcome arrives later as a
+ * system note (a `canvas_response` inbound row).
+ *
+ * canvas_read is blocking (ncl / ask_user_question pattern): it writes a
+ * `canvas_read` system action, then polls the mailbox by requestId for the
+ * host's response row and returns the canvas text inline.
+ */
+import { findCliResponse, markCompleted } from '../db/messages-in.js';
+import { writeMessageOut } from '../db/messages-out.js';
+import { registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `canvas-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const EDIT_OPS = ['append', 'replace_section', 'insert_after_section'] as const;
+type EditOp = (typeof EDIT_OPS)[number];
+
+export const canvasUpdate: McpToolDefinition = {
+  tool: {
+    name: 'canvas_update',
+    description:
+      "Edit a Slack canvas by id — append markdown at the end, replace one named section, or insert new content after a section. Section targeting uses section_text: for section-wide edits the target section's EXACT heading text (from a fresh canvas_read); for a single checklist item, the item's exact text (that deliberately targets just the item — how you mark items done, since checkbox tick state is UI-only and cannot be set via the API). Fire-and-forget: the host applies the edit as your bot identity; a failure wakes you with a system note explaining why, a success note rides along silently on your next wake. Whole-document replace is not possible — edits are always section-scoped. Discipline (canvas-work skill): canvas_read first; replace_section for updating existing content; insert_after_section for new sections or new checklist items; never a heading the canvas already has.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        canvas_id: {
+          type: 'string',
+          description:
+            "Canvas id (F…) — for a room canvas, it is in your destinations list ('<room> canvas comments (canvas F…)')",
+        },
+        op: {
+          type: 'string',
+          enum: [...EDIT_OPS],
+          description: 'append (at document end), replace_section, or insert_after_section',
+        },
+        markdown: { type: 'string', description: 'Markdown content for the edit' },
+        section_text: {
+          type: 'string',
+          description: "Required for replace_section / insert_after_section: the target section's exact heading text",
+        },
+      },
+      required: ['canvas_id', 'op', 'markdown'],
+    },
+  },
+  async handler(args) {
+    const canvasId = args.canvas_id as string;
+    const op = args.op as EditOp;
+    const markdown = args.markdown as string;
+    const sectionText = (args.section_text as string) || '';
+
+    if (!canvasId || !markdown) return err('canvas_id and markdown are required');
+    if (!EDIT_OPS.includes(op)) return err(`op must be one of: ${EDIT_OPS.join(', ')}`);
+    if (op !== 'append' && !sectionText) {
+      return err(`section_text is required for ${op} — the target section's exact heading text`);
+    }
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'canvas_edit',
+        requestId,
+        canvas_id: canvasId,
+        op,
+        section_text: sectionText || undefined,
+        markdown,
+      }),
+    });
+
+    log(`canvas_update: ${requestId} → ${op} on ${canvasId}`);
+    return ok(
+      'Edit submitted. If it fails you will be woken with a system note saying why; verify structural changes with canvas_read.',
+    );
+  },
+};
+
+export const canvasRead: McpToolDefinition = {
+  tool: {
+    name: 'canvas_read',
+    description:
+      'Read a Slack canvas as text (blocking, default 20s; timeout is in SECONDS). A timeout error can fire while the host read still succeeds — on timeout, retry once with a larger timeout. Output over ~8000 chars is truncated with an explicit marker: never conclude a section is absent from a truncated read. Read-before-write is mandatory (canvas-work skill): call this before EVERY edit — human edits produce no events, so your last view is stale by default.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        canvas_id: { type: 'string', description: 'Canvas id (F…) to read' },
+        timeout: { type: 'number', description: 'Timeout in seconds (default: 20)' },
+      },
+      required: ['canvas_id'],
+    },
+  },
+  async handler(args) {
+    const canvasId = args.canvas_id as string;
+    if (!canvasId) return err('canvas_id is required');
+    const timeout = ((args.timeout as number) || 20) * 1000;
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'canvas_read',
+        requestId,
+        canvas_id: canvasId,
+      }),
+    });
+
+    log(`canvas_read: ${requestId} → ${canvasId}`);
+
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const response = findCliResponse(requestId);
+      if (response) {
+        markCompleted([response.id]);
+        const parsed = JSON.parse(response.content) as {
+          status?: string;
+          result?: { text?: string; error?: string };
+        };
+        if (parsed.status === 'ok' && typeof parsed.result?.text === 'string') {
+          log(`canvas_read response: ${requestId} (${parsed.result.text.length} chars)`);
+          return ok(parsed.result.text);
+        }
+        return err(parsed.result?.error || 'canvas read failed');
+      }
+      await sleep(500);
+    }
+
+    log(`canvas_read timeout: ${requestId}`);
+    return err(`Canvas read timed out after ${timeout / 1000}s`);
+  },
+};
+
+registerTools([canvasUpdate, canvasRead]);

--- a/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+++ b/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
@@ -1,0 +1,9 @@
+## create_agent on Slack: acknowledge in the same turn (creation takes ~1 minute)
+
+On this install, every agent you create also gets its own Slack bot. Creation is not instant: a unique avatar is generated and a dedicated Slack app is provisioned, which takes about a minute. From the user's side that is silence — so ALWAYS acknowledge in the SAME turn as the `create_agent` call (before or alongside it), set the expectation, and say what happens next. Example: "On it — creating Pixel now. It takes about a minute; it'll introduce itself in a DM and open a shared room for the three of us."
+
+- What the user will see: roughly a minute of quiet, then an intro DM from the new agent plus a shared three-way room (you, the user, the new agent) — unless you passed `room: 'none'`, which skips the room (the team pattern: several agents with `room:'none'`, then one `create_room` with all of them — see the rooms tools).
+- Give each create a short PUBLIC `purpose` line (under 80 chars) — it appears in the room intro and on the room canvas; never put private detail from the instructions there.
+- In rooms, keep the acknowledgment brief — one short line, no play-by-play.
+- Some workspaces require an admin to approve every app install. When that happens the user gets a link to approve and setup finishes by itself once they do — so if they say the approval went through, or they ask you to finish setting that agent up, just call `create_agent` again with the SAME name. That resumes the app already waiting; it does not create a second one, and it is not a name collision.
+- You'll be notified when the agent is live (or get a failure notice with a fix-it command). Relay completion only when that arrives — never report "done" early.

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -32,3 +32,5 @@ main().catch((err) => {
   log(`MCP server error: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 });
+import './canvas.js';
+import './rooms.js';

--- a/container/agent-runner/src/mcp-tools/rooms.instructions.md
+++ b/container/agent-runner/src/mcp-tools/rooms.instructions.md
@@ -1,0 +1,22 @@
+## Shared rooms (`create_room`, `add_to_room`)
+
+A room is one Slack group conversation shared by the user and N agents, with a canvas tab carrying the room contract (purpose, members). `mcp__nanoclaw__create_room({ name, purpose, agents, include_me? })` opens one; `mcp__nanoclaw__add_to_room({ room, agent })` grows one.
+
+### The team pattern — one room, not N
+
+When the user asks for a TEAM (several agents for one project), never let each `create_agent` open its own room — that yields N separate three-way rooms nobody wants:
+
+1. Create each agent with `room: 'none'` (they still get their operator DM).
+2. When all are live, call `create_room` ONCE with all their names and a short public `purpose`.
+
+For a SINGLE new agent, plain `create_agent` (default `room: 'own'`) is right — don't follow up with `create_room`.
+
+### How it works
+
+- `agents` takes the same names you use with `send_message` — agents you created or can already message. Unknown names come back as an error note, nothing half-created.
+- Both tools are fire-and-forget and may require admin approval; the outcome arrives as a system note. When the room is live, the note tells you the destination to post to and whom to tag — post a brief intro in your own voice (1-2 lines, no mechanics, no member lists).
+- In rooms, agents engage when @-mentioned; everything else accumulates as ambient context. Tag an agent to bring it in.
+
+### Growing a room
+
+`add_to_room` works, but Slack group conversations never grow in place — the room MOVES to a new conversation (everyone re-wired automatically; the old conversation keeps working). Prefer creating rooms complete: if you know the team needs four agents, create all four first, then one `create_room`.

--- a/container/agent-runner/src/mcp-tools/rooms.test.ts
+++ b/container/agent-runner/src/mcp-tools/rooms.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Room MCP tool tests: create_room / add_to_room arg validation and
+ * system-action row shape, plus the extendTool-based create_agent extension
+ * (schema/description growth + purpose/allow_guests/room payload
+ * passthrough) — all fire-and-forget writes to messages_out (authorization
+ * is host-side). Importing ./rooms.js applies the extension, so these tests
+ * exercise the same wiring the barrel produces.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
+import { createAgent } from './agents.js';
+import { addToRoom, createRoom } from './rooms.js';
+
+function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
+  return (
+    getOutboundDb().prepare('SELECT id, kind, content FROM messages_out ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, content: JSON.parse(r.content) }));
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+describe('create_room — arg validation', () => {
+  it('requires name', async () => {
+    const r = await createRoom.handler({ agents: ['Pixel'] });
+    expect(r.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('requires a non-empty agents list of names', async () => {
+    for (const agents of [undefined, [], ['  '], 'Pixel']) {
+      const r = await createRoom.handler({ name: 'Website Team', agents });
+      expect(r.isError).toBe(true);
+    }
+    expect(outboundActions()).toHaveLength(0);
+  });
+});
+
+describe('create_room — submission', () => {
+  it('writes a create_room system action with the full agent list', async () => {
+    const r = await createRoom.handler({
+      name: '  Website Team ',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toContain('Creating room "Website Team"');
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({
+      action: 'create_room',
+      name: 'Website Team',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+    // include_me travels only when explicitly false (host default is true).
+    expect(rows[0].content.include_me).toBeUndefined();
+  });
+
+  it('carries include_me:false only when explicitly set', async () => {
+    await createRoom.handler({ name: 'Duo', agents: ['Pixel'], include_me: false });
+    expect(outboundActions()[0].content).toMatchObject({ action: 'create_room', include_me: false });
+  });
+});
+
+describe('add_to_room', () => {
+  it('requires room and agent', async () => {
+    const r1 = await addToRoom.handler({ agent: 'Devin' });
+    expect(r1.isError).toBe(true);
+    const r2 = await addToRoom.handler({ room: 'Website Team' });
+    expect(r2.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('writes an add_to_room system action', async () => {
+    const r = await addToRoom.handler({ room: 'Website Team', agent: 'Devin' });
+    expect(r.isError).toBeUndefined();
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({ action: 'add_to_room', room: 'Website Team', agent: 'Devin' });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+});
+
+describe('create_agent — Slack extension (extendTool)', () => {
+  it('extends the base tool schema and description without editing agents.ts', () => {
+    const props = (createAgent.tool.inputSchema as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['name', 'instructions', 'purpose', 'allow_guests', 'room']),
+    );
+    expect(createAgent.tool.description).toContain('acknowledge the user in this SAME turn');
+  });
+
+  it('passes the registered keys through into the written system payload', async () => {
+    await createAgent.handler({ name: 'Pixel', room: 'none', purpose: 'design things' });
+    await createAgent.handler({ name: 'Solo' });
+    await createAgent.handler({ name: 'Own', room: 'own' });
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].content).toMatchObject({
+      action: 'create_agent',
+      name: 'Pixel',
+      room: 'none',
+      purpose: 'design things',
+    });
+    // No extension args → the payload stays byte-identical to the base tool's.
+    expect(rows[1].content.room).toBeUndefined();
+    expect(rows[1].content.purpose).toBeUndefined();
+    // The passthrough copies provided values verbatim; the host reads an
+    // explicit 'own' exactly as an absent room (both mean the default
+    // own-room policy), so nothing normalizes it away container-side.
+    expect(rows[2].content.room).toBe('own');
+  });
+});

--- a/container/agent-runner/src/mcp-tools/rooms.ts
+++ b/container/agent-runner/src/mcp-tools/rooms.ts
@@ -1,0 +1,162 @@
+/**
+ * Room management MCP tools: create_room, add_to_room.
+ *
+ * A "room" is one Slack group conversation shared by the user and N agents.
+ * create_room is the team primitive — the multi-agent pattern is N
+ * create_agent calls with room:'none', then ONE create_room naming all of
+ * them. Both tools are fire-and-forget (create_agent pattern): they write an
+ * outbound system row and return; the host resolves names, opens the
+ * conversation, wires everyone, and reports back as a system note.
+ *
+ * Authorization is enforced host-side by the guard (same trust split as
+ * create_agent: trusted global-scope groups act directly, confined groups
+ * hold for admin approval) — the container is untrusted and cannot be relied
+ * on to gate itself.
+ *
+ * This module also extends the base `create_agent` tool (see the extendTool
+ * call at the bottom): the Slack flow adds `purpose` / `allow_guests` /
+ * `room` params and the acknowledge-now guidance without touching the base
+ * tool's source. The barrel imports this module after the base agents
+ * module, which is what makes the extension legal.
+ */
+import { writeMessageOut } from '../db/messages-out.js';
+import { extendTool, registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+export const createRoom: McpToolDefinition = {
+  tool: {
+    name: 'create_room',
+    description:
+      "Open ONE shared Slack room (group conversation) with the user and several agents at once — the team primitive. Use after creating the agents (create_agent with room:'none' for teams): one room with ALL of them, never one room per agent. May require admin approval. Fire-and-forget: the call returns immediately; you will get a system note when the room is live, telling you how to post the intro there.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string', description: 'Room name (also names the Slack conversation and its canvas)' },
+        purpose: {
+          type: 'string',
+          description:
+            'One short PUBLIC line (under 80 chars) saying what the room is for — shown on the room canvas. Never include private details.',
+        },
+        agents: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Agent names to include — the same names you use with send_message (agents you created or can already message).',
+        },
+        include_me: {
+          type: 'boolean',
+          description: 'Include yourself in the room. Default true — keep it unless the user explicitly excludes you.',
+        },
+      },
+      required: ['name', 'agents'],
+    },
+  },
+  async handler(args) {
+    const name = typeof args.name === 'string' ? args.name.trim() : '';
+    if (!name) return err('name is required');
+    const agents = Array.isArray(args.agents) ? args.agents.filter((a) => typeof a === 'string' && a.trim()) : [];
+    if (agents.length === 0) return err('agents must list at least one agent name');
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'create_room',
+        requestId,
+        name,
+        agents,
+        ...(typeof args.purpose === 'string' && args.purpose.trim()
+          ? { purpose: (args.purpose as string).trim() }
+          : {}),
+        ...(args.include_me === false ? { include_me: false } : {}),
+      }),
+    });
+
+    log(`create_room: ${requestId} → "${name}" (${agents.length} agents)`);
+    return ok(`Creating room "${name}". You will be notified when it is live.`);
+  },
+};
+
+export const addToRoom: McpToolDefinition = {
+  tool: {
+    name: 'add_to_room',
+    description:
+      'Add one agent to an existing shared room. Slack group conversations never grow in place — this moves the room to a NEW conversation containing everyone plus the new agent (the old one keeps working). For a planned team, prefer creating the room once, complete, via create_room. May require admin approval. Fire-and-forget: a system note reports the outcome.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        room: { type: 'string', description: 'Room name (as the room was created/named)' },
+        agent: { type: 'string', description: 'Agent name to add — the same name you use with send_message' },
+      },
+      required: ['room', 'agent'],
+    },
+  },
+  async handler(args) {
+    const room = typeof args.room === 'string' ? args.room.trim() : '';
+    const agent = typeof args.agent === 'string' ? args.agent.trim() : '';
+    if (!room) return err('room is required');
+    if (!agent) return err('agent is required');
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({ action: 'add_to_room', requestId, room, agent }),
+    });
+
+    log(`add_to_room: ${requestId} → "${agent}" into "${room}"`);
+    return ok(`Adding "${agent}" to room "${room}". You will be notified when it is done.`);
+  },
+};
+
+registerTools([createRoom, addToRoom]);
+
+// ── create_agent extension (Slack agent flow) ──
+//
+// Additive extension of the base create_agent tool: on a Slack-wired install
+// each created agent also gets a dedicated Slack bot, so the tool grows the
+// flow's three params and the acknowledge-now guidance. The registered
+// passthrough keys are copied verbatim into the system-action payload the
+// base handler writes — the host reads them exactly as it reads name and
+// instructions (room:'own' and allow_guests:false travel explicitly and read
+// as the defaults host-side).
+extendTool('create_agent', {
+  properties: {
+    purpose: {
+      type: 'string',
+      description:
+        'One short PUBLIC line (under 80 chars) saying what this agent is for — shown to everyone in the shared room intro and canvas. ALWAYS provide it. Never include private details from the instructions; without it the room states no purpose at all.',
+    },
+    allow_guests: {
+      type: 'boolean',
+      description:
+        'Set true ONLY if Slack workspace guests must be able to DM this agent — guests cannot access agent-mode bots, so this provisions a plain bot without the agent DM experience. Default false.',
+    },
+    room: {
+      type: 'string',
+      enum: ['own', 'none'],
+      description:
+        "Shared-room policy. 'own' (default) opens a room with you, the user, and the new agent — right for a single create. 'none' skips the room (the agent still gets its DM) — REQUIRED when creating several agents for one team: create each with room:'none', then call create_room ONCE with all of them. Never open per-agent rooms for a team.",
+    },
+  },
+  passthroughKeys: ['purpose', 'allow_guests', 'room'],
+  descriptionSuffix:
+    'The call returns immediately. Creation takes about a minute (a unique avatar is generated and a dedicated Slack bot is provisioned); when ready, the new agent introduces itself via DM and a shared room. You MUST acknowledge the user in this SAME turn, before or alongside this call — say you are on it, set the ~1-minute expectation, and mention the agent will introduce itself.',
+});

--- a/container/skills/canvas-work/SKILL.md
+++ b/container/skills/canvas-work/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: canvas-work
+description: >-
+  Edit Slack canvases without corrupting them — read-before-write, section
+  targeting by heading, replace vs insert discipline. Use EVERY time you
+  edit a canvas with canvas_update (room canvases, task lists, deliverable
+  docs), not just the first time.
+---
+
+# Canvas Work
+
+Canvases are shared documents. Human edits fire no events, so your last view
+is stale by default. Every edit is section-scoped; the wrong op duplicates
+content instead of updating it.
+
+## When to use a canvas
+
+- **Large outputs go in the canvas, not chat.** Any prose or code deliverable
+  longer than ~a dozen lines — a plan, report, spec, analysis, draft, long
+  diff — goes into the canvas (the right existing section, or a new one) and
+  the chat message shrinks to a 1-3 line summary plus a pointer ("Full plan
+  in the canvas under Rollout"). Chat is for coordination; canvas is for
+  content. Binary artifacts (charts, PDFs, images) still go via `send_file`.
+- **Placement for a new deliverable**: a genuinely new section, not stuffed
+  into Notes — `insert_after_section` after the most related section, or
+  `append` when it belongs at the document end.
+- **Collaborative state lives there**: task lists, decisions, running notes
+  that humans and agents co-edit.
+- In a DM with no canvas, a long deliverable may stay a chat message — but
+  where a canvas exists, prefer it (there is no canvas-create tool; "new
+  structure" means a new section on an existing canvas).
+
+## The loop
+
+1. **Read first.** `canvas_read` before editing — never edit from memory or
+   a previous turn's read. One fresh read covers all the edits you compose
+   in the same turn. Read-backs truncate at ~8000 chars with an explicit
+   `…[truncated at N chars]` marker: if you see it, the canvas continues
+   below what you read — never conclude a section is absent from a
+   truncated read (heading-anchored edits still resolve against the full
+   canvas host-side, so editing below the cut is safe).
+2. **Locate the target** in the read-back. For section-wide edits,
+   `section_text` is the exact heading text — a body-text anchor silently
+   degrades a section rewrite into a single-block edit that corrupts the
+   section. For checklist items, a body-text anchor (the item's exact
+   text) is the CORRECT, deliberate way to target that one item (see
+   Checklists).
+3. **Pick the op:**
+   - `replace_section` — the content EXISTS and you are changing it (ticking
+     a box, updating status, rewriting a paragraph). Updates always use this.
+   - `insert_after_section` — a genuinely NEW section, one whose heading
+     appears nowhere in the canvas, placed after a specific section.
+   - `append` — content for the document END: log entries, list additions,
+     or a new final section (markdown starting with its new heading).
+4. **Never create a heading that already exists** — anywhere in your
+   markdown, not just the first line. A best-effort host guard refuses
+   obvious duplicate-heading inserts (the refusal wakes you with a note),
+   but it is narrow — the rule is yours to enforce, the guard is not a
+   backstop. Note: appending log entries whose markdown repeats the log
+   section's heading is the classic way to trip it — append entry lines
+   only, no heading.
+5. **Batch small edits**: one `canvas_update` per section with the complete
+   new section markdown, not a burst of tiny ops.
+6. **Verify structural changes.** A FAILED edit wakes you with a system
+   note saying why — fix from a fresh read. A success note only rides along
+   on your next wake, so after adding, reordering, or rewriting sections,
+   `canvas_read` and confirm the result before reporting done. Never report
+   a structural edit as landed that you haven't re-read.
+
+## Checklists: item-level ops only
+
+Tick state is **UI-only** — a hard platform limit, live-probed: `- [x]` in
+edit markdown is silently ignored (items always land unticked), and any
+section rewrite RESETS every ticked box (the host warns you when that
+happens). So on checklists:
+
+- **Add an item**: `insert_after_section` on the section heading, markdown
+  = just the new `- [ ] item` line. Existing items and their ticks stay
+  intact. Never re-send the whole list to add one item.
+- **Mark an item done**: you cannot tick its box. Edit the ITEM itself —
+  `section_text` = the item's exact text (a non-heading match targets that
+  single item), op `replace_section`, markdown like
+  `- ✅ deploy the site (done)`. Humans tick boxes; agents mark done in
+  the item text.
+- **Remove or reword an item**: same item-level targeting.
+- **Rewrite the whole section only when resetting it is the point** (e.g.
+  replacing placeholder content) — every ticked box comes back unticked.
+
+### Worked example: mark a task done
+
+User: "mark the deploy task done."
+
+1. `canvas_read` → Tasks contains `- [ ] deploy the site` and
+   `- [ ] write the announcement`.
+2. Item-level edit — target the item, not the section:
+
+   ```
+   canvas_update  op=replace_section  section_text="deploy the site"  markdown:
+   - ✅ deploy the site (done)
+   ```
+
+   A full-section rewrite here would land, but with every checkbox reset
+   and no way to express the tick.
+
+For NON-list sections, `replace_section` on the heading swaps the whole
+section region — send the complete section markdown, heading included.
+Lines you omit are deleted.
+
+## Section model
+
+- A section region is a heading plus every block down to the NEXT heading
+  (canvases have three heading levels; any of them ends the region).
+  Sub-headings end the region: `replace_section` on `## Tasks`
+  when it contains `### Sprint 1` replaces only the blocks above the `###`
+  and leaves every subsection in place — resending subsection markdown
+  duplicates it below the new content. Edit the parent's intro and each
+  subsection as separate ops.
+- **Always include the heading line** in `replace_section` markdown. The
+  heading block itself gets replaced: omit it and the section visually
+  merges into the one above and can never be heading-targeted again.
+- These region semantics apply only when `section_text` matches a heading.
+  A body-text match targets ONE block — deliberate and correct for
+  checklist items, silently corrupting for section rewrites. Know which
+  edit you are making.
+- `insert_after_section` inserts after the region's last block, not directly
+  after the heading.
+
+## Pitfalls
+
+- Heading matching: case-insensitive, trimmed; exact match beats contains;
+  contains ties go to the FIRST matching heading in document order (`Task`
+  hits `Tasks` before `Task archive`). Use the full exact heading.
+- Section ids are ephemeral; the host re-resolves them on every edit.
+  Heading text from a fresh read is the only reliable addressing.
+- `canvas_update` is fire-and-forget: failures wake you with a system note
+  (fix from a fresh read); success notes arrive silently on your next wake.
+  For anything structural, `canvas_read` is the confirmation.
+- **Partial replace**: if a read-back (or a failure note) shows your new
+  content in place with old blocks of the same section still sitting below
+  it, re-issue the SAME `replace_section` on the same heading — the
+  leftovers are now that region's body, so the identical retry is the
+  idempotent fix. If the retry leaves the SAME leftovers again, those
+  blocks are unaddressable host-side — stop retrying and tell the human
+  (they can delete them in the canvas UI). For anything else that looks
+  wrong, re-read and compose a fresh edit.
+- `canvas_read`'s `timeout` is in seconds (default 20). A timeout error can
+  fire even though the host read succeeded — retry, optionally with a
+  larger timeout.

--- a/container/skills/slack-construct-agents/SKILL.md
+++ b/container/skills/slack-construct-agents/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: slack-construct-agents
+description: Standing context for Slack sibling agents — one room per team, creator-posted introductions, bot-to-bot hop discipline. Ships as instructions.md composed into the group's CLAUDE.md at spawn; there is no workflow to invoke.
+---
+
+# Slack construct — sibling agents
+
+This skill is a carrier for standing context, not an on-demand workflow. Its
+payload is `instructions.md` in this directory: the rules an agent needs when
+it shares Slack with sibling agents it can create (`create_agent`) and room
+with (`create_room` / `add_to_room`) — team-room shape, who posts the
+introduction, and the bot-to-bot self-limit.
+
+The host composes every container skill's `instructions.md` into each group's
+CLAUDE.md at spawn (`src/claude-md-compose.ts`), so if you are reading this
+from inside a session, those rules are already part of your standing
+instructions. There is nothing further to load or run here.
+
+The room-and-canvas half of the Slack standing context (mention engagement,
+canvas discipline, access rules) ships separately with the Slack channel
+payload as the `slack-construct` skill; this fragment layers the
+sibling-agent rules on top and arrives with the slack-agent-flow skill.

--- a/container/skills/slack-construct-agents/instructions.md
+++ b/container/skills/slack-construct-agents/instructions.md
@@ -1,0 +1,26 @@
+## Your Slack sibling agents
+
+You may be part of a construct of agents on Slack: sibling agents (each with its own bot,
+DM, and workspace) plus shared rooms where humans, you, and siblings talk. Standing rules
+for the sibling half:
+
+- **Teams get ONE room.** When the user asks for several agents for one project ("build me
+  a team"), create each agent with `create_agent({ ..., room: 'none' })` — they still get
+  their operator DM — then open a single shared room with
+  `create_room({ name, purpose, agents: [all of them] })`. Never let each create open its
+  own room: that yields N separate three-way rooms nobody wants. `add_to_room` works for
+  later growth, but Slack group DMs never grow in place — the room MOVES to a new
+  conversation (everyone is re-wired automatically; the old one keeps working), so prefer
+  creating rooms complete.
+- **You introduce agents you create.** When a shared room comes with an agent you created,
+  YOU post the introduction in the room — the host posts nothing there. You'll get a
+  system nudge telling you which destination to use. Keep it to 1-2 lines in your own
+  voice: say what the new agent is for and tag them with their `<@bot-user-id>` mention
+  (send it literally; it renders as a mention). No mechanics, no member lists — the room's
+  canvas tab already holds that.
+- **Bot-to-bot hop budget.** The platform may cap consecutive bot-to-bot messages (~6)
+  until a human speaks again, but do not rely on it — self-limit. Don't ping-pong with
+  siblings: do the work, converge, hand back to the human.
+- **Persist durable facts.** Conversations are per-session; rooms and DMs don't share
+  history. Anything worth keeping (decisions, preferences, ongoing state) goes in your
+  memory directory, not just the chat transcript.

--- a/container/skills/slack-construct/SKILL.md
+++ b/container/skills/slack-construct/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: slack-construct
+description: Standing context for Slack rooms — mention-driven engagement, room canvases, owner-presence access, and DM history. Ships as instructions.md composed into the group's CLAUDE.md at spawn; there is no workflow to invoke.
+---
+
+# Slack construct — standing context
+
+A carrier for standing context, not an on-demand workflow. The payload is
+`instructions.md` in this directory: the Slack room, canvas, access, and
+DM-history rules an agent needs the moment it wakes in a Slack conversation.
+The host composes every container skill's `instructions.md` into each group's
+CLAUDE.md at spawn (`src/claude-md-compose.ts`), so from inside a session
+those rules are already standing instructions — nothing to load or run here.
+
+Two scope notes for maintainers:
+
+- Skill fragments compose into **every** group, regardless of the group's
+  `cli_scope`. The content therefore never names host-CLI (`ncl`) commands —
+  groups with CLI access get that guidance from the CLI module's own
+  instructions fragment, which the host includes only where `ncl` is enabled.
+- Detailed canvas *editing* discipline lives in the `canvas-work` skill; the
+  fragment here only carries the always-on rules (read-before-edit, section
+  ops, comment behavior) at summary level.

--- a/container/skills/slack-construct/instructions.md
+++ b/container/skills/slack-construct/instructions.md
@@ -1,0 +1,56 @@
+## Slack rooms: mentions, canvas, ambient context
+
+On Slack you may share rooms (channels and group DMs) with humans and other
+agents, each with its own canvas. Standing rules:
+
+- **Rooms engage only on @-mention.** In a room you act ONLY when @-mentioned; every other
+  room message reaches you later as ambient context, not as a prompt. Caution: in a wake
+  batch, that backlog renders exactly like the message that prompted you — there is no
+  structural marker. The messages that @-mention you are your prompts (answer each of
+  them; there may be more than one); treat the rest as context. Comments channels differ —
+  see the canvas rules.
+- **The room canvas IS the room's contract.** A room may have a canvas pinned as its
+  canvas tab: purpose, creator, member list, created date, plus
+  Tasks / Decisions / Notes sections you keep current. There is no pinned contract
+  message. Never @-mention a bot (user card or `<@id>`) in a canvas BODY — canvas-body
+  mentions fire a mention event at every tagged agent's instance; use plain agent names in
+  canvas content. Deliberate @-mentions in canvas COMMENTS are fine and are how you summon
+  a specific agent into a comment thread.
+- **Canvas comments reach every room agent.** If you created the canvas you are its
+  default responder and every comment engages you — even USLACKBOT anchor posts and
+  "was mentioned in a canvas" notices, which can arrive as the very message that wakes
+  you: never answer those, only human comments (your prompt there is the newest human
+  comment; if there is none, ending the turn with no message is correct). Otherwise
+  comments accumulate as ambient context and you engage when @-mentioned in one (you'll
+  see the anchored section text as the thread root). A comment tagging another agent wakes
+  both that agent AND the creator — creator: when a comment tags someone else, let
+  them answer. Reply in the comment thread.
+- **Canvas edits follow the `canvas-work` skill.** `canvas_read` first, every time —
+  human edits generate no events, so the canvas may have changed since you last saw it;
+  `replace_section` to update existing sections; insert ops only for genuinely new
+  content — never a heading the canvas already has. A failed edit wakes you with a
+  system note saying why; verify structural changes with a re-read.
+- **Chat stays short; large output goes to the canvas.** Keep messages to a few lines —
+  coordination, answers, pointers. Any prose or code deliverable over ~a dozen lines
+  (plan, report, spec, analysis, long diff) goes into the room canvas (the right
+  section, or a new one) and the chat message becomes a 1-3 line summary pointing at
+  it. Binary artifacts (charts, PDFs, generated images) still go via `send_file`. In a
+  DM with no canvas, long content may stay in chat, but prefer canvas structure
+  wherever one exists.
+- **One reply per prompt.** Send your answer once and end the turn — never follow it
+  with a second message recapping what you just did ("Replied to X: …", "Done — I
+  posted…"). The reply IS the report.
+- **Access follows owner presence.** Rooms, group DMs, and channels where your owner is a
+  member are open — anyone present there may task you directly, with no approval step. If
+  you are added to a conversation your owner is NOT in, the host asks your owner before
+  you engage; until then you stay silent there. Unknown people who DM you 1:1 never reach
+  you at all — the host declines them politely on your behalf and sends your owner a
+  one-line FYI, so you will not see those messages and should never mention them. Once
+  your owner grants someone access, their DMs reach you normally.
+- **Persist durable facts.** Conversations are per-session; rooms and DMs don't share
+  history. Anything worth keeping (decisions, preferences, ongoing state) goes in your
+  memory directory, not just the chat transcript.
+- **`<dm-history>` lines are THIS DM's timeline just before this conversation** — they are
+  first-class history you continue from (entries with sender="you" are your own earlier
+  posts). A short opener ("sure", "yes", "the first one") is answering the most recent
+  `<dm-history>` entry — continue in flow from it. Never re-introduce yourself or restart.

--- a/container/skills/slack-formatting/SKILL.md
+++ b/container/skills/slack-formatting/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: slack-formatting
+description: Format messages for Slack using mrkdwn syntax. Use when responding to Slack channels (folder starts with "slack_" or JID contains slack identifiers).
+---
+
+# Slack Message Formatting (mrkdwn)
+
+When responding to Slack channels, use Slack's mrkdwn syntax instead of standard Markdown.
+
+## How to detect Slack context
+
+Check your group folder name or workspace path:
+- Folder starts with `slack_` (e.g., `slack_engineering`, `slack_general`)
+- Or check `/workspace/group/` path for `slack_` prefix
+
+## Formatting reference
+
+### Text styles
+
+| Style | Syntax | Example |
+|-------|--------|---------|
+| Bold | `*text*` | *bold text* |
+| Italic | `_text_` | _italic text_ |
+| Strikethrough | `~text~` | ~strikethrough~ |
+| Code (inline) | `` `code` `` | `inline code` |
+| Code block | ` ```code``` ` | Multi-line code |
+
+### Links and mentions
+
+```
+<https://example.com|Link text>     # Named link
+<https://example.com>                # Auto-linked URL
+<@U1234567890>                       # Mention user by ID
+<#C1234567890>                       # Mention channel by ID
+<!here>                              # @here
+<!channel>                           # @channel
+```
+
+### Lists
+
+Slack supports simple bullet lists but NOT numbered lists:
+
+```
+• First item
+• Second item
+• Third item
+```
+
+Use `•` (bullet character) or `- ` or `* ` for bullets.
+
+### Block quotes
+
+```
+> This is a block quote
+> It can span multiple lines
+```
+
+### Emoji
+
+Use standard emoji shortcodes: `:white_check_mark:`, `:x:`, `:rocket:`, `:tada:`
+
+## What NOT to use
+
+- **NO** `##` headings (use `*Bold text*` for headers instead)
+- **NO** `**double asterisks**` for bold (use `*single asterisks*`)
+- **NO** `[text](url)` links (use `<url|text>` instead)
+- **NO** `1.` numbered lists (use bullets with numbers: `• 1. First`)
+- **NO** tables (use code blocks or plain text alignment)
+- **NO** `---` horizontal rules
+
+## Example message
+
+```
+*Daily Standup Summary*
+
+_March 21, 2026_
+
+• *Completed:* Fixed authentication bug in login flow
+• *In Progress:* Building new dashboard widgets
+• *Blocked:* Waiting on API access from DevOps
+
+> Next sync: Monday 10am
+
+:white_check_mark: All tests passing | <https://ci.example.com/builds/123|View Build>
+```
+
+## Quick rules
+
+1. Use `*bold*` not `**bold**`
+2. Use `<url|text>` not `[text](url)`
+3. Use `•` bullets, avoid numbered lists
+4. Use `:emoji:` shortcodes
+5. Quote blocks with `>`
+6. Skip headings — use bold text instead

--- a/container/skills/welcome/addenda/slack.md
+++ b/container/skills/welcome/addenda/slack.md
@@ -1,0 +1,50 @@
+---
+channel: slack
+---
+
+# Slack welcome adjustments
+
+Two adjustments when the welcome runs on Slack: agent DMs get a
+notification-shaped welcome instead of a question, and the tour gains
+Slack-specific items — one of which replaces the base Access Control point.
+
+## Agent DMs: the welcome is a NOTIFICATION
+
+If this DM is a Slack agent conversation (threads shown as a timeline above the
+composer), the welcome is a notification, NOT a question — do not end it with an
+offer that expects a reply ("want a tour?"). Suggested prompts pinned at the top of
+this DM already offer the tour and starting points; the user's click (or any new
+message) starts the first conversation.
+
+HARD LENGTH RULE: the whole welcome is AT MOST ~250 characters — 2-3 SHORT
+sentences total. No bullet lists, no headers, no capability catalog, no
+threading explanation (the tour covers all of that). It reads like a text
+message, not a broadcast post.
+
+Shape (adapt the words, keep the size):
+
+> Hey <name> — I'm <agent>, your personal agent. The buttons above are the
+> fastest way to start, or just tell me what you need.
+
+Everything else — capabilities, the threading model, memory — belongs in the
+tour conversation, not here. When the user takes the tour, weave the threading
+tip in there ("each conversation lives in its own thread; a new message in the
+main box starts a fresh one — I keep context either way").
+
+## Tour additions: rooms and access
+
+When the tour runs on Slack, also reveal these — same drip-feed rule, one at a
+time, 2-4 sentences each:
+
+### Shared rooms
+In shared rooms, @-mention an agent to engage it — unmentioned messages are
+context it only sees later. The room's canvas tab (top of the conversation)
+holds the room's purpose, member list, and running Tasks/Decisions — the
+agents keep it current.
+
+### Access (replaces the generic Access Control point on Slack)
+Anyone in a room or channel with both you and your agent can task it directly —
+no approval cards. If the agent gets added somewhere you're not a member,
+you'll be asked first. Strangers who DM your agent 1:1 get a polite automatic
+decline and you get a one-line heads-up (at most one per person per day);
+allow someone any time by asking your agent to add them.

--- a/container/skills/welcome/addenda/teams-tour.md
+++ b/container/skills/welcome/addenda/teams-tour.md
@@ -1,0 +1,17 @@
+---
+channel: slack
+---
+
+# Teams tour item (Slack agent flow)
+
+When the tour runs on Slack, also reveal this — same drip-feed rule as the base
+tour, one item at a time, 2-4 sentences:
+
+### Teams
+
+Want a whole team? Ask your agent to build one — e.g. "create a designer, a
+builder, and a reviewer for my new site, in one shared room." It will create
+the agents first and then open a single room with all of them (plus you). You
+can grow a room later by asking to add an agent, but Slack moves the
+conversation to a new group DM when members change — the old thread keeps
+working, and everything is rewired automatically.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@chat-adapter/slack": "4.29.0",
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
     "@onecli-sh/sdk": "2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@chat-adapter/slack':
+        specifier: 4.29.0
+        version: 4.29.0
       '@clack/core':
         specifier: ^1.2.0
         version: 1.2.0
@@ -71,6 +74,14 @@ importers:
         version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
+
+  '@chat-adapter/shared@4.29.0':
+    resolution: {integrity: sha512-ARqTDoHJHKN9rpytbFPJbNmqqx3fOg5xwsTZdlingQPAssOSeHDBdqrFJkgDhyCRGbmDtG09cuS0FkVzeoh2qg==}
+    engines: {node: '>=20'}
+
+  '@chat-adapter/slack@4.29.0':
+    resolution: {integrity: sha512-s2DXAwkTpmiIKSATXgrO879s1pqFwS70Y0JPd+TRGRzDeh6nfqt5dnKt5Bug0P1zwkB6DoPurhnYS9nqhSmD/w==}
+    engines: {node: '>=20'}
 
   '@clack/core@1.2.0':
     resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
@@ -411,6 +422,22 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/socket-mode@2.0.7':
+    resolution: {integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.22.0':
+    resolution: {integrity: sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.19.0':
+    resolution: {integrity: sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -444,8 +471,14 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -548,6 +581,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -561,6 +598,12 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -582,6 +625,10 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -620,6 +667,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -649,6 +700,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -660,8 +715,28 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -730,6 +805,12 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -779,10 +860,34 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
@@ -799,9 +904,29 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -824,6 +949,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -835,6 +963,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -957,6 +1089,10 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -1074,6 +1210,14 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1103,6 +1247,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1110,6 +1258,18 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1146,6 +1306,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1168,6 +1332,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
@@ -1384,6 +1552,18 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -1397,6 +1577,28 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@chat-adapter/shared@4.29.0':
+    dependencies:
+      chat: 4.29.0
+    transitivePeerDependencies:
+      - ai
+      - supports-color
+      - zod
+
+  '@chat-adapter/slack@4.29.0':
+    dependencies:
+      '@chat-adapter/shared': 4.29.0
+      '@slack/socket-mode': 2.0.7
+      '@slack/web-api': 7.19.0
+      chat: 4.29.0
+    transitivePeerDependencies:
+      - ai
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - zod
 
   '@clack/core@1.2.0':
     dependencies:
@@ -1625,6 +1827,44 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@slack/socket-mode@2.0.7':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/web-api': 7.19.0
+      '@types/node': 22.19.17
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/types@2.22.0': {}
+
+  '@slack/web-api@7.19.0':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.22.0
+      '@types/node': 22.19.17
+      '@types/retry': 0.12.0
+      axios: 1.19.0
+      eventemitter3: 5.0.4
+      form-data: 4.0.6
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1661,7 +1901,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/retry@0.12.0': {}
+
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -1803,6 +2049,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1817,6 +2069,18 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.19.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   bail@2.0.2: {}
 
@@ -1836,6 +2100,11 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   callsites@3.1.0: {}
 
@@ -1868,6 +2137,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -1892,6 +2165,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -1900,7 +2175,28 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2011,6 +2307,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -2051,8 +2351,38 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -2066,7 +2396,26 @@ snapshots:
 
   globals@15.15.0: {}
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -2081,6 +2430,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  is-electron@2.2.2: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2088,6 +2439,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-plain-obj@4.1.0: {}
+
+  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -2176,6 +2529,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -2470,6 +2825,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -2497,6 +2858,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  p-finally@1.0.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -2504,6 +2867,20 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   parent-module@1.0.1:
     dependencies:
@@ -2528,6 +2905,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.2: {}
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -2562,6 +2941,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry@0.13.1: {}
 
   rolldown@1.0.0-rc.15:
     dependencies:
@@ -2748,6 +3129,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.21.3: {}
 
   yaml@2.9.0: {}
 

--- a/scripts/open-a2a-room.ts
+++ b/scripts/open-a2a-room.ts
@@ -1,0 +1,203 @@
+/**
+ * scripts/open-a2a-room.ts — open a Slack agent-to-agent (A2A) room.
+ *
+ * Creates a group DM (MPIM) holding a human plus two or more NanoClaw sibling
+ * bots, posts an intro message from the first bot, prints the channel id, and
+ * appends it to SLACK_A2A_ROOMS in .env so the slack-a2a-rooms bridge filter
+ * starts admitting bot-authored messages there (picked up within ~30s — no
+ * service restart required).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]
+ *
+ * Instance names follow the slack-multi-instance convention: each name reads
+ * its bot token from SLACK_BOT_TOKEN_<NAME> (uppercased, dashes →
+ * underscores); the special name `default` reads SLACK_BOT_TOKEN. The first
+ * listed instance is the caller — it opens the conversation and posts the
+ * intro. Bot user ids are resolved via auth.test per token.
+ *
+ * Requires the `mpim:write` scope on every listed app (see the skill's
+ * prerequisites). Without --user the room holds bots only, which needs at
+ * least three instances (Slack turns a two-party open into a 1:1 IM).
+ *
+ * Token values are never printed.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from '../src/env.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+interface SlackAuth {
+  name: string;
+  envKey: string;
+  token: string;
+  userId: string; // U… bot user id (auth.test user_id)
+  botId: string | null; // B… bot id (auth.test bot_id)
+}
+
+function fail(msg: string): never {
+  console.error(`open-a2a-room: ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): { instances: string[]; user?: string } {
+  let instances: string[] = [];
+  let user: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--instances') {
+      instances = (argv[++i] ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (argv[i] === '--user') {
+      user = argv[++i];
+    } else {
+      fail(
+        `unknown argument: ${argv[i]}\nUsage: pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]`,
+      );
+    }
+  }
+  if (instances.length < 2) fail('--instances needs at least two comma-separated instance names');
+  if (!user && instances.length < 3) {
+    fail(
+      'without --user the room holds bots only, which needs at least three instances (a two-party open becomes a 1:1 IM)',
+    );
+  }
+  if (user && !/^[UW][A-Z0-9]+$/.test(user)) {
+    fail(`--user must be a Slack user id (U…/W…), got: ${user}`);
+  }
+  return { instances, user };
+}
+
+function tokenEnvKey(name: string): string {
+  if (name === 'default') return 'SLACK_BOT_TOKEN';
+  return `SLACK_BOT_TOKEN_${name.toUpperCase().replace(/-/g, '_')}`;
+}
+
+async function slackCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (json.ok !== true) {
+    throw new Error(`${method} failed: ${String(json.error ?? `HTTP ${res.status}`)}`);
+  }
+  return json;
+}
+
+async function resolveAuth(name: string): Promise<SlackAuth> {
+  const envKey = tokenEnvKey(name);
+  const env = readEnvFile([envKey]);
+  const token = env[envKey];
+  if (!token) fail(`missing ${envKey} in .env (slack-multi-instance token convention)`);
+  const auth = await slackCall(token, 'auth.test', {});
+  const userId = typeof auth.user_id === 'string' ? auth.user_id : null;
+  if (!userId) fail(`auth.test for instance "${name}" returned no user_id`);
+  return {
+    name,
+    envKey,
+    token,
+    userId,
+    botId: typeof auth.bot_id === 'string' ? auth.bot_id : null,
+  };
+}
+
+/** Append the room to SLACK_A2A_ROOMS in .env (create the key if absent,
+ * no-op if the id is already listed). */
+function appendRoomToEnv(roomId: string): 'appended' | 'already-present' | 'created' {
+  const envPath = path.join(process.cwd(), '.env');
+  let content = '';
+  try {
+    content = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    // no .env — create one with just this key
+  }
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.trim().startsWith('SLACK_A2A_ROOMS='));
+  if (idx === -1) {
+    const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+    fs.writeFileSync(envPath, `${content}${suffix}SLACK_A2A_ROOMS=${roomId}\n`);
+    return 'created';
+  }
+  const existing = lines[idx].slice(lines[idx].indexOf('=') + 1).trim();
+  const rooms = existing
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (rooms.includes(roomId)) return 'already-present';
+  rooms.push(roomId);
+  lines[idx] = `SLACK_A2A_ROOMS=${rooms.join(',')}`;
+  fs.writeFileSync(envPath, lines.join('\n'));
+  return 'appended';
+}
+
+async function main(): Promise<void> {
+  const { instances, user } = parseArgs(process.argv.slice(2));
+
+  console.log(`Resolving bot identities for: ${instances.join(', ')}`);
+  const auths: SlackAuth[] = [];
+  for (const name of instances) {
+    const auth = await resolveAuth(name);
+    console.log(`  ${name}: bot user ${auth.userId}${auth.botId ? ` (bot id ${auth.botId})` : ''}`);
+    auths.push(auth);
+  }
+
+  const caller = auths[0];
+  const otherBotUserIds = auths.slice(1).map((a) => a.userId);
+  const members = [...(user ? [user] : []), ...otherBotUserIds];
+
+  console.log(`Opening group DM as "${caller.name}" with: ${members.join(', ')}`);
+  const opened = await slackCall(caller.token, 'conversations.open', {
+    users: members.join(','),
+  });
+  const channel = opened.channel as Record<string, unknown> | undefined;
+  const channelId = typeof channel?.id === 'string' ? channel.id : null;
+  if (!channelId) fail('conversations.open returned no channel id');
+  if (channel?.is_mpim !== true) {
+    console.warn(
+      `warning: opened conversation ${channelId} is not an MPIM (is_mpim=${String(channel?.is_mpim)}) — with fewer than three members Slack returns a 1:1 IM`,
+    );
+  }
+
+  const botMentions = otherBotUserIds.map((id) => `<@${id}>`).join(' ');
+  const introText =
+    `:robot_face: Agent-to-agent room opened by "${caller.name}". ` +
+    `${botMentions}${user ? ` <@${user}>` : ''} — bots in this room can hear each other. ` +
+    `Conversation is mention-driven: @-mention a bot to get its reply, and it can @-mention the next one. ` +
+    `After too many consecutive bot messages the room pauses until a human speaks.`;
+  await slackCall(caller.token, 'chat.postMessage', {
+    channel: channelId,
+    text: introText,
+  });
+
+  const envResult = appendRoomToEnv(channelId);
+  console.log('');
+  console.log(`A2A room channel id: ${channelId}`);
+  console.log(
+    envResult === 'already-present'
+      ? 'SLACK_A2A_ROOMS already lists this room — .env unchanged.'
+      : `SLACK_A2A_ROOMS ${envResult === 'created' ? 'created' : 'updated'} in .env — the bridge filter picks it up within ~30s (no restart needed).`,
+  );
+  console.log('');
+  console.log('Next steps (once per room):');
+  console.log(`  - Mention a bot in the room once so the host auto-creates the messaging group,`);
+  console.log(`    then allow bot senders through the access gate, e.g.:`);
+  console.log(
+    `      pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:${channelId}'"`,
+  );
+  console.log(`    (or approve / add the slack:bot:<bot_id> users as members instead of going public).`);
+  console.log(`  - Wire the room to each bot's agent group (ncl messaging-groups / wirings) if not auto-wired.`);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/scripts/slack-agent-flow-finish.ts
+++ b/scripts/slack-agent-flow-finish.ts
@@ -1,0 +1,178 @@
+/**
+ * Finish (or retry) the Slack leg of an agent created via create_agent.
+ *
+ * The in-host slack-agent-flow wrapper points here when the Slack leg fails
+ * partway: re-runs S1–S13 idempotently (provision reuses .env tokens, every
+ * DB row is get-before-create, conversations.open is idempotent on Slack's
+ * side, intro posts are gated on newly-created rows) EXCEPT the S5 hot-add —
+ * a separate process cannot start an adapter inside the live host, so the
+ * new instance comes online via a service restart instead (--restart runs it,
+ * otherwise the command is printed).
+ *
+ * Runs alongside the service the way scripts/init-first-agent.ts does
+ * (WAL-mode sqlite; no channel adapters are connected — the channels barrel
+ * import is registration-only, so declared defaults resolve here).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/slack-agent-flow-finish.ts \
+ *     --group <newAgentGroupId> \
+ *     --name <slug> \
+ *     --source-group <sourceAgentGroupId> \
+ *     [--origin-instance <key>] \   # default: slack
+ *     [--room none] \               # original create used room:'none' — skip the shared room
+ *     [--restart]
+ *
+ * Never prints token values — only key names and ids.
+ */
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+// Registration-only barrel import: channel modules call
+// registerChannelAdapter() at module scope (factories are NOT invoked, no
+// adapter connects), so declared channel defaults resolve here without live
+// adapters.
+import '../src/channels/index.js';
+import { SlackApiError } from '../src/channels/slack-lib.js';
+import { DATA_DIR } from '../src/config.js';
+import { getAgentGroup } from '../src/db/agent-groups.js';
+import { initDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { finishSlackAgentFlow } from '../src/modules/slack-agent-flow/orchestrate.js';
+import { SlackFlowError } from '../src/modules/slack-agent-flow/types.js';
+
+interface Args {
+  group: string;
+  name: string;
+  sourceGroup: string;
+  originInstance: string;
+  restart: boolean;
+  allowGuests: boolean;
+  room?: 'own' | 'none';
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Partial<Args> = {};
+  let restart = false;
+  let allowGuests = false;
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    switch (key) {
+      case '--group':
+        out.group = val;
+        i++;
+        break;
+      case '--name':
+        out.name = val;
+        i++;
+        break;
+      case '--source-group':
+        out.sourceGroup = val;
+        i++;
+        break;
+      case '--origin-instance':
+        out.originInstance = val;
+        i++;
+        break;
+      case '--room': {
+        if (val !== 'own' && val !== 'none') {
+          console.error(`--room must be 'own' or 'none', got "${val}"`);
+          process.exit(2);
+        }
+        out.room = val;
+        i++;
+        break;
+      }
+      case '--restart':
+        restart = true;
+        break;
+      case '--allow-guests':
+        allowGuests = true;
+        break;
+      default:
+        console.error(`Unknown flag: ${key}`);
+        process.exit(2);
+    }
+  }
+  const missing = (['group', 'name', 'sourceGroup'] as const).filter((k) => !out[k]);
+  if (missing.length) {
+    console.error(
+      `Missing required args: ${missing.map((k) => `--${k.replace(/([A-Z])/g, '-$1').toLowerCase()}`).join(', ')}`,
+    );
+    console.error('See scripts/slack-agent-flow-finish.ts header for usage.');
+    process.exit(2);
+  }
+  return {
+    group: out.group!,
+    name: out.name!,
+    sourceGroup: out.sourceGroup!,
+    originInstance: out.originInstance ?? 'slack',
+    restart,
+    allowGuests,
+    room: out.room,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const root = process.cwd();
+
+  const db = await initDb(path.join(DATA_DIR, 'v2.db'));
+  await runMigrations(db); // idempotent
+
+  const newGroup = await getAgentGroup(args.group);
+  if (!newGroup) throw new Error(`agent group ${args.group} not found (--group)`);
+  if (!(await getAgentGroup(args.sourceGroup))) {
+    throw new Error(`agent group ${args.sourceGroup} not found (--source-group)`);
+  }
+
+  const result = await finishSlackAgentFlow({
+    slug: args.name,
+    sourceGroupId: args.sourceGroup,
+    newAgentGroupId: args.group,
+    originInstanceKey: args.originInstance,
+    rootDir: root,
+    allowGuests: args.allowGuests,
+    room: args.room,
+    // A workspace install approval can hold this for minutes; say so rather
+    // than letting the script look hung.
+    onInstallPending: (text) => {
+      console.log('');
+      console.log(text);
+      console.log('Waiting…');
+    },
+  });
+
+  console.log('');
+  console.log('Slack leg complete:');
+  console.log(`  agent     ${newGroup.name} [${args.group}]`);
+  console.log(
+    `  instance  slack-${result.slug} (SLACK_INSTANCES + SLACK_*_TOKEN_${result.slug.toUpperCase().replace(/-/g, '_')})`,
+  );
+  console.log(`  bot       ${result.newBotUserId}`);
+  console.log(`  DM        ${result.dmChannelId} (operator ${result.operatorUserId})`);
+  console.log(
+    result.roomChannelId
+      ? `  room      ${result.roomChannelId} (SLACK_A2A_ROOMS)`
+      : `  room      (skipped — room:'none')`,
+  );
+  console.log('');
+
+  // S5 replacement: the new adapter instance connects on the next service
+  // start — this process cannot hot-add into the live host.
+  if (args.restart) {
+    console.log('Restarting the service so the new instance connects…');
+    execFileSync('bash', [path.join(root, 'setup', 'lib', 'restart.sh')], { cwd: root, stdio: 'inherit' });
+  } else {
+    console.log('Restart the service so the new instance connects: bash setup/lib/restart.sh');
+  }
+}
+
+main().catch((err: unknown) => {
+  if (err instanceof SlackFlowError || err instanceof SlackApiError) {
+    console.error(`slack-agent-flow-finish failed at step '${err.step}': ${err.message}`);
+  } else {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+  process.exit(1);
+});

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -7,3 +7,6 @@
 // self-registration import below.
 
 import './cli.js';
+import './slack.js';
+import './slack-a2a-guard.js';
+import './slack-a2a.js';

--- a/src/channels/slack-a2a-guard.test.ts
+++ b/src/channels/slack-a2a-guard.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for the Slack bot-authored inbound guard.
+ *
+ * The wrap is unit-tested directly (ChannelSetup in → ChannelSetup out, driven
+ * with bridge-shaped inbound fixtures): human pass-through is byte-identical,
+ * bot-authored inbound is dropped by default, and the admission-policy seam's
+ * mechanics (admit / drop / re-attribution / accept-after-downstream) hold.
+ * Allowlist, hop-limit, and attribution *semantics* belong to the
+ * slack-a2a-rooms feature policy and are tested with it, not here.
+ *
+ * Registration note: this branch's bridge predates the inbound-policy seam
+ * (`registerBridgeInboundPolicy`, trunk PR refa-b5-bridge-inbound-policy), so
+ * the module's self-registration is a feature-detected no-op here and the
+ * composed path (SDK dispatch → bridge → policy → host) cannot be driven on
+ * this branch. `registerSlackBotGuard` is pinned against an injected registrar
+ * instead: the guard registers for the `slack` channel type only, which is
+ * what keeps non-Slack adapters untouched. The composed path is covered by
+ * trunk's chat-sdk-bridge-inbound-policy.test.ts and activates automatically
+ * once the seam forward-merges into this branch.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { log } from '../log.js';
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import {
+  botAuthorOf,
+  registerSlackBotGuard,
+  setBotInboundPolicy,
+  wrapSlackBotGuard,
+  type SlackBotInboundContext,
+  type SlackBotInboundDecision,
+} from './slack-a2a-guard.js';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+let nextMessageId = 0;
+
+/** Bridge-shaped inbound fixture (see chat-sdk-bridge.ts messageToInbound). */
+function makeInbound(author: Record<string, unknown>, text = 'hello'): InboundMessage {
+  const id = `msg-${++nextMessageId}`;
+  return {
+    id,
+    kind: 'chat-sdk',
+    content: {
+      id,
+      text,
+      author,
+      senderId: author.userId,
+      sender: author.userName,
+      senderName: author.userName,
+    },
+    timestamp: '2026-01-01T00:00:00.000Z',
+    isMention: false,
+    isGroup: true,
+  };
+}
+
+function humanMessage(text = 'hello'): InboundMessage {
+  return makeInbound({ userId: 'U123', userName: 'human', isBot: false, isMe: false }, text);
+}
+
+function botMessage(botId = 'B0AGENT', text = 'beep'): InboundMessage {
+  return makeInbound({ userId: botId, userName: 'sibling-agent', isBot: true, isMe: false }, text);
+}
+
+interface InboundCall {
+  platformId: string;
+  threadId: string | null;
+  message: InboundMessage;
+}
+
+function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const setup: ChannelSetup = {
+    onInbound:
+      onInbound ??
+      ((platformId, threadId, message) => {
+        calls.push({ platformId, threadId, message });
+      }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { setup, calls };
+}
+
+afterEach(() => {
+  setBotInboundPolicy(null);
+  vi.clearAllMocks();
+});
+
+describe('botAuthorOf', () => {
+  it('returns the bot id for a bot-authored message', () => {
+    expect(botAuthorOf(botMessage('B0FOREIGN'))).toEqual({ botId: 'B0FOREIGN' });
+  });
+
+  it('returns null for a human-authored message', () => {
+    expect(botAuthorOf(humanMessage())).toBeNull();
+  });
+
+  it('returns null when isBot is true but the bot is unattributable (no userId)', () => {
+    expect(botAuthorOf(makeInbound({ isBot: true, userName: 'ghost' }))).toBeNull();
+  });
+
+  it('returns null when content has no author or is not an object', () => {
+    const noAuthor: InboundMessage = { ...humanMessage(), content: { text: 'x' } };
+    expect(botAuthorOf(noAuthor)).toBeNull();
+    const stringContent: InboundMessage = { ...humanMessage(), content: 'just text' };
+    expect(botAuthorOf(stringContent)).toBeNull();
+  });
+});
+
+describe('wrapSlackBotGuard — default (no admission policy)', () => {
+  it('passes human-authored inbound through byte-identical', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const message = humanMessage('untouched');
+    const snapshot = JSON.parse(JSON.stringify(message));
+
+    await wrapped.onInbound('slack:C1', 'slack:C1:T1', message);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].platformId).toBe('slack:C1');
+    expect(calls[0].threadId).toBe('slack:C1:T1');
+    expect(calls[0].message).toBe(message); // same object, not a copy
+    expect(calls[0].message).toEqual(snapshot); // and no field was mutated
+  });
+
+  it('drops bot-authored inbound with a debug log — never reaches the host', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:C1', 'slack:C1:T1', botMessage('B0FOREIGN'));
+
+    expect(calls).toHaveLength(0);
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining('bot-authored inbound dropped'),
+      expect.objectContaining({ botId: 'B0FOREIGN', platformId: 'slack:C1', instanceKey: 'slack' }),
+    );
+  });
+
+  it('leaves the other ChannelSetup members untouched (pass-through references)', () => {
+    const { setup } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    expect(wrapped).not.toBe(setup);
+    expect(wrapped.onInbound).not.toBe(setup.onInbound);
+    expect(wrapped.onInboundEvent).toBe(setup.onInboundEvent);
+    expect(wrapped.onMetadata).toBe(setup.onMetadata);
+    expect(wrapped.onAction).toBe(setup.onAction);
+  });
+});
+
+describe('wrapSlackBotGuard — admission-policy seam', () => {
+  it('consults the policy with full context and admits when it says admit', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack-tester');
+    const seen: SlackBotInboundContext[] = [];
+    setBotInboundPolicy({
+      decideBotInbound(ctx) {
+        seen.push(ctx);
+        return { action: 'admit' };
+      },
+    });
+    const message = botMessage('B0SIBLING');
+
+    await wrapped.onInbound('slack:G7', 'slack:G7:T1', message);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      instanceKey: 'slack-tester',
+      platformId: 'slack:G7',
+      threadId: 'slack:G7:T1',
+      botId: 'B0SIBLING',
+    });
+    expect(seen[0].message).toBe(message);
+    expect(calls).toHaveLength(1);
+    // No senderId in the decision — content is not re-attributed.
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('B0SIBLING');
+  });
+
+  it('re-attributes content.senderId before the host sees the message', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: (ctx) => ({ action: 'admit', senderId: `slack:bot:${ctx.botId}` }),
+    });
+
+    await wrapped.onInbound('slack:G7', null, botMessage('B0SIBLING'));
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('slack:bot:B0SIBLING');
+  });
+
+  it('calls onAccepted only after downstream accepted (resolved without throwing)', async () => {
+    const order: string[] = [];
+    const { setup } = makeSetup(async () => {
+      order.push('downstream');
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'admit', onAccepted: () => order.push('accepted') }),
+    });
+
+    await wrapped.onInbound('slack:G7', null, botMessage());
+
+    expect(order).toEqual(['downstream', 'accepted']);
+  });
+
+  it('does not call onAccepted when downstream throws — the error propagates', async () => {
+    const onAccepted = vi.fn();
+    const { setup } = makeSetup(async () => {
+      throw new Error('router exploded');
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'admit', onAccepted }),
+    });
+
+    await expect(wrapped.onInbound('slack:G7', null, botMessage())).rejects.toThrow('router exploded');
+    expect(onAccepted).not.toHaveBeenCalled();
+  });
+
+  it('drops when the policy says drop', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'drop', reason: 'room not allowlisted' }),
+    });
+
+    await wrapped.onInbound('slack:C1', null, botMessage());
+
+    expect(calls).toHaveLength(0);
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining('dropped by policy'),
+      expect.objectContaining({ reason: 'room not allowlisted' }),
+    );
+  });
+
+  it('fails closed when the policy throws: bot message dropped, warning logged', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => {
+        throw new Error('policy bug');
+      },
+    });
+
+    await expect(wrapped.onInbound('slack:C1', null, botMessage())).resolves.toBeUndefined();
+    expect(calls).toHaveLength(0);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('dropping bot-authored inbound'), expect.anything());
+  });
+
+  it('never consults decideBotInbound for human messages; onHumanInbound observes them', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const decideBotInbound = vi.fn<() => SlackBotInboundDecision>(() => ({ action: 'drop' }));
+    const onHumanInbound = vi.fn();
+    setBotInboundPolicy({ decideBotInbound, onHumanInbound });
+    const message = humanMessage();
+
+    await wrapped.onInbound('slack:C1', 'slack:C1:T1', message);
+
+    expect(decideBotInbound).not.toHaveBeenCalled();
+    expect(onHumanInbound).toHaveBeenCalledWith({
+      instanceKey: 'slack',
+      platformId: 'slack:C1',
+      threadId: 'slack:C1:T1',
+      message,
+    });
+    expect(calls).toHaveLength(1); // observe-only — the human message still passes
+  });
+
+  it('passes human messages through even when the onHumanInbound observer throws', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({
+      decideBotInbound: () => ({ action: 'drop' }),
+      onHumanInbound: () => {
+        throw new Error('observer bug');
+      },
+    });
+
+    await wrapped.onInbound('slack:C1', null, humanMessage());
+
+    expect(calls).toHaveLength(1);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('human message unaffected'), expect.anything());
+  });
+
+  it('clearing the policy (null) restores the default drop', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setBotInboundPolicy({ decideBotInbound: () => ({ action: 'admit' }) });
+    setBotInboundPolicy(null);
+
+    await wrapped.onInbound('slack:C1', null, botMessage());
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('overwriting an installed policy warns (single-provider discipline)', () => {
+    setBotInboundPolicy({ decideBotInbound: () => ({ action: 'drop' }) });
+    expect(log.warn).not.toHaveBeenCalled();
+    setBotInboundPolicy({ decideBotInbound: () => ({ action: 'drop' }) });
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('policy overwritten'));
+  });
+});
+
+describe('registerSlackBotGuard', () => {
+  it("registers the wrap for the 'slack' channel type only — non-Slack bridges stay untouched", () => {
+    const registered: Array<[string, unknown]> = [];
+    registerSlackBotGuard((channelType, wrap) => {
+      registered.push([channelType, wrap]);
+    });
+    expect(registered).toEqual([['slack', wrapSlackBotGuard]]);
+  });
+});

--- a/src/channels/slack-a2a-guard.ts
+++ b/src/channels/slack-a2a-guard.ts
@@ -1,0 +1,233 @@
+/**
+ * Slack bot-authored inbound guard — default drop at the bridge boundary.
+ *
+ * Where bot-authored messages die upstream: neither `@chat-adapter/slack` nor
+ * the Chat SDK core drops a *sibling* bot's messages — the only bot filter in
+ * that stack is `author.isMe` (chat core `handleIncomingMessage`, fed by the
+ * Slack adapter's `isMessageFromSelf`, keyed on this app's own
+ * `bot_id`/`botUserId`). A sibling or foreign bot's message arrives with
+ * `bot_id` set, `isMe: false`, `isBot: true`, flows through the bridge into
+ * the router, and only then dies at the permissions access gate: its sender
+ * resolves to `slack:<bot_id>`, which is never a member, so the messaging
+ * group's `unknown_sender_policy` drops it (and, on the default
+ * `request_approval` policy, spams an approval card). Two bots wired into the
+ * same room can also feed each other into a loop.
+ *
+ * This guard replaces that implicit downstream drop with an explicit one at
+ * the bridge boundary: bot-authored inbound is DROPPED by default, with a
+ * debug log — the safe default every Slack install wants. Human-authored
+ * messages are never touched.
+ *
+ * Extension seam: an optional admission policy (`setBotInboundPolicy`) can
+ * selectively admit bot traffic under its own rules — e.g. the
+ * slack-a2a-rooms skill's allowlist + hop-limit + `slack:bot:<bot_id>`
+ * re-attribution. The policy decides *which* bot messages pass and how they
+ * are attributed; the guard owns the mechanics (default drop, human
+ * pass-through, senderId rewrite, accept accounting). Without a policy,
+ * everything bot-authored is dropped.
+ *
+ * Registration: the guard registers itself for the `slack` channel type via
+ * the bridge's inbound-policy seam (`registerBridgeInboundPolicy`) on barrel
+ * import, so it applies to every Slack bridge instance — and only to Slack.
+ */
+import { log } from '../log.js';
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import * as chatSdkBridge from './chat-sdk-bridge.js';
+
+// ---------------------------------------------------------------------------
+// Bot-author detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the bot author of a bridge-serialized message, or null for human
+ * (or unattributable) messages. Keyed on the Slack event's `bot_id` presence,
+ * which the adapter projects to `author.isBot` / `author.userId` — sibling-bot
+ * messages arrive as plain `message` events with `bot_id` set and subtype
+ * null, so this is the only reliable bot marker.
+ */
+export function botAuthorOf(message: InboundMessage): { botId: string } | null {
+  const content =
+    typeof message.content === 'object' && message.content !== null
+      ? (message.content as Record<string, unknown>)
+      : undefined;
+  const author =
+    content && typeof content.author === 'object' && content.author !== null
+      ? (content.author as Record<string, unknown>)
+      : undefined;
+  if (author?.isBot !== true) return null;
+  const botId = typeof author.userId === 'string' ? author.userId : undefined;
+  return botId ? { botId } : null;
+}
+
+// ---------------------------------------------------------------------------
+// Admission-policy seam (feature-side extension point)
+// ---------------------------------------------------------------------------
+
+/** Inbound context handed to the admission policy. */
+export interface SlackInboundContext {
+  /**
+   * The bridge's registry key (`config.instance ?? 'slack'`). The wrap runs
+   * once per bridge instance, so per-bot-identity policy state keys off this.
+   */
+  instanceKey: string;
+  /** Adapter channel id as the bridge reports it (`slack:C0…`). */
+  platformId: string;
+  threadId: string | null;
+  message: InboundMessage;
+}
+
+/** Bot-authored inbound context — adds the authoring bot's id. */
+export interface SlackBotInboundContext extends SlackInboundContext {
+  /** Slack `bot_id` of the authoring bot (adapter's `author.userId`). */
+  botId: string;
+}
+
+/** Admission decision for one bot-authored inbound message. */
+export type SlackBotInboundDecision =
+  | { action: 'drop'; reason?: string }
+  | {
+      action: 'admit';
+      /**
+       * When set, replaces `content.senderId` before routing (e.g.
+       * `slack:bot:<bot_id>`). The permissions module uses a senderId that
+       * already contains a `:` verbatim (see extractAndUpsertUser), so the
+       * users row becomes distinguishable from human `slack:U…` ids.
+       */
+      senderId?: string;
+      /**
+       * Called only after downstream accepted the message (the host's
+       * onInbound resolved without throwing). Use for accept accounting —
+       * e.g. a hop budget must not be consumed by a message that never
+       * reached a session.
+       */
+      onAccepted?: () => void;
+    };
+
+/**
+ * The narrow surface a feature module (e.g. slack-a2a-rooms) implements to
+ * selectively admit bot traffic. Humans are structurally outside the policy's
+ * power: `onHumanInbound` is observe-only (e.g. to reset hop counters) and
+ * cannot drop or mutate — human pass-through is guaranteed by the guard,
+ * not by policy good behavior.
+ */
+export interface SlackBotInboundPolicy {
+  /** Decide one bot-authored inbound message. A throw is treated as drop. */
+  decideBotInbound(ctx: SlackBotInboundContext): SlackBotInboundDecision;
+  /** Observe a human-authored inbound message. Cannot affect delivery. */
+  onHumanInbound?(ctx: SlackInboundContext): void;
+}
+
+let botInboundPolicy: SlackBotInboundPolicy | null = null;
+
+/**
+ * Install THE admission policy for bot-authored Slack inbound (single
+ * provider — a second installation overwrites with a warning, mirroring the
+ * bridge registry's hook discipline). Pass null to clear and restore the
+ * default drop-everything behavior.
+ */
+export function setBotInboundPolicy(policy: SlackBotInboundPolicy | null): void {
+  if (policy && botInboundPolicy) {
+    log.warn('slack-a2a-guard: bot inbound policy overwritten');
+  }
+  botInboundPolicy = policy;
+}
+
+// ---------------------------------------------------------------------------
+// The ChannelSetup wrap
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a Slack bridge's ChannelSetup so its onInbound applies the bot guard:
+ * human-authored messages pass through byte-identical; bot-authored messages
+ * are dropped unless the installed admission policy admits them. Shaped as a
+ * `BridgeInboundPolicy` — applied once per bridge instance at bridge setup.
+ */
+export function wrapSlackBotGuard(setup: ChannelSetup, instanceKey: string): ChannelSetup {
+  return {
+    ...setup,
+    async onInbound(platformId: string, threadId: string | null, message: InboundMessage) {
+      const bot = botAuthorOf(message);
+
+      if (!bot) {
+        // Human message — pass through untouched. The policy may observe it
+        // (hop-counter resets), but can neither drop nor mutate it.
+        if (botInboundPolicy?.onHumanInbound) {
+          try {
+            botInboundPolicy.onHumanInbound({ instanceKey, platformId, threadId, message });
+          } catch (err) {
+            log.warn('slack-a2a-guard: onHumanInbound observer threw — human message unaffected', {
+              instanceKey,
+              platformId,
+              err,
+            });
+          }
+        }
+        return setup.onInbound(platformId, threadId, message);
+      }
+
+      if (!botInboundPolicy) {
+        log.debug('slack-a2a-guard: bot-authored inbound dropped — no admission policy installed', {
+          instanceKey,
+          platformId,
+          botId: bot.botId,
+        });
+        return;
+      }
+
+      let decision: SlackBotInboundDecision;
+      try {
+        decision = botInboundPolicy.decideBotInbound({ instanceKey, platformId, threadId, message, botId: bot.botId });
+      } catch (err) {
+        // Fail closed: a buggy policy must not fail open into approval spam.
+        log.warn('slack-a2a-guard: admission policy threw — dropping bot-authored inbound', {
+          instanceKey,
+          platformId,
+          botId: bot.botId,
+          err,
+        });
+        return;
+      }
+
+      if (decision.action !== 'admit') {
+        log.debug('slack-a2a-guard: bot-authored inbound dropped by policy', {
+          instanceKey,
+          platformId,
+          botId: bot.botId,
+          reason: decision.reason,
+        });
+        return;
+      }
+
+      if (decision.senderId) {
+        (message.content as Record<string, unknown>).senderId = decision.senderId;
+      }
+      // Report acceptance only after downstream accepted it — a throw in the
+      // host's onInbound must not count a message that never reached a session.
+      const result = await setup.onInbound(platformId, threadId, message);
+      decision.onAccepted?.();
+      return result;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Self-registration (barrel-import side effect)
+// ---------------------------------------------------------------------------
+
+type BridgeInboundPolicyRegistrar = (
+  channelType: string,
+  wrap: (setup: ChannelSetup, instanceKey: string) => ChannelSetup,
+) => void;
+
+/**
+ * Register the guard as THE bridge inbound policy for the `slack` channel
+ * type. Non-Slack bridges are untouched — the bridge applies a policy only to
+ * the channel type it was registered for.
+ */
+export function registerSlackBotGuard(register: BridgeInboundPolicyRegistrar): void {
+  register('slack', wrapSlackBotGuard);
+}
+
+// Registers on import through the bridge's inbound-policy seam (on this
+// branch since the main sync).
+registerSlackBotGuard(chatSdkBridge.registerBridgeInboundPolicy);

--- a/src/channels/slack-a2a.test.ts
+++ b/src/channels/slack-a2a.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Guard for the slack-a2a-rooms admission policy and its registration.
+ *
+ * The skill's one reach-in is the barrel line `import './slack-a2a.js';` in
+ * src/channels/index.ts: importing the module installs the A2A room policy on
+ * the Slack channel layer's bot-inbound guard (setBotInboundPolicy). This
+ * file drives that wiring end-to-end through the REAL guard: it imports the
+ * real channel barrel — never ./slack-a2a.js directly, see the note at the
+ * env-parsing describe — and sends bridge-shaped inbound through
+ * wrapSlackBotGuard, asserting the policy's semantics:
+ *
+ *   - allowlisted rooms admit bot messages re-attributed as slack:bot:<bot_id>
+ *   - non-listed rooms stay dropped; humans pass everywhere, untouched
+ *   - the consecutive-hop limit drops bot messages until a human speaks
+ *   - budgets are tracked per room and per bot identity (bridge instance)
+ *   - a downstream throw does not consume hop budget
+ *
+ * If the barrel line is deleted (or the barrel fails to evaluate), no policy
+ * is installed, the guard's default drop applies, and the admit test goes
+ * red — exactly the composed-install failure this file guards. The guard's
+ * own mechanics (default drop, human byte-identical pass-through, fail-closed
+ * policy errors, non-Slack adapters untouched) are pinned by the channel
+ * payload's slack-a2a-guard.test.ts, not here.
+ *
+ * Config is read from .env (SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS) at first
+ * decision, so the test chdirs into a temp dir carrying a crafted .env BEFORE
+ * importing the barrel. Vitest's per-file process isolation keeps the chdir
+ * and the module cache local to this file. No DB, no Slack.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import { wrapSlackBotGuard } from './slack-a2a-guard.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'slack-a2a-'));
+  writeFileSync(
+    join(dir, '.env'),
+    'SLACK_A2A_ROOMS=G0ALLOW,G0HOPS,G0ROOMA,G0ROOMB,G0INST,G0THROW\nSLACK_A2A_MAX_HOPS=2\n',
+  );
+  process.chdir(dir);
+  await import('./index.js'); // the real barrel — installs the policy via the skill's barrel line
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+interface InboundCall {
+  platformId: string;
+  message: InboundMessage;
+}
+
+function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const setup: ChannelSetup = {
+    onInbound:
+      onInbound ??
+      ((platformId, _threadId, message) => {
+        calls.push({ platformId, message });
+      }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { setup, calls };
+}
+
+let nextMessageId = 0;
+
+/** Bridge-shaped inbound fixture (see chat-sdk-bridge.ts messageToInbound). */
+function makeInbound(author: Record<string, unknown>, text: string): InboundMessage {
+  const id = `msg-${++nextMessageId}`;
+  return {
+    id,
+    kind: 'chat-sdk',
+    content: { id, text, author, senderId: author.userId },
+    timestamp: new Date().toISOString(),
+    isGroup: true,
+  };
+}
+
+function humanMsg(): InboundMessage {
+  return makeInbound({ userId: 'U111', isBot: false, isMe: false }, 'hello');
+}
+
+function botMsg(botId = 'B999'): InboundMessage {
+  return makeInbound({ userId: botId, isBot: true, isMe: false }, 'from a sibling bot');
+}
+
+describe('slack-a2a room policy (registered via the channel barrel)', () => {
+  it('admits allowlisted bot messages re-attributed as slack:bot:<bot_id>', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const msg = botMsg('B42');
+
+    await wrapped.onInbound('slack:G0ALLOW', 'slack:G0ALLOW:171.1', msg);
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('slack:bot:B42');
+  });
+
+  it('drops bot messages for rooms not in SLACK_A2A_ROOMS', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:C0OTHER', null, botMsg());
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes human messages through unchanged — allowlisted room or not', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    const inRoom = humanMsg();
+    await wrapped.onInbound('slack:G0ALLOW', null, inRoom);
+    const outsideRoom = humanMsg();
+    await wrapped.onInbound('slack:C0OTHER', null, outsideRoom);
+
+    expect(calls).toHaveLength(2);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('U111');
+    expect((calls[1].message.content as Record<string, unknown>).senderId).toBe('U111');
+  });
+
+  it('enforces the consecutive-hop limit (SLACK_A2A_MAX_HOPS) and resets on a human message', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0HOPS';
+
+    await wrapped.onInbound(pid, null, botMsg('b1'));
+    await wrapped.onInbound(pid, null, botMsg('b2'));
+    expect(calls).toHaveLength(2);
+
+    // Third consecutive bot message exceeds maxHops=2 — dropped.
+    await wrapped.onInbound(pid, null, botMsg('b3'));
+    expect(calls).toHaveLength(2);
+
+    // A human message passes and resets the counter…
+    await wrapped.onInbound(pid, null, humanMsg());
+    expect(calls).toHaveLength(3);
+
+    // …so bot messages flow again.
+    await wrapped.onInbound(pid, null, botMsg('b4'));
+    expect(calls).toHaveLength(4);
+  });
+
+  it('tracks the hop budget per room', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a1'));
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a2'));
+    expect(calls).toHaveLength(2); // G0ROOMA at its limit (maxHops=2)
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a3'));
+    expect(calls).toHaveLength(2);
+
+    // A different room has its own budget.
+    await wrapped.onInbound('slack:G0ROOMB', null, botMsg('b1'));
+    expect(calls).toHaveLength(3);
+  });
+
+  it('tracks the hop budget per bot identity (bridge instance)', async () => {
+    const a = makeSetup();
+    const b = makeSetup();
+    const wrappedA = wrapSlackBotGuard(a.setup, 'slack');
+    const wrappedB = wrapSlackBotGuard(b.setup, 'slack-dana');
+    const pid = 'slack:G0INST';
+
+    await wrappedA.onInbound(pid, null, botMsg('a1'));
+    await wrappedA.onInbound(pid, null, botMsg('a2'));
+    await wrappedA.onInbound(pid, null, botMsg('a3'));
+    expect(a.calls).toHaveLength(2); // identity A exhausted its budget
+
+    // Identity B in the same room still has a full budget.
+    await wrappedB.onInbound(pid, null, botMsg('b1'));
+    expect(b.calls).toHaveLength(1);
+  });
+
+  it('does not consume hop budget when downstream throws', async () => {
+    let failNext = true;
+    const calls: InboundCall[] = [];
+    const { setup } = makeSetup(async (platformId, _threadId, message) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('router exploded');
+      }
+      calls.push({ platformId, message });
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0THROW';
+
+    // Admitted, but downstream throws — the message never reached a session,
+    // so the budget (maxHops=2) must be untouched.
+    await expect(wrapped.onInbound(pid, null, botMsg('t1'))).rejects.toThrow('router exploded');
+
+    // The full budget of two is still available…
+    await wrapped.onInbound(pid, null, botMsg('t2'));
+    await wrapped.onInbound(pid, null, botMsg('t3'));
+    expect(calls).toHaveLength(2);
+
+    // …and accounting still works: the third accepted hop is over the limit.
+    await wrapped.onInbound(pid, null, botMsg('t4'));
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('env parsing', () => {
+  // Imported dynamically, and only in this describe, which runs AFTER the
+  // behavior tests above: a static (or earlier) import of ./slack-a2a.js
+  // would install the policy as a side effect of this test file itself and
+  // mask a deleted barrel line. Via the barrel the module is already in the
+  // cache, so this import is a no-op read.
+  it('parseRooms splits, trims, and drops empties', async () => {
+    const { parseRooms } = await import('./slack-a2a.js');
+    expect([...parseRooms(' G0A , C0B ,,')]).toEqual(['G0A', 'C0B']);
+    expect(parseRooms(undefined).size).toBe(0);
+  });
+
+  it('parseMaxHops falls back to the default on junk', async () => {
+    const { parseMaxHops, DEFAULT_MAX_HOPS } = await import('./slack-a2a.js');
+    expect(parseMaxHops('4')).toBe(4);
+    expect(parseMaxHops('0')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('-2')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('six')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops(undefined)).toBe(DEFAULT_MAX_HOPS);
+  });
+});

--- a/src/channels/slack-a2a.ts
+++ b/src/channels/slack-a2a.ts
@@ -1,0 +1,135 @@
+/**
+ * Slack agent-to-agent (A2A) rooms — the admission policy for bot-authored
+ * inbound: room allowlist + consecutive-hop limit + `slack:bot:<bot_id>`
+ * re-attribution.
+ *
+ * The Slack channel layer's bot-inbound guard (src/channels/slack-a2a-guard.ts,
+ * installed with the Slack channel) drops every bot-authored inbound message
+ * at the bridge boundary by default — sibling and foreign bots never reach the
+ * router, so they can neither spam unknown-sender approval cards nor feed each
+ * other into loops. The guard exposes a single admission seam
+ * (`setBotInboundPolicy`); this module is that policy:
+ *
+ *   - Rooms allowlisted in `SLACK_A2A_ROOMS` (comma-separated Slack channel
+ *     ids, e.g. the MPIM ids printed by scripts/open-a2a-room.ts): bot-authored
+ *     inbound is admitted, re-attributed with sender id `slack:bot:<bot_id>`,
+ *     under a consecutive-hop limit (`SLACK_A2A_MAX_HOPS`, default 6) that any
+ *     human message in the room resets.
+ *   - Every other room: bot-authored inbound stays dropped (the guard logs the
+ *     drop with this policy's reason).
+ *
+ * Human-authored messages are structurally outside this policy's power: the
+ * guard passes them through untouched and only lets the policy observe them
+ * (for the hop-counter reset).
+ */
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { setBotInboundPolicy, type SlackBotInboundPolicy } from './slack-a2a-guard.js';
+
+export const DEFAULT_MAX_HOPS = 6;
+
+/** How long a read of SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS is cached.
+ * Short enough that a room appended to .env by scripts/open-a2a-room.ts is
+ * picked up without a service restart. */
+const CONFIG_TTL_MS = 30_000;
+
+export interface A2aConfig {
+  /** Raw Slack channel ids (C…/G…) allowed to carry bot-authored inbound. */
+  rooms: Set<string>;
+  /** Consecutive bot-authored inbound messages allowed without a human one. */
+  maxHops: number;
+}
+
+export function parseRooms(raw: string | undefined): Set<string> {
+  return new Set(
+    (raw ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+export function parseMaxHops(raw: string | undefined): number {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_MAX_HOPS;
+}
+
+let cached: { at: number; config: A2aConfig } | null = null;
+
+function readA2aConfig(): A2aConfig {
+  const now = Date.now();
+  if (cached && now - cached.at < CONFIG_TTL_MS) return cached.config;
+  const env = readEnvFile(['SLACK_A2A_ROOMS', 'SLACK_A2A_MAX_HOPS']);
+  cached = {
+    at: now,
+    config: {
+      rooms: parseRooms(env.SLACK_A2A_ROOMS),
+      maxHops: parseMaxHops(env.SLACK_A2A_MAX_HOPS),
+    },
+  };
+  return cached.config;
+}
+
+/** The guard reports the adapter's channel id (`slack:C0…`); the allowlist
+ * holds raw Slack channel ids. */
+function roomFromPlatformId(platformId: string): string {
+  const idx = platformId.indexOf(':');
+  return idx === -1 ? platformId : platformId.slice(idx + 1);
+}
+
+/**
+ * Build the A2A room policy. The hop counter is per bot identity and per room
+ * — keyed on the guard's instanceKey, since each bridge instance is one bot
+ * identity, and a bot's own outbound never arrives here (the SDK drops `isMe`
+ * upstream). With two bots the effective conversation length is therefore
+ * roughly 2×maxHops messages. Any human message in a room resets that room's
+ * counter for the identity that heard it; every co-hosted identity hears the
+ * same human message over its own connection, so the budgets reset together.
+ *
+ * `getConfig` is injectable for tests; production reads .env with a short TTL
+ * cache.
+ */
+export function createA2aRoomPolicy(getConfig: () => A2aConfig = readA2aConfig): SlackBotInboundPolicy {
+  /** Consecutive accepted bot hops, keyed `<instanceKey>:<room>`. */
+  const hops = new Map<string, number>();
+
+  return {
+    decideBotInbound(ctx) {
+      const room = roomFromPlatformId(ctx.platformId);
+      const { rooms, maxHops } = getConfig();
+      if (!rooms.has(room)) {
+        return { action: 'drop', reason: 'room not in SLACK_A2A_ROOMS' };
+      }
+      const key = `${ctx.instanceKey}:${room}`;
+      const count = hops.get(key) ?? 0;
+      if (count >= maxHops) {
+        log.info('slack-a2a: hop limit reached — dropping bot messages until a human speaks', {
+          room,
+          botId: ctx.botId,
+          maxHops,
+        });
+        return { action: 'drop', reason: 'hop limit reached' };
+      }
+      return {
+        action: 'admit',
+        // The permissions module uses a senderId that already contains a ':'
+        // verbatim (see extractAndUpsertUser), so the users row becomes
+        // `slack:bot:<bot_id>` — distinguishable from human `slack:U…` ids.
+        senderId: `slack:bot:${ctx.botId}`,
+        // The guard fires this only after downstream accepted the message —
+        // a throw in the host's onInbound must not consume budget for a
+        // message that never reached a session.
+        onAccepted: () => hops.set(key, count + 1),
+      };
+    },
+    onHumanInbound(ctx) {
+      // Human message — reset this identity's hop counter for the room.
+      hops.delete(`${ctx.instanceKey}:${roomFromPlatformId(ctx.platformId)}`);
+    },
+  };
+}
+
+// Install the policy on the channel layer's guard (single provider — the
+// guard warns if another policy was already installed). Runs on barrel
+// import, like every channel module's self-registration.
+setBotInboundPolicy(createA2aRoomPolicy());

--- a/src/channels/slack-instances-registration.test.ts
+++ b/src/channels/slack-instances-registration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guard for the native SLACK_INSTANCES registrations (slack.ts).
+ *
+ * Integration points under guard:
+ *  1. The barrel reach-in — `import './slack.js';` in src/channels/index.ts.
+ *     Importing the real barrel must run slack.ts's top-level SLACK_INSTANCES
+ *     loop; if the import line is deleted, or the barrel fails to evaluate
+ *     (e.g. @chat-adapter/slack uninstalled), the instance keys are absent
+ *     and this goes red.
+ *  2. The shared declaration — every `slack-<name>` registration must carry
+ *     the same SLACK_DEFAULTS declaration as the default Slack app (declared
+ *     defaults, not the core fallback). hasDeclaredChannelDefaults()
+ *     distinguishes a declared entry from fallbackChannelDefaults(), and
+ *     `group.threads === true` is the field where the two differ with no
+ *     live adapter (fallback resolves threads to false).
+ *  3. The shared factory — the per-name factory delegates to
+ *     createSlackBridge, whose credential path is driven for real here: with
+ *     no SLACK_BOT_TOKEN_<NAME> in .env the factory returns null (the
+ *     registry's "credentials missing, skipping" path). The non-null leg —
+ *     the typed createSlackBridge({envKeySuffix, instanceKey}) call — is
+ *     guarded by the build, which fails if the factory export or its options
+ *     shape drifts.
+ *
+ * SLACK_INSTANCES is read from `.env` at module import (readEnvFile reads
+ * process.cwd()/.env, never process.env), so the test chdirs into a temp dir
+ * carrying a crafted .env BEFORE dynamically importing the barrel. Vitest's
+ * per-file process isolation keeps the chdir and the module cache local to
+ * this file.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { getChannelDefaults, getRegisteredChannelNames, hasDeclaredChannelDefaults } from './channel-registry.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'slack-instances-'));
+  writeFileSync(join(dir, '.env'), 'SLACK_INSTANCES=alpha,gh-bot\n');
+  process.chdir(dir);
+  await import('./index.js'); // the real barrel — triggers every channel's self-registration
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+describe('slack multi-instance registration', () => {
+  it('registers a slack-<name> adapter per SLACK_INSTANCES entry via the channel barrel', () => {
+    const names = getRegisteredChannelNames();
+    expect(names).toContain('slack-alpha');
+    expect(names).toContain('slack-gh-bot');
+    // The default app's registration is untouched.
+    expect(names).toContain('slack');
+  });
+
+  it("every instance registration declares the default app's SLACK_DEFAULTS (not the core fallback)", () => {
+    for (const key of ['slack-alpha', 'slack-gh-bot']) {
+      expect(hasDeclaredChannelDefaults(key)).toBe(true);
+      const defaults = getChannelDefaults(key);
+      // One declaration, shared with the default app — a drifting private
+      // copy of the defaults would fail this even with equal-looking fields
+      // elsewhere.
+      expect(defaults).toEqual(getChannelDefaults('slack'));
+      // group.threads true is SLACK_DEFAULTS; the no-live-adapter fallback
+      // would resolve threads:false. Engagement fields ride along.
+      expect(defaults.group.threads).toBe(true);
+      expect(defaults.group.engageMode).toBe('mention-sticky');
+      expect(defaults.dm).toMatchObject({ engageMode: 'pattern', engagePattern: '.', threads: false });
+      expect(defaults.mentions).toBe('platform');
+    }
+  });
+});
+
+describe('instance factory (via the shared createSlackBridge)', () => {
+  // Imported dynamically, and only in this describe, which runs AFTER the
+  // registration tests above: a static import of ./slack.js would run the
+  // registration loop as a side effect of this test file itself (with the
+  // original cwd's .env) and mask a deleted barrel line. Via the barrel the
+  // module is already in the cache, so this import is a no-op read.
+  it('returns null when the instance token set is absent — the registry "credentials missing" path', async () => {
+    const { slackInstanceBridgeFactory } = await import('./slack.js');
+    // No SLACK_BOT_TOKEN_ALPHA in the temp .env: the shared factory must
+    // report missing credentials rather than construct a token-less bridge.
+    expect(slackInstanceBridgeFactory('alpha')).toBeNull();
+  });
+
+  it('maps an instance name to its env-key suffix (uppercased, dashes → underscores)', async () => {
+    const { instanceEnvKeySuffix } = await import('./slack.js');
+    expect(instanceEnvKeySuffix('gh-bot')).toBe('GH_BOT');
+    expect(instanceEnvKeySuffix('dana')).toBe('DANA');
+  });
+});

--- a/src/channels/slack-lib.test.ts
+++ b/src/channels/slack-lib.test.ts
@@ -1,0 +1,255 @@
+/**
+ * slack-lib — request/error shaping of the shared fetch-based Web API client
+ * and the per-instance bot-token env-key convention.
+ *
+ * Pinned invariants: Slack's error strings surface in thrown messages; token
+ * values never do (Authorization header is the only place a token travels).
+ * All fetches are mocked — no live Slack calls.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  botTokenKeyForInstance,
+  SlackApiError,
+  slackAuthTest,
+  slackCall,
+  slackConversationsInfo,
+  slackConversationsMembers,
+  slackConversationsOpen,
+  slackPostMessage,
+} from './slack-lib.js';
+
+const TOKEN = 'xoxb-secret-test-token-value';
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function mockFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
+  const fn = vi.fn(impl as (...args: unknown[]) => Promise<Response>);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+async function captureError(promise: Promise<unknown>): Promise<SlackApiError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(SlackApiError);
+    return err as SlackApiError;
+  }
+  throw new Error('expected the call to throw');
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('slackCall request shaping', () => {
+  it('POSTs the method to slack.com/api with a JSON body, bearer token, and a timeout signal', async () => {
+    const fetchMock = mockFetch(async () => jsonResponse({ ok: true, stuff: 1 }));
+
+    const json = await slackCall(TOKEN, 'chat.postMessage', { channel: 'C1', text: 'hi' }, 'my-step');
+
+    expect(json).toMatchObject({ ok: true, stuff: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+    expect((init.headers as Record<string, string>)['Content-Type']).toContain('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({ channel: 'C1', text: 'hi' });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('slackCall error shaping', () => {
+  it("surfaces Slack's error string with the method and step — never the token", async () => {
+    mockFetch(async () => jsonResponse({ ok: false, error: 'channel_not_found' }));
+
+    const err = await captureError(slackCall(TOKEN, 'conversations.info', { channel: 'C9' }, 'room-lookup'));
+
+    expect(err.name).toBe('SlackApiError');
+    expect(err.step).toBe('room-lookup');
+    expect(err.message).toBe('slack conversations.info failed: channel_not_found');
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it('falls back to the HTTP status when ok:false carries no error string', async () => {
+    mockFetch(async () => jsonResponse({ ok: false }, 429));
+
+    const err = await captureError(slackCall(TOKEN, 'auth.test', {}, 's'));
+
+    expect(err.message).toBe('slack auth.test failed: HTTP 429');
+  });
+
+  it('wraps fetch-level failures (network error / timeout abort) without leaking the token', async () => {
+    mockFetch(async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    });
+
+    const err = await captureError(slackCall(TOKEN, 'auth.test', {}, 'origin-auth'));
+
+    expect(err.step).toBe('origin-auth');
+    expect(err.message).toBe('slack auth.test failed: The operation was aborted due to timeout');
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it('reports non-JSON bodies as HTTP <status>, non-JSON body', async () => {
+    mockFetch(async () => new Response('<html>bad gateway</html>', { status: 502 }));
+
+    const err = await captureError(slackCall(TOKEN, 'chat.postMessage', { channel: 'C1' }, 's'));
+
+    expect(err.message).toBe('slack chat.postMessage failed: HTTP 502, non-JSON body');
+  });
+});
+
+describe('slackAuthTest', () => {
+  it('maps user_id/team_id/team/url from the response', async () => {
+    mockFetch(async () =>
+      jsonResponse({ ok: true, user_id: 'U123', team_id: 'T456', team: 'acme', url: 'https://acme.slack.com/' }),
+    );
+
+    await expect(slackAuthTest(TOKEN, 's')).resolves.toEqual({
+      userId: 'U123',
+      teamId: 'T456',
+      team: 'acme',
+      url: 'https://acme.slack.com/',
+    });
+  });
+
+  it('throws when the response has no user_id', async () => {
+    mockFetch(async () => jsonResponse({ ok: true }));
+
+    const err = await captureError(slackAuthTest(TOKEN, 'origin-auth'));
+
+    expect(err.step).toBe('origin-auth');
+    expect(err.message).toBe('slack auth.test failed: no user_id in response');
+  });
+});
+
+describe('slackConversationsOpen', () => {
+  it('joins user ids with commas and returns the channel id', async () => {
+    const fetchMock = mockFetch(async () => jsonResponse({ ok: true, channel: { id: 'D777' } }));
+
+    await expect(slackConversationsOpen(TOKEN, ['U1', 'U2', 'U3'], 's')).resolves.toBe('D777');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ users: 'U1,U2,U3' });
+  });
+
+  it('throws when the response has no channel id', async () => {
+    mockFetch(async () => jsonResponse({ ok: true, channel: {} }));
+
+    const err = await captureError(slackConversationsOpen(TOKEN, ['U1'], 'dm-open'));
+
+    expect(err.step).toBe('dm-open');
+    expect(err.message).toBe('slack conversations.open failed: no channel id in response');
+  });
+});
+
+describe('slackPostMessage', () => {
+  it('posts channel and text', async () => {
+    const fetchMock = mockFetch(async () => jsonResponse({ ok: true }));
+
+    await slackPostMessage(TOKEN, 'C1', 'hello there');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    expect(JSON.parse(init.body as string)).toEqual({ channel: 'C1', text: 'hello there' });
+  });
+
+  it('tags failures with the generic default step unless the caller passes one', async () => {
+    mockFetch(async () => jsonResponse({ ok: false, error: 'not_in_channel' }));
+
+    const defaulted = await captureError(slackPostMessage(TOKEN, 'C1', 'x'));
+    expect(defaulted.step).toBe('post-message');
+
+    mockFetch(async () => jsonResponse({ ok: false, error: 'not_in_channel' }));
+    const explicit = await captureError(slackPostMessage(TOKEN, 'C1', 'x', 'welcome-post'));
+    expect(explicit.step).toBe('welcome-post');
+  });
+});
+
+describe('slackConversationsInfo', () => {
+  it('classifies MPIMs and passes name/creator through', async () => {
+    mockFetch(async () =>
+      jsonResponse({ ok: true, channel: { is_mpim: true, name: 'mpdm-a--b--c-1', creator: 'U1' } }),
+    );
+
+    await expect(slackConversationsInfo(TOKEN, 'G123', 's')).resolves.toEqual({
+      isMpim: true,
+      name: 'mpdm-a--b--c-1',
+      creator: 'U1',
+    });
+  });
+
+  it('defaults isMpim to false and omits absent fields', async () => {
+    mockFetch(async () => jsonResponse({ ok: true, channel: {} }));
+
+    await expect(slackConversationsInfo(TOKEN, 'C123', 's')).resolves.toEqual({
+      isMpim: false,
+      name: undefined,
+      creator: undefined,
+    });
+  });
+});
+
+describe('slackConversationsMembers', () => {
+  it('follows next_cursor pagination and concatenates string member ids', async () => {
+    const pages = [
+      jsonResponse({ ok: true, members: ['U1', 'U2', 42], response_metadata: { next_cursor: 'cur2' } }),
+      jsonResponse({ ok: true, members: ['U3'], response_metadata: { next_cursor: '' } }),
+    ];
+    const fetchMock = mockFetch(async () => {
+      const page = pages.shift();
+      if (!page) throw new Error('unexpected extra page fetch');
+      return page;
+    });
+
+    await expect(slackConversationsMembers(TOKEN, 'G1', 's')).resolves.toEqual(['U1', 'U2', 'U3']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const secondBody = JSON.parse((fetchMock.mock.calls[1] as [string, RequestInit])[1].body as string);
+    expect(firstBody).toEqual({ channel: 'G1', limit: 200 });
+    expect(secondBody).toEqual({ channel: 'G1', limit: 200, cursor: 'cur2' });
+  });
+
+  it('stops at the page cap even if Slack keeps returning cursors', async () => {
+    const fetchMock = mockFetch(async () =>
+      jsonResponse({ ok: true, members: ['U1'], response_metadata: { next_cursor: 'again' } }),
+    );
+
+    const members = await slackConversationsMembers(TOKEN, 'G1', 's');
+
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+    expect(members).toHaveLength(10);
+  });
+});
+
+describe('botTokenKeyForInstance', () => {
+  it('maps the default instance to SLACK_BOT_TOKEN', () => {
+    expect(botTokenKeyForInstance('slack')).toBe('SLACK_BOT_TOKEN');
+  });
+
+  it('strips a leading slack- prefix and uppercases the remainder', () => {
+    expect(botTokenKeyForInstance('slack-zulu')).toBe('SLACK_BOT_TOKEN_ZULU');
+  });
+
+  it('normalizes dashes to underscores', () => {
+    expect(botTokenKeyForInstance('slack-growth-bot')).toBe('SLACK_BOT_TOKEN_GROWTH_BOT');
+  });
+
+  it('normalizes case', () => {
+    expect(botTokenKeyForInstance('slack-Zulu')).toBe('SLACK_BOT_TOKEN_ZULU');
+  });
+
+  it('handles keys without the slack- prefix', () => {
+    expect(botTokenKeyForInstance('ops-bot')).toBe('SLACK_BOT_TOKEN_OPS_BOT');
+  });
+
+  it('strips only the leading slack- prefix, not interior occurrences', () => {
+    expect(botTokenKeyForInstance('slack-slack-two')).toBe('SLACK_BOT_TOKEN_SLACK_TWO');
+  });
+});

--- a/src/channels/slack-lib.ts
+++ b/src/channels/slack-lib.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared Slack channel-layer library — the minimal fetch-based Slack Web API
+ * client plus the per-instance bot-token .env key convention. Channel-layer
+ * modules import Slack HTTP plumbing from here so it has exactly one home
+ * (and so nothing in the channel layer reaches into feature modules for it).
+ *
+ * Failures become SlackApiError(step, `slack ${method} failed: ${error}`),
+ * where `step` is a caller-supplied context tag naming where in the caller's
+ * flow the call happened — callers with typed step ids pass them through
+ * (any string union narrows to string).
+ *
+ * Slack's error strings are safe to surface; token values never are — tokens
+ * travel only in the Authorization header and are never interpolated into
+ * messages or logs.
+ */
+
+const SLACK_API = 'https://slack.com/api';
+
+/**
+ * Typed failure for Slack Web API calls. `step` is the caller's context tag
+ * for the call site. `message` MUST never contain a token value.
+ */
+export class SlackApiError extends Error {
+  constructor(
+    readonly step: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SlackApiError';
+  }
+}
+
+/**
+ * POST one Web API method with a JSON body. Returns the parsed response when
+ * `ok: true`; throws SlackApiError otherwise (network failure, timeout,
+ * non-JSON body, or a Slack-side error string).
+ */
+export async function slackCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+  step: string,
+): Promise<Record<string, unknown>> {
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API}/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new SlackApiError(step, `slack ${method} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  let json: Record<string, unknown>;
+  try {
+    json = (await res.json()) as Record<string, unknown>;
+  } catch {
+    throw new SlackApiError(step, `slack ${method} failed: HTTP ${res.status}, non-JSON body`);
+  }
+  if (json.ok !== true) {
+    throw new SlackApiError(step, `slack ${method} failed: ${String(json.error ?? `HTTP ${res.status}`)}`);
+  }
+  return json;
+}
+
+/** auth.test — the calling bot's own identity. `url` is the workspace URL
+ *  (`https://<domain>.slack.com/`) — canvas permalinks hang off it. */
+export async function slackAuthTest(
+  token: string,
+  step: string,
+): Promise<{ userId: string; teamId?: string; team?: string; url?: string }> {
+  const json = await slackCall(token, 'auth.test', {}, step);
+  const userId = typeof json.user_id === 'string' ? json.user_id : null;
+  if (!userId) throw new SlackApiError(step, 'slack auth.test failed: no user_id in response');
+  return {
+    userId,
+    teamId: typeof json.team_id === 'string' ? json.team_id : undefined,
+    team: typeof json.team === 'string' ? json.team : undefined,
+    url: typeof json.url === 'string' ? json.url : undefined,
+  };
+}
+
+/**
+ * conversations.open — one user id opens (or fetches) the 1:1 IM; two or
+ * more open an MPIM. Idempotent on Slack's side. Returns the channel id.
+ */
+export async function slackConversationsOpen(token: string, userIds: string[], step: string): Promise<string> {
+  const json = await slackCall(token, 'conversations.open', { users: userIds.join(',') }, step);
+  const channel = json.channel as Record<string, unknown> | undefined;
+  const channelId = typeof channel?.id === 'string' ? channel.id : null;
+  if (!channelId) throw new SlackApiError(step, 'slack conversations.open failed: no channel id in response');
+  return channelId;
+}
+
+/** chat.postMessage — plain-text post into a channel, DM, or MPIM. */
+export async function slackPostMessage(
+  token: string,
+  channel: string,
+  text: string,
+  step = 'post-message',
+): Promise<void> {
+  await slackCall(token, 'chat.postMessage', { channel, text }, step);
+}
+
+/**
+ * conversations.info — minimal channel classification: is this an MPIM
+ * (group DM), and what is it called?
+ */
+export async function slackConversationsInfo(
+  token: string,
+  channelId: string,
+  step: string,
+): Promise<{ isMpim: boolean; name?: string; creator?: string }> {
+  const json = await slackCall(token, 'conversations.info', { channel: channelId }, step);
+  const channel = json.channel as Record<string, unknown> | undefined;
+  return {
+    isMpim: channel?.is_mpim === true,
+    name: typeof channel?.name === 'string' ? channel.name : undefined,
+    creator: typeof channel?.creator === 'string' ? channel.creator : undefined,
+  };
+}
+
+/**
+ * conversations.members — the channel's full member set (user ids, bots
+ * included). Cursor-paginated; the page cap bounds pathological channels —
+ * membership comparisons only run over small rooms (MPIMs are ≤9 members).
+ */
+export async function slackConversationsMembers(token: string, channelId: string, step: string): Promise<string[]> {
+  const members: string[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < 10; page++) {
+    const json = await slackCall(
+      token,
+      'conversations.members',
+      { channel: channelId, limit: 200, ...(cursor ? { cursor } : {}) },
+      step,
+    );
+    for (const m of (json.members as unknown[] | undefined) ?? []) {
+      if (typeof m === 'string') members.push(m);
+    }
+    const meta = json.response_metadata as { next_cursor?: string } | undefined;
+    cursor = meta?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+  return members;
+}
+
+/** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix shape. */
+function envSuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * .env bot-token key for an adapter-instance key. The default instance
+ * ('slack') maps to SLACK_BOT_TOKEN; any other instance key maps to
+ * SLACK_BOT_TOKEN_<NAME> with a leading 'slack-' prefix stripped and the
+ * remainder uppercased with dashes as underscores (the same suffix shape
+ * multi-instance registration writes). Returns the key name only — reading
+ * the value stays with the caller.
+ */
+export function botTokenKeyForInstance(instanceKey: string): string {
+  if (instanceKey === 'slack') return 'SLACK_BOT_TOKEN';
+  return `SLACK_BOT_TOKEN_${envSuffix(instanceKey.replace(/^slack-/, ''))}`;
+}

--- a/src/channels/slack-registration.test.ts
+++ b/src/channels/slack-registration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Integration test for the slack channel's single reach-in: the self-registration
+ * import in the `src/channels/index.ts` barrel. Importing the barrel runs slack.ts's
+ * top-level `registerChannelAdapter('slack', …)`; without the import the channel is
+ * silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. This reflects what happens at host boot — if the
+ * `import './slack.js';` line is deleted, or the barrel fails to evaluate for any
+ * reason (so the channel genuinely would not register), this goes red. A structural
+ * check of the import line would falsely pass in that second case.
+ *
+ * Importing the barrel is safe: registration is a pure top-level call, and slack.ts
+ * builds the SDK adapter / bridge only inside its factory (invoked at host startup),
+ * never at import. It does require the adapter package to be installed, which holds
+ * in a composed install: the skill's `pnpm install` step runs before this test.
+ *
+ * Note on the Chat SDK family: slack.ts also consumes a load-bearing *core* API —
+ * `createChatSdkBridge(...)` from ./chat-sdk-bridge.js — with a specific options
+ * shape. That core-consumption is a typed call, so the build/typecheck leg
+ * (`pnpm run build`) guards it against upstream drift, not this test. Every Chat SDK
+ * channel (discord, telegram, teams, gchat, webex, …) follows this same shape:
+ * swap the channel name below and the adapter package in the build.
+ *
+ * This file also covers resolveSlackConversation — the adapter-level
+ * conversation classifier (direct / group_dm / channel) that consumers like
+ * approval cards render from. It is a pure function over an injected
+ * SlackAdapter, so it is driven here with mocks; no live API is touched.
+ */
+import type { SlackAdapter } from '@chat-adapter/slack';
+import { describe, it, expect, vi } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import { resolveSlackConversation } from './slack.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('slack channel registration', () => {
+  it('registers slack via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('slack');
+  });
+});
+
+describe('resolveSlackConversation', () => {
+  it('preserves direct messages, channel names, and the API-failure fallback', async () => {
+    const fetchThread = vi
+      .fn()
+      .mockResolvedValueOnce({ channelName: 'general', metadata: { channel: {} } })
+      .mockRejectedValueOnce(new Error('slack unavailable'));
+    const adapter = { fetchThread } as unknown as SlackAdapter;
+
+    await expect(resolveSlackConversation(adapter, 'slack:D123')).resolves.toEqual({
+      type: 'direct',
+      name: null,
+    });
+    expect(fetchThread).not.toHaveBeenCalled();
+    await expect(resolveSlackConversation(adapter, 'C123')).resolves.toEqual({
+      type: 'channel',
+      name: 'general',
+    });
+    expect(fetchThread).toHaveBeenLastCalledWith('slack:C123');
+    // API failure resolves null so the caller falls through to its generic rendering.
+    await expect(resolveSlackConversation(adapter, 'slack:C456')).resolves.toBeNull();
+  });
+
+  it('carries no participant arrays on direct and channel results', async () => {
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({ channelName: 'general', metadata: { channel: {} } }),
+    } as unknown as SlackAdapter;
+
+    const direct = await resolveSlackConversation(adapter, 'slack:D123');
+    expect(direct).not.toHaveProperty('participantNames');
+    expect(direct).not.toHaveProperty('participantIds');
+    const channel = await resolveSlackConversation(adapter, 'slack:C123');
+    expect(channel).not.toHaveProperty('participantNames');
+    expect(channel).not.toHaveProperty('participantIds');
+  });
+
+  it('resolves MPDM human participants and keeps the type when member lookup fails', async () => {
+    const members = vi
+      .fn()
+      .mockResolvedValueOnce({ members: ['U1', 'U2', 'UBOT'] })
+      .mockRejectedValueOnce(new Error('missing scope'));
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({
+        channelName: 'mpdm-avital--omri--avi-1',
+        metadata: { channel: { is_mpim: true } },
+      }),
+      webClient: { conversations: { members } },
+      getUser: vi.fn(async (id: string) => ({
+        userName: id === 'U1' ? 'Avital' : id === 'U2' ? 'Omri' : 'Avi',
+        fullName: id,
+        isBot: id === 'UBOT',
+        userId: id,
+      })),
+    } as unknown as SlackAdapter;
+
+    await expect(resolveSlackConversation(adapter, 'slack:G123')).resolves.toEqual({
+      type: 'group_dm',
+      name: null,
+      participantNames: ['Avital', 'Omri'],
+      participantIds: ['U1', 'U2'],
+    });
+    expect(members).toHaveBeenCalledWith({ channel: 'G123', limit: 100 });
+    await expect(resolveSlackConversation(adapter, 'G123')).resolves.toEqual({
+      type: 'group_dm',
+      name: null,
+    });
+  });
+
+  // participantIds must be raw Slack ids ("U…"), same length and same order
+  // as participantNames, with bots removed from BOTH arrays. A consumer
+  // pairing the arrays positionally (e.g. excluding one participant by id)
+  // breaks silently on a one-sided filter, so the invariant is pinned here.
+  it('keeps participantIds parallel to participantNames when bots are filtered', async () => {
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({ metadata: { channel: { is_mpim: true } } }),
+      webClient: {
+        conversations: {
+          members: vi.fn().mockResolvedValue({ members: ['UBOT1', 'U1', 'UBOT2', 'U2', 'U3'] }),
+        },
+      },
+      getUser: vi.fn(async (id: string) => ({
+        userName: `name-${id}`,
+        fullName: id,
+        isBot: id.startsWith('UBOT'),
+        userId: id,
+      })),
+    } as unknown as SlackAdapter;
+
+    const resolved = await resolveSlackConversation(adapter, 'slack:G777');
+    expect(resolved?.type).toBe('group_dm');
+    expect(resolved?.participantNames).toEqual(['name-U1', 'name-U2', 'name-U3']);
+    expect(resolved?.participantIds).toEqual(['U1', 'U2', 'U3']);
+    expect(resolved?.participantIds).toHaveLength(resolved?.participantNames?.length ?? -1);
+  });
+
+  it('drops a participant whose profile lookup fails from BOTH arrays', async () => {
+    const adapter = {
+      fetchThread: vi.fn().mockResolvedValue({ metadata: { channel: { is_mpim: true } } }),
+      webClient: {
+        conversations: { members: vi.fn().mockResolvedValue({ members: ['U1', 'UGONE', 'U3'] }) },
+      },
+      // UGONE's profile lookup fails (deactivated user / users:read gap) —
+      // getUser resolves null. The member must vanish from names AND ids
+      // together, never from just one array.
+      getUser: vi.fn(async (id: string) =>
+        id === 'UGONE' ? null : { userName: `name-${id}`, fullName: id, isBot: false, userId: id },
+      ),
+    } as unknown as SlackAdapter;
+
+    const resolved = await resolveSlackConversation(adapter, 'slack:G888');
+    expect(resolved).toEqual({
+      type: 'group_dm',
+      name: null,
+      participantNames: ['name-U1', 'name-U3'],
+      participantIds: ['U1', 'U3'],
+    });
+  });
+});

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -1,0 +1,236 @@
+/**
+ * Slack channel adapter (v2) — uses Chat SDK bridge.
+ * Self-registers on import.
+ *
+ * Socket Mode opt-in: set SLACK_APP_TOKEN (xapp-…) to receive events over an
+ * outbound WebSocket instead of an inbound HTTPS webhook.
+ *
+ * Additional bot identities in the same workspace: set
+ * SLACK_INSTANCES=<name>[,<name>…] plus a per-instance token set
+ * (SLACK_BOT_TOKEN_<NAME> / SLACK_APP_TOKEN_<NAME> /
+ * SLACK_SIGNING_SECRET_<NAME>; name uppercased, dashes → underscores). Each
+ * name registers under the `slack-<name>` instance key through the same
+ * createSlackBridge factory as the default app — no mirrored construction.
+ * channelType stays 'slack' either way, so user ids, formatting, container
+ * config, and the wiring-defaults declaration are shared across instances.
+ */
+import { createSlackAdapter, type SlackAdapter } from '@chat-adapter/slack';
+
+import { readEnvFile } from '../env.js';
+import type { ChannelAdapter, ChannelContextDefaults, ChannelDefaults } from './adapter.js';
+import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import { registerChannelAdapter } from './channel-registry.js';
+
+/**
+ * Dedicated bot app on a threaded platform. group threads:true keeps
+ * mention-sticky bounded — engagement sticks per-thread, not forever.
+ * dm.threads:false is a deliberate policy choice, not a capability limit:
+ * Slack users can open sub-threads inside a DM, but by default the agent
+ * replies top-level and all DM sub-threads collapse into the one DM session.
+ * This declaration owns that judgment (it used to be hardcoded router
+ * behavior); operators who want in-thread DM replies override per wiring
+ * with `--threads true`.
+ *
+ * Agent-DM anchors (the settled Slack DM shape) — creation-time stamps, so
+ * they apply to wirings/rows created from this declaration onward and never
+ * flip existing installs:
+ * - dm.sessionMode 'per-thread': Slack's agent-mode DM surface materializes
+ *   a thread per conversation, so a new DM wiring roots a session per thread.
+ *   resolveWiringDefaults derives the threads=1 stamp from this at creation
+ *   (per-thread sessions structurally require honored thread ids — no
+ *   separate field to declare). The live inherit value dm.threads stays
+ *   false, so wirings created earlier (threads column NULL) keep collapsing
+ *   DM sub-threads into the one DM session.
+ * - dm.unknownSenderPolicy 'decline_notify': an unknown DM sender gets a
+ *   polite decline and the owner a one-line FYI — no approval card; access
+ *   grants stay explicit (`ncl members add`). A deliberate, reviewed default
+ *   change for Slack DM rows auto-created after this lands.
+ */
+export const SLACK_DEFAULTS: ChannelDefaults = {
+  dm: {
+    engageMode: 'pattern',
+    engagePattern: '.',
+    threads: false,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'decline_notify',
+  },
+  group: {
+    engageMode: 'mention-sticky',
+    threads: true,
+    // D29: group conversations are per-thread too — Slack channels
+    // materialize a thread per top-level message, and ambient context
+    // (same-mg fan + channel-timeline backfill) is the continuity layer.
+    // Creation-time stamp like dm.sessionMode; existing wirings never flip.
+    // Canvas-comment shadow channels deliberately stay shared (wired
+    // explicitly in room-canvas, the documented D29 exception).
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'request_approval',
+  },
+  mentions: 'platform',
+};
+
+/**
+ * Classify a Slack conversation for consumers that render it to a human
+ * (e.g. approval cards): a 1:1 DM, a group DM (MPDM), or a channel. Channels
+ * resolve their name; MPDMs resolve their human participants through the
+ * calling bot's own authenticated client. Returns null when the Slack API
+ * can't classify the conversation (network failure, missing scope) so the
+ * caller falls through to its generic rendering.
+ */
+export async function resolveSlackConversation(
+  slackAdapter: SlackAdapter,
+  platformId: string,
+): Promise<{
+  type: 'direct' | 'group_dm' | 'channel';
+  name: string | null;
+  participantNames?: string[];
+  participantIds?: string[];
+} | null> {
+  const channelId = platformId.replace(/^slack:/, '').split(':')[0];
+  if (channelId.startsWith('D')) return { type: 'direct', name: null };
+
+  try {
+    const info = await slackAdapter.fetchThread(`slack:${channelId}`);
+    const channel = (info.metadata as { channel?: { is_mpim?: boolean } }).channel;
+    if (!channel?.is_mpim) return { type: 'channel', name: info.channelName ?? null };
+
+    try {
+      const { members = [] } = await slackAdapter.webClient.conversations.members({
+        channel: channelId,
+        limit: 100,
+      });
+      const users = await Promise.all(members.map((id) => slackAdapter.getUser(id)));
+      // participantIds (raw Slack "U…" ids) MUST stay parallel to
+      // participantNames — same length, same order. A consumer pairing the
+      // two arrays positionally (e.g. to exclude one participant by id)
+      // breaks silently if a member is filtered from only ONE array (bot,
+      // failed profile lookup). Both arrays are therefore projected from a
+      // single filtered list: bots and members whose profile lookup failed
+      // drop from BOTH.
+      const humans = members
+        .map((id, i) => ({ id, user: users[i] }))
+        .filter((entry): entry is { id: string; user: NonNullable<(typeof users)[number]> } =>
+          Boolean(entry.user && !entry.user.isBot),
+        );
+      return {
+        type: 'group_dm',
+        name: null,
+        participantNames: humans.map(({ user }) => user.userName || user.fullName),
+        participantIds: humans.map(({ id }) => id),
+      };
+    } catch {
+      return { type: 'group_dm', name: null };
+    }
+  } catch {
+    return null;
+  }
+}
+
+/** Construction knobs for one Slack bot identity. */
+export interface SlackBridgeOptions {
+  /**
+   * Uppercased/underscored instance suffix appended to each token env key
+   * after an underscore — 'ALPHA' reads SLACK_BOT_TOKEN_ALPHA /
+   * SLACK_SIGNING_SECRET_ALPHA / SLACK_APP_TOKEN_ALPHA. Omit (or pass '')
+   * for the default app's unsuffixed keys.
+   */
+  envKeySuffix?: string;
+  /**
+   * Registry/bridge instance key (e.g. 'slack-alpha'). Omit for the default
+   * instance, keyed by channelType. channelType stays 'slack' either way —
+   * instance is a host-side routing key only, so user ids, formatting,
+   * container config, and the wiring-defaults declaration are shared with
+   * the default Slack app.
+   */
+  instanceKey?: string;
+}
+
+/**
+ * Build one Slack bot identity's bridge from its token set. The default app
+ * is the zero-suffix call (used by the registration below); named instances
+ * pass a suffix + instance key and get the exact same construction — Socket
+ * Mode opt-in, channel-name resolution, SLACK_DEFAULTS declaration. Returns
+ * null when the bot token is missing so the registry surfaces its normal
+ * "credentials missing, skipping" warning.
+ */
+export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdapter | null {
+  const suffix = options.envKeySuffix ? `_${options.envKeySuffix}` : '';
+  const keys = {
+    botToken: `SLACK_BOT_TOKEN${suffix}`,
+    signingSecret: `SLACK_SIGNING_SECRET${suffix}`,
+    appToken: `SLACK_APP_TOKEN${suffix}`,
+  };
+  const env = readEnvFile([keys.botToken, keys.signingSecret, keys.appToken]);
+  const botToken = env[keys.botToken];
+  if (!botToken) return null;
+  // An xapp-… token enables Socket Mode: events arrive over an outbound
+  // WebSocket, so no public HTTPS endpoint is required. When set, the
+  // signing secret is optional (Slack signs socket frames separately).
+  const appToken = env[keys.appToken];
+  const slackAdapter = createSlackAdapter({
+    botToken,
+    signingSecret: env[keys.signingSecret],
+    appToken,
+    mode: appToken ? 'socket' : 'webhook',
+  });
+  const bridge = createChatSdkBridge({
+    adapter: slackAdapter,
+    instance: options.instanceKey, // undefined ⇒ default instance (keyed by channelType)
+    concurrency: 'concurrent',
+    supportsThreads: true,
+    defaults: SLACK_DEFAULTS,
+  });
+  bridge.resolveChannelName = async (platformId: string) => {
+    try {
+      const info = await slackAdapter.fetchThread(platformId);
+      return (info as { channelName?: string }).channelName ?? null;
+    } catch {
+      return null;
+    }
+  };
+  // Conversation classification closes over THIS identity's adapter, so
+  // every instance (default or named) resolves through its own token.
+  // ChannelAdapter does not declare resolveConversation yet — the extension
+  // rides on the returned object until the core seam lands.
+  return Object.assign(bridge, {
+    resolveConversation: (platformId: string) => resolveSlackConversation(slackAdapter, platformId),
+  });
+}
+
+/** Env-key suffix for a named instance: uppercased, dashes → underscores. */
+export function instanceEnvKeySuffix(name: string): string {
+  return name.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * Build one named instance's bridge from its per-instance token set, through
+ * the shared factory. Returns null when the bot token is missing so the
+ * registry surfaces its normal "credentials missing, skipping" warning.
+ *
+ * Exported so a test can drive the real factory against a token set.
+ */
+export function slackInstanceBridgeFactory(name: string): ChannelAdapter | null {
+  return createSlackBridge({
+    envKeySuffix: instanceEnvKeySuffix(name),
+    instanceKey: `slack-${name}`,
+  });
+}
+
+registerChannelAdapter('slack', {
+  factory: () => createSlackBridge(),
+  defaults: SLACK_DEFAULTS,
+});
+
+// Named instances — registration is unconditional for every listed name so a
+// missing token set surfaces as the registry's "credentials missing, skipping"
+// warning at boot rather than a silently absent bot. Every registration carries
+// the same SLACK_DEFAULTS declaration as the default app, so offline creation
+// paths (setup, ncl) resolve declared wiring defaults for named instances too.
+for (const raw of (readEnvFile(['SLACK_INSTANCES']).SLACK_INSTANCES ?? '').split(',')) {
+  const name = raw.trim();
+  if (!name) continue;
+  registerChannelAdapter(`slack-${name}`, {
+    factory: () => slackInstanceBridgeFactory(name),
+    defaults: SLACK_DEFAULTS,
+  });
+}

--- a/src/env-file.test.ts
+++ b/src/env-file.test.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+
+describe('env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-file-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'ENVF_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'ENVF_PLAIN=value1',
+          '  ENVF_INDENTED = spaced ',
+          'ENVF_DQUOTED="double quoted"',
+          "ENVF_SQUOTED='single quoted'",
+          'ENVF_EMPTY=',
+          '# ENVF_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'ENVF_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'ENVF_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'ENVF_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'ENVF_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'ENVF_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'ENVF_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('ENVF_PREFERS=file-value\n');
+      vi.stubEnv('ENVF_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'ENVF_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('ENVF_BLANK_ENV=file-value\n');
+      vi.stubEnv('ENVF_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'ENVF_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('ENVF_DUP=first\nENVF_DUP=second\n');
+      expect(readEnvValue(rootDir, 'ENVF_DUP')).toBe('second');
+    });
+  });
+
+  describe('upsertEnvKey', () => {
+    it('creates .env when absent', () => {
+      upsertEnvKey(rootDir, 'ENVF_NEW', 'v1');
+      expect(read()).toBe('ENVF_NEW=v1\n');
+      expect(readEnvValue(rootDir, 'ENVF_NEW')).toBe('v1');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      upsertEnvKey(rootDir, 'ENVF_APPENDED', 'v2');
+      expect(read()).toBe('EXISTING=x\nENVF_APPENDED=v2\n');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nENVF_TARGET=old\nLAST=9\n');
+      upsertEnvKey(rootDir, 'ENVF_TARGET', 'new');
+      expect(read()).toBe('# keep me\nFIRST=1\nENVF_TARGET=new\nLAST=9\n');
+    });
+
+    it('does not touch keys that merely share a prefix', () => {
+      write('ENVF_KEY=keep\nENVF_KEY_LONGER=keep-too\n');
+      upsertEnvKey(rootDir, 'ENVF_KEY', 'changed');
+      expect(read()).toBe('ENVF_KEY=changed\nENVF_KEY_LONGER=keep-too\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('ENVF_DUP=first\nENVF_DUP=second\n');
+      upsertEnvKey(rootDir, 'ENVF_DUP', 'final');
+      expect(read()).toBe('ENVF_DUP=final\nENVF_DUP=final\n');
+      expect(readEnvValue(rootDir, 'ENVF_DUP')).toBe('final');
+    });
+
+    it('replaces an indented assignment (readable lines are writable lines)', () => {
+      write('  ENVF_INDENTED=old\n');
+      upsertEnvKey(rootDir, 'ENVF_INDENTED', 'new');
+      expect(readEnvValue(rootDir, 'ENVF_INDENTED')).toBe('new');
+      expect(read()).not.toContain('old');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates the key and reports the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'alpha')).toBe(true);
+      expect(readEnvValue(rootDir, 'ENVF_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('ENVF_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'ENVF_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('ENVF_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys parse .env only, so the union must be based on
+      // the file, not a stale process.env copy.
+      write('ENVF_LIST=alpha\n');
+      vi.stubEnv('ENVF_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'ENVF_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('ENVF_LIST=alpha,beta');
+    });
+  });
+});

--- a/src/env-file.ts
+++ b/src/env-file.ts
@@ -1,0 +1,93 @@
+/**
+ * .env read/write helpers shared by host code that manages .env keys.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — everything written here is read back through
+ * that parser. Write conventions for module and skill code that manages .env
+ * keys: replace the key's line in place, preserve every other line (comments
+ * and blanks included), append with a clean trailing newline.
+ *
+ * Values written here include live credentials: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value.
+ */
+export function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/src/modules/canvas-actions/canvas-actions.test.ts
+++ b/src/modules/canvas-actions/canvas-actions.test.ts
@@ -1,0 +1,747 @@
+/**
+ * Canvas-actions tests: the safe op mapping (mocked fetch — lookup+edit
+ * sequences, whole-doc replace unconstructible), token resolution, response
+ * rows into inbound.db, and the HTML→text read-back.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import type { MessagingGroup, Session } from '../../types.js';
+import { editCanvas, htmlToReadableText, parseCanvasBlocks, resolveHeadingRegion } from './canvas-api.js';
+import { handleCanvasEdit, handleCanvasRead, resolveSessionBotToken } from './handlers.js';
+
+const { mockWriteSessionMessage } = vi.hoisted(() => ({ mockWriteSessionMessage: vi.fn() }));
+
+vi.mock('../../session-manager.js', () => ({ writeSessionMessage: mockWriteSessionMessage }));
+
+const NOW = new Date().toISOString();
+const MG_ID = 'mg-canvas';
+
+function makeSession(messagingGroupId: string | null = MG_ID): Session {
+  return {
+    id: 'sess-canvas',
+    agent_group_id: 'ag-canvas',
+    messaging_group_id: messagingGroupId,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: NOW,
+  };
+}
+
+function makeMg(overrides: Partial<MessagingGroup> = {}): MessagingGroup {
+  return {
+    id: MG_ID,
+    channel_type: 'slack',
+    platform_id: 'slack:C0ROOM',
+    instance: 'slack-pixel',
+    name: 'Pixel room',
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    denied_at: null,
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+function responseRows(): Array<{ id: string; kind: string; trigger: boolean; content: Record<string, unknown> }> {
+  return mockWriteSessionMessage.mock.calls.map((call) => {
+    const row = call[2] as { id: string; kind: string; trigger: boolean; content: string };
+    return { ...row, content: JSON.parse(row.content) };
+  });
+}
+
+/** The chat-note text of an edit-outcome row (canvas_edit notes are kind='chat'). */
+function editNoteText(row: { kind: string; content: Record<string, unknown> }): string {
+  expect(row.kind).toBe('chat');
+  return row.content.text as string;
+}
+
+function slackJson(body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
+  await createMessagingGroup(makeMg());
+  mockWriteSessionMessage.mockReset();
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  process.env.SLACK_BOT_TOKEN_PIXEL = 'xoxb-pixel-token';
+});
+
+afterEach(async () => {
+  delete process.env.SLACK_BOT_TOKEN_PIXEL;
+  vi.unstubAllGlobals();
+  await closeDb();
+});
+
+describe('resolveSessionBotToken', () => {
+  it('maps the mg instance to its .env token key', async () => {
+    expect(await resolveSessionBotToken(makeSession())).toEqual({ token: 'xoxb-pixel-token' });
+  });
+
+  it('errors (naming the key, not any value) when the token is absent', async () => {
+    delete process.env.SLACK_BOT_TOKEN_PIXEL;
+    const result = await resolveSessionBotToken(makeSession());
+    expect(result).toHaveProperty('error');
+    expect((result as { error: string }).error).toContain('SLACK_BOT_TOKEN_PIXEL');
+  });
+
+  it('rejects sessions with no messaging group and non-Slack channels', async () => {
+    expect(await resolveSessionBotToken(makeSession(null))).toHaveProperty('error');
+    await createMessagingGroup(
+      makeMg({ id: 'mg-tg', channel_type: 'telegram', platform_id: 'tg:1', instance: 'telegram' }),
+    );
+    expect(await resolveSessionBotToken({ ...makeSession(), messaging_group_id: 'mg-tg' })).toHaveProperty('error');
+  });
+});
+
+describe('handleCanvasEdit', () => {
+  it('append maps to a single insert_at_end canvases.edit (no lookup)', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-1', canvas_id: 'F0C', op: 'append', markdown: '- [ ] new task' },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/canvases.edit');
+    const body = JSON.parse(init.body as string);
+    expect(body.canvas_id).toBe('F0C');
+    expect(body.changes).toEqual([
+      { operation: 'insert_at_end', document_content: { type: 'markdown', markdown: '- [ ] new task' } },
+    ]);
+
+    const rows = responseRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('canvas-resp-req-1');
+    expect(rows[0].trigger).toBe(false);
+    expect(editNoteText(rows[0])).toContain('Canvas edit applied');
+  });
+
+  it('replace_section falls back to sections.lookup when the HTML read-back fails', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('offline')) // files.info → no read-back
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [{ id: 'temp:C:SEC1' }] }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-2',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [lookupUrl, lookupInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(lookupUrl).toBe('https://slack.com/api/canvases.sections.lookup');
+    expect(JSON.parse(lookupInit.body as string)).toEqual({
+      canvas_id: 'F0C',
+      criteria: { contains_text: 'Tasks' },
+    });
+    const [, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const editBody = JSON.parse(editInit.body as string);
+    expect(editBody.changes).toEqual([
+      {
+        operation: 'replace',
+        section_id: 'temp:C:SEC1',
+        document_content: { type: 'markdown', markdown: '## Tasks\n\n- [x] done' },
+      },
+    ]);
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
+  });
+
+  it('insert_after_section falls back to insert_after with the looked-up id when the read-back fails', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [{ id: 'temp:C:SEC9' }] }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-3',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Decisions',
+        markdown: '> We ship MPIM rooms.',
+      },
+      makeSession(),
+    );
+
+    const [, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(JSON.parse(editInit.body as string).changes[0]).toMatchObject({
+      operation: 'insert_after',
+      section_id: 'temp:C:SEC9',
+    });
+  });
+
+  it('replace_section WITHOUT section_text fails before any Slack call — whole-doc replace is impossible', async () => {
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-4', canvas_id: 'F0C', op: 'replace_section', markdown: 'boom' },
+      makeSession(),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
+    const note4 = editNoteText(rows[0]);
+    expect(note4).toContain('Canvas edit FAILED');
+    expect(note4).toContain('section_text');
+  });
+
+  it('a lookup with no match errors without ever calling canvases.edit', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('offline')) // files.info → no read-back
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [] }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-5',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Nonexistent',
+        markdown: 'x',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // failed files.info + lookup only
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
+    expect(editNoteText(rows[0])).toContain('Nonexistent');
+  });
+
+  it('a Slack API error becomes a triggering error row', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: false, error: 'canvas_not_found' }));
+
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-6', canvas_id: 'F0C', op: 'append', markdown: 'x' },
+      makeSession(),
+    );
+
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
+    expect(editNoteText(rows[0])).toContain('canvas_not_found');
+  });
+
+  it('editCanvas refuses a sectioned op with an empty section id (belt and braces)', async () => {
+    await expect(editCanvas('xoxb-t', 'F0C', { operation: 'replace', sectionId: '', markdown: 'x' })).rejects.toThrow(
+      /without a resolved section_id/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('duplicate-heading guard (B4)', () => {
+  /** files.info + HTML download pair for a canvas whose read-back has the given body. */
+  function mockReadBack(html: string): void {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(new Response(html, { status: 200 }));
+  }
+
+  it('insert_after_section with a duplicate first heading is refused before any lookup/edit', async () => {
+    mockReadBack('<h1 id="temp:C:A">Room</h1><h2 id="temp:C:B">Tasks</h2><p>- [ ] x</p>');
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g1',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Room',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // files.info + download only — no lookup, no edit
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
+    const guardNote = editNoteText(rows[0]);
+    expect(guardNote).toContain('Canvas edit FAILED');
+    expect(guardNote).toContain('replace_section');
+    expect(guardNote).toContain('Tasks');
+  });
+
+  it('matches case-insensitively and trimmed', async () => {
+    mockReadBack('<h2 id="temp:C:B">Tasks</h2>');
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g2',
+        canvas_id: 'F0C',
+        op: 'append',
+        markdown: '##   tasks  \n\n- [ ] again',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit FAILED');
+  });
+
+  it('a non-duplicate heading passes through — region path, no lookup needed', async () => {
+    mockReadBack('<h2 id="temp:C:B">Tasks</h2>');
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g3',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Tasks',
+        markdown: '## Retro notes\n\n- went well',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // files.info, download, edit — section id from the read-back
+    const [editUrl, editInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(editUrl).toBe('https://slack.com/api/canvases.edit');
+    expect(JSON.parse(editInit.body as string).changes[0]).toMatchObject({
+      operation: 'insert_after',
+      section_id: 'temp:C:B',
+    });
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
+  });
+
+  it('a failed read-back never blocks the edit (guard is best-effort)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: false, error: 'file_not_found' })) // files.info fails
+      .mockResolvedValueOnce(slackJson({ ok: true, sections: [{ id: 'temp:C:SEC1' }] }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g4',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // files.info (failed), lookup, edit
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
+  });
+
+  it('markdown without a heading skips the read-back entirely', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      { action: 'canvas_edit', requestId: 'req-g5', canvas_id: 'F0C', op: 'append', markdown: '- [ ] plain item' },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // straight to canvases.edit
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
+  });
+
+  it('replace_section is exempt — replacing a section with its own heading is the point', async () => {
+    mockReadBack('<h2 id="temp:C:B">Tasks</h2><p id="temp:C:P1" class="line">- [ ] old</p>');
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace heading
+      .mockResolvedValueOnce(slackJson({ ok: true })); // delete old body
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-g6',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4); // files.info, download, replace, delete — no refusal
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
+  });
+});
+
+describe('heading-region ops (Slack sections are blocks, not regions)', () => {
+  /** Trimmed from the live canvas HTML that produced the duplicated-section bug. */
+  const REGION_HTML =
+    '<div class="quip-canvas-content">' +
+    '<h2 id="temp:C:NOTES">Notes</h2>' +
+    '<h2 id="temp:C:OQ">Open Questions</h2>' +
+    '<p id="temp:C:P1" class="line">Questions that need answers:</p>' +
+    "<div data-section-style='5'><ul id='temp:C:L1'><li id='temp:C:LI1'><span id=\"temp:C:LI1\">item</span></li></ul></div>" +
+    '<p id="temp:C:NB" class="line"><i>Working notes</i></p>' +
+    '</div>';
+
+  function mockReadBack(html: string): void {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(new Response(html, { status: 200 }));
+  }
+
+  function editBodies(fromCall: number): Array<Record<string, unknown>> {
+    return fetchMock.mock.calls
+      .slice(fromCall)
+      .map((c) => JSON.parse((c as [string, RequestInit])[1].body as string).changes[0] as Record<string, unknown>);
+  }
+
+  it('replace_section replaces the heading block then deletes every old body block, one call each', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace temp:C:OQ
+      .mockResolvedValueOnce(slackJson({ ok: true })) // delete temp:C:P1
+      .mockResolvedValueOnce(slackJson({ ok: true })) // delete temp:C:L1
+      .mockResolvedValueOnce(slackJson({ ok: true })); // delete temp:C:NB
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h1',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Open Questions',
+        markdown: '## Open Questions\n\n- new list',
+      },
+      makeSession(),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    const changes = editBodies(2);
+    expect(changes[0]).toMatchObject({ operation: 'replace', section_id: 'temp:C:OQ' });
+    expect(changes.slice(1)).toEqual([
+      { operation: 'delete', section_id: 'temp:C:P1' },
+      { operation: 'delete', section_id: 'temp:C:LI1' },
+      { operation: 'delete', section_id: 'temp:C:NB' },
+    ]);
+    expect(editNoteText(responseRows()[0])).toContain('Canvas edit applied');
+  });
+
+  it('insert_after_section lands after the LAST block of the region, not the heading', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h2',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Open Questions',
+        markdown: 'A follow-up paragraph.',
+      },
+      makeSession(),
+    );
+
+    expect(editBodies(2)[0]).toMatchObject({ operation: 'insert_after', section_id: 'temp:C:NB' });
+  });
+
+  it('an empty region (heading directly followed by another heading) targets the heading itself', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h3',
+        canvas_id: 'F0C',
+        op: 'insert_after_section',
+        section_text: 'Notes',
+        markdown: 'Right under the Notes heading.',
+      },
+      makeSession(),
+    );
+
+    expect(editBodies(2)[0]).toMatchObject({ operation: 'insert_after', section_id: 'temp:C:NOTES' });
+  });
+
+  it('a mid-sequence delete failure reports a partial apply (new content in, leftovers named)', async () => {
+    mockReadBack(REGION_HTML);
+    fetchMock
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace ok
+      .mockResolvedValueOnce(slackJson({ ok: false, error: 'section_not_found' })); // first delete fails
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-h4',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Open Questions',
+        markdown: '## Open Questions\n\n- new list',
+      },
+      makeSession(),
+    );
+
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true);
+    const partialNote = editNoteText(rows[0]);
+    expect(partialNote).toContain('partially applied');
+    expect(partialNote).toContain('3 old block(s)');
+  });
+});
+
+describe('checklist tick-state platform limit', () => {
+  it('counts ticked items in the region and warns on rewrite (state is UI-only)', async () => {
+    // Live checklist with one ticked item (li class='checked').
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          '<h2 id="temp:C:T">Tasks</h2>' +
+            "<div data-section-style='7'><ul id='temp:C:U'>" +
+            "<li id='temp:C:SA' class='checked' value='1'><span id=\"temp:C:SA\">done one</span></li>" +
+            '<li id=\'temp:C:SB\'><span id="temp:C:SB">open one</span></li>' +
+            '</ul></div>',
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(slackJson({ ok: true })) // replace heading
+      .mockResolvedValueOnce(slackJson({ ok: true })) // delete SA
+      .mockResolvedValueOnce(slackJson({ ok: true })); // delete SB
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-t1',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [x] done one\n- [ ] open one\n- [ ] new one',
+      },
+      makeSession(),
+    );
+
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(true); // warning must wake the agent
+    const note = editNoteText(rows[0]);
+    expect(note).toContain('Canvas edit applied');
+    expect(note).toContain('[x] states in your markdown were NOT applied');
+    expect(note).toContain('1 ticked item(s)');
+  });
+
+  it('a rewrite of an untick-free checklist without [x] markdown stays a silent success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          '<h2 id="temp:C:T">Tasks</h2>' +
+            "<div data-section-style='7'><ul id='temp:C:U'><li id='temp:C:SB'><span id=\"temp:C:SB\">open one</span></li></ul></div>",
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(slackJson({ ok: true }))
+      .mockResolvedValueOnce(slackJson({ ok: true }));
+
+    await handleCanvasEdit(
+      {
+        action: 'canvas_edit',
+        requestId: 'req-t2',
+        canvas_id: 'F0C',
+        op: 'replace_section',
+        section_text: 'Tasks',
+        markdown: '## Tasks\n\n- [ ] open one\n- [ ] new one',
+      },
+      makeSession(),
+    );
+
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(false);
+    expect(editNoteText(rows[0])).toContain('Canvas edit applied');
+  });
+});
+
+describe('htmlToReadableText checklists', () => {
+  it('renders live-export checklist items as [x]/[ ] from li class, not inputs', () => {
+    const html =
+      '<h2 id="temp:C:T">Tasks</h2>' +
+      '<div data-section-style=\'7\' class="list-numbering-restart-at" style="--indent0: 0">' +
+      "<ul id='temp:C:U'>" +
+      "<li id='temp:C:LA' class='checked' value='1'><span id=\"temp:C:LA\">Draft launch checklist</span><br/></li>" +
+      '<li id=\'temp:C:LB\'><span id="temp:C:LB">Verify canvas scopes</span><br/></li>' +
+      '</ul></div>';
+    const text = htmlToReadableText(html);
+    expect(text).toContain('- [x] Draft launch checklist');
+    expect(text).toContain('- [ ] Verify canvas scopes');
+  });
+
+  it('plain lists keep plain bullets', () => {
+    const html =
+      "<div data-section-style='5'><ul id='temp:C:U'><li id='temp:C:L'><span>plain item</span></li></ul></div>";
+    const text = htmlToReadableText(html);
+    expect(text).toContain('- plain item');
+    expect(text).not.toContain('[ ]');
+  });
+});
+
+describe('handleCanvasRead', () => {
+  it('fetches files.info, downloads the HTML, and returns stripped text without waking', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        slackJson({ ok: true, file: { id: 'F0C', url_private_download: 'https://files.slack.com/canvas.html' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response('<h1 id="temp:C:X">Room</h1><ul><li><input type="checkbox" checked>done</li></ul>', {
+          status: 200,
+        }),
+      );
+
+    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r1', canvas_id: 'F0C' }, makeSession());
+
+    const [infoUrl] = fetchMock.mock.calls[0] as [string];
+    expect(infoUrl).toBe('https://slack.com/api/files.info?file=F0C');
+    const [dlUrl, dlInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(dlUrl).toBe('https://files.slack.com/canvas.html');
+    expect((dlInit.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-pixel-token');
+
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(false);
+    expect(rows[0].content).toMatchObject({ type: 'canvas_response', requestId: 'req-r1', status: 'ok' });
+    const text = (rows[0].content.result as { text: string }).text;
+    expect(text).toContain('# Room');
+    expect(text).toContain('- [x] done');
+    expect(text).not.toContain('temp:C:X');
+  });
+
+  it('read failures come back without waking (the tool is polling)', async () => {
+    fetchMock.mockResolvedValueOnce(slackJson({ ok: false, error: 'file_not_found' }));
+
+    await handleCanvasRead({ action: 'canvas_read', requestId: 'req-r2', canvas_id: 'F0C' }, makeSession());
+
+    const rows = responseRows();
+    expect(rows[0].trigger).toBe(false);
+    expect(rows[0].content).toMatchObject({ status: 'error' });
+    expect((rows[0].content.result as { error: string }).error).toContain('file_not_found');
+  });
+});
+
+describe('htmlToReadableText', () => {
+  it('keeps heading levels, bullets, checkboxes, and table pipes; drops tags and entities', () => {
+    const html =
+      '<style>.x{}</style><h1 id="temp:C:A">Title</h1><h2 id="temp:C:B">Tasks</h2>' +
+      '<ul><li><input type="checkbox">open item</li><li><input type="checkbox" checked>closed item</li></ul>' +
+      '<table><tr><td>a &amp; b</td><td>c</td></tr></table><p>tail &lt;ok&gt;</p>';
+    const text = htmlToReadableText(html);
+    expect(text).toContain('# Title');
+    expect(text).toContain('## Tasks');
+    expect(text).toContain('- [ ] open item');
+    expect(text).toContain('- [x] closed item');
+    expect(text).toContain('a & b | c |');
+    expect(text).toContain('tail <ok>'); // entities decode after tag stripping
+    expect(text).not.toContain('<h1');
+    expect(text).not.toContain('<style>');
+    expect(text).not.toContain('temp:C:');
+  });
+
+  it('caps at maxChars with a truncation note (via fetchCanvasText cap path)', () => {
+    // The cap lives in fetchCanvasText; here just sanity-check big input survives stripping.
+    const text = htmlToReadableText(`<p>${'x'.repeat(10_000)}</p>`);
+    expect(text.length).toBe(10_000);
+  });
+});
+
+describe('parseCanvasBlocks / resolveHeadingRegion', () => {
+  it('parses top-level blocks in order, folding nested structure into its outermost block', () => {
+    const html =
+      '<div class="quip-canvas-content">' +
+      '<h1 id="temp:C:T">Q&amp;A Room</h1>' +
+      '<blockquote><p id="temp:C:BQ" class="line">purpose line</p></blockquote>' +
+      '<h2 id="temp:C:M">Members</h2>' +
+      '<table><tr><td><p id="temp:C:CELL" class="line">cell</p></td></tr></table>' +
+      '<h2 id="temp:C:TK">Tasks</h2>' +
+      "<div data-section-style='7'><ul id='temp:C:UL'><li id='temp:C:LI'><span>item</span><ul><li>nested</li></ul></li></ul></div>" +
+      '<p id="temp:C:TAIL" class="line">tail</p>' +
+      '</div>';
+    const blocks = parseCanvasBlocks(html);
+    expect(blocks.map((b) => `${b.tag}:${b.id}`)).toEqual([
+      'h1:temp:C:T',
+      'blockquote:temp:C:BQ', // quote addressed via its inner <p> id
+      'h2:temp:C:M',
+      'table:null', // cell paragraphs fold into the table block
+      'h2:temp:C:TK',
+      'ul:temp:C:UL', // nested list folds into the outermost ul
+      'p:temp:C:TAIL',
+    ]);
+    expect(blocks[0].text).toBe('Q&A Room'); // heading text entity-decoded, tag-stripped
+  });
+
+  it('resolves a heading region: exact match wins, body stops at the next heading', () => {
+    const html =
+      '<h2 id="temp:C:A">Notes</h2><p id="temp:C:P" class="line">body</p>' +
+      "<ul id='temp:C:U'><li id='temp:C:LX'><span id=\"temp:C:SX\">x</span></li></ul>" +
+      '<h2 id="temp:C:B">Notes archive</h2><p id="temp:C:Q">other</p>';
+    const region = resolveHeadingRegion(html, 'Notes');
+    expect(region).toEqual({
+      headingId: 'temp:C:A',
+      bodyIds: ['temp:C:P', 'temp:C:SX'],
+      lastId: 'temp:C:SX',
+      hasUnaddressableBlocks: false,
+      checkedItemCount: 0,
+    });
+  });
+
+  it('lists resolve to their item span ids — the ul wrapper id is a canvases.edit no-op (live-observed)', () => {
+    // The live checklist export shape: styled wrapper div, one ul per item,
+    // item text in an id-bearing span. Deleting the ul id silently no-ops
+    // (ok:true, canvas unchanged) — the region must carry the span ids.
+    const html =
+      '<h2 id="temp:C:T">Tasks</h2>' +
+      "<div data-section-style='7'><ul id='temp:C:U1'><li id='temp:C:LA'><span id=\"temp:C:SA\">Draft launch checklist</span></li></ul>" +
+      "<ul id='temp:C:U2'><li id='temp:C:LB'><span id=\"temp:C:SB\">Verify canvas scopes</span></li></ul></div>" +
+      '<h2 id="temp:C:D">Decisions</h2>';
+    const region = resolveHeadingRegion(html, 'Tasks');
+    expect(region).toEqual({
+      headingId: 'temp:C:T',
+      bodyIds: ['temp:C:SA', 'temp:C:SB'],
+      lastId: 'temp:C:SB',
+      hasUnaddressableBlocks: false,
+      checkedItemCount: 0,
+    });
+  });
+
+  it('a list without item span ids is flagged unaddressable, not deleted by wrapper id', () => {
+    const html = '<h2 id="temp:C:A">Tasks</h2><ul id=\'temp:C:U\'><li>x</li></ul><p id="temp:C:P">tail</p>';
+    const region = resolveHeadingRegion(html, 'Tasks');
+    expect(region?.bodyIds).toEqual(['temp:C:P']);
+    expect(region?.hasUnaddressableBlocks).toBe(true);
+  });
+
+  it('flags unaddressable body blocks (an id-less table) and falls back to contains-match', () => {
+    const html = '<h2 id="temp:C:A">Member Roster</h2><table><tr><td>x</td></tr></table><p id="temp:C:P">tail</p>';
+    const region = resolveHeadingRegion(html, 'roster');
+    expect(region?.headingId).toBe('temp:C:A');
+    expect(region?.bodyIds).toEqual(['temp:C:P']);
+    expect(region?.hasUnaddressableBlocks).toBe(true);
+  });
+
+  it('returns null when no heading matches (caller falls back to sections.lookup)', () => {
+    expect(resolveHeadingRegion('<h2 id="temp:C:A">Tasks</h2>', 'Decisions')).toBeNull();
+    expect(resolveHeadingRegion('<p id="temp:C:P">Decisions happen here</p>', 'Decisions')).toBeNull();
+  });
+});

--- a/src/modules/canvas-actions/canvas-api.ts
+++ b/src/modules/canvas-actions/canvas-api.ts
@@ -1,0 +1,360 @@
+/**
+ * Slack canvas API calls for the canvas-actions module — sections.lookup,
+ * canvases.edit, and the HTML read-back path (files.info →
+ * url_private_download).
+ *
+ * Safety property (09: whole-doc `replace` confirmed destructive): the
+ * `CanvasChange` type makes an unsectioned `replace` UNREPRESENTABLE —
+ * `replace` and `insert_after` structurally require a sectionId, and
+ * `editCanvas` re-checks it at runtime as belt and braces. `insert_at_end`
+ * (append) is the only sectionless operation this module can emit.
+ *
+ * JSON-body Web API calls go through `slackCall` in src/channels/slack-lib.ts
+ * (same message shape: `slack <method> failed: <error>`). The files.info
+ * read-back stays local — it is a legacy GET-arg method (no JSON body), and
+ * the download itself is a raw file fetch, not a Web API call. Error strings
+ * from Slack are safe to surface; token values never are — tokens travel
+ * only in Authorization headers.
+ */
+import { slackCall } from '../../channels/slack-lib.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export type CanvasChange =
+  | { operation: 'insert_at_end'; markdown: string }
+  | { operation: 'replace' | 'insert_after'; sectionId: string; markdown: string }
+  | { operation: 'delete'; sectionId: string };
+
+/**
+ * canvases.sections.lookup by contains_text. Returns the FIRST matching
+ * section id, or null when nothing matches. Ids are ephemeral (`temp:` — 09):
+ * look up fresh before every edit, never cache.
+ */
+export async function lookupCanvasSection(
+  token: string,
+  canvasId: string,
+  containsText: string,
+): Promise<string | null> {
+  const json = await slackCall(
+    token,
+    'canvases.sections.lookup',
+    { canvas_id: canvasId, criteria: { contains_text: containsText } },
+    'canvas-section-lookup',
+  );
+  const sections = Array.isArray(json.sections) ? (json.sections as Array<Record<string, unknown>>) : [];
+  const first = sections[0];
+  return typeof first?.id === 'string' && first.id ? first.id : null;
+}
+
+/** canvases.edit with exactly one change — the API rejects multi-change
+ *  arrays ("no more than 1 items allowed", live-probed), so region-scoped
+ *  edits are sequences of calls. Throws on any Slack error. */
+export async function editCanvas(token: string, canvasId: string, change: CanvasChange): Promise<void> {
+  let payload: Record<string, unknown>;
+  if (change.operation === 'insert_at_end') {
+    payload = {
+      operation: 'insert_at_end',
+      document_content: { type: 'markdown', markdown: change.markdown },
+    };
+  } else if (change.operation === 'delete') {
+    if (!change.sectionId) {
+      throw new Error('canvases.edit refused: delete without a resolved section_id');
+    }
+    payload = { operation: 'delete', section_id: change.sectionId };
+  } else {
+    // Runtime re-check of the structural guarantee: a replace/insert_after
+    // without a section id must never reach the wire (whole-doc replace).
+    if (!change.sectionId) {
+      throw new Error(`canvases.edit refused: ${change.operation} without a resolved section_id`);
+    }
+    payload = {
+      operation: change.operation,
+      section_id: change.sectionId,
+      document_content: { type: 'markdown', markdown: change.markdown },
+    };
+  }
+  await slackCall(token, 'canvases.edit', { canvas_id: canvasId, changes: [payload] }, 'canvas-edit');
+}
+
+/**
+ * Read a canvas back as readable text: files.info → url_private_download →
+ * HTML → stripped text (09: the download carries the full body; section ids
+ * live in tag attributes and are stripped along with the tags). Capped at
+ * `maxChars`. Throws on any failure.
+ */
+export async function fetchCanvasText(token: string, canvasId: string, maxChars = 8000): Promise<string> {
+  const text = htmlToReadableText(await fetchCanvasHtml(token, canvasId));
+  return text.length > maxChars ? `${text.slice(0, maxChars)}\n…[truncated at ${maxChars} chars]` : text;
+}
+
+/**
+ * The raw canvas HTML export (files.info → url_private_download). Block ids
+ * (`temp:C:…`) ride the tag attributes — this is the addressing source for
+ * region-scoped edits. Throws on any failure.
+ */
+export async function fetchCanvasHtml(token: string, canvasId: string): Promise<string> {
+  // files.info is a legacy GET-arg method (does not accept JSON bodies).
+  let infoRes: Response;
+  try {
+    infoRes = await fetch(`${SLACK_API}/files.info?file=${encodeURIComponent(canvasId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(`slack files.info failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  let info: Record<string, unknown>;
+  try {
+    info = (await infoRes.json()) as Record<string, unknown>;
+  } catch {
+    throw new Error(`slack files.info failed: HTTP ${infoRes.status}, non-JSON body`);
+  }
+  if (info.ok !== true) {
+    throw new Error(`slack files.info failed: ${String(info.error ?? `HTTP ${infoRes.status}`)}`);
+  }
+  const file = info.file as Record<string, unknown> | undefined;
+  const url = typeof file?.url_private_download === 'string' ? file.url_private_download : null;
+  if (!url) throw new Error('slack files.info failed: no url_private_download on file');
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(`canvas download failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok) throw new Error(`canvas download failed: HTTP ${res.status}`);
+  return res.text();
+}
+
+// ── Block/region model of the canvas HTML ──
+//
+// Live-observed platform fact (post-e2e fix): a Slack canvas "section" is an
+// individual BLOCK — a heading and the paragraphs/lists under it are separate
+// sections with separate ids. A naive `replace` on a heading match therefore
+// replaces only the heading block and leaves the old body behind (observed as
+// a duplicated section). The helpers below rebuild the heading-scoped REGION
+// from the HTML export so handlers can edit whole sections.
+
+export interface CanvasBlock {
+  tag: 'h1' | 'h2' | 'h3' | 'p' | 'ul' | 'ol' | 'table' | 'blockquote';
+  /** Slack section id (`temp:C:…`) when the block carries one. */
+  id: string | null;
+  /** Inner text for headings (tag-stripped, entity-decoded); '' otherwise. */
+  text: string;
+  /**
+   * List blocks only: the per-item `<span id=…>` ids. Live-probed platform
+   * fact: a list's addressable sections are its ITEMS — `canvases.edit`
+   * silently no-ops (ok:true, nothing happens) when given the `<ul>`/`<ol>`
+   * wrapper id, while the item span ids (the same ids sections.lookup
+   * returns) delete and anchor correctly. Deleting every item collapses the
+   * list wrapper automatically.
+   */
+  itemIds?: string[];
+  /**
+   * List blocks only: item ids whose `<li>` carries `class='checked'` — a
+   * ticked checklist item. Live-probed: `- [x]` markdown is IGNORED by
+   * canvases.edit (insert, section replace, and item replace all land
+   * unticked), so tick state is UI-only and a section rewrite RESETS it.
+   */
+  checkedItemIds?: string[];
+}
+
+const BLOCK_TAG_RE = /<(\/?)(h1|h2|h3|p|ul|ol|table|blockquote)\b([^>]*)>/gi;
+
+function idFromAttrs(attrs: string): string | null {
+  const m = /\bid=["']([^"']+)["']/.exec(attrs);
+  return m ? m[1] : null;
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'");
+}
+
+/**
+ * Top-level blocks of a canvas HTML export, in document order. Nested
+ * structure folds into its outermost block: everything inside a table is the
+ * table, nested lists are the outermost ul/ol, a blockquote is addressed by
+ * its inner `<p>` id (the quote tag itself carries none).
+ */
+export function parseCanvasBlocks(html: string): CanvasBlock[] {
+  const blocks: CanvasBlock[] = [];
+  let tableDepth = 0;
+  let listDepth = 0;
+  let openBlockquote: CanvasBlock | null = null;
+  let openList: CanvasBlock | null = null;
+  let openListStart = 0;
+  BLOCK_TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = BLOCK_TAG_RE.exec(html)) !== null) {
+    const closing = m[1] === '/';
+    const tag = m[2].toLowerCase() as CanvasBlock['tag'];
+    const attrs = m[3] ?? '';
+    if (closing) {
+      if (tag === 'table') tableDepth = Math.max(0, tableDepth - 1);
+      else if (tag === 'ul' || tag === 'ol') {
+        listDepth = Math.max(0, listDepth - 1);
+        if (listDepth === 0 && openList) {
+          // The list's addressable sections are its item spans (see
+          // CanvasBlock.itemIds) — harvest them from the outermost extent,
+          // plus which items are ticked (li class='checked'; li id == span id).
+          const inner = html.slice(openListStart, m.index);
+          openList.itemIds = [...inner.matchAll(/<span id=["']([^"']+)["']/g)].map((sm) => sm[1]);
+          openList.checkedItemIds = [...inner.matchAll(/<li\b[^>]*>/g)]
+            .filter((lm) => /\bclass=["'][^"']*\bchecked\b/.test(lm[0]))
+            .map((lm) => /\bid=["']([^"']+)["']/.exec(lm[0])?.[1])
+            .filter((id): id is string => Boolean(id));
+          openList = null;
+        }
+      } else if (tag === 'blockquote') openBlockquote = null;
+      continue;
+    }
+    if (tag === 'table') {
+      if (tableDepth === 0) blocks.push({ tag, id: idFromAttrs(attrs), text: '' });
+      tableDepth++;
+      continue;
+    }
+    if (tableDepth > 0) {
+      if (tag === 'ul' || tag === 'ol') listDepth++;
+      continue; // cell contents are part of the table block
+    }
+    if (tag === 'ul' || tag === 'ol') {
+      if (listDepth === 0) {
+        openList = { tag, id: idFromAttrs(attrs), text: '', itemIds: [] };
+        openListStart = BLOCK_TAG_RE.lastIndex;
+        blocks.push(openList);
+      }
+      listDepth++;
+      continue;
+    }
+    if (listDepth > 0) continue; // paragraphs inside list items are part of the list
+    if (tag === 'blockquote') {
+      openBlockquote = { tag, id: idFromAttrs(attrs), text: '' };
+      blocks.push(openBlockquote);
+      continue;
+    }
+    if (tag === 'p') {
+      const id = idFromAttrs(attrs);
+      if (openBlockquote) {
+        if (!openBlockquote.id) openBlockquote.id = id;
+        continue;
+      }
+      blocks.push({ tag, id, text: '' });
+      continue;
+    }
+    // h1-h3: capture inner text up to the matching close tag.
+    const close = html.indexOf(`</${tag}>`, BLOCK_TAG_RE.lastIndex);
+    const inner = close === -1 ? '' : html.slice(BLOCK_TAG_RE.lastIndex, close);
+    blocks.push({ tag, id: idFromAttrs(attrs), text: decodeEntities(inner.replace(/<[^>]+>/g, '')).trim() });
+  }
+  return blocks;
+}
+
+export interface HeadingRegion {
+  headingId: string;
+  /** Ids of the region's body blocks (heading excluded), document order. */
+  bodyIds: string[];
+  /** Last id-bearing block of the region (the heading when the body is empty). */
+  lastId: string;
+  /** True when a body block carried no id (it cannot be edited or deleted). */
+  hasUnaddressableBlocks: boolean;
+  /** Ticked checklist items in the region body — state a rewrite will reset. */
+  checkedItemCount: number;
+}
+
+/**
+ * Resolve a heading-scoped region: the h1-h3 whose text matches `sectionText`
+ * (exact first, then contains — both case-insensitive) plus every following
+ * block up to the next heading. Null when no heading matches — the caller
+ * falls back to single-block sections.lookup behavior.
+ */
+export function resolveHeadingRegion(html: string, sectionText: string): HeadingRegion | null {
+  const wanted = sectionText.trim().toLowerCase();
+  if (!wanted) return null;
+  const blocks = parseCanvasBlocks(html);
+  const isHeading = (b: CanvasBlock): boolean => b.tag === 'h1' || b.tag === 'h2' || b.tag === 'h3';
+  let start = blocks.findIndex((b) => isHeading(b) && b.id !== null && b.text.toLowerCase() === wanted);
+  if (start === -1) {
+    start = blocks.findIndex((b) => isHeading(b) && b.id !== null && b.text.toLowerCase().includes(wanted));
+  }
+  if (start === -1) return null;
+  const headingId = blocks[start].id as string;
+  const bodyIds: string[] = [];
+  let lastId = headingId;
+  let hasUnaddressableBlocks = false;
+  let checkedItemCount = 0;
+  for (let i = start + 1; i < blocks.length; i++) {
+    const b = blocks[i];
+    if (isHeading(b)) break;
+    if (b.tag === 'ul' || b.tag === 'ol') {
+      // Lists are addressed per ITEM: the wrapper ul/ol id is a silent no-op
+      // for canvases.edit, so a list contributes its item span ids instead.
+      if (b.itemIds && b.itemIds.length > 0) {
+        bodyIds.push(...b.itemIds);
+        lastId = b.itemIds[b.itemIds.length - 1];
+      } else {
+        hasUnaddressableBlocks = true;
+      }
+      checkedItemCount += b.checkedItemIds?.length ?? 0;
+      continue;
+    }
+    if (b.id) {
+      bodyIds.push(b.id);
+      lastId = b.id;
+    } else {
+      hasUnaddressableBlocks = true;
+    }
+  }
+  return { headingId, bodyIds, lastId, hasUnaddressableBlocks, checkedItemCount };
+}
+
+/**
+ * Best-effort HTML → readable text: headings keep their markdown level,
+ * list items get bullets, checklist items render as [ ] / [x], table cells
+ * separate with pipes, all other tags (and their id attributes) drop.
+ *
+ * Checklists in the live export are NOT inputs: they are
+ * `<div data-section-style='7'>` wrappers whose `<li>`s carry
+ * `class='checked'` when ticked (live-observed — an agent that can't see
+ * tick states re-issues edits it can't verify).
+ */
+export function htmlToReadableText(html: string): string {
+  const text = html
+    .replace(/<(script|style)\b[\s\S]*?<\/\1>/gi, '')
+    .replace(/<div[^>]*data-section-style=["']?7["']?[^>]*>([\s\S]*?)<\/div>/gi, (_m, inner: string) =>
+      inner.replace(/<li\b[^>]*>/gi, (tag) => (/\bclass=["'][^"']*\bchecked\b/i.test(tag) ? '\n- [x] ' : '\n- [ ] ')),
+    )
+    .replace(/<input\b[^>]*>/gi, (tag) => {
+      if (!/type\s*=\s*["']?checkbox/i.test(tag)) return '';
+      return /\bchecked\b/i.test(tag) ? '[x] ' : '[ ] ';
+    })
+    .replace(/<h1\b[^>]*>/gi, '\n# ')
+    .replace(/<h2\b[^>]*>/gi, '\n## ')
+    .replace(/<h3\b[^>]*>/gi, '\n### ')
+    .replace(/<li\b[^>]*>/gi, '\n- ')
+    .replace(/<blockquote\b[^>]*>/gi, '\n> ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/t[dh]>/gi, ' | ')
+    .replace(/<\/(h1|h2|h3|p|li|div|tr|table|ul|ol|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'");
+  return text
+    .split('\n')
+    .map((line) => line.replace(/\s+$/, ''))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/src/modules/canvas-actions/handlers.ts
+++ b/src/modules/canvas-actions/handlers.ts
@@ -1,0 +1,356 @@
+/**
+ * Delivery-action handlers for agent canvas access: `canvas_edit`
+ * (fire-and-forget section-scoped edits) and `canvas_read` (blocking
+ * read-back the container tool polls for).
+ *
+ * Both act AS the session's own Slack bot identity: session →
+ * messaging group → adapter instance → the instance's bot token from
+ * .env (the SLACK_BOT_TOKEN / SLACK_BOT_TOKEN_<SUFFIX> key convention
+ * from src/channels/slack-lib.ts). No privileged effect: the
+ * agent can only touch canvases its own bot can already see.
+ *
+ * Outcome plumbing differs by action — this is load-bearing:
+ *
+ * - `canvas_read` outcomes are `kind:'system'` rows carrying `requestId`;
+ *   the container tool polls inbound.db for exactly that row and consumes
+ *   it. They never trigger a wake (the requester is already polling) and
+ *   the poll loop deliberately filters system rows out of agent prompts.
+ * - `canvas_edit` outcomes are `kind:'chat'` system notes (sender
+ *   'system', channelType 'agent') — the membership-note shape. NOT
+ *   `kind:'system'`: nothing polls for them, and the poll loop would
+ *   filter them out of every batch, so the agent would never learn an
+ *   edit failed (and an unconsumed triggering system row keeps the session
+ *   permanently "due" for the host sweep — wake churn). As chat rows they
+ *   render like any message: successes are non-triggering (ambient, next
+ *   wake); failures trigger so the agent wakes to correct course —
+ *   it already told the user the edit was submitted.
+ */
+import { botTokenKeyForInstance } from '../../channels/slack-lib.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { readEnvValue } from '../../env-file.js';
+import { log } from '../../log.js';
+import { writeSessionMessage } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+import {
+  editCanvas,
+  fetchCanvasHtml,
+  fetchCanvasText,
+  htmlToReadableText,
+  lookupCanvasSection,
+  resolveHeadingRegion,
+  type CanvasChange,
+  type HeadingRegion,
+} from './canvas-api.js';
+
+const CANVAS_EDIT_OPS = ['append', 'replace_section', 'insert_after_section'] as const;
+type CanvasEditOp = (typeof CANVAS_EDIT_OPS)[number];
+
+/**
+ * The session's own Slack bot token: session → mg → instance → .env.
+ * Error strings are agent-facing — they name the key, never the value.
+ */
+export async function resolveSessionBotToken(session: Session): Promise<{ token: string } | { error: string }> {
+  if (!session.messaging_group_id) {
+    return { error: 'session has no messaging group — cannot resolve a Slack bot identity' };
+  }
+  const mg = await getMessagingGroup(session.messaging_group_id);
+  if (!mg) {
+    return { error: `messaging group ${session.messaging_group_id} not found` };
+  }
+  if (mg.channel_type !== 'slack') {
+    return { error: `canvas actions need a Slack session (this session's channel is ${mg.channel_type})` };
+  }
+  const instanceKey = mg.instance ?? 'slack';
+  const tokenKey = botTokenKeyForInstance(instanceKey);
+  const token = readEnvValue(process.cwd(), tokenKey);
+  if (!token) {
+    return { error: `missing ${tokenKey} in .env for instance '${instanceKey}'` };
+  }
+  return { token };
+}
+
+/** First ATX heading in a markdown fragment (raw text, trimmed), or null. */
+function firstMarkdownHeading(markdown: string): string | null {
+  for (const line of markdown.split('\n')) {
+    const m = /^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/.exec(line);
+    if (m) return m[1].trim();
+  }
+  return null;
+}
+
+/**
+ * Heading texts present in a canvas read-back (the htmlToReadableText shape:
+ * headings are `#`-prefixed lines), normalized for comparison (lowercased,
+ * trimmed).
+ */
+function readBackHeadings(text: string): Set<string> {
+  const headings = new Set<string>();
+  for (const line of text.split('\n')) {
+    const m = /^#{1,6}\s+(.+?)\s*$/.exec(line);
+    if (m) headings.add(m[1].trim().toLowerCase());
+  }
+  return headings;
+}
+
+/** canvas_read outcome — a system row the container tool polls for by requestId. */
+async function writeCanvasResponse(
+  session: Session,
+  args: {
+    requestId: string;
+    action: 'canvas_read';
+    status: 'ok' | 'error';
+    result: Record<string, unknown>;
+  },
+): Promise<void> {
+  await writeSessionMessage(session.agent_group_id, session.id, {
+    id: `canvas-resp-${args.requestId}`,
+    kind: 'system',
+    timestamp: new Date().toISOString(),
+    platformId: null,
+    channelType: null,
+    threadId: null,
+    content: JSON.stringify({
+      type: 'canvas_response',
+      requestId: args.requestId,
+      action: args.action,
+      status: args.status,
+      result: args.result,
+    }),
+    processAfter: null,
+    recurrence: null,
+    trigger: false,
+  });
+}
+
+/**
+ * canvas_edit outcome — a renderable chat note (membership-note shape).
+ * Triggering failures wake the agent with the reason; non-triggering successes
+ * ride along as ambient context on the next wake.
+ */
+async function writeCanvasEditNote(
+  session: Session,
+  args: { requestId: string; text: string; trigger: boolean },
+): Promise<void> {
+  await writeSessionMessage(session.agent_group_id, session.id, {
+    id: `canvas-resp-${args.requestId}`,
+    kind: 'chat',
+    timestamp: new Date().toISOString(),
+    platformId: null,
+    channelType: 'agent',
+    threadId: null,
+    content: JSON.stringify({ text: args.text, sender: 'system', senderId: 'system' }),
+    processAfter: null,
+    recurrence: null,
+    trigger: args.trigger,
+  });
+}
+
+export async function handleCanvasEdit(content: Record<string, unknown>, session: Session): Promise<void> {
+  const requestId =
+    typeof content.requestId === 'string' && content.requestId ? content.requestId : `canvas-${Date.now()}`;
+  const canvasId = typeof content.canvas_id === 'string' ? content.canvas_id : '';
+  const op = content.op as CanvasEditOp;
+  const markdown = typeof content.markdown === 'string' ? content.markdown : '';
+  const sectionText = typeof content.section_text === 'string' ? content.section_text : '';
+
+  const editLabel = `${typeof op === 'string' && op ? op : 'canvas_edit'}${
+    canvasId ? ` on canvas ${canvasId}` : ''
+  }${sectionText ? `, section "${sectionText}"` : ''}`;
+  const fail = async (message: string): Promise<void> => {
+    log.warn('canvas_edit failed', { sessionId: session.id, requestId, error: message });
+    await writeCanvasEditNote(session, {
+      requestId,
+      text: `Canvas edit FAILED (${editLabel}): ${message}`,
+      trigger: true,
+    });
+  };
+  const succeed = async (note?: string): Promise<void> => {
+    await writeCanvasEditNote(session, {
+      requestId,
+      text: `Canvas edit applied (${editLabel}).${note ? ` ${note}` : ''}`,
+      trigger: false,
+    });
+  };
+
+  if (!canvasId || !markdown || !CANVAS_EDIT_OPS.includes(op)) {
+    await fail(`canvas_edit needs canvas_id, markdown, and op (one of ${CANVAS_EDIT_OPS.join(', ')})`);
+    return;
+  }
+  if (op !== 'append' && !sectionText) {
+    // The safe-op invariant: a section-targeted op without lookup criteria
+    // can never fall through to an unsectioned (whole-doc) replace.
+    await fail(`${op} requires section_text (text the target section contains)`);
+    return;
+  }
+
+  const auth = await resolveSessionBotToken(session);
+  if ('error' in auth) {
+    await fail(auth.error);
+    return;
+  }
+
+  // One HTML read-back serves both the duplicate-heading guard and region
+  // resolution. Best-effort: an unreadable canvas skips the guard and falls
+  // back to single-block sections.lookup — never block an edit on a read
+  // failure.
+  let html: string | null = null;
+  if (op !== 'append' || firstMarkdownHeading(markdown)) {
+    try {
+      html = await fetchCanvasHtml(auth.token, canvasId);
+    } catch {
+      /* unreadable canvas → no guard, lookup fallback */
+    }
+  }
+
+  // Duplicate-heading guard (B4): an insert op (append / insert_after_section)
+  // whose markdown opens with a heading the canvas already has is almost always
+  // a misfired update — refuse and point at replace_section.
+  if (op !== 'replace_section' && html) {
+    const newHeading = firstMarkdownHeading(markdown);
+    if (newHeading && readBackHeadings(htmlToReadableText(html)).has(newHeading.toLowerCase())) {
+      await fail(
+        `${op} refused: the canvas already has a "${newHeading}" section — inserting would create a duplicate heading. Use replace_section with section_text "${newHeading}" to update that section instead.`,
+      );
+      return;
+    }
+  }
+
+  // Live-probed platform limit: canvases.edit markdown IGNORES `- [x]` —
+  // every path (insert, section replace, item replace) lands unticked, so
+  // tick state is UI-only and a checklist rewrite RESETS it. Landing the
+  // edit and hiding that would be a silent lie; the note triggers so
+  // the agent can adjust (item-level edits preserve ticks).
+  const tickWarnings: string[] = [];
+  if (/^\s*[-*]\s+\[[xX]\]\s/m.test(markdown)) {
+    tickWarnings.push(
+      'the [x] states in your markdown were NOT applied — the canvas API cannot set tick state; those items landed unticked',
+    );
+  }
+  const finish = async (note?: string): Promise<void> => {
+    if (tickWarnings.length === 0) {
+      await succeed(note);
+      return;
+    }
+    await writeCanvasEditNote(session, {
+      requestId,
+      text: `Canvas edit applied (${editLabel}), BUT ${tickWarnings.join('; also ')}.${note ? ` ${note}` : ''} To preserve or mark checklist state, edit items individually (see the canvas-work skill) and leave ticking to humans.`,
+      trigger: true,
+    });
+  };
+
+  try {
+    if (op === 'append') {
+      await editCanvas(auth.token, canvasId, { operation: 'insert_at_end', markdown });
+      log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
+      await finish();
+      return;
+    }
+
+    // Section-scoped ops. Slack "sections" are individual BLOCKS — a heading
+    // and its body are separate sections — so a heading-matched op must cover
+    // the whole heading REGION or the old body is left behind (live-observed
+    // as a duplicated section). When section_text names a heading, resolve
+    // the region from the HTML export; otherwise (or when the read-back
+    // failed) fall back to the original single-block lookup.
+    const region: HeadingRegion | null = html ? resolveHeadingRegion(html, sectionText) : null;
+    if (op === 'replace_section' && region && region.checkedItemCount > 0) {
+      tickWarnings.push(
+        `${region.checkedItemCount} ticked item(s) in the old section lost their tick state — rewrites reset checkboxes (tick state is UI-only)`,
+      );
+    }
+
+    if (region && op === 'replace_section') {
+      // Replace the heading block FIRST (the new content lands), then delete
+      // the old body. canvases.edit takes one change per call, so a
+      // mid-sequence failure leaves a partial duplicate plus an error nudge —
+      // never content loss.
+      await editCanvas(auth.token, canvasId, { operation: 'replace', sectionId: region.headingId, markdown });
+      let deleted = 0;
+      try {
+        for (const id of region.bodyIds) {
+          await editCanvas(auth.token, canvasId, { operation: 'delete', sectionId: id });
+          deleted++;
+        }
+      } catch (err) {
+        await fail(
+          `replace_section partially applied: the new content is in place but ${region.bodyIds.length - deleted} old block(s) of the previous section remain below it — read the canvas and remove the leftovers. Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return;
+      }
+      log.info('canvas_edit applied', {
+        sessionId: session.id,
+        requestId,
+        canvasId,
+        op,
+        blocksReplaced: region.bodyIds.length + 1,
+      });
+      await finish(
+        region.hasUnaddressableBlocks
+          ? 'Note: some blocks in the old section could not be addressed and were left in place — re-read to verify.'
+          : undefined,
+      );
+      return;
+    }
+
+    if (region && op === 'insert_after_section') {
+      // Insert after the END of the region (its last block), not after the
+      // heading — inserting right after the heading splits the section body.
+      await editCanvas(auth.token, canvasId, { operation: 'insert_after', sectionId: region.lastId, markdown });
+      log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
+      await finish();
+      return;
+    }
+
+    // section_text does not name a heading (or the read-back failed):
+    // single-block behavior via sections.lookup, as before.
+    const sectionId = await lookupCanvasSection(auth.token, canvasId, sectionText);
+    if (!sectionId) {
+      await fail(
+        `no section matching "${sectionText}" found in canvas ${canvasId} — re-read the canvas and retry with text the section actually contains`,
+      );
+      return;
+    }
+    const change: CanvasChange = {
+      operation: op === 'replace_section' ? 'replace' : 'insert_after',
+      sectionId,
+      markdown,
+    };
+    await editCanvas(auth.token, canvasId, change);
+    log.info('canvas_edit applied', { sessionId: session.id, requestId, canvasId, op });
+    await finish();
+  } catch (err) {
+    await fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleCanvasRead(content: Record<string, unknown>, session: Session): Promise<void> {
+  const requestId =
+    typeof content.requestId === 'string' && content.requestId ? content.requestId : `canvas-${Date.now()}`;
+  // Reader responses never wake: the container tool is already polling for
+  // this row (errors included — a wake would double-charge the outcome).
+  const respond = (status: 'ok' | 'error', result: Record<string, unknown>): Promise<void> => {
+    return writeCanvasResponse(session, { requestId, action: 'canvas_read', status, result });
+  };
+
+  const canvasId = typeof content.canvas_id === 'string' ? content.canvas_id : '';
+  if (!canvasId) {
+    await respond('error', { error: 'canvas_read needs canvas_id' });
+    return;
+  }
+
+  const auth = await resolveSessionBotToken(session);
+  if ('error' in auth) {
+    await respond('error', { error: auth.error });
+    return;
+  }
+
+  try {
+    const text = await fetchCanvasText(auth.token, canvasId);
+    log.info('canvas_read served', { sessionId: session.id, requestId, canvasId, chars: text.length });
+    await respond('ok', { canvas_id: canvasId, text });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn('canvas_read failed', { sessionId: session.id, requestId, error: message });
+    await respond('error', { error: message });
+  }
+}

--- a/src/modules/canvas-actions/index.ts
+++ b/src/modules/canvas-actions/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Canvas-actions module — host side of the container's canvas tools
+ * (plan: slack-native 06/09, D19).
+ *
+ * Registers two delivery actions:
+ *  - `canvas_edit` — section-scoped canvas edits (append / replace_section /
+ *    insert_after_section). The op mapping is safe by construction: whole-doc
+ *    replace is unrepresentable (see canvas-api.ts CanvasChange).
+ *  - `canvas_read` — files.info → HTML download → readable text, returned as
+ *    an inbound system row the container tool blocks on.
+ *
+ * Both run unguarded: they act via the session's OWN bot identity (the same
+ * token that delivers this session's ordinary messages), so they can reach
+ * exactly what that bot can already reach — no privileged effect, nothing to
+ * hold for approval.
+ *
+ * Registration targets the trunk guard registry (src/guard/, three-arg
+ * registerDeliveryAction) — on this branch it resolves after the next
+ * main → channels sync; the barrel import stays commented until then.
+ */
+import { registerDeliveryAction } from '../../delivery.js';
+import { unguarded } from '../../guard/index.js';
+import { handleCanvasEdit, handleCanvasRead } from './handlers.js';
+
+registerDeliveryAction(
+  'canvas_edit',
+  handleCanvasEdit,
+  unguarded("canvas content edit via the session's own bot identity; no privileged effect"),
+);
+
+registerDeliveryAction(
+  'canvas_read',
+  handleCanvasRead,
+  unguarded("read-only canvas fetch via the session's own bot identity; no privileged effect"),
+);

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -24,3 +24,7 @@ import './interactive/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './slack-room-membership/index.js';
+import './canvas-actions/index.js';
+import './slack-onboarding/index.js';
+import './slack-agent-flow/index.js';

--- a/src/modules/slack-agent-flow/env-file.test.ts
+++ b/src/modules/slack-agent-flow/env-file.test.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+
+describe('slack-agent-flow env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'SAF_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'SAF_PLAIN=value1',
+          '  SAF_INDENTED = spaced ',
+          'SAF_DQUOTED="double quoted"',
+          "SAF_SQUOTED='single quoted'",
+          'SAF_EMPTY=',
+          '# SAF_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'SAF_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'SAF_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'SAF_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'SAF_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'SAF_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('SAF_PREFERS=file-value\n');
+      vi.stubEnv('SAF_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'SAF_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('SAF_BLANK_ENV=file-value\n');
+      vi.stubEnv('SAF_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'SAF_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('second');
+    });
+  });
+
+  describe('upsertEnvKey', () => {
+    it('creates .env when absent', () => {
+      upsertEnvKey(rootDir, 'SAF_NEW', 'v1');
+      expect(read()).toBe('SAF_NEW=v1\n');
+      expect(readEnvValue(rootDir, 'SAF_NEW')).toBe('v1');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      upsertEnvKey(rootDir, 'SAF_APPENDED', 'v2');
+      expect(read()).toBe('EXISTING=x\nSAF_APPENDED=v2\n');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nSAF_TARGET=old\nLAST=9\n');
+      upsertEnvKey(rootDir, 'SAF_TARGET', 'new');
+      expect(read()).toBe('# keep me\nFIRST=1\nSAF_TARGET=new\nLAST=9\n');
+    });
+
+    it('does not touch keys that merely share a prefix', () => {
+      write('SAF_KEY=keep\nSAF_KEY_LONGER=keep-too\n');
+      upsertEnvKey(rootDir, 'SAF_KEY', 'changed');
+      expect(read()).toBe('SAF_KEY=changed\nSAF_KEY_LONGER=keep-too\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      upsertEnvKey(rootDir, 'SAF_DUP', 'final');
+      expect(read()).toBe('SAF_DUP=final\nSAF_DUP=final\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('final');
+    });
+
+    it('replaces an indented assignment (readable lines are writable lines)', () => {
+      write('  SAF_INDENTED=old\n');
+      upsertEnvKey(rootDir, 'SAF_INDENTED', 'new');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('new');
+      expect(read()).not.toContain('old');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates the key and reports the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'alpha')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('SAF_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('SAF_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys (the adapter's SLACK_INSTANCES loop) parse .env
+      // only, so the union must be based on the file, not a stale
+      // process.env copy.
+      write('SAF_LIST=alpha\n');
+      vi.stubEnv('SAF_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('SAF_LIST=alpha,beta');
+    });
+  });
+});

--- a/src/modules/slack-agent-flow/env-file.ts
+++ b/src/modules/slack-agent-flow/env-file.ts
@@ -1,0 +1,96 @@
+/**
+ * .env read/write helpers for the slack-agent-flow leg.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — the adapter's SLACK_INSTANCES loop
+ * (src/channels/slack.ts) reads back everything written here through that
+ * parser. Write conventions mirror upsertEnvLine /
+ * appendSlackInstance in .claude/skills/slack-managed-agents/scripts/
+ * slack-create-agent.ts: replace the key's line in place, preserve every
+ * other line (comments and blanks included), append with a clean trailing
+ * newline.
+ *
+ * Values written here include live Slack tokens: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value.
+ */
+export function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/src/modules/slack-agent-flow/guard.ts
+++ b/src/modules/slack-agent-flow/guard.ts
@@ -1,0 +1,60 @@
+/**
+ * Slack-agent-flow guard adapter — the module's catalog entries for the
+ * agent-facing room actions, composed at the module edge (imported
+ * by ./index.ts), mirroring agent-to-agent/guard.ts.
+ *
+ * rooms.create / rooms.add_agent — same trust split as agents.create:
+ * `global` cli_scope acts directly (room wiring is the intended primitive for
+ * trusted owner agent groups); anything else — the default `group` scope, and
+ * unknown/missing config, fail-closed — holds for the requesting group's
+ * admin chain. Both actions write central-DB state (messaging groups,
+ * wirings, a2a destinations) and open Slack conversations with the operator,
+ * so a confined container must never reach the handler unheld.
+ */
+import { getContainerConfig } from '../../db/container-configs.js';
+import { ALLOW, DENY, HOLD, defineGuardedAction, type GuardedAction } from '../../guard/index.js';
+import type { GuardDecision, GuardInput } from '../../guard/index.js';
+
+/** The agents.create trust split, reused verbatim for the room actions. */
+async function decideByCliScope(input: GuardInput, action: string): Promise<GuardDecision> {
+  if (input.actor.kind !== 'agent') return DENY(`${action} is a container-originated action.`);
+  const cliScope = (await getContainerConfig(input.actor.agentGroupId))?.cli_scope ?? 'group';
+  if (cliScope === 'global') {
+    // Trusted owner agent group — an approval tap on every room change would
+    // be needless friction.
+    return ALLOW('trusted global-scope agent group');
+  }
+  // The realistic prompt-injection victim (default `group` scope) — and any
+  // unknown config value, fail-closed — requires an admin before any
+  // central-DB write or MPIM open.
+  return HOLD(`agent-initiated ${action} requires admin approval`);
+}
+
+export const roomsCreate: GuardedAction = defineGuardedAction({
+  action: 'rooms.create',
+  grantActionName: 'create_room',
+  // Bind a create_room grant to the room name that was approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      return (JSON.parse(grant.payload) as { name?: string }).name === input.payload.name;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'create_room'),
+});
+
+export const roomsAddAgent: GuardedAction = defineGuardedAction({
+  action: 'rooms.add_agent',
+  grantActionName: 'add_to_room',
+  // Bind an add_to_room grant to the exact (room, agent) pair approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      const p = JSON.parse(grant.payload) as { room?: string; agent?: string };
+      return p.room === input.payload.room && p.agent === input.payload.agent;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'add_to_room'),
+});

--- a/src/modules/slack-agent-flow/index.ts
+++ b/src/modules/slack-agent-flow/index.ts
@@ -1,0 +1,275 @@
+/**
+ * slack-agent-flow module — guarded re-registration of `create_agent`.
+ *
+ * Re-registers the delivery action with the SAME guard pieces as upstream
+ * (agents.create decision, validateCreateAgent precheck) and a handler that
+ * first runs the upstream `createAgent()` (with its premature success notify
+ * suppressed on the Slack path — see slackAwareCreateAgent), then — only when
+ * the request originated from a Slack session — provisions a dedicated Slack
+ * bot for the new group (orchestrate.ts). The barrel imports this module AFTER
+ * agent-to-agent's registration, so this entry wins; the expected boot log is
+ * `Delivery action handler overwritten`. Approved replays re-enter this
+ * wrapper automatically — reenterGuardedDeliveryAction resolves the entry at
+ * call time, so no approval-handler re-registration is needed.
+ *
+ * Also registers the agent-facing room actions: `create_room` (one
+ * MPIM with N bots + the operator over ensureAgentRoom) and `add_to_room`
+ * (superset re-open — MPIM fork), each guard-wrapped with the same
+ * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
+ *
+ * The handler never touches inbound DBs (guarded handlers replay without
+ * one); all requester notifications go through the approvals module's
+ * notifyAgent. Token values never appear in notify texts or logs.
+ */
+import { SlackApiError } from '../../channels/slack-lib.js';
+import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
+import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
+import { agentsCreate } from '../agent-to-agent/guard.js';
+import { notifyAgent, registerApprovalHandler, requestApproval } from '../approvals/index.js';
+import { roomsAddAgent, roomsCreate } from './guard.js';
+import { dedupeSlug, deriveInstanceSlug, runSlackAgentFlow } from './orchestrate.js';
+import {
+  handleAddToRoom,
+  handleCreateRoom,
+  requestAddToRoomHold,
+  requestCreateRoomHold,
+  validateAddToRoom,
+  validateCreateRoom,
+} from './room-actions.js';
+import { pendingInstall, prefetchAvatar, resolveProvisioningCredential } from './provision.js';
+import { SlackFlowError } from './types.js';
+
+/** The Slack gate: the request came in through a Slack-channel session. */
+async function isSlackOriginSession(session: Session): Promise<boolean> {
+  if (!session.messaging_group_id) return false;
+  return (await getMessagingGroup(session.messaging_group_id))?.channel_type === 'slack';
+}
+
+// Avatar prefetch for multi-agent creates ("build me a team"): the batch
+// preview sees every create_agent row in the session's outbound batch before
+// they are processed sequentially, and starts all their avatar generations in
+// parallel — each is an independent async Lambda on the broker, so N waits
+// collapse to ~one (~23s). Gated on ≥2 creates: a single create starts its
+// flow immediately anyway, and skipping the single case means a guard-HELD
+// lone request never generates an avatar it might not get approval for.
+// The (displayName, description) derivation MUST mirror runSlackAgentFlow /
+// orchestrate exactly — a mismatch is harmless (fresh request) but wastes the
+// prefetch.
+registerDeliveryBatchPreview(async (batch, session) => {
+  if (!(await isSlackOriginSession(session))) return;
+  const creates = batch
+    .filter((m) => m.kind === 'system')
+    .map((m) => {
+      try {
+        return JSON.parse(m.content) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (c): c is Record<string, unknown> =>
+        c !== null && c.action === 'create_agent' && typeof c.name === 'string' && c.name !== '',
+    );
+  if (creates.length < 2) return;
+  const credential = resolveProvisioningCredential(process.cwd());
+  if (credential?.mode !== 'broker') return;
+  for (const c of creates) {
+    prefetchAvatar(
+      credential.baseUrl,
+      credential.installToken,
+      c.name as string,
+      typeof c.instructions === 'string' ? c.instructions.slice(0, 300) : undefined,
+    );
+  }
+  log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
+});
+
+function successText(name: string, roomChannelId: string | undefined, deferredInstall = false): string {
+  // The user already knows they were waiting on their workspace — name what
+  // unblocked it so the relay reads as an ending, not a fresh announcement.
+  const installed = deferredInstall ? ' The workspace approved the install, which is what the wait was for.' : '';
+  // room:'none': no shared room was opened — the multi-create
+  // pattern finishes with one create_room naming every agent.
+  if (roomChannelId === undefined) {
+    return (
+      `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
+      `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
+      `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+      installed
+    );
+  }
+  return (
+    `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
+    `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
+    `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+    installed
+  );
+}
+
+function failureText(
+  name: string,
+  localName: string,
+  step: string,
+  message: string,
+  newAgentGroupId: string,
+  slug: string,
+  sourceGroupId: string,
+  roomNone: boolean,
+): string {
+  // room:'none' must survive into the printed finish command too — omitting
+  // it would make the retry grow a room the multi-create pattern skipped.
+  return (
+    `Agent "${name}" was created and is reachable via send_message({ to: "${localName}", ... }), ` +
+    `but its Slack setup failed at step '${step}': ${message}. An operator can finish it with: ` +
+    `pnpm exec tsx scripts/slack-agent-flow-finish.ts --group ${newAgentGroupId} --name ${slug} ` +
+    `--source-group ${sourceGroupId}${roomNone ? ' --room none' : ''} [--origin-instance <key>] [--restart]`
+  );
+}
+
+/** Run the Slack leg for an already-created agent group and report the outcome. */
+async function runSlackLeg(
+  content: Record<string, unknown>,
+  session: Session,
+  args: {
+    name: string;
+    localName: string;
+    newAgentGroupId: string;
+    slug: string;
+  },
+): Promise<void> {
+  const { name, localName, newAgentGroupId, slug } = args;
+  try {
+    const r = await runSlackAgentFlow({ content, session, newAgentGroupId, slug });
+    await notifyAgent(session, successText(name, r.roomChannelId, r.deferredInstall));
+  } catch (err) {
+    // SlackApiError carries the flow step id its call site passed to the
+    // shared Slack lib — surface it like a typed flow step.
+    const step = err instanceof SlackFlowError || err instanceof SlackApiError ? err.step : 'unknown';
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(
+      session,
+      failureText(
+        name,
+        localName,
+        step,
+        message,
+        newAgentGroupId,
+        slug,
+        session.agent_group_id,
+        content.room === 'none',
+      ),
+    );
+    log.error('slack-agent-flow failed', { step });
+  }
+}
+
+async function slackAwareCreateAgent(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = typeof content.name === 'string' ? content.name : '';
+  const localName = normalizeName(name);
+  const before = await getDestinationByName(session.agent_group_id, localName);
+  const slackOrigin = await isSlackOriginSession(session);
+
+  // Resume, not collide: the agent group exists and its Slack app exists, but
+  // the workspace never approved the install, so the flow parked. Asking for
+  // the same agent again is how a user says "finish that" — take them back to
+  // waiting on the app they already have rather than reporting a name clash
+  // (upstream's answer) or provisioning a second one.
+  if (slackOrigin && before?.target_type === 'agent' && name) {
+    const slug = await dedupeSlug(deriveInstanceSlug(name), before.target_id);
+    if (pendingInstall(process.cwd(), slug)) {
+      await runSlackLeg(content, session, { name, localName, newAgentGroupId: before.target_id, slug });
+      return;
+    }
+  }
+
+  // Upstream behavior byte-for-byte on non-Slack sessions. On the Slack path
+  // the upstream "created — you can now message it" success notify is
+  // suppressed: it fires BEFORE Slack provisioning, so relaying it would
+  // report "done" ~a minute early — this wrapper's successText/failureText
+  // is the only completion signal. Upstream error notifies (collision,
+  // invalid path) still fire either way.
+  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+
+  const after = await getDestinationByName(session.agent_group_id, localName);
+  // Creation bailed or collided — upstream already answered the requester.
+  if (!after || after.target_type !== 'agent' || before) return;
+  // Non-Slack sessions (and task/a2a sessions with no messaging group) behave exactly as upstream.
+  if (!slackOrigin) return;
+
+  await runSlackLeg(content, session, {
+    name,
+    localName,
+    newAgentGroupId: after.target_id,
+    slug: await dedupeSlug(deriveInstanceSlug(name), after.target_id),
+  });
+}
+
+/**
+ * Slack-aware hold: same payload shape as upstream ({ name, instructions })
+ * so the approved replay re-enters this wrapper unchanged; only the card text
+ * differs, telling the admin a Slack bot comes with the sub-agent.
+ */
+async function requestSlackCreateAgentHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  if (!(await isSlackOriginSession(session))) {
+    await requestCreateAgentHold(content, session);
+    return;
+  }
+  const name = typeof content.name === 'string' ? content.name : '';
+  const instructions = typeof content.instructions === 'string' ? content.instructions : null;
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_agent',
+    // allow_guests must survive the hold: the approved replay re-enters the
+    // wrapper with this payload, and dropping it would silently upgrade a
+    // guest-accessible request to the agent-view variant.
+    payload: {
+      name,
+      instructions,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.allow_guests === true ? { allow_guests: true } : {}),
+      // room:'none' must survive the hold too — dropping it would grow a
+      // room the multi-create pattern deliberately skipped.
+      ...(content.room === 'none' ? { room: 'none' } : {}),
+    },
+    title: `Create agent: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
+  });
+}
+
+registerDeliveryAction('create_agent', slackAwareCreateAgent, {
+  guardAction: agentsCreate,
+  precheck: validateCreateAgent,
+  requestHold: requestSlackCreateAgentHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_agent denied: ${reason}`),
+});
+
+// Agent-facing room actions — guard-wrapped like create_agent:
+// global-scope groups act directly, everything else holds for the admin
+// chain, and the approval continuation re-enters the same wrapped entry with
+// the approval row as its grant.
+registerDeliveryAction('create_room', handleCreateRoom, {
+  guardAction: roomsCreate,
+  precheck: validateCreateRoom,
+  requestHold: requestCreateRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_room denied: ${reason}`),
+});
+registerApprovalHandler('create_room', reenterGuardedDeliveryAction('create_room'));
+
+registerDeliveryAction('add_to_room', handleAddToRoom, {
+  guardAction: roomsAddAgent,
+  precheck: validateAddToRoom,
+  requestHold: requestAddToRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `add_to_room denied: ${reason}`),
+});
+registerApprovalHandler('add_to_room', reenterGuardedDeliveryAction('add_to_room'));

--- a/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -1,0 +1,930 @@
+/**
+ * End-to-end tests for the slack-agent-flow wrapped create_agent action.
+ *
+ * Drives the REAL guard-wrapped delivery entry (getDeliveryAction) over a real
+ * in-memory central DB; Slack/broker traffic is a recorded fetch stub and the
+ * optional-module seam (slack-deps.js) is a recorded fake — no network, no
+ * skill-installed channel files. rootDir is process.cwd(), so each test runs
+ * chdir'd into its own tmpdir (vitest's default forks pool allows chdir).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ORIGIN_BOT_TOKEN = 'xoxb-origin-secret-token';
+const NEW_BOT_TOKEN = 'xoxb-new-bot-secret-token';
+const NEW_APP_TOKEN = 'xapp-new-app-secret-token';
+const REGISTRY_TOKEN = 'nct-registry-secret-token';
+
+// vi.hoisted: the module import below runs before this file's const
+// initializers, and the mock factories close over this state.
+const {
+  mockNotifyWrite,
+  mockRequestApproval,
+  mockInitGroupFilesystem,
+  mockWriteDestinations,
+  mockCreateRoomCanvas,
+  mockWireCanvasComments,
+  mockAssertSlackInstancesModuleInstalled,
+  fakeDeps,
+} = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+  mockInitGroupFilesystem: vi.fn(),
+  mockWriteDestinations: vi.fn(),
+  mockCreateRoomCanvas: vi.fn(),
+  mockWireCanvasComments: vi.fn(),
+  mockAssertSlackInstancesModuleInstalled: vi.fn().mockResolvedValue(undefined),
+  fakeDeps: {
+    slackInstanceBridgeFactory: vi.fn().mockReturnValue(null),
+    SLACK_DEFAULTS: undefined as unknown, // assigned in beforeEach (TEST_SLACK_DEFAULTS)
+    registerChannelAdapter: vi.fn(),
+    startChannelAdapter: vi.fn().mockResolvedValue('started'),
+  },
+}));
+
+// The optional-module seam — the only door to skill-installed channel files.
+vi.mock('./slack-deps.js', () => ({
+  loadSlackChannelDeps: async () => fakeDeps,
+  assertSlackInstancesModuleInstalled: (...a: unknown[]) => mockAssertSlackInstancesModuleInstalled(...a),
+}));
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+// wireCanvasComments (shadow-channel wiring) rides in the same module.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+// delivery.ts pulls more session-manager exports at import time.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({
+  initGroupFilesystem: (...a: unknown[]) => mockInitGroupFilesystem(...a),
+}));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// wrapper only needs these three. notifyAgent stays REAL (from primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the wrapped create_agent delivery action — the path under test.
+// Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
+import './index.js';
+import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
+import { SlackFlowError } from './types.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+// Mirrors the shape the Slack adapter declares (SLACK_DEFAULTS): the dm
+// context carries the B7 agent-DM declaration (sessionMode 'per-thread';
+// resolveWiringDefaults derives the threads=1 stamp from it) — S8 stamps
+// whatever the declaration resolves, so the per-thread/threads:1 pins below
+// exercise the declaration-driven path, not a hardcode.
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: {
+    engageMode: 'pattern',
+    engagePattern: '.',
+    threads: true,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'strict',
+  },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+/** .env content snapshotted at each chat.postMessage — proves S10 ran before S13. */
+let postMessageEnvSnapshots: string[] = [];
+let brokerStatus = 200;
+let tmpDir = '';
+/** null → the workspace refused auto-install; POST /v1/apps answers with a link instead. */
+let brokerBotToken: string | null = NEW_BOT_TOKEN;
+let brokerInstallUrl = '';
+/** Successive GET /v1/apps/{id} answers; the last one repeats. `http` overrides the status code. */
+let appStateQueue: Array<{ status?: string; bot_token?: string; http?: number }> = [];
+let appStateReads = 0;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const auth = String(init?.headers?.Authorization ?? '');
+  const token = auth.replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.endsWith('/v1/avatars')) {
+    // Pre-create avatar job: dispatched...
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'pending' }, 202));
+  }
+  if (url.includes('/v1/avatars/')) {
+    // ...and ready on the first poll, so the bot is born wearing its face.
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'ready' }));
+  }
+  if (url.includes('/v1/apps/')) {
+    const state = appStateQueue[Math.min(appStateReads, appStateQueue.length - 1)];
+    appStateReads++;
+    if (!state) return Promise.resolve(jsonResponse({ error: 'not_found' }, 404));
+    return Promise.resolve(jsonResponse(state, state.http ?? 200));
+  }
+  if (url.endsWith('/v1/apps')) {
+    if (brokerStatus !== 200) return Promise.resolve(jsonResponse({ message: 'boom' }, brokerStatus));
+    return Promise.resolve(
+      jsonResponse({
+        appId: 'A0TEST',
+        appToken: NEW_APP_TOKEN,
+        ...(brokerBotToken ? { botToken: brokerBotToken } : {}),
+        ...(brokerInstallUrl ? { installUrl: brokerInstallUrl } : {}),
+      }),
+    );
+  }
+  if (url.includes('/api/auth.test')) {
+    const userId = token === ORIGIN_BOT_TOKEN ? 'U0ORIGINBOT' : 'U0NEWBOT';
+    return Promise.resolve(
+      jsonResponse({
+        ok: true,
+        user_id: userId,
+        team_id: 'T0TEST',
+        team: 'NanoCo Test',
+        url: 'https://nanoco-test.slack.com/',
+      }),
+    );
+  }
+  if (url.includes('/api/conversations.open')) {
+    const users = String((JSON.parse(body) as { users?: string }).users ?? '');
+    return Promise.resolve(jsonResponse({ ok: true, channel: { id: users.includes(',') ? 'G0ROOM' : 'D0NEWDM' } }));
+  }
+  if (url.includes('/api/chat.postMessage')) {
+    const envPath = path.join(tmpDir, '.env');
+    postMessageEnvSnapshots.push(fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : '');
+    return Promise.resolve(jsonResponse({ ok: true }));
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+async function runCreateAgent(content: Record<string, unknown>, session: Session = SLACK_SESSION): Promise<void> {
+  const wrapped = getDeliveryAction('create_agent');
+  expect(wrapped).toBeDefined();
+  await wrapped!(content, session);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ORIGIN_BOT_TOKEN, NEW_BOT_TOKEN, NEW_APP_TOKEN, REGISTRY_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  fakeDeps.SLACK_DEFAULTS = TEST_SLACK_DEFAULTS;
+  fakeDeps.startChannelAdapter.mockResolvedValue('started');
+  // Degraded default (free workspace / canvases off): C2 returns undefined —
+  // the flow must tolerate it (no canvas, no link line). Canvas tests opt in.
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  postMessageEnvSnapshots = [];
+  brokerStatus = 200;
+  brokerBotToken = NEW_BOT_TOKEN;
+  brokerInstallUrl = '';
+  appStateQueue = [];
+  appStateReads = 0;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-agent-flow-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ORIGIN_BOT_TOKEN}\n`);
+  process.env.NANOCLAW_REGISTRY_TOKEN = REGISTRY_TOKEN; // broker mode, no account.json / .env lookup
+
+  const db = await initTestDb();
+  await runMigrations(db);
+
+  const now = new Date().toISOString();
+  await createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  await ensureContainerConfig(SRC_GROUP);
+  await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  await upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  await grantRole({
+    user_id: 'slack:U0OPERATOR',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createSession(SLACK_SESSION);
+  // Declared platform defaults so resolveWiringDefaults / validate see slack's
+  // real shape (group: mention-sticky + threads) for the dead named instance.
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  delete process.env.NANOCLAW_REGISTRY_TOKEN;
+  delete process.env.SLACK_INSTALL_WAIT_MS;
+  delete process.env.SLACK_INSTALL_POLL_MS;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slack-aware create_agent — happy path (Slack-origin session)', () => {
+  it('creates the group, provisions the bot, wires DM + room, posts intros in order', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // Upstream leg: group + scaffold + bidirectional a2a destinations.
+    const newGroup = await getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(mockInitGroupFilesystem).toHaveBeenCalledTimes(1);
+    const dest = await getDestinationByName(SRC_GROUP, 'research');
+    expect(dest).toMatchObject({ target_type: 'agent', target_id: newGroup!.id });
+    expect(await getDestinationByName(newGroup!.id, 'parent')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+
+    // Env keys (values themselves never asserted into messages/logs).
+    const env = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    expect(env).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(env).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // Hot-add through the seam.
+    expect(fakeDeps.registerChannelAdapter).toHaveBeenCalledWith(
+      'slack-research',
+      expect.objectContaining({ defaults: TEST_SLACK_DEFAULTS }),
+    );
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+
+    // DM row + wiring on the NEW instance. Agent-view is the default variant
+    // so the DM gets thread-per-conversation sessions:
+    // session_mode 'per-thread' + explicit threads:1.
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(dmMg).toMatchObject({ is_group: 0, unknown_sender_policy: 'strict', name: 'Research DM' });
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'per-thread',
+      threads: 1,
+      priority: 0,
+    });
+
+    // Room: one row PER instance, policy 'public', mention/accumulate wirings
+    // (D4 — flow-created rooms only; mention-sticky is gone from the flow).
+    const roomOrigin = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack');
+    const roomNew = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack-research');
+    expect(roomOrigin).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(roomNew).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(await getMessagingGroupAgentByPair(roomOrigin!.id, SRC_GROUP)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+    expect(await getMessagingGroupAgentByPair(roomNew!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+
+    // Projections pushed into the live source session.
+    expect(mockWriteDestinations).toHaveBeenCalledWith(SRC_GROUP, 'sess-1');
+
+    // No room-contract post: the only chat.postMessage is the DM intro,
+    // and SLACK_A2A_ROOMS was in .env before it.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(posts[0]!.token).toBe(NEW_BOT_TOKEN);
+    expect(postMessageEnvSnapshots).toHaveLength(1);
+    expect(postMessageEnvSnapshots[0]).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // The ORIGIN agent authors the room intro — exactly one
+    // instruction-shaped nudge written into the origin session, tagging the
+    // new bot and addressing the room by its projected destination name.
+    const nudges = notifyTexts().filter((t) => t.includes('introduction'));
+    expect(nudges).toHaveLength(1);
+    const nudgeCall = mockNotifyWrite.mock.calls.find((c) =>
+      String((c[2] as { content: string }).content).includes('introduction'),
+    )!;
+    expect(nudgeCall[0]).toBe(SRC_GROUP);
+    expect(nudgeCall[1]).toBe('sess-1');
+    // notifyAgent leaves `trigger` unset — writeSessionMessage defaults it
+    // to 1, so the nudge wakes the origin agent.
+    expect((nudgeCall[2] as { trigger?: number }).trigger).toBeUndefined();
+    expect(nudges[0]).toContain('<@U0NEWBOT>');
+    expect(nudges[0]).toContain('send_message({ to: "research-room"');
+    expect(nudges[0]).toContain('no mechanics, no member lists');
+    // No explicit purpose was provided — the creation prompt must NOT leak
+    // into the nudge (no fallback — creation prompts are private).
+    expect(nudges[0]).not.toContain('dig deep');
+    // No canvas id → no shadow channel to wire.
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+
+    // MPIM opened as the new bot with operator + origin bot.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(2);
+    expect(JSON.parse(opens[1]!.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT' });
+    expect(opens[1]!.token).toBe(NEW_BOT_TOKEN);
+
+    // Requester heard ONLY the Slack success notify — the upstream "created —
+    // you can now message it" text is suppressed on the Slack path (it fires
+    // before provisioning and would report "done" ~a minute early).
+    const texts = notifyTexts();
+    expect(texts.some((t) => t.includes('Agent "research" created'))).toBe(false);
+    expect(texts.at(-1)).toContain('is live on Slack');
+    expect(texts.at(-1)).toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+});
+
+describe('slack-aware create_agent — manifest variants', () => {
+  it('allow_guests: broker gets allow_guests:true, DM wiring keeps the plain defaults', async () => {
+    await runCreateAgent({ name: 'Guesty', instructions: 'help the guests', allow_guests: true });
+
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBe(true);
+
+    const newGroup = await getAgentGroupByFolder('guesty');
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-guesty');
+    const dmWiring = (await getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id))!;
+    expect(dmWiring).toMatchObject({ session_mode: 'shared' });
+    expect(dmWiring.threads ?? null).toBeNull();
+  });
+
+  it('default (agent-view): broker body carries no allow_guests flag', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBeUndefined();
+  });
+});
+
+describe("slack-aware create_agent — room:'none'", () => {
+  it('skips the room half entirely: DM only, no MPIM, no a2a entry, no canvas, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    expect(await getAgentGroupByFolder('research')).toBeDefined();
+    // Only the operator-DM conversations.open — no MPIM.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(1);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR' });
+    // No room rows on any instance, no a2a allowlist, no canvas, no shadow wiring.
+    expect((await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:G0ROOM')).toHaveLength(0);
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).not.toContain('SLACK_A2A_ROOMS');
+    expect(mockCreateRoomCanvas).not.toHaveBeenCalled();
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+    // The DM intro still posts; the origin agent gets NO intro nudge.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(0);
+    // Success text is the no-room variant pointing at create_room.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain("room:'none'");
+    expect(success).toContain('create_room');
+    expect(success).not.toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+
+  it("hold payload carries room:'none' through to the approved replay (confined group)", async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    // Held — nothing created yet; the replay payload must preserve room:'none'.
+    expect(await getAgentGroupByFolder('research')).toBeUndefined();
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_agent');
+    expect(opts.payload).toMatchObject({ name: 'Research', room: 'none' });
+  });
+});
+
+describe('slack-aware create_agent — room canvas contract', () => {
+  it('canvas available: called with the contract data (plain agent names), all participants wired', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The canvas carries the room contract: purpose, creator, members. Agent
+    // members travel as PLAIN NAMES — never bot user ids (the de-mention rule).
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Research room',
+      purpose: 'Research room',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Research'],
+    });
+    // Shadow-channel wiring rides on canvas success: EVERY participant —
+    // creator identified separately from the full list.
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledWith(
+      'F0CANVAS',
+      expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      [
+        expect.objectContaining({ instanceKey: 'slack', agentGroupId: SRC_GROUP }),
+        expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      ],
+      'Research room',
+    );
+    // Still no room post: the canvas tab IS the pinned surface — no link
+    // message either.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+  });
+});
+
+describe('ensureAgentRoom — N-bot rooms', () => {
+  it('opens the MPIM with every participating bot, wires each instance, and makes destinations pairwise', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    await createAgentGroup({ id: 'ag-third', name: 'Devin', folder: 'devin', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-devin', botUserId: 'U0THIRD', agentGroupId: 'ag-third', agentGroupName: 'Devin' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+
+    const result = await ensureAgentRoom({
+      creator: participants[2]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      rootDir: tmpDir,
+    });
+    expect(result).toMatchObject({ roomChannelId: 'G0ROOM', created: true });
+
+    // MPIM opened as the creator with operator + every OTHER participating bot.
+    const open = fetchCalls.find((c) => c.url.includes('conversations.open'))!;
+    expect(open.token).toBe(NEW_BOT_TOKEN);
+    expect(JSON.parse(open.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT,U0THIRD' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const p of participants) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', p.instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, p.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Destinations symmetry: every distinct agent-group pair, both directions.
+    expect(await getDestinationByName(SRC_GROUP, 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-third',
+    });
+    expect(await getDestinationByName(SRC_GROUP, 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-new',
+    });
+    expect(await getDestinationByName('ag-third', 'andy')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+    expect(await getDestinationByName('ag-third', 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-new',
+    });
+    expect(await getDestinationByName('ag-new', 'andy')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+    expect(await getDestinationByName('ag-new', 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-third',
+    });
+
+    // Allowlisted for a2a. No room-contract post: ensureAgentRoom
+    // itself posts nothing — the origin agent authors the intro, and
+    // the contract data lives on the canvas.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    // The canvas gets the contract data — every agent by plain name.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Devin', 'Pixel'],
+    });
+  });
+
+  it('is idempotent: a second call creates nothing new and grows no second canvas', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+    const args = {
+      creator: participants[1]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      rootDir: tmpDir,
+    };
+
+    await ensureAgentRoom(args);
+    const mgCountAfterFirst = (await getAllMessagingGroups()).length;
+
+    const second = await ensureAgentRoom(args);
+    expect(second).toMatchObject({ roomChannelId: 'G0ROOM', created: false });
+    expect((await getAllMessagingGroups()).length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-aware create_agent — non-Slack parity', () => {
+  it('non-slack session: behaves exactly as upstream, zero Slack side effects', async () => {
+    await createMessagingGroup({
+      id: 'mg-tg',
+      channel_type: 'telegram',
+      platform_id: 'tg:123',
+      name: 'TG DM',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+    const tgSession: Session = { ...SLACK_SESSION, id: 'sess-tg', messaging_group_id: 'mg-tg' };
+    await createSession(tgSession);
+    const envBefore = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    const mgCountBefore = (await getAllMessagingGroups()).length;
+
+    await runCreateAgent({ name: 'Helper' }, tgSession);
+
+    expect(await getAgentGroupByFolder('helper')).toBeDefined(); // upstream leg ran
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toBe(envBefore);
+    expect((await getAllMessagingGroups()).length).toBe(mgCountBefore);
+  });
+
+  it('null messaging_group_id (task/a2a session): skips the Slack leg', async () => {
+    const bareSession: Session = { ...SLACK_SESSION, id: 'sess-bare', messaging_group_id: null };
+    await createSession(bareSession);
+
+    await runCreateAgent({ name: 'Helper' }, bareSession);
+
+    expect(await getAgentGroupByFolder('helper')).toBeDefined();
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack-aware create_agent — failure and retry', () => {
+  it('broker failure: group still exists, failure notify carries the finish command', async () => {
+    brokerStatus = 500;
+
+    await runCreateAgent({ name: 'Research' });
+
+    const newGroup = await getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('scripts/slack-agent-flow-finish.ts');
+    expect(failure).toContain(`--group ${newGroup!.id}`);
+    expect(failure).toContain('--name research');
+    expect(failure).toContain(`--source-group ${SRC_GROUP}`);
+    expect(failure).toContain('send_message({ to: "research", ... })');
+
+    assertNoTokenLeak();
+  });
+
+  it('double invocation: upstream collision short-circuits — no duplicate rows, apps, posts, or nudges', async () => {
+    await runCreateAgent({ name: 'Research' });
+    const fetchCountAfterFirst = fetchCalls.length;
+    const mgCountAfterFirst = (await getAllMessagingGroups()).length;
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(fetchCalls.length).toBe(fetchCountAfterFirst);
+    expect((await getAllMessagingGroups()).length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(1);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+    expect(notifyTexts().at(-1)).toContain('already have a destination named "research"');
+  });
+
+  it('finish-path retry after success: rows exist, so no second canvas, no posts, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const postCountAfterFirst = fetchCalls.filter((c) => c.url.includes('chat.postMessage')).length;
+    const notifyCountAfterFirst = mockNotifyWrite.mock.calls.length;
+
+    // Operator re-runs the finish script — the S8/S11 created-gates hold.
+    await finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id });
+
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(postCountAfterFirst);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockNotifyWrite.mock.calls.length).toBe(notifyCountAfterFirst);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+  });
+
+  it('finish path aborts before wiring DB rows if the multi-instance module is missing', async () => {
+    // Group exists (S1-S4 already ran) but the Slack leg never completed —
+    // same starting state as the "broker failure" case above.
+    brokerStatus = 500;
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    brokerStatus = 200; // retry succeeds at the broker step this time
+    const mgCountBefore = (await getAllMessagingGroups()).length;
+
+    mockAssertSlackInstancesModuleInstalled.mockRejectedValueOnce(
+      new SlackFlowError(
+        'adapter-start',
+        'Slack channel payloads not installed — apply add-slack and slack-multi-instance first',
+      ),
+    );
+
+    await expect(
+      finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id }),
+    ).rejects.toThrow(/multi-instance/);
+
+    // S6-S8 must not have run: no DM messaging group got wired for an
+    // instance the runtime still can't start.
+    expect((await getAllMessagingGroups()).length).toBe(mgCountBefore);
+  });
+});
+
+describe('slack-aware create_agent — workspace install approval', () => {
+  const INSTALL_URL = 'https://slack.com/oauth/v2/authorize?client_id=1.2&state=signed-state';
+
+  /** Auto-install refused: the app is real, but the workspace must approve it. */
+  function refuseAutoInstall(): void {
+    brokerBotToken = null;
+    brokerInstallUrl = INSTALL_URL;
+    process.env.SLACK_INSTALL_POLL_MS = '1';
+    process.env.SLACK_INSTALL_WAIT_MS = '120';
+  }
+
+  function env(): string {
+    return fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+  }
+
+  function postedTexts(): string[] {
+    return fetchCalls
+      .filter((c) => c.url.includes('chat.postMessage'))
+      .map((c) => (JSON.parse(c.body) as { text: string }).text);
+  }
+
+  it('tells the operator what to approve, then finishes the flow on the token the approval releases', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }, { status: 'installed', bot_token: NEW_BOT_TOKEN }];
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The heads-up goes out as the ORIGIN bot, in the conversation the create
+    // was asked for — the origin agent's own reply could not be delivered
+    // while this handler still holds the session.
+    const notice = postedTexts()[0];
+    expect(notice).toContain('needs an admin to approve');
+    expect(notice).toContain(INSTALL_URL);
+    const noticeCall = fetchCalls.find((c) => c.url.includes('chat.postMessage'))!;
+    expect(noticeCall.token).toBe(ORIGIN_BOT_TOKEN);
+    expect((JSON.parse(noticeCall.body) as { channel: string }).channel).toBe('D0OPDM');
+
+    // From the token onward the flow is the ordinary one: adapter hot-add,
+    // DM row + wiring, room, welcome DM.
+    expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env()).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup.id)).toBeDefined();
+    expect(postedTexts().some((t) => t.includes("I'm Research, your new agent"))).toBe(true);
+
+    // Exactly one app, and the consumed install link is retired.
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(env()).toMatch(/^SLACK_INSTALL_URL_RESEARCH=$/m);
+
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('is live on Slack');
+    expect(success).toContain('approved the install');
+    assertNoTokenLeak();
+  });
+
+  it('parks the app when the approval never lands, keeping every part of it for a resume', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    // Nothing to re-create: app token, app id and the link are all on record.
+    expect(env()).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env()).toMatch(/^SLACK_APP_ID_RESEARCH=A0TEST$/m);
+    expect(env()).toContain(`SLACK_INSTALL_URL_RESEARCH=${INSTALL_URL}`);
+    expect(env()).not.toMatch(/^SLACK_BOT_TOKEN_RESEARCH=./m);
+    // The wait really ran rather than falling straight through.
+    expect(appStateReads).toBeGreaterThan(1);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'install-wait'");
+    expect(failure).toContain('still waiting on a workspace install approval');
+    expect(failure).toContain('nothing needs re-creating');
+    expect(failure).toContain('finish setting up Research');
+    assertNoTokenLeak();
+  });
+
+  it('asking again after a park resumes the parked app instead of provisioning a second one', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }];
+    await runCreateAgent({ name: 'Research' });
+    const groupCountAfterPark = (await getAgentGroupByFolder('research'))!.id;
+    const postsAfterPark = postedTexts().length;
+
+    // The operator approves the install, then asks for the same agent again.
+    appStateQueue = [{ status: 'installed', bot_token: NEW_BOT_TOKEN }];
+    appStateReads = 0;
+    await runCreateAgent({ name: 'Research' });
+
+    // One Slack app, one agent group — the second ask finished the first.
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect((await getAgentGroupByFolder('research'))!.id).toBe(groupCountAfterPark);
+    expect(await getAgentGroupByFolder('research-2')).toBeUndefined();
+    // Upstream's name-collision answer must not be what the user hears.
+    expect(notifyTexts().at(-1)).not.toContain('already have a destination');
+    expect(notifyTexts().at(-1)).toContain('is live on Slack');
+
+    // A resume checks before it sleeps, so the standing approval is picked up
+    // on the first read.
+    expect(appStateReads).toBe(1);
+    expect(postedTexts()[postsAfterPark]).toContain('Still waiting on your workspace');
+    expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research')).toBeDefined();
+  });
+
+  it('SLACK_INSTALL_WAIT_MS=0 parks immediately — a slow approval queue need not hold delivery open', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '0';
+    appStateQueue = [{ status: 'pending_install' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(0);
+    // The operator still gets the link — the flow declines to wait, not to ask.
+    expect(postedTexts()[0]).toContain(INSTALL_URL);
+    expect(notifyTexts().at(-1)).toContain("failed at step 'install-wait'");
+    expect(env()).toMatch(/^SLACK_APP_ID_RESEARCH=A0TEST$/m);
+  });
+
+  it('a refusal with no install link keeps the hand-finish instructions — there is nothing to wait for', async () => {
+    brokerBotToken = null;
+    brokerInstallUrl = '';
+    process.env.SLACK_INSTALL_POLL_MS = '1';
+    process.env.SLACK_INSTALL_WAIT_MS = '120';
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(0);
+    expect(postedTexts()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('SLACK_BOT_TOKEN_RESEARCH');
+  });
+
+  it('polls through a service hiccup instead of treating it as a refusal', async () => {
+    refuseAutoInstall();
+    appStateQueue = [
+      { http: 502, status: 'bad_gateway' },
+      { status: 'installed', bot_token: NEW_BOT_TOKEN },
+    ];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(2);
+    expect(notifyTexts().at(-1)).toContain('is live on Slack');
+  });
+
+  it('stops on a credential the service refuses — no later poll can change that answer', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '5000'; // never reached
+    appStateQueue = [{ http: 401, status: 'unauthorized' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(1);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'install-wait'");
+    expect(failure).toContain('refused this install');
+    assertNoTokenLeak();
+  });
+
+  it('a token released to someone else stops the wait rather than burning the whole budget', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '5000'; // never reached
+    appStateQueue = [{ status: 'installed' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(1);
+    expect(notifyTexts().at(-1)).toContain("failed at step 'install-wait'");
+  });
+});

--- a/src/modules/slack-agent-flow/orchestrate.ts
+++ b/src/modules/slack-agent-flow/orchestrate.ts
@@ -1,0 +1,731 @@
+/**
+ * The Slack leg of create_agent — steps S1–S13 (one typed step id each).
+ *
+ * Ordering is load-bearing:
+ *  - S1/S2 are local/cheap prechecks — nothing external is created until the
+ *    operator identity and the origin bot token both resolve.
+ *  - S10 (SLACK_A2A_ROOMS append) runs strictly BEFORE the origin agent is
+ *    nudged to post the room intro, so every sibling instance's a2a
+ *    bridge admits the bot-authored intro instead of dropping it as a bot
+ *    sender.
+ *  - S13's DM intro and the origin intro nudge are gated on rows newly
+ *    created in S8/S11 — a retry (finish script) never double-posts or
+ *    double-nudges.
+ * Every step is idempotent: provision reuses .env tokens, messaging groups
+ * and wirings are get-before-create, conversations.open is idempotent on
+ * Slack's side.
+ *
+ * Slack HTTP plumbing comes from the shared channel-layer lib
+ * (src/channels/slack-lib.ts, installed with the Slack channel payload);
+ * access to the skill-installed adapter modules goes through
+ * loadSlackChannelDeps() so a partial install fails as a typed step error.
+ */
+import {
+  resolveUnknownSenderPolicy,
+  resolveWiringDefaults,
+  validateEngageAgainstChannel,
+} from '../../channels/channel-defaults.js';
+import {
+  SlackApiError,
+  botTokenKeyForInstance,
+  slackAuthTest,
+  slackConversationsOpen,
+  slackPostMessage,
+} from '../../channels/slack-lib.js';
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { MessagingGroup, MessagingGroupAgent, Session } from '../../types.js';
+import {
+  createDestination,
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { notifyAgent, pickApprover } from '../approvals/primitive.js';
+import { appendToEnvList, readEnvValue } from './env-file.js';
+import { provisionSlackApp } from './provision.js';
+import { createRoomCanvas, wireCanvasComments } from './room-canvas.js';
+import { assertSlackInstancesModuleInstalled, loadSlackChannelDeps } from './slack-deps.js';
+import { SlackFlowError, type OrchestrateSuccess, type SlackFlowStep } from './types.js';
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function envSuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/** Wrap a non-typed failure with the step it happened in. Never carries token
+ *  values. A SlackApiError keeps its own step — the shared Slack lib
+ *  (src/channels/slack-lib.ts) tags each call with the flow step id the call
+ *  site passed, which is more precise than the enclosing wrapper's step. */
+function asFlowError(err: unknown, step: SlackFlowStep): SlackFlowError {
+  if (err instanceof SlackFlowError) return err;
+  if (err instanceof SlackApiError) return new SlackFlowError(err.step as SlackFlowStep, err.message);
+  return new SlackFlowError(step, err instanceof Error ? err.message : String(err));
+}
+
+/** One canonical slugger — the same normalizeName the a2a destination namespace uses. */
+export function deriveInstanceSlug(name: string): string {
+  return normalizeName(name);
+}
+
+/**
+ * First approver with a Slack identity, 'slack:' prefix stripped. pickApprover
+ * order (scoped admins → global admins → owners) picks who gets the DM.
+ */
+export async function resolveOperatorSlackUserId(sourceAgentGroupId: string): Promise<string | null> {
+  const hit = (await pickApprover(sourceAgentGroupId)).find((id) => /^slack:U/i.test(id));
+  return hit ? hit.slice('slack:'.length) : null;
+}
+
+/**
+ * A slug conflicts when its .env footprint is already claimed (token key set
+ * or slug listed in SLACK_INSTANCES) AND its `slack-<slug>` instance is wired
+ * to a DIFFERENT agent group. Claimed-but-wired-to-this-group (or to nothing)
+ * is the retry path — reuse.
+ */
+async function slugConflicts(slug: string, newAgentGroupId: string, rootDir: string): Promise<boolean> {
+  const tokenExists = readEnvValue(rootDir, `SLACK_BOT_TOKEN_${envSuffix(slug)}`) !== undefined;
+  const instances = (readEnvValue(rootDir, 'SLACK_INSTANCES') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!tokenExists && !instances.includes(slug)) return false;
+
+  const instanceKey = `slack-${slug}`;
+  for (const mg of await getAllMessagingGroups()) {
+    if (mg.instance !== instanceKey) continue;
+    for (const wiring of await getMessagingGroupAgents(mg.id)) {
+      if (wiring.agent_group_id !== newAgentGroupId) return true;
+    }
+  }
+  return false;
+}
+
+export async function dedupeSlug(
+  base: string,
+  newAgentGroupId: string,
+  rootDir: string = process.cwd(),
+): Promise<string> {
+  let slug = base;
+  for (let n = 2; await slugConflicts(slug, newAgentGroupId, rootDir); n++) slug = `${base}-${n}`;
+  return slug;
+}
+
+async function ensureMessagingGroupRow(spec: {
+  platformId: string;
+  instance: string;
+  name: string;
+  isGroup: boolean;
+  unknownSenderPolicy: MessagingGroup['unknown_sender_policy'];
+}): Promise<{ mg: MessagingGroup; created: boolean }> {
+  const existing = await getMessagingGroupByPlatform('slack', spec.platformId, spec.instance);
+  if (existing) return { mg: existing, created: false };
+  const mg: MessagingGroup = {
+    id: generateId('mg'),
+    channel_type: 'slack',
+    platform_id: spec.platformId,
+    instance: spec.instance,
+    name: spec.name,
+    is_group: spec.isGroup ? 1 : 0,
+    unknown_sender_policy: spec.unknownSenderPolicy,
+    created_at: new Date().toISOString(),
+  };
+  await createMessagingGroup(mg);
+  return { mg, created: true };
+}
+
+/** Flow-chosen deviations from the channel-declared wiring defaults. */
+interface WiringOverrides {
+  /** Set together with engage_pattern to bypass resolveWiringDefaults. */
+  engage_mode?: MessagingGroupAgent['engage_mode'];
+  engage_pattern?: string | null;
+  ignored_message_policy?: MessagingGroupAgent['ignored_message_policy'];
+  session_mode?: MessagingGroupAgent['session_mode'];
+  /** 1/0 explicit stamp; null = explicitly leave the column NULL (inherit the
+   *  channel declaration at fanout time); omitted = follow the derived
+   *  creation-time stamp (resolveWiringDefaults stamps threads=1 when the
+   *  declared sessionMode is 'per-thread', else null). */
+  threads?: number | null;
+}
+
+/** Get-before-create wiring with channel-declared defaults (engage fields,
+ *  plus the B7 session-mode/threads creation-time stamps) unless overridden.
+ *  True iff newly created. */
+async function ensureWiring(
+  mg: MessagingGroup,
+  agentGroupId: string,
+  agentGroupName: string,
+  overrides: WiringOverrides = {},
+): Promise<boolean> {
+  if (await getMessagingGroupAgentByPair(mg.id, agentGroupId)) return false;
+  const channelKey = mg.instance ?? mg.channel_type;
+  // Overriding engage_mode bypasses the declaration entirely (flow-owned
+  // room semantics, D4); declaration-resolved wirings take the declared
+  // session_mode / threads stamps too (B7).
+  const resolved =
+    overrides.engage_mode !== undefined
+      ? undefined
+      : resolveWiringDefaults(channelKey, mg.is_group === 1, agentGroupName, mg.channel_type);
+  const engage = resolved ?? { engage_mode: overrides.engage_mode!, engage_pattern: overrides.engage_pattern ?? null };
+  const threads = overrides.threads !== undefined ? overrides.threads : (resolved?.threads ?? null);
+  const wiring: MessagingGroupAgent = {
+    id: generateId('mga'),
+    messaging_group_id: mg.id,
+    agent_group_id: agentGroupId,
+    engage_mode: engage.engage_mode,
+    engage_pattern: engage.engage_pattern,
+    sender_scope: 'all',
+    ignored_message_policy: overrides.ignored_message_policy ?? 'drop',
+    session_mode: overrides.session_mode ?? resolved?.session_mode ?? 'shared',
+    priority: 0,
+    ...(threads !== null ? { threads } : {}),
+    created_at: new Date().toISOString(),
+  };
+  validateEngageAgainstChannel(wiring, mg);
+  // createMessagingGroupAgent persists an explicit `threads` value itself
+  // (follow-up UPDATE in src/db/messaging-groups.ts) — the declared threads:1 stamp lands.
+  await createMessagingGroupAgent(wiring);
+  return true;
+}
+
+/**
+ * Room-wiring semantics for flow-created rooms (D4): each bot speaks only
+ * when @-mentioned; everything else accumulates as ambient context delivered
+ * with the next mention. Deliberately NOT the channel group default —
+ * flow-created rooms only.
+ */
+const ROOM_WIRING_OVERRIDES: WiringOverrides = {
+  engage_mode: 'mention',
+  engage_pattern: null,
+  ignored_message_policy: 'accumulate',
+};
+
+/** One bot in a shared room: its adapter instance and the agent group behind it. */
+export interface RoomParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  botUserId: string;
+  agentGroupId: string;
+  agentGroupName: string;
+}
+
+/**
+ * Idempotent agent→agent destination (= ACL grant + local name). No-op when
+ * a destination for the target already exists under any name (upstream
+ * create_agent's parent/child rows count). Name collisions get a numeric
+ * suffix, mirroring ensureAgentDestinationForWiring.
+ */
+async function ensureAgentDestination(fromGroupId: string, toGroupId: string, toName: string): Promise<void> {
+  if (fromGroupId === toGroupId) return;
+  if (await getDestinationByTarget(fromGroupId, 'agent', toGroupId)) return;
+  const base = normalizeName(toName) || toGroupId.slice(0, 8);
+  let localName = base;
+  let suffix = 2;
+  while (await getDestinationByName(fromGroupId, localName)) {
+    localName = `${base}-${suffix}`;
+    suffix++;
+  }
+  await createDestination({
+    agent_group_id: fromGroupId,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: toGroupId,
+    created_at: new Date().toISOString(),
+  });
+}
+
+/** Full pairwise a2a destination symmetry between every distinct agent group
+ *  in the room — "ask Devin" must be actionable from any participant. */
+async function ensurePairwiseAgentDestinations(participants: RoomParticipant[]): Promise<void> {
+  for (const a of participants) {
+    for (const b of participants) {
+      if (a.agentGroupId === b.agentGroupId) continue;
+      await ensureAgentDestination(a.agentGroupId, b.agentGroupId, b.agentGroupName);
+    }
+  }
+}
+
+/**
+ * Public purpose: ONLY the explicitly provided line (capped 80). No fallback
+ * from the instructions — the creation prompt is the agent's private persona
+ * and never appears on shared surfaces. No purpose = the intro simply
+ * doesn't state one.
+ */
+export function publicPurpose(explicit: string | undefined): string | undefined {
+  const cleaned = explicit?.trim();
+  if (!cleaned) return undefined;
+  return cleaned.length <= 80 ? cleaned : `${cleaned.slice(0, 80)}…`;
+}
+
+/**
+ * The ORIGIN agent — not a host template — introduces the new agent
+ * in the shared room. This is the instruction the origin session wakes to;
+ * the intro itself stays in the agent's own voice, and the room-contract
+ * data (purpose, members, created date) lives on the canvas, not in chat.
+ */
+function roomIntroNudgeText(args: {
+  newAgentName: string;
+  newBotUserId: string;
+  roomName: string;
+  /** The origin agent's local destination name for the room. */
+  roomDestination: string;
+  purpose?: string;
+}): string {
+  return (
+    `A shared Slack room "${args.roomName}" was just opened with you, the operator, and your new agent ${args.newAgentName}` +
+    `${args.purpose ? ` (${args.purpose})` : ''}. ` +
+    `Post a brief introduction of ${args.newAgentName} there now via send_message({ to: "${args.roomDestination}", ... }): ` +
+    `1-2 lines in your own voice saying what they're for, tagging them with <@${args.newBotUserId}> ` +
+    `(include that literally — it renders as a mention). Just the intro — no mechanics, no member lists.`
+  );
+}
+
+/**
+ * N-bot-capable room step (S9–S13's room half): open the MPIM as `creator`
+ * with the operator + every participating bot, allowlist it for a2a, create
+ * one mg row + mention/accumulate wiring PER participating instance, ensure
+ * pairwise a2a destinations, then (only when rows were newly created) create
+ * the room canvas — the room's pinned contract surface (no contract
+ * message, no link post; the channel canvas is already the room's canvas
+ * tab) — and wire its comment shadow channel for every participant. The
+ * conversational create_agent flow calls this with the 3-way default; any
+ * caller may pass a larger participant list.
+ */
+export async function ensureAgentRoom(args: {
+  /** Bot that opens the MPIM and creates the canvas. Must be one of `participants`. */
+  creator: RoomParticipant;
+  creatorBotToken: string;
+  operatorUserId: string;
+  /** All bots in the room, creator included. */
+  participants: RoomParticipant[];
+  /** Additional member user ids beyond the operator + participating bots —
+   *  e.g. Slack-UI-added humans carried over when add_to_room forks a room.
+   *  Members only; they get no mg rows or wirings. */
+  extraMemberUserIds?: string[];
+  roomName: string;
+  /** Creation prompt (room purpose) — the canvas contract excerpt. */
+  purpose?: string;
+  rootDir: string;
+}): Promise<{ roomChannelId: string; created: boolean }> {
+  const { creator, creatorBotToken, operatorUserId, participants, rootDir } = args;
+
+  // S9 mpim-open — operator + carried extra members + every other
+  // participating bot, opened AS the creator.
+  const otherBotIds = participants.filter((p) => p.botUserId !== creator.botUserId).map((p) => p.botUserId);
+  const roomChannelId = await slackConversationsOpen(
+    creatorBotToken,
+    [operatorUserId, ...(args.extraMemberUserIds ?? []), ...otherBotIds],
+    'mpim-open',
+  );
+
+  // S10 a2a-env — strictly before the origin agent can be nudged to post its
+  // intro: every sibling instance's a2a bridge must already allow the room
+  // or it drops bot-authored posts.
+  try {
+    appendToEnvList(rootDir, 'SLACK_A2A_ROOMS', roomChannelId);
+  } catch (err) {
+    throw asFlowError(err, 'a2a-env');
+  }
+
+  // S11 room-wire — one row PER participating instance (router lookup is
+  // exact-on-instance). unknown_sender_policy 'public' explicitly: sibling
+  // bridges' access gates must never approval-spam admitted bot messages.
+  // Wirings are mention/accumulate (D4 — flow-created rooms only).
+  let created = false;
+  try {
+    for (const p of participants) {
+      const row = await ensureMessagingGroupRow({
+        platformId: `slack:${roomChannelId}`,
+        instance: p.instanceKey,
+        name: args.roomName,
+        isGroup: true,
+        unknownSenderPolicy: 'public',
+      });
+      await ensureWiring(row.mg, p.agentGroupId, p.agentGroupName, ROOM_WIRING_OVERRIDES);
+      created = row.created || created;
+    }
+    await ensurePairwiseAgentDestinations(participants);
+  } catch (err) {
+    throw asFlowError(err, 'room-wire');
+  }
+
+  // S12 projections — in-host-process, so already-running containers see the
+  // auto-created destinations without waiting for the next spawn.
+  for (const groupId of new Set(participants.map((p) => p.agentGroupId))) {
+    await projectDestinationsToSessions(groupId);
+  }
+
+  // S13 room half — gated on newly created rows so a retry never grows a
+  // second canvas. No room-contract message: the canvas tab is the
+  // pinned surface and carries the contract data; the intro is authored by
+  // the ORIGIN agent (nudged by runFlow). Canvas failure is non-fatal
+  // (C2: createRoomCanvas never throws) — no canvas, no shadow channel.
+  if (created) {
+    const canvasId = await createRoomCanvas(creatorBotToken, roomChannelId, {
+      roomName: args.roomName,
+      purpose: args.purpose ?? args.roomName,
+      creatorUserId: operatorUserId,
+      agentNames: participants.map((p) => p.agentGroupName),
+    });
+    // Canvas comments arrive in a Slackbot-owned shadow channel (canvas id
+    // with F→C) — wire EVERY participating instance: creator as the
+    // pattern-engage default responder, siblings mention/accumulate.
+    // Non-throwing; no canvas id, nothing to wire.
+    if (canvasId) await wireCanvasComments(canvasId, creator, participants, args.roomName);
+  }
+
+  return { roomChannelId, created };
+}
+
+/**
+ * How long the flow waits inline for a workspace install approval, and how
+ * often it checks. The default is five minutes at a five-second cadence —
+ * long enough for someone already at their desk, short enough that the app
+ * parks (and stays resumable) rather than holding this session's delivery
+ * open indefinitely.
+ *
+ * `SLACK_INSTALL_WAIT_MS=0` skips the wait entirely: installs that always go
+ * through a slow approval queue are better served by parking immediately and
+ * finishing on a later ask. `SLACK_INSTALL_POLL_MS` moves the cadence.
+ */
+function resolveInstallWait(rootDir: string): { intervalMs?: number; timeoutMs?: number } | undefined {
+  const num = (key: string): number | undefined => {
+    const raw = readEnvValue(rootDir, key);
+    if (raw === undefined) return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  };
+  const timeoutMs = num('SLACK_INSTALL_WAIT_MS');
+  const intervalMs = num('SLACK_INSTALL_POLL_MS');
+  if (timeoutMs === undefined && intervalMs === undefined) return undefined;
+  return { ...(timeoutMs !== undefined ? { timeoutMs } : {}), ...(intervalMs !== undefined ? { intervalMs } : {}) };
+}
+
+/**
+ * The one line the human gets while the flow waits on a workspace install
+ * approval. Short on purpose: the link is the only actionable part, and the
+ * flow says nothing else until it either finishes or parks.
+ */
+export function installPendingText(displayName: string, info: { installUrl?: string; resumed: boolean }): string {
+  const where = info.installUrl ? ` Approve it here: ${info.installUrl}` : '';
+  return info.resumed
+    ? `Still waiting on your workspace to approve installing ${displayName}.${where} — I'll finish setting it up as soon as that lands.`
+    : `${displayName} is created, but your workspace needs an admin to approve installing it.${where} — I'll finish the setup automatically once it's approved.`;
+}
+
+interface FlowArgs {
+  slug: string;
+  displayName: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey: string;
+  /** Slack channel the create was asked for in — where the flow talks back
+   *  while it waits. Absent on the out-of-process finish path, which prints
+   *  to the operator's terminal instead. */
+  originChannelId?: string;
+  rootDir: string;
+  /** false on the out-of-process finish path — S5 needs the live host's registry. */
+  hotStart: boolean;
+  /** Agent instructions excerpt — drives the broker-generated avatar. */
+  description?: string;
+  /** Short PUBLIC line for the room contract + canvas ("what this agent is
+   *  for"). Falls back to a first-sentence excerpt of the instructions —
+   *  never the full creation prompt (it may carry private detail). */
+  purpose?: string;
+  /** true → plain manifest variant (guest-visible); false/absent → agent_view. */
+  allowGuests?: boolean;
+  /** The session whose create_agent call started the flow — receives the
+   *  room-intro nudge. Absent on the out-of-process finish path. */
+  originSession?: Session;
+  /**
+   * Room policy: 'own' (default) opens the shared origin+operator
+   * room; 'none' skips the room half entirely — the multi-create pattern is
+   * N creates with room:'none' followed by one create_room with all of them.
+   */
+  room?: 'own' | 'none';
+  /** Wait budget for a deferred workspace install. Tests shorten it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+  /** Extra sink for the pending-install line — the finish script prints it to
+   *  the operator's terminal, which has no Slack conversation to post into. */
+  onInstallPending?: (text: string) => void;
+}
+
+async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
+  const { slug, displayName, sourceGroupId, newAgentGroupId, originInstanceKey, rootDir } = args;
+  const instanceKey = `slack-${slug}`;
+
+  // S1 operator-identity
+  const operatorUserId = await resolveOperatorSlackUserId(sourceGroupId);
+  if (!operatorUserId) {
+    throw new SlackFlowError(
+      'operator-identity',
+      'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+    );
+  }
+
+  // S2 origin-auth — prove the origin instance's token before provisioning anything.
+  const originTokenKey = botTokenKeyForInstance(originInstanceKey);
+  const originBotToken = readEnvValue(rootDir, originTokenKey);
+  if (!originBotToken) {
+    throw new SlackFlowError(
+      'origin-auth',
+      `missing ${originTokenKey} in .env for origin instance '${originInstanceKey}'`,
+    );
+  }
+  const originAuth = await slackAuthTest(originBotToken, 'origin-auth');
+  const originBotUserId = originAuth.userId;
+
+  // S3/S4 provision. A workspace that requires an admin to approve installs
+  // refuses auto-install, and provisionSlackApp then waits for the human to
+  // finish it in the browser. That wait is silent from the outside, so it
+  // announces itself HERE, as the origin bot, in the conversation the create
+  // was asked for — the origin agent cannot relay it, since its own replies
+  // cannot be delivered while this handler is still running. A failed
+  // announcement is not worth abandoning the wait for.
+  const app = await provisionSlackApp({
+    slug,
+    displayName,
+    rootDir,
+    teamId: originAuth.teamId,
+    description: args.description,
+    allowGuests: args.allowGuests,
+    requestedBy: operatorUserId,
+    installWait: args.installWait ?? resolveInstallWait(rootDir),
+    onInstallPending: async (info) => {
+      const text = installPendingText(displayName, info);
+      log.info('Waiting on a Slack workspace install approval', { step: 'install-wait', appId: info.appId });
+      args.onInstallPending?.(text);
+      if (!args.originChannelId) return;
+      try {
+        await slackPostMessage(originBotToken, args.originChannelId, text, 'install-wait');
+      } catch (err) {
+        log.warn('Could not announce the pending Slack install', {
+          step: 'install-wait',
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  });
+
+  // S5 adapter-start. The multi-instance module must be installed regardless
+  // of hotStart: S6-S8 below wire DB rows to an instance name the runtime
+  // needs to be able to start after a restart, so the out-of-process finish
+  // path (hotStart: false) checks this too instead of silently skipping
+  // straight to DB writes for an instance nothing can ever connect.
+  await assertSlackInstancesModuleInstalled();
+  if (args.hotStart) {
+    // Hot-add the new instance into the live registry.
+    const deps = await loadSlackChannelDeps();
+    deps.registerChannelAdapter(instanceKey, {
+      factory: () => deps.slackInstanceBridgeFactory(slug),
+      defaults: deps.SLACK_DEFAULTS,
+    });
+    let started: 'started' | 'already-active' | 'no-credentials';
+    try {
+      started = await deps.startChannelAdapter(instanceKey);
+    } catch (err) {
+      throw asFlowError(err, 'adapter-start');
+    }
+    // 'already-active' is the retry path — the instance survived a previous attempt.
+    if (started === 'no-credentials') {
+      throw new SlackFlowError(
+        'adapter-start',
+        `adapter '${instanceKey}' found no credentials in .env (SLACK_BOT_TOKEN_${app.envSuffix} / SLACK_APP_TOKEN_${app.envSuffix})`,
+      );
+    }
+  }
+
+  // S6 new-bot identity (auth.test gates the DM open — same step id).
+  const newBotUserId = (await slackAuthTest(app.botToken, 'dm-open')).userId;
+
+  // S7 dm-open — the operator DM, opened AS the new bot.
+  const dmChannelId = await slackConversationsOpen(app.botToken, [operatorUserId], 'dm-open');
+
+  // S8 dm-wire. Agent-view apps (the default variant, allowGuests !== true)
+  // get thread-per-conversation DMs from the CHANNEL DECLARATION: the
+  // Slack adapter's SLACK_DEFAULTS declares dm.sessionMode 'per-thread',
+  // resolveWiringDefaults derives the threads=1 stamp from it (per-thread
+  // sessions structurally require honored thread ids), and ensureWiring
+  // stamps whatever it resolves — nothing is hardcoded here. The plain
+  // (allow_guests) variant has no agent-mode DM surface, so it pins
+  // session_mode 'shared' and leaves the threads column NULL explicitly.
+  let dmCreated = false;
+  try {
+    const dmRow = await ensureMessagingGroupRow({
+      platformId: `slack:${dmChannelId}`,
+      instance: instanceKey,
+      name: `${displayName} DM`,
+      isGroup: false,
+      unknownSenderPolicy: resolveUnknownSenderPolicy(instanceKey, false, 'slack'),
+    });
+    dmCreated = dmRow.created;
+    const agentView = args.allowGuests !== true;
+    await ensureWiring(
+      dmRow.mg,
+      newAgentGroupId,
+      displayName,
+      agentView ? {} : { session_mode: 'shared', threads: null },
+    );
+  } catch (err) {
+    throw asFlowError(err, 'dm-wire');
+  }
+
+  // S9–S13 room half: MPIM + allowlist + per-instance mention/accumulate
+  // wirings + pairwise destinations + canvas + room-contract intro. The
+  // conversational flow's 3-way default; ensureAgentRoom itself is N-capable.
+  // room:'none' skips the whole half — the DM is the entire surface
+  // and the caller composes a shared room later via create_room.
+  let roomChannelId: string | undefined;
+  if (args.room !== 'none') {
+    const sourceGroupName = (await getAgentGroup(sourceGroupId))?.name ?? sourceGroupId;
+    const newParticipant: RoomParticipant = {
+      instanceKey,
+      botUserId: newBotUserId,
+      agentGroupId: newAgentGroupId,
+      agentGroupName: displayName,
+    };
+    const roomName = `${displayName} room`;
+    const roomPurpose = publicPurpose(args.purpose);
+    const room = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: app.botToken,
+      operatorUserId,
+      participants: [
+        {
+          instanceKey: originInstanceKey,
+          botUserId: originBotUserId,
+          agentGroupId: sourceGroupId,
+          agentGroupName: sourceGroupName,
+        },
+        newParticipant,
+      ],
+      roomName,
+      purpose: roomPurpose,
+      rootDir,
+    });
+    roomChannelId = room.roomChannelId;
+
+    // The ORIGIN agent authors the room intro — an instruction-shaped
+    // system nudge (trigger=1 wake via notifyAgent) into the origin session,
+    // gated on the S13 created-gate so a flow retry never double-nudges. The
+    // wizard first-agent path never reaches here (it opens no room); the
+    // out-of-process finish path has no origin session to nudge. The room
+    // destination was projected into the live session in S12.
+    if (room.created && args.originSession) {
+      const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, originInstanceKey);
+      const roomDest = roomMg ? await getDestinationByTarget(sourceGroupId, 'channel', roomMg.id) : undefined;
+      await notifyAgent(
+        args.originSession,
+        roomIntroNudgeText({
+          newAgentName: displayName,
+          newBotUserId,
+          roomName,
+          roomDestination: roomDest?.local_name ?? normalizeName(roomName),
+          purpose: roomPurpose,
+        }),
+      );
+    }
+  }
+
+  // S13 DM half — gated on the row newly created in S8.
+  if (dmCreated) {
+    await slackPostMessage(
+      app.botToken,
+      dmChannelId,
+      `Hi <@${operatorUserId}> — I'm ${displayName}, your new agent. This DM is already wired up; just reply here to start.`,
+      'intro-post',
+    );
+  }
+
+  return {
+    slug,
+    newBotUserId,
+    operatorUserId,
+    dmChannelId,
+    roomChannelId,
+    ...(app.deferredInstall ? { deferredInstall: true } : {}),
+  };
+}
+
+/** In-host entry — the wrapped create_agent handler's Slack leg (hot-add active). */
+export async function runSlackAgentFlow(args: {
+  content: Record<string, unknown>;
+  session: Session;
+  newAgentGroupId: string;
+  slug: string;
+  /** Wait budget for a deferred workspace install. Tests shorten it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+}): Promise<OrchestrateSuccess> {
+  const { content, session, newAgentGroupId, slug } = args;
+  const displayName =
+    typeof content.name === 'string' && content.name
+      ? content.name
+      : ((await getAgentGroup(newAgentGroupId))?.name ?? slug);
+  const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  return runFlow({
+    slug,
+    displayName,
+    sourceGroupId: session.agent_group_id,
+    newAgentGroupId,
+    originInstanceKey: originMg?.instance ?? 'slack',
+    // messaging_groups store 'slack:<channelId>'; the Web API wants the bare id.
+    originChannelId: originMg?.platform_id?.replace(/^slack:/, ''),
+    installWait: args.installWait,
+    rootDir: process.cwd(),
+    hotStart: true,
+    description: typeof content.instructions === 'string' ? content.instructions.slice(0, 300) : undefined,
+    purpose: typeof content.purpose === 'string' ? content.purpose : undefined,
+    allowGuests: content.allow_guests === true,
+    originSession: session,
+    room: content.room === 'none' ? 'none' : 'own',
+  });
+}
+
+/**
+ * Out-of-process finish/retry entry (scripts/slack-agent-flow-finish.ts):
+ * S1–S13 minus the S5 hot-add — a separate process cannot start an adapter
+ * inside the live host, so the script restarts the service (or says how).
+ */
+export async function finishSlackAgentFlow(args: {
+  slug: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey?: string;
+  rootDir?: string;
+  /** Pass true when the original create used allow_guests (plain variant) —
+   *  keeps the finish path's DM wiring congruent with the provisioned app. */
+  allowGuests?: boolean;
+  /** Pass 'none' when the original create used room:'none' — keeps the
+   *  finish path from growing a room the caller deliberately skipped. */
+  room?: 'own' | 'none';
+  /** Called with the pending-install line when the app is waiting on a
+   *  workspace install approval — the script prints it so a five-minute wait
+   *  does not read as a hang. */
+  onInstallPending?: (text: string) => void;
+}): Promise<OrchestrateSuccess> {
+  return runFlow({
+    slug: args.slug,
+    displayName: (await getAgentGroup(args.newAgentGroupId))?.name ?? args.slug,
+    sourceGroupId: args.sourceGroupId,
+    newAgentGroupId: args.newAgentGroupId,
+    originInstanceKey: args.originInstanceKey ?? 'slack',
+    rootDir: args.rootDir ?? process.cwd(),
+    hotStart: false,
+    allowGuests: args.allowGuests,
+    room: args.room,
+    onInstallPending: args.onInstallPending,
+  });
+}

--- a/src/modules/slack-agent-flow/provision.congruence.test.ts
+++ b/src/modules/slack-agent-flow/provision.congruence.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Congruence pins for provision.ts, which deliberately duplicates its broker
+ * protocol and manifest out of the trunk provisioning module
+ * src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts.
+ *
+ * ALL transports carry the same
+ * template: BASE + canvas scopes, BASE + membership events, and the
+ * agent-mode (agent_view) variant pair — matching the broker's BOT_SCOPES /
+ * BOT_EVENTS / AGENT_BOT_* in nanocoai/infra: modules/nanoclaw-slack lambda
+ * service/index.mjs. The pins here hold the mirrors (read as source text —
+ * they are not importable from src/) equal to provision.ts's own sets, and
+ * provision.ts equal to the documented BASE + additions.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_BROKER_BASE,
+  MANAGED_AGENT_BOT_EVENTS,
+  MANAGED_AGENT_BOT_SCOPES,
+  MANAGED_APP_DESCRIPTION,
+  MANAGED_BOT_EVENTS,
+  MANAGED_BOT_SCOPES,
+  buildManagedAppManifest,
+  provisionSlackApp,
+  resolveProvisioningCredential,
+} from './provision.js';
+
+const CREATE_AGENT_SCRIPT = path.resolve(
+  process.cwd(),
+  '.claude/skills/slack-managed-agents/scripts/slack-create-agent.ts',
+);
+const SLACK_PROVISION = path.resolve(process.cwd(), 'src/provisioning/slack-app.ts');
+
+/**
+ * The base managed-app sets, before the additions below. Kept literal so
+ * drift in either direction is loud.
+ */
+const BASE_BOT_SCOPES = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+];
+const BASE_BOT_EVENTS = ['message.channels', 'message.groups', 'message.im', 'message.mpim', 'app_mention'];
+
+/** Additions over the base set (room canvas + read-back; membership events). */
+const CANVAS_SCOPES = ['canvases:read', 'canvases:write', 'files:read'];
+const MEMBERSHIP_EVENTS = ['member_joined_channel', 'member_left_channel'];
+
+/** send_file: files.upload needs files:write, distinct from the canvas read-back path. */
+const SEND_FILE_SCOPES = ['files:write'];
+
+/** All single-quoted strings inside `export const <name> = […]`, comments stripped. */
+function extractStringArray(src: string, name: string): string[] {
+  const m = src.match(new RegExp(`export const ${name}[^=]*= \\[([\\s\\S]*?)\\];`));
+  expect(m, `export const ${name} = […] not found in mirror source`).toBeTruthy();
+  const body = m![1].replace(/\/\/.*$/gm, '');
+  return [...body.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+// The slack-managed-agents skill is optional (its install leg is coupled to
+// the managed-app provisioning service) — the mirror pins run wherever its
+// skill directory is present and skip cleanly where it is not. When present
+// it MUST match; the path is pinned literally, so a moved script fails loudly.
+describe.skipIf(!fs.existsSync(CREATE_AGENT_SCRIPT))('provision.ts congruence with slack-create-agent.ts', () => {
+  it("the mirror's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(extractStringArray(src, 'MANAGED_BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the mirror's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+    expect(src).toContain('--allow-guests');
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts sets', () => {
+  it("the trunk provisioning module's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(extractStringArray(src, 'BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the trunk provisioning module's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+  });
+});
+
+describe('provision.ts manifest shape (broker-congruent, both variants)', () => {
+  it('MANAGED_BOT_SCOPES = base + canvas scopes + send_file scope, bot scopes only', () => {
+    expect([...MANAGED_BOT_SCOPES]).toEqual([...BASE_BOT_SCOPES, ...CANVAS_SCOPES, ...SEND_FILE_SCOPES]);
+  });
+
+  it('MANAGED_BOT_EVENTS = base + membership events', () => {
+    expect([...MANAGED_BOT_EVENTS]).toEqual([...BASE_BOT_EVENTS, ...MEMBERSHIP_EVENTS]);
+  });
+
+  it('agent-mode additions are exactly assistant:write + the two agent events', () => {
+    expect([...MANAGED_AGENT_BOT_SCOPES]).toEqual(['assistant:write']);
+    expect([...MANAGED_AGENT_BOT_EVENTS]).toEqual(['app_home_opened', 'app_context_changed']);
+  });
+
+  interface ManifestShape {
+    display_information: { name: string; description: string };
+    features: {
+      bot_user: { display_name: string; always_online: boolean };
+      agent_view?: { agent_description: string };
+    };
+    oauth_config: { scopes: { bot: string[]; user?: string[] } };
+    settings: {
+      event_subscriptions: { bot_events: string[] };
+      socket_mode_enabled: boolean;
+      interactivity: { is_enabled: boolean };
+    };
+  }
+
+  it('default variant is agent-mode: agent_view + assistant:write + agent events', () => {
+    const manifest = buildManagedAppManifest('Research') as unknown as ManifestShape;
+    expect(manifest.display_information.name).toBe('Research');
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+    expect(manifest.features.bot_user).toEqual({ display_name: 'Research', always_online: true });
+    // The agent_description doubles as the attribution line (≤300-char field).
+    expect(manifest.features.agent_view).toEqual({ agent_description: MANAGED_APP_DESCRIPTION });
+    expect(MANAGED_APP_DESCRIPTION.length).toBeLessThanOrEqual(300);
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES]);
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([
+      ...MANAGED_BOT_EVENTS,
+      ...MANAGED_AGENT_BOT_EVENTS,
+    ]);
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    expect(manifest.settings.interactivity.is_enabled).toBe(false);
+  });
+
+  it('plain variant (agentView:false) omits agent_view, assistant:write, and the agent events', () => {
+    const manifest = buildManagedAppManifest('Research', { agentView: false }) as unknown as ManifestShape;
+    expect(manifest.features.agent_view).toBeUndefined();
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write');
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([...MANAGED_BOT_EVENTS]);
+    for (const ev of MANAGED_AGENT_BOT_EVENTS) {
+      expect(manifest.settings.event_subscriptions.bot_events).not.toContain(ev);
+    }
+    // Both still carry the always-on additions.
+    for (const scope of CANVAS_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const scope of SEND_FILE_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const ev of MEMBERSHIP_EVENTS) expect(manifest.settings.event_subscriptions.bot_events).toContain(ev);
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+  });
+
+  it('both variants stay bot-scopes-only (apps.managedInstall eligibility)', () => {
+    for (const agentView of [true, false]) {
+      const manifest = buildManagedAppManifest('Research', { agentView }) as unknown as ManifestShape;
+      expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
+    }
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts', () => {
+  it('broker base + override key + endpoint match the trunk provisioning module', () => {
+    expect(fs.existsSync(SLACK_PROVISION), `${SLACK_PROVISION} not found — the trunk provisioning module moved?`).toBe(
+      true,
+    );
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    const base = src.match(/export const DEFAULT_SLACK_SERVICE_BASE = '([^']+)'/);
+    expect(base?.[1]).toBe(DEFAULT_BROKER_BASE);
+    expect(src).toContain("'SLACK_SERVICE_BASE'");
+    expect(src).toContain("'/v1/apps'");
+  });
+});
+
+describe('provisionSlackApp broker body (allow_guests threading)', () => {
+  let rootDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-broker-'));
+    fs.writeFileSync(path.join(rootDir, '.env'), 'NANOCLAW_INSTALL_TOKEN=install-token-1\n');
+    for (const key of ['NANOCLAW_REGISTRY_TOKEN', 'SLACK_MANAGER_TOKEN', 'SLACK_SERVICE_BASE']) {
+      vi.stubEnv(key, '');
+    }
+    fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith('/v1/avatars')) {
+        // Generation unavailable → no avatar poll loop, no avatar_id in the create body.
+        return new Response(JSON.stringify({ avatar_id: null, status: 'unavailable' }), { status: 200 });
+      }
+      if (u.endsWith('/v1/apps')) {
+        return new Response(JSON.stringify({ app_id: 'A123', app_token: 'xapp-test', bot_token: 'xoxb-test' }), {
+          status: 201,
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  const createBody = (): Record<string, unknown> => {
+    const call = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/v1/apps'));
+    expect(call, 'POST /v1/apps was never called').toBeTruthy();
+    return JSON.parse((call![1] as RequestInit).body as string) as Record<string, unknown>;
+  };
+
+  it('omits allow_guests by default (broker provisions the agent-mode variant)', async () => {
+    const result = await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1' });
+    expect(result.reused).toBe(false);
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel' });
+  });
+
+  it('threads allowGuests:true into the body as allow_guests (plain variant)', async () => {
+    await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1', allowGuests: true });
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel', allow_guests: true });
+  });
+});
+
+describe('resolveProvisioningCredential', () => {
+  let rootDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-root-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-home-'));
+    // Neutralize the real environment — every key this resolver consults.
+    for (const key of [
+      'NANOCLAW_REGISTRY_TOKEN',
+      'NANOCLAW_INSTALL_TOKEN',
+      'SLACK_MANAGER_TOKEN',
+      'SLACK_SERVICE_BASE',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const writeEnv = (lines: string[]): void => fs.writeFileSync(path.join(rootDir, '.env'), lines.join('\n') + '\n');
+  const writeAccount = (content: string): void => {
+    const dir = path.join(homeDir, '.config', 'nanoclaw');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'account.json'), content);
+  };
+  const resolve = (): ReturnType<typeof resolveProvisioningCredential> =>
+    resolveProvisioningCredential(rootDir, { homeDir });
+
+  it('returns null when no credential exists anywhere', () => {
+    expect(resolve()).toBeNull();
+  });
+
+  it('process.env NANOCLAW_REGISTRY_TOKEN wins over every other source', () => {
+    vi.stubEnv('NANOCLAW_REGISTRY_TOKEN', 'registry-token-from-env');
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'registry-token-from-env',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('.env NANOCLAW_INSTALL_TOKEN beats account.json and the manager token', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('falls back to ~/.config/nanoclaw/account.json before direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({ mode: 'broker', installToken: 'account-token', baseUrl: DEFAULT_BROKER_BASE });
+  });
+
+  it('malformed account.json reads as not-enrolled, not an error', () => {
+    writeAccount('{not json');
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('account.json without a usable token field reads as not-enrolled', () => {
+    writeAccount(JSON.stringify({ token: '   ' }));
+    expect(resolve()).toBeNull();
+  });
+
+  it('SLACK_MANAGER_TOKEN alone selects direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('SLACK_SERVICE_BASE overrides the broker base, trailing slashes stripped', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_SERVICE_BASE=https://broker.example.test///']);
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: 'https://broker.example.test',
+    });
+  });
+});

--- a/src/modules/slack-agent-flow/provision.prefetch.test.ts
+++ b/src/modules/slack-agent-flow/provision.prefetch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Avatar prefetch (multi-agent creates): prefetchAvatar starts the broker job
+ * in the background; the flow's later requestAvatar with the same
+ * (displayName, description) consumes that in-flight job instead of starting
+ * a second generation. A key miss or an already-consumed entry falls back to
+ * a fresh request.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAvatarPrefetches, prefetchAvatar, requestAvatar } from './provision.js';
+
+const fetchMock = vi.fn();
+
+function avatarBrokerResponses(id: string): void {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.endsWith('/v1/avatars')) {
+      return Promise.resolve(new Response(JSON.stringify({ avatar_id: id }), { status: 200 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ status: 'ready' }), { status: 200 }));
+  });
+}
+
+function postCount(): number {
+  return fetchMock.mock.calls.filter((c) => (c as [string])[0].endsWith('/v1/avatars')).length;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  clearAvatarPrefetches();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearAvatarPrefetches();
+});
+
+describe('avatar prefetch', () => {
+  it('requestAvatar consumes a pending prefetch — exactly one generation job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBe('av-1');
+    expect(postCount()).toBe(1);
+  });
+
+  it('a prefetch is consumed once — the next same-key request goes fresh', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('different (name, description) keys never share a job', async () => {
+    avatarBrokerResponses('av-x');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'designer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('duplicate prefetches for one key start one job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(1);
+  });
+
+  it('a failed prefetch resolves undefined without throwing into the flow', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBeUndefined();
+  });
+});

--- a/src/modules/slack-agent-flow/provision.ts
+++ b/src/modules/slack-agent-flow/provision.ts
@@ -1,0 +1,797 @@
+/**
+ * Managed Slack app provisioning for the slack-agent-flow leg.
+ *
+ * CONGRUENCE — this file deliberately duplicates:
+ * - src/provisioning/slack-app.ts (trunk provisioning module) — broker
+ *   protocol (install token from
+ *   ~/.config/nanoclaw/account.json or NANOCLAW_REGISTRY_TOKEN, base
+ *   SLACK_SERVICE_BASE else https://slack.nanoclaw.dev, POST /v1/apps) and the
+ *   direct apps.manifest.create + apps.managedInstall pair.
+ * - .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts —
+ *   MANAGED_BOT_SCOPES / MANAGED_BOT_EVENTS / buildManagedAppManifest,
+ *   credential resolution order, and the crash-safe persist-before-return
+ *   .env write (its step 1/3).
+ * This file, both mirrors, and the broker's server template all carry the
+ * SAME sets: base + canvas scopes, membership events, and the agent_view
+ * variant pair.
+ * provision.congruence.test.ts pins the mirrors against this file's sets and
+ * this file against the broker contract.
+ *
+ * The manager/install token is read, used as a Bearer header, and forgotten.
+ * Only the derived per-app bot/app tokens persist (to .env). No token value
+ * is ever logged or embedded in an error message.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+import { SlackFlowError, type ProvisionInput, type ProvisionResult } from './types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** The deployed managed-Slack broker. Overridable via SLACK_SERVICE_BASE. */
+export const DEFAULT_BROKER_BASE = 'https://slack.nanoclaw.dev';
+
+/**
+ * The managed-apps bot scope set — bot scopes only, no user scopes (that is
+ * the apps.managedInstall eligibility rule). Superset of MANAGED_BOT_SCOPES
+ * in slack-create-agent.ts (the base set) plus the canvas scopes; must stay
+ * identical to the broker's server-side BOT_SCOPES — apps provisioned via
+ * either transport must be scope-identical (pinned by
+ * provision.congruence.test.ts). im:write is what lets the new bot open the
+ * operator DM; mpim:* is what lets it open the three-way room; canvases:* +
+ * files:read is the room-canvas surface (files:read is the read-back path —
+ * canvases are files, the HTML download carries section ids).
+ */
+export const MANAGED_BOT_SCOPES: readonly string[] = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+  'canvases:read',
+  'canvases:write',
+  'files:read',
+  // send_file: agents deliver files they produce (charts, documents,
+  // generated artifacts) via files upload — live-verified missing_scope
+  // failure without it (filesUploadV2 needs files:write).
+  'files:write',
+];
+
+// member_joined/left_channel ride on the channels/groups/mpim:read scopes
+// already present (join-time adopt flow + membership bookkeeping).
+export const MANAGED_BOT_EVENTS: readonly string[] = [
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'app_mention',
+  'member_joined_channel',
+  'member_left_channel',
+];
+
+/**
+ * Agent-mode (features.agent_view) additions — the default variant. Slack
+ * auto-adds assistant:write when agent_view is enabled; declared explicitly
+ * so the manifest states what the app holds. Guests are hard-blocked from
+ * agent-enabled apps, so allowGuests selects the plain variant instead.
+ */
+export const MANAGED_AGENT_BOT_SCOPES: readonly string[] = ['assistant:write'];
+
+export const MANAGED_AGENT_BOT_EVENTS: readonly string[] = ['app_home_opened', 'app_context_changed'];
+
+/**
+ * Fixed attribution line: admins see this, never the creation prompt. Also
+ * the agent_view.agent_description (≤300 chars) on the agent-mode variant.
+ */
+export const MANAGED_APP_DESCRIPTION =
+  'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
+
+/**
+ * Socket-Mode-only managed-app manifest (see the congruence note above).
+ * Two variants, chosen at provision time — agent_view is a one-way door:
+ * agent-mode (default; free workspaces degrade to a plain DM) and plain
+ * (agentView:false, for workspaces that need guest access).
+ */
+export function buildManagedAppManifest(
+  displayName: string,
+  opts: { agentView?: boolean } = {},
+): Record<string, unknown> {
+  const agentView = opts.agentView ?? true;
+  return {
+    display_information: {
+      name: displayName,
+      description: MANAGED_APP_DESCRIPTION,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: displayName,
+        always_online: true,
+      },
+      ...(agentView ? { agent_view: { agent_description: MANAGED_APP_DESCRIPTION } } : {}),
+    },
+    oauth_config: {
+      scopes: { bot: agentView ? [...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES] : [...MANAGED_BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: agentView ? [...MANAGED_BOT_EVENTS, ...MANAGED_AGENT_BOT_EVENTS] : [...MANAGED_BOT_EVENTS],
+      },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+/**
+ * Which provisioning credential this install holds, in the decisive order:
+ * process.env.NANOCLAW_REGISTRY_TOKEN → .env NANOCLAW_INSTALL_TOKEN →
+ * ~/.config/nanoclaw/account.json (broker mode; base = SLACK_SERVICE_BASE
+ * else DEFAULT_BROKER_BASE) → .env SLACK_MANAGER_TOKEN (direct mode) → null.
+ *
+ * `opts.homeDir` overrides os.homedir() for tests only — the account.json
+ * credential is deliberately per-user, not per-checkout.
+ */
+export function resolveProvisioningCredential(
+  rootDir: string,
+  opts: { homeDir?: string } = {},
+): { mode: 'broker'; installToken: string; baseUrl: string } | { mode: 'direct'; managerToken: string } | null {
+  const baseUrl = (readEnvValue(rootDir, 'SLACK_SERVICE_BASE') ?? DEFAULT_BROKER_BASE).replace(/\/+$/, '');
+
+  const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
+  if (fromEnv) return { mode: 'broker', installToken: fromEnv, baseUrl };
+
+  const installToken = readEnvValue(rootDir, 'NANOCLAW_INSTALL_TOKEN');
+  if (installToken) return { mode: 'broker', installToken, baseUrl };
+
+  // Enrollment persists the install token at ~/.config/nanoclaw/account.json
+  // ({ token: "…" }). Malformed or missing reads as "not enrolled".
+  try {
+    const accountPath = path.join(opts.homeDir ?? os.homedir(), '.config', 'nanoclaw', 'account.json');
+    const parsed: unknown = JSON.parse(fs.readFileSync(accountPath, 'utf-8'));
+    const token = (parsed as { token?: unknown } | null)?.token;
+    if (typeof token === 'string' && token.trim()) {
+      return { mode: 'broker', installToken: token.trim(), baseUrl };
+    }
+  } catch {
+    // fall through to direct mode
+  }
+
+  const managerToken = readEnvValue(rootDir, 'SLACK_MANAGER_TOKEN');
+  if (managerToken) return { mode: 'direct', managerToken };
+
+  return null;
+}
+
+interface RawProvisioned {
+  appId: string;
+  appToken: string;
+  botToken?: string;
+  installUrl?: string;
+  installError?: string;
+}
+
+/**
+ * Optional request-origin metadata on the broker's POST /v1/apps body
+ * (requested_by / parent_app_id / template / client_version on the wire).
+ * Sent only when defined; a broker that predates them ignores unknown body
+ * fields. Names and no-value-no-key behavior are pinned across every
+ * provisioning home by provision.congruence.test.ts. The direct transport has
+ * nowhere to record them and never forwards them.
+ */
+interface ProvisionAttribution {
+  requestedBy?: string;
+  parentAppId?: string;
+  template?: string;
+  clientVersion?: string;
+}
+
+/**
+ * The installing host's package.json version — the client_version metadata
+ * field. Optional-shaped: unreadable/absent → undefined and the field is
+ * simply omitted (never a placeholder value).
+ */
+function readClientVersion(rootDir: string): string | undefined {
+  try {
+    const pkg: unknown = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
+    const version = (pkg as { version?: unknown } | null)?.version;
+    return typeof version === 'string' && version.trim() ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Broker mode: POST /v1/apps with the install token; 60s budget. */
+/** Poll cap for the pre-create avatar job — beyond it the bot is born with the mascot. */
+const AVATAR_WAIT_MS = 75_000;
+// Generation measures ~20-23s at the broker's floor settings (quality 'low',
+// 1024px is the model's minimum) — a 2s poll wastes at most ~2s of that,
+// where the old 4s poll wasted up to 4.
+const AVATAR_POLL_MS = 2_000;
+
+// ── Avatar prefetch (multi-agent creates) ──
+//
+// Each generation is an independent async Lambda on the broker, so N avatars
+// CAN run concurrently — the serialization was ours: flows run one at a time,
+// each paying the full ~23s avatar wait. The delivery batch preview
+// (index.ts) starts a prefetch for every create_agent in the batch in
+// parallel; requestAvatar consumes the matching prefetch instead of starting
+// a fresh job, collapsing N waits to ~one. Keyed by the exact
+// (displayName, description) derivation the flow uses, so a miss just means
+// a normal fresh request.
+const avatarPrefetches = new Map<string, { promise: Promise<string | undefined>; at: number }>();
+const AVATAR_PREFETCH_TTL_MS = 10 * 60_000;
+
+function avatarKey(displayName: string, description: string | undefined): string {
+  return `${displayName}\u0000${description ?? ''}`;
+}
+
+/** Start an avatar generation in the background for a create that is about to
+ *  be processed. Fire-and-forget; never throws. Deduped per key. */
+export function prefetchAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): void {
+  const key = avatarKey(displayName, description);
+  const existing = avatarPrefetches.get(key);
+  if (existing && Date.now() - existing.at < AVATAR_PREFETCH_TTL_MS) return;
+  avatarPrefetches.set(key, {
+    promise: requestAvatarFresh(baseUrl, installToken, displayName, description).catch(() => undefined),
+    at: Date.now(),
+  });
+}
+
+/** Test seam: drop all pending prefetches. */
+export function clearAvatarPrefetches(): void {
+  avatarPrefetches.clear();
+}
+
+/**
+ * Ask the broker to generate the agent's avatar BEFORE the app exists, so the
+ * bot's very first workspace appearance wears its face — the mascot default
+ * never shows on the happy path. Consumes a matching prefetch when one is
+ * pending (multi-agent creates start them in parallel). Returns undefined
+ * when generation is unavailable, failed, or over the wait cap (degraded
+ * path: mascot).
+ */
+export async function requestAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  const key = avatarKey(displayName, description);
+  const hit = avatarPrefetches.get(key);
+  if (hit) {
+    avatarPrefetches.delete(key);
+    if (Date.now() - hit.at < AVATAR_PREFETCH_TTL_MS) return hit.promise;
+  }
+  return requestAvatarFresh(baseUrl, installToken, displayName, description);
+}
+
+async function requestAvatarFresh(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  let avatarId: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/v1/avatars`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${installToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: displayName, ...(description ? { description } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = (await res.json()) as { avatar_id?: string | null };
+    avatarId = data.avatar_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+  if (!avatarId) return undefined;
+  const deadline = Date.now() + AVATAR_WAIT_MS;
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) await new Promise((r) => setTimeout(r, AVATAR_POLL_MS));
+    try {
+      const res = await fetch(`${baseUrl}/v1/avatars/${avatarId}`, {
+        headers: { Authorization: `Bearer ${installToken}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'ready') return avatarId;
+      if (data.status && data.status !== 'pending') return undefined;
+    } catch {
+      // Transient — bounded by the deadline.
+    }
+  }
+  return undefined;
+}
+
+async function provisionViaBroker(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  teamId: string | undefined,
+  description: string | undefined,
+  allowGuests = false,
+  attribution: ProvisionAttribution = {},
+): Promise<RawProvisioned> {
+  if (!teamId) {
+    throw new SlackFlowError(
+      'broker',
+      'broker mode needs the origin workspace team_id (origin auth.test returned none)',
+    );
+  }
+  const avatarId = await requestAvatar(baseUrl, installToken, displayName, description);
+  let res: Response;
+  let text: string;
+  try {
+    res = await fetch(`${baseUrl}/v1/apps`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${installToken}`,
+        'Content-Type': 'application/json',
+      },
+      // The deployed broker's contract (POST /v1/apps): it builds the manifest
+      // server-side (agent-mode variant unless allow_guests) and generates
+      // the per-agent avatar from the description.
+      body: JSON.stringify({
+        team_id: teamId,
+        name: displayName,
+        ...(avatarId ? { avatar_id: avatarId } : {}),
+        ...(allowGuests ? { allow_guests: true } : {}),
+        // Request-origin metadata — optional both ways: omitted when
+        // unknown, ignored by a broker that predates the fields.
+        ...(attribution.requestedBy ? { requested_by: attribution.requestedBy } : {}),
+        ...(attribution.parentAppId ? { parent_app_id: attribution.parentAppId } : {}),
+        ...(attribution.template ? { template: attribution.template } : {}),
+        ...(attribution.clientVersion ? { client_version: attribution.clientVersion } : {}),
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    text = await res.text();
+  } catch (err) {
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let data: Record<string, unknown>;
+  try {
+    data = (text ? JSON.parse(text) : {}) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('broker', `broker POST /v1/apps failed: HTTP ${res.status}, non-JSON body`);
+  }
+  if (!res.ok) {
+    // message is the human sentence, error the machine code — show the human one.
+    const detail = (data as { message?: string; error?: string }).message ?? (data as { error?: string }).error;
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: HTTP ${res.status}${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+  // Contract shape is camelCase; the deployed broker speaks snake_case
+  // (BrokerAppResponse in src/provisioning/slack-app.ts) — accept both.
+  const pick = (a: unknown, b: unknown): string | undefined =>
+    typeof a === 'string' && a ? a : typeof b === 'string' && b ? b : undefined;
+  const appId = pick(data.appId, data.app_id);
+  const appToken = pick(data.appToken, data.app_token);
+  if (!appId || !appToken) {
+    throw new SlackFlowError('broker', 'broker POST /v1/apps failed: response missing app id or app token');
+  }
+  return {
+    appId,
+    appToken,
+    botToken: pick(data.botToken, data.bot_token),
+    installUrl: pick(data.installUrl, data.install_url),
+    installError: pick(data.installError, data.install_error),
+  };
+}
+
+// ── Deferred install completion (broker transport) ──
+//
+// A workspace with an admin-approval policy refuses auto-install: POST
+// /v1/apps answers with an install_url and no bot token. That URL carries its
+// own signed state and stays valid for days, so the app is not lost — it sits
+// at pending_install until a human completes the install in the browser, and
+// GET /v1/apps/{app_id} then releases the bot token exactly once. Mirrors
+// waitForInstall in src/provisioning/slack-app.ts.
+
+/** Poll cadence while a workspace install approval is outstanding. */
+export const INSTALL_POLL_INTERVAL_MS = 5_000;
+/** How long the flow waits inline before parking the app for a later resume. */
+export const INSTALL_POLL_TIMEOUT_MS = 5 * 60_000;
+
+type AppStatus = 'installed' | 'pending_install' | 'deleted';
+
+interface AppState {
+  status: AppStatus;
+  botToken?: string;
+}
+
+/**
+ * One app's state, or undefined when the service does not know it (404) —
+ * which for every caller here means the same as "stop waiting". Transport
+ * failures throw so the poll loop can decide whether they are worth retrying.
+ */
+async function fetchAppState(baseUrl: string, installToken: string, appId: string): Promise<AppState | undefined> {
+  const res = await fetch(`${baseUrl}/v1/apps/${encodeURIComponent(appId)}`, {
+    headers: { Authorization: `Bearer ${installToken}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (res.status === 404) return undefined;
+  if (res.status === 401 || res.status === 403) {
+    throw new SlackFlowError(
+      'install-wait',
+      `the Slack service refused this install's credentials (HTTP ${res.status})`,
+    );
+  }
+  if (!res.ok) throw new Error(`GET /v1/apps/${appId}: HTTP ${res.status}`);
+  const data = (await res.json()) as { status?: string; bot_token?: string | null; botToken?: string | null };
+  const status = data.status;
+  if (status !== 'installed' && status !== 'pending_install' && status !== 'deleted') {
+    throw new Error(`GET /v1/apps/${appId}: unrecognized status '${String(status)}'`);
+  }
+  // Contract shape is snake_case; accept camelCase the way the create call does.
+  const botToken = data.bot_token ?? data.botToken ?? undefined;
+  return { status, ...(botToken ? { botToken } : {}) };
+}
+
+/**
+ * Wait out a pending install and return the one-time bot token.
+ *
+ * Undefined means "stop waiting and park the app": the deadline passed, the
+ * service does not know the app, it was deleted, or it reads as installed with
+ * no token left to give (someone else already took it — no further poll
+ * recovers it). A credential refusal is the one failure worth surfacing, since
+ * the next poll cannot change that answer.
+ */
+export async function waitForInstall(
+  baseUrl: string,
+  installToken: string,
+  appId: string,
+  opts: { intervalMs?: number; timeoutMs?: number; checkImmediately?: boolean } = {},
+): Promise<string | undefined> {
+  const intervalMs = opts.intervalMs ?? INSTALL_POLL_INTERVAL_MS;
+  const deadline = Date.now() + (opts.timeoutMs ?? INSTALL_POLL_TIMEOUT_MS);
+  // A resume checks straight away — the approval may have landed while nobody
+  // was waiting, and that is worth one call even when the budget is zero. A
+  // fresh refusal sleeps first: nothing can have changed in the instant since
+  // the service said no.
+  let due = opts.checkImmediately === true;
+  while (due || Date.now() < deadline) {
+    if (!due) await new Promise((r) => setTimeout(r, intervalMs));
+    due = false;
+    let state: AppState | undefined;
+    try {
+      state = await fetchAppState(baseUrl, installToken, appId);
+    } catch (err) {
+      if (err instanceof SlackFlowError) throw err;
+      continue; // transient — the deadline already bounds this
+    }
+    if (!state || state.status === 'deleted') return undefined;
+    if (state.status === 'installed') return state.botToken;
+  }
+  return undefined;
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+async function slackApi<T extends SlackApiResponse>(
+  method: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API}/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(params).toString(),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new SlackFlowError('direct-create', `${method} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok && res.status !== 200) throw new SlackFlowError('direct-create', `${method}: HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+/** Direct mode: apps.manifest.create + apps.managedInstall with the manager token. */
+async function provisionDirect(
+  managerToken: string,
+  displayName: string,
+  allowGuests = false,
+): Promise<RawProvisioned> {
+  const created = await slackApi<
+    SlackApiResponse & { app_id?: string; app_token?: string; oauth_authorize_url?: string }
+  >('apps.manifest.create', managerToken, {
+    manifest: JSON.stringify(buildManagedAppManifest(displayName, { agentView: !allowGuests })),
+    generate_app_token: 'true',
+  });
+  if (!created.ok || !created.app_id) {
+    throw new SlackFlowError(
+      'direct-create',
+      `apps.manifest.create failed: ${created.error ?? 'no app_id in response'}`,
+    );
+  }
+  if (!created.app_token) {
+    throw new SlackFlowError(
+      'direct-create',
+      'apps.manifest.create returned no app-level token (generate_app_token unsupported?)',
+    );
+  }
+  const result: RawProvisioned = {
+    appId: created.app_id,
+    appToken: created.app_token,
+    installUrl: created.oauth_authorize_url ?? '',
+  };
+  const installed = await slackApi<SlackApiResponse & { api_access_tokens?: { bot_access_token?: string } }>(
+    'apps.managedInstall',
+    managerToken,
+    { app_id: created.app_id },
+  );
+  if (installed.ok && installed.api_access_tokens?.bot_access_token) {
+    result.botToken = installed.api_access_tokens.bot_access_token;
+  } else {
+    result.installError = installed.error ?? 'no bot token in response';
+  }
+  return result;
+}
+
+/** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix shape. */
+export function envKeySuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * The .env keys one provisioned instance owns. The app id and install URL are
+ * the resume state for an app whose workspace has not approved the install
+ * yet: without them a retry has nothing to poll and can only create a second
+ * Slack app for the same agent.
+ */
+export function envKeysForSlug(slug: string): {
+  botKey: string;
+  appKey: string;
+  appIdKey: string;
+  installUrlKey: string;
+} {
+  const suffix = envKeySuffix(slug);
+  return {
+    botKey: `SLACK_BOT_TOKEN_${suffix}`,
+    appKey: `SLACK_APP_TOKEN_${suffix}`,
+    appIdKey: `SLACK_APP_ID_${suffix}`,
+    installUrlKey: `SLACK_INSTALL_URL_${suffix}`,
+  };
+}
+
+/**
+ * The app this slug has parked awaiting a workspace install approval, if any:
+ * an app token and an app id on record, no bot token yet. Callers use it to
+ * tell "finish what you started" apart from "start something new".
+ */
+export function pendingInstall(rootDir: string, slug: string): { appId: string; installUrl?: string } | undefined {
+  const { botKey, appKey, appIdKey, installUrlKey } = envKeysForSlug(slug);
+  if (readEnvValue(rootDir, botKey)) return undefined;
+  if (!readEnvValue(rootDir, appKey)) return undefined;
+  const appId = readEnvValue(rootDir, appIdKey);
+  if (!appId) return undefined;
+  return { appId, installUrl: readEnvValue(rootDir, installUrlKey) };
+}
+
+/** Best-effort: a caller's notification must never take the flow down with it. */
+async function announcePending(
+  input: ProvisionInput,
+  info: { appId: string; installUrl?: string; resumed: boolean },
+): Promise<void> {
+  try {
+    await input.onInstallPending?.(info);
+  } catch {
+    // The wait is the point; the announcement is a courtesy.
+  }
+}
+
+/** What the human is told when the wait runs out and the app stays parked. */
+function parkedError(displayName: string, appId: string, installUrl: string | undefined): SlackFlowError {
+  return new SlackFlowError(
+    'install-wait',
+    `Slack app ${appId} for "${displayName}" is still waiting on a workspace install approval. ` +
+      `Nothing was lost and nothing needs re-creating — the app is saved. ` +
+      `${installUrl ? `Approve the install at ${installUrl}, then ask` : 'Once the install is approved, ask'} ` +
+      `to finish setting up ${displayName} and it picks up from here.`,
+  );
+}
+
+/**
+ * Provision (or reuse, or finish) the named instance's Slack app and persist
+ * its tokens.
+ *
+ * Three entries, decided by what .env already holds:
+ *  - both tokens → reuse, no network.
+ *  - app token + app id, no bot token → an app parked awaiting a workspace
+ *    install approval: poll for it rather than provision a second one.
+ *  - nothing → provision. A refused auto-install is not the end of the road:
+ *    the app is real and its install URL stays valid, so the flow announces
+ *    the approval and waits inline for the install to land.
+ *
+ * .env is the resume state, so everything derivable is written the moment it
+ * exists (mirrors slack-create-agent.ts) — a failure after that point never
+ * re-provisions a duplicate Slack app on retry.
+ */
+export async function provisionSlackApp(input: ProvisionInput): Promise<ProvisionResult> {
+  const { slug, displayName, rootDir } = input;
+  const envSuffix = envKeySuffix(slug);
+  const { botKey, appKey, appIdKey, installUrlKey } = envKeysForSlug(slug);
+
+  const existingBot = readEnvValue(rootDir, botKey);
+  const existingApp = readEnvValue(rootDir, appKey);
+  if (existingBot && existingApp) {
+    return {
+      slug,
+      envSuffix,
+      botToken: existingBot,
+      appToken: existingApp,
+      // Recorded since the deferred-install work; older installs have no row,
+      // and nothing downstream of provisioning needs the id.
+      appId: readEnvValue(rootDir, appIdKey) ?? '',
+      reused: true,
+    };
+  }
+  if (existingBot && !existingApp) {
+    throw new SlackFlowError(
+      'no-credentials',
+      `${botKey} is set but ${appKey} is missing — add the app-level xapp-… token to .env as ${appKey} and retry.`,
+    );
+  }
+
+  const credential = resolveProvisioningCredential(rootDir);
+
+  if (existingApp && !existingBot) {
+    const parked = pendingInstall(rootDir, slug);
+    // No app id on record (or no broker to ask) leaves the hand-finish
+    // instructions as the only honest answer.
+    if (!parked || credential?.mode !== 'broker') {
+      throw new SlackFlowError(
+        'no-credentials',
+        `${appKey} is set but ${botKey} is missing — the app exists but was never installed. ` +
+          `Finish the install from the app's page in Slack, put the xoxb-… token in .env as ${botKey}, and retry.`,
+      );
+    }
+    await announcePending(input, { appId: parked.appId, installUrl: parked.installUrl, resumed: true });
+    const botToken = await waitForInstall(credential.baseUrl, credential.installToken, parked.appId, {
+      ...input.installWait,
+      checkImmediately: true,
+    });
+    if (!botToken) throw parkedError(displayName, parked.appId, parked.installUrl);
+    persistInstalled(rootDir, slug, botToken);
+    return {
+      slug,
+      envSuffix,
+      botToken,
+      appToken: existingApp,
+      appId: parked.appId,
+      reused: false,
+      deferredInstall: true,
+    };
+  }
+
+  if (!credential) {
+    throw new SlackFlowError(
+      'no-credentials',
+      'no Slack provisioning credential: set NANOCLAW_INSTALL_TOKEN (managed service) or ' +
+        'SLACK_MANAGER_TOKEN (direct) in .env, or enroll this install with the registry.',
+    );
+  }
+
+  const allowGuests = input.allowGuests ?? false;
+  const app =
+    credential.mode === 'broker'
+      ? await provisionViaBroker(
+          credential.baseUrl,
+          credential.installToken,
+          displayName,
+          input.teamId,
+          input.description,
+          allowGuests,
+          {
+            requestedBy: input.requestedBy,
+            parentAppId: input.parentAppId,
+            template: input.template,
+            clientVersion: readClientVersion(rootDir),
+          },
+        )
+      : await provisionDirect(credential.managerToken, displayName, allowGuests);
+
+  // Persist what we have before anything else can fail. App token, app id and
+  // instance slug land even when auto-install was refused, so a later run can
+  // finish this app instead of creating another.
+  try {
+    upsertEnvKey(rootDir, appKey, app.appToken);
+    if (app.appId) upsertEnvKey(rootDir, appIdKey, app.appId);
+    if (app.botToken) upsertEnvKey(rootDir, botKey, app.botToken);
+    else if (app.installUrl) upsertEnvKey(rootDir, installUrlKey, app.installUrl);
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${appKey}/${botKey}/SLACK_INSTANCES to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!app.botToken) {
+    // Usually a workspace admin-approval policy refusing auto-install. On the
+    // broker transport that is a wait, not a dead end — the install URL is
+    // signed and long-lived, and the service releases the bot token once the
+    // install lands. The direct transport has no such read-back.
+    if (credential.mode === 'broker' && app.installUrl) {
+      await announcePending(input, { appId: app.appId, installUrl: app.installUrl, resumed: false });
+      const botToken = await waitForInstall(
+        credential.baseUrl,
+        credential.installToken,
+        app.appId,
+        input.installWait ?? {},
+      );
+      if (!botToken) throw parkedError(displayName, app.appId, app.installUrl);
+      persistInstalled(rootDir, slug, botToken);
+      return {
+        slug,
+        envSuffix,
+        botToken,
+        appToken: app.appToken,
+        appId: app.appId,
+        reused: false,
+        deferredInstall: true,
+      };
+    }
+    throw new SlackFlowError(
+      credential.mode === 'broker' ? 'broker' : 'direct-create',
+      `Slack refused to auto-install app ${app.appId} (${app.installError ?? 'unknown reason'}). ` +
+        `Install it by hand${app.installUrl ? ` from ${app.installUrl}` : " from the app's page at api.slack.com/apps"}, ` +
+        `put the xoxb-… token in .env as ${botKey}, and retry — the app token is already saved.`,
+    );
+  }
+
+  return { slug, envSuffix, botToken: app.botToken, appToken: app.appToken, appId: app.appId, reused: false };
+}
+
+/**
+ * Record a bot token that arrived after the wait, and retire the install URL
+ * that produced it — a consumed link left on disk reads as work still to do.
+ */
+function persistInstalled(rootDir: string, slug: string, botToken: string): void {
+  const { botKey, installUrlKey } = envKeysForSlug(slug);
+  try {
+    upsertEnvKey(rootDir, botKey, botToken);
+    upsertEnvKey(rootDir, installUrlKey, '');
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${botKey} to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/modules/slack-agent-flow/room-actions.test.ts
+++ b/src/modules/slack-agent-flow/room-actions.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Tests for the agent-facing room actions: create_room and
+ * add_to_room, driven through the REAL guard-wrapped delivery entries
+ * (getDeliveryAction) over a real in-memory central DB. Slack traffic is a
+ * recorded fetch stub (auth.test + conversations.open only — room actions
+ * never provision apps); the canvas leg is mocked like orchestrate.test.ts.
+ * rootDir is process.cwd(), so each test runs chdir'd into its own tmpdir.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ANDY_BOT_TOKEN = 'xoxb-andy-secret-token';
+const PIXEL_BOT_TOKEN = 'xoxb-pixel-secret-token';
+const DEVIN_BOT_TOKEN = 'xoxb-devin-secret-token';
+
+const { mockNotifyWrite, mockRequestApproval, mockWriteDestinations, mockCreateRoomCanvas, mockWireCanvasComments } =
+  vi.hoisted(() => ({
+    mockNotifyWrite: vi.fn(),
+    mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+    mockWriteDestinations: vi.fn(),
+    mockCreateRoomCanvas: vi.fn(),
+    mockWireCanvasComments: vi.fn(),
+  }));
+
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({ initGroupFilesystem: vi.fn() }));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// room actions only need these three. notifyAgent stays REAL (primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the create_room / add_to_room delivery actions — the path under
+// test. Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays
+// unloaded.
+import './index.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { listGuardedActions } from '../../guard/index.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { createDestination, getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'strict' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+let tmpDir = '';
+// conversations.members response for the add_to_room source-room read.
+let sourceRoomMembers: string[] = [];
+let membersFail = false;
+
+const BOT_IDS: Record<string, string> = {
+  [ANDY_BOT_TOKEN]: 'U0ANDYBOT',
+  [PIXEL_BOT_TOKEN]: 'U0PIXELBOT',
+  [DEVIN_BOT_TOKEN]: 'U0DEVINBOT',
+};
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const token = String(init?.headers?.Authorization ?? '').replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.includes('/api/auth.test')) {
+    const userId = BOT_IDS[token];
+    if (!userId) return Promise.resolve(jsonResponse({ ok: false, error: 'invalid_auth' }));
+    return Promise.resolve(jsonResponse({ ok: true, user_id: userId, team_id: 'T0TEST' }));
+  }
+  if (url.includes('/api/conversations.members')) {
+    if (membersFail) return Promise.resolve(jsonResponse({ ok: false, error: 'fetch_members_failed' }));
+    return Promise.resolve(jsonResponse({ ok: true, members: sourceRoomMembers }));
+  }
+  if (url.includes('/api/conversations.open')) {
+    // add_to_room opens the superset AS the newly added agent (Devin in
+    // these tests) — that open forks; every other open is the original room.
+    return Promise.resolve(
+      jsonResponse({ ok: true, channel: { id: token === DEVIN_BOT_TOKEN ? 'G0FORK' : 'G0TEAM' } }),
+    );
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+function roomOpens(): RecordedFetch[] {
+  return fetchCalls.filter((c) => c.url.includes('conversations.open'));
+}
+
+async function runAction(
+  action: string,
+  content: Record<string, unknown>,
+  session: Session = SLACK_SESSION,
+): Promise<void> {
+  const wrapped = getDeliveryAction(action);
+  expect(wrapped).toBeDefined();
+  await wrapped!({ action, ...content }, session);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ANDY_BOT_TOKEN, PIXEL_BOT_TOKEN, DEVIN_BOT_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+/** A provisioned sub-agent: group + DM wiring on its own instance + the
+ *  caller's a2a destination for it (what create_agent leaves behind). */
+async function seedSubAgent(name: string, groupId: string, instanceKey: string): Promise<void> {
+  const now = new Date().toISOString();
+  const localName = name.toLowerCase();
+  await createAgentGroup({ id: groupId, name, folder: localName, agent_provider: null, created_at: now });
+  const dmMgId = `mg-${localName}-dm`;
+  await createMessagingGroup({
+    id: dmMgId,
+    channel_type: 'slack',
+    platform_id: `slack:D0${name.toUpperCase()}DM`,
+    instance: instanceKey,
+    name: `${name} DM`,
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createMessagingGroupAgent({
+    id: `mga-${localName}-dm`,
+    messaging_group_id: dmMgId,
+    agent_group_id: groupId,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+  await createDestination({
+    agent_group_id: SRC_GROUP,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: groupId,
+    created_at: now,
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  // Faithful default: the source room holds exactly the operator + its bots.
+  sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT'];
+  membersFail = false;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-room-actions-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(
+    path.join(tmpDir, '.env'),
+    `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\nSLACK_BOT_TOKEN_PIXEL=${PIXEL_BOT_TOKEN}\nSLACK_BOT_TOKEN_DEVIN=${DEVIN_BOT_TOKEN}\n`,
+  );
+
+  const db = await initTestDb();
+  await runMigrations(db);
+
+  const now = new Date().toISOString();
+  await createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  await ensureContainerConfig(SRC_GROUP);
+  await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  await upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  await grantRole({
+    user_id: 'slack:U0OPERATOR',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createSession(SLACK_SESSION);
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+
+  await seedSubAgent('Pixel', 'ag-pixel', 'slack-pixel');
+  await seedSubAgent('Devin', 'ag-devin', 'slack-devin');
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('guard wiring', () => {
+  it('both room actions are in the guard catalog and their entries are guard-wrapped', () => {
+    const actions = new Set(listGuardedActions().map((s) => s.action));
+    expect(actions.has('rooms.create')).toBe(true);
+    expect(actions.has('rooms.add_agent')).toBe(true);
+    expect(getDeliveryAction('create_room')).toBeDefined();
+    expect(getDeliveryAction('add_to_room')).toBeDefined();
+  });
+
+  it('confined (group-scope) caller: create_room holds for approval, nothing runs', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel', 'Devin'] });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_room');
+    expect(opts.payload).toMatchObject({ name: 'Website Team', agents: ['Pixel', 'Devin'] });
+  });
+
+  it('confined (group-scope) caller: add_to_room holds for approval with the (room, agent) payload', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('add_to_room');
+    expect(opts.payload).toEqual({ room: 'Website Team', agent: 'Devin' });
+  });
+});
+
+describe('create_room', () => {
+  it('resolves names and hands ensureAgentRoom the full participant list (caller included)', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runAction('create_room', { name: 'Website Team', purpose: 'ship the new site', agents: ['Pixel', 'Devin'] });
+
+    // MPIM opened AS the caller with the operator + every other bot.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(ANDY_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0PIXELBOT,U0DEVINBOT' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Pairwise a2a destinations between the sub-agents (caller already had both).
+    expect(await getDestinationByName('ag-pixel', 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-devin',
+    });
+    expect(await getDestinationByName('ag-devin', 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-pixel',
+    });
+
+    // Canvas gets the contract data — every agent by plain name, caller first.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(ANDY_BOT_TOKEN, 'G0TEAM', {
+      roomName: 'Website Team',
+      purpose: 'ship the new site',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Pixel', 'Devin'],
+    });
+
+    // Allowlisted for a2a; success notify tells the CALLER to author the
+    // intro via its projected room destination, tagging both bots.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0TEAM/m);
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Room "Website Team" is live (G0TEAM)');
+    expect(success).toContain('send_message({ to: "website-team"');
+    expect(success).toContain('<@U0PIXELBOT>');
+    expect(success).toContain('<@U0DEVINBOT>');
+    expect(success).not.toContain('<@U0ANDYBOT>');
+    expect(success).toContain('no mechanics, no member lists');
+
+    assertNoTokenLeak();
+  });
+
+  it('include_me:false — first listed agent becomes creator, caller stays out', async () => {
+    await runAction('create_room', { name: 'Duo', agents: ['Pixel', 'Devin'], include_me: false });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(PIXEL_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0DEVINBOT' });
+
+    // No caller-instance row, no caller wiring.
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeUndefined();
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('You are not a member');
+    expect(success).not.toContain('send_message');
+  });
+
+  it('unknown agent name surfaces as a failure notify before anything is opened', async () => {
+    await runAction('create_room', { name: 'Website Team', agents: ['Ghost'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect((await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:G0TEAM')).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('create_room failed: unknown agent "Ghost"');
+  });
+
+  it('missing bot token surfaces as a failure notify naming the key, never the value', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\n`);
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain('create_room failed: no bot token in .env for agent "Pixel"');
+    expect(failure).toContain('SLACK_BOT_TOKEN_PIXEL');
+    assertNoTokenLeak();
+  });
+
+  it('malformed request (no agents) is answered by the precheck without a hold', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: [] });
+
+    expect(mockRequestApproval).not.toHaveBeenCalled();
+    expect(notifyTexts().at(-1)).toContain('agents must be a non-empty list');
+  });
+});
+
+describe('add_to_room', () => {
+  beforeEach(async () => {
+    // An existing room: Andy + Pixel (+ operator), created through the real
+    // primitive so the wiring shape matches production.
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+    mockNotifyWrite.mockClear();
+    fetchCalls = [];
+  });
+
+  it('opens the superset MPIM as the new agent and wires everyone onto the forked channel', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    // Superset open AS Devin: operator + both existing bots → fork id.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(DEVIN_BOT_TOKEN);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(3);
+    expect(users).toContain('U0OPERATOR');
+    expect(users).toContain('U0ANDYBOT');
+    expect(users).toContain('U0PIXELBOT');
+
+    // Every participant wired onto the NEW channel; the old room untouched.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0FORK', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        ignored_message_policy: 'accumulate',
+      });
+    }
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeDefined();
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack-devin')).toBeUndefined();
+
+    // The caller is a room member — the notify explains the fork and asks
+    // for an intro of the new agent in the NEW conversation.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Devin was added to room "Website Team"');
+    expect(success).toContain('moved to a new conversation (G0FORK)');
+    expect(success).toContain('<@U0DEVINBOT>');
+
+    assertNoTokenLeak();
+  });
+
+  it('carries Slack-UI-added humans from the source room into the forked superset', async () => {
+    // A colleague was added to the room via the Slack UI — they exist only
+    // in the platform member list, never in wiring rows.
+    sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT', 'U0COLLEAGUE'];
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(4);
+    expect(users).toContain('U0COLLEAGUE');
+    expect(notifyTexts().at(-1)).toContain('moved to a new conversation (G0FORK)');
+  });
+
+  it('source-room member read failure fails the action — never a fork that silently drops members', async () => {
+    membersFail = true;
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed');
+  });
+
+  it('agent already in the room: says so, opens nothing', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Pixel' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('already in room "Website Team"');
+  });
+
+  it('unknown room surfaces as a failure notify', async () => {
+    await runAction('add_to_room', { room: 'Nope', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed: no wired Slack room named "Nope"');
+  });
+});

--- a/src/modules/slack-agent-flow/room-actions.ts
+++ b/src/modules/slack-agent-flow/room-actions.ts
@@ -1,0 +1,467 @@
+/**
+ * Agent-facing room actions: `create_room` and `add_to_room`
+ * delivery-action bodies over the already-N-capable ensureAgentRoom.
+ *
+ * `create_room` is the "team room" primitive — the multi-agent pattern is N
+ * `create_agent` calls with room:'none' followed by ONE create_room naming
+ * all of them. Agent names resolve through the CALLER's a2a destination
+ * namespace (the same names send_message uses), so an agent can only room
+ * with agents it can already message. Each resolved agent group maps to its
+ * Slack adapter instance via its wired messaging groups; bot identities come
+ * from auth.test on the instance's .env token (botTokenKeyForInstance) —
+ * token values never appear in notify texts or logs.
+ *
+ * `add_to_room` grows an existing room by one agent. Slack platform fact:
+ * MPIMs NEVER grow in place — opening the superset member list FORKS a new
+ * conversation id. ensureAgentRoom wires every participant onto the new id
+ * directly, and the source room's actual member list is read first so
+ * Slack-UI-added humans carry into the fork; the slack-room-membership
+ * MPIM-fork carry-over (membership.ts) remains the path for Slack-UI adds
+ * and stays silent here because the rows
+ * already exist when its join-recheck fires. The old room is left untouched
+ * (both conversations stay alive). For planned teams, prefer one complete
+ * create_room over add_to_room chains.
+ *
+ * Failures surface to the requesting agent via notifyAgent — never silent.
+ */
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  getMessagingGroupsByAgentGroup,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
+import {
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { botTokenKeyForInstance, slackAuthTest, slackConversationsMembers } from '../../channels/slack-lib.js';
+import { notifyAgent, requestApproval } from '../approvals/index.js';
+import { readEnvValue } from './env-file.js';
+import { ensureAgentRoom, publicPurpose, resolveOperatorSlackUserId, type RoomParticipant } from './orchestrate.js';
+
+/** Domain failure with an agent-presentable message (no token values, ever). */
+class RoomActionError extends Error {}
+
+/** A room participant plus the bot token that proves it — token stays local. */
+interface ResolvedParticipant extends RoomParticipant {
+  botToken: string;
+}
+
+// ── Participant resolution ──
+
+/**
+ * An agent name → its agent group, through the CALLER's destination
+ * namespace (normalizeName'd, same as send_message targets).
+ */
+async function resolveAgentByName(callerGroupId: string, name: string): Promise<AgentGroup> {
+  const localName = normalizeName(name);
+  const dest = await getDestinationByName(callerGroupId, localName);
+  if (!dest || dest.target_type !== 'agent') {
+    throw new RoomActionError(
+      `unknown agent "${name}" — you have no agent destination named "${localName}". ` +
+        `Use the names your send_message destinations use.`,
+    );
+  }
+  const group = await getAgentGroup(dest.target_id);
+  if (!group) throw new RoomActionError(`agent group behind destination "${localName}" no longer exists`);
+  return group;
+}
+
+/** Bot token + auth.test identity for one adapter instance. */
+async function identityForInstance(
+  instanceKey: string,
+  agentGroupName: string,
+  rootDir: string,
+): Promise<{ botToken: string; botUserId: string }> {
+  const tokenKey = botTokenKeyForInstance(instanceKey);
+  const botToken = readEnvValue(rootDir, tokenKey);
+  if (!botToken) {
+    throw new RoomActionError(`missing ${tokenKey} in .env for agent "${agentGroupName}" (instance '${instanceKey}')`);
+  }
+  const botUserId = (await slackAuthTest(botToken, 'room-resolve')).userId;
+  return { botToken, botUserId };
+}
+
+/** Build the participant for a known (group, instance) pair. */
+async function participantForInstance(
+  group: AgentGroup,
+  instanceKey: string,
+  rootDir: string,
+): Promise<ResolvedParticipant> {
+  const { botToken, botUserId } = await identityForInstance(instanceKey, group.name, rootDir);
+  return { instanceKey, botUserId, agentGroupId: group.id, agentGroupName: group.name, botToken };
+}
+
+/**
+ * Build the participant for an agent group by finding its Slack adapter
+ * instance among its wired messaging groups (a provisioned agent's DM and
+ * rooms all live on its dedicated `slack-<slug>` instance; the origin agent
+ * lives on its origin instance). Multiple distinct instances is a
+ * pathological state — the first (sorted) with a token in .env wins.
+ */
+async function participantForAgentGroup(group: AgentGroup, rootDir: string): Promise<ResolvedParticipant> {
+  const instances = [
+    ...new Set(
+      (await getMessagingGroupsByAgentGroup(group.id))
+        .filter((mg) => mg.channel_type === 'slack')
+        .map((mg) => mg.instance ?? 'slack'),
+    ),
+  ].sort();
+  if (instances.length === 0) {
+    throw new RoomActionError(
+      `agent "${group.name}" has no Slack presence (no Slack wiring found) — was its Slack bot provisioned?`,
+    );
+  }
+  const withToken = instances.find((key) => readEnvValue(rootDir, botTokenKeyForInstance(key)) !== undefined);
+  if (!withToken) {
+    throw new RoomActionError(
+      `no bot token in .env for agent "${group.name}" (looked for ${instances.map(botTokenKeyForInstance).join(', ')})`,
+    );
+  }
+  return participantForInstance(group, withToken, rootDir);
+}
+
+/**
+ * The CALLING agent as a participant — its instance is the session's origin
+ * instance when the request came in through Slack (mirrors runSlackAgentFlow),
+ * else resolved from its wired messaging groups (task/a2a sessions).
+ */
+async function callerParticipant(session: Session, rootDir: string): Promise<ResolvedParticipant> {
+  const group = await getAgentGroup(session.agent_group_id);
+  if (!group) throw new RoomActionError('source agent group not found');
+  const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  if (originMg?.channel_type === 'slack') {
+    return participantForInstance(group, originMg.instance ?? 'slack', rootDir);
+  }
+  return participantForAgentGroup(group, rootDir);
+}
+
+/** The caller's local destination name for a room channel on its instance. */
+async function callerRoomDestination(
+  callerGroupId: string,
+  callerInstanceKey: string,
+  roomChannelId: string,
+  roomName: string,
+): Promise<string> {
+  const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, callerInstanceKey);
+  const dest = roomMg ? await getDestinationByTarget(callerGroupId, 'channel', roomMg.id) : undefined;
+  return dest?.local_name ?? normalizeName(roomName);
+}
+
+/** `<@U…>, <@U…>` mention tags for every participant except the caller. */
+function mentionTags(participants: RoomParticipant[], excludeGroupId: string): string {
+  return participants
+    .filter((p) => p.agentGroupId !== excludeGroupId)
+    .map((p) => `<@${p.botUserId}>`)
+    .join(', ');
+}
+
+// ── create_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export async function validateCreateRoom(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  if (!name) {
+    await notifyAgent(session, 'create_room failed: name is required.');
+    return false;
+  }
+  const agents = Array.isArray(content.agents) ? content.agents : [];
+  if (agents.length === 0 || !agents.every((a) => typeof a === 'string' && a.trim())) {
+    await notifyAgent(session, 'create_room failed: agents must be a non-empty list of agent names.');
+    return false;
+  }
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'create_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestCreateRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  const agents = (Array.isArray(content.agents) ? content.agents : []).filter(
+    (a): a is string => typeof a === 'string',
+  );
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_room',
+    // Same payload shape as the tool call — the approved replay re-enters
+    // the wrapped action unchanged.
+    payload: {
+      name,
+      agents,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.include_me === false ? { include_me: false } : {}),
+    },
+    title: `Create room: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to open a shared Slack room "${name}" with you and ` +
+      `${agents.join(', ')}${content.include_me === false ? ' (without itself)' : ''}. Approve?`,
+  });
+}
+
+/**
+ * Guard allow body: resolve every named agent (+ the caller unless
+ * include_me:false), then hand the full participant list to ensureAgentRoom
+ * — one MPIM with ALL bots + the operator, one canvas, mention/accumulate
+ * wirings per instance, pairwise a2a destinations. The success notify tells
+ * the CALLER to author the room intro (no host-templated intro).
+ */
+export async function handleCreateRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = (content.name as string).trim();
+  const agentNames = (content.agents as string[]).map((a) => a.trim());
+  const includeMe = content.include_me !== false;
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = await resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    // Caller first when included — it becomes the creator (opens the MPIM,
+    // creates the canvas); otherwise the first listed agent does.
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    if (includeMe) {
+      const caller = await callerParticipant(session, rootDir);
+      seen.add(caller.agentGroupId);
+      participants.push(caller);
+    }
+    for (const agentName of agentNames) {
+      const group = await resolveAgentByName(session.agent_group_id, agentName);
+      if (seen.has(group.id)) continue;
+      seen.add(group.id);
+      participants.push(await participantForAgentGroup(group, rootDir));
+    }
+    if (participants.length === 0) throw new RoomActionError('no agents resolved');
+    const creator = participants[0]!;
+
+    const { roomChannelId, created } = await ensureAgentRoom({
+      creator,
+      creatorBotToken: creator.botToken,
+      operatorUserId,
+      participants,
+      roomName: name,
+      purpose: publicPurpose(typeof content.purpose === 'string' ? content.purpose : undefined),
+      rootDir,
+    });
+
+    const memberNames = participants.map((p) => p.agentGroupName).join(', ');
+    if (!includeMe) {
+      await notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with the operator and ${memberNames}. ` +
+          `You are not a member (include_me was false), so you cannot post there.`,
+      );
+    } else if (!created) {
+      await notifyAgent(session, `Room "${name}" already existed (${roomChannelId}) — nothing new was created.`);
+    } else {
+      // The calling agent authors the intro, in its own voice.
+      const roomDest = await callerRoomDestination(session.agent_group_id, creator.instanceKey, roomChannelId, name);
+      await notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with you, the operator, and ${memberNames}. ` +
+          `Post a brief introduction there now via send_message({ to: "${roomDest}", ... }): ` +
+          `1-2 lines in your own voice on what this room is for, tagging each agent literally ` +
+          `(${mentionTags(participants, session.agent_group_id)}) — the tags render as mentions and are how you ` +
+          `engage them there. Just the intro — no mechanics, no member lists.`,
+      );
+    }
+    log.info('create_room completed', { roomChannelId, created, participantCount: participants.length });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(session, `create_room failed: ${message}`);
+    log.error('create_room failed', { name, err: message });
+  }
+}
+
+// ── add_to_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export async function validateAddToRoom(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  if (typeof content.room !== 'string' || !content.room.trim()) {
+    await notifyAgent(session, 'add_to_room failed: room is required.');
+    return false;
+  }
+  if (typeof content.agent !== 'string' || !content.agent.trim()) {
+    await notifyAgent(session, 'add_to_room failed: agent is required.');
+    return false;
+  }
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'add_to_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestAddToRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const room = typeof content.room === 'string' ? content.room.trim() : '';
+  const agent = typeof content.agent === 'string' ? content.agent.trim() : '';
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'add_to_room',
+    payload: { room, agent },
+    title: `Add ${agent} to room: ${room}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to add agent "${agent}" to the shared Slack room "${room}" ` +
+      `(this opens a new group conversation with everyone plus "${agent}"). Approve?`,
+  });
+}
+
+/**
+ * The room named by an add_to_room call: wired Slack group rooms whose
+ * messaging-group name matches (case-insensitive). Shadow channels never
+ * match — their names carry a "canvas comments" suffix. When several rooms
+ * share the name (e.g. earlier add_to_room forks keep the old room alive
+ * under the same name), the NEWEST family wins — "the room" means its latest
+ * incarnation.
+ */
+async function resolveRoomFamily(roomName: string): Promise<{ family: MessagingGroup[]; name: string }> {
+  const wanted = roomName.trim().toLowerCase();
+  const matches: MessagingGroup[] = [];
+  for (const m of await getAllMessagingGroups()) {
+    if (
+      m.channel_type === 'slack' &&
+      m.is_group === 1 &&
+      !m.denied_at &&
+      m.platform_id.startsWith('slack:') &&
+      (m.name ?? '').trim().toLowerCase() === wanted &&
+      (await getMessagingGroupAgents(m.id)).length > 0
+    ) {
+      matches.push(m);
+    }
+  }
+  if (matches.length === 0) throw new RoomActionError(`no wired Slack room named "${roomName}" found`);
+  const newestFirst = [...new Set(matches.map((m) => m.platform_id))]
+    .map((pid) => ({
+      pid,
+      createdAt: matches
+        .filter((m) => m.platform_id === pid)
+        .map((m) => m.created_at)
+        .sort()[0]!,
+    }))
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  const family = matches.filter((m) => m.platform_id === newestFirst[0]!.pid);
+  return { family, name: family[0]!.name ?? roomName };
+}
+
+/**
+ * Guard allow body: resolve the room's current participants from its wiring
+ * rows, resolve the named agent, and re-run ensureAgentRoom with the
+ * superset. The conversations.open on the superset member list FORKS a new
+ * MPIM (Slack never grows one in place); ensureAgentRoom wires everyone onto
+ * the new id, and the old room stays untouched — same shape the
+ * slack-room-membership fork carry-over produces for Slack-UI adds.
+ */
+export async function handleAddToRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const roomArg = (content.room as string).trim();
+  const agentArg = (content.agent as string).trim();
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = await resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    const { family, name: roomName } = await resolveRoomFamily(roomArg);
+
+    // Current participants — one per wired agent group, on the room row's
+    // own instance (router lookup is exact-on-instance, so the row is the
+    // authoritative instance mapping).
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    for (const mg of family) {
+      for (const wiring of await getMessagingGroupAgents(mg.id)) {
+        if (seen.has(wiring.agent_group_id)) continue;
+        seen.add(wiring.agent_group_id);
+        const group = await getAgentGroup(wiring.agent_group_id);
+        if (!group) continue;
+        participants.push(await participantForInstance(group, mg.instance ?? 'slack', rootDir));
+      }
+    }
+
+    const newGroup = await resolveAgentByName(session.agent_group_id, agentArg);
+    if (seen.has(newGroup.id)) {
+      await notifyAgent(session, `add_to_room: agent "${newGroup.name}" is already in room "${roomName}".`);
+      return;
+    }
+    const newParticipant = await participantForAgentGroup(newGroup, rootDir);
+
+    // Members added via the Slack UI (extra humans, foreign bots) exist only
+    // on the platform — wiring rows carry agents alone. Read the source
+    // room's actual member list so the forked superset carries them instead
+    // of silently dropping them (the membership fork carry-over preserves
+    // members for UI adds; this path must too). A failed read fails the
+    // action (outer catch) — never a fork that quietly excludes someone.
+    let extraMemberUserIds: string[] = [];
+    if (participants.length > 0) {
+      const sourceChannelId = family[0]!.platform_id.slice('slack:'.length);
+      const knownIds = new Set([operatorUserId, newParticipant.botUserId, ...participants.map((p) => p.botUserId)]);
+      const sourceMembers = await slackConversationsMembers(participants[0]!.botToken, sourceChannelId, 'room-resolve');
+      extraMemberUserIds = sourceMembers.filter((id) => !knownIds.has(id));
+    }
+
+    // The NEW agent opens the superset MPIM (mirrors the create flow, where
+    // the newly arriving bot is the opener/canvas creator).
+    const { roomChannelId } = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: newParticipant.botToken,
+      operatorUserId,
+      participants: [...participants, newParticipant],
+      extraMemberUserIds,
+      roomName,
+      rootDir,
+    });
+
+    const callerInRoom = seen.has(session.agent_group_id);
+    let callerMg: MessagingGroup | undefined;
+    for (const mg of family) {
+      if ((await getMessagingGroupAgents(mg.id)).some((w) => w.agent_group_id === session.agent_group_id)) {
+        callerMg = mg;
+        break;
+      }
+    }
+    const roomDestination = callerMg
+      ? await callerRoomDestination(session.agent_group_id, callerMg.instance ?? 'slack', roomChannelId, roomName)
+      : undefined;
+    const intro =
+      callerInRoom && callerMg
+        ? ` Post a brief introduction of ${newParticipant.agentGroupName} there now via send_message({ to: ` +
+          `"${roomDestination}", ... }): ` +
+          `1-2 lines in your own voice, tagging them with <@${newParticipant.botUserId}> (include that literally — ` +
+          `it renders as a mention). Just the intro — no mechanics, no member lists.`
+        : '';
+    await notifyAgent(
+      session,
+      `${newParticipant.agentGroupName} was added to room "${roomName}". Slack group DMs never grow in place, ` +
+        `so the room moved to a new conversation (${roomChannelId}) — everyone is wired there and the old ` +
+        `conversation keeps working.${intro}`,
+    );
+    log.info('add_to_room completed', { roomChannelId, agentGroupId: newGroup.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(session, `add_to_room failed: ${message}`);
+    log.error('add_to_room failed', { room: roomArg, agent: agentArg, err: message });
+  }
+}

--- a/src/modules/slack-agent-flow/room-canvas.test.ts
+++ b/src/modules/slack-agent-flow/room-canvas.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Room canvas creation tests (contract C2): template shape (the canvas IS the
+ * room contract; no bot mentions in the body), the
+ * conversations.canvases.create call, and the non-throwing failure paths.
+ * Plus the canvas-comments shadow-channel wiring (F→C derivation, one mg row
+ * + wiring per participating instance, idempotence, non-throwing).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TIMEZONE } from '../../config.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { formatLocalTime } from '../../timezone.js';
+import {
+  createRoomCanvas,
+  deriveCanvasShadowChannelId,
+  roomCanvasMarkdown,
+  wireCanvasComments,
+} from './room-canvas.js';
+
+const OPTS = {
+  roomName: 'Pixel room',
+  purpose: 'Design work between Gavriel, Pixel, and Mark.\nSecond purpose line.',
+  creatorUserId: 'U0CREATOR',
+  agentNames: ['Pixel', 'Mark', 'Pixel'],
+  createdAt: '2026-08-01T12:00:00.000Z',
+};
+
+describe('roomCanvasMarkdown', () => {
+  const md = roomCanvasMarkdown(OPTS);
+
+  it('leads with the blockquoted purpose — no body H1 (the create-call `title` param renders the document title; a body heading duplicated it, live-observed)', () => {
+    expect(md.startsWith('> Design work between Gavriel, Pixel, and Mark.')).toBe(true);
+    expect(md).not.toContain('# Pixel room');
+    expect(md).toContain('> Second purpose line.');
+  });
+
+  it('carries the room-contract data: creator card, created date, Members table', () => {
+    expect(md).toContain(`Created by ![](@U0CREATOR) on ${formatLocalTime(OPTS.createdAt, TIMEZONE)}.`);
+    expect(md).toContain('## Members');
+    expect(md).toContain('| ![](@U0CREATOR) | creator |');
+  });
+
+  it('lists agents by PLAIN NAME, deduped — never as user cards', () => {
+    expect(md).toContain('| Pixel | agent |');
+    expect(md).toContain('| Mark | agent |');
+    expect(md.match(/\| Pixel \| agent \|/g)).toHaveLength(1);
+  });
+
+  it('never @-mentions a bot: the only user card is the human creator', () => {
+    const cards = md.match(/!\[\]\(@\w+\)/g) ?? [];
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) expect(card).toBe('![](@U0CREATOR)');
+    expect(md).not.toContain('<@');
+  });
+
+  it('carries the Tasks checklist and the Decisions / Notes sections', () => {
+    expect(md).toContain('## Tasks');
+    expect(md).toContain('- [ ] ');
+    expect(md).toContain('## Decisions');
+    expect(md).toContain('## Notes');
+  });
+});
+
+describe('createRoomCanvas', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the template to conversations.canvases.create and returns the canvas id', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true, canvas_id: 'F0CANVAS1' }), { status: 200 }),
+    );
+
+    const id = await createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS);
+
+    expect(id).toBe('F0CANVAS1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/conversations.canvases.create');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-test-token');
+    const body = JSON.parse(init.body as string);
+    expect(body.channel_id).toBe('C0ROOM');
+    expect(body.document_content).toEqual({ type: 'markdown', markdown: roomCanvasMarkdown(OPTS) });
+  });
+
+  it('returns undefined on a Slack error instead of throwing', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, error: 'free_team_not_allowed' }), { status: 200 }),
+    );
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when fetch itself rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when ok:true carries no canvas_id', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+});
+
+describe('deriveCanvasShadowChannelId', () => {
+  it('swaps the leading F for C on a canvas-shaped id', () => {
+    expect(deriveCanvasShadowChannelId('F0BME4DL401')).toBe('C0BME4DL401');
+    expect(deriveCanvasShadowChannelId('F1')).toBe('C1');
+  });
+
+  it('returns undefined for anything not canvas-id shaped', () => {
+    for (const bad of ['C0BME4DL401', 'F', '', 'F0bme4dl401', 'F0BME-4DL401', 'X0BME4DL401', ' F0BME4DL401']) {
+      expect(deriveCanvasShadowChannelId(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe('wireCanvasComments', () => {
+  const CREATOR = { instanceKey: 'slack-pixel', agentGroupId: 'ag-pixel' };
+  // Creator deliberately ALSO present in the list — must not double-wire.
+  const PARTICIPANTS = [
+    { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+    { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    CREATOR,
+  ];
+
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    const now = new Date().toISOString();
+    for (const [id, name, folder] of [
+      ['ag-pixel', 'Pixel', 'pixel'],
+      ['ag-andy', 'Andy', 'andy'],
+      ['ag-mark', 'Mark', 'mark'],
+    ] as const) {
+      await createAgentGroup({ id, name, folder, agent_provider: null, created_at: now });
+    }
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it('wires EVERY participating instance: creator pattern-engage, siblings mention/accumulate', async () => {
+    const shadowId = await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(shadowId).toBe('C0CANVAS1');
+    // One mg row PER instance (router lookup is exact-on-instance), all public.
+    const all = (await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:C0CANVAS1');
+    expect(all).toHaveLength(3);
+    for (const p of PARTICIPANTS) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', p.instanceKey);
+      expect(mg).toMatchObject({
+        channel_type: 'slack',
+        instance: p.instanceKey,
+        name: 'Pixel room canvas comments (canvas F0CANVAS1)',
+        is_group: 1,
+        unknown_sender_policy: 'public',
+      });
+      expect(await getMessagingGroupAgents(mg!.id)).toHaveLength(1);
+    }
+    // Creator = default responder for anchored comments.
+    const creatorMg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel'))!;
+    expect(await getMessagingGroupAgentByPair(creatorMg.id, 'ag-pixel')).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+    });
+    // Siblings = room semantics: mention to trigger, everything else context.
+    for (const sibling of [
+      { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+      { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    ]) {
+      const mg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', sibling.instanceKey))!;
+      expect(await getMessagingGroupAgentByPair(mg.id, sibling.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        sender_scope: 'all',
+        ignored_message_policy: 'accumulate',
+        session_mode: 'shared',
+        priority: 0,
+      });
+    }
+  });
+
+  it('is idempotent: a second call creates no new rows', async () => {
+    await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+    const mgCount = (await getAllMessagingGroups()).length;
+    const mg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel'))!;
+    const wiringId = (await getMessagingGroupAgentByPair(mg.id, 'ag-pixel'))!.id;
+
+    const second = await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(second).toBe('C0CANVAS1');
+    expect((await getAllMessagingGroups()).length).toBe(mgCount);
+    expect(await getMessagingGroupAgents(mg.id)).toHaveLength(1);
+    expect((await getMessagingGroupAgentByPair(mg.id, 'ag-pixel'))!.id).toBe(wiringId);
+  });
+
+  it('returns undefined and writes nothing on an invalid canvas id shape', async () => {
+    const before = (await getAllMessagingGroups()).length;
+    expect(await wireCanvasComments('not-a-canvas', CREATOR, PARTICIPANTS, 'Pixel room')).toBeUndefined();
+    expect((await getAllMessagingGroups()).length).toBe(before);
+  });
+
+  it('never throws: a DB failure (unknown agent group breaks the FK) returns undefined', async () => {
+    expect(
+      await wireCanvasComments('F0CANVAS2', { instanceKey: 'slack', agentGroupId: 'ag-missing' }, [], 'X'),
+    ).toBeUndefined();
+  });
+});

--- a/src/modules/slack-agent-flow/room-canvas.ts
+++ b/src/modules/slack-agent-flow/room-canvas.ts
@@ -1,0 +1,274 @@
+/**
+ * Room canvas creation — the room-contract template, written to the room's
+ * channel-tab canvas at room-creation time.
+ *
+ * Contract C2: `createRoomCanvas` is NON-THROWING — any failure (network,
+ * Slack error, malformed response) logs a warning and returns undefined. Room
+ * creation must never fail because the canvas leg did; the caller tolerates
+ * undefined and simply ships a room without a canvas.
+ *
+ * The Slack call is implemented locally (plain fetch, the shared slack-lib
+ * JSON-body conventions) — this file deliberately does not go through the
+ * lib's throwing helpers: canvas creation is contractually NON-THROWING (C2).
+ * Tokens travel only in the Authorization header and are never interpolated
+ * into messages or logs.
+ *
+ * Live-validated facts this leans on: `conversations.canvases.create`
+ * works on MPIMs and DMs (undocumented but confirmed); every markdown
+ * element in the template — checkboxes, tables with user cards, blockquote —
+ * is accepted; section headings are the later edit-addressing scheme
+ * (`canvases.sections.lookup` by contains_text), so heading text is part of
+ * the template's contract with the canvas-actions module.
+ */
+import { TIMEZONE } from '../../config.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import { formatLocalTime } from '../../timezone.js';
+import type { MessagingGroup } from '../../types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export interface RoomCanvasOpts {
+  roomName: string;
+  purpose: string;
+  /** The human operator who created the room — the ONLY member the template
+   *  may reference by user card. Bot user cards render as @-mentions, and a
+   *  creation-time mention is what triggered every sibling instance and
+   *  generated the approval-card spam. */
+  creatorUserId: string;
+  /** Agent members by display name — rendered as PLAIN TEXT, never mentioned. */
+  agentNames: string[];
+  /** ISO creation timestamp; defaults to now. Rendered install-local. */
+  createdAt?: string;
+}
+
+/** `![](@U…)` — Slack renders this image syntax as an inline user card.
+ *  Humans only: a bot's user card delivers a mention to that bot's instance. */
+function userCard(userId: string): string {
+  return `![](@${userId})`;
+}
+
+/** Blockquote-prefix every line so a multi-line purpose stays one quote block. */
+function asBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+/**
+ * The room-contract template (modeled on a live-verified room-canvas
+ * example). With the room-contract MESSAGE retired, this canvas IS the room
+ * contract: purpose, creator, member list, created date — the canvas tab is
+ * the room's pinned surface. Heading texts ("Tasks", "Decisions", "Notes")
+ * are load-bearing: agents address sections by contains_text lookup, and the
+ * canvas instructions reference them by name.
+ *
+ * The body must never @-mention a BOT — agent members appear by plain
+ * name. Only the (human) creator gets a user card.
+ */
+export function roomCanvasMarkdown(opts: RoomCanvasOpts): string {
+  const memberRows = [
+    `| ${userCard(opts.creatorUserId)} | creator |`,
+    ...opts.agentNames.filter((name, i, arr) => arr.indexOf(name) === i).map((name) => `| ${name} | agent |`),
+  ];
+
+  // No `# <roomName>` heading here: the `title` param on
+  // conversations.canvases.create already renders the canvas title as the
+  // document's H1 — a body heading would duplicate it (live-observed).
+  return [
+    asBlockquote(opts.purpose),
+    '',
+    `Created by ${userCard(opts.creatorUserId)} on ${formatLocalTime(opts.createdAt ?? new Date().toISOString(), TIMEZONE)}.`,
+    '',
+    '## Members',
+    '',
+    '| Who | Role |',
+    '|---|---|',
+    ...memberRows,
+    '',
+    '## Tasks',
+    '',
+    '- [ ] Add the room’s first task',
+    '',
+    '## Decisions',
+    '',
+    '_No decisions recorded yet — quote them here as they land._',
+    '',
+    '## Notes',
+    '',
+    '_Working notes and links — anything worth keeping that isn’t a task or a decision._',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Create the room's channel-tab canvas from the room-contract template.
+ * Returns the canvas id, or undefined on ANY failure (never throws).
+ */
+export async function createRoomCanvas(
+  botToken: string,
+  channelId: string,
+  opts: RoomCanvasOpts,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${SLACK_API}/conversations.canvases.create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        channel_id: channelId,
+        // Undocumented but live-verified: conversations.canvases.create
+        // accepts `title` (otherwise the canvas lists as "Untitled").
+        title: opts.roomName,
+        document_content: { type: 'markdown', markdown: roomCanvasMarkdown(opts) },
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (json.ok !== true) {
+      log.warn('Room canvas create failed', {
+        channelId,
+        error: String(json.error ?? `HTTP ${res.status}`),
+      });
+      return undefined;
+    }
+    const canvasId = typeof json.canvas_id === 'string' ? json.canvas_id : undefined;
+    if (!canvasId) {
+      log.warn('Room canvas create returned no canvas_id', { channelId });
+      return undefined;
+    }
+    log.info('Room canvas created', { channelId, canvasId });
+    return canvasId;
+  } catch (err) {
+    log.warn('Room canvas create failed', {
+      channelId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+// ── Canvas comments (shadow channel) ──
+
+/** Canvas ids are `F` + the base-36-ish Slack id body. */
+const CANVAS_ID_RE = /^F[A-Z0-9]+$/;
+
+/**
+ * Live-probed platform fact: creating ANY canvas makes Slack materialize
+ * a hidden private "shadow channel" owned by USLACKBOT whose id is the canvas
+ * id with the leading `F` swapped for `C` (canvas F0BME4DL401 → channel
+ * C0BME4DL401). Canvas comments live there as threads; members of the canvas
+ * are members of the shadow channel and bots receive its messages as ordinary
+ * message.groups events. Returns undefined for anything not canvas-id shaped.
+ */
+export function deriveCanvasShadowChannelId(canvasId: string): string | undefined {
+  return CANVAS_ID_RE.test(canvasId) ? `C${canvasId.slice(1)}` : undefined;
+}
+
+/** One room bot's instance/group pair, for shadow-channel wiring. The flow's
+ *  RoomParticipant satisfies this structurally. */
+export interface CanvasCommentsParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  agentGroupId: string;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Wire the canvas's shadow channel for EVERY participating instance — the
+ * shadow channel is the room's comment stream, so it gets room semantics for
+ * all room agents, not creator-only. Creator-only wiring is what turned
+ * every sibling's canvas events into unknown-channel approval-card spam.
+ *
+ * Per participant: one messaging-group row on ITS instance (router lookup is
+ * exact-on-instance) plus one wiring to its agent group. The CREATOR is the
+ * default responder — pattern `'.'` (always engage): a comment on the shared
+ * canvas is always addressed to the room's agents, unlike ambient room chat.
+ * Every SIBLING gets mention/accumulate — comments flow to all room agents
+ * as context, and tagging an agent in a comment actually triggers it with
+ * the anchor context. `unknown_sender_policy: 'public'` keeps access gates
+ * from approval-spamming on commenters.
+ *
+ * Idempotent (get-before-create on every row) and NON-THROWING — like
+ * createRoomCanvas, a failure here must never fail room creation. Returns the
+ * shadow channel id, or undefined on invalid canvas-id shape or any error.
+ */
+export async function wireCanvasComments(
+  canvasId: string,
+  creator: CanvasCommentsParticipant,
+  participants: CanvasCommentsParticipant[],
+  roomName: string,
+): Promise<string | undefined> {
+  try {
+    const shadowChannelId = deriveCanvasShadowChannelId(canvasId);
+    if (!shadowChannelId) {
+      log.warn('Canvas comments: unexpected canvas id shape — shadow channel not wired', { canvasId });
+      return undefined;
+    }
+    const platformId = `slack:${shadowChannelId}`;
+
+    // Creator first (its wiring must win even if it also appears in the list).
+    const isCreator = (p: CanvasCommentsParticipant): boolean =>
+      p.instanceKey === creator.instanceKey && p.agentGroupId === creator.agentGroupId;
+    const everyone = [creator, ...participants.filter((p) => !isCreator(p))];
+
+    for (const p of everyone) {
+      let mg = await getMessagingGroupByPlatform('slack', platformId, p.instanceKey);
+      if (!mg) {
+        const row: MessagingGroup = {
+          id: generateId('mg'),
+          channel_type: 'slack',
+          platform_id: platformId,
+          instance: p.instanceKey,
+          name: `${roomName} canvas comments (canvas ${canvasId})`,
+          is_group: 1,
+          unknown_sender_policy: 'public',
+          created_at: new Date().toISOString(),
+        };
+        await createMessagingGroup(row);
+        mg = row;
+      }
+
+      if (!(await getMessagingGroupAgentByPair(mg.id, p.agentGroupId))) {
+        const creatorRow = isCreator(p);
+        await createMessagingGroupAgent({
+          id: generateId('mga'),
+          messaging_group_id: mg.id,
+          agent_group_id: p.agentGroupId,
+          engage_mode: creatorRow ? 'pattern' : 'mention',
+          engage_pattern: creatorRow ? '.' : null,
+          sender_scope: 'all',
+          ignored_message_policy: creatorRow ? 'drop' : 'accumulate',
+          session_mode: 'shared',
+          priority: 0,
+          created_at: new Date().toISOString(),
+        });
+      }
+    }
+
+    log.info('Canvas comments shadow channel wired', {
+      canvasId,
+      shadowChannelId,
+      creatorInstance: creator.instanceKey,
+      participantCount: everyone.length,
+    });
+    return shadowChannelId;
+  } catch (err) {
+    log.warn('Canvas comments shadow-channel wiring failed', {
+      canvasId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}

--- a/src/modules/slack-agent-flow/slack-deps.ts
+++ b/src/modules/slack-agent-flow/slack-deps.ts
@@ -1,0 +1,70 @@
+/**
+ * Optional-module seam — the ONLY file in the slack-agent-flow payload that
+ * touches the skill-installed Slack channel module (src/channels/slack.ts
+ * arrives via the add-slack skill) dynamically. The computed-specifier import
+ * keeps tsc from resolving a file that may not be in the tree, so a missing
+ * or outdated channel payload surfaces at runtime as a typed, actionable
+ * SlackFlowError instead of a crash. The hot-start entry
+ * (startChannelAdapter) is trunk registry API and is imported statically like
+ * registerChannelAdapter.
+ */
+import type { ChannelAdapter, ChannelDefaults } from '../../channels/adapter.js';
+import { registerChannelAdapter, startChannelAdapter } from '../../channels/channel-registry.js';
+import { SlackFlowError } from './types.js';
+
+export interface SlackChannelDeps {
+  slackInstanceBridgeFactory: (name: string) => ChannelAdapter | null;
+  SLACK_DEFAULTS: ChannelDefaults;
+  registerChannelAdapter: (
+    name: string,
+    registration: { factory: () => ChannelAdapter | null; defaults?: ChannelDefaults },
+  ) => void;
+  startChannelAdapter: (key: string) => Promise<'started' | 'already-active' | 'no-credentials'>;
+}
+
+const NOT_INSTALLED =
+  'Slack channel payload not installed or too old — apply add-slack first (multi-instance registration ships with the adapter)';
+
+/**
+ * Fails fast if the installed Slack adapter doesn't carry the multi-instance
+ * factory — checked regardless of hotStart. The adapter owns SLACK_INSTANCES
+ * natively (slackInstanceBridgeFactory + the import-time registration loop
+ * live in slack.ts); an older installed copy without that export would let
+ * S6-S8 wire DB rows to an instance name the runtime could never start, even
+ * after a restart. The out-of-process finish path (hotStart: false) needs
+ * this check just as much as the hot-add branch below.
+ */
+export async function assertSlackInstancesModuleInstalled(): Promise<void> {
+  try {
+    const slackSpec = '../../channels/slack.js';
+    const slackMod = (await import(slackSpec)) as Record<string, unknown>;
+    if (typeof slackMod.slackInstanceBridgeFactory !== 'function' || !slackMod.SLACK_DEFAULTS) {
+      throw new Error('missing exports');
+    }
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+}
+
+export async function loadSlackChannelDeps(): Promise<SlackChannelDeps> {
+  let slackMod: Record<string, unknown>;
+  try {
+    const slackSpec = '../../channels/slack.js';
+    slackMod = (await import(slackSpec)) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  const slackInstanceBridgeFactory = slackMod.slackInstanceBridgeFactory;
+  const SLACK_DEFAULTS = slackMod.SLACK_DEFAULTS;
+  if (typeof slackInstanceBridgeFactory !== 'function' || !SLACK_DEFAULTS) {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  return {
+    slackInstanceBridgeFactory: slackInstanceBridgeFactory as (name: string) => ChannelAdapter | null,
+    SLACK_DEFAULTS: SLACK_DEFAULTS as ChannelDefaults,
+    registerChannelAdapter,
+    startChannelAdapter,
+  };
+}

--- a/src/modules/slack-agent-flow/types.ts
+++ b/src/modules/slack-agent-flow/types.ts
@@ -1,0 +1,109 @@
+/**
+ * slack-agent-flow shared types.
+ * Congruence: env-key shapes mirror the adapter's native SLACK_INSTANCES
+ * conventions (src/channels/slack.ts, instanceEnvKeySuffix);
+ * broker protocol mirrors src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts. Pinned by
+ * provision.congruence.test.ts.
+ */
+
+export type SlackFlowStep =
+  | 'operator-identity'
+  | 'origin-auth'
+  | 'no-credentials'
+  | 'broker'
+  | 'direct-create'
+  /** Waiting out a workspace install approval before the bot token exists. */
+  | 'install-wait'
+  | 'env-write'
+  | 'adapter-start'
+  | 'dm-open'
+  | 'dm-wire'
+  | 'mpim-open'
+  | 'a2a-env'
+  | 'room-wire'
+  | 'intro-post'
+  /** room-actions module — create_room / add_to_room participant resolution. */
+  | 'room-resolve'
+  /** slack-room-membership module — join/left handling, not a create_agent flow step. */
+  | 'membership';
+
+/** Typed failure for the Slack leg. `message` MUST never contain a token value. */
+export class SlackFlowError extends Error {
+  constructor(
+    readonly step: SlackFlowStep,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SlackFlowError';
+  }
+}
+
+export interface ProvisionInput {
+  /** Instance slug: output of normalizeName(), post-dedupe. */
+  slug: string;
+  /** Display name for the Slack app/bot (the raw agent name). */
+  displayName: string;
+  /** Repo root; .env lives at `${rootDir}/.env`. */
+  rootDir: string;
+  /** Slack workspace the app is provisioned into (broker mode requires it). */
+  teamId?: string;
+  /** Agent description/instructions — drives the broker's generated avatar. */
+  description?: string;
+  /**
+   * true → plain manifest variant (no agent_view): workspace guests are
+   * hard-blocked from agent-enabled apps. Default false → agent mode, the
+   * default variant — a one-way door decided at provision time.
+   */
+  allowGuests?: boolean;
+  /**
+   * Request-origin metadata, all optional — sent on the broker's
+   * POST /v1/apps body only when defined (requested_by / parent_app_id /
+   * template on the wire; a broker that predates them ignores unknown body
+   * fields). client_version is derived from rootDir's package.json inside
+   * provisionSlackApp, not supplied here.
+   */
+  /** Slack user id (U…/W…) of the human who asked for this agent. */
+  requestedBy?: string;
+  /** The creating agent's own Slack app id (A…) when an agent created this one. */
+  parentAppId?: string;
+  /** Template name, when the agent was stamped from one. */
+  template?: string;
+  /**
+   * Called once when the workspace has not approved the app's install and the
+   * flow is about to wait for it — `resumed` distinguishes a fresh refusal
+   * from picking a parked app back up. Exceptions are swallowed: telling the
+   * human is best-effort, the wait happens either way.
+   */
+  onInstallPending?: (info: { appId: string; installUrl?: string; resumed: boolean }) => void | Promise<void>;
+  /** Wait budget for a deferred install. Tests shorten it; callers rarely set it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+}
+
+export interface ProvisionResult {
+  slug: string;
+  /** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix. */
+  envSuffix: string;
+  botToken: string; // xoxb-… NEVER log
+  appToken: string; // xapp-… NEVER log
+  appId: string;
+  /** True when tokens were already in .env and no provisioning call was made. */
+  reused: boolean;
+  /**
+   * True when the bot token arrived only after waiting out a workspace install
+   * approval (auto-install was refused). Everything downstream is identical —
+   * the flag exists so the completion message can say what happened.
+   */
+  deferredInstall?: boolean;
+}
+
+export interface OrchestrateSuccess {
+  slug: string;
+  newBotUserId: string;
+  operatorUserId: string;
+  dmChannelId: string;
+  /** Absent when the create ran with room:'none' — no shared room. */
+  roomChannelId?: string;
+  /** True when the bot only came online after a workspace install approval. */
+  deferredInstall?: boolean;
+}

--- a/src/modules/slack-onboarding/index.ts
+++ b/src/modules/slack-onboarding/index.ts
@@ -1,0 +1,160 @@
+/**
+ * Slack DM onboarding + thread auto-title (agent-view DM surface).
+ *
+ * Channel-layer module owning the platform knowledge that used to sit inline
+ * in trunk's delivery.ts/router.ts. Registers exclusively through generic
+ * trunk hooks — trunk carries no Slack literals for any of this:
+ *
+ *   - `registerPostDeliveryHook` (delivery): the FIRST delivery of an
+ *     empty-thread DM session (the welcome) pins the get-started suggested
+ *     prompts at the top of the Messages tab.
+ *   - `setAgentDmOpenedHandler` (Chat SDK bridge): (re)asserts or retires
+ *     the prompts when the user opens the agent DM.
+ *   - `registerSessionCreatedHook` (router): a brand-new per-thread DM
+ *     session names its thread after the first user message (D15) and
+ *     retires the onboarding prompts.
+ *
+ * Everything here is decoration: fire-and-forget, capability-gated inside
+ * the registry passthroughs (adapters without the APIs no-op), and never
+ * allowed to affect delivery or routing.
+ *
+ * Installed with the Slack channel payload; registered via a barrel-appended
+ * import at install time.
+ */
+import { setSuggestedPrompts, setThreadTitle } from '../../channels/channel-registry.js';
+import { setAgentDmOpenedHandler } from '../../channels/chat-sdk-bridge.js';
+import { getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
+import { getActiveSessions } from '../../db/sessions.js';
+import { registerPostDeliveryHook } from '../../delivery.js';
+import { log } from '../../log.js';
+import type { OutboundMessage } from '../../mailbox/index.js';
+import { registerSessionCreatedHook } from '../../router.js';
+
+/**
+ * Auto-title timing. The initial delay lets the first typing
+ * assistant.threads.setStatus materialize the assistant thread before the
+ * title lands (Slack rejects titles on not-yet-assistant threads with
+ * channel_not_found). Mutable as a test seam only.
+ */
+export const titleDelays = { initialMs: 3000, retryMs: 7000 };
+export function setTitleDelaysForTest(initialMs: number, retryMs: number): void {
+  titleDelays.initialMs = initialMs;
+  titleDelays.retryMs = retryMs;
+}
+
+/**
+ * Welcome-notification follow-through (agent-view DMs). The welcome is a
+ * NOTIFICATION — informational, never a question the user replies to
+ * (product decision after the focus-hack dead end: no Slack API can navigate
+ * a user into a thread; conversations are user-rooted by design). The tour
+ * offer lives in SUGGESTED PROMPTS pinned at the top of the Messages tab:
+ * clicking one sends that text as the user's own message, rooting a
+ * conversation thread whose opener carries the intent by itself.
+ * Fire-and-forget; silent no-op on non-agent-view channels via the
+ * capability gates. Scoped by the post-delivery hook's firstDelivery flag
+ * to the FIRST delivery of an empty-thread DM session — i.e. the welcome.
+ */
+const WELCOME_PROMPTS: Array<{ title: string; message: string }> = [
+  { title: 'Give me the tour', message: 'Give me a quick tour of what you can do.' },
+  {
+    title: 'What should I try first?',
+    message: 'What should I try first? Suggest something useful we could do right now.',
+  },
+  { title: 'Help me with something', message: 'I have something specific I want help with.' },
+];
+
+/** True when this DM already has a real conversation (a per-thread session
+ *  with a ts segment) — the get-started prompts are then stale. */
+async function dmHasConversation(mgId: string): Promise<boolean> {
+  return (await getActiveSessions()).some((s) => {
+    if (s.messaging_group_id !== mgId || !s.thread_id) return false;
+    const parts = s.thread_id.split(':');
+    return parts.length >= 3 && parts[parts.length - 1] !== '';
+  });
+}
+
+/** Clear the onboarding prompts once the first conversation starts. Fired
+ *  where the auto-title trigger runs (session-created consumer below). */
+export function clearWelcomePrompts(instanceKey: string, platformId: string): void {
+  void setSuggestedPrompts(instanceKey, platformId, [])
+    .then(() => log.info('Welcome prompts cleared', { platformId }))
+    .catch(() => {});
+}
+
+// (Re)assert or retire the onboarding prompts when the user OPENS the agent
+// DM — prompt sets made before the DM was ever opened may not render
+// (live-hit), and stale get-started buttons should retire once a real
+// conversation exists.
+setAgentDmOpenedHandler(async ({ channelId }) => {
+  const platformId = `slack:${channelId}`;
+  const mg = await getMessagingGroupByPlatform('slack', platformId);
+  if (!mg || mg.is_group !== 0) return;
+  if (await dmHasConversation(mg.id)) {
+    clearWelcomePrompts(mg.instance ?? mg.channel_type, platformId);
+    return;
+  }
+  void setSuggestedPrompts(mg.instance ?? mg.channel_type, platformId, WELCOME_PROMPTS, 'Get started')
+    .then(() => log.info('Welcome prompts re-asserted on DM open', { platformId }))
+    .catch(() => {});
+});
+
+async function offerWelcomePrompts(msg: OutboundMessage): Promise<void> {
+  try {
+    const channelType = msg.channelType;
+    const platformId = msg.platformId;
+    if (!channelType || !platformId) return;
+    const tidParts = (msg.threadId ?? '').split(':');
+    if (tidParts.length >= 3 && tidParts[tidParts.length - 1] !== '') return; // threaded → not the welcome
+    const mg = await getMessagingGroupByPlatform(channelType, platformId);
+    if (!mg || mg.is_group !== 0) return;
+    void setSuggestedPrompts(mg.instance ?? channelType, platformId, WELCOME_PROMPTS, 'Get started')
+      .then(() => log.info('Welcome prompts set', { platformId }))
+      .catch((err) => log.warn('Welcome prompts failed', { platformId, err }));
+  } catch {
+    // Decoration only — never let it affect delivery.
+  }
+}
+
+// Welcome notification follow-through: the FIRST delivery of an empty-thread
+// DM session (the welcome) pins the get-started suggested prompts. The hook
+// already scopes to user-facing rows (non-system, non-agent, non-task_log).
+registerPostDeliveryHook(async (msg, _session, { firstDelivery }) => {
+  if (firstDelivery) await offerWelcomePrompts(msg);
+});
+
+function safeParseContent(raw: string): { text?: string; sender?: string; senderId?: string } {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { text: raw };
+  }
+}
+
+registerSessionCreatedHook(({ session, mg, platformId, threadId, sessionMode, message }) => {
+  if (mg.is_group !== 0 || sessionMode !== 'per-thread' || threadId === null) return;
+  // Agent-mode auto-title (D15): a brand-new per-thread DM session names
+  // its thread after the first user message. Fire-and-forget, capability-
+  // gated inside setThreadTitle (adapters without the API no-op) — zero
+  // behavior change for non-Slack and for shared-session DM wirings.
+  //
+  // Timing: the assistant thread only materializes once the first
+  // assistant.threads.setStatus (the typing fire) lands on it — a
+  // title set before that fails with channel_not_found. Delay past the
+  // initial typing fire and retry once for slow paths.
+  const title = (safeParseContent(message.content).text ?? '').trim().slice(0, 45);
+  if (title) {
+    const trySetTitle = (attempt: number): void => {
+      void setThreadTitle(mg.instance ?? mg.channel_type, platformId, threadId, title).catch((err) => {
+        if (attempt < 1) {
+          setTimeout(() => trySetTitle(attempt + 1), titleDelays.retryMs);
+        } else {
+          log.warn('setThreadTitle failed', { sessionId: session.id, threadId, err });
+        }
+      });
+    };
+    setTimeout(() => trySetTitle(0), titleDelays.initialMs);
+  }
+  // The first real conversation retires the get-started prompts (they
+  // point at starting a conversation, which just happened).
+  clearWelcomePrompts(mg.instance ?? mg.channel_type, platformId);
+});

--- a/src/modules/slack-onboarding/onboarding.test.ts
+++ b/src/modules/slack-onboarding/onboarding.test.ts
@@ -1,0 +1,314 @@
+/**
+ * DM onboarding welcome prompts — NET-NEW coverage (the release branch had
+ * none): the get-started suggested prompts are pinned on the FIRST delivery
+ * of an empty-thread DM session (the welcome), (re)asserted or retired when
+ * the user opens the agent DM depending on whether a real conversation
+ * exists, and retired by the session-created consumer (pinned in
+ * thread-title.test.ts).
+ *
+ * Drives the module through the post-delivery hook (registerPostDeliveryHook)
+ * and the bridge's agent-DM-opened handler (setAgentDmOpenedHandler); the
+ * hook surfaces are mocked at the import seam. The hook itself guarantees
+ * user-facing-rows-only (non-system, non-agent, non-task_log) and the
+ * firstDelivery flag — pinned by refa-b2's delivery test, not here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../delivery.js', () => {
+  const hooks: Array<(msg: unknown, session: unknown, info: { firstDelivery: boolean }) => void> = [];
+  return {
+    registerPostDeliveryHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __postDeliveryHooks: hooks,
+  };
+});
+
+vi.mock('../../router.js', () => {
+  const hooks: Array<(event: never) => void | Promise<void>> = [];
+  return {
+    registerSessionCreatedHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __sessionCreatedHooks: hooks,
+  };
+});
+
+vi.mock('../../channels/chat-sdk-bridge.js', () => {
+  const ref: { handler: ((e: { instance: string; channelId: string }) => void | Promise<void>) | null } = {
+    handler: null,
+  };
+  return {
+    setAgentDmOpenedHandler: (fn: NonNullable<typeof ref.handler>) => {
+      ref.handler = fn;
+    },
+    __dmOpened: ref,
+  };
+});
+
+vi.mock('../../channels/channel-registry.js', () => ({
+  setThreadTitle: vi.fn(async () => {}),
+  setSuggestedPrompts: vi.fn(async () => {}),
+}));
+
+vi.mock('../../db/messaging-groups.js', () => ({ getMessagingGroupByPlatform: vi.fn(() => undefined) }));
+vi.mock('../../db/sessions.js', () => ({ getActiveSessions: vi.fn(() => []) }));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Release-branch prompt copy, pinned verbatim (behavior-preservation gate). */
+const EXPECTED_PROMPTS = [
+  { title: 'Give me the tour', message: 'Give me a quick tour of what you can do.' },
+  {
+    title: 'What should I try first?',
+    message: 'What should I try first? Suggest something useful we could do right now.',
+  },
+  { title: 'Help me with something', message: 'I have something specific I want help with.' },
+];
+
+interface TestMsg {
+  id: string;
+  kind: string;
+  platformId: string | null;
+  channelType: string | null;
+  threadId: string | null;
+  content: string;
+}
+
+function welcomeMsg(overrides: Partial<TestMsg> = {}): TestMsg {
+  return {
+    id: 'out-1',
+    kind: 'chat',
+    platformId: 'slack:D1',
+    channelType: 'slack',
+    threadId: 'slack:D1:',
+    content: JSON.stringify({ text: 'Welcome!' }),
+    ...overrides,
+  };
+}
+
+const dmMg = (overrides: Record<string, unknown> = {}) => ({
+  id: 'mg-dm',
+  channel_type: 'slack',
+  platform_id: 'slack:D1',
+  instance: 'slack',
+  is_group: 0,
+  ...overrides,
+});
+
+/** The module registers its hooks at import time (module singleton), so it
+ *  is loaded once; per-test isolation is mock state — vi.resetAllMocks
+ *  restores the original vi.fn implementations between tests. */
+type Loaded = Awaited<ReturnType<typeof doLoad>>;
+let cached: Loaded | null = null;
+
+async function loadModule(): Promise<Loaded> {
+  if (cached) return cached;
+  cached = await doLoad();
+  return cached;
+}
+
+async function doLoad() {
+  await import('./index.js');
+  const delivery = (await import('../../delivery.js')) as unknown as {
+    __postDeliveryHooks: Array<(msg: TestMsg, session: unknown, info: { firstDelivery: boolean }) => void>;
+  };
+  const bridge = (await import('../../channels/chat-sdk-bridge.js')) as unknown as {
+    __dmOpened: { handler: ((e: { instance: string; channelId: string }) => void | Promise<void>) | null };
+  };
+  const registry = (await import('../../channels/channel-registry.js')) as unknown as {
+    setThreadTitle: ReturnType<typeof vi.fn>;
+    setSuggestedPrompts: ReturnType<typeof vi.fn>;
+  };
+  const { getMessagingGroupByPlatform } = (await import('../../db/messaging-groups.js')) as unknown as {
+    getMessagingGroupByPlatform: ReturnType<typeof vi.fn>;
+  };
+  const { getActiveSessions } = (await import('../../db/sessions.js')) as unknown as {
+    getActiveSessions: ReturnType<typeof vi.fn>;
+  };
+  const { log } = (await import('../../log.js')) as unknown as { log: { warn: ReturnType<typeof vi.fn> } };
+  expect(delivery.__postDeliveryHooks).toHaveLength(1);
+  expect(bridge.__dmOpened.handler).not.toBeNull();
+  return {
+    postDelivery: delivery.__postDeliveryHooks[0],
+    dmOpened: bridge.__dmOpened.handler!,
+    registry,
+    getMessagingGroupByPlatform,
+    getActiveSessions,
+    log,
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(async () => {
+  await loadModule();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('welcome prompts on first delivery (post-delivery hook)', () => {
+  it('pins the get-started prompts on the FIRST delivery of an empty-thread DM', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(getMessagingGroupByPlatform).toHaveBeenCalledWith('slack', 'slack:D1');
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
+  });
+
+  it('a threadless welcome row also counts as the welcome', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg({ threadId: null }), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledTimes(1);
+  });
+
+  it('never on later deliveries', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: false });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never for a threaded delivery (a conversation reply is not the welcome)', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+
+    postDelivery(welcomeMsg({ threadId: 'slack:D1:171' }), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never for group conversations or unknown messaging groups', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ id: 'mg-room', is_group: 1 }));
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    getMessagingGroupByPlatform.mockReturnValue(undefined);
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('no-op when the row has no channel/platform address', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+
+    postDelivery(welcomeMsg({ channelType: null }), { id: 'sess-1' }, { firstDelivery: true });
+    postDelivery(welcomeMsg({ platformId: null }), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(getMessagingGroupByPlatform).not.toHaveBeenCalled();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('keys the prompt set by the mg’s own instance (never a sibling bot)', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ instance: 'slack-teamster' }));
+
+    postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith(
+      'slack-teamster',
+      'slack:D1',
+      EXPECTED_PROMPTS,
+      'Get started',
+    );
+  });
+
+  it('prompt failure is decoration: logged, never thrown into delivery', async () => {
+    const { postDelivery, registry, getMessagingGroupByPlatform, log } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    registry.setSuggestedPrompts.mockRejectedValueOnce(new Error('not_allowed'));
+
+    expect(() => postDelivery(welcomeMsg(), { id: 'sess-1' }, { firstDelivery: true })).not.toThrow();
+
+    await flush();
+    expect(log.warn).toHaveBeenCalledWith(
+      'Welcome prompts failed',
+      expect.objectContaining({ platformId: 'slack:D1' }),
+    );
+  });
+});
+
+describe('agent-DM opened (bridge handler)', () => {
+  it('re-asserts the prompts when the DM is opened before any conversation exists', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    getActiveSessions.mockReturnValue([]);
+
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    await flush();
+    expect(getMessagingGroupByPlatform).toHaveBeenCalledWith('slack', 'slack:D1');
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
+  });
+
+  it('retires the prompts when a real conversation already exists', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    getActiveSessions.mockReturnValue([{ messaging_group_id: 'mg-dm', thread_id: 'slack:D1:171' }]);
+
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', []]]);
+  });
+
+  it('sessions without a ts segment do not count as conversations', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg());
+    getActiveSessions.mockReturnValue([
+      { messaging_group_id: 'mg-dm', thread_id: 'slack:D1:' }, // empty ts → the welcome thread, not a conversation
+      { messaging_group_id: 'mg-dm', thread_id: null }, // threadless session
+      { messaging_group_id: 'mg-other', thread_id: 'slack:D2:999' }, // someone else's conversation
+    ]);
+
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts.mock.calls).toEqual([['slack', 'slack:D1', EXPECTED_PROMPTS, 'Get started']]);
+  });
+
+  it('no-op for unknown or group messaging groups', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform } = await loadModule();
+
+    getMessagingGroupByPlatform.mockReturnValue(undefined);
+    await dmOpened({ instance: 'slack', channelId: 'D1' });
+
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ id: 'mg-room', is_group: 1 }));
+    await dmOpened({ instance: 'slack', channelId: 'C9' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('re-assert keys by the mg’s own instance', async () => {
+    const { dmOpened, registry, getMessagingGroupByPlatform, getActiveSessions } = await loadModule();
+    getMessagingGroupByPlatform.mockReturnValue(dmMg({ instance: 'slack-teamster' }));
+    getActiveSessions.mockReturnValue([]);
+
+    await dmOpened({ instance: 'slack-teamster', channelId: 'D1' });
+
+    await flush();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith(
+      'slack-teamster',
+      'slack:D1',
+      EXPECTED_PROMPTS,
+      'Get started',
+    );
+  });
+});

--- a/src/modules/slack-onboarding/thread-title.test.ts
+++ b/src/modules/slack-onboarding/thread-title.test.ts
@@ -1,0 +1,288 @@
+/**
+ * DM thread auto-title (plan 02, D15) — moved from src/router-thread-title.test.ts
+ * with the auto-title body's extraction into this module: when a brand-new
+ * per-thread DM session is created, the module fire-and-forgets a thread
+ * title — the first user message truncated to 45 chars — through the
+ * registry's setThreadTitle passthrough, on the platform's thread-
+ * materialization timing (delayed initial fire, one retry).
+ *
+ * The tests drive the module through the router's session-created hook
+ * (registerSessionCreatedHook) instead of router internals; the hook
+ * surfaces are mocked at the import seam. What the router itself guarantees
+ * — the hook fires once per CREATED session, never on reuse and never for
+ * the accumulate branch — is pinned by refa-b3's router-session-created
+ * test, not here. Capability gating (adapters without setThreadTitle
+ * no-op) lives in the registry passthrough (stan-adapter-capabilities).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../delivery.js', () => {
+  const hooks: Array<(msg: unknown, session: unknown, info: { firstDelivery: boolean }) => void> = [];
+  return {
+    registerPostDeliveryHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __postDeliveryHooks: hooks,
+  };
+});
+
+vi.mock('../../router.js', () => {
+  const hooks: Array<(event: never) => void | Promise<void>> = [];
+  return {
+    registerSessionCreatedHook: (h: (typeof hooks)[number]) => hooks.push(h),
+    __sessionCreatedHooks: hooks,
+  };
+});
+
+vi.mock('../../channels/chat-sdk-bridge.js', () => {
+  const ref: { handler: ((e: { instance: string; channelId: string }) => void | Promise<void>) | null } = {
+    handler: null,
+  };
+  return {
+    setAgentDmOpenedHandler: (fn: NonNullable<typeof ref.handler>) => {
+      ref.handler = fn;
+    },
+    __dmOpened: ref,
+  };
+});
+
+vi.mock('../../channels/channel-registry.js', () => ({
+  setThreadTitle: vi.fn(async () => {}),
+  setSuggestedPrompts: vi.fn(async () => {}),
+}));
+
+vi.mock('../../db/messaging-groups.js', () => ({ getMessagingGroupByPlatform: vi.fn(() => undefined) }));
+vi.mock('../../db/sessions.js', () => ({ getActiveSessions: vi.fn(() => []) }));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function now() {
+  return new Date().toISOString();
+}
+
+interface TestEvent {
+  session: { id: string };
+  mg: { id: string; channel_type: string; platform_id: string; instance?: string; is_group: number };
+  platformId: string;
+  threadId: string | null;
+  sessionMode: 'shared' | 'per-thread' | 'agent-shared';
+  message: { id: string; kind: string; content: string; timestamp: string };
+}
+
+function dmEvent(text: string, overrides: Partial<TestEvent> = {}): TestEvent {
+  return {
+    session: { id: 'sess-1' },
+    mg: { id: 'mg-dm', channel_type: 'slack', platform_id: 'slack:D1', instance: 'slack', is_group: 0 },
+    platformId: 'slack:D1',
+    threadId: 'slack:D1:171',
+    sessionMode: 'per-thread',
+    message: {
+      id: 'm1',
+      kind: 'chat-sdk',
+      content: JSON.stringify({ sender: 'Gavriel', senderId: 'U1', text }),
+      timestamp: now(),
+    },
+    ...overrides,
+  };
+}
+
+/** The module registers its hooks at import time (module singleton), so it
+ *  is loaded once; per-test isolation is mock state (vi.resetAllMocks
+ *  restores the original vi.fn implementations) + the delays seam. The
+ *  default titleDelays are snapshotted at first load, before any test
+ *  touches setTitleDelaysForTest. */
+type Loaded = {
+  mod: typeof import('./index.js');
+  sessionCreated: (event: TestEvent) => void | Promise<void>;
+  registry: { setThreadTitle: ReturnType<typeof vi.fn>; setSuggestedPrompts: ReturnType<typeof vi.fn> };
+  log: { warn: ReturnType<typeof vi.fn> };
+};
+let cached: Loaded | null = null;
+let defaultDelays: { initialMs: number; retryMs: number } | null = null;
+
+async function loadModule(): Promise<Loaded> {
+  if (cached) return cached;
+  const mod = await import('./index.js');
+  const router = (await import('../../router.js')) as unknown as {
+    __sessionCreatedHooks: Array<(event: TestEvent) => void | Promise<void>>;
+  };
+  const registry = (await import('../../channels/channel-registry.js')) as unknown as {
+    setThreadTitle: ReturnType<typeof vi.fn>;
+    setSuggestedPrompts: ReturnType<typeof vi.fn>;
+  };
+  const { log } = (await import('../../log.js')) as unknown as { log: { warn: ReturnType<typeof vi.fn> } };
+  expect(router.__sessionCreatedHooks).toHaveLength(1);
+  defaultDelays = { ...mod.titleDelays };
+  cached = { mod, sessionCreated: router.__sessionCreatedHooks[0], registry, log };
+  return cached;
+}
+
+/** Title fires on a delayed timer (assistant-thread materialization); the
+ *  tests zero the delays and flush the macrotask queue before asserting. */
+async function flushTitles(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 15));
+}
+
+beforeEach(async () => {
+  await loadModule();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetAllMocks();
+});
+
+describe('DM thread auto-title (session-created hook)', () => {
+  it('preserves the release timing constants: 3s initial, 7s retry', () => {
+    expect(defaultDelays).toEqual({ initialMs: 3000, retryMs: 7000 });
+  });
+
+  it('titles a NEW per-thread DM session with the first message, truncated to 45 chars', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    const longText = 'Can you help me put together the quarterly report for the design review?';
+    sessionCreated(dmEvent(longText));
+
+    await flushTitles();
+    expect(registry.setThreadTitle.mock.calls).toEqual([['slack', 'slack:D1', 'slack:D1:171', longText.slice(0, 45)]]);
+    expect((registry.setThreadTitle.mock.calls[0][3] as string).length).toBe(45);
+  });
+
+  it('titles each created conversation independently (once-per-session is the hook contract)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('first conversation'));
+    sessionCreated(dmEvent('second conversation', { session: { id: 'sess-2' }, threadId: 'slack:D1:999' }));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(2);
+    expect(registry.setThreadTitle).toHaveBeenLastCalledWith(
+      'slack',
+      'slack:D1',
+      'slack:D1:999',
+      'second conversation',
+    );
+  });
+
+  it('never fires for shared-session DM wirings (plain-variant bots keep today’s behavior)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('hello there', { sessionMode: 'shared', threadId: null }));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+    // The whole block is gated: prompt retirement never fires either.
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never fires for group conversations', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(
+      dmEvent('hello there', {
+        mg: { id: 'mg-room', channel_type: 'slack', platform_id: 'slack:C9', instance: 'slack', is_group: 1 },
+        platformId: 'slack:C9',
+      }),
+    );
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+    expect(registry.setSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it('never fires without a resolved thread id', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('hello there', { threadId: null }));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+  });
+
+  it('dispatches through the mg’s own instance key (never a sibling bot)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(
+      dmEvent('hi', {
+        mg: { id: 'mg-dm', channel_type: 'slack', platform_id: 'slack:D1', instance: 'slack-teamster', is_group: 0 },
+      }),
+    );
+
+    await flushTitles();
+    expect(registry.setThreadTitle).toHaveBeenCalledWith('slack-teamster', 'slack:D1', 'slack:D1:171', 'hi');
+  });
+
+  it('treats unparseable content as raw text (safeParseContent fallback)', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(
+      dmEvent('ignored', { message: { id: 'm1', kind: 'chat', content: 'plain text hello', timestamp: now() } }),
+    );
+
+    await flushTitles();
+    expect(registry.setThreadTitle).toHaveBeenCalledWith('slack', 'slack:D1', 'slack:D1:171', 'plain text hello');
+  });
+
+  it('empty first message: no title, but the get-started prompts still retire', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('   '));
+
+    await flushTitles();
+    expect(registry.setThreadTitle).not.toHaveBeenCalled();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith('slack', 'slack:D1', []);
+  });
+
+  it('retires the get-started prompts on the first created conversation', async () => {
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+
+    sessionCreated(dmEvent('let’s go'));
+
+    await flushTitles();
+    expect(registry.setSuggestedPrompts).toHaveBeenCalledWith('slack', 'slack:D1', []);
+  });
+
+  it('delays the title past assistant-thread materialization and retries once on failure', async () => {
+    vi.useFakeTimers();
+    const { mod, sessionCreated, registry } = await loadModule();
+    mod.setTitleDelaysForTest(10, 20);
+    registry.setThreadTitle.mockRejectedValueOnce(new Error('channel_not_found'));
+
+    sessionCreated(dmEvent('needs a retry'));
+    expect(registry.setThreadTitle).not.toHaveBeenCalled(); // nothing before the initial delay
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(1); // initial fire (fails)
+
+    await vi.advanceTimersByTimeAsync(19);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(1); // retry waits the full retryMs
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(2); // single retry succeeds
+    expect(registry.setThreadTitle).toHaveBeenLastCalledWith('slack', 'slack:D1', 'slack:D1:171', 'needs a retry');
+  });
+
+  it('gives up after one retry and logs a warning', async () => {
+    vi.useFakeTimers();
+    const { mod, sessionCreated, registry, log } = await loadModule();
+    mod.setTitleDelaysForTest(0, 0);
+    registry.setThreadTitle.mockRejectedValue(new Error('channel_not_found'));
+
+    sessionCreated(dmEvent('never lands'));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(registry.setThreadTitle).toHaveBeenCalledTimes(2); // initial + one retry, never a third
+    expect(log.warn).toHaveBeenCalledWith(
+      'setThreadTitle failed',
+      expect.objectContaining({ sessionId: 'sess-1', threadId: 'slack:D1:171' }),
+    );
+  });
+});

--- a/src/modules/slack-room-membership/env-file.test.ts
+++ b/src/modules/slack-room-membership/env-file.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the module's vendored .env helpers — the read/append pair only
+ * (the upsert writer is private, exercised through appendToEnvList).
+ * Semantics must stay identical to src/env.ts readEnvFile parsing.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue } from './env-file.js';
+
+describe('slack-room-membership env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'srm-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'SRM_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'SRM_PLAIN=value1',
+          '  SRM_INDENTED = spaced ',
+          'SRM_DQUOTED="double quoted"',
+          "SRM_SQUOTED='single quoted'",
+          'SRM_EMPTY=',
+          '# SRM_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'SRM_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'SRM_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'SRM_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'SRM_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'SRM_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'SRM_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('SRM_PREFERS=file-value\n');
+      vi.stubEnv('SRM_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'SRM_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('SRM_BLANK_ENV=file-value\n');
+      vi.stubEnv('SRM_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'SRM_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('SRM_DUP=first\nSRM_DUP=second\n');
+      expect(readEnvValue(rootDir, 'SRM_DUP')).toBe('second');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates .env and the key, reporting the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'alpha')).toBe(true);
+      expect(read()).toBe('SRM_LIST=alpha\n');
+      expect(readEnvValue(rootDir, 'SRM_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('SRM_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'SRM_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nSRM_LIST=alpha\nLAST=9\n');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'beta')).toBe(true);
+      expect(read()).toBe('# keep me\nFIRST=1\nSRM_LIST=alpha,beta\nLAST=9\n');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'alpha')).toBe(true);
+      expect(read()).toBe('EXISTING=x\nSRM_LIST=alpha\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('SRM_LIST=alpha\nSRM_LIST=beta\n');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'gamma')).toBe(true);
+      expect(read()).toBe('SRM_LIST=beta,gamma\nSRM_LIST=beta,gamma\n');
+      expect(readEnvValue(rootDir, 'SRM_LIST')).toBe('beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('SRM_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys parse .env only, so the union must be based on
+      // the file, not a stale process.env copy.
+      write('SRM_LIST=alpha\n');
+      vi.stubEnv('SRM_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'SRM_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('SRM_LIST=alpha,beta');
+    });
+  });
+});

--- a/src/modules/slack-room-membership/env-file.ts
+++ b/src/modules/slack-room-membership/env-file.ts
@@ -1,0 +1,99 @@
+/**
+ * Vendored .env read helpers for the slack-room-membership module — the two
+ * helpers this module actually uses (readEnvValue, appendToEnvList), nothing
+ * more. Interim home per the series disposition: the trunk env-file hoist was
+ * reversed (no second trunk consumer yet), and this channel-layer module must
+ * not import from a feature module, so it carries its own minimal copy until
+ * a shared trunk home exists. Semantics are verbatim from the original.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — everything written here is read back through
+ * that parser. Write conventions: replace the key's line in place, preserve
+ * every other line (comments and blanks included), append with a clean
+ * trailing newline.
+ *
+ * Values read here include live Slack tokens: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value. Private: this
+ * module only writes through appendToEnvList.
+ */
+function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/src/modules/slack-room-membership/index.ts
+++ b/src/modules/slack-room-membership/index.ts
@@ -1,0 +1,26 @@
+/**
+ * slack-room-membership module — registers THE bridge membership handler
+ * (generic membership seam: setMembershipHandler('slack', …) in
+ * src/channels/chat-sdk-bridge.ts) and THE Slack channel-card interceptor
+ * (permissions seam: registerChannelCardInterceptor). All behavior lives in
+ * ./membership.ts: join-time adopt via the existing channel-approval card,
+ * MPIM-fork carry-over, own-left detachment (migration 021), membership
+ * notes into wired room sessions, and — via the interceptor, consulted by
+ * requestChannelApproval on both the router mention path and the join-time
+ * adopt path — the B2/D24 owner-presence access rule (owner present →
+ * auto-wire, no card; stranger 1:1 DM → decline-and-notify; Slackbot shadow
+ * channels → silently ignored).
+ *
+ * Registered by a skill-appended barrel import at install time (the Slack
+ * channel skill appends this module to src/modules/index.ts).
+ *
+ * No guard registration: this module adds no ncl commands and no delivery
+ * actions — the only privileged surface it touches is the channel-approval
+ * card, whose click path is already guarded (channels.register).
+ */
+import { setMembershipHandler } from '../../channels/chat-sdk-bridge.js';
+import { registerChannelCardInterceptor } from '../permissions/channel-approval.js';
+import { handleSlackMembershipEvent, slackChannelCardInterceptor } from './membership.js';
+
+setMembershipHandler('slack', (event) => handleSlackMembershipEvent(event));
+registerChannelCardInterceptor('slack', (mg, event) => slackChannelCardInterceptor(mg, event));

--- a/src/modules/slack-room-membership/membership.test.ts
+++ b/src/modules/slack-room-membership/membership.test.ts
@@ -1,0 +1,883 @@
+/**
+ * Unit tests for the slack-room-membership handler (generic membership-seam
+ * consumer).
+ *
+ * Every collaborator is mocked at its import seam: the slack-lib Web API
+ * client, the vendored env-file reader, channel-approval / sender-approval /
+ * router / session-manager / destination projection, and — because this
+ * channels-based branch predates the trunk hooks this module composes with
+ * (instance-aware messaging-group lookup, migration 021 detached_at
+ * accessors, decline_notify, the card interceptor) — the central-DB accessor
+ * modules themselves, replaced by in-memory fakes that mirror the composed
+ * trunk accessors' semantics. The release-branch suite ran the same cases
+ * against a real in-memory DB; that composed run is re-established once the
+ * trunk hooks forward-merge into this branch. Every test drives
+ * handleSlackMembershipEvent with joinRecheckDelayMs: 0.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockApi,
+  mockEnv,
+  mockRequestChannelApproval,
+  mockWriteSessionMessage,
+  mockProject,
+  mockRouteInbound,
+  mockDeclineAndNotify,
+  mockRecordDropped,
+  fakeDb,
+} = vi.hoisted(() => {
+  const mockApi = {
+    slackAuthTest: vi.fn(),
+    slackConversationsInfo: vi.fn(),
+    slackConversationsMembers: vi.fn(),
+    slackPostMessage: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockEnv = {
+    readEnvValue: vi.fn(),
+    appendToEnvList: vi.fn().mockReturnValue(true),
+  };
+
+  // ── In-memory central-DB fake ──
+  // Semantics mirror the composed trunk accessors: createMessagingGroup
+  // defaults `instance` to channel_type; the three-arg
+  // getMessagingGroupByPlatform is exact-only on a set instance and resolves
+  // default-instance-first (then lexically-first named instance) when unset;
+  // detached_at is a nullable stamp with set/is accessors (migration 021).
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const state = {
+    messagingGroups: [] as any[],
+    wirings: [] as any[],
+    agentGroups: [] as any[],
+    sessions: [] as any[],
+    roles: [] as any[],
+  };
+  const fakeDb = {
+    reset(): void {
+      state.messagingGroups = [];
+      state.wirings = [];
+      state.agentGroups = [];
+      state.sessions = [];
+      state.roles = [];
+    },
+    // messaging-groups
+    createMessagingGroup(group: any): void {
+      state.messagingGroups.push({
+        denied_at: null,
+        detached_at: null,
+        ...group,
+        instance: group.instance ?? group.channel_type,
+      });
+    },
+    getMessagingGroup(id: string): any {
+      return state.messagingGroups.find((m) => m.id === id);
+    },
+    getMessagingGroupByPlatform(channelType: string, platformId: string, instance?: string): any {
+      const hits = state.messagingGroups.filter((m) => m.channel_type === channelType && m.platform_id === platformId);
+      if (instance !== undefined) return hits.find((m) => m.instance === instance);
+      return hits.sort(
+        (a, b) =>
+          Number(b.instance === b.channel_type) - Number(a.instance === a.channel_type) ||
+          String(a.instance).localeCompare(String(b.instance)),
+      )[0];
+    },
+    getAllMessagingGroups(): any[] {
+      return [...state.messagingGroups];
+    },
+    updateMessagingGroup(id: string, patch: Record<string, unknown>): void {
+      const row = state.messagingGroups.find((m) => m.id === id);
+      if (row) Object.assign(row, patch);
+    },
+    setMessagingGroupDeniedAt(id: string, deniedAt: string | null): void {
+      const row = state.messagingGroups.find((m) => m.id === id);
+      if (row) row.denied_at = deniedAt;
+    },
+    setMessagingGroupDetachedAt(id: string, detachedAt: string | null): void {
+      const row = state.messagingGroups.find((m) => m.id === id);
+      if (row) row.detached_at = detachedAt;
+    },
+    isMessagingGroupDetached(id: string): boolean {
+      return state.messagingGroups.find((m) => m.id === id)?.detached_at != null;
+    },
+    createMessagingGroupAgent(mga: any): void {
+      state.wirings.push({ threads: mga.threads ?? null, ...mga });
+    },
+    getMessagingGroupAgents(messagingGroupId: string): any[] {
+      return state.wirings.filter((w) => w.messaging_group_id === messagingGroupId);
+    },
+    getMessagingGroupAgentByPair(messagingGroupId: string, agentGroupId: string): any {
+      return state.wirings.find((w) => w.messaging_group_id === messagingGroupId && w.agent_group_id === agentGroupId);
+    },
+    // agent-groups
+    createAgentGroup(group: any): void {
+      state.agentGroups.push(group);
+    },
+    getAgentGroup(id: string): any {
+      return state.agentGroups.find((g) => g.id === id);
+    },
+    // sessions
+    createSession(session: any): void {
+      state.sessions.push(session);
+    },
+    getSessionsByAgentGroup(agentGroupId: string): any[] {
+      return state.sessions.filter((s) => s.agent_group_id === agentGroupId);
+    },
+    // user-roles (+ the access fake reads the same rows)
+    grantRole(row: any): void {
+      state.roles.push(row);
+    },
+    getOwners(): any[] {
+      return state.roles.filter((r) => r.role === 'owner');
+    },
+    hasRole(userId: string): boolean {
+      return state.roles.some((r) => r.user_id === userId);
+    },
+  };
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return {
+    mockApi,
+    mockEnv,
+    mockRequestChannelApproval: vi.fn().mockResolvedValue(undefined),
+    mockWriteSessionMessage: vi.fn(),
+    mockProject: vi.fn().mockResolvedValue(undefined),
+    mockRouteInbound: vi.fn().mockResolvedValue(undefined),
+    mockDeclineAndNotify: vi.fn().mockResolvedValue(undefined),
+    mockRecordDropped: vi.fn(),
+    fakeDb,
+  };
+});
+
+vi.mock('../../channels/slack-lib.js', async (importOriginal) => ({
+  // botTokenKeyForInstance (and SlackApiError) stay real — only the four
+  // network-touching calls are mocked. Tests never hit the Slack API.
+  ...(await importOriginal<Record<string, unknown>>()),
+  ...mockApi,
+}));
+vi.mock('./env-file.js', () => mockEnv);
+vi.mock('../permissions/channel-approval.js', () => ({
+  requestChannelApproval: (...a: unknown[]) => mockRequestChannelApproval(...a),
+}));
+vi.mock('../permissions/sender-approval.js', () => ({
+  declineAndNotify: (...a: unknown[]) => mockDeclineAndNotify(...a),
+}));
+vi.mock('../../router.js', () => ({
+  routeInbound: (...a: unknown[]) => mockRouteInbound(...a),
+}));
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockWriteSessionMessage(...a),
+}));
+vi.mock('../../cli/resources/destinations.js', () => ({
+  projectDestinationsToSessions: (...a: unknown[]) => mockProject(...a),
+}));
+// Mirrors the release suite's registered TEST_SLACK_DEFAULTS declaration
+// (group: request_approval, dm: strict) without the channel registry.
+vi.mock('../../channels/channel-defaults.js', () => ({
+  resolveUnknownSenderPolicy: (_instance: string, isGroup: boolean) => (isGroup ? 'request_approval' : 'strict'),
+}));
+vi.mock('../permissions/access.js', () => ({
+  canAccessAgentGroup: (userId: string) => ({ allowed: fakeDb.hasRole(userId) }),
+}));
+vi.mock('../../db/dropped-messages.js', () => ({
+  recordDroppedMessage: (...a: unknown[]) => mockRecordDropped(...a),
+}));
+vi.mock('../../db/messaging-groups.js', () => ({
+  createMessagingGroup: fakeDb.createMessagingGroup,
+  getMessagingGroup: fakeDb.getMessagingGroup,
+  getMessagingGroupByPlatform: fakeDb.getMessagingGroupByPlatform,
+  getAllMessagingGroups: fakeDb.getAllMessagingGroups,
+  updateMessagingGroup: fakeDb.updateMessagingGroup,
+  setMessagingGroupDeniedAt: fakeDb.setMessagingGroupDeniedAt,
+  setMessagingGroupDetachedAt: fakeDb.setMessagingGroupDetachedAt,
+  isMessagingGroupDetached: fakeDb.isMessagingGroupDetached,
+  createMessagingGroupAgent: fakeDb.createMessagingGroupAgent,
+  getMessagingGroupAgents: fakeDb.getMessagingGroupAgents,
+  getMessagingGroupAgentByPair: fakeDb.getMessagingGroupAgentByPair,
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  createAgentGroup: fakeDb.createAgentGroup,
+  getAgentGroup: fakeDb.getAgentGroup,
+}));
+vi.mock('../../db/sessions.js', () => ({
+  createSession: fakeDb.createSession,
+  getSessionsByAgentGroup: fakeDb.getSessionsByAgentGroup,
+}));
+vi.mock('../permissions/db/user-roles.js', () => ({
+  grantRole: fakeDb.grantRole,
+  getOwners: fakeDb.getOwners,
+}));
+
+import { createAgentGroup } from '../../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  isMessagingGroupDetached,
+  setMessagingGroupDeniedAt,
+  setMessagingGroupDetachedAt,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import type { InboundEvent } from '../../channels/adapter.js';
+import type { MessagingGroup, MessagingGroupAgent, Session } from '../../types.js';
+import {
+  clearOwnBotIdCache,
+  handleSlackMembershipEvent,
+  slackChannelCardInterceptor,
+  type MembershipEvent,
+} from './membership.js';
+
+const OWN_BOT = 'U0OWNBOT';
+const PIXEL_BOT = 'U0PIXELBOT';
+const OPERATOR = 'U0OPERATOR';
+
+const now = () => new Date().toISOString();
+
+async function mg(
+  partial: Partial<MessagingGroup> & Pick<MessagingGroup, 'id' | 'platform_id'>,
+): Promise<MessagingGroup> {
+  const row: MessagingGroup = {
+    channel_type: 'slack',
+    instance: 'slack',
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+    ...partial,
+  };
+  await createMessagingGroup(row);
+  return row;
+}
+
+async function wire(
+  mgId: string,
+  agentGroupId: string,
+  partial: Partial<MessagingGroupAgent> = {},
+): Promise<MessagingGroupAgent> {
+  const row: MessagingGroupAgent = {
+    id: `mga-${mgId}-${agentGroupId}`,
+    messaging_group_id: mgId,
+    agent_group_id: agentGroupId,
+    engage_mode: 'mention',
+    engage_pattern: null,
+    sender_scope: 'all',
+    ignored_message_policy: 'accumulate',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now(),
+    ...partial,
+  };
+  await createMessagingGroupAgent(row);
+  return row;
+}
+
+async function session(id: string, agentGroupId: string, messagingGroupId: string | null): Promise<Session> {
+  const s: Session = {
+    id,
+    agent_group_id: agentGroupId,
+    messaging_group_id: messagingGroupId,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: now(),
+  };
+  await createSession(s);
+  return s;
+}
+
+function joinEvent(partial: Partial<MembershipEvent> = {}): MembershipEvent {
+  return {
+    instance: 'slack',
+    channelType: 'slack',
+    channelId: 'C0NEW',
+    userId: OWN_BOT,
+    ...partial,
+  };
+}
+
+async function handle(event: MembershipEvent): Promise<void> {
+  await handleSlackMembershipEvent(event, { joinRecheckDelayMs: 0, rootDir: '/fake-root' });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  clearOwnBotIdCache();
+  fakeDb.reset();
+  await createAgentGroup({ id: 'ag-andy', name: 'Andy', folder: 'andy', agent_provider: null, created_at: now() });
+  await createAgentGroup({ id: 'ag-pixel', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now() });
+
+  // Token table: default instance + pixel sibling. auth.test maps token → bot id.
+  mockEnv.readEnvValue.mockImplementation((_root: string, key: string) => {
+    if (key === 'SLACK_BOT_TOKEN') return 'xoxb-own';
+    if (key === 'SLACK_BOT_TOKEN_PIXEL') return 'xoxb-pixel';
+    if (key === 'SLACK_A2A_ROOMS') return '';
+    return undefined;
+  });
+  mockApi.slackAuthTest.mockImplementation(async (token: string) => ({
+    userId: token === 'xoxb-own' ? OWN_BOT : PIXEL_BOT,
+  }));
+  mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false });
+  mockApi.slackConversationsMembers.mockResolvedValue([]);
+});
+
+describe('own-bot join — adopt flow (case 1)', () => {
+  it('unknown channel: creates the mg row (router shape) and fires the approval card with a synthesized greeting', async () => {
+    await handle(joinEvent({ inviterId: OPERATOR }));
+
+    const created = await getMessagingGroupByPlatform('slack', 'slack:C0NEW', 'slack');
+    expect(created).toMatchObject({
+      channel_type: 'slack',
+      is_group: 1,
+      unknown_sender_policy: 'request_approval', // group context of the declared defaults
+      name: null,
+    });
+
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    const input = mockRequestChannelApproval.mock.calls[0]![0] as {
+      messagingGroupId: string;
+      event: {
+        channelType: string;
+        instance: string;
+        platformId: string;
+        message: { isMention?: boolean; isGroup?: boolean; kind: string; content: string };
+      };
+    };
+    expect(input.messagingGroupId).toBe(created!.id);
+    expect(input.event).toMatchObject({ channelType: 'slack', instance: 'slack', platformId: 'slack:C0NEW' });
+    // Replayable greeting: routes like a mention, carries invited-by context.
+    expect(input.event.message.isMention).toBe(true);
+    expect(input.event.message.isGroup).toBe(true);
+    const content = JSON.parse(input.event.message.content) as Record<string, unknown>;
+    expect(content.text).toContain(`<@${OPERATOR}> invited the bot`);
+    expect(content.senderId).toBe(OPERATOR);
+  });
+
+  it.each([
+    ['slack:C0NEW:', 'C0NEW'],
+    ['slack:G0NEW:', 'G0NEW'],
+    ['slack:C0NEW:1724264405.531769', 'C0NEW'],
+  ])('normalizes encoded channel id %s and reuses the router-created messaging group', async (encoded, raw) => {
+    const existing = await mg({
+      id: `mg-router-${raw}`,
+      platform_id: `slack:${raw}`,
+      unknown_sender_policy: 'request_approval',
+    });
+
+    await handle(joinEvent({ channelId: encoded, inviterId: OPERATOR }));
+
+    expect(await getAllMessagingGroups()).toHaveLength(1);
+    expect(mockApi.slackConversationsInfo).toHaveBeenCalledWith('xoxb-own', raw, 'membership');
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    expect(mockRequestChannelApproval).toHaveBeenCalledWith({
+      messagingGroupId: existing.id,
+      event: expect.objectContaining({ platformId: `slack:${raw}`, threadId: null }),
+    });
+  });
+
+  it('SAF-004 regression: encoded channel id with NO pre-existing row creates exactly one canonical row', async () => {
+    // The literal launch-blocking shape: bot invited before any message ever
+    // routed, so no router-created row exists. The encoded id must collapse
+    // to the raw channel id BEFORE the row is created — the pre-fix code
+    // persisted a malformed `slack:slack:C0NEW:` row here.
+    await handle(joinEvent({ channelId: 'slack:C0NEW:', inviterId: OPERATOR }));
+
+    const all = await getAllMessagingGroups();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ channel_type: 'slack', platform_id: 'slack:C0NEW', instance: 'slack' });
+    expect(await getMessagingGroupByPlatform('slack', 'slack:slack:C0NEW:', 'slack')).toBeUndefined();
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    expect(mockRequestChannelApproval).toHaveBeenCalledWith({
+      messagingGroupId: all[0]!.id,
+      event: expect.objectContaining({ platformId: 'slack:C0NEW' }),
+    });
+  });
+
+  it('rejects a double-prefixed channel id instead of persisting dead wiring', async () => {
+    await handle(joinEvent({ channelId: 'slack:slack:C0NEW:' }));
+
+    expect(await getAllMessagingGroups()).toHaveLength(0);
+    expect(mockApi.slackAuthTest).not.toHaveBeenCalled();
+    expect(mockApi.slackConversationsInfo).not.toHaveBeenCalled();
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+  });
+
+  it('Slackbot-created shadow channel (canvas container): ignored — no mg row, no card', async () => {
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, name: 'Untitled', creator: 'USLACKBOT' });
+
+    await handle(joinEvent({}));
+
+    expect(await getMessagingGroupByPlatform('slack', 'slack:C0NEW', 'slack')).toBeUndefined();
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+  });
+
+  it('denied tombstone holds: no card, no new rows', async () => {
+    const denied = await mg({ id: 'mg-denied', platform_id: 'slack:C0NEW', unknown_sender_policy: 'request_approval' });
+    await setMessagingGroupDeniedAt(denied.id, now());
+
+    await handle(joinEvent({ inviterId: OPERATOR }));
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(await getAllMessagingGroups()).toHaveLength(1);
+  });
+
+  it('already-wired channel: silent, and a rejoin clears detached_at', async () => {
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    await wire(room.id, 'ag-andy');
+    await setMessagingGroupDetachedAt(room.id, now());
+
+    await handle(joinEvent());
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(await isMessagingGroupDetached(room.id)).toBe(false);
+  });
+
+  it('no bot token for the instance: treated as a foreign member, no adopt', async () => {
+    mockEnv.readEnvValue.mockReturnValue(undefined);
+
+    await handle(joinEvent());
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(await getAllMessagingGroups()).toHaveLength(0);
+  });
+});
+
+describe('own-bot join — MPIM-fork carry-over (case 2)', () => {
+  async function seedOldRoom(): Promise<{ oldDefault: MessagingGroup; oldPixel: MessagingGroup }> {
+    // Old wired room G0OLD, two instances (default + pixel sibling).
+    const oldDefault = await mg({ id: 'mg-old-slack', platform_id: 'slack:G0OLD', name: 'Pixel room' });
+    const oldPixel = await mg({
+      id: 'mg-old-pixel',
+      platform_id: 'slack:G0OLD',
+      instance: 'slack-pixel',
+      name: 'Pixel room',
+    });
+    await wire(oldDefault.id, 'ag-andy', {
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+      threads: 1,
+    });
+    await wire(oldPixel.id, 'ag-pixel', { engage_mode: 'mention', ignored_message_policy: 'accumulate' });
+    return { oldDefault, oldPixel };
+  }
+
+  beforeEach(() => {
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: true });
+    mockApi.slackConversationsMembers.mockImplementation(async (_token: string, channelId: string) => {
+      if (channelId === 'G0OLD') return [OPERATOR, OWN_BOT, PIXEL_BOT];
+      if (channelId === 'G0NEW') return [OPERATOR, OWN_BOT, PIXEL_BOT, 'U0NEWHUMAN'];
+      return [];
+    });
+  });
+
+  it('superset MPIM: mirrors every instance row + wiring, carries the allowlist, posts the moved note, no card', async () => {
+    await seedOldRoom();
+    mockEnv.readEnvValue.mockImplementation((_root: string, key: string) => {
+      if (key === 'SLACK_BOT_TOKEN') return 'xoxb-own';
+      if (key === 'SLACK_BOT_TOKEN_PIXEL') return 'xoxb-pixel';
+      if (key === 'SLACK_A2A_ROOMS') return 'G0OLD';
+      return undefined;
+    });
+
+    await handle(joinEvent({ channelId: 'G0NEW' }));
+
+    // No approval card — carry-over replaced it.
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+
+    // Mirrored rows for BOTH instances, same agent groups, same engage values.
+    const newDefault = await getMessagingGroupByPlatform('slack', 'slack:G0NEW', 'slack');
+    const newPixel = await getMessagingGroupByPlatform('slack', 'slack:G0NEW', 'slack-pixel');
+    expect(newDefault).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+    expect(newPixel).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+    expect(await getMessagingGroupAgentByPair(newDefault!.id, 'ag-andy')).toMatchObject({
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+      threads: 1,
+    });
+    expect(await getMessagingGroupAgentByPair(newPixel!.id, 'ag-pixel')).toMatchObject({
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+    });
+
+    // Old room untouched.
+    expect(await getMessagingGroupAgents('mg-old-slack')).toHaveLength(1);
+    expect((await getMessagingGroup('mg-old-slack'))!.denied_at ?? null).toBeNull();
+
+    // Allowlist carried, destinations projected, note posted as the bot.
+    expect(mockEnv.appendToEnvList).toHaveBeenCalledWith('/fake-root', 'SLACK_A2A_ROOMS', 'G0NEW');
+    expect(mockProject).toHaveBeenCalledWith('ag-andy');
+    expect(mockProject).toHaveBeenCalledWith('ag-pixel');
+    expect(mockApi.slackPostMessage).toHaveBeenCalledWith('xoxb-own', 'G0NEW', expect.stringContaining('Room moved'));
+  });
+
+  it('old room not allowlisted: wiring carries over but SLACK_A2A_ROOMS is untouched', async () => {
+    await seedOldRoom();
+
+    await handle(joinEvent({ channelId: 'G0NEW' }));
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(mockEnv.appendToEnvList).not.toHaveBeenCalled();
+  });
+
+  it('non-superset member set: falls through to the adopt card', async () => {
+    await seedOldRoom();
+    mockApi.slackConversationsMembers.mockImplementation(async (_token: string, channelId: string) => {
+      if (channelId === 'G0OLD') return [OPERATOR, OWN_BOT, PIXEL_BOT];
+      if (channelId === 'G0NEW') return [OPERATOR, OWN_BOT, 'U0STRANGER']; // pixel bot missing
+      return [];
+    });
+
+    await handle(joinEvent({ channelId: 'G0NEW' }));
+
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0NEW', 'slack-pixel')).toBeUndefined();
+  });
+
+  it('non-MPIM channel: no fork check, straight to the adopt card', async () => {
+    await seedOldRoom();
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false });
+
+    await handle(joinEvent({ channelId: 'C0CHANNEL' }));
+
+    expect(mockApi.slackConversationsMembers).not.toHaveBeenCalled();
+    expect(mockRequestChannelApproval).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('own-bot left (case 3)', () => {
+  it('wired channel: marks the mg detached', async () => {
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    await wire(room.id, 'ag-andy');
+
+    await handle(joinEvent({ left: true }));
+
+    expect(await isMessagingGroupDetached(room.id)).toBe(true);
+  });
+
+  it('unknown channel: no-op', async () => {
+    await handle(joinEvent({ left: true }));
+    expect(await getAllMessagingGroups()).toHaveLength(0);
+  });
+});
+
+describe('non-bot membership change in a wired room (case 4)', () => {
+  it('human joined: system-sender note (trigger 0, channel_type agent) into every wired room session', async () => {
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    const elsewhere = await mg({ id: 'mg-elsewhere', platform_id: 'slack:D0DM', is_group: 0 });
+    await wire(room.id, 'ag-andy');
+    await wire(room.id, 'ag-pixel');
+    await session('sess-andy-room', 'ag-andy', room.id);
+    await session('sess-andy-dm', 'ag-andy', elsewhere.id); // different mg — no note
+    await session('sess-pixel-room', 'ag-pixel', room.id);
+
+    await handle(joinEvent({ userId: 'U0NEWHUMAN', inviterId: OPERATOR }));
+
+    expect(mockRequestChannelApproval).not.toHaveBeenCalled();
+    expect(mockWriteSessionMessage).toHaveBeenCalledTimes(2);
+    const targets = mockWriteSessionMessage.mock.calls.map((c) => [c[0], c[1]]);
+    expect(targets).toContainEqual(['ag-andy', 'sess-andy-room']);
+    expect(targets).toContainEqual(['ag-pixel', 'sess-pixel-room']);
+    const msg = mockWriteSessionMessage.mock.calls[0]![2] as {
+      kind: string;
+      channelType: string;
+      trigger: boolean;
+      content: string;
+    };
+    // kind 'chat' + sender 'system' (container-restart's system-note shape):
+    // the container poll loop filters kind 'system' rows out of agent batches.
+    expect(msg).toMatchObject({ kind: 'chat', channelType: 'agent', trigger: false });
+    const content = JSON.parse(msg.content) as { text: string; sender: string };
+    expect(content.sender).toBe('system');
+    expect(content.text).toContain('<@U0NEWHUMAN> joined this room');
+    expect(content.text).toContain(`invited by <@${OPERATOR}>`);
+  });
+
+  it('foreign bot left: note says left, no inviter clause', async () => {
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0NEW' });
+    await wire(room.id, 'ag-andy');
+    await session('sess-andy-room', 'ag-andy', room.id);
+
+    await handle(joinEvent({ userId: PIXEL_BOT, left: true }));
+
+    expect(mockWriteSessionMessage).toHaveBeenCalledTimes(1);
+    const content = JSON.parse((mockWriteSessionMessage.mock.calls[0]![2] as { content: string }).content) as {
+      text: string;
+    };
+    expect(content.text).toContain(`<@${PIXEL_BOT}> left this room`);
+    expect(content.text).not.toContain('invited by');
+  });
+
+  it('unwired or unknown channel: no notes', async () => {
+    await handle(joinEvent({ userId: 'U0NEWHUMAN' }));
+    expect(mockWriteSessionMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack channel-card interceptor — owner-presence rule (B2/D24)', () => {
+  function mentionEvent(
+    platformId: string,
+    partial: { isGroup?: boolean; senderId?: string; senderName?: string } = {},
+  ): InboundEvent {
+    return {
+      channelType: 'slack',
+      instance: 'slack',
+      platformId,
+      threadId: null,
+      message: {
+        id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+        kind: 'chat',
+        timestamp: now(),
+        isMention: true,
+        isGroup: partial.isGroup ?? true,
+        content: JSON.stringify({
+          text: '@bot hello',
+          senderId: partial.senderId ?? 'U0SOMEONE',
+          senderName: partial.senderName ?? 'Someone',
+        }),
+      },
+    };
+  }
+
+  /** Owner identity + the instance's DM wiring (what every per-agent
+   *  instance has) — the two facts the interceptor resolves against. */
+  async function seedOwnerAndInstanceDm(): Promise<void> {
+    await grantRole({
+      user_id: `slack:${OPERATOR}`,
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
+    const dm = await mg({ id: 'mg-dm-andy', platform_id: 'slack:D0ANDY', is_group: 0 });
+    await wire(dm.id, 'ag-andy');
+  }
+
+  async function intercept(row: MessagingGroup, event: InboundEvent): Promise<'card' | 'handled'> {
+    return slackChannelCardInterceptor(row, event, { rootDir: '/fake-root' });
+  }
+
+  it('owner present in the channel: auto-wires mention/accumulate, flips mg to public, replays — no card', async () => {
+    await seedOwnerAndInstanceDm();
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: true, creator: OPERATOR });
+    mockApi.slackConversationsMembers.mockResolvedValue([OPERATOR, OWN_BOT, 'U0STRANGER']);
+
+    const event = mentionEvent('slack:C0ROOM');
+    expect(await intercept(room, event)).toBe('handled');
+
+    expect(await getMessagingGroup(room.id)).toMatchObject({ unknown_sender_policy: 'public' });
+    expect(await getMessagingGroupAgentByPair(room.id, 'ag-andy')).toMatchObject({
+      engage_mode: 'mention',
+      ignored_message_policy: 'accumulate',
+      sender_scope: 'all',
+    });
+    expect(mockProject).toHaveBeenCalledWith('ag-andy');
+    expect(mockRouteInbound).toHaveBeenCalledTimes(1);
+    expect(mockRouteInbound).toHaveBeenCalledWith(event);
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('owner absent in a channel: declines in-channel and FYIs the owner — no card, no wiring', async () => {
+    await seedOwnerAndInstanceDm();
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, name: 'dogfood', creator: 'U0STRANGER' });
+    mockApi.slackConversationsMembers.mockResolvedValue([OWN_BOT, 'U0STRANGER']);
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM', { senderId: 'U0STRANGER', senderName: 'Dana' }))).toBe(
+      'handled',
+    );
+
+    expect(mockDeclineAndNotify).toHaveBeenCalledTimes(1);
+    const [call] = mockDeclineAndNotify.mock.calls[0] as [Record<string, unknown>];
+    expect(call.messagingGroupId).toBe('mg-room');
+    // Deduped per channel, not per sender: a second person mentioning the bot
+    // in the same channel must not produce a second post.
+    expect(call.dedupeKey).toBe('channel:requires-owner');
+    expect(call.declineText).toContain('only be connected to a channel by my owner');
+    expect(call.declineText).toContain('remove me from this channel');
+    expect(call.fyiText).toContain('Dana');
+    expect(call.fyiText).toContain('#dogfood');
+    // Not a card, and nothing was wired or routed.
+    expect(await getMessagingGroupAgents(room.id)).toHaveLength(0);
+    expect(await getMessagingGroup(room.id)).toMatchObject({ unknown_sender_policy: 'request_approval' });
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+  });
+
+  it('owner absent in an MPIM: still cards — a group DM invite stays an ask', async () => {
+    await seedOwnerAndInstanceDm();
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: true, creator: 'U0STRANGER' });
+    mockApi.slackConversationsMembers.mockResolvedValue([OWN_BOT, 'U0STRANGER']);
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+    expect(await getMessagingGroupAgents(room.id)).toHaveLength(0);
+    expect(await getMessagingGroup(room.id)).toMatchObject({ unknown_sender_policy: 'request_approval' });
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+  });
+
+  it('owner absent but the conversation could not be classified: cards rather than guessing', async () => {
+    await seedOwnerAndInstanceDm();
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsInfo.mockRejectedValue(new Error('ratelimited'));
+    mockApi.slackConversationsMembers.mockResolvedValue([OWN_BOT, 'U0STRANGER']);
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('owner present but instance→agent-group resolution ambiguous: card', async () => {
+    await seedOwnerAndInstanceDm();
+    // A second DM wiring on the same instance to a different agent group.
+    const dm2 = await mg({ id: 'mg-dm-pixel', platform_id: 'slack:D0PIXEL', is_group: 0 });
+    await wire(dm2.id, 'ag-pixel');
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsMembers.mockResolvedValue([OPERATOR, OWN_BOT]);
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(await getMessagingGroupAgents(room.id)).toHaveLength(0);
+  });
+
+  it('no owner with a Slack identity: card (no members probe)', async () => {
+    const dm = await mg({ id: 'mg-dm-andy', platform_id: 'slack:D0ANDY', is_group: 0 });
+    await wire(dm.id, 'ag-andy');
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(mockApi.slackConversationsMembers).not.toHaveBeenCalled();
+  });
+
+  it('USLACKBOT-created shadow channel: silently handled — no wiring, no decline, no replay', async () => {
+    await seedOwnerAndInstanceDm();
+    const shadow = await mg({
+      id: 'mg-shadow',
+      platform_id: 'slack:C0SHADOW',
+      unknown_sender_policy: 'request_approval',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, name: 'Untitled', creator: 'USLACKBOT' });
+
+    expect(await intercept(shadow, mentionEvent('slack:C0SHADOW'))).toBe('handled');
+
+    expect(await getMessagingGroupAgents(shadow.id)).toHaveLength(0);
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+    expect(mockApi.slackConversationsMembers).not.toHaveBeenCalled();
+  });
+
+  it('stranger 1:1 DM with decline_notify policy: declines and notifies, no card', async () => {
+    await seedOwnerAndInstanceDm();
+    const dm = await mg({
+      id: 'mg-dm-stranger',
+      platform_id: 'slack:D0STRANGER',
+      is_group: 0,
+      unknown_sender_policy: 'decline_notify',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+
+    const event = mentionEvent('slack:D0STRANGER', { isGroup: false, senderId: 'U0STRANGER', senderName: 'Stranger' });
+    expect(await intercept(dm, event)).toBe('handled');
+
+    expect(mockDeclineAndNotify).toHaveBeenCalledTimes(1);
+    expect(mockDeclineAndNotify).toHaveBeenCalledWith({
+      messagingGroupId: dm.id,
+      agentGroupId: 'ag-andy',
+      senderIdentity: 'slack:U0STRANGER',
+      senderName: 'Stranger',
+      event,
+    });
+    expect(mockRecordDropped).toHaveBeenCalledTimes(1);
+    expect(await getMessagingGroupAgents(dm.id)).toHaveLength(0);
+    expect(mockRouteInbound).not.toHaveBeenCalled();
+  });
+
+  it('owner DM with decline_notify policy: never declined — card fallback', async () => {
+    await seedOwnerAndInstanceDm();
+    const dm = await mg({
+      id: 'mg-dm-owner',
+      platform_id: 'slack:D0OWNER',
+      is_group: 0,
+      unknown_sender_policy: 'decline_notify',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: OPERATOR });
+
+    const event = mentionEvent('slack:D0OWNER', { isGroup: false, senderId: OPERATOR, senderName: 'Gavriel' });
+    expect(await intercept(dm, event)).toBe('card');
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('stranger 1:1 DM with the stale request_approval default: declines and stamps the row decline_notify', async () => {
+    await seedOwnerAndInstanceDm();
+    const dm = await mg({
+      id: 'mg-dm-x',
+      platform_id: 'slack:D0X',
+      is_group: 0,
+      unknown_sender_policy: 'request_approval',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+
+    const event = mentionEvent('slack:D0X', { isGroup: false, senderId: 'U0STRANGER', senderName: 'Stranger' });
+    expect(await intercept(dm, event)).toBe('handled');
+
+    expect(mockDeclineAndNotify).toHaveBeenCalledTimes(1);
+    expect(mockDeclineAndNotify).toHaveBeenCalledWith({
+      messagingGroupId: dm.id,
+      agentGroupId: 'ag-andy',
+      senderIdentity: 'slack:U0STRANGER',
+      senderName: 'Stranger',
+      event,
+    });
+    // The D24 flip is stamped onto the row so the DB matches the behavior.
+    expect(await getMessagingGroup(dm.id)).toMatchObject({ unknown_sender_policy: 'decline_notify' });
+  });
+
+  it("1:1 DM with an operator-set 'strict' or 'public' policy keeps today's card", async () => {
+    await seedOwnerAndInstanceDm();
+    for (const policy of ['strict', 'public'] as const) {
+      const dm = await mg({
+        id: `mg-dm-${policy}`,
+        platform_id: `slack:D0${policy.toUpperCase()}`,
+        is_group: 0,
+        unknown_sender_policy: policy,
+      });
+      mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+      expect(await intercept(dm, mentionEvent(dm.platform_id, { isGroup: false, senderId: 'U0STRANGER' }))).toBe(
+        'card',
+      );
+      expect(await getMessagingGroup(dm.id)).toMatchObject({ unknown_sender_policy: policy });
+    }
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('stranger 1:1 DM with ambiguous instance→agent-group resolution: card, no decline', async () => {
+    await seedOwnerAndInstanceDm();
+    // A second DM wiring on the same instance to a different agent group —
+    // privileged senders can't be recognized, so nobody may be declined.
+    const dm2 = await mg({ id: 'mg-dm-pixel', platform_id: 'slack:D0PIXEL', is_group: 0 });
+    await wire(dm2.id, 'ag-pixel');
+    const dm = await mg({
+      id: 'mg-dm-ambig',
+      platform_id: 'slack:D0AMBIG',
+      is_group: 0,
+      unknown_sender_policy: 'decline_notify',
+    });
+    mockApi.slackConversationsInfo.mockResolvedValue({ isMpim: false, creator: 'U0STRANGER' });
+
+    expect(await intercept(dm, mentionEvent('slack:D0AMBIG', { isGroup: false, senderId: 'U0STRANGER' }))).toBe('card');
+    expect(mockDeclineAndNotify).not.toHaveBeenCalled();
+  });
+
+  it('conversations.members failure: card fallback (never silent loss)', async () => {
+    await seedOwnerAndInstanceDm();
+    const room = await mg({ id: 'mg-room', platform_id: 'slack:C0ROOM', unknown_sender_policy: 'request_approval' });
+    mockApi.slackConversationsMembers.mockRejectedValue(new Error('ratelimited'));
+
+    expect(await intercept(room, mentionEvent('slack:C0ROOM'))).toBe('card');
+    expect(await getMessagingGroupAgents(room.id)).toHaveLength(0);
+  });
+});

--- a/src/modules/slack-room-membership/membership.ts
+++ b/src/modules/slack-room-membership/membership.ts
@@ -1,0 +1,824 @@
+/**
+ * Slack room-membership handling (plan 04 §Slack-UI membership changes, D17).
+ *
+ * Reacts to member_joined_channel / member_left_channel events forwarded by
+ * the Chat SDK bridge (generic membership seam: setMembershipHandler('slack',
+ * …) — registration lives in ./index.ts). Four cases:
+ *
+ *  1. OWN bot joined an unknown channel/MPIM → the adopt flow: auto-create
+ *     the messaging-group row (mirroring the router's auto-create shape) and
+ *     fire the EXISTING channel-approval card with a synthesized greeting
+ *     event — the card's dedupe (pending-row PK) rides along for free; the
+ *     `denied_at` tombstone is checked here (the router only checks it on its
+ *     own path). On approve the greeting replays through routeInbound, so the
+ *     agent introduces itself. Since B2/D24 the card is the FALLBACK only:
+ *     requestChannelApproval consults slackChannelCardInterceptor (below)
+ *     first — owner present in the room → auto-wire 'public' +
+ *     mention/accumulate, no card; stranger 1:1 DMs → decline-and-notify.
+ *  2. MPIM-fork carry-over: Slack NEVER adds members to a group DM in place —
+ *     it forks a NEW conversation. Before firing the card in case 1, if the
+ *     joined channel is an MPIM whose member set is a superset of an existing
+ *     wired room's members (checked on this instance), mirror that room's mg
+ *     rows + wirings — for EVERY instance wired to the old room, same engage
+ *     values — onto the new channel id, carry the SLACK_A2A_ROOMS allowlist
+ *     entry when the old room had one, and post a brief "room moved" note
+ *     instead of asking for approval. The old room is left untouched.
+ *  3. OWN bot left a wired channel → mark the mg detached (migration 021,
+ *     `messaging_groups.detached_at`); a rejoin clears the flag. Routing goes
+ *     quiet on its own (no more inbound events); delivery-side callers should
+ *     consult `isMessagingGroupDetached` before sends.
+ *  4. Anyone else (human or foreign bot) joined/left a WIRED room → concise
+ *     system note into the room sessions of every wired agent group so agents
+ *     know the membership changed. No approval, no gating (D17: a2a stays
+ *     unrestricted for these rooms).
+ *
+ * The own-bot join path waits JOIN_RECHECK_DELAY_MS before deciding: when an
+ * agent-provisioning flow itself opens an MPIM, the join event can beat the
+ * flow's own room-wire writes — the recheck sees the flow's rows and stays
+ * silent instead of approval-spamming the operator.
+ */
+import { resolveUnknownSenderPolicy } from '../../channels/channel-defaults.js';
+import type { InboundEvent } from '../../channels/adapter.js';
+import {
+  botTokenKeyForInstance,
+  slackAuthTest,
+  slackConversationsInfo,
+  slackConversationsMembers,
+  slackPostMessage,
+} from '../../channels/slack-lib.js';
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { recordDroppedMessage } from '../../db/dropped-messages.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  setMessagingGroupDetachedAt,
+  updateMessagingGroup,
+} from '../../db/messaging-groups.js';
+import { getSessionsByAgentGroup } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { routeInbound } from '../../router.js';
+import { writeSessionMessage } from '../../session-manager.js';
+import type { MessagingGroup } from '../../types.js';
+import { canAccessAgentGroup } from '../permissions/access.js';
+import { requestChannelApproval } from '../permissions/channel-approval.js';
+import { getOwners } from '../permissions/db/user-roles.js';
+import { declineAndNotify } from '../permissions/sender-approval.js';
+import { appendToEnvList, readEnvValue } from './env-file.js';
+
+/** Structural mirror of the bridge's MembershipEvent (generic membership
+ *  seam) — declared locally so this file (and its tests) has no bridge
+ *  import. */
+export interface MembershipEvent {
+  instance: string;
+  channelType: string;
+  channelId: string;
+  userId: string;
+  inviterId?: string;
+  left?: boolean;
+}
+
+/** Test/config seam for handleSlackMembershipEvent. */
+export interface MembershipOpts {
+  /** Override the own-join recheck delay (tests pass 0). */
+  joinRecheckDelayMs?: number;
+  /** Repo root for .env reads; defaults to process.cwd(). */
+  rootDir?: string;
+}
+
+/** Own-join settle window — covers the provisioning flow's open→wire gap. */
+export const JOIN_RECHECK_DELAY_MS = 3000;
+
+/**
+ * Chat SDK 4.29 encodes member_joined_channel channel ids as Slack thread
+ * ids (`slack:C…:`), while direct/test callers may still supply raw `C…` or
+ * `G…` ids. Collapse both shapes before any DB lookup or Slack API call.
+ *
+ * The `slack` prefix allowlist deliberately covers named instances too:
+ * multi-instance registration (slack-instances.ts, skill-installed) passes
+ * `slack-<name>` only to the BRIDGE as a host-side routing key — the SDK
+ * adapter underneath is always createSlackAdapter, whose encoded ids stay
+ * `slack:C…:`-shaped, and the bridge forwards event.channelId verbatim. So
+ * `slack-<name>:C…`-shaped ids do not occur. Revisit this helper if that
+ * ever changes (e.g. an instance-named SDK adapter).
+ */
+function normalizeSlackMembershipChannelId(value: string): string | null {
+  const parts = value.split(':');
+  const raw =
+    parts.length === 1
+      ? parts[0]
+      : (parts.length === 2 || parts.length === 3) && parts[0] === 'slack'
+        ? parts[1]
+        : undefined;
+  return raw && /^[CG][A-Z0-9]+$/.test(raw) ? raw : null;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+// ── Own-bot identity ──
+
+/** auth.test result per instance — bot user ids are stable for a token's lifetime. */
+const ownBotIdCache = new Map<string, string>();
+
+/** Test seam: forget cached bot identities (tokens rotate between tests). */
+export function clearOwnBotIdCache(): void {
+  ownBotIdCache.clear();
+}
+
+async function resolveOwnBotUserId(instance: string, rootDir: string): Promise<string | undefined> {
+  const cached = ownBotIdCache.get(instance);
+  if (cached) return cached;
+  const token = readEnvValue(rootDir, botTokenKeyForInstance(instance));
+  if (!token) {
+    log.debug('slack-room-membership: no bot token for instance — cannot resolve own identity', { instance });
+    return undefined;
+  }
+  try {
+    const auth = await slackAuthTest(token, 'membership');
+    ownBotIdCache.set(instance, auth.userId);
+    return auth.userId;
+  } catch (err) {
+    log.warn('slack-room-membership: auth.test failed resolving own bot identity', { instance, err });
+    return undefined;
+  }
+}
+
+// ── Case 1: adopt flow ──
+
+/** Mirror of the router's auto-create shape (router.ts routeInbound step 1). */
+async function createAdoptedMessagingGroup(instance: string, platformId: string): Promise<MessagingGroup> {
+  const mg: MessagingGroup = {
+    id: generateId('mg'),
+    channel_type: 'slack',
+    platform_id: platformId,
+    instance,
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: resolveUnknownSenderPolicy(instance, true, 'slack'),
+    denied_at: null,
+    created_at: new Date().toISOString(),
+  };
+  await createMessagingGroup(mg);
+  log.info('Auto-created messaging group (bot invited via Slack UI)', {
+    id: mg.id,
+    platformId,
+    instance,
+  });
+  return mg;
+}
+
+/**
+ * The replayable greeting standing in for the "original message" the
+ * mention-triggered flow would have stored: on approve it routes like a
+ * mention (isMention) and instructs the agent to introduce itself. The
+ * inviter rides as sender/senderId, so the card shows invited-by context and
+ * the approve path auto-admits the inviter as a member.
+ */
+function synthesizeJoinEvent(event: MembershipEvent, platformId: string): InboundEvent {
+  const inviter = event.inviterId;
+  return {
+    channelType: 'slack',
+    instance: event.instance,
+    platformId,
+    threadId: null,
+    message: {
+      id: `slack-join-${event.channelId}-${Date.now()}`,
+      kind: 'chat',
+      timestamp: new Date().toISOString(),
+      isMention: true,
+      isGroup: true,
+      content: JSON.stringify({
+        text: inviter
+          ? `<@${inviter}> invited the bot to this channel. Introduce yourself briefly and say what you can help with.`
+          : 'The bot was added to this channel. Introduce yourself briefly and say what you can help with.',
+        sender: inviter ? `<@${inviter}>` : 'system',
+        ...(inviter ? { senderId: inviter, senderName: `<@${inviter}> (invited the bot)` } : {}),
+      }),
+    },
+  };
+}
+
+// ── Case 2: MPIM-fork carry-over ──
+
+async function tryMpimForkCarryOver(args: {
+  instance: string;
+  channelId: string;
+  platformId: string;
+  token: string;
+  rootDir: string;
+}): Promise<boolean> {
+  let isMpim: boolean;
+  try {
+    isMpim = (await slackConversationsInfo(args.token, args.channelId, 'membership')).isMpim;
+  } catch (err) {
+    log.warn('slack-room-membership: conversations.info failed — skipping fork check', {
+      channelId: args.channelId,
+      err,
+    });
+    return false;
+  }
+  if (!isMpim) return false;
+
+  let newMembers: Set<string>;
+  try {
+    newMembers = new Set(await slackConversationsMembers(args.token, args.channelId, 'membership'));
+  } catch (err) {
+    log.warn('slack-room-membership: conversations.members failed — skipping fork check', {
+      channelId: args.channelId,
+      err,
+    });
+    return false;
+  }
+  if (newMembers.size === 0) return false;
+
+  const all = await getAllMessagingGroups();
+  // Candidate old rooms: wired slack group rooms visible to THIS instance —
+  // the superset check needs our bot in both channels for members reads.
+  const candidates = all.filter(
+    (m) =>
+      m.channel_type === 'slack' &&
+      m.is_group === 1 &&
+      (m.instance ?? m.channel_type) === args.instance &&
+      m.platform_id.startsWith('slack:') &&
+      m.platform_id !== args.platformId &&
+      !m.denied_at,
+  );
+
+  for (const candidate of candidates) {
+    if ((await getMessagingGroupAgents(candidate.id)).length === 0) continue;
+    const oldChannelId = candidate.platform_id.slice('slack:'.length);
+    let oldMembers: string[];
+    try {
+      oldMembers = await slackConversationsMembers(args.token, oldChannelId, 'membership');
+    } catch {
+      continue; // bot no longer in the old room (or API hiccup) — not a fork source we can prove
+    }
+    if (oldMembers.length === 0 || !oldMembers.every((m) => newMembers.has(m))) continue;
+
+    // Fork detected — mirror EVERY instance's row for the old room, same
+    // agent groups, same engage values. The old room stays untouched (it
+    // still works; Slack keeps both conversations alive).
+    const now = new Date().toISOString();
+    const family = all.filter((m) => m.channel_type === 'slack' && m.platform_id === candidate.platform_id);
+    const carriedAgentGroups = new Set<string>();
+    for (const oldMg of family) {
+      const oldWirings = await getMessagingGroupAgents(oldMg.id);
+      if (oldWirings.length === 0) continue;
+      let newMg = await getMessagingGroupByPlatform('slack', args.platformId, oldMg.instance ?? 'slack');
+      if (!newMg) {
+        newMg = {
+          id: generateId('mg'),
+          channel_type: 'slack',
+          platform_id: args.platformId,
+          instance: oldMg.instance ?? 'slack',
+          name: oldMg.name,
+          is_group: 1,
+          unknown_sender_policy: oldMg.unknown_sender_policy,
+          denied_at: null,
+          created_at: now,
+        };
+        await createMessagingGroup(newMg);
+      }
+      for (const oldWiring of oldWirings) {
+        if (await getMessagingGroupAgentByPair(newMg.id, oldWiring.agent_group_id)) continue;
+        await createMessagingGroupAgent({
+          id: generateId('mga'),
+          messaging_group_id: newMg.id,
+          agent_group_id: oldWiring.agent_group_id,
+          engage_mode: oldWiring.engage_mode,
+          engage_pattern: oldWiring.engage_pattern,
+          sender_scope: oldWiring.sender_scope,
+          ignored_message_policy: oldWiring.ignored_message_policy,
+          session_mode: oldWiring.session_mode,
+          priority: oldWiring.priority,
+          ...(oldWiring.threads !== undefined && oldWiring.threads !== null ? { threads: oldWiring.threads } : {}),
+          created_at: now,
+        });
+        carriedAgentGroups.add(oldWiring.agent_group_id);
+      }
+    }
+    for (const agentGroupId of carriedAgentGroups) {
+      await projectDestinationsToSessions(agentGroupId);
+    }
+
+    // Carry the a2a allowlist entry when the old room had one.
+    const allowlisted = (readEnvValue(args.rootDir, 'SLACK_A2A_ROOMS') ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .includes(oldChannelId);
+    if (allowlisted) {
+      try {
+        appendToEnvList(args.rootDir, 'SLACK_A2A_ROOMS', args.channelId);
+      } catch (err) {
+        log.warn('slack-room-membership: SLACK_A2A_ROOMS carry-over write failed', {
+          channelId: args.channelId,
+          err,
+        });
+      }
+    }
+
+    try {
+      await slackPostMessage(
+        args.token,
+        args.channelId,
+        "Room moved — I carried the previous room's wiring over. Same agents, same behavior; the old room keeps working too.",
+      );
+    } catch (err) {
+      log.warn('slack-room-membership: room-moved note failed', { channelId: args.channelId, err });
+    }
+
+    log.info('MPIM fork carry-over applied', {
+      fromChannelId: oldChannelId,
+      toChannelId: args.channelId,
+      instance: args.instance,
+      agentGroups: [...carriedAgentGroups],
+      a2aCarried: allowlisted,
+    });
+    return true;
+  }
+  return false;
+}
+
+// ── Case handlers ──
+
+async function handleOwnJoin(event: MembershipEvent, platformId: string, opts: MembershipOpts): Promise<void> {
+  // Settle window: a provisioning flow's own room rows land moments after
+  // the join event when the flow itself opened the MPIM.
+  await sleep(opts.joinRecheckDelayMs ?? JOIN_RECHECK_DELAY_MS);
+
+  const rootDir = opts.rootDir ?? process.cwd();
+  let mg = await getMessagingGroupByPlatform('slack', platformId, event.instance);
+  if (mg && (await getMessagingGroupAgents(mg.id)).length > 0) {
+    // Already wired (flow-created or previously adopted). A rejoin re-attaches.
+    if (mg.detached_at) {
+      await setMessagingGroupDetachedAt(mg.id, null);
+      log.info('Messaging group re-attached — bot rejoined', { messagingGroupId: mg.id, platformId });
+    }
+    return;
+  }
+  if (mg?.denied_at) {
+    log.debug('Bot invited to a denied channel — tombstone holds, no approval card', {
+      messagingGroupId: mg.id,
+      platformId,
+    });
+    return;
+  }
+  if (mg?.detached_at) await setMessagingGroupDetachedAt(mg.id, null);
+
+  const token = readEnvValue(rootDir, botTokenKeyForInstance(event.instance));
+
+  // Canvas shadow channels: creating a canvas on an MPIM makes Slack
+  // materialize a hidden Slackbot-owned private channel as the canvas's
+  // access container and add the room's members to it (observed live:
+  // canvas F0… spawns channel C0… with the same id suffix). It fires real
+  // member_joined events but is never a conversation to adopt — no mg row,
+  // no approval card. Slackbot never creates adoptable channels, so the
+  // creator check covers this class wholesale.
+  if (token) {
+    try {
+      const info = await slackConversationsInfo(token, event.channelId, 'membership');
+      if (info.creator === 'USLACKBOT') {
+        log.debug('Ignoring Slackbot-created shadow channel', { channelId: event.channelId });
+        return;
+      }
+    } catch (err) {
+      log.warn('slack-room-membership: conversations.info failed — continuing without shadow check', {
+        channelId: event.channelId,
+        err,
+      });
+    }
+  }
+
+  if (
+    token &&
+    (await tryMpimForkCarryOver({
+      instance: event.instance,
+      channelId: event.channelId,
+      platformId,
+      token,
+      rootDir,
+    }))
+  ) {
+    return;
+  }
+
+  if (!mg) mg = await createAdoptedMessagingGroup(event.instance, platformId);
+  // Dedupe of a second join/mention while pending is requestChannelApproval's
+  // own in-flight check (pending_channel_approvals PK on messaging_group_id).
+  // The owner-presence rule (D24) rides along for free: requestChannelApproval
+  // consults slackChannelCardInterceptor below, so an owner-containing room
+  // auto-wires (agent introduces itself via the synthesized greeting) and only
+  // owner-absent rooms actually card.
+  await requestChannelApproval({ messagingGroupId: mg.id, event: synthesizeJoinEvent(event, platformId) });
+}
+
+async function handleOwnLeft(event: MembershipEvent, platformId: string): Promise<void> {
+  const mg = await getMessagingGroupByPlatform('slack', platformId, event.instance);
+  if (!mg) return;
+  await setMessagingGroupDetachedAt(mg.id, new Date().toISOString());
+  log.info('Messaging group detached — bot left the channel', { messagingGroupId: mg.id, platformId });
+}
+
+/** Case 4: membership bookkeeping for wired rooms — a trigger=0 system note
+ *  into every wired agent group's room sessions (D17: no approval, no gating). */
+async function handleMemberChange(event: MembershipEvent, platformId: string): Promise<void> {
+  const mg = await getMessagingGroupByPlatform('slack', platformId, event.instance);
+  if (!mg || mg.is_group !== 1) return;
+  const wirings = await getMessagingGroupAgents(mg.id);
+  if (wirings.length === 0) return;
+
+  const action = event.left ? 'left' : 'joined';
+  const inviter = !event.left && event.inviterId ? ` (invited by <@${event.inviterId}>)` : '';
+  const text = `Room membership changed: <@${event.userId}> ${action} this room${inviter}.`;
+  const timestamp = new Date().toISOString();
+
+  for (const wiring of wirings) {
+    const sessions = (await getSessionsByAgentGroup(wiring.agent_group_id)).filter(
+      (s) => s.messaging_group_id === mg.id && s.status === 'active',
+    );
+    for (const session of sessions) {
+      try {
+        // kind 'chat' + sender 'system' + channelType 'agent' mirrors the
+        // container-restart system-note shape. NOT kind 'system': those rows
+        // are reserved for MCP tool responses and the container poll loop
+        // filters them out of agent batches (poll-loop.ts) — a 'system'-kind
+        // note would sit pending forever and never reach the agent.
+        await writeSessionMessage(wiring.agent_group_id, session.id, {
+          id: generateId(`member-${event.channelId}`),
+          kind: 'chat',
+          timestamp,
+          platformId,
+          channelType: 'agent',
+          threadId: null,
+          content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
+          trigger: false,
+        });
+      } catch (err) {
+        log.warn('slack-room-membership: membership note write failed', {
+          sessionId: session.id,
+          messagingGroupId: mg.id,
+          err,
+        });
+      }
+    }
+  }
+  log.info('Room membership note written', { messagingGroupId: mg.id, userId: event.userId, action });
+}
+
+// ── Owner-presence access rule + channel-card interception (B2/D24) ──
+
+/** Owner Slack user ids (raw U… form) from user_roles — the presence probe key. */
+async function resolveOwnerSlackUserIds(): Promise<string[]> {
+  return (await getOwners())
+    .map((r) => r.user_id)
+    .filter((id) => id.startsWith('slack:'))
+    .map((id) => id.slice('slack:'.length));
+}
+
+/**
+ * The agent group a Slack instance "is": the distinct agent group across the
+ * instance's existing wirings, DM wirings first (every per-agent instance has
+ * one). Exactly one distinct hit wins; ambiguous or empty → undefined and the
+ * caller falls back to the approval card.
+ */
+async function resolveInstanceAgentGroup(instance: string): Promise<{ id: string; name: string } | undefined> {
+  const rows = (await getAllMessagingGroups()).filter(
+    (m) => m.channel_type === 'slack' && (m.instance ?? m.channel_type) === instance,
+  );
+  for (const dmOnly of [true, false]) {
+    const ids = new Set<string>();
+    for (const m of rows) {
+      if (dmOnly && m.is_group !== 0) continue;
+      for (const wiring of await getMessagingGroupAgents(m.id)) ids.add(wiring.agent_group_id);
+    }
+    if (ids.size === 1) {
+      const id = [...ids][0]!;
+      const ag = await getAgentGroup(id);
+      if (ag) return { id, name: ag.name };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Dedupe key for the owner-absent channel decline. Constant on purpose — the
+ * decline describes the channel, so it fires once per channel per the stamp's
+ * 24h window regardless of who triggered it.
+ */
+const CHANNEL_DECLINE_KEY = 'channel:requires-owner';
+
+/**
+ * Owner-absent channel invite: decline it in place instead of asking the
+ * owner to rule on it.
+ *
+ * Slack lets any workspace member add an installed app to a channel, and the
+ * bot shows up in the member list immediately — visibly present before its
+ * owner has consented to anything. The host already keeps it inert, so the
+ * gap this closes is expectation, not authorization: everyone in the channel
+ * sees a bot that looks like it is listening, and the only person told
+ * otherwise was the owner.
+ *
+ * Three effects, none of them a wiring: one line in the channel explaining
+ * the bot cannot be connected by whoever invited it and asking to be removed,
+ * an informational FYI to the owner, and a dropped-message record. Nothing is
+ * routed — the caller returns 'handled', so `requestChannelApproval` never
+ * builds a card.
+ *
+ * The bot cannot remove itself: `conversations.leave` needs a channel write
+ * scope the app does not carry, so the message has to ask a human.
+ *
+ * Dedupe is per CHANNEL, not per sender (declineAndNotify's default): the
+ * decline is a fact about the conversation, and a second person mentioning
+ * the bot should not produce a second post.
+ */
+async function declineChannelInvite(args: {
+  mg: MessagingGroup;
+  event: InboundEvent;
+  agentGroup: { id: string; name: string } | undefined;
+  channelName: string | null;
+}): Promise<'handled'> {
+  const { mg, event, agentGroup, channelName } = args;
+  const sender = senderFromEvent(event);
+  const where = channelName ? `#${channelName}` : 'a channel';
+  const who = sender.name ?? sender.userId ?? 'Someone';
+
+  try {
+    await recordDroppedMessage({
+      channel_type: 'slack',
+      platform_id: event.platformId,
+      user_id: sender.userId,
+      sender_name: sender.name,
+      reason: 'channel_requires_owner',
+      messaging_group_id: mg.id,
+      agent_group_id: agentGroup?.id ?? null,
+    });
+
+    await declineAndNotify({
+      messagingGroupId: mg.id,
+      agentGroupId: agentGroup?.id ?? null,
+      senderIdentity: sender.userId,
+      senderName: sender.name,
+      event,
+      dedupeKey: CHANNEL_DECLINE_KEY,
+      declineText:
+        "I can only be connected to a channel by my owner, so I won't respond here. " +
+        'Please remove me from this channel — if my owner wants me here, they can add me back.',
+      fyiText:
+        `FYI: ${who} added your agent to ${where} on Slack. Only you can connect it there, so it ` +
+        'declined in the channel and asked to be removed. Add it yourself if you do want it there.',
+    });
+  } catch (err) {
+    // Fail closed to 'handled': the point of this branch is that an
+    // owner-absent channel invite does not become a card, and a delivery
+    // failure must not resurrect one.
+    log.error('slack-room-membership: channel decline path failed — suppressed', {
+      messagingGroupId: mg.id,
+      err,
+    });
+  }
+  return 'handled';
+}
+
+/** Sender identity off an inbound payload — top-level senderId/sender (v1,
+ *  synthesized events) or the chat-sdk bridge's nested author.userId. */
+function senderFromEvent(event: InboundEvent): { userId: string | null; name: string | null } {
+  try {
+    const parsed = JSON.parse(event.message.content) as Record<string, unknown>;
+    const author =
+      typeof parsed.author === 'object' && parsed.author !== null
+        ? (parsed.author as Record<string, unknown>)
+        : undefined;
+    const raw =
+      (typeof parsed.senderId === 'string' ? parsed.senderId : undefined) ??
+      (typeof parsed.sender === 'string' ? parsed.sender : undefined) ??
+      (typeof author?.userId === 'string' ? (author.userId as string) : undefined);
+    const name =
+      (typeof parsed.senderName === 'string' ? parsed.senderName : undefined) ??
+      (typeof author?.fullName === 'string' ? (author.fullName as string) : undefined) ??
+      null;
+    if (!raw) return { userId: null, name };
+    return { userId: raw.includes(':') ? raw : `slack:${raw}`, name };
+  } catch {
+    return { userId: null, name: null };
+  }
+}
+
+/**
+ * THE Slack channel-card interceptor (registered via
+ * registerChannelCardInterceptor in ./index.ts) — consulted by
+ * requestChannelApproval before any card goes out, which means BOTH
+ * escalation paths funnel here: the router's mention path (step 1b) and this
+ * module's own join-time adopt (handleOwnJoin calls requestChannelApproval).
+ * Decides per D24's owner-presence rule:
+ *
+ *   - Slackbot-created shadow channel (canvas comment container) → silent
+ *     'handled' — mirrors handleOwnJoin's guard for events that arrive via
+ *     the mention path (canvases created outside our flow).
+ *   - 1:1 DM, unknown sender → polite decline + owner FYI ('handled').
+ *     Keyed on D24 itself, not on a pre-set policy value: the Slack
+ *     adapter's declared DM default is still the pre-B2 'request_approval'
+ *     (the declaration lives on the channels branch), so rows carrying that
+ *     stale default decline exactly like 'decline_notify' ones and get
+ *     stamped 'decline_notify' so the row matches the behavior. Deliberate
+ *     operator overrides ('strict', 'public') and known/privileged senders
+ *     keep the card.
+ *   - Group/MPIM with the OWNER in the member list → auto-wire: mg flips to
+ *     'public', the instance's agent group gets a mention/accumulate wiring
+ *     (room semantics), the triggering event replays ('handled', no card).
+ *   - Anything else (owner absent, no token, ambiguous instance→agent-group
+ *     resolution, API failure) → 'card', today's notify-and-ask flow.
+ */
+export async function slackChannelCardInterceptor(
+  mg: MessagingGroup,
+  event: InboundEvent,
+  opts: MembershipOpts = {},
+): Promise<'card' | 'handled'> {
+  const rootDir = opts.rootDir ?? process.cwd();
+  const instance = mg.instance ?? 'slack';
+  const token = readEnvValue(rootDir, botTokenKeyForInstance(instance));
+  const channelId = mg.platform_id.startsWith('slack:') ? mg.platform_id.slice('slack:'.length) : mg.platform_id;
+
+  // USLACKBOT backstop: shadow channels are never conversations to card.
+  // The same lookup classifies the conversation for the owner-absent branch
+  // below (MPIM vs channel) — one round trip, not two.
+  let convInfo: { isMpim: boolean; name?: string; creator?: string } | null = null;
+  if (token) {
+    try {
+      convInfo = await slackConversationsInfo(token, channelId, 'membership');
+      if (convInfo.creator === 'USLACKBOT') {
+        log.debug('Ignoring Slackbot-created shadow channel (card path)', { channelId });
+        return 'handled';
+      }
+    } catch (err) {
+      log.warn('slack-room-membership: conversations.info failed — continuing without shadow check', {
+        channelId,
+        err,
+      });
+    }
+  }
+
+  const isGroup = event.message.isGroup ?? mg.is_group === 1;
+  const agentGroup = await resolveInstanceAgentGroup(instance);
+
+  if (!isGroup) {
+    // 1:1 DM — the owner is never "present" (D24 table): unknown senders are
+    // declined-and-notified. Keyed on the D24 rule itself, not on a pre-set
+    // policy value: router-auto-created DM rows still carry the adapter's
+    // stale declared default 'request_approval' (the flip lives on the
+    // channels branch), so both shapes decline; deliberate operator
+    // overrides ('strict', 'public') keep today's card.
+    if (mg.unknown_sender_policy !== 'decline_notify' && mg.unknown_sender_policy !== 'request_approval') {
+      return 'card';
+    }
+    if (!agentGroup) {
+      // Ambiguous instance→agent-group resolution (e.g. a shared instance
+      // wired to two agent groups): privileged senders can't be recognized,
+      // so mirror the group branch — card, never a misdirected decline.
+      log.warn('slack-room-membership: DM instance→agent-group resolution is ambiguous — card, no decline', {
+        instance,
+        channelId,
+      });
+      return 'card';
+    }
+    const sender = senderFromEvent(event);
+    // Known/privileged senders are never declined — their DM still cards.
+    if (sender.userId && (await canAccessAgentGroup(sender.userId, agentGroup.id)).allowed) return 'card';
+    // Stamp the D24 default onto rows still carrying the stale declared
+    // policy, so the row reflects the behavior (ncl dumps, access gate).
+    if (mg.unknown_sender_policy !== 'decline_notify') {
+      await updateMessagingGroup(mg.id, { unknown_sender_policy: 'decline_notify' });
+    }
+    await recordDroppedMessage({
+      channel_type: 'slack',
+      platform_id: event.platformId,
+      user_id: sender.userId,
+      sender_name: sender.name,
+      reason: 'unknown_sender_decline_notify',
+      messaging_group_id: mg.id,
+      agent_group_id: agentGroup.id,
+    });
+    await declineAndNotify({
+      messagingGroupId: mg.id,
+      agentGroupId: agentGroup.id,
+      senderIdentity: sender.userId,
+      senderName: sender.name,
+      event,
+    });
+    return 'handled';
+  }
+
+  // Group / MPIM / channel — the owner-presence rule proper.
+  if (!token) return 'card';
+  const ownerIds = await resolveOwnerSlackUserIds();
+  if (ownerIds.length === 0) return 'card';
+  let members: string[];
+  try {
+    members = await slackConversationsMembers(token, channelId, 'membership');
+  } catch (err) {
+    log.warn('slack-room-membership: conversations.members failed — falling back to the card', { channelId, err });
+    return 'card';
+  }
+  if (!ownerIds.some((id) => members.includes(id))) {
+    // Owner absent. A named channel is a surface anyone in the workspace can
+    // drag the bot into, and Slack shows it as a member the moment they do —
+    // before its owner has agreed to anything. Rather than ask the owner to
+    // adjudicate an invitation they did not make, decline it the way an
+    // unknown DM is declined: say so in the channel, tell the owner, wire
+    // nothing. MPIMs keep the card — a group DM is a deliberate, small,
+    // named set of people, and its invite is a normal ask.
+    if (convInfo?.isMpim !== false) return 'card';
+    return declineChannelInvite({ mg, event, agentGroup, channelName: convInfo.name ?? null });
+  }
+
+  if (!agentGroup) {
+    log.warn('slack-room-membership: owner present but instance→agent-group resolution is ambiguous — card', {
+      instance,
+      channelId,
+    });
+    return 'card';
+  }
+
+  // Owner present → open: 'public' mg + mention/accumulate wiring (room
+  // semantics — anyone there can task the agent; unmentioned chatter
+  // accumulates as context). No card, no notification.
+  await updateMessagingGroup(mg.id, { unknown_sender_policy: 'public' });
+  if (!(await getMessagingGroupAgentByPair(mg.id, agentGroup.id))) {
+    await createMessagingGroupAgent({
+      id: generateId('mga'),
+      messaging_group_id: mg.id,
+      agent_group_id: agentGroup.id,
+      engage_mode: 'mention',
+      engage_pattern: null,
+      sender_scope: 'all',
+      ignored_message_policy: 'accumulate',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: new Date().toISOString(),
+    });
+  }
+  await projectDestinationsToSessions(agentGroup.id);
+  log.info('Owner present — channel auto-wired, no card', {
+    messagingGroupId: mg.id,
+    channelId,
+    instance,
+    agentGroupId: agentGroup.id,
+  });
+
+  // Replay the triggering event through normal routing so the agent answers
+  // the mention (or introduces itself, on the join path's synthesized event).
+  try {
+    await routeInbound(event);
+  } catch (err) {
+    log.error('slack-room-membership: replay after auto-wire failed', { messagingGroupId: mg.id, err });
+  }
+  return 'handled';
+}
+
+// ── Entry ──
+
+/**
+ * THE membership handler (registered via setMembershipHandler('slack', …) in
+ * ./index.ts). Never throws — the bridge fire-and-forgets, and a failure here
+ * must never affect SDK dispatch or sibling events.
+ */
+export async function handleSlackMembershipEvent(event: MembershipEvent, opts: MembershipOpts = {}): Promise<void> {
+  try {
+    const channelId = normalizeSlackMembershipChannelId(event.channelId);
+    if (!channelId) {
+      log.warn('slack-room-membership: invalid channel id — ignoring membership event', {
+        channelId: event.channelId,
+        userId: event.userId,
+      });
+      return;
+    }
+
+    const normalizedEvent = channelId === event.channelId ? event : { ...event, channelId };
+    const platformId = `slack:${channelId}`;
+    const ownBotUserId = await resolveOwnBotUserId(normalizedEvent.instance, opts.rootDir ?? process.cwd());
+    const isOwnBot = ownBotUserId !== undefined && normalizedEvent.userId === ownBotUserId;
+
+    if (isOwnBot) {
+      if (normalizedEvent.left) await handleOwnLeft(normalizedEvent, platformId);
+      else await handleOwnJoin(normalizedEvent, platformId, opts);
+      return;
+    }
+    await handleMemberChange(normalizedEvent, platformId);
+  } catch (err) {
+    log.error('slack-room-membership: event handling failed', {
+      channelId: event.channelId,
+      userId: event.userId,
+      err,
+    });
+  }
+}

--- a/src/provisioning/slack-app.test.ts
+++ b/src/provisioning/slack-app.test.ts
@@ -1,0 +1,530 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AGENT_BOT_EVENTS,
+  AGENT_BOT_SCOPES,
+  BOT_EVENTS,
+  BOT_SCOPES,
+  DEFAULT_SLACK_SERVICE_BASE,
+  MANAGED_APP_DESCRIPTION,
+  brokerAppStatus,
+  brokerProvision,
+  buildManagedAppManifest,
+  mapBrokerApp,
+  provisionManagedApp,
+  readInstallToken,
+  readManagerToken,
+  readServiceBase,
+  slackServiceForRegistry,
+  waitForInstall,
+} from './slack-app.js';
+
+interface ManifestShape {
+  display_information: { name: string; description: string };
+  features: {
+    bot_user: { display_name: string };
+    app_home: { messages_tab_enabled: boolean };
+    agent_view?: { agent_description: string };
+  };
+  oauth_config: { scopes: { bot: string[] } };
+  settings: {
+    socket_mode_enabled: boolean;
+    token_rotation_enabled: boolean;
+    event_subscriptions: { bot_events: string[] };
+  };
+}
+
+describe('buildManagedAppManifest', () => {
+  it('builds a socket-mode manifest; the default variant is agent-mode', () => {
+    const manifest = buildManagedAppManifest({ name: 'Trusty' }) as ManifestShape;
+
+    expect(manifest.display_information.name).toBe('Trusty');
+    expect(manifest.features.bot_user.display_name).toBe('Trusty');
+    expect(manifest.features.app_home.messages_tab_enabled).toBe(true);
+    // agent_view default: installs never fail; free workspaces degrade to a
+    // plain DM. The agent_description is the fixed attribution line.
+    expect(manifest.features.agent_view).toEqual({ agent_description: MANAGED_APP_DESCRIPTION });
+    expect(manifest.oauth_config.scopes.bot).toEqual([...BOT_SCOPES, ...AGENT_BOT_SCOPES]);
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([...BOT_EVENTS, ...AGENT_BOT_EVENTS]);
+    // Socket Mode is load-bearing: self-hosted installs have no public URL,
+    // and the adapter selects socket mode from SLACK_APP_TOKEN's presence.
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    // The adapter has no refresh-token handling; rotation must stay off.
+    expect(manifest.settings.token_rotation_enabled).toBe(false);
+  });
+
+  it('agentView:false selects the plain variant (guest-accessible bots)', () => {
+    const manifest = buildManagedAppManifest({ name: 'Trusty', agentView: false }) as ManifestShape;
+    expect(manifest.features.agent_view).toBeUndefined();
+    expect(manifest.oauth_config.scopes.bot).toEqual(BOT_SCOPES);
+    expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write');
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual(BOT_EVENTS);
+  });
+
+  it('never requests user scopes — bot-scopes-only is what makes auto-install eligible', () => {
+    for (const agentView of [true, false]) {
+      const manifest = buildManagedAppManifest({ name: 'x', agentView }) as {
+        oauth_config: { scopes: Record<string, unknown> };
+      };
+      expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
+    }
+  });
+
+  it('attribution fields never alter the manifest — they ride the broker body only', () => {
+    const plain = buildManagedAppManifest({ name: 'Trusty' });
+    const attributed = buildManagedAppManifest({
+      name: 'Trusty',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    expect(attributed).toEqual(plain);
+  });
+});
+
+describe('brokerProvision attribution fields', () => {
+  const fetchMock = vi.fn<(url: string, init?: { body?: unknown }) => Promise<unknown>>();
+  const appResponse = { app_id: 'A0NEW1', app_token: 'xapp-1-new', bot_token: 'xoxb-new' };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    process.env.SLACK_SERVICE_BASE = 'https://broker.test';
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(payload: object): object {
+    return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+  }
+
+  /** Route the module's outbound calls: avatar create, avatar poll, app create. */
+  function routeFetch(avatar: { avatar_id?: string | null; status?: string }): void {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://broker.test/v1/avatars') return jsonResponse({ avatar_id: avatar.avatar_id ?? null });
+      if (url.startsWith('https://broker.test/v1/avatars/')) return jsonResponse({ status: avatar.status ?? 'ready' });
+      if (url === 'https://broker.test/v1/apps') return jsonResponse(appResponse);
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+  }
+
+  function sentAppBody(): Record<string, unknown> {
+    const call = fetchMock.mock.calls.find(([url]) => url === 'https://broker.test/v1/apps');
+    expect(call).toBeDefined();
+    return JSON.parse((call![1] as { body: string }).body) as Record<string, unknown>;
+  }
+
+  it('rides the POST /v1/apps body verbatim when supplied', async () => {
+    routeFetch({ avatar_id: null });
+    const app = await brokerProvision('nct_x', {
+      team_id: 'T1',
+      name: 'Pixel',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    expect(sentAppBody()).toEqual({
+      team_id: 'T1',
+      name: 'Pixel',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    // The response mapping is untouched by the extra request fields.
+    expect(app.appId).toBe('A0NEW1');
+    expect(app.botToken).toBe('xoxb-new');
+  });
+
+  it('sends nothing extra when the fields are absent or explicitly undefined', async () => {
+    routeFetch({ avatar_id: null });
+    await brokerProvision('nct_x', { team_id: 'T1', name: 'Pixel', requested_by: undefined });
+    expect(sentAppBody()).toEqual({ team_id: 'T1', name: 'Pixel' });
+  });
+
+  it('keeps the avatar_id merge unchanged alongside attribution fields', async () => {
+    routeFetch({ avatar_id: 'av1', status: 'ready' });
+    await brokerProvision('nct_x', { team_id: 'T1', name: 'Pixel', client_version: '2.2.0' });
+    expect(sentAppBody()).toEqual({ team_id: 'T1', name: 'Pixel', avatar_id: 'av1', client_version: '2.2.0' });
+  });
+});
+
+describe('provisionManagedApp attribution fields', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('never forwards them to Slack — neither in the manifest nor as call params', async () => {
+    const fetchMock = vi.fn(async (url: string, _init?: { body?: unknown }) => {
+      if (url === 'https://slack.com/api/apps.manifest.create') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, app_id: 'A1', app_token: 'xapp-1', oauth_authorize_url: 'https://x' }),
+        };
+      }
+      if (url === 'https://slack.com/api/apps.managedInstall') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, api_access_tokens: { bot_access_token: 'xoxb-1' } }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const app = await provisionManagedApp('xoxp-mgr', {
+      name: 'Trusty',
+      requested_by: 'U0REQ1234',
+      parent_app_id: 'A0PARENT1',
+      template: 'research-buddy',
+      client_version: '2.2.0',
+    });
+    expect(app.botToken).toBe('xoxb-1');
+
+    const createCall = fetchMock.mock.calls.find(([url]) => url === 'https://slack.com/api/apps.manifest.create');
+    expect(createCall).toBeDefined();
+    const params = new URLSearchParams((createCall![1] as { body: string }).body);
+    expect([...params.keys()].sort()).toEqual(['generate_app_token', 'manifest']);
+    // The manifest is byte-identical to one built without attribution fields.
+    expect(JSON.parse(params.get('manifest')!)).toEqual(buildManagedAppManifest({ name: 'Trusty' }));
+  });
+});
+
+describe('readManagerToken', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    delete process.env.SLACK_MANAGER_TOKEN;
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it('prefers process env over .env', () => {
+    process.env.SLACK_MANAGER_TOKEN = 'xoxp-from-env';
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'SLACK_MANAGER_TOKEN=xoxp-from-file\n');
+    expect(readManagerToken(dir)).toBe('xoxp-from-env');
+  });
+
+  it('reads from .env, stripping quotes', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'OTHER=1\nSLACK_MANAGER_TOKEN="xoxp-from-file"\n');
+    expect(readManagerToken(dir)).toBe('xoxp-from-file');
+  });
+
+  it('returns undefined when absent', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    fs.writeFileSync(path.join(dir, '.env'), 'OTHER=1\n');
+    expect(readManagerToken(dir)).toBeUndefined();
+  });
+});
+
+describe('slackServiceForRegistry', () => {
+  it('swaps the host, keeping everything else about the deployment', () => {
+    expect(slackServiceForRegistry('https://registry.nanoclaw.dev')).toBe('https://slack.nanoclaw.dev');
+    expect(slackServiceForRegistry('https://registry.sandbox.nanoclaw.dev')).toBe('https://slack.sandbox.nanoclaw.dev');
+    expect(slackServiceForRegistry('http://registry.localhost:8080')).toBe('http://slack.localhost:8080');
+  });
+
+  it('drops the path, query and userinfo a credential may have recorded', () => {
+    expect(slackServiceForRegistry('https://user:pw@registry.sandbox.nanoclaw.dev/private?token=secret')).toBe(
+      'https://slack.sandbox.nanoclaw.dev',
+    );
+  });
+
+  it('declines to guess for anything that is not a registry host', () => {
+    expect(slackServiceForRegistry(undefined)).toBeUndefined();
+    expect(slackServiceForRegistry('')).toBeUndefined();
+    expect(slackServiceForRegistry('not a url')).toBeUndefined();
+    expect(slackServiceForRegistry('file:///registry.nanoclaw.dev')).toBeUndefined();
+    // Same deployment, different naming: derive nothing rather than invent it.
+    expect(slackServiceForRegistry('https://accounts.example.test')).toBeUndefined();
+  });
+});
+
+describe('readServiceBase', () => {
+  let dir: string | undefined;
+  let configDir: string | undefined;
+
+  /** An isolated pair of directories: never the developer's own credential. */
+  function dirs(accountApi?: string): [string, string] {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-cfg-'));
+    if (accountApi !== undefined) {
+      fs.writeFileSync(path.join(configDir, 'account.json'), JSON.stringify({ api: accountApi, token: 'nct_x' }));
+    }
+    return [dir, configDir];
+  }
+
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    for (const d of [dir, configDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+    dir = configDir = undefined;
+  });
+
+  it('defaults to the deployed service when nothing says otherwise', () => {
+    expect(readServiceBase(...dirs())).toBe(DEFAULT_SLACK_SERVICE_BASE);
+  });
+
+  it('prefers process env and strips trailing slashes', () => {
+    process.env.SLACK_SERVICE_BASE = 'https://slack-sandbox.example.dev/';
+    expect(readServiceBase(...dirs())).toBe('https://slack-sandbox.example.dev');
+  });
+
+  it('reads from .env, stripping quotes', () => {
+    const [root, cfg] = dirs();
+    fs.writeFileSync(path.join(root, '.env'), 'SLACK_SERVICE_BASE="https://broker.example.test"\n');
+    expect(readServiceBase(root, cfg)).toBe('https://broker.example.test');
+  });
+
+  it('follows the credential to its own deployment rather than the default', () => {
+    expect(readServiceBase(...dirs('https://registry.sandbox.nanoclaw.dev'))).toBe(
+      'https://slack.sandbox.nanoclaw.dev',
+    );
+  });
+
+  it('lets an explicit setting override the credential it was issued against', () => {
+    process.env.SLACK_SERVICE_BASE = 'https://slack.example.test';
+    expect(readServiceBase(...dirs('https://registry.sandbox.nanoclaw.dev'))).toBe('https://slack.example.test');
+  });
+
+  it('falls back to the default when the credential records nothing to derive from', () => {
+    expect(readServiceBase(...dirs('https://accounts.example.test'))).toBe(DEFAULT_SLACK_SERVICE_BASE);
+    for (const d of [dir, configDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+    expect(readServiceBase(...dirs())).toBe(DEFAULT_SLACK_SERVICE_BASE);
+  });
+});
+
+describe('readInstallToken', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    delete process.env.NANOCLAW_REGISTRY_TOKEN;
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  const writeAccount = (configDir: string, content: string): void => {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'account.json'), content);
+  };
+
+  it('reads the token from account.json (the enrollment convention)', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    writeAccount(
+      dir,
+      JSON.stringify({ version: 1, api: 'https://registry.example', account_id: 'acct_1', token: 'nct_abc123' }),
+    );
+    expect(readInstallToken(process.cwd(), dir)).toBe('nct_abc123');
+  });
+
+  it('prefers NANOCLAW_REGISTRY_TOKEN from the process env', () => {
+    process.env.NANOCLAW_REGISTRY_TOKEN = 'nct_from_env';
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    writeAccount(dir, JSON.stringify({ token: 'nct_from_file' }));
+    expect(readInstallToken(process.cwd(), dir)).toBe('nct_from_env');
+  });
+
+  it('returns undefined when no account file exists', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+  });
+
+  it('reads malformed or token-less files as "not enrolled" rather than throwing', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-prov-'));
+    writeAccount(dir, 'not json{');
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+    writeAccount(dir, JSON.stringify({ version: 1, token: '' }));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+    writeAccount(dir, JSON.stringify({ version: 1 }));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+    writeAccount(dir, JSON.stringify(['token']));
+    expect(readInstallToken(process.cwd(), dir)).toBeUndefined();
+  });
+});
+
+describe('mapBrokerApp', () => {
+  it('maps a fully auto-installed app into the ProvisionedApp shape', () => {
+    const app = mapBrokerApp({
+      app_id: 'A0TEST123',
+      team_id: 'T0TEAM456',
+      name: 'Trusty',
+      app_token: 'xapp-1-A0TEST123-x',
+      bot_token: 'xoxb-000-bot',
+      install_url: 'https://slack.com/oauth/install/A0TEST123',
+      install_error: null,
+    });
+    expect(app).toEqual({
+      appId: 'A0TEST123',
+      appToken: 'xapp-1-A0TEST123-x',
+      botToken: 'xoxb-000-bot',
+      installUrl: 'https://slack.com/oauth/install/A0TEST123',
+      installError: undefined,
+    });
+  });
+
+  it('maps a refused auto-install: null bot_token → undefined, install_error carried', () => {
+    const app = mapBrokerApp({
+      app_id: 'A0TEST123',
+      app_token: 'xapp-1-A0TEST123-x',
+      bot_token: null,
+      install_url: 'https://slack.com/oauth/install/A0TEST123',
+      install_error: 'app_approval_request_eligible',
+    });
+    expect(app.botToken).toBeUndefined();
+    expect(app.installError).toBe('app_approval_request_eligible');
+    expect(app.installUrl).toBe('https://slack.com/oauth/install/A0TEST123');
+  });
+
+  it('tolerates absent optional fields — installUrl falls back to empty string', () => {
+    const app = mapBrokerApp({ app_id: 'A1', app_token: 'xapp-1' });
+    expect(app).toEqual({
+      appId: 'A1',
+      appToken: 'xapp-1',
+      botToken: undefined,
+      installUrl: '',
+      installError: undefined,
+    });
+  });
+});
+
+describe('deferred install completion', () => {
+  const fetchMock =
+    vi.fn<(url: string, init?: { method?: string; headers?: Record<string, string> }) => Promise<unknown>>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    process.env.SLACK_SERVICE_BASE = 'https://broker.test';
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    delete process.env.SLACK_SERVICE_BASE;
+    vi.unstubAllGlobals();
+  });
+
+  function response(status: number, payload: unknown): object {
+    return { ok: status >= 200 && status < 300, status, text: async () => JSON.stringify(payload) };
+  }
+
+  /** Answer each successive GET with the next scripted state. */
+  function script(...states: Array<{ status: number; body: unknown }>): void {
+    let i = 0;
+    fetchMock.mockImplementation(async () => {
+      const next = states[Math.min(i, states.length - 1)];
+      i++;
+      return response(next.status, next.body);
+    });
+  }
+
+  /** A fast wait: the cadence under test is the constants' job, not the clock's. */
+  const fast = { intervalMs: 1, timeoutMs: 60 };
+
+  describe('brokerAppStatus', () => {
+    it('reads one app over the authenticated GET', async () => {
+      script({ status: 200, body: { app_id: 'A0PEND1', team_id: 'T1', name: 'Pixel', status: 'pending_install' } });
+
+      await expect(brokerAppStatus('nct_x', 'A0PEND1')).resolves.toEqual({
+        app_id: 'A0PEND1',
+        team_id: 'T1',
+        name: 'Pixel',
+        status: 'pending_install',
+      });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://broker.test/v1/apps/A0PEND1');
+      expect(init?.method).toBe('GET');
+      expect(init?.headers?.Authorization).toBe('Bearer nct_x');
+    });
+
+    it('escapes the app id rather than pasting it into the path', async () => {
+      script({ status: 200, body: { app_id: 'x', status: 'installed' } });
+      await brokerAppStatus('nct_x', 'A0/../v1/workspaces');
+      expect(fetchMock.mock.calls[0][0]).toBe('https://broker.test/v1/apps/A0%2F..%2Fv1%2Fworkspaces');
+    });
+
+    it('surfaces an unknown app as a BrokerHttpError like every other call', async () => {
+      script({ status: 404, body: { error: 'not_found' } });
+      await expect(brokerAppStatus('nct_x', 'A0GONE')).rejects.toMatchObject({ name: 'BrokerHttpError', status: 404 });
+    });
+  });
+
+  describe('waitForInstall', () => {
+    it('polls while the workspace has not approved yet, then takes the one-time token', async () => {
+      script(
+        { status: 200, body: { app_id: 'A0PEND1', status: 'pending_install' } },
+        { status: 200, body: { app_id: 'A0PEND1', status: 'pending_install' } },
+        { status: 200, body: { app_id: 'A0PEND1', status: 'installed', bot_token: 'xoxb-finally' } },
+      );
+
+      await expect(waitForInstall('nct_x', 'A0PEND1', fast)).resolves.toEqual({ botToken: 'xoxb-finally' });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('reports progress to the caller once per attempt', async () => {
+      script(
+        { status: 200, body: { status: 'pending_install' } },
+        { status: 200, body: { status: 'installed', bot_token: 'xoxb-1' } },
+      );
+      const onPoll = vi.fn();
+
+      await waitForInstall('nct_x', 'A0PEND1', { ...fast, onPoll });
+      expect(onPoll).toHaveBeenCalledTimes(2);
+      expect(onPoll.mock.calls.every(([elapsed]) => typeof elapsed === 'number')).toBe(true);
+    });
+
+    it('resolves null when the approval never lands — a timeout is not an error', async () => {
+      script({ status: 200, body: { app_id: 'A0PEND1', status: 'pending_install' } });
+
+      await expect(waitForInstall('nct_x', 'A0PEND1', fast)).resolves.toBeNull();
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('stops on an app the service does not know (404) instead of waiting it out', async () => {
+      script({ status: 404, body: { error: 'not_found' } });
+
+      await expect(waitForInstall('nct_x', 'A0GONE', fast)).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('stops on a deleted app', async () => {
+      script({ status: 200, body: { app_id: 'A0DEAD', status: 'deleted' } });
+
+      await expect(waitForInstall('nct_x', 'A0DEAD', fast)).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('stops when the token was already released — polling cannot get a second copy', async () => {
+      script({ status: 200, body: { app_id: 'A0PEND1', status: 'installed' } });
+
+      await expect(waitForInstall('nct_x', 'A0PEND1', fast)).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('polls through a service hiccup rather than giving up on it', async () => {
+      script(
+        { status: 502, body: { error: 'bad_gateway' } },
+        { status: 200, body: { status: 'installed', bot_token: 'xoxb-after-hiccup' } },
+      );
+
+      await expect(waitForInstall('nct_x', 'A0PEND1', fast)).resolves.toEqual({ botToken: 'xoxb-after-hiccup' });
+    });
+
+    it('rethrows a credential refusal — the next poll cannot change that answer', async () => {
+      script({ status: 401, body: { message: 'Install token expired.' } });
+
+      await expect(waitForInstall('nct_x', 'A0PEND1', fast)).rejects.toMatchObject({
+        name: 'BrokerHttpError',
+        status: 401,
+      });
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/provisioning/slack-app.ts
+++ b/src/provisioning/slack-app.ts
@@ -1,0 +1,651 @@
+/**
+ * Managed Slack app provisioning.
+ *
+ * When the operator holds a manager-app user token (xoxp-… with
+ * app_configurations:write + managed_apps:install), we can create the
+ * bot's Slack app programmatically instead of walking the operator through
+ * api.slack.com/apps by hand:
+ *
+ *   1. apps.manifest.create — socket-mode manifest, generate_app_token=true
+ *      so the response carries the xapp-… app-level token (no public URL
+ *      needed, exactly matching the adapter's Socket Mode path)
+ *   2. apps.managedInstall — bot-scopes-only apps auto-install and return
+ *      the xoxb-… bot token directly
+ *
+ * Auto-install does not bypass Admin Approved Apps: on workspaces where the
+ * admin rules reject it, managedInstall errors and the caller falls back to
+ * the manual install URL (oauth_authorize_url from step 1).
+ *
+ * The manager token is read from SLACK_MANAGER_TOKEN (process env or .env).
+ * It never persists into the container or session env — only the derived
+ * bot + app tokens are handed to the add-slack skill.
+ *
+ * Broker transport ("hosts are always the initiator"): when this install is
+ * enrolled with the NanoClaw registry, the same install token that gates the
+ * hardened agent image also authenticates against the managed-Slack broker
+ * (slack.nanoclaw.dev). The broker holds the Slack manager credential
+ * server-side; the host only ever sees the derived per-app tokens. The
+ * broker client lives here next to the direct-Slack path so callers can
+ * pick whichever the install is set up for.
+ *
+ * This is the provisioning CORE — transport + manifest only, no prompts and
+ * no wizard state. It lives under src/ (main build + test pass) rather than
+ * setup/ because provisioning serves every agent's app creation, not just
+ * first-time setup; the setup wizard is just one caller. Wizard UX stays in
+ * setup/channels/slack-auto.ts.
+ *
+ * Nothing in this module loads on the default wizard path — it is reached
+ * only through the NANOCLAW_SLACK_AGENTS-gated dynamic import chain rooted
+ * in setup/channels/slack-auto-register.ts.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** The deployed managed-Slack broker. Overridable via SLACK_SERVICE_BASE. */
+export const DEFAULT_SLACK_SERVICE_BASE = 'https://slack.nanoclaw.dev';
+
+/**
+ * Superset of the add-slack skill's manual walkthrough: managed apps
+ * additionally carry the mpim + im:write scopes for multi-bot rooms and the
+ * post-provision welcome DM. Baked in at provision time deliberately —
+ * adding scopes to a live app later needs a manifest update AND a reinstall,
+ * a fleet migration we avoid by shipping the full template from day one.
+ * Must match the broker service's server-side template — the two transports
+ * must produce identical apps.
+ */
+export const BOT_SCOPES = [
+  // Required by the app_mention event subscription; the Slack UI adds it
+  // implicitly, so the manual walkthrough never lists it.
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  // users:read.email is deliberately ABSENT: it is outside the approved
+  // scope set for provisioned apps. Scope additions must be approved for
+  // that set BEFORE landing in any transport, or the manual-install
+  // fallback breaks on the unapproved scope.
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+  // Room-canvas surface: create/edit conversation canvases; files:read is
+  // the read-back path (canvases are files, HTML download carries section ids).
+  'canvases:read',
+  'canvases:write',
+  'files:read',
+  // send_file: agents deliver files they produce (charts, documents,
+  // generated artifacts) via files upload — live-verified missing_scope
+  // failure without it (filesUploadV2 needs files:write).
+  'files:write',
+];
+
+// member_joined/left_channel ride on the channels/groups/mpim:read scopes
+// already present above (join-time adopt flow + membership bookkeeping).
+export const BOT_EVENTS = [
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'app_mention',
+  'member_joined_channel',
+  'member_left_channel',
+];
+
+/**
+ * Agent-mode (features.agent_view) additions — the default variant. Slack
+ * auto-adds assistant:write when agent_view is enabled; declared explicitly
+ * so the manifest states what the app holds. Guests are hard-blocked from
+ * agent-enabled apps, so agentView:false selects the plain variant instead.
+ */
+export const AGENT_BOT_SCOPES = ['assistant:write'];
+
+export const AGENT_BOT_EVENTS = ['app_home_opened', 'app_context_changed'];
+
+/**
+ * Fixed attribution: admins see this line, never a caller-supplied text.
+ * Also the agent_view.agent_description (≤300 chars) on the agent-mode variant.
+ */
+export const MANAGED_APP_DESCRIPTION =
+  'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
+
+/**
+ * Optional request-origin metadata fields, all additive. On the broker
+ * transport they ride the POST /v1/apps HTTP body verbatim (sent only when
+ * defined — JSON serialization drops undefined values); a service that does
+ * not know them ignores them. They NEVER influence the Slack app manifest,
+ * scopes, or events, and the direct-Slack transport has nowhere to record
+ * them, so it ignores them entirely. Field names are the wire contract —
+ * snake_case, shared across every transport that provisions managed apps.
+ */
+export interface ProvisionAttribution {
+  /** Slack user id of the human who asked for this app, when known. */
+  requested_by?: string;
+  /** The creating agent's own Slack app id, when an agent created this agent. */
+  parent_app_id?: string;
+  /** Template name, when the app was stamped from one. */
+  template?: string;
+  /** The installing host's package.json version. */
+  client_version?: string;
+}
+
+export interface ManagedAppSpec extends ProvisionAttribution {
+  name: string;
+  description?: string;
+  /**
+   * agent_view is a one-way door decided at provision time (default true):
+   * installs never fail on free plans (chrome degrades to a plain DM), but
+   * agent apps are unusable by workspace guests — pass false for workspaces
+   * that need guest access.
+   */
+  agentView?: boolean;
+}
+
+export function buildManagedAppManifest(spec: ManagedAppSpec): object {
+  const agentView = spec.agentView ?? true;
+  return {
+    display_information: {
+      name: spec.name,
+      description: MANAGED_APP_DESCRIPTION,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: spec.name,
+        always_online: true,
+      },
+      ...(agentView ? { agent_view: { agent_description: MANAGED_APP_DESCRIPTION } } : {}),
+    },
+    oauth_config: {
+      // Copies, not the module constants — callers extend these per app.
+      scopes: { bot: agentView ? [...BOT_SCOPES, ...AGENT_BOT_SCOPES] : [...BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: { bot_events: agentView ? [...BOT_EVENTS, ...AGENT_BOT_EVENTS] : [...BOT_EVENTS] },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+export interface ProvisionedApp {
+  appId: string;
+  /** xapp-… app-level token for Socket Mode. */
+  appToken: string;
+  /** xoxb-… bot token — absent when auto-install was refused. */
+  botToken?: string;
+  /**
+   * Install URL for the browser — the fallback when auto-install was refused.
+   * On the broker transport it arrives with its own signed state and stays
+   * valid for days, so a caller can hand it to a human and pick the app up
+   * afterwards with `waitForInstall` instead of provisioning a second one.
+   */
+  installUrl: string;
+  teamDomain?: string;
+  /** managedInstall error when auto-install was refused (e.g. app_approval_request_eligible). */
+  installError?: string;
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+}
+
+async function slackApi<T extends SlackApiResponse>(
+  method: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<T> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams(params).toString(),
+  });
+  if (!res.ok && res.status !== 200) {
+    throw new Error(`${method}: HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Create and (attempt to) install a managed Slack app. Throws on creation
+ * failure; a refused auto-install is not an error — the result carries the
+ * manual install URL and `installError` instead of `botToken`.
+ */
+export async function provisionManagedApp(managerToken: string, spec: ManagedAppSpec): Promise<ProvisionedApp> {
+  const manifest = buildManagedAppManifest(spec);
+  const created = await slackApi<
+    SlackApiResponse & {
+      app_id?: string;
+      app_token?: string;
+      oauth_authorize_url?: string;
+      team_domain?: string;
+    }
+  >('apps.manifest.create', managerToken, {
+    manifest: JSON.stringify(manifest),
+    generate_app_token: 'true',
+  });
+  if (!created.ok || !created.app_id) {
+    throw new Error(`apps.manifest.create failed: ${created.error ?? 'no app_id in response'}`);
+  }
+  if (!created.app_token) {
+    throw new Error('apps.manifest.create returned no app-level token (generate_app_token unsupported?)');
+  }
+
+  const result: ProvisionedApp = {
+    appId: created.app_id,
+    appToken: created.app_token,
+    installUrl: created.oauth_authorize_url ?? '',
+    teamDomain: created.team_domain,
+  };
+
+  const installed = await slackApi<
+    SlackApiResponse & {
+      api_access_tokens?: { bot_access_token?: string };
+    }
+  >('apps.managedInstall', managerToken, { app_id: created.app_id });
+  if (installed.ok && installed.api_access_tokens?.bot_access_token) {
+    result.botToken = installed.api_access_tokens.bot_access_token;
+  } else {
+    result.installError = installed.error ?? 'no bot token in response';
+  }
+  return result;
+}
+
+/** Process env first, then the install's .env — the same order everywhere. */
+function readEnvSetting(key: string, projectRoot: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const envFile = fs.readFileSync(path.join(projectRoot, '.env'), 'utf-8');
+    const match = envFile.match(new RegExp(`^${key}=(.+)$`, 'm'));
+    const value = match?.[1]?.trim().replace(/^["']|["']$/g, '');
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Manager token from process env or the install's .env. Presence of the
+ * token is what unlocks the auto-provision option in the setup flow.
+ */
+export function readManagerToken(projectRoot = process.cwd()): string | undefined {
+  return readEnvSetting('SLACK_MANAGER_TOKEN', projectRoot);
+}
+
+// ---------------------------------------------------------------------------
+// Broker transport — the managed-Slack service at slack.nanoclaw.dev.
+
+/** Per-user credential directory — where enrollment persists account.json. */
+function defaultConfigDir(): string {
+  return path.join(os.homedir(), '.config', 'nanoclaw');
+}
+
+/**
+ * The Slack-side service belonging to a given account service.
+ *
+ * The two are halves of one deployment: this service authenticates the
+ * install token that service minted, so a token from one is not a credential
+ * at the other. Nothing on disk records the pairing, and the two are
+ * configured independently — which is how an install ends up presenting a
+ * token from one deployment to the other and reading the refusal as an
+ * outage.
+ *
+ * Host swap only, `registry.<rest>` → `slack.<rest>`, so a deployment that
+ * follows the same naming is derived correctly and one that does not yields
+ * undefined rather than a guess.
+ */
+export function slackServiceForRegistry(api: string | undefined): string | undefined {
+  if (!api) return undefined;
+  let url: URL;
+  try {
+    url = new URL(api);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+  if (!url.hostname.startsWith('registry.')) return undefined;
+  url.hostname = `slack.${url.hostname.slice('registry.'.length)}`;
+  // `origin` drops any path, query and userinfo the credential recorded.
+  return url.origin;
+}
+
+/** The account service that issued the credential on disk, if it recorded one. */
+function readAccountApi(configDir: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(configDir, 'account.json'), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const api = (parsed as { api?: unknown }).api;
+  return typeof api === 'string' && api.trim() ? api.trim() : undefined;
+}
+
+/**
+ * Broker base URL: SLACK_SERVICE_BASE (process env or .env) first, then the
+ * service implied by whoever issued the credential we are about to send, and
+ * only then the default.
+ *
+ * Deriving beats defaulting because the credential is the thing being spent:
+ * pairing it with a service that cannot know it produces a 401 that reads as
+ * "Slack is down". An explicit setting still wins — pointing the two halves
+ * at different deployments is a thing an operator may need to do deliberately.
+ *
+ * A token supplied through NANOCLAW_REGISTRY_TOKEN has no account record to
+ * derive from and falls through to the default, so a CI caller retargeting
+ * the service must set SLACK_SERVICE_BASE too.
+ */
+export function readServiceBase(projectRoot = process.cwd(), configDir = defaultConfigDir()): string {
+  const explicit = readEnvSetting('SLACK_SERVICE_BASE', projectRoot);
+  const value = explicit ?? slackServiceForRegistry(readAccountApi(configDir)) ?? DEFAULT_SLACK_SERVICE_BASE;
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * The registry install token, exactly where enrollment persists it:
+ * `~/.config/nanoclaw/account.json` (per-user, not per-checkout — see
+ * `readRegistryAccount` in setup/lib/registry-state.ts; `{ token: "…" }` is
+ * the only required field). A malformed or missing file reads as "not
+ * enrolled" rather than throwing — the next move (fall back to the
+ * manager-token or manual path) is the same either way.
+ *
+ * `NANOCLAW_REGISTRY_TOKEN` in the process env wins, matching the login
+ * driver's CI path. `projectRoot` is accepted for signature parity with
+ * `readManagerToken` but the credential is deliberately per-user;
+ * `configDir` is overridable for tests only.
+ */
+export function readInstallToken(_projectRoot = process.cwd(), configDir = defaultConfigDir()): string | undefined {
+  const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(configDir, 'account.json'), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const token = (parsed as { token?: unknown }).token;
+  return typeof token === 'string' && token.trim() ? token : undefined;
+}
+
+/** Broker failure with enough context to say what broke, never the token. */
+export class BrokerHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly path: string,
+    detail?: string,
+  ) {
+    super(`Slack service ${path}: HTTP ${status}${detail ? ` — ${detail}` : ''}`);
+    this.name = 'BrokerHttpError';
+  }
+}
+
+/**
+ * One authenticated round-trip to the broker. Throws `BrokerHttpError` on any
+ * non-2xx (with the body's `error`/`message` when it has one) and on a 2xx
+ * body that isn't JSON — callers never have to inspect a Response.
+ */
+export async function brokerRequest<T>(
+  method: 'GET' | 'POST' | 'DELETE',
+  apiPath: string,
+  token: string,
+  body?: object,
+  base = readServiceBase(),
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${base}${apiPath}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    throw new BrokerHttpError(0, apiPath, err instanceof Error ? err.message : String(err));
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    let detail: string | undefined;
+    try {
+      const parsed = JSON.parse(text) as { error?: string; message?: string };
+      // message is the human sentence ("Install token expired. Re-run
+      // nanoclaw login."); error is the machine code. Show the human one.
+      detail = parsed.message ?? parsed.error;
+    } catch {
+      detail = text.trim().slice(0, 200) || undefined;
+    }
+    throw new BrokerHttpError(res.status, apiPath, detail);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new BrokerHttpError(res.status, apiPath, 'response was not JSON');
+  }
+}
+
+/** A workspace the operator has connected to the broker via OAuth. */
+export interface BrokerWorkspace {
+  team_id: string;
+  team_name: string;
+  status: string;
+  connected_as?: string;
+  connected_at?: string;
+}
+
+/** OAuth URL the operator opens to connect a workspace to the broker. */
+export async function brokerOauthUrl(token: string): Promise<{ url: string }> {
+  const res = await brokerRequest<{ url?: string }>('POST', '/v1/slack/oauth/url', token, {});
+  if (!res.url) throw new BrokerHttpError(200, '/v1/slack/oauth/url', 'no url in response');
+  return { url: res.url };
+}
+
+export async function brokerListWorkspaces(token: string): Promise<BrokerWorkspace[]> {
+  const res = await brokerRequest<{ workspaces?: BrokerWorkspace[] }>('GET', '/v1/workspaces', token);
+  return res.workspaces ?? [];
+}
+
+// ── Avatar generation (broker-side) ──
+
+/** Poll cap for the pre-create avatar job — beyond it the bot keeps the default icon. */
+const AVATAR_WAIT_MS = 75_000;
+// Generation measures ~20-23s at the broker's floor settings — a 2s poll
+// wastes at most ~2s of that.
+const AVATAR_POLL_MS = 2_000;
+
+/**
+ * Ask the broker to generate the agent's avatar BEFORE the app exists, so
+ * the bot's first workspace appearance already carries it. Returns undefined
+ * when generation is unavailable, failed, or over the wait cap — the
+ * degraded path is the default icon, never an error.
+ */
+export async function requestAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  let avatarId: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/v1/avatars`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${installToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: displayName, ...(description ? { description } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = (await res.json()) as { avatar_id?: string | null };
+    avatarId = data.avatar_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+  if (!avatarId) return undefined;
+  const deadline = Date.now() + AVATAR_WAIT_MS;
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) await new Promise((r) => setTimeout(r, AVATAR_POLL_MS));
+    try {
+      const res = await fetch(`${baseUrl}/v1/avatars/${avatarId}`, {
+        headers: { Authorization: `Bearer ${installToken}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'ready') return avatarId;
+      if (data.status && data.status !== 'pending') return undefined;
+    } catch {
+      // Transient — bounded by the deadline.
+    }
+  }
+  return undefined;
+}
+
+// ── Deferred install completion ──
+//
+// A workspace with an admin-approval policy refuses auto-install, so
+// POST /v1/apps answers with `install_url` and no bot token. That URL carries
+// its own signed state and stays valid for days, so the app is not lost — it
+// sits at `pending_install` until someone completes the OAuth install in the
+// browser. These two helpers are the client half of finishing that: ask the
+// service what state the app is in, and wait for the bot token that appears
+// when the install lands.
+
+/** Poll cadence for a pending install — the workspace-connect cadence. */
+export const INSTALL_POLL_INTERVAL_MS = 5_000;
+/** How long a caller waits inline before parking the app and moving on. */
+export const INSTALL_POLL_TIMEOUT_MS = 5 * 60_000;
+
+/** GET /v1/apps/{app_id} — one provisioned app's current state. */
+export interface BrokerAppState {
+  app_id: string;
+  team_id?: string;
+  name?: string;
+  status: 'installed' | 'pending_install' | 'deleted';
+  /**
+   * xoxb-… — released EXACTLY ONCE, on the first read after the install
+   * completes. Absent before the install and on every read after the one that
+   * carried it, so a caller that drops it cannot ask for it again.
+   */
+  bot_token?: string | null;
+}
+
+/**
+ * One app's state. Throws `BrokerHttpError` like every other broker call —
+ * 404 means the service has no such app under this install's credentials.
+ */
+export async function brokerAppStatus(token: string, appId: string): Promise<BrokerAppState> {
+  return brokerRequest<BrokerAppState>('GET', `/v1/apps/${encodeURIComponent(appId)}`, token);
+}
+
+/**
+ * Wait for a pending install to complete, then hand back the one-time bot
+ * token. Resolves null when the wait runs out, when the service does not know
+ * the app (404), and when the app is gone (`deleted`) — all of which mean the
+ * same thing to a caller: stop waiting and offer the manual path. Transient
+ * failures (5xx, a dropped connection) are polled through rather than
+ * surfaced, since the deadline already bounds them.
+ *
+ * A credential refusal is the exception: it is not going to change on the next
+ * poll, and reading it as a timeout would blame the workspace for something
+ * that is the install's to fix, so it is rethrown.
+ */
+export async function waitForInstall(
+  token: string,
+  appId: string,
+  opts: { intervalMs?: number; timeoutMs?: number; onPoll?: (elapsedMs: number) => void } = {},
+): Promise<{ botToken: string } | null> {
+  const intervalMs = opts.intervalMs ?? INSTALL_POLL_INTERVAL_MS;
+  const start = Date.now();
+  const deadline = start + (opts.timeoutMs ?? INSTALL_POLL_TIMEOUT_MS);
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    opts.onPoll?.(Date.now() - start);
+    let state: BrokerAppState;
+    try {
+      state = await brokerAppStatus(token, appId);
+    } catch (err) {
+      if (err instanceof BrokerHttpError && (err.status === 401 || err.status === 403)) throw err;
+      if (err instanceof BrokerHttpError && err.status === 404) return null;
+      continue;
+    }
+    if (state.status === 'deleted') return null;
+    if (state.status === 'installed') {
+      // Installed with no token is the read AFTER the one that released it —
+      // terminal, not slow, so waiting out the deadline would only delay the
+      // manual path by five minutes.
+      return state.bot_token ? { botToken: state.bot_token } : null;
+    }
+  }
+  return null;
+}
+
+/** The broker's POST /v1/apps response shape. */
+export interface BrokerAppResponse {
+  app_id: string;
+  team_id?: string;
+  name?: string;
+  /** xapp-… app-level token for Socket Mode. */
+  app_token: string;
+  /** xoxb-… bot token — null when auto-install was refused. */
+  bot_token?: string | null;
+  install_url?: string | null;
+  install_error?: string | null;
+}
+
+/**
+ * Broker response → the same `ProvisionedApp` shape the direct-Slack path
+ * produces, so everything downstream of provisioning is transport-agnostic.
+ */
+export function mapBrokerApp(res: BrokerAppResponse): ProvisionedApp {
+  return {
+    appId: res.app_id,
+    appToken: res.app_token,
+    botToken: res.bot_token ?? undefined,
+    installUrl: res.install_url ?? '',
+    installError: res.install_error ?? undefined,
+  };
+}
+
+/**
+ * Create (and attempt to install) a managed app via the broker. Mirrors
+ * `provisionManagedApp`'s contract: throws on creation failure; a refused
+ * auto-install comes back as `installError` + `installUrl`, not an error.
+ */
+export async function brokerProvision(
+  token: string,
+  spec: {
+    team_id: string;
+    name: string;
+    description?: string;
+    icon_url?: string;
+    allow_guests?: boolean;
+  } & ProvisionAttribution,
+): Promise<ProvisionedApp> {
+  // Avatar-first: generate the avatar BEFORE the app exists so the bot's
+  // first appearance already wears it — undefined degrades to the default icon.
+  const avatarId = await requestAvatar(readServiceBase(), token, spec.name, spec.description);
+  const res = await brokerRequest<Partial<BrokerAppResponse>>('POST', '/v1/apps', token, {
+    ...spec,
+    ...(avatarId ? { avatar_id: avatarId } : {}),
+  });
+  if (!res.app_id || !res.app_token) {
+    throw new BrokerHttpError(200, '/v1/apps', 'response missing app_id or app_token');
+  }
+  return mapBrokerApp(res as BrokerAppResponse);
+}


### PR DESCRIPTION
Adds canvas and rooms MCP tools for the agent runner, Slack construct/A2A room skills, and the slack-agent-flow module (orchestration, provisioning, room actions/canvas) with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)