### PR TITLE
feat(setup): gate verify on host health, not agent-group count

### DIFF
--- a/setup/verify.test.ts
+++ b/setup/verify.test.ts
@@ -6,6 +6,9 @@ const healthyBase = {
   service: 'running' as const,
   credentials: 'configured',
   registeredGroups: 1,
+  healthStatus: 'healthy' as const,
+  healthCheckoutMatches: true,
+  healthProcessMatches: true,
 };
 
 describe('determineVerifyStatus', () => {
@@ -13,13 +16,13 @@ describe('determineVerifyStatus', () => {
     expect(determineVerifyStatus(healthyBase)).toBe('success');
   });
 
-  it('fails when no agent groups are registered', () => {
+  it('accepts an explicit empty agent-group state', () => {
     expect(
       determineVerifyStatus({
         ...healthyBase,
         registeredGroups: 0,
       }),
-    ).toBe('failed');
+    ).toBe('success');
   });
 
   // Deferred wire (Teams): configured but zero groups is pending operator
@@ -69,5 +72,31 @@ describe('determineVerifyStatus', () => {
         credentials: 'missing',
       }),
     ).toBe('failed');
+  });
+
+  it('fails when structured health is unavailable or from another checkout', () => {
+    expect(determineVerifyStatus({ ...healthyBase, healthStatus: 'unhealthy', healthCheckoutMatches: false })).toBe(
+      'failed',
+    );
+    expect(determineVerifyStatus({ ...healthyBase, healthStatus: 'healthy', healthCheckoutMatches: false })).toBe(
+      'failed',
+    );
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        healthStatus: 'healthy',
+        healthCheckoutMatches: true,
+        healthProcessMatches: true,
+      }),
+    ).toBe('success');
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        healthStatus: 'healthy',
+        healthCheckoutMatches: true,
+        healthProcessMatches: false,
+      }),
+    ).toBe('failed');
+    expect(determineVerifyStatus({ ...healthyBase, healthStatus: undefined as never })).toBe('failed');
   });
 });

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -11,10 +11,10 @@ import path from 'path';
 
 import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
-import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { inspectCentralDb } from './central-db-inspection.js';
 import { inspectAgentImage, readImageSource } from './lib/registry-state.js';
