### PR TITLE
feat(setup): add secret redaction and a child-env secret deny list

### DIFF
--- a/setup/lib/diagnostics.ts
+++ b/setup/lib/diagnostics.ts
@@ -10,6 +10,8 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
+import { redactSensitiveValues } from './redaction.js';
+
 const POSTHOG_KEY = 'phc_fx1Hhx9ucz8GuaJC8LVZWO8u03yXZZJJ6ObS4yplnaP';
 const POSTHOG_URL = 'https://us.i.posthog.com/capture/';
 const INSTALL_ID_PATH = path.join('data', 'install-id');
@@ -56,7 +58,8 @@ export function emit(
   const cleaned: Record<string, unknown> = { platform: process.platform };
   for (const [k, v] of Object.entries(props)) {
     if (v === undefined) continue;
-    cleaned[k] = v;
+    cleaned[k] =
+      typeof v === 'string' && process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1' ? redactSensitiveValues(v) : v;
   }
 
   const body = JSON.stringify({

--- a/setup/lib/redaction.test.ts
+++ b/setup/lib/redaction.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearSensitiveValuesForTest, createSensitiveRedactor, registerSensitiveValue } from './redaction.js';
+
+afterEach(clearSensitiveValuesForTest);
+
+describe('streaming sensitive-value redaction', () => {
+  it('redacts a secret split across child-output chunks', () => {
+    registerSensitiveValue('secret-value');
+    const redactor = createSensitiveRedactor();
+    const output = redactor.write('before secret-') + redactor.write('value after') + redactor.end();
+    expect(output).toBe('before [REDACTED] after');
+  });
+
+  it('streams safe output while retaining only a possible secret boundary', () => {
+    registerSensitiveValue('secret-value');
+    const redactor = createSensitiveRedactor();
+    const output = redactor.write('visible output '.repeat(100));
+    expect(output.length).toBeGreaterThan(1_000);
+    expect(output).not.toContain('secret-value');
+  });
+
+  it('prefers a longer secret when registered values overlap', () => {
+    registerSensitiveValue('secret');
+    registerSensitiveValue('secret-value');
+    const redactor = createSensitiveRedactor();
+    const output = redactor.write('before secret-value after') + redactor.end();
+    expect(output).toBe('before [REDACTED] after');
+  });
+});

--- a/setup/lib/redaction.ts
+++ b/setup/lib/redaction.ts
@@ -1,0 +1,56 @@
+const sensitiveValues = new Set<string>();
+
+export function registerSensitiveValue(value: string): void {
+  if (value.length > 0) sensitiveValues.add(value);
+}
+
+export function redactSensitiveValues(value: string): string {
+  let redacted = value;
+  for (const secret of [...sensitiveValues].sort((a, b) => b.length - a.length)) {
+    redacted = redacted.split(secret).join('[REDACTED]');
+  }
+  return redacted;
+}
+
+export function createSensitiveRedactor(): { write(chunk: string): string; end(): string } {
+  const secrets = [...sensitiveValues].sort((a, b) => b.length - a.length);
+  const maxLength = Math.max(0, ...secrets.map((secret) => secret.length));
+  let pending = '';
+
+  const drain = (flush: boolean): string => {
+    if (flush) {
+      const output = redactSensitiveValues(pending);
+      pending = '';
+      return output;
+    }
+    const limit = pending.length - Math.max(0, maxLength - 1);
+    let index = 0;
+    let output = '';
+    while (index < limit) {
+      const secret = secrets.find((candidate) => pending.startsWith(candidate, index));
+      if (secret) {
+        output += '[REDACTED]';
+        index += secret.length;
+      } else {
+        output += pending[index];
+        index++;
+      }
+    }
+    pending = pending.slice(index);
+    return output;
+  };
+
+  return {
+    write(chunk) {
+      pending += chunk;
+      return drain(false);
+    },
+    end() {
+      return drain(true);
+    },
+  };
+}
+
+export function clearSensitiveValuesForTest(): void {
+  sensitiveValues.clear();
+}

--- a/setup/lib/secret-file.test.ts
+++ b/setup/lib/secret-file.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { withSecretFile } from './secret-file.js';
+import { childEnvWithoutSetupSecrets, withSecretFile } from './secret-file.js';
 
 describe('withSecretFile', () => {
   it('provides a private file and removes it after the operation', async () => {
@@ -33,5 +33,17 @@ describe('withSecretFile', () => {
 
     expect(fs.existsSync(secretPath)).toBe(false);
     expect(fs.existsSync(path.dirname(secretPath))).toBe(false);
+  });
+
+  it('removes setup credentials from machine child environments', () => {
+    expect(
+      childEnvWithoutSetupSecrets({
+        NANOCLAW_ANTHROPIC_AUTH_TOKEN: 'secret',
+        NANOCLAW_REGISTRY_ENROLL_CODE: 'secret',
+        NANOCLAW_REGISTRY_TOKEN: 'secret',
+        ONECLI_API_KEY: 'secret',
+        PATH: '/bin',
+      }),
+    ).toEqual({ PATH: '/bin' });
   });
 });

--- a/setup/lib/secret-file.ts
+++ b/setup/lib/secret-file.ts
@@ -26,3 +26,19 @@ export async function withSecretFile<T>(secret: string, operation: (filePath: st
     fs.rmdirSync(directory);
   }
 }
+
+export function childEnvWithoutSetupSecrets(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const safe = { ...env };
+  for (const key of [
+    'NANOCLAW_ANTHROPIC_AUTH_TOKEN',
+    'NANOCLAW_ONECLI_API_TOKEN',
+    'NANOCLAW_REGISTRY_ENROLL_CODE',
+    'NANOCLAW_REGISTRY_TOKEN',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ONECLI_API_KEY',
+  ])
+    delete safe[key];
+  return safe;
+}

--- a/setup/logs.ts
+++ b/setup/logs.ts
@@ -23,9 +23,13 @@
 import fs from 'fs';
 import path from 'path';
 
+import { redactSensitiveValues } from './lib/redaction.js';
+
 const LOGS_DIR = 'logs';
 const STEPS_DIR = path.join(LOGS_DIR, 'setup-steps');
 const PROGRESS_LOG = path.join(LOGS_DIR, 'setup.log');
+const logValue = (value: string): string =>
+  process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1' ? redactSensitiveValues(value) : value;
 
 export const progressLogPath = PROGRESS_LOG;
 export const stepsDir = STEPS_DIR;
@@ -56,7 +60,7 @@ export function header(meta: Record<string, string>): void {
   const ts = new Date().toISOString();
   const lines = [`## ${ts} · setup:auto started`];
   for (const [k, v] of Object.entries(meta)) {
-    lines.push(`  ${k}: ${v}`);
+    lines.push(`  ${k}: ${logValue(v)}`);
   }
   lines.push('');
   fs.appendFileSync(PROGRESS_LOG, lines.join('\n') + '\n');
@@ -76,7 +80,7 @@ export function step(
   const lines = [`=== [${ts}] ${name} [${dur}] → ${status} ===`];
   for (const [k, v] of Object.entries(fields)) {
     if (v === undefined || v === null || v === '') continue;
-    lines.push(`  ${k.toLowerCase()}: ${String(v)}`);
+    lines.push(`  ${k.toLowerCase()}: ${logValue(String(v))}`);
   }
   if (rawRel) lines.push(`  raw: ${rawRel}`);
   lines.push('');
@@ -91,7 +95,7 @@ export function step(
 export function userInput(key: string, value: string): void {
   fs.mkdirSync(LOGS_DIR, { recursive: true });
   const ts = new Date().toISOString();
-  fs.appendFileSync(PROGRESS_LOG, `=== [${ts}] user-input → ${key} ===\n  value: ${value}\n\n`);
+  fs.appendFileSync(PROGRESS_LOG, `=== [${ts}] user-input → ${key} ===\n  value: ${logValue(value)}\n\n`);
 }
 
 /** Append the success footer. */
@@ -103,7 +107,7 @@ export function complete(totalMs: number): void {
 /** Append the failure footer. Keep error short — full context lives in the failing step's raw log. */
 export function abort(stepName: string, error: string): void {
   const ts = new Date().toISOString();
-  fs.appendFileSync(PROGRESS_LOG, `## ${ts} · aborted at ${stepName} (${error})\n`);
+  fs.appendFileSync(PROGRESS_LOG, `## ${ts} · aborted at ${stepName} (${logValue(error)})\n`);
 }
 
 /**


### PR DESCRIPTION
## TL;DR

Proposes two small leaf modules that later pull requests in this stack use to keep prompted secrets out of setup logs, analytics payloads and child process environments. Nothing in this pull request is reachable yet: both wirings are gated on an environment variable that no code sets until a later pull request, and the secret registry is empty until a later pull request starts filling it.

## Background, in one paragraph

This stack proposes a machine drivable mode for NanoClaw setup, where a native macOS app drives the installer over a line based JSON protocol on stdin and stdout instead of a human answering terminal prompts. That mode is selected by the environment variable `NANOCLAW_PROTOCOL=nanoclaw.driver.v1`. In that mode the app, not a person, supplies API keys and tokens, and setup writes a persistent progress log plus optional analytics events. So the machine path needs a way to keep those values out of anything it writes down.

## What this pull request proposes

1. `setup/lib/redaction.ts`, a new module with four exports:
   - `registerSensitiveValue(value)`, adding a string to a process wide set of values that must never be printed.
   - `redactSensitiveValues(text)`, replacing every registered value in a string with `[REDACTED]`, longest value first so that overlapping secrets (for example `secret` and `secret-value`) do not leave a fragment behind.
   - `createSensitiveRedactor()`, a streaming version with `write(chunk)` and `end()`. Child process output arrives in arbitrary chunks, so a secret can be split across two of them. The redactor holds back the last `longestSecret - 1` characters of what it has seen, emits everything before that, and flushes the remainder on `end()`. When no secrets are registered it holds nothing back and passes text straight through.
   - `clearSensitiveValuesForTest()`, used only by tests.
2. `childEnvWithoutSetupSecrets(env = process.env)` in `setup/lib/secret-file.ts`, returning a copy of an environment with eight credential variables deleted (`NANOCLAW_ANTHROPIC_AUTH_TOKEN`, `NANOCLAW_ONECLI_API_TOKEN`, `NANOCLAW_REGISTRY_ENROLL_CODE`, `NANOCLAW_REGISTRY_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ONECLI_API_KEY`). The existing `withSecretFile` helper is untouched.
3. Two call sites: `setup/logs.ts` runs header fields, step fields, recorded user input and the abort reason through `redactSensitiveValues`, and `setup/lib/diagnostics.ts` does the same for every string valued analytics property.

## What is dormant, and which pull request switches it on

This matters for reviewing it honestly, so it is spelled out:

| Piece | Inert because | Turned on by |
| --- | --- | --- |
| Redaction in `logs.ts` and `diagnostics.ts` | Both call sites check `process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1'`, which nothing in the tree sets yet | The `nanoclaw.sh` protocol front door pull request, four positions later, which exports that variable |
| The secret registry itself | `registerSensitiveValue` has no production caller yet, so the set is empty and redaction is a no-op even if the variable were set | The terminal driver pull request, immediately after this one, which registers every value answered to a `secret` prompt |
| `childEnvWithoutSetupSecrets` | No caller in the tree | Imported by the step runner pull request and first actually used by the machine step children pull request |

Consequence: merging this pull request alone changes no observable behaviour anywhere, in terminal mode or otherwise, which is also why every existing setup test keeps byte identical output.

## Things that trip people up

- **The protocol string is a bare literal here.** Both call sites compare against `'nanoclaw.driver.v1'` written out in full rather than importing a constant. The constant `DRIVER_PROTOCOL` is defined in the very next pull request in this stack, so this pull request cannot import it. If you prefer, the literals can be replaced by the import once that lands.
- **Terminal mode logs stay unredacted.** This is deliberate, not an oversight: in terminal mode a human typed the value into their own terminal on their own machine. Only the machine driven path redacts. Worth agreeing on explicitly rather than quietly fixing.
- **The registry is process wide and append only.** Values registered later are redacted from then on, but anything already written to the log file stays written. Redaction protects future writes only.
- **Snapshot versus live set.** `createSensitiveRedactor()` snapshots the registered values at creation time for its streaming path, while its final `end()` flush calls `redactSensitiveValues`, which reads the live set. A secret registered after a redactor was created is therefore caught on flush but not necessarily mid stream. In practice a redactor is created per child process, after prompting, so this does not bite, but it is the kind of thing worth a reviewer's eye.
- **Deny list completeness is the real review question.** The list is hand maintained. A new credential environment variable added later will leak into machine child processes unless someone remembers to add it here.

## What to review

1. Is the streaming redactor correct at the boundary? Specifically the `limit = pending.length - (longest - 1)` retention and the longest first matching.
2. Is the eight name deny list complete for this repository today?
3. Is machine only redaction the policy you want, or should terminal logs be redacted too?

## Verification

New tests in `setup/lib/redaction.test.ts` cover a secret split across two chunks, safe output streaming through while a possible boundary is retained, and longest match preference. `setup/lib/secret-file.test.ts` gains one case for the deny list. This commit passes the setup inclusive TypeScript check and `bash -n nanoclaw.sh`, and the vitest suite is green apart from four failures that are pre existing on the author's machine (a git tag signing issue that also fails on a clean upstream checkout). Note that the repository's `tsconfig.json` includes only `src/**/*`, so continuous integration does not type check `setup/`; the type check above is run separately by this stack.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is not a skill, and it is not a fix either: it adds new setup infrastructure that is dormant at this commit and fixes no existing defect. It is one slice of a larger proposed feature that is being reviewed one piece at a time.

## Description

See the sections above. In short: proposes a secret redaction module and a child environment deny list, wires them into the setup log writer and the analytics emitter behind a machine mode check, and leaves both inert until later pull requests in this stack set the environment variable and register the first secret.

## For Skills

Not a skill, so this checklist does not apply.
