### PR TITLE
fix(env): read quoted .env values the same way everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **Quoted `.env` values now read the same everywhere.** Setup had its own `.env` parser that did not strip surrounding quotes, so a hand-edited `TZ="America/New_York"` or `NANOCLAW_TEMPLATE_PATH="/opt/my templates"` reached the wizard with the quotes still attached — the template path was then bridged into `process.env` unusable. Both readers now share the host parser (`envValue` in `src/env.ts`, the single-key form of `readEnvFile`).
+
 - [BREAKING] **Agents now receive their capability instructions.** `CLAUDE.md` was a list of `@` imports into `/app`; Claude Code silently drops imports resolving outside the project directory, so eight of nine instruction sections never reached the model. It is now one flat file with every source inlined, shared with the Codex provider. Customized source breaks on two surfaces: `src/claude-md-compose.ts` is now `src/project-doc-compose.ts` with `composeGroupClaudeMd(group)` becoming `composeGroupProjectDoc(group, groupDir, spec)`, and the `/app/CLAUDE.md` and `/workspace/agent/.claude-fragments` mounts are gone. **Migration:** `grep -rn "claude-md-compose\|composeGroupClaudeMd\|claude-fragments" src/ setup/ scripts/` — no hits means nothing to do; otherwise repoint the import and pass `DEFAULT_PROJECT_DOC` as the third argument. Then clear the leftovers once: `rm -rf groups/*/.claude-fragments groups/*/.claude-shared.md` — they are inert (nothing reads them) but sit in the agent's working directory.
 
 ## [2.3.0] - 2026-08-24

--- a/setup/environment.test.ts
+++ b/setup/environment.test.ts
@@ -137,3 +137,38 @@ describe('channel auth detection', () => {
     expect(hasAuth('/tmp/nonexistent_auth_dir_xyz')).toBe(false);
   });
 });
+
+describe('readEnvKey', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-envkey-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const write = (content: string) => fs.writeFileSync(path.join(tempDir, '.env'), content);
+
+  // The regression: this reader had its own parser, which did not strip quotes.
+  // A hand-edited `TZ="America/New_York"` came back with the quotes attached,
+  // and a quoted NANOCLAW_TEMPLATE_PATH was bridged into process.env unusable.
+  it('returns quoted values unquoted, matching the host reader', async () => {
+    const { readEnvKey } = await import('./environment.js');
+    const { envValue } = await import('../src/env.js');
+    write('TZ="America/New_York"\nNANOCLAW_TEMPLATE_PATH="/opt/my templates"\n');
+    expect(readEnvKey('TZ', tempDir)).toBe('America/New_York');
+    expect(readEnvKey('NANOCLAW_TEMPLATE_PATH', tempDir)).toBe('/opt/my templates');
+    expect(readEnvKey('TZ', tempDir)).toBe(envValue('TZ', tempDir));
+  });
+
+  it('returns null for a missing key, an empty value, and a missing file', async () => {
+    const { readEnvKey } = await import('./environment.js');
+    write('SET=value\nEMPTY=\n');
+    expect(readEnvKey('SET', tempDir)).toBe('value');
+    expect(readEnvKey('ABSENT', tempDir)).toBeNull();
+    expect(readEnvKey('EMPTY', tempDir)).toBeNull();
+    expect(readEnvKey('SET', path.join(tempDir, 'nowhere'))).toBeNull();
+  });
+});

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -5,6 +5,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { envValue } from '../src/env.js';
 import { log } from '../src/log.js';
 import { inspectCentralDb } from './central-db-inspection.js';
 import { commandExists, getPlatform, isHeadless, isWSL } from './platform.js';
