### PR TITLE
fix(signal): queue outbound sends while disconnected; forward voice audio without transcription

### DIFF
--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 // --- Mocks ---
 
@@ -395,6 +397,52 @@ describe('SignalAdapter', () => {
       );
 
       await adapter.teardown();
+    });
+
+    it('forwards the raw audio bytes as an attachment even when transcription is unavailable', async () => {
+      const prevWhisperBin = process.env.WHISPER_BIN;
+      const prevOpenaiKey = process.env.OPENAI_API_KEY;
+      delete process.env.WHISPER_BIN;
+      delete process.env.OPENAI_API_KEY;
+      const attachmentsDir = join('/tmp/signal-cli-test-data', 'attachments');
+      mkdirSync(attachmentsDir, { recursive: true });
+      const attachmentPath = join(attachmentsDir, 'voice123');
+      writeFileSync(attachmentPath, Buffer.from('fake-audio-bytes'));
+
+      try {
+        const adapter = createAdapter();
+        const cfg = createMockSetup();
+        await adapter.setup(cfg);
+
+        pushEvent({
+          sourceNumber: '+15555550123',
+          sourceName: 'Alice',
+          dataMessage: {
+            timestamp: 1700000000000,
+            attachments: [{ id: 'voice123', contentType: 'audio/aac', size: 12345 }],
+          },
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(cfg.onInbound).toHaveBeenCalledWith(
+          '+15555550123',
+          null,
+          expect.objectContaining({
+            content: expect.objectContaining({
+              text: '[Voice Message]',
+              attachments: [expect.objectContaining({ path: attachmentPath, contentType: 'audio/aac' })],
+            }),
+          }),
+        );
+
+        await adapter.teardown();
+      } finally {
+        rmSync(attachmentsDir, { recursive: true, force: true });
+        if (prevWhisperBin === undefined) delete process.env.WHISPER_BIN;
+        else process.env.WHISPER_BIN = prevWhisperBin;
+        if (prevOpenaiKey === undefined) delete process.env.OPENAI_API_KEY;
+        else process.env.OPENAI_API_KEY = prevOpenaiKey;
+      }
     });
   });
 
