### PR TITLE
fix(setup): resolve setup paths from the checkout, not the cwd

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -28,6 +28,7 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import * as os from 'os';
 import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 import * as p from '@clack/prompts';
 import k from 'kleur';
@@ -103,6 +104,7 @@ import {
   type TemplateOperation,
 } from './templates.js';
 
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CLI_AGENT_NAME = 'Terminal Agent';
 const RUN_START = Date.now();
 
@@ -1732,7 +1734,7 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
 }
 
 function writeEnvLine(key: string, value: string): void {
-  const envFile = path.join(process.cwd(), '.env');
+  const envFile = path.join(PROJECT_ROOT, '.env');
   const content = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf-8') : '';
   const re = new RegExp(`^${key}=.*$`, 'm');
   const next = re.test(content)
@@ -1742,7 +1744,7 @@ function writeEnvLine(key: string, value: string): void {
 }
 
 function appendProviderImport(modulePath: string): void {
-  const file = path.join(process.cwd(), 'src', 'providers', 'index.ts');
+  const file = path.join(PROJECT_ROOT, 'src', 'providers', 'index.ts');
   const content = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
   const line = `import '${modulePath}';`;
   if (content.includes(line)) return;
@@ -2082,6 +2084,7 @@ function initProgressionLog(): void {
   let commit = '';
   try {
     commit = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: PROJECT_ROOT,
       encoding: 'utf-8',
     }).stdout.trim();
   } catch {
@@ -2090,6 +2093,7 @@ function initProgressionLog(): void {
   let branch = '';
   try {
     branch = spawnSync('git', ['branch', '--show-current'], {
+      cwd: PROJECT_ROOT,
       encoding: 'utf-8',
     }).stdout.trim();
   } catch {
@@ -2098,7 +2102,7 @@ function initProgressionLog(): void {
   setupLog.reset({
     invocation: 'setup:auto (standalone)',
     user: process.env.USER ?? 'unknown',
-    cwd: process.cwd(),
+    cwd: PROJECT_ROOT,
     branch: branch || 'unknown',
     commit: commit || 'unknown',
   });

--- a/setup/provider-auth.ts
+++ b/setup/provider-auth.ts
@@ -12,6 +12,9 @@
  * provider rewrite, no service changes. Provider install skills call this as
  * their auth step so there is exactly one auth implementation per provider.
  */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { buildContainerImage } from './lib/container-build.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
@@ -26,8 +29,10 @@ import './providers/index.js';
 const INSTALL_SKILLS: Record<string, string> = {
   codex: '.claude/skills/add-codex',
 };
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 export async function run(args: string[]): Promise<void> {
+  process.chdir(PROJECT_ROOT);
   const name = args[0]?.trim().toLowerCase();
   const withAuth = listSetupProviders().filter((entry) => entry.runAuth);
 
@@ -49,14 +54,14 @@ export async function run(args: string[]): Promise<void> {
     // we rebuild the image whenever the install mutated anything (the container
     // CLI manifest is baked into the image, unlike the mounted payload code).
     console.log(`${entry ? 'Refreshing' : 'Installing'} ${name}…`);
-    const { changed, blockers } = await applyProviderSkill(skillDir, process.cwd());
+    const { changed, blockers } = await applyProviderSkill(skillDir, PROJECT_ROOT);
     if (blockers.length) {
       console.error(`Couldn't install ${name}: ${blockers.join('; ')}`);
       process.exit(1);
     }
     if (changed) {
       console.log('Provider payload installed — rebuilding the container image…');
-      const rebuild = buildContainerImage();
+      const rebuild = buildContainerImage(PROJECT_ROOT);
       if (!rebuild.ok) {
         // Stop here rather than authenticating a runtime the image can't start:
         // the payload files are mounted, but the CLI manifest is baked in.


### PR DESCRIPTION
**Proposed.** Nothing here is merged yet. This is one commit out of a 39 part stack that splits a single oversized upstream change into reviewable pieces. The whole stack adds a machine drivable setup protocol; this piece is a small, self contained correctness fix that the rest of the stack depends on.

## TL;DR

Two setup entry points worked out where the repository lives by asking "what directory is this process running in?" (`process.cwd()`). This changes them to work it out from the location of the setup source file itself, so setup writes into the checkout no matter where it was launched from.

## The problem

`setup/auto.ts` (the interactive setup flow) and `setup/provider-auth.ts` (the standalone `--step provider-auth <name>` entry point, used when an existing install adds an AI provider later) both built file paths by joining onto `process.cwd()`, the caller's current working directory. That is only correct if the caller happens to be standing in the checkout.

When it is not, the consequences are real: `.env` gets created in the wrong directory, the `src/providers/index.ts` barrel file (the list of import lines that registers provider code) gets appended to in the wrong directory, and the setup progression log records git branch and commit from whatever repository the caller was standing in.

In practice `nanoclaw.sh` already `cd`s to the checkout before it runs anything, so the normal bootstrap path was never wrong. The exposure is the standalone step and any programmatic caller, and the stack adds more programmatic entry points later.

## How it works

Both files compute the same constant:

```ts
const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
```

`import.meta.url` is the URL of the running module, so this resolves to the checkout root from the source file's own location, independent of the caller. Then:

- `setup/auto.ts`: three functions swap `process.cwd()` for `PROJECT_ROOT`. `writeEnvLine` (writes `.env`), `appendProviderImport` (appends to the providers barrel), and `initProgressionLog`, which additionally gains `cwd: PROJECT_ROOT` on its two `spawnSync` git probes so the recorded branch and commit come from the checkout.
- `setup/provider-auth.ts`: `run()` calls `process.chdir(PROJECT_ROOT)` as its first statement, and passes `PROJECT_ROOT` explicitly to `applyProviderSkill(...)` and `buildContainerImage(...)`. Both of those functions already accepted a project root parameter that defaulted to `process.cwd()`, so this only makes the argument explicit rather than changing their signatures.

Total: 19 changed production lines across 2 files, no new tests.

## What trips people up

1. **`process.chdir` is a global side effect.** It appears only in the standalone `provider-auth` entry point, and it moves the working directory for every call downstream of it in that process, including `entry.runAuth()`. That is intentional (the standalone step owns its whole process), but it is the one line in this diff with reach beyond the statement it sits in. `setup/auto.ts` does not chdir.
2. **`pathToFileURL` is imported here and never referenced at this commit.** It is not dead code and it is not an accident: a later PR in the stack adds an entry point guard that uses it. It is imported now to keep this file's import block stable across the stack.
3. **This is not a complete sweep.** `setup/auto.ts` had 8 `process.cwd()` uses; this PR converts 3 of them and leaves 5. The remaining 5 sit inside regions that later PRs in the stack rewrite wholesale, and they are converted there. By the tip of the stack the file has none left.
4. **The behaviour change is user visible for one workflow.** Anyone who ran a setup step from a subdirectory previously got files written next to themselves; now they get files written into the checkout. That is the intended correction, not a regression, but it is a change.

## What to review

- Is `path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')` correct for both files? Both live directly under `setup/`, so `..` is the checkout root. Worth a second pair of eyes because both files are compiled and run through `tsx`, not from a `dist/` directory with different nesting.
- Is `process.chdir` acceptable in `provider-auth.ts`'s `run()`, or should the remaining `process.cwd()` consumers downstream take an explicit root instead? Passing the root explicitly is cleaner; chdir was chosen because the downstream surface is wide and this entry point is a whole process.
- The three converted functions in `auto.ts` are the only places whose sole change in this commit is the root swap. Confirm no fourth site was missed that is not claimed by a later PR.

## Verification

- `tsc` over the setup inclusive project config, no new errors against the baseline.
- `vitest` over `setup` and `scripts`.
- Note for context: the repository's `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`. The setup inclusive typecheck above is run locally against a separate config.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

Ticked as a fix because it corrects incorrect path resolution in source code. To be plain about the severity: no user reported this, and the shipped bootstrap path was already safe because `nanoclaw.sh` changes directory first. The defect is latent and reachable through the standalone step and programmatic callers.

## Description

See above. Two setup files stop deriving paths from the caller's working directory and derive them from the module's own location instead.

## For Skills

Not a skill, so the skill checklist does not apply.