### PR TITLE
fix(task-script): say a pre-task script timed out instead of "Command failed"

### DIFF
--- a/container/agent-runner/src/scheduling/task-script.test.ts
+++ b/container/agent-runner/src/scheduling/task-script.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
 import { getPendingMessages, markScriptSkipped } from '../db/messages-in.js';
-import { applyPreTaskScripts } from './task-script.js';
+import { applyPreTaskScripts, runScript } from './task-script.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -35,8 +35,11 @@ function insertTask(id: string, script: string) {
 }
 
 const ackStatus = (id: string): string | undefined =>
-  (getOutboundDb().prepare('SELECT status FROM processing_ack WHERE message_id = ?').get(id) as { status: string } | undefined)
-    ?.status;
+  (
+    getOutboundDb().prepare('SELECT status FROM processing_ack WHERE message_id = ?').get(id) as
+      | { status: string }
+      | undefined
+  )?.status;
 
 describe('script-skip ack chain (container leg)', () => {
   it('an erroring script skips with reason "error" and acks script-skip:error', async () => {
@@ -68,5 +71,47 @@ describe('script-skip ack chain (container leg)', () => {
     expect(skipped).toHaveLength(0);
     expect(keep).toHaveLength(1);
     expect(JSON.parse(keep[0].content).scriptOutput).toEqual({ alerts: 2 });
+  });
+});
+
+describe('a timed-out script is reported as a timeout', () => {
+  /**
+   * execFile kills on timeout, so the callback receives a generic
+   * "Command failed" — the same shape a script that exited non-zero produces.
+   * `killed` is the only thing that tells them apart. Without it the log said
+   * `error: Command failed: bash /tmp/task-script-<id>.sh` for a script that
+   * ran too long, which reads as a broken script and sends whoever is
+   * debugging it looking for a bug that isn't there.
+   */
+  const captureLogs = async (fn: () => Promise<unknown>): Promise<string[]> => {
+    const lines: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => void lines.push(args.map(String).join(' '));
+    try {
+      await fn();
+    } finally {
+      console.error = original;
+    }
+    return lines;
+  };
+
+  it('names the timeout and the ceiling it hit, not a generic command failure', async () => {
+    const lines = await captureLogs(() => runScript('sleep 5', 't-timeout', 150));
+    const joined = lines.join('\n');
+    expect(joined).toContain('[t-timeout] timed out after 150ms');
+    expect(joined).not.toContain('error: Command failed');
+  });
+
+  it('still resolves null, so the task is skipped exactly as before', async () => {
+    await captureLogs(async () => {
+      expect(await runScript('sleep 5', 't-timeout-null', 150)).toBeNull();
+    });
+  });
+
+  it('leaves a genuine non-zero exit reported as an error', async () => {
+    const lines = await captureLogs(() => runScript('exit 3', 't-exit', 5000));
+    const joined = lines.join('\n');
+    expect(joined).toContain('error: Command failed');
+    expect(joined).not.toContain('timed out');
   });
 });

--- a/container/agent-runner/src/scheduling/task-script.ts
+++ b/container/agent-runner/src/scheduling/task-script.ts
@@ -16,7 +16,11 @@ function log(msg: string): void {
   console.error(`[task-script] ${msg}`);
 }
 
-export async function runScript(script: string, taskId: string): Promise<ScriptResult | null> {
+export async function runScript(
+  script: string,
+  taskId: string,
+  timeoutMs: number = SCRIPT_TIMEOUT_MS,
+): Promise<ScriptResult | null> {
   const scriptPath = path.join('/tmp', `task-script-${taskId}.sh`);
   fs.writeFileSync(scriptPath, script, { mode: 0o755 });
 
@@ -24,7 +28,7 @@ export async function runScript(script: string, taskId: string): Promise<ScriptR
     execFile(
       'bash',
       [scriptPath],
-      { timeout: SCRIPT_TIMEOUT_MS, maxBuffer: SCRIPT_MAX_BUFFER, env: process.env },
+      { timeout: timeoutMs, maxBuffer: SCRIPT_MAX_BUFFER, env: process.env },
       (error, stdout, stderr) => {
         try {
           fs.unlinkSync(scriptPath);
@@ -37,7 +41,15 @@ export async function runScript(script: string, taskId: string): Promise<ScriptR
         }
 
         if (error) {
-          log(`[${taskId}] error: ${error.message}`);
+          // execFile kills on timeout, so a script that ran too long arrives
+          // here as a generic "Command failed" — indistinguishable from one
+          // that exited non-zero on its first line. `killed` is what separates
+          // them; say which happened, and name the ceiling that was hit.
+          if ((error as { killed?: boolean }).killed) {
+            log(`[${taskId}] timed out after ${timeoutMs}ms and was killed; output discarded`);
+          } else {
+            log(`[${taskId}] error: ${error.message}`);
+          }
           return resolve(null);
         }
 
@@ -112,7 +124,7 @@ export async function applyPreTaskScripts(messages: MessageInRow[]): Promise<Tas
 
     if (!result || !result.wakeAgent) {
       const reason: ScriptSkipReason = result ? 'gated' : 'error';
-      log(`task ${msg.id} skipped: ${reason === 'gated' ? 'wakeAgent=false' : 'script error/no output'}`);
+      log(`task ${msg.id} skipped: ${reason === 'gated' ? 'wakeAgent=false' : 'script error, timeout, or no output'}`);
       skipped.push({ id: msg.id, reason });
       continue;
     }


### PR DESCRIPTION
## The problem

`runScript` runs a pre-task script under `execFile` with `timeout: SCRIPT_TIMEOUT_MS` (30s). When that fires, Node kills the process and hands the callback an error — with the same shape as a script that simply exited non-zero. Both fell through the same branch:

```ts
if (error) {
  log(`[${taskId}] error: ${error.message}`);
  return resolve(null);
}
```

So a script that ran a little too long logged:

```
[task-script] [t-42] error: Command failed: bash /tmp/task-script-t-42.sh
```

…which reads as a broken script. Whoever debugs it goes looking for a bug in a script that works, and the one fact that would end the search — it was killed at 30 seconds — is the fact that was dropped. `error.killed` distinguishes the two and was never consulted.

The summary line right after had the same problem: it reported `script error/no output` for a case that is neither.

## The change

Consult `killed`, and say which happened:

```
[task-script] [t-42] timed out after 30000ms and was killed; output discarded
```

"output discarded" is worth stating: on a timeout `stdout` is whatever the script managed to emit before the kill, and the script's verdict is the *last* line — so a partial buffer is not a verdict, and the run resolves null exactly as before.

Deliberately unchanged: the skip reason stays `'error'`. A script that never produced a verdict cannot wake the agent whether it crashed or ran long, and the host's consecutive-failure backoff should keep counting it. This is a reporting fix, not a behavior change.

## The test seam

`runScript` gains an optional third argument for the timeout, defaulting to the same `SCRIPT_TIMEOUT_MS`:

```ts
export async function runScript(script: string, taskId: string, timeoutMs: number = SCRIPT_TIMEOUT_MS)
```

That is the whole reason it exists — the timeout arm is otherwise unreachable from a test without a 30-second wait. No caller passes it, and the default is the constant, so nothing changes at runtime.

## Tests

Three cases in `task-script.test.ts`: a timeout names the timeout and the ceiling and does *not* log a generic command failure; it still resolves null so the task is skipped exactly as before; and a genuine `exit 3` is still reported as an error and never as a timeout.

**Verified red against the old code** — reverting the source and re-running:

```
98 |     expect(joined).toContain('[t-timeout] timed out after 150ms');
error: expect(received).toContain(expected)
```

`bun test` in `container/agent-runner`: 6 pass, 0 fail. `tsc --noEmit` clean, `prettier --check` clean.