### PR TITLE
feat(setup): thread an optional driver through the step runners

### DIFF
--- a/setup/lib/runner.ts
+++ b/setup/lib/runner.ts
@@ -20,6 +20,9 @@ import k from 'kleur';
 import * as setupLog from '../logs.js';
 import { offerClaudeOnFailure } from './claude-handoff.js';
 import { emit as phEmit } from './diagnostics.js';
+import { createSensitiveRedactor, redactSensitiveValues } from './redaction.js';
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
 import { brandBody, fitToWidth, fmtDuration } from './theme.js';
 
 export type Fields = Record<string, string>;
@@ -115,6 +118,7 @@ export function spawnStep(
   onBlock: (block: Block) => void,
   rawLogPath: string,
   onLine?: (line: string) => void,
+  driver?: SetupDriver,
 ): Promise<StepResult> {
   return new Promise((resolve) => {
     const args = ['exec', 'tsx', 'setup/index.ts', '--step', stepName];
@@ -176,6 +180,7 @@ export function spawnQuiet(
   args: string[],
   rawLogPath: string,
   envOverride?: NodeJS.ProcessEnv,
+  driver?: SetupDriver,
 ): Promise<QuietChildResult> {
   return new Promise((resolve) => {
     const child = spawn(cmd, args, {
@@ -210,18 +215,27 @@ export async function runQuietStep(
   stepName: string,
   labels: SpinnerLabels,
   extra: string[] = [],
+  driver?: SetupDriver,
 ): Promise<StepResult & { rawLog: string; durationMs: number }> {
   const rawLog = setupLog.stepRawLog(stepName);
   const start = Date.now();
+  driver?.throwIfCancelled();
+  driver?.progress(stepName, 'pending', labels.running.replace(/…$/, ''));
   phEmit('step_started', { step: stepName });
-  const result = await runUnderSpinner(labels, () => spawnStep(stepName, extra, () => {}, rawLog));
+  const result = await runUnderSpinner(
+    labels,
+    () => spawnStep(stepName, extra, () => {}, rawLog, undefined, driver),
+    driver,
+    stepName,
+  );
   const durationMs = Date.now() - start;
-  writeStepEntry(stepName, result, durationMs, rawLog);
+  writeStepEntry(stepName, result, durationMs, rawLog, driver?.mode === 'ndjson');
   phEmit('step_completed', {
     step: stepName,
     status: outcomeStatus(result),
     duration_ms: durationMs,
   });
+  driver?.throwIfCancelled();
   return { ...result, rawLog, durationMs };
 }
 
@@ -237,14 +251,17 @@ export async function runQuietChild(
     /** Environment overrides to pass to the child process. */
     env?: NodeJS.ProcessEnv;
   },
+  driver?: SetupDriver,
 ): Promise<QuietChildResult & { rawLog: string; durationMs: number }> {
   const rawLog = setupLog.stepRawLog(logName);
   const start = Date.now();
+  driver?.throwIfCancelled();
+  driver?.progress(logName, 'pending', labels.running.replace(/…$/, ''));
   phEmit('step_started', { step: logName });
-  const result = await runUnderSpinner(labels, () => spawnQuiet(cmd, args, rawLog, opts?.env));
+  const result = await runUnderSpinner(labels, () => spawnQuiet(cmd, args, rawLog, opts?.env, driver), driver, logName);
   const durationMs = Date.now() - start;
 
-  const blockFields = summariseTerminalFields(result.terminal);
+  const blockFields = summariseTerminalFields(result.terminal, driver?.mode === 'ndjson');
   const fields = { ...blockFields, ...(opts?.extraFields ?? {}) };
   const rawStatus = result.terminal?.fields.STATUS;
   const status: 'success' | 'skipped' | 'failed' = !result.ok
@@ -254,6 +271,7 @@ export async function runQuietChild(
       : 'success';
   setupLog.step(logName, status, durationMs, fields, rawLog);
   phEmit('step_completed', { step: logName, status, duration_ms: durationMs });
+  driver?.throwIfCancelled();
   return { ...result, rawLog, durationMs };
 }
 
@@ -265,25 +283,31 @@ function outcomeStatus(result: StepResult): 'success' | 'skipped' | 'failed' {
 }
 
 /** Turn a step's terminal-block fields into a concise progression-log entry. */
-export function writeStepEntry(stepName: string, result: StepResult, durationMs: number, rawLog: string): void {
+export function writeStepEntry(
+  stepName: string,
+  result: StepResult,
+  durationMs: number,
+  rawLog: string,
+  redact = false,
+): void {
   const rawStatus = result.terminal?.fields.STATUS;
   const logStatus: 'success' | 'skipped' | 'failed' = !result.ok
     ? 'failed'
     : rawStatus === 'skipped'
       ? 'skipped'
       : 'success';
-  const fields = summariseTerminalFields(result.terminal);
+  const fields = summariseTerminalFields(result.terminal, redact);
   setupLog.step(stepName, logStatus, durationMs, fields, rawLog);
 }
 
 /** Strip STATUS + LOG (redundant) and any oversize values from the terminal block's fields. */
-export function summariseTerminalFields(block: Block | null): Record<string, string> {
+export function summariseTerminalFields(block: Block | null, redact = false): Record<string, string> {
   if (!block) return {};
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(block.fields)) {
     if (k === 'STATUS' || k === 'LOG') continue;
     if (v.length > 120) continue; // keep it skimmable; full value lives in the raw log
-    out[k] = v;
+    out[k] = redact ? redactSensitiveValues(v) : v;
   }
   return out;
 }
@@ -300,9 +324,24 @@ export function summariseTerminalFields(block: Block | null): Record<string, str
  * done/skipped/failed headline (bold) with the elapsed time (dim); on a failure
  * it also dumps the transcript tail when one is supplied.
  */
-export function startSpinner(labels: SpinnerLabels): {
+export function startSpinner(
+  labels: SpinnerLabels,
+  driver?: SetupDriver,
+  stepId = labels.running
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase(),
+): {
   stop: (outcome: { ok: boolean; skipped?: boolean; transcript?: string }) => void;
 } {
+  if (driver?.mode === 'ndjson') {
+    driver.progress(stepId, 'running', labels.running.replace(/…$/, ''));
+    return {
+      stop({ ok, skipped }) {
+        driver.progress(stepId, ok ? 'succeeded' : 'failed');
+      },
+    };
+  }
   const s = p.spinner();
   const start = Date.now();
   s.start(fitToWidth(labels.running, ' (99m 59s)'));
@@ -331,8 +370,10 @@ export function startSpinner(labels: SpinnerLabels): {
 async function runUnderSpinner<T extends { ok: boolean; transcript: string; terminal?: Block | null }>(
   labels: SpinnerLabels,
   work: () => Promise<T>,
+  driver?: SetupDriver,
+  stepId?: string,
 ): Promise<T> {
-  const spinner = startSpinner(labels);
+  const spinner = startSpinner(labels, driver, stepId);
   const result = await work();
   spinner.stop({
     ok: result.ok,
@@ -366,9 +407,33 @@ export function dumpTranscriptOnFailure(transcript: string): void {
  * process.exit. The return type is `Promise<never>`; control-flow
  * narrowing still works after `await`.
  */
-export async function fail(stepName: string, msg: string, hint?: string, rawLogPath?: string): Promise<never> {
+export async function fail(
+  stepName: string,
+  msg: string,
+  hint?: string,
+  rawLogPath?: string,
+  driver?: SetupDriver,
+): Promise<never> {
+  // A signal received during an atomic child/health operation wins over that
+  // operation's failure result: machine cancellation is terminal exit 2.
+  driver?.throwIfCancelled();
   setupLog.abort(stepName, msg);
   phEmit('setup_aborted', { step: stepName, reason: msg });
+  if (driver?.mode === 'ndjson') {
+    driver.progress(stepName, 'failed');
+    driver.error(
+      'step_failed',
+      msg,
+      [
+        {
+          kind: 'manual',
+          title: 'Fix the failed prerequisite and rerun',
+          instructions: [hint ?? 'Inspect logs/setup.log and the matching raw step log.'],
+        },
+      ],
+      stepName,
+    );
+  }
   p.log.error(msg);
   if (hint) p.log.message(k.dim(hint));
   p.log.message(k.dim('Logs: logs/setup.log · Raw: logs/setup-steps/'));

--- a/setup/lib/windowed-runner.ts
+++ b/setup/lib/windowed-runner.ts
@@ -24,6 +24,7 @@ import type { StepResult, SpinnerLabels } from './runner.js';
 import { dumpTranscriptOnFailure, spawnStep, writeStepEntry } from './runner.js';
 import * as setupLog from '../logs.js';
 import { brandBody, fitToWidth, fmtDuration } from './theme.js';
+import type { SetupDriver } from './setup-driver.js';
 
 const WINDOW_SIZE = 3;
 const SPINNER_FRAMES = ['◒', '◐', '◓', '◑'];
@@ -40,20 +41,31 @@ export async function runWindowedStep(
   stepName: string,
   labels: SpinnerLabels,
   extra: string[] = [],
+  driver?: SetupDriver,
 ): Promise<StepResult & { rawLog: string; durationMs: number }> {
   const rawLog = setupLog.stepRawLog(stepName);
   const start = Date.now();
+  driver?.throwIfCancelled();
   phEmit('step_started', { step: stepName });
 
-  const result = await runUnderWindow(stepName, labels, extra, rawLog);
+  let result: StepResult;
+  if (driver?.mode === 'ndjson') {
+    driver.progress(stepName, 'pending', labels.running.replace(/…$/, ''));
+    driver.progress(stepName, 'running', labels.running.replace(/…$/, ''));
+    result = await spawnStep(stepName, extra, () => {}, rawLog, undefined, driver);
+    driver.progress(stepName, result.ok ? 'succeeded' : 'failed');
+  } else {
+    result = await runUnderWindow(stepName, labels, extra, rawLog, driver);
+  }
 
   const durationMs = Date.now() - start;
-  writeStepEntry(stepName, result, durationMs, rawLog);
+  writeStepEntry(stepName, result, durationMs, rawLog, driver?.mode === 'ndjson');
   phEmit('step_completed', {
     step: stepName,
     status: outcomeStatus(result),
     duration_ms: durationMs,
   });
+  driver?.throwIfCancelled();
   return { ...result, rawLog, durationMs };
 }
 
@@ -73,6 +85,7 @@ async function runUnderWindow(
   labels: SpinnerLabels,
   extra: string[],
   rawLog: string,
+  driver?: SetupDriver,
 ): Promise<StepResult> {
   const out = process.stdout;
   const start = Date.now();
@@ -155,7 +168,7 @@ async function runUnderWindow(
     redraw();
   };
 
-  const result = await spawnStep(stepName, extra, () => {}, rawLog, onLine);
+  const result = await spawnStep(stepName, extra, () => {}, rawLog, onLine, driver);
 
   clearInterval(frameTick);
   clearInterval(stallCheck);


### PR DESCRIPTION
## TL;DR

Proposed: give every setup step runner an optional `driver` argument so a later PR can run setup from a native macOS app instead of a terminal. Nothing passes a driver yet, so on the terminal path this proposal changes nothing.

## What problem this solves

`setup/` is the NanoClaw installer. Today it talks to a human through `clack` (the interactive terminal prompt library, imported as `p`): spinners, prompts, error output. This stack proposes a `SetupDriver` interface that abstracts every user interaction, with two implementations: `TerminalSetupDriver` (still clack, so terminal behaviour is identical) and `NdjsonSetupDriver`, which speaks newline delimited JSON over stdin and stdout so a GUI app can drive setup headlessly. ndjson mode is opt in; an unconverted call site still works in the terminal.

This PR is the runner layer: `setup/lib/runner.ts` and `setup/lib/windowed-runner.ts`, the code that spawns each setup step as a child process, shows a spinner or a three line scrolling output window, writes an entry into the progression log, and aborts the run on failure. It has to accept a driver before any step can be converted.

## How it works

An optional `driver?: SetupDriver` parameter is appended to `spawnStep`, `spawnQuiet`, `runQuietStep`, `runQuietChild`, `runWindowedStep`, `runUnderWindow`, `startSpinner`, `runUnderSpinner` and `fail`. Every new behaviour is behind `driver?.mode === 'ndjson'`, so four things happen only in machine mode:

1. Progress instead of animation. `startSpinner` returns a stub that emits a `progress` frame (`running`, then `succeeded` or `failed`) rather than driving a clack spinner, and `runWindowedStep` skips the ANSI window redraw entirely, calling `spawnStep` directly and bracketing it with progress frames.
2. Cancellation checkpoints. `driver.throwIfCancelled()` runs before and after each step and as the first statement of `fail()`, so a cancel from the app wins over a step's own failure result.
3. Log redaction. `writeStepEntry` and `summariseTerminalFields` gain a `redact` flag (default `false`); ndjson callers pass `true`, which runs each step field through `redactSensitiveValues` before it reaches `logs/setup.log`.
4. Typed failure. `fail()` emits a `step_failed` error frame with a manual recovery hint. Because `NdjsonSetupDriver.error` throws, machine mode never reaches the clack error output, the Claude assisted debugging offer, or the retry prompt below it.

## What trips people up

- This is dormant code. No caller in the tree passes a driver at this commit, so every ndjson branch is unreachable until later PRs thread a driver from `setup/auto.ts` and the channel call sites. On the terminal path the only diff is extra optional parameters and a `redact` flag that defaults to `false`. Even passing a `TerminalSetupDriver` would be inert, since its `progress` and `throwIfCancelled` are empty methods.
- Three things land unused on purpose: the `driver` parameter on `spawnStep` and `spawnQuiet` (their bodies are untouched here), and the imports `createSensitiveRedactor` and `childEnvWithoutSetupSecrets`. All three are consumed by the next PR in the stack, which bounds and reaps machine step children and redacts their output. They are kept here so the import lines match the final tree exactly.
- `startSpinner` derives its progress `stepId` by slugging the spinner label when a caller does not supply one, so ad hoc spinners get label derived ids rather than stable identifiers.
- The ndjson windowed path emits `pending` and `running` back to back and then one terminal state. No per line output stream reaches the driver in this PR.

## What to review

- That nothing changes for a terminal run: every new parameter is optional and `redact` defaults to `false`.
- That the progress and error frames match the vocabulary defined in the earlier `SetupDriver` interface PR.
- Whether the cancellation checkpoint placement (before a step starts, after it finishes, and first thing in `fail`) is the semantics you want.
- Whether skipping the Claude assisted debugging offer and the retry prompt in machine mode is intended. It is a consequence of `driver.error` being declared `never`.

## Testing

No tests are added here, and the base has no test importing `runner.ts` or `windowed-runner.ts`. Coverage for this half arrives with the next PR's `runner.test.ts` and the shell driver suite. Gate run for this commit: a setup inclusive `tsc` pass (note that the repo's `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`), `bash -n nanoclaw.sh`, and `vitest` over `setup` and `scripts`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this is neither a skill nor a bug fix, it proposes internal plumbing in the setup installer for a machine drivable setup protocol.

## Description

Adds an optional `SetupDriver` argument to the setup step runners and spinner helpers, with ndjson only branches for progress reporting, cancellation, log redaction and typed failure. Terminal behaviour is unchanged because no caller passes a driver yet.

## For Skills

Not a skill, so the skill checklist does not apply.