### PR TITLE
feat(skills): add deterministic apply directives

### DIFF
--- a/.claude/skills/add-anydoc/SKILL.md
+++ b/.claude/skills/add-anydoc/SKILL.md
@@ -79,9 +79,18 @@ cp "$skill_dir/container-skills/convert-documents-to-markdown/SKILL.md" \
 cp "$skill_dir/anydoc-manifest.test.ts" src/anydoc-manifest.test.ts
 ```
 
+```nc:copy
+container-skills/convert-documents-to-markdown/SKILL.md -> container/skills/convert-documents-to-markdown/SKILL.md
+anydoc-manifest.test.ts -> src/anydoc-manifest.test.ts
+```
+
 If the manifest has no AnyDoc entry, append this exact object to its JSON array. Do not add `onlyBuilt`; the package and its prebuilt Linux bindings have no install lifecycle script.
 
 ```json
+{ "name": "@firecrawl/anydoc", "version": "0.1.6" }
+```
+
+```nc:json-merge into:container/cli-tools.json key:name
 { "name": "@firecrawl/anydoc", "version": "0.1.6" }
 ```
 
@@ -93,6 +102,15 @@ Run validation before building the image:
 pnpm exec vitest run src/anydoc-manifest.test.ts container/cli-tools.test.ts
 pnpm run build
 ./container/build.sh
+```
+
+```nc:run effect:build
+pnpm run build
+./container/build.sh
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/anydoc-manifest.test.ts container/cli-tools.test.ts
 ```
 
 If pnpm rejects the package as too new, stop. Do not bypass the release-age policy.

--- a/.claude/skills/add-atomic-chat-tool/SKILL.md
+++ b/.claude/skills/add-atomic-chat-tool/SKILL.md
@@ -54,6 +54,13 @@ cp $S/atomic-chat-env.ts              src/atomic-chat-env.ts
 cp $S/atomic-chat-wiring.test.ts      src/atomic-chat-wiring.test.ts
 ```
 
+```nc:copy
+atomic-chat-mcp-stdio.ts -> container/agent-runner/src/atomic-chat-mcp-stdio.ts
+atomic-chat-registration.test.ts -> container/agent-runner/src/atomic-chat-registration.test.ts
+atomic-chat-env.ts -> src/atomic-chat-env.ts
+atomic-chat-wiring.test.ts -> src/atomic-chat-wiring.test.ts
+```
+
 ### Register the MCP server in the agent-runner
 
 Edit `container/agent-runner/src/index.ts`. Find the `mcpServers` object that currently looks like this:
@@ -140,6 +147,10 @@ Replace the `log.debug` line with a prefix branch (leave the stderr-tail lines i
     });
 ```
 
+```nc:run
+bash .claude/skills/add-atomic-chat-tool/apply.sh
+```
+
 ### Add env-var stubs to `.env.example`
 
 Append to `.env.example`:
@@ -154,6 +165,15 @@ Append to `.env.example`:
 # ATOMIC_CHAT_API_KEY=
 ```
 
+```nc:append to:.env.example
+# Atomic Chat MCP tool (.claude/skills/add-atomic-chat-tool)
+# Override the host where Atomic Chat exposes its OpenAI-compatible API.
+# Default: http://host.docker.internal:1337 (with fallback to localhost)
+# ATOMIC_CHAT_HOST=http://host.docker.internal:1337
+# Optional API key. Leave unset for a local Atomic Chat install — it does not require auth.
+# ATOMIC_CHAT_API_KEY=
+```
+
 ### Validate code changes
 
 ```bash
@@ -164,6 +184,17 @@ pnpm exec vitest run src/atomic-chat-wiring.test.ts
 # Container tree: index.ts registration
 (cd container/agent-runner && bun test src/atomic-chat-registration.test.ts)
 ./container/build.sh
