### PR TITLE
feat(setup): add the SetupDriver protocol surface, no callers yet

### DIFF
--- a/setup/lib/setup-driver.ts
+++ b/setup/lib/setup-driver.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from 'node:crypto';
+
+import * as p from '@clack/prompts';
+
+import { brightSelect } from './bright-select.js';
+import { redactSensitiveValues, registerSensitiveValue } from './redaction.js';
+
+export const DRIVER_PROTOCOL = 'nanoclaw.driver.v1' as const;
+
+export type DriverOperation = 'setup' | 'uninstall';
+export type ProgressState = 'pending' | 'running' | 'succeeded' | 'failed';
+export type UninstallGroup = 'service' | 'data' | 'user' | 'onecli';
+export type UninstallChoice = 'preserve' | 'remove';
+export type ActionOutcome = 'removed' | 'preserved' | 'failed' | 'untouched' | 'alreadyAbsent';
+
+export type Validation = {
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+};
+
+export type DriverPrompt = {
+  id?: string;
+  kind: 'confirm' | 'singleChoice' | 'text' | 'secret';
+  message: string;
+  sensitive?: boolean;
+  choices?: Array<{ id: string; label: string; hint?: string }>;
+  default?: boolean | string;
+  /** Terminal-only hint; deliberately absent from the wire schema. */
+  placeholder?: string;
+  /** Terminal-only search UI; deliberately absent from the wire schema. */
+  searchable?: boolean;
+  validation?: Validation;
+  /** Driver-side validation that is enforced but not serialized on the wire. */
+  validateValue?: (value: boolean | string) => string | undefined;
+};
+
+export type DriverDisplay =
+  | { id: string; kind: 'text' | 'code'; content: string; sensitive: boolean; label?: string }
+  | { id: string; kind: 'url'; url: string; label: string; sensitive: boolean }
+  | { id: string; kind: 'qr'; payload: string; sensitive: boolean; label?: string };
+
+export type ExternalAction =
+  | { id?: string; kind: 'openURL'; title: string; url: string }
+  | { id?: string; kind: 'startApplication'; title: string; application: string }
+  | { id?: string; kind: 'systemPermission'; title: string; instructions: string[] };
+
+export type ExternalActionResult = 'attempted' | 'declined' | 'unsupported';
+
+export type Recovery = { kind: 'rerun'; args: string[] } | { kind: 'manual'; title: string; instructions: string[] };
+
+export type Artifact = {
+  id: string;
+  kind: string;
+  label: string;
+  location: string;
+  disposition: 'owned' | 'shared' | 'external' | 'uninspectable' | 'alreadyAbsent';
+  decisionGroup?: UninstallGroup;
+};
+
+export type UninstallPlan = {
+  id: string;
+  groups: Array<{
+    id: UninstallGroup;
+    label: string;
+    description: string;
+    default: 'preserve';
+    choices: ['preserve', 'remove'];
+  }>;
+  artifacts: Artifact[];
+};
+
+export type UninstallActionResult = {
+  actionId: string;
+  artifactId: string;
+  outcome: ActionOutcome;
+  error?: { code: string; message: string };
+};
+
+export type UninstallReceipt = {
+  version: 1;
+  outcome: 'success' | 'incomplete';
+  results: UninstallActionResult[];
+  remaining: Artifact[];
+  checkoutRemoval: {
+    safe: boolean;
+    blockers: string[];
+  };
+  completedAt: string;
+};
+
+export type SetupReceipt = {
+  version: 1;
+  service: {
+    state: 'running';
+    manager: 'launchd' | 'systemd-user' | 'systemd-system' | 'pidfile';
+    checkoutRoot: string;
+  };
+  health: { status: 'healthy' };
+  resources: {
+    groups: { state: 'loaded' | 'empty'; count: number };
+    policies: { state: 'loaded' | 'empty'; count: number };
+    skills: { state: 'loaded' | 'empty'; count: number };
+  };
+  completedAt: string;
+};
+
+export class DriverCancelled extends Error {
+  constructor(readonly reason?: string) {
+    super('driver cancelled');
+  }
+}
+
+type LogLevel = 'info' | 'success' | 'warn' | 'error' | 'step' | 'message';
+
+export interface SetupDriver {
+  readonly mode: 'terminal' | 'ndjson';
+  readonly operation: DriverOperation;
+  readonly cancellationSignal?: AbortSignal;
+  prompt(spec: DriverPrompt): Promise<boolean | string>;
+  progress(stepId: string, state: ProgressState, label?: string): void;
+  display(display: DriverDisplay): void;
+  clearDisplay(displayId: string): void;
+  note(content: string, label?: string): void;
+  log(level: LogLevel, message: string): void;
+  intro(message: string): void;
+  outro(message: string): void;
+  externalAction(action: ExternalAction, verify: () => boolean | Promise<boolean>): Promise<ExternalActionResult>;
+  waitForUninstall(
+    plan: UninstallPlan,
+    validate: (choices: Map<UninstallGroup, UninstallChoice>) => string | undefined,
+  ): Promise<Map<UninstallGroup, UninstallChoice>>;
+  uninstallAction(result: UninstallActionResult): void;
+  throwIfCancelled(): void;
+  error(code: string, message: string, recovery?: Recovery[], stepId?: string): never;
+  completeSetup(receipt: SetupReceipt): void;
+  completeUninstall(receipt: UninstallReceipt): void;
+  cancelled(details?: { lastStepId?: string; results?: UninstallActionResult[]; remaining?: Artifact[] }): void;
+  handoff(): void;
+  close(): void;
+}
+
+function validateValue(spec: DriverPrompt, value: unknown): string | undefined {
+  if (spec.kind === 'confirm') return typeof value === 'boolean' ? undefined : 'Expected a boolean.';
+  if (typeof value !== 'string') return 'Expected a string.';
+  if (spec.kind === 'singleChoice') {
+    return spec.choices?.some((choice) => choice.id === value) ? undefined : 'Unknown choice.';
+  }
+  const validation = spec.validation;
+  if (validation?.required && value.length === 0) return 'A value is required.';
+  if (validation?.minLength !== undefined && value.length < validation.minLength) {
+    return `Value must be at least ${validation.minLength} characters.`;
+  }
+  if (validation?.maxLength !== undefined && value.length > validation.maxLength) {
+    return `Value must be at most ${validation.maxLength} characters.`;
+  }
+  if (validation?.pattern !== undefined) {
+    try {
+      if (!new RegExp(validation.pattern).test(value)) return 'Value does not match the expected format.';
+    } catch {
+      return 'Prompt validation is invalid.';
+    }
+  }
+  return spec.validateValue?.(value);
+}
+
+function isUninstallGroup(value: unknown): value is UninstallGroup {
+  return typeof value === 'string' && ['service', 'data', 'user', 'onecli'].includes(value);
+}
+
+const PRESENTATION_FIELDS = new Set(['content', 'instructions', 'label', 'location', 'message', 'payload', 'title']);
+
+function redactProtocolPresentation(value: unknown, field?: string): unknown {
+  if (typeof value === 'string') {
+    return field && PRESENTATION_FIELDS.has(field) ? redactSensitiveValues(value) : value;
+  }
+  if (Array.isArray(value)) return value.map((item) => redactProtocolPresentation(item, field));
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactProtocolPresentation(item, key)]));
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}


