### PR TITLE
fix(agent-runner): surface Gateway usage blocks in Slack

### DIFF
--- a/container/agent-runner/src/poll-loop.gateway-block.test.ts
+++ b/container/agent-runner/src/poll-loop.gateway-block.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { getPendingMessages } from './db/messages-in.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { closeSessionDb, getInboundDb, initTestSessionDb } from './mailbox/sqlite/connection.js';
+import { processQuery, runPollLoop } from './poll-loop.js';
+import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
+
+const USAGE_CAP_MESSAGE =
+  'Your organization’s AI usage limit has been reached. Please try again later or contact your administrator.';
+const POLICY_DENIED_MESSAGE = 'Your organization’s AI policy blocked this request. Please contact your administrator.';
+
+const USAGE_CAP_ERROR =
+  'API Error: 429 {"type":"https://nanoco.ai/problems/usage-enforcement","title":"Usage enforcement blocked the request","status":429,"code":"usage_cap_reached"}';
+const POLICY_DENIED_ERROR = 'API Error: 403 {"error":"policy_denied"}';
+
+const SLACK_ROUTING = {
+  platformId: 'C012345',
+  channelType: 'slack',
+  threadId: '1712345678.000100',
+  inReplyTo: 'slack-message-1',
+  taskRun: false,
+};
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+function resultQuery(text: string): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  async function* events(): AsyncGenerator<ProviderEvent> {
+    yield { type: 'result', text, isError: true };
+  }
+  return {
+    pushes,
+    query: {
+      push(message) {
+        pushes.push(message);
+      },
+      end() {},
+      abort() {},
+      events: events(),
+    },
+  };
+}
+
+function repeatedResultQuery(text: string): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  async function* events(): AsyncGenerator<ProviderEvent> {
+    yield { type: 'result', text, isError: true };
+    yield { type: 'result', text, isError: true };
+  }
+  return {
+    pushes,
+    query: {
+      push(message) {
+        pushes.push(message);
+      },
+      end() {},
+      abort() {},
+      events: events(),
+    },
+  };
+}
+
+function outboundTexts(): string[] {
+  return getUndeliveredMessages().map((row) => (JSON.parse(row.content) as { text: string }).text);
+}
+
+describe('Gateway provider blocks', () => {
+  it('converts only 429 usage_cap_reached into one local Slack mailbox message without retrying', async () => {
+    const { query, pushes } = resultQuery(USAGE_CAP_ERROR);
+
+    await processQuery(query, SLACK_ROUTING, ['slack-message-1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(outboundTexts()).toEqual([USAGE_CAP_MESSAGE]);
+    expect(getUndeliveredMessages()[0]).toMatchObject({
+      kind: 'chat',
+      platform_id: SLACK_ROUTING.platformId,
+      channel_type: 'slack',
+      thread_id: SLACK_ROUTING.threadId,
+      in_reply_to: SLACK_ROUTING.inReplyTo,
+    });
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('handles 403 policy_denied separately with a generic safe message', async () => {
+    const { query, pushes } = resultQuery(POLICY_DENIED_ERROR);
+
+    await processQuery(query, SLACK_ROUTING, ['slack-message-1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(outboundTexts()).toEqual([POLICY_DENIED_MESSAGE]);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('does not expose usage totals or policy details from a recognized block', async () => {
+    const detailed =
+      'API Error: 429 {"status":429,"code":"usage_cap_reached","usage_total":987654,"policy":{"id":"private-policy"}}';
+    const { query } = resultQuery(detailed);
+
+    await processQuery(query, SLACK_ROUTING, ['slack-message-1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(outboundTexts()).toEqual([USAGE_CAP_MESSAGE]);
+    expect(getUndeliveredMessages()[0].content).not.toContain('987654');
+    expect(getUndeliveredMessages()[0].content).not.toContain('private-policy');
+  });
+
+  it('delivers one notice when the provider repeats the same terminal result', async () => {
+    const { query, pushes } = repeatedResultQuery(USAGE_CAP_ERROR);
+
+    await processQuery(query, SLACK_ROUTING, ['slack-message-1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(outboundTexts()).toEqual([USAGE_CAP_MESSAGE]);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('does not classify a mismatched status/code pair', async () => {
+    const mismatched = 'API Error: 403 {"status":403,"code":"usage_cap_reached"}';
+    const { query } = resultQuery(mismatched);
+
+    await processQuery(query, SLACK_ROUTING, ['slack-message-1'], 'claude', undefined, 'prompt', undefined, true);
+
+    expect(outboundTexts()).toEqual([mismatched]);
+  });
+
+  it('acks the blocked turn so a fresh runner neither duplicates delivery nor queries again', async () => {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in
+           (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
+         VALUES (?, 'chat', ?, 'pending', ?, 'slack', ?, ?)`,
+      )
+      .run(
+        'slack-message-1',
+        new Date().toISOString(),
+        SLACK_ROUTING.platformId,
+        SLACK_ROUTING.threadId,
+        JSON.stringify({ sender: 'U012345', text: 'hello' }),
+      );
+
+    const provider = new BlockedProvider(USAGE_CAP_ERROR, true);
+    await runUntil(() => getUndeliveredMessages().length === 1, provider);
+
+    expect(outboundTexts()).toEqual([USAGE_CAP_MESSAGE]);
+    expect(getPendingMessages()).toHaveLength(0);
+    expect(provider.queryCalls).toBe(1);
+    expect(provider.pushCalls).toBe(0);
+
+    await runFor(1_100, provider);
+
+    expect(outboundTexts()).toEqual([USAGE_CAP_MESSAGE]);
+    expect(provider.queryCalls).toBe(1);
+    expect(provider.pushCalls).toBe(0);
+  });
+});
+
+class BlockedProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+  queryCalls = 0;
+  pushCalls = 0;
+
+  constructor(
+    private readonly error: string,
+    private readonly throwFromStream = false,
+  ) {}
+
+  query(): AgentQuery {
+    this.queryCalls += 1;
+    const owner = this;
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      if (owner.throwFromStream) throw new Error(owner.error);
+      yield { type: 'result', text: owner.error, isError: true };
+    }
+    return {
+      push() {
+        owner.pushCalls += 1;
+      },
+      end() {},
+      abort() {},
+      events: events(),
+    };
+  }
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+}
+
+async function runUntil(condition: () => boolean, provider: AgentProvider, timeoutMs = 2_000): Promise<void> {
+  const controller = new AbortController();
+  const loop = runPollLoop({ provider, providerName: 'blocked-test', cwd: '/tmp', signal: controller.signal });
+  const started = Date.now();
+  while (!condition() && Date.now() - started < timeoutMs) await Bun.sleep(20);
+  const matched = condition();
+  controller.abort();
+  await Promise.race([loop, Bun.sleep(250)]);
+  if (!matched) throw new Error('runUntil timeout');
+}
+
+async function runFor(durationMs: number, provider: AgentProvider): Promise<void> {
+  const controller = new AbortController();
+  const loop = runPollLoop({ provider, providerName: 'blocked-test', cwd: '/tmp', signal: controller.signal });
+  await Bun.sleep(durationMs);
+  controller.abort();
+  await Promise.race([loop, Bun.sleep(250)]);
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -28,6 +28,11 @@ import {
   type RoutingContext,
 } from './formatter.js';
 import { stripHarnessTagArtifacts } from './harness-tag-strip.js';
+import {
+  classifyGatewayProviderBlock,
+  gatewayProviderBlockMessage,
+  type GatewayProviderBlock,
+} from './providers/gateway-block.js';
 import { isUploadTraceCommand, uploadTrace } from './upload-trace.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderExchange } from './providers/types.js';
 
@@ -260,7 +265,8 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      log(`Query error: ${errMsg}`);
+      const gatewayBlock = classifyGatewayProviderBlock(errMsg);
+      log(gatewayBlock ? `Provider request blocked (${gatewayBlock})` : `Query error: ${errMsg}`);
 
       // Stale/corrupt continuation recovery: ask the provider whether
       // this error means the stored continuation is unusable, and clear
@@ -271,15 +277,20 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         clearContinuation(config.providerName);
       }
 
-      // Write error response so the user knows something went wrong
-      await writeMessageOut({
-        id: generateId(),
-        kind: 'chat',
-        platform_id: routing.platformId,
-        channel_type: routing.channelType,
-        thread_id: routing.threadId,
-        content: JSON.stringify({ text: `Error: ${errMsg}` }),
-      });
+      // Write error response so the user knows something went wrong. Gateway
+      // blocks use the same local safe-message path as terminal result events.
+      if (gatewayBlock) {
+        await deliverGatewayProviderBlock(gatewayBlock, routing);
+      } else {
+        await writeMessageOut({
+          id: generateId(),
+          kind: 'chat',
+          platform_id: routing.platformId,
+          channel_type: routing.channelType,
+          thread_id: routing.threadId,
+          content: JSON.stringify({ text: `Error: ${errMsg}` }),
+        });
+      }
 
       // The batch is still acked completed below (no redelivery). Without
       // this line the only log trace of the errored turn is "Query error"
@@ -555,6 +566,25 @@ export async function processQuery(
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
         if (event.text) {
+          const gatewayBlock = event.isError === true ? classifyGatewayProviderBlock(event.text) : null;
+          if (gatewayBlock) {
+            const blockedPrompt = archivePrompts.shift();
+            if (blockedPrompt !== undefined) {
+              await deliverGatewayProviderBlock(gatewayBlock, routing);
+              notifyExchangeComplete(onExchangeComplete, {
+                prompt: blockedPrompt,
+                result: gatewayProviderBlockMessage(gatewayBlock),
+                continuation: queryContinuation ?? initialContinuation,
+                status: 'error',
+              });
+            } else {
+              log(`Ignoring duplicate ${gatewayBlock} terminal result with no pending prompt`);
+            }
+            midTurnSent = 0;
+            turnStartSeq = maxOutboundSeq();
+            midTurnTail = '';
+            continue;
+          }
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = await dispatchResultText(event.text, routing, {
             midTurnSent,
             // For emitsMidTurnText providers the result door NEVER delivers
@@ -677,7 +707,14 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
       log(`Session: ${event.continuation}`);
       break;
     case 'result':
-      log(`Result: ${event.text ? event.text.slice(0, 200) : '(empty)'}`);
+      {
+        const gatewayBlock = event.isError === true ? classifyGatewayProviderBlock(event.text) : null;
+        log(
+          gatewayBlock
+            ? `Provider request blocked (${gatewayBlock})`
+            : `Result: ${event.text ? event.text.slice(0, 200) : '(empty)'}`,
+        );
+      }
       break;
     case 'error':
       log(
@@ -690,12 +727,25 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
   }
 }
 
+async function deliverGatewayProviderBlock(reason: GatewayProviderBlock, routing: RoutingContext): Promise<void> {
+  log(`Writing local ${reason} notice to outbound mailbox`);
+  await writeMessageOut({
+    id: generateId(),
+    in_reply_to: routing.inReplyTo,
+    kind: 'chat',
+    platform_id: routing.platformId,
+    channel_type: routing.channelType,
+    thread_id: routing.threadId,
+    content: JSON.stringify({ text: gatewayProviderBlockMessage(reason) }),
+  });
+}
+
 /**
  * Deliver a turn's text straight to the channel the batch arrived on. Used when
- * a turn ends in a provider error (e.g. a non-retryable 403 billing_error) with
- * no <message> envelope: the notice would otherwise be dropped as scratchpad.
- * This is the same user-facing write the outer catch block does, minus the
- * `Error:` prefix — the provider's text is already a user-facing message.
+ * a turn ends in an unclassified provider error (e.g. a non-retryable billing
+ * error) with no <message> envelope: the notice would otherwise be dropped as
+ * scratchpad. Recognized Gateway blocks take the local safe-message path above
+ * and never reach this function.
  */
 async function deliverErrorResult(text: string, routing: RoutingContext): Promise<void> {
   log('Error result with no <message> envelope — delivering to channel');

--- a/container/agent-runner/src/providers/gateway-block.ts
+++ b/container/agent-runner/src/providers/gateway-block.ts
@@ -1,0 +1,60 @@
+export type GatewayProviderBlock = 'usage_cap_reached' | 'policy_denied';
+
+const GATEWAY_BLOCK_MESSAGES: Record<GatewayProviderBlock, string> = {
+  usage_cap_reached:
+    'Your organization’s AI usage limit has been reached. Please try again later or contact your administrator.',
+  policy_denied: 'Your organization’s AI policy blocked this request. Please contact your administrator.',
+};
+
+/**
+ * Recognize only the Gateway's canonical terminal provider blocks. The Claude
+ * SDK currently surfaces the HTTP response through a result error string, so
+ * the agent-runner must require both the status and code instead of guessing
+ * from provider prose.
+ */
+export function classifyGatewayProviderBlock(value: unknown): GatewayProviderBlock | null {
+  if (typeof value !== 'string') return null;
+
+  const prefixStatus = apiErrorStatus(value);
+  const body = jsonBody(value);
+  const bodyStatus = body?.status;
+  if (prefixStatus !== null && bodyStatus !== undefined && prefixStatus !== bodyStatus) return null;
+
+  const status = bodyStatus ?? prefixStatus;
+  const code = body?.code ?? body?.error;
+  if (status === 429 && code === 'usage_cap_reached') return 'usage_cap_reached';
+  if (status === 403 && code === 'policy_denied') return 'policy_denied';
+
+  const plain = value.match(/\bAPI Error:\s*(403|429)\s+(usage_cap_reached|policy_denied)\s*$/);
+  if (!plain) return null;
+  if (plain[1] === '429' && plain[2] === 'usage_cap_reached') return 'usage_cap_reached';
+  if (plain[1] === '403' && plain[2] === 'policy_denied') return 'policy_denied';
+  return null;
+}
+
+export function gatewayProviderBlockMessage(reason: GatewayProviderBlock): string {
+  return GATEWAY_BLOCK_MESSAGES[reason];
+}
+
+function apiErrorStatus(value: string): number | null {
+  const match = value.match(/\bAPI Error:\s*(\d{3})\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+function jsonBody(value: string): { status?: number; code?: string; error?: string } | null {
+  const start = value.indexOf('{');
+  const end = value.lastIndexOf('}');
+  if (start < 0 || end < start) return null;
+  try {
+    const parsed = JSON.parse(value.slice(start, end + 1)) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const record = parsed as Record<string, unknown>;
+    return {
+      status: typeof record.status === 'number' ? record.status : undefined,
+      code: typeof record.code === 'string' ? record.code : undefined,
+      error: typeof record.error === 'string' ? record.error : undefined,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [x] **Fix**
- [ ] **Simplification**
- [ ] **Documentation**

## Description

Gateway usage enforcement returns HTTP 429 with `code: usage_cap_reached` before credential retrieval or upstream provider I/O. The Claude SDK surfaces that terminal response at the provider/agent-runner result boundary, where NanoClaw previously forwarded the raw error body.

Recognize only the exact 429/`usage_cap_reached` and 403/`policy_denied` status-code pairs. Write one local safe chat response through the normal outbound mailbox, preserve Slack routing, suppress duplicate terminal results, and leave unrelated provider errors unchanged. No model re-wrap, provider retry, credential lookup, usage totals, or policy details are involved.

## Testing

- `cd container/agent-runner && bun test src/poll-loop.gateway-block.test.ts` — 6 passed
- `cd container/agent-runner && bun test` — 349 passed, 1 skipped
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`
- `pnpm run build`
