### PR TITLE
feat(setup): add the terminal driver and the ndjson wire parser

### DIFF
--- a/setup/lib/setup-driver.ts
+++ b/setup/lib/setup-driver.ts
@@ -179,6 +179,295 @@ function redactProtocolPresentation(value: unknown, field?: string): unknown {
   if (!isRecord(value)) return value;
   return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactProtocolPresentation(item, key)]));
 }
+
+export class TerminalSetupDriver implements SetupDriver {
+  readonly mode = 'terminal' as const;
+
+  constructor(readonly operation: DriverOperation) {}
+
+  async prompt(spec: DriverPrompt): Promise<boolean | string> {
+    const validate = (value: string | undefined): string | undefined => validateValue(spec, value ?? '');
+    let answer: boolean | string | symbol;
+    if (spec.kind === 'confirm') {
+      answer = await p.confirm({
+        message: spec.message,
+        initialValue: spec.default === undefined ? true : spec.default === true,
+      });
+    } else if (spec.kind === 'singleChoice') {
+      const options = (spec.choices ?? []).map(({ id, label, hint }) => ({ value: id, label, hint }));
+      answer = spec.searchable
+        ? await p.autocomplete({
+            message: spec.message,
+            options,
+            initialValue: typeof spec.default === 'string' ? spec.default : undefined,
+            maxItems: 5,
+            placeholder: spec.placeholder,
+          })
+        : await brightSelect({
+            message: spec.message,
+            options,
+            initialValue: typeof spec.default === 'string' ? spec.default : undefined,
+          });
+    } else if (spec.kind === 'secret') {
+      answer = await p.password({ message: spec.message, clearOnError: true, validate });
+    } else {
+      answer = await p.text({
+        message: spec.message,
+        placeholder: spec.placeholder,
+        defaultValue: typeof spec.default === 'string' ? spec.default : undefined,
+        validate,
+      });
+    }
+    if (p.isCancel(answer)) throw new DriverCancelled();
+    const value = typeof answer === 'boolean' ? answer : String(answer);
+    if (spec.kind === 'secret' && typeof value === 'string') registerSensitiveValue(value);
+    return value;
+  }
+
+  progress(_stepId: string, _state: ProgressState, _label?: string): void {}
+
+  display(display: DriverDisplay): void {
+    const content = 'content' in display ? display.content : 'url' in display ? display.url : display.payload;
+    p.note(content, display.label);
+  }
+
+  clearDisplay(_displayId: string): void {}
+
+  note(content: string, label?: string): void {
+    p.note(content, label);
+  }
+
+  log(level: LogLevel, message: string): void {
+    p.log[level](message);
+  }
+
+  intro(message: string): void {
+    p.intro(message);
+  }
+
+  outro(message: string): void {
+    p.outro(message);
+  }
+
+  async externalAction(
+    action: ExternalAction,
+    verify: () => boolean | Promise<boolean>,
+  ): Promise<ExternalActionResult> {
+    if (action.kind === 'openURL') {
+      const answer = await this.prompt({
+        kind: 'confirm',
+        message: `Open ${action.url} in your browser?`,
+        default: true,
+      });
+      if (answer !== true) return 'declined';
+    }
+    return (await verify()) ? 'attempted' : 'unsupported';
+  }
+
+  async waitForUninstall(): Promise<Map<UninstallGroup, UninstallChoice>> {
+    throw new Error('terminal uninstall collects choices through its existing prompts');
+  }
+
+  uninstallAction(_result: UninstallActionResult): void {}
+
+  throwIfCancelled(): void {}
+
+  error(_code: string, message: string, _recovery: Recovery[] = [], _stepId?: string): never {
+    throw new Error(message);
+  }
+
+  completeSetup(_receipt: SetupReceipt): void {}
+  completeUninstall(_receipt: UninstallReceipt): void {}
+
+  cancelled(): void {
+    p.cancel(this.operation === 'setup' ? 'Setup cancelled.' : 'Uninstall cancelled.');
+  }
+
+  handoff(): void {}
+  close(): void {}
+}
+
+type Pending = {
+  id: string;
+  accept(command: Record<string, unknown>): Promise<{ done: boolean; rejected?: boolean; value?: unknown }>;
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+};
+
+const MAX_INPUT_LINE_BYTES = 1_048_576;
+const MAX_COMMAND_STRING_BYTES = 64 * 1024;
+const MAX_COMMAND_ARRAY_LENGTH = 64;
+
+type DriverCommand =
+  | {
+      protocol: typeof DRIVER_PROTOCOL;
+      operation: DriverOperation;
+      type: 'answer';
+      promptId: string;
+      value: boolean | string;
+    }
+  | {
+      protocol: typeof DRIVER_PROTOCOL;
+      operation: DriverOperation;
+      type: 'externalActionCompleted';
+      actionId: string;
+      result: ExternalActionResult;
+    }
+  | {
+      protocol: typeof DRIVER_PROTOCOL;
+      operation: DriverOperation;
+      type: 'applyUninstall';
+      planId: string;
+      choices: Array<{ groupId: UninstallGroup; choice: UninstallChoice }>;
+    }
+  | { protocol: typeof DRIVER_PROTOCOL; operation: DriverOperation; type: 'cancel'; reason?: string };
+
+function boundedString(value: unknown, maxBytes = MAX_COMMAND_STRING_BYTES): value is string {
+  return typeof value === 'string' && Buffer.byteLength(value, 'utf8') <= maxBytes;
+}
+
+function validUninstallArtifact(artifact: Artifact): boolean {
+  return (
+    boundedString(artifact.id, 256) &&
+    boundedString(artifact.kind, 256) &&
+    boundedString(artifact.label) &&
+    boundedString(artifact.location) &&
+    (artifact.decisionGroup === undefined || isUninstallGroup(artifact.decisionGroup))
+  );
+}
+
+function validUninstallResult(result: UninstallActionResult): boolean {
+  return (
+    boundedString(result.actionId, 256) &&
+    boundedString(result.artifactId, 256) &&
+    (result.error === undefined || (boundedString(result.error.code, 256) && boundedString(result.error.message)))
+  );
+}
+
+function validUninstallPlan(plan: UninstallPlan): boolean {
+  return (
+    boundedString(plan.id, 256) &&
+    plan.groups.length <= MAX_COMMAND_ARRAY_LENGTH &&
+    plan.groups.every(
+      (group) =>
+        isUninstallGroup(group.id) &&
+        boundedString(group.label) &&
+        boundedString(group.description) &&
+        group.default === 'preserve' &&
+        group.choices.length === 2 &&
+        group.choices.every((choice) => choice === 'preserve' || choice === 'remove'),
+    ) &&
+    plan.artifacts.every(validUninstallArtifact)
+  );
+}
+
+function validRecovery(recovery: Recovery[]): boolean {
+  return (
+    recovery.length <= MAX_COMMAND_ARRAY_LENGTH &&
+    recovery.every((item) =>
+      item.kind === 'rerun'
+        ? item.args.length <= MAX_COMMAND_ARRAY_LENGTH && item.args.every((arg) => boundedString(arg))
+        : boundedString(item.title) &&
+          item.instructions.length <= MAX_COMMAND_ARRAY_LENGTH &&
+          item.instructions.every((instruction) => boundedString(instruction)),
+    )
+  );
+}
+
+function parseCommand(value: unknown, operation: DriverOperation): DriverCommand | { error: string; itemId?: string } {
+  if (!isRecord(value)) return { error: 'Command must be a JSON object.' };
+  if (value.protocol !== DRIVER_PROTOCOL || value.operation !== operation) {
+    return { error: 'Protocol or operation does not match this run.' };
+  }
+  const type = value.type;
+  if (type === 'answer') {
+    if (!boundedString(value.promptId, 256)) return { error: 'promptId must be a bounded string.' };
+    if (!(typeof value.value === 'boolean' || boundedString(value.value)))
+      return { error: 'answer value is invalid.', itemId: value.promptId };
+    return { protocol: DRIVER_PROTOCOL, operation, type, promptId: value.promptId, value: value.value };
+  }
+  if (type === 'externalActionCompleted') {
+    if (!boundedString(value.actionId, 256)) return { error: 'actionId must be a bounded string.' };
+    const result = value.result;
+    if (result !== 'attempted' && result !== 'declined' && result !== 'unsupported') {
+      return { error: 'result must be attempted, declined, or unsupported.', itemId: value.actionId };
+    }
+    return { protocol: DRIVER_PROTOCOL, operation, type, actionId: value.actionId, result };
+  }
+  if (type === 'applyUninstall') {
+    if (
+      !boundedString(value.planId, 256) ||
+      !Array.isArray(value.choices) ||
+      value.choices.length > MAX_COMMAND_ARRAY_LENGTH
+    ) {
+      return {
+        error: 'Uninstall choices are invalid.',
+        itemId: typeof value.planId === 'string' ? value.planId : undefined,
+      };
+    }
+    const choices: Array<{ groupId: UninstallGroup; choice: UninstallChoice }> = [];
+    for (const entry of value.choices) {
+      if (
+        !isRecord(entry) ||
+        !isUninstallGroup(entry.groupId) ||
+        (entry.choice !== 'preserve' && entry.choice !== 'remove')
+      ) {
+        return { error: 'Uninstall choices are invalid.', itemId: value.planId };
+      }
+      choices.push({ groupId: entry.groupId, choice: entry.choice });
+    }
+    return { protocol: DRIVER_PROTOCOL, operation, type, planId: value.planId, choices };
+  }
+  if (type === 'cancel') {
+    if (value.reason !== undefined && !boundedString(value.reason, 4 * 1024))
+      return { error: 'Cancel reason is invalid.' };
+    return {
+      protocol: DRIVER_PROTOCOL,
+      operation,
+      type,
+      ...(value.reason === undefined ? {} : { reason: value.reason }),
+    };
+  }
+  return { error: 'Unknown command type.' };
+}
+
+class InputLines {
+  private buffer = Buffer.alloc(0);
+  private discarding = false;
+  constructor(private readonly onLine: (line: string | null) => void) {}
+
+  push(chunk: Buffer): void {
+    let start = 0;
+    while (start < chunk.length) {
+      const newline = chunk.indexOf(0x0a, start);
+      const end = newline === -1 ? chunk.length : newline;
+      const part = chunk.subarray(start, end);
+      if (this.discarding) {
+        if (newline !== -1) this.discarding = false;
+      } else if (this.buffer.length + part.length > MAX_INPUT_LINE_BYTES) {
+        this.buffer = Buffer.alloc(0);
+        this.discarding = newline === -1;
+        this.onLine(null);
+      } else {
+        this.buffer = Buffer.concat([this.buffer, part]);
+        if (newline !== -1) {
+          const line = this.buffer.toString('utf8').replace(/\r$/, '');
+          this.buffer = Buffer.alloc(0);
+          this.onLine(line);
+        }
+      }
+      if (newline === -1) break;
+      start = newline + 1;
+    }
+  }
+
+  end(): void {
+    if (this.discarding) return;
+    if (this.buffer.length > 0) this.onLine(this.buffer.toString('utf8'));
+    this.buffer = Buffer.alloc(0);
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }


### PR DESCRIPTION
## TL;DR

Proposed: add two dormant halves of the setup driver to `setup/lib/setup-driver.ts`, a terminal implementation that just forwards to the prompt library we already use, and a parser for the machine wire format. Nothing imports the file yet, so this PR changes no behaviour at all.

## What problem it solves

The wider stack proposes a `SetupDriver` interface: one abstraction over every user interaction in setup (pick one of these, yes/no, type a value, type a secret, progress, show something, go do something outside the terminal). The previous PR proposed the interface and its types. Two implementations of it are planned:

- terminal, which drives the existing clack prompts (clack is the interactive terminal prompt library, imported as `p`), so people running `nanoclaw.sh` in a shell see exactly what they see today;
- ndjson, which speaks newline-delimited JSON (one JSON object per line) over stdin/stdout, so the native macOS app can drive setup with no terminal.

This PR proposes the terminal implementation, and the input-parsing machinery the ndjson one will need. Splitting them out keeps the next PR, which carries the 450-line machine driver plus its test suite, reviewable.

## How it works

`TerminalSetupDriver`:

- `prompt()` maps the four prompt kinds onto clack: `confirm`, `autocomplete` or `brightSelect` for a single choice, `password` for a secret, `text` otherwise. A clack cancel (ctrl-c) becomes a `DriverCancelled` throw.
- a secret answer is passed to `registerSensitiveValue`, the in-process set of strings that later machine-mode code redacts out of logs and child output. This PR is the first caller of it anywhere, so the redaction added a few PRs back finally has something to redact. In terminal mode registering is harmless: nothing in terminal mode reads that set.
- the members that only mean something to a GUI (`progress`, `clearDisplay`, `uninstallAction`, `completeSetup`, `completeUninstall`, `handoff`, `close`, `throwIfCancelled`) are deliberately empty, `error()` throws a plain `Error` with the message, and `waitForUninstall()` throws, because the terminal uninstall flow keeps collecting choices through its own prompts.

The wire half:

- `parseCommand()` accepts only the four commands a GUI peer may send (`answer`, `externalActionCompleted`, `applyUninstall`, `cancel`), and only when the envelope's `protocol` and `operation` match the run in progress. Anything else comes back as an error object, never a throw.
- `InputLines` reassembles stdin bytes into lines. A line over 1 MiB is dropped, the reader keeps discarding until the next newline, and it reports one rejection rather than buffering without limit.
- bounds throughout: 64 KiB per string, 64 entries per array.
- `validUninstallArtifact` / `validUninstallResult` / `validUninstallPlan` / `validRecovery` are the outbound direction: self-checks the machine driver runs on its own payloads before writing them, so it refuses to emit something oversized or malformed.

## What trips people up

- **Two trust boundaries land in one file.** The terminal class trusts a local human at a keyboard; the parser must assume the process on stdin is a peer that may send anything. They are in one PR because they are one file and the second is useless without the first, but review them separately.
- **There are no tests in this PR, honestly stated.** `parseCommand` and `InputLines` have no caller here, so there is nothing to exercise. Their first tests arrive with the NDJSON driver in the next PR (a child-process suite that feeds bad JSON, wrong envelopes, stale ids and a 1 MiB line). `TerminalSetupDriver` is not covered until the terminal-versus-machine parity test near the top of the stack, which cannot run before every call site is converted.
- **Still-unused imports.** `randomUUID` remains unreferenced until the next PR. `validateValue` and `isUninstallGroup`, defined but unused in the previous PR, get their first callers here.
- **Terminal mode does not enforce every validation rule.** `validateValue` is wired into the text and secret prompts only. For confirm and single-choice the answer is constrained by the widget itself, so a `validateValue` callback on those kinds is not run in terminal mode.

## What to review

1. `parseCommand`: is every accepted shape actually one of the four commands, and is every rejection an error object rather than an exception.
2. `InputLines`: the discard-until-newline path after an oversized line, and that a partial trailing line at end-of-input is handled the way you would want.
3. That `TerminalSetupDriver` really is pass-through, that is, that no prompt text, default or ordering differs from what clack does today.
4. The bound constants: 1 MiB line, 64 KiB string, 64 array entries.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this adds new setup infrastructure under `setup/`, it is not a skill, not a bug fix, and it does not simplify or document existing code.

## Description

Adds `TerminalSetupDriver` (the clack-backed implementation of the `SetupDriver` interface) and the NDJSON command parser with its byte bounds to `setup/lib/setup-driver.ts`. 289 added lines in one file, no deletions, no other file touched. The file has no importer at this commit, so behaviour is unchanged in every mode.

## For Skills

Not a skill, so this checklist does not apply.

## Verification

Setup-inclusive typecheck and `bash -n nanoclaw.sh` pass; the full vitest run is unchanged from the previous commit in the stack apart from the four pre-existing failures caused by a git tag-signing issue on the author's machine, which also fail on a clean upstream checkout. Note that CI does not typecheck `setup/`: `tsconfig.json` includes only `src/**/*`, so the setup-inclusive typecheck is run separately.