### PR TITLE
feat(setup): add the bounded machine-mode interactive child runner

### DIFF
--- a/setup/lib/fixtures/interactive-process-parent-exit.ts
+++ b/setup/lib/fixtures/interactive-process-parent-exit.ts
@@ -1,0 +1,28 @@
+import { runInteractiveProcess } from '../interactive-process.js';
+import type { SetupDriver } from '../setup-driver.js';
+
+const driver = {
+  mode: 'ndjson',
+  operation: 'setup',
+  throwIfCancelled() {},
+} as SetupDriver;
+
+void runInteractiveProcess(
+  driver,
+  process.execPath,
+  [
+    '-e',
+    `
+    const { spawn } = require('node:child_process');
+    const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+    process.stdout.write(String(grandchild.pid) + '\\n');
+    setInterval(() => {}, 1000);
+  `,
+  ],
+  {
+    onOutput(chunk) {
+      process.stdout.write(chunk);
+      process.exit(23);
+    },
+  },
+);

--- a/setup/lib/interactive-process.test.ts
+++ b/setup/lib/interactive-process.test.ts
@@ -1,0 +1,203 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { runInteractiveProcess } from './interactive-process.js';
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+
+const STUBBORN_GRANDCHILD = `
+  process.on('SIGTERM', () => {});
+  process.stdout.write('ready\\n');
+  setInterval(() => {}, 1000);
+`;
+
+function machineDriver(controller = new AbortController()): SetupDriver {
+  return {
+    mode: 'ndjson',
+    operation: 'setup',
+    cancellationSignal: controller.signal,
+    throwIfCancelled() {
+      if (controller.signal.aborted) throw new DriverCancelled('test');
+    },
+  } as SetupDriver;
+}
+
+describe('runInteractiveProcess', () => {
+  it('pipes provider output and accepts provider input in machine mode', async () => {
+    const seen: string[] = [];
+    let answered = false;
+    const result = await runInteractiveProcess(
+      machineDriver(),
+      process.execPath,
+      [
+        '-e',
+        `
+        process.stdout.write('code?\\n');
+        process.stdin.once('data', (chunk) => {
+          process.stdout.write(chunk.toString() === 'answer\\n' ? 'accepted\\n' : 'rejected\\n');
+        });
+      `,
+      ],
+      {
+        onOutput(chunk, _stream, input) {
+          seen.push(chunk);
+          if (!answered && chunk.includes('code?')) {
+            answered = true;
+            input.write('answer\n');
+            input.end();
+          }
+        },
+      },
+    );
+
+    expect(result).toEqual({ reason: 'exited', exitCode: 0 });
+    expect(seen.join('')).toContain('accepted');
+  });
+
+  it('passes only the machine allowlist plus explicit isolated overrides', async () => {
+    const previous = process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN;
+    process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN = 'must-not-leak';
+    let output = '';
+    try {
+      const result = await runInteractiveProcess(
+        machineDriver(),
+        process.execPath,
+        [
+          '-e',
+          `process.stdout.write(JSON.stringify({ home: process.env.HOME, leaked: process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN, color: process.env.NO_COLOR }))`,
+        ],
+        {
+          env: { HOME: '/tmp/isolated-auth-home' },
+          onOutput(chunk) {
+            output += chunk;
+          },
+        },
+      );
+      expect(result).toEqual({ reason: 'exited', exitCode: 0 });
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN;
+      else process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN = previous;
+    }
+
+    expect(JSON.parse(output)).toEqual({
+      home: '/tmp/isolated-auth-home',
+      color: '1',
+    });
+  });
+
+  it('stops a machine child whose output exceeds the fixed bound', async () => {
+    const result = await runInteractiveProcess(machineDriver(), process.execPath, [
+      '-e',
+      `process.stdout.write(Buffer.alloc(${256 * 1024 + 1}, 120))`,
+    ]);
+
+    expect(result).toEqual({ reason: 'output_limit' });
+  });
+
+  it('stops a machine child at the provider deadline', async () => {
+    const result = await runInteractiveProcess(
+      machineDriver(),
+      process.execPath,
+      ['-e', 'setInterval(() => {}, 1000)'],
+      { timeoutMs: 25 },
+    );
+
+    expect(result).toEqual({ reason: 'timed_out' });
+  });
+
+  it.skipIf(process.platform === 'win32')('kills the whole process group on cancellation', async () => {
+    const controller = new AbortController();
+    let grandchildPid = 0;
+    const running = runInteractiveProcess(
+      machineDriver(controller),
+      process.execPath,
+      [
+        '-e',
+        `
+        const { spawn } = require('node:child_process');
+        const child = spawn(process.execPath, ['-e', ${JSON.stringify(STUBBORN_GRANDCHILD)}], {
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        child.stdout.once('data', () => process.stdout.write(String(child.pid) + '\\n'));
+        setInterval(() => {}, 1000);
+      `,
+      ],
+      {
+        onOutput(chunk) {
+          grandchildPid = Number(chunk.trim());
+          controller.abort();
+        },
+      },
+    );
+
+    try {
+      await expect(running).rejects.toBeInstanceOf(DriverCancelled);
+      expect(grandchildPid).toBeGreaterThan(0);
+      await waitUntilGone(grandchildPid);
+      expect(() => process.kill(grandchildPid, 0)).toThrow();
+    } finally {
+      if (grandchildPid > 0) {
+        try {
+          process.kill(grandchildPid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')('kills the whole process group when the setup parent exits', async () => {
+    const fixture = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'interactive-process-parent-exit.ts',
+    );
+    const tsx = path.resolve('node_modules/tsx/dist/cli.mjs');
+    const child = spawn(process.execPath, [tsx, fixture], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+
+    expect(exitCode).toBe(23);
+    const grandchildPid = Number(stdout.trim());
+    expect(grandchildPid).toBeGreaterThan(0);
+    await waitUntilGone(grandchildPid);
+    expect(() => process.kill(grandchildPid, 0)).toThrow();
+  });
+});
+
+describe('setup process-group escalation', () => {
+  it('does not gate SIGKILL on the process-group leader still running', () => {
+    const setupDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    for (const file of [
+      'auto.ts',
+      'lib/agent-ping.ts',
+      'lib/interactive-process.ts',
+      'lib/runner.ts',
+      'lib/skill-driver.ts',
+      'lib/tz-from-claude.ts',
+    ]) {
+      const source = fs.readFileSync(path.join(setupDir, file), 'utf8');
+      expect(source, file).not.toContain('child.exitCode === null');
+    }
+  });
+});
+
+async function waitUntilGone(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}

--- a/setup/lib/interactive-process.ts
+++ b/setup/lib/interactive-process.ts
@@ -1,0 +1,194 @@
+import { spawn } from 'node:child_process';
+
+import { redactSensitiveValues } from './redaction.js';
+import { childEnvWithoutSetupSecrets } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
+
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const MACHINE_ENV_KEYS = [
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'PATH',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
+  'TEMP',
+  'TMP',
+  'TMPDIR',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME',
+] as const;
+
+export type InteractiveProcessResult =
+  | { reason: 'exited'; exitCode: number }
+  | { reason: 'spawn_failed'; message: string }
+  | { reason: 'output_limit' }
+  | { reason: 'timed_out' };
+
+export type InteractiveProcessInput = {
+  write(value: string): void;
+  end(): void;
+};
+
+type InteractiveProcessOptions = {
+  env?: Record<string, string | undefined>;
+  /** Machine-mode deadline. Terminal mode remains operator-controlled. */
+  timeoutMs?: number;
+  onOutput?: (chunk: string, stream: 'stdout' | 'stderr', input: InteractiveProcessInput) => void | Promise<void>;
+};
+
+export function machineChildEnvironment(
+  overrides: Record<string, string | undefined> = {},
+  source: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { NO_COLOR: '1' };
+  for (const key of MACHINE_ENV_KEYS) {
+    if (source[key] !== undefined) env[key] = source[key];
+  }
+  return childEnvWithoutSetupSecrets({ ...env, ...overrides });
+}
+
+/**
+ * Run one provider-owned interactive CLI.
+ *
+ * Terminal mode preserves inherited stdio. Machine mode exposes bounded raw
+ * chunks only to the provider callback, which owns interpretation and
+ * redaction, while this helper owns child lifetime and process-group cleanup.
+ */
+export function runInteractiveProcess(
+  driver: SetupDriver,
+  command: string,
+  args: string[],
+  options: InteractiveProcessOptions = {},
+): Promise<InteractiveProcessResult> {
+  driver.throwIfCancelled();
+  const machine = driver.mode === 'ndjson';
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: machine ? ['pipe', 'pipe', 'pipe'] : 'inherit',
+      env: machine
+        ? machineChildEnvironment(options.env)
+        : options.env
+          ? { ...process.env, ...options.env }
+          : process.env,
+      ...(machine ? { detached: true } : {}),
+    });
+
+    let outputBytes = 0;
+    let outputLimitExceeded = false;
+    let timedOut = false;
+    let spawnFailure: string | undefined;
+    let callbackFailure: unknown;
+    let callbackChain = Promise.resolve();
+    let finished = false;
+
+    const stopGroup = (): void => {
+      if (!machine || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+
+    const onParentExit = (): void => {
+      if (!machine || !child.pid) return;
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    };
+    if (machine) process.once('exit', onParentExit);
+    const timeout =
+      machine && options.timeoutMs !== undefined
+        ? setTimeout(() => {
+            timedOut = true;
+            stopGroup();
+          }, options.timeoutMs).unref()
+        : undefined;
+
+    const input: InteractiveProcessInput = {
+      write(value) {
+        if (machine && child.stdin?.writable) child.stdin.write(value);
+      },
+      end() {
+        if (machine && child.stdin?.writable) child.stdin.end();
+      },
+    };
+
+    const forward = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+      if (outputLimitExceeded || callbackFailure !== undefined) return;
+      outputBytes += chunk.byteLength;
+      if (outputBytes > MAX_OUTPUT_BYTES) {
+        outputLimitExceeded = true;
+        stopGroup();
+        return;
+      }
+      if (!options.onOutput) return;
+      const text = chunk.toString('utf8');
+      callbackChain = callbackChain
+        .then(() => options.onOutput?.(text, stream, input))
+        .catch((error: unknown) => {
+          callbackFailure = error;
+          stopGroup();
+        });
+    };
+
+    if (machine) {
+      child.stdout?.on('data', (chunk: Buffer) => forward(chunk, 'stdout'));
+      child.stderr?.on('data', (chunk: Buffer) => forward(chunk, 'stderr'));
+    }
+
+    const onCancel = (): void => stopGroup();
+    driver.cancellationSignal?.addEventListener('abort', onCancel, { once: true });
+    if (driver.cancellationSignal?.aborted) stopGroup();
+
+    const finish = async (code: number | null): Promise<void> => {
+      if (finished) return;
+      finished = true;
+      if (timeout) clearTimeout(timeout);
+      if (machine) process.removeListener('exit', onParentExit);
+      driver.cancellationSignal?.removeEventListener('abort', onCancel);
+      await callbackChain;
+      if (callbackFailure !== undefined) {
+        reject(callbackFailure);
+        return;
+      }
+      try {
+        driver.throwIfCancelled();
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      if (timedOut) {
+        resolve({ reason: 'timed_out' });
+      } else if (outputLimitExceeded) {
+        resolve({ reason: 'output_limit' });
+      } else if (spawnFailure !== undefined) {
+        resolve({ reason: 'spawn_failed', message: spawnFailure });
+      } else {
+        resolve({ reason: 'exited', exitCode: code ?? 1 });
+      }
+    };
+
+    child.on('error', (error) => {
+      spawnFailure = redactSensitiveValues(error.message);
+    });
+    child.on('close', (code) => {
+      void finish(code);
+    });
+  });
+}


### PR DESCRIPTION
## TL;DR

Proposes one new helper, `runInteractiveProcess`, that runs a provider's own interactive command line tool (for example `claude setup-token`) either the way it works today in a terminal, or, when setup is being driven by a program instead of a person, over pipes with a hard output cap, an optional deadline and reliable process-group cleanup. Nothing in the tree calls it at this commit.

## Background, in plain terms

This stack adds a "setup driver": an interface that stands in for every question setup asks. There are two implementations. `TerminalSetupDriver` draws the normal prompts for a human. `NdjsonSetupDriver` speaks a line-based JSON protocol on stdin and stdout so the native macOS app can run setup with no terminal attached. A driver exposes `mode`, which is `'terminal'` or `'ndjson'`; `'ndjson'` is what the rest of this description calls machine mode.

Some setup steps do not ask their own questions, they hand the terminal to somebody else's tool that asks its own. That works fine for a person: the tool inherits the terminal and the user types into it. It does not work at all in machine mode, where there is no terminal, nobody to type, and no guarantee the tool ever exits. This PR is the primitive that fixes that.

## How it works

`runInteractiveProcess(driver, command, args, options)` branches on `driver.mode`.

Terminal mode is deliberately the status quo: `stdio: 'inherit'`, the full parent environment (plus any `options.env`), no cap, no deadline, no detaching. Nothing about today's operator experience changes.

Machine mode:

- stdio is piped. Every chunk goes to the `onOutput(chunk, stream, input)` callback, which gets an `input` handle with `write()` and `end()` so it can answer a prompt it recognises. Interpreting the tool's output is the caller's job, not this helper's.
- The environment is rebuilt from scratch: `NO_COLOR=1` plus an allowlist of 14 variables (`HOME`, `PATH`, `LANG`, the `LC_*` pair, `SSL_CERT_*`, the temp-dir trio, the `XDG_*` group), then any caller overrides, then `childEnvWithoutSetupSecrets` strips eight known credential variables back out. A test asserts a fake `NANOCLAW_ANTHROPIC_AUTH_TOKEN` does not reach the child.
- Combined stdout plus stderr is capped at 256 KiB. Past that the child is killed and the call resolves `{ reason: 'output_limit' }`.
- `options.timeoutMs` is an optional deadline, machine mode only, resolving `{ reason: 'timed_out' }`.
- The child is spawned `detached`, so it leads its own process group and `kill(-pid)` reaches its grandchildren too. Shutdown is SIGTERM, then SIGKILL 250 ms later, triggered by cancellation, the deadline, the cap, a throwing callback, or the setup process itself exiting (a `process.once('exit')` hook).
- The result is a tagged union: `exited` with the code, `spawn_failed` with a message, `output_limit`, or `timed_out`. Cancellation is not a result, it rejects with `DriverCancelled`.

## What trips people up

- **Only the spawn error message is redacted.** `error.message` goes through `redactSensitiveValues`. Raw child output does not, by design, since the callback owns interpretation. Any future caller that logs what it receives has to redact first.
- **The cap and the deadline resolve, they do not throw.** Callers must read `reason`, not just check for an exception.
- **No proxy variables in the allowlist.** `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are absent, so a provider tool that needs a proxy would fail in machine mode. Worth a conscious yes or no from a reviewer.
- **The second `describe` block is a tripwire, not a test of this file.** `setup process-group escalation` reads five unrelated setup files and asserts none contains the string `child.exitCode === null`, that is, none of them gates the SIGKILL escalation on the group leader still being alive. All five are already clean, so it is green on arrival, but it constrains later PRs in this stack that touch `skill-driver.ts` and `auto.ts`.
- Two process-group tests skip on Windows. The parent-exit test shells out to `node_modules/tsx/dist/cli.mjs` to run a fixture as a real separate setup process.

## What to review

1. The environment allowlist in `MACHINE_ENV_KEYS`: too narrow, too wide, or right.
2. The kill path: SIGTERM then SIGKILL after 250 ms, negative-pid group kill, and the `process.once('exit')` hook that is removed in `finish`.
3. That terminal mode really is untouched, `stdio: 'inherit'` with no cap, deadline or detach.
4. The single-resolution guard in `finish`, which awaits the callback chain and prefers a callback failure, then cancellation, then timeout, cap, spawn failure and finally the exit code.

## Verification

`pnpm exec vitest run setup/lib/interactive-process.test.ts` passes, 7 of 7, spawning real child processes with no mocks. The commit also passes the stack's setup-inclusive `tsc` gate. The whole split stack reproduces one upstream commit byte for byte and changes no behaviour overall; this piece is dormant until the next PR in the stack, Claude subscription sign-in, calls it.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is a new internal helper in the `setup/` installer, not a skill, not a bug fix, and not a simplification.

## Description

See the sections above: it proposes `setup/lib/interactive-process.ts`, its test file and one test fixture, adding no callers.

## For Skills

Not a skill, so the skill checklist does not apply.