### PR TITLE
ci(labels): PR template v2 with token parsing and managed-kind reconcile

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
 <!-- nanoclaw-pr-template:v2 -->
 
+<!-- Please give this PR a conventional-commit title (`fix:`, `feat:`, `docs:`,
+     `refactor:`, `chore:`, `ci:`, `test:`, `build:`, `style:`, `perf:`) —
+     a request, not a requirement; it helps labeling when no kind box is checked. -->
+
 ## Summary
 
 <!-- What changed, why it matters, and the intended outcome. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,25 @@
 
 <!-- Please give this PR a conventional-commit title (`fix:`, `feat:`, `docs:`,
      `refactor:`, `chore:`, `ci:`, `test:`, `build:`, `style:`, `perf:`) —
-     a request, not a requirement; it helps labeling when no kind box is checked. -->
+     a request, not a requirement; it helps labeling when no kind box is checked.
+
+     Plain English, short sentences, no filler. Write for a reviewer with 60
+     seconds — technical terms fine, decoration not. If a sentence adds no
+     reviewable fact, delete it. -->
 
 ## Summary
 
-<!-- What changed, why it matters, and the intended outcome. -->
+<!-- Shape, by example — one purpose sentence first, then bold-led bullets,
+     one fact each:
+
+       Stops the sweep killing slow local-model turns mid-decode.
+       - **Problem**: heartbeat only ticks on stream events, so silence = dead.
+       - **Fix**: poll tick vouches while the last event is under a cap.
+       - **Out of scope**: per-group config; the ceiling PR covers that.
+
+     A reviewer reading only the first sentence should know why this PR
+     exists. No prose walls; depth only some reviewers need goes in a
+     <details> appendix. -->
 
 ## Related work
 
@@ -24,7 +38,12 @@ Closes #
 
 ## Validation
 
-<!-- Exact commands and results. Add the manual path for behavior CI cannot cover. -->
+<!-- A bullet per piece of evidence: command -> result. Add the manual path
+     for behavior CI cannot cover. New or changed behavior needs a new or
+     changed test — or one line saying why not (docs-only, config-only,
+     unreachable in CI). -->
+
+- [ ] Tests cover the changed behavior (or Validation says why not)
 
 ## User and release impact
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,11 @@
 
      Plain English, short sentences, no filler. Write for a reviewer with 60
      seconds — technical terms fine, decoration not. If a sentence adds no
-     reviewable fact, delete it. -->
+     reviewable fact, delete it.
+
+     Keep Summary, Change kind, Validation, Security, and AI assistance in
+     every PR ("None." beats deletion); Related work, User and release
+     impact, and Skill delivery may go when they don't apply. -->
 
 ## Summary
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,3 +36,13 @@ Closes #
 
 - [ ] Not a skill
 - [ ] Skill: apply/remove footprint and fresh-clone verification are described above
+
+## AI assistance
+
+<!-- Check exactly one. -->
+- [ ] No AI assistance
+- [ ] AI-assisted: a person wrote this with AI help
+- [ ] Agent-authored: an AI agent wrote this
+
+<!-- Required when either AI box above is checked. -->
+- [ ] A human has reviewed this PR and stands behind every change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,38 @@
-<!-- contributing-guide: v1 -->
-## Type of Change
+<!-- nanoclaw-pr-template:v2 -->
 
-- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
-- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
-- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
-- [ ] **Fix** - bug fix or security fix to source code
-- [ ] **Simplification** - reduces or simplifies source code
-- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only
+## Summary
 
-## Description
+<!-- What changed, why it matters, and the intended outcome. -->
 
+## Related work
 
-## For Skills
+Closes #
+<!-- If there is no issue, say why the change is safe to review directly. -->
 
-- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
-- [ ] SKILL.md is under 500 lines
-- [ ] I tested this skill on a fresh clone
+## Change kind
+
+<!-- Check exactly one. -->
+- [ ] `kind/bug`
+- [ ] `kind/feature`
+- [ ] `kind/documentation`
+- [ ] `kind/cleanup`
+- [ ] `kind/hardening`
+
+## Validation
+
+<!-- Exact commands and results. Add the manual path for behavior CI cannot cover. -->
+
+## User and release impact
+
+- [ ] No user-visible behavior change
+- [ ] User-visible change; docs and changelog are updated where needed
+- [ ] Breaking change; detect / why / fix / verify / rollback migration path is included
+
+## Security and trust boundaries
+
+<!-- Permissions, credentials, untrusted input, workflows, containers, or "None". -->
+
+## Skill delivery
+
+- [ ] Not a skill
+- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,9 +24,14 @@ Closes #
 
 ## User and release impact
 
+<!-- Maintainers own CHANGELOG.md — do not edit it in this PR. -->
 - [ ] No user-visible behavior change
-- [ ] User-visible change; docs and changelog are updated where needed
-- [ ] Breaking change; detect / why / fix / verify / rollback migration path is included
+- [ ] User-visible change — release note below
+- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback
+
+```release-note
+Optional: one user-facing line for the changelog. Skip it and a maintainer will write one.
+```
 
 ## Security and trust boundaries
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,10 +39,7 @@ Closes #
 
 ## AI assistance
 
-<!-- Check exactly one. -->
-- [ ] No AI assistance
-- [ ] AI-assisted: a person wrote this with AI help
-- [ ] Agent-authored: an AI agent wrote this
+- [ ] AI tools or agents helped produce this change
 
-<!-- Required when either AI box above is checked. -->
+<!-- Required. -->
 - [ ] A human has reviewed this PR and stands behind every change

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -35,22 +35,57 @@ jobs:
             // name that is not in the fixed vocabularies below.
             //
             // Two body contracts, selected by marker:
-            //   v2 (`nanoclaw-pr-template:v2`): stable-token parsing — exactly
-            //     one managed `kind/*` checkbox; a conventional-commit title
-            //     prefix is the fallback when zero or several boxes are
-            //     checked; still ambiguous → apply no kind and leave the PR
-            //     for triage (never guess). The managed kind set is
-            //     reconciled: stale managed kinds are removed before the
-            //     current one is added.
+            //   v2 (the exact HTML comment `<!-- nanoclaw-pr-template:v2 -->`):
+            //     stable-token parsing on flush-left checkbox lines, with
+            //     fenced blocks stripped first. Exactly one checked kind box
+            //     is an explicit verdict: it is added and the managed set is
+            //     reconciled — stale kinds AND their legacy `PR: *` twins are
+            //     removed, keeping the two vocabularies in lockstep. With
+            //     zero or several boxes, the conventional-commit title prefix
+            //     is an ADVISORY fallback: it only adds a kind when the PR
+            //     carries no managed kind at all, and it never removes
+            //     anything — so a maintainer's triage classification always
+            //     survives later edited/reopened/ready_for_review events.
+            //     Still ambiguous → apply nothing; the PR lands in triage.
             //   v1 (`contributing-guide: v1`, or no marker): the pre-v2
             //     behavior, byte-frozen — visible-substring checkbox matching,
             //     add-only, emitting both the legacy `PR: *` vocabulary and
             //     its `kind/*` equivalent.