@@ -943,6 +991,36 @@ describe('SignalAdapter', () => {
       await new Promise((r) => setTimeout(r, 20));
 
       expect(adapter.isConnected()).toBe(false);
+
+      await adapter.teardown();
+    });
+
+    it('queues sends made while disconnected instead of dropping them, and flushes on the next setup()', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      expect(adapter.isConnected()).toBe(true);
+
+      // Simulate the daemon dropping the TCP connection.
+      tcpRef.fakeSocket.destroy();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(adapter.isConnected()).toBe(false);
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'text',
+        content: { text: 'queued while disconnected' },
+      });
+      expect(getRpcCallsForMethod('send')).toHaveLength(0);
+
+      // This adapter has no reconnect loop (see the onClose handler comment
+      // in signal.ts) — recovery today is a service restart, which calls
+      // setup() again and flushes anything still queued.
+      await adapter.setup(createMockSetup());
+      expect(adapter.isConnected()).toBe(true);
+      await new Promise((r) => setTimeout(r, 20));
+
+      const sendCalls = getRpcCallsForMethod('send');
+      expect(sendCalls).toHaveLength(1);
+      expect(sendCalls[0].params.message).toBe('queued while disconnected');
 
       await adapter.teardown();
     });

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -551,6 +551,14 @@ export function createSignalAdapter(config: {
   let connected = false;
   const echoCache = new EchoCache();
   let setup: ChannelSetup | null = null;
+  // Outbound sends attempted while disconnected are queued here and flushed
+  // once the TCP connection to signal-cli is (re)established, instead of
+  // being silently dropped.
+  type QueuedSend =
+    | { kind: 'text'; platformId: string; text: string }
+    | { kind: 'attachments'; platformId: string; files: { filename: string; data: Buffer }[] };
+  const outgoingQueue: QueuedSend[] = [];
+  let flushingOutgoingQueue = false;
 
   // -- inbound handling --
 
@@ -643,9 +651,17 @@ export function createSignalAdapter(config: {
 
     let content = text;
 
+    // Image attachments — emit `[Image: <path>]` lines so the agent's Read
+    // tool can pick them up, and surface the structured `attachments` array
+    // for consumers that prefer that shape. Without this, vision-capable
+    // models never see images sent over Signal.
+    const attachmentRefs: Array<{ path: string; contentType: string }> = [];
+
     // Voice attachment — try transcription if WHISPER_BIN or OPENAI_API_KEY
-    // is configured; otherwise fall back to the original placeholder so
-    // operators who don't want transcription get the same UX as before.
+    // is configured; otherwise fall back to a placeholder. The raw audio is
+    // always forwarded as an attachment (when the file exists) so a human —
+    // or a future transcription pass — can still get at it when transcription
+    // is unavailable or fails, instead of losing the message content entirely.
     if (hasVoice && audioAttachment?.id) {
       const attachmentPath = join(config.signalDataDir, 'attachments', audioAttachment.id);
       if (existsSync(attachmentPath)) {
@@ -654,6 +670,7 @@ export function createSignalAdapter(config: {
           attachmentId: audioAttachment.id,
           path: attachmentPath,
         });
+        attachmentRefs.push({ path: attachmentPath, contentType: audioAttachment.contentType || 'audio/aac' });
         const transcript = await transcribeAudioOptional(attachmentPath);
         if (transcript) {
           content = `[Voice: ${transcript}]`;
@@ -670,11 +687,6 @@ export function createSignalAdapter(config: {
       }
     }
 
-    // Image attachments — emit `[Image: <path>]` lines so the agent's Read
-    // tool can pick them up, and surface the structured `attachments` array
-    // for consumers that prefer that shape. Without this, vision-capable
-    // models never see images sent over Signal.
-    const attachmentRefs: Array<{ path: string; contentType: string }> = [];
     for (const img of imageAttachments) {
       const imagePath = join(config.signalDataDir, 'attachments', img.id!);
       const imageLine = `[Image: ${imagePath}]`;
@@ -727,7 +739,16 @@ export function createSignalAdapter(config: {
   // -- send helpers --
 
   async function sendText(platformId: string, text: string): Promise<void> {
-    if (!connected || !tcp) return;
+    if (!connected || !tcp) {
+      outgoingQueue.push({ kind: 'text', platformId, text });
+      log.info('Signal disconnected, queued outbound message', { platformId, queueSize: outgoingQueue.length });
+      return;
+    }
+    await sendTextNow(platformId, text);
+  }
+
+  async function sendTextNow(platformId: string, text: string): Promise<void> {
+    if (!tcp) return;
 
     echoCache.remember(platformId, text);
 
@@ -780,8 +801,17 @@ export function createSignalAdapter(config: {
    * caption colliding with signal-cli's per-message size limits.
    */
   async function sendAttachments(platformId: string, files: { filename: string; data: Buffer }[]): Promise<void> {
-    if (!connected || !tcp) return;
     if (files.length === 0) return;
+    if (!connected || !tcp) {
+      outgoingQueue.push({ kind: 'attachments', platformId, files });
+      log.info('Signal disconnected, queued outbound attachments', { platformId, queueSize: outgoingQueue.length });
+      return;
+    }
+    await sendAttachmentsNow(platformId, files);
+  }
+
+  async function sendAttachmentsNow(platformId: string, files: { filename: string; data: Buffer }[]): Promise<void> {
+    if (!tcp || files.length === 0) return;
 
     const tempPaths: string[] = [];
     for (const file of files) {
@@ -811,6 +841,35 @@ export function createSignalAdapter(config: {
           /* best-effort cleanup */
         }
       }
+    }
+  }
+
+  async function flushOutgoingQueue(): Promise<void> {
+    if (flushingOutgoingQueue || outgoingQueue.length === 0) return;
+    flushingOutgoingQueue = true;
+    try {
+      log.info('Signal: flushing queued outbound sends', { count: outgoingQueue.length });
+      while (outgoingQueue.length > 0) {
+        if (!connected || !tcp) break;
+        const item = outgoingQueue.shift()!;
+        try {
+          if (item.kind === 'text') {
+            await sendTextNow(item.platformId, item.text);
+          } else {
+            await sendAttachmentsNow(item.platformId, item.files);
+          }
+        } catch (err) {
+          log.error('Signal: failed to flush queued send, re-queueing', {
+            kind: item.kind,
+            platformId: item.platformId,
+            err,
+          });
+          outgoingQueue.unshift(item);
+          break;
+        }
+      }
+    } finally {
+      flushingOutgoingQueue = false;
     }
   }
 
@@ -899,6 +958,7 @@ export function createSignalAdapter(config: {
         host: config.tcpHost,
         port: config.tcpPort,
       });
+      void flushOutgoingQueue();
     },
 
     async teardown(): Promise<void> {


### PR DESCRIPTION
## Summary
- `sendText`/`sendAttachments` silently dropped outbound messages whenever the TCP connection to `signal-cli` was down. They now queue and flush automatically the next time `setup()` connects. This adapter has no reconnect loop yet (see the `onClose` handler comment), so today that flush point is a service restart — same recovery path as any other outbound send after a drop.
- Voice messages only ever produced a text placeholder (`[Voice: ...]` / `[Voice Message]`), even when the raw audio file existed on disk. The audio is now always forwarded as a structured attachment (the same `[Image: <path>]` / `attachments[]` mechanism already used for images), regardless of whether transcription succeeds, is unavailable, or isn't configured.

## Test plan
- [x] `pnpm exec vitest run src/channels/signal.test.ts` — 45/45 passing, including two new tests covering each fix
- [x] `pnpm run build` — no new typecheck errors introduced by this change (pre-existing unrelated errors on this branch: `deltachat.ts`, `local-web*.ts`, `slack.ts`, `canvas-actions/handlers.ts`, `slack-room-membership/membership.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)