### PR TITLE
fix(cli): resolve tasks that live in a chat session, not just task sessions

### DIFF
--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -81,6 +81,40 @@ async function ownSession(sessionId: string, ctx: CallerContext): Promise<Scoped
   return { id: session.id, agent_group_id: session.agent_group_id };
 }
 
+/**
+ * Sessions that actually hold task rows but are not shaped like task sessions.
+ *
+ * LOOKUP ONLY — never lifecycle. Installs predating per-series task sessions
+ * keep their tasks in the session that created them; for a chat-created task
+ * that is a chat session, which `findTaskSessions` excludes because it requires
+ * `messaging_group_id IS NULL` and a `system:tasks` thread id. Such tasks still
+ * FIRE (the host sweep walks every active session, shape-agnostic) but were
+ * unreachable from `ncl tasks`, so an agent could not list, pause, resume,
+ * update or cancel its own schedule.
+ *
+ * Deliberately NOT expressed by widening `isTaskThread()`. That predicate gates
+ * task-session LIFECYCLE: `shouldCloseTaskSession` (reconcile-session.ts) is
+ * `isTaskThread(threadId) && !containerRunning && liveTaskCount === 0`. If a live
+ * chat session ever satisfied `isTaskThread`, the reconciler would close it as
+ * soon as its container stopped with no live tasks, and channel delivery for
+ * that session would die. Keeping the widening here confines it to resolution.
+ *
+ * Unioned with `findTaskSessions` rather than used only as an empty-result
+ * fallback: a group can hold legacy rows *and* per-series sessions at once (it
+ * does the moment such an install creates one new task), and a plain fallback
+ * would hide the legacy rows again at that point.
+ */
+async function legacyTaskSessions(agentGroupId: string): Promise<ScopedSession[]> {
+  const found: ScopedSession[] = [];
+  for (const session of await getActiveSessions()) {
+    if (session.agent_group_id !== agentGroupId) continue;
+    const scoped: ScopedSession = { id: session.id, agent_group_id: session.agent_group_id };
+    const live = await withInbound(scoped, (mailbox) => mailbox.countLiveTasks());
+    if ((live ?? 0) > 0) found.push(scoped);
+  }
+  return found;
+}
+
 async function selectedSessions(
   args: Record<string, unknown>,
   ctx: CallerContext,
@@ -92,10 +126,19 @@ async function selectedSessions(
   const group = groupArg(args, ctx);
   if (group) {
     // One session per live task series — the loops below already fan out across them.
-    return (await findTaskSessions(group, includeClosed)).map((s) => ({
-      id: s.id,
-      agent_group_id: s.agent_group_id,
-    }));
+    const scoped: ScopedSession[] = [];
+    const seen = new Set<string>();
+    for (const s of await findTaskSessions(group, includeClosed)) {
+      if (seen.has(s.id)) continue;
+      seen.add(s.id);
+      scoped.push({ id: s.id, agent_group_id: s.agent_group_id });
+    }
+    for (const s of await legacyTaskSessions(group)) {
+      if (seen.has(s.id)) continue;
+      seen.add(s.id);
+      scoped.push(s);
+    }
+    return scoped;
   }
 
   if (ctx.caller === 'agent') return [];


### PR DESCRIPTION
## Problem

On an install whose scheduled tasks predate per-series task sessions, `ncl tasks` cannot see them. The agent asks for its own schedule and gets `No tasks.` while its mailbox holds live series.

On the install this was found on: **44 live series — 11 pending, 33 paused, 3602 completed occurrences — all invisible.**

The tasks still **fire correctly**. `host-sweep.ts` walks `getActiveSessions()` and is shape-agnostic, so the scheduler sees them fine (verified empirically: a series fired on schedule and `handleRecurrence` armed the next occurrence with recurrence preserved). This is a **management-plane defect only** — no data is lost or at risk.

## Cause

`findTaskSessions()` (`src/db/sessions.ts`) resolves tasks only through sessions shaped like task sessions:

```sql
WHERE agent_group_id = ?
  AND messaging_group_id IS NULL
  AND (thread_id = 'system:tasks' OR thread_id LIKE 'system:tasks:%')
```

Tasks scheduled from chat before per-series task sessions existed live in **the session that created them** — a chat session, with `messaging_group_id NOT NULL` and `thread_id NULL`. It matches none of those predicates. No migration (001–024) backfills this, and `isTaskThread`'s comment anticipates a "legacy shared" `system:tasks` session but not this older shape.

## Reproduction

On a group whose tasks were scheduled from chat before per-series task sessions:

```bash
# host, unscoped — enumerates every active session, so it finds them
ncl tasks list --all          # 44 rows

# group-scoped (this is what an agent gets) — goes through findTaskSessions
ncl tasks list --group <agent_group_id>   # "No tasks."
```

Equivalently, from inside the agent container: `ncl tasks list` → `No tasks.`

## Fix

Widen the **lookup resolver only**. `selectedSessions` in `src/cli/resources/tasks.ts` now unions `findTaskSessions` with the group's active sessions whose mailbox reports `countLiveTasks() > 0`, deduped by session id.

## Why not widen `isTaskThread()`

That is the smaller-looking change and it is unsafe. `isTaskThread` gates task-session **lifecycle**, not just lookup:

```ts
// src/reconcile-session.ts
return isTaskThread(threadId) && !containerRunning && liveTaskCount === 0;
```

If a live chat session satisfied `isTaskThread`, `shouldCloseTaskSession` would close it as soon as its container stopped with no live tasks — killing channel delivery for that session. The widening therefore stays confined to the resolver. `src/db/sessions.ts`, `src/reconcile-session.ts` and `src/host-sweep.ts` are deliberately untouched.

## Why a union rather than an empty-result fallback

A group can hold legacy rows *and* per-series sessions at once — it does the moment such an install creates one new task. A plain "only if `findTaskSessions` is empty" fallback would hide the legacy rows again at exactly that point.

## Verification

On the affected install:

- in-container `ncl tasks list`: **0 → 44** rows
- `--status pending` → 11, `--status paused` → 33, next-fire times intact
- pause/resume round-trip on one series preserves `process_after` and `recurrence`
- full host suite: **191 files, 2235 tests passed**

Installs with no legacy rows are unaffected: the extra probe is one `countLiveTasks()` per active session in the group, and returns nothing.