### PR TITLE
feat(setup): map status blocks to sensitive driver displays

### DIFF
--- a/scripts/photon-setup.test.ts
+++ b/scripts/photon-setup.test.ts
@@ -528,6 +528,30 @@ describe('photon setup flow (mocked API)', () => {
     expect(written.join('')).toContain('Text +15558887777');
   });
 
+  it('emits replaceable opt-in instructions in embedded mode', async () => {
+    const { fetchFn } = makeMockFetch({ optInAfterListPolls: 2 });
+    const written: string[] = [];
+    const realWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      expect(
+        await main(
+          ['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive', '--embedded'],
+          fetchFn,
+          noSleep,
+        ),
+      ).toBe(0);
+    } finally {
+      process.stdout.write = realWrite;
+    }
+    const output = written.join('');
+    expect(output).toContain('=== NANOCLAW SETUP: PHOTON_OPT_IN ===\nPHONE: +15551234567\nLINE: +15558887777');
+    expect(output).toContain('=== NANOCLAW SETUP: PHOTON_OPT_IN_CLEAR ===');
+  });
+
   it('does not create a second row when a completed setup is re-run', async () => {
     const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 1 });
     expect(

--- a/scripts/photon-setup.ts
+++ b/scripts/photon-setup.ts
@@ -831,6 +831,7 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
     p.log.step('[1/5] Photon device login');
     const code = await requestDeviceCode(fetchFn, args.dashboardHost);
     const target = code.verification_uri_complete || code.verification_uri;
+    if (args.embedded) emitEmbeddedBlock('PHOTON_DEVICE', { URL: target, CODE: code.user_code });
     p.note(`Open:  ${target}\nCode:  ${code.user_code}`, 'Approve this device');
     if (!args.noBrowser) openBrowser(target);
     const spin = p.spinner();
@@ -844,6 +845,7 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
       return 1;
     }
     spin.stop('Logged in');
+    if (args.embedded) emitEmbeddedBlock('PHOTON_DEVICE_CLEAR');
     saveAuth({ access_token: token });
   }
 
@@ -920,6 +922,12 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
         p.log.info('Phone already opted in');
         assigned = line;
       } else {
+        if (args.embedded) {
+          emitEmbeddedBlock('PHOTON_OPT_IN', {
+            PHONE: phone,
+            ...(line ? { LINE: line } : {}),
+          });
+        }
         p.note(optInInstructions(phone, line).join('\n'), 'One step needed on your phone');
         const opted = await waitForOptedInUser(fetchFn, args.spectrumHost, projectId, secret, phone, {
           sleepFn: deps.sleepFn,
@@ -928,6 +936,7 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
             if (attempt % 6 === 0) p.log.message(`Still waiting for the opt-in for ${phone}…`);
           },
         });
+        if (args.embedded) emitEmbeddedBlock('PHOTON_OPT_IN_CLEAR');
         p.log.info('Phone registered and opted in');
         assigned = userAssignedLine(opted) ?? line;
       }
@@ -990,6 +999,17 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
     process.stdout.write(fields.join('\n') + '\n');
   }
   return 0;
+}
+
+function emitEmbeddedBlock(type: string, fields: Record<string, string> = {}): void {
+  process.stdout.write(
+    [
+      `=== NANOCLAW SETUP: ${type} ===`,
+      ...Object.entries(fields).map(([key, value]) => `${key}: ${value}`),
+      '=== END ===',
+      '',
+    ].join('\n'),
+  );
 }
 
 export async function main(argv: string[], fetchFn: FetchFn = fetch, deps: SetupDeps = {}): Promise<number> {

--- a/setup/lib/skill-driver.test.ts
+++ b/setup/lib/skill-driver.test.ts
@@ -411,6 +411,81 @@ process.stdout.write('=== NANOCLAW SETUP: TEST ===\\nSTATUS: success\\n=== END =
     }
   });
 
