### PR TITLE
feat(setup): add machine entry guards refusing secrets on argv/env

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -79,7 +79,7 @@ import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import type { AgentGroup } from '../src/types.js';
 import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-claude.js';
 import * as setupLog from './logs.js';
-import { ensureAnswer, fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
+import { fail, runQuietChild, runQuietStep, spawnQuiet } from './lib/runner.js';
 import { emit as phEmit } from './lib/diagnostics.js';
 import {
   accentGreen,
@@ -188,16 +188,47 @@ async function main(driver: SetupDriver): Promise<void> {
   // NANOCLAW_* sees them unchanged.
   const flagResult = parseFlags(process.argv.slice(2));
   if (flagResult.help) {
+    if (driver.mode === 'ndjson') {
+      driver.error('help_requested', 'Machine mode does not render terminal help.', [
+        { kind: 'rerun', args: ['--help'] },
+      ]);
+    }
     printHelp();
-    process.exit(0);
+    return;
   }
   if (flagResult.errors.length > 0) {
+    if (driver.mode === 'ndjson') {
+      driver.error('invalid_arguments', flagResult.errors.join('; '));
+    }
     for (const err of flagResult.errors) console.error(`error: ${err}`);
     console.error('');
     console.error('Run with --help for the full list of supported flags.');
     process.exit(1);
   }
   let configValues = { ...readFromEnv(), ...flagResult.values };
+  if (driver.mode === 'ndjson') {
+    const secretEntries = CONFIG.filter((entry) => entry.secret);
+    const secretLaunch =
+      secretEntries.some((entry) => process.env[envVarFor(entry)] !== undefined) ||
+      process.env.NANOCLAW_REGISTRY_ENROLL_CODE !== undefined ||
+      process.env.NANOCLAW_REGISTRY_TOKEN !== undefined;
+    const secretFlag = secretEntries.some((entry) => entry.key in flagResult.values);
+    if (secretLaunch || secretFlag) {
+      driver.error(
+        'secret_transport_forbidden',
+        'Machine setup does not accept secrets through flags or environment. Use the structured authentication prompts instead.',
+      );
+    }
+    if (configValues.anthropicBaseUrl !== undefined) {
+      driver.error(
+        'custom_endpoint_unsupported',
+        'Machine setup does not accept custom Anthropic endpoints through advanced configuration.',
+      );
+    }
+  }
+  for (const value of [configValues.onecliApiToken, configValues.anthropicAuthToken]) {
+    if (typeof value === 'string') registerSensitiveValue(value);
+  }
   applyToEnv(configValues);
 
   // --uninstall routes to the uninstall flow before any setup side effects —
@@ -223,20 +254,24 @@ async function main(driver: SetupDriver): Promise<void> {
   // On sg re-exec, the user already chose — skip straight to standard.
   let startChoice: 'default' | 'advanced' = 'default';
   if (process.env.NANOCLAW_REEXEC_SG !== '1') {
-    startChoice = ensureAnswer(
-      await brightSelect<'default' | 'advanced'>({
-        message: 'How would you like to begin?',
-        options: [
-          { value: 'default', label: 'Standard setup' },
-          { value: 'advanced', label: 'Advanced', hint: 'override defaults' },
-        ],
-        initialValue: 'default',
-      }),
-    ) as 'default' | 'advanced';
+    startChoice = await selectPrompt(driver, 'setup-start-choice', {
+      message: 'How would you like to begin?',
+      options: [
+        { value: 'default', label: 'Standard setup' },
+        { value: 'advanced', label: 'Advanced', hint: 'override defaults' },
+      ],
+      initialValue: 'default',
+    });
     setupLog.userInput('start_choice', startChoice);
   }
   if (startChoice === 'advanced') {
-    configValues = await runAdvancedScreen(configValues);
+    configValues = await runAdvancedScreen(configValues, driver);
+    if (driver.mode === 'ndjson' && configValues.anthropicBaseUrl !== undefined) {
+      driver.error(
+        'custom_endpoint_unsupported',
+        'Machine setup does not accept custom Anthropic endpoints through advanced configuration.',
+      );
+    }
     applyToEnv(configValues);
   }
 
@@ -246,35 +281,43 @@ async function main(driver: SetupDriver): Promise<void> {
       .map((s) => s.trim())
       .filter(Boolean),
   );
+  if (driver.mode === 'ndjson' && skip.has('verify')) {
+    driver.error('verify_cannot_be_skipped', 'Machine setup must run the existing verification step.');
+  }
 
   // Offer removal when setup lands on an existing install. Skipped on every
   // resume path — both the fail() retry and the sg-docker re-exec pass
   // NANOCLAW_SKIP (and the latter sets NANOCLAW_REEXEC_SG) — so the prompt
   // appears at most once per fresh run.
   const isResume = process.env.NANOCLAW_REEXEC_SG === '1' || skip.size > 0;
-  if (!isResume && detectExistingInstall(process.cwd())) {
-    const action = ensureAnswer(
-      await brightSelect<'keep' | 'uninstall'>({
-        message: 'NanoClaw is already installed in this folder. What would you like to do?',
-        options: [
-          {
-            value: 'keep',
-            label: 'Keep it & continue setup',
-            hint: 'recommended — re-running setup is safe',
-          },
-          {
-            value: 'uninstall',
-            label: 'Uninstall NanoClaw & exit',
-            hint: 'removes service, data, and agent files — asks before each step',
-          },
-        ],
-        initialValue: 'keep',
-      }),
-    ) as 'keep' | 'uninstall';
+  if (!isResume && detectExistingInstall(PROJECT_ROOT)) {
+    const action = await selectPrompt(driver, 'existing-install-action', {
+      message: 'NanoClaw is already installed in this folder. What would you like to do?',
+      options: [
+        {
+          value: 'keep',
+          label: 'Keep it & continue setup',
+          hint: 'recommended - re-running setup is safe',
+        },
+        {
+          value: 'uninstall',
+          label: 'Uninstall NanoClaw & exit',
+          hint: 'removes service, data, and agent files - asks before each step',
+        },
+      ],
+      initialValue: 'keep',
+    });
     setupLog.userInput('existing_install', action);
     phEmit('existing_install_detected', { action });
     if (action === 'uninstall') {
-      await runUninstallFlow({ dryRun: false, yes: false, invokedFrom: 'setup-detection' });
+      if (driver.mode === 'ndjson') {
+        driver.error(
+          'uninstall_requires_fresh_run',
+          'Start a fresh uninstall operation so its plan and receipt use the uninstall envelope.',
+          [{ kind: 'rerun', args: ['--uninstall', '--protocol', 'nanoclaw.driver.v1'] }],
+        );
+      }
+      await runUninstallFlow({ dryRun: false, yes: false, invokedFrom: 'setup-detection' }, driver);
     }
   }
 

--- a/setup/protocol.test.ts
+++ b/setup/protocol.test.ts
@@ -1,0 +1,67 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const AUTO = path.join(ROOT, 'setup', 'auto.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
+
+let setupRoot: string;
+let testHome: string;
+
+beforeEach(() => {
+  setupRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-setup-protocol-'));
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-setup-home-'));
+  const bin = path.join(testHome, '.local', 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(
+    path.join(bin, 'pnpm'),
+    '#!/bin/sh\nprintf \'=== NANOCLAW SETUP: verify ===\\nSTATUS: %s\\nCREDENTIALS: configured\\nSERVICE: running\\nCONFIGURED_CHANNELS: 0\\n=== END ===\\n\' "$VERIFY_STATUS"\n',
+    { mode: 0o755 },
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(setupRoot, { recursive: true, force: true });
+  fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+describe('machine setup completion boundary', () => {
+  it.each([
+    ['flag', ['--onecli-api-token', 'oc_direct-secret'], {}],
+    ['environment', [], { NANOCLAW_ONECLI_API_TOKEN: 'oc_direct-secret' }],
+    ['registry enrollment environment', [], { NANOCLAW_REGISTRY_ENROLL_CODE: 'oc_direct-secret' }],
+    ['registry token environment', [], { NANOCLAW_REGISTRY_TOKEN: 'oc_direct-secret' }],
+  ] as const)('rejects direct machine secret transport through %s', (_source, args, extraEnv) => {
+    const result = spawnSync(process.execPath, ['--import', TSX_LOADER, AUTO, ...args], {
+      cwd: setupRoot,
+      env: {
+        ...process.env,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_OPERATION: 'setup',
+        NANOCLAW_NO_DIAGNOSTICS: '1',
+        ...extraEnv,
+      },
+      encoding: 'utf8',
+      input: '',
+    });
+
+    expect(result.status, result.stderr).toBe(1);
+    const events = result.stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        type: 'error',
+        code: 'secret_transport_forbidden',
+      }),
+    );
+    expect(`${result.stdout}${result.stderr}`).not.toContain('oc_direct-secret');
+  });
+
+});


### PR DESCRIPTION
## TL;DR

Proposed: when NanoClaw setup is being driven by a program rather than a person, it now refuses up front, with a typed error, to accept a credential passed on the command line or in an environment variable, plus four other inputs it cannot honestly serve in that mode.

## Terms, defined inline

- **Machine mode (ndjson mode)**: the opt-in mode this stack adds, where `setup/auto.ts` speaks newline-delimited JSON over stdin/stdout to a GUI instead of drawing a terminal UI. It turns on only when `NANOCLAW_PROTOCOL=nanoclaw.driver.v1`. Nothing in the product sets that yet.
- **SetupDriver**: the interface every prompt goes through. `driver.mode` is `'terminal'` or `'ndjson'`. `driver.error(code, message, recovery)` emits one typed error event and never returns (exit 1).

## The problem

A GUI peer that could hand setup a token on argv or in the launch environment would leak it: argv is world readable through `ps`, and the environment is inherited by every child process setup spawns. The protocol already has a proper channel for secrets, a prompt answered over stdin. `nanoclaw.sh` refuses those env vars at the front door, but setup can also be started directly with `tsx setup/auto.ts`, which skips the shell entirely. This PR is the second line of defence, at the Node entry point.

## How it works

Every guard is inside `if (driver.mode === 'ndjson')`, placed right after flag parsing and before `applyToEnv`, so a rejected value is never written into the environment.

| error code | trigger |
| --- | --- |
| `secret_transport_forbidden` | any CONFIG entry marked `secret` (today `onecliApiToken`, `anthropicAuthToken`) supplied by flag or env var, or `NANOCLAW_REGISTRY_TOKEN` / `NANOCLAW_REGISTRY_ENROLL_CODE` present |
| `custom_endpoint_unsupported` | `anthropicBaseUrl` set, whether by flag/env or later through the advanced screen |
| `help_requested` | `--help`, which has no machine rendering |
| `verify_cannot_be_skipped` | `NANOCLAW_SKIP` contains `verify` |
| `uninstall_requires_fresh_run` | the operator picks "uninstall" at the existing-install prompt; machine uninstall has to be its own run so its plan and receipt use the uninstall envelope |

Also here: the last two clack prompts in `main` (start choice, existing-install action) move onto the driver, rendering the identical widget in terminal mode; flag or env supplied `onecliApiToken` and `anthropicAuthToken` are registered with the log redactor (in machine mode those inputs already abort, so this is a terminal-mode improvement); and `runUninstallFlow` is called with the driver, whose two-argument form landed in the previous PR.

## What trips people up

- **Two terminal-mode changes hide in here.** `--help` ends with `return` instead of `process.exit(0)` (the terminal driver holds no open handles, so the process still exits 0), and the existing-install probe reads `PROJECT_ROOT`, the checkout root derived from the module URL, instead of `process.cwd()`. Same answer when setup is launched from the checkout root, which `nanoclaw.sh` does; different if someone runs it from another directory.
- **The secret gate is an enumeration, not a pattern.** A future config entry that carries a credential but is not marked `secret: true`, or a third registry env var, walks straight through it.
- **Test coverage is one guard of five.** The new `setup/protocol.test.ts` exercises only `secret_transport_forbidden`, in four cases (flag, env var, and the two registry env vars), asserting exit status 1, that the last NDJSON event carries that code, and that the token never appears in stdout or stderr. The other four codes are untested in this PR.
- Two em dashes in the existing-install hint text become plain hyphens, wording only.

## What to review

1. Whether the enumeration in the secret gate is the right shape, or whether it should live next to the config definitions so a new secret entry cannot forget it.
2. The `process.cwd()` to `PROJECT_ROOT` swap: is there a supported way of invoking setup where those differ and the old behaviour was intended?
3. Guard placement before `applyToEnv`, which is what keeps a rejected secret out of the process environment.
4. Whether `--help` deserving a hard error in machine mode is the behaviour you want, versus emitting structured help.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is part of a feature, the machine-drivable setup protocol, not a skill; and it is not a fix, because the mode it guards is new and not reachable in the shipped product yet, so there is no existing bug being corrected.

## Description

One PR in a stack of 39 that splits a single oversized upstream commit, "feat(setup): add structured setup driver protocol", into reviewable pieces. The stack as a whole reproduces that commit exactly: the final tree is byte-identical to it, and no behaviour is added beyond what that commit contained. This piece adds the machine-mode entry guards in `setup/auto.ts` plus the first test file for them.

## For Skills

Not a skill, so the skill checklist does not apply.