### PR TITLE
feat(setup): add machine-mode claude subscription sign-in module

### DIFF
--- a/setup/lib/claude-subscription-auth.test.ts
+++ b/setup/lib/claude-subscription-auth.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+
+const mockRunInteractiveProcess = vi.fn();
+
+vi.mock('./interactive-process.js', () => ({
+  machineChildEnvironment: () => ({ PATH: process.env.PATH }),
+  runInteractiveProcess: (...args: unknown[]) => mockRunInteractiveProcess(...args),
+}));
+import { runClaudeSubscriptionMachineAuth } from './claude-subscription-auth.js';
+
+const TOKEN = `sk-ant-oat${'A'.repeat(90)}AA`;
+const URL = 'https://claude.com/cai/oauth/authorize?code=true&state=test-state';
+
+function driver(): SetupDriver & {
+  actions: unknown[];
+  displays: unknown[];
+  cleared: string[];
+  progresses: Array<{ stepId: string; state: string; label?: string }>;
+} {
+  const actions: unknown[] = [];
+  const displays: unknown[] = [];
+  const cleared: string[] = [];
+  const progresses: Array<{ stepId: string; state: string; label?: string }> = [];
+  return {
+    mode: 'ndjson',
+    operation: 'setup',
+    actions,
+    displays,
+    cleared,
+    progresses,
+    prompt: vi.fn().mockResolvedValue('authorization-code'),
+    externalAction: vi.fn(async (action) => {
+      actions.push(action);
+      return 'attempted';
+    }),
+    display(value) {
+      displays.push(value);
+    },
+    clearDisplay(id) {
+      cleared.push(id);
+    },
+    progress(stepId, state, label) {
+      progresses.push({ stepId, state, ...(label ? { label } : {}) });
+    },
+    log: vi.fn(),
+    throwIfCancelled: vi.fn(),
+  } as unknown as SetupDriver & {
+    actions: unknown[];
+    displays: unknown[];
+    cleared: string[];
+    progresses: Array<{ stepId: string; state: string; label?: string }>;
+  };
+}
+
+describe('runClaudeSubscriptionMachineAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the provider URL, sends the code on stdin, and vaults through a private file', async () => {
+    let isolatedEnv: Record<string, string> | undefined;
+    const writes: string[] = [];
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const command = args[1] as string;
+      const childArgs = args[2] as string[];
+      const options = args[3] as {
+        env: Record<string, string>;
+        timeoutMs: number;
+        onOutput: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      if (command === 'onecli') {
+        const filePath = childArgs[childArgs.indexOf('--file') + 1];
+        expect(childArgs).not.toContain('--value');
+        expect(fs.readFileSync(filePath, 'utf8')).toBe(TOKEN);
+        expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+        expect(options.timeoutMs).toBe(2 * 60 * 1000);
+        return { reason: 'exited', exitCode: 0 };
+      }
+      isolatedEnv = options.env;
+      const input = {
+        write(value: string) {
+          writes.push(value);
+        },
+        end: vi.fn(),
+      };
+      await options.onOutput(`Open this URL:\n${URL}\n`, 'stdout', input);
+      await options.onOutput(`Your OAuth token:\n${TOKEN}\n`, 'stdout', input);
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    const fake = driver();
+    await expect(runClaudeSubscriptionMachineAuth(fake)).resolves.toEqual({ ok: true });
+
+    expect(fake.actions).toEqual([]);
+    expect(fake.displays).toEqual([expect.objectContaining({ kind: 'url', url: URL, sensitive: true })]);
+    expect(fake.cleared).toEqual(['claude-subscription-url']);
+    expect(writes).toEqual(['authorization-code\n']);
+    expect(fake.progresses).toEqual([
+      { stepId: 'claude-login', state: 'running', label: 'Waiting for Claude sign-in' },
+      { stepId: 'claude-login', state: 'succeeded' },
+      { stepId: 'auth', state: 'running', label: 'Saving your Claude credentials to your OneCLI vault' },
+      { stepId: 'auth', state: 'succeeded' },
+    ]);
+    expect(mockRunInteractiveProcess.mock.calls.map((call) => call[1])).toEqual(['claude', 'onecli']);
+    expect(isolatedEnv).toBeDefined();
+    for (const location of Object.values(isolatedEnv!)) expect(fs.existsSync(location)).toBe(false);
+  });
+
+  it('fails closed when provider output has no allowlisted login URL', async () => {
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const options = args[3] as {
+        onOutput: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      await options.onOutput(`https://evil.example/oauth/authorize\n${TOKEN}\n`, 'stdout', {
+        write: vi.fn(),
+        end: vi.fn(),
+      });
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    const fake = driver();
+    await expect(runClaudeSubscriptionMachineAuth(fake)).resolves.toEqual({
+      ok: false,
+      reason: 'login_url_missing',
+    });
+    expect(fake.progresses.at(-1)).toEqual({ stepId: 'claude-login', state: 'failed' });
+    expect(mockRunInteractiveProcess).toHaveBeenCalledOnce();
+  });
+
+  it('waits for a complete URL line and ignores interleaved stderr', async () => {
+    const fake = driver();
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      if (args[1] === 'onecli') return { reason: 'exited', exitCode: 0 };
+      const options = args[3] as {
+        onOutput: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      const input = { write: vi.fn(), end: vi.fn() };
+      await options.onOutput('https://claude.com/cai/oauth/authorize?code=true&sta', 'stdout', input);
+      await options.onOutput('opening browser…\n', 'stderr', input);
+      expect(fake.actions).toEqual([]);
+      await options.onOutput(`te=split\n${TOKEN}\n`, 'stdout', input);
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    await expect(runClaudeSubscriptionMachineAuth(fake)).resolves.toEqual({ ok: true });
+
+    expect(fake.actions).toEqual([]);
+    expect(fake.displays).toEqual([
+      expect.objectContaining({
+        url: 'https://claude.com/cai/oauth/authorize?code=true&state=split',
+        sensitive: true,
+      }),
+    ]);
+  });
+
+  it('removes the isolated home when the driver cancels', async () => {
+    let isolatedRoot = '';
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const options = args[3] as { env: Record<string, string> };
+      isolatedRoot = options.env.HOME.replace(/\/home$/, '');
+      throw new DriverCancelled('test');
+    });
+
+    await expect(runClaudeSubscriptionMachineAuth(driver())).rejects.toBeInstanceOf(DriverCancelled);
+    expect(fs.existsSync(isolatedRoot)).toBe(false);
+  });
+
+  it('removes both credential files when cancellation happens during vaulting', async () => {
+    let isolatedRoot = '';
+    let secretFile = '';
+    mockRunInteractiveProcess.mockImplementation(async (...args: unknown[]) => {
+      const command = args[1] as string;
+      const childArgs = args[2] as string[];
+      const options = args[3] as {
+        env: Record<string, string>;
+        onOutput?: (
+          chunk: string,
+          stream: 'stdout' | 'stderr',
+          input: { write(value: string): void; end(): void },
+        ) => Promise<void>;
+      };
+      if (command === 'onecli') {
+        secretFile = childArgs[childArgs.indexOf('--file') + 1];
+        throw new DriverCancelled('test');
+      }
+      isolatedRoot = options.env.HOME.replace(/\/home$/, '');
+      await options.onOutput?.(`Open this URL:\n${URL}\n${TOKEN}\n`, 'stdout', {
+        write: vi.fn(),
+        end: vi.fn(),
+      });
+      return { reason: 'exited', exitCode: 0 };
+    });
+
+    await expect(runClaudeSubscriptionMachineAuth(driver())).rejects.toBeInstanceOf(DriverCancelled);
+
+    expect(fs.existsSync(isolatedRoot)).toBe(false);
+    expect(secretFile).not.toBe('');
+    expect(fs.existsSync(secretFile)).toBe(false);
+  });
+});

