### PR TITLE
feat(setup): add the ndjson setup driver and the driver selector

### DIFF
--- a/setup/lib/fixtures/setup-driver-cancel-race.ts
+++ b/setup/lib/fixtures/setup-driver-cancel-race.ts
@@ -1,0 +1,23 @@
+import { DriverCancelled, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  await driver.externalAction(
+    {
+      id: 'slow-postcondition',
+      kind: 'systemPermission',
+      title: 'Complete the slow action',
+      instructions: ['Test only.'],
+    },
+    async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return false;
+    },
+  );
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverCancelled)) throw error;
+  driver.cancelled();
+  process.exitCode = 2;
+}

--- a/setup/lib/fixtures/setup-driver-child.ts
+++ b/setup/lib/fixtures/setup-driver-child.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { emit as emitDiagnostic } from '../../lib/diagnostics.js';
+import * as setupLog from '../../logs.js';
+import { NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const outputDir = process.env.NANOCLAW_TEST_OUTPUT_DIR;
+if (outputDir) process.chdir(outputDir);
+
+const driver = new NdjsonSetupDriver('setup');
+
+driver.display({ id: 'rotating-code', kind: 'code', content: 'display-one', sensitive: true });
+driver.display({ id: 'rotating-code', kind: 'code', content: 'display-two', sensitive: true });
+driver.clearDisplay('rotating-code');
+driver.note('display-one and display-two are no longer live');
+
+const secret = await driver.prompt({
+  id: 'credential',
+  kind: 'secret',
+  message: 'Credential',
+  sensitive: true,
+  validation: { required: true, pattern: '^secret-' },
+});
+driver.note(`accepted ${secret}`);
+if (outputDir) {
+  setupLog.reset({ accepted: `${secret} display-one display-two` });
+  setupLog.userInput('credential', String(secret));
+  setupLog.step('fixture', 'success', 1, { value: `${secret} display-one display-two` });
+  globalThis.fetch = (async (_input, init) => {
+    fs.writeFileSync(path.join(outputDir, 'diagnostic-body.json'), String(init?.body ?? ''));
+    return { ok: true } as Response;
+  }) as typeof fetch;
+  emitDiagnostic('driver_fixture', { value: `${secret} display-one display-two` }, { persistId: false });
+}
+
+await driver.prompt({ id: 'continue', kind: 'confirm', message: 'Continue?', default: true });
+
+let postconditionChecks = 0;
+await driver.externalAction(
+  {
+    id: 'permission',
+    kind: 'systemPermission',
+    title: 'Grant test permission',
+    instructions: ['Enable the test permission.'],
+  },
+  () => ++postconditionChecks > 1,
+);
+driver.completeSetup(fixtureSetupReceipt());

--- a/setup/lib/fixtures/setup-driver-continuation.ts
+++ b/setup/lib/fixtures/setup-driver-continuation.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+
+import { createSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const tsxLoader = process.env.NANOCLAW_TEST_TSX_LOADER;
+if (!tsxLoader) throw new Error('NANOCLAW_TEST_TSX_LOADER is required');
+
+const driver = createSetupDriver('setup');
+if (process.env.NANOCLAW_TEST_CONTINUED === '1') {
+  await driver.prompt({ id: 'continued-confirm', kind: 'confirm', message: 'Continue?', default: true });
+  driver.completeSetup(fixtureSetupReceipt());
+} else {
+  driver.handoff();
+  const result = spawnSync(process.execPath, ['--import', tsxLoader, process.argv[1]], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NANOCLAW_TEST_CONTINUED: '1',
+      NANOCLAW_DRIVER_CONTINUATION: '1',
+    },
+  });
+  process.exit(result.status ?? 1);
+}

--- a/setup/lib/fixtures/setup-receipt.ts
+++ b/setup/lib/fixtures/setup-receipt.ts
@@ -1,0 +1,15 @@
+import type { SetupReceipt } from '../setup-driver.js';
+
+export function fixtureSetupReceipt(): SetupReceipt {
+  return {
+    version: 1,
+    service: { state: 'running', manager: 'pidfile', checkoutRoot: process.cwd() },
+    health: { status: 'healthy' },
+    resources: {
+      groups: { state: 'empty', count: 0 },
+      policies: { state: 'empty', count: 0 },
+      skills: { state: 'empty', count: 0 },
+    },
+    completedAt: new Date().toISOString(),
+  };
+}

