### PR TITLE
fix(container): retry the Bun install instead of failing the image build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **The agent image build retries the Bun install.** The pinned Bun runtime is fetched from a release asset during `container/build.sh`; one transient network failure there aborted the whole image build. It is now attempted up to three times from a clean slate, with the same pinned version and the same result — and still fails the build if all three fail.
+
 - [BREAKING] **Agents now receive their capability instructions.** `CLAUDE.md` was a list of `@` imports into `/app`; Claude Code silently drops imports resolving outside the project directory, so eight of nine instruction sections never reached the model. It is now one flat file with every source inlined, shared with the Codex provider. Customized source breaks on two surfaces: `src/claude-md-compose.ts` is now `src/project-doc-compose.ts` with `composeGroupClaudeMd(group)` becoming `composeGroupProjectDoc(group, groupDir, spec)`, and the `/app/CLAUDE.md` and `/workspace/agent/.claude-fragments` mounts are gone. **Migration:** `grep -rn "claude-md-compose\|composeGroupClaudeMd\|claude-fragments" src/ setup/ scripts/` — no hits means nothing to do; otherwise repoint the import and pass `DEFAULT_PROJECT_DOC` as the third argument. Then clear the leftovers once: `rm -rf groups/*/.claude-fragments groups/*/.claude-shared.md` — they are inert (nothing reads them) but sit in the agent's working directory.
 
 ## [2.3.0] - 2026-08-24

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -65,9 +65,32 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 # ---- Bun runtime -------------------------------------------------------------
 # Install via the official script (handles multi-arch detection), then move
 # the binary to /usr/local/bin so the non-root `node` user can execute it.
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
-    install -m 0755 /root/.bun/bin/bun /usr/local/bin/bun && \
-    rm -rf /root/.bun
+#
+# Retried up to three times: the installer fetches a release asset over the
+# network, and a single transient failure there otherwise aborts the whole
+# image build. Each attempt starts from a clean slate so a half-written tree
+# from a failed download can never be the thing that gets installed, and
+# exhaustion still fails the build.
+RUN set -eu; \
+    attempt=1; \
+    while [ "$attempt" -le 3 ]; do \
+      rm -rf /root/.bun /tmp/bun-install.sh; \
+      if curl -fsSL --connect-timeout 10 --max-time 120 \
+           -o /tmp/bun-install.sh https://bun.sh/install && \
+         bash /tmp/bun-install.sh "bun-v${BUN_VERSION}"; then \
+        break; \
+      fi; \
+      if [ "$attempt" -eq 3 ]; then \
+        echo "Bun ${BUN_VERSION} install failed after 3 attempts" >&2; \
+        exit 1; \
+      fi; \
+      echo "Bun ${BUN_VERSION} install failed; retrying (attempt ${attempt})" >&2; \
+      sleep $((attempt * 2)); \
+      attempt=$((attempt + 1)); \
+    done; \
+    test -x /root/.bun/bin/bun; \
+    install -m 0755 /root/.bun/bin/bun /usr/local/bin/bun; \
+    rm -rf /root/.bun /tmp/bun-install.sh
 
 # ---- agent-runner deps -------------------------------------------------------
 # Deps are cached independently of CLI versions. Source is NOT baked in —


### PR DESCRIPTION
## The problem

`container/Dockerfile` installs the pinned Bun runtime by piping the official installer into bash:

```dockerfile
RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
    install -m 0755 /root/.bun/bin/bun /usr/local/bin/bun && \
    rm -rf /root/.bun
```

That fetches a GitHub release asset over the network. One transient failure — a 5xx from the CDN, a dropped connection, a slow mirror — aborts the entire agent image build. It is the only network fetch in the Dockerfile with no retry, and it is not a step whose failure means anything is actually wrong.

## The change

Attempt it up to three times. Same pinned `BUN_VERSION`, same installer, same destination, same final binary — only the number of chances changes.

Two details that matter:

- **Each attempt starts clean.** `rm -rf /root/.bun /tmp/bun-install.sh` before every try, so a half-written tree from a failed download can never be what gets installed. A retry that inherits partial state is worse than no retry.
- **`curl` writes to a file instead of piping.** That is what makes the clean-slate retry possible, and it also means a truncated download fails at `curl` rather than being handed to `bash` and executed. Bounded `--connect-timeout` / `--max-time` stop a hung fetch from stalling the build indefinitely.

Exhaustion still fails the build closed — three failures print the version that could not be installed and `exit 1`. `test -x` before `install` keeps the success path from proceeding on a missing binary.

## Verification

The loop was exercised with a stubbed `curl` at each arm:

| scenario | curl calls | exit |
|---|---|---|
| succeeds first try | 1 | 0 |
| fails twice, then succeeds | 3 | 0 |
| fails all three | 3 | 1 |

Failure output on exhaustion:

```
Bun 1.2.3 install failed; retrying (attempt 1)
Bun 1.2.3 install failed; retrying (attempt 2)
Bun 1.2.3 install failed after 3 attempts
```

Dockerfile-only change; no source, no tests affected.