--- a/setup/lib/claude-subscription-auth.ts
+++ b/setup/lib/claude-subscription-auth.ts
@@ -1,0 +1,159 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { extractClaudeOAuthToken } from './captured-token.js';
+import { machineChildEnvironment, runInteractiveProcess } from './interactive-process.js';
+import { registerSensitiveValue } from './redaction.js';
+import { withSecretFile } from './secret-file.js';
+import type { SetupDriver } from './setup-driver.js';
+
+const PROVIDER_STREAM_BUFFER_BYTES = 64 * 1024;
+const LOGIN_TIMEOUT_MS = 15 * 60 * 1000;
+const VAULT_TIMEOUT_MS = 2 * 60 * 1000;
+
+export type ClaudeSubscriptionMachineResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | 'login_url_missing'
+        | 'login_failed'
+        | 'output_limit'
+        | 'spawn_failed'
+        | 'timed_out'
+        | 'token_missing'
+        | 'vault_failed';
+      detail?: string;
+    };
+
+function makePrivateDirectory(parent: string, name: string): string {
+  const directory = path.join(parent, name);
+  fs.mkdirSync(directory, { mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  return directory;
+}
+
+function findClaudeLoginUrl(output: string): string | undefined {
+  const clean = output.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+  for (const match of clean.matchAll(/https:\/\/[^\s<>"']+/g)) {
+    const candidate = match[0].replace(/[),.;]+$/, '');
+    try {
+      const url = new URL(candidate);
+      if ((url.hostname === 'claude.ai' || url.hostname === 'claude.com') && url.pathname.includes('/oauth/authorize'))
+        return url.toString();
+    } catch {
+      // A partial chunk is expected; the next chunk extends the rolling buffer.
+    }
+  }
+  return undefined;
+}
+
+/** Run Claude's subscription setup-token flow through semantic driver events. */
+export async function runClaudeSubscriptionMachineAuth(driver: SetupDriver): Promise<ClaudeSubscriptionMachineResult> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-claude-login-'));
+  fs.chmodSync(root, 0o700);
+  const home = makePrivateDirectory(root, 'home');
+  const config = makePrivateDirectory(root, 'config');
+  const cache = makePrivateDirectory(root, 'cache');
+  const data = makePrivateDirectory(root, 'data');
+
+  const buffers = { stdout: '', stderr: '' };
+  let loginUrl: string | undefined;
+  let token: string | undefined;
+  let urlDisplayed = false;
+
+  const failed = (
+    reason: Exclude<ClaudeSubscriptionMachineResult, { ok: true }>['reason'],
+    detail?: string,
+  ): ClaudeSubscriptionMachineResult => {
+    driver.progress('claude-login', 'failed');
+    return { ok: false, reason, ...(detail ? { detail } : {}) };
+  };
+
+  try {
+    driver.progress('claude-login', 'running', 'Waiting for Claude sign-in');
+    const login = await runInteractiveProcess(driver, 'claude', ['setup-token'], {
+      timeoutMs: LOGIN_TIMEOUT_MS,
+      env: {
+        HOME: home,
+        XDG_CONFIG_HOME: config,
+        XDG_CACHE_HOME: cache,
+        XDG_DATA_HOME: data,
+      },
+      async onOutput(chunk, stream, input) {
+        buffers[stream] = `${buffers[stream]}${chunk}`.slice(-PROVIDER_STREAM_BUFFER_BYTES);
+        const completeOutput = buffers[stream].slice(
+          0,
+          Math.max(buffers[stream].lastIndexOf('\n'), buffers[stream].lastIndexOf('\r')) + 1,
+        );
+        token ??= extractClaudeOAuthToken(completeOutput) ?? undefined;
+        if (token) registerSensitiveValue(token);
+
+        loginUrl ??= findClaudeLoginUrl(completeOutput);
+        if (!loginUrl || urlDisplayed) return;
+        urlDisplayed = true;
+        registerSensitiveValue(loginUrl);
+        driver.display({
+          id: 'claude-subscription-url',
+          kind: 'url',
+          url: loginUrl,
+          label: 'Claude sign-in',
+          sensitive: true,
+        });
+        const code = String(
+          await driver.prompt({
+            id: 'claude-authorization-code',
+            kind: 'secret',
+            message: 'Paste the Claude authorization code',
+            validation: { required: true, maxLength: 4096 },
+          }),
+        ).trim();
+        input.write(`${code}\n`);
+        input.end();
+      },
+    });
+
+    token ??= extractClaudeOAuthToken(`${buffers.stdout}\n${buffers.stderr}`) ?? undefined;
+    if (token) registerSensitiveValue(token);
+
+    if (login.reason === 'spawn_failed') {
+      return failed('spawn_failed', login.message);
+    }
+    if (login.reason === 'output_limit') return failed('output_limit');
+    if (login.reason === 'timed_out') return failed('timed_out');
+    if (login.exitCode !== 0) {
+      return failed('login_failed', `exit ${login.exitCode}`);
+    }
+    if (!loginUrl) return failed('login_url_missing');
+    if (!token) return failed('token_missing');
+    driver.progress('claude-login', 'succeeded');
+
+    const saved = await withSecretFile(token, async (filePath) => {
+      const args = [
+        'secrets',
+        'create',
+        '--name',
+        'Anthropic',
+        '--type',
+        'anthropic',
+        '--file',
+        filePath,
+        '--host-pattern',
+        'api.anthropic.com',
+      ];
+      driver.progress('auth', 'running', 'Saving your Claude credentials to your OneCLI vault');
+      const result = await runInteractiveProcess(driver, 'onecli', args, {
+        env: machineChildEnvironment(),
+        timeoutMs: VAULT_TIMEOUT_MS,
+      });
+      const ok = result.reason === 'exited' && result.exitCode === 0;
+      driver.progress('auth', ok ? 'succeeded' : 'failed');
+      return ok;
+    });
+    return saved ? { ok: true } : { ok: false, reason: 'vault_failed' };
+  } finally {
+    if (urlDisplayed) driver.clearDisplay('claude-subscription-url');
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/setup/lib/claude-subscription-driver.test.ts
+++ b/setup/lib/claude-subscription-driver.test.ts
@@ -1,0 +1,143 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const TOKEN = `sk-ant-oat${'A'.repeat(90)}AA`;
+const URL = 'https://claude.com/cai/oauth/authorize?code=true&state=driver-test';
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-claude-driver-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function executable(name: string, contents: string): string {
+  const file = path.join(root, 'bin', name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents, { mode: 0o755 });
+  return file;
+}
+
+describe('Claude subscription through the NDJSON driver', () => {
+  it('translates a bidirectional provider login into semantic events only', async () => {
+    const marker = path.join(root, 'vaulted');
+    executable(
+      'claude',
+      `#!/usr/bin/env bash
+printf 'private provider noise\\n%s\\n' '${URL}'
+IFS= read -r code
+test "$code" = 'authorization-code' || exit 9
+printf '%s\\n' '${TOKEN}'
+`,
+    );
+    executable(
+      'onecli',
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const index = args.indexOf('--file');
+if (index < 0 || args.includes('--value')) process.exit(7);
+const file = args[index + 1];
+const secret = fs.readFileSync(file, 'utf8');
+if (!/^sk-ant-oat[A-Za-z0-9_-]{80,500}AA$/.test(secret)) process.exit(8);
+if ((fs.statSync(file).mode & 0o777) !== 0o600) process.exit(9);
+fs.writeFileSync(${JSON.stringify(marker)}, 'ok');
+`,
+    );
+
+    const fixture = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'claude-subscription-driver.ts',
+    );
+    const tsx = path.resolve('node_modules/tsx/dist/cli.mjs');
+    const child = spawn(process.execPath, [tsx, fixture], {
+      env: { ...process.env, PATH: `${path.join(root, 'bin')}${path.delimiter}${process.env.PATH ?? ''}` },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const events: Array<Record<string, unknown>> = [];
+    let stdout = '';
+    let stderr = '';
+    let buffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stdout += text;
+      buffer += text;
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        if (event.type === 'externalAction') {
+          const action = event.action as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({
+              protocol: 'nanoclaw.driver.v1',
+              operation: 'setup',
+              type: 'externalActionCompleted',
+              actionId: action.id,
+              result: 'attempted',
+            })}\n`,
+          );
+        }
+        if (event.type === 'prompt') {
+          const prompt = event.prompt as { id: string };
+          child.stdin.write(
+            `${JSON.stringify({
+              protocol: 'nanoclaw.driver.v1',
+              operation: 'setup',
+              type: 'answer',
+              promptId: prompt.id,
+              value: 'authorization-code',
+            })}\n`,
+          );
+        }
+      }
+    });
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+
+    expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
+    expect(events[0]?.type).toBe('hello');
+    expect(events.at(-1)?.type).toBe('complete');
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'display',
+        display: expect.objectContaining({ kind: 'url', url: URL, sensitive: true }),
+      }),
+    );
+    expect(events.some((event) => event.type === 'externalAction')).toBe(false);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'prompt',
+        prompt: expect.objectContaining({ id: 'claude-authorization-code', sensitive: true }),
+      }),
+    );
+    expect(events.filter((event) => event.type === 'progress').map((event) => event.state)).toEqual([
+      'running',
+      'succeeded',
+      'running',
+      'succeeded',
+    ]);
+    expect(stdout).not.toContain(TOKEN);
+    expect(stdout).not.toContain('private provider noise');
+    expect(stderr).not.toContain(TOKEN);
+    expect(fs.readFileSync(marker, 'utf8')).toBe('ok');
+  }, 10_000);
+});