### PR DESCRIPTION
## TL;DR

Proposes one new file, `setup/lib/setup-driver.ts`, that declares the contract every later PR in this stack codes against. It is types and one interface. No file imports it yet, so merging it changes nothing that runs.

## What problem this solves

NanoClaw's setup script talks to a human through a terminal prompt library (clack). A native macOS app cannot answer a terminal prompt. The plan for the rest of this stack is to put an interface, `SetupDriver`, in front of every user interaction, then supply two implementations: one that renders in the terminal exactly as today, and one that speaks newline delimited JSON (NDJSON, one JSON object per line) over stdin/stdout so an app can drive setup with no terminal. This PR is that interface plus the data shapes it moves.

## How it works

- `SetupDriver` has one method per kind of interaction: `prompt` (confirm, single choice, free text, secret), `progress`, `display`, `note`/`log`/`intro`/`outro`, `externalAction` (open a URL, launch an app, grant a system permission), the uninstall plan/choice exchange, terminal states (`error`, `completeSetup`, `completeUninstall`, `cancelled`, `handoff`, `close`), and `throwIfCancelled`.
- The receipt types (`SetupReceipt`, `UninstallReceipt`) are the structured "what happened" payloads a GUI client would read instead of scraping console text.
- Some prompt fields are marked terminal only in comments (`placeholder`, `searchable`, `validateValue`). They exist for the clack implementation and are deliberately not part of what would go on the wire.
- `DRIVER_PROTOCOL = 'nanoclaw.driver.v1'` is defined here. PR 6 in this stack already gates on that same string as a bare literal; this is the named constant later PRs use.
- Three private helpers land with the types: `validateValue` (checks a prompt answer against the declared validation), `isUninstallGroup` (a type guard), and `redactProtocolPresentation` (walks a message object and scrubs registered secrets out of the human readable fields only).

## What trips people up

This file is completely dormant at this commit and deliberately so. Nothing imports it, and it carries imports and functions with no caller inside it: `randomUUID`, `import * as p` from clack, `brightSelect`, `registerSensitiveValue`, plus `validateValue`, `isUninstallGroup` and `redactProtocolPresentation`. That would normally be a red flag. It typechecks because `noUnusedLocals` is off and eslint is scoped to `src/**`, and the file is split this way so the contract can be reviewed on its own before any implementation lands. The next PR (terminal driver plus NDJSON command parser) consumes all of them except `randomUUID` and `redactProtocolPresentation`, which the PR after that consumes. There are no tests here because there is nothing executable to test yet; the first tests of this file arrive with the NDJSON driver two PRs later.

Also worth knowing: the repo's `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`. This file was checked with a setup inclusive tsc config run locally, not by the repo's default gate.

## What to review

This is the PR whose review matters most for anything outside this repository, because these types are the wire contract a native client would be built against and changing them later is a breaking change. Worth checking: are the prompt kinds and validation fields enough for every real setup question; are the receipt shapes complete enough for a GUI to show a truthful result; is the terminal only versus wire split drawn in the right place; and is `redactProtocolPresentation`'s field allowlist (`content`, `instructions`, `label`, `location`, `message`, `payload`, `title`) the right set to scrub.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this is not a skill, not a bug fix, and not a simplification. It adds a new type only module under `setup/` as the first step of a larger feature that is split across a stack of PRs.

## Description

Adds `setup/lib/setup-driver.ts`, declaring `DRIVER_PROTOCOL`, the setup driver data types, `DriverCancelled`, the `SetupDriver` interface and three private helpers. No caller exists at this commit, so runtime behaviour is unchanged.

## For Skills

Not a skill, so this checklist does not apply.