### PR TITLE
feat(setup): add the nanoclaw.sh machine front door and preflight gates

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -39,9 +39,127 @@ done
 set -- ${_filtered_args[@]+"${_filtered_args[@]}"}
 unset _filtered_args
 
+# Parse the opt-in machine protocol before any output or mutation.
+DRIVER_MODE=false
+DRIVER_OPERATION=setup
+DRIVER_PROTOCOL=""
+DRIVER_PROTOCOL_COUNT=0
+DRIVER_EXPECT_PROTOCOL=false
+for arg in "$@"; do
+  if [ "$DRIVER_EXPECT_PROTOCOL" = true ]; then
+    DRIVER_PROTOCOL="$arg"
+    DRIVER_EXPECT_PROTOCOL=false
+    continue
+  fi
+  case "$arg" in
+    --protocol) DRIVER_PROTOCOL_COUNT=$((DRIVER_PROTOCOL_COUNT + 1)); DRIVER_EXPECT_PROTOCOL=true ;;
+    --protocol=*) DRIVER_PROTOCOL_COUNT=$((DRIVER_PROTOCOL_COUNT + 1)); DRIVER_PROTOCOL="${arg#--protocol=}" ;;
+    --uninstall) DRIVER_OPERATION=uninstall ;;
+  esac
+done
+
+if [ "$DRIVER_EXPECT_PROTOCOL" = true ]; then
+  echo "error: --protocol requires a value" >&2
+  exit 1
+fi
+if [ -n "$DRIVER_PROTOCOL" ] && [ "$DRIVER_PROTOCOL" != "nanoclaw.driver.v1" ]; then
+  echo "error: unsupported protocol '$DRIVER_PROTOCOL'" >&2
+  exit 1
+fi
+if [ "$DRIVER_PROTOCOL_COUNT" -gt 1 ]; then
+  if [ "$DRIVER_PROTOCOL" = "nanoclaw.driver.v1" ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"duplicate_protocol","message":"--protocol may be supplied only once.","recovery":[]}\n' "$DRIVER_OPERATION"
+  else
+    echo "error: --protocol may be supplied only once" >&2
+  fi
+  exit 1
+fi
+
+DRIVER_ARGS=()
+DRIVER_ACKS=""
+if [ "$DRIVER_PROTOCOL" = "nanoclaw.driver.v1" ]; then
+  DRIVER_MODE=true
+  DRIVER_SKIP_NEXT=""
+  for arg in "$@"; do
+    if [ "$DRIVER_SKIP_NEXT" = protocol ]; then DRIVER_SKIP_NEXT=""; continue; fi
+    if [ "$DRIVER_SKIP_NEXT" = ack ]; then
+      case "$arg" in low-memory|gce|root) ;; *)
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_driver_ack","message":"Unknown driver acknowledgement.","recovery":[]}\n' "$DRIVER_OPERATION"
+        exit 1
+      esac
+      DRIVER_ACKS="${DRIVER_ACKS:+${DRIVER_ACKS},}${arg}"
+      DRIVER_SKIP_NEXT=""
+      continue
+    fi
+    case "$arg" in
+      --protocol) DRIVER_SKIP_NEXT=protocol ;;
+      --protocol=*) ;;
+      --driver-ack) DRIVER_SKIP_NEXT=ack ;;
+      --driver-ack=*)
+        ack="${arg#--driver-ack=}"
+        case "$ack" in low-memory|gce|root) DRIVER_ACKS="${DRIVER_ACKS:+${DRIVER_ACKS},}${ack}" ;; *)
+          printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+          printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_driver_ack","message":"Unknown driver acknowledgement.","recovery":[]}\n' "$DRIVER_OPERATION"
+          exit 1
+        esac
+        ;;
+      --onecli-api-token|--anthropic-auth-token|--onecli-api-token=*|--anthropic-auth-token=*)
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+        printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"secret_transport_forbidden","message":"Secret answers must arrive through protocol stdin, not driver arguments.","recovery":[]}\n' "$DRIVER_OPERATION"
+        exit 1
+        ;;
+      *) DRIVER_ARGS+=("$arg") ;;
+    esac
+  done
+  if [ "$DRIVER_SKIP_NEXT" = ack ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_driver_ack","message":"--driver-ack requires a value.","recovery":[]}\n' "$DRIVER_OPERATION"
+    exit 1
+  fi
+  printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"hello"}\n' "$DRIVER_OPERATION"
+  for arg in ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"}; do
+    if [[ "$arg" =~ [[:cntrl:]] ]]; then
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"invalid_arguments","message":"Driver arguments may not contain control characters.","recovery":[]}\n' "$DRIVER_OPERATION"
+      exit 1
+    fi
+  done
+  if [ -n "${NANOCLAW_ONECLI_API_TOKEN:-}" ] || [ -n "${NANOCLAW_ANTHROPIC_AUTH_TOKEN:-}" ] || [ -n "${NANOCLAW_REGISTRY_ENROLL_CODE:-}" ] || [ -n "${NANOCLAW_REGISTRY_TOKEN:-}" ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"secret_transport_forbidden","message":"Secret answers must arrive through protocol stdin, not the launch environment.","recovery":[]}\n' "$DRIVER_OPERATION"
+    exit 1
+  fi
+  set -- ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"}
+fi
+
+driver_has_ack() { case ",$DRIVER_ACKS," in *,$1,*) return 0 ;; *) return 1 ;; esac; }
+driver_json_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '"%s"' "$value"
+}
+driver_recovery_args() {
+  local ack="$1"
+  shift
+  printf '["--protocol","nanoclaw.driver.v1"'
+  for arg in "$@"; do printf ',%s' "$(driver_json_string "$arg")"; done
+  for known in low-memory gce root; do
+    if driver_has_ack "$known"; then printf ',"--driver-ack","%s"' "$known"; fi
+  done
+  printf ',"--driver-ack","%s"]' "$ack"
+}
+
 # ─── --help: show usage without bootstrapping ──────────────────────────
 for arg in "$@"; do
   if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then
