### PR TITLE
test(skill-directives): expect the slack-raw-text files add-slack copies

### DIFF
--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -70,6 +70,9 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'src/channels/slack-lib.test.ts',
       'src/channels/slack-a2a-guard.ts',
       'src/channels/slack-a2a-guard.test.ts',
+      // slack.ts imports slack-raw-text directly, so it travels with the adapter.
+      'src/channels/slack-raw-text.ts',
+      'src/channels/slack-raw-text.test.ts',
       'src/channels/slack-registration.test.ts',
       'src/channels/slack-instances-registration.test.ts',
       'src/provisioning/slack-app.ts',


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — adds `src/channels/slack-raw-text.ts` and `src/channels/slack-raw-text.test.ts` to the copy-payload assertion in `scripts/skill-directives.test.ts`.

**Why** — `pnpm test` is currently red on a clean checkout of `main`. #3667 (`fa1bbb67`) added those two files to the add-slack copy directive in `.claude/skills/add-slack/SKILL.md`, but the test that pins that exact list wasn't updated alongside it:

```
AssertionError: expected [ 'src/channels/slack.ts', …(11) ] to deeply equal [ 'src/channels/slack.ts', …(9) ]

+   "src/channels/slack-raw-text.ts",
+   "src/channels/slack-raw-text.test.ts",
```

The test reads the shipped `SKILL.md`, so this isn't install-specific drift — it's red for everyone.

It also blocks `/update-nanoclaw`: the transaction runs the full suite in its staging worktree and refuses cutover on any failure, so this stops an otherwise-valid update from landing.

**How it works** — expectation updated to match the SKILL.md, in the same document order, with a one-line note on why the file travels with the adapter.

**How it was tested** — `pnpm exec vitest run scripts/skill-directives.test.ts` → 56 passed (was 55 passed / 1 failed). Full suite green afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)