-import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
+import { inspectService, queryHostHealth } from './lib/service-health.js';
+import { getPlatform } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -32,81 +32,16 @@ export async function run(_args: string[]): Promise<void> {
   // developers with multiple clones), nothing in this checkout is actually
   // wired up. Surface the mismatch directly so the user knows to point the
   // service at the right folder.
-  let service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' = 'not_found';
-  let runningFromPath: string | null = null;
-  const mgr = getServiceManager();
-
-  const launchdLabel = getLaunchdLabel(projectRoot);
-  const systemdUnit = getSystemdUnit(projectRoot);
-
-  if (mgr === 'launchd') {
-    try {
-      const output = execSync('launchctl list', { encoding: 'utf-8' });
-      const line = output.split('\n').find((l) => l.includes(launchdLabel));
-      if (line) {
-        const pidField = line.trim().split(/\s+/)[0];
-        if (pidField !== '-' && pidField) {
-          service = 'running';
-          const pid = Number(pidField);
-          if (Number.isInteger(pid) && pid > 0) {
-            runningFromPath = resolveBinaryScript(pid);
-          }
-        } else {
-          service = 'stopped';
-        }
-      }
-    } catch {
-      // launchctl not available
-    }
-  } else if (mgr === 'systemd') {
-    const prefix = isRoot() ? 'systemctl' : 'systemctl --user';
-    try {
-      execSync(`${prefix} is-active ${systemdUnit}`, { stdio: 'ignore' });
-      service = 'running';
-      try {
-        const pidStr = execSync(`${prefix} show ${systemdUnit} -p MainPID --value`, { encoding: 'utf-8' }).trim();
-        const pid = Number(pidStr);
-        if (Number.isInteger(pid) && pid > 0) {
-          runningFromPath = resolveBinaryScript(pid);
-        }
-      } catch {
-        // couldn't read MainPID; leave runningFromPath null
-      }
-    } catch {
-      try {
-        const output = execSync(`${prefix} list-unit-files`, {
-          encoding: 'utf-8',
-        });
-        if (output.includes(systemdUnit)) {
-          service = 'stopped';
-        }
-      } catch {
-        // systemctl not available
-      }
-    }
-  } else {
-    // Check for nohup PID file
-    const pidFile = path.join(projectRoot, 'nanoclaw.pid');
-    if (fs.existsSync(pidFile)) {
-      try {
-        const raw = fs.readFileSync(pidFile, 'utf-8').trim();
-        const pid = Number(raw);
-        if (raw && Number.isInteger(pid) && pid > 0) {
-          process.kill(pid, 0);
-          service = 'running';
-          runningFromPath = resolveBinaryScript(pid);
-        }
-      } catch {
-        service = 'stopped';
-      }
-    }
-  }
-
-  if (service === 'running' && runningFromPath && !isPathInside(runningFromPath, projectRoot)) {
-    service = 'running_other_checkout';
-  }
-
-  log.info('Service status', { service, runningFromPath });
+  const serviceCheck = inspectService(projectRoot);
+  const service = serviceCheck.state;
+  const health = await queryHostHealth(projectRoot);
+  log.info('Service status', {
+    service,
+    manager: serviceCheck.manager,
+    pid: serviceCheck.pid,
+    checkoutRoot: serviceCheck.checkoutRoot,
+    health: health?.status,
+  });
 
   // 2. Check container runtime
   let containerRuntime = 'none';
@@ -222,6 +157,9 @@ export async function run(_args: string[]): Promise<void> {
     credentials,
     registeredGroups,
     wiringPending,
+    healthStatus: health?.status,
+    healthCheckoutMatches: health?.checkoutRoot === projectRoot && health?.process.cwd === projectRoot,
+    healthProcessMatches: health?.process.pid === serviceCheck.pid,
   });
 
   log.info('Verification complete', {
@@ -241,6 +179,11 @@ export async function run(_args: string[]): Promise<void> {
   // (setup/auto.ts) at installs that are working exactly as designed.
   emitStatus('VERIFY', {
     SERVICE: service,
+    SERVICE_MANAGER: serviceCheck.manager,
+    SERVICE_CHECKOUT_ROOT: serviceCheck.checkoutRoot ?? '',
+    SERVICE_PID: serviceCheck.pid ?? '',
+    HEALTH_STATUS: health?.status ?? 'unavailable',
+    HEALTH_CHECKOUT_ROOT: health?.checkoutRoot ?? '',
     CONTAINER_RUNTIME: containerRuntime,
     CREDENTIALS: credentials,
     CONFIGURED_CHANNELS: configuredChannels.join(','),
@@ -271,41 +214,15 @@ export async function run(_args: string[]): Promise<void> {
 export const DEFER_WIRE_CHANNELS = new Set(['teams']);
 
 export function determineVerifyStatus(input: {
-  service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout';
+  service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' | 'identity_unknown';
   credentials: string;
   registeredGroups: number;
   /** Zero groups but every configured channel defers wiring to the first DM. */
   wiringPending?: boolean;
+  healthStatus: 'healthy' | 'unhealthy';
+  healthCheckoutMatches: boolean;
+  healthProcessMatches: boolean;
 }): 'success' | 'failed' {
-  return input.service === 'running' &&
-    input.credentials !== 'missing' &&
-    (input.registeredGroups > 0 || input.wiringPending === true)
-    ? 'success'
-    : 'failed';
-}
-
-/**
- * Given a PID, resolve the script path the process is executing (i.e. the
- * first `.js` / `.ts` / `.mjs` arg after `node`). Returns null on any
- * error — callers should treat null as "couldn't tell" and skip the
- * mismatch check rather than flag a false positive.
- */
-function resolveBinaryScript(pid: number): string | null {
-  try {
-    // BSD ps (macOS) and util-linux both honour `-o command=` (full argv,
-    // no header). Node argv: "node /path/to/dist/index.js ...".
-    const out = execSync(`ps -p ${pid} -o command=`, {
-      encoding: 'utf-8',
-    }).trim();
-    const tokens = out.split(/\s+/);
-    const script = tokens.find((t) => /\.(js|mjs|cjs|ts)$/.test(t));
-    return script ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function isPathInside(candidate: string, parent: string): boolean {
-  const rel = path.relative(parent, candidate);
-  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+  const healthOkay = input.healthStatus === 'healthy' && input.healthCheckoutMatches && input.healthProcessMatches;
+  return input.service === 'running' && input.credentials !== 'missing' && healthOkay ? 'success' : 'failed';
 }


### PR DESCRIPTION
**Proposed, not merged.** This is PR 17 of a 39-PR stack that splits one oversized upstream commit into pieces that can be reviewed one at a time. The stack as a whole adds a machine-drivable setup protocol to NanoClaw; this PR is one step in it.

## TL;DR

`setup verify`, the end-of-setup health check, stops carrying its own copy of service-detection code and delegates to the service health module added in the previous PR. It also changes what counts as a passing install: a live structured health answer from the running host is now required, and the number of wired agent groups no longer matters.

## What problem it solves

`setup/verify.ts` had roughly 110 lines of hand-rolled probing: parse `launchctl list`, or shell out to `systemctl`, or read `nanoclaw.pid`, then run `ps -p <pid> -o command=` to guess which script the process is executing and compare that path against this checkout. The previous PR moved that logic into `setup/lib/service-health.ts` with tests. This PR deletes the duplicate and calls the module, so there is one implementation of "is the service running, and is it *this* checkout's service".

Terms used below: a *checkout* is one clone of the NanoClaw repo (developers commonly have several, and only one service can own a given install slug). An *agent group* is a chat group wired to an agent. `data/ncl.sock` is the unix domain socket the running host listens on for local CLI commands.

## How it works, and the three policy changes

`run()` now calls `inspectService(projectRoot)` for the service state and `await queryHostHealth(projectRoot)` for a structured health answer, then feeds both into `determineVerifyStatus`. That function went from:

```
service === 'running' && credentials !== 'missing' && (registeredGroups > 0 || wiringPending)
```

to:

```
service === 'running' && credentials !== 'missing' && healthOkay
```

Three separate policy changes are folded into that one line. Please read them as three:

1. **Agent-group count stops gating verify.** `registeredGroups` and `wiringPending` are never read again. They remain in the input type and `run()` still passes them, so they are now dead inputs. The test `fails when no agent groups are registered` is flipped in this PR to `accepts an explicit empty agent-group state`, asserting `'success'` where it previously asserted `'failed'`.
2. **A structured health answer becomes a hard requirement.** `queryHostHealth` sends a `health` command over `data/ncl.sock` with a 1 second timeout and a 256 KiB response cap. Verify passes only if the reply is `healthy`, its `checkoutRoot` and `process.cwd` both equal this checkout, and its `process.pid` equals the pid the service manager reported. No reply, a malformed reply, or a socket that is not listening all mean failure.
3. **"Couldn't tell" now fails.** The old `ps`-based resolver returned `null` on any error and the code deliberately treated that as "skip the mismatch check rather than flag a false positive", leaving the state at `running`. The health module instead returns a new `identity_unknown` state, which is added to the `service` union here. `identity_unknown` is not `running`, so verify fails.

Verify's machine-readable `VERIFY` status block also gains `SERVICE_MANAGER`, `SERVICE_CHECKOUT_ROOT`, `SERVICE_PID`, `HEALTH_STATUS` and `HEALTH_CHECKOUT_ROOT`. Nothing else in the tree reads those keys today (grepped); they are for the native app driver later in the stack.

## What trips people up

- Verify calls `process.exit(1)` on failure, and setup reacts to that (it triggers `offerClaudeOnFailure` in `setup/auto.ts`). A stricter verify therefore makes setup fail more loudly. A machine where the service is up but the socket is not answering used to report success and now reports failure.
- `wiringPending` is the Teams "deferred wire" case: a channel configured but not yet wired because the platform id only exists after the first inbound DM. Two tests still exercise it and still pass, but it can no longer change the outcome. That is the state of the upstream commit this stack reproduces byte for byte, so it is left as is rather than cleaned up here.
- `setup/verify.ts:160` passes `health?.status` (optional) into a parameter declared `'healthy' | 'unhealthy'` (required). That is a genuine TS2322, and it is present in the upstream commit as well, so it is inherited rather than fixed. Worth knowing: `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/` at all. The stack runs a separate setup-inclusive tsc gate against a recorded baseline, and this one error is whitelisted there.
- The ~110 deleted lines are not lost behaviour. Their replacement landed in `setup/lib/service-health.ts` in the previous PR.

## What to review

- `determineVerifyStatus` at the bottom of `setup/verify.ts`. It is four lines. The question is whether dropping the agent-group requirement is the policy you want, given that a wired group used to be the only proof an agent was reachable.
- The three-way comparison around `setup/verify.ts:158`: checkout root, process cwd and pid all matched against this checkout. Are all three the right conditions, and is pid equality too strict if the service restarts between `inspectService` and `queryHostHealth`?
- Whether "no health answer means fail" is right for the terminal setup path, which is the only caller today.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is not a skill, and it is not a bug fix: it changes what verify accepts as a healthy install. It does delete more lines than it adds, but calling it a Simplification would hide the policy change, so nothing is ticked.

## Description

`setup verify` delegates service detection to `setup/lib/service-health.ts` and adds a required structured host-health check. Three policy changes: agent-group count no longer gates the result, a matching health answer over `data/ncl.sock` is now mandatory, and an unresolvable service identity now fails instead of passing. Files touched: `setup/verify.ts`, `setup/verify.test.ts`.

## For Skills

Not a skill, so this checklist does not apply.