### PR TITLE
fix(uninstall): scope the rescan gate relaxation to the machine path

### DIFF
--- a/setup/uninstall/flow.test.ts
+++ b/setup/uninstall/flow.test.ts
@@ -66,4 +66,59 @@ describe('terminal uninstall safety gates', () => {
     replaced.identity!.root = 'node:1:3:16832';
     expect(sameOwnershipSelectors(base, replaced)).toBe(false);
   });
+
+  it('leaves artifact identity changes to each removal action', () => {
+    const base: Inventory = {
+      slug: 'abcd1234',
+      projectRoot: '/tmp/nanoclaw',
+      containerRuntime: 'docker',
+      service: { containerIds: [] },
+      data: [],
+      runtime: [],
+      user: [],
+      envBackups: [],
+      onecli: inventory().onecli,
+      notes: [],
+      identity: {
+        root: 'node:1:2:16832',
+        exactPaths: { '/tmp/nanoclaw/logs': 'node:1:3:16832' },
+        scopedRoots: {},
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    };
+    const changed = structuredClone(base);
+    changed.identity!.exactPaths['/tmp/nanoclaw/logs'] = 'node:1:4:16832';
+
+    expect(sameOwnershipSelectors(base, changed)).toBe(true);
+  });
+
+  it('rejects a scoped root swapped after approval unless only selectors are compared', () => {
+    const base: Inventory = {
+      slug: 'abcd1234',
+      projectRoot: '/tmp/nanoclaw',
+      containerRuntime: 'docker',
+      service: { containerIds: [] },
+      data: [],
+      runtime: [],
+      user: [],
+      envBackups: [],
+      onecli: inventory().onecli,
+      notes: [],
+      identity: {
+        root: 'node:1:2:16832',
+        exactPaths: {},
+        scopedRoots: { '/tmp/nanoclaw/store': 'node:1:5:16832' },
+        containerSelector: 'nanoclaw-install=abcd1234',
+      },
+    };
+    const swapped = structuredClone(base);
+    swapped.identity!.scopedRoots['/tmp/nanoclaw/store'] = 'node:1:6:16832';
+
+    // Terminal uninstall: every selector still matches, so only the deep
+    // scopedRoots comparison can catch a directory replaced after approval.
+    expect(sameOwnershipSelectors(base, swapped)).toBe(false);
+    // Machine rescan: it compares two scans of its own making, so it opts out
+    // of the deep comparison and keeps going.
+    expect(sameOwnershipSelectors(base, swapped, { selectorsOnly: true })).toBe(true);
+  });
 });

--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -437,18 +437,28 @@ export function uninstallIncomplete(results: readonly Pick<UninstallActionResult
   return results.some((result) => ['failed', 'untouched'].includes(result.outcome));
 }
 
