### PR TITLE
feat(setup): add cancellable machine bootstrap with a success gate

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -556,22 +556,61 @@ BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"
 BOOTSTRAP_LABEL="Installing the basics"
 BOOTSTRAP_START=$(date +%s)
 
-spinner_start "$BOOTSTRAP_LABEL"
-
-# Run in the background so we can tick elapsed time. Capture exit code via
-# a tmpfile (subshell $? is lost after the while loop finishes).
-BOOTSTRAP_EXIT_FILE=$(mktemp -t nanoclaw-bootstrap-exit.XXXXXX)
-(
-  # setup.sh's legacy `log()` writes to a file; point it at the raw log
-  # so its verbose entries land alongside the stdout we're capturing.
-  export NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW"
-  if bash setup.sh > "$BOOTSTRAP_RAW" 2>&1; then
-    echo 0 > "$BOOTSTRAP_EXIT_FILE"
+# Run in the background so terminal mode can tick elapsed time. Machine mode
+# owns the process group so cancellation reaches bootstrap descendants.
+BOOTSTRAP_EXIT_FILE=""
+BOOTSTRAP_MONITOR=false
+BOOTSTRAP_PID=""
+DRIVER_STDIN_WATCH_PID=""
+if [ "$DRIVER_MODE" = true ]; then
+  DRIVER_PARENT_PID=$$
+  exec 3<&0
+  driver_stop_stdin_watcher() {
+    if [ -n "$DRIVER_STDIN_WATCH_PID" ]; then
+      kill "$DRIVER_STDIN_WATCH_PID" 2>/dev/null || true
+      wait "$DRIVER_STDIN_WATCH_PID" 2>/dev/null || true
+      DRIVER_STDIN_WATCH_PID=""
+    fi
+    exec 3<&-
+  }
+  driver_cancel_bootstrap() {
+    trap - INT TERM
+    driver_stop_stdin_watcher
+    if [ -n "$BOOTSTRAP_PID" ]; then
+      kill -TERM -- "-$BOOTSTRAP_PID" 2>/dev/null || kill -TERM "$BOOTSTRAP_PID" 2>/dev/null || true
+      sleep 0.25
+      kill -KILL -- "-$BOOTSTRAP_PID" 2>/dev/null || kill -KILL "$BOOTSTRAP_PID" 2>/dev/null || true
+      wait "$BOOTSTRAP_PID" 2>/dev/null || true
+    fi
+    [ "$BOOTSTRAP_MONITOR" = false ] || set +m
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"cancelled","lastStepId":"bootstrap"}\n'
+    exit 2
+  }
+  trap driver_cancel_bootstrap INT TERM
+  (IFS= read -r _ || true; kill -TERM "$DRIVER_PARENT_PID" 2>/dev/null || true) <&3 &
+  DRIVER_STDIN_WATCH_PID=$!
+  spinner_start "$BOOTSTRAP_LABEL"
+  if [ "${NANOCLAW_DISABLE_SETSID:-0}" != 1 ] && command -v setsid >/dev/null 2>&1; then
+    NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW" setsid bash setup.sh </dev/null > "$BOOTSTRAP_RAW" 2>&1 &
   else
-    echo $? > "$BOOTSTRAP_EXIT_FILE"
+    set -m
+    BOOTSTRAP_MONITOR=true
+    NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW" bash setup.sh </dev/null > "$BOOTSTRAP_RAW" 2>&1 &
   fi
-) &
-BOOTSTRAP_PID=$!
+  BOOTSTRAP_PID=$!
+else
+  spinner_start "$BOOTSTRAP_LABEL"
+  BOOTSTRAP_EXIT_FILE=$(mktemp -t nanoclaw-bootstrap-exit.XXXXXX)
+  (
+    export NANOCLAW_BOOTSTRAP_LOG="$BOOTSTRAP_RAW"
+    if bash setup.sh > "$BOOTSTRAP_RAW" 2>&1; then
+      echo 0 > "$BOOTSTRAP_EXIT_FILE"
+    else
+      echo $? > "$BOOTSTRAP_EXIT_FILE"
+    fi
+  ) &
+  BOOTSTRAP_PID=$!
+fi
 
 while kill -0 "$BOOTSTRAP_PID" 2>/dev/null; do
   sleep 1
@@ -579,11 +618,23 @@ while kill -0 "$BOOTSTRAP_PID" 2>/dev/null; do
     spinner_update "$BOOTSTRAP_LABEL" "$(( $(date +%s) - BOOTSTRAP_START ))"
   fi
 done
