### PR TITLE
feat(cli): bound every ncl socket request with a timeout and cap

### DIFF
--- a/src/cli/socket-client.ts
+++ b/src/cli/socket-client.ts
@@ -14,36 +14,58 @@ import type { Transport } from './transport.js';
 
 export const DEFAULT_SOCKET_PATH = path.join(DATA_DIR, 'ncl.sock');
 
+export type SocketRequestOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+};
+
 export class SocketTransport implements Transport {
   constructor(private readonly socketPath: string = DEFAULT_SOCKET_PATH) {}
 
-  async sendFrame(req: RequestFrame): Promise<ResponseFrame> {
+  async sendFrame(req: RequestFrame, options: SocketRequestOptions = {}): Promise<ResponseFrame> {
     return new Promise((resolve, reject) => {
       const client = net.createConnection(this.socketPath);
-      let buffer = '';
+      const timeoutMs = options.timeoutMs ?? 30_000;
+      const maxResponseBytes = options.maxResponseBytes ?? 1024 * 1024;
+      let buffer = Buffer.alloc(0);
       let settled = false;
+
+      const abort = (): void => settle('reject', new Error('host request aborted'));
+      const timer = setTimeout(
+        () => settle('reject', new Error(`host request timed out after ${timeoutMs} ms`)),
+        timeoutMs,
+      );
 
       const settle = (action: 'resolve' | 'reject', valueOrErr: ResponseFrame | Error): void => {
         if (settled) return;
         settled = true;
-        try {
-          client.end();
-        } catch (_e) {
-          // best-effort
-        }
+        clearTimeout(timer);
+        options.signal?.removeEventListener('abort', abort);
+        client.destroy();
         if (action === 'resolve') resolve(valueOrErr as ResponseFrame);
         else reject(valueOrErr as Error);
       };
+
+      options.signal?.addEventListener('abort', abort, { once: true });
+      if (options.signal?.aborted) {
+        abort();
+        return;
+      }
 
       client.on('connect', () => {
         client.write(JSON.stringify(req) + '\n');
       });
 
       client.on('data', (chunk) => {
-        buffer += chunk.toString('utf8');
-        const idx = buffer.indexOf('\n');
+        if (buffer.byteLength + chunk.byteLength > maxResponseBytes) {
+          settle('reject', new Error(`host response exceeded ${maxResponseBytes} bytes`));
+          return;
+        }
+        buffer = Buffer.concat([buffer, chunk]);
+        const idx = buffer.indexOf(0x0a);
         if (idx < 0) return;
-        const line = buffer.slice(0, idx);
+        const line = buffer.subarray(0, idx).toString('utf8');
         try {
           const frame = JSON.parse(line) as ResponseFrame;
           settle('resolve', frame);


### PR DESCRIPTION
## TL;DR

Proposes putting a deadline and a size ceiling on every request the `ncl` command line tool sends to the local NanoClaw background service: 30 seconds and 1 MiB by default, plus optional cancellation. One file, 32 added lines, no new dependencies. This is a behaviour change for all existing `ncl` commands, not only for setup.

## The problem

`ncl` is the small command line client that talks to the NanoClaw daemon running on the same machine. It connects to a Unix domain socket at `data/ncl.sock`, writes one JSON request followed by a newline, reads one JSON response line, and closes. That code lives in `src/cli/socket-client.ts` as `SocketTransport.sendFrame`.

Today `sendFrame` has no bounds at all. If the daemon accepts the connection and then never answers, `ncl` waits forever with no way out. If it answers with an enormous line, the client buffers the whole thing in memory. There is also no way for a caller to cancel a request in flight.

That is tolerable for a human typing `ncl` in a terminal and hitting Ctrl-C. It is not tolerable for the setup wizard, which is the reason this PR exists: a later PR in this stack (16) asks the daemon "are you healthy?" during setup, and a health probe that can hang forever would freeze the whole wizard. The transport has to be bounded before anything in setup is allowed to call it.

## How it works

`sendFrame` gets an optional second argument:

```ts
export type SocketRequestOptions = {
  signal?: AbortSignal;      // caller cancellation
  timeoutMs?: number;        // default 30_000
  maxResponseBytes?: number; // default 1024 * 1024
};
```

Four concrete changes inside the promise:

1. A `setTimeout` armed before the connection is even opened, so the deadline covers connect time as well as response time. On expiry the promise rejects with `host request timed out after N ms`.
2. An `AbortSignal` listener that rejects with `host request aborted`. `AbortSignal` is the standard web and Node cancellation object. Adding a listener to a signal that has already fired does not fire it again, so there is an explicit `if (options.signal?.aborted)` early return next to it. That check is load bearing, not defensive noise.
3. A byte ceiling checked on each incoming chunk before it is appended. Over the limit rejects with `host response exceeded N bytes`.
4. The read accumulator changes from a JavaScript string built with `+=` to a `Buffer` built with `Buffer.concat`, and the newline search from `indexOf('\n')` to `indexOf(0x0a)`. Two consequences: the size cap now counts actual bytes rather than UTF-16 units, and a multi-byte UTF-8 character that happens to be split across two network chunks is no longer decoded half at a time and mangled.

The single cleanup path, `settle()`, now clears the timer, removes the abort listener, and calls `client.destroy()` where it previously wrapped `client.end()` in a try/catch. `end()` sends a polite close and waits for the other side; `destroy()` tears the socket down immediately. Since the protocol is one response per connection and we are done reading, immediate teardown is the right call and it means an unresponsive daemon cannot leave us holding a half open socket.

## What trips people up

- **The defaults are on for callers that did not ask for them.** `src/cli/transport.ts` still declares `sendFrame(req)` with one parameter, so anything holding the `Transport` interface, which is what `src/cli/client.ts` (the `ncl` entry point) holds, cannot pass options and simply inherits 30 s and 1 MiB. `setup/auto.ts` holds a concrete `SocketTransport` and also passes nothing. Every `ncl` subcommand in the repo therefore gains both bounds and two new possible error strings in this PR.
- **The 1 MiB ceiling wants a maintainer opinion.** `client.ts` already carries a comment naming `ncl sessions list --json` at scale as the command that produces genuinely large output. I have not measured a real response against 1 MiB. If any command can legitimately exceed it, this PR breaks that command, and the number should be raised or that call site should opt out.
- **Nothing exercises the new options at this commit.** The options bag is dormant here. The first caller is `queryHostHealth` in PR 16, which asks for a 1 second timeout and a 256 KiB cap, and PR 17 puts that on the setup verify path. Reviewing this in isolation is the point of the split, but do not expect to find a consumer in the diff.
- **There is no test.** The repo has no direct test for `SocketTransport`, before this change or after the full stack. `src/cli/transport-errors.test.ts` only covers error formatting, and the parity test in setup mocks the class out entirely. This file is, however, one of the few in this stack that CI genuinely typechecks, because `tsconfig.json` includes only `src/**/*`.

## What to review

- Are 30 seconds and 1 MiB the right defaults for every `ncl` command, or should the bounds be opt in and setup pass its own?
- The size check rejects when `buffer + chunk` would exceed the cap, even if the terminating newline sits before the limit inside that same chunk. Slightly conservative. Acceptable?
- The switch from `end()` to `destroy()`, in case anything relied on the graceful close.
- The declaration order: `abort` and the timer callback reference `settle` before its `const` is initialised. Safe here because neither runs synchronously before that line, but worth a second pair of eyes.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is hardening of an existing transport, it adds no skill, and it is not fixing a reported bug, so ticking "Fix" would overstate it.

## Description

See the sections above. In one line: `SocketTransport.sendFrame` takes an optional `{ signal, timeoutMs, maxResponseBytes }` argument and applies a 30 second deadline and a 1 MiB response cap by default to every `ncl` request.

## For Skills

Not a skill, so this checklist does not apply.
