### PR TITLE
feat(slack): recover pasted tables from the raw event

### DIFF
--- a/src/channels/slack-raw-text.test.ts
+++ b/src/channels/slack-raw-text.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { appendRawText } from './chat-sdk-bridge.js';
+import { extractSlackRawText } from './slack-raw-text.js';
+
+const pastedTableEvent = {
+  text: 'Analyze this attendee list:',
+  attachments: [
+    {
+      fallback: '[no preview available]',
+      blocks: [
+        {
+          type: 'table',
+          rows: [
+            [
+              {
+                type: 'rich_text',
+                elements: [
+                  {
+                    type: 'rich_text_section',
+                    elements: [{ type: 'text', text: 'Company', style: { bold: true } }],
+                  },
+                ],
+              },
+              {
+                type: 'rich_text',
+                elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text: 'Title' }] }],
+              },
+            ],
+            [
+              { type: 'raw_text', text: 'Agria Pet Insurance' },
+              { type: 'raw_text', text: 'Head of IT Operations' },
+            ],
+            [
+              { type: 'raw_text', text: 'AVEVA' },
+              { type: 'raw_text', text: 'Head of Cyber Security Risk and Assurance' },
+            ],
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('Slack pasted-table ingestion', () => {
+  it('flattens table attachment blocks into readable rows', () => {
+    expect(extractSlackRawText(pastedTableEvent)).toBe(
+      [
+        'Company | Title',
+        'Agria Pet Insurance | Head of IT Operations',
+        'AVEVA | Head of Cyber Security Risk and Assurance',
+      ].join('\n'),
+    );
+  });
+
+  it('ignores ordinary attachments and malformed table blocks', () => {
+    expect(extractSlackRawText({ text: 'hello' })).toBeNull();
+    expect(extractSlackRawText({ attachments: [{ fallback: 'link preview' }] })).toBeNull();
+    expect(extractSlackRawText({ attachments: [{ blocks: [{ type: 'table', rows: 'bad' }] }] })).toBeNull();
+  });
+
+  it('appends rescued rows to the user text before raw payload removal', () => {
+    const serialized: Record<string, unknown> = { text: 'Analyze this attendee list:' };
+    appendRawText(serialized, pastedTableEvent, extractSlackRawText);
+    expect(serialized.text).toContain('Analyze this attendee list:\n\nCompany | Title');
+    expect(serialized.text).toContain('Agria Pet Insurance | Head of IT Operations');
+  });
+
+  it('caps unexpectedly large pasted tables', () => {
+    const rows = Array.from({ length: 20_000 }, (_, index) => [
+      { type: 'raw_text', text: `row-${index}-with-padding` },
+    ]);
+    const text = extractSlackRawText({ attachments: [{ blocks: [{ type: 'table', rows }] }] });
+    expect(text).not.toBeNull();
+    expect(text!.length).toBeLessThanOrEqual(100_000);
+    expect(text).toContain('[table truncated]');
+  });
+
+  it('keeps the default Slack factory wired to the extractor', () => {
+    const source = readFileSync(join(new URL('.', import.meta.url).pathname, 'slack.ts'), 'utf8');
+    expect(source).toContain("import { extractSlackRawText } from './slack-raw-text.js';");
+    expect(source).toContain('extractRawText: extractSlackRawText');
+  });
+});

--- a/src/channels/slack-raw-text.ts
+++ b/src/channels/slack-raw-text.ts
@@ -1,0 +1,51 @@
+/**
+ * Recover pasted-table content from a raw Slack event.
+ *
+ * Slack sends pasted tables as attachment blocks instead of message text or
+ * files. The Chat SDK adapter currently leaves those blocks only in
+ * `message.raw`, which the host deliberately drops before persistence.
+ */
+
+const MAX_TABLE_CHARS = 100_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Collect the text leaves in a Slack cell's raw_text/rich_text subtree. */
+function cellText(value: unknown): string {
+  const parts: string[] = [];
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (!isRecord(node)) return;
+    if (typeof node.text === 'string') parts.push(node.text);
+    Object.values(node).forEach(visit);
+  };
+  visit(value);
+  return parts.join(' ').trim();
+}
+
+export function extractSlackRawText(raw: Record<string, unknown>): string | null {
+  const attachments = Array.isArray(raw.attachments) ? raw.attachments : [];
+  const lines: string[] = [];
+
+  for (const attachment of attachments) {
+    if (!isRecord(attachment)) continue;
+    const blocks = Array.isArray(attachment.blocks) ? attachment.blocks : [];
+    for (const block of blocks) {
+      if (!isRecord(block) || block.type !== 'table' || !Array.isArray(block.rows)) continue;
+      for (const row of block.rows) {
+        if (!Array.isArray(row)) continue;
+        lines.push(row.map(cellText).join(' | '));
+      }
+    }
+  }
+
+  if (lines.length === 0) return null;
+  const text = lines.join('\n');
+  if (text.length <= MAX_TABLE_CHARS) return text;
+  return `${text.slice(0, MAX_TABLE_CHARS - 20)}\n[table truncated]`;
+}

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -20,6 +20,7 @@ import { readEnvFile } from '../env.js';
 import type { ChannelAdapter, ChannelContextDefaults, ChannelDefaults } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import { extractSlackRawText } from './slack-raw-text.js';
 
 /**
  * Dedicated bot app on a threaded platform. group threads:true keeps
@@ -175,6 +176,7 @@ export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdap
   });
   const bridge = createChatSdkBridge({
     adapter: slackAdapter,
+    extractRawText: extractSlackRawText,
     instance: options.instanceKey, // undefined ⇒ default instance (keyed by channelType)
     concurrency: 'concurrent',
     supportsThreads: true,


### PR DESCRIPTION
> **Draft — depends on #3665.** That PR adds the generic `extractRawText` hook to `chat-sdk-bridge.ts` on `main`. This branch does not carry it yet, so one test here fails until #3665 lands and `channels` syncs with `main`. Everything else is green; see Verification.

## The problem

Slack represents a **pasted table** as `attachments[].blocks[]` entries of type `table`. It appears in neither the message text nor the file list, and the adapter leaves it only in `message.raw` — which the bridge drops before persisting.

So an agent receives the sentence before the table and nothing else. There is no error and no marker: the table silently did not arrive, which is worse than a visible failure because nobody knows to ask again.

## The change

`src/channels/slack-raw-text.ts` — a bounded extractor:

- walks `attachments[].blocks[]` for `type: 'table'` with a `rows` array
- projects each row to `cell | cell | cell`
- collects cell text from the rich_text subtree (the text leaves), so formatted cells survive
- caps the whole projection at 100,000 characters and appends `[table truncated]` rather than letting it grow with whatever was pasted
- returns `null` when there is no table, so a message without one is untouched

Wired to the bridge's `extractRawText` hook on the **shared factory**, so the default app and every named instance get it from one place:

```ts
const bridge = createChatSdkBridge({
  adapter: slackAdapter,
  extractRawText: extractSlackRawText,
```

The raw event is still discarded. Only the projected table text is persisted.

## Verification

`src/channels/slack-raw-text.test.ts` — 5 cases: a real pasted-table event projected to rows; no tables returns null; malformed blocks and rows skipped rather than thrown on; the truncation cap; and the end-to-end append onto an existing message body.

Run against this branch with #3665's `chat-sdk-bridge.ts` temporarily in place — the state this will be in once that lands and `channels` syncs:

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Without it, the four extractor cases pass and the one integration case fails on `appendRawText is not a function`, which is precisely the dependency.

Note: `slack-registration.test.ts` and `slack-instances-registration.test.ts` cannot execute in a bare worktree — `@chat-adapter/slack` is not in the checkout's `node_modules`, and they fail identically on an unmodified `channels`. This change adds two lines to `slack.ts` (one import, one config member) and touches nothing they cover.