+```
+
+```nc:run effect:build
+pnpm run build
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+./container/build.sh
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/atomic-chat-wiring.test.ts
+cd container/agent-runner && bun test src/atomic-chat-registration.test.ts
 ```
 
 All must be clean before proceeding. The wiring and registration tests confirm the two

--- a/.claude/skills/add-atomic-chat-tool/apply.sh
+++ b/.claude/skills/add-atomic-chat-tool/apply.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if ! grep -q '^[[:space:]]*atomic_chat:' container/agent-runner/src/index.ts; then
+  awk '
+    /^[[:space:]]*nanoclaw: \{/ { in_nanoclaw = 1 }
+    in_nanoclaw && /^    },$/ && !added {
+      print
+      print "    atomic_chat: {"
+      print "      command: '\''bun'\'',"
+      print "      args: ['\''run'\'', path.join(__dirname, '\''atomic-chat-mcp-stdio.ts'\'')],"
+      print "      env: {"
+      print "        ...(process.env.ATOMIC_CHAT_HOST ? { ATOMIC_CHAT_HOST: process.env.ATOMIC_CHAT_HOST } : {}),"
+      print "        ...(process.env.ATOMIC_CHAT_API_KEY ? { ATOMIC_CHAT_API_KEY: process.env.ATOMIC_CHAT_API_KEY } : {}),"
+      print "      },"
+      print "    },"
+      added = 1
+      in_nanoclaw = 0
+      next
+    }
+    { print }
+    END { if (!added) exit 1 }
+  ' container/agent-runner/src/index.ts > "$tmp"
+  cp "$tmp" container/agent-runner/src/index.ts
+fi
+
+if ! grep -q "import { atomicChatEnv } from './atomic-chat-env.js';" src/container-runner.ts; then
+  awk '
+    { print }
+    /} from '\''\.\/providers\/provider-container-registry\.js'\'';/ && !added {
+      print "import { atomicChatEnv } from '\''./atomic-chat-env.js'\'';"
+      added = 1
+    }
+    END { if (!added) exit 1 }
+  ' src/container-runner.ts > "$tmp"
+  cp "$tmp" src/container-runner.ts
+fi
+
+if ! grep -q '\.\.\.atomicChatEnv(),' src/container-runner.ts; then
+  awk '
+    /    \.\.\.\(gateway\.env \?\? \{\}\),/ && !added {
+      print
+      print "    ...atomicChatEnv(),"
+      added = 1
+      next
+    }
+    { print }
+    END { if (!added) exit 1 }
+  ' src/container-runner.ts > "$tmp"
+  cp "$tmp" src/container-runner.ts
+fi
+
+if ! grep -q "line.includes('\[ATOMIC\]')" src/drivers/docker-driver.ts; then
+  perl -pi -e '
+    my $q = chr 39;
+    if (/^      if \(line\.includes\(.*\[OLLAMA\].*\)\) \{$/) {
+      chomp;
+      s/\) \{$//;
+      $_ .= " || line.includes(${q}[ATOMIC]${q})) {\n";
+      $added = 1;
+    } elsif (/^      log\.debug\(line, \{ container: this\.name \}\);$/) {
+      $_ = "      if (line.includes(${q}[ATOMIC]${q})) {\n" .
+        "        log.info(line, { container: this.name });\n" .
+        "      } else {\n" .
+        "        log.debug(line, { container: this.name });\n" .
+        "      }\n";
+      $added = 1;
+    }
+    END { exit 1 unless $added }
+  ' src/drivers/docker-driver.ts
+fi

--- a/.claude/skills/add-clidash/SKILL.md
+++ b/.claude/skills/add-clidash/SKILL.md
@@ -49,6 +49,43 @@ mkdir -p tools
 cp -R .claude/skills/add-clidash/add/tools/clidash tools/clidash
 ```
 