+  it('maps Photon embedded blocks to replaceable sensitive displays', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-photon-'));
+    const seen: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      display: (display: { id: string; sensitive: boolean }) => seen.push(`display:${display.id}:${display.sensitive}`),
+      clearDisplay: (id: string) => seen.push(`clear:${id}`),
+    } as unknown as SetupDriver;
+    const out = await hostExecStream(
+      root,
+      driver,
+    )(
+      [
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_DEVICE ===' 'URL: https://example.com/device' 'CODE: ABCD-1234' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_DEVICE_CLEAR ===' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_OPT_IN ===' 'PHONE: +15551234567' 'LINE: +15558887777' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON_OPT_IN_CLEAR ===' '=== END ==='",
+        "printf '%s\\n' '=== NANOCLAW SETUP: PHOTON ===' 'STATUS: success' 'PHONE: +15551234567' '=== END ==='",
+      ].join('; '),
+    );
+    expect(out.ok).toBe(true);
+    expect(seen).toEqual([
+      'display:photon-device:true',
+      'clear:photon-device',
+      'display:photon-opt-in:true',
+      'clear:photon-opt-in',
+    ]);
+  });
+
+  it('renders Teams device login as an external action in machine mode', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'driver-teams-'));
+    const prefix = join(root, 'global');
+    const bin = join(root, 'bin');
+    mkdirSync(join(prefix, 'bin'), { recursive: true });
+    mkdirSync(bin);
+    writeFileSync(join(bin, 'npm'), `#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(prefix)}\n`);
+    writeFileSync(
+      join(prefix, 'bin', 'teams'),
+      "#!/bin/sh\nprintf 'Open https://microsoft.com/devicelogin\\nEnter code ABCD-EFGH\\n=== NANOCLAW SETUP: TEAMS-LOGIN ===\\nSTATUS: success\\n=== END ===\\n'\n",
+    );
+    chmodSync(join(bin, 'npm'), 0o755);
+    chmodSync(join(prefix, 'bin', 'teams'), 0o755);
+    const actions: Array<{ kind: string; url?: string }> = [];
+    const displays: Array<{ id: string; kind: string; sensitive: boolean; content?: string }> = [];
+    const cleared: string[] = [];
+    const driver = {
+      mode: 'ndjson',
+      externalAction: async (action: { kind: string; url?: string }, verify: () => boolean | Promise<boolean>) => {
+        actions.push(action);
+        expect(await verify()).toBe(true);
+        return 'attempted' as const;
+      },
+      display: (display: { id: string; kind: string; sensitive: boolean; content?: string }) => displays.push(display),
+      clearDisplay: (id: string) => cleared.push(id),
+    } as unknown as SetupDriver;
+    const result = await hostExecStream(
+      root,
+      driver,
+    )('"$(npm prefix -g 2>/dev/null)/bin/teams" login && echo \'"loggedIn": true\'');
+    expect(result.ok).toBe(true);
+    expect(actions).toEqual([
+      {
+        id: 'teams-login-open-url',
+        kind: 'openURL',
+        title: 'Open Microsoft device login',
+        url: 'https://microsoft.com/devicelogin',
+      },
+    ]);
+    expect(displays).toEqual([
+      expect.objectContaining({ id: 'teams-login-url', kind: 'url', sensitive: true }),
+      expect.objectContaining({ id: 'teams-login-code', kind: 'code', content: 'ABCD-EFGH', sensitive: true }),
+    ]);
+    expect(cleared).toEqual(['teams-login-url', 'teams-login-code']);
+  });
+
   function reuseScratch(): { root: string; skill: string } {
     const root = mkdtempSync(join(tmpdir(), 'reuse-'));
     const skill = mkdtempSync(join(tmpdir(), 'reuse-skill-'));

--- a/setup/lib/skill-driver.ts
+++ b/setup/lib/skill-driver.ts
@@ -642,6 +642,72 @@ export function hostExecStream(
           });
         }
       };
