### PR TITLE
ci(labels): report-only template-compliance status with a single fix comment

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -12,14 +12,19 @@ name: Label PR
 # shipped code cannot drift. Edit the function only between the markers.
 on:
   pull_request_target:
-    types: [opened, edited, reopened, ready_for_review]
+    # `synchronize` is for the template-compliance status only (a commit
+    # status is per-SHA, so every push needs a fresh one). Label mutations
+    # stay gated off synchronize in the driver below, preserving the
+    # labels-only-on-body-events behavior.
+    types: [opened, edited, reopened, ready_for_review, synchronize]
 
 jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: write # createLabel — auto-provisions the core-team label (v1-era behavior, kept until Decision 4)
+      issues: write # createLabel (core-team, until Decision 4) + list/create the single compliance comment
+      statuses: write # report-only template-compliance commit status
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -177,15 +182,90 @@ jobs:
 
               return { add, remove, coreTeam };
             }
+
+            // Report-only template compliance (CI-04: the classification
+            // check runs and reports long before it is ever required).
+            //   - v2-marker body with a kind classification (parser verdict,
+            //     title fallback, or an already-applied managed kind) →
+            //     'success'.
+            //   - v2-marker body with no classification at all → 'failure':
+            //     a red X on the commit status, deliberately NOT in the
+            //     required-checks list, so the PR stays mergeable and nothing
+            //     is ever auto-closed.
+            //   - v1 / no-marker bodies → null: untouched, no status at all.
+            function decideCompliance({ body, add, currentLabels }) {
+              if (!(body || '').includes('<!-- nanoclaw-pr-template:v2 -->')) return { state: null };
+              const MANAGED_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
+              const classified =
+                add.some((l) => MANAGED_KINDS.includes(l)) ||
+                (currentLabels || []).some((l) => MANAGED_KINDS.includes(l));
+              return { state: classified ? 'success' : 'failure' };
+            }
+
+            // One fix-instructions comment per PR, ever — not one per push.
+            // The hidden marker identifies our comment; a marker hit from any
+            // earlier run suppresses a new one.
+            const COMPLIANCE_COMMENT_MARKER = '<!-- nanoclaw-template-compliance -->';
+            function shouldPostComplianceComment(state, existingCommentBodies) {
+              if (state !== 'failure') return false;
+              return !(existingCommentBodies || []).some((b) => (b || '').includes(COMPLIANCE_COMMENT_MARKER));
+            }
             // NANOCLAW-LABEL-LOGIC-END
 
             const pr = context.payload.pull_request;
+            const currentLabels = (pr.labels || []).map((l) => l.name);
             const { add, remove, coreTeam } = computeLabels({
               body: pr.body,
               title: pr.title,
               author: pr.user.login,
-              currentLabels: (pr.labels || []).map((l) => l.name),
+              currentLabels,
             });