+    if [ "$DRIVER_MODE" = true ]; then
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"%s","type":"error","code":"help_requested","message":"Machine mode does not render terminal help.","recovery":[{"kind":"rerun","args":["--help"]}]}\n' "$DRIVER_OPERATION"
+      exit 1
+    fi
     if command -v node >/dev/null 2>&1 && [ -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; then
       exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/auto.ts" "$@"
     fi
@@ -67,7 +185,16 @@ for arg in "$@"; do
     # everything after it as positional args and the flags get dropped.
     # Gate on node (tsx's shebang interpreter) — pnpm isn't used here.
     if command -v node >/dev/null 2>&1 && [ -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; then
+      if [ "$DRIVER_MODE" = true ]; then
+        export NANOCLAW_PROTOCOL=nanoclaw.driver.v1
+        export NANOCLAW_OPERATION=uninstall
+        export NANOCLAW_DRIVER_SHELL_HELLO=1
+      fi
       exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/auto.ts" "$@"
+    fi
+    if [ "$DRIVER_MODE" = true ]; then
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"uninstall","type":"error","code":"runtime_missing","message":"The TypeScript runtime is unavailable; uninstall left everything untouched.","recovery":[{"kind":"manual","title":"Restore the runtime","instructions":["Run bash nanoclaw.sh once without uninstall, then retry."]}]}\n'
+      exit 1
     fi
     export NANOCLAW_PROJECT_ROOT="$PROJECT_ROOT"
     # shellcheck source=setup/lib/install-slug.sh
@@ -97,13 +224,15 @@ LOGS_DIR="$PROJECT_ROOT/logs"
 STEPS_DIR="$LOGS_DIR/setup-steps"
 PROGRESS_LOG="$LOGS_DIR/setup.log"
 
-# Diagnostics: persisted install-id + fire-and-forget emit. Sourced early
-# so `setup_launched` covers dropoff before bootstrap even starts.
+# Diagnostics: persisted install-id + fire-and-forget emit.
 # shellcheck source=setup/lib/diagnostics.sh
 source "$PROJECT_ROOT/setup/lib/diagnostics.sh"
-ph_event setup_launched \
-  platform="$(uname -s | tr 'A-Z' 'a-z')" \
-  is_wsl="$([ -f /proc/version ] && grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && echo true || echo false)"
+emit_launch_diagnostic() {
+  ph_event setup_launched \
+    platform="$(uname -s | tr 'A-Z' 'a-z')" \
+    is_wsl="$([ -f /proc/version ] && grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && echo true || echo false)"
+}
+[ "$DRIVER_MODE" = true ] || emit_launch_diagnostic
 
 # ─── log helpers ────────────────────────────────────────────────────────
 
@@ -185,17 +314,39 @@ brand_bold() {
 }
 clear_line() { use_ansi && printf '\r\033[2K' || printf '\n'; }
 
-spinner_start()   { printf '%s  %s…' "$(gray '◒')" "$1"; }
-spinner_update()  { clear_line; printf '%s  %s… %s' "$(gray '◒')" "$1" "$(dim "(${2}s)")"; }
-spinner_success() { clear_line; printf '%s  %s %s\n' "$(gray '◇')" "$1" "$(dim "(${2}s)")"; }
-spinner_failure() { clear_line; printf '%s  %s %s\n' "$(red '✗')"  "$1" "$(dim "(${2}s)")"; }
+spinner_start() {
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"progress","stepId":"bootstrap","state":"running","label":"Installing the basics"}\n'
+  else
+    printf '%s  %s…' "$(gray '◒')" "$1"
+  fi
+}
+spinner_update()  { [ "$DRIVER_MODE" = true ] || { clear_line; printf '%s  %s… %s' "$(gray '◒')" "$1" "$(dim "(${2}s)")"; }; }
+spinner_success() {
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"progress","stepId":"bootstrap","state":"succeeded","label":"Basics ready"}\n'
+  else
+    clear_line; printf '%s  %s %s\n' "$(gray '◇')" "$1" "$(dim "(${2}s)")"
+  fi
+}
+spinner_failure() {
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"progress","stepId":"bootstrap","state":"failed","label":"Installing the basics"}\n'
+  else
+    clear_line; printf '%s  %s %s\n' "$(red '✗')" "$1" "$(dim "(${2}s)")"
+  fi
+}
 
 # ─── fresh-run setup ────────────────────────────────────────────────────
 
