### PR TITLE
fix(setup): mark failed setup spinners as errors, not success

### DIFF
--- a/setup/lib/claude-handoff.ts
+++ b/setup/lib/claude-handoff.ts
@@ -153,14 +153,14 @@ export const HELP_ESCAPE_SENTINEL = '__NANOCLAW_HELP_ESCAPE__';
  */
 export function validateWithHelpEscape(
   inner?: (value: string) => string | Error | undefined,
-): (value: string) => string | Error | undefined {
-  return (value: string) => {
+): (value: string | undefined) => string | Error | undefined {
+  return (value) => {
     if ((value ?? '').trim() === '?') {
       // Returning undefined lets clack accept the `?` as the "answer". The
       // caller sees a literal "?" and should compare + escape to handoff.
       return undefined;
     }
-    return inner ? inner(value) : undefined;
+    return inner ? inner(value ?? '') : undefined;
   };
 }
 

--- a/setup/lib/runner.ts
+++ b/setup/lib/runner.ts
@@ -321,7 +321,7 @@ export function startSpinner(labels: SpinnerLabels): {
         s.stop(`${k.bold(fitToWidth(msg, suffix))}${k.dim(suffix)}`);
       } else {
         const failMsg = labels.failed ?? labels.running.replace(/…$/, ' failed');
-        s.stop(`${k.bold(fitToWidth(failMsg, suffix))}${k.dim(suffix)}`, 1);
+        s.error(`${k.bold(fitToWidth(failMsg, suffix))}${k.dim(suffix)}`);
         if (transcript) dumpTranscriptOnFailure(transcript);
       }
     },

--- a/setup/lib/tz-from-claude.ts
+++ b/setup/lib/tz-from-claude.ts
@@ -58,7 +58,7 @@ export async function resolveTimezoneViaClaude(input: string): Promise<string | 
     s.stop(`${fitToWidth(`Interpreted as ${resolved}.`, suffix)}${k.dim(suffix)}`);
     return resolved;
   }
-  s.stop(`${fitToWidth("Couldn't interpret that as a timezone.", suffix)}${k.dim(suffix)}`, 1);
+  s.error(`${fitToWidth("Couldn't interpret that as a timezone.", suffix)}${k.dim(suffix)}`);
   return null;
 }
 


### PR DESCRIPTION
## TL;DR

Proposed: two setup spinners that are supposed to render a red failure symbol have been rendering a green success symbol ever since the repo moved to clack 1.2, and one prompt-validator signature no longer matches clack's. This fixes all three, and clears four pre-existing typecheck errors in the process.

## Background, in plain language

`clack` is the terminal prompt library the setup wizard uses (`@clack/prompts`, pinned at `^1.2.0` in `package.json`). A "spinner" is the animated line shown while a long step runs. When it finishes, the library stamps a symbol at the front of the line: green for success, red for failure.

In clack 0.x you signalled failure with a second argument: `s.stop(message, 1)`. In clack 1.2 that argument is gone. `spinner()` now returns `stop(msg?: string)` plus separate `cancel(msg?)` and `error(msg?)` methods. The compiled library reads `stop: (m = '') => W(m, 0)`, where `0` is the success code, so a second argument is silently ignored.

## The problem

Two call sites still used the old two-argument form:

| File | What the user actually saw |
| --- | --- |
| `setup/lib/runner.ts:324` | a setup step that failed showed a green success symbol |
| `setup/lib/tz-from-claude.ts:61` | "Couldn't interpret that as a timezone." showed a green success symbol |

Separately, `validateWithHelpEscape` in `setup/lib/claude-handoff.ts` returns a validator function that clack calls when the user submits a prompt. It was typed `(value: string) => ...`, but clack 1.2 declares `validate` as `(value: string | undefined) => ...`. TypeScript rejects the narrower function, so handing it to `p.text` / `p.password` was a type error.

## What this changes

1. `runner.ts` and `tz-from-claude.ts` swap `s.stop(msg, 1)` for `s.error(msg)`. Same message, correct symbol.
2. `validateWithHelpEscape` widens its return type to accept `string | undefined` and passes `value ?? ''` to the caller-supplied inner validator.

Ten production lines across three files. No new tests, no new dependencies.

## What trips people up

- Item 1 is a real, user-visible change. A failing setup step will now look like it failed. That is the point, but it is not a pure refactor, so please do not review it as one.
- Item 2 is a type fix only. The one in-tree inner validator is `promptValidator` in `setup/lib/skill-driver.ts`, which already does `(v ?? '').trim()`, so the added `?? ''` changes no behaviour today. It matters because it makes the compiler accept the value.
- This clears four typecheck errors while touching three files. The two extra errors are at `setup/lib/skill-driver.ts:122` and `:123`, which pass the result of `validateWithHelpEscape` straight into `p.password` and `p.text`. Widening the return type fixes them without editing that file.
- Ten more `s.stop(msg, 1)` calls survive in `setup/channels/slack-auto.ts`. They are deliberately out of scope here and still fail the typecheck. Fixing them is a separate change.
- CI catches none of this today: `tsconfig.json` includes only `src/**/*`, so `setup/` is never typechecked by the repo's own build.

## What to review

- That `error()` and not `cancel()` is the right method for a step that failed. `cancel()` is the red symbol clack uses when the user aborts, which is a different thing.
- That widening the validator's parameter type is safe. It widens the parameter of a returned function, which is contravariant, so it accepts strictly more than before.
- That the failure messages themselves are unchanged. They are, only the method called changes.

## How it was checked

- A setup-inclusive `tsc` run (an ad-hoc config that includes `setup/**` and `scripts/**`, since the repo's own `tsconfig.json` does not) over the base branch and over this commit: exactly four errors removed (`runner.ts:324`, `tz-from-claude.ts:61`, `skill-driver.ts:122`, `skill-driver.ts:123`), zero added.
- `vitest run setup/lib`: 9 files, 77 tests, all passing.

## Context

This is proposed as PR 1 of a 39 PR draft stack that splits one oversized upstream commit ("feat(setup): add structured setup driver protocol", +9856/-1125 across 76 files) into pieces that can be reviewed one at a time. The stack as a whole proposes a machine-drivable setup protocol. This first PR is the housekeeping the rest of it leans on: it gets the setup tree to a clean enough typecheck baseline that every later PR can be gated on "no new errors versus the baseline".

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Two setup spinners called clack 0.x's `s.stop(message, 1)` to signal failure. clack 1.2 ignores that second argument and always renders the success symbol, so failed setup steps have been showing a green tick. Both now call `s.error(message)`. Separately, `validateWithHelpEscape` widens its return type to clack 1.2's `(value: string | undefined)` shape, which also clears two typecheck errors in `skill-driver.ts` without editing that file. Ten production lines across three files. No behaviour change beyond the corrected symbol.

## For Skills

Not a skill, so this checklist does not apply.