### PR TITLE
feat(release): harvest PR release-note blocks into a draft changelog

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,6 +23,29 @@ A release is cut by a maintainer publishing it. The trigger is a release PR that
 - **Minor items** as single plain bullets at the bottom of the entry, no bold lead-in.
 - **No PR numbers** in the user-facing prose. PR references can live in the GitHub Release's `## Contributors` section.
 
+## Harvesting release notes from merged pull requests
+
+The v2 pull request template (`<!-- nanoclaw-pr-template:v2 -->`) carries an optional fenced
+```release-note``` block: one user-facing line, written by the contributor who knows what changed.
+`scripts/release-notes.mjs` collects those blocks across a merge range and prints a draft for you
+to edit:
+
+```bash
+node scripts/release-notes.mjs draft                      # since the last tag reachable from HEAD
+node scripts/release-notes.mjs draft --since v2.3.0        # explicit range start
+node scripts/release-notes.mjs draft --until <sha> --json  # machine-readable
+```
+
+It reads pull request bodies and labels through `gh api graphql`, so an authenticated `gh` is
+required. Harvested notes are grouped by the PR's `kind/*` label — the same managed vocabulary
+`.github/workflows/label-pr.yml` applies — and each bullet carries its PR link and author so you can
+go back to the source. Pull requests whose block is absent or still holds the template prompt are
+listed under **Needs a line** instead of being dropped silently; write a line for the user-visible
+ones and ignore the rest.
+
+The draft is a starting point, not the entry. Curate it into the shape described above, then paste
+what you keep under `## [Unreleased]`. The tool prints to stdout and never writes `CHANGELOG.md`.
+
 ## Publishing the release
 
 Before any release run, a repository administrator must configure and re-check its external safety controls:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "setup:auto": "tsx setup/auto.ts",
     "ncl": "tsx src/cli/client.ts",
     "migrate": "tsx scripts/migrate.ts",
+    "release-notes": "node scripts/release-notes.mjs",
     "chat": "tsx scripts/chat.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+
