### PR TITLE
fix(setup): reject malformed config urls and canonicalize .env base url

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -61,6 +61,7 @@ import {
 import { upsertEnvVar } from './set-env.js';
 import { applyToEnv, parseFlags, printHelp, readFromEnv } from './lib/setup-config-parse.js';
 import { runAdvancedScreen } from './lib/setup-config-screen.js';
+import { CONFIG, envVarFor, validateHttpUrl } from './lib/setup-config.js';
 import { runWindowedStep } from './lib/windowed-runner.js';
 import { runUninstallFlow } from './uninstall/flow.js';
 import { detectExistingInstall } from './uninstall/scan.js';
@@ -1669,8 +1670,13 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
  */
 async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<void> {
   let host: string;
+  let canonicalBaseUrl: string;
   try {
-    host = new URL(baseUrl).hostname;
+    const invalid = validateHttpUrl(baseUrl);
+    if (invalid) throw new Error(invalid);
+    const parsed = new URL(baseUrl);
+    host = parsed.hostname;
+    canonicalBaseUrl = parsed.toString();
   } catch {
     await fail('auth', `Invalid Anthropic base URL: ${baseUrl}`, 'Check --anthropic-base-url and retry.');
     return;
@@ -1716,7 +1722,7 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
   // ANTHROPIC_BASE_URL has to be in .env so the runtime provider config
   // reads it when building container env. The token is *not* written —
   // OneCLI holds it.
-  writeEnvLine('ANTHROPIC_BASE_URL', baseUrl);
+  writeEnvLine('ANTHROPIC_BASE_URL', canonicalBaseUrl);
 
   // Register the claude provider so the runtime passes ANTHROPIC_BASE_URL
   // and the placeholder bearer into the container. Only appended when the

--- a/setup/lib/setup-config-parse.ts
+++ b/setup/lib/setup-config-parse.ts
@@ -40,6 +40,7 @@ export function readFromEnv(env: NodeJS.ProcessEnv = process.env): ConfigValues 
     const raw = env[envVarFor(e)];
     if (raw === undefined || raw === '') continue;
     const v = coerce(e, raw);
+    if ((e.type === 'string' || e.type === 'url') && e.validate?.(raw)) continue;
     if (v !== undefined) out[e.key] = v;
   }
   return out;

--- a/setup/lib/setup-config.test.ts
+++ b/setup/lib/setup-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFlags, readFromEnv } from './setup-config-parse.js';
+import { validateHttpUrl } from './setup-config.js';
+
+describe('setup URL validation', () => {
+  it('accepts only fully parsed HTTP(S) URLs without control characters', () => {
+    expect(validateHttpUrl('https://api.example.com/v1')).toBeUndefined();
+    expect(validateHttpUrl('https://api.example.com\nINJECTED=value')).toMatch(/control/);
+    expect(validateHttpUrl('https://api.example.com trailing')).toMatch(/whitespace/);
+    expect(validateHttpUrl('file:///tmp/secret')).toMatch(/http/);
+  });
+
+  it('rejects unsafe URL flags and environment values at both config boundaries', () => {
+    const unsafe = 'https://api.example.com\nINJECTED=value';
+    expect(parseFlags(['--anthropic-base-url', unsafe]).errors).toHaveLength(1);
+    expect(readFromEnv({ NANOCLAW_ANTHROPIC_BASE_URL: unsafe })).toEqual({});
+  });
+});

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -59,7 +59,15 @@ interface IntEntry extends BaseEntry {
 
 export type Entry = StringEntry | EnumEntry | BoolEntry | IntEntry;
 
-const httpUrl = (v: string): string | undefined => (/^https?:\/\/\S+/.test(v) ? undefined : 'Must be http(s)://…');
+export function validateHttpUrl(value: string): string | undefined {
+  if (/[\u0000-\u0020\u007f]/.test(value)) return 'Must not contain whitespace or control characters';
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.hostname ? undefined : 'Must be http(s)://…';
+  } catch {
+    return 'Must be http(s)://…';
+  }
+}
 
 export const CONFIG: Entry[] = [
   {
@@ -71,7 +79,7 @@ export const CONFIG: Entry[] = [
     type: 'url',
     default: 'https://api.onecli.sh',
     placeholder: 'https://api.onecli.sh',
-    validate: httpUrl,
+    validate: validateHttpUrl,
   },
   {
     key: 'onecliApiToken',
@@ -92,7 +100,7 @@ export const CONFIG: Entry[] = [
     group: 'Anthropic',
     type: 'url',
     placeholder: 'https://api.anthropic.com',
-    validate: httpUrl,
+    validate: validateHttpUrl,
   },
   {
     key: 'anthropicAuthToken',


### PR DESCRIPTION
**TL;DR** Proposed: setup's two configuration entry points (CLI flags and `NANOCLAW_*` environment variables) validate URL values with a real URL parse instead of a loose regex, and the Anthropic base URL is written to `.env` in its canonical parsed form instead of verbatim. This is PR 2 of a 39 PR stack that splits one oversized setup commit into reviewable pieces. Nothing here is merged.

## Background

`setup/lib/setup-config.ts` is a registry that describes every advanced setup option exactly once: its CLI flag, its environment variable name, its type, and an optional `validate` function. `setup/lib/setup-config-parse.ts` holds two readers over that registry, `parseFlags` (reads argv) and `readFromEnv` (reads the environment). Two registry entries are URLs: the OneCLI vault URL and the Anthropic API base URL.

## What problem this solves

1. The URL validator was the regex `/^https?:\/\/\S+/`. It is not anchored at the end and only has to match a prefix, so it accepted a value carrying an embedded newline followed by arbitrary text.
2. `readFromEnv` never called `validate` at all. Any value supplied through the environment bypassed every check the flag path applied.
3. `runCustomEndpointAuth` in `setup/auto.ts` wrote the operator supplied base URL verbatim into `.env`, the file the runtime reads when building container environment. A value containing a newline therefore injected an extra `KEY=value` line into that file.

## How it works

`validateHttpUrl` replaces the regex. It rejects any character in U+0000 to U+0020 or U+007F (control characters and whitespace), then runs `new URL(value)` and requires an `http:` or `https:` protocol plus a non empty hostname. Both URL entries now point at it, and it is exported so call sites can reuse it. `readFromEnv` gains one line so that `string` and `url` entries run their validator and skip the value when it fails. `runCustomEndpointAuth` calls the validator before use and writes `new URL(baseUrl).toString()`, the canonical form, to `.env`.

## What trips people up

- The two boundaries fail differently for the same bad value. A bad flag becomes a visible parse error; a bad environment variable is dropped silently and setup proceeds as though it were unset.
- Dropping a value inside `readFromEnv` does not unset it in `process.env`. Code that reads `process.env.NANOCLAW_ANTHROPIC_BASE_URL` directly (auto.ts does, when deciding whether a custom endpoint is configured) still sees the raw string. That is why the validator is also called at the point of use, which is the real hard stop.
- The new env side check is not URL only. The added line covers `string` entries too, so a `NANOCLAW_ONECLI_API_TOKEN` that does not begin with `oc_`, and a blank `NANOCLAW_ANTHROPIC_AUTH_TOKEN`, are now dropped where they used to be accepted.
- Canonicalization is visible on disk: `https://api.anthropic.com` is written as `https://api.anthropic.com/`. The only consumer, `src/providers/claude.ts`, passes the value straight to the SDK, so no behaviour change is expected, but the file contents differ from before.
- `CONFIG` and `envVarFor` are added to the auto.ts import line and nothing in this PR uses them. They are first consumed by the later "machine entry guards" PR in this stack, which registers secret environment values for redaction. Deliberate, so the import line does not churn again.

## What to review

Whether tightening these two boundaries could lock out a real existing configuration (a URL with trailing whitespace, or a scheme that used to slip past the prefix regex), and whether silently dropping an invalid environment value is the right failure mode compared with erroring the way the flag path does.

## Verification

New `setup/lib/setup-config.test.ts` exercises both boundaries; 2 tests pass locally. The setup inclusive typecheck and `bash -n nanoclaw.sh` pass at this commit. Worth knowing: the repo `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`.

## Type of Change
- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

Ticked as a fix because it closes an input validation gap and an injection path into `.env`. It came from hardening rather than a reported bug report, so read it as a security fix, not a regression repair.

## Description

Replaces the permissive URL regex in the setup config registry with a parsing validator, makes the environment reader apply entry validators the way the flag parser already did, and writes the canonical parsed Anthropic base URL to `.env` rather than the raw operator supplied string. Covered by a new test file.

## For Skills

Not a skill, so this checklist does not apply.