+```nc:copy
+add/tools/clidash/README.md -> tools/clidash/README.md
+add/tools/clidash/activity.js -> tools/clidash/activity.js
+add/tools/clidash/clidash.config.example.json -> tools/clidash/clidash.config.example.json
+add/tools/clidash/docs.js -> tools/clidash/docs.js
+add/tools/clidash/logs.js -> tools/clidash/logs.js
+add/tools/clidash/package.json -> tools/clidash/package.json
+add/tools/clidash/parsers.js -> tools/clidash/parsers.js
+add/tools/clidash/public/app.js -> tools/clidash/public/app.js
+add/tools/clidash/public/apple-touch-icon.png -> tools/clidash/public/apple-touch-icon.png
+add/tools/clidash/public/favicon.ico -> tools/clidash/public/favicon.ico
+add/tools/clidash/public/favicon.svg -> tools/clidash/public/favicon.svg
+add/tools/clidash/public/icon-192.png -> tools/clidash/public/icon-192.png
+add/tools/clidash/public/icon-512.png -> tools/clidash/public/icon-512.png
+add/tools/clidash/public/index.html -> tools/clidash/public/index.html
+add/tools/clidash/public/md.js -> tools/clidash/public/md.js
+add/tools/clidash/public/site.webmanifest -> tools/clidash/public/site.webmanifest
+add/tools/clidash/public/style.css -> tools/clidash/public/style.css
+add/tools/clidash/server.js -> tools/clidash/server.js
+add/tools/clidash/test/activity-server.test.js -> tools/clidash/test/activity-server.test.js
+add/tools/clidash/test/activity.test.js -> tools/clidash/test/activity.test.js
+add/tools/clidash/test/cmd.test.js -> tools/clidash/test/cmd.test.js
+add/tools/clidash/test/css.test.js -> tools/clidash/test/css.test.js
+add/tools/clidash/test/docs-server.test.js -> tools/clidash/test/docs-server.test.js
+add/tools/clidash/test/docs.test.js -> tools/clidash/test/docs.test.js
+add/tools/clidash/test/fixtures/ncl-help.txt -> tools/clidash/test/fixtures/ncl-help.txt
+add/tools/clidash/test/fixtures/stub-cli.js -> tools/clidash/test/fixtures/stub-cli.js
+add/tools/clidash/test/help.test.js -> tools/clidash/test/help.test.js
+add/tools/clidash/test/logs.test.js -> tools/clidash/test/logs.test.js
+add/tools/clidash/test/md.test.js -> tools/clidash/test/md.test.js
+add/tools/clidash/test/ncl-overview.test.js -> tools/clidash/test/ncl-overview.test.js
+add/tools/clidash/test/parsers.test.js -> tools/clidash/test/parsers.test.js
+add/tools/clidash/test/server.test.js -> tools/clidash/test/server.test.js
+add/tools/clidash/test/smoke.sh -> tools/clidash/test/smoke.sh
+add/tools/clidash/views/ncl-overview.js -> tools/clidash/views/ncl-overview.js
+```
+
 That is the only file change this skill makes. Nothing in NanoClaw `src/` is
 touched, no dependency is added.
 
@@ -60,6 +97,10 @@ root, so it works as-is when you run clidash from `tools/clidash/`:
 ```bash
 cd tools/clidash
 cp clidash.config.example.json clidash.config.json
+```
+
+```nc:copy
+add/tools/clidash/clidash.config.example.json -> tools/clidash/clidash.config.json
 ```
 
 `clidash.config.json` is your local config — add it to `.gitignore` if you
@@ -78,6 +119,10 @@ Tests use a stub CLI — no real `ncl` or `docker` needed:
 
 ```bash
 npm test
+```
+
+```nc:run effect:test
+cd tools/clidash && npm test
 ```
 
 All tests should pass (Node ≥ 22.5, `node:test`, zero dependencies).

--- a/.claude/skills/add-dashboard/REMOVE.md
+++ b/.claude/skills/add-dashboard/REMOVE.md
@@ -1,0 +1,17 @@
+# Remove Dashboard
+
+Safe to re-run even if some pieces are already gone.
+
+```bash
+rm -f src/dashboard-pusher.ts src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts
+pnpm uninstall @nanoco/nanoclaw-dashboard 2>/dev/null || true
+```
+
+Remove the dashboard block from `main()` in `src/index.ts`: the
+`// Dashboard (optional…)` comment, the dynamic import, and the
+`await startDashboard();` call. Remove `DASHBOARD_SECRET` and
+`DASHBOARD_PORT` from `.env`, then run:
+
+```bash
+pnpm run build
+```

--- a/.claude/skills/add-dashboard/SKILL.md
+++ b/.claude/skills/add-dashboard/SKILL.md
@@ -25,7 +25,11 @@ NanoClaw (pusher)              Dashboard (npm package)
 ### 1. Install the npm package
 
 ```bash
-pnpm install @nanoco/nanoclaw-dashboard
+pnpm install @nanoco/nanoclaw-dashboard@0.3.0
+```
+
+```nc:dep
+@nanoco/nanoclaw-dashboard@0.3.0
 ```
 
 ### 2. Copy the pusher module and its tests
