### PR TITLE
fix(update): snapshot symlinked mutable roots

### DIFF
--- a/scripts/update/transaction.e2e.test.ts
+++ b/scripts/update/transaction.e2e.test.ts
@@ -222,6 +222,84 @@ describe('update-nanoclaw transaction end to end', () => {
     expect(fs.readFileSync(path.join(fixture.install, 'nanoclaw.pid'), 'utf8')).toBe('1234\n');
   });
 
+  it('snapshots and restores symlinked mutable roots without replacing the link', async () => {
+    const fixture = createForkFixture();
+    previousUpdateDir = process.env.NANOCLAW_UPDATE_DIR;
+    process.env.NANOCLAW_UPDATE_DIR = temp('nanoclaw-update-state-');
+    const externalRoot = temp('nanoclaw-external-data-');
+    const externalData = path.join(externalRoot, 'data');
+    const dataLink = path.join(fixture.install, 'data');
+    fs.renameSync(dataLink, externalData);
+    const relativeTarget = path.relative(fixture.install, externalData);
+    fs.symlinkSync(relativeTarget, dataLink);
+    fs.appendFileSync(path.join(fixture.install, '.git/info/exclude'), '\n/data\n');
+    const { runtime } = fakeRuntime(fixture.install);
+
+    let state = prepareUpdate({ projectRoot: fixture.install, upstreamRef: 'upstream/main' }, runtime);
+    state = await validateUpdate(fixture.install, state.id, runtime);
+    state = await cutoverUpdate(fixture.install, state.id, runtime);
+
+    const snapshotData = path.join(state.transactionRoot, 'snapshot', 'data');
+    expect(fs.lstatSync(snapshotData).isDirectory()).toBe(true);
+    expect(fs.readFileSync(path.join(snapshotData, 'v2.db'), 'utf8')).toBe('old-schema');
+    expect(state.snapshot?.find((entry) => entry.relativePath === 'data')?.symlinkTarget).toBe(relativeTarget);
+
+    fs.writeFileSync(path.join(externalData, 'v2.db'), 'forward-migrated-schema');
+    state = await rollbackUpdate(fixture.install, state.id, runtime);
+
+    expect(state.phase).toBe('rolled-back');
+    expect(fs.lstatSync(dataLink).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(dataLink)).toBe(relativeTarget);
+    expect(fs.readFileSync(path.join(externalData, 'v2.db'), 'utf8')).toBe('old-schema');
+  });
+
+  it('fails closed before restore when a mutable-root symlink changed after snapshot', async () => {
+    const fixture = createForkFixture();
+    previousUpdateDir = process.env.NANOCLAW_UPDATE_DIR;
+    process.env.NANOCLAW_UPDATE_DIR = temp('nanoclaw-update-state-');
+    const externalRoot = temp('nanoclaw-external-data-');
+    const externalData = path.join(externalRoot, 'data');
+    const replacementData = path.join(externalRoot, 'replacement');
+    const dataLink = path.join(fixture.install, 'data');
+    fs.renameSync(dataLink, externalData);
+    fs.mkdirSync(replacementData);
+    fs.symlinkSync(path.relative(fixture.install, externalData), dataLink);
+    fs.appendFileSync(path.join(fixture.install, '.git/info/exclude'), '\n/data\n');
+    const { runtime } = fakeRuntime(fixture.install);
+
+    let state = prepareUpdate({ projectRoot: fixture.install, upstreamRef: 'upstream/main' }, runtime);
+    state = await validateUpdate(fixture.install, state.id, runtime);
+    state = await cutoverUpdate(fixture.install, state.id, runtime);
+    fs.writeFileSync(path.join(fixture.install, '.env'), 'EXAMPLE=post-update\n');
+    fs.rmSync(dataLink);
+    fs.symlinkSync(path.relative(fixture.install, replacementData), dataLink);
+
+    await expect(rollbackUpdate(fixture.install, state.id, runtime)).rejects.toThrow(
+      'Mutable-state symlink changed after snapshot',
+    );
+    expect(fs.readFileSync(path.join(fixture.install, '.env'), 'utf8')).toBe('EXAMPLE=post-update\n');
+    expect(fs.readlinkSync(dataLink)).toBe(path.relative(fixture.install, replacementData));
+  });
+
+  it('fails snapshot creation for a dangling mutable-root symlink', async () => {
+    const fixture = createForkFixture();
+    previousUpdateDir = process.env.NANOCLAW_UPDATE_DIR;
+    process.env.NANOCLAW_UPDATE_DIR = temp('nanoclaw-update-state-');
+    const dataLink = path.join(fixture.install, 'data');
+    fs.rmSync(dataLink, { recursive: true });
+    fs.symlinkSync('../missing-nanoclaw-data', dataLink);
+    fs.appendFileSync(path.join(fixture.install, '.git/info/exclude'), '\n/data\n');
+    const { runtime } = fakeRuntime(fixture.install);
+
+    let state = prepareUpdate({ projectRoot: fixture.install, upstreamRef: 'upstream/main' }, runtime);
+    state = await validateUpdate(fixture.install, state.id, runtime);
+
+    await expect(cutoverUpdate(fixture.install, state.id, runtime)).rejects.toThrow(/ENOENT/);
+    state = loadState(fixture.install, state.id);
+    expect(state.phase).toBe('validated');
+    expect(state.snapshot).toBeUndefined();
+  });
+
   it('prunes only older terminal transactions and keeps the selected rollback point', async () => {
     const fixture = createForkFixture();
     previousUpdateDir = process.env.NANOCLAW_UPDATE_DIR;

--- a/scripts/update/transaction.ts
+++ b/scripts/update/transaction.ts
@@ -31,6 +31,7 @@ export interface UpdateRequirement {
 export interface SnapshotEntry {
   relativePath: string;
   existed: boolean;
+  symlinkTarget?: string;
 }
 
 export interface UpdateState {
@@ -373,8 +374,18 @@ export async function validateUpdate(
 
 const MUTABLE_PATHS = ['.env', 'data', 'groups', 'store', 'start-nanoclaw.sh', 'nanoclaw.pid'];
 
-function copyEntry(source: string, destination: string): void {
-  const stat = fs.lstatSync(source);
+function lstatIfExists(source: string): fs.Stats | undefined {
+  try {
+    return fs.lstatSync(source);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
+function copyEntry(source: string, destination: string, dereferenceRoot = false): void {
+  const linkStat = fs.lstatSync(source);
+  const stat = dereferenceRoot && linkStat.isSymbolicLink() ? fs.statSync(source) : linkStat;
   if (stat.isDirectory()) {
     fs.mkdirSync(destination, { recursive: true, mode: stat.mode });
     for (const entry of fs.readdirSync(source)) copyEntry(path.join(source, entry), path.join(destination, entry));
@@ -415,7 +426,7 @@ function createSnapshot(state: UpdateState): SnapshotEntry[] {
   fs.mkdirSync(buildRoot, { recursive: true, mode: 0o700 });
   const bytesNeeded = MUTABLE_PATHS.reduce((total, relativePath) => {
     const source = path.join(state.projectRoot, relativePath);
-    return total + (fs.existsSync(source) ? entrySize(source) : 0);
+    return total + (lstatIfExists(source) ? entrySize(source, true) : 0);
   }, 0);
   const disk = fs.statfsSync(buildRoot);
   const bytesAvailable = Number(disk.bavail) * Number(disk.bsize);
@@ -427,9 +438,11 @@ function createSnapshot(state: UpdateState): SnapshotEntry[] {
   }
   const entries = MUTABLE_PATHS.map((relativePath) => {
     const source = path.join(state.projectRoot, relativePath);
-    const existed = fs.existsSync(source);
-    if (existed) copyEntry(source, path.join(buildRoot, relativePath));
-    return { relativePath, existed };
+    const sourceStat = lstatIfExists(source);
+    const existed = sourceStat !== undefined;
+    const symlinkTarget = sourceStat?.isSymbolicLink() ? fs.readlinkSync(source) : undefined;
+    if (existed) copyEntry(source, path.join(buildRoot, relativePath), true);
+    return { relativePath, existed, ...(symlinkTarget === undefined ? {} : { symlinkTarget }) };
   });
   if (fs.existsSync(snapshotRoot)) fs.renameSync(snapshotRoot, supersededRoot);
   fs.renameSync(buildRoot, snapshotRoot);
@@ -437,8 +450,9 @@ function createSnapshot(state: UpdateState): SnapshotEntry[] {
   return entries;
 }
 
-function entrySize(source: string): number {
-  const stat = fs.lstatSync(source);
+function entrySize(source: string, dereferenceRoot = false): number {
+  const linkStat = fs.lstatSync(source);
+  const stat = dereferenceRoot && linkStat.isSymbolicLink() ? fs.statSync(source) : linkStat;
   if (stat.isFile()) return stat.size;
   if (!stat.isDirectory()) return 0;
   return fs.readdirSync(source).reduce((total, entry) => total + entrySize(path.join(source, entry)), 0);
@@ -451,9 +465,19 @@ function restoreSnapshot(state: UpdateState): void {
   // it entry-by-entry would delete live targets and then fail anyway.
   if (!fs.existsSync(snapshotRoot)) throw new Error(`Mutable-state snapshot missing: ${snapshotRoot}`);
   for (const entry of state.snapshot) {
+    if (entry.symlinkTarget === undefined) continue;
     const target = path.join(state.projectRoot, entry.relativePath);
-    fs.rmSync(target, { recursive: true, force: true });
-    if (entry.existed) copyEntry(path.join(snapshotRoot, entry.relativePath), target);
+    const stat = fs.lstatSync(target);
+    if (!stat.isSymbolicLink() || fs.readlinkSync(target) !== entry.symlinkTarget) {
+      throw new Error(`Mutable-state symlink changed after snapshot: ${target}`);
+    }
+  }
+  for (const entry of state.snapshot) {
+    const target = path.join(state.projectRoot, entry.relativePath);
+    const restoreTarget =
+      entry.symlinkTarget === undefined ? target : realResolve(path.resolve(path.dirname(target), entry.symlinkTarget));
+    fs.rmSync(restoreTarget, { recursive: true, force: true });
+    if (entry.existed) copyEntry(path.join(snapshotRoot, entry.relativePath), restoreTarget);
   }
 }
 


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #3684.

Mutable paths that are symlinked at their root now snapshot the target content rather than the link alone. Internal symlinks remain links. The snapshot records the original root link target, disk-space accounting includes the dereferenced content, and rollback restores content through the unchanged link instead of replacing the user's external-data layout.

Rollback preflights every recorded root symlink before deleting live mutable state. A changed link fails closed, and a dangling root fails during snapshot creation rather than producing an empty successful backup.

## Testing

- `pnpm exec vitest run scripts/update/transaction.e2e.test.ts` — 10 passed
- `pnpm run typecheck` — passed
- `pnpm run build` — passed
- Prettier check on both changed files — passed
- Full suite reached 2,155 passing tests; 18 unrelated baseline/environment failures came from Node 26 `module.register()` deprecation output, intentionally skipped `better-sqlite3` build scripts, and an existing channel-skill fixture mismatch

The new E2E coverage verifies relative symlink snapshot/rollback with content restoration, preservation of the original symlink, changed-link fail-closed behavior before any mutable entry is restored, and rejection of dangling mutable-root links.

## AI Assistance Disclosure

TRAE assisted with issue analysis, implementation, tests, and command execution. The contributor reviewed the filesystem safety contract, diff, and validation evidence.