### PR TITLE
feat(setup): drive Claude auth and hard-fail unstructured providers

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -40,7 +40,7 @@ import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runChannelSkillWithPreStep } from './channels/run-channel-skill.js';
 import { runInheritScript } from './lib/inherit-script.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
-import { getSetupProvider, listSetupProviders } from './providers/registry.js';
+import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
@@ -516,7 +516,7 @@ async function main(driver: SetupDriver): Promise<void> {
     // each via `ncl groups config update --provider` right after creating it
     // (the creation scripts inherit it and apply at create — see picked-provider). Existing groups switch the
     // same way (docs/provider-migration.md).
-    agentProvider = await askAgentProviderChoice();
+    agentProvider = await askAgentProviderChoice(driver);
     setPickedProvider(agentProvider);
 
     // A pulled image bakes /app/node_modules and the CLI manifest, and every
@@ -525,22 +525,24 @@ async function main(driver: SetupDriver): Promise<void> {
     // pinned install, and reaching that refusal aborts setup with no way out
     // short of re-running it.
     if (agentProvider !== 'claude' && readImageSource() === 'hardened') {
-      const leave = ensureAnswer(
-        await p.confirm({
-          message: `${agentProvider} needs a sandbox image built on this machine. Stop using the pre-built one?`,
-          initialValue: true,
-        }),
+      const leave = await confirmPrompt(
+        driver,
+        'provider-leave-hardened-image',
+        `${agentProvider} needs a sandbox image built on this machine. Stop using the pre-built one?`,
+        true,
       );
       if (!leave) {
         await fail(
           'auth',
           `${agentProvider} can't run on the pre-built sandbox image.`,
           'Re-run setup and choose Claude to keep the pre-built image.',
+          undefined,
+          driver,
         );
       }
       writeImageSource('local');
       setupLog.userInput('image_source', 'local');
-      p.log.info(brandBody('Switched back to a locally built sandbox image.'));
+      driver.log('info', brandBody('Switched back to a locally built sandbox image.'));
     }
 
     let providerEntry = getSetupProvider(agentProvider);
@@ -552,42 +554,53 @@ async function main(driver: SetupDriver): Promise<void> {
       // already ran, the CLI manifest just changed), then load the payload's
       // setup module so it self-registers.
       const skillDir = `.claude/skills/add-${agentProvider}`;
-      const s = p.spinner();
-      s.start(`Installing ${agentProvider}…`);
+      const providerSpinner = driver.mode === 'terminal' ? p.spinner() : null;
+      if (providerSpinner) providerSpinner.start(`Installing ${agentProvider}…`);
+      else driver.progress(`add-${agentProvider}`, 'running', `Installing ${agentProvider}`);
       let blockers: string[];
       try {
-        ({ blockers } = await applyProviderSkill(skillDir, process.cwd()));
+        ({ blockers } = await applyProviderSkill(skillDir, PROJECT_ROOT));
       } catch (err) {
-        s.stop(`Couldn't install ${agentProvider}.`, 1);
+        if (providerSpinner) providerSpinner.error(`Couldn't install ${agentProvider}.`);
+        else driver.progress(`add-${agentProvider}`, 'failed');
         const message = err instanceof Error ? err.message : String(err);
-        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, message);
+        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, message, undefined, driver);
         return; // unreachable — fail() exits — but narrows blockers for TS
       }
       if (blockers.length) {
-        s.stop(`Couldn't install ${agentProvider}.`, 1);
-        await fail(`add-${agentProvider}`, `Couldn't install ${agentProvider}.`, blockers.join('; '));
+        if (providerSpinner) providerSpinner.error(`Couldn't install ${agentProvider}.`);
+        else driver.progress(`add-${agentProvider}`, 'failed');
+        await fail(
+          `add-${agentProvider}`,
+          `Couldn't install ${agentProvider}.`,
+          blockers.join('; '),
+          undefined,
+          driver,
+        );
       }
-      s.stop(`${agentProvider} installed.`);
-      p.log.info(brandBody('Rebuilding the container image with the new provider…'));
+      if (providerSpinner) providerSpinner.stop(`${agentProvider} installed.`);
+      else driver.progress(`add-${agentProvider}`, 'succeeded');
+      driver.log('info', brandBody('Rebuilding the container image with the new provider…'));
       // The rebuild is not optional here: the provider's CLI manifest is baked
       // into the image, so continuing past a failed build would authenticate a
       // runtime the container cannot actually start.
-      const rebuild = buildContainerImage();
+      const rebuild = driver.mode === 'ndjson' ? await rebuildProviderImage(driver) : buildContainerImage();
       if (!rebuild.ok) {
         await fail(
           `add-${agentProvider}`,
           `Couldn't rebuild the container image for ${agentProvider}. ${rebuild.message}`,
           rebuild.hint,
+          undefined,
+          driver,
         );
       }
       await import(`./providers/${agentProvider}.js`);
       providerEntry = getSetupProvider(agentProvider);
     }
     if (providerEntry?.runAuth) {
-      await providerEntry.runAuth();
-      await providerEntry.runInstallCheck?.();
+      await runSetupProviderAuth(providerEntry, driver);
     } else {
-      await runAuthStep();
+      await runAuthStep(driver);
     }
     // Persist the pick as the instance-wide default so every future group
     // (channel-approved, ncl-created) is created on this provider. Read from
@@ -1560,7 +1573,7 @@ function finishRegistryLogin(driver: SetupDriver, durationMs: number, method?: s
   driver.log('success', brandBody("Authenticated. Your assistant's sandbox will be fetched, not built."));
 }
 
-async function askAgentProviderChoice(): Promise<string> {
+async function askAgentProviderChoice(driver: SetupDriver): Promise<string> {
   const installed = listSetupProviders();
   const installedNames = new Set(installed.map((entry) => entry.value));
   // Offer the hard-wired installable providers this install hasn't wired yet —
@@ -1597,21 +1610,19 @@ async function askAgentProviderChoice(): Promise<string> {
   // instead of silently resetting it to claude. Fall back to claude if the
   // persisted default isn't an offered option (e.g. its provider was removed).
   const currentDefault = options.some((o) => o.value === DEFAULT_AGENT_PROVIDER) ? DEFAULT_AGENT_PROVIDER : 'claude';
-  const choice = ensureAnswer(
-    await brightSelect<string>({
-      message: 'Which agent runtime should power your assistant?',
-      options,
-      initialValue: currentDefault,
-    }),
-  ) as string;
+  const choice = await selectPrompt(driver, 'agent-provider', {
+    message: 'Which agent runtime should power your assistant?',
+    options,
+    initialValue: currentDefault,
+  });
   setupLog.userInput('agent_provider', choice);
   phEmit('agent_provider_chosen', { provider: choice });
   return choice;
 }
 
-async function runAuthStep(): Promise<void> {
+async function runAuthStep(driver: SetupDriver): Promise<void> {
   if (anthropicSecretExists()) {
-    p.log.success(brandBody('Your Claude account is already connected.'));
+    driver.log('success', brandBody('Your Claude account is already connected.'));
     setupLog.step('auth', 'skipped', 0, { REASON: 'secret-already-present' });
     return;
   }
@@ -1622,72 +1633,96 @@ async function runAuthStep(): Promise<void> {
   const customBaseUrl = process.env.NANOCLAW_ANTHROPIC_BASE_URL?.trim();
   const customAuthToken = process.env.NANOCLAW_ANTHROPIC_AUTH_TOKEN?.trim();
   if (customBaseUrl && customAuthToken) {
-    await runCustomEndpointAuth(customBaseUrl, customAuthToken);
+    registerSensitiveValue(customAuthToken);
+    await runCustomEndpointAuth(driver, customBaseUrl, customAuthToken);
     return;
   }
 
-  const method = ensureAnswer(
-    await brightSelect({
-      message: 'How would you like to connect to Claude?',
-      options: [
-        {
-          value: 'subscription',
-          label: 'Sign in with my Claude subscription',
-          hint: 'recommended if you have Pro or Max',
-        },
-        {
-          value: 'oauth',
-          label: 'Paste an OAuth token I already have',
-          hint: 'sk-ant-oat…',
-        },
-        {
-          value: 'api',
-          label: 'Paste an Anthropic API key',
-          hint: 'pay-per-use via console.anthropic.com',
-        },
-        {
-          value: 'skip',
-          label: "Skip — I'll connect later",
-          hint: 'not recommended — Claude helps debug setup issues',
-        },
-      ],
-    }),
-  ) as 'subscription' | 'oauth' | 'api' | 'skip';
+  const method = await selectPrompt(driver, 'anthropic-auth-method', {
+    message: 'How would you like to connect to Claude?',
+    options: [
+      {
+        value: 'subscription',
+        label: 'Sign in with my Claude subscription',
+        hint: 'recommended if you have Pro or Max',
+      },
+      {
+        value: 'oauth',
+        label: 'Paste an OAuth token I already have',
+        hint: 'sk-ant-oat…',
+      },
+      {
+        value: 'api',
+        label: 'Paste an Anthropic API key',
+        hint: 'pay-per-use via console.anthropic.com',
+      },
+      {
+        value: 'skip',
+        label: "Skip - I'll connect later",
+        hint: 'not recommended - Claude helps debug setup issues',
+      },
+    ],
+  });
   setupLog.userInput('auth_method', method);
   phEmit('auth_method_chosen', { method });
 
   if (method === 'skip') {
-    const confirmed = ensureAnswer(
-      await p.confirm({
-        message:
-          "Skip Claude sign-in? The agent won't be able to run until you connect, and we won't be able to help debug setup errors.",
-        initialValue: false,
-      }),
+    const confirmed = await confirmPrompt(
+      driver,
+      'anthropic-auth-skip-confirm',
+      "Skip Claude sign-in? The agent won't be able to run until you connect, and we won't be able to help debug setup errors.",
+      false,
     );
     if (!confirmed) {
       // Loop back to the auth picker so they can choose a real method.
-      return runAuthStep();
+      return runAuthStep(driver);
     }
     setupLog.step('auth', 'skipped', 0, { REASON: 'user-skipped' });
-    p.log.warn(brandBody('Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.'));
+    driver.log('warn', brandBody('Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.'));
     return;
   }
 
   if (method === 'subscription') {
-    await runSubscriptionAuth();
+    await runSubscriptionAuth(driver);
   } else {
-    await runPasteAuth(method);
+    await runPasteAuth(driver, method);
   }
 }
 
-async function runSubscriptionAuth(): Promise<void> {
-  p.log.step(brandBody('Opening the Claude sign-in flow…'));
-  console.log(k.dim('   (a browser will open for sign-in; this part is interactive)'));
-  console.log();
+async function runSubscriptionAuth(driver: SetupDriver): Promise<void> {
+  driver.log('step', brandBody('Opening the Claude sign-in flow…'));
+  if (driver.mode === 'ndjson') {
+    const start = Date.now();
+    const result = await runClaudeSubscriptionMachineAuth(driver);
+    const durationMs = Date.now() - start;
+    if (!result.ok) {
+      setupLog.step('auth', 'failed', durationMs, {
+        METHOD: 'subscription',
+        ERROR: result.reason,
+        ...(result.detail ? { DETAIL: result.detail } : {}),
+      });
+      await fail(
+        'auth',
+        "Couldn't complete the Claude sign-in.",
+        result.reason === 'spawn_failed'
+          ? 'Install the Claude CLI, then rerun setup or choose a paste option.'
+          : 'Re-run setup and try again, or choose a paste option instead.',
+        undefined,
+        driver,
+      );
+    }
+    setupLog.step('auth', 'interactive', durationMs, { METHOD: 'subscription' });
+    driver.log('success', brandBody('Claude account connected.'));
+    return;
+  }
+  if (driver.mode === 'terminal') {
+    console.log(k.dim('   (a browser will open for sign-in; this part is interactive)'));
+    console.log();
+  }
   const start = Date.now();
   const code = await runInheritScript('bash', ['setup/register-claude-token.sh']);
   const durationMs = Date.now() - start;
-  console.log();
+  if (driver.mode === 'terminal') console.log();
   if (code !== 0) {
     setupLog.step('auth', 'failed', durationMs, {
       EXIT_CODE: code,
@@ -1697,71 +1732,77 @@ async function runSubscriptionAuth(): Promise<void> {
       'auth',
       "Couldn't complete the Claude sign-in.",
       'Re-run setup and try again, or choose a paste option instead.',
+      undefined,
+      driver,
     );
   }
   setupLog.step('auth', 'interactive', durationMs, { METHOD: 'subscription' });
-  p.log.success(brandBody('Claude account connected.'));
+  driver.log('success', brandBody('Claude account connected.'));
 }
 
-async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
+async function runPasteAuth(driver: SetupDriver, method: 'oauth' | 'api'): Promise<void> {
   const label = method === 'oauth' ? 'OAuth token' : 'API key';
   const prefix = method === 'oauth' ? 'sk-ant-oat' : 'sk-ant-api';
 
-  const answer = ensureAnswer(
-    await p.password({
-      message: `Paste your ${label}`,
-      clearOnError: true,
-      validate: (v) => {
-        // Strip any internal whitespace so a line-wrapped paste that did
-        // survive into clack can still validate. The mid-token-newline
-        // case where clack only sees the first line is caught by the
-        // shape check below.
-        const cleaned = (v ?? '').replace(/\s+/g, '');
-        if (!cleaned) return 'Required';
-        if (!cleaned.startsWith(prefix)) {
-          return `Should start with ${prefix}…`;
-        }
-        if (method === 'oauth' && !/^sk-ant-oat[A-Za-z0-9_-]{80,500}AA$/.test(cleaned)) {
-          return cleaned.length < 90
-            ? 'Token looks truncated — line breaks in the paste can cut it off. Widen your terminal so the token fits on one line, then paste again.'
-            : "Token shape doesn't look right (expected sk-ant-oat…AA).";
-        }
-        return undefined;
-      },
-    }),
-  );
+  const answer = await secretPrompt(driver, `anthropic-${method}-secret`, {
+    message: `Paste your ${label}`,
+    validateValue: (answerValue) => {
+      const v = String(answerValue);
+      // Strip any internal whitespace so a line-wrapped paste that did
+      // survive into clack can still validate. The mid-token-newline
+      // case where clack only sees the first line is caught by the
+      // shape check below.
+      const cleaned = (v ?? '').replace(/\s+/g, '');
+      if (!cleaned) return 'Required';
+      if (!cleaned.startsWith(prefix)) {
+        return `Should start with ${prefix}…`;
+      }
+      if (method === 'oauth' && !/^sk-ant-oat[A-Za-z0-9_-]{80,500}AA$/.test(cleaned)) {
+        return cleaned.length < 90
+          ? 'Token looks truncated - line breaks in the paste can cut it off. Widen your terminal so the token fits on one line, then paste again.'
+          : "Token shape doesn't look right (expected sk-ant-oat…AA).";
+      }
+      return undefined;
+    },
+  });
   const token = (answer as string).replace(/\s+/g, '');
 
-  const res = await withSecretFile(token, (filePath) =>
+  const run = (childArgs: string[]): Promise<Awaited<ReturnType<typeof runQuietChild>>> =>
     runQuietChild(
       'auth',
       'onecli',
-      [
-        'secrets',
-        'create',
-        '--name',
-        'Anthropic',
-        '--type',
-        'anthropic',
-        '--file',
-        filePath,
-        '--host-pattern',
-        'api.anthropic.com',
-      ],
+      childArgs,
       {
         running: `Saving your ${label} to your OneCLI vault…`,
         done: 'Claude account connected.',
       },
       {
         extraFields: { METHOD: method },
+        ...(driver.mode === 'ndjson' ? { env: childEnvWithoutSetupSecrets() } : {}),
       },
-    ),
+      driver,
+    );
+  const res = await withSecretFile(token, (filePath) =>
+    run([
+      'secrets',
+      'create',
+      '--name',
+      'Anthropic',
+      '--type',
+      'anthropic',
+      '--file',
+      filePath,
+      '--host-pattern',
+      'api.anthropic.com',
+    ]),
   );
   if (!res.ok) {
     await fail(
       'auth',
       `Couldn't save your ${label} to the vault.`,
       'Make sure OneCLI is running (`onecli version`), then retry.',
+      undefined,
+      driver,
     );
   }
 }
@@ -1772,7 +1813,7 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
  * Authorization header on the wire — the container only ever sees
  * ANTHROPIC_BASE_URL + a placeholder bearer.
  */
-async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<void> {
+async function runCustomEndpointAuth(driver: SetupDriver, baseUrl: string, token: string): Promise<void> {
   let host: string;
   let canonicalBaseUrl: string;
   try {
@@ -1782,44 +1823,55 @@ async function runCustomEndpointAuth(baseUrl: string, token: string): Promise<vo
     host = parsed.hostname;
     canonicalBaseUrl = parsed.toString();
   } catch {
-    await fail('auth', `Invalid Anthropic base URL: ${baseUrl}`, 'Check --anthropic-base-url and retry.');
+    await fail(
+      'auth',
+      `Invalid Anthropic base URL: ${baseUrl}`,
+      'Check --anthropic-base-url and retry.',
+      undefined,
+      driver,
+    );
     return;
   }
 
-  const res = await withSecretFile(token, (filePath) =>
+  const args = (filePath: string): string[] => [
+    'secrets',
+    'create',
+    '--name',
+    'Anthropic',
+    '--type',
+    'generic',
+    '--file',
+    filePath,
+    '--host-pattern',
+    host,
+    '--header-name',
+    'Authorization',
+    '--value-format',
+    'Bearer {value}',
+  ];
+  const run = (childArgs: string[]): Promise<Awaited<ReturnType<typeof runQuietChild>>> =>
     runQuietChild(
       'auth',
       'onecli',
-      [
-        'secrets',
-        'create',
-        '--name',
-        'Anthropic',
-        '--type',
-        'generic',
-        '--file',
-        filePath,
-        '--host-pattern',
-        host,
-        '--header-name',
-        'Authorization',
-        '--value-format',
-        'Bearer {value}',
-      ],
+      childArgs,
       {
         running: `Saving your Anthropic auth token to your OneCLI vault…`,
         done: 'Claude account connected.',
       },
       {
         extraFields: { METHOD: 'custom-endpoint', HOST: host },
+        ...(driver.mode === 'ndjson' ? { env: childEnvWithoutSetupSecrets() } : {}),
       },
-    ),
-  );
+      driver,
+    );
+  const res = await withSecretFile(token, (filePath) => run(args(filePath)));
   if (!res.ok) {
     await fail(
       'auth',
       `Couldn't save your Anthropic auth token to the vault.`,
       'Make sure OneCLI is running (`onecli version`), then retry.',
+      undefined,
+      driver,
     );
   }
 

--- a/setup/provider-auth.ts
+++ b/setup/provider-auth.ts
@@ -16,7 +16,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { buildContainerImage } from './lib/container-build.js';
-import { getSetupProvider, listSetupProviders } from './providers/registry.js';
+import { TerminalSetupDriver } from './lib/setup-driver.js';
+import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register on import.
 import './providers/index.js';
@@ -91,6 +92,6 @@ export async function run(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  await entry.runAuth();
-  await entry.runInstallCheck?.();
+  const driver = new TerminalSetupDriver('setup');
+  await runSetupProviderAuth(entry, driver);
 }

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -13,9 +13,11 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { getSetupProvider, listSetupProviders } from './registry.js';
+import { NdjsonSetupDriver } from '../lib/setup-driver.js';
+import type { SetupDriver } from '../lib/setup-driver.js';
+import { getSetupProvider, listSetupProviders, registerSetupProvider, runSetupProviderAuth } from './registry.js';
 import './index.js'; // the real setup provider barrel — triggers self-registration
 
 describe('setup provider registry', () => {
@@ -24,6 +26,98 @@ describe('setup provider registry', () => {
     expect(claude).toBeDefined();
     expect(claude!.runAuth).toBeUndefined();
     expect(listSetupProviders()[0]!.value).toBe('claude');
+  });
+
+  it('gives structured provider auth and install checks the machine driver without raw stdout', async () => {
+    let received: NdjsonSetupDriver | undefined;
+    registerSetupProvider({
+      value: 'driver-check-fixture',
+      label: 'Driver check fixture',
+      hint: '',
+      supportsStructuredAuth: true,
+      async runAuth(driver) {
+        received = driver as NdjsonSetupDriver;
+      },
+      async runInstallCheck(driver) {
+        expect(driver).toBe(received);
+        driver.log('success', 'Provider install check passed.');
+      },
+    });
+    const output: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+    const driver = new NdjsonSetupDriver('setup', { emitHello: false });
+    try {
+      await runSetupProviderAuth(getSetupProvider('driver-check-fixture')!, driver);
+    } finally {
+      driver.close();
+      write.mockRestore();
+    }
+
+    expect(received).toBe(driver);
+    expect(output).toHaveLength(1);
+    expect(JSON.parse(output[0])).toMatchObject({
+      protocol: 'nanoclaw.driver.v1',
+      operation: 'setup',
+      type: 'display',
+      display: { kind: 'text', content: 'Provider install check passed.', sensitive: false },
+    });
+  });
+
+  it('fails before invoking an old terminal-only provider in machine mode', async () => {
+    let invoked = false;
+    registerSetupProvider({
+      value: 'terminal-only-fixture',
+      label: 'Terminal-only fixture',
+      hint: '',
+      async runAuth() {
+        invoked = true;
+      },
+    });
+    const output: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+    const driver = new NdjsonSetupDriver('setup', { emitHello: false });
+    try {
+      await expect(runSetupProviderAuth(getSetupProvider('terminal-only-fixture')!, driver)).rejects.toMatchObject({
+        exitCode: 1,
+      });
+    } finally {
+      driver.close();
+      write.mockRestore();
+    }
+
+    expect(invoked).toBe(false);
+    expect(output).toHaveLength(1);
+    expect(JSON.parse(output[0])).toMatchObject({
+      type: 'error',
+      code: 'provider_auth_update_required',
+      stepId: 'auth',
+    });
+  });
+
+  it('keeps old provider auth working through the terminal driver', async () => {
+    const calls: string[] = [];
+    const entry = {
+      value: 'old-terminal-fixture',
+      label: 'Old terminal fixture',
+      hint: '',
+      async runAuth(driver: SetupDriver) {
+        expect(driver.mode).toBe('terminal');
+        calls.push('auth');
+      },
+      async runInstallCheck(driver: SetupDriver) {
+        expect(driver.mode).toBe('terminal');
+        calls.push('check');
+      },
+    };
+
+    await runSetupProviderAuth(entry, { mode: 'terminal' } as SetupDriver);
+    expect(calls).toEqual(['auth', 'check']);
   });
 });
 
@@ -35,6 +129,7 @@ describe('setup flow consumes the registry (structural)', () => {
     expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
     // The capability-keyed branch — a provider's own auth runs iff it declares one.
     expect(src).toMatch(/providerEntry\?\.runAuth/);
+    expect(src).toContain('await runSetupProviderAuth(providerEntry, driver);');
   });
 
   it('the provider preset is exposed as an env setup knob', () => {
@@ -46,5 +141,8 @@ describe('setup flow consumes the registry (structural)', () => {
   it('the standalone provider-auth step is reachable from the STEPS map', () => {
     const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'index.ts'), 'utf-8');
     expect(src).toContain("'provider-auth'");
+    const auth = fs.readFileSync(path.join(process.cwd(), 'setup', 'provider-auth.ts'), 'utf-8');
+    expect(auth).toContain("const driver = new TerminalSetupDriver('setup');");
+    expect(auth).toContain('await runSetupProviderAuth(entry, driver);');
   });
 });

--- a/setup/providers/registry.ts
+++ b/setup/providers/registry.ts
@@ -11,6 +11,7 @@
  * provider registries, guarded the same way (a barrel-driven registration test).
  */
 import type { AssistContext } from '../lib/claude-assist.js'; // type-only — registry stays runtime-dependency-free
+import type { SetupDriver } from '../lib/setup-driver.js';
 
 /**
  * Outcome of a provider-owned failure-assist hook:
@@ -26,9 +27,11 @@ export interface SetupProviderEntry {
   label: string;
   hint: string;
   /** Provider-owned auth walk-through (vault-only). Absent → standard auth step. */
-  runAuth?: () => Promise<void>;
+  runAuth?: (driver: SetupDriver) => Promise<void>;
+  /** The provider-owned auth walk-through emits only SetupDriver semantics in machine mode. */
+  supportsStructuredAuth?: true;
   /** Verifies the provider's payload is wired (files, barrels, Dockerfile pin). */
-  runInstallCheck?: () => Promise<void>;
+  runInstallCheck?: (driver: SetupDriver) => Promise<void>;
   /** Provider-owned interactive failure debugger. 'unavailable' → dispatcher
    *  falls back to the guarded Claude offer (never install/sign-in). */
   offerFailureAssist?: (ctx: AssistContext, projectRoot: string) => Promise<FailureAssistResult>;
@@ -51,6 +54,27 @@ export function registerSetupProvider(entry: SetupProviderEntry): void {
 
 export function getSetupProvider(name: string): SetupProviderEntry | undefined {
   return registry.get(name.toLowerCase());
+}
+
+/** Run one provider-owned auth flow without letting an old terminal-only adapter corrupt NDJSON. */
+export async function runSetupProviderAuth(entry: SetupProviderEntry, driver: SetupDriver): Promise<void> {
+  if (!entry.runAuth) throw new Error(`Setup provider has no auth flow: ${entry.value}`);
+  if (driver.mode === 'ndjson' && entry.supportsStructuredAuth !== true) {
+    driver.error(
+      'provider_auth_update_required',
+      `${entry.label} setup does not support structured authentication yet.`,
+      [
+        {
+          kind: 'manual',
+          title: `Update the ${entry.label} provider`,
+          instructions: ['Install the matching provider update, then rerun setup.'],
+        },
+      ],
+      'auth',
+    );
+  }
+  await entry.runAuth(driver);
+  await entry.runInstallCheck?.(driver);
 }
 
 /** Claude (the default) first, then the rest in registration order. */


### PR DESCRIPTION
## TL;DR

Proposed: move the agent-provider picker and the whole Claude sign-in step off the terminal prompt library and onto the setup driver, and add a gate that refuses, in machine mode, any provider whose auth flow has not been updated for the driver.

## What problem this solves

Setup currently talks to the user through `clack` (imported as `p`), a terminal prompt library that writes straight to stdout. The stack that this PR belongs to introduces a `SetupDriver`: one interface for every user interaction (choice, confirm, text, secret, progress, display, external action), with two implementations. `TerminalSetupDriver` renders through the same clack UI, so terminal behaviour is unchanged. `NdjsonSetupDriver` speaks a newline-delimited JSON protocol on stdin and stdout ("ndjson mode", also called machine mode) so the native macOS app can drive setup with no terminal. Machine mode is opt-in and nothing in the repo turns it on yet.

This PR converts the credential-bearing half of setup. Any raw clack write left in that path would corrupt the JSON stream, and any prompt left on clack would hang waiting for a keystroke nobody can send.

## How it works

- `setup/auto.ts`: the provider picker, the "stop using the pre-built sandbox image" confirm, the provider install step, the Claude connection-method picker, the skip confirm, the token and API key paste prompts, and the custom-endpoint path all go through driver helpers (`selectPrompt`, `confirmPrompt`, `secretPrompt`, `driver.log`, `driver.progress`) instead of `p.*`.
- The provider install step keeps the clack spinner in terminal mode and emits `driver.progress` frames in machine mode. Same for the container rebuild: terminal calls `buildContainerImage()` directly, machine mode calls `rebuildProviderImage(driver)` so build output becomes progress frames.
- Subscription sign-in in machine mode calls `runClaudeSubscriptionMachineAuth` (added earlier in the stack) rather than the interactive `register-claude-token.sh`, and logs a different failure taxonomy (`ERROR`/`DETAIL`, with a distinct hint for `spawn_failed`) than the terminal path's `EXIT_CODE`.
- `setup/providers/registry.ts`: `SetupProviderEntry.runAuth` and `runInstallCheck` now take a `SetupDriver` argument, a new optional `supportsStructuredAuth?: true` marks a provider whose auth flow is driver-clean, and a new `runSetupProviderAuth(entry, driver)` runs auth then the install check in one place.
- `setup/provider-auth.ts`, the standalone step, constructs a `TerminalSetupDriver` and goes through the same helper, so there is exactly one call path.

## Two things that trip people up

1. **This is a policy change, not only a rewiring.** In ndjson mode, `runSetupProviderAuth` aborts with error code `provider_auth_update_required` before invoking any provider that does not declare `supportsStructuredAuth: true`. That is deliberate: an old terminal-only provider would print clack escape codes into the JSON stream. Nothing in this repo is affected, because `setup/providers/index.ts` is an empty barrel on main and no in-tree provider declares the flag. The out-of-tree providers registry branch (codex and friends) does need a matching commit before it can run under machine mode. Terminal mode is unaffected: an unmarked provider still runs exactly as before.

2. **Why the interface widening had to land in this commit.** Before this change, `auto.ts` called `providerEntry.runAuth()` with no argument. Widening the signature in one commit and converting the caller in another would leave every intermediate commit in the stack with two type errors in a file it does not touch. Interface and sole in-tree caller therefore move together.

## What to review

- `runSetupProviderAuth` in `setup/providers/registry.ts`: the gate, and that it preserves the old ordering (auth, then install check).
- The two secret paste paths in `auto.ts`: validation is preserved by passing the same checks as `validateValue` on the prompt spec, the token is still written to a temporary file rather than an argument, machine mode now passes `childEnvWithoutSetupSecrets()` to the `onecli` child, and the environment-supplied `NANOCLAW_ANTHROPIC_AUTH_TOKEN` is registered for log redaction.
- Two small behaviour details worth a look: provider skills are now installed from `PROJECT_ROOT` instead of `process.cwd()`, and a handful of prompt hints have an em dash replaced by a hyphen, which is user-visible text.
- Tests: three new cases in `setup/providers/registry.test.ts` cover the structured path over a real `NdjsonSetupDriver` (asserting the only stdout write is one protocol frame), the machine-mode refusal of an unmarked provider (asserting the provider is never invoked), and an unmarked provider still working in terminal mode. The `auto.ts` conversion itself is covered only by the existing structural assertions plus the type gate.

Verification: the setup-inclusive TypeScript gate is clean at this commit, and the setup suites pass. Note that the repo's `tsconfig.json` includes only `src/**/*`, so CI does not typecheck `setup/`; that gate was run manually.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this is one slice of a new setup driver protocol in `setup/`, not a skill, not a bug fix, and not a simplification.

## Description

Converts the agent-provider picker and every Claude authentication method in `setup/auto.ts` to the `SetupDriver` interface, widens `SetupProviderEntry.runAuth` and `runInstallCheck` to take a driver, and adds `runSetupProviderAuth`, which in ndjson mode refuses any provider that has not declared `supportsStructuredAuth: true`. Terminal behaviour is unchanged.

## For Skills

Not a skill, so this checklist does not apply.