### PR TITLE
feat(setup): gate machine setup on docker readiness and socket access

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -311,7 +311,9 @@ async function main(driver: SetupDriver): Promise<void> {
   }
 
   if (!skip.has('container')) {
-    p.log.message(
+    await ensureMachineContainerRuntime(driver);
+    driver.log(
+      'message',
       brandBody(dimWrap('Your assistant lives in its own sandbox. It can only see what you explicitly share.', 4)),
     );
     // Asked before the step runs, because the step is what acts on the answer.
@@ -610,10 +612,16 @@ async function main(driver: SetupDriver): Promise<void> {
   }
 
   if (!skip.has('service')) {
-    const res = await runQuietStep('service', {
-      running: 'Starting NanoClaw in the background…',
-      done: 'NanoClaw is running.',
-    });
+    await ensureMachineServicePermissions(driver);
+    const res = await runQuietStep(
+      'service',
+      {
+        running: 'Starting NanoClaw in the background…',
+        done: 'NanoClaw is running.',
+      },
+      [],
+      driver,
+    );
     if (!res.ok) {
       await fail('service', "Couldn't start NanoClaw.", 'See logs/nanoclaw.error.log for details.', undefined, driver);
     }
@@ -2051,6 +2059,125 @@ async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELE
 }
 
 // ─── interactive / env helpers ─────────────────────────────────────────
+
+type ContainerRuntimeStatus = 'ready' | 'missing' | 'stopped' | 'permission' | 'other';
+
+function containerRuntimeStatus(): ContainerRuntimeStatus {
+  const result = spawnSync('docker', ['info'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') return 'missing';
+  if (result.status === 0) return 'ready';
+  const output = `${result.stderr ?? ''}\n${result.stdout ?? ''}`;
+  if (/permission denied/i.test(output)) return 'permission';
+  if (/cannot connect|is the docker daemon running|no such file/i.test(output)) return 'stopped';
+  return 'other';
+}
+
+async function waitForContainerRuntime(): Promise<boolean> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    if (containerRuntimeStatus() === 'ready') return true;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  return false;
+}
+
+async function ensureMachineContainerRuntime(driver: SetupDriver): Promise<void> {
+  if (driver.mode !== 'ndjson') return;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const status = containerRuntimeStatus();
+    if (status === 'ready') return;
+    if (status === 'missing') {
+      driver.error('container_runtime_required', 'Docker must be installed before setup can continue.', [
+        {
+          kind: 'manual',
+          title: 'Install Docker',
+          instructions: ['Install Docker Desktop on macOS or Docker Engine on Linux, then rerun setup.'],
+        },
+      ]);
+    }
+    if (status === 'stopped') {
+      const action =
+        process.platform === 'darwin'
+          ? {
+              id: 'start-docker',
+              kind: 'startApplication' as const,
+              title: 'Start Docker Desktop',
+              application: 'Docker',
+            }
+          : null;
+      if (!action)
+        driver.error('container_runtime_not_started', 'Docker must be running before setup can continue.', [
+          {
+            kind: 'manual',
+            title: 'Start Docker',
+            instructions: ['Start the Docker service in a terminal, then rerun setup.'],
+          },
+        ]);
+      const result = await driver.externalAction(action, waitForContainerRuntime);
+      if (result === 'attempted') continue;
+      driver.error('container_runtime_not_started', 'Docker must be running before setup can continue.', [
+        { kind: 'manual', title: 'Start Docker', instructions: ['Start Docker Desktop, then rerun setup.'] },
+      ]);
+    }
+    if (status === 'permission') {
+      const user = process.env.USER?.trim();
+      const groups = user
+        ? (spawnSync('id', ['-nG', user], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).stdout ?? '')
+        : '';
+      if (groups.split(/\s+/).includes('docker')) maybeReexecUnderSg(driver);
+      driver.error('container_runtime_permission', 'This login session cannot access Docker yet.', [
+        {
+          kind: 'manual',
+          title: 'Refresh Docker group membership',
+          instructions: ['Add your user to the docker group if needed.', 'Log out and back in, then rerun setup.'],
+        },
+      ]);
+    }
+    driver.error('container_runtime_unavailable', 'Docker is installed but its status could not be verified.', [
+      {
+        kind: 'manual',
+        title: 'Check Docker',
+        instructions: ['Run docker info in a terminal, fix the reported problem, then rerun setup.'],
+      },
+    ]);
+  }
+  driver.error('container_runtime_unavailable', 'Docker did not become ready.');
+}
+
+async function ensureMachineServicePermissions(driver: SetupDriver): Promise<void> {
+  if (driver.mode !== 'ndjson' || process.platform !== 'linux' || process.getuid?.() === 0) return;
+  if (spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' }).status !== 0) return;
+  if (containerRuntimeStatus() !== 'ready') return;
+  const probe = (): boolean =>
+    spawnSync('systemd-run', ['--user', '--pipe', '--wait', 'docker', 'info'], { stdio: 'ignore' }).status === 0;
+  if (probe() || spawnSync('which', ['setfacl'], { stdio: 'ignore' }).status !== 0) return;
+  const user = process.env.USER?.trim();
+  if (!user) driver.error('service_permission_unknown_user', 'Could not determine the user for Docker socket access.');
+  driver.error('service_permission_required', 'The service cannot access Docker in machine mode.', [
+    {
+      kind: 'manual',
+      title: 'Grant Docker socket access',
+      instructions: [`Run setfacl for ${user} in a terminal, then rerun setup.`],
+    },
+  ]);
+}
+
+async function rebuildProviderImage(driver: SetupDriver): Promise<ReturnType<typeof buildContainerImage>> {
+  const result = await runQuietChild(
+    'provider-image-build',
+    path.join(PROJECT_ROOT, 'container', 'build.sh'),
+    [],
+    { running: 'Rebuilding the sandbox image…', done: 'Sandbox image rebuilt.' },
+    undefined,
+    driver,
+  );
+  return result.ok
+    ? { ok: true }
+    : {
+        ok: false,
+        message: `The container image build failed (exit ${result.exitCode}).`,
+        hint: `Inspect ${result.rawLog}, fix Docker or the build input, then retry.`,
+      };
+}
 
 function ensureLocalBinOnPath(): void {
   const localBin = path.join(os.homedir(), '.local', 'bin');


### PR DESCRIPTION
## TL;DR

Proposed: when setup is driven by a program instead of a person, check that Docker is actually usable before the container step, and that the background service will be able to reach the Docker socket before the service step, and stop with a structured, machine-readable error if not. Terminal setup is unchanged. Nothing here is merged; this is PR 29 of a 39-PR draft stack that splits one oversized upstream commit into reviewable pieces.

## Background, in plain terms

The stack adds a `SetupDriver`: one interface that every setup prompt, log line, progress update and error goes through. There are two implementations. `TerminalSetupDriver` (`driver.mode === 'terminal'`) is the existing terminal UI, unchanged. `NdjsonSetupDriver` (`driver.mode === 'ndjson'`) speaks newline-delimited JSON over stdin/stdout so the macOS app can run setup with no terminal attached. "machine mode" below means ndjson mode. It is opt-in and nothing in the tree turns it on yet.

## What problem this solves

In a terminal, a broken Docker is survivable: the user reads the failure and fixes it. Under the protocol nobody is watching the terminal, so an unusable Docker becomes an opaque failure deep inside a build step and the GUI has nothing actionable to show. Separately, on Linux, `docker info` working in the login shell does not mean the systemd **user** unit that will run NanoClaw can reach `/var/run/docker.sock`, and that only surfaces later as a service that will not start.

## How it works

- `containerRuntimeStatus()` runs `docker info` and classifies the result as ready, missing, stopped, permission or other.
- `ensureMachineContainerRuntime(driver)` returns immediately unless mode is ndjson. ready: continue. missing or other: `driver.error(...)` with a manual recovery step. stopped: on macOS it emits an **external action** (`startApplication` "Docker"), which is a request the GUI performs on the user's behalf, then polls `waitForContainerRuntime()` (30 attempts, 2 seconds apart, so up to 60 seconds); on any other platform, or if the GUI does not report that it tried, it errors. permission: if the user is already in the `docker` group it calls the existing `maybeReexecUnderSg`, which can re-exec the whole run under `sg docker`; otherwise it errors.
- `driver.error()` is typed `never` (`setup/lib/setup-driver.ts:136`): the ndjson driver emits an error frame and ends the run, the terminal driver throws. That is why those branches read as if they fall through.
- `ensureMachineServicePermissions(driver)` applies only in ndjson mode, on Linux, as non-root. It probes with `systemd-run --user --pipe --wait docker info`. If that succeeds, or any precondition is not met, it returns silently; if it fails and `setfacl` exists, it stops with instructions.
- `rebuildProviderImage(driver)` runs `container/build.sh` through `runQuietChild`, which captures the child's output into a step log instead of letting it reach stdout. It has no caller in this PR; PR 31 calls it, ndjson-only, in place of `buildContainerImage()`.

## What trips people up

1. **This is a behaviour change, not plumbing.** Machine mode now refuses to enter the container or service step in cases where terminal mode would carry on and let the step fail. The refusal is machine-only: every helper early-returns in terminal mode, and the single `p.log.message` to `driver.log('message', ...)` swap calls `p.log.message` in terminal mode.
2. **The 3-attempt loop is nearly single-pass.** Every branch except "ready" and "stopped, and the GUI reported it attempted" ends in `driver.error`, which never returns. Only the start-Docker retry actually loops.
3. `waitForContainerRuntime` blocks the setup process for up to 60 seconds, calling `docker info` synchronously each time.
4. `ensureMachineServicePermissions` diagnoses, it never fixes. It does not run `setfacl`, it tells the operator to, and it returns silently in several cases, so treat it as best-effort detection rather than a guarantee.
5. `rebuildProviderImage` is a **second image-build path**. It bypasses `buildContainerImage()` and therefore skips that function's up-front refusal on pinned ("hardened") installs. `container/build.sh` keeps its own pinned guard (overlay when the agent-runner lockfile matches the image label, otherwise exit 3), so that protection is not lost, but the two paths report failures differently and can drift.
6. **No tests in this PR.** Note that `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/` either. Verified locally with a setup-inclusive tsc config and `vitest run setup scripts`. The stack's end-to-end protocol test arrives at PR 38 and does not exercise these paths.

## What to review

- Whether stopping is the right call for each `containerRuntimeStatus` bucket, especially the catch-all `other`.
- The regexes that classify docker's stderr into stopped vs permission.
- Whether losing `buildContainerImage`'s pinned-image pre-check and its richer failure hints in machine mode is acceptable, given build.sh's own guard.
- The silent-return paths in `ensureMachineServicePermissions`.
- Whether 60 seconds is the right budget for a user to start Docker Desktop.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this is not a skill, not a bug fix and not a simplification. It adds new machine-mode-only setup preflight behaviour behind an opt-in protocol that nothing enables yet.

## Description

See above. One file changes, `setup/auto.ts`: two new preflight calls in `main`, six new helpers, and the `service` step's `runQuietStep` call gains the driver argument that the rest of the step conversions already use.

## For Skills

Not a skill, so the skill checklist does not apply.