### PR TITLE
feat(setup): redact, bound, and reap machine setup step children

### DIFF
--- a/setup/lib/fixtures/setup-driver-child-cancel.ts
+++ b/setup/lib/fixtures/setup-driver-child-cancel.ts
@@ -1,0 +1,37 @@
+import { DriverCancelled, NdjsonSetupDriver } from '../setup-driver.js';
+import { runQuietChild } from '../runner.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+const marker = process.env.NANOCLAW_TEST_CHILD_MARKER;
+if (!marker) driver.error('test_fixture', 'missing child marker');
+const stubbornGrandchild = `
+  process.on('SIGTERM', () => {});
+  process.stdout.write('ready\\n');
+  setInterval(() => {}, 1000);
+`;
+const childScript = `
+  const { spawn } = require('node:child_process');
+  const fs = require('node:fs');
+  const child = spawn(process.execPath, ['-e', ${JSON.stringify(stubbornGrandchild)}], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  child.stdout.once('data', () => fs.writeFileSync(${JSON.stringify(marker)}, String(child.pid)));
+  setInterval(() => {}, 1000);
+`;
+
+try {
+  await runQuietChild(
+    'cancel-child',
+    process.execPath,
+    ['-e', childScript],
+    { running: 'Starting child…', done: 'Child done.' },
+    undefined,
+    driver,
+  );
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverCancelled)) throw error;
+  driver.cancelled();
+  process.exitCode = 2;
+}

--- a/setup/lib/fixtures/setup-driver-windowed-cancel.ts
+++ b/setup/lib/fixtures/setup-driver-windowed-cancel.ts
@@ -1,0 +1,28 @@
+import { DriverCancelled, NdjsonSetupDriver } from '../setup-driver.js';
+import { runWindowedStep } from '../windowed-runner.js';
+
+const driver = new NdjsonSetupDriver('setup');
+
+try {
+  await runWindowedStep(
+    'cancel-window',
+    { running: 'Starting windowed step…', done: 'Windowed step done.' },
+    [],
+    driver,
+  );
+  driver.completeSetup({
+    version: 1,
+    service: { state: 'running', manager: 'pidfile', checkoutRoot: process.cwd() },
+    health: { status: 'healthy' },
+    resources: {
+      groups: { state: 'empty', count: 0 },
+      policies: { state: 'empty', count: 0 },
+      skills: { state: 'empty', count: 0 },
+    },
+    completedAt: new Date().toISOString(),
+  });
+} catch (error) {
+  if (!(error instanceof DriverCancelled)) throw error;
+  driver.cancelled();
+  process.exitCode = 2;
+}

