### PR TITLE
feat(setup): add driver-rendered registry sign-in entry point

### DIFF
--- a/docs/hardened-image.md
+++ b/docs/hardened-image.md
@@ -95,6 +95,11 @@ All optional, all read from `.env` or the environment.
 | `NANOCLAW_REGISTRY_TOKEN` | Adopt an existing account token directly. |
 | `NANOCLAW_ALLOW_UNLABELED_IMAGE` | Accept an image with no agent-runner lock label — needed for a `docker save`/`load` or third-party image. |
 
+`NANOCLAW_REGISTRY_API` is a trust boundary, not just a routing override. When
+you point it at a self-hosted account service, that service may declare the
+HTTPS identity-provider endpoints used for browser sign-in. Set it only to a
+service you trust; the setup driver rejects non-HTTPS sign-in URLs.
+
 If you point this at your own registry you need none of these beyond
 `NANOCLAW_HARDENED_IMAGE` and a reference: authentication is whatever
 `docker login` already holds, and there is no account involved.

--- a/setup/registry-login.driver.test.ts
+++ b/setup/registry-login.driver.test.ts
@@ -1,0 +1,539 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DriverCancelled } from './lib/setup-driver.js';
+import type {
+  DriverDisplay,
+  DriverPrompt,
+  ExternalAction,
+  ExternalActionResult,
+  SetupDriver,
+} from './lib/setup-driver.js';
+
+vi.mock('./install-cred-helper.js', () => ({
+  installCredentialHelper: () => ({ helperPath: '/tmp/docker-credential-nanoclaw', onPath: true }),
+}));
+vi.mock('./lib/registry-state.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./lib/registry-state.js')>()),
+  writeImageSource: vi.fn(),
+}));
+
+const ENV_KEYS = [
+  'NANOCLAW_REGISTRY_API',
+  'NANOCLAW_REGISTRY_TOKEN',
+  'NANOCLAW_REGISTRY_ENROLL_CODE',
+  'NANOCLAW_WORKOS_CLIENT_ID',
+  'NANOCLAW_WORKOS_DEVICE_ENDPOINT',
+  'NANOCLAW_WORKOS_TOKEN_ENDPOINT',
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+const originalHome = process.env.HOME;
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-registry-driver-'));
+const configDir = path.join(testHome, '.config', 'nanoclaw');
+const accountFile = path.join(configDir, 'account.json');
+const registryAuthFile = path.join(configDir, 'registry-auth.json');
+
+let runRegistryLoginWithDriver: typeof import('./registry-login.js').runRegistryLoginWithDriver;
+const servers: Server[] = [];
+
+beforeAll(async () => {
+  process.env.HOME = testHome;
+  ({ runRegistryLoginWithDriver } = await import('./registry-login.js'));
+});
+
+beforeEach(() => {
+  fs.rmSync(configDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+afterAll(() => {
+  fs.rmSync(testHome, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+interface DriverHarness extends SetupDriver {
+  actions: ExternalAction[];
+  cleared: string[];
+  displays: DriverDisplay[];
+  logs: string[];
+  notes: string[];
+  progresses: Array<{ stepId: string; state: string; label?: string }>;
+  prompts: DriverPrompt[];
+}
+
+function driver(
+  answers: Array<boolean | string>,
+  controller = new AbortController(),
+  externalResult: ExternalActionResult = 'attempted',
+): DriverHarness {
+  const prompts: DriverPrompt[] = [];
+  const displays: DriverDisplay[] = [];
+  const actions: ExternalAction[] = [];
+  const cleared: string[] = [];
+  const logs: string[] = [];
+  const notes: string[] = [];
+  const progresses: DriverHarness['progresses'] = [];
+  return {
+    mode: 'ndjson',
+    operation: 'setup',
+    cancellationSignal: controller.signal,
+    prompts,
+    displays,
+    actions,
+    cleared,
+    logs,
+    notes,
+    progresses,
+    async prompt(spec) {
+      prompts.push(spec);
+      const answer = answers.shift();
+      if (answer === undefined) throw new Error(`No answer for ${spec.id}`);
+      return answer;
+    },
+    async externalAction(action, verify): Promise<ExternalActionResult> {
+      actions.push(action);
+      if (externalResult !== 'attempted') return externalResult;
+      return (await verify()) ? 'attempted' : 'unsupported';
+    },
+    display(value) {
+      displays.push(value);
+    },
+    clearDisplay(id) {
+      cleared.push(id);
+    },
+    note(content) {
+      notes.push(content);
+    },
+    log(_level, message) {
+      logs.push(message);
+    },
+    progress(stepId, state, label) {
+      progresses.push({ stepId, state, ...(label ? { label } : {}) });
+    },
+    throwIfCancelled() {
+      if (controller.signal.aborted) throw new DriverCancelled('test');
+    },
+  } as unknown as DriverHarness;
+}
+
+interface FixtureOptions {
+  idp?: boolean;
+  device?: Record<string, unknown>;
+  tokens?: Array<{ status: number; body: Record<string, unknown> }>;
+  enroll?: Record<string, unknown>;
+  probe?: { status: number; body: Record<string, unknown> };
+  onTokenRequest?: (res: ServerResponse) => boolean;
+}
+
+interface Fixture {
+  api: string;
+  requests: Array<{ method: string; path: string; body: string }>;
+}
+
+async function fixture(options: FixtureOptions = {}): Promise<Fixture> {
+  const requests: Fixture['requests'] = [];
+  let api = '';
+  let tokenIndex = 0;
+  const server = createServer(async (req, res) => {
+    const body = await requestBody(req);
+    const pathname = new URL(req.url ?? '/', 'http://fixture').pathname;
+    requests.push({ method: req.method ?? 'GET', path: pathname, body });
+    if (pathname === '/v1/auth-config') {
+      send(
+        res,
+        options.idp === false ? 503 : 200,
+        options.idp === false
+          ? { device_flow_available: false }
+          : {
+              device_flow_available: true,
+              client_id: 'fixture-client',
+              device_authorization_endpoint: `${api}/device`,
+              token_endpoint: `${api}/token`,
+            },
+      );
+      return;
+    }
+    if (pathname === '/device') {
+      send(
+        res,
+        200,
+        options.device ?? {
+          device_code: 'device-secret',
+          user_code: 'ABCD-EFGH',
+          verification_uri: 'https://idp.example/verify',
+          verification_uri_complete: 'https://idp.example/verify?user_code=ABCD-EFGH',
+          expires_in: 60,
+          interval: 1,
+        },
+      );
+      return;
+    }
+    if (pathname === '/token') {
+      if (options.onTokenRequest?.(res)) return;
+      const responses = options.tokens ?? [{ status: 200, body: { access_token: 'idp-secret' } }];
+      const response = responses[Math.min(tokenIndex++, responses.length - 1)];
+      send(res, response.status, response.body);
+      return;
+    }
+    if (pathname === '/v1/enroll') {
+      send(
+        res,
+        201,
+        options.enroll ?? {
+          token: 'registry-secret',
+          account_id: 'acct-1',
+          email: 'owner@example.com',
+          registry: 'registry.example.com',
+          entitlements: ['hardened-image'],
+          email_updates: false,
+        },
+      );
+      return;
+    }
+    if (pathname === '/v1/session/probe') {
+      const response = options.probe ?? { status: 401, body: {} };
+      send(res, response.status, response.body);
+      return;
+    }
+    if (pathname === '/v1/account/preferences') {
+      send(res, 200, {});
+      return;
+    }
+    send(res, 404, {});
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('fixture did not bind');
+  api = `http://127.0.0.1:${address.port}`;
+  return { api, requests };
+}
+
+function send(res: ServerResponse, status: number, body: Record<string, unknown>): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function requestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function expectNoCredential(): void {
+  expect(fs.existsSync(accountFile)).toBe(false);
+  expect(fs.existsSync(registryAuthFile)).toBe(false);
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('condition was not reached');
+}
+
+describe('runRegistryLoginWithDriver', () => {
+  it('completes pending device auth, emits sensitive semantics, records consent, and writes owner-only credentials', async () => {
+    const local = await fixture({
+      tokens: [
+        { status: 400, body: { error: 'authorization_pending' } },
+        { status: 200, body: { access_token: 'idp-secret' } },
+      ],
+      enroll: {
+        token: 'registry-secret',
+        account_id: 'acct-1',
+        registry: 'registry.example.com',
+        entitlements: [],
+        email_updates: null,
+      },
+    });
+    fs.mkdirSync(configDir, { recursive: true });
+    for (const file of [`${accountFile}.tmp`, `${registryAuthFile}.tmp`]) {
+      fs.writeFileSync(file, 'stale', { mode: 0o644 });
+      fs.chmodSync(file, 0o644);
+    }
+    const harness = driver(['', false]);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'device',
+    });
+
+    expect(local.requests.filter((request) => request.path === '/token')).toHaveLength(2);
+    expect(local.requests.find((request) => request.path === '/v1/account/preferences')?.body).toContain(
+      '"email_updates":false',
+    );
+    expect(harness.displays).toEqual([
+      expect.objectContaining({ kind: 'url', sensitive: true, url: expect.stringMatching(/^https:/) }),
+      expect.objectContaining({ kind: 'code', sensitive: true, content: 'ABCD-EFGH' }),
+    ]);
+    expect(harness.actions).toEqual([expect.objectContaining({ kind: 'openURL', url: 'https://idp.example/verify' })]);
+    expect(harness.cleared).toEqual(['registry-verification-url', 'registry-user-code']);
+    expect(harness.progresses).toEqual([
+      { stepId: 'registry-login', state: 'running', label: 'Authenticating with NanoClaw' },
+      { stepId: 'registry-login', state: 'running', label: 'Waiting for browser approval' },
+      { stepId: 'registry-login', state: 'succeeded' },
+    ]);
+    for (const file of [accountFile, registryAuthFile, path.join(configDir, 'host-id')]) {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+    expect(fs.existsSync(`${accountFile}.tmp`)).toBe(false);
+    expect(fs.existsSync(`${registryAuthFile}.tmp`)).toBe(false);
+    expect(JSON.stringify(harness)).not.toContain('registry-secret');
+    expect(JSON.parse(fs.readFileSync(registryAuthFile, 'utf8'))).toMatchObject({
+      broker_url: local.api,
+      registry: 'registry.example.com',
+      token: 'registry-secret',
+    });
+  }, 5_000);
+
+  it('honors slow_down before accepting the next token response', async () => {
+    const local = await fixture({
+      tokens: [
+        { status: 400, body: { error: 'slow_down' } },
+        { status: 200, body: { access_token: 'idp-secret' } },
+      ],
+    });
+
+    await expect(runRegistryLoginWithDriver(driver(['', 'browser']), { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'device',
+    });
+    expect(local.requests.filter((request) => request.path === '/token')).toHaveLength(2);
+  }, 9_000);
+
+  it.each([
+    ['declined', { tokens: [{ status: 400, body: { error: 'access_denied' } }] }],
+    [
+      'expired',
+      {
+        device: {
+          device_code: 'd',
+          user_code: 'u',
+          verification_uri: 'https://idp.example/verify',
+          expires_in: 0,
+          interval: 1,
+        },
+      },
+    ],
+    ['malformed device response', { device: { device_code: 'd', verification_uri: 'https://idp.example/verify' } }],
+    ['malformed token response', { tokens: [{ status: 200, body: {} }] }],
+    [
+      'unsafe browser URL',
+      {
+        device: {
+          device_code: 'd',
+          user_code: 'u',
+          verification_uri: 'http://idp.example/verify',
+          expires_in: 60,
+          interval: 1,
+        },
+      },
+    ],
+  ] satisfies Array<[string, FixtureOptions]>)(
+    'fails closed for a %s',
+    async (_name, options) => {
+      const local = await fixture(options);
+      const harness = driver(['', 'browser']);
+
+      await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+        kind: 'failed',
+        reason: 'sign-in-failed',
+      });
+      expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'failed' });
+      expectNoCredential();
+    },
+    3_000,
+  );
+
+  it.each([
+    ['unsupported', { kind: 'ready', method: 'device' }],
+    ['declined', { kind: 'skipped', reason: 'declined' }],
+  ] as const)(
+    'handles an %s browser action and clears its sensitive displays',
+    async (action, expected) => {
+      const local = await fixture();
+      const harness = driver(['', 'browser'], new AbortController(), action);
+
+      await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual(expected);
+      expect(harness.cleared).toEqual(['registry-verification-url', 'registry-user-code']);
+      expect(local.requests.filter((request) => request.path === '/token')).toHaveLength(action === 'declined' ? 0 : 1);
+      expect(harness.progresses.at(-1)).toEqual({
+        stepId: 'registry-login',
+        state: 'succeeded',
+      });
+    },
+    3_000,
+  );
+
+  it('cancels promptly during the polling wait and clears sensitive displays', async () => {
+    const controller = new AbortController();
+    const local = await fixture();
+    const harness = driver(['', 'browser'], controller);
+    const running = runRegistryLoginWithDriver(harness, { api: local.api });
+    await waitUntil(() => harness.actions.length === 1);
+    controller.abort('operator_cancelled');
+
+    await expect(running).rejects.toBeInstanceOf(DriverCancelled);
+    expect(harness.cleared).toEqual(['registry-verification-url', 'registry-user-code']);
+    expectNoCredential();
+  });
+
+  it('aborts an in-flight token request without persisting a partial credential', async () => {
+    const controller = new AbortController();
+    const local = await fixture({
+      onTokenRequest() {
+        controller.abort('operator_cancelled');
+        return true;
+      },
+    });
+
+    await expect(
+      runRegistryLoginWithDriver(driver(['', 'browser'], controller), { api: local.api }),
+    ).rejects.toBeInstanceOf(DriverCancelled);
+    expectNoCredential();
+  }, 3_000);
+
+  it('uses a secret enrollment prompt when the broker has no identity provider', async () => {
+    const local = await fixture({ idp: false });
+    const harness = driver(['enroll-secret']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'code',
+    });
+    expect(harness.prompts).toEqual([
+      expect.objectContaining({ id: 'registry-enrollment-code', kind: 'secret', sensitive: true }),
+    ]);
+    expect(local.requests.find((request) => request.path === '/v1/enroll')?.body).toContain('enroll-secret');
+    expect(JSON.stringify({ logs: harness.logs, notes: harness.notes, prompts: harness.prompts })).not.toContain(
+      'enroll-secret',
+    );
+  });
+
+  it('accepts an enrollment code when browser authentication is available', async () => {
+    const local = await fixture();
+    const harness = driver(['enroll-secret']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'code',
+    });
+    expect(harness.prompts).toEqual([
+      expect.objectContaining({ id: 'registry-enrollment-code', kind: 'secret', sensitive: true }),
+    ]);
+    expect(local.requests.some((request) => request.path === '/device')).toBe(false);
+    expect(local.requests.find((request) => request.path === '/v1/enroll')?.body).toContain('enroll-secret');
+  });
+
+  it('keeps a valid existing credential without prompting again', async () => {
+    const local = await fixture({
+      probe: {
+        status: 200,
+        body: { account_id: 'acct-1', email: 'fresh@example.com', registry: 'registry.example.com', entitlements: [] },
+      },
+    });
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      accountFile,
+      JSON.stringify({
+        version: 1,
+        api: local.api,
+        account_id: 'acct-1',
+        token: 'existing-secret',
+        entitlements: [],
+        created_at: new Date(0).toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+    const harness = driver([]);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'existing',
+    });
+    expect(harness.prompts).toHaveLength(0);
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'succeeded' });
+    expect(JSON.parse(fs.readFileSync(accountFile, 'utf8'))).toMatchObject({ email: 'fresh@example.com' });
+  });
+
+  it('returns a skip result when the enrollment code is left blank', async () => {
+    const local = await fixture({ idp: false });
+    const harness = driver(['']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'declined',
+    });
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'succeeded' });
+    expectNoCredential();
+  });
+
+  it('fails without buffering an oversized registry response', async () => {
+    const local = await fixture({ idp: false, enroll: { padding: 'x'.repeat(300_000) } });
+    const harness = driver(['enroll-secret']);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'failed',
+      reason: 'sign-in-failed',
+    });
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'failed' });
+    expectNoCredential();
+  });
+
+  it('adopts a preset account token from the environment without prompting', async () => {
+    const local = await fixture({
+      probe: {
+        status: 200,
+        body: { account_id: 'acct-1', email: 'ci@example.com', registry: 'registry.example.com', entitlements: [] },
+      },
+    });
+    process.env.NANOCLAW_REGISTRY_TOKEN = 'preset-token-secret';
+    const harness = driver([]);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'existing',
+    });
+    // A scripted or CI install has nobody at the keyboard, so a single prompt
+    // is the whole regression: the run stalls on a masked enrollment code.
+    expect(harness.prompts).toEqual([]);
+    expect(local.requests.some((request) => request.path === '/device')).toBe(false);
+    expect(harness.progresses.at(-1)).toEqual({ stepId: 'registry-login', state: 'succeeded' });
+    expect(JSON.parse(fs.readFileSync(registryAuthFile, 'utf8'))).toMatchObject({
+      broker_url: local.api,
+      registry: 'registry.example.com',
+      token: 'preset-token-secret',
+    });
+  });
+
+  it('enrolls with a preset enrollment code from the environment without prompting', async () => {
+    const local = await fixture();
+    process.env.NANOCLAW_REGISTRY_ENROLL_CODE = 'preset-code-secret';
+    const harness = driver([]);
+
+    await expect(runRegistryLoginWithDriver(harness, { api: local.api })).resolves.toEqual({
+      kind: 'ready',
+      method: 'code',
+    });
+    expect(harness.prompts).toEqual([]);
+    expect(local.requests.some((request) => request.path === '/device')).toBe(false);
+    expect(local.requests.find((request) => request.path === '/v1/enroll')?.body).toContain('preset-code-secret');
+    expect(JSON.parse(fs.readFileSync(registryAuthFile, 'utf8'))).toMatchObject({ token: 'registry-secret' });
+  });
+});