-rm -rf "$STEPS_DIR"
-rm -f  "$PROGRESS_LOG"
-mkdir -p "$STEPS_DIR" "$LOGS_DIR"
-write_header
+# Machine preflight failures must not create setup state. Terminal mode keeps
+# its established log timing.
+if [ "$DRIVER_MODE" = false ]; then
+  rm -rf "$STEPS_DIR"
+  rm -f  "$PROGRESS_LOG"
+  mkdir -p "$STEPS_DIR" "$LOGS_DIR"
+  write_header
+fi
 
 # NanoClaw splash — under-the-sea lobster mascot in truecolor braille,
 # with the figlet wordmark and taglines below. Pre-rendered into
@@ -203,7 +354,7 @@ write_header
 # figlet); the bash script just streams the literal frame. clack's intro
 # then carries the "let's get you set up" framing — setup:auto sees
 # NANOCLAW_BOOTSTRAPPED=1 and skips re-printing the wordmark.
-cat "$PROJECT_ROOT/assets/setup-splash.txt"
+[ "$DRIVER_MODE" = true ] || cat "$PROJECT_ROOT/assets/setup-splash.txt"
 
 # ─── pre-flight: minimum hardware specs ────────────────────────────────
 # NanoClaw runs an agent container per session. Below this threshold the