@@ -12,26 +13,13 @@ import { emitStatus } from './status.js';
 
 /**
  * Read a single key from `.env` on disk (not process.env).
- * Returns the trimmed value or null if the key isn't set / file doesn't exist.
+ * Returns the value or null if the key isn't set / file doesn't exist.
+ *
+ * Delegates to the host's parser so both readers agree — notably on quoted
+ * values, which this one used to return with the quotes still attached.
  */
 export function readEnvKey(key: string, projectRoot?: string): string | null {
-  const envPath = path.join(projectRoot ?? process.cwd(), '.env');
-  let content: string;
-  try {
-    content = fs.readFileSync(envPath, 'utf-8');
-  } catch {
-    return null;
-  }
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq < 1) continue;
-    if (trimmed.slice(0, eq) === key) {
-      return trimmed.slice(eq + 1).trim() || null;
-    }
-  }
-  return null;
+  return envValue(key, projectRoot) ?? null;
 }
 
 /**

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { envValue, readEnvFile } from './env.js';
+
+/**
+ * `envValue` is the single-key form of `readEnvFile` — same file, same parser,
+ * same rules. These pin that equivalence, because the reason it exists is that
+ * a second hand-rolled parser drifted from this one on quoted values.
+ */
+describe('envValue', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const write = (content: string): void => fs.writeFileSync(path.join(root, '.env'), content);
+
+  it('strips surrounding quotes, exactly as readEnvFile does', () => {
+    write('TZ="America/New_York"\nPLAIN=bare\nSINGLE=\'quoted\'\n');
+    expect(envValue('TZ', root)).toBe('America/New_York');
+    expect(envValue('PLAIN', root)).toBe('bare');
+    expect(envValue('SINGLE', root)).toBe('quoted');
+    for (const key of ['TZ', 'PLAIN', 'SINGLE']) {
+      expect(envValue(key, root)).toBe(readEnvFile([key], root)[key]);
+    }
+  });
+
+  it('preserves a quoted value that contains spaces', () => {
+    write('TEMPLATE_PATH="/opt/my templates"\n');
+    expect(envValue('TEMPLATE_PATH', root)).toBe('/opt/my templates');
+  });
+
+  it('returns undefined for a missing key, an empty value, and a missing file', () => {
+    write('SET=value\nEMPTY=\n# COMMENT=no\n');
+    expect(envValue('ABSENT', root)).toBeUndefined();
+    expect(envValue('EMPTY', root)).toBeUndefined();
+    expect(envValue('COMMENT', root)).toBeUndefined();
+    expect(envValue('SET', path.join(root, 'nowhere'))).toBeUndefined();
+  });
+
+  it('keeps = inside the value', () => {
+    write('TOKEN=abc=def==\n');
+    expect(envValue('TOKEN', root)).toBe('abc=def==');
+  });
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,9 +7,12 @@ import { log } from './log.js';
  * Does NOT load anything into process.env — callers decide what to
  * do with the values. This keeps secrets out of the process environment
  * so they don't leak to child processes.
+ *
+ * `projectRoot` defaults to the current working directory; pass it when
+ * reading a .env that is not the running process's own.
  */
-export function readEnvFile(keys: string[]): Record<string, string> {
-  const envFile = path.join(process.cwd(), '.env');
+export function readEnvFile(keys: string[], projectRoot?: string): Record<string, string> {
+  const envFile = path.join(projectRoot ?? process.cwd(), '.env');
   let content: string;
   try {
     content = fs.readFileSync(envFile, 'utf-8');
@@ -39,4 +42,15 @@ export function readEnvFile(keys: string[]): Record<string, string> {
   }
 
   return result;
+}
+
+/**
+ * Read one key from the .env file. Same parser, same rules as `readEnvFile` —
+ * this is the single-key form of it, so a caller wanting one value does not
+ * hand-roll `readEnvFile([KEY])[KEY]` and does not grow a second parser.
+ *
+ * Returns undefined when the file, the key, or the value is absent.
+ */
+export function envValue(key: string, projectRoot?: string): string | undefined {
+  return readEnvFile([key], projectRoot)[key];
 }


### PR DESCRIPTION
## The bug

There are two `.env` parsers. `src/env.ts:readEnvFile` strips surrounding quotes; `setup/environment.ts:readEnvKey` had its own loop and did not. The same file read two different ways depending on which reader saw it:

| `.env` line | `readEnvFile` | `readEnvKey` |
|---|---|---|
| `TZ="America/New_York"` | `America/New_York` | `"America/New_York"` |
| `NANOCLAW_TEMPLATE_PATH="/opt/my templates"` | `/opt/my templates` | `"/opt/my templates"` |

Quoting a value in `.env` is ordinary, and the two keys above are ones people hand-edit.

The visible symptom is the template path. `setup/auto.ts` reads it with `readEnvKey` and bridges it into `process.env.NANOCLAW_TEMPLATE_PATH` so the pick survives a full process restart — the comment there says exactly that. A path quoted *because it contains a space* is bridged with the quotes attached, so the restart it exists to survive silently loses the pick anyway. `readEnvKey('TZ')` feeds the template install the same way.

`upsertEnvKey` writes unquoted, so values NanoClaw wrote itself are unaffected. This only bites hand-edited files.

## The fix

Give `src/env.ts` the single-key form it was missing and implement setup's reader on top of it:

```ts
export function envValue(key: string, projectRoot?: string): string | undefined {
  return readEnvFile([key], projectRoot)[key];
}
```

```ts
export function readEnvKey(key: string, projectRoot?: string): string | null {
  return envValue(key, projectRoot) ?? null;
}
```

`readEnvFile` gains an optional `projectRoot` (it was hardcoded to `process.cwd()`; setup's reader already took one). One parser, one set of rules, ~20 lines of duplicate parsing deleted.

`readEnvKey`'s contract is otherwise unchanged: still `.env` only — never `process.env` — still `string | null`, still null for an absent key, an empty value, or a missing file.

## Why `envValue` and not just inlining it

Eleven sites already hand-roll the single-key read as `readEnvFile([KEY])[KEY]` — in `src/drivers/index.ts`, `src/gateway-providers/index.ts`, `src/providers/claude.ts`, `setup/registry-login.ts`, `setup/lib/registry-state.ts` (×3), `setup/migrate-v2/{db,tasks}.ts`, `setup/channels/telegram-pre-step.ts`. Reading one key was awkward enough that a second parser got written instead. Now there is somewhere to land. Collapsing those call sites is a separate cleanup, not in this PR.

## Tests

- `src/env.test.ts` (new) — `envValue`: quote stripping (double and single), a quoted value containing a space, `=` inside the value, and undefined for absent key / empty value / missing file. Each asserts equivalence with `readEnvFile` on the same key.
- `setup/environment.test.ts` — `readEnvKey` returns quoted values unquoted and agrees with `envValue`; nulls unchanged.

**The regression test goes red on the old parser** — verified by reverting `readEnvKey` and re-running:

```
× returns quoted values unquoted, matching the host reader
  AssertionError: expected '"America/New_York"' to be 'America/New_York'
```

## Checks

`tsc --noEmit` clean · `prettier --check` clean · `eslint src/` unchanged (0 errors) · full suite **183 files, 2156 tests, all passing**.