+// Harvests the optional fenced `release-note` block that the v2 pull request
+// template (marker `nanoclaw-pr-template:v2`) asks contributors to fill in, and
+// renders a draft changelog section for a maintainer to edit.
+//
+// This tool never writes CHANGELOG.md. It prints a draft to stdout; moving any
+// of it into the changelog stays a deliberate human edit, per RELEASING.md.
+
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+// Canonical order. Kept byte-identical to MANAGED_KINDS in
+// .github/workflows/label-pr.yml — a PR carrying several kind labels is
+// grouped under the first one listed here, so grouping is deterministic.
+export const MANAGED_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
+
+export const KIND_HEADINGS = {
+  'kind/bug': 'Fixes',
+  'kind/feature': 'Features',
+  'kind/documentation': 'Documentation',
+  'kind/cleanup': 'Cleanup',
+  'kind/hardening': 'Hardening',
+};
+
+export const UNLABELLED_HEADING = 'Unlabelled';
+
+// The literal prompt shipped inside the template's fence. A contributor who
+// never touched the block leaves this behind; it is not a release note.
+const TEMPLATE_PLACEHOLDER =
+  'Optional: one user-facing line for the changelog. Skip it and a maintainer will write one.';
+
+const RELEASE_NOTE_INFO_STRINGS = new Set(['release-note', 'release-notes']);
+
+function collapseWhitespace(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Returns the body of the first flush-left fenced block whose info string is
+ * `release-note` (or `release-notes`), or null when there is no usable note.
+ *
+ * The fence grammar deliberately matches the one the v2 label workflow already
+ * applies when it strips fences before parsing checkboxes: flush-left, three or
+ * more backticks or tildes, closed by a run of the same character at least as
+ * long. An unterminated fence runs to the end of the body, as CommonMark says.
+ */
+export function extractReleaseNote(body) {
+  const lines = String(body ?? '')
+    .replaceAll('\r\n', '\n')
+    .split('\n');
+
+  let fenceChar = null;
+  let fenceLength = 0;
+  let collecting = false;
+  const collected = [];
+
+  for (const line of lines) {
+    if (fenceChar === null) {
+      const opener = /^(`{3,}|~{3,})[ \t]*(.*)$/.exec(line);
+      if (!opener) continue;
+      const marker = opener[1];
+      const info = opener[2].trim();
+      // A backtick fence's info string may not contain a backtick (CommonMark).
+      if (marker[0] === '`' && info.includes('`')) continue;
+      fenceChar = marker[0];
+      fenceLength = marker.length;
+      collecting = RELEASE_NOTE_INFO_STRINGS.has(info.toLowerCase());
+      continue;
+    }
+
+    const closer = new RegExp(`^\\${fenceChar}{${fenceLength},}[ \\t]*$`).test(line);
+    if (closer) {
+      if (collecting) return finishNote(collected);
+      fenceChar = null;
+      fenceLength = 0;
+      continue;
+    }
+    if (collecting) collected.push(line);
+  }
+
+  return collecting ? finishNote(collected) : null;
+}
+
+function finishNote(lines) {
+  let text = lines.join('\n').replace(/<!--[\s\S]*?-->/g, '');
+
+  // Tolerate a contributor who wrote their line under the untouched prompt.
+  const withoutPlaceholder = text
+    .split('\n')
+    .filter((line) => collapseWhitespace(line) !== TEMPLATE_PLACEHOLDER)
+    .join('\n');
+  if (collapseWhitespace(withoutPlaceholder)) text = withoutPlaceholder;
+
+  const trimmed = text.replace(/^\n+/, '').replace(/\s+$/, '');
+  if (!collapseWhitespace(trimmed)) return null;
+  if (collapseWhitespace(trimmed) === TEMPLATE_PLACEHOLDER) return null;
+  return trimmed;
+}
+
+/** The kind this PR is grouped under, or null when it carries no managed kind. */
+export function pullRequestKind(labels) {
+  const names = new Set(
+    (labels ?? []).map((label) => (typeof label === 'string' ? label : label?.name)).filter(Boolean),
+  );
+  return MANAGED_KINDS.find((kind) => names.has(kind)) ?? null;
+}
+
+/** True when the v2 "Breaking change" box is checked outside any fenced block. */
+export function isBreakingChange(body) {
+  const text = String(body ?? '').replaceAll('\r\n', '\n');
+  const lines = [];
+  let fenceChar = null;
+  let fenceLength = 0;
+  for (const line of text.split('\n')) {
+    const marker = /^(`{3,}|~{3,})/.exec(line);
+    if (marker) {
+      if (fenceChar === null) {
+        fenceChar = marker[1][0];
+        fenceLength = marker[1].length;
+      } else if (line[0] === fenceChar && marker[1].length >= fenceLength) {
+        fenceChar = null;
+        fenceLength = 0;
+      }
+      continue;
+    }
+    if (fenceChar === null) lines.push(line);
+  }
+  return lines.some((line) => /^- \[x\]\s+Breaking change\b/i.test(line));
+}
+
+/**
+ * Splits merged pull requests into per-kind groups of harvested notes plus the
+ * list of PRs that still need a line. Input order is preserved inside a group.
+ */
+export function collectReleaseNotes(pullRequests) {
+  const groups = new Map();
+  const missing = [];
+
+  for (const pr of pullRequests ?? []) {
+    const kind = pullRequestKind(pr.labels);
+    const note = extractReleaseNote(pr.body);
+    const entry = {
+      number: pr.number,
+      title: pr.title ?? '',
+      url: pr.url ?? '',
+      author: pr.author ?? '',
+      kind,
+      breaking: isBreakingChange(pr.body),
+      note,
+    };
+
+    if (note === null) {
+      missing.push(entry);
+      continue;
+    }
+    const key = kind ?? '';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(entry);
+  }
+
+  const ordered = [...MANAGED_KINDS, '']
+    .filter((key) => groups.has(key))
+    .map((key) => ({
+      kind: key || null,
+      heading: key ? KIND_HEADINGS[key] : UNLABELLED_HEADING,
+      entries: groups.get(key),
+    }));
+
+  return { groups: ordered, missing };
+}
+
+function attribution(entry) {
+  const reference = entry.url ? `[#${entry.number}](${entry.url})` : `#${entry.number}`;
+  return entry.author ? `(${reference}, @${entry.author})` : `(${reference})`;
+}
+
+function renderNoteBullet(entry) {
+  const prefix = entry.breaking ? '[BREAKING] ' : '';
+  const lines = `${prefix}${entry.note}`.split('\n');
+  const rendered = lines.map((line, index) => (index === 0 ? `- ${line}` : line === '' ? '' : `  ${line}`));
+  rendered[rendered.length - 1] += ` ${attribution(entry)}`;
+  return rendered.join('\n');
+}
+
+/** Renders the whole draft. Markdown only; nothing here touches the repository. */
+export function renderDraftChangelog({ groups, missing }, meta = {}) {
+  const {
+    since = '',
+    until = '',
+    total = groups.reduce((count, group) => count + group.entries.length, 0) + missing.length,
+  } = meta;
+  const out = ['# Draft release notes', ''];
+
+  const range = since && until ? ` merged between \`${since}\` and \`${until}\`` : '';
+  out.push(
+    `_Harvested from ${total} pull request${total === 1 ? '' : 's'}${range}. ` +
+      'Edit this, then move the lines you keep into `## [Unreleased]` yourself — ' +
+      'this tool never writes `CHANGELOG.md`._',
+    '',
+  );
+
+  if (groups.length === 0) out.push('No release notes were found in this range.', '');
+
+  for (const group of groups) {
+    out.push(`## ${group.heading}`, '');
+    for (const entry of group.entries) out.push(renderNoteBullet(entry));
+    out.push('');
+  }
+
+  out.push(`## Needs a line (${missing.length})`, '');
+  if (missing.length === 0) {
+    out.push('Every merged pull request in this range carried a release note.', '');
+  } else {
+    out.push(
+      'These merged pull requests had no `release-note` block. Write a line for the user-visible ones, and ignore the rest.',
+      '',
+    );
+    for (const entry of missing) {
+      const kind = entry.kind ? ` \`${entry.kind}\`` : '';
+      out.push(`- ${attribution(entry)}${kind} — ${entry.title}`);
+    }
+    out.push('');
+  }
+
+  return `${out
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()}\n`;
+}
+
+/** Pull request numbers referenced by the commits in a `git log` subject list. */
+export function pullRequestNumbersFromLog(log) {
+  const numbers = [];
+  const seen = new Set();
+  for (const line of String(log ?? '').split('\n')) {
+    const match = /^Merge pull request #(\d+) /.exec(line) ?? /\(#(\d+)\)\s*$/.exec(line);
+    if (!match) continue;
+    const number = Number(match[1]);
+    if (seen.has(number)) continue;
+    seen.add(number);
+    numbers.push(number);
+  }
+  return numbers.sort((a, b) => a - b);
+}
+
+export function pullRequestQuery(repository, numbers) {
+  const [owner, name] = repository.split('/');
+  if (!owner || !name) throw new Error(`--repo must be owner/name; got ${repository}`);
+  const fields = 'number title url body author { login } labels(first: 50) { nodes { name } } mergedAt';
+  const selections = numbers
+    .map((number) => `    pr${number}: pullRequest(number: ${number}) { ${fields} }`)
+    .join('\n');
+  return `query {\n  repository(owner: "${owner}", name: "${name}") {\n${selections}\n  }\n}`;
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+function fetchPullRequests(repository, numbers, chunkSize = 25) {
+  const fetched = [];
+  for (let index = 0; index < numbers.length; index += chunkSize) {
+    const chunk = numbers.slice(index, index + chunkSize);
+    const raw = execFileSync('gh', ['api', 'graphql', '-f', `query=${pullRequestQuery(repository, chunk)}`], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const node = JSON.parse(raw)?.data?.repository ?? {};
+    for (const number of chunk) {
+      const pr = node[`pr${number}`];
+      if (!pr || !pr.mergedAt) continue;
+      fetched.push({
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        body: pr.body,
+        author: pr.author?.login ?? '',
+        labels: pr.labels?.nodes ?? [],
+      });
+    }
+  }
+  return fetched;
+}
+
+function parseArgs(argv) {
+  const options = { since: '', until: 'HEAD', repo: 'nanocoai/nanoclaw', json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--since' || arg === '--until' || arg === '--repo') {
+      const value = argv[index + 1];
+      if (!value) throw new Error(`${arg} requires a value`);
+      options[arg.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument ${arg}`);
+  }
+  return options;
+}
+
+export function main(argv) {
+  const [command, ...rest] = argv;
+  if (command !== 'draft') {
+    throw new Error(
+      'usage: node scripts/release-notes.mjs draft [--since <ref>] [--until <ref>] [--repo owner/name] [--json]',
+    );
+  }
+
+  const options = parseArgs(rest);
+  const until = git(['rev-parse', options.until]).trim();
+  const since = (options.since || git(['describe', '--tags', '--abbrev=0', until])).trim();
+
+  const log = git(['log', '--format=%s', `${since}..${until}`]);
+  const numbers = pullRequestNumbersFromLog(log);
+  const pullRequests = fetchPullRequests(options.repo, numbers);
+  const collected = collectReleaseNotes(pullRequests);
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ since, until, ...collected }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(renderDraftChangelog(collected, { since, until: options.until, total: pullRequests.length }));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectReleaseNotes,
+  extractReleaseNote,
+  isBreakingChange,
+  pullRequestKind,
+  pullRequestNumbersFromLog,
+  pullRequestQuery,
+  renderDraftChangelog,
+} from './release-notes.mjs';
+
+const TEMPLATE_BLOCK = [
+  '## User and release impact',
+  '',
+  '- [ ] No user-visible behavior change',
+  '- [x] User-visible change — release note below',
+  '',
+  '```release-note',
+  'Optional: one user-facing line for the changelog. Skip it and a maintainer will write one.',
+  '```',
+  '',
+].join('\n');
+
+function body(note: string, fence = '```release-note'): string {
+  return ['## Summary', '', 'Some description.', '', fence, note, fence.replace(/[^`~]+$/, ''), ''].join('\n');
+}
+
+describe('release-note extraction', () => {
+  it('extracts a single-line note from a backtick fence', () => {
+    expect(extractReleaseNote(body('Scheduled tasks now survive a host restart.'))).toBe(
+      'Scheduled tasks now survive a host restart.',
+    );
+  });
+
+  it('accepts tilde fences and longer backtick runs', () => {
+    expect(extractReleaseNote(body('Tilde note.', '~~~release-note'))).toBe('Tilde note.');
+    expect(extractReleaseNote(body('Four-backtick note.', '````release-note'))).toBe('Four-backtick note.');
+  });
+
+  it('accepts the release-notes plural and mixed-case info strings', () => {
+    expect(extractReleaseNote(body('Plural note.', '```release-notes'))).toBe('Plural note.');
+    expect(extractReleaseNote(body('Cased note.', '```Release-Note'))).toBe('Cased note.');
+  });
+
+  it('treats the untouched template placeholder as no note', () => {
+    expect(extractReleaseNote(TEMPLATE_BLOCK)).toBeNull();
+  });
+
+  it('drops the placeholder line when the contributor wrote underneath it', () => {
+    const mixed = body(
+      [
+        'Optional: one user-facing line for the changelog. Skip it and a maintainer will write one.',
+        'The real line.',
+      ].join('\n'),
+    );
+    expect(extractReleaseNote(mixed)).toBe('The real line.');
+  });
+
+  it('returns null for an empty block and for a body with no release-note fence', () => {
+    expect(extractReleaseNote(body('   '))).toBeNull();
+    expect(extractReleaseNote('## Summary\n\nNo fence at all.\n')).toBeNull();
+  });
+
+  it('skips unrelated fenced blocks that precede the release note', () => {
+    const withCode = ['```bash', 'pnpm test', '```', '', '```release-note', 'After the code block.', '```'].join('\n');
+    expect(extractReleaseNote(withCode)).toBe('After the code block.');
+  });
+
+  it('does not let a backtick line close a tilde fence', () => {
+    const crossed = ['~~~release-note', 'Line one.', '```', 'Line two.', '~~~'].join('\n');
+    expect(extractReleaseNote(crossed)).toBe('Line one.\n```\nLine two.');
+  });
+
+  it('keeps multiple paragraphs verbatim', () => {
+    const note = 'First paragraph.\n\nSecond paragraph with **detail**.';
+    expect(extractReleaseNote(body(note))).toBe(note);
+  });
+
+  it('runs an unterminated fence to the end of the body', () => {
+    expect(extractReleaseNote('```release-note\nTrailing note.\n')).toBe('Trailing note.');
+  });
+
+  it('ignores an indented fence, matching the label workflow flush-left rule', () => {
+    expect(extractReleaseNote('  ```release-note\n  Indented.\n  ```\n')).toBeNull();
+  });
+
+  it('strips HTML comments out of the harvested note', () => {
+    expect(extractReleaseNote(body('Visible line. <!-- reviewer note -->'))).toBe('Visible line.');
+  });
+});
+
+describe('kind grouping', () => {
+  it('picks the first managed kind in canonical order', () => {
+    expect(pullRequestKind([{ name: 'kind/cleanup' }, { name: 'kind/bug' }])).toBe('kind/bug');
+    expect(pullRequestKind(['kind/hardening'])).toBe('kind/hardening');
+  });
+
+  it('returns null when no managed kind label is present', () => {
+    expect(pullRequestKind([{ name: 'PR: Fix' }, { name: 'core-team' }])).toBeNull();
+    expect(pullRequestKind([])).toBeNull();
+  });
+});
+
+describe('breaking-change detection', () => {
+  it('detects the checked breaking box', () => {
+    expect(isBreakingChange('- [x] Breaking change — release note below covers detect\n')).toBe(true);
+    expect(isBreakingChange('- [ ] Breaking change — release note below\n')).toBe(false);
+  });
+
+  it('ignores a checkbox that only appears inside a fenced block', () => {
+    expect(isBreakingChange('```release-note\n- [x] Breaking change\n```\n')).toBe(false);
+  });
+});
+
+describe('draft assembly', () => {
+  const pullRequests = [
+    {
+      number: 10,
+      title: 'feat: cards',
+      url: 'https://example.test/10',
+      author: 'ada',
+      labels: [{ name: 'kind/feature' }],
+      body: body('Cards render inline.'),
+    },
+    {
+      number: 11,
+      title: 'fix: crash',
+      url: 'https://example.test/11',
+      author: 'grace',
+      labels: [{ name: 'kind/bug' }],
+      body: body('The host no longer crashes on restart.'),
+    },
+    {
+      number: 12,
+      title: 'chore: tidy',
+      url: 'https://example.test/12',
+      author: 'linus',
+      labels: [{ name: 'kind/cleanup' }],
+      body: TEMPLATE_BLOCK,
+    },
+    {
+      number: 13,
+      title: 'feat: untagged',
+      url: 'https://example.test/13',
+      author: 'ken',
+      labels: [],
+      body: body('No kind label on this one.'),
+    },
+  ];
+
+  it('groups notes by kind and lists note-less PRs separately', () => {
+    const collected = collectReleaseNotes(pullRequests);
+    expect(collected.groups.map((group) => group.heading)).toEqual(['Fixes', 'Features', 'Unlabelled']);
+    expect(collected.missing.map((entry) => entry.number)).toEqual([12]);
+  });
+
+  it('renders each note with its PR link and author', () => {
+    const markdown = renderDraftChangelog(collectReleaseNotes(pullRequests), { since: 'v2.3.0', until: 'HEAD' });
+    expect(markdown).toContain('- The host no longer crashes on restart. ([#11](https://example.test/11), @grace)');
+    expect(markdown).toContain('## Needs a line (1)');
+    expect(markdown).toContain('- ([#12](https://example.test/12), @linus) `kind/cleanup` — chore: tidy');
+  });
+
+  it('keeps a multi-paragraph note inside one bullet and flags breaking changes', () => {
+    const breaking = [
+      '- [x] Breaking change — release note below covers detect',
+      '',
+      '```release-note',
+      'The seam moved.',
+      '',
+      'Migration: run the detector.',
+      '```',
+    ].join('\n');
+    const markdown = renderDraftChangelog(
+      collectReleaseNotes([
+        { number: 20, title: 't', url: 'u', author: 'ada', labels: ['kind/hardening'], body: breaking },
+      ]),
+    );
+    expect(markdown).toContain('- [BREAKING] The seam moved.\n\n  Migration: run the detector. ([#20](u), @ada)');
+  });
+
+  it('says so when nothing in the range needs a line', () => {
+    const markdown = renderDraftChangelog(collectReleaseNotes([pullRequests[0]]));
+    expect(markdown).toContain('Every merged pull request in this range carried a release note.');
+  });
+
+  it('tells the maintainer the draft is theirs to move', () => {
+    const markdown = renderDraftChangelog(collectReleaseNotes([]), { since: 'v2.3.0', until: 'HEAD' });
+    expect(markdown).toContain('this tool never writes `CHANGELOG.md`');
+    expect(markdown).toContain('No release notes were found in this range.');
+  });
+});
+
+describe('range collection', () => {
+  it('collects PR numbers from squash subjects and merge commits, deduped and ordered', () => {
+    const log = [
+      'fix(agent-runner): tell the agent send_card drops callback actions (#3426)',
+      'Merge pull request #3582 from GetDial-AI/fix/add-dial-copy-status-test',
+      'fix(add-dial): add dial-status.test.ts to the nc:copy list (#3582)',
+      'chore: no pull request reference here',
+    ].join('\n');
+    expect(pullRequestNumbersFromLog(log)).toEqual([3426, 3582]);
+  });
+
+  it('builds one aliased GraphQL query per chunk', () => {
+    const query = pullRequestQuery('nanocoai/nanoclaw', [1, 2]);
+    expect(query).toContain('repository(owner: "nanocoai", name: "nanoclaw")');
+    expect(query).toContain('pr1: pullRequest(number: 1)');
+    expect(query).toContain('pr2: pullRequest(number: 2)');
+    expect(query).toContain('mergedAt');
+  });
+
+  it('rejects a repository argument that is not owner/name', () => {
+    expect(() => pullRequestQuery('nanoclaw', [1])).toThrow('owner/name');
+  });
+});


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

The v2 pull request template adds an optional fenced ```` ```release-note ```` block — one
user-facing line written by the contributor who actually knows what changed — but nothing
harvests it, so a maintainer still reconstructs every changelog entry from PR titles at
release time.

`scripts/release-notes.mjs draft` walks the merge range since the last reachable tag, reads
each merged PR's body and labels through `gh api graphql`, and prints a markdown draft
grouped by the PR's `kind/*` label, each bullet carrying its PR link and author. PRs with no
block — or with the untouched template prompt still inside it — are listed under **Needs a
line** rather than dropped silently.

The tool prints to stdout. It never writes `CHANGELOG.md`: curating the draft into an entry
stays a human edit, exactly as `RELEASING.md` describes.

Parser notes:

- The fence grammar mirrors the one `.github/workflows/label-pr.yml` already applies when it
  strips fences before parsing checkboxes — flush-left, three or more backticks **or** tildes,
  closed by a run of the same character at least as long, an unterminated fence running to the
  end of the body. A ``` line cannot close a ~~~ fence.
- `release-note` and `release-notes`, any letter case, are accepted info strings.
- Multi-paragraph notes are kept verbatim inside one bullet.
- A checked "Breaking change" box prefixes the line with `[BREAKING]`, matching the changelog's
  own convention. Checkboxes inside fenced blocks are ignored.
- `MANAGED_KINDS` is kept byte-identical to the label workflow's list, and a PR carrying several
  kinds is grouped under the first one in that canonical order, so grouping is deterministic.

## Related work

Closes #

Pairs with #3648 (PR template v2), which introduces the block this reads. This PR is
independent of that train — it is off `main` and changes no workflow — and becomes fully
useful once #3648 merges and merged PRs start carrying `release-note` blocks and `kind/*`
labels. Until then the dry run is all "Needs a line", which is the correct answer for the
back catalogue.

## Change kind

<!-- Check exactly one. -->
- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

```
node_modules/.bin/vitest run scripts/release-notes.test.ts   # 24 passed
node_modules/.bin/tsc --noEmit                                # clean
node_modules/.bin/prettier --check "src/**/*.ts"              # clean
```

Full `vitest run`: 2086 passed, 11 failed in `scripts/update/transaction.e2e.test.ts`,
`scripts/update-skills.test.ts`, `src/cli/stdin-json.test.ts` and `src/cli/stdin-json.e2e.test.ts`.
Those same 11 fail on a clean `origin/main` checkout in this environment (verified by stashing
this branch's changes and re-running) — they are git-fixture/e2e environment failures, not
caused by this change.

Dry run against the real range since `v2.3.0` (15 merged PRs, none of which predates the
`release-note` block, so every one lands in the "needs a line" list — which is the behavior
being demonstrated):

```
# Draft release notes

_Harvested from 15 pull requests merged between `v2.3.0` and `HEAD`. Edit this, then move the
lines you keep into `## [Unreleased]` yourself — this tool never writes `CHANGELOG.md`._

No release notes were found in this range.

## Needs a line (15)

These merged pull requests had no `release-note` block. Write a line for the user-visible ones, and ignore the rest.

- ([#3385](https://github.com/nanocoai/nanoclaw/pull/3385), @Koshkoshinsk) — fix(approvals): MPDM-aware approval cards via resolveConversation seam
- ([#3496](https://github.com/nanocoai/nanoclaw/pull/3496), @gavrielc) — versions: repin to hardened-2026-08-23 and let benign lock drift through
- ([#3536](https://github.com/nanocoai/nanoclaw/pull/3536), @amit-shafnir) — fix(compose): inline every instruction source into one project document
…
```

Grouping, multi-paragraph rendering, `[BREAKING]`, fence variants and placeholder rejection are
covered by the 24 unit tests rather than by the live range, which has no filled blocks yet.

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Optional: one user-facing line for the changelog. Skip it and a maintainer will write one.
```

Maintainer tooling only — no runtime or agent-visible behavior changes. `CHANGELOG.md` is
untouched by this PR and by the tool it adds.

## Security and trust boundaries

No workflow, permission, or container change. The script is a local command a maintainer runs;
it reads through the maintainer's own authenticated `gh`, shells out only to `git` and `gh` via
`execFileSync` with argument arrays (no shell interpolation), and writes nothing anywhere — it
prints to stdout. PR bodies are treated as untrusted text and only ever rendered into markdown,
never evaluated.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [ ] A human has reviewed this PR and stands behind every change
