### PR TITLE
fix(ncl tasks): reject an empty --prompt on update

### DIFF
--- a/src/cli/resources/tasks.test.ts
+++ b/src/cli/resources/tasks.test.ts
@@ -245,6 +245,28 @@ describe('tasks CLI resource', () => {
     if (!upd.ok) expect(upd.error.message).toContain('this task has not been scheduled');
   });
 
+  it('update rejects an empty --prompt instead of blanking the task', async () => {
+    const created = await dispatch(
+      { id: 'c', command: 'tasks-create', args: { prompt: 'keep me', name: 'blank-guard', recurrence: '0 9 * * *' } },
+      agentCtx(),
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const seriesId = (created.data as { series_id: string }).series_id;
+
+    for (const prompt of ['', '   \n']) {
+      const upd = await dispatch({ id: 'u', command: 'tasks-update', args: { id: seriesId, prompt } }, agentCtx());
+      expect(upd.ok).toBe(false);
+      if (!upd.ok) expect(upd.error.message).toContain('--prompt must not be empty');
+    }
+
+    const listed = await dispatch({ id: 'l', command: 'tasks-list', args: {} }, agentCtx());
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const row = (listed.data as Array<{ row_id: string; prompt: string }>).find((t) => t.row_id === seriesId);
+    expect(row?.prompt).toBe('keep me');
+  });
+
   it('tasks create --help carries the script contract and the frequency-limit caveat', async () => {
     // --help and `tasks help create` render the same deep verb help.
     const resp = await dispatch({ id: 'h', command: 'tasks-create', args: { help: true } }, agentCtx());

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -322,7 +322,13 @@ async function deleteTaskCommand(args: Record<string, unknown>, ctx: CallerConte
 async function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   const id = taskId(args);
   const update: TaskUpdate = {};
-  if (typeof args.prompt === 'string') update.prompt = args.prompt;
+  if (typeof args.prompt === 'string') {
+    // `create` refuses an empty prompt; `update` must too, or a shell
+    // substitution over a missing file (`--prompt "$(cat gone.txt)"`) silently
+    // blanks a live task and the next run wakes the agent with no instruction.
+    if (!args.prompt.trim()) throw new Error('--prompt must not be empty; omit it to keep the current prompt');
+    update.prompt = args.prompt;
+  }
   const recurrence = normalizeNullableString(args.recurrence);
   const script = normalizeNullableString(args.script);
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What.** `ncl tasks update` now refuses an empty or whitespace-only `--prompt` with `--prompt must not be empty; omit it to keep the current prompt`, matching the guard `create` already has. One `if` in `src/cli/resources/tasks.ts` plus a test.

**Why.** An agent ran `ncl tasks update <id> --prompt "$(cat /tmp/prompt.txt)"` after a container restart had wiped `/tmp`. The substitution expanded to an empty string, `update` accepted it, and a live recurring task was silently blanked — its next run would have woken the agent with no instruction.

**How it was tested.** `pnpm exec vitest run src/cli/resources/tasks.test.ts` (31 tests, including the new one) and `tsc --noEmit` pass; reproduced the blanking before the fix and the rejection after it on a live install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMv5EVFUSQ2uBBPRxNkS5w