+
+            // ── Report-only template-compliance status (every event) ──
+            const compliance = decideCompliance({ body: pr.body, add, currentLabels });
+            if (compliance.state !== null) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state: compliance.state,
+                context: 'template-compliance',
+                description:
+                  compliance.state === 'success'
+                    ? 'PR carries a kind classification'
+                    : 'No kind classification — check one kind/* box (report-only, does not block merge)',
+              });
+              if (compliance.state === 'failure') {
+                const existing = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  per_page: 100,
+                });
+                if (shouldPostComplianceComment(compliance.state, existing.data.map((c) => c.body))) {
+                  // Static text only — never interpolate PR-controlled content
+                  // into a comment posted with write permissions.
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: [
+                      COMPLIANCE_COMMENT_MARKER,
+                      'This PR uses the v2 template but has no kind classification, so the report-only `template-compliance` status is red. It does not block merging.',
+                      '',
+                      'To fix, either:',
+                      '- check exactly one box in the **Change kind** section (`kind/bug`, `kind/feature`, `kind/documentation`, `kind/cleanup`, or `kind/hardening`), or',
+                      '- give the PR a conventional-commit title (`fix:`, `feat:`, `docs:`, `refactor:`, `chore:`, `ci:`, `test:`, `build:`, `style:`, `perf:`) and edit the description to re-trigger labeling.',
+                      '',
+                      'A maintainer can also apply a `kind/*` label directly at triage.',
+                    ].join('\n'),
+                  });
+                }
+              }
+            }
+
+            // ── Label mutations: body events only, never on synchronize ──
+            if (context.payload.action === 'synchronize') return;
 
             if (coreTeam) {
               try {

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -18,6 +18,14 @@ on:
     # labels-only-on-body-events behavior.
     types: [opened, edited, reopened, ready_for_review, synchronize]
 
+# Serialize runs per PR. Two events landing together (a push and a body edit)
+# would otherwise race on the check-then-act that posts the single fix comment,
+# and both runs could see no comment and post one. Queue rather than cancel:
+# a cancelled run leaves the commit status for its SHA unwritten.
+concurrency:
+  group: label-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -87,6 +95,12 @@ jobs:
               return out.join('\n');
             }
 
+            // The managed kind vocabulary, shared by the two functions that
+            // must agree on it: computeLabels emits from this set, and
+            // decideCompliance reads it to decide whether a PR is classified.
+            // One declaration, so the two can never drift apart.
+            const MANAGED_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
+
             function computeLabels({ body, title, author, currentLabels }) {
               body = body || '';
               title = title || '';
@@ -94,7 +108,6 @@ jobs:
               const add = [];
               const remove = [];
 
-              const MANAGED_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
               // Legacy vocabulary kept in lockstep until Decision 4. Hardening
               // has no PR:* equivalent, so none is emitted rather than
               // guessing one.
@@ -195,7 +208,6 @@ jobs:
             //   - v1 / no-marker bodies → null: untouched, no status at all.
             function decideCompliance({ body, add, currentLabels }) {
               if (!(body || '').includes('<!-- nanoclaw-pr-template:v2 -->')) return { state: null };
-              const MANAGED_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
               const classified =
                 add.some((l) => MANAGED_KINDS.includes(l)) ||
                 (currentLabels || []).some((l) => MANAGED_KINDS.includes(l));
@@ -236,13 +248,17 @@ jobs:
                     : 'No kind classification — check one kind/* box (report-only, does not block merge)',
               });
               if (compliance.state === 'failure') {
-                const existing = await github.rest.issues.listComments({
+                // Paginate: the 'one comment ever' guarantee is a check-then-act
+                // over the whole comment list, so reading only the first page
+                // would re-post on any PR whose discussion has outgrown it.
+                // github.paginate returns the flat array, not a { data } envelope.
+                const existing = await github.paginate(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
                   per_page: 100,
                 });
-                if (shouldPostComplianceComment(compliance.state, existing.data.map((c) => c.body))) {
+                if (shouldPostComplianceComment(compliance.state, existing.map((c) => c.body))) {
                   // Static text only — never interpolate PR-controlled content
                   // into a comment posted with write permissions.
                   await github.rest.issues.createComment({
@@ -257,7 +273,7 @@ jobs:
                       '- check exactly one box in the **Change kind** section (`kind/bug`, `kind/feature`, `kind/documentation`, `kind/cleanup`, or `kind/hardening`), or',
                       '- give the PR a conventional-commit title (`fix:`, `feat:`, `docs:`, `refactor:`, `chore:`, `ci:`, `test:`, `build:`, `style:`, `perf:`) and edit the description to re-trigger labeling.',
                       '',
-                      'A maintainer can also apply a `kind/*` label directly at triage.',
+                      'A maintainer can also apply a `kind/*` label directly. Applying the label does not clear this status on its own: the status is recalculated on the next push or description edit.',
                     ].join('\n'),
                   });
                 }

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -68,13 +68,20 @@ function complianceFor(body: string, title: string, currentLabels: string[] = []
   return decideCompliance({ body, add, currentLabels });
 }
 
+/** Raw workflow text, for fixtures that couple prose promises to parser behavior. */
+function workflowText(): string {
+  return fs.readFileSync(path.join(__dirname, '..', '.github', 'workflows', 'label-pr.yml'), 'utf8');
+}
+
 const V2 = '<!-- nanoclaw-pr-template:v2 -->\n';
+/** The kind boxes the PR template offers, i.e. every kind a verdict can name. */
+const TEMPLATE_KINDS = ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening'];
 // Blank template: no kind box, neither skill box. `skill: true` checks the
 // Skill box; `notSkill: true` checks the "Not a skill" box.
 const v2Body = (kinds: string[], opts: { skill?: boolean; notSkill?: boolean } = {}) =>
   V2 +
   '## Change kind\n' +
-  ['kind/bug', 'kind/feature', 'kind/documentation', 'kind/cleanup', 'kind/hardening']
+  TEMPLATE_KINDS
     .map((k) => `- [${kinds.includes(k) ? 'x' : ' '}] \`${k}\``)
     .join('\n') +
   '\n## Skill delivery\n' +
@@ -343,6 +350,41 @@ describe('template-compliance (report-only)', () => {
     // Green states never comment.
     expect(shouldPostComplianceComment('success', [])).toBe(false);
     expect(shouldPostComplianceComment(null, [])).toBe(false);
+  });
+
+  it('decideCompliance recognizes every kind computeLabels can emit', () => {
+    // computeLabels and decideCompliance share one MANAGED_KINDS declaration.
+    // This pins the property that declaration exists to protect: a kind the
+    // parser can emit must also count as a classification, so an honestly
+    // filled-in template can never leave the status red.
+    for (const kind of TEMPLATE_KINDS) {
+      const res = computeLabels({ body: v2Body([kind]), title: 'Update stuff', author: FORK_AUTHOR });
+      expect(res.add).toContain(kind);
+      expect(complianceFor(v2Body([kind]), 'Update stuff').state).toBe('success');
+      // Same kind arriving as maintainer triage rather than a checkbox.
+      expect(complianceFor(v2Body([]), 'Update stuff', [kind]).state).toBe('success');
+    }
+  });
+
+  it('every conventional-commit prefix the fix comment promises actually maps to a kind', () => {
+    // The comment tells contributors a conventional-commit title will classify
+    // the PR, and names the prefixes. Read them back out of that sentence so
+    // the promise cannot drift away from what the parser accepts.
+    const line = workflowText()
+      .split('\n')
+      .find((l) => l.includes('give the PR a conventional-commit title'));
+    expect(line, 'fix-comment prefix sentence not found in label-pr.yml').toBeDefined();
+    const promised = [...(line as string).matchAll(/`([a-z]+):`/g)].map((m) => m[1]);
+    expect(promised).toEqual(['fix', 'feat', 'docs', 'refactor', 'chore', 'ci', 'test', 'build', 'style', 'perf']);
+    for (const prefix of promised) {
+      const res = computeLabels({
+        body: v2Body([]),
+        title: `${prefix}: something`,
+        author: FORK_AUTHOR,
+        currentLabels: [],
+      });
+      expect(res.add.filter((l) => l.startsWith('kind/')), `prefix ${prefix}: promised a kind, got none`).toHaveLength(1);
+    }
   });
 });
 

--- a/scripts/label-pr-workflow.test.ts
+++ b/scripts/label-pr-workflow.test.ts
@@ -24,7 +24,21 @@ type ComputeLabels = (args: {
   currentLabels?: string[];
 }) => LabelDecision;
 
-function extractComputeLabels(): ComputeLabels {
+type DecideCompliance = (args: {
+  body?: string | null;
+  add: string[];
+  currentLabels?: string[];
+}) => { state: 'success' | 'failure' | null };
+
+type ShouldPostComplianceComment = (state: string | null, existingCommentBodies: Array<string | null>) => boolean;
+
+interface ExtractedLogic {
+  computeLabels: ComputeLabels;
+  decideCompliance: DecideCompliance;
+  shouldPostComplianceComment: ShouldPostComplianceComment;
+}
+
+function extractLogic(): ExtractedLogic {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'label-pr.yml'),
     'utf8',
@@ -41,10 +55,18 @@ function extractComputeLabels(): ComputeLabels {
     .slice(1) // drop the START marker line itself
     .map((line) => line.replace(/^ {12}/, ''))
     .join('\n');
-  return new Function(`${code}\nreturn computeLabels;`)() as ComputeLabels;
+  return new Function(
+    `${code}\nreturn { computeLabels, decideCompliance, shouldPostComplianceComment };`,
+  )() as ExtractedLogic;
 }
 
-const computeLabels = extractComputeLabels();
+const { computeLabels, decideCompliance, shouldPostComplianceComment } = extractLogic();
+
+/** Full pipeline as the driver runs it: parse, then judge compliance. */
+function complianceFor(body: string, title: string, currentLabels: string[] = []) {
+  const { add } = computeLabels({ body, title, author: 'drive-by-contributor', currentLabels });
+  return decideCompliance({ body, add, currentLabels });
+}
 
 const V2 = '<!-- nanoclaw-pr-template:v2 -->\n';
 // Blank template: no kind box, neither skill box. `skill: true` checks the
@@ -290,6 +312,37 @@ describe('v1 bodies (frozen pre-v2 behavior)', () => {
     const res = computeLabels({ body: null, title: null, author: FORK_AUTHOR });
     expect(res.add).toEqual([]);
     expect(res.remove).toEqual([]);
+  });
+});
+
+describe('template-compliance (report-only)', () => {
+  it('v2 body with zero kind verdict: failing status', () => {
+    expect(complianceFor(v2Body([]), 'Update stuff').state).toBe('failure');
+  });
+
+  it('good bodies are green: checkbox verdict, title fallback, or an already-applied kind', () => {
+    expect(complianceFor(v2Body(['kind/bug']), 'x').state).toBe('success');
+    expect(complianceFor(v2Body([]), 'fix: something').state).toBe('success');
+    // Maintainer classified at triage; blank body must NOT go red.
+    expect(complianceFor(v2Body([]), 'Update stuff', ['kind/cleanup']).state).toBe('success');
+  });
+
+  it('v1 and no-marker bodies are untouched: no status at all', () => {
+    expect(complianceFor('<!-- contributing-guide: v1 -->\n- [x] **Fix** - bug fix', 'x').state).toBeNull();
+    expect(complianceFor('just a hand-written body', 'fix: x').state).toBeNull();
+  });
+
+  it('the fix comment posts once, ever — idempotent across pushes', () => {
+    // First failing push: no comments yet -> post.
+    expect(shouldPostComplianceComment('failure', [])).toBe(true);
+    // Later pushes: our marker comment exists -> never repeat.
+    const marked = ['<!-- nanoclaw-template-compliance -->\nThis PR uses the v2 template…'];
+    expect(shouldPostComplianceComment('failure', marked)).toBe(false);
+    // Unrelated comments do not suppress it.
+    expect(shouldPostComplianceComment('failure', ['LGTM', null])).toBe(true);
+    // Green states never comment.
+    expect(shouldPostComplianceComment('success', [])).toBe(false);
+    expect(shouldPostComplianceComment(null, [])).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

CI-04's classification check in its run-and-report phase — a report-only `template-compliance` commit status:

- **Red X (failure)**: v2-marker body with no `kind/*` classification at all — no checkbox verdict, no conventional-title fallback, no maintainer-applied kind
- **Never blocks**: the context is deliberately NOT in the required-checks list; the PR stays mergeable and nothing is ever auto-closed
- **Green (success)**: classified v2 body
- **No status at all**: v1 and no-marker bodies — completely untouched
- **One comment per PR, ever**: a failure posts fix instructions once; a hidden marker suppresses repeats across pushes. Comment text is static — nothing PR-controlled is interpolated into content posted with write permissions

## Related work

Closes no issue — top layer of stacked PRs #3647 → #3648 → #3657: the report-only enforcement step of the intake plan's label-workflow acceptance criteria.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [x] `kind/hardening`

## Validation

`GIT_CONFIG_GLOBAL=/dev/null NODE_OPTIONS=--disable-warning=DEP0205 npx vitest run scripts/label-pr-workflow.test.ts` — **29/29** (was 25). The compliance functions live inside the `NANOCLAW-LABEL-LOGIC` markers, so the fixtures extract and evaluate the exact shipped code:

- zero-verdict → failure status
- checkbox / title-fallback / maintainer-applied kind → success
- v1 and no-marker → no status
- comment idempotency: first failure posts, marker suppresses repeats, unrelated comments don't suppress, success/null never post

Note: as `pull_request_target` this never executes on its own PR — first live run happens on the first PR after merge.

## Security and trust boundaries

- Adds `statuses: write` (for `createCommitStatus`)
- `issues: write` (already declared for `createLabel`) also covers `listComments`/`createComment`
- Still metadata-only: no checkout of PR code; the single bot comment is static text

## AI assistance

- [x] AI tools or agents helped produce this change
- [x] A human has reviewed this PR and stands behind every change