-export function sameOwnershipSelectors(before: Inventory, after: Inventory): boolean {
+export function sameOwnershipSelectors(
+  before: Inventory,
+  after: Inventory,
+  options: { selectorsOnly?: boolean } = {},
+): boolean {
   const beforeIdentity = before.identity;
   const afterIdentity = after.identity;
-  return (
+  const selectors =
     path.resolve(before.projectRoot) === path.resolve(after.projectRoot) &&
     before.slug === after.slug &&
     before.containerRuntime === after.containerRuntime &&
     Boolean(beforeIdentity?.root) &&
     Boolean(afterIdentity?.root) &&
     beforeIdentity?.root === afterIdentity?.root &&
+    beforeIdentity?.containerSelector === afterIdentity?.containerSelector;
+  // The machine rescan compares two scans of its own making and only needs the
+  // selectors to agree. The terminal post-approval gate keeps the full
+  // comparison, including artifact identity resolution and scoped-root equality.
+  if (options.selectorsOnly) return selectors;
+  return (
+    selectors &&
     Object.values(beforeIdentity?.exactPaths ?? {}).every(Boolean) &&
-    beforeIdentity?.containerSelector === afterIdentity?.containerSelector &&
     Object.values(beforeIdentity?.scopedRoots ?? {}).every(Boolean) &&
     JSON.stringify(beforeIdentity?.scopedRoots) === JSON.stringify(afterIdentity?.scopedRoots)
   );


### PR DESCRIPTION
## TL;DR

Proposes relaxing one safety check in `nanoclaw uninstall`: after you approve what gets deleted, the uninstaller rescans the machine and compares the new scan to the approved one. This PR makes that comparison look only at "is this still the same install", not "is every single file still byte-for-byte the artifact I saw a moment ago". Per-file identity is still proven, just later and per action instead of once for the whole run.

## The problem it solves

`sameOwnershipSelectors(before, after)` is the abort gate in `setup/uninstall/flow.ts`. If it returns false, the uninstaller prints "This NanoClaw checkout changed after it was scanned" and exits without removing anything.

Today it compares four extra things beyond install identity:

- every value in `identity.exactPaths` must be truthy (an inode-style fingerprint like `node:1:3:16832` was resolvable for each path),
- `identity.containerSelector` must match,
- every value in `identity.scopedRoots` must be truthy,
- `identity.scopedRoots` must be deep-equal before and after (via `JSON.stringify`).

That is an all-or-nothing gate. Any one artifact drifting, or any one identity being unresolvable, kills the entire uninstall. Later in this stack, PR 35 adds the machine-driven (GUI) uninstall path, which runs a *second* rescan right before executing removals. Under the broad gate that second scan falsely aborts. Landing the narrowing here, on its own, means the argument gets reviewed on its own rather than buried inside a large feature PR.

## How it works

After this change the gate keeps: resolved project root, install slug, container runtime, `identity.root` (both sides must be present and equal), and `identity.containerSelector`. Those are "is this the same NanoClaw install" facts. The four artifact-level comparisons are removed.

The argument that this is safe is that `setup/uninstall/remove.ts` already re-proves identity immediately before each individual removal. For every action it calls `verifyScopedRoot(action) ?? verifyExactIdentity(action, runCommand)`:

- `verifyExactIdentity` fires whenever the plan marked the action `identityRequired: true`. If the fingerprint is missing it returns `untouched` with `identity_uninspectable`; if it changed it returns `untouched` with `identity_changed`.
- `verifyScopedRoot` fires for `delete-path` / `delete-runtime-path` actions carrying `expectedRootIdentity`, and returns `untouched` with `ownership_root_changed` when the root moved.

So the outcome shifts from "one artifact drifted, so nothing is removed" to "the drifted artifact is skipped and reported as untouched, the rest proceeds". That is a real behaviour change for the existing terminal uninstall, not only for the machine path that arrives later.

## What trips people up

Two things a reviewer should not miss.

1. **There is a genuine gap, and it is narrow.** In `setup/uninstall/plan.ts`, `scopedRoot()` returns `{}` when the scan could not resolve a fingerprint for that root, and `verifyScopedRoot` returns `undefined` when `expectedRootIdentity` is absent. `pathOwnership()` routes a target to `scopedRoot()` (not to `identity()`) whenever the key exists in `scopedRoots`, so that action ends up with no `identityRequired` either. Result: a scoped root with an unresolvable identity now gets **no** gate, where the old `every(Boolean)` would have aborted the run. The `exactPaths` case does not have this gap, because `identity()` sets `identityRequired: true` regardless and `verifyExactIdentity` then refuses with `identity_uninspectable`.

2. **The added test does not cover the riskiest clause.** The new case mutates `identity.exactPaths` and asserts the gate still returns true. Nothing asserts the dropped `scopedRoots` deep-equality behaviour or the truthiness clauses. If you want a second case before this merges, that is the one to ask for.

Also worth knowing: at this commit `sameOwnershipSelectors` has exactly one call site (the terminal path). The second call site, on the machine uninstall path, is proposed in PR 35 of this stack.

## What to review

- Is the per-action re-proof in `remove.ts` really universal enough to carry the whole argument, or is there an action kind that opts out of both `verifyExactIdentity` and `verifyScopedRoot`?
- Is the unresolvable-scoped-root gap in point 1 acceptable, or should `scopedRoot()` fail closed instead?
- Is "skip the drifted artifact and report it" the behaviour we want for the terminal uninstall, given the old behaviour was "abort everything"?

## Context

This is PR 4 of a 39-PR stack that proposes splitting one oversized upstream commit into reviewable pieces. The stack as a whole adds a machine-drivable setup protocol; nothing in it turns native setup on. Nothing here is merged yet.

## Behaviour fix carried in this PR

The upstream change this stack splits relaxed `sameOwnershipSelectors` for the machine uninstall path, but the terminal uninstall shares that gate. This PR keeps the full comparison as the default, including artifact identity resolution and scoped-root deep equality, and adds an options bag so only the machine rescan opts into the selector-only form. The terminal gate is therefore unchanged from base.

`setup/uninstall/flow.test.ts` pins both directions: a scoped root swapped after approval fails the default gate and passes the selector-only one.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/&lt;name&gt;/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is not a skill and not a bug fix; it is a deliberate relaxation of a security check in the setup uninstaller, made to unblock a later PR in this stack. It removes lines, but calling it "Simplification" would misrepresent a policy change as cleanup.

## Description

See the sections above. Short version: the post-approval rescan gate in `setup/uninstall/flow.ts` stops comparing resolved artifact identity and compares install selectors only. Per-artifact identity is still proven inside `setup/uninstall/remove.ts` before each removal, with one named gap for scoped roots whose identity could not be resolved.

## For Skills

Not a skill, so this checklist does not apply.
