### PR TITLE
feat(uninstall): add the ndjson machine uninstall path

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -204,11 +204,14 @@ async function main(driver: SetupDriver): Promise<void> {
   // in particular before initProgressionLog(), so an uninstall never resets
   // logs/setup.log on its way to (possibly) deleting logs/ entirely.
   if (configValues.uninstall === true) {
-    await runUninstallFlow({
-      dryRun: configValues.dryRun === true,
-      yes: configValues.yes === true,
-      invokedFrom: 'flag',
-    });
+    await runUninstallFlow(
+      {
+        dryRun: configValues.dryRun === true,
+        yes: configValues.yes === true,
+        invokedFrom: 'flag',
+      },
+      driver,
+    );
   }
 
   printIntro(driver);

--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -13,6 +13,7 @@
  * Ctrl-C anywhere in the confirm phase leaves the install untouched.
  */
 import { spawnSync } from 'child_process';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -24,9 +25,19 @@ import { emit as phEmit } from '../lib/diagnostics.js';
 import { note } from '../lib/theme.js';
 import * as setupLog from '../logs.js';
 import { resolveOnecliDeletions, type RunCommand, type VaultAgent } from './onecli-agents.js';
-import { buildRemovalPlan, validateDecisions, type Decisions } from './plan.js';
-import { executePlan, type ExecDeps, type UninstallActionResult } from './remove.js';
+import { buildRemovalPlan, validateDecisions, type Decisions, type RemovalAction } from './plan.js';
+import { actionId, artifactId, executePlan, type ExecDeps, type UninstallActionResult } from './remove.js';
 import { scanInstall, tilde, type Inventory } from './scan.js';
+import {
+  DriverCancelled,
+  DriverTerminalError,
+  type Artifact,
+  type SetupDriver,
+  type UninstallChoice,
+  type UninstallGroup,
+  type UninstallPlan,
+  type UninstallReceipt,
+} from '../lib/setup-driver.js';
 
 const GROUPS = {
   service: {
@@ -59,12 +70,17 @@ const runCommand: RunCommand = (cmd, args) => {
   };
 };
 
-export async function runUninstallFlow(opts: {
-  dryRun: boolean;
-  yes: boolean;
-  invokedFrom: 'flag' | 'setup-detection';
-}): Promise<never> {
+export async function runUninstallFlow(
+  opts: {
+    dryRun: boolean;
+    yes: boolean;
+    invokedFrom: 'flag' | 'setup-detection';
+  },
+  driver?: SetupDriver,
+): Promise<never> {
   const { dryRun, yes } = opts;
+
+  if (driver?.mode === 'ndjson') return runMachineUninstall(opts, driver);
 
   if (!process.stdin.isTTY && !yes && !dryRun) {
     console.error(
@@ -298,6 +314,304 @@ export async function runUninstallFlow(opts: {
 
   console.log(`\n✓ Done. NanoClaw copy ${inv.slug} has been uninstalled.`);
   process.exit(0);
+}
+
+async function runMachineUninstall(
+  opts: { dryRun: boolean; yes: boolean; invokedFrom: 'flag' | 'setup-detection' },
+  driver: SetupDriver,
+): Promise<never> {
+  if (opts.dryRun || opts.yes) {
+    driver.error(
+      'unsupported_machine_option',
+      'Machine uninstall is already plan-first; --dry-run and --yes are terminal-only options.',
+      [{ kind: 'rerun', args: ['--uninstall', '--protocol', 'nanoclaw.driver.v1'] }],
+    );
+  }
+
+  const projectRoot = process.cwd();
+  const home = os.homedir();
+  const scan = (): Inventory => scanInstall({ projectRoot, home, platform: process.platform, runCommand });
+
+  driver.progress('uninstall-scan', 'running', 'Checking this NanoClaw copy');
+  const approved = scan();
+  driver.progress('uninstall-scan', 'succeeded');
+  const plan = protocolPlan(approved);
+  const choices = await driver.waitForUninstall(plan, (candidate) =>
+    uninstallSelectionError(approved, decisionsFromChoices(approved, candidate)),
+  );
+  driver.throwIfCancelled();
+
+  const actions = buildRemovalPlan(approved, decisionsFromChoices(approved, choices));
+  const selectedIds = new Set(actions.map(artifactId));
+  const results: UninstallActionResult[] = [];
+  const emit = (result: UninstallActionResult): void => {
+    results.push(result);
+    driver.uninstallAction(result);
+  };
+
+  for (const artifact of plan.artifacts) {
+    if (!selectedIds.has(artifact.id)) {
+      emit({
+        actionId: `preserve-${artifact.id}`,
+        artifactId: artifact.id,
+        outcome: artifact.disposition === 'alreadyAbsent' ? 'alreadyAbsent' : 'preserved',
+      });
+    }
+  }
+
+  const current = scan();
+  if (!sameOwnershipSelectors(approved, current, { selectorsOnly: true })) {
+    for (const action of actions) {
+      emit({
+        actionId: actionId(action),
+        artifactId: artifactId(action),
+        outcome: 'untouched',
+        error: { code: 'checkout_identity_changed', message: 'The checkout identity changed after approval.' },
+      });
+    }
+    driver.completeUninstall(receiptFor('incomplete', results, current));
+    throw new DriverTerminalError(1);
+  }
+
+  let prerequisiteFailed = false;
+  let lastStepId: string | undefined;
+  for (const action of actions) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (driverCancelled(driver)) break;
+    lastStepId = actionId(action);
+    prerequisiteFailed = executePlan([action], {
+      runCommand,
+      log: () => {},
+      isRoot: process.getuid?.() === 0,
+      prerequisiteFailed,
+      onResult: emit,
+    }).prerequisiteFailed;
+  }
+
+  if (driverCancelled(driver)) {
+    driver.cancelled({ lastStepId, results, remaining: remainingArtifacts(scan()) });
+    throw new DriverTerminalError(2);
+  }
+
+  const after = scan();
+  const remaining = remainingArtifacts(after);
+  const residueIds = new Set(remaining.map((artifact) => artifact.id));
+  const incomplete =
+    results.some((result) => result.outcome === 'failed' || result.outcome === 'untouched') ||
+    [...selectedIds].some((id) => residueIds.has(id));
+  driver.completeUninstall(receiptFor(incomplete ? 'incomplete' : 'success', results, after));
+  throw new DriverTerminalError(incomplete ? 1 : 0);
+}
+
+function driverCancelled(driver: SetupDriver): boolean {
+  try {
+    driver.throwIfCancelled();
+    return false;
+  } catch (error) {
+    if (error instanceof DriverCancelled) return true;
+    throw error;
+  }
+}
+
+function decisionsFromChoices(inventory: Inventory, choices: Map<UninstallGroup, UninstallChoice>): Decisions {
+  return {
+    service: choices.get('service') === 'remove',
+    data: choices.get('data') === 'remove',
+    user: choices.get('user') === 'remove',
+    onecliDelete: choices.get('onecli') === 'remove' ? inventory.onecli.mine : [],
+  };
+}
+
+function protocolPlan(inventory: Inventory): UninstallPlan {
+  const actions = buildRemovalPlan(inventory, {
+    service: true,
+    data: true,
+    user: true,
+    onecliDelete: inventory.onecli.mine,
+  });
+  const artifacts = actions.map((action) => artifactForAction(inventory, action));
+  artifacts.push(
+    sharedArtifact('checkout-root', 'checkout', 'NanoClaw source checkout', inventory.projectRoot),
+    sharedArtifact(
+      'onecli-shared-vault',
+      'shared-vault',
+      'OneCLI app, vault, and credentials',
+      '~/.local/share/onecli',
+    ),
+    sharedArtifact('host-shared-config', 'shared-config', 'Host-wide NanoClaw configuration', '~/.config/nanoclaw'),
+  );
+  for (const backup of inventory.envBackups) {
+    artifacts.push({
+      id: `credential-backup-${shortHash(backup.path)}`,
+      kind: 'credential-backup',
+      label: backup.what,
+      location: backup.path,
+      disposition: 'external',
+    });
+  }
+  for (const backup of inventory.legacyEnvBackups ?? []) {
+    artifacts.push({
+      id: `legacy-credential-backup-${shortHash(backup.path)}`,
+      kind: 'credential-backup-inside-checkout',
+      label: 'Legacy credential backup inside checkout',
+      location: backup.path,
+      disposition: 'uninspectable',
+    });
+  }
+  for (const agent of inventory.onecli.orphans) {
+    artifacts.push({
+      id: `onecli-orphan-${agent.uuid}`,
+      kind: 'onecli-agent',
+      label: agent.name || agent.identifier,
+      location: `onecli-agent:${agent.uuid}`,
+      disposition: 'uninspectable',
+    });
+  }
+  for (const [index, message] of inventory.notes.entries()) {
+    artifacts.push({
+      id: `uninspectable-${index + 1}`,
+      kind: 'uninspectable',
+      label: message,
+      location: inventory.projectRoot,
+      disposition: 'uninspectable',
+    });
+  }
+
+  return {
+    id: randomUUID(),
+    groups: [
+      protocolGroup('service', GROUPS.service.title, GROUPS.service.desc),
+      protocolGroup('data', GROUPS.data.title, GROUPS.data.desc),
+      protocolGroup('user', GROUPS.user.title, GROUPS.user.desc),
+      protocolGroup('onecli', GROUPS.onecli.title, GROUPS.onecli.desc),
+    ],
+    artifacts,
+  };
+}
+
+function protocolGroup(id: UninstallGroup, label: string, description: string): UninstallPlan['groups'][number] {
+  return { id, label, description, default: 'preserve', choices: ['preserve', 'remove'] };
+}
+
+function sharedArtifact(id: string, kind: string, label: string, location: string): Artifact {
+  return { id, kind, label, location, disposition: 'shared' };
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+function artifactForAction(inventory: Inventory, action: RemovalAction): Artifact {
+  const identityMissing = 'identityRequired' in action && action.identityRequired === true && !action.expectedIdentity;
+  const processListMissing = action.kind === 'pkill-host' && inventory.service.hostProcessIds === undefined;
+  const containerListMissing = action.kind === 'rm-containers' && inventory.service.containerRuntimeAvailable === false;
+  const absent =
+    (action.kind === 'rm-containers' && !containerListMissing && inventory.service.containerIds.length === 0) ||
+    (action.kind === 'pkill-host' && inventory.service.hostProcessIds?.length === 0);
+  return {
+    id: artifactId(action),
+    kind: action.kind,
+    label: actionLabel(action),
+    location: actionLocation(action),
+    disposition:
+      identityMissing || processListMissing || containerListMissing
+        ? 'uninspectable'
+        : absent
+          ? 'alreadyAbsent'
+          : 'owned',
+    decisionGroup: groupForAction(inventory, action),
+  };
+}
+
+function groupForAction(inventory: Inventory, action: RemovalAction): UninstallGroup {
+  if (action.kind === 'delete-onecli-agent') return 'onecli';
+  if (['unload-service', 'kill-pid', 'pkill-host', 'rm-containers', 'rmi', 'rm-ncl-symlink'].includes(action.kind)) {
+    return 'service';
+  }
+  if (
+    (action.kind === 'delete-path' || action.kind === 'delete-runtime-path') &&
+    inventory.user.some((item) => item.path === action.item.path)
+  )
+    return 'user';
+  return 'data';
+}
+
+function actionLocation(action: RemovalAction): string {
+  switch (action.kind) {
+    case 'unload-service':
+      return action.unitPath;
+    case 'kill-pid':
+      return action.pidFile;
+    case 'pkill-host':
+      return action.pattern;
+    case 'rm-containers':
+      return `${action.runtime}:${action.labelFilter}`;
+    case 'rmi':
+      return action.image;
+    case 'rm-ncl-symlink':
+      return action.linkPath;
+    case 'delete-onecli-agent':
+      return `onecli-agent:${action.agent.uuid}`;
+    case 'backup-env':
+      return action.envPath;
+    case 'delete-path':
+    case 'delete-runtime-path':
+      return action.item.path;
+  }
+}
+
+function actionLabel(action: RemovalAction): string {
+  if (action.kind === 'delete-onecli-agent') return `OneCLI agent ${action.agent.name || action.agent.identifier}`;
+  if (action.kind === 'delete-path' || action.kind === 'delete-runtime-path') return action.item.what;
+  if (action.kind === 'backup-env') return 'Secrets and API keys (.env, backed up first)';
+  return action.kind.replaceAll('-', ' ');
+}
+
+function remainingArtifacts(inventory: Inventory): Artifact[] {
+  return protocolPlan(inventory).artifacts.filter((artifact) => artifact.disposition !== 'alreadyAbsent');
+}
+
+function receiptFor(
+  outcome: 'success' | 'incomplete',
+  results: UninstallActionResult[],
+  inventory: Inventory,
+): UninstallReceipt {
+  return {
+    version: 1,
+    outcome,
+    results,
+    remaining: remainingArtifacts(inventory),
+    checkoutRemoval: checkoutRemovalFor(inventory),
+    completedAt: new Date().toISOString(),
+  };
+}
+
+function checkoutRemovalFor(inventory: Inventory): { safe: boolean; blockers: string[] } {
+  const blockers: string[] = [];
+  const service = inventory.service;
+  if (service.launchdPlist) blockers.push(`background service remains: ${service.launchdPlist}`);
+  if (service.systemdUserUnit) blockers.push(`background service remains: ${service.systemdUserUnit}`);
+  if (service.systemdSystemUnit) blockers.push(`system service remains: ${service.systemdSystemUnit}`);
+  if (service.pidFile) blockers.push(`pidfile remains: ${service.pidFile}`);
+  if (service.hostProcessIds === undefined) blockers.push('host process identity could not be inspected');
+  else if (service.hostProcessIds.length > 0) blockers.push('checkout-owned host process remains');
+  if (service.containerIds.length > 0) blockers.push('checkout-owned container remains');
+  if (service.nclSymlink) blockers.push(`ncl symlink remains: ${service.nclSymlink}`);
+  if (service.containerRuntimeAvailable === false) blockers.push('container runtime state could not be inspected');
+
+  for (const item of [...inventory.data, ...inventory.runtime, ...inventory.user]) {
+    try {
+      fs.lstatSync(item.path);
+      blockers.push(`checkout artifact remains: ${item.path}`);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') blockers.push(`checkout artifact could not be inspected: ${item.path}`);
+    }
+  }
+  for (const item of inventory.legacyEnvBackups ?? []) {
+    blockers.push(`credential backup remains inside checkout: ${item.path}`);
+  }
+  return { safe: blockers.length === 0, blockers };
 }
 
 /** Unwrap a confirm result; Ctrl-C / Esc cancels the whole uninstall — nothing deleted. */

--- a/setup/uninstall/protocol.test.ts
+++ b/setup/uninstall/protocol.test.ts
@@ -1,0 +1,339 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getInstallSlug } from '../../src/install-slug.js';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const AUTO = path.join(ROOT, 'setup', 'auto.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'uninstall' } as const;
+
+type Child = ReturnType<typeof spawn>;
+type Event = Record<string, unknown>;
+type Artifact = { id: string; kind: string; location: string; disposition: string };
+
+let installRoot: string;
+
+beforeEach(() => {
+  installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-uninstall-protocol-'));
+});
+
+afterEach(() => {
+  fs.rmSync(installRoot, { recursive: true, force: true });
+});
+
+function start(env: NodeJS.ProcessEnv = {}): Child {
+  return spawn(process.execPath, ['--import', TSX_LOADER, AUTO, '--uninstall'], {
+    cwd: installRoot,
+    env: {
+      ...process.env,
+      NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+      NANOCLAW_OPERATION: 'uninstall',
+      NANOCLAW_NO_DIAGNOSTICS: '1',
+      ...env,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+function installEmptyOnecli(): string {
+  const fakeBin = path.join(installRoot, 'fake-bin');
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nprintf %s \'{"data":[]}\'\n', { mode: 0o755 });
+  return fakeBin;
+}
+
+function choices(service: 'preserve' | 'remove', data: 'preserve' | 'remove') {
+  return [
+    { groupId: 'service', choice: service },
+    { groupId: 'data', choice: data },
+    { groupId: 'user', choice: 'preserve' },
+    { groupId: 'onecli', choice: 'preserve' },
+  ];
+}
+
+function apply(child: Child, planId: string, values = choices('preserve', 'preserve')): void {
+  child.stdin!.write(
+    `${JSON.stringify({
+      ...envelope,
+      type: 'applyUninstall',
+      planId,
+      choices: values,
+    })}\n`,
+  );
+}
+
+async function collect(
+  child: Child,
+  onEvent: (event: Event) => void,
+): Promise<{ code: number | null; stdout: string; stderr: string; events: Event[] }> {
+  const events: Event[] = [];
+  let stdout = '';
+  let stderr = '';
+  let buffer = '';
+  child.stdout!.on('data', (chunk: Buffer) => {
+    const text = chunk.toString('utf8');
+    stdout += text;
+    buffer += text;
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const event = JSON.parse(line) as Event;
+      events.push(event);
+      onEvent(event);
+    }
+  });
+  child.stderr!.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  return { code, stdout, stderr, events };
+}
+
+function planItems(events: Event[]): Artifact[] {
+  return events.filter((event) => event.type === 'uninstallPlanItem').map((event) => event.artifact as Artifact);
+}
+
+function receiptItems(events: Event[]): Artifact[] {
+  return events.filter((event) => event.type === 'uninstallReceiptItem').map((event) => event.artifact as Artifact);
+}
+
+describe('machine uninstall session', () => {
+  it('rejects unsafe choices, then preserves the four-group streamed plan', async () => {
+    const child = start();
+    let answered = false;
+    const result = await collect(child, (event) => {
+      if (event.type !== 'uninstallPlan' || answered) return;
+      answered = true;
+      const plan = event.plan as { id: string; groups: Array<{ id: string; default: string }> };
+      expect(plan).not.toHaveProperty('artifacts');
+      expect(plan.groups.map((group) => group.id)).toEqual(['service', 'data', 'user', 'onecli']);
+      expect(plan.groups.every((group) => group.default === 'preserve')).toBe(true);
+      apply(child, plan.id, choices('preserve', 'remove'));
+      apply(child, plan.id);
+    });
+
+    const items = planItems(result.events);
+    const actions = result.events
+      .filter((event) => event.type === 'uninstallAction')
+      .map((event) => event.result as { artifactId: string });
+    const complete = result.events.find((event) => event.type === 'complete') as {
+      receipt: { outcome: string };
+    };
+
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout[0]).toBe('{');
+    expect(result.events.filter((event) => event.type === 'hello')).toHaveLength(1);
+    expect(
+      result.events.some((event) => event.type === 'inputRejected' && event.code === 'unsafe_uninstall_choices'),
+    ).toBe(true);
+    expect(new Set(actions.map((action) => action.artifactId))).toEqual(new Set(items.map((item) => item.id)));
+    expect(complete.receipt.outcome).toBe('success');
+    expect(complete.receipt).not.toHaveProperty('results');
+    expect(complete.receipt).not.toHaveProperty('remaining');
+    expect(result.events.some((event) => String(event.type).includes('Page'))).toBe(false);
+    expect(fs.readdirSync(installRoot)).toEqual([]);
+  }, 15_000);
+
+  it('rejects app-data deletion when OneCLI cannot be inspected', async () => {
+    const fakeBin = path.join(installRoot, 'fake-unavailable-bin');
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    const localBin = path.join(os.homedir(), '.local', 'bin');
+    const child = start({ PATH: `${fakeBin}${path.delimiter}${localBin}` });
+    let answered = false;
+    const result = await collect(child, (event) => {
+      if (event.type !== 'uninstallPlan' || answered) return;
+      answered = true;
+      const planId = (event.plan as { id: string }).id;
+      apply(child, planId, choices('remove', 'remove'));
+      apply(child, planId);
+    });
+
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        type: 'inputRejected',
+        code: 'unsafe_uninstall_choices',
+        message: expect.stringContaining('Restore OneCLI'),
+      }),
+    );
+  }, 15_000);
+
+  it('skips a replaced data directory while removing an unchanged logs directory', async () => {
+    const data = path.join(installRoot, 'data');
+    fs.mkdirSync(data);
+    fs.writeFileSync(path.join(data, 'approved.txt'), 'approved');
+    const logs = path.join(installRoot, 'logs');
+    fs.mkdirSync(logs);
+    fs.writeFileSync(path.join(logs, 'remove.txt'), 'remove');
+    const fakeBin = installEmptyOnecli();
+    const child = start({ PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}` });
+    const result = await collect(child, (event) => {
+      if (event.type !== 'uninstallPlan') return;
+      fs.renameSync(data, path.join(installRoot, 'data.old'));
+      fs.mkdirSync(data);
+      fs.writeFileSync(path.join(data, 'replacement.txt'), 'replacement');
+      apply(child, (event.plan as { id: string }).id, choices('remove', 'remove'));
+    });
+
+    const complete = result.events.find((event) => event.type === 'complete') as {
+      receipt: { outcome: string };
+    };
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(1);
+    expect(complete.receipt.outcome).toBe('incomplete');
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        type: 'uninstallAction',
+        result: expect.objectContaining({
+          outcome: 'untouched',
+          error: expect.objectContaining({ code: 'ownership_root_changed' }),
+        }),
+      }),
+    );
+    expect(fs.readFileSync(path.join(data, 'replacement.txt'), 'utf8')).toBe('replacement');
+    expect(fs.readFileSync(path.join(installRoot, 'data.old', 'approved.txt'), 'utf8')).toBe('approved');
+    expect(fs.existsSync(logs)).toBe(false);
+  }, 15_000);
+
+  it('streams the external credential backup after successful .env removal', async () => {
+    fs.writeFileSync(path.join(installRoot, '.env'), 'TOKEN=fixture-secret');
+    const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-uninstall-backup-home-'));
+    const runtime = path.join(installRoot, 'fake-container-runtime');
+    const fakeBin = path.join(installRoot, 'fake-bin');
+    fs.writeFileSync(runtime, '#!/bin/sh\n[ "$1" = ps ] && exit 0\nexit 1\n', { mode: 0o755 });
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nprintf %s \'{"data":[]}\'\n', { mode: 0o755 });
+
+    try {
+      const child = start({
+        HOME: testHome,
+        CONTAINER_RUNTIME: runtime,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+      });
+      const result = await collect(child, (event) => {
+        if (event.type === 'uninstallPlan') {
+          apply(child, (event.plan as { id: string }).id, choices('remove', 'remove'));
+        }
+      });
+      const complete = result.events.find((event) => event.type === 'complete') as {
+        receipt: { outcome: string; checkoutRemoval: { safe: boolean; blockers: string[] } };
+      };
+      const backupRoot = path.join(
+        testHome,
+        'Library',
+        'Application Support',
+        'NanoClaw',
+        'uninstall-backups',
+        getInstallSlug(fs.realpathSync(installRoot)),
+      );
+      const backupPath = path.join(backupRoot, '.env.bak');
+
+      expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(complete.receipt).toEqual(
+        expect.objectContaining({
+          outcome: 'success',
+          checkoutRemoval: { safe: true, blockers: [] },
+        }),
+      );
+      expect(receiptItems(result.events)).toContainEqual(
+        expect.objectContaining({
+          kind: 'credential-backup',
+          location: backupPath,
+          disposition: 'external',
+        }),
+      );
+      expect(fs.readFileSync(backupPath, 'utf8')).toBe('TOKEN=fixture-secret');
+      expect(fs.statSync(backupRoot).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(backupPath).mode & 0o777).toBe(0o600);
+      expect(JSON.stringify(result.events)).not.toContain('fixture-secret');
+    } finally {
+      fs.rmSync(testHome, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('stops before the next action when cancelled during apply', async () => {
+    fs.writeFileSync(path.join(installRoot, '.env'), 'TOKEN=still-here');
+    const fakeBin = path.join(installRoot, 'fake-bin');
+    const runtime = path.join(installRoot, 'fake-runtime');
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(fakeBin, 'onecli'), '#!/bin/sh\nprintf %s \'{"data":[]}\'\n', { mode: 0o755 });
+    fs.writeFileSync(runtime, '#!/bin/sh\n[ "$1" = ps ] && exit 0\nexit 1\n', { mode: 0o755 });
+
+    const child = start({
+      CONTAINER_RUNTIME: runtime,
+      PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+    });
+    let cancelled = false;
+    const result = await collect(child, (event) => {
+      if (event.type === 'uninstallPlan') {
+        apply(child, (event.plan as { id: string }).id, choices('remove', 'remove'));
+      } else if (event.type === 'uninstallAction' && !cancelled) {
+        const action = event.result as { actionId: string };
+        if (!action.actionId.startsWith('preserve-')) {
+          cancelled = true;
+          child.stdin!.write(`${JSON.stringify({ ...envelope, type: 'cancel', reason: 'stop now' })}\n`);
+        }
+      }
+    });
+
+    const terminal = result.events.at(-1) as Event;
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(2);
+    expect(terminal.type).toBe('cancelled');
+    expect(terminal).not.toHaveProperty('results');
+    expect(terminal).not.toHaveProperty('remaining');
+    expect(receiptItems(result.events)).toContainEqual(
+      expect.objectContaining({
+        location: path.join(fs.realpathSync(installRoot), '.env'),
+      }),
+    );
+    expect(fs.readFileSync(path.join(installRoot, '.env'), 'utf8')).toBe('TOKEN=still-here');
+  }, 15_000);
+
+  it('streams a large plan and one result per artifact without pagination', async () => {
+    const fakeBin = path.join(installRoot, 'fake-bin');
+    const runtime = path.join(installRoot, 'fake-runtime');
+    fs.mkdirSync(fakeBin);
+    const agents = Array.from({ length: 65 }, (_, index) => ({
+      id: `agent-${index}`,
+      identifier: `ag-${index}`,
+      name: `Agent ${index}`,
+      isDefault: false,
+    }));
+    fs.writeFileSync(
+      path.join(fakeBin, 'onecli'),
+      `#!/bin/sh\nprintf %s ${JSON.stringify(JSON.stringify({ data: agents }))}\n`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(path.join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(runtime, '#!/bin/sh\n[ "$1" = ps ] && exit 0\nexit 1\n', { mode: 0o755 });
+
+    const child = start({
+      CONTAINER_RUNTIME: runtime,
+      PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+    });
+    const result = await collect(child, (event) => {
+      if (event.type === 'uninstallPlan') apply(child, (event.plan as { id: string }).id);
+    });
+    const artifacts = planItems(result.events);
+    const actionIds = result.events
+      .filter((event) => event.type === 'uninstallAction')
+      .map((event) => (event.result as { artifactId: string }).artifactId);
+
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(artifacts.length).toBeGreaterThan(65);
+    expect(new Set(actionIds)).toEqual(new Set(artifacts.map((artifact) => artifact.id)));
+    expect(result.events.some((event) => String(event.type).includes('Page'))).toBe(false);
+  }, 15_000);
+});


### PR DESCRIPTION
## TL;DR

Proposed: give `nanoclaw.sh --uninstall` a second implementation that a GUI can drive, so a native app can present the uninstall plan, collect one approval, and read back a machine-readable receipt. The terminal uninstall is untouched.

## The problem

Today uninstall is a terminal conversation. `runUninstallFlow` in `setup/uninstall/flow.ts` scans the machine, asks four yes/no questions with clack (the terminal prompt library), then deletes. A GUI app cannot answer clack prompts, and it cannot tell from console text what was removed and what survived.

Earlier PRs in this stack added a "driver": an interface that abstracts every user interaction, with a terminal implementation (unchanged behaviour) and an NDJSON implementation that speaks newline-delimited JSON over stdin and stdout to a program driving setup headlessly. This PR is the uninstall half of that.

## How it works

`runUninstallFlow` takes an optional driver and, when the driver is in `ndjson` mode, hands off to a new `runMachineUninstall`:

1. Scan the install, then project the inventory into a protocol plan: four decision groups (service, data, user, onecli), each defaulting to `preserve`, plus one artifact per removable item with an id, a kind, a location and a disposition (`owned`, `alreadyAbsent`, `shared`, `external`, `uninspectable`).
2. Send the plan and wait for one `applyUninstall` message carrying a choice per group. The candidate choices go through `uninstallSelectionError`, the same validator the terminal path uses, so an unsafe selection (for example deleting app data while OneCLI cannot be inspected) is rejected with `inputRejected` and the peer can answer again instead of the process exiting.
3. Emit a `preserved` or `alreadyAbsent` result for every artifact the peer did not select, so the peer gets exactly one result per artifact.
4. Re-scan and compare ownership. If the checkout identity moved, mark every selected action `untouched` with code `checkout_identity_changed`, send an `incomplete` receipt, exit 1.
5. Otherwise run the actions one at a time, streaming each result, checking for cancellation between actions.
6. Finish with a receipt: per-action results, what remains, and a `checkoutRemoval: { safe, blockers }` verdict telling the app whether it is safe to delete the source folder itself.

Exit codes: 0 success, 1 incomplete, 2 cancelled.

The only other production change is one call site in `setup/auto.ts`: the `--uninstall` flag path now passes the driver through. In terminal mode the driver's mode is not `ndjson`, so that call behaves exactly as before. The second call site (uninstall offered after setup detects an existing install) is wired in a later PR in this stack.

## What trips people up

This is not a port of the terminal flow. Real differences inside the new path, all deliberate:

- No "uninstall needs an interactive terminal" guard. The peer owns stdin, so the TTY check is bypassed by design.
- `--dry-run` and `--yes` are refused with `unsupported_machine_option`. The machine path is already plan-first and already explicit, so those two terminal conveniences have no meaning here.
- Four separate terminal confirms collapse into one plan approval.
- No `phEmit` diagnostics event and no `logs/setup.log` decision record. The terminal path writes both.
- Execution shape differs. The terminal path batches actions into prerequisites, destructive and runtime tail, and escalates: a failed OneCLI agent delete holds back app data, and any incomplete head holds back `dist/` and `node_modules/`. The machine loop only threads `prerequisiteFailed`, which `executePlan` sets when a service-stopping action fails. Those two extra escalations do not exist in machine mode.

## What to review

- The post-approval re-scan is the first caller that needs PR 4's narrowed `sameOwnershipSelectors`. With the old broad gate this whole run would abort on any identity value it could not resolve. The narrowing is safe here because `remove.ts` re-proves identity per action, and the third test shows it: a data directory swapped between approval and execution comes back `untouched` with `ownership_root_changed` while an unchanged `logs/` is still removed. The broad gate would have refused both.
- Confirm the one-at-a-time loop produces the same ordering and skip semantics as the batched terminal path. `prerequisiteFailed` is sticky inside `executePlan` (it only ever goes true), and `delete-runtime-path` actions are already last in `buildRemovalPlan`, so ordering should match, but the two escalations named above genuinely do not carry over.
- Cancellation is checked between actions, not during one, so a cancel arriving mid delete lands after that delete finishes.

## Testing

New `setup/uninstall/protocol.test.ts`: six tests that spawn `setup/auto.ts --uninstall` for real under the protocol against a temporary install root, covering preserve-everything, the unsafe-choice re-ask, the swapped data directory, the `.env` backup path (including that the secret never appears in the event stream and that the backup is 0600 inside a 0700 directory), cancel mid-apply, and a 65-agent plan streamed without pagination.

Stack context: this is one of 39 proposed PRs that together reproduce one upstream commit that was too large to review. The final tree is byte-identical to that commit. Every commit passes a setup-inclusive `tsc` check and `bash -n nanoclaw.sh`; full vitest goes from 2038 passed / 4 failed at the base to 2150 passed / 4 failed at the tip, the 4 being a pre-existing git tag-signing failure on the author's machine that also fails on a clean upstream checkout. Note that `tsconfig.json` covers only `src/**/*`, so CI does not typecheck `setup/`.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this adds a machine-drivable uninstall path to the setup code, which is not a skill, not a bug fix, not a simplification and not documentation.

## Description

Adds `runMachineUninstall`, an NDJSON-driven uninstall that streams a plan, takes one approval, re-verifies ownership, executes and streams a receipt, plus the `setup/auto.ts` hunk that passes the driver into `runUninstallFlow`. Terminal uninstall behaviour is unchanged.

## For Skills

Not a skill, so this checklist does not apply.