### PR TITLE
ci(skills): parallelize composition checks

### DIFF
--- a/.github/workflows/registry-skills.yml
+++ b/.github/workflows/registry-skills.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         include: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Increase the skill-composition matrix from four to eight parallel jobs. This changes scheduling only; the 31-job coverage is added by #3677.

The full 31-composition workflow passes locally with `act`.
