### PR TITLE
feat(setup): add fail-closed service identity and health checks

### DIFF
--- a/setup/lib/service-health.test.ts
+++ b/setup/lib/service-health.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import net, { type Server, type Socket } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { getLaunchdLabel } from '../../src/install-slug.js';
+import { buildSetupReceipt, inspectService, queryHostHealth } from './service-health.js';
+
+async function stalledServer(root: string): Promise<{ server: Server; sockets: Set<Socket> }> {
+  const socketPath = path.join(root, 'data', 'ncl.sock');
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+  const sockets = new Set<Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  return { server, sockets };
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) socket.destroy();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe('inspectService', () => {
+  it.skipIf(process.platform !== 'darwin')('uses the launchd PID and verifies the NanoClaw script identity', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-'));
+    const calls: string[][] = [];
+    const result = inspectService(root, (file, args) => {
+      calls.push([file, ...args]);
+      if (file === 'launchctl') return `${process.pid}\t0\t${getLaunchdLabel(root)}`;
+      if (file === 'ps') return `node ${root}/dist/index.js`;
+      throw new Error('not used');
+    });
+    expect(result.state).toBe('running');
+    expect(result.manager).toBe('launchd');
+    expect(result.pid).toBe(process.pid);
+    expect(result.checkoutRoot).toBe(root);
+    expect(calls.some(([file]) => file === 'ps')).toBe(true);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform !== 'darwin')('verifies a NanoClaw script path containing spaces', () => {
+    const root = '/tmp/nano claw';
+    const result = inspectService(root, (file) => {
+      if (file === 'launchctl') return `${process.pid}\t0\t${getLaunchdLabel(root)}`;
+      if (file === 'ps') return `node ${root}/dist/index.js`;
+      throw new Error('not used');
+    });
+
+    expect(result).toMatchObject({
+      state: 'running',
+      manager: 'launchd',
+      pid: process.pid,
+      checkoutRoot: root,
+    });
+  });
+});
+
+describe('buildSetupReceipt', () => {
+  const root = process.cwd();
+  const service = { state: 'running' as const, manager: 'pidfile' as const, pid: 42, checkoutRoot: root };
+  const health = {
+    status: 'healthy' as const,
+    checkoutRoot: root,
+    process: { pid: 42, ppid: 1, executable: '/usr/bin/node', script: `${root}/dist/index.js`, cwd: root },
+    resources: {
+      groups: { state: 'empty' as const, count: 0 },
+      policies: { state: 'empty' as const, count: 0 },
+      skills: { state: 'empty' as const, count: 0 },
+    },
+  };
+
+  it('builds a complete-ready receipt for a valid zero-group health report', () => {
+    const result = buildSetupReceipt(root, service, health);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.receipt.resources.groups).toEqual({ state: 'empty', count: 0 });
+      expect(result.receipt.resources.policies).toEqual({ state: 'empty', count: 0 });
+      expect(result.receipt.health.status).toBe('healthy');
+    }
+  });
+
+  it('rejects mismatched service PID, checkout, or unhealthy health', () => {
+    expect(buildSetupReceipt(root, { ...service, pid: 43 }, health)).toMatchObject({
+      ok: false,
+      code: 'health_postcondition_failed',
+    });
+    expect(buildSetupReceipt('/other/checkout', service, health)).toMatchObject({
+      ok: false,
+      code: 'service_identity_unproven',
+    });
+    expect(buildSetupReceipt(root, service, { ...health, status: 'unhealthy' })).toMatchObject({
+      ok: false,
+      code: 'health_postcondition_failed',
+    });
+  });
+});
+
+describe('queryHostHealth', () => {
+  it('bounds a stalled socket request', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-socket-'));
+    const { server, sockets } = await stalledServer(root);
+    try {
+      await expect(queryHostHealth(root, { timeoutMs: 20 })).resolves.toBeNull();
+    } finally {
+      await closeServer(server, sockets);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('cancels an in-flight socket request', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-health-abort-'));
+    const { server, sockets } = await stalledServer(root);
+    const controller = new AbortController();
+    try {
+      const pending = queryHostHealth(root, { signal: controller.signal, timeoutMs: 5_000 });
+      controller.abort();
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      await closeServer(server, sockets);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/setup/lib/service-health.ts
+++ b/setup/lib/service-health.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
+import { SocketTransport } from '../../src/cli/socket-client.js';
+import type { ResponseFrame } from '../../src/cli/frame.js';
+import type { HostHealth, HealthResource } from '../../src/health.js';
+import type { SetupReceipt } from './setup-driver.js';
+import { getPlatform, getServiceManager, isRoot } from '../platform.js';
+
+export type ServiceState = 'running' | 'stopped' | 'not_found' | 'running_other_checkout' | 'identity_unknown';
+
+export type ServiceCheck = {
+  state: ServiceState;
+  manager: 'launchd' | 'systemd-user' | 'systemd-system' | 'pidfile';
+  pid?: number;
+  checkoutRoot?: string;
+  reason?: string;
+};
+
+export type ReceiptBuildResult =
+  | { ok: true; receipt: SetupReceipt }
+  | { ok: false; code: 'service_identity_unproven' | 'health_postcondition_failed'; message: string };
+
+type Exec = (file: string, args: string[]) => string;
+
+const run: Exec = (file, args) => execFileSync(file, args, { encoding: 'utf8' });
+
+/** Inspect the install-owned service without trusting a human status string. */
+export function inspectService(projectRoot: string, execute: Exec = run): ServiceCheck {
+  const root = path.resolve(projectRoot);
+  const manager = serviceManager();
+  if (manager === 'launchd') return inspectLaunchd(root, execute);
+  if (manager === 'systemd-user' || manager === 'systemd-system') return inspectSystemd(root, manager, execute);
+  return inspectPidfile(root, execute);
+}
+
+export async function queryHostHealth(
+  projectRoot: string,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<HostHealth | null> {
+  const socketPath = path.join(path.resolve(projectRoot), 'data', 'ncl.sock');
+  let response: ResponseFrame;
+  try {
+    response = await new SocketTransport(socketPath).sendFrame(
+      { id: randomUUID(), command: 'health', args: {} },
+      { signal: options.signal, timeoutMs: options.timeoutMs ?? 1_000, maxResponseBytes: 256 * 1024 },
+    );
+  } catch {
+    return null;
+  }
+  if (!response.ok || !isHostHealth(response.data)) return null;
+  return response.data;
+}
+
+export function buildSetupReceipt(
+  projectRoot: string,
+  service: ServiceCheck,
+  health: HostHealth | null,
+): ReceiptBuildResult {
+  const checkoutRoot = path.resolve(projectRoot);
+  if (service.state !== 'running' || service.checkoutRoot !== checkoutRoot || service.pid === undefined) {
+    return {
+      ok: false,
+      code: 'service_identity_unproven',
+      message:
+        service.state === 'running_other_checkout'
+          ? 'NanoClaw is running from a different checkout.'
+          : 'NanoClaw service identity could not be proven.',
+    };
+  }
+  if (
+    !health ||
+    health.status !== 'healthy' ||
+    health.checkoutRoot !== checkoutRoot ||
+    health.process.cwd !== checkoutRoot ||
+    health.process.pid !== service.pid
+  ) {
+    return {
+      ok: false,
+      code: 'health_postcondition_failed',
+      message: 'NanoClaw service is running, but structured health could not prove this checkout is healthy.',
+    };
+  }
+  return {
+    ok: true,
+    receipt: {
+      version: 1,
+      service: { state: 'running', manager: service.manager, checkoutRoot },
+      health: { status: 'healthy' },
+      resources: health.resources,
+      completedAt: new Date().toISOString(),
+    },
+  };
+}
+
+function serviceManager(): ServiceCheck['manager'] {
+  if (getPlatform() === 'macos') return 'launchd';
+  if (getServiceManager() === 'systemd') return isRoot() ? 'systemd-system' : 'systemd-user';
+  return 'pidfile';
+}
+
+function inspectLaunchd(root: string, execute: Exec): ServiceCheck {
+  const manager = 'launchd' as const;
+  const label = getLaunchdLabel(root);
+  let output: string;
+  try {
+    output = execute('launchctl', ['list']);
+  } catch {
+    return { state: 'identity_unknown', manager, reason: 'launchctl_unavailable' };
+  }
+  const line = output.split('\n').find((candidate) => candidate.trim().split(/\s+/).at(-1) === label);
+  if (!line) return { state: 'not_found', manager };
+  const pidText = line.trim().split(/\s+/)[0];
+  if (pidText === '-') return { state: 'stopped', manager };
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid <= 0) return { state: 'identity_unknown', manager, reason: 'invalid_launchd_pid' };
+  return finishIdentity(manager, pid, root, execute);
+}
+
+function inspectSystemd(root: string, manager: 'systemd-user' | 'systemd-system', execute: Exec): ServiceCheck {
+  const unit = getSystemdUnit(root);
+  const command = manager === 'systemd-system' ? 'systemctl' : 'systemctl';
+  const prefix = manager === 'systemd-system' ? [] : ['--user'];
+  try {
+    execute(command, [...prefix, 'is-active', unit]);
+  } catch {
+    return { state: 'stopped', manager };
+  }
+  let pidText: string;
+  try {
+    pidText = execute(command, [...prefix, 'show', unit, '-p', 'MainPID', '--value']).trim();
+  } catch {
+    return { state: 'identity_unknown', manager, reason: 'systemd_pid_unavailable' };
+  }
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid <= 0) return { state: 'identity_unknown', manager, reason: 'invalid_systemd_pid' };
+  return finishIdentity(manager, pid, root, execute);
+}
+
+function inspectPidfile(root: string, execute: Exec): ServiceCheck {
+  const manager = 'pidfile' as const;
+  const pidPath = path.join(root, 'nanoclaw.pid');
+  let pidText: string;
+  try {
+    pidText = fs.readFileSync(pidPath, 'utf8').trim();
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+      ? { state: 'not_found', manager }
+      : { state: 'identity_unknown', manager, reason: 'pidfile_unreadable' };
+  }
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid <= 0) return { state: 'identity_unknown', manager, reason: 'invalid_pidfile_pid' };
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return { state: 'stopped', manager, pid };
+  }
+  return finishIdentity(manager, pid, root, execute);
+}
+
+function finishIdentity(
+  manager: ServiceCheck['manager'],
+  pid: number,
+  expectedRoot: string,
+  execute: Exec,
+): ServiceCheck {
+  const actualRoot = resolveProcessCheckout(pid, expectedRoot, execute);
+  if (!actualRoot) return { state: 'identity_unknown', manager, pid, reason: 'process_checkout_unavailable' };
+  return {
+    state: actualRoot === expectedRoot ? 'running' : 'running_other_checkout',
+    manager,
+    pid,
+    checkoutRoot: actualRoot,
+  };
+}
+
+function resolveProcessCheckout(pid: number, expectedRoot: string, execute: Exec): string | null {
+  const script = resolveProcessScript(pid, expectedRoot, execute);
+  if (!script) return null;
+  return path.resolve(script, '..', '..');
+}
+
+function resolveProcessScript(pid: number, expectedRoot: string, execute: Exec): string | null {
+  try {
+    const args = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8').split('\0').filter(Boolean);
+    const script = args.find((arg) => /\/dist\/index\.(?:js|mjs|cjs|ts)$/.test(arg));
+    if (script) return path.resolve(script);
+  } catch {
+    // macOS has no /proc; use lsof/ps below.
+  }
+  try {
+    const output = execute('ps', ['-p', String(pid), '-o', 'command=']).trim();
+    const expectedScript = ['js', 'mjs', 'cjs', 'ts']
+      .map((extension) => path.join(expectedRoot, 'dist', `index.${extension}`))
+      .find((candidate) =>
+        new RegExp(`(?:^|\\s)${candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$)`).test(output),
+      );
+    if (expectedScript) return expectedScript;
+    const marker = output.indexOf('/dist/index.');
+    if (marker > 0) {
+      const start = output.lastIndexOf(' ', marker) + 1;
+      const script = output.slice(start, marker + output.slice(marker).search(/(?:\s|$)/));
+      if (/\/dist\/index\.(?:js|mjs|cjs|ts)$/.test(script)) return path.resolve(script);
+    }
+  } catch {
+    // Identity is intentionally fail-closed.
+  }
+  try {
+    const output = execute('lsof', ['-a', '-p', String(pid), '-d', 'txt', '-Fn']);
+    const script = output
+      .split('\n')
+      .find((line) => line.startsWith('n') && /\/dist\/index\.(?:js|mjs|cjs|ts)$/.test(line.slice(1)))
+      ?.slice(1)
+      .trim();
+    if (script) return path.resolve(script);
+  } catch {
+    // Identity is intentionally fail-closed.
+  }
+  return null;
+}
+
+function isResource(value: unknown): value is HealthResource {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.state === 'loaded' || record.state === 'empty') &&
+    typeof record.count === 'number' &&
+    Number.isInteger(record.count) &&
+    record.count >= 0
+  );
+}
+
+function isHostHealth(value: unknown): value is HostHealth {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  const processIdentity = record.process;
+  const resources = record.resources;
+  if (
+    record.status !== 'healthy' ||
+    typeof record.checkoutRoot !== 'string' ||
+    !processIdentity ||
+    typeof processIdentity !== 'object' ||
+    !resources ||
+    typeof resources !== 'object'
+  )
+    return false;
+  const processRecord = processIdentity as Record<string, unknown>;
+  const resourceRecord = resources as Record<string, unknown>;
+  return (
+    typeof processRecord.pid === 'number' &&
+    processRecord.pid > 0 &&
+    typeof processRecord.ppid === 'number' &&
+    typeof processRecord.executable === 'string' &&
+    typeof processRecord.script === 'string' &&
+    typeof processRecord.cwd === 'string' &&
+    isResource(resourceRecord.groups) &&
+    isResource(resourceRecord.policies) &&
+    isResource(resourceRecord.skills)
+  );
+}


### PR DESCRIPTION
## TL;DR

Proposed: a new setup helper module, `setup/lib/service-health.ts`, that proves the NanoClaw background service is really running from this checkout and is really healthy, instead of trusting a human readable status string. Two new files, no existing file touched, and nothing calls it yet.

## What problem it solves

Setup currently decides "the service is up" by reading text meant for a person. That is fine when a human is watching, but this stack adds a mode where a native macOS app drives setup headlessly over a JSON protocol, and the app needs a machine checkable answer: is the service running, is it running *this* checkout and not another copy on the same machine, and does the host itself report healthy. This module is that answer, and it is written to fail closed: if it cannot prove something, it says so rather than assuming success.

## How it works

Three exported functions:

- `inspectService(projectRoot)` finds the service under whichever service manager applies (launchd on macOS, systemd user or system on Linux, or a plain `nanoclaw.pid` file), gets its PID, then resolves which checkout that PID is actually executing from by looking at `/proc/<pid>/cmdline`, `ps`, or `lsof`. It returns one of `running`, `stopped`, `not_found`, `running_other_checkout`, or `identity_unknown`. `identity_unknown` is the "I could not tell" case: an unreadable pidfile, a nonsense PID, `launchctl` missing, or a process whose script path could not be recovered.
- `queryHostHealth(projectRoot)` sends a `health` command to the running host over the unix socket at `data/ncl.sock`, using the timeout, cancellation, and response size cap added to `SocketTransport` in the previous PR in this stack. It validates the reply field by field and returns `null` on any error, timeout, or malformed shape.
- `buildSetupReceipt(...)` combines the two into a small signed off record. It returns `ok: false` with `service_identity_unproven` unless the service is running with a known PID in this exact checkout, and `ok: false` with `health_postcondition_failed` unless the host health reply says healthy and agrees with that same checkout root and PID. Only then does it produce a receipt.

The process is injectable (`inspectService` takes an optional command runner) so the tests do not need a real service.

## What trips people up

- **It is dormant at this PR.** Only its own tests import it. PR 17 in this stack points `setup/verify.ts` at `inspectService` and `queryHostHealth`; PR 37 uses `buildSetupReceipt` to gate completion in the headless path. Reviewing it as dead code is the wrong lens: review the policy it encodes, because later PRs act on that policy.
- **Test coverage is thin and platform skewed.** The two `inspectService` tests are `it.skipIf(process.platform !== 'darwin')`, so on a Linux runner they do not run at all. The systemd and pidfile branches, and the `/proc` and `lsof` paths inside `resolveProcessScript`, have no coverage on any platform. The `buildSetupReceipt` and `queryHostHealth` tests are platform independent and do run everywhere.
- **CI does not typecheck this file.** `tsconfig.json` includes only `src/**/*`, so `setup/` is outside the repo's typecheck and lint gate. It was checked locally with a setup inclusive tsc config.
- The file is proposed byte for byte as it appears in the single large upstream commit this stack splits up, including a no-op ternary at line 125 (`manager === 'systemd-system' ? 'systemctl' : 'systemctl'`). Left as is so the stack's final tree stays identical to that commit; worth a follow-up, not a change here.

## What to review

1. The fail-closed policy. Is `identity_unknown` the right verdict for each case that produces it, given that PR 17 makes `identity_unknown` fail verification where the old check would have passed.
2. `resolveProcessScript`, the trickiest function here: it matches the expected `<root>/dist/index.{js,mjs,cjs,ts}` against `ps` output with an escaped regex so checkout paths containing spaces still match, and only falls back to a looser scan for `/dist/index.` afterwards.
3. `buildSetupReceipt`'s conjunction: service running, PID known, service checkout equals this root, health status healthy, health checkoutRoot equals this root, health cwd equals this root, health PID equals the service PID.
4. `isHostHealth`, the hand written validator for the socket reply. It is the trust boundary for data coming off `data/ncl.sock`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This adds a new internal setup module for the machine drivable setup protocol. It is not a skill, it fixes no reported bug, it simplifies nothing, and it changes no documentation.

## Description

See the sections above. Proposed change: add `setup/lib/service-health.ts` (service identity resolution, bounded structured host health query, and a proven-state receipt builder) and `setup/lib/service-health.test.ts`. No existing file is modified. Part of a stack that splits one oversized upstream commit into individually reviewable pieces; the stack as a whole changes no terminal behaviour, and the headless protocol stays opt-in.

## For Skills

Not a skill, so this checklist does not apply.