### PR TITLE
feat(setup): bound, cancel and scrub env for machine setup probes

### DIFF
--- a/setup/lib/agent-ping.test.ts
+++ b/setup/lib/agent-ping.test.ts
@@ -1,7 +1,12 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { isValidGroupFolder } from '../../src/group-folder.js';
-import { classifyPingResult, PING_AGENT_FOLDER } from './agent-ping.js';
+import { classifyPingResult, PING_AGENT_FOLDER, pingCliAgent } from './agent-ping.js';
+import type { SetupDriver } from './setup-driver.js';
 
 it('uses a runtime-safe folder for the setup ping agent', () => {
   expect(isValidGroupFolder(PING_AGENT_FOLDER)).toBe(true);
@@ -37,4 +42,101 @@ describe('classifyPingResult', () => {
   it('treats empty output as no reply', () => {
     expect(classifyPingResult(0, '')).toBe('no_reply');
   });
+
+  it('stops a noisy machine ping before its output can grow without bound', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-ping-limit-'));
+    const bin = path.join(temp, 'bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, 'pnpm'),
+      `#!/usr/bin/env node
+process.stdout.write('x'.repeat(70 * 1024));
+setInterval(() => {}, 1000);
+`,
+      { mode: 0o755 },
+    );
+    const previousPath = process.env.PATH;
+    try {
+      process.env.PATH = `${bin}:${previousPath ?? ''}`;
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      await expect(pingCliAgent(30_000, driver)).resolves.toBe('output_limit');
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it('scrubs machine credentials and kills the ping process group on cancellation', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-ping-cancel-'));
+    const bin = path.join(temp, 'bin');
+    const envMarker = path.join(temp, 'env');
+    const pidMarker = path.join(temp, 'pid');
+    fs.mkdirSync(bin);
+    const stubborn = path.join(bin, 'stubborn');
+    fs.writeFileSync(
+      stubborn,
+      `#!/bin/sh
+trap '' TERM
+echo $$ > "$PING_PID_MARKER"
+exec sleep 30
+`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(bin, 'pnpm'),
+      `#!/bin/sh
+printf '%s' "\${ANTHROPIC_API_KEY-missing}" > "$PING_ENV_MARKER"
+${JSON.stringify(stubborn)} &
+wait
+`,
+      { mode: 0o755 },
+    );
+    const previous = {
+      path: process.env.PATH,
+      key: process.env.ANTHROPIC_API_KEY,
+      envMarker: process.env.PING_ENV_MARKER,
+      pidMarker: process.env.PING_PID_MARKER,
+    };
+    const controller = new AbortController();
+    let pid = 0;
+    try {
+      process.env.PATH = `${bin}:${previous.path ?? ''}`;
+      process.env.ANTHROPIC_API_KEY = 'must-not-reach-child';
+      process.env.PING_ENV_MARKER = envMarker;
+      process.env.PING_PID_MARKER = pidMarker;
+      const driver = { mode: 'ndjson', cancellationSignal: controller.signal } as SetupDriver;
+      const result = pingCliAgent(30_000, driver);
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(pidMarker) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(fs.readFileSync(envMarker, 'utf8')).toBe('missing');
+      controller.abort();
+      expect(await result).toBe('no_reply');
+      pid = Number(fs.readFileSync(pidMarker, 'utf8'));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      controller.abort();
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      for (const [key, value] of Object.entries({
+        PATH: previous.path,
+        ANTHROPIC_API_KEY: previous.key,
+        PING_ENV_MARKER: previous.envMarker,
+        PING_PID_MARKER: previous.pidMarker,
+      })) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 10_000);
 });

--- a/setup/lib/agent-ping.ts
+++ b/setup/lib/agent-ping.ts
@@ -13,9 +13,14 @@
  */
 import { spawn } from 'child_process';
 
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
+
 export const PING_AGENT_FOLDER = 'ping_test';
 
-export type PingResult = 'ok' | 'no_reply' | 'socket_error' | 'auth_error';
+const MAX_MACHINE_PING_OUTPUT_BYTES = 64 * 1024;
+
+export type PingResult = 'ok' | 'no_reply' | 'socket_error' | 'auth_error' | 'output_limit';
 
 export function classifyPingResult(exitCode: number | null, stdout: string, stderr = ''): PingResult {
   const output = `${stdout}\n${stderr}`;
@@ -34,38 +39,79 @@ export function classifyPingResult(exitCode: number | null, stdout: string, stde
   return 'no_reply';
 }
 
-export function pingCliAgent(timeoutMs = 30_000): Promise<PingResult> {
+export function pingCliAgent(timeoutMs = 30_000, driver?: SetupDriver): Promise<PingResult> {
   return new Promise((resolve) => {
+    const machine = driver?.mode === 'ndjson';
     const child = spawn('pnpm', ['run', 'chat', 'ping'], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      ...(machine ? { detached: true, env: childEnvWithoutSetupSecrets() } : {}),
     });
     let stdout = '';
     let stderr = '';
+    let outputBytes = 0;
     let settled = false;
-    const timer = setTimeout(() => {
+    const stopGroup = (): void => {
+      if (!child.pid) return;
+      if (!machine) {
+        child.kill('SIGKILL');
+        return;
+      }
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    const onAbort = (): void => {
+      stopGroup();
+      settle('no_reply');
+    };
+    const settle = (result: PingResult): void => {
       if (settled) return;
       settled = true;
-      child.kill('SIGKILL');
-      resolve('no_reply');
+      clearTimeout(timer);
+      driver?.cancellationSignal?.removeEventListener('abort', onAbort);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      stopGroup();
+      settle('no_reply');
     }, timeoutMs);
+    driver?.cancellationSignal?.addEventListener('abort', onAbort, { once: true });
+    if (driver?.cancellationSignal?.aborted) onAbort();
 
+    const append = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+      if (settled) return;
+      if (machine) {
+        outputBytes += chunk.byteLength;
+        if (outputBytes > MAX_MACHINE_PING_OUTPUT_BYTES) {
+          stopGroup();
+          settle('output_limit');
+          return;
+        }
+      }
+      if (stream === 'stdout') stdout += chunk.toString('utf-8');
+      else stderr += chunk.toString('utf-8');
+    };
     child.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString('utf-8');
+      append(chunk, 'stdout');
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString('utf-8');
+      append(chunk, 'stderr');
     });
     child.on('close', (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(classifyPingResult(code, stdout, stderr));
+      settle(classifyPingResult(code, stdout, stderr));
     });
     child.on('error', () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve('socket_error');
+      settle('socket_error');
     });
   });
 }

--- a/setup/lib/tz-from-claude.test.ts
+++ b/setup/lib/tz-from-claude.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+import { resolveTimezoneViaClaude } from './tz-from-claude.js';
+
+describe('machine timezone lookup', () => {
+  it('stops a noisy machine lookup before its output can grow without bound', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-timezone-limit-'));
+    const bin = path.join(temp, 'bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, 'claude'),
+      `#!/usr/bin/env node
+process.stdout.write('x'.repeat(70 * 1024));
+setInterval(() => {}, 1000);
+`,
+      { mode: 0o755 },
+    );
+    const previousPath = process.env.PATH;
+    try {
+      process.env.PATH = `${bin}:${previousPath ?? ''}`;
+      const driver = {
+        mode: 'ndjson',
+        progress: () => {},
+        throwIfCancelled: () => {},
+      } as unknown as SetupDriver;
+      await expect(resolveTimezoneViaClaude('Jerusalem', driver)).resolves.toBeNull();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it('scrubs credentials and kills the Claude process group on cancellation', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-timezone-cancel-'));
+    const bin = path.join(temp, 'bin');
+    const envMarker = path.join(temp, 'env');
+    const pidMarker = path.join(temp, 'pid');
+    fs.mkdirSync(bin);
+    const stubborn = path.join(bin, 'stubborn');
+    fs.writeFileSync(
+      stubborn,
+      `#!/bin/sh
+trap '' TERM
+echo $$ > "$TZ_PID_MARKER"
+exec sleep 30
+`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(bin, 'claude'),
+      `#!/bin/sh
+printf '%s' "\${ANTHROPIC_AUTH_TOKEN-missing}" > "$TZ_ENV_MARKER"
+${JSON.stringify(stubborn)} &
+wait
+`,
+      { mode: 0o755 },
+    );
+    const previous = {
+      path: process.env.PATH,
+      token: process.env.ANTHROPIC_AUTH_TOKEN,
+      envMarker: process.env.TZ_ENV_MARKER,
+      pidMarker: process.env.TZ_PID_MARKER,
+    };
+    const controller = new AbortController();
+    const driver = {
+      mode: 'ndjson',
+      cancellationSignal: controller.signal,
+      progress: () => {},
+      throwIfCancelled: () => {
+        if (controller.signal.aborted) throw new DriverCancelled('test');
+      },
+    } as unknown as SetupDriver;
+    let pid = 0;
+    try {
+      process.env.PATH = `${bin}:${previous.path ?? ''}`;
+      process.env.ANTHROPIC_AUTH_TOKEN = 'must-not-reach-child';
+      process.env.TZ_ENV_MARKER = envMarker;
+      process.env.TZ_PID_MARKER = pidMarker;
+      const result = resolveTimezoneViaClaude('Jerusalem', driver);
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(pidMarker) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(fs.readFileSync(envMarker, 'utf8')).toBe('missing');
+      controller.abort();
+      await expect(result).rejects.toBeInstanceOf(DriverCancelled);
+      pid = Number(fs.readFileSync(pidMarker, 'utf8'));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      controller.abort();
+      if (pid > 0) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      for (const [key, value] of Object.entries({
+        PATH: previous.path,
+        ANTHROPIC_AUTH_TOKEN: previous.token,
+        TZ_ENV_MARKER: previous.envMarker,
+        TZ_PID_MARKER: previous.pidMarker,
+      })) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/setup/lib/tz-from-claude.ts
+++ b/setup/lib/tz-from-claude.ts
@@ -17,11 +17,18 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import { isValidTimezone } from '../../src/timezone.js';
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
 import { fitToWidth, fmtDuration } from './theme.js';
+import type { SetupDriver } from './setup-driver.js';
 
-export function claudeCliAvailable(): boolean {
+const MAX_MACHINE_TIMEZONE_OUTPUT_BYTES = 64 * 1024;
+
+export function claudeCliAvailable(driver?: SetupDriver): boolean {
   try {
-    execSync('command -v claude', { stdio: 'ignore' });
+    execSync('command -v claude', {
+      stdio: 'ignore',
+      ...(driver?.mode === 'ndjson' ? { env: childEnvWithoutSetupSecrets() } : {}),
+    });
     return true;
   } catch {
     return false;
@@ -34,10 +41,19 @@ export function claudeCliAvailable(): boolean {
  * resolved zone string on success, or null if the CLI is missing, Claude
  * errored, or the reply wasn't a valid IANA zone.
  */
-export async function resolveTimezoneViaClaude(input: string): Promise<string | null> {
-  if (!claudeCliAvailable()) return null;
+export async function resolveTimezoneViaClaude(input: string, driver?: SetupDriver): Promise<string | null> {
+  if (!claudeCliAvailable(driver)) return null;
 
   const prompt = buildPrompt(input);
+
+  if (driver?.mode === 'ndjson') {
+    driver.progress('timezone-lookup', 'running', 'Looking up that timezone');
+    const reply = await queryClaude(prompt, driver);
+    driver.throwIfCancelled();
+    const resolved = reply ? extractTimezone(reply) : null;
+    driver.progress('timezone-lookup', resolved ? 'succeeded' : 'failed');
+    return resolved;
+  }
 
   const s = p.spinner();
   const start = Date.now();
@@ -75,26 +91,69 @@ function buildPrompt(input: string): string {
   ].join('\n');
 }
 
-function queryClaude(prompt: string): Promise<string | null> {
+function queryClaude(prompt: string, driver?: SetupDriver): Promise<string | null> {
   return new Promise((resolve) => {
+    const machine = driver?.mode === 'ndjson';
     const child = spawn('claude', ['-p', '--output-format', 'text'], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(machine ? { detached: true, env: childEnvWithoutSetupSecrets() } : {}),
     });
     let stdout = '';
+    let outputBytes = 0;
     let settled = false;
     const settle = (value: string | null): void => {
       if (settled) return;
       settled = true;
+      driver?.cancellationSignal?.removeEventListener('abort', onAbort);
       resolve(value);
     };
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    const onAbort = (): void => {
+      stopGroup();
+      settle(null);
+    };
+    driver?.cancellationSignal?.addEventListener('abort', onAbort, { once: true });
+    if (driver?.cancellationSignal?.aborted) onAbort();
 
+    const accepts = (chunk: Buffer): boolean => {
+      if (settled) return false;
+      if (machine) {
+        outputBytes += chunk.byteLength;
+        if (outputBytes > MAX_MACHINE_TIMEZONE_OUTPUT_BYTES) {
+          stopGroup();
+          settle(null);
+          return false;
+        }
+      }
+      return true;
+    };
     child.stdout.on('data', (c: Buffer) => {
+      if (!accepts(c)) return;
       stdout += c.toString('utf-8');
+    });
+    child.stderr.on('data', (c: Buffer) => {
+      accepts(c);
     });
     child.on('close', (code) => {
       settle(code === 0 && stdout.trim() ? stdout : null);
     });
     child.on('error', () => settle(null));
+    child.stdin.on('error', () => settle(null));
 
     child.stdin.end(prompt);
   });


### PR DESCRIPTION
**TL;DR:** proposes making the two setup steps that shell out, the Claude timezone lookup and the "is the assistant awake" agent ping, safe to run when setup is being driven by a program instead of a person: bounded output, killable, and with secrets stripped from the child's environment. Terminal setup behaviour is unchanged. Nothing calls the new code path yet.

### Terms, defined inline

- **SetupDriver**: the interface (proposed earlier in this stack) that setup uses for every user interaction. It has a `mode` of `'terminal'` (the normal clack terminal UI) or `'ndjson'` (a newline-delimited JSON wire protocol, so a native macOS app can drive setup with no terminal). Throughout this PR, "machine mode" means `mode === 'ndjson'`.
- **Probe**: a setup step that spawns a child process to ask a question. Here: `claude -p` to turn "Jerusalem" into an IANA timezone, and `pnpm run chat ping` to check the assistant replies.

### The problem

In terminal mode a person is watching. If a probe hangs or floods the screen they hit Ctrl+C, and the child dies with the terminal. In machine mode there is no terminal and no human: a wedged child can run forever, unbounded output can grow until the driving app runs out of memory, a child that forked its own children survives a kill of the direct child, and setup's environment carries auth tokens that a probe has no business inheriting.

### How it works

Both functions gain an optional `driver?: SetupDriver` parameter. Every new behaviour is behind `driver?.mode === 'ndjson'`, so passing nothing, which is what every caller does today, is exactly the old code path. In machine mode:

- the child is spawned `detached: true`, giving it its own process group;
- its environment comes from `childEnvWithoutSetupSecrets()`, which deletes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `ONECLI_API_KEY` and the `NANOCLAW_*` token variables;
- stdout plus stderr are counted, and past 64 KiB the probe stops and gives up;
- the driver's `cancellationSignal` (an `AbortSignal`) stops the probe, and cleanup signals the whole group, `SIGTERM` then `SIGKILL` 250 ms later, so grandchildren die too.

Two smaller changes: `PingResult` gains an `'output_limit'` member, and in machine mode the timezone lookup emits driver progress events rather than starting a clack spinner that has no terminal to draw on.

### What trips people up

- **This is dormant.** At this commit `setup/auto.ts` still calls `pingCliAgent()` and `resolveTimezoneViaClaude(raw)` with no driver, so none of it runs. The timezone lookup is handed a driver in PR 28 and the ping in PR 34.
- **Two lines are not gated on machine mode and do change terminal behaviour, for the better.** The Claude child's stderr was piped but never read, so a chatty child could block on a full pipe; it is now drained and discarded. And a stdin write failure now resolves `null` instead of surfacing an unhandled `EPIPE`.
- **Cancelling a ping returns `'no_reply'`,** not a distinct "cancelled" result. The ping is a plain promise with no throw path; the caller aborts anyway.
- **Cancelling a timezone lookup throws `DriverCancelled`,** via `driver.throwIfCancelled()`, which means the `timezone-lookup` progress row never receives a terminal state. Setup is tearing down at that point.
- **`'output_limit'` widens a union.** The only other consumer, `renderPingFailureNote` in `setup/auto.ts`, has no exhaustive switch: it falls into the generic "didn't reply" note, and the cap only exists in machine mode, which is unreachable at this commit. A dedicated message is proposed later in the stack.

### What to review

1. Is the kill sequence right? `process.kill(-pid, ...)` relies on `detached: true` having made the pid a process group id, and both `try/catch` around an already-gone group.
2. The output cap is per probe and counts both streams; 64 KiB against a `claude -p` reply and a ping transcript.
3. The scrubbed environment list in `childEnvWithoutSetupSecrets` versus what these two children legitimately need. The Claude CLI is expected to use its own on-disk credentials, not an inherited token.
4. The two new test files are the most environment-sensitive in the stack: they write shell and node stubs to a temp dir, prepend it to `PATH`, set `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`, spawn a child that traps `SIGTERM`, then assert the process group is actually gone and that the token never reached the child. Worth a look for flakiness and for restoring `process.env` on failure.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is not a skill, and it is not a fix to reported behaviour: it adds bounded, cancellable, secret-free child processes for a setup mode that is not switched on yet.

## Description

Adds an optional `SetupDriver` parameter to `resolveTimezoneViaClaude`, `claudeCliAvailable` and `pingCliAgent`. When the driver is in ndjson mode, both probes spawn detached with a secret-scrubbed environment, cap combined child output at 64 KiB, and are killed as a process group on cancellation. `PingResult` gains `'output_limit'`. Terminal mode is unchanged apart from draining the Claude child's stderr and handling a stdin write error. Files touched: `setup/lib/tz-from-claude.ts`, `setup/lib/agent-ping.ts` and their tests.

## For Skills

Not a skill, so this checklist does not apply.