### PR TITLE
refactor(setup): add the driver seam and an import-safe entry to auto

### DIFF
--- a/setup/auto-entry.test.ts
+++ b/setup/auto-entry.test.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const TSX = path.join(ROOT, 'node_modules', '.bin', 'tsx');
+const REAL_ENTRY = path.join(ROOT, 'setup', 'auto.ts');
+
+let fixtureRoot: string;
+
+beforeEach(() => {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-auto-entry-'));
+});
+
+afterEach(() => {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe('setup/auto.ts module entry guard', () => {
+  it('runs main() when the checkout is reached through a symlink', () => {
+    // nanoclaw.sh builds PROJECT_ROOT from bash's logical pwd, so it execs an
+    // absolute $PROJECT_ROOT/setup/auto.ts that still carries the symlink.
+    // Node resolves symlinks for import.meta.url but not for process.argv[1],
+    // so a guard comparing the two raw paths is false through a symlinked
+    // checkout: main() never runs and --help and --uninstall exit 0 having
+    // done nothing. --help exercises the identical guard without destroying
+    // anything.
+    const linkedRoot = path.join(fixtureRoot, 'checkout');
+    fs.symlinkSync(ROOT, linkedRoot);
+    const linkedEntry = path.join(linkedRoot, 'setup', 'auto.ts');
+    // The symlink must be a genuinely different literal path onto the same
+    // file, otherwise this test would prove nothing.
+    expect(linkedEntry).not.toBe(REAL_ENTRY);
+    expect(fs.realpathSync(linkedEntry)).toBe(fs.realpathSync(REAL_ENTRY));
+
+    const result = spawnSync(TSX, [linkedEntry, '--help'], {
+      cwd: linkedRoot,
+      env: { ...process.env, NANOCLAW_NO_DIAGNOSTICS: '1' },
+      encoding: 'utf8',
+      timeout: 15_000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Usage: bash nanoclaw.sh');
+    expect(result.stdout).toContain('--uninstall');
+  }, 15_000);
+});

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -65,6 +65,15 @@ import { runAdvancedScreen } from './lib/setup-config-screen.js';
 import { CONFIG, envVarFor, validateHttpUrl } from './lib/setup-config.js';
 import { runWindowedStep } from './lib/windowed-runner.js';
 import { runUninstallFlow } from './uninstall/flow.js';
+import {
+  createSetupDriver,
+  DriverCancelled,
+  DriverTerminalError,
+  type DriverPrompt,
+  type SetupReceipt,
+  type SetupDriver,
+} from './lib/setup-driver.js';
+import { buildSetupReceipt, inspectService, queryHostHealth } from './lib/service-health.js';
 import { detectExistingInstall } from './uninstall/scan.js';
 import { detectRegisteredGroups, detectExistingDisplayName, readEnvKey } from './environment.js';
 import { pollHealth } from './onecli.js';
@@ -126,7 +135,45 @@ type ChannelChoice =
   | 'other'
   | 'skip';
 
-async function main(): Promise<void> {
+async function selectPrompt<T extends string>(
+  driver: SetupDriver,
+  id: string,
+  opts: {
+    message: string;
+    options: Array<{ value: T; label: string; hint?: string }>;
+    initialValue?: T;
+  },
+): Promise<T> {
+  return driver.prompt({
+    id,
+    kind: 'singleChoice',
+    message: opts.message,
+    choices: opts.options.map(({ value, label, hint }) => ({ id: value, label, hint })),
+    ...(opts.initialValue !== undefined ? { default: opts.initialValue } : {}),
+  }) as Promise<T>;
+}
+
+async function confirmPrompt(driver: SetupDriver, id: string, message: string, initialValue = false): Promise<boolean> {
+  return driver.prompt({ id, kind: 'confirm', message, default: initialValue }) as Promise<boolean>;
+}
+
+async function textPrompt(
+  driver: SetupDriver,
+  id: string,
+  spec: Omit<DriverPrompt, 'id' | 'kind' | 'sensitive'>,
+): Promise<string> {
+  return driver.prompt({ ...spec, id, kind: 'text', sensitive: false }) as Promise<string>;
+}
+
+async function secretPrompt(
+  driver: SetupDriver,
+  id: string,
+  spec: Omit<DriverPrompt, 'id' | 'kind' | 'sensitive'>,
+): Promise<string> {
+  return driver.prompt({ ...spec, id, kind: 'secret', sensitive: true }) as Promise<string>;
+}
+
+async function main(driver: SetupDriver): Promise<void> {
   // Make sure ~/.local/bin is on PATH for every child process we spawn.
   // Installers we run mid-setup (OneCLI, claude) drop binaries there and
   // append a PATH line to the user's shell rc, but rc updates don't reach
@@ -162,7 +209,7 @@ async function main(): Promise<void> {
     });
   }
 
-  printIntro();
+  printIntro(driver);
   initProgressionLog();
   phEmit('auto_started');
 
@@ -2057,12 +2104,12 @@ function maybeReexecUnderSg(): void {
 
 // ─── intro + progression-log init ──────────────────────────────────────
 
-function printIntro(): void {
+function printIntro(driver: SetupDriver): void {
   const isReexec = process.env.NANOCLAW_REEXEC_SG === '1';
   const wordmark = `${k.bold('Nano')}${brandBold('Claw')}`;
 
   if (isReexec) {
-    p.intro(`${brandChip(' Welcome ')}  ${wordmark}  ${k.dim('· picking up where we left off')}`);
+    driver.intro(`${brandChip(' Welcome ')}  ${wordmark}  ${k.dim('· picking up where we left off')}`);
     return;
   }
 
@@ -2070,7 +2117,7 @@ function printIntro(): void {
   // welcome framing alone so the two don't double up. Standalone runs of
   // setup:auto still see this as the first line — fine without the wordmark
   // since the line itself signals the start of the flow.
-  p.intro("Let's get you set up.");
+  driver.intro("Let's get you set up.");
 }
 
 /**
@@ -2108,8 +2155,52 @@ function initProgressionLog(): void {
   });
 }
 
-main().catch((err) => {
-  p.log.error(err instanceof Error ? err.message : String(err));
-  p.cancel('Setup aborted.');
-  process.exit(1);
-});
+// Compare realpaths. Node resolves symlinks for `import.meta.url` but not for
+// `process.argv[1]`, and nanoclaw.sh execs this file by an absolute path built
+// from bash's logical pwd. Without the realpath a symlinked checkout made
+// `--help` and `--uninstall` exit 0 having done nothing.
+const nanoclawEntryPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+let nanoclawEntryHref = nanoclawEntryPath ? pathToFileURL(nanoclawEntryPath).href : '';
+if (nanoclawEntryPath) {
+  try {
+    nanoclawEntryHref = pathToFileURL(fs.realpathSync(nanoclawEntryPath)).href;
+  } catch {
+    // An entry path that cannot be resolved simply will not match.
+  }
+}
+if (nanoclawEntryHref === import.meta.url) {
+  const rootDriver = createSetupDriver(
+    process.argv.includes('--uninstall') || process.env.NANOCLAW_OPERATION === 'uninstall' ? 'uninstall' : 'setup',
+  );
+
+  main(rootDriver).catch((err) => {
+    if (err instanceof DriverCancelled) {
+      rootDriver.cancelled();
+      process.exitCode = rootDriver.mode === 'ndjson' ? 2 : 0;
+      return;
+    }
+    if (err instanceof DriverTerminalError) {
+      process.exitCode = err.exitCode;
+      return;
+    }
+    if (rootDriver.mode === 'ndjson') {
+      try {
+        rootDriver.error('unexpected_error', err instanceof Error ? err.message : String(err), [
+          {
+            kind: 'rerun',
+            args:
+              rootDriver.operation === 'uninstall'
+                ? ['--uninstall', '--protocol', 'nanoclaw.driver.v1']
+                : ['--protocol', 'nanoclaw.driver.v1'],
+          },
+        ]);
+      } catch {
+        process.exitCode = 1;
+      }
+      return;
+    }
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.cancel('Setup aborted.');
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
**TL;DR (proposed, nothing here is merged):** `setup/auto.ts` gets the plumbing it needs to stop talking to the terminal directly. `main()` now receives a driver object, the file only starts a setup run when it is executed directly rather than imported, and the top-level error handler learns four outcomes instead of one. One line of output moves onto the driver; every other prompt still goes through the old terminal path.

## The problem this solves

NanoClaw's installer lives in `setup/auto.ts` (about 2,200 lines). It prints and prompts by calling **clack**, a terminal prompt library imported as `p`. That works for a person sitting at a terminal and nowhere else.

The stack this PR belongs to adds a **SetupDriver**: an interface that covers every kind of user interaction setup performs (pick one of a list, confirm, type text, type a secret, show progress, display information, go do something outside the installer). One implementation renders through the same clack UI, so terminal behaviour is unchanged. A second implementation speaks **NDJSON** (newline-delimited JSON, one JSON object per line) over stdin and stdout, so the native macOS app can run setup with no terminal at all.

Before any of `auto.ts`'s prompts can move across, the file needs a place to obtain a driver and a defined way to end. That is all this PR builds.

## How it works

Four pieces, all in `setup/auto.ts`:

1. **Imports** the driver factory, its two control-flow error classes, and its types.
2. **`main()` becomes `main(driver: SetupDriver)`.** The body is untouched.
3. **`printIntro` takes the driver** and its two `p.intro(...)` calls become `driver.intro(...)`. This is the only call site converted here; roughly 69 `p.` calls remain in the file and still render through clack.
4. **The entry point** replaces the old `main().catch(...)` tail:
   - It is wrapped in a guard that compares `process.argv[1]` to this module's own URL, so importing `auto.ts` no longer launches a setup run. That is what makes the renderer parity test in PR 38 possible.
   - `createSetupDriver(...)` is passed `'uninstall'` when `--uninstall` is on the command line or `NANOCLAW_OPERATION=uninstall` is set, otherwise `'setup'`. The factory itself picks terminal or NDJSON based on the `NANOCLAW_PROTOCOL` environment variable.
   - The catch has four arms: a user cancellation (`DriverCancelled`) prints the driver's cancel notice and exits 0 in terminal mode, 2 in NDJSON mode; a `DriverTerminalError` carries its own exit code; an unexpected error in NDJSON mode is emitted as a structured `error` frame carrying a "rerun with these arguments" recovery hint; and anything else falls back to the previous clack error plus "Setup aborted."

## What trips people up

- **Four helper functions are dead code at this commit.** `selectPrompt`, `confirmPrompt`, `textPrompt` and `secretPrompt` wrap `driver.prompt(...)` and nothing calls them yet. PR 28 (step runs and the timezone step) is the first consumer, and the conversion PRs after it use them heavily. They are here so the shared shape is reviewed once, on its own, rather than buried inside a prompt-conversion diff.
- **The `service-health` import is also unused here** (`buildSetupReceipt`, `inspectService`, `queryHostHealth`, and the `SetupReceipt` type). It is consumed by the completion-receipt work later in the stack. Both this and the point above are deliberate; flag them if you disagree, but they are not oversights.
- **One real behaviour change:** the terminal failure path now sets `process.exitCode = 1` instead of calling `process.exit(1)`. The exit status is the same, but the process now returns through normal shutdown instead of terminating immediately, so an open handle or an unreaped child can delay exit where it previously could not. This is required for the import guard to be worth anything.
- **The empty `catch {}` around the NDJSON error emit is intentional.** `driver.error(...)` is typed `never` and always throws `DriverTerminalError` after writing the frame; the catch converts that into exit code 1. It is not swallowing a genuine failure.
- **`--protocol nanoclaw.driver.v1` is reachable from this PR but the file is only half converted.** Terminal mode is correct at every PR in this stack. NDJSON mode is not claimed to work end to end until PR 38: an unconverted clack call site would block waiting on a terminal that is not there. Nothing ships a user into that path; the macOS app still hard-codes no protocol.
- **Import safety is not complete yet.** `--help` inside `main()` still calls `process.exit(0)`. PR 36 changes it to `return`.

## What to review

- The entry guard comparison: `pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url`. Does it hold for how this repo actually starts setup (`tsx setup/auto.ts` via the `setup:auto` package script, and through `nanoclaw.sh`)?
- The four catch arms, in particular the exit codes: cancel is 0 in terminal mode and 2 in NDJSON mode.
- The operation detection. `--uninstall` and `NANOCLAW_OPERATION` are read here, while `main()` decides the uninstall route from parsed config flags. If those two ever disagree, the driver would be labelled with the wrong operation.
- Nit worth calling: the rerun recovery inlines the string `'nanoclaw.driver.v1'` twice rather than using the exported `DRIVER_PROTOCOL` constant from the same module.

## Verification

Setup-inclusive TypeScript check with no new errors against the baseline, `bash -n nanoclaw.sh`, and vitest over `setup` and `scripts`. Note that the repo's own `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`; the check above was run explicitly. No new tests: this PR adds no branch that can be exercised without the later conversions, and PR 38 covers the entry point by importing this module.

## Behaviour fix carried in this PR

The entry guard compares realpaths. Node resolves symlinks for `import.meta.url` but not for `process.argv[1]`, and `nanoclaw.sh` execs this file by an absolute path built from bash's logical pwd. Comparing the two directly makes `--help` and `--uninstall` print nothing and exit 0 from any checkout reached through a symlink, which on a destructive command means the user believes they uninstalled and did not.

`setup/auto-entry.test.ts` spawns the real entry point through a symlink to pin it.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is installer infrastructure: it adds no skill, fixes no bug, and adds lines rather than removing them.

## Description

See above. One file, `setup/auto.ts`, +88/-10.

## For Skills

Not a skill, so the skill checklist does not apply.