### PR TITLE
ci(stale): add author-blocked stale policy in dry-run mode

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,152 @@
+# Stale policy, lane A: author-blocked items only.
+#
+# This workflow never examines the backlog at large. It looks at exactly two
+# populations, both of which mean a human already read the item and asked its
+# author for something:
+#
+#   issues  carrying  triage/needs-repro   (we asked for a reproduction)
+#   PRs     carrying  triage/needs-author  (a maintainer requested changes)
+#
+# Everything else is invisible to it. An item waiting on us for review, for
+# triage, or for a decision is never marked and never closed, because the
+# absence of those labels is what "the ball is ours" looks like in this repo.
+# The rule the policy is built on: a bot may close an item only when the ball
+# is demonstrably in the author's court, and only after the bot said so out
+# loud and gave a deadline.
+#
+# Timings: 21 days of silence marks an item stale. A stale issue closes 14 days
+# later (35 total), a stale PR 21 days later (42 total). remove-stale-when-
+# updated is on, so any reply, commit, or comment clears the label and restarts
+# the clock. Closes use the not_planned reason, which renders as "not planned"
+# rather than "completed" and keeps these out of resolved metrics.
+#
+# Escape hatches, in order of how often they should be reached for:
+#   - reply to the item                -> label comes off automatically
+#   - remove the triage/* label        -> item leaves the population entirely
+#   - add triage/keep                  -> permanent exemption, no argument
+#
+# ---------------------------------------------------------------------------
+# DRY RUN. debug-only is true. ARMING IS DUE 2026-09-12.
+#
+# Until that date this workflow performs NO writes. It logs what it would have
+# marked and closed and stops there: no labels, no comments, no closes, no
+# notifications to anyone. The two weeks exist so a mis-scoped label filter is
+# caught by reading a log rather than by several hundred contributors reading a
+# bot comment.
+#
+# Flipping debug-only to false is the arming step and it is not reversible for
+# anything already sent. Before flipping, on 2026-09-12 or later:
+#   1. Read the most recent run's log and confirm every item it lists is
+#      genuinely author-blocked.
+#   2. Confirm the "stale" label exists on the repo. It does not today; GitHub
+#      would auto-create it with a default colour on the first armed run, which
+#      is not how the rest of this taxonomy was made.
+#   3. Confirm triage/keep is on anything a maintainer wants frozen, so the
+#      escape hatch is in place on day one rather than after the first
+#      complaint.
+# Day-1 blast radius when this shipped was zero items, because neither trigger
+# label was applied to anything yet. Volume can only grow as fast as triage
+# applies those labels, which is to say never faster than a human reading the
+# item first.
+# ---------------------------------------------------------------------------
+#
+# Lane B (a slow, forward-dated general-inactivity lane) is deliberately not
+# here. It is a separate decision and a separate change.
+
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # actions/stale v11.0.0, pinned to the commit the tag resolves to.
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93
+        with:
+          # DRY RUN. See the arming note above. Due 2026-09-12.
+          debug-only: true
+
+          # The population. Nothing outside these two label sets is examined.
+          any-of-issue-labels: 'triage/needs-repro'
+          any-of-pr-labels: 'triage/needs-author'
+
+          days-before-issue-stale: 21
+          days-before-issue-close: 14
+          days-before-pr-stale: 21
+          days-before-pr-close: 21
+
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          remove-stale-when-updated: true
+          close-issue-reason: 'not_planned'
+
+          # Never touch a contributor's branch. This is also the default; it is
+          # set explicitly so a later edit has to be deliberate.
+          delete-branch: false
+
+          # Exemptions. Every entry is a label or a piece of metadata, so none
+          # of this is a judgment call at runtime.
+          #
+          #   kind/security, kind/hardening  an unfixed vulnerability does not
+          #                                  stop being one because nobody
+          #                                  commented
+          #   priority/critical, /high       maintainer-set; if we said it
+          #                                  matters, the bot gets no vote
+          #   good first issue, help wanted  parked on purpose, for newcomers;
+          #                                  idleness is the intended state
+          #                                  ("help wanted" does not exist on
+          #                                  this repo today, so it is listed
+          #                                  as forward protection)
+          #   core-team                      our own work; nudge a colleague,
+          #                                  never close their branch
+          #   triage/keep                    the manual freeze, permanent
+          exempt-issue-labels: 'kind/security,kind/hardening,priority/critical,priority/high,good first issue,help wanted,core-team,triage/keep'
+          exempt-pr-labels: 'kind/security,kind/hardening,priority/critical,priority/high,good first issue,help wanted,core-team,triage/keep'
+
+          # Free insurance: no milestones exist today, so this costs nothing
+          # now and protects any release milestone created later. An assignee
+          # means a human took it, which means it is waiting on us.
+          exempt-all-milestones: true
+          exempt-all-assignees: true
+
+          # A draft is a work in progress by definition.
+          exempt-draft-pr: true
+
+          # Lane A alone can never produce a large sweep, so the rate-limit
+          # ceiling is set for headroom rather than for backlog scale.
+          operations-per-run: 100
+
+          stale-pr-message: >-
+            **This PR is waiting on a change from you.** A maintainer asked for something above and
+            we have not heard back, so it is now labelled `stale`. Push a commit, leave a comment,
+            or tell us you need more time. Any of those removes the label automatically. If nothing
+            arrives in 21 days we will close it, so the open queue stays an honest picture of what
+            is moving. A close here is bookkeeping, not a verdict on your work. Thank you for the
+            contribution.
+
+          close-pr-message: >-
+            **Closing this for now.** Nothing came back on the request above, so we are closing to
+            keep the review queue matched to what is actually moving. This is not a rejection and
+            it is not permanent. Reopen this PR whenever you pick it back up, or open a fresh one
+            against current `main`. Either way it gets a first response within 7 days, like any new
+            contribution. Thank you for the work you put into it.
+
+          stale-issue-message: >-
+            **We still need a reproduction before this can move.** We asked above and have not heard
+            back, so this is now labelled `stale`. Add the steps, your NanoClaw version, and the
+            relevant lines from `logs/nanoclaw.error.log`. That removes the label automatically.
+            Without a reproduction we will close in 14 days, because we cannot fix behaviour we
+            cannot see. Reply with the details at any point and we will reopen.
+
+          close-issue-message: >-
+            **Closing this for now, because we could not reproduce it.** That is a limit on what we
+            can see from here, not a judgment on the report. Reply with steps, a version, and logs
+            at any time and we will reopen this issue and pick it up. Thank you for taking the time
+            to file it.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

