### PR TITLE
feat(setup): drive advanced config, refuse secrets in ndjson mode

### DIFF
--- a/setup/lib/setup-config-screen.test.ts
+++ b/setup/lib/setup-config-screen.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runAdvancedScreen } from './setup-config-screen.js';
+import type { SetupDriver } from './setup-driver.js';
+
+describe('machine advanced configuration', () => {
+  const envKey = 'NANOCLAW_ONECLI_API_TOKEN';
+  let previousToken: string | undefined;
+
+  afterEach(() => {
+    if (previousToken === undefined) delete process.env[envKey];
+    else process.env[envKey] = previousToken;
+    previousToken = undefined;
+  });
+
+  it('rejects secret entries before an answer can reach process.env', async () => {
+    previousToken = process.env[envKey];
+    delete process.env[envKey];
+    const driver = {
+      mode: 'ndjson' as const,
+      prompt: async () => 'onecliApiToken',
+      error(code: string): never {
+        throw new Error(code);
+      },
+    } as unknown as SetupDriver;
+
+    await expect(runAdvancedScreen({}, driver)).rejects.toThrow('secret_transport_forbidden');
+    expect(process.env[envKey]).toBeUndefined();
+  });
+});

--- a/setup/lib/setup-config-screen.ts
+++ b/setup/lib/setup-config-screen.ts
@@ -16,12 +16,13 @@ import { brightSelect } from './bright-select.js';
 import { ensureAnswer } from './runner.js';
 import { CONFIG, type Entry } from './setup-config.js';
 import type { ConfigValues } from './setup-config-parse.js';
+import type { SetupDriver } from './setup-driver.js';
 
 const SKIP_SENTINEL = '__leave_unchanged__';
 const DONE_SENTINEL = '__done__';
 const MASK = '••••••••';
 
-export async function runAdvancedScreen(initial: ConfigValues): Promise<ConfigValues> {
+export async function runAdvancedScreen(initial: ConfigValues, driver?: SetupDriver): Promise<ConfigValues> {
   const result: ConfigValues = { ...initial };
   const visible = CONFIG.filter((e) => e.surface === 'flag+ui');
 
@@ -32,20 +33,36 @@ export async function runAdvancedScreen(initial: ConfigValues): Promise<ConfigVa
         label: e.label,
         hint: hintFor(e, result),
       })),
-      { value: DONE_SENTINEL, label: 'Done — continue with setup' },
+      { value: DONE_SENTINEL, label: 'Done - continue with setup', hint: undefined },
     ];
 
-    const choice = ensureAnswer(
-      await brightSelect<string>({
-        message: 'Pick a setting to override',
-        options,
-        initialValue: DONE_SENTINEL,
-      }),
-    ) as string;
+    const choice = driver
+      ? String(
+          await driver.prompt({
+            id: 'advanced-setting',
+            kind: 'singleChoice',
+            message: 'Pick a setting to override',
+            choices: options.map(({ value, label, hint }) => ({ id: value, label, hint })),
+            default: DONE_SENTINEL,
+          }),
+        )
+      : (ensureAnswer(
+          await brightSelect<string>({
+            message: 'Pick a setting to override',
+            options,
+            initialValue: DONE_SENTINEL,
+          }),
+        ) as string);
 
     if (choice === DONE_SENTINEL) return result;
     const entry = visible.find((e) => e.key === choice);
-    if (entry) await promptOne(entry, result);
+    if (entry?.secret && driver?.mode === 'ndjson') {
+      driver.error(
+        'secret_transport_forbidden',
+        'Machine setup does not accept secrets through advanced configuration. Use the structured authentication prompts instead.',
+      );
+    }
+    if (entry) await promptOne(entry, result, driver);
   }
 }
 
@@ -56,42 +73,62 @@ function hintFor(e: Entry, values: ConfigValues): string {
   return String(v);
 }
 
