### PR TITLE
refactor(setup): drive the channel loop, drop ndjson back navigation

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -657,7 +657,7 @@ async function main(driver: SetupDriver): Promise<void> {
     const preset = process.env.NANOCLAW_DISPLAY_NAME?.trim();
     const existing = await detectExistingDisplayName(process.cwd());
     const fallback = process.env.USER?.trim() || 'Operator';
-    displayName = preset || existing || (await askDisplayName(fallback));
+    displayName = preset || existing || (await askDisplayName(driver, fallback));
     return displayName;
   }
 
@@ -795,36 +795,41 @@ async function main(driver: SetupDriver): Promise<void> {
     let backed = true;
     while (backed) {
       backed = false;
-      channelChoice = await askChannelChoice();
+      channelChoice = await askChannelChoice(driver);
       if (channelChoice !== 'skip' && channelChoice !== 'other') {
         await resolveDisplayName();
       }
-      let result: void | typeof BACK_TO_CHANNEL_SELECTION;
+      let result: void | typeof BACK_TO_CHANNEL_SELECTION = undefined;
       // Every channel now runs through the SKILL.md-driven flow — the whole
       // connect+wire procedure lives in each add-<channel>/SKILL.md.
       if (channelChoice === 'telegram') {
-        result = await runChannelSkillWithPreStep('telegram', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('telegram', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'discord') {
-        result = await runChannelSkillWithPreStep('discord', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('discord', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'whatsapp') {
-        result = await runChannelSkillWithPreStep('whatsapp', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('whatsapp', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'signal') {
-        result = await runChannelSkillWithPreStep('signal', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('signal', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'teams') {
         // Fresh create resolves the owner DM proactively and wires inline (the
         // welcome message reaches the human first); a drop-through re-run
         // resolves nothing and falls back to the deferred-wire ending.
-        result = await runChannelSkillWithPreStep('teams', displayName!, { wireIfResolved: true, offerBack: true });
+        result = await runChannelSkillWithPreStep('teams', displayName!, {
+          wireIfResolved: true,
+          offerBack: true,
+          driver,
+        });
       } else if (channelChoice === 'slack') {
-        result = await runChannelSkillWithPreStep('slack', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('slack', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'imessage') {
-        result = await runChannelSkillWithPreStep('imessage', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('imessage', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'dial') {
-        result = await runChannelSkillWithPreStep('dial', displayName!, { offerBack: true });
+        result = await runChannelSkillWithPreStep('dial', displayName!, { offerBack: true, driver });
       } else if (channelChoice === 'other') {
-        result = await askOtherChannelName();
+        result = await askOtherChannelName(driver);
       } else {
-        p.log.info(
+        driver.log(
+          'info',
           brandBody(
             wrapForGutter(
               'No messaging app for now. You can add one later (like Telegram, Discord, WhatsApp, Teams, Slack, or iMessage).',
@@ -2060,53 +2065,53 @@ async function runTimezoneStep(driver: SetupDriver): Promise<void> {
 
 // ─── prompts owned by the sequencer ────────────────────────────────────
 
-async function askDisplayName(fallback: string): Promise<string> {
-  const answer = ensureAnswer(
-    await p.text({
-      message: `What should your assistant call ${accentGreen('you')}?`,
-      placeholder: fallback,
-      defaultValue: fallback,
-    }),
-  );
+async function askDisplayName(driver: SetupDriver, fallback: string): Promise<string> {
+  const answer = await textPrompt(driver, 'display-name', {
+    message: `What should your assistant call ${accentGreen('you')}?`,
+    placeholder: fallback,
+    default: fallback,
+  });
   const value = (answer as string).trim() || fallback;
   setupLog.userInput('display_name', value);
   return value;
 }
 
-async function askChannelChoice(): Promise<ChannelChoice> {
-  const choice = ensureAnswer(
-    await brightSelect<ChannelChoice>({
-      message: 'Want to chat with your assistant from your phone?',
-      options: [
-        { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
-        { value: 'teams', label: 'Yes, connect Microsoft Teams' },
-        { value: 'telegram', label: 'Yes, connect Telegram' },
-        { value: 'discord', label: 'Yes, connect Discord' },
-        { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
-        { value: 'dial', label: 'Yes, connect Dial', hint: 'a dedicated phone number for your agent — place calls, SMS — worldwide' },
-        {
-          value: 'signal',
-          label: 'Yes, connect Signal',
-          hint: 'needs signal-cli installed',
-        },
-        {
-          value: 'imessage',
-          label: 'Yes, connect iMessage',
-          hint: 'local Mac or hosted iMessage (via photon.codes)',
-        },
-        { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
-        { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
-      ],
-    }),
-  );
+async function askChannelChoice(driver: SetupDriver): Promise<ChannelChoice> {
+  const choice = await selectPrompt(driver, 'channel-choice', {
+    message: 'Want to chat with your assistant from your phone?',
+    options: [
+      { value: 'slack', label: 'Yes, connect Slack', hint: 'NEW!! one-click install' },
+      { value: 'teams', label: 'Yes, connect Microsoft Teams' },
+      { value: 'telegram', label: 'Yes, connect Telegram' },
+      { value: 'discord', label: 'Yes, connect Discord' },
+      { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
+      {
+        value: 'dial',
+        label: 'Yes, connect Dial',
+        hint: 'a dedicated phone number for your agent — place calls, SMS — worldwide',
+      },
+      {
+        value: 'signal',
+        label: 'Yes, connect Signal',
+        hint: 'needs signal-cli installed',
+      },
+      {
+        value: 'imessage',
+        label: 'Yes, connect iMessage',
+        hint: 'local Mac or hosted iMessage (via photon.codes)',
+      },
+      { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
+      { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
+    ],
+  });
   setupLog.userInput('channel_choice', String(choice));
   phEmit('channel_chosen', { channel: String(choice) });
   return choice;
 }
 
-async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELECTION> {
-  const action = ensureAnswer(
-    await brightSelect<'type' | 'back'>({
+async function askOtherChannelName(driver: SetupDriver): Promise<void | typeof BACK_TO_CHANNEL_SELECTION> {
+  if (driver.mode === 'terminal') {
+    const action = await selectPrompt(driver, 'other-channel-action', {
       message: 'Which channel would you like to install?',
       options: [
         {
@@ -2117,23 +2122,22 @@ async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELE
         { value: 'back', label: '← Back to channel selection' },
       ],
       initialValue: 'type',
-    }),
-  );
-  if (action === 'back') return BACK_TO_CHANNEL_SELECTION;
+    });
+    if (action === 'back') return BACK_TO_CHANNEL_SELECTION;
+  }
 
-  const answer = ensureAnswer(
-    await p.text({
-      message: 'Channel name',
-      placeholder: 'e.g. matrix, github, linear, webex',
-    }),
-  );
+  const answer = await textPrompt(driver, 'other-channel-name', {
+    message: 'Channel name',
+    placeholder: 'e.g. matrix, github, linear, webex',
+  });
   const name = (answer as string)
     .trim()
     .toLowerCase()
     .replace(/^\/?(add-)?/, '');
   setupLog.userInput('other_channel', name);
   phEmit('channel_other_named', { channel: name });
-  p.log.info(
+  driver.log(
+    'info',
     brandBody(
       wrapForGutter(
         `No bash installer for ${k.bold(name)} — open Claude Code after setup and run ${k.bold(`/add-${name}`)} to install it.`,


### PR DESCRIPTION
## TL;DR

Proposes moving the channel-selection loop in `setup/auto.ts` off the terminal prompt library and onto the setup driver, and, in doing so, removes back navigation from the "Other..." prompt when setup is driven by a machine.

## What problem this solves

NanoClaw's interactive setup currently talks straight to `clack`, a terminal prompt library (imported as `p`), so it only works when a human is sitting at a TTY. The wider stack introduces a `SetupDriver`: one interface for every user interaction (select, confirm, text, secret, progress, display, external action). `TerminalSetupDriver` implements it over the same clack UI, so terminal output stays identical; `NdjsonSetupDriver` implements it over newline-delimited JSON on stdin/stdout so a native macOS app can drive setup with no terminal. Call sites are being converted a few at a time. This PR converts the "want to chat from your phone?" loop, the last big cluster of prompts in that file.

## How it works

- `askDisplayName`, `askChannelChoice` and `askOtherChannelName` each take a `SetupDriver` as their first parameter and issue their prompts through the small `selectPrompt` / `textPrompt` helpers already in the file, which forward to `driver.prompt(...)`. Each prompt gains a stable string id (`display-name`, `channel-choice`, `other-channel-action`, `other-channel-name`) so a machine peer can recognise it.
- All nine branches of the loop (telegram, discord, whatsapp, signal, teams, slack, imessage, dial, other) now pass `driver` through to `runChannelSkillWithPreStep`, which already accepts it.
- The "skip for now" branch swaps `p.log.info(...)` for `driver.log('info', ...)`. The message text is unchanged.
- `let result: void | typeof BACK_TO_CHANNEL_SELECTION` is now explicitly initialised to `undefined`. That clears a pre-existing TypeScript error (TS2454, "used before being assigned") in this file.

## What trips people up

**This is not a pure substitution.** `askOtherChannelName` now wraps its whole first select, the one offering "type a channel name" versus "back to channel selection", in `if (driver.mode === 'terminal')`. Under the machine protocol that select never runs, so the function can never return the `BACK_TO_CHANNEL_SELECTION` sentinel that the loop uses to re-ask the channel question. Terminal users keep the back option exactly as before.

Combined with an earlier PR in this stack, which suppresses the per-channel `offerBack` prompt whenever the driver is in ndjson mode, the effect is that a machine-driven run has **no back navigation anywhere in channel selection**: once a channel is picked, the only exits are finishing it or failing. That may well be the right call for a GUI that draws its own back button, but it is a deliberate protocol-level divergence and should be accepted knowingly, not waved through as part of a mechanical conversion.

Smaller thing worth a glance: clack's `defaultValue` on the display-name prompt becomes the driver's `default`. `TerminalSetupDriver` maps `default` back onto `defaultValue`, and `askDisplayName` still falls back to the placeholder on an empty answer, so terminal behaviour is preserved.

## What to review

1. The `driver.mode === 'terminal'` guard in `askOtherChannelName`: is losing back navigation under the protocol acceptable, and should the machine flow get some other escape hatch instead?
2. That the nine channel branches are genuinely identical apart from threading `driver` through (the teams branch is only reformatted onto multiple lines).
3. The prompt ids, since they become part of the wire contract a GUI peer matches on.

**Tests:** none in this PR. The renderer parity test later in the stack does not reach channel selection, so the only proof here is the typecheck plus manual terminal runs. The gate run was `tsc -p tsconfig.setupcheck.json`, showing one pre-existing error removed and none added, and `vitest` over `setup`. Note that the repo's own `tsconfig.json` covers `src/**/*` only, so CI does not typecheck `setup/` at all.

**Behaviour:** nothing here turns machine-driven setup on. The macOS app still hard-codes `setupProtocol: nil`, and ndjson mode is opt-in, so terminal setup is the only path anyone hits today.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is not a skill, not a bug fix, and it does not reduce code: it re-points existing setup prompts at the driver interface and changes one back-navigation behaviour under the machine protocol.

## For Skills

Not a skill, so the skill checklist does not apply.