### PR TITLE
refactor(setup): add registry sign-in seams, stop retrying LoginError

### DIFF
--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -47,6 +47,7 @@ import * as p from '@clack/prompts';
 import { installCredentialHelper } from './install-cred-helper.js';
 import { readEnvFile } from '../src/env.js';
 import { DEFAULT_BROKER_URL, readAgentImagePin, writeImageSource } from './lib/registry-state.js';
+import { DriverCancelled, DriverTerminalError, type SetupDriver } from './lib/setup-driver.js';
 import { commandExists, isHeadless, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
@@ -200,6 +201,11 @@ function message(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw new DriverCancelled(typeof signal.reason === 'string' ? signal.reason : undefined);
+}
+
 // ---------------------------------------------------------------------------
 // HTTP
 
@@ -254,12 +260,20 @@ async function readBoundedResponseBody(res: Response): Promise<string> {
  * data here, because the device grant signals `authorization_pending` as a 400
  * and that is the normal case, not an exception.
  */
-async function http(url: string, req: HttpRequest, timeoutMs: number): Promise<HttpResult> {
+async function http(
+  url: string,
+  req: HttpRequest,
+  timeoutMs: number,
+  cancellationSignal?: AbortSignal,
+): Promise<HttpResult> {
+  throwIfAborted(cancellationSignal);
   const res = await fetch(url, {
     method: req.method,
     headers: req.headers,
     body: req.body,
-    signal: AbortSignal.timeout(timeoutMs),
+    signal: cancellationSignal
+      ? AbortSignal.any([AbortSignal.timeout(timeoutMs), cancellationSignal])
+      : AbortSignal.timeout(timeoutMs),
   });
   const text = await readBoundedResponseBody(res);
   let body: Record<string, unknown> | undefined;
@@ -356,14 +370,14 @@ function readFileOrUndefined(file: string): string | undefined {
   }
 }
 
-function readAccountCredential(): AccountCredential | undefined {
+function readAccountCredential(report: (line: string) => void = console.log): AccountCredential | undefined {
   const raw = readFileOrUndefined(ACCOUNT_FILE);
   if (!raw) return undefined;
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    console.log(`Ignoring an unreadable credential at ${ACCOUNT_FILE}; signing in again.`);
+    report(`Ignoring an unreadable credential at ${ACCOUNT_FILE}; signing in again.`);
     return undefined;
   }
   if (!parsed || typeof parsed !== 'object') return undefined;
@@ -409,7 +423,7 @@ function resolveRegistryHost(fromBroker: string | undefined): string | undefined
  * worth trusting. Any cached password the helper stashed there is dropped: a
  * new token invalidates it.
  */
-function persistCredential(cred: AccountCredential): void {
+function persistCredential(cred: AccountCredential, report: (line: string) => void = console.log): void {
   const record: AccountCredential = { ...cred, registry: resolveRegistryHost(cred.registry) };
   writeSecretFile(ACCOUNT_FILE, `${JSON.stringify(record, null, 2)}\n`);
   ensureHostId();
@@ -418,9 +432,9 @@ function persistCredential(cred: AccountCredential): void {
     `${JSON.stringify({ version: 1, broker_url: record.api, registry: record.registry ?? '', token: record.token }, null, 2)}\n`,
   );
   if (!record.registry) {
-    console.log('   Note: no registry is pinned yet, so the image pull will have nothing to authenticate against.');
+    report('   Note: no registry is pinned yet, so the image pull will have nothing to authenticate against.');
   }
-  wireDockerCredentialHelper(record.registry);
+  wireDockerCredentialHelper(record.registry, report);
 
   // Record that this install pulls, HERE rather than at the call sites.
   //
@@ -447,16 +461,16 @@ function persistCredential(cred: AccountCredential): void {
  * succeeded is worth keeping even when we cannot write to a bin directory, and
  * `--step registry -- --status` reports the gap.
  */
-function wireDockerCredentialHelper(registry?: string): void {
+function wireDockerCredentialHelper(registry?: string, report: (line: string) => void = console.log): void {
   if (!registry) return;
   try {
     const result = installCredentialHelper({ registryHost: registry });
     if (!result.onPath) {
-      console.log(`   Note: ${path.dirname(result.helperPath)} is not on PATH, so docker will not find the helper.`);
+      report(`   Note: ${path.dirname(result.helperPath)} is not on PATH, so docker will not find the helper.`);
     }
   } catch (err) {
-    console.log(`   Note: couldn't point docker at the credential helper (${message(err)}).`);
-    console.log('   Run `pnpm exec tsx setup/install-cred-helper.ts` once that is fixed.');
+    report(`   Note: couldn't point docker at the credential helper (${message(err)}).`);
+    report('   Run `pnpm exec tsx setup/install-cred-helper.ts` once that is fixed.');
   }
 }
 
@@ -496,11 +510,12 @@ type ProbeState =
   | { state: 'unreachable'; reason: string };
 
 /** Is this token still good? Used for idempotence, so it must not be fatal. */
-async function probeSession(api: string, token: string): Promise<ProbeState> {
+async function probeSession(api: string, token: string, cancellationSignal?: AbortSignal): Promise<ProbeState> {
   let res: HttpResult;
   try {
-    res = await http(`${api}/v1/session/probe`, bearerGet(token), PROBE_TIMEOUT_MS);
+    res = await http(`${api}/v1/session/probe`, bearerGet(token), PROBE_TIMEOUT_MS, cancellationSignal);
   } catch (err) {
+    throwIfAborted(cancellationSignal);
     return { state: 'unreachable', reason: message(err) };
   }
   if (res.status === 401 || res.status === 403) return { state: 'unauthorized' };
@@ -535,11 +550,13 @@ function enrollWire(body: EnrollBody): Record<string, unknown> {
   return body.method === 'idp' ? { ...common, workos_token: body.access_token } : common;
 }
 
-async function enroll(api: string, body: EnrollBody): Promise<EnrollResult> {
+async function enroll(api: string, body: EnrollBody, cancellationSignal?: AbortSignal): Promise<EnrollResult> {
   let res: HttpResult;
   try {
-    res = await http(`${api}/v1/enroll`, json(enrollWire(body)), HTTP_TIMEOUT_MS);
+    res = await http(`${api}/v1/enroll`, json(enrollWire(body)), HTTP_TIMEOUT_MS, cancellationSignal);
   } catch (err) {
+    throwIfAborted(cancellationSignal);
+    if (err instanceof LoginError) throw err;
     throw new LoginError(
       `Couldn't reach the NanoClaw account service at ${api}: ${message(err)}`,
       `Check your network, then re-run. Point ${ENV.api} elsewhere if you run your own.`,
@@ -669,7 +686,7 @@ interface IdpConfig {
  */
 type BrokerProbe = { kind: 'idp'; config: IdpConfig } | { kind: 'no-idp' } | { kind: 'not-a-broker'; detail: string };
 
-async function probeBroker(api: string): Promise<BrokerProbe> {
+async function probeBroker(api: string, cancellationSignal?: AbortSignal): Promise<BrokerProbe> {
   const fromEnv = str(process.env[ENV.clientId]);
   if (fromEnv) {
     return {
@@ -688,8 +705,10 @@ async function probeBroker(api: string): Promise<BrokerProbe> {
       `${api}/v1/auth-config`,
       { method: 'GET', headers: { accept: 'application/json' } },
       PROBE_TIMEOUT_MS,
+      cancellationSignal,
     );
   } catch (err) {
+    throwIfAborted(cancellationSignal);
     return { kind: 'not-a-broker', detail: message(err) };
   }
 
@@ -730,11 +749,16 @@ interface DeviceAuthorization {
   intervalS: number;
 }
 
-async function requestDeviceAuthorization(cfg: IdpConfig): Promise<DeviceAuthorization> {
+async function requestDeviceAuthorization(
+  cfg: IdpConfig,
+  cancellationSignal?: AbortSignal,
+): Promise<DeviceAuthorization> {
   let res: HttpResult;
   try {
-    res = await http(cfg.deviceEndpoint, form({ client_id: cfg.clientId }), HTTP_TIMEOUT_MS);
+    res = await http(cfg.deviceEndpoint, form({ client_id: cfg.clientId }), HTTP_TIMEOUT_MS, cancellationSignal);
   } catch (err) {
+    throwIfAborted(cancellationSignal);
+    if (err instanceof LoginError) throw err;
     throw new LoginError(`Couldn't reach the sign-in provider: ${message(err)}`, 'Check your network and re-run.');
   }
 
@@ -821,16 +845,26 @@ function openInBrowser(url: string): void {
   }
 }
 
-async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Promise<string> {
+async function pollForIdpToken(
+  cfg: IdpConfig,
+  device: DeviceAuthorization,
+  cancellationSignal?: AbortSignal,
+): Promise<string> {
   let intervalMs = device.intervalS * 1000;
   const deadline = Date.now() + Math.min(device.expiresInS * 1000, MAX_DEVICE_WAIT_MS);
   let transportFailures = 0;
 
   for (;;) {
+    throwIfAborted(cancellationSignal);
     if (Date.now() >= deadline) {
       throw new LoginError('Timed out waiting for the sign-in to be approved.', 'Re-run setup to get a fresh code.');
     }
-    await sleep(intervalMs);
+    try {
+      await sleep(intervalMs, undefined, cancellationSignal ? { signal: cancellationSignal } : undefined);
+    } catch (err) {
+      throwIfAborted(cancellationSignal);
+      throw err;
+    }
 
     let res: HttpResult;
     try {
@@ -838,8 +872,11 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
         cfg.tokenEndpoint,
         form({ grant_type: DEVICE_GRANT_TYPE, device_code: device.deviceCode, client_id: cfg.clientId }),
         HTTP_TIMEOUT_MS,
+        cancellationSignal,
       );
     } catch (err) {
+      throwIfAborted(cancellationSignal);
+      if (err instanceof LoginError) throw err;
       // A closed lid or a flaky hotspot must not cost the user their code, so a
       // transport failure is retried rather than surfaced.
       if (++transportFailures > MAX_POLL_TRANSPORT_FAILURES) {
@@ -886,14 +923,107 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
   }
 }
 
-async function deviceLogin(api: string, cfg: IdpConfig): Promise<EnrollResult> {
-  const device = await requestDeviceAuthorization(cfg);
-  const headless = isHeadless();
-  printDeviceCard(device, headless);
-  if (!headless) openInBrowser(device.verificationUriComplete ?? device.verificationUri);
+type DevicePresentation = (device: DeviceAuthorization) => boolean | Promise<boolean>;
 
-  const idpToken = await pollForIdpToken(cfg, device);
-  return enroll(api, { method: 'idp', provider: 'workos', access_token: idpToken, client: clientRecord() });
+async function deviceLogin(
+  api: string,
+  cfg: IdpConfig,
+  present: DevicePresentation = (device) => {
+    const headless = isHeadless();
+    printDeviceCard(device, headless);
+    if (!headless) openInBrowser(device.verificationUriComplete ?? device.verificationUri);
+    return true;
+  },
+  cancellationSignal?: AbortSignal,
+): Promise<{ kind: 'ready'; enrollment: EnrollResult } | { kind: 'skipped' }> {
+  const device = await requestDeviceAuthorization(cfg, cancellationSignal);
+  if (!(await present(device))) return { kind: 'skipped' };
+  const idpToken = await pollForIdpToken(cfg, device, cancellationSignal);
+  const enrollment = await enroll(
+    api,
+    { method: 'idp', provider: 'workos', access_token: idpToken, client: clientRecord() },
+    cancellationSignal,
+  );
+  return { kind: 'ready', enrollment };
+}
+
+function httpsUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'https:') return url.href;
+  } catch {
+    // Rejected below with a fixed message so untrusted URL text never reaches output.
+  }
+  throw new LoginError('The sign-in provider returned an unsafe verification URL.');
+}
+
+async function presentDeviceAuthorization(driver: SetupDriver, device: DeviceAuthorization): Promise<boolean> {
+  driver.throwIfCancelled();
+  const verificationUrl = httpsUrl(device.verificationUri);
+  const displayUrl = httpsUrl(device.verificationUriComplete ?? device.verificationUri);
+  driver.display({
+    id: 'registry-verification-url',
+    kind: 'url',
+    url: displayUrl,
+    label: 'NanoClaw sign-in URL',
+    sensitive: true,
+  });
+  driver.display({
+    id: 'registry-user-code',
+    kind: 'code',
+    content: device.userCode,
+    label: 'Verification code',
+    sensitive: true,
+  });
+  const action = await driver.externalAction(
+    {
+      id: 'registry-open-browser',
+      kind: 'openURL',
+      title: 'Open NanoClaw sign-in',
+      // The complete URL embeds the code. Keep it in the sensitive display;
+      // the action uses the provider's code-free verification page.
+      url: verificationUrl,
+    },
+    () => true,
+  );
+  if (action === 'attempted' && driver.mode === 'terminal' && !isHeadless()) {
+    openInBrowser(displayUrl);
+  }
+  if (action !== 'declined') {
+    driver.progress('registry-login', 'running', 'Waiting for browser approval');
+  }
+  return action !== 'declined';
+}
+
+type StoredCredentialResult =
+  | { kind: 'none' | 'invalid' }
+  | { kind: 'different'; api: string }
+  | { kind: 'ready'; credential: AccountCredential; verified: true }
+  | { kind: 'ready'; credential: AccountCredential; verified: false; reason: string };
+
+async function resolveStoredCredential(
+  api: string,
+  force: boolean,
+  cancellationSignal?: AbortSignal,
+  report: (line: string) => void = console.log,
+): Promise<StoredCredentialResult> {
+  const existing = readAccountCredential(report);
+  if (!existing || force) return { kind: 'none' };
+  if (existing.api !== api) return { kind: 'different', api: existing.api };
+
+  const probe = await probeSession(existing.api, existing.token, cancellationSignal);
+  if (probe.state === 'unauthorized') return { kind: 'invalid' };
+  if (probe.state === 'unreachable') {
+    return { kind: 'ready', credential: existing, verified: false, reason: probe.reason };
+  }
+  const refreshed: AccountCredential = {
+    ...existing,
+    email: probe.email ?? existing.email,
+    registry: probe.registry ?? existing.registry,
+    entitlements: probe.entitlements,
+  };
+  persistCredential(refreshed, report);
+  return { kind: 'ready', credential: refreshed, verified: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -1084,57 +1214,48 @@ export async function run(argv: string[]): Promise<void> {
   // through a browser dance it already completed. A credential for a different
   // service is not that — tokens are meaningless across brokers, so retargeting
   // has to mean signing in again rather than probing the old one.
-  const existing = readAccountCredential();
-  if (existing && !opts.force && existing.api !== api) {
-    console.log(`The stored sign-in is for ${existing.api}; signing in to ${api} instead.`);
-  } else if (existing && !opts.force) {
-    const probe = await probeSession(existing.api, existing.token);
-    if (probe.state === 'ok') {
-      const refreshed: AccountCredential = {
-        ...existing,
-        email: probe.email ?? existing.email,
-        registry: probe.registry ?? existing.registry,
-        entitlements: probe.entitlements,
-      };
-      persistCredential(refreshed);
-      console.log(`Already authenticated as ${refreshed.email ?? refreshed.account_id}.`);
+  const stored = await resolveStoredCredential(api, opts.force);
+  if (stored.kind === 'different') {
+    console.log(`The stored sign-in is for ${stored.api}; signing in to ${api} instead.`);
+  } else if (stored.kind === 'ready') {
+    if (stored.verified) {
+      console.log(`Already authenticated as ${stored.credential.email ?? stored.credential.account_id}.`);
       emitLoginStatus({
         STATUS: 'skipped',
         REASON: 'already-signed-in',
-        ACCOUNT: refreshed.account_id,
-        EMAIL: refreshed.email ?? '',
-        ENTITLEMENTS: refreshed.entitlements.join(','),
+        ACCOUNT: stored.credential.account_id,
+        EMAIL: stored.credential.email ?? '',
+        ENTITLEMENTS: stored.credential.entitlements.join(','),
       });
       return;
     }
-    if (probe.state === 'unreachable') {
-      // `unreachable` is broader than "offline": probeSession reports it for
-      // every status that is not 200/401/403, so a gateway 404, a proxy error
-      // and a credential the service no longer knows all land here. Keeping
-      // the credential is therefore a guess, and which way to guess depends
-      // on what the caller does next.
-      //
-      // It is also the only outcome a stale credential can reach without
-      // being caught: the `existing.api !== api` check above cannot fire on
-      // a record written before that field existed, because
-      // `readAccountCredential` fills the gap with the current target.
-      if (opts.requireVerified) {
-        reportSkipped(
-          'unverified',
-          `Couldn't reach the account service (${probe.reason}); the stored sign-in could not be checked.`,
-        );
-        return;
-      }
-      // Offline is not a reason to discard a working credential — the pull that
-      // needs it may well be served from the local image cache anyway.
-      console.log(`Couldn't reach the account service (${probe.reason}); keeping the stored sign-in.`);
-      emitLoginStatus({
-        STATUS: 'skipped',
-        REASON: 'already-signed-in-unverified',
-        ACCOUNT: existing.account_id,
-      });
+    // `unreachable` is broader than "offline": probeSession reports it for
+    // every status that is not 200/401/403, so a gateway 404, a proxy error
+    // and a credential the service no longer knows all land here. Keeping
+    // the credential is therefore a guess, and which way to guess depends
+    // on what the caller does next.
+    //
+    // It is also the only outcome a stale credential can reach without
+    // being caught: the `different` check above cannot fire on a record
+    // written before the api field existed, because `readAccountCredential`
+    // fills the gap with the current target.
+    if (opts.requireVerified) {
+      reportSkipped(
+        'unverified',
+        `Couldn't reach the account service (${stored.reason}); the stored sign-in could not be checked.`,
+      );
       return;
     }
+    // Offline is not a reason to discard a working credential. The pull that
+    // needs it may well be served from the local image cache anyway.
+    console.log(`Couldn't reach the account service (${stored.reason}); keeping the stored sign-in.`);
+    emitLoginStatus({
+      STATUS: 'skipped',
+      REASON: 'already-signed-in-unverified',
+      ACCOUNT: stored.credential.account_id,
+    });
+    return;
+  } else if (stored.kind === 'invalid') {
     console.log('The stored NanoClaw sign-in is no longer valid — signing in again.');
   }
 
@@ -1218,9 +1339,14 @@ export async function run(argv: string[]): Promise<void> {
     reportSkipped('declined');
     return;
   }
-  const { credential: cred, emailUpdates } = typed
-    ? await enroll(api, { method: 'code', code: typed, client: clientRecord() })
+  const result = typed
+    ? { kind: 'ready' as const, enrollment: await enroll(api, { method: 'code', code: typed, client: clientRecord() }) }
     : await deviceLogin(api, idp);
+  if (result.kind === 'skipped') {
+    reportSkipped('declined');
+    return;
+  }
+  const { credential: cred, emailUpdates } = result.enrollment;
   persistCredential(cred);
 
   reportSuccess(cred, typed ? 'code' : 'device');


### PR DESCRIPTION
## TL;DR

Proposed: reshape `setup/registry-login.ts` (the container-registry sign-in flow) so a second, non-terminal caller can drive it, plus one real behaviour change: three network error paths now abort on an oversized response instead of retrying it. One file, no new tests, terminal sign-in behaves exactly as before.

## The problem

`setup/registry-login.ts` runs an RFC 8628 device-code sign-in: it asks the account service for a short user code and a URL, prints a card to the terminal, opens a browser, then polls until the user approves. Every step writes to `console.log`, opens the browser itself, and has no way to be cancelled. A native macOS app driving setup over the NDJSON wire protocol (the wider goal of this stack) cannot use any of that: it has no terminal to print to and needs to be able to cancel a sign-in the user walked away from.

## How it works

Five mechanical seams, all additive with defaults that reproduce today's behaviour:

- `report: (line: string) => void = console.log` added to `readAccountCredential`, `persistCredential` and `wireDockerCredentialHelper`, so their notes can be routed somewhere other than stdout.
- `cancellationSignal?: AbortSignal` threaded through `http`, `probeSession`, `enroll`, `probeBroker`, `requestDeviceAuthorization` and `pollForIdpToken`. `http` combines it with the existing timeout via `AbortSignal.any`, a new `throwIfAborted` helper converts an aborted signal into `DriverCancelled`, and the poll loop's `sleep` now takes the signal so a cancel does not wait out the interval.
- `deviceLogin` takes an injectable `DevicePresentation` callback (default: the existing print-card-and-open-browser code) and returns `{ kind: 'ready' } | { kind: 'skipped' }` so a caller can decline. In terminal mode the default always returns true, so `skipped` is unreachable there.
- `resolveStoredCredential` extracted out of `run()`. It collapses the four inline branches of the old stored-credential block into one five-case union: `none`, `different`, `ready`+verified, `ready`+unverified, `invalid`. Traced line by line as behaviour identical, including the `requireVerified` early return and both `emitLoginStatus` REASON values (`already-signed-in`, `already-signed-in-unverified`).

And one behaviour change, which is why this is not purely mechanical: the catch blocks in `enroll`, `requestDeviceAuthorization` and `pollForIdpToken` gained `if (err instanceof LoginError) throw err;`. `LoginError` is thrown from inside `http` by the 256 KiB response-body bound. Before, those three blocks swallowed it: two rewrote it as a generic "couldn't reach the service" message, and the poll loop counted it as a retryable transport failure and kept polling. Now an oversized body from the account service or the identity provider aborts the sign-in on the first occurrence with its own message.

## What trips people up

- `httpsUrl` and `presentDeviceAuthorization` are defined here but nothing calls them at this commit. They are consumed by the next PR in the stack, which adds the driver-rendered entry point. Same for two of the three imported names: `DriverTerminalError` and `SetupDriver` land in one import line here, and only `SetupDriver` is referenced (by the dormant function).
- `resolveStoredCredential` is called from `run()` without a `report` argument, so the sink defaults to `console.log`. The seams are dormant defaults at this commit.
- This PR has zero new tests. The gate is a setup-inclusive `tsc` run plus the unchanged 181-line `setup/registry-login.test.ts`. Note that CI's `tsconfig.json` covers only `src/**/*`, so `setup/` is not typechecked by CI today.

## What to review

1. The `run()` rewrite against the base version, side by side. This is the largest risk in the PR: four inline branches became a five-case union, and it is asserted equivalent rather than tested equivalent.
2. Whether aborting rather than retrying an over-256-KiB response is the behaviour you want in the poll loop specifically. That is the one place a retry used to protect the user's short-lived code.
3. That the `deviceLogin` default presentation is byte-for-byte the old inline body (print the card, open the browser unless headless).

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is a refactor of existing setup code to add injection points and cancellation for a later caller, carrying one deliberate error-handling change. It adds no skill, fixes no reported bug, and adds lines rather than removing them.

## Description

See the sections above. Proposed as one PR in a stack that splits a single oversized upstream commit into independently reviewable pieces; the stack as a whole adds a machine-drivable setup protocol and changes no terminal behaviour.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

Not a skill, so this checklist does not apply.