-async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
+async function promptOne(e: Entry, values: ConfigValues, driver?: SetupDriver): Promise<void> {
   if (e.type === 'boolean') {
     const init = typeof values[e.key] === 'boolean' ? (values[e.key] as boolean) : (e.default ?? false);
-    const ans = ensureAnswer(await p.confirm({ message: e.label, initialValue: init }));
+    const ans = driver
+      ? await driver.prompt({ id: `advanced-${e.key}`, kind: 'confirm', message: e.label, default: init })
+      : ensureAnswer(await p.confirm({ message: e.label, initialValue: init }));
     values[e.key] = ans as boolean;
     return;
   }
 
   if (e.type === 'enum') {
-    const ans = ensureAnswer(
-      await brightSelect<string>({
-        message: e.label,
-        options: [{ value: SKIP_SENTINEL, label: 'Leave unchanged' }, ...e.options],
-        initialValue: SKIP_SENTINEL,
-      }),
-    );
+    const options = [{ value: SKIP_SENTINEL, label: 'Leave unchanged' }, ...e.options];
+    const ans = driver
+      ? await driver.prompt({
+          id: `advanced-${e.key}`,
+          kind: 'singleChoice',
+          message: e.label,
+          choices: options.map(({ value, label }) => ({ id: value, label })),
+          default: SKIP_SENTINEL,
+        })
+      : ensureAnswer(
+          await brightSelect<string>({
+            message: e.label,
+            options,
+            initialValue: SKIP_SENTINEL,
+          }),
+        );
     if (ans !== SKIP_SENTINEL) values[e.key] = ans as string;
     return;
   }
 
   if (e.type === 'integer') {
-    const ans = ensureAnswer(
-      await p.text({
-        message: e.label,
-        placeholder: e.default !== undefined ? String(e.default) : undefined,
-        validate: (v) => {
-          const s = (v ?? '').trim();
-          if (!s) return undefined;
-          const n = Number(s);
-          if (!Number.isFinite(n)) return 'Must be a number';
-          if (e.min !== undefined && n < e.min) return `Must be ≥ ${e.min}`;
-          if (e.max !== undefined && n > e.max) return `Must be ≤ ${e.max}`;
-          return undefined;
-        },
-      }),
-    );
+    const validate = (value: boolean | string): string | undefined => {
+      const s = String(value).trim();
+      if (!s) return undefined;
+      const n = Number(s);
+      if (!Number.isFinite(n)) return 'Must be a number';
+      if (e.min !== undefined && n < e.min) return `Must be ≥ ${e.min}`;
+      if (e.max !== undefined && n > e.max) return `Must be ≤ ${e.max}`;
+      return undefined;
+    };
+    const ans = driver
+      ? await driver.prompt({
+          id: `advanced-${e.key}`,
+          kind: 'text',
+          message: e.label,
+          placeholder: e.default !== undefined ? String(e.default) : undefined,
+          validateValue: validate,
+        })
+      : ensureAnswer(
+          await p.text({
+            message: e.label,
+            placeholder: e.default !== undefined ? String(e.default) : undefined,
+            validate: (v) => validate(v ?? ''),
+          }),
+        );
     const trimmed = ((ans as string) ?? '').trim();
     if (trimmed) values[e.key] = Number(trimmed);
     return;
@@ -103,15 +140,24 @@ async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
     if (!s) return undefined;
     return e.validate?.(s);
   };
-  const ans = ensureAnswer(
-    e.secret
-      ? await p.password({ message: e.label, clearOnError: true, validate })
-      : await p.text({
-          message: e.label,
-          placeholder: e.placeholder ?? e.default,
-          validate,
-        }),
-  );
+  const ans = driver
+    ? await driver.prompt({
+        id: `advanced-${e.key}`,
+        kind: e.secret ? 'secret' : 'text',
+        message: e.label,
+        sensitive: e.secret,
+        placeholder: e.placeholder ?? e.default,
+        validateValue: (value) => validate(String(value)),
+      })
+    : ensureAnswer(
+        e.secret
+          ? await p.password({ message: e.label, clearOnError: true, validate })
+          : await p.text({
+              message: e.label,
+              placeholder: e.placeholder ?? e.default,
+              validate,
+            }),
+      );
   const trimmed = ((ans as string) ?? '').trim();
   if (trimmed) values[e.key] = trimmed;
 }


