### PR TITLE
fix(add-slack): copy slack-raw-text with the adapter that imports it

### DIFF
--- a/.claude/skills/add-slack/REMOVE.md
+++ b/.claude/skills/add-slack/REMOVE.md
@@ -13,6 +13,7 @@ Delete the appended lines (skip any already gone):
 ```bash
 rm -f src/channels/slack.ts src/channels/slack-lib.ts src/channels/slack-lib.test.ts \
   src/channels/slack-a2a-guard.ts src/channels/slack-a2a-guard.test.ts \
+  src/channels/slack-raw-text.ts src/channels/slack-raw-text.test.ts \
   src/channels/slack-registration.test.ts \
   src/channels/slack-instances-registration.test.ts \
   src/provisioning/slack-app.ts src/provisioning/slack-app.test.ts \

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -31,6 +31,8 @@ src/channels/slack-lib.ts
 src/channels/slack-lib.test.ts
 src/channels/slack-a2a-guard.ts
 src/channels/slack-a2a-guard.test.ts
+src/channels/slack-raw-text.ts
+src/channels/slack-raw-text.test.ts
 src/channels/slack-registration.test.ts
 src/channels/slack-instances-registration.test.ts
 src/provisioning/slack-app.ts
@@ -40,6 +42,7 @@ container/skills/slack-formatting/SKILL.md
 
 - **Adapter + shared lib** (`slack.ts`, `slack-lib.ts`): bridge registration, wiring defaults, conversation resolver, the native `SLACK_INSTANCES` loop — pinned by the two registration tests.
 - **Bot-inbound guard** (`slack-a2a-guard.ts`): drops bot-authored inbound at the bridge by default; feature skills register a narrower admission policy on its seam.
+- **Raw-text recovery** (`slack-raw-text.ts`): recovers pasted tables, which Slack delivers as attachment blocks in `message.raw` rather than as text — `slack.ts` imports it directly, so it travels with the adapter.
 - **Provisioning core** (`src/provisioning/slack-app.ts`): manifest template, scope/event constants, and the broker + manager-token transports for creating a Slack app programmatically. Nothing on the adapter path imports it — the setup wizard's auto-provision pre-step and feature skills do.
 - **Container skills**: `slack-formatting/` (mrkdwn syntax; synced to `~/.claude/skills`).
 


### PR DESCRIPTION
## What broke

[`f62ffeb2`](https://github.com/nanocoai/nanoclaw/commit/f62ffeb2) on the `channels` branch added `src/channels/slack-raw-text.ts` and added this import to `slack.ts`:

```ts
import { extractSlackRawText } from './slack-raw-text.js';
```

The `nc:copy from-branch:channels` list in `add-slack/SKILL.md` was never extended to match. Since the `channels` branch is canonical for the payload but the copy list decides what actually lands, every composed tree since then gets a `slack.ts` that imports a module which was never copied:

```
src/channels/slack.ts(23,37): error TS2307: Cannot find module './slack-raw-text.js'
```

## Blast radius

It's a hard typecheck failure, so it takes down every recipe in `nanoco-recipes` that applies `add-slack` — currently all six (`nanoco-k8s-{fresh-vpc,kata,pass1,runc,stanford-demo,v2}`). The recipes float on `main` tips by design, so this landed on them the moment the `channels` commit did: run `33263323393` (16:34) was green, `33270240582` (19:11) was the first red one.

## The fix

Add `slack-raw-text.ts` and its test to the copy block, and to `REMOVE.md`'s `rm` list so uninstall stays symmetric with install. Documented the module alongside the other payload bullets.

Pairing the module with its `.test.ts` follows the existing convention here (`slack-lib.ts` / `slack-lib.test.ts`, `slack-a2a-guard.ts` / `slack-a2a-guard.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)