-            // Both paths keep emitting `PR: *` and `follows-guidelines` until
-            // Decision 4 retires them.
-            function computeLabels({ body, title, author }) {
+            // Both paths keep emitting `PR: *`; v2 earns `follows-guidelines`
+            // only from an explicit checkbox verdict (an unfilled template
+            // earns nothing). All of `PR: *`, `follows-guidelines`, and
+            // `core-team` stay until Decision 4 retires them.
+
+            // Drop fenced code blocks (``` and ~~~, any info string). A line
+            // scanner rather than a regex so an UNTERMINATED fence hides
+            // everything after it instead of nothing, and so ``` cannot close
+            // a ~~~ fence. Fences must be flush-left, like the checkbox
+            // tokens they protect.
+            function stripFences(text) {
+              const out = [];
+              let fence = null;
+              for (const line of text.split('\n')) {
+                const open = /^(`{3,}|~{3,})/.exec(line);
+                if (open) {
+                  if (fence === null) {
+                    fence = open[1][0];
+                    continue;
+                  }
+                  if (line[0] === fence) {
+                    fence = null;
+                    continue;
+                  }
+                  continue; // a ``` line inside a ~~~ fence (or vice versa) stays hidden
+                }
+                if (fence === null) out.push(line);
+              }
+              return out.join('\n');
+            }
+
+            function computeLabels({ body, title, author, currentLabels }) {
               body = body || '';
               title = title || '';
+              const current = new Set(currentLabels || []);
               const add = [];
               const remove = [];
 
@@ -71,6 +106,11 @@ jobs:
                 docs: 'kind/documentation',
                 refactor: 'kind/cleanup',
                 chore: 'kind/cleanup',
+                ci: 'kind/cleanup',
+                test: 'kind/cleanup',
+                build: 'kind/cleanup',
+                style: 'kind/cleanup',
+                perf: 'kind/cleanup',
               };
 
               // Lowercase GitHub logins; keep in sync with the core team roster.
@@ -78,36 +118,51 @@ jobs:
               const coreTeam = CORE_TEAM.includes((author || '').toLowerCase());
               if (coreTeam) add.push('core-team');
 
-              if (body.includes('nanoclaw-pr-template:v2')) {
-                // ── v2: stable-token parsing + managed-kind reconcile ──
-                // Fenced code blocks (the release-note block included) are
-                // stripped before token matching, so checkbox-looking text
-                // pasted inside a fence can never register as a selection.
-                const scanned = body.replace(/```[\s\S]*?```/g, '');
+              if (body.includes('<!-- nanoclaw-pr-template:v2 -->')) {
+                // ── v2: stable-token parsing ──
+                const scanned = stripFences(body);
                 const checked = MANAGED_KINDS.filter((kind) =>
-                  new RegExp('-\\s*\\[[xX]\\]\\s*`' + kind.replace('/', '\\/') + '`').test(scanned),
+                  new RegExp('^-\\s*\\[[xX]\\]\\s*`' + kind.replace('/', '\\/') + '`', 'm').test(scanned),
                 );
-                let kind = checked.length === 1 ? checked[0] : undefined;
-                if (kind === undefined) {
-                  // Zero or several boxes: fall back to the conventional-commit
-                  // title prefix; if that is ambiguous too, apply nothing.
-                  const m = /^([a-z]+)(\([^)]*\))?!?:/.exec(title.trim());
-                  if (m && TITLE_PREFIX_TO_KIND[m[1]]) kind = TITLE_PREFIX_TO_KIND[m[1]];
-                }
-                if (kind !== undefined) {
+
+                if (checked.length === 1) {
+                  // Explicit checkbox verdict: add, and reconcile BOTH
+                  // vocabularies so an edited selection swaps cleanly instead
+                  // of accumulating (kind/bug leaving and PR: Fix staying
+                  // would desync the legacy set the triage queue still reads).
+                  const kind = checked[0];
                   add.push(kind);
                   if (KIND_TO_LEGACY[kind]) add.push(KIND_TO_LEGACY[kind]);
-                  // Reconcile only what this parser owns, and only when it
-                  // reached a verdict: stale managed kinds are removed so an
-                  // edited selection does not accumulate. With no verdict,
-                  // nothing is removed — a maintainer-applied kind must survive.
-                  for (const stale of MANAGED_KINDS) if (stale !== kind) remove.push(stale);
+                  for (const stale of MANAGED_KINDS) {
+                    if (stale === kind) continue;
+                    remove.push(stale);
+                    if (KIND_TO_LEGACY[stale]) remove.push(KIND_TO_LEGACY[stale]);
+                  }
+                  add.push('follows-guidelines');
+                } else {
+                  // Zero or several boxes: the conventional-commit title
+                  // prefix is advisory — it fills a blank, never overrules.
+                  // No removals, and no addition when the PR already carries
+                  // a managed kind (maintainer triage wins).
+                  const m = /^([a-z]+)(\([^)]*\))?!?:/.exec(title.trim());
+                  const kind = m ? TITLE_PREFIX_TO_KIND[m[1]] : undefined;
+                  const hasManagedKind = MANAGED_KINDS.some((k) => current.has(k));
+                  if (kind !== undefined && !hasManagedKind) {
+                    add.push(kind);
+                    if (KIND_TO_LEGACY[kind]) add.push(KIND_TO_LEGACY[kind]);
+                  }
                 }
-                if (/-\s*\[[xX]\]\s*Skill:/.test(scanned)) {
+
+                // Skill delivery: explicit checkbox verdicts only, kept in
+                // lockstep with its legacy twin. No box checked → no verdict,
+                // nothing changes.
+                if (/^-\s*\[[xX]\]\s*Skill:/m.test(scanned)) {
                   add.push('delivery/skill');
                   add.push('PR: Skill');
+                } else if (/^-\s*\[[xX]\]\s*Not a skill/m.test(scanned)) {
+                  remove.push('delivery/skill');
+                  remove.push('PR: Skill');
                 }
-                add.push('follows-guidelines');
               } else {
                 // ── v1: pre-v2 behavior, byte-frozen (add-only) ──
                 if (body.includes('[x] **Feature skill**'))       { add.push('PR: Skill'); add.push('PR: Feature'); add.push('kind/feature'); add.push('delivery/skill'); }
@@ -129,6 +184,7 @@ jobs:
               body: pr.body,
               title: pr.title,
               author: pr.user.login,
+              currentLabels: (pr.labels || []).map((l) => l.name),
             });
 
             if (coreTeam) {

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -5,46 +5,129 @@ name: Label PR
 # Keep it metadata-only — do NOT add actions/checkout or any step that
 # executes PR-supplied content (install scripts, build commands, etc.).
 # See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+#
+# The labeling logic lives inline between the NANOCLAW-LABEL-LOGIC markers as a
+# pure function; scripts/label-pr-workflow.test.ts extracts that exact block
+# from this file and runs fixture tests against it, so the tested code and the
+# shipped code cannot drift. Edit the function only between the markers.
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, reopened, ready_for_review]
 
 jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: write # createLabel — auto-provisions the core-team label
+      issues: write # createLabel — auto-provisions the core-team label (v1-era behavior, kept until Decision 4)
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const body = context.payload.pull_request.body || '';
-            const labels = [];
-
-            // Every string pushed below must byte-match an existing repo label
-            // (`gh label list`). addLabels auto-creates unknown names with a
-            // random color and no description, so a typo invents a label.
+            // NANOCLAW-LABEL-LOGIC-START
+            // Pure decision function. No API calls, no environment reads — the
+            // driver below feeds it payload fields and applies the result.
             //
-            // Each branch emits both vocabularies: the legacy `PR: *` label the
-            // triage reconciler still reads, and its `kind/*` (+ `delivery/*`)
-            // equivalent in the current taxonomy. Retiring `PR: *` is a separate
-            // decision; until then both must stay in sync.
+            // Every label string emitted here must byte-match a label that
+            // already exists in the repo (`gh label list`): addLabels
+            // auto-creates unknown names with a random color and no
+            // description, so a typo silently invents a label. Never push a
+            // name that is not in the fixed vocabularies below.
+            //
+            // Two body contracts, selected by marker:
+            //   v2 (`nanoclaw-pr-template:v2`): stable-token parsing — exactly
+            //     one managed `kind/*` checkbox; a conventional-commit title
+            //     prefix is the fallback when zero or several boxes are
+            //     checked; still ambiguous → apply no kind and leave the PR
+            //     for triage (never guess). The managed kind set is
+            //     reconciled: stale managed kinds are removed before the
+            //     current one is added.
+            //   v1 (`contributing-guide: v1`, or no marker): the pre-v2
+            //     behavior, byte-frozen — visible-substring checkbox matching,
+            //     add-only, emitting both the legacy `PR: *` vocabulary and
+            //     its `kind/*` equivalent.
+            // Both paths keep emitting `PR: *` and `follows-guidelines` until
+            // Decision 4 retires them.
+            function computeLabels({ body, title, author }) {
+              body = body || '';
+              title = title || '';
+              const add = [];
+              const remove = [];
 
-            if (body.includes('[x] **Feature skill**'))       { labels.push('PR: Skill'); labels.push('PR: Feature'); labels.push('kind/feature'); labels.push('delivery/skill'); }
-            else if (body.includes('[x] **Utility skill**'))   { labels.push('PR: Skill'); labels.push('kind/feature'); labels.push('delivery/skill'); }
-            else if (body.includes('[x] **Operational/container skill**')) { labels.push('PR: Skill'); labels.push('kind/feature'); labels.push('delivery/skill'); }
-            else if (body.includes('[x] **Fix**'))             { labels.push('PR: Fix'); labels.push('kind/bug'); }
-            else if (body.includes('[x] **Simplification**'))  { labels.push('PR: Refactor'); labels.push('kind/cleanup'); }
-            else if (body.includes('[x] **Documentation**'))   { labels.push('PR: Docs'); labels.push('kind/documentation'); }
+              const MANAGED_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
+              // Legacy vocabulary kept in lockstep until Decision 4. Hardening
+              // has no PR:* equivalent, so none is emitted rather than
+              // guessing one.
+              const KIND_TO_LEGACY = {
+                'kind/bug': 'PR: Fix',
+                'kind/feature': 'PR: Feature',
+                'kind/documentation': 'PR: Docs',
+                'kind/cleanup': 'PR: Refactor',
+                'kind/hardening': null,
+              };
+              const TITLE_PREFIX_TO_KIND = {
+                fix: 'kind/bug',
+                feat: 'kind/feature',
+                docs: 'kind/documentation',
+                refactor: 'kind/cleanup',
+                chore: 'kind/cleanup',
+              };
 
-            if (body.includes('contributing-guide: v1')) labels.push('follows-guidelines');
+              // Lowercase GitHub logins; keep in sync with the core team roster.
+              const CORE_TEAM = ['gavrielc', 'koshkoshinsk', 'glifocat', 'gabi-simons', 'omri-maya', 'amit-shafnir', 'moshe-nanoco', 'zvi-fried'];
+              const coreTeam = CORE_TEAM.includes((author || '').toLowerCase());
+              if (coreTeam) add.push('core-team');
 
-            // Lowercase GitHub logins; keep in sync with the core team roster.
-            const CORE_TEAM = ['gavrielc', 'koshkoshinsk', 'glifocat', 'gabi-simons', 'omri-maya', 'amit-shafnir', 'moshe-nanoco', 'zvi-fried'];
-            const author = context.payload.pull_request.user.login.toLowerCase();
-            if (CORE_TEAM.includes(author)) {
-              labels.push('core-team');
+              if (body.includes('nanoclaw-pr-template:v2')) {
+                // ── v2: stable-token parsing + managed-kind reconcile ──
+                const checked = MANAGED_KINDS.filter((kind) =>
+                  new RegExp('-\\s*\\[[xX]\\]\\s*`' + kind.replace('/', '\\/') + '`').test(body),
+                );
+                let kind = checked.length === 1 ? checked[0] : undefined;
+                if (kind === undefined) {
+                  // Zero or several boxes: fall back to the conventional-commit
+                  // title prefix; if that is ambiguous too, apply nothing.
+                  const m = /^([a-z]+)(\([^)]*\))?!?:/.exec(title.trim());
+                  if (m && TITLE_PREFIX_TO_KIND[m[1]]) kind = TITLE_PREFIX_TO_KIND[m[1]];
+                }
+                if (kind !== undefined) {
+                  add.push(kind);
+                  if (KIND_TO_LEGACY[kind]) add.push(KIND_TO_LEGACY[kind]);
+                  // Reconcile only what this parser owns, and only when it
+                  // reached a verdict: stale managed kinds are removed so an
+                  // edited selection does not accumulate. With no verdict,
+                  // nothing is removed — a maintainer-applied kind must survive.
+                  for (const stale of MANAGED_KINDS) if (stale !== kind) remove.push(stale);
+                }
+                if (/-\s*\[[xX]\]\s*Skill:/.test(body)) {
+                  add.push('delivery/skill');
+                  add.push('PR: Skill');
+                }
+                add.push('follows-guidelines');
+              } else {
+                // ── v1: pre-v2 behavior, byte-frozen (add-only) ──
+                if (body.includes('[x] **Feature skill**'))       { add.push('PR: Skill'); add.push('PR: Feature'); add.push('kind/feature'); add.push('delivery/skill'); }
+                else if (body.includes('[x] **Utility skill**'))   { add.push('PR: Skill'); add.push('kind/feature'); add.push('delivery/skill'); }
+                else if (body.includes('[x] **Operational/container skill**')) { add.push('PR: Skill'); add.push('kind/feature'); add.push('delivery/skill'); }
+                else if (body.includes('[x] **Fix**'))             { add.push('PR: Fix'); add.push('kind/bug'); }
+                else if (body.includes('[x] **Simplification**'))  { add.push('PR: Refactor'); add.push('kind/cleanup'); }
+                else if (body.includes('[x] **Documentation**'))   { add.push('PR: Docs'); add.push('kind/documentation'); }
+
+                if (body.includes('contributing-guide: v1')) add.push('follows-guidelines');
+              }
+
+              return { add, remove, coreTeam };
+            }
+            // NANOCLAW-LABEL-LOGIC-END
+
+            const pr = context.payload.pull_request;
+            const { add, remove, coreTeam } = computeLabels({
+              body: pr.body,
+              title: pr.title,
+              author: pr.user.login,
+            });
+
+            if (coreTeam) {
               try {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
@@ -58,11 +141,28 @@ jobs:
               }
             }
 
-            if (labels.length > 0) {
+            // Removals first, and only of labels actually on the PR, so an
+            // edited kind selection swaps cleanly instead of accumulating.
+            const current = new Set((pr.labels || []).map((l) => l.name));
+            for (const name of remove) {
+              if (!current.has(name)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e; // 404: already gone
+              }
+            }
+
+            if (add.length > 0) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels,
+                issue_number: pr.number,
+                labels: add,
               });
             }

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -80,8 +80,12 @@ jobs:
 
               if (body.includes('nanoclaw-pr-template:v2')) {
                 // ── v2: stable-token parsing + managed-kind reconcile ──
+                // Fenced code blocks (the release-note block included) are
+                // stripped before token matching, so checkbox-looking text
+                // pasted inside a fence can never register as a selection.
+                const scanned = body.replace(/```[\s\S]*?```/g, '');
                 const checked = MANAGED_KINDS.filter((kind) =>
-                  new RegExp('-\\s*\\[[xX]\\]\\s*`' + kind.replace('/', '\\/') + '`').test(body),
+                  new RegExp('-\\s*\\[[xX]\\]\\s*`' + kind.replace('/', '\\/') + '`').test(scanned),
                 );
                 let kind = checked.length === 1 ? checked[0] : undefined;
                 if (kind === undefined) {
@@ -99,7 +103,7 @@ jobs:
                   // nothing is removed — a maintainer-applied kind must survive.
                   for (const stale of MANAGED_KINDS) if (stale !== kind) remove.push(stale);
                 }
-                if (/-\s*\[[xX]\]\s*Skill:/.test(body)) {
+                if (/-\s*\[[xX]\]\s*Skill:/.test(scanned)) {
                   add.push('delivery/skill');
                   add.push('PR: Skill');
                 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,16 +163,25 @@ Test your contribution on a fresh clone before submitting. For skills, run the s
 1. **Link related issues.** If your PR resolves an open issue, include `Closes #123` in the description so it's auto-closed on merge.
 2. **Test thoroughly.** Run the feature yourself. For skills, test on a fresh clone.
 3. **Check for installation-specific files.** Before creating a PR, verify no installation-specific files are in your diff (see PR Hygiene in CLAUDE.md).
-4. **Check the right box** in the PR template. Labels are auto-applied based on your selection:
+4. **Check exactly one change kind** in the PR template. The kind label is auto-applied from your selection:
 
-| Checkbox | Label |
-|----------|-------|
-| Feature skill | `PR: Skill` + `PR: Feature` |
-| Utility skill | `PR: Skill` |
-| Operational/container skill | `PR: Skill` |
-| Fix | `PR: Fix` |
-| Simplification | `PR: Refactor` |
-| Documentation | `PR: Docs` |
+| Checkbox | Meaning |
+|----------|---------|
+| `kind/bug` | Something is not working as expected |
+| `kind/feature` | New capability or improvement |
+| `kind/documentation` | Documentation is wrong, missing, or unclear |
+| `kind/cleanup` | Refactor or cleanup with no behavior change |
+| `kind/hardening` | Defense-in-depth improvement; not an exploitable vulnerability |
+
+   Check one box, not several — with zero or multiple boxes checked, the workflow falls back to your PR title's [conventional-commit](https://www.conventionalcommits.org/) prefix (`fix:` → `kind/bug`, `feat:` → `kind/feature`, `docs:` → `kind/documentation`, `refactor:`/`chore:` → `kind/cleanup`). If that is ambiguous too, no kind is applied and a maintainer classifies the PR at triage; nothing is auto-closed.
+
+5. **Skill delivery is separate from kind.** If your PR ships a skill, check the skill box in the Skill delivery section — a skill can be a feature, a fix, or a docs change, and the checkbox adds `delivery/skill` without changing the kind.
+
+6. **AI assistance.** If AI tools or agents helped produce the change, check the disclosure box. The human-review attestation — "A human has reviewed this PR and stands behind every change" — is required either way: you must stand behind every line you submit.
+
+7. **Opening PRs from the CLI or API** (`gh pr create`, agents): GitHub does not apply the template there, so paste `.github/PULL_REQUEST_TEMPLATE.md` into the body — or at minimum use a conventional-commit title so the kind fallback can classify the PR.
+
+Area labels (`area/*`) are applied automatically from the files your PR touches; you don't pick one.
 
 ### PR description
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,14 +185,48 @@ Area labels (`area/*`) are applied automatically from the files your PR touches;
 
 **Changelog:** `CHANGELOG.md` is maintainer-owned — don't edit it in your PR. If your change is user-visible, put one user-facing line in the template's `release-note` block; it's optional raw material that maintainers harvest at release time. Skip it and a maintainer writes the line. For a breaking change, the release note must cover detect, why, fix/migration, and rollback.
 
-### PR description
+### PR body shape
 
-Keep it concise. Remove any template sections that don't apply. The description should cover:
+This applies to humans and coding agents alike:
 
-- **What** — what the PR adds or changes
-- **Why** — the motivation
-- **How it works** — brief explanation of the approach
-- **How it was tested** — what you did to verify it works
-- **Usage** — how the user invokes it (for skills)
+- First line of Summary = the purpose, one sentence. A reviewer reading only
+  it knows why the PR exists.
+- Then bold-led bullets, one fact per bullet (**Problem**: / **Fix**: /
+  **Out of scope**:). No prose walls; depth only some reviewers need goes in
+  a `<details>` appendix.
+- Plain English, short sentences, no filler. If a sentence adds no
+  reviewable fact, delete it.
+- Concise stays king, but five attestation sections are always present —
+  Summary, Change kind, Validation, Security and trust boundaries, AI
+  assistance — because silence is ambiguous: "None." beats deletion, and
+  reviewers rely on the fixed five landing in the same place every PR.
+- Three situational sections may be deleted when they don't apply: Related
+  work, User and release impact (only when there is no user-visible change),
+  Skill delivery (only when this is not a skill).
+- Validation lists receipts, one bullet per piece of evidence:
+  command -> result. Name the test that covers the changed behavior, or say
+  in one line why none does (docs-only, config-only, unreachable in CI).
 
-Don't pad the description. A few clear sentences are better than lengthy paragraphs.
+One pair, same facts, the shape is the difference.
+
+Hard to review:
+
+> The host sweep's ABSOLUTE_CEILING_MS was a hardcoded 30 minutes, so a slow
+> local-model backend that legitimately spends longer decoding one turn gets
+> cold-killed mid-turn, and this change makes the ceiling configurable by
+> resolving it per group from the new turn_ceiling_ms column added by
+> migration 024, falling back to the NANOCLAW_TURN_CEILING_MS env var and
+> then the built-in default, while invalid values fall through a level and
+> values below 60s are refused and a declared Bash timeout still extends
+> whatever ceiling wins.
+
+Easy to review:
+
+> **Problem**: `ABSOLUTE_CEILING_MS` is a hardcoded 30 minutes — slow
+> local-model turns get cold-killed mid-decode.
+>
+> **Fix**: ceiling resolved per group: (1) `turn_ceiling_ms` (migration 024),
+> (2) `NANOCLAW_TURN_CEILING_MS`, (3) the unchanged 30-minute default.
+>
+> **Guardrails**: invalid values fall through a level; sub-60s refused; a
+> declared Bash timeout still extends whatever ceiling wins.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,8 @@ Test your contribution on a fresh clone before submitting. For skills, run the s
 
 Area labels (`area/*`) are applied automatically from the files your PR touches; you don't pick one.
 
+**Changelog:** `CHANGELOG.md` is maintainer-owned — don't edit it in your PR. If your change is user-visible, put one user-facing line in the template's `release-note` block; it's optional raw material that maintainers harvest at release time. Skip it and a maintainer writes the line. For a breaking change, the release note must cover detect, why, fix/migration, and rollback.
+
 ### PR description
 
 Keep it concise. Remove any template sections that don't apply. The description should cover:

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -113,6 +113,25 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
     expect(res.add).toContain('kind/bug');
   });
 
+  it('AI-assistance checkboxes carry no label semantics and do not confuse the kind parser', () => {
+    const ai =
+      '## AI assistance\n' +
+      '- [ ] No AI assistance\n' +
+      '- [ ] AI-assisted: a person wrote this with AI help\n' +
+      '- [x] Agent-authored: an AI agent wrote this\n' +
+      '- [x] A human has reviewed this PR and stands behind every change\n';
+    const withKind = computeLabels({ body: v2Body(['kind/bug']) + ai, title: 'x', author: FORK_AUTHOR });
+    expect(withKind.add).toContain('kind/bug');
+    expect(withKind.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/bug']);
+    expect(withKind.add).not.toContain('delivery/skill');
+
+    // No kind box checked: the AI section must not register as a kind or a
+    // skill, and the title fallback still decides.
+    const fallback = computeLabels({ body: v2Body([]) + ai, title: 'docs: clarify setup', author: FORK_AUTHOR });
+    expect(fallback.add).toContain('kind/documentation');
+    expect(fallback.add).not.toContain('PR: Skill');
+  });
+
   it('chore and refactor title prefixes both map to kind/cleanup', () => {
     for (const title of ['chore(deps): bump x', 'refactor: flatten y']) {
       const res = computeLabels({ body: v2Body([]), title, author: FORK_AUTHOR });

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Fixture tests for the PR labeling decision logic (CI-04 acceptance
+ * criteria). The logic ships inline in .github/workflows/label-pr.yml (the
+ * pull_request_target workflow is metadata-only and never checks out the
+ * repo, so it cannot read a script file at runtime); these tests extract the
+ * exact code between the NANOCLAW-LABEL-LOGIC markers from the workflow file
+ * and evaluate it, so the tested function and the shipped function cannot
+ * drift.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface LabelDecision {
+  add: string[];
+  remove: string[];
+  coreTeam: boolean;
+}
+
+type ComputeLabels = (args: { body?: string | null; title?: string | null; author?: string | null }) => LabelDecision;
+
+function extractComputeLabels(): ComputeLabels {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'label-pr.yml'),
+    'utf8',
+  );
+  const start = workflow.indexOf('NANOCLAW-LABEL-LOGIC-START');
+  const end = workflow.indexOf('NANOCLAW-LABEL-LOGIC-END');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('NANOCLAW-LABEL-LOGIC markers not found in label-pr.yml');
+  }
+  const block = workflow.slice(start, end);
+  // Strip the YAML block-scalar indentation so the code parses standalone.
+  const code = block
+    .split('\n')
+    .slice(1) // drop the START marker line itself
+    .map((line) => line.replace(/^ {12}/, ''))
+    .join('\n');
+  return new Function(`${code}\nreturn computeLabels;`)() as ComputeLabels;
+}
+
+const computeLabels = extractComputeLabels();
+
+const V2 = '<!-- nanoclaw-pr-template:v2 -->\n';
+const v2Body = (kinds: string[], opts: { skill?: boolean } = {}) =>
+  V2 +
+  '## Change kind\n' +
+  ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening']
+    .map((k) => `- [${kinds.includes(k) ? 'x' : ' '}] \`${k}\``)
+    .join('\n') +
+  '\n## Skill delivery\n' +
+  `- [${opts.skill ? ' ' : 'x'}] Not a skill\n` +
+  `- [${opts.skill ? 'x' : ' '}] Skill: apply/remove footprint and fresh-clone verification are described above\n`;
+
+const FORK_AUTHOR = 'drive-by-contributor';
+
+describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
+  it('exactly one checked kind: adds it, its legacy twin, and removes the other managed kinds', () => {
+    const res = computeLabels({ body: v2Body(['kind/bug']), title: 'anything', author: FORK_AUTHOR });
+    expect(res.add).toContain('kind/bug');
+    expect(res.add).toContain('PR: Fix');
+    expect(res.add).toContain('follows-guidelines');
+    expect(res.remove).toEqual(
+      expect.arrayContaining(['kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening']),
+    );
+    expect(res.remove).not.toContain('kind/bug');
+  });
+
+  it('kind/hardening has no legacy PR:* twin', () => {
+    const res = computeLabels({ body: v2Body(['kind/hardening']), title: 'x', author: FORK_AUTHOR });
+    expect(res.add).toContain('kind/hardening');
+    expect(res.add.filter((l) => l.startsWith('PR: '))).toEqual([]);
+  });
+
+  it('zero checked kinds: falls back to the conventional-commit title prefix', () => {
+    const res = computeLabels({ body: v2Body([]), title: 'fix(host-sweep): make the ceiling configurable', author: FORK_AUTHOR });
+    expect(res.add).toContain('kind/bug');
+    expect(res.add).toContain('PR: Fix');
+    expect(res.remove).toContain('kind/feature');
+  });
+
+  it('multiple checked kinds: title prefix decides, checkboxes are ignored', () => {
+    const res = computeLabels({ body: v2Body(['kind/bug', 'kind/feature']), title: 'docs: fix a typo', author: FORK_AUTHOR });
+    expect(res.add).toContain('kind/documentation');
+    expect(res.add).not.toContain('kind/bug');
+    expect(res.add).not.toContain('kind/feature');
+  });
+
+  it('still ambiguous (no boxes, unmappable title): applies no kind and removes nothing', () => {
+    const res = computeLabels({ body: v2Body([]), title: 'Update stuff', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual([]);
+    expect(res.remove).toEqual([]);
+  });
+
+  it('edited selection reconciles: the newly checked kind lands, every other managed kind is removed', () => {
+    // Simulates the second run after an author unchecks bug and checks cleanup.
+    const res = computeLabels({ body: v2Body(['kind/cleanup']), title: 'x', author: FORK_AUTHOR });
+    expect(res.add).toContain('kind/cleanup');
+    expect(res.add).toContain('PR: Refactor');
+    expect(res.remove).toContain('kind/bug');
+  });
+
+  it('checkbox case: [X] counts as checked', () => {
+    const body = V2 + '- [X] `kind/feature`\n';
+    const res = computeLabels({ body, title: 'x', author: FORK_AUTHOR });
+    expect(res.add).toContain('kind/feature');
+  });
+
+  it('skill delivery checkbox adds delivery/skill and the legacy PR: Skill', () => {
+    const res = computeLabels({ body: v2Body(['kind/bug'], { skill: true }), title: 'x', author: FORK_AUTHOR });
+    expect(res.add).toContain('delivery/skill');
+    expect(res.add).toContain('PR: Skill');
+    expect(res.add).toContain('kind/bug');
+  });
+
+  it('chore and refactor title prefixes both map to kind/cleanup', () => {
+    for (const title of ['chore(deps): bump x', 'refactor: flatten y']) {
+      const res = computeLabels({ body: v2Body([]), title, author: FORK_AUTHOR });
+      expect(res.add).toContain('kind/cleanup');
+    }
+  });
+
+  it('never emits a label outside the fixed vocabularies', () => {
+    const KNOWN = new Set([
+      'kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening',
+      'PR: Fix', 'PR: Feature', 'PR: Docs', 'PR: Refactor', 'PR: Skill',
+      'delivery/skill', 'follows-guidelines', 'core-team',
+    ]);
+    for (const body of [v2Body(['kind/bug'], { skill: true }), v2Body([]), v2Body(['kind/hardening'])]) {
+      for (const label of computeLabels({ body, title: 'feat!: breaking', author: 'glifocat' }).add) {
+        expect(KNOWN.has(label), label).toBe(true);
+      }
+    }
+  });
+});
+
+describe('v1 bodies (frozen pre-v2 behavior)', () => {
+  it('checkbox substring adds both vocabularies, add-only', () => {
+    const res = computeLabels({ body: '<!-- contributing-guide: v1 -->\n- [x] **Fix** - bug fix', title: 'x', author: FORK_AUTHOR });
+    expect(res.add).toContain('PR: Fix');
+    expect(res.add).toContain('kind/bug');
+    expect(res.add).toContain('follows-guidelines');
+    expect(res.remove).toEqual([]);
+  });
+
+  it('feature skill emits the full four-label set', () => {
+    const res = computeLabels({ body: '- [x] **Feature skill** - adds a channel', title: 'x', author: FORK_AUTHOR });
+    expect(res.add).toEqual(expect.arrayContaining(['PR: Skill', 'PR: Feature', 'kind/feature', 'delivery/skill']));
+  });
+
+  it('first checked box wins, exactly as before', () => {
+    const res = computeLabels({
+      body: '- [x] **Fix** - bug fix\n- [x] **Documentation** - docs only',
+      title: 'x',
+      author: FORK_AUTHOR,
+    });
+    expect(res.add).toContain('PR: Fix');
+    expect(res.add).not.toContain('PR: Docs');
+  });
+
+  it('v1 matching stays case-sensitive: [X] is not recognized', () => {
+    const res = computeLabels({ body: '- [X] **Fix** - bug fix', title: 'x', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('PR: '))).toEqual([]);
+  });
+
+  it('missing body: no labels, no removals, no crash', () => {
+    const res = computeLabels({ body: null, title: null, author: FORK_AUTHOR });
+    expect(res.add).toEqual([]);
+    expect(res.remove).toEqual([]);
+  });
+});
+
+describe('author handling (both paths)', () => {
+  it('fork-authored PR gets no core-team label', () => {
+    const res = computeLabels({ body: v2Body(['kind/bug']), title: 'x', author: FORK_AUTHOR });
+    expect(res.add).not.toContain('core-team');
+    expect(res.coreTeam).toBe(false);
+  });
+
+  it('core-team roster match is case-insensitive on the login', () => {
+    const res = computeLabels({ body: v2Body(['kind/bug']), title: 'x', author: 'Glifocat' });
+    expect(res.add).toContain('core-team');
+    expect(res.coreTeam).toBe(true);
+  });
+});

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -219,6 +219,19 @@ describe('v2 bodies — token robustness', () => {
     expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual([]);
   });
 
+  it('the Validation test-coverage checkbox carries no label semantics', () => {
+    const validation =
+      '## Validation\n' +
+      '- [x] Tests cover the changed behavior (or Validation says why not)\n';
+    const withKind = computeLabels({ body: v2Body(['kind/bug']) + validation, title: 'x', author: FORK_AUTHOR });
+    expect(withKind.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/bug']);
+    expect(withKind.add).not.toContain('delivery/skill');
+
+    // Checked with no kind box: still no verdict from it — title fallback decides.
+    const alone = computeLabels({ body: v2Body([]) + validation, title: 'docs: x', author: FORK_AUTHOR });
+    expect(alone.add).toContain('kind/documentation');
+  });
+
   it('AI-assistance checkboxes carry no label semantics and do not confuse the kind parser', () => {
     const ai =
       '## AI assistance\n' +

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -130,6 +130,18 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
     expect(fallback.add).not.toContain('PR: Skill');
   });
 
+  it('a filled release-note block carries no label semantics and does not confuse the kind parser', () => {
+    const note =
+      '## User and release impact\n' +
+      '- [x] User-visible change — release note below\n' +
+      '```release-note\n' +
+      'Scheduled tasks now see their scheduled time. Fixes `kind/bug` handling and - [x] `kind/feature` mentions inside prose.\n' +
+      '```\n';
+    const res = computeLabels({ body: v2Body(['kind/cleanup']) + note, title: 'x', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/cleanup']);
+    expect(res.remove).toContain('kind/bug');
+  });
+
   it('chore and refactor title prefixes both map to kind/cleanup', () => {
     for (const title of ['chore(deps): bump x', 'refactor: flatten y']) {
       const res = computeLabels({ body: v2Body([]), title, author: FORK_AUTHOR });

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -17,7 +17,12 @@ interface LabelDecision {
   coreTeam: boolean;
 }
 
-type ComputeLabels = (args: { body?: string | null; title?: string | null; author?: string | null }) => LabelDecision;
+type ComputeLabels = (args: {
+  body?: string | null;
+  title?: string | null;
+  author?: string | null;
+  currentLabels?: string[];
+}) => LabelDecision;
 
 function extractComputeLabels(): ComputeLabels {
   const workflow = fs.readFileSync(
@@ -42,20 +47,23 @@ function extractComputeLabels(): ComputeLabels {
 const computeLabels = extractComputeLabels();
 
 const V2 = '<!-- nanoclaw-pr-template:v2 -->\n';
-const v2Body = (kinds: string[], opts: { skill?: boolean } = {}) =>
+// Blank template: no kind box, neither skill box. `skill: true` checks the
+// Skill box; `notSkill: true` checks the "Not a skill" box.
+const v2Body = (kinds: string[], opts: { skill?: boolean; notSkill?: boolean } = {}) =>
   V2 +
   '## Change kind\n' +
   ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening']
     .map((k) => `- [${kinds.includes(k) ? 'x' : ' '}] \`${k}\``)
     .join('\n') +
   '\n## Skill delivery\n' +
-  `- [${opts.skill ? ' ' : 'x'}] Not a skill\n` +
+  `- [${opts.notSkill ? 'x' : ' '}] Not a skill\n` +
   `- [${opts.skill ? 'x' : ' '}] Skill: apply/remove footprint and fresh-clone verification are described above\n`;
 
 const FORK_AUTHOR = 'drive-by-contributor';
+const LEGACY_TWINS = ['PR: Fix', 'PR: Feature', 'PR: Docs', 'PR: Refactor'];
 
-describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
-  it('exactly one checked kind: adds it, its legacy twin, and removes the other managed kinds', () => {
+describe('v2 bodies — explicit checkbox verdicts', () => {
+  it('one checked kind: adds it + its legacy twin, reconciles BOTH vocabularies', () => {
     const res = computeLabels({ body: v2Body(['kind/bug']), title: 'anything', author: FORK_AUTHOR });
     expect(res.add).toContain('kind/bug');
     expect(res.add).toContain('PR: Fix');
@@ -63,27 +71,78 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
     expect(res.remove).toEqual(
       expect.arrayContaining(['kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening']),
     );
+    // B2: the stale kinds' legacy twins go too — no PR: Fix + PR: Refactor pileup.
+    expect(res.remove).toEqual(expect.arrayContaining(['PR: Feature', 'PR: Docs', 'PR: Refactor']));
     expect(res.remove).not.toContain('kind/bug');
+    expect(res.remove).not.toContain('PR: Fix');
   });
 
-  it('kind/hardening has no legacy PR:* twin', () => {
+  it('reclassifying bug -> cleanup removes kind/bug AND PR: Fix in the same pass', () => {
+    const res = computeLabels({
+      body: v2Body(['kind/cleanup']),
+      title: 'x',
+      author: FORK_AUTHOR,
+      currentLabels: ['kind/bug', 'PR: Fix'],
+    });
+    expect(res.add).toEqual(expect.arrayContaining(['kind/cleanup', 'PR: Refactor']));
+    expect(res.remove).toContain('kind/bug');
+    expect(res.remove).toContain('PR: Fix');
+  });
+
+  it('kind/hardening has no legacy PR:* twin, added or removed', () => {
     const res = computeLabels({ body: v2Body(['kind/hardening']), title: 'x', author: FORK_AUTHOR });
     expect(res.add).toContain('kind/hardening');
     expect(res.add.filter((l) => l.startsWith('PR: '))).toEqual([]);
+    expect(res.remove).toEqual(expect.arrayContaining(LEGACY_TWINS));
   });
 
-  it('zero checked kinds: falls back to the conventional-commit title prefix', () => {
-    const res = computeLabels({ body: v2Body([]), title: 'fix(host-sweep): make the ceiling configurable', author: FORK_AUTHOR });
-    expect(res.add).toContain('kind/bug');
-    expect(res.add).toContain('PR: Fix');
-    expect(res.remove).toContain('kind/feature');
+  it('skill checkbox adds delivery/skill + PR: Skill; "Not a skill" removes both; neither box changes nothing', () => {
+    const on = computeLabels({ body: v2Body(['kind/bug'], { skill: true }), title: 'x', author: FORK_AUTHOR });
+    expect(on.add).toEqual(expect.arrayContaining(['delivery/skill', 'PR: Skill']));
+
+    const off = computeLabels({ body: v2Body(['kind/bug'], { notSkill: true }), title: 'x', author: FORK_AUTHOR });
+    expect(off.remove).toEqual(expect.arrayContaining(['delivery/skill', 'PR: Skill']));
+
+    const blank = computeLabels({ body: v2Body(['kind/bug']), title: 'x', author: FORK_AUTHOR });
+    expect(blank.add).not.toContain('delivery/skill');
+    expect(blank.remove).not.toContain('delivery/skill');
+  });
+});
+
+describe('v2 bodies — advisory title fallback (B1: never removes, never overrules)', () => {
+  it('zero boxes + mappable title + no existing kind: adds kind + twin, removes NOTHING', () => {
+    const res = computeLabels({
+      body: v2Body([]),
+      title: 'fix(host-sweep): make the ceiling configurable',
+      author: FORK_AUTHOR,
+      currentLabels: [],
+    });
+    expect(res.add).toEqual(expect.arrayContaining(['kind/bug', 'PR: Fix']));
+    expect(res.remove).toEqual([]);
   });
 
-  it('multiple checked kinds: title prefix decides, checkboxes are ignored', () => {
-    const res = computeLabels({ body: v2Body(['kind/bug', 'kind/feature']), title: 'docs: fix a typo', author: FORK_AUTHOR });
+  it("maintainer reclassification survives a later edited event: fallback adds nothing when a managed kind is present", () => {
+    // PR titled fix:, no box checked; maintainer set kind/cleanup at triage.
+    const res = computeLabels({
+      body: v2Body([]),
+      title: 'fix: something',
+      author: FORK_AUTHOR,
+      currentLabels: ['kind/cleanup', 'PR: Refactor'],
+    });
+    expect(res.add.filter((l) => l.startsWith('kind/') || l.startsWith('PR: '))).toEqual([]);
+    expect(res.remove).toEqual([]);
+  });
+
+  it('multiple checked boxes: no checkbox verdict — title is advisory, no removals', () => {
+    const res = computeLabels({
+      body: v2Body(['kind/bug', 'kind/feature']),
+      title: 'docs: fix a typo',
+      author: FORK_AUTHOR,
+      currentLabels: [],
+    });
     expect(res.add).toContain('kind/documentation');
     expect(res.add).not.toContain('kind/bug');
-    expect(res.add).not.toContain('kind/feature');
+    expect(res.remove).toEqual([]);
   });
 
   it('still ambiguous (no boxes, unmappable title): applies no kind and removes nothing', () => {
@@ -92,12 +151,40 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
     expect(res.remove).toEqual([]);
   });
 
-  it('edited selection reconciles: the newly checked kind lands, every other managed kind is removed', () => {
-    // Simulates the second run after an author unchecks bug and checks cleanup.
-    const res = computeLabels({ body: v2Body(['kind/cleanup']), title: 'x', author: FORK_AUTHOR });
-    expect(res.add).toContain('kind/cleanup');
-    expect(res.add).toContain('PR: Refactor');
-    expect(res.remove).toContain('kind/bug');
+  it('repo-convention prefixes ci/test/build/style/perf map to kind/cleanup, chore/refactor too', () => {
+    for (const title of ['ci(labels): x', 'test: y', 'build(deps): z', 'style: w', 'perf: v', 'chore(deps): u', 'refactor: t']) {
+      const res = computeLabels({ body: v2Body([]), title, author: FORK_AUTHOR, currentLabels: [] });
+      expect(res.add, title).toContain('kind/cleanup');
+    }
+  });
+
+  it('follows-guidelines is earned only by a checkbox verdict, not by the bare marker or the fallback', () => {
+    const unfilled = computeLabels({ body: v2Body([]), title: 'fix: x', author: FORK_AUTHOR });
+    expect(unfilled.add).not.toContain('follows-guidelines');
+    const filled = computeLabels({ body: v2Body(['kind/bug']), title: 'x', author: FORK_AUTHOR });
+    expect(filled.add).toContain('follows-guidelines');
+  });
+});
+
+describe('v2 bodies — token robustness', () => {
+  it('marker requires the exact HTML comment: a prose mention stays on the v1 path', () => {
+    const res = computeLabels({
+      body: 'I copied nanoclaw-pr-template:v2 from docs\n- [x] `kind/bug`',
+      title: 'feat: x',
+      author: FORK_AUTHOR,
+    });
+    // v1 path: backticked kind tokens mean nothing there, and no v1 boxes are checked.
+    expect(res.add.filter((l) => l.startsWith('kind/') || l.startsWith('PR: '))).toEqual([]);
+    expect(res.remove).toEqual([]);
+  });
+
+  it('checkbox tokens must start the line: inline and indented mentions do not register', () => {
+    const body =
+      V2 +
+      'see - [x] `kind/bug` discussed inline\n' +
+      '  - [x] `kind/feature` (indented, quoted from another PR)\n';
+    const res = computeLabels({ body, title: 'Update stuff', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual([]);
   });
 
   it('checkbox case: [X] counts as checked', () => {
@@ -106,11 +193,30 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
     expect(res.add).toContain('kind/feature');
   });
 
-  it('skill delivery checkbox adds delivery/skill and the legacy PR: Skill', () => {
-    const res = computeLabels({ body: v2Body(['kind/bug'], { skill: true }), title: 'x', author: FORK_AUTHOR });
-    expect(res.add).toContain('delivery/skill');
-    expect(res.add).toContain('PR: Skill');
-    expect(res.add).toContain('kind/bug');
+  it('a filled release-note block carries no label semantics', () => {
+    const note =
+      '## User and release impact\n' +
+      '- [x] User-visible change — release note below\n' +
+      '```release-note\n' +
+      'Fixes `kind/bug` handling.\n' +
+      '- [x] `kind/feature`\n' +
+      '```\n';
+    const res = computeLabels({ body: v2Body(['kind/cleanup']) + note, title: 'x', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/cleanup']);
+    expect(res.remove).toContain('kind/bug');
+    expect(res.remove).toContain('PR: Fix');
+  });
+
+  it('~~~ fences hide checkbox-looking text too', () => {
+    const body = v2Body(['kind/cleanup']) + '~~~\n- [x] `kind/bug`\n~~~\n';
+    const res = computeLabels({ body, title: 'x', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/cleanup']);
+  });
+
+  it('an unterminated fence hides everything after it', () => {
+    const body = v2Body([]) + '```\n- [x] `kind/bug`\n';
+    const res = computeLabels({ body, title: 'Update stuff', author: FORK_AUTHOR });
+    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual([]);
   });
 
   it('AI-assistance checkboxes carry no label semantics and do not confuse the kind parser', () => {
@@ -119,34 +225,8 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
       '- [x] AI tools or agents helped produce this change\n' +
       '- [x] A human has reviewed this PR and stands behind every change\n';
     const withKind = computeLabels({ body: v2Body(['kind/bug']) + ai, title: 'x', author: FORK_AUTHOR });
-    expect(withKind.add).toContain('kind/bug');
     expect(withKind.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/bug']);
     expect(withKind.add).not.toContain('delivery/skill');
-
-    // No kind box checked: the AI section must not register as a kind or a
-    // skill, and the title fallback still decides.
-    const fallback = computeLabels({ body: v2Body([]) + ai, title: 'docs: clarify setup', author: FORK_AUTHOR });
-    expect(fallback.add).toContain('kind/documentation');
-    expect(fallback.add).not.toContain('PR: Skill');
-  });
-
-  it('a filled release-note block carries no label semantics and does not confuse the kind parser', () => {
-    const note =
-      '## User and release impact\n' +
-      '- [x] User-visible change — release note below\n' +
-      '```release-note\n' +
-      'Scheduled tasks now see their scheduled time. Fixes `kind/bug` handling and - [x] `kind/feature` mentions inside prose.\n' +
-      '```\n';
-    const res = computeLabels({ body: v2Body(['kind/cleanup']) + note, title: 'x', author: FORK_AUTHOR });
-    expect(res.add.filter((l) => l.startsWith('kind/'))).toEqual(['kind/cleanup']);
-    expect(res.remove).toContain('kind/bug');
-  });
-
-  it('chore and refactor title prefixes both map to kind/cleanup', () => {
-    for (const title of ['chore(deps): bump x', 'refactor: flatten y']) {
-      const res = computeLabels({ body: v2Body([]), title, author: FORK_AUTHOR });
-      expect(res.add).toContain('kind/cleanup');
-    }
   });
 
   it('never emits a label outside the fixed vocabularies', () => {
@@ -155,8 +235,9 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
       'PR: Fix', 'PR: Feature', 'PR: Docs', 'PR: Refactor', 'PR: Skill',
       'delivery/skill', 'follows-guidelines', 'core-team',
     ]);
-    for (const body of [v2Body(['kind/bug'], { skill: true }), v2Body([]), v2Body(['kind/hardening'])]) {
-      for (const label of computeLabels({ body, title: 'feat!: breaking', author: 'glifocat' }).add) {
+    for (const body of [v2Body(['kind/bug'], { skill: true }), v2Body([]), v2Body(['kind/hardening'], { notSkill: true })]) {
+      const res = computeLabels({ body, title: 'feat!: breaking', author: 'glifocat' });
+      for (const label of [...res.add, ...res.remove]) {
         expect(KNOWN.has(label), label).toBe(true);
       }
     }

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -116,9 +116,7 @@ describe('v2 bodies (nanoclaw-pr-template:v2 marker)', () => {
   it('AI-assistance checkboxes carry no label semantics and do not confuse the kind parser', () => {
     const ai =
       '## AI assistance\n' +
-      '- [ ] No AI assistance\n' +
-      '- [ ] AI-assisted: a person wrote this with AI help\n' +
-      '- [x] Agent-authored: an AI agent wrote this\n' +
+      '- [x] AI tools or agents helped produce this change\n' +
       '- [x] A human has reviewed this PR and stands behind every change\n';
     const withKind = computeLabels({ body: v2Body(['kind/bug']) + ai, title: 'x', author: FORK_AUTHOR });
     expect(withKind.add).toContain('kind/bug');


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

The CI-04 PR-template/parser pairing.

**Template** — `.github/PULL_REQUEST_TEMPLATE.md` becomes the compact v2 contract (marker `nanoclaw-pr-template:v2`):

- Sections: Summary · Related work · one `kind/*` checkbox · Validation · User and release impact (optional fenced `release-note` block) · Security and trust boundaries · Skill delivery · AI assistance
- Upfront request for a conventional-commit PR title
- Separate skill checkbox ends v1's conflation of delivery with kind (v1 forced every skill PR to `kind/feature`, even fixes and docs)
- **AI assistance**: authorship checkbox + required attestation "A human has reviewed this PR and stands behind every change" — the maintainer decision that the PR surface discloses too

**Parser** — `label-pr.yml` branches on the marker:

- **v2 bodies**: stable-token parsing; removal power only on an explicit single-checkbox verdict; `kind/*` reconciled in lockstep with its legacy `PR: *` twin (an edited selection swaps, never accumulates)
- **Title fallback**: ten conventional prefixes (`fix:` … `perf:`), advisory only — add-only when zero/several boxes checked, never applied over an existing managed kind, so maintainer triage always survives
- Still ambiguous → nothing applied; the PR lands in triage
- **v1 bodies**: previous behavior byte-frozen — the ~30 open PRs keep labeling exactly as today
- Both paths keep emitting `PR: *`, `follows-guidelines`, `core-team` until Decision 4

## Related work

Closes no issue — middle layer of stacked PRs #3647 → #3648 → #3657 (retargets to `main` automatically when #3647 merges; **do not merge before it**). Implements the intake plan's CI-04 template/parser criteria.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- No-checkout posture means the workflow can't read a script file at runtime, so the logic lives inline between `NANOCLAW-LABEL-LOGIC` markers — `scripts/label-pr-workflow.test.ts` extracts and evaluates that exact block: **tested code and shipped code cannot drift**
- **25 fixtures**: zero/one/multiple kinds · edited-selection reconcile with `PR: *` lockstep · explicit-verdict-only removals · title fallback (add-only, never over a maintainer kind) · missing body · checkbox case on both paths · fork-authored · AI-section isolation · vocabulary closure
- Full CI matrix runs at retarget (base=main), before merge

## Security and trust boundaries

- `actions/github-script` pinned to full reviewed SHA (v7.0.1)
- `pull_request_target`, no checkout, no PR-supplied content executed; permissions unchanged
- Labels emitted only from fixed vocabularies verified byte-identical against `gh label list`; nothing created at runtime except the pre-existing `core-team` provisioning (stays until Decision 4)

## AI assistance

- [x] AI tools or agents helped produce this change
- [x] A human has reviewed this PR and stands behind every change