### PR DESCRIPTION
## TL;DR

Proposes routing the "Advanced" settings screen of `bash nanoclaw.sh` through the setup driver, and proposes a new rule: when setup is being driven by a machine over the NDJSON wire protocol, picking one of the two secret settings is refused outright instead of prompted for.

## What problem this solves

Background for reviewers with no prior context: this stack proposes a `SetupDriver`, a small interface that every setup question goes through (choose one of a list, confirm yes/no, free text, secret text, progress, display, external action). One implementation talks to the existing terminal UI so terminal behaviour is unchanged. Another implementation speaks newline-delimited JSON on stdin/stdout ("ndjson mode") so the native macOS app can run setup without a human at a terminal. Call sites are converted one at a time, and nothing turns machine setup on yet.

`setup/lib/setup-config-screen.ts` is one such call site: the screen you get by choosing "Advanced" at the start of setup, which lets you override individual config entries (ports, URLs, tokens, agent template, and so on). It called the terminal prompt library directly, so a machine-driven run could not answer it.

## How it works

- `runAdvancedScreen(initial)` becomes `runAdvancedScreen(initial, driver?)`. The driver is an **optional trailing parameter**, so the existing one-argument call in `setup/auto.ts` still compiles and still runs the old terminal path unchanged at this commit.
- When a driver is passed, each of the four prompt shapes (single choice, confirm, integer text, string/secret text) is expressed as a driver prompt instead of a direct terminal call. The integer validator was pulled out into a named local so both paths share one copy of the range checks.
- **The policy change:** two config entries are marked `secret: true` (`onecliApiToken`, the OneCLI access token, and `anthropicAuthToken`). If the driver is in ndjson mode and one of those is selected, the screen calls `driver.error('secret_transport_forbidden', ...)`, which never returns and ends the run. It fires *before* the prompt, so no value is ever requested, returned, or applied to the environment. The intent is that machine setup receives secrets only through the dedicated structured authentication prompts, not through the generic override screen. In terminal mode (with or without a driver) secrets are still prompted normally.
- One user-visible copy change: the last menu option goes from "Done — continue with setup" to "Done - continue with setup" (em dash to hyphen). Real people see this in the terminal today.

## What trips people up

- The `kind: 'secret'` branch further down in `promptOne` looks like it contradicts the new refusal. It does not: ndjson runs never reach it because the guard above aborts first. It is live only for a terminal driver, where it prompts with a masked field and registers the value for log redaction.
- The code is **dormant at this commit**. `setup/auto.ts` does not pass a driver until PR 36 of this stack ("add the machine entry guards"), which is also where the returned values get written into the environment. So nothing in this PR changes behaviour today except the em dash.
- The new test asserts `process.env.NANOCLAW_ONECLI_API_TOKEN` is still unset after the refusal. That is guarding the eventual composed flow, since this function does not write the environment itself.

## What to review

1. Whether refusing secrets in the machine-driven advanced screen is the policy you want, and whether hard-failing the run is the right response versus skipping the entry.
2. That the two non-driver branches are faithful to the code they replaced, especially the extracted integer validator.
3. That the optional trailing parameter really does leave the existing call site and terminal behaviour alone.

Gate: the setup-inclusive `tsc -p tsconfig.setupcheck.json` and `vitest run setup/lib/setup-config-screen.test.ts`. Note that the repo's `tsconfig.json` covers only `src/**/*`, so CI does not typecheck `setup/`; this file is checked by the stack's own setup-inclusive config.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is not a skill, not a bug fix, and not a simplification: it is one step of the proposed machine-drivable setup protocol, adding a driver seam plus a secret-handling rule to an existing setup screen.

## Description

See the sections above.

## For Skills

Not a skill, so the skill checklist does not apply.