@@ -36,6 +40,12 @@ Copy all three resource files into `src/`. The tests ship with the skill and run
 .claude/skills/add-dashboard/resources/dashboard-pusher.ts       → src/dashboard-pusher.ts
 .claude/skills/add-dashboard/resources/dashboard-pusher.test.ts  → src/dashboard-pusher.test.ts
 .claude/skills/add-dashboard/resources/dashboard-wiring.test.ts  → src/dashboard-wiring.test.ts
+```
+
+```nc:copy
+resources/dashboard-pusher.ts -> src/dashboard-pusher.ts
+resources/dashboard-pusher.test.ts -> src/dashboard-pusher.test.ts
+resources/dashboard-wiring.test.ts -> src/dashboard-wiring.test.ts
 ```
 
 - `dashboard-pusher.test.ts` — behavior: starts the pusher, posts a real snapshot to a fake dashboard.
@@ -51,6 +61,10 @@ Add this block inside `main()`, just before the `log.info('NanoClaw running')` l
   // Dashboard (optional; no-ops without DASHBOARD_SECRET)
   const { startDashboard } = await import('./dashboard-pusher.js');
   await startDashboard();
+```
+
+```nc:run
+bash .claude/skills/add-dashboard/apply.sh
 ```
 
 `startDashboard()` reads `DASHBOARD_SECRET`/`DASHBOARD_PORT` itself and no-ops if the secret is unset, so nothing else in core needs to change.
@@ -74,6 +88,14 @@ pnpm exec vitest run src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts  
 source setup/lib/install-slug.sh
 systemctl --user restart $(systemd_unit)              # Linux
 # or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+```
+
+```nc:run effect:build
+pnpm run build
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts
 ```
 
 Run `build` **before** the tests: it's what guards the `@nanoco/nanoclaw-dashboard` dependency. `dashboard-pusher.ts` reaches the package through `await import('@nanoco/nanoclaw-dashboard')`, so if step 4 was skipped, `pnpm run build` fails with `TS2307: Cannot find module`. The behavior test deliberately *mocks* that package — its `startDashboard` binds a real dashboard port, a side effect we don't want in a test — so the test alone would pass with the dependency missing. Build is therefore the leg that verifies the dependency is installed; keep it ahead of the tests in the validate step.

--- a/.claude/skills/add-dashboard/apply.sh
+++ b/.claude/skills/add-dashboard/apply.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target=src/index.ts
+grep -q "import('./dashboard-pusher.js')" "$target" && exit 0
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+awk '
+  /  log\.info\('\''NanoClaw running'\''\);/ && !added {
+    print "  // Dashboard (optional; no-ops without DASHBOARD_SECRET)"
+    print "  const { startDashboard } = await import('\''./dashboard-pusher.js'\'');"
+    print "  await startDashboard();"
+    print ""
+    added = 1
+  }
+  { print }
+  END { if (!added) exit 1 }
+' "$target" > "$tmp"
+cp "$tmp" "$target"

--- a/.claude/skills/add-macos-statusbar/SKILL.md
+++ b/.claude/skills/add-macos-statusbar/SKILL.md
@@ -24,6 +24,10 @@ If not on macOS, stop and tell the user:
 which swiftc
 ```
 
+```nc:run effect:check
+test "$(uname -s)" = Darwin && command -v swiftc >/dev/null
+```
+
 If not found, tell the user:
 
 > Xcode Command Line Tools are required. Install them by running:
@@ -53,12 +57,20 @@ mkdir -p dist
 swiftc -O -o dist/statusbar "${CLAUDE_SKILL_DIR}/add/src/statusbar.swift"
 ```
 
+```nc:run effect:external
+mkdir -p dist && swiftc -O -o dist/statusbar .claude/skills/add-macos-statusbar/add/src/statusbar.swift
+```
+
 This produces a small native binary at `dist/statusbar`.
 
 On macOS Sequoia or later, clear the quarantine attribute so the binary can run:
 
 ```bash
 xattr -cr dist/statusbar
+```
+
+```nc:run effect:external
+xattr -cr dist/statusbar 2>/dev/null || true
 ```
 
 ### Create the launchd plist

