### PR TITLE
feat(setup): drive channel prompts; ndjson skips back gate and pre-step

### DIFF
--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -27,6 +27,7 @@ import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../
 import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
 import { channelsRemote, hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
+import type { SetupDriver } from '../lib/setup-driver.js';
 import { clearTemplatePick } from '../templates.js';
 import { getChannelPreStep, getCompanionSkills } from './companions.js';
 
@@ -180,9 +181,18 @@ interface WireArgs {
   instance?: string;
 }
 
-export async function resolveAgentName(): Promise<string> {
+export async function resolveAgentName(driver?: SetupDriver): Promise<string> {
   const preset = process.env.NANOCLAW_AGENT_NAME?.trim();
   if (preset) return preset;
+  if (driver) {
+    const answer = await driver.prompt({
+      kind: 'text',
+      message: 'What should your assistant be called?',
+      placeholder: DEFAULT_AGENT_NAME,
+      default: DEFAULT_AGENT_NAME,
+    });
+    return String(answer).trim() || DEFAULT_AGENT_NAME;
+  }
   const answer = ensureAnswer(
     await p.text({
       message: 'What should your assistant be called?',
@@ -194,7 +204,7 @@ export async function resolveAgentName(): Promise<string> {
 }
 
 /** The shared wire: init-first-agent (group + owner role + cli_scope + wiring + /welcome). */
-async function initFirstAgent(args: WireArgs): Promise<boolean> {
+async function initFirstAgent(args: WireArgs, driver?: SetupDriver): Promise<boolean> {
   const res = await runQuietChild(
     'init-first-agent',
     'pnpm',
@@ -220,6 +230,7 @@ async function initFirstAgent(args: WireArgs): Promise<boolean> {
     ],
     { running: `Wiring ${args.agentName} to your ${args.channel} DMs…`, done: 'Agent wired.' },
     { extraFields: { CHANNEL: args.channel, AGENT_NAME: args.agentName, PLATFORM_ID: args.platformId } },
+    driver,
   );
   return res.ok;
 }
@@ -266,25 +277,27 @@ export async function runChannelSkill(
   // First-prompt back gate — the very first thing, before any side effect
   // (agent-name/role prompts, the skill run, the wire).
   // Opt-in via offerBack so headless callers + existing tests are unaffected.
-  if (overrides.offerBack) {
+  if (overrides.offerBack && overrides.driver?.mode !== 'ndjson') {
     const label = channel.charAt(0).toUpperCase() + channel.slice(1);
     const gate = await (overrides.backGate ?? backGate)(label);
     if (gate === BACK_TO_CHANNEL_SELECTION) return BACK_TO_CHANNEL_SELECTION;
   }
 
   const projectRoot = overrides.projectRoot ?? process.cwd();
-  const failWith = overrides.fail ?? fail;
+  const failWith =
+    overrides.fail ?? ((stepName, msg, hint, rawLogPath) => fail(stepName, msg, hint, rawLogPath, overrides.driver));
   // The agent name + role are wire inputs — in wireIfResolved mode, defer the
   // prompts past the skill run (only a fresh create resolves the wire inputs;
   // a drop-through re-run asks nothing).
   const askLater = overrides.wireIfResolved;
-  let agentName = askLater ? '' : (overrides.agentName ?? (await resolveAgentName()));
-  let role = askLater ? undefined : (overrides.role ?? (await askOperatorRole(channel)));
+  let agentName = askLater ? '' : (overrides.agentName ?? (await resolveAgentName(overrides.driver)));
+  let role = askLater ? undefined : (overrides.role ?? (await askOperatorRole(channel, overrides.driver)));
 
   // Channel-specific: install adapter, collect credentials, resolve the wire
   // inputs. The whole channel-specific procedure lives in the SKILL.md.
   const res = await runSkill(`.claude/skills/add-${channel}`, {
     projectRoot,
+    driver: overrides.driver,
     exec: overrides.exec,
     execStream: overrides.execStream,
     resolveInput: overrides.resolveInput,
@@ -309,14 +322,18 @@ export async function runChannelSkill(
     step: overrides.step ?? `${channel}-install`,
   });
   if (!fullyApplied(res)) {
-    if (res.deferred.length) p.log.warn(`Still needs: ${res.deferred.join(', ')}`);
+    if (res.deferred.length) {
+      const warning = `Still needs: ${res.deferred.join(', ')}`;
+      if (overrides.driver) overrides.driver.log('warn', warning);
+      else p.log.warn(warning);
+    }
     // A bounced reason can carry a full stderr dump (a Node stacktrace). The
     // terminal gets ONE line per bounce — the first line, which hostExec
     // composes as `exit <code>: <first stderr line>` — and the full text goes
     // to a raw step log, written only when there's actually more than one line
     // to keep (SSF-004; the reference prose is deliberately not dumped either).
     let rawLog: string | undefined;
-    if (res.agentTasks.some((t) => t.reason.includes('\n'))) {
+    if (overrides.driver?.mode !== 'ndjson' && res.agentTasks.some((t) => t.reason.includes('\n'))) {
       rawLog = setupLog.stepRawLog(`${channel}-install-bounce`);
       writeFileSync(rawLog, res.agentTasks.map((t) => `## ${t.kind} (line ${t.line})\n${t.reason}\n`).join('\n'));
     }
@@ -326,7 +343,12 @@ export async function runChannelSkill(
         .map((l) => l.trim())
         .filter(Boolean);
       const more = lines.length > 1 ? ` (+${lines.length - 1} more lines in ${rawLog})` : '';
-      p.log.warn(`Needs an agent (${t.kind}): ${lines[0] ?? t.reason}${more}`);
+      const warning =
+        overrides.driver?.mode === 'ndjson'
+          ? `Needs an agent (${t.kind}); see the authored recovery below.`
+          : `Needs an agent (${t.kind}): ${lines[0] ?? t.reason}${more}`;
+      if (overrides.driver) overrides.driver.log('warn', warning);
+      else p.log.warn(warning);
     }
     // Surface the bounced step's OWN prose as the failure hint + Claude-handoff
     // context (fail() dims the hint and forwards it to offerClaudeOnFailure),
@@ -347,7 +369,11 @@ export async function runChannelSkill(
   await applyCompanionSkills(channel, projectRoot, overrides);
 
   // Identity confirmation captured by the skill (e.g. add-slack's auth.test).
-  if (res.vars.connected_as) p.log.success(`Connected to ${channel} as ${res.vars.connected_as}.`);
+  if (res.vars.connected_as) {
+    const message = `Connected to ${channel} as ${res.vars.connected_as}.`;
+    if (overrides.driver) overrides.driver.log('success', message);
+    else p.log.success(message);
+  }
 
   const ownerHandle = res.vars.owner_handle;
   const platformId = res.vars.platform_id;
@@ -365,13 +391,13 @@ export async function runChannelSkill(
     );
   }
   if (overrides.wireIfResolved) {
-    agentName = overrides.agentName ?? (await resolveAgentName());
-    role = overrides.role ?? (await askOperatorRole(channel));
+    agentName = overrides.agentName ?? (await resolveAgentName(overrides.driver));
+    role = overrides.role ?? (await askOperatorRole(channel, overrides.driver));
   }
 
   // Shared wire — the same procedure for every channel. role is defined here:
   // it's only undefined in an unresolved wireIfResolved run (returned above).
-  const wire = overrides.wire ?? initFirstAgent;
+  const wire = overrides.wire ?? ((args) => initFirstAgent(args, overrides.driver));
   // A skill-resolved engage pattern (WhatsApp shared-mode "@<name> only"
   // self-chat) rides along to init-first-agent's --engage-pattern; unset means
   // the wiring's own DM default applies.
@@ -419,14 +445,16 @@ export async function runChannelSkillWithPreStep(
   overrides: ChannelSkillOverrides = {},
 ): Promise<ChannelFlowResult> {
   const preStep = getChannelPreStep(channel);
-  if (!preStep) return runChannelSkill(channel, displayName, overrides);
+  // Pre-steps own terminal prompts of their own. Under the machine protocol every
+  // prompt must flow through the driver, so the manual skill path runs instead.
+  if (!preStep || overrides.driver?.mode === 'ndjson') return runChannelSkill(channel, displayName, overrides);
 
   if (overrides.offerBack) {
     const label = channel.charAt(0).toUpperCase() + channel.slice(1);
     const gate = await (overrides.backGate ?? backGate)(label);
     if (gate === BACK_TO_CHANNEL_SELECTION) return BACK_TO_CHANNEL_SELECTION;
   }
-  const agentName = overrides.agentName ?? (await resolveAgentName());
+  const agentName = overrides.agentName ?? (await resolveAgentName(overrides.driver));
   const preBound = await preStep(agentName);
   return runChannelSkill(channel, displayName, {
     ...overrides,

--- a/setup/lib/role-prompt.ts
+++ b/setup/lib/role-prompt.ts
@@ -10,10 +10,25 @@
  */
 import { brightSelect } from './bright-select.js';
 import { ensureAnswer } from './runner.js';
+import type { SetupDriver } from './setup-driver.js';
 
 export type OperatorRole = 'owner' | 'admin' | 'member';
 
-export async function askOperatorRole(channelLabel: string): Promise<OperatorRole> {
+export async function askOperatorRole(channelLabel: string, driver?: SetupDriver): Promise<OperatorRole> {
+  if (driver) {
+    return String(
+      await driver.prompt({
+        kind: 'singleChoice',
+        message: `How should this ${channelLabel} account be registered?`,
+        default: 'owner',
+        choices: [
+          { id: 'owner', label: 'Owner', hint: 'full access - recommended for your own account' },
+          { id: 'admin', label: 'Admin', hint: 'can manage the agent for this channel' },
+          { id: 'member', label: 'Member', hint: 'can chat with the agent but nothing more' },
+        ],
+      }),
+    ) as OperatorRole;
+  }
   const choice = ensureAnswer(
     await brightSelect<OperatorRole>({
       message: `How should this ${channelLabel} account be registered?`,


### PR DESCRIPTION
**TL;DR.** Proposed: the channel setup wizard and the "how should this account be registered?" role prompt stop calling the terminal UI directly and call the setup driver instead. Three of the wizard's behaviours are deliberately different when the driver is the machine one, and this PR ships those differences with no tests.

**Background.** Setup today talks to a human through clack, a terminal prompt library, imported as `p`. The stack this PR belongs to introduces a `SetupDriver`: one interface for every user interaction, with two implementations. `TerminalSetupDriver` renders through the same clack calls, so terminal runs look identical. `NdjsonSetupDriver` (`mode === 'ndjson'`) speaks a newline-delimited JSON protocol over stdin and stdout so a native macOS app can run setup with no terminal at all. Call sites are converted one PR at a time, and an unconverted call site still works.

**What this PR changes.** `resolveAgentName(driver?)` and `askOperatorRole(channelLabel, driver?)` gain an optional trailing driver parameter; given one, they ask through `driver.prompt` instead of `p.text` / `brightSelect`. `runChannelSkill` passes `overrides.driver` down to both, into `runSkill`, into the `fail` abort path, and into the `init-first-agent` child wire, and sends its "Still needs: ...", "Needs an agent (...)" and "Connected to ... as ..." lines through `driver.log` when a driver exists. Both parameters are optional and trailing, so every existing caller compiles and behaves as before.

**What trips people up: this is not a pure conversion.** Three branches change behaviour, and only under `mode === 'ndjson'`:

1. `if (overrides.offerBack && overrides.driver?.mode !== 'ndjson')` suppresses the "Back to channel selection" gate, so a machine-driven operator loses that navigation affordance and cannot back out of a channel before the first side effect.
2. `if (overrides.driver?.mode !== 'ndjson' && res.agentTasks.some(...))` stops writing the raw bounce log, and each bounce warning becomes `Needs an agent (<kind>); see the authored recovery below.` instead of the first stderr line plus a "+N more lines in <path>" pointer. The detail is meant to reach the client as the structured recovery that `fail()` emits.
3. `if (!preStep || overrides.driver?.mode === 'ndjson') return runChannelSkill(...)` in `runChannelSkillWithPreStep` skips a registered pre-step entirely and takes the plain skill path. The stated reason is that pre-steps own their own terminal prompts, which would bypass the protocol. On trunk the registered pre-steps are Slack auto-provisioning and the Telegram "use the existing bot, or add another?" flow, so under the protocol Slack app auto-provisioning never runs and an operator who already has `TELEGRAM_BOT_TOKEN` set is never offered a second bot; both fall through to the manual skill walkthrough with a different prompt sequence.

**Dormant at this commit.** Nothing passes a driver into the channel wizard yet: `setup/auto.ts` still calls `runChannelSkillWithPreStep(channel, name, { offerBack: true })`. The next PR in the stack, "introduce the driver seam in setup auto", supplies the driver and turns all of the above on. Terminal behaviour after this PR alone is unchanged.

**What to review.** Whether the three `ndjson` divergences are the right product calls, especially the suppressed back gate and the skipped Slack and Telegram pre-steps, and whether they belong behind a test. There is no automated coverage for any of them: no test in the tree passes a driver into `runChannelSkill`, `runChannelSkillWithPreStep` or `askOperatorRole`, at this commit or at the tip of the stack, so the existing channel tests only exercise the unchanged terminal path. Also worth a look: the driver path for the role prompt rebuilds the three choices as protocol choices, and one hint loses an em dash ("full access - recommended"), which is the only visible change on the terminal driver.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is a slice of a new setup driver protocol under `setup/`: it changes source code but adds no skill, fixes no bug, and simplifies nothing.

## Description

Two files, +59/-16: `setup/channels/run-channel-skill.ts` and `setup/lib/role-prompt.ts`. Optional driver parameters on the agent-name and role prompts, driver forwarding through the channel wizard, and the three `ndjson`-only behaviour changes described above. Part of a 39 PR stack that together reproduces one upstream commit exactly; the stack's final tree is byte-identical to it.

## For Skills

Not a skill, so this checklist does not apply.