--- a/setup/lib/fixtures/claude-subscription-driver.ts
+++ b/setup/lib/fixtures/claude-subscription-driver.ts
@@ -1,0 +1,13 @@
+import { runClaudeSubscriptionMachineAuth } from '../claude-subscription-auth.js';
+import { DriverTerminalError, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  const result = await runClaudeSubscriptionMachineAuth(driver);
+  if (!result.ok) driver.error('claude_auth_failed', 'Claude authentication failed in the fixture.');
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverTerminalError)) throw error;
+  process.exitCode = error.exitCode;
+}


### PR DESCRIPTION
## TL;DR

Proposes one new module that signs a user into their Claude subscription without a terminal, by driving the `claude setup-token` command and relaying its prompts as structured events. Nothing calls it yet: it is imported only by its own tests until a later PR in this stack.

## What problem this solves

This stack is adding a "setup driver", an interface that abstracts every user interaction during NanoClaw setup (pick one of these, confirm, type text, type a secret, progress, show something, do this outside the app). The terminal implementation keeps the existing look. A second implementation speaks newline delimited JSON (NDJSON) over stdin and stdout so a native macOS app can run setup with no terminal at all.

Claude subscription sign-in was the one step with no headless story. Today it shells out to `bash setup/register-claude-token.sh`, which takes over the terminal, prints a sign in URL, and waits for the user to paste back an authorization code. A GUI cannot participate in that. This PR adds a version of the same flow expressed entirely in driver events.