--- a/.claude/skills/add-mnemon/SKILL.md
+++ b/.claude/skills/add-mnemon/SKILL.md
@@ -79,6 +79,10 @@ cat > /tmp/input.json
 exec bun run /app/src/index.ts < /tmp/input.json
 ```
 
+```nc:run
+bash .claude/skills/add-mnemon/apply.sh
+```
+
 `>/dev/stderr 2>&1` routes all mnemon output to stderr (docker logs) so it doesn't interfere with the JSON stdin handshake between host and agent-runner.
 
 ### 3. Copy the integration tests
@@ -91,6 +95,11 @@ cp .claude/skills/add-mnemon/mnemon-entrypoint.test.ts src/mnemon-entrypoint.tes
 pnpm exec vitest run src/mnemon-dockerfile.test.ts src/mnemon-entrypoint.test.ts
 ```
 
+```nc:copy
+mnemon-dockerfile.test.ts -> src/mnemon-dockerfile.test.ts
+mnemon-entrypoint.test.ts -> src/mnemon-entrypoint.test.ts
+```
+
 `mnemon-dockerfile.test.ts` asserts the `MNEMON_VERSION` ARG and `MNEMON_DATA_DIR` ENV are present (red if the install layer is dropped on an upgrade). `mnemon-entrypoint.test.ts` asserts the entrypoint invokes `mnemon setup --target claude-code` (red if the wiring is removed).
 
 ### 4. Rebuild and smoke-test the image
@@ -98,6 +107,14 @@ pnpm exec vitest run src/mnemon-dockerfile.test.ts src/mnemon-entrypoint.test.ts
 ```bash
 ./container/build.sh
 docker run --rm --entrypoint mnemon nanoclaw-agent:latest --version
+```
+
+```nc:run effect:build
+./container/build.sh
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/mnemon-dockerfile.test.ts src/mnemon-entrypoint.test.ts
 ```
 
 ## Phase 3: Restart and Verify

--- a/.claude/skills/add-mnemon/apply.sh
+++ b/.claude/skills/add-mnemon/apply.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if ! grep -q 'ARG MNEMON_VERSION' container/Dockerfile; then
+  awk '
+    /^# ---- Bun runtime/ && !added {
+      print "# ---- mnemon — persistent agent memory ----------------------------------------"
+      print "ARG MNEMON_VERSION=0.1.1"
+      printf "%s%c\n", "RUN ARCH=$(dpkg --print-architecture) && ", 92
+      printf "%s%c\n", "    curl -fsSL \"https://github.com/mnemon-dev/mnemon/releases/download/v${MNEMON_VERSION}/mnemon_${MNEMON_VERSION}_linux_${ARCH}.tar.gz\" ", 92
+      printf "%s%c\n", "    | tar -xz -C /usr/local/bin mnemon && ", 92
+      print "    chmod +x /usr/local/bin/mnemon"
+      print ""
+      print "ENV MNEMON_DATA_DIR=/home/node/.claude/mnemon"
+      print ""
+      added = 1
+    }
+    { print }
+    END { if (!added) exit 1 }
+  ' container/Dockerfile > "$tmp"
+  cp "$tmp" container/Dockerfile
+fi
+
+if ! grep -q 'mnemon setup --target claude-code' container/entrypoint.sh; then
+  awk '
+    /^set -e$/ && !added {
+      print
+      print ""
+      print "mnemon setup --target claude-code --yes --global >/dev/stderr 2>&1"
+      added = 1
+      next
+    }
+    { print }
+    END { if (!added) exit 1 }
+  ' container/entrypoint.sh > "$tmp"
+  cp "$tmp" container/entrypoint.sh
+fi

--- a/.claude/skills/add-ollama-provider/REMOVE.md
+++ b/.claude/skills/add-ollama-provider/REMOVE.md
@@ -1,0 +1,16 @@
+# Remove Ollama Provider
+
+For each configured agent group:
+
+1. Remove the `env` and `blockedHosts` keys from
+   `groups/<FOLDER>/container.json`.
+2. Remove the `model` key from
+   `data/v2-sessions/<group-id>/.claude-shared/settings.json` while preserving
+   every other setting.
+3. Restart the group so the next container uses the default Claude route.
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+No image rebuild is required.

