### PR TITLE
test(setup): add renderer parity test and auto.ts driver lint

### DIFF
--- a/setup/lib/fixtures/setup-driver-transcript-child.ts
+++ b/setup/lib/fixtures/setup-driver-transcript-child.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import net, { type Socket } from 'node:net';
+import path from 'node:path';
+
+import { PLUGIN_SCHEMA_URL } from '../../../src/templates/manifest.js';
+import { NdjsonSetupDriver } from '../setup-driver.js';
+import { fixtureSetupReceipt } from './setup-receipt.js';
+
+const scenario = process.argv[2];
+if (scenario !== 'standard' && scenario !== 'template-first-agent') {
+  throw new Error('unknown production parity scenario');
+}
+
+const driver = new NdjsonSetupDriver('setup');
+const auto = await import('../../auto.js');
+
+if (scenario === 'standard') {
+  await auto.runTemplateSetup(driver, false, false);
+} else {
+  // The production helper lists template carriers before creating one, which
+  // reads the template's manifest from the local templates directory.
+  const templateDir = path.join(process.cwd(), 'templates', 'sales', 'sdr');
+  fs.mkdirSync(templateDir, { recursive: true });
+  fs.writeFileSync(path.join(templateDir, 'plugin.json'), JSON.stringify({ $schema: PLUGIN_SCHEMA_URL, name: 'sdr' }));
+  const socketPath = path.join(process.cwd(), 'data', 'ncl.sock');
+  const requests: Array<{ command: string; args: Record<string, unknown> }> = [];
+  const sockets = new Set<Socket>();
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    let buffer = '';
+    socket.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const newline = buffer.indexOf('\n');
+      if (newline < 0) return;
+      const request = JSON.parse(buffer.slice(0, newline)) as {
+        id: string;
+        command: string;
+        args: Record<string, unknown>;
+      };
+      requests.push({ command: request.command, args: request.args });
+      const data =
+        request.command === 'groups-create'
+          ? {
+              id: 'ag-template',
+              name: 'SDR',
+              folder: 'sdr',
+              agent_provider: null,
+              created_at: '2026-01-01T00:00:00.000Z',
+            }
+          : request.command === 'groups-list' || request.command === 'wirings-list'
+            ? []
+            : {};
+      socket.end(`${JSON.stringify({ id: request.id, ok: true, data })}\n`);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  try {
+    await auto.installSelectedTemplateAgent(driver, 'claude');
+    if (process.env.NANOCLAW_TEST_REQUESTS) {
+      fs.writeFileSync(process.env.NANOCLAW_TEST_REQUESTS, JSON.stringify(requests));
+    }
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+driver.completeSetup(fixtureSetupReceipt());

--- a/setup/setup-driver-parity.test.ts
+++ b/setup/setup-driver-parity.test.ts
@@ -1,0 +1,260 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const terminal = vi.hoisted(() => ({
+  events: [] as Array<Record<string, unknown>>,
+  confirmAnswers: [] as boolean[],
+  selectAnswers: [] as string[],
+}));
+const socket = vi.hoisted(() => ({
+  requests: [] as Array<{ command: string; args: Record<string, unknown> }>,
+}));
+
+vi.mock('@clack/prompts', () => ({
+  autocomplete: vi.fn(
+    async (opts: { options: Array<{ value: string }> }) => terminal.selectAnswers.shift() ?? opts.options[0]?.value,
+  ),
+  confirm: vi.fn(async (opts: { message: string; initialValue?: boolean }) => {
+    terminal.events.push({
+      type: 'prompt',
+      kind: 'confirm',
+      message: opts.message,
+      default: opts.initialValue,
+    });
+    return terminal.confirmAnswers.shift() ?? opts.initialValue ?? true;
+  }),
+  intro: vi.fn(),
+  isCancel: vi.fn(() => false),
+  note: vi.fn(),
+  outro: vi.fn(),
+  password: vi.fn(),
+  text: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock('./lib/bright-select.js', () => ({
+  brightSelect: vi.fn(
+    async (opts: { message: string; options: Array<{ value: string; label: string }>; initialValue?: string }) => {
+      terminal.events.push({
+        type: 'prompt',
+        kind: 'singleChoice',
+        message: opts.message,
+        choices: opts.options.map(({ value, label }) => ({ id: value, label })),
+        default: opts.initialValue,
+      });
+      return terminal.selectAnswers.shift() ?? opts.initialValue ?? opts.options[0]?.value;
+    },
+  ),
+}));
+
+// The production helper lists template carriers before creating one, which
+// reads the template manifest from the local templates directory. Point it
+// at a scratch root so the test never depends on the checkout's templates/.
+const PARITY_TEMPLATES_DIR = '/tmp/nanoclaw-setup-driver-parity/templates';
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/config.js')>()),
+  TEMPLATES_DIR: '/tmp/nanoclaw-setup-driver-parity/templates',
+}));
+vi.mock('../src/cli/socket-client.js', () => ({
+  SocketTransport: class {
+    async sendFrame(request: { command: string; args: Record<string, unknown> }) {
+      socket.requests.push({ command: request.command, args: request.args });
+      return {
+        id: 'fixture',
+        ok: true,
+        data:
+          request.command === 'groups-create'
+            ? {
+                id: 'ag-template',
+                name: 'SDR',
+                folder: 'sdr',
+                agent_provider: null,
+                created_at: '2026-01-01T00:00:00.000Z',
+              }
+            : request.command === 'groups-list' || request.command === 'wirings-list'
+              ? []
+              : {},
+      };
+    }
+  },
+}));
+
+import { PLUGIN_SCHEMA_URL } from '../src/templates/manifest.js';
+import { installSelectedTemplateAgent, runTemplateSetup } from './auto.js';
+import { TerminalSetupDriver } from './lib/setup-driver.js';
+
+const ROOT = process.cwd();
+const TSX_LOADER = import.meta.resolve('tsx');
+const CHILD = path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-transcript-child.ts');
+const envelope = { protocol: 'nanoclaw.driver.v1', operation: 'setup' } as const;
+
+beforeEach(() => {
+  terminal.events.length = 0;
+  terminal.confirmAnswers.length = 0;
+  terminal.selectAnswers.length = 0;
+  socket.requests.length = 0;
+  fs.rmSync(PARITY_TEMPLATES_DIR, { recursive: true, force: true });
+  fs.mkdirSync(path.join(PARITY_TEMPLATES_DIR, 'sales', 'sdr'), { recursive: true });
+  fs.writeFileSync(
+    path.join(PARITY_TEMPLATES_DIR, 'sales', 'sdr', 'plugin.json'),
+    JSON.stringify({ $schema: PLUGIN_SCHEMA_URL, name: 'sdr' }),
+  );
+  process.env.NANOCLAW_NO_DIAGNOSTICS = '1';
+  delete process.env.NANOCLAW_TEMPLATE_PATH;
+  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
+  delete process.env.NANOCLAW_AGENT_NAME;
+});
+
+afterEach(() => {
+  fs.rmSync(PARITY_TEMPLATES_DIR, { recursive: true, force: true });
+  delete process.env.NANOCLAW_NO_DIAGNOSTICS;
+  delete process.env.NANOCLAW_TEMPLATE_PATH;
+  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
+  delete process.env.NANOCLAW_AGENT_NAME;
+});
+
+async function machineProduction(scenario: 'standard' | 'template-first-agent') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-production-parity-'));
+  const requestsPath = path.join(root, 'requests.json');
+  const child = spawn(process.execPath, ['--import', TSX_LOADER, CHILD, scenario], {
+    cwd: root,
+    env: {
+      ...process.env,
+      NANOCLAW_PROTOCOL: 'nanoclaw.driver.v1',
+      NANOCLAW_OPERATION: 'setup',
+      NANOCLAW_NO_DIAGNOSTICS: '1',
+      NANOCLAW_TEMPLATE_PATH: scenario === 'template-first-agent' ? 'sales/sdr' : '',
+      NANOCLAW_TEMPLATE_AGENT_ID: '',
+      NANOCLAW_AGENT_NAME: '',
+      NANOCLAW_TEST_REQUESTS: requestsPath,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const events: Array<Record<string, unknown>> = [];
+  let buffer = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString('utf8');
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const event = JSON.parse(line) as Record<string, unknown>;
+      events.push(event);
+      if (event.type !== 'prompt') continue;
+      const prompt = event.prompt as { id: string };
+      child.stdin.write(`${JSON.stringify({ ...envelope, type: 'answer', promptId: prompt.id, value: 'none' })}\n`);
+    }
+  });
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  try {
+    expect(code, stderr).toBe(0);
+    return {
+      events,
+      requests: fs.existsSync(requestsPath)
+        ? (JSON.parse(fs.readFileSync(requestsPath, 'utf8')) as Array<{
+            command: string;
+            args: Record<string, unknown>;
+          }>)
+        : [],
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function promptShape(value: Record<string, unknown>) {
+  const prompt = value.prompt as Record<string, unknown> | undefined;
+  return prompt
+    ? {
+        kind: prompt.kind,
+        message: prompt.message,
+        choices: prompt.choices,
+        default: prompt.default,
+      }
+    : {
+        kind: value.kind,
+        message: value.message,
+        choices: value.choices,
+        default: value.default,
+      };
+}
+
+describe('setup driver production parity', () => {
+  it('uses the production first-agent choice in both renderers', async () => {
+    terminal.selectAnswers.push('none');
+    await runTemplateSetup(new TerminalSetupDriver('setup'), false, false);
+    const machine = await machineProduction('standard');
+
+    const terminalPrompt = terminal.events.find((event) => event.type === 'prompt');
+    const machinePrompt = machine.events.find((event) => event.type === 'prompt');
+    expect(terminalPrompt).toBeDefined();
+    expect(machinePrompt).toBeDefined();
+    expect(promptShape(machinePrompt!)).toEqual(promptShape(terminalPrompt!));
+  });
+
+  it('stamps the selected template through the real socket-backed production helper', async () => {
+    process.env.NANOCLAW_TEMPLATE_PATH = 'sales/sdr';
+    await installSelectedTemplateAgent(new TerminalSetupDriver('setup'), 'claude');
+    const machine = await machineProduction('template-first-agent');
+
+    // Production lists the template's existing carriers (to offer connect /
+    // update / create another) before stamping a fresh agent.
+    const expected = [
+      { command: 'groups-list', args: { limit: Number.MAX_SAFE_INTEGER } },
+      { command: 'wirings-list', args: { limit: Number.MAX_SAFE_INTEGER } },
+      { command: 'groups-create', args: { template: 'sales/sdr', new: true } },
+      { command: 'groups-config-update', args: { id: 'ag-template', provider: 'claude' } },
+    ];
+    expect(socket.requests).toEqual(expected);
+    expect(machine.requests).toEqual(expected);
+    expect(machine.events).toContainEqual(
+      expect.objectContaining({
+        type: 'progress',
+        stepId: 'template-agent',
+        state: 'succeeded',
+      }),
+    );
+    expect(process.env.NANOCLAW_TEMPLATE_AGENT_ID).toBe('ag-template');
+  });
+
+  it('keeps production ordering and direct prompt primitives behind the driver', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'setup', 'auto.ts'), 'utf8');
+    expect(source).not.toMatch(/\bp\.(confirm|text|password)\s*\(/);
+    expect(source).not.toMatch(/\bbrightSelect\s*\(/);
+    expect(source.match(/createSetupDriver\s*\(/g)).toHaveLength(1);
+    expect(source.indexOf('await runTemplateSetup(driver')).toBeLessThan(source.indexOf("if (!skip.has('container'))"));
+    expect(source.indexOf('await runTimezoneStep(driver)')).toBeLessThan(
+      source.indexOf('await installSelectedTemplateAgent(driver'),
+    );
+    expect(source.indexOf('await installSelectedTemplateAgent(driver')).toBeLessThan(
+      source.indexOf("if (!skip.has('channel')"),
+    );
+    const registryFlow = source.slice(
+      source.indexOf('async function chooseImageSource'),
+      source.indexOf('async function askAgentProviderChoice'),
+    );
+    expect(registryFlow).not.toContain("driver.mode === 'terminal'");
+    expect(registryFlow.match(/runRegistryLoginWithDriver\s*\(/g)).toHaveLength(1);
+    expect(fs.existsSync(path.join(ROOT, 'setup', 'lib', 'fixtures', 'setup-driver-transcript.ts'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Proposed: a test that runs the same real setup code twice, once through the terminal renderer and once through the machine (NDJSON) renderer, and asserts the two agree. No production code changes.

## The problem it proposes to solve

Earlier PRs in this stack move every setup prompt behind a `SetupDriver` interface, with two implementations: `TerminalSetupDriver` (draws the existing terminal UI) and `NdjsonSetupDriver` (speaks newline-delimited JSON on stdin/stdout so a native macOS app can drive setup with no terminal). Nothing so far proves the two renderers actually behave the same on the same production code path, or that a stray direct terminal-prompt call has not survived the conversion. This adds that proof.

## How it works

Two new files, both tests:

- `setup/lib/fixtures/setup-driver-transcript-child.ts` is a small program the test launches as a real child process. It builds an `NdjsonSetupDriver`, imports the real `setup/auto.ts`, and calls one of two production helpers depending on the scenario argument. In the template scenario it also stands up a real unix domain socket at `<tmpdir>/data/ncl.sock` and answers the requests setup sends, so the machine run exercises the genuine socket client rather than a stub.
- `setup/setup-driver-parity.test.ts` has three cases:
  1. Calls `runTemplateSetup` in-process with `TerminalSetupDriver` (the `@clack/prompts` terminal library and the `brightSelect` helper are mocked to record what was asked), then runs the same helper in the child under `NANOCLAW_PROTOCOL=nanoclaw.driver.v1`, replying to each prompt over stdin. It asserts both sides produced the same prompt shape: kind, message, choices, default.
  2. Calls `installSelectedTemplateAgent` both ways and asserts both produce the identical sequence of `ncl` commands (`groups-list`, `wirings-list`, `groups-create`, `groups-config-update`), and that the machine run emitted a `progress` event for step `template-agent` in state `succeeded`.
  3. Reads `setup/auto.ts` as text and asserts the conversion is complete: zero direct `p.confirm|text|password(` calls (the pre-stack file has 12), zero `brightSelect(` calls (3 before), exactly one `createSetupDriver(`, a few call-ordering constraints, and that the registry sign-in region contains no `driver.mode === 'terminal'` special case.

## What trips people up

- "Parity" here is narrower than the name suggests. Case 1 compares only the **first** prompt of the flow, not a full transcript; case 2 compares socket traffic, not the rest of the event stream. It is a spot check on two flows, not a general equivalence proof.
- Case 3 is a text lint, not a type check. Its ordering assertions use `String.indexOf` on literal call snippets, so if a call is renamed the search returns `-1` and a `toBeLessThan` comparison can pass for the wrong reason. Same class of issue for `expect(...existsSync('setup/lib/fixtures/setup-driver-transcript.ts')).toBe(false)`: that file does not exist anywhere in the branch history, so today the assertion only guards against reintroducing a mock-transcript fixture.
- The test mutates process-wide state: `NANOCLAW_TEMPLATE_PATH`, `NANOCLAW_TEMPLATE_AGENT_ID`, `NANOCLAW_AGENT_NAME`, `NANOCLAW_NO_DIAGNOSTICS`, and it deletes and recreates the fixed path `/tmp/nanoclaw-setup-driver-parity/templates` in `beforeEach`/`afterEach`. Fine in isolation; worth watching if another `setup/` test lands in the same vitest worker.
- The child is spawned as `process.execPath --import tsx`, so it needs the repo's `tsx` devDependency present. Its working directory is a fresh `mkdtemp` root that is removed afterwards.

## What to review

- Whether case 3's ordering assertions are worth their brittleness, or should be tightened so a missing snippet fails loudly instead of comparing against `-1`.
- Whether comparing only the first prompt in case 1 is enough certification for the claim the stack is making.
- Whether the fixed `/tmp` path and the env mutation are acceptable for this suite.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in .claude/skills/<name>/, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

No box fits: this PR adds test files only. It is not a skill, not a fix, not a simplification, and not documentation.

## Description

Adds a two-renderer parity test for the proposed setup driver protocol, plus a source-text lint over `setup/auto.ts` that pins the conversion as complete. 330 added lines, all test code, zero production lines.

Verification: `pnpm exec vitest run setup/setup-driver-parity.test.ts`. CI does execute it, since `vitest.config.ts` includes `setup/**/*.test.ts`, even though `tsconfig.json` includes only `src/**/*` and therefore does not typecheck `setup/`.

## For Skills

Not a skill, so this checklist does not apply.