### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Or run `/customize` for guided changes.
 
 The codebase is small enough that Claude can safely modify it.
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/NanoClaw/)
+
 ## Contributing
 
 **Don't add features. Add skills.**


### PR DESCRIPTION
Adds a RepoCloud one-click deploy button in a new "☁️ One-Click Deploy" section, placed between the "Customizing" and "Contributing" sections.

 - Added `## ☁️ One-Click Deploy` section with deploy button
 - Button links to https://repocloud.io/details/NanoClaw/