--- a/.claude/skills/add-ollama-tool/SKILL.md
+++ b/.claude/skills/add-ollama-tool/SKILL.md
@@ -66,6 +66,13 @@ cp $S/ollama-env.ts             src/ollama-env.ts
 cp $S/ollama-wiring.test.ts     src/ollama-wiring.test.ts
 ```
 
+```nc:copy
+ollama-mcp-stdio.ts -> container/agent-runner/src/ollama-mcp-stdio.ts
+ollama-registration.test.ts -> container/agent-runner/src/ollama-registration.test.ts
+ollama-env.ts -> src/ollama-env.ts
+ollama-wiring.test.ts -> src/ollama-wiring.test.ts
+```
+
 ### Register the MCP server in the agent-runner
 
 Edit `container/agent-runner/src/index.ts`. Find the `mcpServers` object that currently looks like this:
@@ -161,6 +168,10 @@ If `add-atomic-chat-tool` (or another local-model tool) has already turned this 
 multi-branch block, just add an `else if (line.includes('[OLLAMA]'))` branch instead of
 replacing it.
 
+```nc:run
+bash .claude/skills/add-ollama-tool/apply.sh
+```
+
 ### Add env-var stubs to `.env.example`
 
 Append to `.env.example`:
@@ -176,6 +187,15 @@ Append to `.env.example`:
 # OLLAMA_ADMIN_TOOLS=true
 ```
 
+```nc:append to:.env.example
+# Ollama MCP tool (.claude/skills/add-ollama-tool)
+# Override the host where the Ollama daemon listens.
+# Default: http://host.docker.internal:11434 (with fallback to localhost)
+# OLLAMA_HOST=http://host.docker.internal:11434
+# Opt in to library-management tools (pull, delete, show, list-running).
+# OLLAMA_ADMIN_TOOLS=true
+```
+
 ### Validate code changes
 
 ```bash
@@ -186,6 +206,17 @@ pnpm exec vitest run src/ollama-wiring.test.ts
 # Container tree: index.ts registration
 (cd container/agent-runner && bun test src/ollama-registration.test.ts)
 ./container/build.sh
+```
+
+```nc:run effect:build
+pnpm run build
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+./container/build.sh
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/ollama-wiring.test.ts
+cd container/agent-runner && bun test src/ollama-registration.test.ts
 ```
 
 All must be clean before proceeding. The wiring and registration tests confirm the two

--- a/.claude/skills/add-ollama-tool/apply.sh
+++ b/.claude/skills/add-ollama-tool/apply.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if ! grep -q '^[[:space:]]*ollama:' container/agent-runner/src/index.ts; then
+  awk '
+    /^[[:space:]]*nanoclaw: \{/ { in_nanoclaw = 1 }
+    in_nanoclaw && /^    },$/ && !added {
+      print
+      print "    ollama: {"
+      print "      command: '\''bun'\'',"
+      print "      args: ['\''run'\'', path.join(__dirname, '\''ollama-mcp-stdio.ts'\'')],"
+      print "      env: {"
+      print "        ...(process.env.OLLAMA_HOST ? { OLLAMA_HOST: process.env.OLLAMA_HOST } : {}),"
+      print "        ...(process.env.OLLAMA_ADMIN_TOOLS ? { OLLAMA_ADMIN_TOOLS: process.env.OLLAMA_ADMIN_TOOLS } : {}),"
+      print "      },"
+      print "    },"
+      added = 1
+      in_nanoclaw = 0
+      next
+    }
+    { print }
+    END { if (!added) exit 1 }
+  ' container/agent-runner/src/index.ts > "$tmp"
+  cp "$tmp" container/agent-runner/src/index.ts
+fi
+
+if ! grep -q "import { ollamaEnv } from './ollama-env.js';" src/container-runner.ts; then
+  awk '
+    { print }
+    /} from '\''\.\/providers\/provider-container-registry\.js'\'';/ && !added {
+      print "import { ollamaEnv } from '\''./ollama-env.js'\'';"
+      added = 1
+    }
+    END { if (!added) exit 1 }
+  ' src/container-runner.ts > "$tmp"
+  cp "$tmp" src/container-runner.ts
+fi
+
+if ! grep -q '\.\.\.ollamaEnv(),' src/container-runner.ts; then
+  awk '
+    /    TZ: containerConfig\.timezone \?\? TIMEZONE,/ && !added {
+      print
+      print "    ...ollamaEnv(),"
+      added = 1
+      next
+    }
+    { print }
+    END { if (!added) exit 1 }
+  ' src/container-runner.ts > "$tmp"
+  cp "$tmp" src/container-runner.ts
+fi
+
+if ! grep -q "line.includes('\[OLLAMA\]')" src/drivers/docker-driver.ts; then
+  perl -pi -e '
+    my $q = chr 39;
+    if (/^      if \(line\.includes\(.*\[ATOMIC\].*\)\) \{$/) {
+      chomp;
+      s/\) \{$//;
+      $_ .= " || line.includes(${q}[OLLAMA]${q})) {\n";
+      $added = 1;
+    } elsif (/^      log\.debug\(line, \{ container: this\.name \}\);$/) {
+      $_ = "      if (line.includes(${q}[OLLAMA]${q})) {\n" .
+        "        log.info(line, { container: this.name });\n" .
+        "      } else {\n" .
+        "        log.debug(line, { container: this.name });\n" .
+        "      }\n";
+      $added = 1;
+    }
+    END { exit 1 unless $added }
+  ' src/drivers/docker-driver.ts
+fi

--- a/.claude/skills/add-tavily-tool/SKILL.md
+++ b/.claude/skills/add-tavily-tool/SKILL.md
@@ -46,6 +46,10 @@ entry named `mcp-remote` is not already present:
 }
 ```
 
+```nc:json-merge into:container/cli-tools.json key:name
+{ "name": "mcp-remote", "version": "0.1.38" }
+```
+
 Keep the JSON valid and limit the entry to the two fields shown; this package
 does not require a native build-script opt-in.
 
@@ -55,10 +59,22 @@ Copy the dependency guard into the host test tree:
 cp .claude/skills/add-tavily-tool/tavily-manifest.test.ts src/tavily-manifest.test.ts
 ```
 