+      const renderBlock = (block: { type: string; fields: Record<string, string> }): void => {
+        if (driver?.mode !== 'ndjson') return;
+        if (block.type === 'PAIR_TELEGRAM_CODE' && block.fields.CODE) {
+          activeDisplayIds.add('telegram-pairing-code');
+          driver.display({
+            id: 'telegram-pairing-code',
+            kind: 'code',
+            content: block.fields.CODE,
+            sensitive: true,
+            label: 'Telegram pairing code',
+          });
+        } else if (block.type === 'WHATSAPP_AUTH_QR' && block.fields.QR) {
+          activeDisplayIds.add('whatsapp-auth');
+          driver.display({
+            id: 'whatsapp-auth',
+            kind: 'qr',
+            payload: block.fields.QR,
+            sensitive: true,
+            label: 'WhatsApp QR code',
+          });
+        } else if (block.type === 'WHATSAPP_AUTH_PAIRING_CODE' && block.fields.CODE) {
+          activeDisplayIds.add('whatsapp-auth');
+          driver.display({
+            id: 'whatsapp-auth',
+            kind: 'code',
+            content: block.fields.CODE,
+            sensitive: true,
+            label: 'WhatsApp pairing code',
+          });
+        } else if (block.type === 'SIGNAL_AUTH_QR' && block.fields.QR) {
+          activeDisplayIds.add('signal-auth');
+          driver.display({
+            id: 'signal-auth',
+            kind: 'qr',
+            payload: block.fields.QR,
+            sensitive: true,
+            label: 'Signal linking QR',
+          });
+        } else if (block.type === 'PHOTON_DEVICE' && block.fields.URL && block.fields.CODE) {
+          activeDisplayIds.add('photon-device');
+          driver.display({
+            id: 'photon-device',
+            kind: 'code',
+            content: `${block.fields.URL}\n${block.fields.CODE}`,
+            sensitive: true,
+            label: 'Approve this Photon device',
+          });
+        } else if (block.type === 'PHOTON_DEVICE_CLEAR') {
+          activeDisplayIds.delete('photon-device');
+          driver.clearDisplay('photon-device');
+        } else if (block.type === 'PHOTON_OPT_IN' && block.fields.PHONE) {
+          activeDisplayIds.add('photon-opt-in');
+          driver.display({
+            id: 'photon-opt-in',
+            kind: 'text',
+            content: block.fields.LINE
+              ? `Open Messages on ${block.fields.PHONE} and send one message to ${block.fields.LINE}. Setup continues when Photon confirms the opt-in.`
+              : `Photon has not assigned an iMessage line to ${block.fields.PHONE} yet. Setup is waiting for the line and the first message from that phone.`,
+            sensitive: true,
+            label: 'One step needed on your phone',
+          });
+        } else if (block.type === 'PHOTON_OPT_IN_CLEAR') {
+          activeDisplayIds.delete('photon-opt-in');
+          driver.clearDisplay('photon-opt-in');
+        }
+      };
       let buf = '';
       const onChunk = (chunk: Buffer): void => {
         if (outputLimitExceeded) return;
@@ -665,7 +731,10 @@ export function hostExecStream(
             continue;
           }
           if (line.startsWith('=== END ===')) {
-            if (current) blocks.push(current);
+            if (current) {
+              blocks.push(current);
+              renderBlock(current);
+            }
             current = null;
             continue;
           }

--- a/setup/signal-auth.ts
+++ b/setup/signal-auth.ts
@@ -20,7 +20,8 @@
  * SIGNAL_AUTH block is parsed — the driver's `capture:<var>=ACCOUNT` reads the
  * phone number from it.
  *
- * Block schema (parent parses this one block):
+ * Block schema:
+ *   SIGNAL_AUTH_QR       { QR: "sgnl://…" }                  sensitive display
  *   SIGNAL_AUTH          { STATUS: success, ACCOUNT: +<digits> }  — terminal
  *                        { STATUS: skipped, ACCOUNT, REASON: already-authenticated }
  *                        { STATUS: failed, ERROR: <reason> }
@@ -170,6 +171,7 @@ export async function run(_args: string[]): Promise<void> {
         // NANOCLAW SETUP block would be consumed, not shown).
         if (/^(sgnl|tsdevice):\/\/linkdevice\?/.test(line) && !qrEmitted) {
           qrEmitted = true;
+          emitStatus('SIGNAL_AUTH_QR', { QR: line });
           printLink(line);
         }
       }


### PR DESCRIPTION
## Summary

Proposed: when setup runs a skill step in machine mode, the structured status blocks that helper scripts already print on stdout are turned into typed "display" messages for the native app, instead of being swallowed. Terminal runs are unaffected.

## The problem

NanoClaw's setup helper scripts talk to their parent by printing plain-text blocks on stdout, like this:

```
=== NANOCLAW SETUP: PAIR_TELEGRAM_CODE ===
CODE: 12345
=== END ===
```

The parent (`hostExecStream` in `setup/lib/skill-driver.ts`) already parsed those blocks, but only to find the final one carrying a `STATUS:` field, so it could decide whether the step succeeded. Everything in between was consumed and dropped. In terminal mode that is fine, because the helper also prints a human-readable version of the same thing right next to the block. In machine mode, where a native macOS app drives setup over a JSON protocol instead of a terminal, there is nobody to read that human-readable text, so a pairing code or a QR code simply never reached the user.

A "driver" here is the interface this stack introduced for every user interaction. `TerminalSetupDriver` renders over the existing terminal UI; `NdjsonSetupDriver` renders by writing newline-delimited JSON to stdout for the app. `display(...)` puts something on screen with a stable id, `clearDisplay(id)` takes it down again.

## How it works

- A new `renderBlock` function runs whenever the block parser closes a block. It first returns unless `driver.mode === 'ndjson'`, so nothing changes for terminal users.
- Seven block types are mapped: `PAIR_TELEGRAM_CODE`, `WHATSAPP_AUTH_QR`, `WHATSAPP_AUTH_PAIRING_CODE`, `SIGNAL_AUTH_QR`, `PHOTON_DEVICE`, `PHOTON_OPT_IN`, plus the two `*_CLEAR` variants for Photon. WhatsApp's QR and pairing code deliberately share one display id (`whatsapp-auth`) so a rotating QR replaces the previous one rather than stacking up.
- Two producers land alongside the consumer so the loop is closed in one PR. `scripts/photon-setup.ts` gets a small `emitEmbeddedBlock` helper and four call sites (device login shown and cleared, phone opt-in shown and cleared), all gated on the pre-existing `--embedded` flag. `setup/signal-auth.ts` emits `SIGNAL_AUTH_QR` immediately before the existing `printLink(line)`, which stays, so terminal users still see the QR.
- Telegram and WhatsApp needed no producer change; those scripts already emitted these blocks on main.

## What trips people up

- **Every display is marked `sensitive: true`.** That has a second effect beyond presentation: `NdjsonSetupDriver.display` calls `registerSensitiveValue(payload)`, so the pairing code, the QR string and the Photon device URL are added to the redaction set and will be scrubbed from later machine logs and child output. A client that hides sensitive content from view must still actually render these, because for a QR code the whole point is that the user looks at it.
- **Only Photon gets explicit clear blocks.** Telegram, WhatsApp and Signal displays are torn down only when the child exits, via the existing `clearDisplay` loop in the close and error handlers.
- **Neither new block carries a `STATUS:` field**, so neither can be mistaken for the step's terminal result block.
- **The new block lines are invisible in terminal mode**, because the parser consumes everything between the markers without echoing it. That is why both producers keep their existing human-readable output right next to the emit.

## What to review

1. The `sensitive: true` blanket decision, and specifically the Photon opt-in case: the registered value is the whole rendered sentence, and redaction is exact-string, so registering it does not by itself redact the phone number anywhere else.
2. The Photon block placement in `runSetup`: emit before the wait, clear after it, in both branches.
3. That `renderBlock`'s early return is the only gate between machine and terminal behaviour.

Tests: `setup/lib/skill-driver.test.ts` gains a case driving all four Photon blocks through a real child and asserting the display/clear sequence, plus an end-to-end case for the Teams external-action path (that code shipped in the previous PR in the stack; this is its first direct test, using a real child process). `scripts/photon-setup.test.ts` gains a case asserting the opt-in block text on stdout. The `PHOTON_DEVICE` emit itself is covered only through the synthetic skill-driver case, not through a photon-setup run.

This is part 24 of a 39-part stack that splits one oversized commit into reviewable pieces. The stack changes no terminal behaviour and nothing enables machine-driven setup: the macOS app still passes `setupProtocol: nil`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this adds part of the machine-drivable setup driver protocol to `setup/` and `scripts/`. It is not a skill, not a bug fix, and it does not reduce code.

## Description

See the summary above. Adds `renderBlock` in `setup/lib/skill-driver.ts`, the Photon embedded block emitter in `scripts/photon-setup.ts`, and the `SIGNAL_AUTH_QR` emit in `setup/signal-auth.ts`, with three tests.

## For Skills

Not a skill, so the skill checklist does not apply.
