### PR TITLE
test(update): isolate git fixtures from operator global config

### DIFF
--- a/scripts/git-fixture.ts
+++ b/scripts/git-fixture.ts
@@ -1,0 +1,99 @@
+/**
+ * Git isolation for fixture repositories created by tests.
+ *
+ * A fixture repo inherits the operator's global git config, and several settings
+ * commonly found there break its commits on an ordinary developer machine:
+ *
+ * - `core.hooksPath` — a global hooks directory applies to every repo on the
+ *   machine, including a throwaway fixture under the temp dir. A policy
+ *   pre-commit hook that refuses commits outside a sanctioned checkout fails
+ *   every commit a fixture makes.
+ * - `commit.gpgsign` / `tag.gpgsign` — signing needs the operator's key, which in
+ *   a test run is either unavailable ("failed to write commit object") or
+ *   prompts for hardware confirmation that nobody is there to give.
+ * - `merge.verifySignatures` — the code under test merges, and an unsigned
+ *   fixture commit is then refused with "does not have a GPG signature".
+ * - `core.excludesFile` — a global ignore file that happens to match a fixture
+ *   path makes `git add .` skip it silently, so the fixture is built wrong
+ *   rather than failing loudly.
+ *
+ * Isolation happens in two phases, because these settings do not all apply at
+ * the same time:
+ *
+ * 1. `FIXTURE_GIT_FLAGS` covers commands that run BEFORE there is a repo to
+ *    configure. `git clone` checks out a working tree and speaks a transport
+ *    while creating the repo, so `core.autocrlf` has already rewritten line
+ *    endings and `protocol.file.allow=never` has already refused a local-path
+ *    clone by the time any repo-local config could exist.
+ * 2. `isolateFixtureRepo` covers everything afterwards, as repo-local config.
+ *
+ * LOAD-BEARING, two ways:
+ *
+ * 1. Phase 2 settings are written to the fixture's own config rather than passed
+ *    as `-c` overrides on the test's git calls, because the code under test
+ *    spawns git itself. Only repo-local config reaches those child processes.
+ * 2. Do not replace either phase with environment variables (`GIT_CONFIG_GLOBAL`
+ *    and friends), whether set in the test runner or exported by the caller.
+ *    That makes a green suite a property of how it was invoked, so the next
+ *    contributor without the magic env line sees the same failures again.
+ *
+ * The two phases together are narrower than blanking the global config
+ * wholesale: they neutralize the settings that are known to reach these
+ * fixtures, not every setting that could. A fixture that starts failing because
+ * of some other global setting belongs here, as one more line.
+ *
+ * Call `isolateFixtureRepo` on every fixture repo right after `git init` or
+ * `git clone`; config is per-repo, and a clone does not inherit its source's
+ * local settings.
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+/** Identity used for fixture commits, so the operator's own is never required. */
+const FIXTURE_AUTHOR = { name: 'Test', email: 'test@example.com' } as const;
+
+/**
+ * Prefix for `git init` and `git clone`, which act before `isolateFixtureRepo`
+ * can. Splice it in ahead of the subcommand: `git`, `[...FIXTURE_GIT_FLAGS,
+ * 'clone', source, target]`.
+ */
+export const FIXTURE_GIT_FLAGS: readonly string[] = [
+  // Fixtures assert on file contents and parse `nc:` directive fences; CRLF
+  // rewriting at checkout time corrupts both.
+  '-c',
+  'core.autocrlf=false',
+  // Fixtures clone each other over local paths.
+  '-c',
+  'protocol.file.allow=always',
+];
+
+function config(root: string, key: string, value: string): void {
+  execFileSync('git', ['config', key, value], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * Detach one fixture repository from the operator's global git config.
+ *
+ * `root` is the repo's working tree, or the repository directory itself for a
+ * bare clone. The hooks and excludes paths deliberately point at files that do
+ * not exist: git treats a missing hook or ignore file as "nothing to apply", so
+ * neither has to be created or cleaned up. Both are resolved to absolute paths,
+ * because git resolves a relative `core.hooksPath` against the git process's
+ * working directory rather than the repository.
+ */
+export function isolateFixtureRepo(root: string): void {
+  config(root, 'core.hooksPath', path.resolve(root, 'nanoclaw-fixture-no-hooks'));
+  config(root, 'core.excludesFile', path.resolve(root, 'nanoclaw-fixture-no-excludes'));
+  config(root, 'core.autocrlf', 'false');
+  // The code under test fetches and clones between fixtures over local paths.
+  config(root, 'protocol.file.allow', 'always');
+  config(root, 'commit.gpgsign', 'false');
+  config(root, 'tag.gpgsign', 'false');
+  config(root, 'merge.verifySignatures', 'false');
+  config(root, 'user.name', FIXTURE_AUTHOR.name);
+  config(root, 'user.email', FIXTURE_AUTHOR.email);
+}

--- a/scripts/update-skills.test.ts
+++ b/scripts/update-skills.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { FIXTURE_GIT_FLAGS, isolateFixtureRepo } from './git-fixture.js';
 import { detectInstalledSkills, refreshInstalledSkills } from './update-skills.js';
 
 const tempRoots: string[] = [];
@@ -29,9 +30,11 @@ function write(root: string, rel: string, content: string): void {
   fs.writeFileSync(target, content);
 }
 
+// Identity comes from the repo's own config (isolateFixtureRepo), so it applies
+// to the git commands the code under test runs too, not just these.
 function commit(root: string, message: string): void {
   run(root, 'git', ['add', '.']);
-  run(root, 'git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', message]);
+  run(root, 'git', ['commit', '-m', message]);
 }
 
 afterEach(() => {
@@ -81,7 +84,8 @@ describe('registry refresh end to end', () => {
 
   it('refreshes from official upstream when the user fork origin has no registry branch', async () => {
     const seed = temp('nanoclaw-skills-seed-');
-    run(seed, 'git', ['init', '-b', 'main']);
+    run(seed, 'git', [...FIXTURE_GIT_FLAGS, 'init', '-b', 'main']);
+    isolateFixtureRepo(seed);
     write(seed, 'src/channels/index.ts', "import './cli.js';\n");
     write(
       seed,
@@ -108,15 +112,18 @@ describe('registry refresh end to end', () => {
 
     const official = temp('nanoclaw-skills-official-');
     fs.rmSync(official, { recursive: true });
-    run(path.dirname(official), 'git', ['clone', '--bare', seed, official]);
+    run(path.dirname(official), 'git', [...FIXTURE_GIT_FLAGS, 'clone', '--bare', seed, official]);
+    isolateFixtureRepo(official);
     const fork = temp('nanoclaw-skills-fork-');
     fs.rmSync(fork, { recursive: true });
-    run(path.dirname(fork), 'git', ['clone', '--bare', official, fork]);
+    run(path.dirname(fork), 'git', [...FIXTURE_GIT_FLAGS, 'clone', '--bare', official, fork]);
+    isolateFixtureRepo(fork);
     run(fork, 'git', ['update-ref', '-d', 'refs/heads/channels']);
 
     const install = temp('nanoclaw-skills-install-');
     fs.rmSync(install, { recursive: true });
-    run(path.dirname(install), 'git', ['clone', fork, install]);
+    run(path.dirname(install), 'git', [...FIXTURE_GIT_FLAGS, 'clone', fork, install]);
+    isolateFixtureRepo(install);
     run(install, 'git', ['remote', 'add', 'upstream', official]);
     write(install, 'src/channels/demo.ts', 'export const payload = "installed-old";\n');
     fs.appendFileSync(path.join(install, 'src/channels/index.ts'), "import './demo.js';\n");

--- a/scripts/update/transaction.e2e.test.ts
+++ b/scripts/update/transaction.e2e.test.ts
@@ -17,6 +17,7 @@ import {
   validateUpdate,
   type UpdateRuntime,
 } from './transaction.js';
+import { FIXTURE_GIT_FLAGS, isolateFixtureRepo } from '../git-fixture.js';
 import { stopService } from './service.js';
 import type { CommandRunner, ServiceHandle } from './service.js';
 
@@ -43,9 +44,11 @@ function write(root: string, rel: string, content: string): void {
   fs.writeFileSync(target, content);
 }
 
+// Identity comes from the repo's own config (isolateFixtureRepo), so it applies
+// to the git commands the code under test runs too, not just these.
 function commit(root: string, message: string): string {
   exec(root, 'git', ['add', '.']);
-  exec(root, 'git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', message]);
+  exec(root, 'git', ['commit', '-m', message]);
   return exec(root, 'git', ['rev-parse', 'HEAD']);
 }
 
@@ -57,7 +60,8 @@ interface Fixture {
 
 function createForkFixture(options: { breaking?: boolean; externalPinMove?: boolean } = {}): Fixture {
   const seed = temp('nanoclaw-update-seed-');
-  exec(seed, 'git', ['init', '-b', 'main']);
+  exec(seed, 'git', [...FIXTURE_GIT_FLAGS, 'init', '-b', 'main']);
+  isolateFixtureRepo(seed);
   write(seed, 'package.json', '{"name":"nanoclaw-test","version":"2.1.54"}\n');
   write(seed, '.gitignore', 'data/\n.env\nstart-nanoclaw.sh\nnanoclaw.pid\n');
   write(seed, 'pnpm-lock.yaml', 'lockfileVersion: 9\n');
@@ -71,10 +75,12 @@ function createForkFixture(options: { breaking?: boolean; externalPinMove?: bool
 
   const official = temp('nanoclaw-update-official-');
   fs.rmSync(official, { recursive: true });
-  exec(path.dirname(official), 'git', ['clone', '--bare', seed, official]);
+  exec(path.dirname(official), 'git', [...FIXTURE_GIT_FLAGS, 'clone', '--bare', seed, official]);
+  isolateFixtureRepo(official);
   const fork = temp('nanoclaw-update-fork-');
   fs.rmSync(fork, { recursive: true });
-  exec(path.dirname(fork), 'git', ['clone', '--bare', official, fork]);
+  exec(path.dirname(fork), 'git', [...FIXTURE_GIT_FLAGS, 'clone', '--bare', official, fork]);
+  isolateFixtureRepo(fork);
 
   write(seed, 'src/value.ts', 'export const value = "new";\n');
   if (options.breaking) {
@@ -93,9 +99,8 @@ function createForkFixture(options: { breaking?: boolean; externalPinMove?: bool
 
   const install = temp('nanoclaw-update-install-');
   fs.rmSync(install, { recursive: true });
-  exec(path.dirname(install), 'git', ['clone', fork, install]);
-  exec(install, 'git', ['config', 'user.name', 'Test']);
-  exec(install, 'git', ['config', 'user.email', 'test@example.com']);
+  exec(path.dirname(install), 'git', [...FIXTURE_GIT_FLAGS, 'clone', fork, install]);
+  isolateFixtureRepo(install);
   exec(install, 'git', ['remote', 'add', 'upstream', official]);
   exec(install, 'git', ['fetch', 'upstream']);
   write(install, 'local-customization.txt', 'keep me\n');


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Makes the suite pass on a developer machine whose global git config is not empty.

- **Problem**: fixtures that make real git commits inherit the operator's global config. `core.hooksPath`, `commit.gpgsign`, `merge.verifySignatures`, and `core.excludesFile` each break them, so 8 tests fail for reasons unrelated to the code under test.
- **Workaround this replaces**: prefixing every run with `GIT_CONFIG_GLOBAL=/dev/null`, which makes a green suite a property of how it was invoked rather than of the code.
- **Fix**: new `scripts/git-fixture.ts`, applied in two phases. `-c` flags for `git init` and `git clone`, which act before a repo exists to hold local config; then repo-local config, which is the only kind that reaches the git children the code under test spawns itself.
- **Out of scope**: the 3 remaining suite failures. They are DEP0205 stderr noise and fail on `main` too.

## Related work

No issue. Test-only change touching no production file, and every claim below reproduces with one command.

## Change kind

- [x] `kind/bug`

## Validation

Run on a machine with `core.hooksPath` and `commit.gpgsign` set globally. **No env prefix on any command below.**

- `pnpm vitest run scripts/update/transaction.e2e.test.ts scripts/update-skills.test.ts` on `main` -> 8 failed, 3 passed
- The same command on this branch -> 11 passed
- `pnpm test` on `main` -> 11 failed, 2215 passed
- `pnpm test` on this branch -> 3 failed, 2223 passed. The 3 are DEP0205 stderr noise in `src/cli/stdin-json*`, identical on `main`
- CI, where the global config is already bare -> 26/26 green, so the change is neutral there

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change

## Security and trust boundaries

`protocol.file.allow=always` is set on fixture repositories, both as a `-c` flag for `git clone` and in each fixture's local config. Git restricts that protocol by default (CVE-2022-39253). It is scoped to throwaway fixtures under the temp dir, which clone and fetch from each other over local paths; no global config is written and no contributor repository is touched.

`core.hooksPath` and `core.excludesFile` are pointed at paths that deliberately do not exist, so the operator's hooks and ignore rules stop applying to fixtures without anything being created or cleaned up.

## Skill delivery

- [x] Not a skill

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
