### PR TITLE
chore: use a neutral placeholder name in examples and fixtures

### DIFF
--- a/scripts/init-cli-agent.ts
+++ b/scripts/init-cli-agent.ts
@@ -15,7 +15,7 @@
  *
  * Usage:
  *   pnpm exec tsx scripts/init-cli-agent.ts \
- *     --display-name "Gavriel" \
+ *     --display-name "Alex" \
  *     [--agent-name "Andy"]
  */
 // Registration-only: makes the in-tree cli adapter's declared defaults

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -22,7 +22,7 @@
  *     --channel discord \
  *     --user-id discord:1470183333427675709 \
  *     --platform-id discord:@me:1491573333382523708 \
- *     --display-name "Gavriel" \
+ *     --display-name "Alex" \
  *     [--agent-name "Andy"] \
  *     [--agent-group-id <id>] \       # wire an agent setup already created
  *     [--welcome "System instruction: ..."] \

--- a/scripts/test-v2-agent.ts
+++ b/scripts/test-v2-agent.ts
@@ -36,7 +36,7 @@ db.exec(`
 db.prepare(`INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES (?, 'chat', ?, 'pending', ?)`).run(
   'test-1',
   new Date().toISOString(),
-  JSON.stringify({ sender: 'Gavriel', text: 'Say "Hello from v2!" and nothing else. Do not use any tools.' }),
+  JSON.stringify({ sender: 'Alex', text: 'Say "Hello from v2!" and nothing else. Do not use any tools.' }),
 );
 console.log('✓ Session DB created with test message');
 db.close();

--- a/scripts/test-v2-channel-e2e.ts
+++ b/scripts/test-v2-channel-e2e.ts
@@ -162,7 +162,7 @@ await routeInbound({
     id: 'msg-chan-1',
     kind: 'chat',
     content: JSON.stringify({
-      sender: 'Gavriel',
+      sender: 'Alex',
       text: 'Call the send_message tool 3 times: text="Update 1", text="Update 2", text="Update 3". Make each call separately. After all 3, say "Done".',
     }),
     timestamp: new Date().toISOString(),

--- a/scripts/test-v2-host.ts
+++ b/scripts/test-v2-host.ts
@@ -81,7 +81,7 @@ await routeInbound({
     id: 'msg-e2e-1',
     kind: 'chat',
     content: JSON.stringify({
-      sender: 'Gavriel',
+      sender: 'Alex',
       text: 'Say "E2E works!" and nothing else. Do not use any tools.',
     }),
     timestamp: new Date().toISOString(),

--- a/src/channels/chat-sdk-bridge-byline.test.ts
+++ b/src/channels/chat-sdk-bridge-byline.test.ts
@@ -112,24 +112,24 @@ afterEach(async () => {
 
 describe('chat-sdk-bridge approval-card terminal state', () => {
   it('retains the body, removes actions, and shows the acting user', async () => {
-    const { edits, actions } = await fireAction({ userId: 'U1', userName: 'gavriel', fullName: 'Gavriel C' });
+    const { edits, actions } = await fireAction({ userId: 'U1', userName: 'alex', fullName: 'Alex C' });
 
     expect(edits).toHaveLength(1);
     expect(edits[0].threadId).toBe('T-1');
     expect(edits[0].messageId).toBe('msg-1');
     expect(terminalText(edits[0])).toEqual([
       { type: 'text', content: 'Keep these full request details.' },
-      { type: 'text', content: '✅ Approved by gavriel', style: 'muted' },
+      { type: 'text', content: '✅ Approved by alex', style: 'muted' },
     ]);
     expect(terminalText(edits[0]).some((child) => child.type === 'actions')).toBe(false);
     expect(actions).toEqual(['q-1:approve:U1']);
   });
 
   it('falls back to fullName when userName is missing', async () => {
-    const { edits } = await fireAction({ userId: 'U2', fullName: 'Gavriel C' });
+    const { edits } = await fireAction({ userId: 'U2', fullName: 'Alex C' });
 
     expect(edits).toHaveLength(1);
-    expect(terminalText(edits[0]).at(-1)?.content).toBe('✅ Approved by Gavriel C');
+    expect(terminalText(edits[0]).at(-1)?.content).toBe('✅ Approved by Alex C');
   });
 
   it('renders a rejected decision with the actor and original body', async () => {

--- a/src/modules/cross-session-context/backfill.test.ts
+++ b/src/modules/cross-session-context/backfill.test.ts
@@ -50,7 +50,7 @@ const NEW_SESSION = {
   thread_id: 'slack:D1:2.0',
 } as never;
 
-function chat(text: string, sender = 'Gavriel', senderId = 'U1'): string {
+function chat(text: string, sender = 'Alex', senderId = 'U1'): string {
   return JSON.stringify({ text, sender, senderId });
 }
 
@@ -66,7 +66,7 @@ beforeEach(() => {
 describe('backfillNewSession', () => {
   it('seeds the new session with sibling roots + top-level agent posts, ordered by time', async () => {
     outboundRows = [
-      { timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'Hey Gavriel! I am Pete… tour?' }) },
+      { timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'Hey Alex! I am Pete… tour?' }) },
     ];
     inboundRows = [{ timestamp: '2026-08-01T19:10:00Z', content: chat('hello there') }];
 
@@ -82,7 +82,7 @@ describe('backfillNewSession', () => {
     const first = JSON.parse(written[0]!.content as string) as Record<string, unknown>;
     const second = JSON.parse(written[1]!.content as string) as Record<string, unknown>;
     expect(first.text).toBe('hello there');
-    expect(second.text).toBe('Hey Gavriel! I am Pete… tour?');
+    expect(second.text).toBe('Hey Alex! I am Pete… tour?');
     expect(second.sender).toBe('Pete');
     expect((second.echo as Record<string, unknown>).surface).toBe('dm-timeline');
     expect(second.self).toBe(true);

--- a/src/modules/cross-session-context/fan.test.ts
+++ b/src/modules/cross-session-context/fan.test.ts
@@ -69,7 +69,7 @@ function session(
 }
 
 const ROOM_MG = mg('mg-room', 'C123', 1, 'pixel-room');
-const DM_MG = mg('mg-dm', 'D456', 0, 'Gavriel');
+const DM_MG = mg('mg-dm', 'D456', 0, 'Alex');
 const ROOM2_MG = mg('mg-room2', 'C789', 1, null);
 const DM2_MG = mg('mg-dm2', 'D999', 0, 'Someone');
 
@@ -93,7 +93,7 @@ function readEchoRows(sessionId: string): Array<Record<string, unknown>> {
 }
 
 function chatContent(text: string): string {
-  return JSON.stringify({ text, sender: 'Gavriel', senderId: 'slack:U1' });
+  return JSON.stringify({ text, sender: 'Alex', senderId: 'slack:U1' });
 }
 
 beforeEach(async () => {
@@ -173,11 +173,11 @@ describe('fanInboundMessage', () => {
     expect(sibRows[0].source_session_id).toBe('s-dm');
     const sibContent = JSON.parse(sibRows[0].content as string);
     expect(sibContent.text).toBe('private note');
-    expect(sibContent.sender).toBe('Gavriel');
+    expect(sibContent.sender).toBe('Alex');
     expect(sibContent.senderId).toBe('slack:U1');
     expect(sibContent.echo).toEqual({
       surface: ECHO_SIBLING_SURFACE,
-      label: 'another conversation with Gavriel',
+      label: 'another conversation with Alex',
     });
 
     // Nothing else in the group hears it: not task sessions, not rooms, not
@@ -315,7 +315,7 @@ describe('fanOutboundMessage', () => {
     expect(sibContent.senderId).toBe(AG);
     expect(sibContent.echo).toEqual({
       surface: ECHO_SIBLING_SURFACE,
-      label: 'another conversation with Gavriel',
+      label: 'another conversation with Alex',
     });
   });
 
@@ -475,13 +475,13 @@ describe('label + truncation helpers', () => {
   it('buildEchoLabel renders room and DM labels', async () => {
     expect(buildEchoLabel({ name: 'pixel-room', platform_id: 'C1', is_group: 1 })).toBe('#pixel-room room');
     expect(buildEchoLabel({ name: null, platform_id: 'C1', is_group: 1 })).toBe('#C1 room');
-    expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, 'Gavriel')).toBe('DM with Gavriel');
+    expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, 'Alex')).toBe('DM with Alex');
     expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, null)).toBe('DM (D1)');
   });
 
   it('buildSiblingEchoLabel renders same-DM sibling labels with sensible fallbacks', async () => {
-    expect(buildSiblingEchoLabel({ name: 'Gavriel', platform_id: 'D1', is_group: 0 })).toBe(
-      'another conversation with Gavriel',
+    expect(buildSiblingEchoLabel({ name: 'Alex', platform_id: 'D1', is_group: 0 })).toBe(
+      'another conversation with Alex',
     );
     expect(buildSiblingEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, 'Gav')).toBe(
       'another conversation with Gav',

--- a/src/modules/cross-session-context/fan.ts
+++ b/src/modules/cross-session-context/fan.ts
@@ -56,7 +56,7 @@ export function echoRowId(origMessageId: string, targetSessionId: string): strin
   return `${origMessageId}:echo:${targetSessionId}`;
 }
 
-/** Human label for the source conversation, e.g. '#Pixel room' / 'DM with Gavriel'. */
+/** Human label for the source conversation, e.g. '#Pixel room' / 'DM with Alex'. */
 export function buildEchoLabel(
   mg: Pick<MessagingGroup, 'name' | 'platform_id' | 'is_group'>,
   senderName?: string | null,

--- a/src/modules/cross-session-context/history.test.ts
+++ b/src/modules/cross-session-context/history.test.ts
@@ -30,7 +30,7 @@ const FOREIGN_AGENT: CallerContext = {
   messagingGroupId: 'mg-y',
 };
 
-async function writeInbound(id: string, timestamp: string, text: string, sender = 'Gavriel'): Promise<void> {
+async function writeInbound(id: string, timestamp: string, text: string, sender = 'Alex'): Promise<void> {
   await writeSessionMessage(AG, SESS, {
     id,
     kind: 'chat',
@@ -93,7 +93,7 @@ describe('sessionHistory', () => {
       timestamp: '2026-08-01T10:00:00.000Z',
       direction: 'in',
       kind: 'chat',
-      sender: 'Gavriel',
+      sender: 'Alex',
       text: 'hello there',
     });
     expect(rows[1].text).toBe('second message');
@@ -106,7 +106,7 @@ describe('sessionHistory', () => {
   it('formatHistoryLines renders pipe lines with localized stamps and capped cells', async () => {
     await writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
     const lines = formatHistoryLines(await sessionHistory({ id: SESS }, HOST), 'UTC').split('\n');
-    expect(lines).toEqual(['2026-08-01 10:00|in|chat|Gavriel|hello there']);
+    expect(lines).toEqual(['2026-08-01 10:00|in|chat|Alex|hello there']);
     // A non-UTC install timezone shifts the human stamp; data stays ISO.
     const berlin = formatHistoryLines(await sessionHistory({ id: SESS }, HOST), 'Europe/Berlin');
     expect(berlin.startsWith('2026-08-01 12:00|')).toBe(true);

--- a/src/modules/permissions/sender-decline-notify.test.ts
+++ b/src/modules/permissions/sender-decline-notify.test.ts
@@ -99,7 +99,7 @@ beforeEach(async () => {
   });
 
   // Owner user (with display name — feeds the decline copy) + their DM.
-  await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Gavriel', created_at: now() });
+  await upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Alex', created_at: now() });
   await grantRole({
     user_id: 'telegram:owner',
     role: 'owner',
@@ -204,7 +204,7 @@ describe('unknown-sender decline_notify flow', () => {
     expect(dThread).toBeNull();
     expect(dKind).toBe('chat-sdk');
     const decline = JSON.parse(dContent as string);
-    expect(decline.text).toBe("I'm Gavriel's personal agent — I can't help you directly.");
+    expect(decline.text).toBe("I'm Alex's personal agent — I can't help you directly.");
     expect(decline.options).toBeUndefined(); // plain text, no buttons
 
     // (b) One-line FYI to the owner's DM — informational, not a card.

--- a/src/router-session-created.test.ts
+++ b/src/router-session-created.test.ts
@@ -120,7 +120,7 @@ async function inbound(id: string, threadId: string | null, text: string, isMent
     message: {
       id,
       kind: 'chat-sdk',
-      content: JSON.stringify({ sender: 'Gavriel', senderId: 'U1', text }),
+      content: JSON.stringify({ sender: 'Alex', senderId: 'U1', text }),
       timestamp: now(),
       isMention,
       isGroup: false,

--- a/src/router-unknown-engage-mode.test.ts
+++ b/src/router-unknown-engage-mode.test.ts
@@ -123,7 +123,7 @@ async function inbound(id: string, text: string): Promise<void> {
     message: {
       id,
       kind: 'chat-sdk',
-      content: JSON.stringify({ sender: 'Gavriel', senderId: 'U1', text }),
+      content: JSON.stringify({ sender: 'Alex', senderId: 'U1', text }),
       timestamp: now(),
       isMention: true,
       isGroup: false,


### PR DESCRIPTION
## What

A maintainer's first name is the stand-in person across the tree. Most visibly it is in the usage block a new user copies:

```
 *     --display-name "Gavriel" \
```

…in `scripts/init-first-agent.ts` and `scripts/init-cli-agent.ts`. The rest are dev-harness senders (`scripts/test-v2-*.ts`), test fixtures (`cross-session-context`, `chat-sdk-bridge-byline`, router and permissions tests), and one doc comment in `src/modules/cross-session-context/fan.ts`.

Replaced with `Alex`. An example reads better with an obviously-placeholder name — a real one invites the reader to wonder whether it means something, and in a copy-paste usage block it is the kind of thing that ends up in someone's actual config.

## Scope

Strings only: example arguments, fixture senders and display names, one doc comment. No behavior change and no assertion changes beyond the fixture names those assertions pin.

**`scripts/release.test.ts` is deliberately untouched** — its `EXPECTED_REVIEWERS='["gavrielc","omri-maya"]'` are real GitHub handles identifying actual reviewers, not placeholders.

13 files, 28 lines each way.

## Checks

`tsc --noEmit` clean · `prettier --check` clean on every changed file · full suite **182 files, 2150 tests, all passing**.