--- a/setup/lib/setup-driver.test.ts
+++ b/setup/lib/setup-driver.test.ts
@@ -1,0 +1,235 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child.ts');
+const CONTINUATION_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-continuation.ts');
+const CANCEL_RACE_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-cancel-race.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
+
+describe('NDJSON setup driver child boundary', () => {
+  it('keeps stdout parseable, rejects bad commands, and redacts accepted secrets', async () => {
+    const secret = 'secret-value"\nnext\\part';
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-output-'));
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, HARNESS], {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_NO_DIAGNOSTICS: '0',
+        NANOCLAW_TEST_OUTPUT_DIR: outputDir,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let stdout = '';
+    let stderr = '';
+    let buffer = '';
+    let answeredCredential = false;
+    let answeredContinue = false;
+    const send = (command: Record<string, unknown>): void => {
+      child.stdin.write(`${JSON.stringify({ ...envelope, ...command })}\n`);
+    };
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stdout += text;
+      buffer += text;
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'prompt') {
+          const prompt = event.prompt as { id: string };
+          if (prompt.id === 'credential' && !answeredCredential) {
+            answeredCredential = true;
+            child.stdin.write('not-json\n');
+            send({ operation: 'uninstall', type: 'answer', promptId: prompt.id, value: secret });
+            send({ type: 'futureCommand', promptId: prompt.id });
+            send({ type: 'answer', promptId: 'stale', value: secret });
+            send({ type: 'answer', promptId: prompt.id, value: false });
+            const valid = { type: 'answer', promptId: prompt.id, value: secret, futureField: 'ignored' };
+            send(valid);
+            send(valid);
+          } else if (prompt.id === 'continue' && !answeredContinue) {
+            answeredContinue = true;
+            send({ type: 'answer', promptId: prompt.id, value: true });
+          }
+          continue;
+        }
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          send({ type: 'externalActionCompleted', actionId: action.id, result: 'attempted' });
+          send({ type: 'externalActionCompleted', actionId: action.id, result: 'attempted' });
+        }
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout[0]).toBe('{');
+    expect(stdout).not.toMatch(/\x1b\[[0-9;]*[A-Za-z]/);
+    expect(
+      stdout
+        .trim()
+        .split('\n')
+        .every((line) => JSON.parse(line)),
+    ).toBe(true);
+    expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'complete')).toHaveLength(1);
+    for (const event of events.filter((candidate) => candidate.type === 'externalAction')) {
+      const action = event.action as Record<string, unknown>;
+      expect(['openURL', 'startApplication', 'systemPermission']).toContain(action.kind);
+      expect(action).not.toHaveProperty('executable');
+      expect(action).not.toHaveProperty('args');
+      expect(action).not.toHaveProperty('command');
+    }
+    expect(events.filter((event) => event.type === 'inputRejected').map((event) => event.code)).toEqual([
+      'invalid_json',
+      'wrong_envelope',
+      'unknown_command',
+      'stale_command',
+      'invalid_answer',
+      'stale_command',
+      'postcondition_failed',
+    ]);
+    expect(stdout).not.toContain('secret-value');
+    expect(stdout.match(/display-one/g)).toHaveLength(1);
+    expect(stdout.match(/display-two/g)).toHaveLength(1);
+    expect(events.some((event) => event.type === 'clearDisplay' && event.displayId === 'rotating-code')).toBe(true);
+    const persisted =
+      fs.readFileSync(path.join(outputDir, 'logs', 'setup.log'), 'utf8') +
+      fs.readFileSync(path.join(outputDir, 'diagnostic-body.json'), 'utf8');
+    expect(persisted).not.toContain('secret-value');
+    expect(persisted).not.toContain('display-one');
+    expect(persisted).not.toContain('display-two');
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('continues an sg-style re-exec with one hello and one stdin reader', () => {
+    const result = spawnSync(process.execPath, ['--import', TSX_LOADER, CONTINUATION_HARNESS], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      input: JSON.stringify({ ...envelope, type: 'answer', promptId: 'continued-confirm', value: true }) + '\n',
+      env: {
+        ...process.env,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_TEST_TSX_LOADER: TSX_LOADER,
+      },
+    });
+    const events = result.stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { type: string });
+    expect(result.status).toBe(0);
+    expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'prompt')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'complete')).toHaveLength(1);
+  });
+
+  it('rejects an oversized raw line before a newline is received', async () => {
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, HARNESS], {
+      cwd: ROOT,
+      env: { ...process.env, NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let buffer = '';
+    let sentOversized = false;
+    let sentValid = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'prompt') {
+          const prompt = event.prompt as { id: string };
+          if (prompt.id === 'credential' && !sentOversized) {
+            sentOversized = true;
+            child.stdin.write(`${'x'.repeat(1_048_577)}\n`);
+          } else if (prompt.id === 'continue' && !sentValid) {
+            sentValid = true;
+            child.stdin.write(`${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: true })}\n`);
+          }
+        }
+        if (event.type === 'inputRejected' && event.code === 'command_too_large') {
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'answer', promptId: 'credential', value: 'secret-value' })}\n`,
+          );
+        }
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+          );
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+          );
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    expect(code).toBe(0);
+    expect(events.some((event) => event.type === 'inputRejected' && event.code === 'command_too_large')).toBe(true);
+    expect(events.at(-1)?.type).toBe('complete');
+  }, 15_000);
+
+  it('keeps cancelled terminal when an in-flight postcondition finishes later', async () => {
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, CANCEL_RACE_HARNESS], {
+      cwd: ROOT,
+      env: { ...process.env, NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let buffer = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+          );
+          setTimeout(() => child.kill('SIGINT'), 20);
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    expect(code).toBe(2);
+    expect(events.filter((event) => event.type === 'cancelled')).toHaveLength(1);
+    expect(events.at(-1)?.type).toBe('cancelled');
+    expect(events.some((event) => event.type === 'inputRejected')).toBe(false);
+  }, 15_000);
+});

--- a/setup/lib/setup-driver.ts
+++ b/setup/lib/setup-driver.ts
@@ -471,3 +471,459 @@ class InputLines {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
+
+export class NdjsonSetupDriver implements SetupDriver {
+  readonly mode = 'ndjson' as const;
+  readonly cancellationSignal: AbortSignal;
+  private input: typeof process.stdin | undefined;
+  private readonly inputLines: InputLines;
+  private readonly abortController = new AbortController();
+  private pending: Pending | undefined;
+  private isCancelled = false;
+  private isTerminal = false;
+  private cancelReason: string | undefined;
+  private inputChain = Promise.resolve();
+  private readonly write: (text: string) => boolean;
+  private readonly onSignal = (): void => this.requestCancellation();
+  private readonly onInputData = (chunk: Buffer | string): void =>
+    this.inputLines.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  private readonly onInputEnd = (): void => {
+    this.inputLines.end();
+    if (!this.isTerminal) this.requestCancellation('stdin_closed');
+  };
+  private readonly onInputError = (): void => this.requestCancellation('stdin_error');
+
+  constructor(
+    readonly operation: DriverOperation,
+    opts: { emitHello?: boolean } = {},
+  ) {
+    this.cancellationSignal = this.abortController.signal;
+    this.write = process.stdout.write.bind(process.stdout);
+    if (opts.emitHello !== false) this.emit({ type: 'hello' });
+    this.inputLines = new InputLines((line) => {
+      this.inputChain = this.inputChain
+        .then(() =>
+          line === null
+            ? this.rejectInput(
+                this.pending?.id,
+                'command_too_large',
+                `Command exceeds the ${MAX_INPUT_LINE_BYTES} byte limit.`,
+              )
+            : this.handleLine(line),
+        )
+        .catch((error: unknown) => {
+          if (error instanceof DriverCancelled || error instanceof DriverTerminalError) return;
+          const message = error instanceof Error ? error.message : String(error);
+          try {
+            this.error('protocol_input_failed', message);
+          } catch (terminal) {
+            if (!(terminal instanceof DriverTerminalError)) throw terminal;
+          }
+        });
+    });
+    this.input = process.stdin;
+    process.stdin.on('data', this.onInputData);
+    process.stdin.on('end', this.onInputEnd);
+    process.stdin.on('error', this.onInputError);
+    process.once('SIGINT', this.onSignal);
+    process.once('SIGTERM', this.onSignal);
+  }
+
+  async prompt(spec: DriverPrompt): Promise<boolean | string> {
+    this.throwIfCancelled();
+    if (
+      !boundedString(spec.message) ||
+      (spec.choices?.length ?? 0) > MAX_COMMAND_ARRAY_LENGTH ||
+      spec.choices?.some(
+        (choice) =>
+          !boundedString(choice.id, 256) ||
+          !boundedString(choice.label) ||
+          (choice.hint !== undefined && !boundedString(choice.hint)),
+      )
+    ) {
+      this.error('presentation_too_large', 'Prompt presentation exceeds protocol limits.');
+    }
+    const prompt = {
+      id: spec.id ?? randomUUID(),
+      kind: spec.kind,
+      message: redactSensitiveValues(spec.message),
+      sensitive: spec.sensitive ?? spec.kind === 'secret',
+      ...(spec.choices
+        ? { choices: spec.choices.map(({ id, label }) => ({ id, label: redactSensitiveValues(label) })) }
+        : {}),
+      ...(spec.default !== undefined && spec.kind !== 'secret' ? { default: spec.default } : {}),
+      ...(spec.validation ? { validation: spec.validation } : {}),
+    };
+    this.emit({ type: 'prompt', prompt });
+    const value = await this.wait(prompt.id, async (command) => {
+      if (command.type !== 'answer' || command.promptId !== prompt.id) return { done: false };
+      const error = validateValue(spec, command.value);
+      if (error) {
+        this.rejectInput(prompt.id, 'invalid_answer', error);
+        return { done: false, rejected: true };
+      }
+      if (spec.kind === 'secret' && typeof command.value === 'string') registerSensitiveValue(command.value);
+      return { done: true, value: command.value };
+    });
+    return typeof value === 'boolean' ? value : String(value);
+  }
+
+  progress(stepId: string, state: ProgressState, label?: string): void {
+    if (!boundedString(stepId, 256) || (label !== undefined && !boundedString(label))) {
+      this.error('presentation_too_large', 'Progress presentation exceeds protocol limits.');
+    }
+    this.emit({ type: 'progress', stepId, state, ...(label ? { label: redactSensitiveValues(label) } : {}) });
+  }
+
+  display(display: DriverDisplay): void {
+    const payload = 'content' in display ? display.content : 'url' in display ? display.url : display.payload;
+    if (
+      !boundedString(display.id, 256) ||
+      !boundedString(payload) ||
+      (display.label !== undefined && !boundedString(display.label))
+    ) {
+      this.error('presentation_too_large', 'Display payload exceeds protocol limits.');
+    }
+    if (display.kind === 'qr' && payload.length > MAX_COMMAND_STRING_BYTES) {
+      this.error('presentation_too_large', 'Display payload exceeds protocol limits.');
+    }
+    if (display.sensitive) {
+      const value = 'content' in display ? display.content : 'url' in display ? display.url : display.payload;
+      registerSensitiveValue(value);
+    }
+    const safeDisplay =
+      !display.sensitive && 'url' in display ? { ...display, url: redactSensitiveValues(display.url) } : display;
+    this.emit(
+      {
+        type: 'display',
+        display: {
+          ...safeDisplay,
+          ...(display.label ? { label: redactSensitiveValues(display.label) } : {}),
+        },
+      },
+      display.sensitive,
+    );
+  }
+
+  clearDisplay(displayId: string): void {
+    if (!boundedString(displayId, 256)) this.error('presentation_too_large', 'Display id exceeds protocol limits.');
+    this.emit({ type: 'clearDisplay', displayId });
+  }
+
+  note(content: string, label?: string): void {
+    this.display({ id: randomUUID(), kind: 'text', content, sensitive: false, ...(label ? { label } : {}) });
+  }
+
+  log(_level: LogLevel, message: string): void {
+    this.note(message);
+  }
+
+  intro(message: string): void {
+    this.note(message);
+  }
+
+  outro(message: string): void {
+    this.note(message);
+  }
+
+  async externalAction(
+    action: ExternalAction,
+    verify: () => boolean | Promise<boolean>,
+  ): Promise<ExternalActionResult> {
+    this.throwIfCancelled();
+    if (!boundedString(action.title) || !boundedString(action.id ?? '', 256)) {
+      this.error('invalid_external_action', 'External action presentation exceeds protocol limits.');
+    }
+    if (action.kind === 'openURL' && new URL(action.url).protocol !== 'https:') {
+      this.error('invalid_external_action', 'openURL actions require an HTTPS URL.');
+    }
+    if (action.kind === 'openURL' && !boundedString(action.url))
+      this.error('invalid_external_action', 'External action URL exceeds protocol limits.');
+    if (action.kind === 'startApplication' && !boundedString(action.application, 256))
+      this.error('invalid_external_action', 'Application name exceeds protocol limits.');
+    if (
+      action.kind === 'systemPermission' &&
+      (action.instructions.length > MAX_COMMAND_ARRAY_LENGTH ||
+        action.instructions.some((instruction) => !boundedString(instruction)))
+    ) {
+      this.error('invalid_external_action', 'Permission instructions exceed protocol limits.');
+    }
+    const withId = { ...action, id: action.id ?? randomUUID() };
+    this.emit({ type: 'externalAction', action: withId });
+    const value = await this.wait(withId.id, async (command) => {
+      if (command.type !== 'externalActionCompleted' || command.actionId !== withId.id) {
+        return { done: false };
+      }
+      if (command.result === 'declined' || command.result === 'unsupported')
+        return { done: true, value: command.result };
+      if (!(await verify())) {
+        this.rejectInput(withId.id, 'postcondition_failed', 'The required postcondition is not satisfied.');
+        return { done: false, rejected: true };
+      }
+      return { done: true, value: 'attempted' };
+    });
+    return value as ExternalActionResult;
+  }
+
+  async waitForUninstall(
+    plan: UninstallPlan,
+    validate: (choices: Map<UninstallGroup, UninstallChoice>) => string | undefined,
+  ): Promise<Map<UninstallGroup, UninstallChoice>> {
+    if (!validUninstallPlan(plan)) {
+      this.error('presentation_too_large', 'Uninstall plan presentation exceeds protocol limits.');
+    }
+    for (const artifact of plan.artifacts) {
+      this.emit({ type: 'uninstallPlanItem', planId: plan.id, artifact });
+    }
+    this.emit({
+      type: 'uninstallPlan',
+      plan: { id: plan.id, groups: plan.groups },
+    });
+    const value = await this.wait(plan.id, async (command) => {
+      if (command.type !== 'applyUninstall' || command.planId !== plan.id) return { done: false };
+      if (!Array.isArray(command.choices)) {
+        this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Expected a choices array.');
+        return { done: false, rejected: true };
+      }
+      const choices = new Map<UninstallGroup, UninstallChoice>();
+      for (const entry of command.choices) {
+        if (!isRecord(entry)) {
+          this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Every choice must be an object.');
+          return { done: false, rejected: true };
+        }
+        const groupId = entry.groupId;
+        const choice = entry.choice;
+        if (!isUninstallGroup(groupId)) {
+          this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Unknown uninstall group.');
+          return { done: false, rejected: true };
+        }
+        if (choice !== 'preserve' && choice !== 'remove') {
+          this.rejectInput(plan.id, 'invalid_uninstall_choices', 'Unknown uninstall choice.');
+          return { done: false, rejected: true };
+        }
+        const group = groupId;
+        if (choices.has(group)) {
+          this.rejectInput(plan.id, 'duplicate_uninstall_group', `Duplicate choice for ${group}.`);
+          return { done: false, rejected: true };
+        }
+        choices.set(group, choice);
+      }
+      if (choices.size !== plan.groups.length || plan.groups.some((group) => !choices.has(group.id))) {
+        this.rejectInput(plan.id, 'incomplete_uninstall_choices', 'Supply exactly one choice for every group.');
+        return { done: false, rejected: true };
+      }
+      const error = validate(choices);
+      if (error) {
+        this.rejectInput(plan.id, 'unsafe_uninstall_choices', error);
+        return { done: false, rejected: true };
+      }
+      return { done: true, value: choices };
+    });
+    if (!(value instanceof Map)) throw new Error('invalid uninstall command result');
+    return value;
+  }
+
+  uninstallAction(result: UninstallActionResult): void {
+    if (!validUninstallResult(result)) {
+      this.error('presentation_too_large', 'Uninstall action presentation exceeds protocol limits.');
+    }
+    this.emit({ type: 'uninstallAction', result });
+  }
+
+  throwIfCancelled(): void {
+    if (this.isCancelled) throw new DriverCancelled(this.cancelReason);
+  }
+
+  error(code: string, message: string, recovery: Recovery[] = [], stepId?: string): never {
+    if (
+      !boundedString(code, 256) ||
+      !boundedString(message) ||
+      (stepId !== undefined && !boundedString(stepId, 256)) ||
+      !validRecovery(recovery)
+    ) {
+      code = 'presentation_too_large';
+      message = 'Error presentation exceeds protocol limits.';
+      recovery = [];
+      stepId = undefined;
+    }
+    this.terminate({
+      type: 'error',
+      code,
+      ...(stepId ? { stepId } : {}),
+      message: redactSensitiveValues(message),
+      recovery,
+    });
+    throw new DriverTerminalError(1);
+  }
+
+  completeSetup(receipt: SetupReceipt): void {
+    this.throwIfCancelled();
+    this.terminate({ type: 'complete', receipt });
+  }
+
+  completeUninstall(receipt: UninstallReceipt): void {
+    this.throwIfCancelled();
+    if (
+      !receipt.results.every(validUninstallResult) ||
+      !receipt.remaining.every(validUninstallArtifact) ||
+      !receipt.checkoutRemoval.blockers.every((blocker) => boundedString(blocker)) ||
+      !boundedString(receipt.completedAt, 256)
+    ) {
+      this.error('presentation_too_large', 'Uninstall receipt presentation exceeds protocol limits.');
+    }
+    for (const artifact of receipt.remaining) {
+      this.emit({ type: 'uninstallReceiptItem', section: 'remaining', artifact });
+    }
+    this.terminate({
+      type: 'complete',
+      receipt: {
+        version: receipt.version,
+        outcome: receipt.outcome,
+        checkoutRemoval: receipt.checkoutRemoval,
+        completedAt: receipt.completedAt,
+      },
+    });
+  }
+
+  cancelled(
+    details: {
+      lastStepId?: string;
+      results?: UninstallActionResult[];
+      remaining?: Artifact[];
+    } = {},
+  ): void {
+    if (this.operation !== 'uninstall') {
+      this.terminate({ type: 'cancelled', ...details });
+      return;
+    }
+    if (
+      (details.results !== undefined && !details.results.every(validUninstallResult)) ||
+      (details.remaining !== undefined && !details.remaining.every(validUninstallArtifact)) ||
+      (details.lastStepId !== undefined && !boundedString(details.lastStepId, 256))
+    ) {
+      this.error('presentation_too_large', 'Uninstall cancellation details exceed protocol limits.');
+    }
+    for (const artifact of details.remaining ?? []) {
+      this.emit({ type: 'uninstallReceiptItem', section: 'remaining', artifact });
+    }
+    this.terminate({
+      type: 'cancelled',
+      ...(details.lastStepId ? { lastStepId: details.lastStepId } : {}),
+    });
+  }
+
+  handoff(): void {
+    this.input?.off('data', this.onInputData);
+    this.input?.off('end', this.onInputEnd);
+    this.input?.off('error', this.onInputError);
+    this.input?.pause();
+    this.input = undefined;
+  }
+
+  close(): void {
+    this.handoff();
+    process.off('SIGINT', this.onSignal);
+    process.off('SIGTERM', this.onSignal);
+  }
+
+  private emit(event: Record<string, unknown>, allowSensitive = false): void {
+    if (this.isTerminal) return;
+    this.writeEvent(event, allowSensitive);
+  }
+
+  private terminate(event: Record<string, unknown>): void {
+    if (this.isTerminal) return;
+    this.isTerminal = true;
+    this.writeEvent(event);
+    this.close();
+  }
+
+  private writeEvent(event: Record<string, unknown>, allowSensitive = false): void {
+    const payload = allowSensitive ? event : (redactProtocolPresentation(event) as Record<string, unknown>);
+    this.write(JSON.stringify({ protocol: DRIVER_PROTOCOL, operation: this.operation, ...payload }) + '\n');
+  }
+
+  private wait(id: string, accept: Pending['accept']): Promise<unknown> {
+    if (this.pending) throw new Error('driver already has a pending item');
+    return new Promise((resolve, reject) => {
+      this.pending = { id, accept, resolve, reject };
+    });
+  }
+
+  private async handleLine(line: string): Promise<void> {
+    if (this.isTerminal) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.rejectInput(undefined, 'invalid_json', 'Command must be one JSON object.');
+      return;
+    }
+    const command = parseCommand(parsed, this.operation);
+    if ('error' in command) {
+      const code =
+        isRecord(parsed) && parsed.protocol === DRIVER_PROTOCOL && parsed.operation === this.operation
+          ? typeof parsed.type === 'string' &&
+            !['answer', 'externalActionCompleted', 'applyUninstall', 'cancel'].includes(parsed.type)
+            ? 'unknown_command'
+            : 'invalid_command'
+          : 'wrong_envelope';
+      this.rejectInput(command.itemId, code, command.error);
+      return;
+    }
+    if (command.type === 'cancel') {
+      this.requestCancellation(command.reason);
+      return;
+    }
+    const pending = this.pending;
+    if (!pending) {
+      this.rejectInput(this.commandItemId(command), 'stale_command', 'There is no matching pending item.');
+      return;
+    }
+    const result = await pending.accept(command);
+    if (this.isTerminal || this.isCancelled) return;
+    if (!result.done) {
+      if (!result.rejected) {
+        this.rejectInput(this.commandItemId(command), 'stale_command', 'Command does not match the pending item.');
+      }
+      return;
+    }
+    this.pending = undefined;
+    pending.resolve(result.value);
+  }
+
+  private commandItemId(command: Record<string, unknown>): string | undefined {
+    for (const key of ['promptId', 'actionId', 'planId']) {
+      if (typeof command[key] === 'string') return command[key];
+    }
+    return undefined;
+  }
+
+  private rejectInput(itemId: string | undefined, code: string, message: string): void {
+    this.emit({ type: 'inputRejected', ...(itemId ? { itemId } : {}), code, message });
+  }
+
+  private requestCancellation(reason?: string): void {
+    if (this.isTerminal) return;
+    this.isCancelled = true;
+    this.cancelReason = reason;
+    this.abortController.abort(reason);
+    const pending = this.pending;
+    this.pending = undefined;
+    pending?.reject(new DriverCancelled(this.cancelReason));
+  }
+}
+
+export class DriverTerminalError extends Error {
+  constructor(readonly exitCode: 0 | 1 | 2) {
+    super(`driver terminated with exit ${exitCode}`);
+  }
+}
+
+export function createSetupDriver(operation: DriverOperation): SetupDriver {
+  return process.env.NANOCLAW_PROTOCOL === DRIVER_PROTOCOL
+    ? new NdjsonSetupDriver(operation, {
+        emitHello: process.env.NANOCLAW_DRIVER_SHELL_HELLO !== '1' && process.env.NANOCLAW_DRIVER_CONTINUATION !== '1',
+      })
+    : new TerminalSetupDriver(operation);
+}


### PR DESCRIPTION
## TL;DR

Proposed: add `NdjsonSetupDriver`, the machine-facing half of the setup driver, plus the one function that decides which driver a setup run gets. It is dormant at this commit; nothing selects it yet, so terminal setup behaviour is unchanged.

## The problem

`bash nanoclaw.sh` asks the user questions through clack, a terminal prompt library. A native macOS app cannot answer a terminal prompt. PR 7 proposed a `SetupDriver` interface that names every interaction abstractly (select, confirm, text, secret, progress, display, external action) and PR 8 proposed two pieces: `TerminalSetupDriver`, which implements that interface over the existing clack UI, and a parser for a machine wire format. This PR proposes the second implementation and the switch between the two.

## How it works

`NdjsonSetupDriver` speaks NDJSON, meaning newline-delimited JSON: one JSON object per line, no framing beyond the newline. It writes events to stdout (`hello`, `prompt`, `progress`, `display`, `clearDisplay`, `externalAction`, `uninstallPlan`, `inputRejected`, and one terminal event of `complete`, `cancelled` or `error`) and reads commands from stdin (`answer`, `externalActionCompleted`, `applyUninstall`, `cancel`), parsed by the PR 8 parser. Everything goes to stdout so the stream stays machine-parseable; stderr must stay empty.

Four properties are worth naming:

- **One question at a time.** The driver holds at most one pending item. A command that does not match it gets an `inputRejected` event with a reason code, not a crash and not a silent accept.
- **Terminal is terminal.** After `complete`, `cancelled` or `error` the driver emits nothing further, detaches its stdin listeners and removes its signal handlers. Cancellation (SIGINT, SIGTERM, a `cancel` command, or stdin closing) aborts an `AbortSignal` and rejects the pending item, and a slow postcondition that resolves afterwards cannot un-cancel the run.
- **Redaction on the way out.** Every event is passed through the presentation redactor added in PR 6 before it is written, and an accepted `secret` answer is registered as sensitive so it is scrubbed from later events, logs and diagnostics. Displays explicitly marked sensitive (a pairing code, a device URL) are the one exception and are written unredacted on purpose, since the GUI has to render them.
- **Everything is bounded.** Message, label, id, choice and instruction lengths are checked before emitting; over the limit is a hard `error` rather than a truncated event. `openURL` external actions must be HTTPS.

`createSetupDriver(operation)` returns the NDJSON driver when the environment variable `NANOCLAW_PROTOCOL` equals the protocol string, and `TerminalSetupDriver` otherwise. Two escape hatches suppress the opening `hello` event: `NANOCLAW_DRIVER_SHELL_HELLO=1` when the shell wrapper already sent it, and `NANOCLAW_DRIVER_CONTINUATION=1` when setup re-executes itself and a second `hello` would confuse the peer.

## What trips people up

- **This code does nothing yet.** No production file calls `createSetupDriver` at this commit; the only caller is a test fixture. Nothing sets `NANOCLAW_PROTOCOL` until PR 10 adds the `nanoclaw.sh` front door, and the first real call site is PR 27. Reviewing this as live behaviour will mislead you.
- **The tests here are the security review.** The class is 456 lines and cannot be split: it declares `implements SetupDriver` against a 17-member interface, so a partial class does not typecheck. The four tests spawn a real child process rather than mocking, and they are also the first tests for the PR 8 parser, which shipped untested. They assert: stdout is parseable NDJSON with no ANSI escapes; the rejection codes arrive in the exact order `invalid_json, wrong_envelope, unknown_command, stale_command, invalid_answer, stale_command, postcondition_failed`; external action events never carry `executable`, `args` or `command`; an accepted secret appears in neither stdout, nor `logs/setup.log`, nor the diagnostics request body; a 1 MiB line is rejected before its newline arrives and the run still completes; and a SIGINT racing a slow postcondition ends in exactly one `cancelled` event with exit code 2.
- **Two tests carry a 15 second timeout** because they write a megabyte or sleep on a postcondition. That is deliberate, not a flake shield.

## What to review

- `setup/lib/setup-driver.ts`, the appended `NdjsonSetupDriver`, `DriverTerminalError` and `createSetupDriver`. Focus on the cancellation and terminal-state paths and on whether any event can be written without passing through redaction.
- The bounds checks: is any presentation field emitted before it is validated?
- `createSetupDriver`: the terminal driver must remain the default for every environment that does not explicitly opt in.
- `setup/lib/setup-driver.test.ts` and the three new fixtures under `setup/lib/fixtures/`.

Verification run: TypeScript checked with a setup-inclusive tsconfig (note that the repo's CI `tsconfig.json` covers only `src/**/*`, so `setup/` is not typechecked by CI), `bash -n nanoclaw.sh`, and `pnpm exec vitest run setup/lib/setup-driver.test.ts`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This adds new setup infrastructure, the NDJSON driver implementation, and it is not a skill, not a bug fix, and not a simplification.

## Description

Proposes `NdjsonSetupDriver`, an implementation of the `SetupDriver` interface that carries setup over a newline-delimited JSON protocol on stdin and stdout, plus `createSetupDriver`, which selects it when `NANOCLAW_PROTOCOL` opts in and falls back to the terminal driver otherwise. Purely additive: 803 added lines across six files, no deletions, no existing call site touched. Ships with four child-process conformance tests and three fixtures.

## For Skills

Not a skill, so this checklist does not apply.