-# `wait` surfaces the child's exit code; we've already captured it.
-wait "$BOOTSTRAP_PID" 2>/dev/null || true
-
-BOOTSTRAP_RC=$(cat "$BOOTSTRAP_EXIT_FILE")
-rm -f "$BOOTSTRAP_EXIT_FILE"
+if [ "$DRIVER_MODE" = true ]; then
+  if wait "$BOOTSTRAP_PID"; then BOOTSTRAP_RC=0; else BOOTSTRAP_RC=$?; fi
+  driver_stop_stdin_watcher
+  [ "$BOOTSTRAP_MONITOR" = false ] || set +m
+  trap - INT TERM
+  BOOTSTRAP_STATUS=$(grep '^STATUS:' "$BOOTSTRAP_RAW" 2>/dev/null | tail -1 | sed 's/^STATUS: *//' || true)
+  if [ "$BOOTSTRAP_RC" -eq 0 ] \
+    && { [ "$BOOTSTRAP_STATUS" != success ] \
+      || ! command -v node >/dev/null 2>&1 \
+      || [ ! -x "$PROJECT_ROOT/node_modules/.bin/tsx" ]; }; then
+    BOOTSTRAP_RC=1
+  fi
+else
+  wait "$BOOTSTRAP_PID" 2>/dev/null || true
+  BOOTSTRAP_RC=$(cat "$BOOTSTRAP_EXIT_FILE")
+  rm -f "$BOOTSTRAP_EXIT_FILE"
+fi
 BOOTSTRAP_DUR=$(( $(date +%s) - BOOTSTRAP_START ))
 
 if [ "$BOOTSTRAP_RC" -eq 0 ]; then
@@ -593,6 +644,11 @@ else
   spinner_failure "Couldn't install the basics" "$BOOTSTRAP_DUR"
   write_bootstrap_entry failed "$BOOTSTRAP_DUR" "$BOOTSTRAP_RAW"
   write_abort_entry bootstrap "exit-${BOOTSTRAP_RC}"
+
+  if [ "$DRIVER_MODE" = true ]; then
+    printf '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"error","code":"bootstrap_failed","stepId":"bootstrap","message":"Could not install the required runtime non-interactively.","recovery":[{"kind":"manual","title":"Inspect the bootstrap log","instructions":["Review logs/setup-steps/01-bootstrap.log without sharing secrets.","Complete any terminal-owned prerequisite, then rerun setup."]}]}\n'
+    exit 1
+  fi
 
   echo
   echo "$(dim '── last 40 lines of ')$(dim "$BOOTSTRAP_RAW")$(dim ' ──')"

--- a/setup/driver-shell.test.ts
+++ b/setup/driver-shell.test.ts
@@ -102,6 +102,170 @@ describe('nanoclaw.sh NDJSON boundary', () => {
     );
   });
 