--- a/setup/lib/runner.test.ts
+++ b/setup/lib/runner.test.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { spawnQuiet } from './runner.js';
+import type { SetupDriver } from './setup-driver.js';
+
+describe('machine child output bounds', () => {
+  it('stops a noisy quiet child before its in-memory transcript can grow without bound', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-runner-limit-'));
+    const rawLog = path.join(root, 'raw.log');
+    const driver = { mode: 'ndjson' } as SetupDriver;
+    try {
+      const result = await spawnQuiet(
+        process.execPath,
+        ['-e', `process.stdout.write('x'.repeat(5 * 1024 * 1024))`],
+        rawLog,
+        undefined,
+        driver,
+      );
+
+      expect(result).toMatchObject({ ok: false, failure: 'output_limit' });
+      expect(Buffer.byteLength(result.transcript, 'utf8')).toBeLessThanOrEqual(4 * 1024 * 1024);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/lib/runner.ts
+++ b/setup/lib/runner.ts
@@ -25,12 +25,15 @@ import { childEnvWithoutSetupSecrets } from './secret-file.js';
 import type { SetupDriver } from './setup-driver.js';
 import { brandBody, fitToWidth, fmtDuration } from './theme.js';
 
+const MAX_MACHINE_CHILD_OUTPUT_BYTES = 4 * 1024 * 1024;
+
 export type Fields = Record<string, string>;
 export type Block = { type: string; fields: Fields };
 
 export type StepResult = {
   ok: boolean;
   exitCode: number;
+  failure?: 'output_limit';
   blocks: Block[];
   transcript: string;
   /** The last block with a STATUS field (the terminal/result block). */
@@ -40,6 +43,7 @@ export type StepResult = {
 export type QuietChildResult = {
   ok: boolean;
   exitCode: number;
+  failure?: 'output_limit';
   transcript: string;
   terminal: Block | null;
   blocks: Block[];
@@ -124,10 +128,45 @@ export function spawnStep(
     const args = ['exec', 'tsx', 'setup/index.ts', '--step', stepName];
     if (extra.length > 0) args.push('--', ...extra);
 
-    const child = spawn('pnpm', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const machine = driver?.mode === 'ndjson';
+    const child = spawn('pnpm', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...(machine ? { detached: true, env: childEnvWithoutSetupSecrets() } : {}),
+    });
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+    if (driver?.cancellationSignal?.aborted) stopGroup();
     const stream = new StatusStream(onBlock);
+    const stdoutRedactor = machine ? createSensitiveRedactor() : undefined;
+    const stderrRedactor = machine ? createSensitiveRedactor() : undefined;
     const raw = fs.createWriteStream(rawLogPath, { flags: 'w' });
     raw.write(`# ${stepName} — ${new Date().toISOString()}\n\n`);
+    let outputBytes = 0;
+    let outputLimitExceeded = false;
+    const accepts = (chunk: Buffer): boolean => {
+      if (!machine) return true;
+      if (outputLimitExceeded) return false;
+      outputBytes += chunk.byteLength;
+      if (outputBytes <= MAX_MACHINE_CHILD_OUTPUT_BYTES) return true;
+      outputLimitExceeded = true;
+      stopGroup();
+      return false;
+    };
 
     // Per-line forwarder for the optional onLine callback. We keep our own
     // buffer (separate from StatusStream's) so the parser still gets raw
@@ -147,31 +186,54 @@ export function spawnStep(
     };
 
     child.stdout.on('data', (chunk: Buffer) => {
+      if (!accepts(chunk)) return;
       const s = chunk.toString('utf-8');
-      stream.write(s);
-      raw.write(chunk);
-      pushLines(s);
+      const safe = stdoutRedactor?.write(s) ?? s;
+      stream.write(safe);
+      raw.write(safe);
+      pushLines(safe);
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      const s = chunk.toString('utf-8');
-      stream.transcript += s;
-      raw.write(chunk);
-      pushLines(s);
+      if (!accepts(chunk)) return;
+      const safe = stderrRedactor?.write(chunk.toString('utf-8')) ?? chunk.toString('utf-8');
+      stream.transcript += safe;
+      raw.write(safe);
+      pushLines(safe);
     });
 
-    child.on('close', (code) => {
+    let finished = false;
+    const finish = (code: number | null): void => {
+      if (finished) return;
+      finished = true;
+      driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+      const stdoutTail = stdoutRedactor?.end() ?? '';
+      const stderrTail = stderrRedactor?.end() ?? '';
+      stream.write(stdoutTail);
+      stream.transcript += stderrTail;
+      raw.write(stdoutTail);
+      raw.write(stderrTail);
+      pushLines(stdoutTail);
+      pushLines(stderrTail);
       raw.end();
       const terminal = [...stream.blocks].reverse().find((b) => b.fields.STATUS) ?? null;
       const status = terminal?.fields.STATUS;
-      const ok = code === 0 && (status === 'success' || status === 'skipped');
+      const ok = !outputLimitExceeded && code === 0 && (status === 'success' || status === 'skipped');
       resolve({
         ok,
         exitCode: code ?? 1,
+        ...(outputLimitExceeded ? { failure: 'output_limit' as const } : {}),
         blocks: stream.blocks,
         transcript: stream.transcript,
         terminal,
       });
+    };
+    child.on('error', (error) => {
+      const safe = machine ? redactSensitiveValues(error.message) : error.message;
+      stream.transcript += safe;
+      raw.write(safe);
+      finish(1);
     });
+    child.on('close', finish);
   });
 }
 
@@ -183,30 +245,100 @@ export function spawnQuiet(
   driver?: SetupDriver,
 ): Promise<QuietChildResult> {
   return new Promise((resolve) => {
+    const machine = driver?.mode === 'ndjson';
     const child = spawn(cmd, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: envOverride ? { ...process.env, ...envOverride } : process.env,
+      // Machine callers pass a complete sanitized environment. Merging it
+      // with the parent environment would reintroduce setup secrets; terminal
+      // callers retain the existing partial-override behavior.
+      env: machine
+        ? childEnvWithoutSetupSecrets(envOverride ?? process.env)
+        : envOverride
+          ? { ...process.env, ...envOverride }
+          : process.env,
+      ...(machine ? { detached: true } : {}),
     });
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+    if (driver?.cancellationSignal?.aborted) stopGroup();
     let transcript = '';
     const raw = fs.createWriteStream(rawLogPath, { flags: 'w' });
-    raw.write(`# ${[cmd, ...args].join(' ')} — ${new Date().toISOString()}\n\n`);
+    raw.write(
+      `# ${machine ? redactSensitiveValues([cmd, ...args].join(' ')) : [cmd, ...args].join(' ')} - ${new Date().toISOString()}\n\n`,
+    );
     const blocks: Block[] = [];
     const stream = new StatusStream((b) => blocks.push(b));
+    const stdoutRedactor = machine ? createSensitiveRedactor() : undefined;
+    const stderrRedactor = machine ? createSensitiveRedactor() : undefined;
+    let outputBytes = 0;
+    let outputLimitExceeded = false;
+    const accepts = (chunk: Buffer): boolean => {
+      if (!machine) return true;
+      if (outputLimitExceeded) return false;
+      outputBytes += chunk.byteLength;
+      if (outputBytes <= MAX_MACHINE_CHILD_OUTPUT_BYTES) return true;
+      outputLimitExceeded = true;
+      stopGroup();
+      return false;
+    };
     child.stdout.on('data', (c: Buffer) => {
+      if (!accepts(c)) return;
       const s = c.toString('utf-8');
-      transcript += s;
-      stream.write(s);
-      raw.write(c);
+      const safe = stdoutRedactor?.write(s) ?? s;
+      transcript += safe;
+      stream.write(safe);
+      raw.write(safe);
     });
     child.stderr.on('data', (c: Buffer) => {
-      transcript += c.toString('utf-8');
-      raw.write(c);
+      if (!accepts(c)) return;
+      const safe = stderrRedactor?.write(c.toString('utf-8')) ?? c.toString('utf-8');
+      transcript += safe;
+      raw.write(safe);
     });
-    child.on('close', (code) => {
+    let finished = false;
+    const finish = (code: number | null): void => {
+      if (finished) return;
+      finished = true;
+      driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+      const stdoutTail = stdoutRedactor?.end() ?? '';
+      const stderrTail = stderrRedactor?.end() ?? '';
+      transcript += stdoutTail + stderrTail;
+      stream.write(stdoutTail);
+      raw.write(stdoutTail);
+      raw.write(stderrTail);
       raw.end();
       const terminal = [...blocks].reverse().find((b) => b.fields.STATUS) ?? null;
-      resolve({ ok: code === 0, exitCode: code ?? 1, transcript, terminal, blocks });
+      resolve({
+        ok: !outputLimitExceeded && code === 0,
+        exitCode: code ?? 1,
+        ...(outputLimitExceeded ? { failure: 'output_limit' as const } : {}),
+        transcript,
+        terminal,
+        blocks,
+      });
+    };
+    child.on('error', (error) => {
+      const safe = machine ? redactSensitiveValues(error.message) : error.message;
+      transcript += safe;
+      raw.write(safe);
+      finish(1);
     });
+    child.on('close', finish);
   });
 }
 

--- a/setup/lib/setup-driver.test.ts
+++ b/setup/lib/setup-driver.test.ts
@@ -10,6 +10,8 @@ const TSX_LOADER = import.meta.resolve('tsx');
 const HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child.ts');
 const CONTINUATION_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-continuation.ts');
 const CANCEL_RACE_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-cancel-race.ts');
+const CHILD_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child-cancel.ts');
+const WINDOWED_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-windowed-cancel.ts');
 const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
 
 describe('NDJSON setup driver child boundary', () => {
@@ -231,5 +233,138 @@ describe('NDJSON setup driver child boundary', () => {
     expect(events.filter((event) => event.type === 'cancelled')).toHaveLength(1);
     expect(events.at(-1)?.type).toBe('cancelled');
     expect(events.some((event) => event.type === 'inputRejected')).toBe(false);
+  }, 15_000);
+
+  it('SIGKILLs a runner grandchild that ignores SIGTERM after its leader exits', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-child-cancel-'));
+    const marker = path.join(temp, 'child.pid');
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, CHILD_CANCEL_HARNESS], {
+      cwd: ROOT,
+      env: { ...process.env, NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1', NANOCLAW_TEST_CHILD_MARKER: marker },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<{ type: string; state?: string }> = [];
+    let buffer = '';
+    let stderr = '';
+    let cancelled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as { type: string; state?: string };
+        events.push(event);
+        if (event.type === 'progress' && event.state === 'running' && !cancelled) {
+          cancelled = true;
+          void (async () => {
+            const deadline = Date.now() + 5_000;
+            while (!fs.existsSync(marker) && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            child.stdin.write(`${JSON.stringify({ ...envelope, type: 'cancel', reason: 'test' })}\n`);
+          })();
+        }
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    let pid = 0;
+    try {
+      expect(code, `${JSON.stringify(events)}\n${stderr}`).toBe(2);
+      expect(events.at(-1)?.type).toBe('cancelled');
+      expect(fs.existsSync(marker)).toBe(true);
+      pid = Number(fs.readFileSync(marker, 'utf8').trim());
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('SIGKILLs a windowed-step grandchild that ignores SIGTERM after its leader exits', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-windowed-cancel-'));
+    const marker = path.join(temp, 'child.pid');
+    const bin = path.join(temp, 'bin');
+    fs.mkdirSync(bin);
+    const stubborn = path.join(bin, 'stubborn');
+    fs.writeFileSync(stubborn, `#!/bin/sh\ntrap '' TERM\necho $$ > ${JSON.stringify(marker)}\nexec sleep 30\n`, {
+      mode: 0o755,
+    });
+    fs.writeFileSync(
+      path.join(bin, 'pnpm'),
+      `#!/bin/sh\n${JSON.stringify(stubborn)} &\nwhile [ ! -s ${JSON.stringify(marker)} ]; do sleep 0.01; done\nprintf '%s\\n' '=== NANOCLAW SETUP: cancel-window ===' 'STATUS: success' '=== END ==='\nwait\n`,
+      { mode: 0o755 },
+    );
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, WINDOWED_CANCEL_HARNESS], {
+      cwd: temp,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_NO_DIAGNOSTICS: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<{ type: string; state?: string }> = [];
+    let buffer = '';
+    let cancelled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as { type: string; state?: string; stepId?: string };
+        events.push(event);
+        if (event.type === 'progress' && event.state === 'running' && !cancelled) {
+          cancelled = true;
+          void (async () => {
+            const deadline = Date.now() + 5_000;
+            while (!fs.existsSync(marker) && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            child.stdin.write(`${JSON.stringify({ ...envelope, type: 'cancel', reason: 'test' })}\n`);
+          })();
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    let pid = 0;
+    try {
+      expect(code).toBe(2);
+      expect(events.at(-1)?.type).toBe('cancelled');
+      expect(fs.existsSync(marker)).toBe(true);
+      pid = Number(fs.readFileSync(marker, 'utf8').trim());
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
   }, 15_000);
 });


### PR DESCRIPTION
**TL;DR:** proposed change to the setup step runner so that, when setup is being driven by a program instead of a person, child processes cannot leak prompted secrets into logs or their own environment, cannot flood memory with output, and cannot survive a cancel.

## What problem this solves

This stack is adding a "driver" layer to `setup/` so a native macOS app can run setup headlessly over a line-based JSON protocol on stdin/stdout (`driver.mode === 'ndjson'`, called "machine mode" below). Terminal mode is the existing human-facing clack UI and must not change.

Setup shells out constantly: `spawnStep` runs a setup step through `pnpm exec tsx setup/index.ts --step <name>`, and `spawnQuiet` runs an arbitrary command such as `onecli` or the container build script. In machine mode three things about that were unsafe:

1. Child output is forwarded verbatim to the driver transcript, the status-block parser, the per-line callback and the raw step log. A secret the user just typed into a driver prompt could be echoed back by a child and end up on the wire and on disk.
2. Children inherited the full parent environment, including setup secrets such as `ANTHROPIC_API_KEY` and `NANOCLAW_REGISTRY_TOKEN`.
3. A cancel from the GUI killed nothing, and a runaway child could grow the in-memory transcript without limit.

## How it works

All of this is gated on `machine = driver?.mode === 'ndjson'`, so the terminal path is untouched by items 1 to 3.

- **Redaction.** `createSensitiveRedactor()` (already in the tree) returns a streaming filter that replaces any value previously registered via `registerSensitiveValue` with `[REDACTED]`, buffering enough tail bytes to catch a secret split across two chunks. Machine mode now runs stdout and stderr through one redactor each, flushes the buffered tail in `finish()`, and also redacts the spawn `error.message` and the command line written into the `spawnQuiet` raw-log header. Secrets get registered when the driver serves a `kind: 'secret'` prompt, which already happens earlier in the stack, so this is live, not dormant.
- **Environment.** Machine children are spawned with `childEnvWithoutSetupSecrets()`, which copies the environment minus eight known secret variables. This is that helper's first real caller. For `spawnQuiet`, machine mode passes the caller's `envOverride` through the filter as the complete environment rather than merging it onto `process.env`; every machine call site in the stack already passes a full env, so nothing is silently stripped of `PATH`.
- **Reaping.** Machine children are spawned `detached: true`, which puts them in their own process group. `stopGroup()` signals the negative pid, so `SIGTERM` and, 250 ms later, `SIGKILL` reach grandchildren too. It is wired to the driver's `cancellationSignal` (and fires immediately if the signal is already aborted) and unwired in `finish()`.
- **Output bound.** A shared 4 MiB counter over stdout and stderr; on overflow the runner stops accepting chunks, kills the group, and resolves with `ok: false` and a new `failure: 'output_limit'` field on `StepResult` / `QuietChildResult`.
- **Completion.** A single-shot `finish()` now backs both `close` and a newly added `error` handler.

## Two changes that also affect terminal mode

Please review these deliberately, they are not machine-only:

- `child.on('error', ...)` did not exist before in either mode. A spawn failure previously surfaced as an unhandled `error` event; now it appends the message to the transcript and resolves with `exitCode: 1`.
- The `spawnQuiet` raw-log header separator changed from an em dash to an ASCII hyphen in both branches, so terminal raw logs differ by one character.

## What trips people up

- The redactor snapshots the registered secret set when it is constructed, which is at spawn time. A secret registered while a child is already running is not redacted in that child's stream.
- The 4 MiB counter counts raw bytes read, before redaction, so the resulting transcript can be smaller than the cap.
- The two cancellation tests spawn deliberately stubborn `SIGTERM`-ignoring grandchildren with 15 s timeouts. They are POSIX process-group dependent and are the most machine-sensitive tests in the stack.

## What to review

Test coverage is honestly partial: `setup/lib/runner.test.ts` covers only the 4 MiB cap, and the two new cases in `setup/lib/setup-driver.test.ts` cover only grandchild `SIGKILL` for the quiet-child and windowed-step paths. **The redaction and the sanitized child environment have no direct test in this PR.** Worth a close read: that every output sink (transcript, status parser, `onLine`, raw log) is fed the redacted string and not the original; that the tail flush in `finish()` cannot drop or duplicate bytes; that `stopGroup` can never signal group 0 or the parent; and the two terminal-mode changes above.

Note that `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`. This was checked locally with a setup-inclusive `tsc` config and with vitest.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is one slice of a proposed setup-driver protocol stack: it hardens a new machine-mode code path rather than adding a skill or fixing shipped behaviour. The one exception is the small terminal-mode `error`-handler change noted above, which is too minor to justify ticking "Fix" for the whole PR.

## Description

Proposed: in ndjson driver mode, `spawnStep` and `spawnQuiet` redact prompted secrets out of all child output and error text, drop setup secrets from the child environment, cap child output at 4 MiB, and terminate the child's whole process group on cancel or overflow. Terminal mode keeps its behaviour apart from the two changes listed above. Nothing here is enabled by default: ndjson mode is opt-in and the macOS app still passes `setupProtocol: nil`.

## For Skills

Not a skill, so the skill checklist does not apply.