### PR TITLE
fix(slack): preserve human authorship for delegated uploads

### DIFF
--- a/src/channels/slack-a2a-guard.test.ts
+++ b/src/channels/slack-a2a-guard.test.ts
@@ -25,6 +25,7 @@ import type { ChannelSetup, InboundMessage } from './adapter.js';
 import {
   botAuthorOf,
   registerSlackBotGuard,
+  setSlackAuthorIsBotResolver,
   setBotInboundPolicy,
   wrapSlackBotGuard,
   type SlackBotInboundContext,
@@ -88,6 +89,7 @@ function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup
 
 afterEach(() => {
   setBotInboundPolicy(null);
+  setSlackAuthorIsBotResolver('slack', null);
   vi.clearAllMocks();
 });
 
@@ -138,6 +140,33 @@ describe('wrapSlackBotGuard — default (no admission policy)', () => {
     expect(log.debug).toHaveBeenCalledWith(
       expect.stringContaining('bot-authored inbound dropped'),
       expect.objectContaining({ botId: 'B0FOREIGN', platformId: 'slack:C1', instanceKey: 'slack' }),
+    );
+  });
+
+  it('passes a delegated upload when Slack confirms its author is human', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setSlackAuthorIsBotResolver('slack', async () => false);
+    const message = botMessage('U123', 'file');
+
+    await wrapped.onInbound('slack:D1', null, message);
+
+    expect(calls).toEqual([{ platformId: 'slack:D1', threadId: null, message }]);
+  });
+
+  it('fails closed when an ambiguous author lookup fails', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    setSlackAuthorIsBotResolver('slack', async () => {
+      throw new Error('lookup failed');
+    });
+
+    await wrapped.onInbound('slack:D1', null, botMessage('U123', 'file'));
+
+    expect(calls).toHaveLength(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('keeping bot classification'),
+      expect.objectContaining({ instanceKey: 'slack', platformId: 'slack:D1' }),
     );
   });
 

--- a/src/channels/slack-a2a-guard.ts
+++ b/src/channels/slack-a2a-guard.ts
@@ -119,6 +119,20 @@ export interface SlackBotInboundPolicy {
 
 let botInboundPolicy: SlackBotInboundPolicy | null = null;
 
+type SlackAuthorIsBotResolver = (userId: string) => Promise<boolean | null>;
+const authorIsBotResolvers = new Map<string, SlackAuthorIsBotResolver>();
+
+/**
+ * Resolve ambiguous Slack authors through the adapter's user directory.
+ * Some delegated file uploads carry both a human `user` and an app `bot_id`,
+ * which Chat SDK currently serializes as `isBot: true` for the human user.
+ * Missing lookups and errors stay bot-authored so the guard fails closed.
+ */
+export function setSlackAuthorIsBotResolver(instanceKey: string, resolver: SlackAuthorIsBotResolver | null): void {
+  if (resolver) authorIsBotResolvers.set(instanceKey, resolver);
+  else authorIsBotResolvers.delete(instanceKey);
+}
+
 /**
  * Install THE admission policy for bot-authored Slack inbound (single
  * provider — a second installation overwrites with a warning, mirroring the
@@ -146,7 +160,19 @@ export function wrapSlackBotGuard(setup: ChannelSetup, instanceKey: string): Cha
   return {
     ...setup,
     async onInbound(platformId: string, threadId: string | null, message: InboundMessage) {
-      const bot = botAuthorOf(message);
+      let bot = botAuthorOf(message);
+      const resolveAuthorIsBot = bot && /^[UW]/.test(bot.botId) && authorIsBotResolvers.get(instanceKey);
+      if (bot && resolveAuthorIsBot) {
+        try {
+          if ((await resolveAuthorIsBot(bot.botId)) === false) bot = null;
+        } catch (err) {
+          log.warn('slack-a2a-guard: author lookup failed — keeping bot classification', {
+            instanceKey,
+            platformId,
+            err,
+          });
+        }
+      }
 
       if (!bot) {
         // Human message — pass through untouched. The policy may observe it

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -20,6 +20,7 @@ import { readEnvFile } from '../env.js';
 import type { ChannelAdapter, ChannelContextDefaults, ChannelDefaults } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import { setSlackAuthorIsBotResolver } from './slack-a2a-guard.js';
 import { extractSlackRawText } from './slack-raw-text.js';
 
 /**
@@ -173,6 +174,10 @@ export function createSlackBridge(options: SlackBridgeOptions = {}): ChannelAdap
     signingSecret: env[keys.signingSecret],
     appToken,
     mode: appToken ? 'socket' : 'webhook',
+  });
+  setSlackAuthorIsBotResolver(options.instanceKey ?? 'slack', async (userId) => {
+    const user = await slackAdapter.getUser(userId);
+    return user?.isBot ?? null;
   });
   const bridge = createChatSdkBridge({
     adapter: slackAdapter,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Slack can attach an app `bot_id` to delegated file uploads even when the message author is a human user. Resolve ambiguous `U…`/`W…` authors through the adapter user directory before the bot-inbound guard runs, while keeping lookup failures fail-closed.

Regression coverage verifies delegated human uploads pass and lookup failures remain classified as bot-authored.

Tested with:

- `pnpm exec vitest run src/channels/slack-a2a-guard.test.ts src/channels/chat-sdk-bridge.test.ts`

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