+  it('keeps cold bootstrap output private and hands frontend stdin to TypeScript', async () => {
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'setup.sh'),
+      '#!/usr/bin/env bash\nif IFS= read -r line; then echo "unexpected-stdin:$line"; else echo stdin-closed; fi\necho bootstrap-private-output\necho "STATUS: success"\n',
+    );
+    const tsx = path.join(fixtureRoot, 'node_modules', '.bin', 'tsx');
+    fs.mkdirSync(path.dirname(tsx), { recursive: true });
+    fs.writeFileSync(
+      tsx,
+      '#!/usr/bin/env bash\nprintf \'{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"prompt","prompt":{"id":"handoff","kind":"confirm","message":"Continue?","sensitive":false}}\\n\'\nIFS= read -r _\nprintf \'{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"complete","completedAt":"2026-01-01T00:00:00.000Z"}\\n\'\n',
+    );
+    fs.chmodSync(tsx, 0o755);
+
+    const child = spawn('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS], {
+      cwd: fixtureRoot,
+      env: driverEnv(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let buffer = '';
+    const result = await collectShell(child, (chunk) => {
+      buffer += chunk;
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line && (JSON.parse(line) as { type: string }).type === 'prompt') {
+          child.stdin?.write(
+            '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"answer","promptId":"handoff","value":true}\n',
+          );
+        }
+      }
+    });
+
+    const bootstrapLog = path.join(fixtureRoot, 'logs', 'setup-steps', '01-bootstrap.log');
+    expect(
+      result.status,
+      `${result.stderr}\n${result.stdout}\n${fs.existsSync(bootstrapLog) ? fs.readFileSync(bootstrapLog, 'utf8') : ''}`,
+    ).toBe(0);
+    const events = parseEvents(result.stdout);
+    expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(events.some((event) => event.type === 'progress' && event.stepId === 'bootstrap')).toBe(true);
+    expect(events.at(-1)?.type).toBe('complete');
+    expect(result.stdout).not.toContain('bootstrap-private-output');
+    expect(result.stdout).not.toContain('stdin-closed');
+    expect(fs.readFileSync(bootstrapLog, 'utf8')).toContain('stdin-closed\nbootstrap-private-output\nSTATUS: success');
+  });
+
+  it('SIGKILLs a bootstrap grandchild that ignores SIGTERM after its leader exits', async () => {
+    executable('uname', 'echo Linux');
+    executable('awk', 'echo 8192');
+    executable('grep', 'exit 1');
+    executable('id', 'echo 1000');
+    const marker = path.join(fixtureRoot, 'descendant.pid');
+    const stubborn = executable('stubborn', `trap '' TERM\necho $$ > ${JSON.stringify(marker)}\nexec sleep 30`);
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'setup.sh'),
+      `#!/usr/bin/env bash\n${JSON.stringify(stubborn)} &\necho "STATUS: success"\nwait\n`,
+      { mode: 0o755 },
+    );
+    const child = spawn('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS], {
+      cwd: fixtureRoot,
+      env: { ...driverEnv(), PATH: `${path.join(fixtureRoot, 'fake-bin')}:/bin`, NANOCLAW_DISABLE_SETSID: '1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let buffer = '';
+    let cancelled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as { type: string; stepId?: string };
+        if (event.type === 'progress' && event.stepId === 'bootstrap' && !cancelled) {
+          cancelled = true;
+          void (async () => {
+            const deadline = Date.now() + 5_000;
+            while (!fs.existsSync(marker) && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            child.kill('SIGINT');
+          })();
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    let pid = 0;
+    try {
+      expect(code, stdout).toBe(2);
+      expect(fs.existsSync(marker)).toBe(true);
+      pid = Number(fs.readFileSync(marker, 'utf8').trim());
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  }, 15_000);
+
+  it.each(['disconnect', 'cancel'] as const)(
+    'cancels bootstrap when the frontend sends %s',
+    async (mode) => {
+      fs.writeFileSync(path.join(fixtureRoot, 'setup.sh'), '#!/usr/bin/env bash\nexec sleep 30\n');
+      const child = spawn(
+        'bash',
+        [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS],
+        { cwd: fixtureRoot, env: driverEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      let buffer = '';
+      let sent = false;
+      const result = await collectShell(child, (chunk) => {
+        buffer += chunk;
+        let newline: number;
+        while ((newline = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (!line) continue;
+          const event = JSON.parse(line) as { type: string; stepId?: string };
+          if (!sent && event.type === 'progress' && event.stepId === 'bootstrap') {
+            sent = true;
+            if (mode === 'disconnect') child.stdin?.end();
+            else
+              child.stdin?.write(
+                '{"protocol":"nanoclaw.driver.v1","operation":"setup","type":"cancel","reason":"test"}\n',
+              );
+          }
+        }
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
+      expect(parseEvents(result.stdout).at(-1)?.type).toBe('cancelled');
+    },
+    10_000,
+  );
+
+  it('requires the bootstrap status postcondition before handing off', async () => {
+    fs.writeFileSync(path.join(fixtureRoot, 'setup.sh'), '#!/usr/bin/env bash\necho "STATUS: deps_failed"\n');
+    const tsx = path.join(fixtureRoot, 'node_modules', '.bin', 'tsx');
+    fs.mkdirSync(path.dirname(tsx), { recursive: true });
+    fs.writeFileSync(tsx, '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+
+    const child = spawn('bash', [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS], {
+      cwd: fixtureRoot,
+      env: driverEnv(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const result = await collectShell(child);
+
+    expect(result.status).toBe(1);
+    const events = parseEvents(result.stdout);
+    expect(events.at(-1)?.type).toBe('error');
+    expect(events.at(-1)?.code).toBe('bootstrap_failed');
+    expect(events.some((event) => event.type === 'complete')).toBe(false);
+  });
 
   it.each([
     ['gce_unsupported', 'rerun'],
@@ -258,4 +422,35 @@ describe('nanoclaw.sh NDJSON boundary', () => {
     );
   });
 
+  it.each(['SIGINT', 'SIGTERM'] as const)(
+    'turns a bootstrap %s into cancelled and exit 2',
+    async (signal) => {
+      fs.writeFileSync(path.join(fixtureRoot, 'setup.sh'), '#!/usr/bin/env bash\nexec sleep 30\n');
+      const child = spawn(
+        'bash',
+        [path.join(fixtureRoot, 'nanoclaw.sh'), '--protocol', 'nanoclaw.driver.v1', ...ACKS],
+        { cwd: fixtureRoot, env: driverEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      let stdout = '';
+      let signalled = false;
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+        if (!signalled && stdout.includes('"stepId":"bootstrap"')) {
+          signalled = true;
+          child.kill(signal);
+        }
+      });
+
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', resolve);
+      });
+
+      expect(code).toBe(2);
+      const events = parseEvents(stdout);
+      expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+      expect(events.at(-1)?.type).toBe('cancelled');
+    },
+    10_000,
+  );
 });


### PR DESCRIPTION
## TL;DR

Proposed: when `nanoclaw.sh` is started in machine mode, the bootstrap phase (which runs `setup.sh` to install the required runtime) now runs in its own process group, can be cancelled by the calling app, and is only allowed to hand off to TypeScript if it provably succeeded. Terminal setup is untouched.

## Background, in one paragraph

This is part of a proposed stack that lets a native macOS app drive NanoClaw setup without a terminal. In that mode the shell speaks NDJSON (newline-delimited JSON: one JSON object per line) on stdout and reads commands on stdin, gated behind a new `--protocol nanoclaw.driver.v1` flag. The previous PR added the flag, the handshake and the pre-install guards. That left one gap: the shell printed the handshake and then ran the old bootstrap block, which prints human output, cannot be interrupted, and hands off to TypeScript regardless of whether the runtime install actually worked. This PR closes that gap. After it, `nanoclaw.sh` is at its final state for the whole stack.

## What it changes

Only inside `if [ "$DRIVER_MODE" = true ]`; the `else` branch is the old code moved verbatim.

- Launch: `setup.sh` is started with `</dev/null` and with its stdout and stderr going only to `logs/setup-steps/01-bootstrap.log`, so no human text ever leaks onto the NDJSON stream. It is launched under `setsid` so it leads its own process group; where `setsid` is unavailable (or `NANOCLAW_DISABLE_SETSID=1`) the shell falls back to `set -m`, which also puts the background job in its own group.
- Cancellation: `exec 3<&0` copies the caller's stdin to file descriptor 3, and a background subshell reads one line from it. Any line, or plain end-of-file, sends SIGTERM to the main shell. The trap then sends SIGTERM to the whole process group, waits 0.25s, sends SIGKILL, emits `{"type":"cancelled","lastStepId":"bootstrap"}` and exits 2. A SIGINT or SIGTERM from the outside (Ctrl-C, the app killing the process) runs the same trap. Killing the group is what makes a grandchild that ignores SIGTERM still die.
- Success postcondition: after `wait`, machine mode demands that the bootstrap log's last `STATUS:` line is `success`, that `node` is on PATH, and that `node_modules/.bin/tsx` is executable. If any fails, it emits a typed `bootstrap_failed` error with recovery instructions and exits 1, instead of the terminal path's `tail -40` of the log.

## What trips people up

- The stdin watcher does not parse what it reads. During bootstrap, ANY line on stdin cancels, not just a `cancel` command; the "cancel" test passes only because cancelling is what both inputs do. fd 3 is a duplicate of fd 0 and shares its read offset, so a frontend that writes a prompt answer early has that line consumed and read as a cancel. The contract is: send nothing until bootstrap reports done.
- Closing stdin cancels. That is deliberate (the app going away should not leave an install running) but it surprises people who expect EOF to mean "no more input".
- `setup.sh` gets `/dev/null` for stdin in machine mode. Any bootstrap step that used to read from the terminal silently changes behaviour there.
- The postcondition is stricter than terminal mode: a bootstrap that exits 0 without printing `STATUS: success` now fails in machine mode and passes in terminal mode. That asymmetry is intentional, since a headless app cannot read a log tail.

## What to review

- The trap and `wait` interaction: `driver_stop_stdin_watcher`, `set +m` restore, and `trap - INT TERM` on both the normal and the cancelled path.
- `kill -TERM -- "-$PID"` with the plain-PID fallback, and whether 0.25s before SIGKILL is the right grace window.
- That the terminal `else` branch is unchanged from the previous version.
- Tests: `setup/driver-shell.test.ts` gains 5 blocks (7 cases) covering private bootstrap output plus stdin handed cleanly to TypeScript, SIGKILL of a SIGTERM-ignoring grandchild, cancel via disconnect and via a cancel command, the `bootstrap_failed` postcondition, and SIGINT/SIGTERM to exit 2. The file is now complete at 14 tests. The grandchild test spawns a real process and is timing sensitive.

Verification: `bash -n nanoclaw.sh`, the setup-inclusive `tsc` gate, and `pnpm exec vitest run setup/driver-shell.test.ts`. Note that CI's `tsconfig.json` covers only `src/**/*`, so `setup/` is not typechecked by CI. Machine mode is unreachable from anything shipped: nothing passes `--protocol`, and the macOS app still hard-codes `setupProtocol: nil`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this adds new machine-mode behaviour to the installer shell script. It is not a skill, it fixes no existing bug, it simplifies nothing, and it is not documentation.

## Description

See above. In short: machine-mode bootstrap now runs isolated and cancellable, and must prove it succeeded before setup continues.

## For Skills

Not a skill, so the skill checklist does not apply.