## How it works

`runClaudeSubscriptionMachineAuth(driver)`:

1. Creates a private temp root (mode 0700) and points the child's `HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME` and `XDG_DATA_HOME` at it, so the sign in cannot touch the user's real Claude config.
2. Spawns `claude setup-token` and watches its output through a rolling 64 KiB buffer, only ever parsing whole lines so a URL split across two chunks is not shown half formed.
3. Strips ANSI escapes and looks for an https URL whose host is `claude.ai` or `claude.com` and whose path contains `/oauth/authorize`. Anything else is ignored, and if no such URL ever appears the function returns `login_url_missing` rather than opening whatever the child printed.
4. Emits `driver.display` with that URL (marked sensitive) and a `secret` prompt for the authorization code, then writes the answer to the child's stdin and closes it.
5. Extracts the OAuth token from the output and stores it by writing it to a 0600 temp file and running `onecli secrets create --name Anthropic --file <path>`. The token is never a command line argument.
6. In a `finally` block, clears the displayed URL and deletes the temp root, including when the driver cancels mid flow.

Both the URL and the token are passed to `registerSensitiveValue`, the redaction registry added earlier in this stack, so they are masked in machine mode logs. Timeouts: 15 minutes for the sign in, 2 minutes for the vault write. Expected failures come back as a result union (`login_url_missing`, `login_failed`, `output_limit`, `spawn_failed`, `timed_out`, `token_missing`, `vault_failed`) instead of throwing.

