### PR TITLE
fix(slack): make agent-flow tests executable

### DIFF
--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -210,7 +210,7 @@ pnpm exec vitest run src/modules/slack-agent-flow src/modules/slack-room-members
 ```
 
 ```nc:run effect:test
-source "$PWD/setup/lib/install-slug.sh" && "${CONTAINER_RUNTIME:-docker}" run --rm --entrypoint bun --workdir /app --volume "$PWD/container/agent-runner/src:/app/src:ro" "$(container_image_base):latest" test --preload /app/src/modules/index.ts src/mcp-tools/rooms.test.ts src/mcp-tools/canvas.test.ts
+source "$PWD/setup/lib/install-slug.sh" && "${CONTAINER_RUNTIME:-docker}" run --rm --entrypoint bun --workdir /app --volume "$PWD/container/agent-runner/src:/app/src:ro" "$(container_image_base):latest" test --preload /app/src/modules/index.ts ./src/mcp-tools/rooms.test.ts ./src/mcp-tools/canvas.test.ts
 ```
 
 ### 9. Restart the host


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Make the Slack agent-flow skill's existing Vitest command executable by the registry composition runner.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
