### PR TITLE
feat(setup): drive the first chat and bound its machine child

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -117,6 +117,7 @@ import {
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CLI_AGENT_NAME = 'Terminal Agent';
 const RUN_START = Date.now();
+const MAX_MACHINE_CHAT_OUTPUT_BYTES = 64 * 1024;
 
 /** How an operator reaches the registry step again once setup has finished. */
 const REGISTRY_STEP = 'pnpm exec tsx setup/index.ts --step registry';
@@ -655,13 +656,13 @@ async function main(driver: SetupDriver): Promise<void> {
   async function resolveDisplayName(): Promise<string> {
     if (displayName) return displayName;
     const preset = process.env.NANOCLAW_DISPLAY_NAME?.trim();
-    const existing = await detectExistingDisplayName(process.cwd());
+    const existing = await detectExistingDisplayName(PROJECT_ROOT);
     const fallback = process.env.USER?.trim() || 'Operator';
     displayName = preset || existing || (await askDisplayName(driver, fallback));
     return displayName;
   }
 
-  if (!skip.has('cli-agent') && (await detectRegisteredGroups(process.cwd()))) {
+  if (!skip.has('cli-agent') && (await detectRegisteredGroups(PROJECT_ROOT))) {
     skip.add('cli-agent');
     skip.add('first-chat');
   }
@@ -675,16 +676,20 @@ async function main(driver: SetupDriver): Promise<void> {
         done: 'Assistant wired up.',
       },
       ['--display-name', displayName!, '--agent-name', CLI_AGENT_NAME, '--folder', PING_AGENT_FOLDER],
+      driver,
     );
     if (!res.ok) {
       await fail(
         'cli-agent',
         "Couldn't bring your assistant online.",
         `You can retry later with \`pnpm exec tsx scripts/init-cli-agent.ts --display-name "${displayName!}" --agent-name "${CLI_AGENT_NAME}"\`.`,
+        undefined,
+        driver,
       );
     }
     if (!skip.has('first-chat')) {
-      p.log.message(
+      driver.log(
+        'message',
         brandBody(
           dimWrap(
             "Your assistant runs in an isolated sandbox. I'm going to send it a quick test message (ping) and wait for a reply (pong) to confirm it's responding. First startup typically takes 30–60 seconds while the sandbox warms up.",
@@ -692,7 +697,7 @@ async function main(driver: SetupDriver): Promise<void> {
           ),
         ),
       );
-      const ping = await confirmAssistantResponds();
+      const ping = await confirmAssistantResponds(driver);
       if (ping === 'ok') {
         phEmit('first_chat_ready');
         const cleanupRawLog = setupLog.stepRawLog('cleanup-cli-agent');
@@ -701,6 +706,8 @@ async function main(driver: SetupDriver): Promise<void> {
           'pnpm',
           ['exec', 'tsx', 'scripts/delete-cli-agent.ts', '--folder', PING_AGENT_FOLDER],
           cleanupRawLog,
+          undefined,
+          driver,
         );
         setupLog.step(
           'cleanup-cli-agent',
@@ -710,28 +717,27 @@ async function main(driver: SetupDriver): Promise<void> {
           cleanupRawLog,
         );
         if (!cleanup.ok) {
-          p.log.warn(
+          driver.log(
+            'warn',
             brandBody(
               `Couldn't clean up the test agent — it may still appear in your agent list. See ${cleanupRawLog} for details.`,
             ),
           );
         }
-        const next = ensureAnswer(
-          await brightSelect<'continue' | 'chat'>({
-            message: 'What next?',
-            options: [
-              {
-                value: 'continue',
-                label: 'Continue with setup',
-                hint: 'recommended',
-              },
-              {
-                value: 'chat',
-                label: 'Pause here and chat with your agent from the terminal',
-              },
-            ],
-          }),
-        ) as 'continue' | 'chat';
+        const next = await selectPrompt(driver, 'first-chat-next', {
+          message: 'What next?',
+          options: [
+            {
+              value: 'continue',
+              label: 'Continue with setup',
+              hint: 'recommended',
+            },
+            {
+              value: 'chat',
+              label: 'Pause here and chat with your agent from the terminal',
+            },
+          ],
+        });
         setupLog.userInput('first_chat_choice', next);
         if (next === 'chat') {
           const terminalAgentName = `${displayName!}'s Terminal`;
@@ -748,30 +754,40 @@ async function main(driver: SetupDriver): Promise<void> {
               terminalAgentName,
             ],
             { running: `Creating ${terminalAgentName}…`, done: `${terminalAgentName} is ready.` },
+            undefined,
+            driver,
           );
           if (!createRes.ok) {
             await fail(
               'create-terminal-agent',
               `Couldn't create ${terminalAgentName}.`,
               'You can retry later with `pnpm exec tsx scripts/init-cli-agent.ts`.',
+              undefined,
+              driver,
             );
           }
-          await runFirstChat();
+          await runFirstChat(driver);
         }
       } else {
         phEmit('first_chat_failed', { reason: ping });
-        renderPingFailureNote(ping);
-        await offerClaudeOnFailure({
-          stepName: 'cli-agent',
-          msg:
-            ping === 'socket_error'
-              ? "NanoClaw service isn't listening on its CLI socket."
-              : 'No reply from the assistant within 30 seconds.',
-          hint:
-            ping === 'socket_error'
-              ? 'Socket at data/cli.sock did not accept a connection.'
-              : 'Agent container may be failing to start or authenticate.',
-        });
+        renderPingFailureNote(driver, ping);
+        if (driver.mode === 'terminal') {
+          await offerClaudeOnFailure({
+            stepName: 'cli-agent',
+            msg:
+              ping === 'socket_error'
+                ? "NanoClaw service isn't listening on its CLI socket."
+                : ping === 'output_limit'
+                  ? 'The assistant returned more output than setup can safely display.'
+                  : 'No reply from the assistant within 30 seconds.',
+            hint:
+              ping === 'socket_error'
+                ? 'Socket at data/cli.sock did not accept a connection.'
+                : ping === 'output_limit'
+                  ? 'Inspect logs/nanoclaw.log for a runaway response.'
+                  : 'Agent container may be failing to start or authenticate.',
+          });
+        }
       }
     }
   }
@@ -983,7 +999,14 @@ function channelDmLabel(choice: ChannelChoice): string | null {
  * "patient" and "is this hung?". Returns the raw result so the caller can
  * branch between the chat loop (ok) and a diagnostic note (anything else).
  */
-async function confirmAssistantResponds(): Promise<PingResult> {
+async function confirmAssistantResponds(driver: SetupDriver): Promise<PingResult> {
+  if (driver.mode === 'ndjson') {
+    driver.progress('first-chat-ping', 'running', 'Waking your assistant');
+    const result = await pingCliAgent(30_000, driver);
+    driver.throwIfCancelled();
+    driver.progress('first-chat-ping', result === 'ok' ? 'succeeded' : 'failed');
+    return result;
+  }
   const s = p.spinner();
   const start = Date.now();
   const label = 'Waking your assistant…';
@@ -1001,13 +1024,17 @@ async function confirmAssistantResponds(): Promise<PingResult> {
     s.stop(`${k.bold(fitToWidth('Your assistant is ready.', suffix))}${k.dim(suffix)}`);
   } else {
     const msg =
-      result === 'socket_error' ? "Couldn't reach the NanoClaw service." : "Your assistant didn't reply in time.";
-    s.stop(`${k.bold(fitToWidth(msg, suffix))}${k.dim(suffix)}`, 1);
+      result === 'socket_error'
+        ? "Couldn't reach the NanoClaw service."
+        : result === 'output_limit'
+          ? 'Your assistant returned too much output.'
+          : "Your assistant didn't reply in time.";
+    s.error(`${k.bold(fitToWidth(msg, suffix))}${k.dim(suffix)}`);
   }
   return result;
 }
 
-function renderPingFailureNote(result: PingResult): void {
+function renderPingFailureNote(driver: SetupDriver, result: PingResult): void {
   const body =
     result === 'socket_error'
       ? [
@@ -1019,11 +1046,16 @@ function renderPingFailureNote(result: PingResult): void {
           `  macOS:  launchctl kickstart -k gui/$(id -u)/${getLaunchdLabel()}`,
           `  Linux:  systemctl --user restart ${getSystemdUnit()}`,
         ].join('\n')
-      : wrapForGutter(
-          'No reply from your assistant within 30 seconds. Check `logs/nanoclaw.log` for clues, then try `pnpm run chat hi`.',
-          6,
-        );
-  note(body, 'Skipping the first chat');
+      : result === 'output_limit'
+        ? wrapForGutter(
+            'The assistant returned more output than setup can safely display. Check `logs/nanoclaw.log`, then try `pnpm run chat hi`.',
+            6,
+          )
+        : wrapForGutter(
+            'No reply from your assistant within 30 seconds. Check `logs/nanoclaw.log` for clues, then try `pnpm run chat hi`.',
+            6,
+          );
+  driver.note(body, 'Skipping the first chat');
 }
 
 /**
@@ -1037,8 +1069,8 @@ function renderPingFailureNote(result: PingResult): void {
  * explain once, then offer "message or Enter to continue" so the chat is
  * clearly optional.
  */
-async function runFirstChat(): Promise<void> {
-  note(
+async function runFirstChat(driver: SetupDriver): Promise<void> {
+  driver.note(
     wrapForGutter(
       [
         'Your assistant runs in a sandbox on this machine.',
@@ -1051,31 +1083,107 @@ async function runFirstChat(): Promise<void> {
     'How this works',
   );
   let first = true;
-  while (true) {
-    const answer = ensureAnswer(
-      await p.text({
+  try {
+    while (true) {
+      const answer = await textPrompt(driver, first ? 'first-chat-message' : 'first-chat-another', {
         message: first
           ? 'Try a quick hello — or press Enter to continue setup'
           : 'Another message? Press Enter to continue setup',
         placeholder: first ? 'e.g. "hi, what can you do?"' : 'press Enter to continue',
-      }),
-    );
-    first = false;
-    const text = ((answer as string | undefined) ?? '').trim();
-    if (!text) return;
-    await sendChatMessage(text);
+      });
+      first = false;
+      const text = answer.trim();
+      if (!text) return;
+      await sendChatMessage(driver, text);
+    }
+  } finally {
+    if (driver.mode === 'ndjson') driver.clearDisplay('first-chat-response');
   }
 }
 
-function sendChatMessage(message: string): Promise<void> {
-  return new Promise((resolve) => {
+function sendChatMessage(driver: SetupDriver, message: string): Promise<void> {
+  return new Promise((resolve, reject) => {
     // `pnpm --silent` suppresses the `> nanoclaw@… chat` preamble so the
     // agent's reply reads as a clean block under the prompt. Splitting on
     // whitespace mirrors `pnpm run chat hello world` — chat.ts joins argv
     // with spaces on the far side.
-    const child = spawn('pnpm', ['--silent', 'run', 'chat', ...message.split(/\s+/)], {
-      stdio: ['ignore', 'inherit', 'inherit'],
-    });
+    const child = spawn(
+      'pnpm',
+      ['--silent', 'run', 'chat', ...message.split(/\s+/)],
+      driver.mode === 'ndjson'
+        ? { stdio: ['ignore', 'pipe', 'pipe'], detached: true, env: childEnvWithoutSetupSecrets() }
+        : { stdio: ['ignore', 'inherit', 'inherit'] },
+    );
+    const stopGroup = (): void => {
+      if (driver.mode !== 'ndjson' || !child.pid) return;
+      const processGroupId = child.pid;
+      try {
+        process.kill(-processGroupId, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-processGroupId, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 250);
+    };
+    driver.cancellationSignal?.addEventListener('abort', stopGroup, { once: true });
+    if (driver.cancellationSignal?.aborted) stopGroup();
+    if (driver.mode === 'ndjson') {
+      let response = '';
+      let responseBytes = 0;
+      let outputLimitExceeded = false;
+      let settled = false;
+      const append = (chunk: Buffer): void => {
+        if (outputLimitExceeded) return;
+        responseBytes += chunk.byteLength;
+        if (responseBytes > MAX_MACHINE_CHAT_OUTPUT_BYTES) {
+          outputLimitExceeded = true;
+          stopGroup();
+          return;
+        }
+        response += chunk.toString('utf8');
+      };
+      child.stdout?.on('data', (chunk: Buffer) => {
+        append(chunk);
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        append(chunk);
+      });
+      child.on('close', () => {
+        if (settled) return;
+        settled = true;
+        driver.cancellationSignal?.removeEventListener('abort', stopGroup);
+        if (outputLimitExceeded) {
+          try {
+            driver.error('first_chat_output_limit', 'The terminal chat returned more than 64 KiB of output.');
+          } catch (error) {
+            reject(error);
+          }
+          return;
+        }
+        if (response.trim()) {
+          driver.display({
+            id: 'first-chat-response',
+            kind: 'text',
+            content: response.trim(),
+            sensitive: false,
+            label: 'Assistant',
+          });
+        }
+        resolve();
+      });
+      child.on('error', () => {
+        if (settled) return;
+        settled = true;
+        driver.cancellationSignal?.removeEventListener('abort', stopGroup);
+        resolve();
+      });
+      return;
+    }
     child.on('close', () => resolve());
     child.on('error', () => resolve());
   });


### PR DESCRIPTION
**TL;DR** Proposed: move the "say hi to your assistant" step of NanoClaw setup off the terminal UI library and onto the setup driver, and put a byte cap, a kill path and a secret-free environment around the chat child process when setup is driven by a program instead of a person. Terminal setup looks the same, with two small behaviour changes noted below.

## What problem this solves

Setup currently talks to a human through clack, a terminal prompt library. A parallel effort (this stack) introduces a `SetupDriver`, one interface that every user interaction goes through, with two implementations: `TerminalSetupDriver` (clack, unchanged behaviour) and `NdjsonSetupDriver` (newline-delimited JSON over stdin/stdout, so the macOS app can run setup with no terminal). ndjson mode is opt-in and nothing enables it yet.

The first-chat step was one of the last call sites still calling clack directly, and it spawns `pnpm run chat` with `stdio: inherit`, which writes straight to the terminal. Under the JSON protocol that would corrupt the wire, run unbounded, and survive a cancel.

## How it works

- The ping, the "what next?" choice, the chat prompt loop and the failure notes now go through the driver (`driver.progress`, `selectPrompt`, `textPrompt`, `driver.note`, `driver.display`).
- In ndjson mode the chat child is spawned `detached` with piped stdio and `childEnvWithoutSetupSecrets()`, its combined stdout and stderr are buffered up to 64 KiB and emitted as a single `first-chat-response` display, and the display is cleared when the loop ends. Cancellation sends SIGTERM then, 250 ms later, SIGKILL to the whole process group.
- Over the cap, the run aborts with a `first_chat_output_limit` protocol error rather than truncating.
- Terminal mode keeps `stdio: inherit`, the elapsed-time spinner, and streaming replies.

## Two behaviour changes, please read

1. `detectExistingDisplayName` and `detectRegisteredGroups` now take `PROJECT_ROOT` (the checkout) instead of `process.cwd()`. This affects terminal mode too: if setup is launched from a different working directory, the "already has agent groups, skip the first chat" check and the saved display name are now read from the checkout, which is where they actually live. A sibling call site was already switched earlier in the stack; this finishes the file.
2. In ndjson mode a failed ping no longer offers the Claude-assisted troubleshooting handoff (`offerClaudeOnFailure`), because that helper drives its own terminal prompts. The failure note is still shown, now via `driver.note`. Terminal mode is unaffected.

Also here: the new `output_limit` ping outcome gets its own spinner text, failure note and handoff hint, and the failure spinner moves from `s.stop(msg, 1)` to clack 1.2's `s.error(...)`, which clears the last type error in this file under the setup-inclusive tsc config.

## What trips people up

- The 250 ms SIGTERM-to-SIGKILL timer is not `unref`'d, so it can hold the Node event loop open for a quarter second after a cancel. Harmless, but worth a look.
- `driver.error(...)` is typed `never` and throws, so the over-the-cap branch aborts the run; the surrounding `try`/`catch` exists only so that throw rejects the promise instead of escaping the callback.
- ndjson replies are buffered and shown once at the end, not streamed. That is deliberate: the protocol has no streaming display.

## What to review

The `sendChatMessage` rewrite, especially the group-kill and the cap accounting; the `PROJECT_ROOT` switch; and the ndjson-only skip of `offerClaudeOnFailure`. This commit adds no tests, so it rests on review.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this is one slice of a new machine-drivable setup protocol under `setup/`, not a skill, not a bug fix, and not a simplification.

## Description

Proposed change to `setup/auto.ts` only, 167 added and 59 removed lines. Routes the first-chat step through the `SetupDriver` interface, bounds and reaps the `pnpm run chat` child under the JSON protocol, strips setup secrets from that child's environment, and switches two checkout detections from `process.cwd()` to the checkout root. Part of a 39-PR stack that together reproduces one upstream commit; the stack's final tree is byte-identical to it.

## For Skills

Not a skill, so the skill checklist does not apply.

## Verification

Setup-inclusive `tsc` and `bash -n nanoclaw.sh` pass at this commit. `pnpm exec vitest run setup scripts` passes. Note that CI's `tsconfig.json` covers only `src/**/*`, so `setup/` is not typechecked upstream. Four failures in the full vitest run are pre-existing on the author's machine (git tag signing) and also fail on a clean upstream checkout.