+```nc:copy
+tavily-manifest.test.ts -> src/tavily-manifest.test.ts
+```
+
 Build the image and run the guard:
 
 ```bash
 ./container/build.sh
+pnpm exec vitest run src/tavily-manifest.test.ts
+```
+
+```nc:run effect:build
+./container/build.sh
+```
+
+```nc:run effect:test
 pnpm exec vitest run src/tavily-manifest.test.ts
 ```
 

--- a/.claude/skills/add-vercel/SKILL.md
+++ b/.claude/skills/add-vercel/SKILL.md
@@ -139,6 +139,23 @@ cp .claude/skills/add-vercel/vercel-manifest.test.ts src/vercel-manifest.test.ts
 pnpm exec vitest run src/vercel-manifest.test.ts
 ```
 
+```nc:copy
+container-skills/vercel-cli/SKILL.md -> container/skills/vercel-cli/SKILL.md
+vercel-manifest.test.ts -> src/vercel-manifest.test.ts
+```
+
+```nc:json-merge into:container/cli-tools.json key:name
+{ "name": "vercel", "version": "52.2.1" }
+```
+
+```nc:run effect:build
+./container/build.sh
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/vercel-manifest.test.ts
+```
+
 The test asserts both halves of the install: a pinned `vercel` entry in `container/cli-tools.json`, and the container skill at `container/skills/vercel-cli/`. Either alone is a broken install — a manifest entry with no skill leaves the agent a binary nobody told it about, and a skill with no entry tells it to run a command that is not there.
 
 ## Phase 5: Sync Skills to Running Agent Groups

--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -70,6 +70,8 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'src/channels/slack-lib.test.ts',
       'src/channels/slack-a2a-guard.ts',
       'src/channels/slack-a2a-guard.test.ts',
+      'src/channels/slack-raw-text.ts',
+      'src/channels/slack-raw-text.test.ts',
       'src/channels/slack-registration.test.ts',
       'src/channels/slack-instances-registration.test.ts',
       'src/provisioning/slack-app.ts',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Add deterministic `nc:` apply and test directives to nine repeatable installer skills. This makes their repeatable steps available to the generic composition runner; platform-specific and external steps remain explicitly marked.

Keep each existing operator workflow intact. Multiline source edits live in small Bash helpers; no JavaScript or MJS installer code is added. Existing focused unit and conformance tests remain in place.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