@@ -234,6 +385,13 @@ LOW_MEM=false
 [ "$MEM_MB" -gt 0 ] && [ "$MEM_MB" -lt "$MIN_MEM_MB" ] && LOW_MEM=true
 
 if [ "$LOW_MEM" = true ]; then
+  if [ "$DRIVER_MODE" = true ]; then
+    if ! driver_has_ack low-memory; then
+      DRIVER_RERUN_ARGS=$(driver_recovery_args low-memory ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"})
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"low_memory","message":"This machine has less than the recommended 4 GB of memory.","recovery":[{"kind":"rerun","args":%s}]}\n' "$DRIVER_RERUN_ARGS"
+      exit 1
+    fi
+  else
   printf '  %s\n' "$(red 'Warning: this machine likely cannot run NanoClaw.')"
   printf '  %s\n' "$(dim 'NanoClaw recommends a 4 GB+ RAM machine. Below this, the host + agent')"
   printf '  %s\n' "$(dim 'container will run out of memory under most workloads. A stronger')"
@@ -253,6 +411,7 @@ if [ "$LOW_MEM" = true ]; then
       exit 1
       ;;
   esac
+  fi
 fi
 
 # ─── pre-flight: Google Cloud VM warning (Linux) ──────────────────────
@@ -264,6 +423,13 @@ fi
 if [ "$(uname -s)" = "Linux" ] \
   && { grep -qi 'Google' /sys/class/dmi/id/product_name 2>/dev/null \
     || grep -qi 'Google' /sys/class/dmi/id/sys_vendor   2>/dev/null; }; then
+  if [ "$DRIVER_MODE" = true ]; then
+    if ! driver_has_ack gce; then
+      DRIVER_RERUN_ARGS=$(driver_recovery_args gce ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"})
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"gce_unsupported","message":"Google Cloud VM detected; NanoClaw is unlikely to run reliably there.","recovery":[{"kind":"rerun","args":%s},{"kind":"manual","title":"Use another provider","instructions":["Move this checkout to a supported non-GCE host, then rerun setup."]}]}\n' "$DRIVER_RERUN_ARGS"
+      exit 1
+    fi
+  else
   printf '  %s\n' "$(red 'Warning: Google Cloud VM detected.')"
   printf '  %s\n' "$(dim 'Google blocks sudo commands, so NanoClaw is unlikely to run successfully on this VM.')"
   printf '  %s\n\n' "$(dim 'If you want to run NanoClaw successfully, switch to a different provider (Hetzner, Hostinger, exe.dev and others..).')"
@@ -280,10 +446,18 @@ if [ "$(uname -s)" = "Linux" ] \
       exit 1
       ;;
   esac
+  fi
 fi
 
 # ─── pre-flight: root user warning (Linux) ────────────────────────────
 if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -eq 0 ]; then
+  if [ "$DRIVER_MODE" = true ]; then
+    if ! driver_has_ack root; then
+      DRIVER_RERUN_ARGS=$(driver_recovery_args root ${DRIVER_ARGS[@]+"${DRIVER_ARGS[@]}"})
+      printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"root_user","message":"Running NanoClaw as root can cause unsafe service and file ownership.","recovery":[{"kind":"rerun","args":%s},{"kind":"manual","title":"Create a regular Linux user","instructions":["Create a non-root user with sudo access.","Log in as that user and rerun setup."]}]}\n' "$DRIVER_RERUN_ARGS"
+      exit 1
+    fi
+  else
   printf '  %s\n' \
     "$(red 'Warning: you are running as root.')"
   printf '  %s\n' \
@@ -313,6 +487,7 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -eq 0 ]; then
       exit 1
       ;;
   esac
+  fi
 fi
 
 # ─── pre-flight: Homebrew on macOS ─────────────────────────────────────
