### PR TITLE
test(setup): give the spawn-based mailbox checks a realistic timeout

### DIFF
--- a/setup/mailbox-compatibility.test.ts
+++ b/setup/mailbox-compatibility.test.ts
@@ -6,6 +6,13 @@ import { describe, expect, it } from 'vitest';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+// Each case spawns a Node process that transforms the TypeScript graph through
+// tsx on a cold cache. That is comfortably over vitest's 5s default on a loaded
+// machine -- it passes when the file runs alone and times out in a full-suite
+// run, which reads as a flaky failure rather than the slow-by-construction test
+// it is.
+const SPAWN_TIMEOUT_MS = 60_000;
+
 describe('standalone setup mailbox composition', () => {
   it.each(['setup/migrate-v2/sessions.ts', 'setup/migrate-v2/tasks.ts'])(
     '%s loads before validating argv',
@@ -19,6 +26,7 @@ describe('standalone setup mailbox composition', () => {
       expect(result.stderr).toContain('Usage:');
       expect(result.stderr).not.toContain('SyntaxError');
     },
+    SPAWN_TIMEOUT_MS,
   );
 
   it('setup/register.ts loads with the default mailbox composition', () => {
@@ -36,5 +44,5 @@ describe('standalone setup mailbox composition', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('function:true');
-  });
+  }, SPAWN_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — gives the three cases in `setup/mailbox-compatibility.test.ts` a 60s timeout instead of vitest's 5s default.

**Why** — each case spawns a Node process that transforms the TypeScript graph through tsx on a cold cache. Measured at **4.96s running the file alone**, which leaves nothing at all for a loaded machine:

```
FAIL  setup/mailbox-compatibility.test.ts > standalone setup mailbox composition >
      setup/register.ts loads with the default mailbox composition
Error: Test timed out in 5000ms.
```

It passes every time the file is run on its own and fails in a full-suite run, which presents as flake rather than as the slow-by-construction test it is.

On the update path it's worse than noise: `/update-nanoclaw` runs the full suite in its staging worktree and refuses cutover on any failure, so a slower machine can block a legitimate update on this alone. That's how I hit it.

**How it works** — a named `SPAWN_TIMEOUT_MS` constant passed as the timeout argument to `it.each` and `it`, with a comment recording the measurement so the number isn't mistaken for an arbitrary bump. No production code touched.

**How it was tested** — `pnpm exec vitest run setup/mailbox-compatibility.test.ts` → 3 passed. Full suite green in a run that previously failed on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)