### PR TITLE
ci(labels): automatic area/* from changed paths and kind/* from PR type

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,321 @@
+# Path -> area/* mapping for actions/labeler.
+#
+# Every key below must byte-match a label that already exists in the repo
+# (`gh label list`). GitHub's addLabels API auto-creates unknown labels with a
+# random color and no description, so a typo here silently invents a label.
+#
+# A PR may carry several area/* labels; the labeler only adds, never removes
+# (`sync-labels: false`), so a maintainer can prune to the primary subsystem by
+# hand and the workflow will not put it back.
+#
+# Paths with no confident owner are deliberately left unmapped rather than
+# guessed. See .github/workflows/label-area.yml for the runner side.
+
+"area/agent-memory":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "container/agent-runner/src/memory/**"
+          - "src/migrate-claude-memory-settings*"
+          - "src/memory-migration-contract.test.ts"
+          - "docs/memory.md"
+          - ".claude/skills/migrate-memory/**"
+          - ".claude/skills/add-mnemon/**"
+          - ".claude/skills/add-karpathy-llm-wiki/**"
+
+"area/agent-runner":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "container/agent-runner/**"
+          - "docs/agent-runner-details.md"
+          - "docs/SDK_DEEP_DIVE.md"
+
+"area/channels":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/channels/**"
+          - "src/modules/interactive/**"
+          - "src/modules/typing/**"
+          - "setup/channels/**"
+          - "setup/pair-dial*"
+          - "setup/pair-telegram*"
+          - "setup/signal-auth*"
+          - "setup/whatsapp-auth*"
+          - "setup/install-signal-cli.sh"
+          - "scripts/photon-setup*"
+          - "scripts/seed-discord.ts"
+          - "docs/isolation-model.md"
+          - ".claude/skills/manage-channels/**"
+          - ".claude/skills/migrate-slack-agents/**"
+          - ".claude/skills/add-deltachat/**"
+          - ".claude/skills/add-dial/**"
+          - ".claude/skills/add-dial-number/**"
+          - ".claude/skills/add-discord/**"
+          - ".claude/skills/add-emacs/**"
+          - ".claude/skills/add-gchat/**"
+          - ".claude/skills/add-github/**"
+          - ".claude/skills/add-imessage/**"
+          - ".claude/skills/add-linear/**"
+          - ".claude/skills/add-matrix/**"
+          - ".claude/skills/add-mattermost/**"
+          - ".claude/skills/add-resend/**"
+          - ".claude/skills/add-signal/**"
+          - ".claude/skills/add-slack/**"
+          - ".claude/skills/add-teams/**"
+          - ".claude/skills/add-telegram/**"
+          - ".claude/skills/add-webex/**"
+          - ".claude/skills/add-wechat/**"
+          - ".claude/skills/add-whatsapp/**"
+          - ".claude/skills/add-whatsapp-cloud/**"
+
+"area/configuration":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/config*"
+          - "src/env*"
+          - "src/container-config*"
+          - "src/backfill-container-configs*"
+          - "src/db/container-configs*"
+          - "src/group-folder*"
+          - "src/group-init*"
+          - "src/group-persona*"
+          - "src/project-doc-compose*"
+          - "src/timezone*"
+          - "container/agent-runner/src/config*"
+          - "config-examples/**"
+          - ".env.example"
+          - ".claude/skills/customize/**"
+          - "docs/customizing.md"
+
+"area/containers":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "container/Dockerfile"
+          - "container/.dockerignore"
+          - "container/entrypoint.sh"
+          - "container/build.sh"
+          - "container/pull.sh"
+          - "container/install-cli-tools.sh"
+          - "container/cli-tools*"
+          - "container/CLAUDE.md"
+          - "src/container-runner*"
+          - "src/container-runtime*"
+          - "src/container-restart*"
+          - "src/drivers/**"
+          - "src/mount-composition.test.ts"
+          - "src/modules/self-mod/**"
+          - "src/egress-lockdown*"
+          - "setup/container*"
+          - "setup/lib/container-build*"
+          - "scripts/detect-driver-migration*"
+          - "docs/build-and-runtime.md"
+          - "docs/hardened-image.md"
+          - "docs/host-lifecycle-migration.md"
+          - ".github/workflows/approve-agent-image.yml"
+          - ".github/workflows/refresh-agent-image.yml"
+          - ".github/workflows/verify-agent-image.yml"
+          - ".claude/skills/manage-mounts/**"
+
+"area/core":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/index*"
+          - "src/router*"
+          - "src/delivery*"
+          - "src/delivery-guard*"
+          - "src/host-sweep*"
+          - "src/host-lifecycle*"
+          - "src/host-core.test.ts"
+          - "src/circuit-breaker*"
+          - "src/response-registry*"
+          - "src/webhook-server*"
+          - "src/state-sqlite*"
+          - "src/attachment-naming*"
+          - "src/platform-id*"
+          - "src/log.ts"
+          - "src/types.ts"
+          - "src/mailbox/**"
+          - "src/db/**"
+          - "src/modules/agent-to-agent/**"
+          - "src/modules/cross-session-context/**"
+          - "container/agent-runner/src/mailbox/**"
+          - "container/agent-runner/src/poll-loop*"
+          - "docs/architecture.md"
+          - "docs/architecture-diagram.md"
+          - "docs/architecture-diagram.html"
+          - "docs/api-details.md"
+          - "docs/db.md"
+          - "docs/db-central.md"
+          - "docs/agent-mailbox-seam-migration.md"
+          - "docs/central-db-async-migration.md"
+
+"area/credentials":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/gateway-providers/**"
+          - "src/modules/approvals/onecli-approvals.ts"
+          - "container/skills/onecli-gateway/**"
+          - "setup/onecli*"
+          - "setup/install-cred-helper*"
+          - "setup/registry-login*"
+          - "setup/registry/credential-helper.mjs"
+          - "docs/onecli-upgrades.md"
+          - ".claude/skills/init-onecli/**"
+
+"area/ncl-cli":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/cli/**"
+          - "src/command-gate*"
+          - "container/agent-runner/src/cli/**"
+          - "bin/ncl"
+          - "scripts/q*"
+
+"area/providers":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/providers/**"
+          - "src/provider-surfaces.test.ts"
+          - "container/agent-runner/src/providers/**"
+          - "setup/providers/**"
+          - "setup/provider-auth*"
+          - "setup/lib/picked-provider*"
+          - "docs/provider-migration.md"
+          - "docs/ollama.md"
+          - ".claude/skills/add-codex/**"
+          - ".claude/skills/add-opencode/**"
+          - ".claude/skills/add-ollama-provider/**"
+
+"area/repository-maintenance":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - ".husky/**"
+          - ".gitignore"
+          - ".npmrc"
+          - ".nvmrc"
+          - ".prettierrc"
+          - "eslint.config.js"
+          - "tsconfig.json"
+          - "vitest.config.ts"
+          - "vitest.skills.config.ts"
+          - "src/test-setup.ts"
+          - "versions.json"
+          - "AGENTS.md"
+          - "CLAUDE.md"
+          - ".claude/settings.json"
+          - "assets/**"
+          - "package.json"
+          - "pnpm-lock.yaml"
+          - "pnpm-workspace.yaml"
+          - "README.md"
+          - "README_ja.md"
+          - "README_ko.md"
+          - "README_zh.md"
+          - "CHANGELOG.md"
+          - "CODE_OF_CONDUCT.md"
+          - "CONTRIBUTING.md"
+          - "CONTRIBUTORS.md"
+          - "LICENSE"
+          - "RELEASING.md"
+          - "docs/README.md"
+          - "docs/BRANCH-FORK-MAINTENANCE.md"
+          - "repo-tokens/**"
+          - "scripts/release*"
+
+"area/scheduled-tasks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/modules/scheduling/**"
+          - "container/agent-runner/src/scheduling/**"
+          - "docs/scheduled-tasks.md"
+          - "docs/ncl-tasks-migration.md"
+
+"area/security":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/guard/**"
+          - "src/modules/approvals/**"
+          - "src/modules/permissions/**"
+          - "src/modules/mount-security/**"
+          - "src/attachment-safety*"
+          - "src/inbox-safety*"
+          - "container/agent-runner/src/harness-tag-strip*"
+          - "docs/SECURITY.md"
+
+"area/sessions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/session-manager*"
+          - "src/db/sessions*"
+          - "docs/db-session.md"
+          - "scripts/cleanup-sessions.sh"
+
+"area/setup-installation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "setup/**"
+          - "launchd/**"
+          - "nanoclaw.sh"
+          - "migrate-v2.sh"
+          - "migrate-v2-reset.sh"
+          - "src/install-slug*"
+          - "src/upgrade-state*"
+          - "scripts/upgrade-state.ts"
+          - "scripts/update-nanoclaw*"
+          - "scripts/update/**"
+          - "setup.sh"
+          - "uninstall.sh"
+          - "scripts/init-first-agent*"
+          - "scripts/init-cli-agent*"
+          - "scripts/delete-cli-agent*"
+          - "scripts/migrate*"
+          - "scripts/run-migrations*"
+          - "docs/setup-flow.md"
+          - "docs/setup-wiring.md"
+          - "docs/migration-dev.md"
+          - "docs/v1-to-v2-changes.md"
+          - "docs/upgrade-recovery.md"
+          - ".claude/skills/setup/**"
+          - ".claude/skills/init-first-agent/**"
+          - ".claude/skills/debug/**"
+          - ".claude/skills/migrate-from-v1/**"
+          - ".claude/skills/migrate-from-openclaw/**"
+          - ".claude/skills/migrate-nanoclaw/**"
+          - ".claude/skills/update-nanoclaw/**"
+
+"area/skills":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".claude/skills/**"
+          - ".agents/skills"
+          - "container/skills/**"
+          - "src/group-skills*"
+          - "scripts/skill-*"
+          - "scripts/test-registry-skills.ts"
+          - "scripts/update-skills*"
+          - "setup/lib/skill-driver*"
+          - "docs/skills-model.md"
+          - "docs/skill-guidelines.md"
+          - "docs/skill-directives.md"
+          - "docs/skill-engine-seam.md"
+          - ".github/workflows/registry-skills.yml"
+
+"area/tools":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "container/agent-runner/src/mcp-tools/**"
+          - "container/agent-runner/src/plugin-mcp*"
+          - "container/skills/agent-browser/**"
+          - "container/skills/frontend-engineer/**"
+          - ".mcp.json"
+          - ".claude/skills/add-anydoc/**"
+          - ".claude/skills/add-atomic-chat-tool/**"
+          - ".claude/skills/add-clidash/**"
+          - ".claude/skills/add-dashboard/**"
+          - ".claude/skills/add-dial-tool/**"
+          - ".claude/skills/add-macos-statusbar/**"
+          - ".claude/skills/add-ollama-tool/**"
+          - ".claude/skills/add-rtk/**"
+          - ".claude/skills/add-tavily-tool/**"
+          - ".claude/skills/add-vercel/**"
+          - "scripts/add-dial-tool-scope.test.ts"

--- a/.github/workflows/label-area.yml
+++ b/.github/workflows/label-area.yml
@@ -17,6 +17,11 @@ jobs:
   area:
     runs-on: ubuntu-latest
     permissions:
+      # contents: read is required: with no checkout, labeler fetches
+      # .github/labeler.yml via repos.getContent, which this scope gates.
+      # It resolves at the base-branch SHA under pull_request_target, so it
+      # does not weaken the no-checkout posture.
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/label-area.yml
+++ b/.github/workflows/label-area.yml
@@ -1,0 +1,27 @@
+name: Label PR Area
+
+# SECURITY: this workflow runs with write access to the base repo on fork PRs,
+# because `pull_request_target` executes in the context of the base branch.
+# Keep it metadata-only — do NOT add actions/checkout or any step that
+# executes PR-supplied content (install scripts, build commands, etc.).
+# actions/labeler never checks out the PR; when the config file is absent from
+# the runner it fetches `.github/labeler.yml` through the GitHub API at
+# `github.context.sha`, which under `pull_request_target` is the base branch.
+# A fork therefore cannot substitute its own label config.
+# See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  area:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          configuration-path: .github/labeler.yml
+          # Add only. A maintainer pruning area/* down to the primary subsystem
+          # must not have the workflow put the labels back on the next push.
+          sync-labels: false

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -22,12 +22,21 @@ jobs:
             const body = context.payload.pull_request.body || '';
             const labels = [];
 
-            if (body.includes('[x] **Feature skill**'))       { labels.push('PR: Skill'); labels.push('PR: Feature'); }
-            else if (body.includes('[x] **Utility skill**'))   labels.push('PR: Skill');
-            else if (body.includes('[x] **Operational/container skill**')) labels.push('PR: Skill');
-            else if (body.includes('[x] **Fix**'))             labels.push('PR: Fix');
-            else if (body.includes('[x] **Simplification**'))  labels.push('PR: Refactor');
-            else if (body.includes('[x] **Documentation**'))   labels.push('PR: Docs');
+            // Every string pushed below must byte-match an existing repo label
+            // (`gh label list`). addLabels auto-creates unknown names with a
+            // random color and no description, so a typo invents a label.
+            //
+            // Each branch emits both vocabularies: the legacy `PR: *` label the
+            // triage reconciler still reads, and its `kind/*` (+ `delivery/*`)
+            // equivalent in the current taxonomy. Retiring `PR: *` is a separate
+            // decision; until then both must stay in sync.
+
+            if (body.includes('[x] **Feature skill**'))       { labels.push('PR: Skill'); labels.push('PR: Feature'); labels.push('kind/feature'); labels.push('delivery/skill'); }
+            else if (body.includes('[x] **Utility skill**'))   { labels.push('PR: Skill'); labels.push('kind/feature'); labels.push('delivery/skill'); }
+            else if (body.includes('[x] **Operational/container skill**')) { labels.push('PR: Skill'); labels.push('kind/feature'); labels.push('delivery/skill'); }
+            else if (body.includes('[x] **Fix**'))             { labels.push('PR: Fix'); labels.push('kind/bug'); }
+            else if (body.includes('[x] **Simplification**'))  { labels.push('PR: Refactor'); labels.push('kind/cleanup'); }
+            else if (body.includes('[x] **Documentation**'))   { labels.push('PR: Docs'); labels.push('kind/documentation'); }
 
             if (body.includes('contributing-guide: v1')) labels.push('follows-guidelines');
 


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

The new label taxonomy (16 `area/*`, `kind/*`, `delivery/skill`) is live on the repo but nothing applies it — triage sorts by hand. This makes both halves automatic, **additively**; nothing that exists today changes behavior.

**1. `area/*` from changed paths** — new `.github/labeler.yml` + `.github/workflows/label-area.yml`:

- `actions/labeler@v5`, pinned to full SHA `8558fd74291d67161a8a78ce36a881fa63b766a9`
- 245 globs across 16 areas: 855 of 882 tracked files (97%)
- `sync-labels: false` = add-only; a maintainer pruning to the primary subsystem is never overridden

**2. `kind/*` from template checkboxes** — `label-pr.yml` keeps every `PR: *` it emits today, adds the taxonomy twin alongside:

- Fix → `kind/bug` · Simplification → `kind/cleanup` · Documentation → `kind/documentation` · skill boxes → `kind/feature` + `delivery/skill`
- `PR: *` stays (the triage reconciler reads it); retiring it is a separate decision
- v1 template has no Hardening box, so `kind/hardening` stays maintainer-applied

## Related work

Closes no issue — the CI-04 lane of the approved intake plan; base layer of stacked PRs #3647 → #3648 → #3657. Two workflows plus one config file, all additive.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- Every label string in both files checked byte-for-byte against `gh label list` (16 `area/*` keys, 12 `label-pr.yml` strings) — `addLabels` auto-creates unknown labels, so a typo would silently invent one outside the taxonomy
- `pull_request_target` never executes on its introducing PR: green CI here proves the base workflows; the **first live run happens on the first PR after merge** and is being watched at merge time

## Security and trust boundaries

- Metadata-only discipline on both workflows: `pull_request_target`, no `actions/checkout`, no step runs PR-supplied content
- `label-area.yml`: `pull-requests: write` + `contents: read` — the labeler reads `.github/labeler.yml` via `repos.getContent` at `ref: github.context.sha`, which under `pull_request_target` is the **base branch**, so a fork cannot substitute the config (verified in labeler source at `v5.0.0`; no checkout means the API path is always taken)

## AI assistance

- [x] AI tools or agents helped produce this change
- [x] A human has reviewed this PR and stands behind every change

---

<details>
<summary><b>Appendix: path map (label → globs) and deliberately unmapped files</b></summary>

| Label | Paths (globs, abbreviated) |
| --- | --- |
| `area/agent-memory` | `container/agent-runner/src/memory/**`, `src/migrate-claude-memory-settings*`, `src/memory-migration-contract.test.ts`, `docs/memory.md`, `.claude/skills/migrate-memory/**`, 2 × `.claude/skills/add-*/**` |
| `area/agent-runner` | `container/agent-runner/**`, `docs/agent-runner-details.md`, `docs/SDK_DEEP_DIVE.md` |
| `area/channels` | `src/channels/**`, `src/modules/interactive/**`, `src/modules/typing/**`, `setup/channels/**`, `setup/pair-dial*`, `setup/pair-telegram*`, `setup/signal-auth*`, `setup/whatsapp-auth*`, `setup/install-signal-cli.sh`, `scripts/photon-setup*`, `scripts/seed-discord.ts`, `docs/isolation-model.md`, `.claude/skills/manage-channels/**`, `.claude/skills/migrate-slack-agents/**`, 20 × `.claude/skills/add-*/**` |
| `area/configuration` | `src/config*`, `src/env*`, `src/container-config*`, `src/backfill-container-configs*`, `src/db/container-configs*`, `src/group-folder*`, `src/group-init*`, `src/group-persona*`, `src/project-doc-compose*`, `src/timezone*`, `container/agent-runner/src/config*`, `config-examples/**`, `.env.example`, `.claude/skills/customize/**`, `docs/customizing.md` |
| `area/containers` | `container/Dockerfile`, `container/.dockerignore`, `container/entrypoint.sh`, `container/build.sh`, `container/pull.sh`, `container/install-cli-tools.sh`, `container/cli-tools*`, `container/CLAUDE.md`, `src/container-runner*`, `src/container-runtime*`, `src/container-restart*`, `src/drivers/**`, `src/mount-composition.test.ts`, `src/modules/self-mod/**`, `src/egress-lockdown*`, `setup/container*`, `setup/lib/container-build*`, `scripts/detect-driver-migration*`, `docs/build-and-runtime.md`, `docs/hardened-image.md`, `docs/host-lifecycle-migration.md`, `.github/workflows/approve-agent-image.yml`, `.github/workflows/refresh-agent-image.yml`, `.github/workflows/verify-agent-image.yml`, `.claude/skills/manage-mounts/**` |
| `area/core` | `src/index*`, `src/router*`, `src/delivery*`, `src/delivery-guard*`, `src/host-sweep*`, `src/host-lifecycle*`, `src/host-core.test.ts`, `src/circuit-breaker*`, `src/response-registry*`, `src/webhook-server*`, `src/state-sqlite*`, `src/attachment-naming*`, `src/platform-id*`, `src/log.ts`, `src/types.ts`, `src/mailbox/**`, `src/db/**`, `src/modules/agent-to-agent/**`, `src/modules/cross-session-context/**`, `container/agent-runner/src/mailbox/**`, `container/agent-runner/src/poll-loop*`, `docs/architecture.md`, `docs/architecture-diagram.md`, `docs/architecture-diagram.html`, `docs/api-details.md`, `docs/db.md`, `docs/db-central.md`, `docs/agent-mailbox-seam-migration.md`, `docs/central-db-async-migration.md` |
| `area/credentials` | `src/gateway-providers/**`, `src/modules/approvals/onecli-approvals.ts`, `container/skills/onecli-gateway/**`, `setup/onecli*`, `setup/install-cred-helper*`, `setup/registry-login*`, `setup/registry/credential-helper.mjs`, `docs/onecli-upgrades.md`, `.claude/skills/init-onecli/**` |
| `area/ncl-cli` | `src/cli/**`, `src/command-gate*`, `container/agent-runner/src/cli/**`, `bin/ncl`, `scripts/q*` |
| `area/providers` | `src/providers/**`, `src/provider-surfaces.test.ts`, `container/agent-runner/src/providers/**`, `setup/providers/**`, `setup/provider-auth*`, `setup/lib/picked-provider*`, `docs/provider-migration.md`, `docs/ollama.md`, 3 × `.claude/skills/add-*/**` |
| `area/repository-maintenance` | `.github/**`, `.husky/**`, `.gitignore`, `.npmrc`, `.nvmrc`, `.prettierrc`, `eslint.config.js`, `tsconfig.json`, `vitest.config.ts`, `vitest.skills.config.ts`, `src/test-setup.ts`, `versions.json`, `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, `assets/**`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `README.md`, `README_ja.md`, `README_ko.md`, `README_zh.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `CONTRIBUTORS.md`, `LICENSE`, `RELEASING.md`, `docs/README.md`, `docs/BRANCH-FORK-MAINTENANCE.md`, `repo-tokens/**`, `scripts/release*` |
| `area/scheduled-tasks` | `src/modules/scheduling/**`, `container/agent-runner/src/scheduling/**`, `docs/scheduled-tasks.md`, `docs/ncl-tasks-migration.md` |
| `area/security` | `src/guard/**`, `src/modules/approvals/**`, `src/modules/permissions/**`, `src/modules/mount-security/**`, `src/attachment-safety*`, `src/inbox-safety*`, `container/agent-runner/src/harness-tag-strip*`, `docs/SECURITY.md` |
| `area/sessions` | `src/session-manager*`, `src/db/sessions*`, `docs/db-session.md`, `scripts/cleanup-sessions.sh` |
| `area/setup-installation` | `setup/**`, `launchd/**`, `nanoclaw.sh`, `migrate-v2.sh`, `migrate-v2-reset.sh`, `src/install-slug*`, `src/upgrade-state*`, `scripts/upgrade-state.ts`, `scripts/update-nanoclaw*`, `scripts/update/**`, `setup.sh`, `uninstall.sh`, `scripts/init-first-agent*`, `scripts/init-cli-agent*`, `scripts/delete-cli-agent*`, `scripts/migrate*`, `scripts/run-migrations*`, `docs/setup-flow.md`, `docs/setup-wiring.md`, `docs/migration-dev.md`, `docs/v1-to-v2-changes.md`, `docs/upgrade-recovery.md`, `.claude/skills/setup/**`, `.claude/skills/init-first-agent/**`, `.claude/skills/debug/**`, `.claude/skills/migrate-from-v1/**`, `.claude/skills/migrate-from-openclaw/**`, `.claude/skills/migrate-nanoclaw/**`, `.claude/skills/update-nanoclaw/**` |
| `area/skills` | `.claude/skills/**`, `.agents/skills`, `container/skills/**`, `src/group-skills*`, `scripts/skill-*`, `scripts/test-registry-skills.ts`, `scripts/update-skills*`, `setup/lib/skill-driver*`, `docs/skills-model.md`, `docs/skill-guidelines.md`, `docs/skill-directives.md`, `docs/skill-engine-seam.md`, `.github/workflows/registry-skills.yml` |
| `area/tools` | `container/agent-runner/src/mcp-tools/**`, `container/agent-runner/src/plugin-mcp*`, `container/skills/agent-browser/**`, `container/skills/frontend-engineer/**`, `.mcp.json`, `scripts/add-dial-tool-scope.test.ts`, 10 × `.claude/skills/add-*/**` |

**Left unmapped** — 27 files map to no area, deliberately rather than by guess:

- `src/templates/**`, `templates/README.md`, `docs/templates.md` — agent templates straddle `area/configuration` and `area/setup-installation`; no approved area covers them cleanly.
- `docs/REQUIREMENTS.md`, `docs/SPEC.md` — whole-product specs, not one subsystem.
- `scripts/chat.ts`, `scripts/sanity-live-poll.ts`, `scripts/sync-stdin-json.sh`, `scripts/test-v2-{agent,channel-e2e,host}.ts` — ad-hoc dev harnesses.
- `src/modules/index.ts` (barrel), `.claude/scheduled_tasks.lock` (install state).

Adding a mapping later is a one-line change; a wrong mapping has to be noticed first.

</details>