--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -165,6 +165,11 @@ class LoginError extends Error {
 
 type LoginMethod = 'device' | 'code' | 'token';
 
+export type RegistryLoginDriverResult =
+  | { kind: 'ready'; method: 'device' | 'code' | 'existing' }
+  | { kind: 'skipped'; reason: 'declined' }
+  | { kind: 'failed'; reason: 'sign-in-failed' };
+
 interface Options {
   interactive: boolean;
   /** Sign in again even when a valid credential is already on disk. */
@@ -1178,6 +1183,37 @@ async function maybeAskEmailConsent(api: string, cred: AccountCredential, curren
   if (optIn) p.log.success("You're on the list.");
 }
 
+async function maybeAskEmailConsentWithDriver(
+  api: string,
+  cred: AccountCredential,
+  current: boolean | null,
+  driver: SetupDriver,
+): Promise<void> {
+  if (current !== null) return;
+  driver.note(CONSENT_LINES.join('\n'));
+  const answer = await driver.prompt({
+    id: 'registry-email-consent',
+    kind: 'confirm',
+    message: 'Email me security and project updates?',
+    default: true,
+  });
+  const optIn = answer === true;
+  try {
+    const res = await http(
+      `${api}/v1/account/preferences`,
+      json({ email_updates: optIn, consent_version: CONSENT_VERSION, source: 'cli' }, cred.token),
+      HTTP_TIMEOUT_MS,
+      driver.cancellationSignal,
+    );
+    if (res.status !== 200) throw new Error(`HTTP ${res.status}`);
+  } catch (err) {
+    throwIfAborted(driver.cancellationSignal);
+    if (optIn) driver.log('warn', "Couldn't record the email preference. Sign in again to retry.");
+    return;
+  }
+  if (optIn) driver.log('success', "You're on the list.");
+}
+
 function reportSuccess(cred: AccountCredential, method: LoginMethod): void {
   // The wizard reports the outcome itself, in its own voice, immediately after
   // we exit. Saying it here too gives the user the same fact twice in two
@@ -1202,6 +1238,121 @@ function reportSkipped(reason: string, detail?: string): void {
   if (detail) console.log(detail);
   process.exitCode = EXIT_SKIPPED;
   emitLoginStatus({ STATUS: 'skipped', REASON: reason });
+}
+
+function finishDriverLogin(driver: SetupDriver, result: RegistryLoginDriverResult): RegistryLoginDriverResult {
+  driver.progress('registry-login', result.kind === 'ready' || result.kind === 'skipped' ? 'succeeded' : 'failed');
+  return result;
+}
+
+/** Registry authentication rendered by either setup driver. */
+export async function runRegistryLoginWithDriver(
+  driver: SetupDriver,
+  options: { force?: boolean; api?: string } = {},
+): Promise<RegistryLoginDriverResult> {
+  const api = resolveApiBase(options.api);
+  const report = (line: string): void => driver.log('info', line.trim());
+
+  try {
+    driver.throwIfCancelled();
+    driver.progress('registry-login', 'running', 'Authenticating with NanoClaw');
+    const stored = await resolveStoredCredential(api, options.force ?? false, driver.cancellationSignal, report);
+    if (stored.kind === 'ready') return finishDriverLogin(driver, { kind: 'ready', method: 'existing' });
+
+    // The scripted and CI route, preserved from the shell entry point this
+    // replaced. No consent prompt on either path: there is nobody to ask, and a
+    // default of "yes" would not be consent.
+    const presetToken = str(process.env[ENV.token]);
+    if (presetToken) {
+      const probe = await probeSession(api, presetToken);
+      if (probe.state !== 'ok') {
+        const why =
+          probe.state === 'unauthorized' ? 'it was rejected' : `the service was unreachable (${probe.reason})`;
+        throw new LoginError(`The token in ${ENV.token} can't be used: ${why}.`);
+      }
+      persistCredential({
+        version: 1,
+        api,
+        account_id: probe.account_id,
+        email: probe.email,
+        token: presetToken,
+        registry: probe.registry,
+        entitlements: probe.entitlements,
+        created_at: new Date().toISOString(),
+      });
+      return finishDriverLogin(driver, { kind: 'ready', method: 'existing' });
+    }
+
+    const presetCode = str(process.env[ENV.enrollCode]);
+    if (presetCode) {
+      const preset = await enroll(
+        api,
+        { method: 'code', code: presetCode, client: clientRecord() },
+        driver.cancellationSignal,
+      );
+      persistCredential(preset.credential);
+      return finishDriverLogin(driver, { kind: 'ready', method: 'code' });
+    }
+
+    const broker = await probeBroker(api, driver.cancellationSignal);
+    if (broker.kind === 'not-a-broker') {
+      return finishDriverLogin(driver, { kind: 'failed', reason: 'sign-in-failed' });
+    }
+
+    if (broker.kind === 'no-idp') driver.note('Browser authentication is not configured for this registry.');
+    const code = await driver.prompt({
+      id: 'registry-enrollment-code',
+      kind: 'secret',
+      message:
+        broker.kind === 'no-idp'
+          ? 'Enrollment code (leave blank to build locally)'
+          : 'Enrollment code (optional, leave blank to sign in with your browser)',
+      sensitive: true,
+      validation: { maxLength: 4096 },
+    });
+
+    let enrollment: EnrollResult;
+    let loginMethod: 'device' | 'code';
+    if (typeof code === 'string' && code.length > 0) {
+      enrollment = await enroll(api, { method: 'code', code, client: clientRecord() }, driver.cancellationSignal);
+      loginMethod = 'code';
+    } else if (broker.kind === 'no-idp') {
+      return finishDriverLogin(driver, { kind: 'skipped', reason: 'declined' });
+    } else {
+      let displayed = false;
+      let deviceResult: Awaited<ReturnType<typeof deviceLogin>>;
+      try {
+        deviceResult = await deviceLogin(
+          api,
+          broker.config,
+          async (device) => {
+            displayed = true;
+            return presentDeviceAuthorization(driver, device);
+          },
+          driver.cancellationSignal,
+        );
+      } finally {
+        if (displayed) {
+          driver.clearDisplay('registry-verification-url');
+          driver.clearDisplay('registry-user-code');
+        }
+      }
+      if (deviceResult.kind === 'skipped') {
+        return finishDriverLogin(driver, { kind: 'skipped', reason: 'declined' });
+      }
+      enrollment = deviceResult.enrollment;
+      loginMethod = 'device';
+    }
+
+    driver.throwIfCancelled();
+    persistCredential(enrollment.credential, report);
+    await maybeAskEmailConsentWithDriver(api, enrollment.credential, enrollment.emailUpdates, driver);
+    return finishDriverLogin(driver, { kind: 'ready', method: loginMethod });
+  } catch (err) {
+    if (err instanceof DriverCancelled || err instanceof DriverTerminalError) throw err;
+    throwIfAborted(driver.cancellationSignal);
+    return finishDriverLogin(driver, { kind: 'failed', reason: 'sign-in-failed' });
+  }
 }
 
 export async function run(argv: string[]): Promise<void> {


### PR DESCRIPTION
## TL;DR

Proposes a second, machine-drivable entry point into NanoClaw's existing registry sign-in flow, `runRegistryLoginWithDriver`, rendered through the setup driver rather than the terminal prompt library. The existing terminal path is untouched and nothing calls the new export yet.

## Background, in plain terms

NanoClaw's setup wizard signs the user in to the NanoClaw account service so it can pull the hardened container image. Sign-in uses the OAuth device flow (RFC 8628): the CLI asks the identity provider for a short user code and a verification URL, shows both to the user, the user approves in a browser, and the CLI polls until a token comes back. Today all of that is drawn with `clack` (the interactive terminal prompt library, imported as `p` in this codebase), which means it only works when a human is sitting at a TTY.

This stack introduces a `SetupDriver`: one interface for every user interaction (select, confirm, text, secret, progress, display, external action). A terminal driver renders it with clack exactly as before; an NDJSON driver renders it as newline-delimited JSON on stdin/stdout so a native macOS app can drive setup with no terminal. This PR is the registry sign-in half of that conversion.

## What this PR proposes

One new exported function in `setup/registry-login.ts`, plus three small helpers and a test suite:

- `runRegistryLoginWithDriver(driver, { force?, api? })` walks the same flow as the terminal `run()`: reuse a stored credential, probe the registry, offer an enrollment code, otherwise run the device flow. Every screen goes through the driver.
- It returns a structured result instead of printing and exiting: `{ kind: 'ready', method: 'device' | 'code' | 'existing' }`, `{ kind: 'skipped', reason: 'declined' }`, or `{ kind: 'failed', reason: 'sign-in-failed' }`.
- `finishDriverLogin` stamps the matching `progress('registry-login', ...)` event on every exit path, so a GUI never sees a step left spinning.
- `maybeAskEmailConsentWithDriver` is the driver twin of the existing email opt-in prompt. It drops the raw error text from the failure warning, so an untrusted service's error string never reaches the machine channel.
- The enrollment code is asked for with a `kind: 'secret'` prompt (`sensitive: true`, max length 4096), and the browser URL and user code are emitted as `sensitive` displays that are explicitly cleared in a `finally` block once the device flow ends.

Everything it plugs into (the injectable report sink, `resolveStoredCredential`, `presentDeviceAuthorization`, `httpsUrl`, and the `AbortSignal` threading) landed in the previous PR in this stack. This PR is purely additive: no existing line changes.

It also adds five lines to `docs/hardened-image.md` recording that `NANOCLAW_REGISTRY_API` is a trust boundary, not just a routing override: a self-hosted account service declares the HTTPS identity-provider endpoints used for browser sign-in, and the setup driver rejects any non-HTTPS sign-in URL.

## What trips people up

- **Failure policy differs from the terminal path, on purpose.** Where terminal `run()` throws a `LoginError` (for example when the address is not a NanoClaw registry), the driver path catches it and returns `{ kind: 'failed' }`. Only `DriverCancelled` and `DriverTerminalError` are rethrown, and an aborted signal is re-raised as cancellation. A GUI gets a result, not a stack trace.
- **The driver path does not read the environment presets.** `NANOCLAW_REGISTRY_TOKEN` and `NANOCLAW_REGISTRY_ENROLL_CODE`, and the `--require-verified` behaviour, are handled only inside terminal `run()`. On the driver path a stored-but-unverifiable credential is accepted as `ready`. That is the intended shape for an interactive GUI, but it is a real difference and worth an explicit nod.
- **Nothing calls this yet.** The export is dormant at this commit. PR 31 in this stack wires it into `setup/auto.ts`, and PR 39's parity test asserts there is exactly one call to it there. Please do not delete it as unused.
- **Two tests are timing sensitive**, a 9 second `slow_down` case and two abort races that poll with a `waitUntil` helper.

## What to review

- The exit accounting in `runRegistryLoginWithDriver`: every `return` goes through `finishDriverLogin`, and the `finally` block clears both sensitive displays whenever the device screen was shown.
- The catch block's rethrow list, which is what decides cancellation versus failure.
- `httpsUrl` rejecting a plain-HTTP verification URL. It landed in the previous PR but is first exercised here, and the doc claim added in this PR depends on it. The `fails closed for a %s` table covers it alongside declined, expired, malformed device response and malformed token response.
- The 498 line suite drives the real code against a `node:http` fixture registry with a fake driver harness: 9 `it` blocks, one of them a 5 case table. It asserts owner-only credential file permissions, that no credential is written on any failure or abort, and that the browser action gets the code-free verification page while the code-bearing URL stays in the sensitive display.

Proposed gate for this PR: `tsc -p tsconfig.setupcheck.json` with no new errors against the baseline, and `pnpm exec vitest run setup/registry-login.driver.test.ts setup/registry-login.test.ts`. Note that the repo's `tsconfig.json` covers only `src/**/*`, so CI does not typecheck `setup/`; the setup-inclusive typecheck is run manually for this stack.

## Behaviour fix carried in this PR

The shell entry point this replaces honoured `NANOCLAW_REGISTRY_TOKEN` and `NANOCLAW_REGISTRY_ENROLL_CODE`. The rewrite read neither, so an unattended install that set either variable stopped at an interactive masked enrollment-code prompt. Both preset routes are restored ahead of any prompt, and neither asks for consent: there is nobody to ask, and a default of "yes" would not be consent.

Two tests in `setup/registry-login.driver.test.ts` cover both variables and assert no prompt is issued.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This adds a new setup-driver entry point under `setup/`, which is neither a skill, a bug fix, a simplification, nor a docs-only change (it touches `docs/hardened-image.md`, but as one part of a code change).

## Description

Proposes `runRegistryLoginWithDriver`, a driver-rendered entry point into the existing registry device-flow sign-in, returning a structured ready/skipped/failed result and failing closed on non-cancellation errors. Terminal behaviour is unchanged and the export has no caller until a later PR in this stack. Adds a 498 line suite that drives it against a local HTTP fixture registry, and documents `NANOCLAW_REGISTRY_API` as a trust boundary.

## For Skills

Not a skill, so this checklist does not apply.