### PR TITLE
feat(setup): drive runSkill and keep its secrets out of child argv

### DIFF
--- a/setup/lib/fixtures/setup-driver-skill.ts
+++ b/setup/lib/fixtures/setup-driver-skill.ts
@@ -1,0 +1,22 @@
+import { fullyApplied } from '../../../scripts/skill-apply.js';
+import { hostExec, runSkill } from '../skill-driver.js';
+import { DriverTerminalError, NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const skillDir = process.env.NANOCLAW_TEST_SKILL_DIR;
+const projectRoot = process.env.NANOCLAW_TEST_PROJECT_ROOT;
+if (!skillDir || !projectRoot) throw new Error('missing skill fixture paths');
+
+const driver = new NdjsonSetupDriver('setup');
+try {
+  const result = await runSkill(skillDir, {
+    driver,
+    projectRoot,
+    exec: hostExec(projectRoot),
+  });
+  if (!fullyApplied(result)) driver.error('skill_incomplete', 'The fixture skill did not complete.');
+  driver.completeSetup(fixtureSetupReceipt());
+} catch (error) {
+  if (error instanceof DriverTerminalError) process.exitCode = error.exitCode;
+  else throw error;
+}

--- a/setup/lib/setup-driver.test.ts
+++ b/setup/lib/setup-driver.test.ts
@@ -10,6 +10,7 @@ const TSX_LOADER = import.meta.resolve('tsx');
 const HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child.ts');
 const CONTINUATION_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-continuation.ts');
 const TTY_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-tty.ts');
+const SKILL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-skill.ts');
 const CANCEL_RACE_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-cancel-race.ts');
 const CHILD_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-child-cancel.ts');
 const WINDOWED_CANCEL_HARNESS = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-windowed-cancel.ts');
@@ -276,6 +277,63 @@ describe('NDJSON setup driver child boundary', () => {
       expect(fs.readFileSync(calls, 'utf8')).toContain('login');
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('treats a machine skill answer as data, not shell syntax', async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-skill-project-'));
+    const skillDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-driver-skill-'));
+    const markers = ['single-injected', 'double-injected', 'bare-injected'].map((name) => path.join(projectRoot, name));
+    const answer = `x'; touch ${markers[0]}; #' "$(touch ${markers[1]})" \`touch ${markers[2]}\` $HOME`;
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{"name":"fixture"}');
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      "# fixture\n\n```nc:prompt agent_name normalize:trim validate:^.+$\nAssistant name?\n```\n```nc:run effect:external\nprintf '%s\\n' '{{agent_name}}' > single.txt\nprintf '%s\\n' \"{{agent_name}}\" > double.txt\nprintf '%s\\n' {{agent_name}} > bare.txt\n```\n",
+    );
+    try {
+      const child = spawn(process.execPath, ['--import', TSX_LOADER, SKILL_HARNESS], {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+          NANOCLAW_TEST_PROJECT_ROOT: projectRoot,
+          NANOCLAW_TEST_SKILL_DIR: skillDir,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const events: Array<Record<string, unknown>> = [];
+      let buffer = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        let newline: number;
+        while ((newline = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (!line) continue;
+          const event = JSON.parse(line) as Record<string, unknown>;
+          events.push(event);
+          if (event.type === 'prompt') {
+            const prompt = event.prompt as { id: string };
+            child.stdin.write(
+              `${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: answer })}\n`,
+            );
+          }
+        }
+      });
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', resolve);
+      });
+
+      expect(code).toBe(0);
+      expect(events.at(-1)?.type).toBe('complete');
+      expect(markers.every((marker) => !fs.existsSync(marker))).toBe(true);
+      for (const file of ['single.txt', 'double.txt', 'bare.txt']) {
+        expect(fs.readFileSync(path.join(projectRoot, file), 'utf8')).toBe(`${answer}\n`);
+      }
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+      fs.rmSync(skillDir, { recursive: true, force: true });
     }
   }, 15_000);
 

--- a/setup/lib/skill-driver.test.ts
+++ b/setup/lib/skill-driver.test.ts
@@ -611,6 +611,87 @@ process.stdout.write('=== NANOCLAW SETUP: TEST ===\\nSTATUS: success\\n=== END =
     expect(fullyApplied(res)).toBe(true);
   });
 
