### PR TITLE
feat(setup): gate machine completion on a proven service receipt

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -44,7 +44,6 @@ import { getSetupProvider, listSetupProviders, runSetupProviderAuth } from './pr
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
-import { brightSelect } from './lib/bright-select.js';
 import { buildContainerImage } from './lib/container-build.js';
 import { offerClaudeOnFailure } from './lib/claude-handoff.js';
 import { setPickedProvider } from './lib/picked-provider.js';
@@ -89,7 +88,6 @@ import {
   dimWrap,
   fitToWidth,
   fmtDuration,
-  note,
   wrapForGutter,
 } from './lib/theme.js';
 import { isValidTimezone } from '../src/timezone.js';
@@ -913,13 +911,19 @@ async function main(driver: SetupDriver): Promise<void> {
   // premature "your assistant is saying hi" (no welcome DM exists yet).
   let wiringPending = false;
 
+  let verified = false;
   if (!skip.has('verify')) {
-    const res = await runQuietStep('verify', {
-      running: 'Making sure everything works together…',
-      done: "Everything's connected.",
-      failed: 'A few things still need your attention.',
-    });
-    if (!res.ok) {
+    const res = await runQuietStep(
+      'verify',
+      {
+        running: 'Making sure everything works together…',
+        done: "Everything's connected.",
+        failed: 'A few things still need your attention.',
+      },
+      [],
+      driver,
+    );
+    if (!res.ok || (driver.mode === 'ndjson' && res.terminal?.fields.STATUS !== 'success')) {
       const notes: string[] = [];
       if (res.terminal?.fields.CREDENTIALS !== 'configured') {
         notes.push("• Your Claude account isn't connected. Re-run setup and try again.");
@@ -945,7 +949,7 @@ async function main(driver: SetupDriver): Promise<void> {
         );
       }
       if (notes.length > 0) {
-        note(notes.join('\n'), "What's left");
+        driver.note(notes.join('\n'), "What's left");
       }
       // "What's left" is a soft failure — we don't abort like fail(), but the
       // user is still stuck and a fix is exactly what claude-assist is for.
@@ -958,17 +962,43 @@ async function main(driver: SetupDriver): Promise<void> {
         service_running: res.terminal?.fields.SERVICE === 'running',
         has_credentials: res.terminal?.fields.CREDENTIALS === 'configured',
       });
-      await offerClaudeOnFailure({
-        stepName: 'verify',
-        msg: summary || 'Verification completed with unresolved issues.',
-        hint: `Terminal block: ${JSON.stringify(res.terminal?.fields ?? {})}`,
-        rawLogPath: res.rawLog,
-      });
-      p.outro(k.yellow('Almost there. A few things still need your attention.'));
-      return;
+      if (driver.mode === 'terminal') {
+        await offerClaudeOnFailure({
+          stepName: 'verify',
+          msg: summary || 'Verification completed with unresolved issues.',
+          hint: `Terminal block: ${JSON.stringify(res.terminal?.fields ?? {})}`,
+          rawLogPath: res.rawLog,
+        });
+        driver.outro(k.yellow('Almost there. A few things still need your attention.'));
+        return;
+      }
+      driver.error(
+        'verification_failed',
+        summary || 'Verification completed with unresolved issues.',
+        [
+          {
+            kind: 'manual',
+            title: 'Resolve verification issues',
+            instructions: notes.length ? notes : ['Inspect the verify raw log, fix the issue, and rerun setup.'],
+          },
+        ],
+        'verify',
+      );
     }
+    verified = res.terminal?.fields.STATUS === 'success';
     wiringPending = res.terminal?.fields.WIRING === 'pending_first_dm';
   }
+
+  if (driver.mode === 'ndjson' && !verified) {
+    driver.error(
+      'verification_required',
+      'Setup cannot complete until verification reports STATUS: success.',
+      [],
+      'verify',
+    );
+  }
+
+  const setupReceipt = await completionReceipt(driver);
 
   const rows: [string, string][] = [
     ['Chat in the terminal:', 'pnpm run chat hi'],
@@ -977,11 +1007,11 @@ async function main(driver: SetupDriver): Promise<void> {
   ];
   const labelWidth = Math.max(...rows.map(([l]) => l.length));
   const nextSteps = rows.map(([l, c]) => `${k.cyan(l.padEnd(labelWidth))}  ${c}`).join('\n');
-  note(nextSteps, 'Try these');
+  driver.note(nextSteps, 'Try these');
 
   // Always-on warning goes before the "check your DMs" directive so the
   // caveat doesn't land after the user's already looked away at their phone.
-  note(
+  driver.note(
     wrapForGutter(
       "NanoClaw runs on this machine. It's only reachable while this computer is on and connected to the internet. For always-on availability, run it on a cloud VM — or keep this machine awake.",
       6,
@@ -989,6 +1019,7 @@ async function main(driver: SetupDriver): Promise<void> {
     'Heads up',
   );
 
+  driver.throwIfCancelled();
   setupLog.complete(Date.now() - RUN_START);
   phEmit('setup_completed', { duration_ms: Date.now() - RUN_START });
 
@@ -996,21 +1027,65 @@ async function main(driver: SetupDriver): Promise<void> {
   if (wiringPending) {
     // No welcome DM exists yet — the one remaining action is the last thing
     // on screen, in the same bright framed style as the "go say hi" banner.
-    note(
+    driver.note(
       `${brandBold('→')} ${k.bold(`Have the person you want wired DM the bot once in ${dmTarget ?? 'your chat app'} ("hi" works).`)}\nNanoClaw registers their identity and chat from that first message; then run /init-first-agent with your coding agent and pick them.`,
       "What's left",
     );
-    p.outro(k.green("You're set — one DM to go."));
+    driver.outro(k.green("You're set - one DM to go."));
   } else if (dmTarget) {
     // Bright framed banner (not dim) — the whole point of the feedback was
     // that the welcome-message signal was too easy to miss. Use p.note so it
     // renders with a visible box, cyan-bold the directive line, and put it
     // as the last thing before outro.
-    note(`${brandBold('→')} ${k.bold(`Check your ${dmTarget} — your assistant is saying hi.`)}`, 'Go say hi');
-    p.outro(k.green("You're set."));
+    driver.note(`${brandBold('→')} ${k.bold(`Check your ${dmTarget} - your assistant is saying hi.`)}`, 'Go say hi');
+    driver.outro(k.green("You're set."));
   } else {
-    p.outro(k.green("You're ready! Chat with `pnpm run chat hi`."));
+    driver.outro(k.green("You're ready! Chat with `pnpm run chat hi`."));
   }
+  driver.throwIfCancelled();
+  driver.completeSetup(setupReceipt);
+}
+
+async function completionReceipt(driver: SetupDriver): Promise<SetupReceipt> {
+  if (driver.mode === 'terminal') {
+    return {
+      version: 1,
+      service: { state: 'running', manager: 'pidfile', checkoutRoot: PROJECT_ROOT },
+      health: { status: 'healthy' },
+      resources: {
+        groups: { state: 'empty', count: 0 },
+        policies: { state: 'empty', count: 0 },
+        skills: { state: 'empty', count: 0 },
+      },
+      completedAt: new Date().toISOString(),
+    };
+  }
+  driver.throwIfCancelled();
+  const service = inspectService(PROJECT_ROOT);
+  let health = await queryHostHealth(PROJECT_ROOT, { signal: driver.cancellationSignal });
+  for (let attempt = 0; !health && attempt < 20; attempt++) {
+    driver.throwIfCancelled();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    driver.throwIfCancelled();
+    health = await queryHostHealth(PROJECT_ROOT, { signal: driver.cancellationSignal });
+  }
+  driver.throwIfCancelled();
+  const result = buildSetupReceipt(PROJECT_ROOT, service, health);
+  if (!result.ok) {
+    driver.error(
+      result.code,
+      result.message,
+      [
+        {
+          kind: 'manual',
+          title: 'Inspect the running service',
+          instructions: ['Confirm the service points at this checkout and rerun machine setup.'],
+        },
+      ],
+      'verify',
+    );
+  }
+  return result.receipt;
 }
 
 function channelDmLabel(choice: ChannelChoice): string | null {

--- a/setup/protocol.test.ts
+++ b/setup/protocol.test.ts
@@ -30,6 +30,52 @@ afterEach(() => {
   fs.rmSync(testHome, { recursive: true, force: true });
 });
 
+async function run(status: 'success' | 'failed' | 'skipped'): Promise<{
+  code: number | null;
+  stdout: string;
+  events: Array<Record<string, unknown>>;
+}> {
+  const child = spawn(process.execPath, ['--import', TSX_LOADER, AUTO], {
+    cwd: setupRoot,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+      NANOCLAW_OPERATION: 'setup',
+      NANOCLAW_NO_DIAGNOSTICS: '1',
+      NANOCLAW_SKIP: 'environment,container,onecli,auth,mounts,service,cli-agent,timezone,channel,first-chat',
+      VERIFY_STATUS: status,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const events: Array<Record<string, unknown>> = [];
+  let stdout = '';
+  let buffer = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString('utf8');
+    buffer += chunk.toString('utf8');
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const event = JSON.parse(line) as Record<string, unknown>;
+      events.push(event);
+      const prompt = event.prompt as { id?: string } | undefined;
+      if (event.type === 'prompt' && prompt?.id === 'setup-start-choice') {
+        child.stdin.write(
+          `${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: 'default' })}\n`,
+        );
+      }
+    }
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  return { code, stdout, events };
+}
+
 describe('machine setup completion boundary', () => {
   it.each([
     ['flag', ['--onecli-api-token', 'oc_direct-secret'], {}],
@@ -64,4 +110,82 @@ describe('machine setup completion boundary', () => {
     expect(`${result.stdout}${result.stderr}`).not.toContain('oc_direct-secret');
   });
 
+  it.each([
+    ['success', 1, false, 'service_identity_unproven'],
+    ['failed', 1, false, 'verification_failed'],
+    ['skipped', 1, false, 'verification_failed'],
+  ] as const)(
+    'requires verify and service health before completion (%s)',
+    async (status, exitCode, completes, errorCode) => {
+      const result = await run(status);
+
+      expect(result.code, result.stdout).toBe(exitCode);
+      expect(result.stdout[0]).toBe('{');
+      expect(result.events.filter((event) => event.type === 'hello')).toHaveLength(1);
+      expect(result.events.some((event) => event.type === 'complete')).toBe(completes);
+      if (!completes) {
+        expect(result.events.at(-1)).toEqual(
+          expect.objectContaining({
+            type: 'error',
+            code: errorCode,
+          }),
+        );
+      }
+    },
+    15_000,
+  );
+
+  it('reports SIGINT during the remote health check as cancelled with exit 2', async () => {
+    const child = spawn(process.execPath, ['--import', TSX_LOADER, AUTO], {
+      cwd: setupRoot,
+      env: {
+        ...process.env,
+        HOME: testHome,
+        NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+        NANOCLAW_OPERATION: 'setup',
+        NANOCLAW_NO_DIAGNOSTICS: '1',
+        NANOCLAW_ONECLI_API_HOST: 'http://127.0.0.1:1',
+        NANOCLAW_SKIP: 'environment,container,auth,mounts,service,cli-agent,timezone,channel,first-chat',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    let buffer = '';
+    let signalled = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        const event = JSON.parse(line) as Record<string, unknown>;
+        events.push(event);
+        const prompt = event.prompt as { id?: string } | undefined;
+        if (event.type === 'prompt' && prompt?.id === 'setup-start-choice') {
+          child.stdin.write(
+            `${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: 'default' })}\n`,
+          );
+        }
+        if (
+          event.type === 'progress' &&
+          event.stepId === 'onecli-remote-check' &&
+          event.state === 'running' &&
+          !signalled
+        ) {
+          signalled = true;
+          child.kill('SIGINT');
+        }
+      }
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+
+    expect(signalled).toBe(true);
+    expect(code).toBe(2);
+    expect(events.at(-1)?.type).toBe('cancelled');
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+  }, 15_000);
 });


### PR DESCRIPTION
## TL;DR

Proposed: when setup is driven by a machine (the native macOS app), it may only report success after it has independently proven the NanoClaw background service is running from this checkout and answering a health query. Terminal setup behaviour is unchanged.

## The problem this solves

Background, for a reviewer with no prior context: this stack adds a `SetupDriver`, an interface that abstracts every user interaction in `setup/auto.ts`. `TerminalSetupDriver` renders it with the existing terminal UI, so terminal runs look identical. `NdjsonSetupDriver` renders it as newline-delimited JSON on stdin/stdout so a GUI app can run setup with no human at a keyboard. Machine mode is opt-in, and nothing turns it on yet.

A GUI needs a trustworthy answer to "did setup actually work". Until this PR, machine mode would have finished on the same basis as the terminal: the `verify` step exited non-zero or not. That is too weak. `verify` can exit 0 while printing `STATUS: failed`, `verify` can be skipped entirely, and even a clean verify does not prove the running service belongs to this checkout rather than another one on the same machine.

## How it works

Two new gates on the machine path only:

1. **Verify must actually pass.** The completion check becomes `!res.ok || (driver.mode === 'ndjson' && res.terminal?.fields.STATUS !== 'success')`. A separate guard rejects the case where `verify` was skipped. Terminal mode keeps its existing soft-fail path: print "What's left", offer the Claude handoff, exit.
2. **A service receipt must be provable.** A new `completionReceipt` helper calls `inspectService` (which resolves the launchd, systemd, or pidfile PID and reads that process's actual checkout) and `queryHostHealth` (a `health` command over the `data/ncl.sock` unix socket). `buildSetupReceipt` only returns a receipt if the service state is `running`, its checkout root equals this one, and the health reply reports `healthy` with a matching checkout root, cwd, and PID. Anything else is `service_identity_unproven` or `health_postcondition_failed`.

On failure the driver emits a structured `error` event and exits 1. On success it emits a `complete` event carrying the receipt (service manager, checkout root, health status, counts of groups, policies, and skills). The `verify` step is now also passed the driver, so it emits progress events and can be cancelled mid-run.

This is also the last conversion in `setup/auto.ts`: the final two direct terminal calls move to the driver, which lets the now-unused `brightSelect` and `note` imports go.

## What trips people up

- **Machine mode is strictly stricter than terminal mode on identical `verify` output.** That asymmetry is deliberate, not a bug.
- **Terminal mode returns a fabricated receipt** (`state: 'running'`, `manager: 'pidfile'`, `health: 'healthy'`, all resource counts zero). `TerminalSetupDriver.completeSetup` is a no-op, so nothing reads it today. It would be a lie if anything ever did.
- **The health check polls.** Up to 21 attempts, 250 ms apart, each with a 1 second socket timeout. A socket that is simply absent fails fast, so the realistic wait is a few seconds; a socket that accepts and then hangs can stretch it to roughly 26 seconds before the error event. There is no separate overall deadline.
- **Two copy edits ride along**, replacing an em dash with a hyphen in the "You're set" and "your assistant is saying hi" terminal strings. Cosmetic, terminal-visible.

## What to review

- `setup/lib/service-health.ts` is not modified here, but the equality conditions in `buildSetupReceipt` are the whole security argument. Confirm you agree that state plus checkout root plus PID plus socket health is the right proof.
- The skipped-verify guard: it fires whenever machine mode reaches the end without a `success` verify, including when the operator passed `NANOCLAW_SKIP=verify`.
- Whether the polling loop should have a wall-clock deadline instead of an attempt count.
- The new tests in `setup/protocol.test.ts` spawn real setup with a stubbed verify script and assert: `success` still fails with `service_identity_unproven` (no service is running in the test environment), `failed` and `skipped` fail with `verification_failed`, no `complete` event is emitted in any case, and SIGINT during the health check produces a `cancelled` event with exit code 2 and no `error` event.

Verification: `setup/auto.ts` and `setup/protocol.test.ts` at this commit are byte-identical to the corresponding files in the single upstream commit this stack reproduces. The setup-inclusive TypeScript check and `bash -n nanoclaw.sh` pass. Note that CI's `tsconfig.json` covers only `src/**/*`, so `setup/` is not typechecked by CI.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits. This is neither a skill nor a fix to existing behaviour: it adds a completion gate to the new machine-driven setup path, which no released version exposes yet.

## For Skills

Not a skill, so the skill checklist does not apply.