@@ -322,6 +497,10 @@ fi
 # before the spinner starts, so the user knows what's about to happen and
 # brew's own interactive sudo/CLT prompts stay readable.
 if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"homebrew_required","message":"Homebrew is required before machine setup can continue.","recovery":[{"kind":"manual","title":"Install Homebrew","instructions":["Install Homebrew from https://brew.sh in a terminal.","Rerun the same NanoClaw setup command."]}]}\n'
+    exit 1
+  fi
   printf '  %s\n' \
     "$(dim "Homebrew isn't installed. NanoClaw uses it to install Node and Docker on your Mac.")"
   printf '  %s\n\n' \
@@ -364,6 +543,14 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
 fi
 
 # ─── first step: install the basics (Node + pnpm + native modules) ─────
+
+if [ "$DRIVER_MODE" = true ]; then
+  rm -rf "$STEPS_DIR"
+  rm -f  "$PROGRESS_LOG"
+  mkdir -p "$STEPS_DIR" "$LOGS_DIR"
+  write_header
+  emit_launch_diagnostic
+fi
 
 BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"
 BOOTSTRAP_LABEL="Installing the basics"
@@ -439,4 +626,10 @@ fi
 # into setup:auto's spinner. exec so signals (Ctrl-C) propagate directly.
 # pnpm forwards arguments after the script name directly. Passing an extra
 # `--` would reach setup:auto and make its parser stop before our flags.
+if [ "$DRIVER_MODE" = true ]; then
+  export NANOCLAW_PROTOCOL=nanoclaw.driver.v1
+  export NANOCLAW_OPERATION=setup
+  export NANOCLAW_DRIVER_SHELL_HELLO=1
+  exec "$PROJECT_ROOT/node_modules/.bin/tsx" "$PROJECT_ROOT/setup/auto.ts" "$@"
+fi
 exec pnpm --silent run setup:auto "$@"

