### PR TITLE
fix(setup): pass skill prompt values as argv, not shell text

### DIFF
--- a/.claude/skills/add-imessage/apply-fixtures.json
+++ b/.claude/skills/add-imessage/apply-fixtures.json
@@ -8,7 +8,10 @@
         "owner_handle": "owner@example.com"
       },
       "exec": [
-        { "match": "echo \"owner@example.com\"", "stdout": "owner@example.com" }
+        {
+          "match": "echo owner@example.com",
+          "stdout": "owner@example.com"
+        }
       ]
     },
     {
@@ -18,7 +21,10 @@
         "owner_handle": "+15551234567"
       },
       "exec": [
-        { "match": "echo \"+15551234567\"", "stdout": "+15551234567" }
+        {
+          "match": "echo +15551234567",
+          "stdout": "+15551234567"
+        }
       ]
     }
   ]

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -53,7 +53,15 @@ const headless =
     vals[name];
 const recordingExec = () => {
   const cmds: string[] = [];
-  return { cmds, exec: (c: string) => void cmds.push(c) };
+  const calls: Array<{ command: string; args: string[] }> = [];
+  return {
+    cmds,
+    calls,
+    exec: (command: string, args: string[] = []) => {
+      cmds.push(command);
+      calls.push({ command, args });
+    },
+  };
 };
 
 beforeEach(() => {
@@ -409,14 +417,16 @@ describe('nc:run variable substitution', () => {
   });
 
   it('interpolates a prompted {{var}} into run commands; var-free runs pass through unchanged', async () => {
-    const { cmds, exec } = recordingExec();
+    const { cmds, calls, exec } = recordingExec();
     await applySkill(rskill, rroot, { resolveInput: headless({ owner_email: 'you@example.com' }), exec });
-    expect(cmds).toContain(
-      'ncl messaging-groups create --channel-type resend --platform-id resend:you@example.com --is-group 0',
-    );
-    expect(cmds).toContain(
-      'ncl messaging-groups send --channel-type resend --platform-id resend:you@example.com --text "hello"',
-    );
+    expect(calls).toContainEqual({
+      command: 'ncl messaging-groups create --channel-type resend --platform-id resend:"${1}" --is-group 0',
+      args: ['you@example.com'],
+    });
+    expect(calls).toContainEqual({
+      command: 'ncl messaging-groups send --channel-type resend --platform-id resend:"${1}" --text "hello"',
+      args: ['you@example.com'],
+    });
     expect(cmds).toContain('pnpm run build');
   });
 
@@ -471,15 +481,18 @@ describe('nc:run capture', () => {
   });
 
   it('binds a command stdout (trimmed) into {{var}} and substitutes it downstream', async () => {
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     // exec returns stdout for the resolve command (simulating `… | jq -r .channel.id`).
-    const exec = (c: string): string | void => {
-      cmds.push(c);
-      if (c.startsWith('resolve-dm')) return 'D0SLACK123\n';
+    const exec = (command: string, args: string[] = []): string | void => {
+      calls.push({ command, args });
+      if (command.startsWith('resolve-dm')) return 'D0SLACK123\n';
     };
     await applySkill(cskill, croot, { resolveInput: headless({ user_id: 'U999' }), exec });
-    expect(cmds).toContain('resolve-dm U999'); // resolved with the prompted id
-    expect(cmds).toContain('ncl messaging-groups create --channel-type slack --platform-id slack:D0SLACK123'); // captured value flowed downstream
+    expect(calls).toContainEqual({ command: 'resolve-dm "${1}"', args: ['U999'] });
+    expect(calls).toContainEqual({
+      command: 'ncl messaging-groups create --channel-type slack --platform-id slack:"${1}"',
+      args: ['D0SLACK123'],
+    });
   });
 
   it('lint accepts {{dm_channel}} as defined by the earlier capture', () => {
@@ -656,17 +669,20 @@ describe('programmatic apply via inputs', () => {
 
   it('runs the whole skill from inputs alone — no resolver, nothing deferred or bounced', async () => {
     writeFileSync(join(pskill, 'SKILL.md'), PROGRAMMATIC_SKILL);
-    const cmds: string[] = [];
-    const exec = (c: string): string | void => {
-      cmds.push(c);
-      if (c.startsWith('resolve-thing')) return 'T-42\n';
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const exec = (command: string, args: string[] = []): string | void => {
+      calls.push({ command, args });
+      if (command.startsWith('resolve-thing')) return 'T-42\n';
     };
     const res = await applySkill(pskill, proot, { inputs: { owner: 'ada' }, exec });
     expect(fullyApplied(res)).toBe(true);
     expect(res.deferred).toEqual([]);
     expect(res.agentTasks).toEqual([]);
-    expect(cmds).toContain('resolve-thing ada'); // prompt input flowed through
-    expect(cmds).toContain('ncl wire --owner ada --thing T-42'); // captured value flowed through
+    expect(calls).toContainEqual({ command: 'resolve-thing "${1}"', args: ['ada'] });
+    expect(calls).toContainEqual({
+      command: 'ncl wire --owner "${1}" --thing "${2}"',
+      args: ['ada', 'T-42'],
+    });
     expect(res.operatorMessages).toEqual(['Go create the thing, ada.']); // human step collected for relay
   });
 

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -75,6 +75,9 @@ export interface StepOutcome {
   fields: Record<string, string>;
 }
 
+export type SkillExec = (command: string, args?: string[]) => string | void | Promise<string | void>;
+export type SkillExecStream = (command: string, args?: string[]) => Promise<StepOutcome>;
+
 export type StepStatus = 'skip' | 'apply' | 'needs-input' | 'agent';
 export interface PlanStep {
   n: number;
@@ -294,7 +297,7 @@ export interface ApplyOptions {
   onEvent?: (e: ApplyEvent) => void | Promise<void>;
   // dep/run/branch-fetch; injectable for tests. Returns the command's stdout so
   // a `run capture:<var>` can bind it into a {{var}} (the twin of `prompt`).
-  exec?: (cmd: string) => string | void | Promise<string | void>;
+  exec?: SkillExec;
   // Override dependency commands when the declared package manager is not
   // directly available on the host (for example, run the container's pinned
   // Bun through pnpm dlx during a refresh).
@@ -304,7 +307,7 @@ export interface ApplyOptions {
   // `=== NANOCLAW SETUP: … ===` status blocks, renders them to the operator live,
   // and resolves with the terminal block's fields (bound via capture:<var>=<FIELD>).
   // Absent ⇒ a step directive degrades to an agent (runs the step from the prose).
-  execStream?: (cmd: string) => Promise<StepOutcome>;
+  execStream?: SkillExecStream;
   // Run effects the CALLER owns and will perform itself — those runs are skipped
   // (not executed). e.g. a headless rebuild or a setup that restarts once at the
   // end passes ['restart']; applyProviderSkill passes ['build','test'].
@@ -570,6 +573,50 @@ function substitute(value: string, vars: Map<string, { value: string; secret: bo
   });
 }
 
+/**
+ * Bind prompt values as positional arguments to NanoClaw-authored shell text.
+ * Values never enter the script string. Existing skills place placeholders
+ * bare and inside both quote kinds, so the generated parameter reference must
+ * preserve the authored quote context.
+ */
+function bindShell(
+  value: string,
+  vars: Map<string, { value: string; secret: boolean }>,
+): { command: string; args: string[] } {
+  const args: string[] = [];
+  const command = value.replace(VAR_REF, (_match, name: string, offset: number) => {
+    const variable = vars.get(name);
+    if (!variable) throw new Error(`unresolved {{${name}}}`);
+    args.push(variable.value);
+    const ref = `\${${args.length}}`;
+    const quote = shellQuoteAt(value, offset);
+    if (quote === 'single') return `'"${ref}"'`;
+    if (quote === 'double') return ref;
+    return `"${ref}"`;
+  });
+  return { command, args };
+}
+
+function shellQuoteAt(source: string, end: number): 'none' | 'single' | 'double' {
+  let quote: 'none' | 'single' | 'double' = 'none';
+  for (let i = 0; i < end; i += 1) {
+    const char = source[i];
+    if (quote === 'single') {
+      if (char === "'") quote = 'none';
+    } else if (quote === 'double') {
+      if (char === '\\') i += 1;
+      else if (char === '"') quote = 'none';
+    } else if (char === '\\') {
+      i += 1;
+    } else if (char === "'") {
+      quote = 'single';
+    } else if (char === '"') {
+      quote = 'double';
+    }
+  }
+  return quote;
+}
+
 // A `when:<var>=<value>` guard: the directive applies only when an earlier
 // prompt/capture bound <var> to exactly <value>. Unmet — including the var still
 // unresolved (a deferred prompt) — skips the directive, so a guarded prompt is
@@ -635,8 +682,8 @@ async function applyOne(
   ctx: {
     root: string;
     skillDir: string;
-    exec: (c: string) => string | void | Promise<string | void>;
-    execStream?: (c: string) => Promise<StepOutcome>;
+    exec: SkillExec;
+    execStream?: SkillExecStream;
     resolveRemote: (b: string) => string;
     resolveDependencyCommand?: (request: DependencyCommandRequest) => string;
     vars: Map<string, { value: string; secret: boolean }>;
@@ -730,7 +777,10 @@ async function applyOne(
       // (a restart, a pairing/QR step, a wire) that follow — a broken local
       // config or an un-registered app never reaches a doomed restart/QR.
       if (d.attrs.effect === 'check') {
-        for (const cmd of d.body) await exec(substitute(cmd, vars));
+        for (const cmd of d.body) {
+          const bound = bindShell(cmd, vars);
+          await exec(bound.command, bound.args);
+        }
         break;
       }
       // effect:step runs a long-running, operator-interactive step (a pairing
@@ -741,7 +791,8 @@ async function applyOne(
       if (d.attrs.effect === 'step') {
         if (!ctx.execStream)
           throw new Error('effect:step needs a streaming exec — an agent runs the step from the prose');
-        const { ok, fields } = await ctx.execStream(substitute(d.body.join('\n'), vars));
+        const bound = bindShell(d.body.join('\n'), vars);
+        const { ok, fields } = await ctx.execStream(bound.command, bound.args);
         if (!ok) throw new Error('the step did not complete');
         if (capture) {
           for (const pair of capture.split(',')) {
@@ -757,11 +808,11 @@ async function applyOne(
         break;
       }
       for (const cmd of d.body) {
-        // Interpolate prompted {{vars}} the same way env-set does, so a run can
-        // call `ncl ... {{owner_email}}` to wire from collected input. A command
-        // with no {{...}} (build/test) is returned unchanged; an unresolved var
-        // throws → caught → deferred (the prompt hasn't been answered yet).
-        const out = await exec(substitute(cmd, vars));
+        // Bind prompted {{vars}} as positional arguments, so a run can call
+        // `ncl ... {{owner_email}}` without caller data becoming shell text.
+        // An unresolved var throws → caught → deferred.
+        const bound = bindShell(cmd, vars);
+        const out = await exec(bound.command, bound.args);
         // Last command wins for capture (a capture run should be a single command).
         // bindCapture binds stdout-as-is OR a multi-field JSON spec, and enforces
         // validate:<re> — a mismatch / unparseable JSON throws → bounced to an agent.

--- a/scripts/skill-conformance.test.ts
+++ b/scripts/skill-conformance.test.ts
@@ -42,6 +42,7 @@ import {
   type Directive,
 } from './skill-directives.js';
 
+import { renderedCommand } from '../setup/lib/fixtures/rendered-command.js';
 const ROOT = process.cwd();
 const SKILLS_DIR = join(ROOT, '.claude/skills');
 const CHAT_VERSION = resolveChatCoreVersion(ROOT);
@@ -141,7 +142,8 @@ async function runScenario(skillDir: string, sc: Scenario): Promise<RunOutcome> 
     // resolveRemote MUST be injected: the default shells out to real
     // `git remote` + `git ls-remote` — network in CI, nondeterministic on forks.
     resolveRemote: () => 'origin',
-    exec: (c) => {
+    exec: (command, args) => {
+      const c = renderedCommand(command, args);
       cmds.push(c);
       return sc.exec?.find((e) => c.includes(e.match))?.stdout;
     },
@@ -339,7 +341,8 @@ describe.each(SKILLS)('%s', (name) => {
           current = byLine.get(e.line);
           if (sabotagedLine >= 0 && isSideEffectRun(current)) sideEffectStartsAfterSabotage.push(e.line);
         },
-        exec: (c) => {
+        exec: (command, args) => {
+          const c = renderedCommand(command, args);
           if (
             sabotagedLine < 0 &&
             current?.kind === 'run' &&

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -23,6 +23,9 @@ vi.mock('../lib/bright-select.js', async (importActual) => {
 
 afterEach(() => delete process.env.NANOCLAW_TEMPLATE_AGENT_ID);
 
+const renderedCommand = (command: string, args: string[] = []): string =>
+  command.replace(/\$\{(\d+)\}/g, (_match, index: string) => args[Number(index) - 1] ?? '');
+
 // Drives the real add-slack skill through the adapter with every side effect
 // injected (no real ncl/git/clack/init-first-agent): confirms it runs the skill
 // (install + creds + resolve), reads the resolved owner_handle + platform_id from
@@ -37,7 +40,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
 
     const cmds: string[] = [];
-    const exec = (c: string): string | void => {
+    const exec = (command: string, args: string[] = []): string | void => {
+      const c = renderedCommand(command, args);
       cmds.push(c);
       if (c.includes('auth.test')) return '@bot in Acme\n'; // identity capture
       // the resolve run: conversations.open piped through jq → "slack:<channel>"
@@ -109,7 +113,8 @@ describe('runChannelSkill adapter (Option A)', () => {
 
     await runChannelSkill('teams', 'Acme Corp', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'yes'; // the have_creds probe
       },
@@ -206,7 +211,8 @@ describe('runChannelSkill adapter (Option A)', () => {
 
     const res = await runSkill('.claude/skills/add-teams', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'no'; // the have_creds probe: nothing configured yet
         if (c.includes(' app create ')) {
@@ -268,7 +274,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     expect(
       log.some(
         (c) =>
-          c.includes(' app update tapp-123') &&
+          c.includes(' app update ') &&
+          c.includes('tapp-123') &&
           c.includes('--color-icon setup/assets/teams/color.png') &&
           c.includes('--outline-icon setup/assets/teams/outline.png'),
       ),
@@ -319,7 +326,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     const log: string[] = [];
     const res = await runSkill('.claude/skills/add-teams', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'no';
         if (c.includes(' app create ')) {
@@ -378,7 +386,8 @@ describe('runChannelSkill adapter (Option A)', () => {
     const log: string[] = [];
     const res = await runSkill('.claude/skills/add-teams', {
       projectRoot: root,
-      exec: (c) => {
+      exec: (command, args) => {
+        const c = renderedCommand(command, args);
         log.push(`exec:${c}`);
         if (c.includes('TEAMS_APP_ID=.')) return 'no'; // probe first — it also contains "echo yes"
         if (c.trim() === 'echo yes') return 'yes'; // the logged-in-account rebind

--- a/setup/channels/telegram-flow.test.ts
+++ b/setup/channels/telegram-flow.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it } from 'vitest';
 import { applySkill, fullyApplied, type ApplyResult } from '../../scripts/skill-apply.js';
 import { parseDirectives } from '../../scripts/skill-directives.js';
 
+import { renderedCommand } from '../lib/fixtures/rendered-command.js';
 const SKILL_DIR = path.join(process.cwd(), '.claude/skills/add-telegram');
 const OLD_TOKEN = '123456789:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const NEW_TOKEN = '987654321:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
@@ -62,13 +63,15 @@ async function run(
   const envValues: string[] = [];
   const res = await applySkill(SKILL_DIR, root, {
     inputs,
-    exec: (cmd) => {
+    exec: (command, args = []) => {
+      const cmd = renderedCommand(command, args);
       execs.push(cmd);
       if (/^(git|pnpm|bash)\b/.test(cmd)) return '';
       if (cmd.startsWith('curl')) return getMe(cmd);
-      return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
+      return execFileSync('bash', ['-c', command, 'nanoclaw-skill', ...args], { cwd: root, encoding: 'utf-8' });
     },
-    execStream: async (cmd) => {
+    execStream: async (command, args = []) => {
+      const cmd = renderedCommand(command, args);
       steps.push(cmd);
       // set-env itself is trunk code (setup/set-env.ts); only its value
       // pipeline is the skill's own, so that is what runs here.

--- a/setup/channels/telegram-pre-step.test.ts
+++ b/setup/channels/telegram-pre-step.test.ts
@@ -53,6 +53,7 @@ import { getChannelPreStep } from './companions.js';
 import { runChannelSkillWithPreStep } from './run-channel-skill.js';
 import { registerTelegramPreStep } from './telegram-pre-step.js';
 
+import { renderedCommand } from '../lib/fixtures/rendered-command.js';
 const originalCwd = process.cwd();
 const roots: string[] = [];
 
@@ -165,13 +166,15 @@ async function runTelegramWizard(root: string) {
   const wired: Array<{ instance?: string }> = [];
   await runChannelSkillWithPreStep('telegram', 'Bob Smith', {
     projectRoot: root,
-    exec: (cmd: string): string => {
+    exec: (command: string, args: string[] = []): string => {
+      const cmd = renderedCommand(command, args);
       execs.push(cmd);
       if (/^(git|pnpm|bash)\b/.test(cmd)) return '';
       if (cmd.startsWith('curl')) return cmd.includes(NEW_TOKEN) ? 'mega_bot' : 'nanoclaw_bot';
-      return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
+      return execFileSync('bash', ['-c', command, 'nanoclaw-skill', ...args], { cwd: root, encoding: 'utf-8' });
     },
-    execStream: async (cmd) => {
+    execStream: async (command, args = []) => {
+      const cmd = renderedCommand(command, args);
       steps.push(cmd);
       return { ok: true, fields: { PLATFORM_ID: 'telegram:555', ADMIN_USER_ID: '555' } };
     },

--- a/setup/channels/whatsapp-flow.test.ts
+++ b/setup/channels/whatsapp-flow.test.ts
@@ -37,10 +37,11 @@ async function run(inputs: Record<string, string>): Promise<Recorded> {
   const seq: Recorded['seq'] = [];
   const res = await applySkill(SKILL_DIR, root, {
     inputs,
-    exec: (cmd: string) => {
-      seq.push({ type: 'exec', text: cmd });
+    exec: (cmd: string, args: string[] = []) => {
+      const rendered = cmd.replace(/\$\{(\d+)\}/g, (_match, index: string) => args[Number(index) - 1] ?? '');
+      seq.push({ type: 'exec', text: rendered });
       if (/^(git|pnpm|bash)\b/.test(cmd) || cmd.startsWith('grep') || cmd.startsWith('touch')) return '';
-      return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
+      return execFileSync('bash', ['-c', cmd, 'nanoclaw-skill', ...args], { cwd: root, encoding: 'utf-8' });
     },
     execStream: async () => ({ ok: true, fields: { PHONE: BOT_PHONE } }),
     resolveRemote: () => 'origin',

--- a/setup/channels/wizard-hooks.test.ts
+++ b/setup/channels/wizard-hooks.test.ts
@@ -82,9 +82,12 @@ function scratchRoot(prefix: string): string {
   return root;
 }
 
-/** Exec fixture: records commands, answers the channel skill's resolve runs. */
+/** Exec fixture: records rendered commands, answers the channel skill's resolve runs. */
 function makeExec(channel: string, cmds: string[], failOn?: string) {
-  return (c: string): string | void => {
+  return (command: string, args: string[] = []): string | void => {
+    // The skill engine hands bound values separately from the command template,
+    // as double-quoted positional parameters; render them the way a shell would.
+    const c = command.replace(/"?\$\{(\d+)\}"?/g, (_match, index: string) => args[Number(index) - 1] ?? '');
     cmds.push(c);
     if (failOn && c.includes(failOn)) throw new Error(`boom: ${failOn}`);
     if (c.startsWith(`${channel}-resolve-owner`)) return 'U777\n';
@@ -261,7 +264,9 @@ describe('companion skills', () => {
     // and appended barrel imports before failing, and restarting could boot
     // that half-applied state. The operator is told to repair, then restart.
     expect(cmds.filter((c) => c === 'bash setup/lib/restart.sh')).toHaveLength(0);
-    const held = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('Skipping the deferred service restart'));
+    const held = warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('Skipping the deferred service restart'));
     expect(held).toHaveLength(1);
   });
 

--- a/setup/lib/fixtures/rendered-command.ts
+++ b/setup/lib/fixtures/rendered-command.ts
@@ -1,0 +1,22 @@
+/**
+ * Test helper: reconstruct what the shell actually sees, the inverse of
+ * skill-apply's `bindShell`.
+ *
+ * `hostExec` runs `bash -c <command> nanoclaw-skill <args…>`, so a bound prompt
+ * value reaches the shell as a positional parameter (`${1}`) instead of being
+ * pasted into the command text — that is what keeps secrets out of the command
+ * string. `bindShell` wraps each reference in the quote context the skill
+ * author wrote, and bash strips those quotes before the command runs, so a
+ * fixture comparing against command text wants the same joined form.
+ *
+ * Only a MATCHED pair is removed. A `${1}` already inside a double-quoted
+ * string owns no quotes of its own, and eating a neighbour's would corrupt the
+ * command.
+ */
+export function renderedCommand(command: string, args: readonly string[] = []): string {
+  return command.replace(
+    /'"\$\{(\d+)\}"'|"\$\{(\d+)\}"|\$\{(\d+)\}/g,
+    (_match, singleQuoted?: string, doubleQuoted?: string, bare?: string) =>
+      args[Number(singleQuoted ?? doubleQuoted ?? bare) - 1] ?? '',
+  );
+}

--- a/setup/lib/fixtures/setup-driver-tty.ts
+++ b/setup/lib/fixtures/setup-driver-tty.ts
@@ -1,0 +1,16 @@
+import { hostExecStream } from '../skill-driver.js';
+import { DriverTerminalError, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  const result = await hostExecStream(
+    process.cwd(),
+    driver,
+  )('"$(npm prefix -g 2>/dev/null)/bin/teams" login && echo \'"loggedIn": true\'');
+  if (!result.ok) driver.error('tty_action_failed', 'The terminal-owned action did not satisfy its postcondition.');
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (!(error instanceof DriverTerminalError)) throw error;
+  process.exitCode = error.exitCode;
+}

--- a/setup/lib/setup-driver.test.ts
+++ b/setup/lib/setup-driver.test.ts
@@ -9,6 +9,7 @@ const ROOT = process.cwd();
 const TSX_LOADER = import.meta.resolve('tsx');
 const HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child.ts');
 const CONTINUATION_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-continuation.ts');
+const TTY_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-tty.ts');
 const CANCEL_RACE_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-cancel-race.ts');
 const CHILD_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child-cancel.ts');
 const WINDOWED_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-windowed-cancel.ts');
@@ -196,6 +197,86 @@ describe('NDJSON setup driver child boundary', () => {
     expect(code).toBe(0);
     expect(events.some((event) => event.type === 'inputRejected' && event.code === 'command_too_large')).toBe(true);
     expect(events.at(-1)?.type).toBe('complete');
+  }, 15_000);
+
+  it('renders a TTY-owning device login through machine semantics', async () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-tty-'));
+    const prefix = path.join(temp, 'global');
+    const fakeBin = path.join(temp, 'bin');
+    const calls = path.join(temp, 'teams.calls');
+    fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'npm'), '#!/bin/sh\nprintf \'%s\\n\' "$TEST_TEAMS_PREFIX"\n', { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(prefix, 'bin', 'teams'),
+      '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$TEST_TEAMS_CALLS"\nprintf \'Open https://microsoft.com/devicelogin\\nEnter code ABCD-EFGH\\n=== NANOCLAW SETUP: TEAMS-LOGIN ===\\nSTATUS: success\\n=== END ===\\n\'\n',
+      { mode: 0o755 },
+    );
+    try {
+      const child = spawn(process.execPath, ['--import', TSX_LOADER, TTY_HARNESS], {
+        cwd: temp,
+        env: {
+          ...process.env,
+          NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          TEST_TEAMS_PREFIX: prefix,
+          TEST_TEAMS_CALLS: calls,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const events: Array<Record<string, unknown>> = [];
+      let stdout = '';
+      let stderr = '';
+      let buffer = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf8');
+        stdout += text;
+        buffer += text;
+        let newline: number;
+        while ((newline = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (!line) continue;
+          const event = JSON.parse(line) as Record<string, unknown>;
+          events.push(event);
+          if (event.type === 'externalAction') {
+            const action = event.action as { id: string };
+            child.stdin.write(
+              `${JSON.stringify({ ...envelope, type: 'externalActionCompleted', actionId: action.id, result: 'attempted' })}\n`,
+            );
+          }
+        }
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', resolve);
+      });
+
+      expect(code, `${stdout}\n${stderr}`).toBe(0);
+      expect(stderr).toBe('');
+      expect(events.filter((event) => event.type === 'hello')).toHaveLength(1);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'externalAction',
+          action: expect.objectContaining({ kind: 'openURL', url: 'https://microsoft.com/devicelogin' }),
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'display',
+          display: expect.objectContaining({ id: 'teams-login-code', content: 'ABCD-EFGH', sensitive: true }),
+        }),
+      );
+      expect(events).toContainEqual(expect.objectContaining({ type: 'clearDisplay', displayId: 'teams-login-url' }));
+      expect(events).toContainEqual(expect.objectContaining({ type: 'clearDisplay', displayId: 'teams-login-code' }));
+      expect(events.at(-1)?.type).toBe('complete');
+      expect(fs.readFileSync(calls, 'utf8')).toContain('login');
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
   }, 15_000);
 
   it('keeps cancelled terminal when an in-flight postcondition finishes later', async () => {

--- a/setup/lib/skill-driver.test.ts
+++ b/setup/lib/skill-driver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as p from '@clack/prompts';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -17,6 +17,8 @@ import {
   type RunSkillOptions,
 } from './skill-driver.js';
 import { fullyApplied, type ApplyEvent, type ApplyResult } from '../../scripts/skill-apply.js';
+import { clearSensitiveValuesForTest, registerSensitiveValue } from './redaction.js';
+import type { SetupDriver } from './setup-driver.js';
 
 // Shared test state for the clack + claude-handoff mocks (hoisted so the vi.mock
 // factories — which run before imports — can close over it). `answers` is the
@@ -86,7 +88,7 @@ describe('thin skill driver', () => {
     const { root, skill } = scratch();
     const asked: Array<{ name: string; secret: boolean }> = [];
     const told: string[] = [];
-    const ran: string[] = [];
+    const ran: Array<{ command: string; args: string[] }> = [];
     const opts: RunSkillOptions = {
       projectRoot: root,
       resolveInput: async (name, meta) => {
@@ -97,26 +99,26 @@ describe('thin skill driver', () => {
       onEvent: (e: ApplyEvent) => {
         if (e.type === 'operator') told.push(e.text);
       },
-      exec: (c) => void ran.push(c),
+      exec: (command, args = []) => void ran.push({ command, args }),
     };
     const res = await runSkill(skill, opts);
 
     expect(asked).toEqual([{ name: 'token', secret: true }]); // the prompt was driven through resolveInput, meta intact
     expect(told).toEqual(['Go create the app and copy the token.']); // operator relayed through the event
-    expect(ran).toContain('ncl wire --token T0KEN'); // wiring executed with the answer substituted in
+    expect(ran).toContainEqual({ command: 'ncl wire --token "${1}"', args: ['T0KEN'] });
     expect(res.operatorMessages).toEqual(['Go create the app and copy the token.']);
   });
 
   it('runs fully from inputs — resolveInput never touched', async () => {
     const { root, skill } = scratch();
-    const ran: string[] = [];
+    const ran: Array<{ command: string; args: string[] }> = [];
     const res = await runSkill(skill, {
       projectRoot: root,
       inputs: { token: 'FROM-INPUTS' },
-      exec: (c) => void ran.push(c),
+      exec: (command, args = []) => void ran.push({ command, args }),
     });
     expect(fullyApplied(res)).toBe(true);
-    expect(ran).toContain('ncl wire --token FROM-INPUTS');
+    expect(ran).toContainEqual({ command: 'ncl wire --token "${1}"', args: ['FROM-INPUTS'] });
   });
 
   it('emits step events through an injected onEvent — the wire run under its heading', async () => {
@@ -169,6 +171,206 @@ describe('thin skill driver', () => {
     expect(log).toContain('dying-gasp'); // the failing command's output survives too
   });
 
+  it('leaves terminal command logs unchanged by protocol redaction', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-secret-'));
+    const rawLog = join(root, 'raw.log');
+    const secret = 'token-value';
+    registerSensitiveValue(secret);
+    try {
+      const out = await hostExec(root, rawLog)(`printf '%s' 'prefix ${secret} suffix'`);
+      expect(out).toBe(`prefix ${secret} suffix`);
+      expect(readFileSync(rawLog, 'utf8')).toContain(secret);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain('[REDACTED]');
+    } finally {
+      clearSensitiveValuesForTest();
+    }
+  });
+
+  it('keeps machine-mode captured output in memory and out of raw logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-capture-'));
+    const rawLog = join(root, 'raw.log');
+    const previous = process.env.NANOCLAW_PROTOCOL;
+    process.env.NANOCLAW_PROTOCOL = 'nanoclaw.driver.v1';
+    try {
+      const out = await hostExec(root, rawLog)("printf 'minted-credenti%s' al");
+      expect(out).toBe('minted-credential');
+      expect(readFileSync(rawLog, 'utf8')).not.toContain('minted-credential');
+    } finally {
+      if (previous === undefined) delete process.env.NANOCLAW_PROTOCOL;
+      else process.env.NANOCLAW_PROTOCOL = previous;
+    }
+  });
+
+  it('keeps machine-mode secret runs out of child argv, env, and raw logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-secret-'));
+    const bin = join(root, 'bin');
+    const probe = join(root, 'probe.json');
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, 'onecli'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const file = args[args.indexOf('--file') + 1];
+fs.writeFileSync(${JSON.stringify(probe)}, JSON.stringify({ args, env: process.env, file, value: fs.readFileSync(file, 'utf8') }));
+`,
+    );
+    chmodSync(join(bin, 'onecli'), 0o755);
+    const secret = 'machine-secret-value';
+    const rawLog = join(root, 'raw.log');
+    const previous = process.env.DRIVER_SECRET_PROBE;
+    process.env.DRIVER_SECRET_PROBE = secret;
+    try {
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      await hostExec(root, rawLog, driver, new Set([secret]))('onecli secrets create --value "${1}"', [secret]);
+      const observed = JSON.parse(readFileSync(probe, 'utf8')) as {
+        args: string[];
+        env: NodeJS.ProcessEnv;
+        file: string;
+        value: string;
+      };
+      expect(observed.args).toContain('--file');
+      expect(observed.args).not.toContain('--value');
+      expect(observed.args).not.toContain(secret);
+      expect(observed.env.DRIVER_SECRET_PROBE).toBeUndefined();
+      expect(observed.value).toBe(secret);
+      expect(existsSync(observed.file)).toBe(false);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain(secret);
+    } finally {
+      if (previous === undefined) delete process.env.DRIVER_SECRET_PROBE;
+      else process.env.DRIVER_SECRET_PROBE = previous;
+    }
+  });
+
+  it('keeps curl secrets in a private config and out of child argv, env, and raw logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-curl-secret-'));
+    const bin = join(root, 'bin');
+    const probe = join(root, 'curl.json');
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, 'curl'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const file = args[args.indexOf('--config') + 1];
+fs.writeFileSync(${JSON.stringify(probe)}, JSON.stringify({ args, env: process.env, file, config: fs.readFileSync(file, 'utf8') }));
+process.stdout.write('ok');
+`,
+    );
+    chmodSync(join(bin, 'curl'), 0o755);
+    const telegram = 'telegram-machine-secret';
+    const slack = 'slack-machine-secret';
+    const rawLog = join(root, 'raw.log');
+    process.env.DRIVER_TELEGRAM_SECRET = telegram;
+    process.env.DRIVER_SLACK_SECRET = slack;
+    try {
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      await hostExec(
+        root,
+        rawLog,
+        driver,
+        new Set([telegram, slack]),
+      )('curl -sf -X POST https://example.com/channel -H "Authorization: Bot ${1}" --data-urlencode "token=${2}"', [
+        telegram,
+        slack,
+      ]);
+      const observed = JSON.parse(readFileSync(probe, 'utf8')) as {
+        args: string[];
+        env: NodeJS.ProcessEnv;
+        file: string;
+        config: string;
+      };
+      expect(observed.args).toEqual(['--config', observed.file]);
+      expect(JSON.stringify(observed.env)).not.toContain(telegram);
+      expect(JSON.stringify(observed.env)).not.toContain(slack);
+      expect(observed.config).toContain(`Authorization: Bot ${telegram}`);
+      expect(observed.config).toContain(`token=${slack}`);
+      expect(existsSync(observed.file)).toBe(false);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain(telegram);
+      expect(readFileSync(rawLog, 'utf8')).not.toContain(slack);
+    } finally {
+      delete process.env.DRIVER_TELEGRAM_SECRET;
+      delete process.env.DRIVER_SLACK_SECRET;
+    }
+  });
+
+  it('rejects unsupported machine secret interpolation before spawning', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-secret-reject-'));
+    const errors: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      error: (code: string): never => {
+        errors.push(code);
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+    await expect(
+      hostExec(root, undefined, driver, new Set(['machine-secret']))('printf "%s" "${1}"', ['machine-secret']),
+    ).rejects.toThrow('secret_transport_unsupported');
+    expect(errors).toEqual(['secret_transport_unsupported']);
+  });
+
+  it('stops a machine capture when combined child output exceeds its byte limit', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-output-limit-'));
+    const errors: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      error: (code: string): never => {
+        errors.push(code);
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+
+    await expect(
+      hostExec(root, undefined, driver)(`node -e 'process.stdout.write("x".repeat(300000))'`),
+    ).rejects.toThrow('skill_output_limit');
+    expect(errors).toEqual(['skill_output_limit']);
+  });
+
+  it('keeps machine-mode streaming secret runs out of child argv and env', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-stream-secret-'));
+    const bin = join(root, 'bin');
+    const probe = join(root, 'probe.json');
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, 'onecli'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const file = args[args.indexOf('--file') + 1];
+fs.writeFileSync(${JSON.stringify(probe)}, JSON.stringify({ args, env: process.env, file, value: fs.readFileSync(file, 'utf8') }));
+process.stdout.write('=== NANOCLAW SETUP: TEST ===\\nSTATUS: success\\n=== END ===\\n');
+`,
+    );
+    chmodSync(join(bin, 'onecli'), 0o755);
+    const secret = 'machine-stream-secret';
+    const previous = process.env.DRIVER_STREAM_SECRET;
+    process.env.DRIVER_STREAM_SECRET = secret;
+    try {
+      const driver = { mode: 'ndjson' } as SetupDriver;
+      const result = await hostExecStream(
+        root,
+        driver,
+        new Set([secret]),
+      )('onecli secrets create --value "${1}"', [secret]);
+      const observed = JSON.parse(readFileSync(probe, 'utf8')) as {
+        args: string[];
+        env: NodeJS.ProcessEnv;
+        file: string;
+        value: string;
+      };
+      expect(result.ok).toBe(true);
+      expect(observed.args).toContain('--file');
+      expect(observed.args).not.toContain(secret);
+      expect(observed.env.DRIVER_STREAM_SECRET).toBeUndefined();
+      expect(observed.value).toBe(secret);
+      expect(existsSync(observed.file)).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.DRIVER_STREAM_SECRET;
+      else process.env.DRIVER_STREAM_SECRET = previous;
+    }
+  });
+
   it('hostExecStream runs a step and captures the terminal status block fields (for effect:step)', async () => {
     const root = mkdtempSync(join(tmpdir(), 'driver-step-'));
     const out = await hostExecStream(root)(
@@ -176,6 +378,23 @@ describe('thin skill driver', () => {
     );
     expect(out.ok).toBe(true);
     expect(out.fields.PLATFORM_ID).toBe('telegram:42');
+  });
+
+  it('stops a machine streaming step before an unterminated line can grow without bound', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-machine-stream-limit-'));
+    const errors: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      error: (code: string): never => {
+        errors.push(code);
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+
+    await expect(hostExecStream(root, driver)(`node -e 'process.stdout.write("x".repeat(300000))'`)).rejects.toThrow(
+      'skill_output_limit',
+    );
+    expect(errors).toEqual(['skill_output_limit']);
   });
 
   it('hostExecStream children run with LOG_LEVEL=warn — host logger info noise stays off the wizard', async () => {
@@ -208,7 +427,7 @@ describe('thin skill driver', () => {
   it('reuse:true offers an existing .env credential via the confirm seam and skips the prompt when accepted', async () => {
     const { root, skill } = reuseScratch();
     const asked: string[] = [];
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     await runSkill(skill, {
       projectRoot: root,
       reuse: true,
@@ -217,16 +436,39 @@ describe('thin skill driver', () => {
         asked.push(n);
         return 'NEWLY-PASTED';
       },
-      exec: (c) => void cmds.push(c),
+      exec: (command, args = []) => void calls.push({ command, args }),
     });
     expect(asked).not.toContain('bot_token'); // reused from .env → never prompted
-    expect(cmds).toContain('use xoxb-existing-token'); // the reused value flowed downstream
+    expect(calls).toContainEqual({ command: 'use "${1}"', args: ['xoxb-existing-token'] });
+  });
+
+  it('does not expose credential fragments in a machine reuse prompt', async () => {
+    const { root, skill } = reuseScratch();
+    const prompts: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      prompt: async (spec: { message: string }) => {
+        prompts.push(spec.message);
+        return true;
+      },
+    } as unknown as SetupDriver;
+
+    await runSkill(skill, {
+      projectRoot: root,
+      reuse: true,
+      driver,
+      exec: () => {},
+    });
+
+    expect(prompts).toContain('Found an existing SLACK_BOT_TOKEN. Use it?');
+    expect(prompts.join('\n')).not.toContain('xoxb-e');
+    expect(prompts.join('\n')).not.toContain('oken');
   });
 
   it('reuse: declining keeps the prompt', async () => {
     const { root, skill } = reuseScratch();
     const asked: string[] = [];
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     await runSkill(skill, {
       projectRoot: root,
       reuse: true,
@@ -235,10 +477,10 @@ describe('thin skill driver', () => {
         asked.push(n);
         return 'NEWLY-PASTED';
       },
-      exec: (c) => void cmds.push(c),
+      exec: (command, args = []) => void calls.push({ command, args }),
     });
     expect(asked).toContain('bot_token'); // declined → prompted
-    expect(cmds).toContain('use NEWLY-PASTED');
+    expect(calls).toContainEqual({ command: 'use "${1}"', args: ['NEWLY-PASTED'] });
   });
 
   // A cred a HELPER SCRIPT owns (written by effect:external, not nc:env-set) has no
@@ -260,7 +502,7 @@ describe('thin skill driver', () => {
   it('reuse: offers an existing .env value for a HELPER-owned cred (no env-set linkage)', async () => {
     const { root, skill } = helperReuseScratch();
     const asked: string[] = [];
-    const cmds: string[] = [];
+    const calls: Array<{ command: string; args: string[] }> = [];
     const confirmed: string[] = [];
     await runSkill(skill, {
       projectRoot: root,
@@ -273,11 +515,14 @@ describe('thin skill driver', () => {
         asked.push(n);
         return 'https://typed.example';
       },
-      exec: (c) => void cmds.push(c),
+      exec: (command, args = []) => void calls.push({ command, args }),
     });
     expect(confirmed.some((m) => /IMESSAGE_SERVER_URL/.test(m))).toBe(true); // the reuse: link surfaced the offer
     expect(asked).not.toContain('server_url'); // accepted → never re-prompted
-    expect(cmds).toContain('bash configure.sh "https://photon.example.com"'); // reused value flowed downstream
+    expect(calls).toContainEqual({
+      command: 'bash configure.sh "${1}"',
+      args: ['https://photon.example.com'],
+    });
   });
 
   // §5.4 pre-filter: a stale .env value that would fail the prompt's declared

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -12,7 +12,7 @@
  * policy module (scripts/skill-policy.ts): the natural-barrier gate confirm,
  * the URL offer, the prose-derived validation message.
  */
-import { execSync, spawn } from 'node:child_process';
+import { execSync, spawn, spawnSync } from 'node:child_process';
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
@@ -26,6 +26,8 @@ import {
   type ApplyEvent,
   type ApplyResult,
   type InputMeta,
+  type SkillExec,
+  type SkillExecStream,
   type StepOutcome,
 } from '../../scripts/skill-apply.js';
 import { parseDirectives, promptVar } from '../../scripts/skill-directives.js';
@@ -35,7 +37,23 @@ import { isHeadless } from '../platform.js';
 import { emitStatus } from '../status.js';
 import { openUrl } from './browser.js';
 import { isHelpEscape, offerClaudeHandoff, validateWithHelpEscape } from './claude-handoff.js';
+import { redactSensitiveValues, registerSensitiveValue } from './redaction.js';
+import { childEnvWithoutSetupSecrets, withSecretFile } from './secret-file.js';
 import { startSpinner } from './runner.js';
+import { DriverCancelled, type SetupDriver } from './setup-driver.js';
+
+const MAX_MACHINE_EFFECT_OUTPUT_BYTES = 256 * 1024;
+
+function machineEffectOutputLimitError(driver?: SetupDriver): Error {
+  const message = 'A setup command exceeded the 256 KiB machine-output limit.';
+  if (!driver) return new Error(message);
+  try {
+    driver.error('skill_output_limit', message);
+  } catch (error) {
+    return error instanceof Error ? error : new Error(message);
+  }
+  return new Error(message);
+}
 
 /**
  * Build the clack `validate` callback an `nc:prompt` carries — the interactive
@@ -192,6 +210,7 @@ async function reuseFromEnv(
   projectRoot: string,
   alreadyHave: Record<string, string>,
   confirm: (message: string) => Promise<boolean>,
+  showMaskedValue = true,
 ): Promise<Record<string, string>> {
   let md: string;
   try {
@@ -243,9 +262,186 @@ async function reuseFromEnv(
     const shape = promptShape.get(v);
     if (shape?.validate && !new RegExp(shape.validate, shape.flags).test(normalizeValue(existing, shape.normalize)))
       continue;
-    if (await confirm(`Found an existing ${key} (${maskValue(existing)}). Use it?`)) reuse[v] = existing;
+    const existingLabel = showMaskedValue ? ` (${maskValue(existing)})` : '';
+    if (await confirm(`Found an existing ${key}${existingLabel}. Use it?`)) reuse[v] = existing;
   }
   return reuse;
+}
+
+class MachineSecretTransportError extends Error {
+  readonly code = 'secret_transport_unsupported';
+
+  constructor() {
+    super('A secret-valued skill command cannot be transported safely in machine mode.');
+  }
+}
+
+function failMachineSecretTransport(driver?: SetupDriver): never {
+  const message = 'This skill needs a secret transport that machine mode does not support.';
+  if (driver && typeof driver.error === 'function') {
+    return driver.error('secret_transport_unsupported', message, [
+      {
+        kind: 'manual',
+        title: 'Complete this step in a terminal',
+        instructions: ['Run this skill from a terminal, then retry setup.'],
+      },
+    ]);
+  }
+  throw new MachineSecretTransportError();
+}
+
+function isOneCliCommand(command: string): boolean {
+  return /^\s*(?:[^\s;&|]+\/)?onecli(?:\s|$)/.test(command);
+}
+
+function replaceOneCliValue(command: string, argIndex: number): string | undefined {
+  if (!isOneCliCommand(command)) return undefined;
+  const ref = `\\$\\{${argIndex + 1}\\}`;
+  const value = new RegExp(`--value(\\s+)("${ref}"|'${ref}'|'"${ref}"'|${ref})`);
+  const match = value.exec(command);
+  if (!match || match.index === undefined) return undefined;
+  return `${command.slice(0, match.index)}--file${match[0].slice('--value'.length)}${command.slice(match.index + match[0].length)}`;
+}
+
+function oneCliValueArgs(command: string): Set<number> {
+  const indexes = new Set<number>();
+  const value = /--value\s+(?:"\$\{(\d+)\}"|'\$\{(\d+)\}'|'"\$\{(\d+)\}"'|\$\{(\d+)\})/g;
+  let match: RegExpExecArray | null;
+  while ((match = value.exec(command)) !== null) {
+    const index = Number(match[1] ?? match[2] ?? match[3] ?? match[4]);
+    if (Number.isSafeInteger(index) && index > 0) indexes.add(index - 1);
+  }
+  return indexes;
+}
+
+function isCurlCommand(command: string): boolean {
+  return /^\s*(?:[^\s;&|]+\/)?curl(?:\s|$)/.test(command);
+}
+
+function curlSecretCommand(command: string, indexes: number[], configPath: string): string | undefined {
+  if (!isCurlCommand(command)) return undefined;
+  let safeCommand = command;
+  const markers = indexes.map((index) => `__NANOCLAW_SECRET_${index}__`);
+  for (const [position, index] of indexes.entries()) {
+    const reference = `\${${index + 1}}`;
+    if (!safeCommand.includes(reference)) return undefined;
+    safeCommand = safeCommand.replaceAll(reference, markers[position]);
+  }
+
+  const resolveSecrets = indexes.flatMap((index, position) => [`nc_secret_${position}=$(<"\${${index + 1}}")`]);
+  const replaceMarkers = markers.map(
+    (marker, position) =>
+      `  case "$value" in *${marker}*) value="\${value%%${marker}*}$nc_secret_${position}\${value#*${marker}}" ;; esac`,
+  );
+  return [
+    `nc_curl_config=${JSON.stringify(configPath)}`,
+    ...resolveSecrets,
+    'nc_curl_resolve() {',
+    '  local value="$1"',
+    ...replaceMarkers,
+    '  printf %s "$value"',
+    '}',
+    'nc_curl_quote() {',
+    '  local value="$1"',
+    '  value="${value//\\\\/\\\\\\\\}"',
+    '  value="${value//\\"/\\\\\\"}"',
+    '  value="${value//$\'\\n\'/\\n}"',
+    '  value="${value//$\'\\r\'/\\r}"',
+    '  printf %s "$value"',
+    '}',
+    'nc_curl_option() {',
+    '  local value',
+    '  value=$(nc_curl_resolve "$2")',
+    '  printf \'%s = "%s"\\n\' "$1" "$(nc_curl_quote "$value")" >> "$nc_curl_config"',
+    '}',
+    'curl() {',
+    '  : > "$nc_curl_config"',
+    '  while [ "$#" -gt 0 ]; do',
+    '    case "$1" in',
+    '      -s) printf \'silent\\n\' >> "$nc_curl_config" ;;',
+    '      -f) printf \'fail\\n\' >> "$nc_curl_config" ;;',
+    '      -S) printf \'show-error\\n\' >> "$nc_curl_config" ;;',
+    '      -L) printf \'location\\n\' >> "$nc_curl_config" ;;',
+    '      -sf|-fs) printf \'silent\\nfail\\n\' >> "$nc_curl_config" ;;',
+    '      -X|--request|-H|--header|-d|--data|--data-raw|--data-binary|--data-urlencode|--url|--connect-timeout|--max-time)',
+    '        case "$1" in',
+    '          -X|--request) nc_curl_name=request ;;',
+    '          -H|--header) nc_curl_name=header ;;',
+    '          -d|--data|--data-raw|--data-binary) nc_curl_name=data ;;',
+    '          --data-urlencode) nc_curl_name=data-urlencode ;;',
+    '          --url) nc_curl_name=url ;;',
+    '          --connect-timeout) nc_curl_name=connect-timeout ;;',
+    '          --max-time) nc_curl_name=max-time ;;',
+    '        esac',
+    '        shift',
+    '        [ "$#" -gt 0 ] || return 64',
+    '        nc_curl_option "$nc_curl_name" "$1"',
+    '        ;;',
+    '      --) shift; while [ "$#" -gt 0 ]; do nc_curl_option url "$1"; shift; done; break ;;',
+    '      -*) return 64 ;;',
+    '      *) nc_curl_option url "$1" ;;',
+    '    esac',
+    '    shift',
+    '  done',
+    '  command curl --config "$nc_curl_config"',
+    '}',
+    safeCommand,
+  ].join('\n');
+}
+
+async function withMachineSecretTransport<T>(
+  command: string,
+  args: string[],
+  secrets: ReadonlySet<string>,
+  driver: SetupDriver | undefined,
+  run: (command: string, args: string[]) => Promise<T>,
+): Promise<T> {
+  const secretArgs = new Set<number>(oneCliValueArgs(command));
+  args.forEach((value, index) => {
+    if (secrets.has(value)) secretArgs.add(index);
+  });
+  if (secretArgs.size === 0) return run(command, args);
+
+  let safeCommand = command;
+  const indexes = [...secretArgs];
+  const onecli = isOneCliCommand(command);
+  if (onecli) {
+    for (const index of indexes) {
+      const replaced = replaceOneCliValue(safeCommand, index);
+      if (replaced === undefined) failMachineSecretTransport(driver);
+      safeCommand = replaced;
+    }
+  } else if (!isCurlCommand(command)) {
+    failMachineSecretTransport(driver);
+  }
+
+  const pass = async (position: number, currentArgs: string[]): Promise<T> => {
+    if (position === indexes.length) {
+      if (onecli) return run(safeCommand, currentArgs);
+      return withSecretFile('', (configPath) => {
+        const wrapped = curlSecretCommand(safeCommand, indexes, configPath);
+        if (wrapped === undefined) failMachineSecretTransport(driver);
+        return run(wrapped, currentArgs);
+      });
+    }
+    const index = indexes[position];
+    const secret = args[index];
+    if (secret === undefined) failMachineSecretTransport(driver);
+    return withSecretFile(secret, (filePath) => {
+      const nextArgs = [...currentArgs];
+      nextArgs[index] = filePath;
+      return pass(position + 1, nextArgs);
+    });
+  };
+  return pass(0, [...args]);
+}
+
+function machineChildEnv(secrets: ReadonlySet<string>): NodeJS.ProcessEnv {
+  const env = childEnvWithoutSetupSecrets();
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined && [...secrets].some((secret) => value.includes(secret))) delete env[key];
+  }
+  return env;
 }
 
 /**
@@ -267,32 +463,76 @@ async function reuseFromEnv(
  * appended there (level 3, like runner.ts's per-step raw logs) so the silenced
  * noise stays inspectable.
  */
-export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) => Promise<string> {
-  const tee = (cmd: string, stdout: string, stderr: string): void => {
+export function hostExec(
+  projectRoot: string,
+  rawLog?: string,
+  driver?: SetupDriver,
+  secrets: ReadonlySet<string> = new Set<string>(),
+): SkillExec {
+  const tee = (cmd: string, stdout: string, stderr: string, machine: boolean): void => {
     if (!rawLog) return;
-    const body = [stdout, stderr].filter(Boolean).join('');
-    appendFileSync(rawLog, `$ ${cmd}\n${body}${body && !body.endsWith('\n') ? '\n' : ''}\n`);
+    // A capture can mint a credential before the engine knows which field is
+    // sensitive. Machine runs keep that output in memory for capture only.
+    const body = machine ? '' : [stdout, stderr].filter(Boolean).join('');
+    const header = machine ? '$ [machine command omitted]' : `$ ${cmd}`;
+    appendFileSync(rawLog, `${header}\n${body}${body && !body.endsWith('\n') ? '\n' : ''}\n`);
   };
-  return (cmd) =>
+  const run = (cmd: string, args: string[]): Promise<string> =>
     new Promise((resolve, reject) => {
-      const child = spawn('bash', ['-c', cmd], {
+      const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+      const baseEnv = machine ? machineChildEnv(secrets) : process.env;
+      const child = spawn('bash', ['-c', cmd, 'nanoclaw-skill', ...args], {
         cwd: projectRoot,
-        env: { ...process.env, PATH: `${join(projectRoot, 'bin')}:${process.env.PATH ?? ''}` },
+        env: { ...baseEnv, PATH: `${join(projectRoot, 'bin')}:${baseEnv.PATH ?? ''}` },
         stdio: ['ignore', 'pipe', 'pipe'],
+        ...(machine ? { detached: true } : {}),
       });
+      const stopGroup = (): void => {
+        if (!machine || !child.pid) return;
+        const processGroupId = child.pid;
+        try {
+          process.kill(-processGroupId, 'SIGTERM');
+        } catch {
+          /* already gone */
+        }
+        setTimeout(() => {
+          try {
+            process.kill(-processGroupId, 'SIGKILL');
+          } catch {
+            /* already gone */
+          }
+        }, 250);
+      };
+      driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+      if (driver?.cancellationSignal?.aborted) stopGroup();
       let out = '';
       let err = '';
-      child.stdout.on('data', (c: Buffer) => {
-        out += c.toString('utf8');
-      });
-      child.stderr.on('data', (c: Buffer) => {
-        err += c.toString('utf8');
-      });
+      let outputBytes = 0;
+      let outputLimitExceeded = false;
+      const capture = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+        if (outputLimitExceeded) return;
+        if (machine) {
+          outputBytes += chunk.byteLength;
+          if (outputBytes > MAX_MACHINE_EFFECT_OUTPUT_BYTES) {
+            outputLimitExceeded = true;
+            stopGroup();
+            return;
+          }
+        }
+        if (stream === 'stdout') out += chunk.toString('utf8');
+        else err += chunk.toString('utf8');
+      };
+      child.stdout.on('data', (chunk: Buffer) => capture(chunk, 'stdout'));
+      child.stderr.on('data', (chunk: Buffer) => capture(chunk, 'stderr'));
       child.on('error', reject);
       child.on('close', (code) => {
-        tee(cmd, out, err);
+        driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+        tee(cmd, out, err, machine);
+        if (driver?.cancellationSignal?.aborted) return reject(new DriverCancelled('cancelled'));
+        if (outputLimitExceeded) return reject(machineEffectOutputLimitError(driver));
         if (code === 0) return resolve(out);
-        const stderr = err.trim();
+        if (machine) return reject(new Error(`exit ${code ?? '?'}: command failed`));
+        const stderr = machine ? redactSensitiveValues(err.trim()) : err.trim();
         const head =
           stderr
             .split('\n')
@@ -301,6 +541,10 @@ export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) =>
         reject(new Error(`exit ${code ?? '?'}: ${head}${stderr ? `\n${stderr}` : ''}`));
       });
     });
+  return (cmd, args = []) => {
+    const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+    return machine ? withMachineSecretTransport(cmd, args, secrets, driver, run) : run(cmd, args);
+  };
 }
 
 /**
@@ -311,14 +555,21 @@ export function hostExec(projectRoot: string, rawLog?: string): (cmd: string) =>
  * fields so the engine can `capture:<var>=<FIELD>` them. The block protocol mirrors
  * setup/lib/runner.ts's StatusStream — a step is just a command that emits blocks.
  */
-export function hostExecStream(projectRoot: string): (cmd: string) => Promise<StepOutcome> {
-  return (cmd) =>
-    new Promise((resolve) => {
-      const child = spawn('bash', ['-c', cmd], {
+export function hostExecStream(
+  projectRoot: string,
+  driver?: SetupDriver,
+  secrets: ReadonlySet<string> = new Set<string>(),
+): SkillExecStream {
+  const run = async (cmd: string, args: string[] = []) => {
+    return new Promise<StepOutcome>((resolve, reject) => {
+      const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+      const teamsLogin = machine && cmd.includes('/bin/teams" login &&');
+      const baseEnv = machine ? machineChildEnv(secrets) : process.env;
+      const child = spawn('bash', ['-c', cmd, 'nanoclaw-skill', ...args], {
         cwd: projectRoot,
         env: {
-          ...process.env,
-          PATH: `${join(projectRoot, 'bin')}:${process.env.PATH ?? ''}`,
+          ...baseEnv,
+          PATH: `${join(projectRoot, 'bin')}:${baseEnv.PATH ?? ''}`,
           // A step renders curated operator UI (a code card, a QR) — the host
           // logger's info noise doesn't belong on the wizard screen, and it
           // always emits ANSI so it can't be filtered by stream. Warnings and
@@ -330,19 +581,87 @@ export function hostExecStream(projectRoot: string): (cmd: string) => Promise<St
           // there — force color so the child's card matches the parent.
           ...(process.stdout.isTTY ? { FORCE_COLOR: '1' } : {}),
         },
-        stdio: ['inherit', 'pipe', 'pipe'],
+        stdio: [machine ? 'ignore' : 'inherit', 'pipe', 'pipe'],
+        ...(machine ? { detached: true } : {}),
       });
-      const blocks: Array<{ fields: Record<string, string> }> = [];
-      let current: { fields: Record<string, string> } | null = null;
+      const stopGroup = (): void => {
+        if (!machine || !child.pid) return;
+        const processGroupId = child.pid;
+        try {
+          process.kill(-processGroupId, 'SIGTERM');
+        } catch {
+          /* already gone */
+        }
+        setTimeout(() => {
+          try {
+            process.kill(-processGroupId, 'SIGKILL');
+          } catch {
+            /* already gone */
+          }
+        }, 250);
+      };
+      driver?.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+      if (driver?.cancellationSignal?.aborted) stopGroup();
+      const blocks: Array<{ type: string; fields: Record<string, string> }> = [];
+      let current: { type: string; fields: Record<string, string> } | null = null;
+      let outputBytes = 0;
+      let outputLimitExceeded = false;
+      const activeDisplayIds = new Set<string>();
+      let teamsAction: Promise<unknown> | undefined;
+      const renderTeamsDeviceLine = (line: string): void => {
+        if (!teamsLogin || !driver) return;
+        const url = line.match(/https:\/\/[^\s]+/)?.[0];
+        if (url && !activeDisplayIds.has('teams-login-url')) {
+          activeDisplayIds.add('teams-login-url');
+          driver.display({
+            id: 'teams-login-url',
+            kind: 'url',
+            url,
+            sensitive: true,
+            label: 'Microsoft device login',
+          });
+          teamsAction = driver
+            .externalAction(
+              { id: 'teams-login-open-url', kind: 'openURL', title: 'Open Microsoft device login', url },
+              () => true,
+            )
+            .catch((error: unknown) => {
+              stopGroup();
+              throw error;
+            });
+        }
+        const code = line.match(/\b[A-Z0-9]{4,}(?:-[A-Z0-9]{4,})+\b/)?.[0];
+        if (code && !activeDisplayIds.has('teams-login-code')) {
+          activeDisplayIds.add('teams-login-code');
+          driver.display({
+            id: 'teams-login-code',
+            kind: 'code',
+            content: code,
+            sensitive: true,
+            label: 'Microsoft device code',
+          });
+        }
+      };
       let buf = '';
       const onChunk = (chunk: Buffer): void => {
+        if (outputLimitExceeded) return;
+        if (machine) {
+          outputBytes += chunk.byteLength;
+          if (outputBytes > MAX_MACHINE_EFFECT_OUTPUT_BYTES) {
+            outputLimitExceeded = true;
+            stopGroup();
+            return;
+          }
+        }
         buf += chunk.toString('utf8');
         let idx: number;
         while ((idx = buf.indexOf('\n')) !== -1) {
           const line = buf.slice(0, idx);
           buf = buf.slice(idx + 1);
-          if (/^=== NANOCLAW SETUP: \S+ ===/.test(line)) {
-            current = { fields: {} };
+          renderTeamsDeviceLine(line);
+          const start = line.match(/^=== NANOCLAW SETUP: (\S+) ===/);
+          if (start) {
+            current = { type: start[1], fields: {} };
             continue;
           }
           if (line.startsWith('=== END ===')) {
@@ -355,17 +674,35 @@ export function hostExecStream(projectRoot: string): (cmd: string) => Promise<St
             if (c > 0) current.fields[line.slice(0, c).trim()] = line.slice(c + 1).trim();
             continue;
           }
-          process.stdout.write(line + '\n'); // operator-facing line (a QR, a code) — show it live
+          if (driver?.mode !== 'ndjson') process.stdout.write(line + '\n');
         }
       };
       child.stdout.on('data', onChunk);
       child.stderr.on('data', onChunk);
-      child.on('close', (code) => {
+      child.on('error', () => {
+        for (const id of activeDisplayIds) driver?.clearDisplay(id);
+        resolve({ ok: false, fields: {} });
+      });
+      child.on('close', async (code) => {
+        driver?.cancellationSignal?.removeEventListener('abort', stopGroup);
+        if (driver?.cancellationSignal?.aborted) return reject(new DriverCancelled('cancelled'));
+        for (const id of activeDisplayIds) driver?.clearDisplay(id);
+        if (outputLimitExceeded) return reject(machineEffectOutputLimitError(driver));
+        try {
+          await teamsAction;
+        } catch (error) {
+          return reject(error);
+        }
         const terminal = [...blocks].reverse().find((b) => b.fields.STATUS) ?? null;
         const status = terminal?.fields.STATUS;
         resolve({ ok: code === 0 && (status === 'success' || status === 'skipped'), fields: terminal?.fields ?? {} });
       });
     });
+  };
+  return (cmd, args = []) => {
+    const machine = driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+    return machine ? withMachineSecretTransport(cmd, args, secrets, driver, run) : run(cmd, args);
+  };
 }
 
 // The barrier-confirm wording per gate flavor (§5.1.5). Decline = proceed: the
@@ -481,6 +818,8 @@ export function channelsRemote(projectRoot: string): () => string {
 }
 
 export interface RunSkillOptions {
+  /** Shared setup presentation; omitted by standalone and test consumers. */
+  driver?: SetupDriver;
   projectRoot?: string;
   /** Pre-supplied prompt answers — pass them all for a fully programmatic run. */
   inputs?: Record<string, string>;
@@ -491,9 +830,9 @@ export interface RunSkillOptions {
    */
   resolveInput?: (name: string, meta: InputMeta) => Promise<string | undefined>;
   /** Defaults to `hostExec`. */
-  exec?: (cmd: string) => string | void | Promise<string | void>;
+  exec?: SkillExec;
   /** Defaults to `hostExecStream`. Streaming exec for `nc:run effect:step`. */
-  execStream?: (cmd: string) => Promise<StepOutcome>;
+  execStream?: SkillExecStream;
   /** Defaults to the fork-aware channels-branch resolver. */
   resolveRemote?: (branch: string) => string;
   /** Run effects the caller owns (e.g. `['restart']` when it restarts once). */
@@ -537,13 +876,39 @@ export interface RunSkillOptions {
  */
 export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Promise<ApplyResult> {
   const projectRoot = opts.projectRoot ?? process.cwd();
-  const confirm = opts.confirm ?? defaultConfirm;
-  const open = opts.openUrl ?? defaultOpenUrl;
+  const confirm =
+    opts.confirm ??
+    (opts.driver
+      ? async (message: string) =>
+          (await opts.driver!.prompt({
+            kind: 'confirm',
+            message,
+            default: true,
+          })) === true
+      : defaultConfirm);
+  const open =
+    opts.openUrl ??
+    (opts.driver?.mode === 'ndjson'
+      ? async (url: string) => {
+          // Browser opens have no NanoClaw-observable postcondition. Keep the
+          // URL in the typed display channel instead of trusting a client's
+          // `attempted` response from an external action.
+          opts.driver!.display({
+            id: `url-${basename(skillDir)}`,
+            kind: 'url',
+            url,
+            label: 'Open this URL',
+            sensitive: false,
+          });
+        }
+      : defaultOpenUrl);
   let inputs = opts.inputs;
   // Offer to reuse credentials already in .env before the engine prompts for them.
   if (opts.reuse) {
-    const reused = await reuseFromEnv(skillDir, projectRoot, inputs ?? {}, confirm);
-    if (Object.keys(reused).length) inputs = { ...inputs, ...reused };
+    const reused = await reuseFromEnv(skillDir, projectRoot, inputs ?? {}, confirm, opts.driver?.mode !== 'ndjson');
+    if (Object.keys(reused).length) {
+      inputs = { ...inputs, ...reused };
+    }
   }
   // The default operator policy derives from the skill document itself
   // (gatePolicy keys on directive lines) — read it once here; the engine reads


### PR DESCRIPTION
## TL;DR

Proposed: values an operator types during a setup skill stop being pasted into the shell command and are passed to `bash -c` as positional arguments instead. This one changes behaviour on the terminal path today, unlike most of the stack. It also adds the machine-mode plumbing that keeps those values out of a child process's argv, environment and logs.

## Background, in plain terms

A "skill" here is a markdown file (`.claude/skills/<name>/SKILL.md`) with directives in it. `nc:prompt` asks the operator a question; `nc:run` (and its `effect:check` / `effect:step` variants) runs shell commands, and a command can reference an answer with `{{owner_handle}}`.

This PR is part of a 39-PR stack that splits one oversized upstream commit. The stack adds a "setup driver": an interface that lets a native macOS app drive setup headlessly over a newline-delimited JSON protocol on stdin/stdout ("ndjson" or "machine" mode). Machine mode is off unless `NANOCLAW_PROTOCOL=nanoclaw.driver.v1` is set, so terminal setup keeps running exactly as before.

## The problem

`substitute()` replaced `{{var}}` with the raw answer inside the command string, and that string was handed to `bash -c`. An answer containing backticks, `$( )` or `;` was shell syntax, not data. A secret answer also ended up in the command text, which is exactly what gets written to logs and shown in process listings.

## How the fix works

- New `bindShell()` in `scripts/skill-apply.ts` replaces each `{{var}}` with a positional reference and returns `{ command, args }`. `hostExec` / `hostExecStream` now spawn `bash -c <command> nanoclaw-skill <args…>`, so the answers arrive as `$1`, `$2`, … and never as text.
- `shellQuoteAt()` preserves the quoting the skill author wrote, so the effective command is unchanged: bare becomes `"${n}"`, inside double quotes becomes `${n}`, inside single quotes becomes `'"${n}"'`.
- `substitute()` survives for the two places that are not shell: writing `env-set` values into `.env`, and prose text.
- Machine mode adds `withMachineSecretTransport`: an `onecli --value ${n}` is rewritten to `--file <temp file>`, and a `curl` command runs through a generated bash function that writes its options into a private `--config` file. Anything else carrying a secret is refused with `secret_transport_unsupported` and the operator is told to finish that step in a terminal.
- Machine children are also bounded: `detached: true` so the whole process group can be signalled, SIGTERM then SIGKILL 250 ms later when the driver cancels, a 256 KiB cap on combined stdout+stderr, stdin ignored, the environment scrubbed of setup secrets, and the level-3 raw log reduced to `$ [machine command omitted]` with no body. Failure messages in machine mode collapse to `exit N: command failed`.
- `hostExecStream` also learns to render a Teams device login (URL plus code) as typed driver displays instead of writing to stdout.

## What trips people up

- **The transport is not yet doing its main job.** The set of known secrets is empty until PR 23 populates it, so at this commit only an `onecli --value` is detected (from the command text alone) and routed through a file. Every other prompted secret is still visible as a plain positional argument in the child's argv. What this PR buys today is that the value is no longer inside the command string.
- **Three exec implementations silently drop the new args:** `setup/providers/install.ts:61`, `scripts/update-skills.ts:175`, `scripts/test-registry-skills.ts:162` all take `(cmd)` only. On those paths a `{{var}}` inside a `run` or `check` directive becomes `"${1}"` with no `$1` set, so bash expands it to an empty string. No in-tree skill hits this today, but the failure mode is a silent empty string, and the providers registry branch was not audited.
- **One fixture changed shape.** 18 `apply-fixtures.json` files replay skills against recorded commands; only `add-imessage` changed, because it is the only skill whose match string contained a quoted placeholder. A new test helper, `renderedCommand()`, inverts `bindShell` so fixtures can still compare against command text.
- **`scripts/skill-conformance.test.ts` now imports from `setup/`**, a scripts-to-setup dependency direction that is new in this repo.

## What to review

1. `bindShell` and `shellQuoteAt`: does the quote-context mapping produce the same effective command for every skill in the tree? This is the part that changes terminal behaviour.
2. The generated `curl` shim in `curlSecretCommand`: it handles a fixed flag list and returns exit 64 for anything else. Does it cover the flags real skills actually use?
3. The fail-closed default: a future skill that pastes a secret into any command other than `onecli --value` or `curl` becomes terminal-only in machine mode, with no compile-time signal.
4. `detached: true` changes process-group semantics for every machine skill child. The two new bounds tests cover the byte cap; the SIGKILL escalation path is reviewed by reading, not by a green test.
5. The raw-log suppression is a deliberate observability loss: a failed machine skill leaves nothing in the level-3 log.

Ten tests are added across `scripts/skill-apply.test.ts`, `setup/lib/skill-driver.test.ts` and `setup/lib/setup-driver.test.ts`, including ones that spawn real children and assert on observed argv and environment.

## Type of Change

- [x] **Fix** - bug fix or security fix to source code

Ticked for the positional-argument binding, which is a security fix to how operator input reaches the shell. Note that this PR is mixed: it also adds new machine-mode code (secret transport, child bounds, environment scrub) that no box on this template covers.

## Description

Binds skill prompt values as shell positional parameters instead of interpolating them into the command string, and adds the machine-mode secret transport, output bounds, process-group teardown and environment scrub for skill child processes. Terminal behaviour is unchanged apart from the argv binding. Nothing here turns machine mode on.

## For Skills

Not a skill: this changes the setup engine, so the SKILL.md checklist does not apply.