### PR TITLE
fix(agent-runner): opt-in bounded heartbeat keep-alive while a provider stream is open

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -9,6 +9,7 @@ import {
 import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { clearStaleProcessingAcks } from './db/container-state.js';
 import { touchHeartbeat } from './heartbeat.js';
+import { parseStreamKeepAliveMs, shouldKeepAliveTouch } from './stream-keepalive.js';
 import { getAgentMailbox } from './mailbox/index.js';
 import {
   clearContinuation,
@@ -408,6 +409,13 @@ export async function processQuery(
   let pollInFlight = false;
   let endedForCommand = false;
   let mailboxFailureStreak = 0;
+  // Stream keep-alive (opt-in, bounded — see stream-keepalive.ts): while the
+  // last provider event is younger than the cap, this poll tick vouches for
+  // the container by touching the heartbeat, so a slow model decoding
+  // between events is not read as stuck. Silent past the cap, the heartbeat
+  // ages normally and the host's turn ceiling still fires.
+  const streamKeepAliveMs = parseStreamKeepAliveMs(process.env.NANOCLAW_STREAM_KEEPALIVE_MS);
+  let lastProviderEventMs = Date.now();
   const pollHandle = setInterval(() => {
     if (done || pollInFlight || endedForCommand) return;
     pollInFlight = true;
@@ -415,6 +423,12 @@ export async function processQuery(
     void (async () => {
       try {
         const pending = getPendingMessages();
+        // A successful mailbox read just proved the event loop AND the
+        // session DB are alive — safe to vouch. Placed after the read so a
+        // wedged mailbox driver never keeps the container looking healthy.
+        if (shouldKeepAliveTouch(Date.now(), lastProviderEventMs, streamKeepAliveMs)) {
+          touchHeartbeat();
+        }
 
         // Slash commands need a fresh query: /clear resets the SDK's
         // resume id (fixed at sdkQuery() time); admin/passthrough commands
@@ -523,6 +537,7 @@ export async function processQuery(
     for await (const event of query.events) {
       handleEvent(event, routing);
       touchHeartbeat();
+      lastProviderEventMs = Date.now();
 
       if (event.type === 'init') {
         queryContinuation = event.continuation;

--- a/container/agent-runner/src/stream-keepalive.test.ts
+++ b/container/agent-runner/src/stream-keepalive.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Stream keep-alive policy tests: off-by-default parsing, the 60s floor, and
+ * the bounded vouching window that preserves the hung-provider backstop
+ * (#2668) while keeping slow decodes (#3643) alive.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { MIN_STREAM_KEEPALIVE_MS, parseStreamKeepAliveMs, shouldKeepAliveTouch } from './stream-keepalive.js';
+
+describe('parseStreamKeepAliveMs', () => {
+  it('is off (undefined) when unset, empty, or invalid', () => {
+    expect(parseStreamKeepAliveMs(undefined)).toBeUndefined();
+    expect(parseStreamKeepAliveMs(null)).toBeUndefined();
+    expect(parseStreamKeepAliveMs('')).toBeUndefined();
+    expect(parseStreamKeepAliveMs('ninety minutes')).toBeUndefined();
+    expect(parseStreamKeepAliveMs('1.5')).toBeUndefined();
+    expect(parseStreamKeepAliveMs('0')).toBeUndefined();
+    expect(parseStreamKeepAliveMs('-1')).toBeUndefined();
+    expect(parseStreamKeepAliveMs(String(MIN_STREAM_KEEPALIVE_MS - 1))).toBeUndefined();
+    expect(parseStreamKeepAliveMs('Infinity')).toBeUndefined();
+  });
+
+  it('accepts integer ms at or above the 60s floor', () => {
+    expect(parseStreamKeepAliveMs(String(MIN_STREAM_KEEPALIVE_MS))).toBe(MIN_STREAM_KEEPALIVE_MS);
+    expect(parseStreamKeepAliveMs('5400000')).toBe(5_400_000);
+    expect(parseStreamKeepAliveMs(' 5400000 ')).toBe(5_400_000);
+  });
+});
+
+describe('shouldKeepAliveTouch', () => {
+  const T0 = 1_000_000_000;
+
+  it('never touches when keep-alive is off', () => {
+    expect(shouldKeepAliveTouch(T0, T0, undefined)).toBe(false);
+  });
+
+  it('touches while the last provider event is younger than the cap', () => {
+    const cap = 90 * 60 * 1000;
+    expect(shouldKeepAliveTouch(T0 + 1, T0, cap)).toBe(true);
+    expect(shouldKeepAliveTouch(T0 + cap - 1, T0, cap)).toBe(true);
+  });
+
+  it('stops vouching once the stream has been silent past the cap — the ceiling backstop survives', () => {
+    const cap = 90 * 60 * 1000;
+    expect(shouldKeepAliveTouch(T0 + cap, T0, cap)).toBe(false);
+    expect(shouldKeepAliveTouch(T0 + cap + 1, T0, cap)).toBe(false);
+  });
+
+  it('a fresh provider event reopens the window', () => {
+    const cap = 90 * 60 * 1000;
+    const silentPast = T0 + cap + 60_000;
+    expect(shouldKeepAliveTouch(silentPast, T0, cap)).toBe(false);
+    // Event lands at silentPast: lastEvent moves forward, vouching resumes.
+    expect(shouldKeepAliveTouch(silentPast + 1, silentPast, cap)).toBe(true);
+  });
+});

--- a/container/agent-runner/src/stream-keepalive.ts
+++ b/container/agent-runner/src/stream-keepalive.ts
@@ -1,0 +1,49 @@
+/**
+ * Stream keep-alive policy — whether the runner's follow-up poll tick may
+ * touch the heartbeat while a provider stream is open.
+ *
+ * The heartbeat normally ticks only on provider stream events, so the host
+ * sweep reads a slow local model (minutes between events while decoding) the
+ * same as a dead container and cold-kills it at the turn ceiling (#3643).
+ * The follow-up poll proves the runner's event loop and mailbox are alive
+ * every 500ms, so it can honestly vouch for the container — but an
+ * UNCONDITIONAL touch would also keep a genuinely hung provider call or tool
+ * alive forever, deleting the only backstop #2668 relies on. Hence:
+ *
+ *   - Opt-in: NANOCLAW_STREAM_KEEPALIVE_MS unset/invalid = keep-alive off,
+ *     exactly today's behavior.
+ *   - Bounded: touches happen only while the last REAL provider event is
+ *     younger than the cap. A stream silent past the cap stops being vouched
+ *     for; the heartbeat then ages normally and the turn ceiling still
+ *     fires. Effective kill time for a silent stream = cap + ceiling.
+ *
+ * Operators pair it with the per-group turn ceiling: a slow-model install
+ * sets a cap that covers its longest legitimate decode and can then keep the
+ * ceiling itself short.
+ */
+
+// A cap below the sweep's claim-stuck tolerance (60s) would be meaningless —
+// the sweep could kill between two vouches. Mirror the host-side floor.
+export const MIN_STREAM_KEEPALIVE_MS = 60 * 1000;
+
+/**
+ * Parse NANOCLAW_STREAM_KEEPALIVE_MS. Returns undefined (keep-alive off) for
+ * anything that is not a finite integer >= MIN_STREAM_KEEPALIVE_MS, so a
+ * typo'd value degrades to today's behavior instead of an over-eager or
+ * unbounded keep-alive.
+ */
+export function parseStreamKeepAliveMs(raw: unknown): number | undefined {
+  if (raw === null || raw === undefined || raw === '') return undefined;
+  const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+  if (!Number.isInteger(n) || n < MIN_STREAM_KEEPALIVE_MS) return undefined;
+  return n;
+}
+
+/**
+ * Should this poll tick touch the heartbeat? True only when keep-alive is
+ * enabled and the last provider event is still younger than the cap.
+ */
+export function shouldKeepAliveTouch(nowMs: number, lastEventMs: number, capMs: number | undefined): boolean {
+  if (capMs === undefined) return false;
+  return nowMs - lastEventMs < capMs;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ const envConfig = readEnvFile([
   'NANOCLAW_EGRESS_LOCKDOWN',
   'NANOCLAW_EGRESS_NETWORK',
   'ONECLI_GATEWAY_CONTAINER',
+  'NANOCLAW_STREAM_KEEPALIVE_MS',
 ]);
 
 /**
@@ -96,6 +97,11 @@ export const EGRESS_NETWORK =
   process.env.NANOCLAW_EGRESS_NETWORK || envConfig.NANOCLAW_EGRESS_NETWORK || 'nanoclaw-egress';
 export const ONECLI_GATEWAY_CONTAINER =
   process.env.ONECLI_GATEWAY_CONTAINER || envConfig.ONECLI_GATEWAY_CONTAINER || 'onecli';
+// Opt-in stream keep-alive cap for agent containers, in ms. Raw string here;
+// parsed + validated in the container (stream-keepalive.ts) so an invalid
+// value degrades to keep-alive-off rather than surprising behavior.
+export const STREAM_KEEPALIVE_MS_RAW =
+  process.env.NANOCLAW_STREAM_KEEPALIVE_MS || envConfig.NANOCLAW_STREAM_KEEPALIVE_MS || '';
 
 // Timezone for scheduled tasks, message formatting, etc.
 // Validates each candidate is a real IANA identifier before accepting.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -21,6 +21,7 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   INSTALL_SLUG,
+  STREAM_KEEPALIVE_MS_RAW,
   TIMEZONE,
 } from './config.js';
 import { CONTAINER_PLUGINS_DIR, materializeContainerJson } from './container-config.js';
@@ -652,6 +653,9 @@ export function composeSessionSpec(input: ComposeSessionSpecInput): SessionSpec 
     TZ: containerConfig.timezone ?? TIMEZONE,
     ...mailboxEnvironment,
   };
+  // Opt-in stream keep-alive (see container/agent-runner/src/stream-keepalive.ts).
+  // Unset = absent from the container = keep-alive off, today's behavior.
+  if (STREAM_KEEPALIVE_MS_RAW) env.NANOCLAW_STREAM_KEEPALIVE_MS = STREAM_KEEPALIVE_MS_RAW;
   // The contributed lane (ContainerSpec.contributedEnv): registry-sourced env,
   // exempt from the credential-NAME check and still refused credential VALUES.
   // The model provider's contribution fills first, the gateway's second — a


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The heartbeat ticks only on provider stream events, so any backend slower than hosted inference goes quiet for minutes while genuinely decoding, and the host sweep reads it exactly like a dead container. This is the shared root behind #2668, #3455, and #3643 ("heartbeat only ticks on stream events"). #3646 made the kill ceiling configurable; this PR fixes the blind spot itself, opt-in and bounded:

- **Mechanism:** the runner's follow-up poll already proves the event loop and session mailbox are alive every 500ms while a stream is open. With `NANOCLAW_STREAM_KEEPALIVE_MS` set, a successful poll tick touches the heartbeat — but only while the last real provider event is younger than that cap.
- **The #2668 backstop survives:** a stream silent past the cap stops being vouched for, the heartbeat ages normally, and the turn ceiling still fires. Effective kill time for a genuinely hung provider call is cap + ceiling, never infinity. An unconditional keep-alive would have deleted that backstop, which is why this is bounded and opt-in.
- **Default unchanged:** unset, invalid, or sub-60s values leave keep-alive off — byte-for-byte today's behavior. The touch sits after a successful mailbox read, so a wedged mailbox driver can never keep a container looking healthy, and the existing failure-streak exit path silences it exactly as it silences event-driven touches.
- **Host side:** the raw env value passes through `composeSessionSpec` into the container env only when set (no per-group config surface yet — an install-level knob, pairable with the per-group turn ceiling from #3646).

## How I verified it

- `container/agent-runner/src/stream-keepalive.test.ts` (bun:test, 6 tests): off-by-default parsing incl. the 60s floor, touch-within-window, stop-past-cap, and the window reopening on a fresh provider event.
- `cd container/agent-runner && bun run typecheck` clean; host `pnpm run build` clean; `container-runner` + `mount-composition` suites pass (45 tests).

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change *(checked at human review, before this PR leaves draft)*