--- a/setup/driver-shell.test.ts
+++ b/setup/driver-shell.test.ts
@@ -1,0 +1,261 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const ACKS = ['--driver-ack', 'low-memory', '--driver-ack', 'gce', '--driver-ack', 'root'];
+
+let fixtureRoot: string;
+
+beforeEach(() => {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-shell-'));
+  fs.mkdirSync(path.join(fixtureRoot, 'setup', 'lib'), { recursive: true });
+  fs.copyFileSync(path.join(ROOT, 'nanoclaw.sh'), path.join(fixtureRoot, 'nanoclaw.sh'));
+  fs.copyFileSync(
+    path.join(ROOT, 'setup', 'lib', 'diagnostics.sh'),
+    path.join(fixtureRoot, 'setup', 'lib', 'diagnostics.sh'),
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+function parseEvents(stdout: string): Array<Record<string, unknown>> {
+  expect(stdout[0]).toBe('{');
+  return stdout
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function driverEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, NANOCLAW_NO_DIAGNOSTICS: '1' };
+}
+
+function executable(name: string, body: string): string {
+  const file = path.join(fixtureRoot, 'fake-bin', name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+  return file;
+}
+
+async function collectShell(
+  child: ReturnType<typeof spawn>,
+  onStdout?: (chunk: string) => void,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString('utf8');
+    stdout += text;
+    onStdout?.(text);
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+  const status = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  return { status, stdout, stderr };
+}
+
+describe('nanoclaw.sh NDJSON boundary', () => {
+  it('reports missing uninstall runtime without creating setup state', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--uninstall', '--protocol', 'nanoclaw.driver.v1'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.map((event) => event.type)).toEqual(['hello', 'error']);
+    expect(events[1].code).toBe('runtime_missing');
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixtureRoot, 'data'))).toBe(false);
+  });
+
+  it('keeps terminal uninstall as the default presentation', () => {
+    const tsx = path.join(fixtureRoot, 'node_modules', '.bin', 'tsx');
+    fs.mkdirSync(path.dirname(tsx), { recursive: true });
+    fs.writeFileSync(tsx, '#!/bin/sh\nprintf \'%s\\n\' "$*" > "$PWD/tsx.args"\necho terminal-uninstall-child\n', {
+      mode: 0o755,
+    });
+
+    const result = spawnSync('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--uninstall'], {
+      cwd: fixtureRoot,
+      env: driverEnv(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('terminal-uninstall-child');
+    expect(result.stdout.trimStart().startsWith('{')).toBe(false);
+    expect(fs.readFileSync(path.join(fixtureRoot, 'tsx.args'), 'utf8').trim()).toBe(
+      `${path.join(fixtureRoot, 'setup', 'auto.ts')} --uninstall`,
+    );
+  });
+
+
+  it.each([
+    ['gce_unsupported', 'rerun'],
+    ['root_user', 'rerun'],
+    ['homebrew_required', 'manual'],
+  ] as const)('reports the %s pre-Node decision before mutation', (code, recoveryKind) => {
+    if (code === 'homebrew_required') {
+      executable('uname', 'echo Darwin');
+      executable('sysctl', 'echo 8589934592');
+    } else {
+      executable('uname', 'echo Linux');
+      executable('awk', 'echo 8192');
+      executable('grep', code === 'gce_unsupported' ? 'exit 0' : 'exit 1');
+      executable('id', code === 'root_user' ? 'echo 0' : 'echo 1000');
+    }
+    const result = spawnSync('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1'], {
+      cwd: fixtureRoot,
+      env: {
+        ...driverEnv(),
+        PATH: `${path.join(fixtureRoot, 'fake-bin')}:/usr/bin:/bin`,
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    const event = parseEvents(result.stdout).at(-1);
+    expect(event?.code, `${result.stdout}\n${result.stderr}`).toBe(code);
+    expect((event?.recovery as Array<{ kind: string }>)[0].kind).toBe(recoveryKind);
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixtureRoot, 'data'))).toBe(false);
+  });
+
+  it('rejects an unrecognized acknowledgement before creating setup state', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', '--driver-ack', 'invented'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.map((event) => event.type)).toEqual(['hello', 'error']);
+    expect(events[1].code).toBe('invalid_driver_ack');
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixtureRoot, 'data'))).toBe(false);
+  });
+
+  it('rejects duplicate versioned protocol flags with hello then typed error', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', '--protocol', 'nanoclaw.driver.v1'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+    expect(result.status).toBe(1);
+    expect(parseEvents(result.stdout).map((event) => event.type)).toEqual(['hello', 'error']);
+    expect(parseEvents(result.stdout).at(-1)?.code).toBe('duplicate_protocol');
+    expect(fs.existsSync(path.join(fixtureRoot, 'logs'))).toBe(false);
+  });
+
+  it('preserves non-secret setup arguments in acknowledgement recovery', () => {
+    const bin = path.join(fixtureRoot, 'fake-bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(bin, 'uname'), '#!/bin/sh\necho Linux\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(bin, 'awk'), '#!/bin/sh\necho 1024\n', { mode: 0o755 });
+    const result = spawnSync(
+      'bash',
+      [
+        path.join(fixtureRoot, 'nanoclaw.sh'),
+        '--display-name',
+        'A "B"',
+        '--protocol',
+        'nanoclaw.driver.v1',
+        '--driver-ack',
+        'gce',
+      ],
+      {
+        cwd: fixtureRoot,
+        env: { ...driverEnv(), PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}` },
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.at(-1)?.code).toBe('low_memory');
+    expect((events.at(-1)?.recovery as Array<{ args?: string[] }>)[0].args).toEqual([
+      '--protocol',
+      'nanoclaw.driver.v1',
+      '--display-name',
+      'A "B"',
+      '--driver-ack',
+      'gce',
+      '--driver-ack',
+      'low-memory',
+    ]);
+  });
+
+  it.each([
+    ['argument', ['--onecli-api-token', 'launch-secret'], {}],
+    ['environment', [], { NANOCLAW_ONECLI_API_TOKEN: 'launch-secret' }],
+    ['registry enrollment environment', [], { NANOCLAW_REGISTRY_ENROLL_CODE: 'launch-secret' }],
+    ['registry token environment', [], { NANOCLAW_REGISTRY_TOKEN: 'launch-secret' }],
+  ] as const)('rejects secret transport through the launch %s', (_source, args, extraEnv) => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...args],
+      { cwd: fixtureRoot, env: { ...driverEnv(), ...extraEnv }, encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    expect(parseEvents(result.stdout).at(-1)?.code).toBe('secret_transport_forbidden');
+    expect(`${result.stdout}${result.stderr}`).not.toContain('launch-secret');
+  });
+
+  it('rejects control characters before recovery JSON is constructed', () => {
+    const result = spawnSync(
+      'bash',
+      [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', '--display-name', 'bad\u0001value'],
+      { cwd: fixtureRoot, env: driverEnv(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(1);
+    expect(parseEvents(result.stdout).at(-1)?.code).toBe('invalid_arguments');
+  });
+
+  it('keeps terminal setup as the default path and preserves bootstrap ordering', () => {
+    executable('uname', 'echo Darwin');
+    executable('sysctl', 'echo 8589934592');
+    executable('brew', 'exit 0');
+    executable('pnpm', 'echo pnpm >> "$PWD/order"\necho "$*" > "$PWD/pnpm.args"\necho terminal-setup-child');
+    fs.mkdirSync(path.join(fixtureRoot, 'assets'));
+    fs.writeFileSync(path.join(fixtureRoot, 'assets', 'setup-splash.txt'), 'terminal-splash\n');
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'setup.sh'),
+      '#!/usr/bin/env bash\necho bootstrap >> "$PWD/order"\necho STATUS: success\n',
+    );
+
+    const result = spawnSync('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--display-name', 'Terminal'], {
+      cwd: fixtureRoot,
+      env: {
+        ...driverEnv(),
+        PATH: `${path.join(fixtureRoot, 'fake-bin')}:/usr/bin:/bin`,
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('terminal-splash');
+    expect(result.stdout).toContain('terminal-setup-child');
+    expect(result.stdout.trimStart().startsWith('{')).toBe(false);
+    expect(fs.readFileSync(path.join(fixtureRoot, 'order'), 'utf8').trim().split('\n')).toEqual(['bootstrap', 'pnpm']);
+    expect(fs.readFileSync(path.join(fixtureRoot, 'pnpm.args'), 'utf8').trim()).toBe(
+      '--silent run setup:auto --display-name Terminal',
+    );
+  });
+
+});


### PR DESCRIPTION
## TL;DR

Proposed: give `nanoclaw.sh`, the shell installer, an opt-in machine mode (`--protocol nanoclaw.driver.v1`) in which everything the shell decides before Node exists is emitted as NDJSON (one JSON object per line on stdout) instead of colored prompts, and in which secrets are refused on the command line and in the launch environment. Terminal behaviour is byte-for-byte unchanged.

## The problem

`nanoclaw.sh` makes several decisions before any TypeScript runs: parse flags, check memory, detect a Google Cloud VM, detect root, check for Homebrew, then bootstrap Node. Today each of those is an ANSI warning plus a `y/n` prompt on a terminal. A native macOS app driving setup headlessly has no terminal to answer them, and it cannot parse pretty text. It also must never receive a prompt it cannot see, and must never be silently overridden on a decision the user is supposed to make.

## How it works

- `--protocol nanoclaw.driver.v1` turns on machine mode. Any other protocol value, a missing value, or a repeated flag is rejected before anything is printed or written.
- The first line out is a `hello` event. Every failure afterwards is a typed error: a `code`, a human `message`, and a `recovery` array.
- The three warning gates (low memory, Google Cloud VM, root user) exit with a typed error whose recovery is `{"kind":"rerun","args":[...]}`, replaying the original arguments plus `--driver-ack low-memory|gce|root`. The consent the terminal collected with a `y/n` is still required, it just has to be given explicitly by relaunching. Missing Homebrew has no acknowledgement, only manual instructions, because it cannot be waved through.
- Secret boundary (a real policy change, machine mode only): `--onecli-api-token` and `--anthropic-auth-token`, and the `NANOCLAW_ONECLI_API_TOKEN`, `NANOCLAW_ANTHROPIC_AUTH_TOKEN`, `NANOCLAW_REGISTRY_ENROLL_CODE` and `NANOCLAW_REGISTRY_TOKEN` environment variables, are a hard `secret_transport_forbidden` failure. Argv and the environment are readable by other processes on the box; later PRs in this stack carry secrets over the protocol's stdin instead. Terminal mode still honours those variables. Note the two argv flags are not parsed anywhere in the tree today, so that half of the guard is forward-looking.
- Arguments containing control characters are rejected before any recovery JSON is built, so nothing can inject a forged line into the stream.
- Mutation ordering changes for machine mode: the wipe of `logs/setup-steps`, the log header, the splash, and the `setup_launched` diagnostic are all deferred until every gate has passed. A rejected machine launch leaves no `logs/` and no `data/` behind. Terminal keeps its existing timing exactly.
- On success the shell strips `--protocol`/`--driver-ack` from the arguments, exports `NANOCLAW_PROTOCOL`, `NANOCLAW_OPERATION` and `NANOCLAW_DRIVER_SHELL_HELLO` (so the Node side knows the `hello` was already sent) and execs `tsx setup/auto.ts` directly rather than through pnpm, so only NDJSON reaches stdout.

## What trips people up

- **This door is half-built on purpose.** After this PR, a machine launch gets NDJSON for the shell phase and then hands off to a Node setup that still renders the normal terminal UI, because `setup/auto.ts` does not consult the driver until a later PR in this stack. Nothing ships that passes the flag (the macOS app still sends no protocol), so no user path reaches this.
- This is the first place that sets `NANOCLAW_PROTOCOL` in a real run, which switches on the log and diagnostic redaction added earlier in the stack. The redaction list is still empty until the registration calls land later, so it is armed but has nothing to redact yet.
- The diff reads noisier than it is. Each preflight gate wraps the old terminal block in `if machine ... else <old block> fi`, and the two halves are ~25 lines apart in the same file; they must stay in one PR or `bash -n` fails. The old text is unchanged apart from its boundary indentation.
- The bootstrap spinner now emits `progress` events in machine mode, but the bootstrap child itself is only hardened (process group, cancellation) in the next PR.

## What to review

1. That no terminal path changed: the two characterization tests cover terminal setup and terminal uninstall and pass on the base commit as well, deliberately.
2. `driver_recovery_args` / `driver_json_string`: the reconstructed rerun arguments must round-trip quotes and must never grow a secret.
3. Gate ordering: nothing may be created or deleted before a gate can reject.
4. Coverage of the secret guard, both the argv and the environment side.

Tests: `setup/driver-shell.test.ts`, nine cases, no TypeScript dependency. It copies only `nanoclaw.sh` and `setup/lib/diagnostics.sh` into a temp directory and supplies fake `uname`, `awk`, `grep`, `id`, `brew`, `sysctl`, `pnpm` and `tsx`. Gate run: `bash -n nanoclaw.sh` and vitest on that file. Heads up: `tsconfig.json` covers only `src/**/*`, so CI does not typecheck `setup/`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This adds an opt-in machine protocol to the installer shell: it is not a skill, not a bug fix, and it adds code rather than simplifying it.

## Description

See above. One shell file plus one new test file, proposed as part of a stack that splits one large setup-driver commit into reviewable pieces.

## For Skills

Not a skill, so the skill checklist does not apply.