## What trips people up

- **It is dead code at this commit, on purpose.** The only importers in the tree are the unit test and `setup/lib/fixtures/claude-subscription-driver.ts`, a small program the end to end test spawns. PR 31 of this stack ("convert the provider picker and the Claude auth methods") is what calls it, and only when the driver is in ndjson mode.
- **The terminal path is untouched.** `runSubscriptionAuth` still runs `bash setup/register-claude-token.sh` for terminal users, before and after this stack. There is no double implementation risk here because none of this logic previously existed in `setup/auto.ts`.
- **The URL allowlist fails closed.** A provider that changes its sign in host will stop working in machine mode rather than sending the user somewhere unverified. That is the intended trade.
- **CI does not typecheck this file.** `tsconfig.json` includes only `src/**/*`, so `setup/` is outside the CI typecheck. It was checked locally with a setup inclusive tsc config.

## What to review

- The URL allowlist in `findClaudeLoginUrl` and the decision to fail rather than guess.
- Secret handling: token to a 0600 file rather than argv, both values registered for redaction, no token in any driver event.
- The `finally` cleanup, in particular that a cancelled driver still removes the temp root and the secret file.
- Whether 15 minutes and 2 minutes are the right timeouts.

Tests added here: five unit tests (happy path, missing URL, URL split across chunks with stderr interleaved, cancellation during login, cancellation during vaulting) plus one end to end test that runs the NDJSON fixture as a real child process with fake `claude` and `onecli` executables on `PATH` and asserts the exact progress sequence, that no `externalAction` event is emitted, that the secret file arrives at mode 0600, and that stdout contains neither the token nor the provider's raw output line.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this adds a new internal setup module and its tests, it is not a skill, not a bug fix, and it adds code rather than reducing it.

## Description

Adds `setup/lib/claude-subscription-auth.ts`, its unit suite, an NDJSON fixture program, and an end to end driver test. 531 added lines, 0 removed, 4 new files, no existing file changed. Behaviour of the shipped product is unchanged at this commit because nothing imports the module yet.

## For Skills

Not a skill, so the skill checklist does not apply.