### PR TITLE
fix(setup): cap registry sign-in HTTP response bodies at 256 KiB

### DIFF
--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -79,6 +79,7 @@ const HOST_ID_FILE = path.join(CONFIG_DIR, 'host-id');
 const MAX_DEVICE_WAIT_MS = 900_000;
 const HTTP_TIMEOUT_MS = 20_000;
 const PROBE_TIMEOUT_MS = 8_000;
+const MAX_HTTP_RESPONSE_BYTES = 256 * 1024;
 /**
  * RFC 8628 §3.5 puts the `slow_down` step at 5 seconds. WorkOS documents a
  * smaller one; the spec's is compliant with both and costs a few seconds of
@@ -213,10 +214,45 @@ interface HttpResult {
   body: Record<string, unknown> | undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function readBoundedResponseBody(res: Response): Promise<string> {
+  // A body-less response (204, HEAD, or a minimal test double) has nothing to
+  // bound; `text()` resolves to what little there is.
+  if (!res.body) return res.text();
+  const reader = res.body.getReader();
+  const chunks: Buffer[] = [];
+  let receivedBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      receivedBytes += value.byteLength;
+      if (receivedBytes > MAX_HTTP_RESPONSE_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The size failure below is the useful diagnosis; cancellation is best-effort cleanup.
+        }
+        throw new LoginError(
+          'The authentication service returned more than 256 KiB of data.',
+          'Check the configured registry and identity-provider endpoints, then retry.',
+        );
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, receivedBytes).toString('utf8');
+}
+
 /**
- * Throws only on transport failure — an HTTP error status is data here, because
- * the device grant signals `authorization_pending` as a 400 and that is the
- * normal case, not an exception.
+ * Throws on transport failure or an oversized body. An HTTP error status is
+ * data here, because the device grant signals `authorization_pending` as a 400
+ * and that is the normal case, not an exception.
  */
 async function http(url: string, req: HttpRequest, timeoutMs: number): Promise<HttpResult> {
   const res = await fetch(url, {
@@ -225,11 +261,11 @@ async function http(url: string, req: HttpRequest, timeoutMs: number): Promise<H
     body: req.body,
     signal: AbortSignal.timeout(timeoutMs),
   });
-  const text = await res.text();
+  const text = await readBoundedResponseBody(res);
   let body: Record<string, unknown> | undefined;
   try {
     const parsed: unknown = text ? JSON.parse(text) : undefined;
-    body = parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+    body = isRecord(parsed) ? parsed : undefined;
   } catch {
     // A proxy's HTML error page, most likely. The status still tells us enough.
   }


### PR DESCRIPTION
## TL;DR

Proposed: NanoClaw's setup code reads every reply from the sign-in servers into memory with no size limit. This PR streams those replies instead and refuses anything over 256 KiB.

This is PR 3 of a 39-PR stack that splits one oversized upstream commit into reviewable pieces. Nothing here is merged yet, and this PR stands on its own.

## The problem

`setup/registry-login.ts` is the code that signs a machine in to the NanoClaw account service and to the identity provider behind it (the "device flow", where the terminal shows you a code and you approve it in a browser). It talks to those two servers through a single helper, `http()`, which did `await res.text()`. `res.text()` buffers the whole response body into a string with no ceiling, so a hostile, hijacked, or simply misconfigured endpoint (including one pointed at by the `NANOCLAW_REGISTRY_API` environment override) could hand back an arbitrarily large body and drive the setup process into memory exhaustion before a single byte was parsed.

## How it works

* New constant `MAX_HTTP_RESPONSE_BYTES = 256 * 1024`.
* New `readBoundedResponseBody(res)` pulls the response through its stream reader chunk by chunk, adds up the bytes, and the moment the running total passes 256 KiB it cancels the reader and throws a `LoginError` ("The authentication service returned more than 256 KiB of data."). Under the limit it concatenates the chunks and returns the text exactly as before.
* `http()` swaps its one `res.text()` for `readBoundedResponseBody(res)`. `http()` is the only `fetch` call in the file, so this covers every request setup makes to both servers.
* A response with no body at all (a 204, a HEAD, or a minimal test double) short-circuits to `res.text()`, because there is nothing to bound.
* Small tidy in the same function: the inline `parsed && typeof parsed === 'object'` check becomes a named `isRecord()` type guard that also excludes arrays, so a JSON array reply is no longer treated as a key-value body object.

Nothing else in the file changes. No signature is widened, no new dependency, no new configuration.

## What trips people up

1. **The bound does not yet produce its own error message.** The three callers of `http()` (`enroll`, `requestDeviceAuthorization`, and the token poll in `pollForIdpToken`) each catch everything and rewrap it. So at this commit an oversized body is reported as "Couldn't reach the NanoClaw account service" or "Couldn't reach the sign-in provider", and in the token poll it counts as a retryable transport failure and is retried up to 10 times before giving up. PR 20 in this stack adds `if (err instanceof LoginError) throw err;` to those three catch blocks, which turns the overflow into an immediate, correctly labelled abort. Reviewing this PR on its own: the memory bound is real and effective from here, the diagnosis is not.
2. **No new test file here.** The oversized-body case is asserted in `setup/registry-login.driver.test.ts`, which depends on later work and lands in PR 21. The existing `setup/registry-login.test.ts` is unchanged and still passes; its fetch stub is `{ status: 200, text: async () => '{}' }` with no `.body`, which means the body-less fallback line is what keeps that suite green. That line is load-bearing, not defensive padding.
3. **CI does not typecheck this file.** `tsconfig.json` includes only `src/**/*`, so `setup/` is outside the CI typecheck. This PR was checked with a setup-inclusive `tsc` configuration locally.

## What to review

* Is 256 KiB comfortably above any legitimate reply? The real payloads here are small JSON objects (enrollment result, device authorization, token response), so the headroom is large, but confirm nothing legitimate can approach it.
* The byte accounting in `readBoundedResponseBody`: `receivedBytes` accumulates `value.byteLength` before the check, the reader is cancelled on overflow, and `reader.releaseLock()` runs in a `finally`.
* The `if (!res.body) return res.text();` fallback, and whether you are comfortable that a body-less response is unbounded by definition rather than by omission.
* `isRecord` now rejects arrays where the old check accepted them. A top-level JSON array from either server used to become a `Record` and would now be `undefined`, which downstream code already handles as "no usable body".

## Type of Change

- [x] **Fix** - bug fix or security fix to source code

This is a security fix: it removes an unbounded read of a remote response. It is not a skill and adds no feature surface.

## Description

Caps every HTTP response body read during registry and identity-provider sign-in at 256 KiB by streaming the body and aborting past the limit, replacing an unbounded `res.text()`. Also narrows the JSON body check so arrays are not read as objects. No behaviour change for normal, correctly sized responses.

## For Skills

Not a skill, so this checklist does not apply.