### PR TITLE
chore(github): repair CODEOWNERS — default owner, automation surface, supply-chain files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,15 +6,11 @@
 # a matching rule with no owner deliberately clears ownership — that is how
 # the contributor-extension paths below stay open.
 #
-# Every name here has consented to the ownership it carries. Names are added
-# by consent, never derived from activity alone. Candidate co-owners, pending
-# consent (see t67):
-#   /src/ /container/        @gavrielc  @amit-shafnir
-#   /.github/                @gavrielc
-#   /versions.json           @gavrielc  @amit-shafnir
-#   /.claude/skills reviews  @Koshkoshinsk
-# gabi-simons was removed from the previous file's rules and can rejoin any
-# rule the same way — by consent.
+# Pre-existing owners are carried over unchanged; new names are added by
+# consent, never derived from activity alone. Candidates for additional
+# coverage, pending consent (see t67):
+#   /src/ /container/ /versions.json   @amit-shafnir
+#   /.claude/skills reviews            @Koshkoshinsk
 
 # Default owner: everything not matched below routes to the active maintainer.
 * @glifocat
@@ -25,12 +21,12 @@
 /.github/ @glifocat
 
 # Runtime core
-/src/ @glifocat
-/container/ @glifocat
-/launchd/ @glifocat
+/src/ @gavrielc @gabi-simons @glifocat
+/container/ @gavrielc @gabi-simons @glifocat
+/launchd/ @gavrielc @gabi-simons @glifocat
 
 # Supply-chain pins and lockfiles (see CLAUDE.md "Supply Chain Security")
-/package.json @glifocat
+/package.json @gavrielc @gabi-simons @glifocat
 /pnpm-lock.yaml @glifocat
 /pnpm-workspace.yaml @glifocat
 /container/agent-runner/package.json @glifocat

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,44 @@
-# Core code - maintainer only
-/src/ @gavrielc @gabi-simons
-/container/ @gavrielc @gabi-simons
-/groups/ @gavrielc @gabi-simons
-/launchd/ @gavrielc @gabi-simons
-/package.json @gavrielc @gabi-simons
-/package-lock.json @gavrielc @gabi-simons
+# Ownership philosophy
+#
+# CODEOWNERS is review ROUTING today: the main ruleset does not require
+# code-owner approval, so these rules request reviews without gating merges.
+# Rules are ordered least- to most-specific; the LAST matching rule wins, and
+# a matching rule with no owner deliberately clears ownership — that is how
+# the contributor-extension paths below stay open.
+#
+# Every name here has consented to the ownership it carries. Names are added
+# by consent, never derived from activity alone. Candidate co-owners, pending
+# consent (see t67):
+#   /src/ /container/        @gavrielc  @amit-shafnir
+#   /.github/                @gavrielc
+#   /versions.json           @gavrielc  @amit-shafnir
+#   /.claude/skills reviews  @Koshkoshinsk
+# gabi-simons was removed from the previous file's rules and can rejoin any
+# rule the same way — by consent.
 
-# Skills - open to contributors
+# Default owner: everything not matched below routes to the active maintainer.
+* @glifocat
+
+# Repository policy and automation — the highest-risk surface: workflows run
+# with write permissions on pull_request_target, and this file governs review
+# routing itself.
+/.github/ @glifocat
+
+# Runtime core
+/src/ @glifocat
+/container/ @glifocat
+/launchd/ @glifocat
+
+# Supply-chain pins and lockfiles (see CLAUDE.md "Supply Chain Security")
+/package.json @glifocat
+/pnpm-lock.yaml @glifocat
+/pnpm-workspace.yaml @glifocat
+/container/agent-runner/package.json @glifocat
+/container/agent-runner/bun.lock @glifocat
+/versions.json @glifocat
+/repo-tokens/ @glifocat
+
+# Contributor extensions — deliberately unowned (open to contributors)
 /.claude/skills/
+/templates/
+/config-examples/


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Repairs `.github/CODEOWNERS` per the CODEOWNERS + merge-gate audit (step 1: file repair, advisory only). The audit's central finding: **`.github/` was entirely unowned** — the `pull_request_target` label workflows (which run with write permissions) and CODEOWNERS itself could be edited with no owner review requested — and anything unmatched by the seven old rules had no review routing at all.

Changes:

- `*` default owner, plus explicit coverage for `.github/` and the supply-chain files (`versions.json`, `repo-tokens/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `container/agent-runner/package.json`, `container/agent-runner/bun.lock`) that CLAUDE.md's supply-chain policy protects.
- **Pre-existing owners are kept exactly as they were**: gavrielc and gabi-simons stay on `/src/`, `/container/`, `/launchd/`, and `/package.json`, with glifocat added alongside. glifocat is sole owner only where nothing was owned before.
- Two dead rules removed: `/groups/` (not in the tree — runtime-created) and `/package-lock.json` (the repo is pnpm).
- The deliberately-unowned contributor-extension pattern is kept and extended: `/.claude/skills/`, `/templates/`, `/config-examples/` stay open.
- A header comment documents the philosophy (routing-only today, last-match-wins, unowned-clears, names added by consent) and lists candidates for additional coverage pending consent (amit-shafnir, Koshkoshinsk).

Enforcement is deliberately unchanged: the main ruleset keeps `require_code_owner_review` off, so this file stays review **routing** until the consent round and the ruleset decision land as their own steps.

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change *(checked at human review, before this PR leaves draft)*
