### PR TITLE
test(skills): cover main and companion skills

### DIFF
--- a/.github/workflows/registry-skills.yml
+++ b/.github/workflows/registry-skills.yml
@@ -34,6 +34,13 @@ jobs:
           git fetch origin channels providers
           echo "channels=$(git rev-parse origin/channels)" >> "$GITHUB_OUTPUT"
           echo "providers=$(git rev-parse origin/providers)" >> "$GITHUB_OUTPUT"
+      - name: Validate all checked-in skills
+        run: pnpm exec vitest run scripts/skill-conformance.test.ts
+      - name: Validate registry skill documents
+        env:
+          REGISTRY_CHANNELS_SHA: ${{ steps.refs.outputs.channels }}
+          REGISTRY_PROVIDERS_SHA: ${{ steps.refs.outputs.providers }}
+        run: pnpm exec tsx scripts/test-registry-skills.ts --validate-docs
 
   test:
     needs: discover

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -423,7 +423,7 @@ export function referenceProse(md: string): string {
 // A hardcoded `origin` breaks forks where the registry branch lives on
 // `upstream`. Generic mirror of channels-remote.sh: explicit override → the
 // first remote that actually has the branch → origin.
-function defaultResolveRemote(branch: string, root: string): string {
+export function defaultResolveRemote(branch: string, root: string): string {
   const override = process.env.NANOCLAW_CHANNELS_REMOTE;
   if (override) return override;
   const cap = (cmd: string): string => {

--- a/scripts/skill-conformance.test.ts
+++ b/scripts/skill-conformance.test.ts
@@ -27,11 +27,14 @@
 // milliseconds inside the normal vitest CI step.
 
 import { describe, it, expect, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { applySkill, fullyApplied, type ApplyEvent, type ApplyResult } from './skill-apply.js';
+import { getSkillCompanions } from '../setup/skill-compositions.js';
+import { validateSkill } from '../src/templates/skills.js';
 import {
   parseDirectives,
   validate,
@@ -45,6 +48,16 @@ import {
 const ROOT = process.cwd();
 const SKILLS_DIR = join(ROOT, '.claude/skills');
 const CHAT_VERSION = resolveChatCoreVersion(ROOT);
+
+function findSkillDirs(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) return [];
+    const dir = join(root, entry.name);
+    return [...(existsSync(join(dir, 'SKILL.md')) ? [dir] : []), ...findSkillDirs(dir)];
+  });
+}
+
+const ALL_SKILL_DIRS = [SKILLS_DIR, join(ROOT, 'container/skills')].flatMap(findSkillDirs);
 
 // ---------------------------------------------------------------------------
 // Discovery: every skill whose SKILL.md opens an nc: fence.
@@ -163,6 +176,31 @@ const isSideEffectRun = (d: Directive | undefined): boolean =>
 // ---------------------------------------------------------------------------
 
 describe('skill discovery', () => {
+  it.each(ALL_SKILL_DIRS)('%s has valid skill anatomy', (dir) => {
+    expect(validateSkill(dir)).toBeUndefined();
+  });
+
+  it('includes every declared companion composition in the E2E list', () => {
+    const listed = JSON.parse(
+      execFileSync('pnpm', ['exec', 'tsx', 'scripts/test-registry-skills.ts', '--list'], {
+        cwd: ROOT,
+        encoding: 'utf8',
+      }),
+    ) as Array<{ skill: string }>;
+    const expected = readdirSync(SKILLS_DIR)
+      .filter((name) => name.startsWith('add-') && existsSync(join(SKILLS_DIR, name, 'SKILL.md')))
+      .map((name) => [name, ...getSkillCompanions(name).map(({ skill }) => skill)])
+      .filter((steps) => steps.length > 1)
+      .map((steps) => steps.join('+'))
+      .sort();
+    expect(
+      listed
+        .map(({ skill }) => skill)
+        .filter((skill) => skill.includes('+'))
+        .sort(),
+    ).toEqual(expected);
+  });
+
   it('finds the fence-carrying skills', () => {
     // Sanity floor: discovery walking the wrong directory (or the fence regex
     // regressing) must fail loudly, not silently skip the whole suite.
@@ -174,6 +212,12 @@ describe('skill discovery', () => {
   it('finds the prose docs', () => {
     expect(SKILL_DOCS.map((d) => d.doc)).toContain('add-slack/REMOVE.md');
     expect(SKILL_DOCS.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('finds nested skills', () => {
+    const topLevel = readdirSync(SKILLS_DIR).filter((name) => existsSync(join(SKILLS_DIR, name, 'SKILL.md')));
+    expect(ALL_SKILL_DIRS.length).toBeGreaterThan(topLevel.length);
+    expect(ALL_SKILL_DIRS).toContain(join(ROOT, 'container/skills/welcome'));
   });
 });
 

--- a/scripts/test-registry-skills.ts
+++ b/scripts/test-registry-skills.ts
@@ -4,10 +4,12 @@
 // its build/test directives. `--all` is the local equivalent of the CI matrix.
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
+import { getSkillCompanions, materializeSkillCompanion, type SkillCompanion } from '../setup/skill-compositions.js';
+import { validateSkill, validateSkillMarkdown } from '../src/templates/skills.js';
 import { applySkill, fullyApplied } from './skill-apply.js';
 import {
   lintGateAmbiguity,
@@ -20,15 +22,20 @@ import { resolveRegistryRemote } from './update-skills.js';
 
 const SOURCE_ROOT = process.cwd();
 const SKILLS_ROOT = join(SOURCE_ROOT, '.claude/skills');
+const TEMP_ROOT = process.env.ACT ? SOURCE_ROOT : tmpdir();
 const REGISTRY_MENTION = /(?:from-branch:|origin\/|git fetch\s+\S+\s+)(channels|providers)(?![A-Za-z0-9._\/-])/g;
 const REGISTRY_BRANCHES = new Set(['channels', 'providers']);
+const MUTATION_KINDS = new Set(['append', 'copy', 'dep', 'env-set', 'json-merge']);
 const STUBBED_EFFECTS = new Set(['check', 'external', 'fetch']);
+const COMPOSED_STUBBED_EFFECTS = new Set(['external', 'fetch']);
 const SKIPPED_EFFECTS = ['restart', 'wire'];
 
 interface RegistrySkill {
   skill: string;
+  steps: SkillCompanion[];
   branches: string[];
   bun: boolean;
+  image: boolean;
   executable: boolean;
   dir: string;
   markdown: string;
@@ -51,7 +58,7 @@ function git(args: string[], cwd = SOURCE_ROOT): string {
 
 function command(cmd: string, cwd: string, quiet = false): string {
   if (!quiet) console.log(`  $ ${cmd}`);
-  const result = spawnSync(cmd, { cwd, shell: true, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+  const result = spawnSync(cmd, { cwd, shell: '/bin/bash', encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
   if (result.status !== 0) {
     if (result.stdout) process.stdout.write(result.stdout);
     if (result.stderr) process.stderr.write(result.stderr);
@@ -61,15 +68,20 @@ function command(cmd: string, cwd: string, quiet = false): string {
 }
 
 function discover(): RegistrySkill[] {
-  return readdirSync(SKILLS_ROOT)
+  const standalone = readdirSync(SKILLS_ROOT)
     .filter((name) => name.startsWith('add-'))
     .flatMap((skill) => {
       const dir = join(SKILLS_ROOT, skill);
       const path = join(dir, 'SKILL.md');
       if (!existsSync(path)) return [];
       const markdown = readFileSync(path, 'utf8');
-      if (![...markdown.matchAll(REGISTRY_MENTION)].length) return [];
       const directives = parseDirectives(markdown);
+      const registryBacked = [...markdown.matchAll(REGISTRY_MENTION)].length > 0;
+      const mutatesProject = directives.some(
+        (directive) =>
+          MUTATION_KINDS.has(directive.kind) || (directive.kind === 'run' && directive.attrs.effect === undefined),
+      );
+      if (!registryBacked && !mutatesProject) return [];
       const branches = [
         ...new Set(
           directives
@@ -77,31 +89,56 @@ function discover(): RegistrySkill[] {
             .map((d) => String(d.attrs['from-branch'])),
         ),
       ].sort();
-      if (branches.some((branch) => !REGISTRY_BRANCHES.has(branch))) return [];
+      const unsupported = branches.find((branch) => !REGISTRY_BRANCHES.has(branch));
+      if (unsupported) throw new Error(`${skill} uses unsupported registry branch ${unsupported}`);
       return [
         {
           skill,
+          steps: [{ skill }],
           branches,
           bun: markdown.includes('container/agent-runner'),
-          executable: branches.length > 0,
+          image: false,
+          executable: !registryBacked || branches.length > 0,
           dir,
           markdown,
         },
       ];
     })
     .sort((a, b) => a.skill.localeCompare(b.skill));
+
+  return standalone.flatMap((meta) => {
+    const companions = getSkillCompanions(meta.skill);
+    if (companions.length === 0) return [meta];
+    const unsupported = companions.find(({ branch }) => branch && !REGISTRY_BRANCHES.has(branch));
+    if (unsupported?.branch) {
+      throw new Error(`${unsupported.skill} uses unsupported registry branch ${unsupported.branch}`);
+    }
+    return [
+      meta,
+      {
+        ...meta,
+        skill: [meta.skill, ...companions.map(({ skill }) => skill)].join('+'),
+        steps: [{ skill: meta.skill }, ...companions],
+        branches: [
+          ...new Set([...meta.branches, ...companions.flatMap(({ branch }) => (branch ? [branch] : []))]),
+        ].sort(),
+        bun: true,
+        image: true,
+      },
+    ];
+  });
 }
 
-function fixtureScenarios(meta: RegistrySkill): FixtureScenario[] {
-  const path = join(meta.dir, 'apply-fixtures.json');
+function fixtureScenarios(dir: string): FixtureScenario[] {
+  const path = join(dir, 'apply-fixtures.json');
   if (!existsSync(path)) return [{}];
   const fixture = JSON.parse(readFileSync(path, 'utf8')) as Fixture;
   return fixture.scenarios?.length ? fixture.scenarios : [{}];
 }
 
-function resolveRegistryRefs(): Record<string, string> {
+function resolveRegistryRefs(branches: Iterable<string> = REGISTRY_BRANCHES): Record<string, string> {
   const refs: Record<string, string> = {};
-  for (const branch of REGISTRY_BRANCHES) {
+  for (const branch of branches) {
     const remote = resolveRegistryRemote(SOURCE_ROOT, branch);
     const envName = `REGISTRY_${branch.toUpperCase()}_SHA`;
     const pinned = process.env[envName];
@@ -121,6 +158,40 @@ function resolveRegistryRefs(): Record<string, string> {
   return refs;
 }
 
+function validateRegistrySkillDocs(refs: Record<string, string>): void {
+  const failures: string[] = [];
+  const activeSkills = new Set(
+    readdirSync(SKILLS_ROOT).filter((name) => existsSync(join(SKILLS_ROOT, name, 'SKILL.md'))),
+  );
+  for (const name of [...activeSkills]) {
+    getSkillCompanions(name).forEach(({ skill }) => activeSkills.add(skill));
+  }
+  let count = 0;
+  let inactive = 0;
+  for (const [branch, ref] of Object.entries(refs)) {
+    const paths = git(['ls-tree', '-r', '--name-only', ref])
+      .split('\n')
+      .filter(
+        (path) =>
+          path.endsWith('/SKILL.md') && (path.startsWith('.claude/skills/') || path.startsWith('container/skills/')),
+      );
+    for (const path of paths) {
+      const skill = path.startsWith('.claude/skills/') ? path.slice('.claude/skills/'.length).split('/')[0] : '';
+      if (skill && !activeSkills.has(skill)) {
+        inactive += 1;
+        continue;
+      }
+      count += 1;
+      const problem = validateSkillMarkdown(git(['show', `${ref}:${path}`]));
+      if (problem) failures.push(`${branch}:${path}: ${problem}`);
+    }
+  }
+  if (failures.length) throw new Error(failures.join('\n'));
+  console.log(
+    `${count} active registry skill documents passed anatomy validation; ${inactive} inactive documents skipped.`,
+  );
+}
+
 function pinRegistryRef(root: string, branch: string, commit: string): void {
   try {
     git(['cat-file', '-e', `${commit}^{commit}`], root);
@@ -130,85 +201,125 @@ function pinRegistryRef(root: string, branch: string, commit: string): void {
   git(['update-ref', `refs/remotes/skill-ci/${branch}`, commit], root);
 }
 
+function workspaceState(root: string): string {
+  const paths = git(['ls-files', '--others', '--exclude-standard'], root).split('\n').filter(Boolean);
+  if (existsSync(join(root, '.env'))) paths.push('.env');
+  const hashes = [...new Set(paths)]
+    .sort()
+    .map((path) => `${path}:${git(['hash-object', path], root)}`)
+    .join('\n');
+  return `${git(['diff', '--binary', 'HEAD'], root)}\n${hashes}`;
+}
+
 async function testSkill(
   meta: RegistrySkill,
+  dir: string,
+  markdown: string,
   fixture: FixtureScenario,
   root: string,
   refs: Record<string, string>,
 ): Promise<void> {
   if (!meta.executable) {
-    throw new Error(`${meta.skill} pulls registry code but has no nc:copy from-branch directive`);
+    throw new Error(`${meta.skill} has no deterministic apply directive`);
   }
 
-  const directives = parseDirectives(meta.markdown);
+  const anatomy = validateSkill(dir);
+  if (anatomy) throw new Error(anatomy);
+  const directives = parseDirectives(markdown);
+  if (directives.length === 0) throw new Error(`${basename(dir)} has no nc: directives`);
   const problems = [
     ...validate(directives, { chatVersion: resolveChatCoreVersion(root) }),
     ...lintGateAmbiguity(directives),
-    ...lintReferenceFloor(meta.markdown),
+    ...lintReferenceFloor(markdown),
   ];
   if (problems.length) throw new Error(problems.map((p) => `line ${p.line}: ${p.message}`).join('\n'));
 
   for (const branch of meta.branches) pinRegistryRef(root, branch, refs[branch]);
   const byLine = new Map(directives.map((directive) => [directive.line, directive]));
-  let current = directives[0];
+  const repeatSkipEffects = [...SKIPPED_EFFECTS, 'build', 'test'];
+  let firstState = '';
 
-  const result = await applySkill(meta.dir, root, {
-    inputs: fixture.inputs ?? {},
-    skipEffects: SKIPPED_EFFECTS,
-    resolveRemote: () => 'skill-ci',
-    onEvent: (event) => {
-      if (event.type === 'step-start') current = byLine.get(event.line);
-    },
-    exec: (cmd) => {
-      if (/^git fetch skill-ci (channels|providers)$/.test(cmd)) return '';
-      const stub = fixture.exec?.find((candidate) => cmd.includes(candidate.match));
-      if (stub) return stub.stdout;
-      if (current?.kind === 'run' && STUBBED_EFFECTS.has(String(current.attrs.effect))) {
-        return '';
-      }
-      return command(cmd, root);
-    },
-    execStream: async () => ({ ok: true, fields: fixture.stepFields ?? {} }),
-  });
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    let current = directives[0];
+    const result = await applySkill(dir, root, {
+      inputs: fixture.inputs ?? {},
+      skipEffects: attempt === 1 ? SKIPPED_EFFECTS : repeatSkipEffects,
+      resolveRemote: () => 'skill-ci',
+      onEvent: (event) => {
+        if (event.type === 'step-start') current = byLine.get(event.line);
+      },
+      exec: (cmd) => {
+        if (/^git fetch skill-ci (channels|providers)$/.test(cmd)) return '';
+        const stub = fixture.exec?.find((candidate) => cmd.includes(candidate.match));
+        if (stub) return stub.stdout;
+        const stubbedEffects = meta.steps.length > 1 ? COMPOSED_STUBBED_EFFECTS : STUBBED_EFFECTS;
+        if (current?.kind === 'run' && stubbedEffects.has(String(current.attrs.effect))) {
+          return '';
+        }
+        return command(cmd, root);
+      },
+      execStream: async () => ({ ok: true, fields: fixture.stepFields ?? {} }),
+    });
 
-  if (!fullyApplied(result)) {
-    const failures = [
-      ...result.deferred.map((value) => `deferred: ${value}`),
-      ...result.agentTasks.map((task) => `line ${task.line}: ${task.reason}`),
-    ];
-    throw new Error(failures.join('\n'));
+    if (!fullyApplied(result)) {
+      const failures = [
+        ...result.deferred.map((value) => `deferred: ${value}`),
+        ...result.agentTasks.map((task) => `line ${task.line}: ${task.reason}`),
+      ];
+      throw new Error(failures.join('\n'));
+    }
+
+    const state = workspaceState(root);
+    if (attempt === 1) firstState = state;
+    else if (state !== firstState) throw new Error('second apply changed the composed project');
   }
 }
 
 async function testAll(skills: RegistrySkill[]): Promise<void> {
-  const refs = resolveRegistryRefs();
+  const refs = resolveRegistryRefs(new Set(skills.flatMap(({ branches }) => branches)));
   const head = git(['rev-parse', 'HEAD']);
   const failures: string[] = [];
 
   for (const meta of skills) {
     console.log(`\n==> ${meta.skill}`);
     if (!meta.executable) {
-      failures.push(`${meta.skill}: no nc:copy from-branch directive`);
+      failures.push(`${meta.skill}: no deterministic apply directive`);
       console.error(`  FAIL: ${failures.at(-1)}`);
       continue;
     }
 
-    const temp = mkdtempSync(join(tmpdir(), 'nanoclaw-skill-ci-'));
+    const temp = mkdtempSync(join(TEMP_ROOT, '.nanoclaw-skill-ci-'));
+    chmodSync(temp, 0o755);
     const root = join(temp, 'repo');
     try {
       git(['clone', '--quiet', '--shared', '--no-checkout', SOURCE_ROOT, root]);
       git(['checkout', '--quiet', '--detach', head], root);
       command('pnpm install --frozen-lockfile --prefer-offline', root);
       if (meta.bun) command('bun install --frozen-lockfile', join(root, 'container/agent-runner'));
-      const scenarios = fixtureScenarios(meta);
-      for (const [index, fixture] of scenarios.entries()) {
-        const scenario = fixture.name ?? String(index + 1);
-        if (scenarios.length > 1) console.log(`  scenario: ${scenario}`);
-        try {
-          await testSkill(meta, fixture, root, refs);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          throw new Error(`${scenario}: ${message}`);
+      if (meta.image) command('./container/build.sh', root);
+
+      for (const [index, step] of meta.steps.entries()) {
+        const skill = step.skill;
+        let dir = meta.dir;
+        if (index > 0) {
+          const ok = materializeSkillCompanion(step, root, {
+            resolveRemote: () => 'skill-ci',
+            exec: (cmd) => (/^git fetch skill-ci (channels|providers)$/.test(cmd) ? '' : command(cmd, root, true)),
+          });
+          if (!ok) throw new Error(`could not materialize companion skill ${skill}`);
+          dir = join(root, '.claude/skills', skill);
+        }
+        const markdown = readFileSync(join(dir, 'SKILL.md'), 'utf8');
+        const scenarios = fixtureScenarios(dir);
+        for (const [scenarioIndex, fixture] of scenarios.entries()) {
+          const scenario = fixture.name ?? String(scenarioIndex + 1);
+          if (meta.steps.length > 1 || scenarios.length > 1) console.log(`  ${skill}: ${scenario}`);
+          try {
+            await testSkill(meta, dir, markdown, fixture, root, refs);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`${scenario}: ${message}`);
+          }
         }
       }
       console.log(`  PASS: ${meta.skill}`);
@@ -222,7 +333,7 @@ async function testAll(skills: RegistrySkill[]): Promise<void> {
   }
 
   if (failures.length) throw new Error(`\n${failures.length}/${skills.length} skills failed:\n${failures.join('\n')}`);
-  console.log(`\n${skills.length}/${skills.length} registry skills passed.`);
+  console.log(`\n${skills.length}/${skills.length} skill compositions passed.`);
 }
 
 const skills = discover();
@@ -230,6 +341,8 @@ const arg = process.argv[2];
 
 if (arg === '--list') {
   console.log(JSON.stringify(skills.map(({ skill, bun, executable }) => ({ skill, bun, executable }))));
+} else if (arg === '--validate-docs') {
+  validateRegistrySkillDocs(resolveRegistryRefs());
 } else if (arg === '--all') {
   const requested = process.argv.slice(3);
   const selected = requested.length ? skills.filter(({ skill }) => requested.includes(skill)) : skills;
@@ -241,6 +354,6 @@ if (arg === '--list') {
   if (!meta) throw new Error(`unknown registry skill: ${arg}`);
   await testAll([meta]);
 } else {
-  console.error('usage: pnpm exec tsx scripts/test-registry-skills.ts --list|--all [skill...]|<skill>');
+  console.error('usage: pnpm exec tsx scripts/test-registry-skills.ts --list|--validate-docs|--all [skill...]|<skill>');
   process.exitCode = 2;
 }

--- a/setup/channels/companions.ts
+++ b/setup/channels/companions.ts
@@ -1,23 +1,15 @@
 /**
- * Per-channel wizard extension registries — the trunk seams that keep
+ * Per-channel wizard extension registry — the trunk seam that keeps
  * setup/auto.ts and run-channel-skill.ts free of channel-specific imports
  * and conditionals.
  *
- * Two registrations, both consulted generically by the channel flow:
- *
- *  - Auto-provision pre-step: runs BEFORE the channel's install skill
+ * Auto-provision pre-steps run BEFORE the channel's install skill
  *    and may return pre-bound skill `inputs` (e.g. when the channel's app /
  *    credentials can be obtained programmatically). The resolved agent name
  *    is passed in — for platforms where it doubles as the provisioned app's
  *    name. Returning undefined means "walk the manual path"; the skill flow
  *    then prompts as usual. Pre-steps own their prompts and must never throw
  *    for expected declines.
- *
- *  - Companion skills: additional skills applied right after the
- *    channel's main install skill, each with per-skill restarts skipped and
- *    ONE deferred service restart after all of them (see
- *    run-channel-skill.ts). For channels whose full payload is bigger than
- *    the adapter install itself.
  *
  * Registration import point: a channel feature payload appends its
  * self-registration import below (same discipline as the src/channels/index.ts
@@ -35,7 +27,6 @@ import { registerTelegramPreStep } from './telegram-pre-step.js';
 export type ChannelPreStep = (agentName: string) => Promise<Record<string, string> | undefined>;
 
 const preSteps = new Map<string, ChannelPreStep>();
-const companionSkills = new Map<string, readonly string[]>();
 
 /** Register the auto-provision pre-step for a channel (last write wins). */
 export function registerChannelPreStep(channel: string, step: ChannelPreStep): void {
@@ -46,21 +37,9 @@ export function getChannelPreStep(channel: string): ChannelPreStep | undefined {
   return preSteps.get(channel);
 }
 
-/**
- * Declare the companion skills applied after a channel's main install skill,
- * in order (skill directory names under `.claude/skills/`; last write wins).
- */
-export function registerCompanionSkills(channel: string, skills: readonly string[]): void {
-  companionSkills.set(channel, skills);
-}
-
-export function getCompanionSkills(channel: string): readonly string[] {
-  return companionSkills.get(channel) ?? [];
-}
-
 // ── Feature self-registration imports (appended by channel install skills) ──
 
 // Registrations shipped with trunk. The register function is passed in
 // (rather than the shim importing it) so each shim stays cycle-free.
-registerSlackAutoProvision(registerChannelPreStep, registerCompanionSkills);
+registerSlackAutoProvision(registerChannelPreStep);
 registerTelegramPreStep(registerChannelPreStep);

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -15,20 +15,20 @@
  * So the wire lives in exactly one place (init-first-agent) and is never
  * duplicated across channel skills.
  */
-import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import * as p from '@clack/prompts';
 
-import { firstFailureHint, fullyApplied } from '../../scripts/skill-apply.js';
+import { defaultResolveRemote, firstFailureHint, fullyApplied } from '../../scripts/skill-apply.js';
 import * as setupLog from '../logs.js';
+import { getSkillCompanions, materializeSkillCompanion } from '../skill-compositions.js';
 import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../lib/back-nav.js';
 import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
-import { channelsRemote, hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
+import { hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
 import { clearTemplatePick } from '../templates.js';
-import { getChannelPreStep, getCompanionSkills } from './companions.js';
+import { getChannelPreStep } from './companions.js';
 
 const DEFAULT_AGENT_NAME = 'Nano';
 
@@ -47,42 +47,13 @@ const CHANNELS_BRANCH = 'channels';
 export function materializeCompanionSkill(
   skill: string,
   projectRoot: string,
-  deps: { exec?: (command: string) => string; resolveRemote?: () => string } = {},
+  deps: { exec?: (command: string) => string; resolveRemote?: (branch: string) => string } = {},
 ): boolean {
-  const dir = `.claude/skills/${skill}`;
-  // Key the short-circuit on SKILL.md, not the directory: a directory left by
-  // an interrupted materialization would otherwise read as installed, and a
-  // missing SKILL.md parses as zero directives — "fully applied" while the
-  // feature is absent.
-  if (existsSync(join(projectRoot, dir, 'SKILL.md'))) return true;
-  const exec =
-    deps.exec ??
-    ((command: string) =>
-      execSync(command, { cwd: projectRoot, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
-  try {
-    const remote = (deps.resolveRemote ?? channelsRemote(projectRoot))();
-    exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
-    const files = exec(`git ls-tree -r --name-only '${remote}/${CHANNELS_BRANCH}' -- '${dir}'`)
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (files.length === 0) return false;
-    for (const file of files) {
-      mkdirSync(dirname(join(projectRoot, file)), { recursive: true });
-      exec(`git show '${remote}/${CHANNELS_BRANCH}:${file}' > '${file}'`);
-    }
-    return true;
-  } catch {
-    // Leave no partial directory behind — the SKILL.md short-circuit above
-    // makes a leftover half-fetched dir permanent on the next run. Deleting
-    // is safe here: this path only runs when the skill was absent on entry.
-    rmSync(join(projectRoot, dir), { recursive: true, force: true });
-    return false;
-  }
+  return materializeSkillCompanion({ skill, branch: CHANNELS_BRANCH }, projectRoot, deps);
 }
 
 /**
- * Apply a channel's declared companion skills (setup/channels/companions.ts)
+ * Apply a channel's declared companion skills (setup/skill-compositions.ts)
  * after its main install skill. Some channel payloads are bigger than the
  * adapter install itself — capabilities that live in their own skills and
  * used to be applied by hand, which is exactly how a fresh install ships a
@@ -105,15 +76,16 @@ async function applyCompanionSkills(
   projectRoot: string,
   overrides: ChannelSkillOverrides,
 ): Promise<void> {
-  const companions = getCompanionSkills(channel);
+  const companions = getSkillCompanions(`add-${channel}`);
   let applied = false;
   let degraded = false;
-  for (const skill of companions) {
-    if (!materializeCompanionSkill(skill, projectRoot)) {
+  for (const companion of companions) {
+    const skill = companion.skill;
+    if (!materializeSkillCompanion(companion, projectRoot)) {
       degraded = true;
       p.log.warn(
         `Companion skill ${skill} is not in this checkout and could not be fetched from the ` +
-          `${CHANNELS_BRANCH} branch. The ${channel} channel works, but the capability that ` +
+          `declared source. The ${channel} channel works, but the capability that ` +
           `skill adds is missing until you fetch and apply it: ` +
           `pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/${skill}`,
       );
@@ -122,7 +94,7 @@ async function applyCompanionSkills(
     const res = await runSkill(`.claude/skills/${skill}`, {
       projectRoot,
       exec: overrides.exec,
-      resolveRemote: overrides.resolveRemote,
+      resolveRemote: overrides.resolveRemote ?? ((branch) => defaultResolveRemote(branch, projectRoot)),
       // Skip per-skill restarts; this function performs ONE after all, below.
       skipEffects: overrides.skipEffects ?? ['restart'],
       onEvent: overrides.onEvent,

--- a/setup/channels/slack-auto-register.test.ts
+++ b/setup/channels/slack-auto-register.test.ts
@@ -1,13 +1,13 @@
 /**
  * The Slack auto-provision registration — the default Slack experience.
  *
- * Registration is unconditional: pre-step for slack, companion skills
- * declared in prerequisite order, and the provisioning flow lazy-loaded
- * only when the wizard actually invokes the pre-step.
+ * Registration is unconditional: the Slack pre-step is present, while the
+ * provisioning flow is lazy-loaded only when the wizard invokes it.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { registerSlackAutoProvision, SLACK_AGENTS_COMPANION_SKILLS } from './slack-auto-register.js';
+import { getSkillCompanions } from '../skill-compositions.js';
+import { registerSlackAutoProvision } from './slack-auto-register.js';
 
 afterEach(() => {
   vi.doUnmock('./slack-auto.js');
@@ -17,7 +17,7 @@ afterEach(() => {
 describe('registerSlackAutoProvision', () => {
   it('registers a slack pre-step that lazy-loads and delegates to the flow', async () => {
     const register = vi.fn();
-    registerSlackAutoProvision(register, vi.fn());
+    registerSlackAutoProvision(register);
 
     expect(register).toHaveBeenCalledTimes(1);
     const [channel, step] = register.mock.calls[0];
@@ -30,24 +30,18 @@ describe('registerSlackAutoProvision', () => {
     expect(maybeAutoProvisionSlack).toHaveBeenCalledExactlyOnceWith('Nano');
   });
 
-  it('declares the agents companion skills in prerequisite order', () => {
-    const registerCompanions = vi.fn();
-    registerSlackAutoProvision(vi.fn(), registerCompanions);
-
-    expect(registerCompanions).toHaveBeenCalledExactlyOnceWith('slack', SLACK_AGENTS_COMPANION_SKILLS);
-    // The room admission policy is the flow's prerequisite — order is the API.
-    expect(SLACK_AGENTS_COMPANION_SKILLS).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
+  it('the generic skill registry declares the agents companions in prerequisite order', () => {
+    expect(getSkillCompanions('add-slack')).toEqual([
+      { skill: 'slack-a2a-rooms', branch: 'channels' },
+      { skill: 'slack-agent-flow', branch: 'channels' },
+    ]);
   });
 });
 
-describe('companions registry wiring', () => {
-  it('a fresh companions module carries the slack pre-step and companion list', async () => {
+describe('channel pre-step registry wiring', () => {
+  it('a fresh companions module carries the slack pre-step', async () => {
     vi.resetModules();
     const companions = await import('./companions.js');
     expect(companions.getChannelPreStep('slack')).toBeTypeOf('function');
-    // Declared at wizard boot — a registration appended to the registry file
-    // mid-run would be invisible to the already-imported module, so the whole
-    // agents install rides on this boot-time declaration.
-    expect(companions.getCompanionSkills('slack')).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
   });
 });

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -10,36 +10,14 @@
  * import only when the wizard actually invokes the Slack pre-step. No
  * fetch, no import, nothing runs unless Slack is chosen.
  *
- * Registration also declares the Slack agents companion skills. `/add-slack`
- * alone is the base experience (one bot, DM/channel chat); the agents
- * feature — child bots provisioned from `create_agent`, shared a2a rooms,
- * canvases, DM onboarding — ships in the `slack-a2a-rooms` and
- * `slack-agent-flow` skills on the channels branch. Declaring them HERE, at
- * wizard boot, is load-bearing: the wizard imports the companion registry
- * once, so a registration appended to the registry file mid-run is invisible
- * to the process that would apply it. The channel flow materializes the
- * skill directories from the channels branch when this checkout doesn't
- * carry them.
- *
- * The register functions are injected by the caller (companions.ts passes
- * `registerChannelPreStep` / `registerCompanionSkills`) so this module has
- * zero runtime imports — no import cycle with the registry.
+ * The register function is injected by the caller so this module has zero
+ * runtime imports — no import cycle with the registry.
  */
 import type { ChannelPreStep } from './companions.js';
 
-/**
- * Applied in order after `/add-slack`: the room admission policy first (the
- * flow's prerequisite), then the create_agent → provisioned-bot flow.
- */
-export const SLACK_AGENTS_COMPANION_SKILLS = ['slack-a2a-rooms', 'slack-agent-flow'] as const;
-
-export function registerSlackAutoProvision(
-  register: (channel: string, step: ChannelPreStep) => void,
-  registerCompanions: (channel: string, skills: readonly string[]) => void,
-): void {
+export function registerSlackAutoProvision(register: (channel: string, step: ChannelPreStep) => void): void {
   register('slack', async (agentName) => {
     const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
     return maybeAutoProvisionSlack(agentName);
   });
-  registerCompanions('slack', SLACK_AGENTS_COMPANION_SKILLS);
 }

--- a/setup/channels/wizard-hooks.test.ts
+++ b/setup/channels/wizard-hooks.test.ts
@@ -17,8 +17,9 @@ import { join } from 'node:path';
 
 import * as p from '@clack/prompts';
 
+import { registerSkillCompanions } from '../skill-compositions.js';
 import { runChannelSkill, runChannelSkillWithPreStep } from './run-channel-skill.js';
-import { registerChannelPreStep, registerCompanionSkills } from './companions.js';
+import { registerChannelPreStep } from './companions.js';
 import { BACK_TO_CHANNEL_SELECTION } from '../lib/back-nav.js';
 
 /** Write a channel install skill that resolves the wire inputs and, when the
@@ -204,7 +205,7 @@ describe('companion skills', () => {
     writeCompanionSkill(root, 'fixture-companion-a');
     writeCompanionSkill(root, 'fixture-companion-b');
     process.chdir(root);
-    registerCompanionSkills('fixturecomp', ['fixture-companion-a', 'fixture-companion-b']);
+    registerSkillCompanions('add-fixturecomp', [{ skill: 'fixture-companion-a' }, { skill: 'fixture-companion-b' }]);
 
     const cmds: string[] = [];
     await runChannelSkill('fixturecomp', 'Bob Smith', {
@@ -237,7 +238,7 @@ describe('companion skills', () => {
     writeCompanionSkill(root, 'fixture-companion-ok');
     writeCompanionSkill(root, 'fixture-companion-bad');
     process.chdir(root);
-    registerCompanionSkills('fixturedeg', ['fixture-companion-ok', 'fixture-companion-bad']);
+    registerSkillCompanions('add-fixturedeg', [{ skill: 'fixture-companion-ok' }, { skill: 'fixture-companion-bad' }]);
 
     const warn = vi.spyOn(p.log, 'warn').mockImplementation(() => {});
     const cmds: string[] = [];
@@ -261,7 +262,9 @@ describe('companion skills', () => {
     // and appended barrel imports before failing, and restarting could boot
     // that half-applied state. The operator is told to repair, then restart.
     expect(cmds.filter((c) => c === 'bash setup/lib/restart.sh')).toHaveLength(0);
-    const held = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('Skipping the deferred service restart'));
+    const held = warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('Skipping the deferred service restart'));
     expect(held).toHaveLength(1);
   });
 

--- a/setup/skill-compositions.test.ts
+++ b/setup/skill-compositions.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSkillCompanions, registerSkillCompanions } from './skill-compositions.js';
+
+describe('skill composition registry', () => {
+  it('stores ordered companions by full skill name without channel semantics', () => {
+    registerSkillCompanions('add-sample-tool', [
+      { skill: 'sample-runtime', branch: 'providers' },
+      { skill: 'sample-helper' },
+    ]);
+
+    expect(getSkillCompanions('add-sample-tool')).toEqual([
+      { skill: 'sample-runtime', branch: 'providers' },
+      { skill: 'sample-helper' },
+    ]);
+  });
+});

--- a/setup/skill-compositions.ts
+++ b/setup/skill-compositions.ts
@@ -1,0 +1,60 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { defaultResolveRemote } from '../scripts/skill-apply.js';
+
+export interface SkillCompanion {
+  skill: string;
+  branch?: string;
+}
+
+const companionsBySkill = new Map<string, readonly SkillCompanion[]>();
+
+/** Declare ordered skills applied after a base skill. */
+export function registerSkillCompanions(baseSkill: string, companions: readonly SkillCompanion[]): void {
+  companionsBySkill.set(baseSkill, companions);
+}
+
+export function getSkillCompanions(baseSkill: string): readonly SkillCompanion[] {
+  return companionsBySkill.get(baseSkill) ?? [];
+}
+
+/** Materialize a branch-backed companion that is not already in the checkout. */
+export function materializeSkillCompanion(
+  companion: SkillCompanion,
+  projectRoot: string,
+  deps: {
+    exec?: (command: string) => string;
+    resolveRemote?: (branch: string) => string;
+  } = {},
+): boolean {
+  const dir = `.claude/skills/${companion.skill}`;
+  if (existsSync(join(projectRoot, dir, 'SKILL.md'))) return true;
+  if (!companion.branch) return false;
+  const exec =
+    deps.exec ??
+    ((command: string) => execSync(command, { cwd: projectRoot, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
+  try {
+    const remote = (deps.resolveRemote ?? ((branch) => defaultResolveRemote(branch, projectRoot)))(companion.branch);
+    exec(`git fetch ${remote} ${companion.branch}`);
+    const files = exec(`git ls-tree -r --name-only '${remote}/${companion.branch}' -- '${dir}'`)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (files.length === 0) return false;
+    for (const file of files) {
+      mkdirSync(dirname(join(projectRoot, file)), { recursive: true });
+      exec(`git show '${remote}/${companion.branch}:${file}' > '${file}'`);
+    }
+    return true;
+  } catch {
+    rmSync(join(projectRoot, dir), { recursive: true, force: true });
+    return false;
+  }
+}
+
+registerSkillCompanions('add-slack', [
+  { skill: 'slack-a2a-rooms', branch: 'channels' },
+  { skill: 'slack-agent-flow', branch: 'channels' },
+]);

--- a/src/templates/skills.ts
+++ b/src/templates/skills.ts
@@ -43,14 +43,19 @@ export function readPluginSkills(pluginDir: string): { skills: PluginSkill[]; re
 }
 
 /** Returns a problem description, or undefined when the skill conforms. */
-function validateSkill(skillDir: string): string | undefined {
+export function validateSkill(skillDir: string): string | undefined {
   const skillMd = path.join(skillDir, 'SKILL.md');
   if (!fs.existsSync(skillMd)) return 'no SKILL.md';
   if (fs.lstatSync(skillMd).isSymbolicLink() || !fs.lstatSync(skillMd).isFile()) {
     return 'SKILL.md is not a regular file';
   }
 
-  const lines = fs.readFileSync(skillMd, 'utf-8').split(/\r?\n/);
+  return validateSkillMarkdown(fs.readFileSync(skillMd, 'utf-8'));
+}
+
+/** Returns a problem description, or undefined when SKILL.md content conforms. */
+export function validateSkillMarkdown(markdown: string): string | undefined {
+  const lines = markdown.split(/\r?\n/);
   if (lines[0] !== '---') return 'SKILL.md is missing YAML frontmatter';
   const closing = lines.indexOf('---', 1);
   if (closing === -1) return 'SKILL.md frontmatter is missing the closing ---';


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Close the CI gap where a base skill could pass alone while its real companion sequence was broken. The composition matrix grows from 21 to 31 jobs and now covers every currently deterministic project-mutating `add-*` installer plus every declared companion composition.

These are ten additional composition jobs, not ten previously untested skills. Existing focused unit and conformance tests remain in place.

## Runtime companion registry

Move companion declarations and branch-backed materialization from the channel-specific registry into `setup/skill-compositions.ts`. Production setup and CI now read the same ordered declaration:

`add-slack → slack-a2a-rooms → slack-agent-flow`

The Slack install order, degraded-mode warning, and single deferred-restart behavior are unchanged. The channel setup files now delegate companion lookup and materialization to the generic registry.

## Changed files

- `setup/skill-compositions.ts` and `.test.ts` — generic ordered companion registry and materializer.
- `setup/channels/companions.ts` — retain channel pre-steps; remove the duplicate companion registry.
- `setup/channels/run-channel-skill.ts` — consume the generic registry while preserving existing restart and failure behavior.
- `setup/channels/slack-auto-register.ts` and `.test.ts` — keep Slack auto-provision registration and verify the Slack chain in the generic registry.
- `setup/channels/wizard-hooks.test.ts` — exercise companion order, degradation, and deferred restart through the new registry.
- `scripts/test-registry-skills.ts` — discover local deterministic installers and companion chains, materialize each step, run declared build/tests, and compare project state after a second apply.
- `scripts/skill-conformance.test.ts` — validate all checked-in and nested skill directories and require every declared companion chain to appear in the E2E matrix.
- `scripts/skill-apply.ts` — export the existing remote resolver for reuse by the generic materializer.
- `src/templates/skills.ts` — expose content-based validation so branch-loaded `SKILL.md` files use the existing validator.
- `.github/workflows/registry-skills.yml` — run checked-in conformance and active branch-document validation before the composition matrix.

## Slack regression protection

Slack is protected at four levels:

1. A focused test fixes the exact ordered chain in the generic registry.
2. A discovery test fails if a declared companion chain is missing from the E2E matrix.
3. Wizard tests verify ordered application, degraded behavior, and the final restart boundary.
4. CI applies `add-slack → slack-a2a-rooms → slack-agent-flow` to a disposable clone, builds and tests the composed result, reapplies it, and fails if the second apply changes the project.

Instruction-only, container, and platform/external-only skills receive anatomy and conformance validation rather than installation execution.

## Verification

- Focused companion, Slack registration, wizard, and conformance suites: 317 tests passed.
- GitHub-hosted standalone Slack and full Slack companion composition jobs passed.
- Full local `act` workflow: 31/31 compositions passed. Local `act` uses #3675 for path compatibility; GitHub-hosted CI passes against the current `channels` branch.
