### PR TITLE
test(skill-directives): expect the slack-raw-text pair in add-slack's copy fence

### DIFF
--- a/scripts/skill-directives.test.ts
+++ b/scripts/skill-directives.test.ts
@@ -70,6 +70,8 @@ describe('skill-directives parser, on the converted add-slack', () => {
       'src/channels/slack-lib.test.ts',
       'src/channels/slack-a2a-guard.ts',
       'src/channels/slack-a2a-guard.test.ts',
+      'src/channels/slack-raw-text.ts',
+      'src/channels/slack-raw-text.test.ts',
       'src/channels/slack-registration.test.ts',
       'src/channels/slack-instances-registration.test.ts',
       'src/provisioning/slack-app.ts',


### PR DESCRIPTION
`main` is red on `scripts/skill-directives.test.ts`.

`fa1bbb67` extended add-slack's `nc:copy` fence with `src/channels/slack-raw-text.ts` and `src/channels/slack-raw-text.test.ts` without updating the hardcoded file list the test asserts at line 67.

**The test was the stale side, not the fence.** Copying a `.test.ts` alongside its adapter is the convention across these fences — add-telegram copies 5 test files, add-mattermost 3, add-discord/signal/matrix/webex 1 each — and add-slack already paired `slack-lib.ts` with `slack-lib.test.ts` and `slack-a2a-guard.ts` with `slack-a2a-guard.test.ts` before `fa1bbb67`. The adapter's registration test is also fetched and run as the install's verification step. So the fence is left untouched and the expectation is brought up to date.

Two added lines, one file.

**Verification** (`GIT_CONFIG_GLOBAL=/dev/null NODE_OPTIONS=--disable-warning=DEP0205`, unsandboxed):
- `scripts/skill-directives.test.ts` — 56 passed (was 1 failed | 55 passed)
- full suite — 185 files, 2170 passed