+  it('machine driver preserves URL-offer and natural-barrier policy before the side effect', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'machine-policy-'));
+    const skill = mkdtempSync(join(tmpdir(), 'machine-policy-skill-'));
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+    writeFileSync(
+      join(skill, 'SKILL.md'),
+      '# machine policy\n\n```nc:operator\nOpen https://example.com/setup and finish.\n```\n```nc:run effect:build\necho build\n```\n',
+    );
+    const calls: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      operation: 'setup',
+      prompt: async (spec: { message: string }) => {
+        calls.push(`prompt:${spec.message}`);
+        return true;
+      },
+      display: (display: { kind: string }) => {
+        calls.push(`display:${display.kind}`);
+      },
+      note: () => {
+        calls.push('note');
+      },
+      progress: (_id: string, state: string) => {
+        calls.push(`progress:${state}`);
+      },
+      throwIfCancelled: () => {},
+    } as unknown as SetupDriver;
+
+    await runSkill(skill, {
+      projectRoot: root,
+      driver,
+      exec: () => {
+        calls.push('exec');
+      },
+    });
+
+    expect(calls).toEqual([
+      'note',
+      'prompt:Open https://example.com/setup in your browser?',
+      'display:url',
+      "prompt:Done with the steps above? Continue when you're ready.",
+      'progress:pending',
+      'progress:running',
+      'exec',
+      'progress:succeeded',
+    ]);
+  });
+
+  it('stops before a later skill side effect when the driver is cancelled', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'machine-cancel-'));
+    const skill = mkdtempSync(join(tmpdir(), 'machine-cancel-skill-'));
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+    writeFileSync(
+      join(skill, 'SKILL.md'),
+      '# cancel\n\n```nc:run effect:build\nfirst\n```\n```nc:run effect:wire\nsecond\n```\n',
+    );
+    let cancelled = false;
+    const commands: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      operation: 'setup',
+      progress: () => {},
+      throwIfCancelled: () => {
+        if (cancelled) throw new Error('driver cancelled');
+      },
+    } as unknown as SetupDriver;
+
+    await expect(
+      runSkill(skill, {
+        projectRoot: root,
+        driver,
+        exec: (command) => {
+          commands.push(command);
+          cancelled = true;
+        },
+      }),
+    ).rejects.toThrow('driver cancelled');
+
+    expect(commands).toEqual(['first']);
+  });
+
   it('default handler: readiness flavor before an effect:step; decline = proceed (never an abort)', async () => {
     const root = mkdtempSync(join(tmpdir(), 'gate-step-'));
     const skill = mkdtempSync(join(tmpdir(), 'gate-step-skill-'));
@@ -824,5 +905,54 @@ describe('non-TTY step lines (CI logs, a nested apply under the parent driver)',
     expect(success).toHaveBeenCalledTimes(1);
     expect(success.mock.calls[0][0]).toMatch(/^Build the image \(\d+s\)$/);
     success.mockRestore();
+  });
+});
+
+describe('headless confirm invariant (terminal driver, stdout not a TTY)', () => {
+  // Every terminal-channel install now hands runSkill a driver, so the driver's
+  // presence must not decide the confirm seam on its own. A terminal run
+  // redirected to a log file has a driver and no TTY, and it has to keep
+  // defaultConfirm's invariant: resolve true WITHOUT prompting, so a scripted
+  // install with full inputs never stalls at a URL offer or a natural barrier.
+  it('terminal driver + non-TTY stdout: confirm proceeds without prompting the driver', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'headless-confirm-'));
+    const skill = mkdtempSync(join(tmpdir(), 'headless-confirm-skill-'));
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+    writeFileSync(
+      join(skill, 'SKILL.md'),
+      '# headless demo\n\n## Portal step\nTell the user:\n```nc:operator\nOpen https://example.com/setup and finish the app.\n```\n\n## Build\n```nc:run effect:build\necho build\n```\n',
+    );
+    const prompted: string[] = [];
+    const driver = {
+      mode: 'terminal',
+      operation: 'setup',
+      prompt: async (spec: { message: string }) => {
+        prompted.push(spec.message);
+        return true;
+      },
+      note: () => {},
+      progress: () => {},
+      throwIfCancelled: () => {},
+    } as unknown as SetupDriver;
+
+    const prevTTY = process.stdout.isTTY;
+    process.stdout.isTTY = false; // a headless run: setup redirected to a log file
+    const opened: string[] = [];
+    const ran: string[] = [];
+    try {
+      // `confirm` is deliberately NOT injected here: the default seam is the thing under test.
+      const res = await runSkill(skill, {
+        projectRoot: root,
+        driver,
+        openUrl: async (u) => void opened.push(u),
+        exec: (command) => void ran.push(command),
+      });
+      expect(prompted).toEqual([]); // never stalled: no URL offer, no barrier question
+      expect(opened).toEqual(['https://example.com/setup']); // auto-accepted, so the open still happened
+      expect(ran).toEqual(['echo build']); // and the gated side effect still ran
+      expect(fullyApplied(res)).toBe(true);
+    } finally {
+      process.stdout.isTTY = prevTTY;
+    }
   });
 });

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -758,6 +758,7 @@ function defaultOnEvent(
   md: string,
   confirm: (message: string) => Promise<boolean>,
   open: (url: string) => Promise<void>,
+  driver?: SetupDriver,
 ): (e: ApplyEvent) => Promise<void> {
   const gates = gatePolicy(md);
   const ordinals = labelOrdinals(md);
@@ -769,6 +770,12 @@ function defaultOnEvent(
   let plain: { base: string; start: number } | null = null;
   return async (e) => {
     if (e.type === 'step-start') {
+      if (driver?.mode === 'ndjson') {
+        const id = `skill-${e.line}`;
+        driver.progress(id, 'pending', e.label ?? e.kind);
+        driver.progress(id, 'running', e.label ?? e.kind);
+        return;
+      }
       if (e.label === null) return; // instant/cheap step — no caption declared
       const base = e.label.replace(/…+$/, '') + (ordinals.get(e.line) ?? '');
       if (!process.stdout.isTTY) {
@@ -779,6 +786,11 @@ function defaultOnEvent(
       return;
     }
     if (e.type === 'step-end') {
+      if (driver?.mode === 'ndjson') {
+        driver.progress(`skill-${e.line}`, e.ok ? 'succeeded' : 'failed', e.label ?? e.kind);
+        driver.throwIfCancelled();
+        return;
+      }
       if (active) {
         active.stop({ ok: e.ok });
         active = null;
@@ -791,7 +803,8 @@ function defaultOnEvent(
       return;
     }
     // operator: note → URL offer → natural-barrier confirm.
-    p.note(e.text, 'Your turn');
+    if (driver) driver.note(e.text, 'Your turn');
+    else p.note(e.text, 'Your turn');
     const url = extractOfferUrl(e.text);
     if (url !== undefined && (await confirm(`Open ${url} in your browser?`))) await open(url);
     const gate = gates.get(e.line);
@@ -879,12 +892,19 @@ export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Pr
   const confirm =
     opts.confirm ??
     (opts.driver
-      ? async (message: string) =>
-          (await opts.driver!.prompt({
-            kind: 'confirm',
-            message,
-            default: true,
-          })) === true
+      ? async (message: string) => {
+          // Terminal mode keeps defaultConfirm's headless invariant: a non-TTY
+          // run proceeds without prompting, so a scripted install with full
+          // inputs never stalls on a barrier or an offer.
+          if (opts.driver!.mode === 'terminal' && !process.stdout.isTTY) return true;
+          return (
+            (await opts.driver!.prompt({
+              kind: 'confirm',
+              message,
+              default: true,
+            })) === true
+          );
+        }
       : defaultConfirm);
   const open =
     opts.openUrl ??
@@ -910,6 +930,7 @@ export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Pr
       inputs = { ...inputs, ...reused };
     }
   }
+  const machineSecrets = new Set<string>();
   // The default operator policy derives from the skill document itself
   // (gatePolicy keys on directive lines) — read it once here; the engine reads
   // the same file for the actual apply.
@@ -919,6 +940,49 @@ export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Pr
   } catch {
     // missing SKILL.md — the engine will produce an empty result anyway
   }
+  for (const directive of parseDirectives(md)) {
+    if (directive.kind !== 'prompt') continue;
+    const name = promptVar(directive);
+    const value = name ? inputs?.[name] : undefined;
+    if (!value) continue;
+    const normalized = normalizeValue(
+      value,
+      typeof directive.attrs.normalize === 'string' ? directive.attrs.normalize : undefined,
+    );
+    if (!directive.args.includes('secret')) continue;
+    registerSensitiveValue(value);
+    registerSensitiveValue(normalized);
+    machineSecrets.add(value);
+    machineSecrets.add(normalized);
+  }
+  const acquireInput =
+    opts.resolveInput ??
+    (opts.driver?.mode === 'ndjson'
+      ? async (name: string, meta: InputMeta): Promise<string | undefined> => {
+          const choices = meta.secret ? null : literalChoices(meta.validate);
+          const value = await opts.driver!.prompt({
+            id: `skill-${basename(skillDir)}-${name}`,
+            kind: choices ? 'singleChoice' : meta.secret ? 'secret' : 'text',
+            message: meta.question,
+            sensitive: meta.secret,
+            ...(choices ? { choices: choices.map((choice) => ({ id: choice, label: choice })) } : {}),
+            validateValue: (answer) => promptValidator(meta.validate, meta.flags, meta.question)?.(String(answer)),
+          });
+          return typeof value === 'string' && value.length > 0 ? value : undefined;
+        }
+      : clackResolveInput({ channel: opts.channel, step: opts.step }));
+  const resolveInput = async (name: string, meta: InputMeta): Promise<string | undefined> => {
+    const value = await acquireInput(name, meta);
+    if (!value) return undefined;
+    const normalized = normalizeValue(value, meta.normalize);
+    if (meta.secret) {
+      registerSensitiveValue(value);
+      registerSensitiveValue(normalized);
+      machineSecrets.add(value);
+      machineSecrets.add(normalized);
+    }
+    return value;
+  };
   // One raw log per skill apply (level 3): every default-exec command appends
   // its `$ cmd` + output there. Allocated only when the default exec is used —
   // an injected exec (tests, agent relay) owns its own capture.
@@ -927,15 +991,38 @@ export async function runSkill(skillDir: string, opts: RunSkillOptions = {}): Pr
     rawLog = setupLog.stepRawLog(`skill-${basename(skillDir)}`);
     writeFileSync(rawLog, `# skill ${basename(skillDir)} — ${new Date().toISOString()}\n\n`);
   }
-  return applySkill(skillDir, projectRoot, {
+  const defaultExec = opts.exec ?? hostExec(projectRoot, rawLog, opts.driver, machineSecrets);
+  const defaultExecStream = opts.execStream ?? hostExecStream(projectRoot, opts.driver, machineSecrets);
+  const machine = opts.driver?.mode === 'ndjson' || process.env.NANOCLAW_PROTOCOL === 'nanoclaw.driver.v1';
+  const exec =
+    machine && opts.exec
+      ? (command: string, args: string[] = []) =>
+          withMachineSecretTransport(command, args, machineSecrets, opts.driver, async (safeCommand, safeArgs) =>
+            opts.exec!(safeCommand, safeArgs),
+          )
+      : defaultExec;
+  const execStream =
+    machine && opts.execStream
+      ? (command: string, args: string[] = []) =>
+          withMachineSecretTransport(command, args, machineSecrets, opts.driver, opts.execStream!)
+      : defaultExecStream;
+  const onEvent = opts.onEvent ?? defaultOnEvent(md, confirm, open, opts.driver);
+  opts.driver?.throwIfCancelled?.();
+  const result = await applySkill(skillDir, projectRoot, {
     inputs,
-    resolveInput: opts.resolveInput ?? clackResolveInput({ channel: opts.channel, step: opts.step }),
-    onEvent: opts.onEvent ?? defaultOnEvent(md, confirm, open),
-    exec: opts.exec ?? hostExec(projectRoot, rawLog),
-    execStream: opts.execStream ?? hostExecStream(projectRoot),
+    resolveInput,
+    onEvent: async (event) => {
+      opts.driver?.throwIfCancelled?.();
+      await onEvent(event);
+      opts.driver?.throwIfCancelled?.();
+    },
+    exec,
+    execStream,
     resolveRemote: opts.resolveRemote ?? channelsRemote(projectRoot),
     skipEffects: opts.skipEffects,
   });
+  opts.driver?.throwIfCancelled?.();
+  return result;
 }
 
 /**


### PR DESCRIPTION
## TL;DR

Proposed: `runSkill`, the function that runs a `SKILL.md` document end to end, learns to talk to the setup driver instead of only to the terminal. It is also the first caller that tells the machine-mode secret transport which values are actually secret, so a prompted password stops reaching the child process as a command-line argument. Terminal setup behaviour does not change.

## Vocabulary, three lines

- A **driver** is the interface every setup interaction goes through in this stack. `TerminalSetupDriver` renders through the existing terminal prompt library (imported as `p`); `NdjsonSetupDriver` speaks newline-delimited JSON over stdin and stdout so a native macOS app can drive setup with no terminal. "Machine mode" means the ndjson driver is in use.
- A **skill** here is a `SKILL.md` file made of directives: `nc:prompt` asks the user for a value, `nc:run` runs a shell command, `nc:operator` prints steps a human performs by hand.
- **PR 22** stopped pasting prompted values into command text and started passing them as bash positional parameters (`${1}`) plus a separate argument array. It also added `withMachineSecretTransport`, which writes a secret to a temporary file and hands the child a path instead of the value. That transport shipped inert, because nothing told it which values were secret.

## What problem this solves

Two, in one place.

1. `runSkill` had no way to ask a GUI for input. Everything went through the terminal prompt library, so a skill could not run under the native app.
2. The secret transport from PR 22 was dead weight. `runSkill` called `hostExec(projectRoot, rawLog)` and the secrets set defaulted to empty, so in machine mode a prompted secret was still visible in the child's argv as a positional parameter.

## How it works

- `runSkill` builds a `machineSecrets` set from two sources: values already supplied or reused from `.env` before the run (a loop over the parsed directives that picks out the ones marked `secret`), and values the driver prompts for during the run (a wrapper around input resolution). Both call `registerSensitiveValue`, which feeds the output redactor added earlier in the stack.
- That set is passed to `hostExec` and `hostExecStream`. Their machine-mode branch, already present since PR 22, now has something to match on, so a secret argument is replaced by a temporary file path and the raw step log and child environment no longer carry the value.
- Input resolution: in ndjson mode a `nc:prompt` becomes a typed driver prompt (`singleChoice` when the validation pattern is a plain list of literals, `secret` when the directive is marked secret, otherwise `text`), carrying the same validator the terminal path uses. In every other mode it still calls `clackResolveInput`, byte for byte the previous behaviour.
- Step events: in ndjson mode a step start emits `progress(pending)` then `progress(running)`, and a step end emits `succeeded` or `failed`, instead of driving a terminal spinner. Every apply event is bracketed by a cancellation check, so a cancel from the client stops the run before the next side effect rather than after it.

## What trips people up

- The operator note swap is `if (driver) driver.note(...)`, not "if ndjson". It fires for the terminal driver too. That is safe because `TerminalSetupDriver.note(content, label)` is exactly the `p.note(content, label)` call it replaces, but the condition is deliberately broader than the rest of the routing.
- In machine mode an **injected** `exec` (from tests, or from a caller that relays commands elsewhere) is now wrapped in the secret transport as well. Such a caller no longer receives the raw secret in its argument array.
- `machineSecrets` covers values that arrive as pre-supplied or reused inputs and values the driver prompts for. A secret reaching the skill by some other route is not in the set and gets no protection.
- The registration loop computes the normalized form before it checks whether the directive is a secret. Wasteful but harmless, and left alone on purpose: this stack has to reproduce the original tree byte for byte.
- The URL branch does not use the driver's external-action call. Opening a browser has no postcondition NanoClaw can observe, so the URL is sent as a typed display and the run continues to the existing confirm barrier.

## Dormancy

Nothing in the shipped product passes a `driver` to `runSkill` at this commit. The channel wizard picks it up in PR 27 and setup auto from PR 28 onward. The only driver-passing caller here is a new test fixture.

## What to review

1. The two places that populate `machineSecrets`, and that both hand it to `hostExec` and `hostExecStream`.
2. The wrapping of an injected `exec` and `execStream` under machine mode.
3. That the non-ndjson path still resolves input through `clackResolveInput` and still takes the terminal branches of the default event handler.
4. The exact ordering asserted by the new policy test: note, URL offer prompt, URL display, barrier confirm, progress pending, progress running, exec, progress succeeded. Any reordering of the operator policy fails loudly there.

## Verification

Three new tests. One end-to-end child test feeds an answer full of shell metacharacters over the wire and asserts that no injected command runs and that the value round-trips verbatim through single-quoted, double-quoted and bare interpolation. One asserts the operator policy ordering above under a machine driver. One asserts a cancelled driver stops before the second side effect. Per the planning gate, `setup/lib/skill-driver.test.ts` is 40/40 and `setup/lib/setup-driver.test.ts` is 7/7 green at this commit, with the setup-inclusive `tsc` error set unchanged from the previous PR. Note that `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`; the typecheck gate for this stack is run separately.

The unit tests for the transport itself (onecli, curl, the unsupported-interpolation rejection) landed with the transport in PR 22 and are not repeated here.

## Behaviour fix carried in this PR

`defaultConfirm` returned true without prompting on a non-TTY, so a headless run redirected to a log file never stalled at a skill barrier or a URL offer. Preferring the driver's confirm whenever a driver is supplied would have dropped that, and a driver is now supplied on every terminal channel install. Terminal mode keeps the invariant explicitly.

A test in `setup/lib/skill-driver.test.ts` pins it.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is one slice of a larger setup-driver feature, not a skill, and not a fix: the secret handling it switches on hardens a machine mode that no shipped caller can reach yet, so it corrects no existing behaviour.

## Description

See above. In one line: `runSkill` gains driver-backed prompts, progress and cancellation, all gated on an optional `driver`, and starts declaring which prompted values are secret so the machine-mode secret transport stops being inert.

## For Skills

Not a skill, so this checklist does not apply.