### PR TITLE
fix(delivery): carry a mime type on outbound files so Teams accepts them

### DIFF
--- a/src/attachment-naming.test.ts
+++ b/src/attachment-naming.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { deriveAttachmentName, extForMime } from './attachment-naming.js';
+import { deriveAttachmentName, extForMime, mimeForFilename } from './attachment-naming.js';
 
 describe('extForMime', () => {
   it('returns empty for undefined / non-string / empty', () => {
@@ -67,5 +67,42 @@ describe('deriveAttachmentName', () => {
   it('does not crash on non-string mimeType (defensive against buggy bridges)', () => {
     expect(() => deriveAttachmentName({ mimeType: { foo: 'bar' } })).not.toThrow();
     expect(deriveAttachmentName({ mimeType: { foo: 'bar' } })).toMatch(/^attachment-\d+$/);
+  });
+});
+
+describe('mimeForFilename', () => {
+  it('maps the extensions agents actually produce', () => {
+    expect(mimeForFilename('chart.png')).toBe('image/png');
+    expect(mimeForFilename('photo.jpg')).toBe('image/jpeg');
+    expect(mimeForFilename('photo.jpeg')).toBe('image/jpeg');
+    expect(mimeForFilename('report.pdf')).toBe('application/pdf');
+    expect(mimeForFilename('data.csv')).toBe('text/csv');
+    expect(mimeForFilename('notes.md')).toBe('text/markdown');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(mimeForFilename('CHART.PNG')).toBe('image/png');
+  });
+
+  it('uses the last dot, so dotted names still resolve', () => {
+    expect(mimeForFilename('qa-ingestion.v2.png')).toBe('image/png');
+  });
+
+  it('returns undefined rather than guessing octet-stream', () => {
+    // Adapters own their own fallback; handing them a guess as though it were
+    // a fact is what produced the Teams 400 in the first place.
+    expect(mimeForFilename('archive.unknownext')).toBeUndefined();
+    expect(mimeForFilename('no-extension')).toBeUndefined();
+    expect(mimeForFilename('')).toBeUndefined();
+    expect(mimeForFilename(undefined)).toBeUndefined();
+    expect(mimeForFilename(42)).toBeUndefined();
+  });
+
+  it('round-trips every mime the inbound direction knows', () => {
+    // EXT_TO_MIME is derived from MIME_TO_EXT; this pins the invariant so a
+    // future edit to one table cannot silently desync the other.
+    for (const mime of ['image/png', 'image/jpeg', 'application/pdf', 'video/mp4', 'audio/ogg']) {
+      expect(mimeForFilename(`f.${extForMime(mime)}`)).toBe(mime);
+    }
   });
 });

--- a/src/attachment-naming.ts
+++ b/src/attachment-naming.ts
@@ -51,10 +51,38 @@ const TYPE_TO_EXT: Record<string, string> = {
   animation: 'mp4',
 };
 
+// The reverse direction, for files the agent sends *out*. Derived from
+// MIME_TO_EXT so the two can't drift, plus the spellings that map onto a MIME
+// already listed above but aren't its canonical extension.
+const EXT_TO_MIME: Record<string, string> = {
+  ...Object.fromEntries(Object.entries(MIME_TO_EXT).map(([mime, ext]) => [ext, mime])),
+  jpeg: 'image/jpeg',
+  htm: 'text/html',
+  html: 'text/html',
+  csv: 'text/csv',
+  md: 'text/markdown',
+  svg: 'image/svg+xml',
+};
+
 export function extForMime(mime: unknown): string {
   if (typeof mime !== 'string' || !mime) return '';
   const clean = mime.split(';')[0].trim().toLowerCase();
   return MIME_TO_EXT[clean] ?? '';
+}
+
+/**
+ * MIME type for an outbound filename, or undefined when the extension isn't
+ * one we recognize.
+ *
+ * Undefined rather than 'application/octet-stream': adapters already default
+ * to that, and a caller that can do something smarter with "unknown" should
+ * not have the guess handed to it as though it were a fact.
+ */
+export function mimeForFilename(filename: unknown): string | undefined {
+  if (typeof filename !== 'string') return undefined;
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) return undefined;
+  return EXT_TO_MIME[filename.slice(dot + 1).toLowerCase()];
 }
 
 export function deriveAttachmentName(att: Record<string, unknown>): string {

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -96,6 +96,20 @@ export interface InboundMessage {
 export interface OutboundFile {
   filename: string;
   data: Buffer;
+  /**
+   * MIME type, derived from the filename extension when we recognize it.
+   *
+   * Load-bearing, not decorative: an adapter that has to declare a content
+   * type has nothing else to go on. The Teams adapter defaults to
+   * `application/octet-stream` and inlines the bytes as a
+   * `data:<contentType>;base64,...` URI, and Teams rejects that activity with
+   * a 400 — so a PNG sent without this never reaches the channel at all.
+   * (Oversize is a *413*, so a 400 here is the content type, not the size.)
+   *
+   * Undefined for extensions we don't recognize; adapters keep their own
+   * fallback for that case.
+   */
+  mimeType?: string;
 }
 
 /** Outbound message from host to adapter. */

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -24,7 +24,7 @@ import { log } from '../log.js';
 import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
-import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage } from './adapter.js';
+import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage, OutboundFile } from './adapter.js';
 import { INSTANCE_KEY_RE } from './channel-registry.js';
 import { resolveQuestionRender } from './question-render-registry.js';
 
@@ -918,10 +918,14 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       const rawText = (content.markdown as string) || (content.text as string);
       const text = rawText ? transformText(rawText) : rawText;
       if (text) {
-        // Attach files if present (FileUpload format: { data, filename })
-        const fileUploads = message.files?.map((f: { data: Buffer; filename: string }) => ({
+        // Attach files if present (FileUpload format: { data, filename, mimeType }).
+        // mimeType must be forwarded: adapters that inline the bytes as a
+        // data URI put it in the content type, and Teams 400s on
+        // application/octet-stream — the adapter's fallback when it's absent.
+        const fileUploads = message.files?.map((f: OutboundFile) => ({
           data: f.data,
           filename: f.filename,
+          mimeType: f.mimeType,
         }));
         // Split if over the adapter's max length. Files ride on the first
         // chunk so the head of the reply still carries them.
@@ -942,9 +946,10 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         return firstId;
       } else if (message.files && message.files.length > 0) {
         // Files only, no text
-        const fileUploads = message.files.map((f: { data: Buffer; filename: string }) => ({
+        const fileUploads = message.files.map((f: OutboundFile) => ({
           data: f.data,
           filename: f.filename,
+          mimeType: f.mimeType,
         }));
         const result = await adapter.postMessage(tid, { markdown: '', files: fileUploads });
         return result?.id;

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -158,9 +158,25 @@ describe('session manager', () => {
     expect(files).toHaveLength(1);
     expect(files?.[0]?.filename).toBe('result.txt');
     expect(files?.[0]?.data.toString()).toBe('ok');
+    expect(files?.[0]?.mimeType).toBe('text/plain');
 
     clearOutbox('ag-1', 'sess-test', 'msg-1');
     expect(fs.existsSync(msgOutbox)).toBe(false);
+  });
+
+  it('should tag outbox files with a mime type derived from the extension', () => {
+    initSessionFolder('ag-1', 'sess-test');
+    const msgOutbox = path.join(sessionDir('ag-1', 'sess-test'), 'outbox', 'msg-png');
+    fs.mkdirSync(msgOutbox, { recursive: true });
+    fs.writeFileSync(path.join(msgOutbox, 'chart.png'), 'not-really-a-png');
+    fs.writeFileSync(path.join(msgOutbox, 'blob.weird'), 'unknown');
+
+    const files = readOutboxFiles('ag-1', 'sess-test', 'msg-png', ['chart.png', 'blob.weird']);
+
+    // Without this the Teams adapter falls back to application/octet-stream,
+    // inlines the bytes as a data URI, and the activity is rejected with 400.
+    expect(files?.find((f) => f.filename === 'chart.png')?.mimeType).toBe('image/png');
+    expect(files?.find((f) => f.filename === 'blob.weird')?.mimeType).toBeUndefined();
   });
 
   it('should reject inbound attachment writes through a pre-placed symlinked inbox dir', async () => {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -6,7 +6,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 import fs from 'fs';
 import path from 'path';
 
-import { deriveAttachmentName } from './attachment-naming.js';
+import { deriveAttachmentName, mimeForFilename } from './attachment-naming.js';
 import { isSafeAttachmentName } from './attachment-safety.js';
 import type { OutboundFile } from './channels/adapter.js';
 import { DATA_DIR } from './config.js';
@@ -540,7 +540,11 @@ export function readOutboxFiles(
         log.warn('Rejecting outbox file outside message directory', { messageId, filename });
         continue;
       }
-      files.push({ filename, data: fs.readFileSync(realFilePath) });
+      files.push({
+        filename,
+        data: fs.readFileSync(realFilePath),
+        mimeType: mimeForFilename(filename),
+      });
     } catch {
       log.warn('Outbox file not found', { messageId, filename });
     }


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — adds an optional `mimeType` to `OutboundFile`, derives it from the filename extension where the outbox is read, and stops the chat-sdk bridge dropping it on the way to the adapter.

**Why** — an agent that produces an image can't deliver it on Teams. Every `send_file` with a PNG fails, and the agent is never told: `send_file` reports success as soon as the row is written, and the failure happens later on the host's delivery poll. From the agent's side the file simply never arrives.

`OutboundFile` carried only `{ filename, data }`, and the bridge forwarded exactly those two fields. `@chat-adapter/teams` then does:

```js
const mimeType = file.mimeType || "application/octet-stream";
const dataUri = bufferToDataUri(buffer, mimeType);
```

so a PNG goes out as `contentUrl: "data:application/octet-stream;base64,..."` and Teams rejects the whole activity with `400 Bad Request`.

Worth stating explicitly, because it's the tempting reading for a 133KB image: **this is not the size limit.** Teams answers oversize with `413`/`MessageSizeTooBig`, and base64 image payloads are [explicitly excluded](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages) from its 100KB activity budget. A 400 is the content type.

**How it works** — `mimeForFilename()` in `attachment-naming.ts`, called from `readOutboxFiles()`; the bridge forwards the field in both of its file-upload paths. `EXT_TO_MIME` is derived from the existing `MIME_TO_EXT` rather than written out a second time, with a round-trip test, so the inbound and outbound tables can't drift.

It returns `undefined` for unrecognized extensions rather than guessing `application/octet-stream`. Adapters already have that fallback, and handing them a guess dressed as a fact is what caused this.

**How it was tested** — typecheck clean and 84 tests green on this branch standing alone on `main`. Then on a live install: the same PNG that had failed three times with a 400 delivered on the first retry after the fix — `Message delivered ... channelType="teams" fileCount=1`, outbox cleared, no error.

## Related

- #1988 fixes the same class of bug one adapter down, with an extension→mimetype map inside `src/channels/whatsapp.ts`. This addresses it once at the shared seam instead, which covers Teams and every other adapter that has to declare a content type — and would make that local map redundant. Happy to rebase around whichever you'd rather land first.
- Touches `src/session-manager.ts` and `src/host-core.test.ts`, which #3505 also moves — likely a small conflict depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)