None of the six categories covers repository automation, so none is checked. This adds one GitHub Actions workflow and touches no product code, no skill, and no docs.

## Description

Adds `.github/workflows/stale.yml`: an inactivity policy that fires on author-blocked items only, shipped in dry-run mode.

### What it looks at

Two populations, and nothing else:

| Population | Trigger label | Marked stale after | Closed after stale |
|---|---|---|---|
| Issues where we asked for a reproduction | `triage/needs-repro` | 21 days | 14 days (35 total) |
| PRs where a maintainer requested changes | `triage/needs-author` | 21 days | 21 days (42 total) |

Both labels mean a human already read the item and asked its author for something. An item waiting on us for review, for triage, or for a decision carries neither label, so the bot never sees it. That is the whole design: a bot may close an item only when the ball is demonstrably in the author's court, and only after it said so out loud and gave a deadline.

`remove-stale-when-updated` is on, so a commit, a comment, or a reply clears the label and restarts the clock. Closes use the `not_planned` reason, which renders as "not planned" rather than "completed". Contributor branches are never deleted (`delete-branch: false`, set explicitly rather than left to the default).

### What it never touches

Exempt by label: `kind/security`, `kind/hardening`, `priority/critical`, `priority/high`, `good first issue`, `help wanted`, `core-team`, `triage/keep`. Exempt by metadata: anything with a milestone, anything with an assignee, and draft PRs.

`triage/keep` is the manual freeze: one label, permanent, no argument with a bot every cycle. `help wanted` does not exist on this repo today and is listed as forward protection if it is ever created.

### Day-1 blast radius: zero items

Measured, not estimated. When this policy was designed neither trigger label was applied to anything in the repo, so a live first run would mark 0 issues and 0 PRs. From here the volume can only grow as fast as triage applies those labels, which is to say never faster than a maintainer reading the item and asking a question first. That property is why this lane is safe to ship before any decision about the existing backlog.

For contrast, the same measurement on a whole-backlog policy at 90 days of inactivity was 301 PRs and 185 issues marked in a single run. This ships none of that.

### Dry run, and the arming date

`debug-only: true`. Until it is flipped the workflow performs no writes at all: no labels, no comments, no closes, no notifications. It logs what it would have done and stops.

**Arming is due 2026-09-12**, two weeks after this lands. The workflow header carries the same date and the pre-arming checklist. Flipping `debug-only` to `false` is the arming step, and before doing it:

1. Read the most recent run log and confirm every listed item is genuinely author-blocked.
2. Create the `stale` label deliberately. It does not exist today, and GitHub would otherwise auto-create it with a default colour on the first armed run, outside the rest of the taxonomy.
3. Confirm `triage/keep` is applied to anything a maintainer wants frozen, so the escape hatch is real on day one rather than after the first complaint.

The two weeks exist so that a mis-scoped label filter is caught by reading a log rather than by several hundred contributors reading a bot comment.

### Notes

- `actions/stale` is pinned to `4391f3da665fdf50b6810c1a66712fb9ba21aa93`, the commit behind release `v11.0.0` (2026-07-28). The `v11` moving tag resolves to the same commit.
- The bot's four messages are in the workflow verbatim. Each one names what we are waiting for, states the deadline as a number, says exactly what removes it, and says that a close is reversible and not a verdict.
- `operations-per-run: 100` is headroom, not backlog scale. This lane cannot produce a large sweep.
- A slower, forward-dated general-inactivity lane was designed alongside this one and is deliberately not included. It is a separate decision and a separate change. A `CONTRIBUTING.md` paragraph explaining the policy to contributors is also deliberately out of scope here and should land before arming.

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [x] A human has reviewed this PR and stands behind every change

