### PR TITLE
feat(skills): the Slack agents companion skills move in-tree — main is canonical

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -14,8 +14,10 @@ directives); all idempotent.
 This is the base Slack experience: one bot, DM and channel chat. The Slack
 **agents** feature — child bots provisioned from `create_agent`, shared rooms,
 canvases, DM onboarding — ships separately in `/slack-a2a-rooms` +
-`/slack-agent-flow`; the setup wizard applies them automatically, and they can be applied on top
-of this install at any time.
+`/slack-agent-flow`, in-tree under `.claude/skills/` (their canonical home;
+the channels branch keeps a compatibility copy for older checkouts). The
+setup wizard applies them automatically, and they can be applied on top of
+this install at any time.
 Existing classic installs that want the Slack agents experience should use
 `/migrate-slack-agents` rather than re-running this skill (classic keeps
 working; that migration is optional).
@@ -187,8 +189,8 @@ bash setup/lib/restart.sh
 
 Mid-`/setup`: return to the setup flow. Otherwise wire the channel with `/init-first-agent`
 (or `/manage-channels`). For the Slack agents feature (child bots from
-`create_agent`, shared rooms, canvases), apply `/slack-a2a-rooms` then
-`/slack-agent-flow` — the setup wizard does both automatically by default.
+`create_agent`, shared rooms, canvases), apply the in-tree `/slack-a2a-rooms`
+then `/slack-agent-flow` — the setup wizard does both automatically by default.
 
 ## Channel Info
 

--- a/.claude/skills/slack-a2a-rooms/SKILL.md
+++ b/.claude/skills/slack-a2a-rooms/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: slack-a2a-rooms
+description: Agent-to-agent Slack rooms — a group DM (MPIM) holding a human plus two or more NanoClaw sibling bots, where each bot hears the room over its own Socket Mode connection. Registers the admission policy on the Slack channel's bot-inbound guard so bot-authored inbound is admitted only for rooms allowlisted in SLACK_A2A_ROOMS (re-attributed as slack:bot:<bot_id>, hop-limited via SLACK_A2A_MAX_HOPS), plus scripts/open-a2a-room.ts to open a room and register it.
+---
+
+# Slack agent-to-agent rooms (SLACK_A2A_ROOMS)
+
+Lets two or more NanoClaw Slack bots talk to each other — and to a human — in
+a shared group DM (MPIM). Empirically established against live Slack:
+`conversations.open` with `users=[<human>, <other bot user id>…]` works from a
+bot token holding `mpim:write` and returns an `is_mpim` channel, and bots
+receive each other's messages over their own Socket Mode connections as plain
+`message` events with `channel_type: "mpim"`, `bot_id` set, and `subtype`
+null.
+
+**Canonical home.** This directory on `main` is the skill's canonical source —
+the setup wizard and any direct apply read it from the checkout. The copy on
+the `channels` branch is a compatibility mirror for older checkouts whose
+setup fetches companions from there; edits land here, never there.
+
+**Where sibling-bot messages die today.** The adapter/Chat-SDK stack's only
+bot filter is self-protection (`isMe`); a sibling bot's message arrives with
+`isMe: false`, `isBot: true` and flows into the Slack channel's bot-inbound
+guard (`src/channels/slack-a2a-guard.ts`, installed with `/add-slack`), which
+drops all bot-authored inbound at the bridge boundary by default — before the
+router, before any sender-approval flow. The guard exposes a single admission
+seam, `setBotInboundPolicy`; this skill registers the policy that opens it up
+selectively:
+
+- Rooms listed in `SLACK_A2A_ROOMS`: bot-authored inbound passes, attributed
+  to the user id `slack:bot:<bot_id>`, under a consecutive-hop limit.
+- Everywhere else: bot-authored inbound stays dropped at the bridge, exactly
+  as the guard's default already does.
+
+**Loop safety.** After N consecutive bot-authored inbound messages in an A2A
+room without a human message (N = `SLACK_A2A_MAX_HOPS`, default 6), further
+bot messages are dropped with a log line until a human speaks. The counter is
+per bot identity and per room; any human message resets it.
+
+**Requires:**
+
+- The Slack channel installed (`/add-slack`), current enough to ship the
+  bot-inbound guard (`src/channels/slack-a2a-guard.ts` with the
+  `setBotInboundPolicy` seam). The default drop arrives with that payload;
+  this skill only adds the allowlisted-room admission on top.
+- At least two Slack bot identities on this host (or sibling bots on other
+  hosts sharing the workspace). Named identities are registered natively by
+  the adapter from `SLACK_INSTANCES` — see the `slack-multi-instance` skill
+  for the env-key format. `scripts/open-a2a-room.ts` reads tokens by that
+  convention (`SLACK_BOT_TOKEN_<NAME>`; `default` → `SLACK_BOT_TOKEN`).
+- Every participating app's manifest must carry the MPIM scopes and event:
+  `mpim:write` (open the room), `mpim:history` + `mpim:read` (see it), and
+  the `message.mpim` bot event (hear it). Apps provisioned through the
+  managed flow (`apps.manifest.create` + `apps.managedInstall`) already
+  include all of these.
+
+## Apply
+
+### 1. Verify the installed Slack channel ships the bot-inbound guard
+
+The policy module copied next imports `setBotInboundPolicy` from the installed
+`src/channels/slack-a2a-guard.ts`. On a Slack payload that predates the guard,
+that import takes down the channel barrel — and with it **every** adapter — so
+verify the seam first. If the check fails, **stop**: re-run `/add-slack` from a
+channels branch that ships the guard, then re-apply this skill.
+
+```nc:run effect:check
+grep -sq 'export function setBotInboundPolicy' src/channels/slack-a2a-guard.ts || { echo 'slack-a2a-rooms: src/channels/slack-a2a-guard.ts is missing or does not export setBotInboundPolicy. Installing anyway would break the channel barrel and take down every channel adapter. Update the installed Slack channel first (re-run /add-slack from a channels branch that ships the bot-inbound guard), then re-apply this skill.' >&2; exit 1; }
+```
+
+### 2. Copy the policy module, its guard test, and the room-opener script
+
+This skill ships three files alongside this document; copy them into the tree
+at the same relative paths (overwrite; the skill's copies are canonical):
+
+```nc:copy
+src/channels/slack-a2a.ts
+src/channels/slack-a2a.test.ts
+scripts/open-a2a-room.ts
+```
+
+- `slack-a2a.ts` — the admission policy: `SLACK_A2A_ROOMS` /
+  `SLACK_A2A_MAX_HOPS` parsing (re-read with a ~30s cache so a freshly opened
+  room needs no restart), the per-room, per-identity consecutive-hop counter
+  with human reset, and the `slack:bot:<bot_id>` re-attribution. The module
+  registers itself onto the guard's admission seam on import.
+- `slack-a2a.test.ts` — the guard: drives the real channel barrel and the
+  real bot-inbound guard end-to-end (see step 4 for what it pins).
+- `open-a2a-room.ts` — operator CLI to open a room (see Configuration).
+
+### 3. Register the policy module
+
+Append the self-registration import to the channel barrel (skipped if the
+line is already present). Appending at the end keeps it after the Slack
+channel's own imports:
+
+```nc:append to:src/channels/index.ts
+import './slack-a2a.js';
+```
+
+### 4. Build and validate
+
+Build first — it guards the typed `setBotInboundPolicy` call against guard
+drift. The test imports the real channel barrel (a deleted or broken barrel
+line goes red) and asserts the policy end-to-end: allowlisted-room admission
+with `slack:bot:<bot_id>` re-attribution, non-listed-room drop, the hop limit
+with human reset, per-room/per-identity budgets, and that a downstream throw
+consumes no hop budget:
+
+```nc:run effect:build
+pnpm run build
+```
+
+```nc:run effect:test
+pnpm exec vitest run src/channels/slack-a2a.test.ts
+```
+
+## Configuration
+
+`.env` keys (both re-read with a ~30s cache — no restart needed after edits):
+
+- `SLACK_A2A_ROOMS` — comma-separated raw Slack channel ids (the MPIM ids the
+  opener script prints, e.g. `G0AAAAAAA` — note MPIM ids may start with `G`
+  or `C` depending on workspace vintage). Only these rooms admit bot-authored
+  inbound.
+- `SLACK_A2A_MAX_HOPS` — consecutive bot-authored inbound messages allowed in
+  an A2A room without a human message before further bot messages are dropped.
+  Default `6`.
+
+### Opening a room
+
+```bash
+pnpm exec tsx scripts/open-a2a-room.ts --instances dana,eli --user U0AAAAAAA
+```
+
+The first listed instance opens the conversation (via `conversations.open`
+with the human + the other bots' user ids, resolved through `auth.test` per
+token) and posts an intro message. The script prints the channel id and
+appends it to `SLACK_A2A_ROOMS` in `.env`. Without `--user` you get a
+bots-only room, which needs at least three instances (Slack collapses a
+two-party open into a 1:1 IM).
+
+### Letting bot senders through the access gate
+
+The room allowlist gets bot messages *to* the router; the permissions module
+still gates them like any sender. Bot senders arrive as user id
+`slack:bot:<bot_id>`, which starts unknown. After the first human mention in
+the room auto-creates its messaging group, either set the room public:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:<channel id>'"
+```
+
+or keep `request_approval` and approve each `slack:bot:<bot_id>` sender once
+(or add them as members of the agent group). A private A2A room with known
+humans is a reasonable place for `public`.
+
+## Engagement: A2A conversation is mention-driven
+
+An MPIM is a *group* context in NanoClaw's channel-defaults model (Slack DMs
+are only `D…` channels), so the Slack group defaults apply:
+`engage_mode: mention-sticky`, per-thread stickiness. That means a bot
+replies when it is @-mentioned (then stays engaged in that thread) — it does
+not answer every room message. Bot-to-bot conversation is therefore
+**mention-driven by design**: bot A's reply reaches bot B's agent when it
+@-mentions bot B, and the chain continues only as long as each reply
+mentions the next speaker. Slack does not emit `app_mention` for
+bot-authored messages, but mention detection still works: the Chat SDK's
+text-level detector matches the bot's own `<@U…>` token, which the adapter
+deliberately leaves unresolved in the text. This is the intended loop
+governor alongside the hop limit — prompt the agents (group CLAUDE.md /
+personality) to @-mention the sibling they want an answer from, and to stop
+mentioning anyone when the exchange has converged.
+
+## Remove
+
+1. Delete the three copied files: `src/channels/slack-a2a.ts`,
+   `src/channels/slack-a2a.test.ts`, `scripts/open-a2a-room.ts`.
+2. Delete the `import './slack-a2a.js';` line from `src/channels/index.ts`.
+3. Remove `SLACK_A2A_ROOMS` and `SLACK_A2A_MAX_HOPS` from `.env`.
+4. Optionally re-tighten any messaging groups you set to
+   `unknown_sender_policy='public'`, and archive/leave the MPIMs from Slack
+   (the rooms themselves are ordinary Slack conversations; NanoClaw holds no
+   other state for them beyond the usual messaging-group/session rows).
+5. Rebuild (`pnpm run build`).
+
+With the skill removed, the channel guard's default applies everywhere again:
+bot-authored inbound is dropped in every room.
+
+## Notes
+
+- **Bot senders outside A2A rooms**: the Slack channel's bot-inbound guard
+  drops bot-authored messages in rooms not listed in `SLACK_A2A_ROOMS` at the
+  bridge — before the router and before any sender-approval flow — with or
+  without this skill applied. If an install relies on a bot sender (another
+  workspace app posting into a channel the agent watches), add that room to
+  `SLACK_A2A_ROOMS`. Human messages are never affected.
+- **Access-gate story is manual.** The recipe deliberately leaves letting
+  `slack:bot:<bot_id>` senders through the gate as an operator step (public
+  policy or per-bot approval). Should `open-a2a-room.ts` instead pre-create
+  the messaging group + wirings + members via `ncl` so a room works with zero
+  extra steps? That needs the host running and a choice of agent group per
+  bot — deferred.
+- **Hop-counter scope.** The counter counts bot-authored *inbound* per bot
+  identity (bridge instance). A bot's own outbound is invisible to it (`isMe`
+  dropped upstream), so with two bots the effective conversation length is
+  roughly `2×maxHops` messages; with k bots each message increments k−1
+  counters. If per-room total (not per-identity) semantics are wanted, the
+  counter needs to live host-side (router/session), not in the channel layer.
+- **Cross-host rooms.** For sibling bots on *different* NanoClaw hosts, each
+  host needs this skill (its own allowlist entry). The opener script only
+  handles co-hosted tokens; opening a cross-host room means running it where
+  the first bot's token lives and adding the room id to the other host's
+  `.env` manually.
+- **`message_changed` / edited bot messages** are not admitted (the adapter
+  only forwards unfurl data for edits) — fine for v1.
+- **Attribution name.** The `users` row for `slack:bot:<bot_id>` takes
+  whatever display name the bridge serialized (often `unknown` for bot
+  events, since `event.username` is frequently absent and `event.user` is
+  unset). A nicety would be resolving the bot's profile name via
+  `bots.info` — deferred.
+- **MPIM id prefix.** Older workspaces mint MPIM ids starting with `G`,
+  newer ones with `C`. The allowlist matches exact ids so both work, but the
+  adapter's `getChannelVisibility` calls `C…` ids "workspace"-visible —
+  cosmetic only, nothing here branches on it.

--- a/.claude/skills/slack-a2a-rooms/scripts/open-a2a-room.ts
+++ b/.claude/skills/slack-a2a-rooms/scripts/open-a2a-room.ts
@@ -1,0 +1,203 @@
+/**
+ * scripts/open-a2a-room.ts — open a Slack agent-to-agent (A2A) room.
+ *
+ * Creates a group DM (MPIM) holding a human plus two or more NanoClaw sibling
+ * bots, posts an intro message from the first bot, prints the channel id, and
+ * appends it to SLACK_A2A_ROOMS in .env so the slack-a2a-rooms bridge filter
+ * starts admitting bot-authored messages there (picked up within ~30s — no
+ * service restart required).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]
+ *
+ * Instance names follow the slack-multi-instance convention: each name reads
+ * its bot token from SLACK_BOT_TOKEN_<NAME> (uppercased, dashes →
+ * underscores); the special name `default` reads SLACK_BOT_TOKEN. The first
+ * listed instance is the caller — it opens the conversation and posts the
+ * intro. Bot user ids are resolved via auth.test per token.
+ *
+ * Requires the `mpim:write` scope on every listed app (see the skill's
+ * prerequisites). Without --user the room holds bots only, which needs at
+ * least three instances (Slack turns a two-party open into a 1:1 IM).
+ *
+ * Token values are never printed.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from '../src/env.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+interface SlackAuth {
+  name: string;
+  envKey: string;
+  token: string;
+  userId: string; // U… bot user id (auth.test user_id)
+  botId: string | null; // B… bot id (auth.test bot_id)
+}
+
+function fail(msg: string): never {
+  console.error(`open-a2a-room: ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): { instances: string[]; user?: string } {
+  let instances: string[] = [];
+  let user: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--instances') {
+      instances = (argv[++i] ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (argv[i] === '--user') {
+      user = argv[++i];
+    } else {
+      fail(
+        `unknown argument: ${argv[i]}\nUsage: pnpm exec tsx scripts/open-a2a-room.ts --instances <name,name…> [--user <slack user id>]`,
+      );
+    }
+  }
+  if (instances.length < 2) fail('--instances needs at least two comma-separated instance names');
+  if (!user && instances.length < 3) {
+    fail(
+      'without --user the room holds bots only, which needs at least three instances (a two-party open becomes a 1:1 IM)',
+    );
+  }
+  if (user && !/^[UW][A-Z0-9]+$/.test(user)) {
+    fail(`--user must be a Slack user id (U…/W…), got: ${user}`);
+  }
+  return { instances, user };
+}
+
+function tokenEnvKey(name: string): string {
+  if (name === 'default') return 'SLACK_BOT_TOKEN';
+  return `SLACK_BOT_TOKEN_${name.toUpperCase().replace(/-/g, '_')}`;
+}
+
+async function slackCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (json.ok !== true) {
+    throw new Error(`${method} failed: ${String(json.error ?? `HTTP ${res.status}`)}`);
+  }
+  return json;
+}
+
+async function resolveAuth(name: string): Promise<SlackAuth> {
+  const envKey = tokenEnvKey(name);
+  const env = readEnvFile([envKey]);
+  const token = env[envKey];
+  if (!token) fail(`missing ${envKey} in .env (slack-multi-instance token convention)`);
+  const auth = await slackCall(token, 'auth.test', {});
+  const userId = typeof auth.user_id === 'string' ? auth.user_id : null;
+  if (!userId) fail(`auth.test for instance "${name}" returned no user_id`);
+  return {
+    name,
+    envKey,
+    token,
+    userId,
+    botId: typeof auth.bot_id === 'string' ? auth.bot_id : null,
+  };
+}
+
+/** Append the room to SLACK_A2A_ROOMS in .env (create the key if absent,
+ * no-op if the id is already listed). */
+function appendRoomToEnv(roomId: string): 'appended' | 'already-present' | 'created' {
+  const envPath = path.join(process.cwd(), '.env');
+  let content = '';
+  try {
+    content = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    // no .env — create one with just this key
+  }
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.trim().startsWith('SLACK_A2A_ROOMS='));
+  if (idx === -1) {
+    const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+    fs.writeFileSync(envPath, `${content}${suffix}SLACK_A2A_ROOMS=${roomId}\n`);
+    return 'created';
+  }
+  const existing = lines[idx].slice(lines[idx].indexOf('=') + 1).trim();
+  const rooms = existing
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (rooms.includes(roomId)) return 'already-present';
+  rooms.push(roomId);
+  lines[idx] = `SLACK_A2A_ROOMS=${rooms.join(',')}`;
+  fs.writeFileSync(envPath, lines.join('\n'));
+  return 'appended';
+}
+
+async function main(): Promise<void> {
+  const { instances, user } = parseArgs(process.argv.slice(2));
+
+  console.log(`Resolving bot identities for: ${instances.join(', ')}`);
+  const auths: SlackAuth[] = [];
+  for (const name of instances) {
+    const auth = await resolveAuth(name);
+    console.log(`  ${name}: bot user ${auth.userId}${auth.botId ? ` (bot id ${auth.botId})` : ''}`);
+    auths.push(auth);
+  }
+
+  const caller = auths[0];
+  const otherBotUserIds = auths.slice(1).map((a) => a.userId);
+  const members = [...(user ? [user] : []), ...otherBotUserIds];
+
+  console.log(`Opening group DM as "${caller.name}" with: ${members.join(', ')}`);
+  const opened = await slackCall(caller.token, 'conversations.open', {
+    users: members.join(','),
+  });
+  const channel = opened.channel as Record<string, unknown> | undefined;
+  const channelId = typeof channel?.id === 'string' ? channel.id : null;
+  if (!channelId) fail('conversations.open returned no channel id');
+  if (channel?.is_mpim !== true) {
+    console.warn(
+      `warning: opened conversation ${channelId} is not an MPIM (is_mpim=${String(channel?.is_mpim)}) — with fewer than three members Slack returns a 1:1 IM`,
+    );
+  }
+
+  const botMentions = otherBotUserIds.map((id) => `<@${id}>`).join(' ');
+  const introText =
+    `:robot_face: Agent-to-agent room opened by "${caller.name}". ` +
+    `${botMentions}${user ? ` <@${user}>` : ''} — bots in this room can hear each other. ` +
+    `Conversation is mention-driven: @-mention a bot to get its reply, and it can @-mention the next one. ` +
+    `After too many consecutive bot messages the room pauses until a human speaks.`;
+  await slackCall(caller.token, 'chat.postMessage', {
+    channel: channelId,
+    text: introText,
+  });
+
+  const envResult = appendRoomToEnv(channelId);
+  console.log('');
+  console.log(`A2A room channel id: ${channelId}`);
+  console.log(
+    envResult === 'already-present'
+      ? 'SLACK_A2A_ROOMS already lists this room — .env unchanged.'
+      : `SLACK_A2A_ROOMS ${envResult === 'created' ? 'created' : 'updated'} in .env — the bridge filter picks it up within ~30s (no restart needed).`,
+  );
+  console.log('');
+  console.log('Next steps (once per room):');
+  console.log(`  - Mention a bot in the room once so the host auto-creates the messaging group,`);
+  console.log(`    then allow bot senders through the access gate, e.g.:`);
+  console.log(
+    `      pnpm exec tsx scripts/q.ts data/v2.db "UPDATE messaging_groups SET unknown_sender_policy='public' WHERE platform_id='slack:${channelId}'"`,
+  );
+  console.log(`    (or approve / add the slack:bot:<bot_id> users as members instead of going public).`);
+  console.log(`  - Wire the room to each bot's agent group (ncl messaging-groups / wirings) if not auto-wired.`);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.test.ts
+++ b/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Guard for the slack-a2a-rooms admission policy and its registration.
+ *
+ * The skill's one reach-in is the barrel line `import './slack-a2a.js';` in
+ * src/channels/index.ts: importing the module installs the A2A room policy on
+ * the Slack channel layer's bot-inbound guard (setBotInboundPolicy). This
+ * file drives that wiring end-to-end through the REAL guard: it imports the
+ * real channel barrel — never ./slack-a2a.js directly, see the note at the
+ * env-parsing describe — and sends bridge-shaped inbound through
+ * wrapSlackBotGuard, asserting the policy's semantics:
+ *
+ *   - allowlisted rooms admit bot messages re-attributed as slack:bot:<bot_id>
+ *   - non-listed rooms stay dropped; humans pass everywhere, untouched
+ *   - the consecutive-hop limit drops bot messages until a human speaks
+ *   - budgets are tracked per room and per bot identity (bridge instance)
+ *   - a downstream throw does not consume hop budget
+ *
+ * If the barrel line is deleted (or the barrel fails to evaluate), no policy
+ * is installed, the guard's default drop applies, and the admit test goes
+ * red — exactly the composed-install failure this file guards. The guard's
+ * own mechanics (default drop, human byte-identical pass-through, fail-closed
+ * policy errors, non-Slack adapters untouched) are pinned by the channel
+ * payload's slack-a2a-guard.test.ts, not here.
+ *
+ * Config is read from .env (SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS) at first
+ * decision, so the test chdirs into a temp dir carrying a crafted .env BEFORE
+ * importing the barrel. Vitest's per-file process isolation keeps the chdir
+ * and the module cache local to this file. No DB, no Slack.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import { wrapSlackBotGuard } from './slack-a2a-guard.js';
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'slack-a2a-'));
+  writeFileSync(
+    join(dir, '.env'),
+    'SLACK_A2A_ROOMS=G0ALLOW,G0HOPS,G0ROOMA,G0ROOMB,G0INST,G0THROW\nSLACK_A2A_MAX_HOPS=2\n',
+  );
+  process.chdir(dir);
+  await import('./index.js'); // the real barrel — installs the policy via the skill's barrel line
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+interface InboundCall {
+  platformId: string;
+  message: InboundMessage;
+}
+
+function makeSetup(onInbound?: ChannelSetup['onInbound']): { setup: ChannelSetup; calls: InboundCall[] } {
+  const calls: InboundCall[] = [];
+  const setup: ChannelSetup = {
+    onInbound:
+      onInbound ??
+      ((platformId, _threadId, message) => {
+        calls.push({ platformId, message });
+      }),
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+  return { setup, calls };
+}
+
+let nextMessageId = 0;
+
+/** Bridge-shaped inbound fixture (see chat-sdk-bridge.ts messageToInbound). */
+function makeInbound(author: Record<string, unknown>, text: string): InboundMessage {
+  const id = `msg-${++nextMessageId}`;
+  return {
+    id,
+    kind: 'chat-sdk',
+    content: { id, text, author, senderId: author.userId },
+    timestamp: new Date().toISOString(),
+    isGroup: true,
+  };
+}
+
+function humanMsg(): InboundMessage {
+  return makeInbound({ userId: 'U111', isBot: false, isMe: false }, 'hello');
+}
+
+function botMsg(botId = 'B999'): InboundMessage {
+  return makeInbound({ userId: botId, isBot: true, isMe: false }, 'from a sibling bot');
+}
+
+describe('slack-a2a room policy (registered via the channel barrel)', () => {
+  it('admits allowlisted bot messages re-attributed as slack:bot:<bot_id>', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const msg = botMsg('B42');
+
+    await wrapped.onInbound('slack:G0ALLOW', 'slack:G0ALLOW:171.1', msg);
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('slack:bot:B42');
+  });
+
+  it('drops bot messages for rooms not in SLACK_A2A_ROOMS', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:C0OTHER', null, botMsg());
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes human messages through unchanged — allowlisted room or not', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    const inRoom = humanMsg();
+    await wrapped.onInbound('slack:G0ALLOW', null, inRoom);
+    const outsideRoom = humanMsg();
+    await wrapped.onInbound('slack:C0OTHER', null, outsideRoom);
+
+    expect(calls).toHaveLength(2);
+    expect((calls[0].message.content as Record<string, unknown>).senderId).toBe('U111');
+    expect((calls[1].message.content as Record<string, unknown>).senderId).toBe('U111');
+  });
+
+  it('enforces the consecutive-hop limit (SLACK_A2A_MAX_HOPS) and resets on a human message', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0HOPS';
+
+    await wrapped.onInbound(pid, null, botMsg('b1'));
+    await wrapped.onInbound(pid, null, botMsg('b2'));
+    expect(calls).toHaveLength(2);
+
+    // Third consecutive bot message exceeds maxHops=2 — dropped.
+    await wrapped.onInbound(pid, null, botMsg('b3'));
+    expect(calls).toHaveLength(2);
+
+    // A human message passes and resets the counter…
+    await wrapped.onInbound(pid, null, humanMsg());
+    expect(calls).toHaveLength(3);
+
+    // …so bot messages flow again.
+    await wrapped.onInbound(pid, null, botMsg('b4'));
+    expect(calls).toHaveLength(4);
+  });
+
+  it('tracks the hop budget per room', async () => {
+    const { setup, calls } = makeSetup();
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a1'));
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a2'));
+    expect(calls).toHaveLength(2); // G0ROOMA at its limit (maxHops=2)
+
+    await wrapped.onInbound('slack:G0ROOMA', null, botMsg('a3'));
+    expect(calls).toHaveLength(2);
+
+    // A different room has its own budget.
+    await wrapped.onInbound('slack:G0ROOMB', null, botMsg('b1'));
+    expect(calls).toHaveLength(3);
+  });
+
+  it('tracks the hop budget per bot identity (bridge instance)', async () => {
+    const a = makeSetup();
+    const b = makeSetup();
+    const wrappedA = wrapSlackBotGuard(a.setup, 'slack');
+    const wrappedB = wrapSlackBotGuard(b.setup, 'slack-dana');
+    const pid = 'slack:G0INST';
+
+    await wrappedA.onInbound(pid, null, botMsg('a1'));
+    await wrappedA.onInbound(pid, null, botMsg('a2'));
+    await wrappedA.onInbound(pid, null, botMsg('a3'));
+    expect(a.calls).toHaveLength(2); // identity A exhausted its budget
+
+    // Identity B in the same room still has a full budget.
+    await wrappedB.onInbound(pid, null, botMsg('b1'));
+    expect(b.calls).toHaveLength(1);
+  });
+
+  it('does not consume hop budget when downstream throws', async () => {
+    let failNext = true;
+    const calls: InboundCall[] = [];
+    const { setup } = makeSetup(async (platformId, _threadId, message) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('router exploded');
+      }
+      calls.push({ platformId, message });
+    });
+    const wrapped = wrapSlackBotGuard(setup, 'slack');
+    const pid = 'slack:G0THROW';
+
+    // Admitted, but downstream throws — the message never reached a session,
+    // so the budget (maxHops=2) must be untouched.
+    await expect(wrapped.onInbound(pid, null, botMsg('t1'))).rejects.toThrow('router exploded');
+
+    // The full budget of two is still available…
+    await wrapped.onInbound(pid, null, botMsg('t2'));
+    await wrapped.onInbound(pid, null, botMsg('t3'));
+    expect(calls).toHaveLength(2);
+
+    // …and accounting still works: the third accepted hop is over the limit.
+    await wrapped.onInbound(pid, null, botMsg('t4'));
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('env parsing', () => {
+  // Imported dynamically, and only in this describe, which runs AFTER the
+  // behavior tests above: a static (or earlier) import of ./slack-a2a.js
+  // would install the policy as a side effect of this test file itself and
+  // mask a deleted barrel line. Via the barrel the module is already in the
+  // cache, so this import is a no-op read.
+  it('parseRooms splits, trims, and drops empties', async () => {
+    const { parseRooms } = await import('./slack-a2a.js');
+    expect([...parseRooms(' G0A , C0B ,,')]).toEqual(['G0A', 'C0B']);
+    expect(parseRooms(undefined).size).toBe(0);
+  });
+
+  it('parseMaxHops falls back to the default on junk', async () => {
+    const { parseMaxHops, DEFAULT_MAX_HOPS } = await import('./slack-a2a.js');
+    expect(parseMaxHops('4')).toBe(4);
+    expect(parseMaxHops('0')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('-2')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops('six')).toBe(DEFAULT_MAX_HOPS);
+    expect(parseMaxHops(undefined)).toBe(DEFAULT_MAX_HOPS);
+  });
+});

--- a/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.ts
+++ b/.claude/skills/slack-a2a-rooms/src/channels/slack-a2a.ts
@@ -1,0 +1,135 @@
+/**
+ * Slack agent-to-agent (A2A) rooms — the admission policy for bot-authored
+ * inbound: room allowlist + consecutive-hop limit + `slack:bot:<bot_id>`
+ * re-attribution.
+ *
+ * The Slack channel layer's bot-inbound guard (src/channels/slack-a2a-guard.ts,
+ * installed with the Slack channel) drops every bot-authored inbound message
+ * at the bridge boundary by default — sibling and foreign bots never reach the
+ * router, so they can neither spam unknown-sender approval cards nor feed each
+ * other into loops. The guard exposes a single admission seam
+ * (`setBotInboundPolicy`); this module is that policy:
+ *
+ *   - Rooms allowlisted in `SLACK_A2A_ROOMS` (comma-separated Slack channel
+ *     ids, e.g. the MPIM ids printed by scripts/open-a2a-room.ts): bot-authored
+ *     inbound is admitted, re-attributed with sender id `slack:bot:<bot_id>`,
+ *     under a consecutive-hop limit (`SLACK_A2A_MAX_HOPS`, default 6) that any
+ *     human message in the room resets.
+ *   - Every other room: bot-authored inbound stays dropped (the guard logs the
+ *     drop with this policy's reason).
+ *
+ * Human-authored messages are structurally outside this policy's power: the
+ * guard passes them through untouched and only lets the policy observe them
+ * (for the hop-counter reset).
+ */
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { setBotInboundPolicy, type SlackBotInboundPolicy } from './slack-a2a-guard.js';
+
+export const DEFAULT_MAX_HOPS = 6;
+
+/** How long a read of SLACK_A2A_ROOMS / SLACK_A2A_MAX_HOPS is cached.
+ * Short enough that a room appended to .env by scripts/open-a2a-room.ts is
+ * picked up without a service restart. */
+const CONFIG_TTL_MS = 30_000;
+
+export interface A2aConfig {
+  /** Raw Slack channel ids (C…/G…) allowed to carry bot-authored inbound. */
+  rooms: Set<string>;
+  /** Consecutive bot-authored inbound messages allowed without a human one. */
+  maxHops: number;
+}
+
+export function parseRooms(raw: string | undefined): Set<string> {
+  return new Set(
+    (raw ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+export function parseMaxHops(raw: string | undefined): number {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_MAX_HOPS;
+}
+
+let cached: { at: number; config: A2aConfig } | null = null;
+
+function readA2aConfig(): A2aConfig {
+  const now = Date.now();
+  if (cached && now - cached.at < CONFIG_TTL_MS) return cached.config;
+  const env = readEnvFile(['SLACK_A2A_ROOMS', 'SLACK_A2A_MAX_HOPS']);
+  cached = {
+    at: now,
+    config: {
+      rooms: parseRooms(env.SLACK_A2A_ROOMS),
+      maxHops: parseMaxHops(env.SLACK_A2A_MAX_HOPS),
+    },
+  };
+  return cached.config;
+}
+
+/** The guard reports the adapter's channel id (`slack:C0…`); the allowlist
+ * holds raw Slack channel ids. */
+function roomFromPlatformId(platformId: string): string {
+  const idx = platformId.indexOf(':');
+  return idx === -1 ? platformId : platformId.slice(idx + 1);
+}
+
+/**
+ * Build the A2A room policy. The hop counter is per bot identity and per room
+ * — keyed on the guard's instanceKey, since each bridge instance is one bot
+ * identity, and a bot's own outbound never arrives here (the SDK drops `isMe`
+ * upstream). With two bots the effective conversation length is therefore
+ * roughly 2×maxHops messages. Any human message in a room resets that room's
+ * counter for the identity that heard it; every co-hosted identity hears the
+ * same human message over its own connection, so the budgets reset together.
+ *
+ * `getConfig` is injectable for tests; production reads .env with a short TTL
+ * cache.
+ */
+export function createA2aRoomPolicy(getConfig: () => A2aConfig = readA2aConfig): SlackBotInboundPolicy {
+  /** Consecutive accepted bot hops, keyed `<instanceKey>:<room>`. */
+  const hops = new Map<string, number>();
+
+  return {
+    decideBotInbound(ctx) {
+      const room = roomFromPlatformId(ctx.platformId);
+      const { rooms, maxHops } = getConfig();
+      if (!rooms.has(room)) {
+        return { action: 'drop', reason: 'room not in SLACK_A2A_ROOMS' };
+      }
+      const key = `${ctx.instanceKey}:${room}`;
+      const count = hops.get(key) ?? 0;
+      if (count >= maxHops) {
+        log.info('slack-a2a: hop limit reached — dropping bot messages until a human speaks', {
+          room,
+          botId: ctx.botId,
+          maxHops,
+        });
+        return { action: 'drop', reason: 'hop limit reached' };
+      }
+      return {
+        action: 'admit',
+        // The permissions module uses a senderId that already contains a ':'
+        // verbatim (see extractAndUpsertUser), so the users row becomes
+        // `slack:bot:<bot_id>` — distinguishable from human `slack:U…` ids.
+        senderId: `slack:bot:${ctx.botId}`,
+        // The guard fires this only after downstream accepted the message —
+        // a throw in the host's onInbound must not consume budget for a
+        // message that never reached a session.
+        onAccepted: () => hops.set(key, count + 1),
+      };
+    },
+    onHumanInbound(ctx) {
+      // Human message — reset this identity's hop counter for the room.
+      hops.delete(`${ctx.instanceKey}:${roomFromPlatformId(ctx.platformId)}`);
+    },
+  };
+}
+
+// Install the policy on the channel layer's guard (single provider — the
+// guard warns if another policy was already installed). Runs on barrel
+// import, like every channel module's self-registration.
+setBotInboundPolicy(createA2aRoomPolicy());

--- a/.claude/skills/slack-agent-flow/REMOVE.md
+++ b/.claude/skills/slack-agent-flow/REMOVE.md
@@ -1,0 +1,45 @@
+# Remove slack-agent-flow
+
+Reverses everything Apply added. Runtime data the flow created (agent groups,
+messaging groups, wirings, `.env` token/instance/room lines, provisioned Slack
+apps) is user data and is deliberately left alone — for per-agent teardown of
+a provisioned bot, follow the slack-managed-agents skill's teardown section.
+
+1. Delete the barrel registration lines (delete, don't comment out):
+   - `import './slack-agent-flow/index.js';`, `import './slack-room-membership/index.js';`,
+     `import './canvas-actions/index.js';`, and `import './slack-onboarding/index.js';`
+     from `src/modules/index.ts`
+   - `import './rooms.js';` and `import './canvas.js';` from
+     `container/agent-runner/src/mcp-tools/index.ts`
+
+2. Delete the copied payload files (the flow's own plus the shared feature
+   payload it copies from the channels branch):
+
+   ```bash
+   rm -rf src/modules/slack-agent-flow src/modules/slack-room-membership \
+          src/modules/canvas-actions src/modules/slack-onboarding
+   rm -f src/env-file.ts src/env-file.test.ts
+   rm -f scripts/slack-agent-flow-finish.ts
+   rm -f container/agent-runner/src/mcp-tools/rooms.ts \
+         container/agent-runner/src/mcp-tools/rooms.test.ts \
+         container/agent-runner/src/mcp-tools/rooms.instructions.md \
+         container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md \
+         container/agent-runner/src/mcp-tools/canvas.ts \
+         container/agent-runner/src/mcp-tools/canvas.instructions.md \
+         container/agent-runner/src/mcp-tools/canvas.test.ts
+   rm -rf container/skills/slack-construct-agents container/skills/slack-construct \
+          container/skills/canvas-work
+   rm -f container/skills/welcome/addenda/teams-tour.md \
+         container/skills/welcome/addenda/slack.md
+   ```
+
+3. Rebuild and restart:
+
+   ```bash
+   pnpm run build
+   bash setup/lib/restart.sh
+   ```
+
+Composed group CLAUDE.md files regenerate on the next container spawn, so the
+dropped instructions fragment and welcome addendum disappear from agents
+without any manual cleanup.

--- a/.claude/skills/slack-agent-flow/SKILL.md
+++ b/.claude/skills/slack-agent-flow/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: slack-agent-flow
+description: Let an existing Slack agent create new agents that arrive as their own Slack bots — provisioned app, operator DM, and a shared three-way room, hot-started without a host restart.
+---
+
+# Slack agent flow (create_agent → provisioned Slack bot)
+
+Composes the Slack extension skills into one conversational flow: a user tells
+an existing Slack-wired agent "create an agent called Research", and the new
+agent doesn't just exist as a `send_message` destination — it arrives in Slack
+as **its own bot**. The host provisions a Slack app for it (managed broker, or
+a workspace manager token), registers it as a `slack-<name>` instance,
+hot-starts the adapter in the running host, opens a DM between the new bot and
+the operator, opens a three-way MPIM (operator + originating bot + new bot)
+registered as an agent-to-agent room, and wires everything so both agents hear
+the room. The flow also adds two agent-facing room actions — `create_room`
+(one shared room with N agents at once, the team primitive) and `add_to_room`
+(grow a room by one agent) — and extends the base `create_agent` tool with the
+flow's `purpose` / `allow_guests` / `room` parameters. Non-Slack sessions are
+untouched: `create_agent` from any other channel behaves exactly as upstream.
+
+**Canonical home.** This directory on `main` is the skill's canonical source —
+the setup wizard and any direct apply read it from the checkout. The copy on
+the `channels` branch is a compatibility mirror for older checkouts whose
+setup fetches companions from there; edits land here, never there. The
+payload the Apply steps fetch with `from-branch:channels` stays on the
+channels branch, exactly like `/add-slack`'s own.
+
+## Prerequisites
+
+All prose below assumes these are already in place, in this order:
+
+1. **`add-slack`** — the Slack channel install (`src/channels/slack.ts` and
+   the shared channel-layer lib `src/channels/slack-lib.ts` present, with
+   `slack.ts` exporting its `SLACK_DEFAULTS` declaration and the
+   multi-instance factory `slackInstanceBridgeFactory` — the adapter owns
+   `SLACK_INSTANCES` registration natively, and the flow writes each new
+   agent's tokens under that env-key scheme).
+2. **`slack-a2a-rooms`** — the bot-sender room policy
+   (`src/channels/slack-a2a.ts` present), so shared rooms admit the sibling
+   bots' posts.
+3. **A provisioning credential in `.env`** — `NANOCLAW_INSTALL_TOKEN` (managed
+   broker) or `SLACK_MANAGER_TOKEN` (direct workspace-level app creation).
+   Without one, agent creation still works but the Slack leg reports
+   `no-credentials` and points at the finish script.
+4. **At least one Slack owner/admin in `user_roles`** — the flow resolves "the
+   operator" from the approver chain (scoped admins → global admins → owners)
+   and needs a `slack:U…` identity there to open the DM and the room.
+
+## Apply
+
+### 1. Check the Slack payloads are installed
+
+The flow imports the skill-installed Slack channel modules; verify they are in
+the tree before copying anything. If `slack-lib.ts`, the `SLACK_DEFAULTS`
+export, or the `slackInstanceBridgeFactory` export is missing, the installed
+Slack channel payload predates this flow — re-apply the two skills above (or
+`/update-skills`) first:
+
+```nc:run effect:check
+test -f src/channels/slack.ts && test -f src/channels/slack-lib.ts && test -f src/channels/slack-a2a.ts && grep -q "export const SLACK_DEFAULTS" src/channels/slack.ts && grep -q "export function slackInstanceBridgeFactory" src/channels/slack.ts
+```
+
+### 2. Check the trunk extension seams
+
+Everything this flow plugs into is standard trunk API — the adapter hot-start
+entry, the delivery batch preview, the mailbox delivery/session helpers, the
+create-agent notify option, the decline-and-notify overrides, the container
+tool-extension hook, and the setup wizard's channel registries. This is a
+trunk **version requirement, not an edit**: if the check below fails, the
+NanoClaw trunk is too old for this skill — bring the install up to date
+(`/update-nanoclaw`) instead of patching any of these files by hand:
+
+```nc:run effect:check
+grep -q "export async function startChannelAdapter" src/channels/channel-registry.ts && grep -q "export function registerDeliveryBatchPreview" src/delivery.ts && grep -q "session: Session) => Promise<void>" src/delivery.ts && grep -q "trigger?: boolean" src/session-manager.ts && grep -q "findCliResponse" container/agent-runner/src/db/messages-in.ts && grep -q "Promise<number>" container/agent-runner/src/db/messages-out.ts && grep -q "suppressCreatedNotify" src/modules/agent-to-agent/create-agent.ts && grep -q "dedupeKey?: string" src/modules/permissions/sender-approval.ts && grep -q "declineText?: string" src/modules/permissions/sender-approval.ts && grep -q "fyiText?: string" src/modules/permissions/sender-approval.ts && grep -q "export function extendTool" container/agent-runner/src/mcp-tools/server.ts && grep -q "export function registerChannelPreStep" setup/channels/companions.ts && grep -q "instructions.md" src/project-doc-compose.ts && grep -q "await action.decide" src/guard/guard.ts
+```
+
+The last term requires an async-capable guard seam: the flow's `create_agent`
+and room-action guards read container config asynchronously, and on a trunk
+whose `guard()` does not await `decide` a returned Promise would be treated
+as an allow — the check turns that silent fail-open into a fail-fast here.
+
+### 3. Copy the shared feature payload from the channels branch
+
+The agents experience needs more than the base adapter: the room-membership
+module (invite-to-room adoption, group-DM fork carry-over, detach on removal,
+owner-presence access rule), canvas actions + the container `canvas` tool +
+the `canvas-work` skill (section-scoped canvas edits/reads via the session's
+own bot identity), DM onboarding (get-started prompts, per-thread DM titles),
+and their `env-file.ts` dotenv plumbing. They live on the `channels` branch;
+fetch and copy them into place (overwrite — the branch is canonical):
+
+```nc:copy from-branch:channels
+src/env-file.ts
+src/env-file.test.ts
+src/modules/slack-room-membership/index.ts
+src/modules/slack-room-membership/membership.ts
+src/modules/slack-room-membership/membership.test.ts
+src/modules/slack-room-membership/env-file.ts
+src/modules/slack-room-membership/env-file.test.ts
+src/modules/canvas-actions/index.ts
+src/modules/canvas-actions/handlers.ts
+src/modules/canvas-actions/canvas-api.ts
+src/modules/canvas-actions/canvas-actions.test.ts
+src/modules/slack-onboarding/index.ts
+src/modules/slack-onboarding/onboarding.test.ts
+src/modules/slack-onboarding/thread-title.test.ts
+container/agent-runner/src/mcp-tools/canvas.ts
+container/agent-runner/src/mcp-tools/canvas.instructions.md
+container/agent-runner/src/mcp-tools/canvas.test.ts
+container/skills/slack-construct/SKILL.md
+container/skills/slack-construct/instructions.md
+container/skills/canvas-work/SKILL.md
+container/skills/welcome/addenda/slack.md
+```
+
+The welcome addendum rides with the agents feature deliberately: its tour
+content describes rooms, canvases, suggested-prompt DMs, and the agents
+access model — none of which exist on a base `/add-slack` install.
+
+Register the three host modules in the modules barrel and the canvas tool in
+the container tool barrel (each append is skipped if already present; these
+must precede the flow module's own barrel line, which the fence order here
+guarantees):
+
+```nc:append to:src/modules/index.ts
+import './slack-room-membership/index.js';
+import './canvas-actions/index.js';
+import './slack-onboarding/index.js';
+```
+
+```nc:append to:container/agent-runner/src/mcp-tools/index.ts
+import './canvas.js';
+```
+
+### 4. Copy the flow payload
+
+This skill ships its payload alongside this document; copy the files into the
+tree at the same relative paths (overwrite; the skill's copies are canonical).
+The host module carries the wrapped `create_agent` handler and the room
+actions; the container files carry the room tools, the `create_agent`
+extension, the sibling-agent standing-context skill, and the welcome-tour
+addendum. The two `mcp-tools/*.instructions.md` fragments and the
+`slack-construct-agents` skill's `instructions.md` are picked up by the
+CLAUDE.md compose scan; the welcome addendum is consumed by the host's
+channel-matched addenda mechanism (inert on hosts that predate it) — so
+copying the files is the whole install:
+
+```nc:copy
+src/modules/slack-agent-flow/types.ts
+src/modules/slack-agent-flow/env-file.ts
+src/modules/slack-agent-flow/provision.ts
+src/modules/slack-agent-flow/slack-deps.ts
+src/modules/slack-agent-flow/orchestrate.ts
+src/modules/slack-agent-flow/guard.ts
+src/modules/slack-agent-flow/room-actions.ts
+src/modules/slack-agent-flow/room-canvas.ts
+src/modules/slack-agent-flow/index.ts
+src/modules/slack-agent-flow/env-file.test.ts
+src/modules/slack-agent-flow/provision.congruence.test.ts
+src/modules/slack-agent-flow/provision.prefetch.test.ts
+src/modules/slack-agent-flow/orchestrate.test.ts
+src/modules/slack-agent-flow/room-actions.test.ts
+src/modules/slack-agent-flow/room-canvas.test.ts
+scripts/slack-agent-flow-finish.ts
+container/agent-runner/src/mcp-tools/rooms.ts
+container/agent-runner/src/mcp-tools/rooms.test.ts
+container/agent-runner/src/mcp-tools/rooms.instructions.md
+container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+container/skills/slack-construct-agents/SKILL.md
+container/skills/slack-construct-agents/instructions.md
+container/skills/welcome/addenda/teams-tour.md
+```
+
+### 5. Register the host module
+
+Append the self-registration import to the module barrel (skipped if the line
+is already present). It must evaluate after the agent-to-agent module's own
+registration, which appending at the end guarantees — the flow's `create_agent`
+handler re-registers over upstream's:
+
+```nc:append to:src/modules/index.ts
+import './slack-agent-flow/index.js';
+```
+
+### 6. Register the container room tools
+
+Append the tool-module import to the container MCP-tools barrel (skipped if
+already present). The module registers `create_room` / `add_to_room` and
+extends the base `create_agent` tool, so it must evaluate after the base
+agents module — import order follows document order, and appending at the end
+guarantees it:
+
+```nc:append to:container/agent-runner/src/mcp-tools/index.ts
+import './rooms.js';
+```
+
+### 7. Build
+
+The build guards every typed call the flow makes into trunk (delivery
+registration, DB helpers, channel defaults, the shared Slack lib) against
+drift:
+
+```nc:run effect:build
+pnpm run build
+```
+
+### 8. Validate
+
+The flow's own tests, the shared feature payload's module tests, and the trunk
+hot-start seam's test run on the host. The room-tool tests run through the
+already-built agent image, so setup does not require Bun on the host; they also
+pin the `create_agent` extension:
+
+```nc:run effect:test
+pnpm exec vitest run src/modules/slack-agent-flow src/modules/slack-room-membership src/modules/canvas-actions src/modules/slack-onboarding src/env-file.test.ts src/channels/adapter-hot-start.test.ts
+```
+
+```nc:run effect:test
+source "$PWD/setup/lib/install-slug.sh" && "${CONTAINER_RUNTIME:-docker}" run --rm --entrypoint bun --workdir /app --volume "$PWD/container/agent-runner/src:/app/src:ro" "$(container_image_base):latest" test --preload /app/src/modules/index.ts src/mcp-tools/rooms.test.ts src/mcp-tools/canvas.test.ts
+```
+
+### 9. Restart the host
+
+The flow module registers at boot, and container mounts are read-only at
+runtime — restart so the running host picks everything up (new sessions see
+the container-side files; no image rebuild):
+
+```nc:run effect:restart
+bash setup/lib/restart.sh
+```
+
+## How it behaves
+
+- **Guard/approval flow is upstream's.** The flow re-registers `create_agent`
+  with the same guard action and precheck as the agent-to-agent module; only
+  the hold question changes when the request originates from a Slack session
+  (it names the Slack provisioning side effects — new app, operator DM,
+  shared room). The room actions get the same trust split: `global` cli_scope
+  groups act directly, everything else holds for the admin chain, and
+  approved replays re-enter the wrapped handlers automatically.
+- **Expected boot warning.** Because the barrel imports the flow module after
+  the agent-to-agent module, every boot logs
+  `Delivery action handler overwritten` for `create_agent`. That warning is
+  the intended signal that the wrapper won the registry — its absence means
+  the barrel line is missing or ordered wrong.
+- **What a successful run does.** Provisions (or reuses) the app — agent-mode
+  by default; `allow_guests: true` selects the plain, guest-accessible
+  variant — writes `SLACK_BOT_TOKEN_<NAME>` / `SLACK_APP_TOKEN_<NAME>` and
+  unions the slug into `SLACK_INSTANCES`, hot-starts `slack-<name>`, opens
+  the operator DM and wires it to the new agent group (agent-mode DMs get
+  thread-per-conversation sessions straight from the channel declaration),
+  opens the three-way MPIM with the new bot's token, appends the room's
+  channel id to `SLACK_A2A_ROOMS`, creates one room messaging group per
+  instance (both mention-gated), creates the room's canvas-tab contract, then
+  posts the DM intro and nudges the originating agent to introduce the new
+  one in the room. The new bot typically answers within ~10 seconds; if it
+  stays silent for a minute, an operator can run `bash setup/lib/restart.sh`
+  as the fallback.
+- **Workspaces that gate installs.** Where an admin must approve every app
+  install, the workspace refuses the automatic one and the managed service
+  answers with an install link instead of a bot token. The flow does not fall
+  back to hand-building an app: it posts one line into the conversation the
+  create came from — as the ORIGINATING bot, since the origin agent's own
+  reply cannot be delivered while the handler is still running — naming the
+  link to approve, then polls the service (5s, up to 5 minutes) for the bot
+  token the completed install releases. On arrival the rest of the flow runs
+  exactly as if the install had been automatic. On timeout the app parks:
+  `SLACK_APP_TOKEN_<NAME>`, `SLACK_APP_ID_<NAME>` and
+  `SLACK_INSTALL_URL_<NAME>` stay in `.env`, and asking the same agent for the
+  same name again resumes THAT app — it never provisions a second one.
+  `SLACK_INSTALL_WAIT_MS=0` skips the inline wait for installs that always go
+  through a slow approval queue; `SLACK_INSTALL_POLL_MS` moves the cadence.
+- **Teams get one room.** `create_agent({ ..., room: 'none' })` skips the
+  shared room; the multi-agent pattern is N such creates followed by ONE
+  `create_room` naming all of them. When a batch of creates arrives together,
+  their avatar generations are prefetched in parallel, so N waits collapse to
+  roughly one.
+- **A2A cache staleness.** The a2a room allowlist is re-read from `.env` on a
+  ≤30s cache. The room id is appended before any intro is posted, but the
+  originating agent's own bridge may still miss ingesting the intro inside
+  that window — harmless; the intro is for the human, and the originating
+  session is told the room id and wirings directly in its success message.
+- **Failures are resumable.** Any Slack-leg failure leaves the agent group
+  fully working via `send_message`, reports the exact step that failed, and
+  names the retry command. The finish script re-runs the whole leg
+  idempotently (tokens are reused from `.env`, rows are get-before-create,
+  intro posts fire only for newly created rows):
+
+  ```bash
+  pnpm exec tsx scripts/slack-agent-flow-finish.ts --group <newAgentGroupId> --name <slug> --source-group <sourceGroupId> [--origin-instance <key>] [--room none] [--allow-guests] [--restart]
+  ```
+
+  It runs outside the host process, so it cannot hot-start the adapter:
+  `--restart` runs `bash setup/lib/restart.sh` for you, otherwise it prints
+  the restart instruction.
+
+- **Setup-wizard leg.** `bash nanoclaw.sh` does the whole install by default:
+  the managed-provisioning pre-step and the companion list (`slack-a2a-rooms`,
+  then this skill) register unconditionally at wizard boot
+  (`setup/channels/slack-auto-register.ts` → `setup/channels/companions.ts`),
+  so the wizard provisions the first app, applies `/add-slack`, then applies
+  both feature skills with one deferred restart. A plain-bot install is the
+  manual choice inside the flow. That leg ships with trunk, and this skill
+  does not touch it.
+
+Everything the flow creates at runtime is user data, not skill payload: agent
+groups, messaging groups, and wirings stay in the central DB; token lines,
+`SLACK_INSTANCES` entries, and `SLACK_A2A_ROOMS` entries stay in `.env`;
+provisioned Slack apps stay in the workspace. Removal (see REMOVE.md) never
+touches any of it — for per-agent teardown of a provisioned bot, follow the
+slack-managed-agents skill's teardown section.

--- a/.claude/skills/slack-agent-flow/apply-fixtures.json
+++ b/.claude/skills/slack-agent-flow/apply-fixtures.json
@@ -1,0 +1,9 @@
+{
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — this skill declares no prompts and captures nothing, so one default scenario with no inputs covers the whole document (the two effect:check gates and the build/test/restart runs are exec-stubbed).",
+  "scenarios": [
+    {
+      "name": "default",
+      "inputs": {}
+    }
+  ]
+}

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/create-agent-slack.instructions.md
@@ -1,0 +1,9 @@
+## create_agent on Slack: acknowledge in the same turn (creation takes ~1 minute)
+
+On this install, every agent you create also gets its own Slack bot. Creation is not instant: a unique avatar is generated and a dedicated Slack app is provisioned, which takes about a minute. From the user's side that is silence — so ALWAYS acknowledge in the SAME turn as the `create_agent` call (before or alongside it), set the expectation, and say what happens next. Example: "On it — creating Pixel now. It takes about a minute; it'll introduce itself in a DM and open a shared room for the three of us."
+
+- What the user will see: roughly a minute of quiet, then an intro DM from the new agent plus a shared three-way room (you, the user, the new agent) — unless you passed `room: 'none'`, which skips the room (the team pattern: several agents with `room:'none'`, then one `create_room` with all of them — see the rooms tools).
+- Give each create a short PUBLIC `purpose` line (under 80 chars) — it appears in the room intro and on the room canvas; never put private detail from the instructions there.
+- In rooms, keep the acknowledgment brief — one short line, no play-by-play.
+- Some workspaces require an admin to approve every app install. When that happens the user gets a link to approve and setup finishes by itself once they do — so if they say the approval went through, or they ask you to finish setting that agent up, just call `create_agent` again with the SAME name. That resumes the app already waiting; it does not create a second one, and it is not a name collision.
+- You'll be notified when the agent is live (or get a failure notice with a fix-it command). Relay completion only when that arrives — never report "done" early.

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.instructions.md
@@ -1,0 +1,22 @@
+## Shared rooms (`create_room`, `add_to_room`)
+
+A room is one Slack group conversation shared by the user and N agents, with a canvas tab carrying the room contract (purpose, members). `mcp__nanoclaw__create_room({ name, purpose, agents, include_me? })` opens one; `mcp__nanoclaw__add_to_room({ room, agent })` grows one.
+
+### The team pattern — one room, not N
+
+When the user asks for a TEAM (several agents for one project), never let each `create_agent` open its own room — that yields N separate three-way rooms nobody wants:
+
+1. Create each agent with `room: 'none'` (they still get their operator DM).
+2. When all are live, call `create_room` ONCE with all their names and a short public `purpose`.
+
+For a SINGLE new agent, plain `create_agent` (default `room: 'own'`) is right — don't follow up with `create_room`.
+
+### How it works
+
+- `agents` takes the same names you use with `send_message` — agents you created or can already message. Unknown names come back as an error note, nothing half-created.
+- Both tools are fire-and-forget and may require admin approval; the outcome arrives as a system note. When the room is live, the note tells you the destination to post to and whom to tag — post a brief intro in your own voice (1-2 lines, no mechanics, no member lists).
+- In rooms, agents engage when @-mentioned; everything else accumulates as ambient context. Tag an agent to bring it in.
+
+### Growing a room
+
+`add_to_room` works, but Slack group conversations never grow in place — the room MOVES to a new conversation (everyone re-wired automatically; the old conversation keeps working). Prefer creating rooms complete: if you know the team needs four agents, create all four first, then one `create_room`.

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Room MCP tool tests: create_room / add_to_room arg validation and
+ * system-action row shape, plus the extendTool-based create_agent extension
+ * (schema/description growth + purpose/allow_guests/room payload
+ * passthrough) — all fire-and-forget writes to messages_out (authorization
+ * is host-side). Importing ./rooms.js applies the extension, so these tests
+ * exercise the same wiring the barrel produces.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getOutboundDb } from '../mailbox/sqlite/connection.js';
+import { createAgent } from './agents.js';
+import { addToRoom, createRoom } from './rooms.js';
+
+function outboundActions(): Array<{ id: string; kind: string; content: Record<string, unknown> }> {
+  return (
+    getOutboundDb().prepare('SELECT id, kind, content FROM messages_out ORDER BY seq').all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+    }>
+  ).map((r) => ({ id: r.id, kind: r.kind, content: JSON.parse(r.content) }));
+}
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+describe('create_room — arg validation', () => {
+  it('requires name', async () => {
+    const r = await createRoom.handler({ agents: ['Pixel'] });
+    expect(r.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('requires a non-empty agents list of names', async () => {
+    for (const agents of [undefined, [], ['  '], 'Pixel']) {
+      const r = await createRoom.handler({ name: 'Website Team', agents });
+      expect(r.isError).toBe(true);
+    }
+    expect(outboundActions()).toHaveLength(0);
+  });
+});
+
+describe('create_room — submission', () => {
+  it('writes a create_room system action with the full agent list', async () => {
+    const r = await createRoom.handler({
+      name: '  Website Team ',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect((r.content[0] as { text: string }).text).toContain('Creating room "Website Team"');
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({
+      action: 'create_room',
+      name: 'Website Team',
+      purpose: 'ship the site',
+      agents: ['Pixel', 'Devin'],
+    });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+    // include_me travels only when explicitly false (host default is true).
+    expect(rows[0].content.include_me).toBeUndefined();
+  });
+
+  it('carries include_me:false only when explicitly set', async () => {
+    await createRoom.handler({ name: 'Duo', agents: ['Pixel'], include_me: false });
+    expect(outboundActions()[0].content).toMatchObject({ action: 'create_room', include_me: false });
+  });
+});
+
+describe('add_to_room', () => {
+  it('requires room and agent', async () => {
+    const r1 = await addToRoom.handler({ agent: 'Devin' });
+    expect(r1.isError).toBe(true);
+    const r2 = await addToRoom.handler({ room: 'Website Team' });
+    expect(r2.isError).toBe(true);
+    expect(outboundActions()).toHaveLength(0);
+  });
+
+  it('writes an add_to_room system action', async () => {
+    const r = await addToRoom.handler({ room: 'Website Team', agent: 'Devin' });
+    expect(r.isError).toBeUndefined();
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('system');
+    expect(rows[0].content).toMatchObject({ action: 'add_to_room', room: 'Website Team', agent: 'Devin' });
+    expect(rows[0].content.requestId).toBe(rows[0].id);
+  });
+});
+
+describe('create_agent — Slack extension (extendTool)', () => {
+  it('extends the base tool schema and description without editing agents.ts', () => {
+    const props = (createAgent.tool.inputSchema as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['name', 'instructions', 'purpose', 'allow_guests', 'room']),
+    );
+    expect(createAgent.tool.description).toContain('acknowledge the user in this SAME turn');
+  });
+
+  it('passes the registered keys through into the written system payload', async () => {
+    await createAgent.handler({ name: 'Pixel', room: 'none', purpose: 'design things' });
+    await createAgent.handler({ name: 'Solo' });
+    await createAgent.handler({ name: 'Own', room: 'own' });
+
+    const rows = outboundActions();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].content).toMatchObject({
+      action: 'create_agent',
+      name: 'Pixel',
+      room: 'none',
+      purpose: 'design things',
+    });
+    // No extension args → the payload stays byte-identical to the base tool's.
+    expect(rows[1].content.room).toBeUndefined();
+    expect(rows[1].content.purpose).toBeUndefined();
+    // The passthrough copies provided values verbatim; the host reads an
+    // explicit 'own' exactly as an absent room (both mean the default
+    // own-room policy), so nothing normalizes it away container-side.
+    expect(rows[2].content.room).toBe('own');
+  });
+});

--- a/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
+++ b/.claude/skills/slack-agent-flow/container/agent-runner/src/mcp-tools/rooms.ts
@@ -1,0 +1,162 @@
+/**
+ * Room management MCP tools: create_room, add_to_room.
+ *
+ * A "room" is one Slack group conversation shared by the user and N agents.
+ * create_room is the team primitive — the multi-agent pattern is N
+ * create_agent calls with room:'none', then ONE create_room naming all of
+ * them. Both tools are fire-and-forget (create_agent pattern): they write an
+ * outbound system row and return; the host resolves names, opens the
+ * conversation, wires everyone, and reports back as a system note.
+ *
+ * Authorization is enforced host-side by the guard (same trust split as
+ * create_agent: trusted global-scope groups act directly, confined groups
+ * hold for admin approval) — the container is untrusted and cannot be relied
+ * on to gate itself.
+ *
+ * This module also extends the base `create_agent` tool (see the extendTool
+ * call at the bottom): the Slack flow adds `purpose` / `allow_guests` /
+ * `room` params and the acknowledge-now guidance without touching the base
+ * tool's source. The barrel imports this module after the base agents
+ * module, which is what makes the extension legal.
+ */
+import { writeMessageOut } from '../db/messages-out.js';
+import { extendTool, registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+export const createRoom: McpToolDefinition = {
+  tool: {
+    name: 'create_room',
+    description:
+      "Open ONE shared Slack room (group conversation) with the user and several agents at once — the team primitive. Use after creating the agents (create_agent with room:'none' for teams): one room with ALL of them, never one room per agent. May require admin approval. Fire-and-forget: the call returns immediately; you will get a system note when the room is live, telling you how to post the intro there.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string', description: 'Room name (also names the Slack conversation and its canvas)' },
+        purpose: {
+          type: 'string',
+          description:
+            'One short PUBLIC line (under 80 chars) saying what the room is for — shown on the room canvas. Never include private details.',
+        },
+        agents: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Agent names to include — the same names you use with send_message (agents you created or can already message).',
+        },
+        include_me: {
+          type: 'boolean',
+          description: 'Include yourself in the room. Default true — keep it unless the user explicitly excludes you.',
+        },
+      },
+      required: ['name', 'agents'],
+    },
+  },
+  async handler(args) {
+    const name = typeof args.name === 'string' ? args.name.trim() : '';
+    if (!name) return err('name is required');
+    const agents = Array.isArray(args.agents) ? args.agents.filter((a) => typeof a === 'string' && a.trim()) : [];
+    if (agents.length === 0) return err('agents must list at least one agent name');
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'create_room',
+        requestId,
+        name,
+        agents,
+        ...(typeof args.purpose === 'string' && args.purpose.trim()
+          ? { purpose: (args.purpose as string).trim() }
+          : {}),
+        ...(args.include_me === false ? { include_me: false } : {}),
+      }),
+    });
+
+    log(`create_room: ${requestId} → "${name}" (${agents.length} agents)`);
+    return ok(`Creating room "${name}". You will be notified when it is live.`);
+  },
+};
+
+export const addToRoom: McpToolDefinition = {
+  tool: {
+    name: 'add_to_room',
+    description:
+      'Add one agent to an existing shared room. Slack group conversations never grow in place — this moves the room to a NEW conversation containing everyone plus the new agent (the old one keeps working). For a planned team, prefer creating the room once, complete, via create_room. May require admin approval. Fire-and-forget: a system note reports the outcome.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        room: { type: 'string', description: 'Room name (as the room was created/named)' },
+        agent: { type: 'string', description: 'Agent name to add — the same name you use with send_message' },
+      },
+      required: ['room', 'agent'],
+    },
+  },
+  async handler(args) {
+    const room = typeof args.room === 'string' ? args.room.trim() : '';
+    const agent = typeof args.agent === 'string' ? args.agent.trim() : '';
+    if (!room) return err('room is required');
+    if (!agent) return err('agent is required');
+
+    const requestId = generateId();
+    await writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({ action: 'add_to_room', requestId, room, agent }),
+    });
+
+    log(`add_to_room: ${requestId} → "${agent}" into "${room}"`);
+    return ok(`Adding "${agent}" to room "${room}". You will be notified when it is done.`);
+  },
+};
+
+registerTools([createRoom, addToRoom]);
+
+// ── create_agent extension (Slack agent flow) ──
+//
+// Additive extension of the base create_agent tool: on a Slack-wired install
+// each created agent also gets a dedicated Slack bot, so the tool grows the
+// flow's three params and the acknowledge-now guidance. The registered
+// passthrough keys are copied verbatim into the system-action payload the
+// base handler writes — the host reads them exactly as it reads name and
+// instructions (room:'own' and allow_guests:false travel explicitly and read
+// as the defaults host-side).
+extendTool('create_agent', {
+  properties: {
+    purpose: {
+      type: 'string',
+      description:
+        'One short PUBLIC line (under 80 chars) saying what this agent is for — shown to everyone in the shared room intro and canvas. ALWAYS provide it. Never include private details from the instructions; without it the room states no purpose at all.',
+    },
+    allow_guests: {
+      type: 'boolean',
+      description:
+        'Set true ONLY if Slack workspace guests must be able to DM this agent — guests cannot access agent-mode bots, so this provisions a plain bot without the agent DM experience. Default false.',
+    },
+    room: {
+      type: 'string',
+      enum: ['own', 'none'],
+      description:
+        "Shared-room policy. 'own' (default) opens a room with you, the user, and the new agent — right for a single create. 'none' skips the room (the agent still gets its DM) — REQUIRED when creating several agents for one team: create each with room:'none', then call create_room ONCE with all of them. Never open per-agent rooms for a team.",
+    },
+  },
+  passthroughKeys: ['purpose', 'allow_guests', 'room'],
+  descriptionSuffix:
+    'The call returns immediately. Creation takes about a minute (a unique avatar is generated and a dedicated Slack bot is provisioned); when ready, the new agent introduces itself via DM and a shared room. You MUST acknowledge the user in this SAME turn, before or alongside this call — say you are on it, set the ~1-minute expectation, and mention the agent will introduce itself.',
+});

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/SKILL.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: slack-construct-agents
+description: Standing context for Slack sibling agents — one room per team, creator-posted introductions, bot-to-bot hop discipline. Ships as instructions.md composed into the group's CLAUDE.md at spawn; there is no workflow to invoke.
+---
+
+# Slack construct — sibling agents
+
+This skill is a carrier for standing context, not an on-demand workflow. Its
+payload is `instructions.md` in this directory: the rules an agent needs when
+it shares Slack with sibling agents it can create (`create_agent`) and room
+with (`create_room` / `add_to_room`) — team-room shape, who posts the
+introduction, and the bot-to-bot self-limit.
+
+The host composes every container skill's `instructions.md` into each group's
+CLAUDE.md at spawn (`src/project-doc-compose.ts`), so if you are reading this
+from inside a session, those rules are already part of your standing
+instructions. There is nothing further to load or run here.
+
+The room-and-canvas half of the Slack standing context (mention engagement,
+canvas discipline, access rules) ships separately with the Slack channel
+payload as the `slack-construct` skill; this fragment layers the
+sibling-agent rules on top and arrives with the slack-agent-flow skill.

--- a/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
+++ b/.claude/skills/slack-agent-flow/container/skills/slack-construct-agents/instructions.md
@@ -1,0 +1,26 @@
+## Your Slack sibling agents
+
+You may be part of a construct of agents on Slack: sibling agents (each with its own bot,
+DM, and workspace) plus shared rooms where humans, you, and siblings talk. Standing rules
+for the sibling half:
+
+- **Teams get ONE room.** When the user asks for several agents for one project ("build me
+  a team"), create each agent with `create_agent({ ..., room: 'none' })` — they still get
+  their operator DM — then open a single shared room with
+  `create_room({ name, purpose, agents: [all of them] })`. Never let each create open its
+  own room: that yields N separate three-way rooms nobody wants. `add_to_room` works for
+  later growth, but Slack group DMs never grow in place — the room MOVES to a new
+  conversation (everyone is re-wired automatically; the old one keeps working), so prefer
+  creating rooms complete.
+- **You introduce agents you create.** When a shared room comes with an agent you created,
+  YOU post the introduction in the room — the host posts nothing there. You'll get a
+  system nudge telling you which destination to use. Keep it to 1-2 lines in your own
+  voice: say what the new agent is for and tag them with their `<@bot-user-id>` mention
+  (send it literally; it renders as a mention). No mechanics, no member lists — the room's
+  canvas tab already holds that.
+- **Bot-to-bot hop budget.** The platform may cap consecutive bot-to-bot messages (~6)
+  until a human speaks again, but do not rely on it — self-limit. Don't ping-pong with
+  siblings: do the work, converge, hand back to the human.
+- **Persist durable facts.** Conversations are per-session; rooms and DMs don't share
+  history. Anything worth keeping (decisions, preferences, ongoing state) goes in your
+  memory directory, not just the chat transcript.

--- a/.claude/skills/slack-agent-flow/container/skills/welcome/addenda/teams-tour.md
+++ b/.claude/skills/slack-agent-flow/container/skills/welcome/addenda/teams-tour.md
@@ -1,0 +1,17 @@
+---
+channel: slack
+---
+
+# Teams tour item (Slack agent flow)
+
+When the tour runs on Slack, also reveal this — same drip-feed rule as the base
+tour, one item at a time, 2-4 sentences:
+
+### Teams
+
+Want a whole team? Ask your agent to build one — e.g. "create a designer, a
+builder, and a reviewer for my new site, in one shared room." It will create
+the agents first and then open a single room with all of them (plus you). You
+can grow a room later by asking to add an agent, but Slack moves the
+conversation to a new group DM when members change — the old thread keeps
+working, and everything is rewired automatically.

--- a/.claude/skills/slack-agent-flow/scripts/slack-agent-flow-finish.ts
+++ b/.claude/skills/slack-agent-flow/scripts/slack-agent-flow-finish.ts
@@ -1,0 +1,178 @@
+/**
+ * Finish (or retry) the Slack leg of an agent created via create_agent.
+ *
+ * The in-host slack-agent-flow wrapper points here when the Slack leg fails
+ * partway: re-runs S1–S13 idempotently (provision reuses .env tokens, every
+ * DB row is get-before-create, conversations.open is idempotent on Slack's
+ * side, intro posts are gated on newly-created rows) EXCEPT the S5 hot-add —
+ * a separate process cannot start an adapter inside the live host, so the
+ * new instance comes online via a service restart instead (--restart runs it,
+ * otherwise the command is printed).
+ *
+ * Runs alongside the service the way scripts/init-first-agent.ts does
+ * (WAL-mode sqlite; no channel adapters are connected — the channels barrel
+ * import is registration-only, so declared defaults resolve here).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/slack-agent-flow-finish.ts \
+ *     --group <newAgentGroupId> \
+ *     --name <slug> \
+ *     --source-group <sourceAgentGroupId> \
+ *     [--origin-instance <key>] \   # default: slack
+ *     [--room none] \               # original create used room:'none' — skip the shared room
+ *     [--restart]
+ *
+ * Never prints token values — only key names and ids.
+ */
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+// Registration-only barrel import: channel modules call
+// registerChannelAdapter() at module scope (factories are NOT invoked, no
+// adapter connects), so declared channel defaults resolve here without live
+// adapters.
+import '../src/channels/index.js';
+import { SlackApiError } from '../src/channels/slack-lib.js';
+import { DATA_DIR } from '../src/config.js';
+import { getAgentGroup } from '../src/db/agent-groups.js';
+import { initDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { finishSlackAgentFlow } from '../src/modules/slack-agent-flow/orchestrate.js';
+import { SlackFlowError } from '../src/modules/slack-agent-flow/types.js';
+
+interface Args {
+  group: string;
+  name: string;
+  sourceGroup: string;
+  originInstance: string;
+  restart: boolean;
+  allowGuests: boolean;
+  room?: 'own' | 'none';
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Partial<Args> = {};
+  let restart = false;
+  let allowGuests = false;
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    switch (key) {
+      case '--group':
+        out.group = val;
+        i++;
+        break;
+      case '--name':
+        out.name = val;
+        i++;
+        break;
+      case '--source-group':
+        out.sourceGroup = val;
+        i++;
+        break;
+      case '--origin-instance':
+        out.originInstance = val;
+        i++;
+        break;
+      case '--room': {
+        if (val !== 'own' && val !== 'none') {
+          console.error(`--room must be 'own' or 'none', got "${val}"`);
+          process.exit(2);
+        }
+        out.room = val;
+        i++;
+        break;
+      }
+      case '--restart':
+        restart = true;
+        break;
+      case '--allow-guests':
+        allowGuests = true;
+        break;
+      default:
+        console.error(`Unknown flag: ${key}`);
+        process.exit(2);
+    }
+  }
+  const missing = (['group', 'name', 'sourceGroup'] as const).filter((k) => !out[k]);
+  if (missing.length) {
+    console.error(
+      `Missing required args: ${missing.map((k) => `--${k.replace(/([A-Z])/g, '-$1').toLowerCase()}`).join(', ')}`,
+    );
+    console.error('See scripts/slack-agent-flow-finish.ts header for usage.');
+    process.exit(2);
+  }
+  return {
+    group: out.group!,
+    name: out.name!,
+    sourceGroup: out.sourceGroup!,
+    originInstance: out.originInstance ?? 'slack',
+    restart,
+    allowGuests,
+    room: out.room,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const root = process.cwd();
+
+  const db = await initDb(path.join(DATA_DIR, 'v2.db'));
+  await runMigrations(db); // idempotent
+
+  const newGroup = await getAgentGroup(args.group);
+  if (!newGroup) throw new Error(`agent group ${args.group} not found (--group)`);
+  if (!(await getAgentGroup(args.sourceGroup))) {
+    throw new Error(`agent group ${args.sourceGroup} not found (--source-group)`);
+  }
+
+  const result = await finishSlackAgentFlow({
+    slug: args.name,
+    sourceGroupId: args.sourceGroup,
+    newAgentGroupId: args.group,
+    originInstanceKey: args.originInstance,
+    rootDir: root,
+    allowGuests: args.allowGuests,
+    room: args.room,
+    // A workspace install approval can hold this for minutes; say so rather
+    // than letting the script look hung.
+    onInstallPending: (text) => {
+      console.log('');
+      console.log(text);
+      console.log('Waiting…');
+    },
+  });
+
+  console.log('');
+  console.log('Slack leg complete:');
+  console.log(`  agent     ${newGroup.name} [${args.group}]`);
+  console.log(
+    `  instance  slack-${result.slug} (SLACK_INSTANCES + SLACK_*_TOKEN_${result.slug.toUpperCase().replace(/-/g, '_')})`,
+  );
+  console.log(`  bot       ${result.newBotUserId}`);
+  console.log(`  DM        ${result.dmChannelId} (operator ${result.operatorUserId})`);
+  console.log(
+    result.roomChannelId
+      ? `  room      ${result.roomChannelId} (SLACK_A2A_ROOMS)`
+      : `  room      (skipped — room:'none')`,
+  );
+  console.log('');
+
+  // S5 replacement: the new adapter instance connects on the next service
+  // start — this process cannot hot-add into the live host.
+  if (args.restart) {
+    console.log('Restarting the service so the new instance connects…');
+    execFileSync('bash', [path.join(root, 'setup', 'lib', 'restart.sh')], { cwd: root, stdio: 'inherit' });
+  } else {
+    console.log('Restart the service so the new instance connects: bash setup/lib/restart.sh');
+  }
+}
+
+main().catch((err: unknown) => {
+  if (err instanceof SlackFlowError || err instanceof SlackApiError) {
+    console.error(`slack-agent-flow-finish failed at step '${err.step}': ${err.message}`);
+  } else {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+  process.exit(1);
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.test.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+
+describe('slack-agent-flow env-file', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const envPath = (): string => path.join(rootDir, '.env');
+  const write = (text: string): void => fs.writeFileSync(envPath(), text);
+  const read = (): string => fs.readFileSync(envPath(), 'utf-8');
+
+  describe('readEnvValue', () => {
+    it('returns undefined when .env is absent', () => {
+      expect(readEnvValue(rootDir, 'SAF_TEST_MISSING')).toBeUndefined();
+    });
+
+    it('parses with src/env.ts semantics: comments, blanks, quotes, whitespace', () => {
+      write(
+        [
+          '# leading comment',
+          '',
+          'SAF_PLAIN=value1',
+          '  SAF_INDENTED = spaced ',
+          'SAF_DQUOTED="double quoted"',
+          "SAF_SQUOTED='single quoted'",
+          'SAF_EMPTY=',
+          '# SAF_COMMENTED=nope',
+          'NOT_AN_ASSIGNMENT',
+        ].join('\n'),
+      );
+      expect(readEnvValue(rootDir, 'SAF_PLAIN')).toBe('value1');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('spaced');
+      expect(readEnvValue(rootDir, 'SAF_DQUOTED')).toBe('double quoted');
+      expect(readEnvValue(rootDir, 'SAF_SQUOTED')).toBe('single quoted');
+      expect(readEnvValue(rootDir, 'SAF_EMPTY')).toBeUndefined();
+      expect(readEnvValue(rootDir, 'SAF_COMMENTED')).toBeUndefined();
+    });
+
+    it('prefers process.env over the file', () => {
+      write('SAF_PREFERS=file-value\n');
+      vi.stubEnv('SAF_PREFERS', 'env-value');
+      expect(readEnvValue(rootDir, 'SAF_PREFERS')).toBe('env-value');
+    });
+
+    it('falls through a blank process.env value to the file', () => {
+      write('SAF_BLANK_ENV=file-value\n');
+      vi.stubEnv('SAF_BLANK_ENV', '   ');
+      expect(readEnvValue(rootDir, 'SAF_BLANK_ENV')).toBe('file-value');
+    });
+
+    it('last duplicate line wins, matching readEnvFile', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('second');
+    });
+  });
+
+  describe('upsertEnvKey', () => {
+    it('creates .env when absent', () => {
+      upsertEnvKey(rootDir, 'SAF_NEW', 'v1');
+      expect(read()).toBe('SAF_NEW=v1\n');
+      expect(readEnvValue(rootDir, 'SAF_NEW')).toBe('v1');
+    });
+
+    it('appends after a file without a trailing newline', () => {
+      write('EXISTING=x');
+      upsertEnvKey(rootDir, 'SAF_APPENDED', 'v2');
+      expect(read()).toBe('EXISTING=x\nSAF_APPENDED=v2\n');
+    });
+
+    it('replaces in place, preserving unrelated lines and comments', () => {
+      write('# keep me\nFIRST=1\nSAF_TARGET=old\nLAST=9\n');
+      upsertEnvKey(rootDir, 'SAF_TARGET', 'new');
+      expect(read()).toBe('# keep me\nFIRST=1\nSAF_TARGET=new\nLAST=9\n');
+    });
+
+    it('does not touch keys that merely share a prefix', () => {
+      write('SAF_KEY=keep\nSAF_KEY_LONGER=keep-too\n');
+      upsertEnvKey(rootDir, 'SAF_KEY', 'changed');
+      expect(read()).toBe('SAF_KEY=changed\nSAF_KEY_LONGER=keep-too\n');
+    });
+
+    it('rewrites every duplicate line so a stale value can never win the read', () => {
+      write('SAF_DUP=first\nSAF_DUP=second\n');
+      upsertEnvKey(rootDir, 'SAF_DUP', 'final');
+      expect(read()).toBe('SAF_DUP=final\nSAF_DUP=final\n');
+      expect(readEnvValue(rootDir, 'SAF_DUP')).toBe('final');
+    });
+
+    it('replaces an indented assignment (readable lines are writable lines)', () => {
+      write('  SAF_INDENTED=old\n');
+      upsertEnvKey(rootDir, 'SAF_INDENTED', 'new');
+      expect(readEnvValue(rootDir, 'SAF_INDENTED')).toBe('new');
+      expect(read()).not.toContain('old');
+    });
+  });
+
+  describe('appendToEnvList', () => {
+    it('creates the key and reports the entry as new', () => {
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'alpha')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha');
+    });
+
+    it('unions new entries and preserves existing ones', () => {
+      write('SAF_LIST=alpha, beta\n');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'gamma')).toBe(true);
+      expect(readEnvValue(rootDir, 'SAF_LIST')).toBe('alpha,beta,gamma');
+    });
+
+    it('is idempotent: an existing entry returns false and leaves the file alone', () => {
+      write('SAF_LIST=alpha,beta\nOTHER=1\n');
+      const before = read();
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(false);
+      expect(read()).toBe(before);
+    });
+
+    it('unions against the file value even when process.env differs', () => {
+      // Readers of list keys (the adapter's SLACK_INSTANCES loop) parse .env
+      // only, so the union must be based on the file, not a stale
+      // process.env copy.
+      write('SAF_LIST=alpha\n');
+      vi.stubEnv('SAF_LIST', 'alpha,from-process-env');
+      expect(appendToEnvList(rootDir, 'SAF_LIST', 'beta')).toBe(true);
+      expect(read()).toContain('SAF_LIST=alpha,beta');
+    });
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/env-file.ts
@@ -1,0 +1,96 @@
+/**
+ * .env read/write helpers for the slack-agent-flow leg.
+ *
+ * Read semantics MUST stay compatible with src/env.ts readEnvFile (trimmed
+ * lines, `#` comments, first `=` splits, matched surrounding quotes stripped,
+ * empty values read as absent) — the adapter's SLACK_INSTANCES loop
+ * (src/channels/slack.ts) reads back everything written here through that
+ * parser. Write conventions mirror upsertEnvLine /
+ * appendSlackInstance in .claude/skills/slack-managed-agents/scripts/
+ * slack-create-agent.ts: replace the key's line in place, preserve every
+ * other line (comments and blanks included), append with a clean trailing
+ * newline.
+ *
+ * Values written here include live Slack tokens: never log values, only key
+ * names. (No log calls exist in this file — keep it that way.)
+ */
+import fs from 'fs';
+import path from 'path';
+
+function envPath(rootDir: string): string {
+  return path.join(rootDir, '.env');
+}
+
+function readEnvText(rootDir: string): string {
+  try {
+    return fs.readFileSync(envPath(rootDir), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Parse one KEY from dotenv-style text with src/env.ts semantics. Last line wins. */
+function parseEnvText(text: string, key: string): string | undefined {
+  let result: string | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (trimmed.slice(0, eqIdx).trim() !== key) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result = value;
+  }
+  return result;
+}
+
+/** Process env first, then `${rootDir}/.env` — the same order everywhere. */
+export function readEnvValue(rootDir: string, key: string): string | undefined {
+  const fromEnv = process.env[key]?.trim();
+  if (fromEnv) return fromEnv;
+  return parseEnvText(readEnvText(rootDir), key);
+}
+
+/**
+ * Replace KEY's line(s) in place, else append; creates .env when absent.
+ * Every matching line is rewritten (not just the first) so the parser's
+ * last-line-wins read can never resurface a stale value.
+ */
+export function upsertEnvKey(rootDir: string, key: string, value: string): void {
+  const text = readEnvText(rootDir);
+  const line = `${key}=${value}`;
+  const lines = text.split('\n');
+  let replaced = false;
+  const next = lines.map((l) => {
+    const trimmed = l.trim();
+    if (trimmed.startsWith('#')) return l;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1 || trimmed.slice(0, eqIdx).trim() !== key) return l;
+    replaced = true;
+    return line;
+  });
+  const out = replaced ? next.join('\n') : text + (text.endsWith('\n') || text === '' ? '' : '\n') + line + '\n';
+  fs.writeFileSync(envPath(rootDir), out);
+}
+
+/**
+ * Set-union `entry` into KEY's comma-separated list (file value, not process
+ * env — the list's readers parse .env only). Creates the key when absent.
+ * Returns true iff the entry was newly added.
+ */
+export function appendToEnvList(rootDir: string, key: string, entry: string): boolean {
+  const current = parseEnvText(readEnvText(rootDir), key);
+  const entries = (current ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.includes(entry)) return false;
+  upsertEnvKey(rootDir, key, [...entries, entry].join(','));
+  return true;
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/guard.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/guard.ts
@@ -1,0 +1,60 @@
+/**
+ * Slack-agent-flow guard adapter — the module's catalog entries for the
+ * agent-facing room actions, composed at the module edge (imported
+ * by ./index.ts), mirroring agent-to-agent/guard.ts.
+ *
+ * rooms.create / rooms.add_agent — same trust split as agents.create:
+ * `global` cli_scope acts directly (room wiring is the intended primitive for
+ * trusted owner agent groups); anything else — the default `group` scope, and
+ * unknown/missing config, fail-closed — holds for the requesting group's
+ * admin chain. Both actions write central-DB state (messaging groups,
+ * wirings, a2a destinations) and open Slack conversations with the operator,
+ * so a confined container must never reach the handler unheld.
+ */
+import { getContainerConfig } from '../../db/container-configs.js';
+import { ALLOW, DENY, HOLD, defineGuardedAction, type GuardedAction } from '../../guard/index.js';
+import type { GuardDecision, GuardInput } from '../../guard/index.js';
+
+/** The agents.create trust split, reused verbatim for the room actions. */
+async function decideByCliScope(input: GuardInput, action: string): Promise<GuardDecision> {
+  if (input.actor.kind !== 'agent') return DENY(`${action} is a container-originated action.`);
+  const cliScope = (await getContainerConfig(input.actor.agentGroupId))?.cli_scope ?? 'group';
+  if (cliScope === 'global') {
+    // Trusted owner agent group — an approval tap on every room change would
+    // be needless friction.
+    return ALLOW('trusted global-scope agent group');
+  }
+  // The realistic prompt-injection victim (default `group` scope) — and any
+  // unknown config value, fail-closed — requires an admin before any
+  // central-DB write or MPIM open.
+  return HOLD(`agent-initiated ${action} requires admin approval`);
+}
+
+export const roomsCreate: GuardedAction = defineGuardedAction({
+  action: 'rooms.create',
+  grantActionName: 'create_room',
+  // Bind a create_room grant to the room name that was approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      return (JSON.parse(grant.payload) as { name?: string }).name === input.payload.name;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'create_room'),
+});
+
+export const roomsAddAgent: GuardedAction = defineGuardedAction({
+  action: 'rooms.add_agent',
+  grantActionName: 'add_to_room',
+  // Bind an add_to_room grant to the exact (room, agent) pair approved.
+  grantCoversRequest: (grant, input) => {
+    try {
+      const p = JSON.parse(grant.payload) as { room?: string; agent?: string };
+      return p.room === input.payload.room && p.agent === input.payload.agent;
+    } catch {
+      return false;
+    }
+  },
+  decide: (input) => decideByCliScope(input, 'add_to_room'),
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts
@@ -1,0 +1,275 @@
+/**
+ * slack-agent-flow module — guarded re-registration of `create_agent`.
+ *
+ * Re-registers the delivery action with the SAME guard pieces as upstream
+ * (agents.create decision, validateCreateAgent precheck) and a handler that
+ * first runs the upstream `createAgent()` (with its premature success notify
+ * suppressed on the Slack path — see slackAwareCreateAgent), then — only when
+ * the request originated from a Slack session — provisions a dedicated Slack
+ * bot for the new group (orchestrate.ts). The barrel imports this module AFTER
+ * agent-to-agent's registration, so this entry wins; the expected boot log is
+ * `Delivery action handler overwritten`. Approved replays re-enter this
+ * wrapper automatically — reenterGuardedDeliveryAction resolves the entry at
+ * call time, so no approval-handler re-registration is needed.
+ *
+ * Also registers the agent-facing room actions: `create_room` (one
+ * MPIM with N bots + the operator over ensureAgentRoom) and `add_to_room`
+ * (superset re-open — MPIM fork), each guard-wrapped with the same
+ * cli_scope trust split as create_agent (./guard.ts, ./room-actions.ts).
+ *
+ * The handler never touches inbound DBs (guarded handlers replay without
+ * one); all requester notifications go through the approvals module's
+ * notifyAgent. Token values never appear in notify texts or logs.
+ */
+import { SlackApiError } from '../../channels/slack-lib.js';
+import { reenterGuardedDeliveryAction, registerDeliveryAction, registerDeliveryBatchPreview } from '../../delivery.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { getDestinationByName, normalizeName } from '../agent-to-agent/db/agent-destinations.js';
+import { createAgent, requestCreateAgentHold, validateCreateAgent } from '../agent-to-agent/create-agent.js';
+import { agentsCreate } from '../agent-to-agent/guard.js';
+import { notifyAgent, registerApprovalHandler, requestApproval } from '../approvals/index.js';
+import { roomsAddAgent, roomsCreate } from './guard.js';
+import { dedupeSlug, deriveInstanceSlug, runSlackAgentFlow } from './orchestrate.js';
+import {
+  handleAddToRoom,
+  handleCreateRoom,
+  requestAddToRoomHold,
+  requestCreateRoomHold,
+  validateAddToRoom,
+  validateCreateRoom,
+} from './room-actions.js';
+import { pendingInstall, prefetchAvatar, resolveProvisioningCredential } from './provision.js';
+import { SlackFlowError } from './types.js';
+
+/** The Slack gate: the request came in through a Slack-channel session. */
+async function isSlackOriginSession(session: Session): Promise<boolean> {
+  if (!session.messaging_group_id) return false;
+  return (await getMessagingGroup(session.messaging_group_id))?.channel_type === 'slack';
+}
+
+// Avatar prefetch for multi-agent creates ("build me a team"): the batch
+// preview sees every create_agent row in the session's outbound batch before
+// they are processed sequentially, and starts all their avatar generations in
+// parallel — each is an independent async Lambda on the broker, so N waits
+// collapse to ~one (~23s). Gated on ≥2 creates: a single create starts its
+// flow immediately anyway, and skipping the single case means a guard-HELD
+// lone request never generates an avatar it might not get approval for.
+// The (displayName, description) derivation MUST mirror runSlackAgentFlow /
+// orchestrate exactly — a mismatch is harmless (fresh request) but wastes the
+// prefetch.
+registerDeliveryBatchPreview(async (batch, session) => {
+  if (!(await isSlackOriginSession(session))) return;
+  const creates = batch
+    .filter((m) => m.kind === 'system')
+    .map((m) => {
+      try {
+        return JSON.parse(m.content) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (c): c is Record<string, unknown> =>
+        c !== null && c.action === 'create_agent' && typeof c.name === 'string' && c.name !== '',
+    );
+  if (creates.length < 2) return;
+  const credential = resolveProvisioningCredential(process.cwd());
+  if (credential?.mode !== 'broker') return;
+  for (const c of creates) {
+    prefetchAvatar(
+      credential.baseUrl,
+      credential.installToken,
+      c.name as string,
+      typeof c.instructions === 'string' ? c.instructions.slice(0, 300) : undefined,
+    );
+  }
+  log.info('Avatar prefetch started for multi-create batch', { count: creates.length });
+});
+
+function successText(name: string, roomChannelId: string | undefined, deferredInstall = false): string {
+  // The user already knows they were waiting on their workspace — name what
+  // unblocked it so the relay reads as an ending, not a fresh announcement.
+  const installed = deferredInstall ? ' The workspace approved the install, which is what the wait was for.' : '';
+  // room:'none': no shared room was opened — the multi-create
+  // pattern finishes with one create_room naming every agent.
+  if (roomChannelId === undefined) {
+    return (
+      `Agent "${name}" is live on Slack with its own bot and a DM with the operator. No shared room was ` +
+      `opened (room:'none') — when the set is complete, open ONE room for all of them with create_room. ` +
+      `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+      installed
+    );
+  }
+  return (
+    `Agent "${name}" is live on Slack with its own bot. I opened a DM between it and the operator, ` +
+    `and a shared room (${roomChannelId}) where you, I, and it can talk — @-mention it there to engage it. ` +
+    `It came online just now; if it doesn't respond within a minute, an operator can run: bash setup/lib/restart.sh` +
+    installed
+  );
+}
+
+function failureText(
+  name: string,
+  localName: string,
+  step: string,
+  message: string,
+  newAgentGroupId: string,
+  slug: string,
+  sourceGroupId: string,
+  roomNone: boolean,
+): string {
+  // room:'none' must survive into the printed finish command too — omitting
+  // it would make the retry grow a room the multi-create pattern skipped.
+  return (
+    `Agent "${name}" was created and is reachable via send_message({ to: "${localName}", ... }), ` +
+    `but its Slack setup failed at step '${step}': ${message}. An operator can finish it with: ` +
+    `pnpm exec tsx scripts/slack-agent-flow-finish.ts --group ${newAgentGroupId} --name ${slug} ` +
+    `--source-group ${sourceGroupId}${roomNone ? ' --room none' : ''} [--origin-instance <key>] [--restart]`
+  );
+}
+
+/** Run the Slack leg for an already-created agent group and report the outcome. */
+async function runSlackLeg(
+  content: Record<string, unknown>,
+  session: Session,
+  args: {
+    name: string;
+    localName: string;
+    newAgentGroupId: string;
+    slug: string;
+  },
+): Promise<void> {
+  const { name, localName, newAgentGroupId, slug } = args;
+  try {
+    const r = await runSlackAgentFlow({ content, session, newAgentGroupId, slug });
+    await notifyAgent(session, successText(name, r.roomChannelId, r.deferredInstall));
+  } catch (err) {
+    // SlackApiError carries the flow step id its call site passed to the
+    // shared Slack lib — surface it like a typed flow step.
+    const step = err instanceof SlackFlowError || err instanceof SlackApiError ? err.step : 'unknown';
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(
+      session,
+      failureText(
+        name,
+        localName,
+        step,
+        message,
+        newAgentGroupId,
+        slug,
+        session.agent_group_id,
+        content.room === 'none',
+      ),
+    );
+    log.error('slack-agent-flow failed', { step });
+  }
+}
+
+async function slackAwareCreateAgent(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = typeof content.name === 'string' ? content.name : '';
+  const localName = normalizeName(name);
+  const before = await getDestinationByName(session.agent_group_id, localName);
+  const slackOrigin = await isSlackOriginSession(session);
+
+  // Resume, not collide: the agent group exists and its Slack app exists, but
+  // the workspace never approved the install, so the flow parked. Asking for
+  // the same agent again is how a user says "finish that" — take them back to
+  // waiting on the app they already have rather than reporting a name clash
+  // (upstream's answer) or provisioning a second one.
+  if (slackOrigin && before?.target_type === 'agent' && name) {
+    const slug = await dedupeSlug(deriveInstanceSlug(name), before.target_id);
+    if (pendingInstall(process.cwd(), slug)) {
+      await runSlackLeg(content, session, { name, localName, newAgentGroupId: before.target_id, slug });
+      return;
+    }
+  }
+
+  // Upstream behavior byte-for-byte on non-Slack sessions. On the Slack path
+  // the upstream "created — you can now message it" success notify is
+  // suppressed: it fires BEFORE Slack provisioning, so relaying it would
+  // report "done" ~a minute early — this wrapper's successText/failureText
+  // is the only completion signal. Upstream error notifies (collision,
+  // invalid path) still fire either way.
+  await createAgent(content, session, slackOrigin ? { suppressCreatedNotify: true } : undefined);
+
+  const after = await getDestinationByName(session.agent_group_id, localName);
+  // Creation bailed or collided — upstream already answered the requester.
+  if (!after || after.target_type !== 'agent' || before) return;
+  // Non-Slack sessions (and task/a2a sessions with no messaging group) behave exactly as upstream.
+  if (!slackOrigin) return;
+
+  await runSlackLeg(content, session, {
+    name,
+    localName,
+    newAgentGroupId: after.target_id,
+    slug: await dedupeSlug(deriveInstanceSlug(name), after.target_id),
+  });
+}
+
+/**
+ * Slack-aware hold: same payload shape as upstream ({ name, instructions })
+ * so the approved replay re-enters this wrapper unchanged; only the card text
+ * differs, telling the admin a Slack bot comes with the sub-agent.
+ */
+async function requestSlackCreateAgentHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  if (!(await isSlackOriginSession(session))) {
+    await requestCreateAgentHold(content, session);
+    return;
+  }
+  const name = typeof content.name === 'string' ? content.name : '';
+  const instructions = typeof content.instructions === 'string' ? content.instructions : null;
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_agent',
+    // allow_guests must survive the hold: the approved replay re-enters the
+    // wrapper with this payload, and dropping it would silently upgrade a
+    // guest-accessible request to the agent-view variant.
+    payload: {
+      name,
+      instructions,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.allow_guests === true ? { allow_guests: true } : {}),
+      // room:'none' must survive the hold too — dropping it would grow a
+      // room the multi-create pattern deliberately skipped.
+      ...(content.room === 'none' ? { room: 'none' } : {}),
+    },
+    title: `Create agent: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to create a new sub-agent "${name}" AND provision a dedicated ` +
+      `Slack bot for it (new Slack app, DM with you, and a shared three-way room). Approve?`,
+  });
+}
+
+registerDeliveryAction('create_agent', slackAwareCreateAgent, {
+  guardAction: agentsCreate,
+  precheck: validateCreateAgent,
+  requestHold: requestSlackCreateAgentHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_agent denied: ${reason}`),
+});
+
+// Agent-facing room actions — guard-wrapped like create_agent:
+// global-scope groups act directly, everything else holds for the admin
+// chain, and the approval continuation re-enters the same wrapped entry with
+// the approval row as its grant.
+registerDeliveryAction('create_room', handleCreateRoom, {
+  guardAction: roomsCreate,
+  precheck: validateCreateRoom,
+  requestHold: requestCreateRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `create_room denied: ${reason}`),
+});
+registerApprovalHandler('create_room', reenterGuardedDeliveryAction('create_room'));
+
+registerDeliveryAction('add_to_room', handleAddToRoom, {
+  guardAction: roomsAddAgent,
+  precheck: validateAddToRoom,
+  requestHold: requestAddToRoomHold,
+  onDeny: (_content, session, reason) => notifyAgent(session, `add_to_room denied: ${reason}`),
+});
+registerApprovalHandler('add_to_room', reenterGuardedDeliveryAction('add_to_room'));

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.test.ts
@@ -1,0 +1,930 @@
+/**
+ * End-to-end tests for the slack-agent-flow wrapped create_agent action.
+ *
+ * Drives the REAL guard-wrapped delivery entry (getDeliveryAction) over a real
+ * in-memory central DB; Slack/broker traffic is a recorded fetch stub and the
+ * optional-module seam (slack-deps.js) is a recorded fake — no network, no
+ * skill-installed channel files. rootDir is process.cwd(), so each test runs
+ * chdir'd into its own tmpdir (vitest's default forks pool allows chdir).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ORIGIN_BOT_TOKEN = 'xoxb-origin-secret-token';
+const NEW_BOT_TOKEN = 'xoxb-new-bot-secret-token';
+const NEW_APP_TOKEN = 'xapp-new-app-secret-token';
+const REGISTRY_TOKEN = 'nct-registry-secret-token';
+
+// vi.hoisted: the module import below runs before this file's const
+// initializers, and the mock factories close over this state.
+const {
+  mockNotifyWrite,
+  mockRequestApproval,
+  mockInitGroupFilesystem,
+  mockWriteDestinations,
+  mockCreateRoomCanvas,
+  mockWireCanvasComments,
+  mockAssertSlackInstancesModuleInstalled,
+  fakeDeps,
+} = vi.hoisted(() => ({
+  mockNotifyWrite: vi.fn(),
+  mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+  mockInitGroupFilesystem: vi.fn(),
+  mockWriteDestinations: vi.fn(),
+  mockCreateRoomCanvas: vi.fn(),
+  mockWireCanvasComments: vi.fn(),
+  mockAssertSlackInstancesModuleInstalled: vi.fn().mockResolvedValue(undefined),
+  fakeDeps: {
+    slackInstanceBridgeFactory: vi.fn().mockReturnValue(null),
+    SLACK_DEFAULTS: undefined as unknown, // assigned in beforeEach (TEST_SLACK_DEFAULTS)
+    registerChannelAdapter: vi.fn(),
+    startChannelAdapter: vi.fn().mockResolvedValue('started'),
+  },
+}));
+
+// The optional-module seam — the only door to skill-installed channel files.
+vi.mock('./slack-deps.js', () => ({
+  loadSlackChannelDeps: async () => fakeDeps,
+  assertSlackInstancesModuleInstalled: (...a: unknown[]) => mockAssertSlackInstancesModuleInstalled(...a),
+}));
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+// wireCanvasComments (shadow-channel wiring) rides in the same module.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+// delivery.ts pulls more session-manager exports at import time.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({
+  initGroupFilesystem: (...a: unknown[]) => mockInitGroupFilesystem(...a),
+}));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// wrapper only needs these three. notifyAgent stays REAL (from primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the wrapped create_agent delivery action — the path under test.
+// Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays unloaded.
+import './index.js';
+import { ensureAgentRoom, finishSlackAgentFlow } from './orchestrate.js';
+import { SlackFlowError } from './types.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+// Mirrors the shape the Slack adapter declares (SLACK_DEFAULTS): the dm
+// context carries the B7 agent-DM declaration (sessionMode 'per-thread';
+// resolveWiringDefaults derives the threads=1 stamp from it) — S8 stamps
+// whatever the declaration resolves, so the per-thread/threads:1 pins below
+// exercise the declaration-driven path, not a hardcode.
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: {
+    engageMode: 'pattern',
+    engagePattern: '.',
+    threads: true,
+    sessionMode: 'per-thread',
+    unknownSenderPolicy: 'strict',
+  },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+/** .env content snapshotted at each chat.postMessage — proves S10 ran before S13. */
+let postMessageEnvSnapshots: string[] = [];
+let brokerStatus = 200;
+let tmpDir = '';
+/** null → the workspace refused auto-install; POST /v1/apps answers with a link instead. */
+let brokerBotToken: string | null = NEW_BOT_TOKEN;
+let brokerInstallUrl = '';
+/** Successive GET /v1/apps/{id} answers; the last one repeats. `http` overrides the status code. */
+let appStateQueue: Array<{ status?: string; bot_token?: string; http?: number }> = [];
+let appStateReads = 0;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const auth = String(init?.headers?.Authorization ?? '');
+  const token = auth.replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.endsWith('/v1/avatars')) {
+    // Pre-create avatar job: dispatched...
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'pending' }, 202));
+  }
+  if (url.includes('/v1/avatars/')) {
+    // ...and ready on the first poll, so the bot is born wearing its face.
+    return Promise.resolve(jsonResponse({ avatar_id: 'av-test', status: 'ready' }));
+  }
+  if (url.includes('/v1/apps/')) {
+    const state = appStateQueue[Math.min(appStateReads, appStateQueue.length - 1)];
+    appStateReads++;
+    if (!state) return Promise.resolve(jsonResponse({ error: 'not_found' }, 404));
+    return Promise.resolve(jsonResponse(state, state.http ?? 200));
+  }
+  if (url.endsWith('/v1/apps')) {
+    if (brokerStatus !== 200) return Promise.resolve(jsonResponse({ message: 'boom' }, brokerStatus));
+    return Promise.resolve(
+      jsonResponse({
+        appId: 'A0TEST',
+        appToken: NEW_APP_TOKEN,
+        ...(brokerBotToken ? { botToken: brokerBotToken } : {}),
+        ...(brokerInstallUrl ? { installUrl: brokerInstallUrl } : {}),
+      }),
+    );
+  }
+  if (url.includes('/api/auth.test')) {
+    const userId = token === ORIGIN_BOT_TOKEN ? 'U0ORIGINBOT' : 'U0NEWBOT';
+    return Promise.resolve(
+      jsonResponse({
+        ok: true,
+        user_id: userId,
+        team_id: 'T0TEST',
+        team: 'NanoCo Test',
+        url: 'https://nanoco-test.slack.com/',
+      }),
+    );
+  }
+  if (url.includes('/api/conversations.open')) {
+    const users = String((JSON.parse(body) as { users?: string }).users ?? '');
+    return Promise.resolve(jsonResponse({ ok: true, channel: { id: users.includes(',') ? 'G0ROOM' : 'D0NEWDM' } }));
+  }
+  if (url.includes('/api/chat.postMessage')) {
+    const envPath = path.join(tmpDir, '.env');
+    postMessageEnvSnapshots.push(fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : '');
+    return Promise.resolve(jsonResponse({ ok: true }));
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+async function runCreateAgent(content: Record<string, unknown>, session: Session = SLACK_SESSION): Promise<void> {
+  const wrapped = getDeliveryAction('create_agent');
+  expect(wrapped).toBeDefined();
+  await wrapped!(content, session);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ORIGIN_BOT_TOKEN, NEW_BOT_TOKEN, NEW_APP_TOKEN, REGISTRY_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  fakeDeps.SLACK_DEFAULTS = TEST_SLACK_DEFAULTS;
+  fakeDeps.startChannelAdapter.mockResolvedValue('started');
+  // Degraded default (free workspace / canvases off): C2 returns undefined —
+  // the flow must tolerate it (no canvas, no link line). Canvas tests opt in.
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  postMessageEnvSnapshots = [];
+  brokerStatus = 200;
+  brokerBotToken = NEW_BOT_TOKEN;
+  brokerInstallUrl = '';
+  appStateQueue = [];
+  appStateReads = 0;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-agent-flow-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ORIGIN_BOT_TOKEN}\n`);
+  process.env.NANOCLAW_REGISTRY_TOKEN = REGISTRY_TOKEN; // broker mode, no account.json / .env lookup
+
+  const db = await initTestDb();
+  await runMigrations(db);
+
+  const now = new Date().toISOString();
+  await createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  await ensureContainerConfig(SRC_GROUP);
+  await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  await upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  await grantRole({
+    user_id: 'slack:U0OPERATOR',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createSession(SLACK_SESSION);
+  // Declared platform defaults so resolveWiringDefaults / validate see slack's
+  // real shape (group: mention-sticky + threads) for the dead named instance.
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  delete process.env.NANOCLAW_REGISTRY_TOKEN;
+  delete process.env.SLACK_INSTALL_WAIT_MS;
+  delete process.env.SLACK_INSTALL_POLL_MS;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slack-aware create_agent — happy path (Slack-origin session)', () => {
+  it('creates the group, provisions the bot, wires DM + room, posts intros in order', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // Upstream leg: group + scaffold + bidirectional a2a destinations.
+    const newGroup = await getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(mockInitGroupFilesystem).toHaveBeenCalledTimes(1);
+    const dest = await getDestinationByName(SRC_GROUP, 'research');
+    expect(dest).toMatchObject({ target_type: 'agent', target_id: newGroup!.id });
+    expect(await getDestinationByName(newGroup!.id, 'parent')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+
+    // Env keys (values themselves never asserted into messages/logs).
+    const env = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    expect(env).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(env).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // Hot-add through the seam.
+    expect(fakeDeps.registerChannelAdapter).toHaveBeenCalledWith(
+      'slack-research',
+      expect.objectContaining({ defaults: TEST_SLACK_DEFAULTS }),
+    );
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+
+    // DM row + wiring on the NEW instance. Agent-view is the default variant
+    // so the DM gets thread-per-conversation sessions:
+    // session_mode 'per-thread' + explicit threads:1.
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(dmMg).toMatchObject({ is_group: 0, unknown_sender_policy: 'strict', name: 'Research DM' });
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'per-thread',
+      threads: 1,
+      priority: 0,
+    });
+
+    // Room: one row PER instance, policy 'public', mention/accumulate wirings
+    // (D4 — flow-created rooms only; mention-sticky is gone from the flow).
+    const roomOrigin = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack');
+    const roomNew = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', 'slack-research');
+    expect(roomOrigin).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(roomNew).toMatchObject({ is_group: 1, unknown_sender_policy: 'public' });
+    expect(await getMessagingGroupAgentByPair(roomOrigin!.id, SRC_GROUP)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+    expect(await getMessagingGroupAgentByPair(roomNew!.id, newGroup!.id)).toMatchObject({
+      engage_mode: 'mention',
+      engage_pattern: null,
+      ignored_message_policy: 'accumulate',
+    });
+
+    // Projections pushed into the live source session.
+    expect(mockWriteDestinations).toHaveBeenCalledWith(SRC_GROUP, 'sess-1');
+
+    // No room-contract post: the only chat.postMessage is the DM intro,
+    // and SLACK_A2A_ROOMS was in .env before it.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(posts[0]!.token).toBe(NEW_BOT_TOKEN);
+    expect(postMessageEnvSnapshots).toHaveLength(1);
+    expect(postMessageEnvSnapshots[0]).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+
+    // The ORIGIN agent authors the room intro — exactly one
+    // instruction-shaped nudge written into the origin session, tagging the
+    // new bot and addressing the room by its projected destination name.
+    const nudges = notifyTexts().filter((t) => t.includes('introduction'));
+    expect(nudges).toHaveLength(1);
+    const nudgeCall = mockNotifyWrite.mock.calls.find((c) =>
+      String((c[2] as { content: string }).content).includes('introduction'),
+    )!;
+    expect(nudgeCall[0]).toBe(SRC_GROUP);
+    expect(nudgeCall[1]).toBe('sess-1');
+    // notifyAgent leaves `trigger` unset — writeSessionMessage defaults it
+    // to 1, so the nudge wakes the origin agent.
+    expect((nudgeCall[2] as { trigger?: number }).trigger).toBeUndefined();
+    expect(nudges[0]).toContain('<@U0NEWBOT>');
+    expect(nudges[0]).toContain('send_message({ to: "research-room"');
+    expect(nudges[0]).toContain('no mechanics, no member lists');
+    // No explicit purpose was provided — the creation prompt must NOT leak
+    // into the nudge (no fallback — creation prompts are private).
+    expect(nudges[0]).not.toContain('dig deep');
+    // No canvas id → no shadow channel to wire.
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+
+    // MPIM opened as the new bot with operator + origin bot.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(2);
+    expect(JSON.parse(opens[1]!.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT' });
+    expect(opens[1]!.token).toBe(NEW_BOT_TOKEN);
+
+    // Requester heard ONLY the Slack success notify — the upstream "created —
+    // you can now message it" text is suppressed on the Slack path (it fires
+    // before provisioning and would report "done" ~a minute early).
+    const texts = notifyTexts();
+    expect(texts.some((t) => t.includes('Agent "research" created'))).toBe(false);
+    expect(texts.at(-1)).toContain('is live on Slack');
+    expect(texts.at(-1)).toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+});
+
+describe('slack-aware create_agent — manifest variants', () => {
+  it('allow_guests: broker gets allow_guests:true, DM wiring keeps the plain defaults', async () => {
+    await runCreateAgent({ name: 'Guesty', instructions: 'help the guests', allow_guests: true });
+
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBe(true);
+
+    const newGroup = await getAgentGroupByFolder('guesty');
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-guesty');
+    const dmWiring = (await getMessagingGroupAgentByPair(dmMg!.id, newGroup!.id))!;
+    expect(dmWiring).toMatchObject({ session_mode: 'shared' });
+    expect(dmWiring.threads ?? null).toBeNull();
+  });
+
+  it('default (agent-view): broker body carries no allow_guests flag', async () => {
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+    const appBody = JSON.parse(fetchCalls.find((c) => c.url.endsWith('/v1/apps'))!.body) as Record<string, unknown>;
+    expect(appBody.allow_guests).toBeUndefined();
+  });
+});
+
+describe("slack-aware create_agent — room:'none'", () => {
+  it('skips the room half entirely: DM only, no MPIM, no a2a entry, no canvas, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    expect(await getAgentGroupByFolder('research')).toBeDefined();
+    // Only the operator-DM conversations.open — no MPIM.
+    const opens = fetchCalls.filter((c) => c.url.includes('conversations.open'));
+    expect(opens).toHaveLength(1);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR' });
+    // No room rows on any instance, no a2a allowlist, no canvas, no shadow wiring.
+    expect((await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:G0ROOM')).toHaveLength(0);
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).not.toContain('SLACK_A2A_ROOMS');
+    expect(mockCreateRoomCanvas).not.toHaveBeenCalled();
+    expect(mockWireCanvasComments).not.toHaveBeenCalled();
+    // The DM intro still posts; the origin agent gets NO intro nudge.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(0);
+    // Success text is the no-room variant pointing at create_room.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain("room:'none'");
+    expect(success).toContain('create_room');
+    expect(success).not.toContain('G0ROOM');
+
+    assertNoTokenLeak();
+  });
+
+  it("hold payload carries room:'none' through to the approved replay (confined group)", async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep', room: 'none' });
+
+    // Held — nothing created yet; the replay payload must preserve room:'none'.
+    expect(await getAgentGroupByFolder('research')).toBeUndefined();
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_agent');
+    expect(opts.payload).toMatchObject({ name: 'Research', room: 'none' });
+  });
+});
+
+describe('slack-aware create_agent — room canvas contract', () => {
+  it('canvas available: called with the contract data (plain agent names), all participants wired', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The canvas carries the room contract: purpose, creator, members. Agent
+    // members travel as PLAIN NAMES — never bot user ids (the de-mention rule).
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Research room',
+      purpose: 'Research room',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Research'],
+    });
+    // Shadow-channel wiring rides on canvas success: EVERY participant —
+    // creator identified separately from the full list.
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledWith(
+      'F0CANVAS',
+      expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      [
+        expect.objectContaining({ instanceKey: 'slack', agentGroupId: SRC_GROUP }),
+        expect.objectContaining({ instanceKey: 'slack-research', agentGroupId: newGroup.id }),
+      ],
+      'Research room',
+    );
+    // Still no room post: the canvas tab IS the pinned surface — no link
+    // message either.
+    const posts = fetchCalls.filter((c) => c.url.includes('chat.postMessage'));
+    expect(posts).toHaveLength(1);
+    expect((JSON.parse(posts[0]!.body) as { channel: string }).channel).toBe('D0NEWDM');
+  });
+});
+
+describe('ensureAgentRoom — N-bot rooms', () => {
+  it('opens the MPIM with every participating bot, wires each instance, and makes destinations pairwise', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    await createAgentGroup({ id: 'ag-third', name: 'Devin', folder: 'devin', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-devin', botUserId: 'U0THIRD', agentGroupId: 'ag-third', agentGroupName: 'Devin' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+
+    const result = await ensureAgentRoom({
+      creator: participants[2]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      rootDir: tmpDir,
+    });
+    expect(result).toMatchObject({ roomChannelId: 'G0ROOM', created: true });
+
+    // MPIM opened as the creator with operator + every OTHER participating bot.
+    const open = fetchCalls.find((c) => c.url.includes('conversations.open'))!;
+    expect(open.token).toBe(NEW_BOT_TOKEN);
+    expect(JSON.parse(open.body)).toMatchObject({ users: 'U0OPERATOR,U0ORIGINBOT,U0THIRD' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const p of participants) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0ROOM', p.instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Pixel room' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, p.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Destinations symmetry: every distinct agent-group pair, both directions.
+    expect(await getDestinationByName(SRC_GROUP, 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-third',
+    });
+    expect(await getDestinationByName(SRC_GROUP, 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-new',
+    });
+    expect(await getDestinationByName('ag-third', 'andy')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+    expect(await getDestinationByName('ag-third', 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-new',
+    });
+    expect(await getDestinationByName('ag-new', 'andy')).toMatchObject({
+      target_type: 'agent',
+      target_id: SRC_GROUP,
+    });
+    expect(await getDestinationByName('ag-new', 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-third',
+    });
+
+    // Allowlisted for a2a. No room-contract post: ensureAgentRoom
+    // itself posts nothing — the origin agent authors the intro, and
+    // the contract data lives on the canvas.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0ROOM/m);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    // The canvas gets the contract data — every agent by plain name.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(NEW_BOT_TOKEN, 'G0ROOM', {
+      roomName: 'Pixel room',
+      purpose: 'coordinate the redesign',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Devin', 'Pixel'],
+    });
+  });
+
+  it('is idempotent: a second call creates nothing new and grows no second canvas', async () => {
+    const now = new Date().toISOString();
+    await createAgentGroup({ id: 'ag-new', name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: now });
+    const participants = [
+      { instanceKey: 'slack', botUserId: 'U0ORIGINBOT', agentGroupId: SRC_GROUP, agentGroupName: 'Andy' },
+      { instanceKey: 'slack-pixel', botUserId: 'U0NEWBOT', agentGroupId: 'ag-new', agentGroupName: 'Pixel' },
+    ];
+    const args = {
+      creator: participants[1]!,
+      creatorBotToken: NEW_BOT_TOKEN,
+      operatorUserId: 'U0OPERATOR',
+      participants,
+      roomName: 'Pixel room',
+      rootDir: tmpDir,
+    };
+
+    await ensureAgentRoom(args);
+    const mgCountAfterFirst = (await getAllMessagingGroups()).length;
+
+    const second = await ensureAgentRoom(args);
+    expect(second).toMatchObject({ roomChannelId: 'G0ROOM', created: false });
+    expect((await getAllMessagingGroups()).length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-aware create_agent — non-Slack parity', () => {
+  it('non-slack session: behaves exactly as upstream, zero Slack side effects', async () => {
+    await createMessagingGroup({
+      id: 'mg-tg',
+      channel_type: 'telegram',
+      platform_id: 'tg:123',
+      name: 'TG DM',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+    const tgSession: Session = { ...SLACK_SESSION, id: 'sess-tg', messaging_group_id: 'mg-tg' };
+    await createSession(tgSession);
+    const envBefore = fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+    const mgCountBefore = (await getAllMessagingGroups()).length;
+
+    await runCreateAgent({ name: 'Helper' }, tgSession);
+
+    expect(await getAgentGroupByFolder('helper')).toBeDefined(); // upstream leg ran
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toBe(envBefore);
+    expect((await getAllMessagingGroups()).length).toBe(mgCountBefore);
+  });
+
+  it('null messaging_group_id (task/a2a session): skips the Slack leg', async () => {
+    const bareSession: Session = { ...SLACK_SESSION, id: 'sess-bare', messaging_group_id: null };
+    await createSession(bareSession);
+
+    await runCreateAgent({ name: 'Helper' }, bareSession);
+
+    expect(await getAgentGroupByFolder('helper')).toBeDefined();
+    expect(fetchCalls).toHaveLength(0);
+    expect(fakeDeps.startChannelAdapter).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack-aware create_agent — failure and retry', () => {
+  it('broker failure: group still exists, failure notify carries the finish command', async () => {
+    brokerStatus = 500;
+
+    await runCreateAgent({ name: 'Research' });
+
+    const newGroup = await getAgentGroupByFolder('research');
+    expect(newGroup).toBeDefined();
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(0);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('scripts/slack-agent-flow-finish.ts');
+    expect(failure).toContain(`--group ${newGroup!.id}`);
+    expect(failure).toContain('--name research');
+    expect(failure).toContain(`--source-group ${SRC_GROUP}`);
+    expect(failure).toContain('send_message({ to: "research", ... })');
+
+    assertNoTokenLeak();
+  });
+
+  it('double invocation: upstream collision short-circuits — no duplicate rows, apps, posts, or nudges', async () => {
+    await runCreateAgent({ name: 'Research' });
+    const fetchCountAfterFirst = fetchCalls.length;
+    const mgCountAfterFirst = (await getAllMessagingGroups()).length;
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(fetchCalls.length).toBe(fetchCountAfterFirst);
+    expect((await getAllMessagingGroups()).length).toBe(mgCountAfterFirst);
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(1);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+    expect(notifyTexts().at(-1)).toContain('already have a destination named "research"');
+  });
+
+  it('finish-path retry after success: rows exist, so no second canvas, no posts, no intro nudge', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const postCountAfterFirst = fetchCalls.filter((c) => c.url.includes('chat.postMessage')).length;
+    const notifyCountAfterFirst = mockNotifyWrite.mock.calls.length;
+
+    // Operator re-runs the finish script — the S8/S11 created-gates hold.
+    await finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id });
+
+    expect(fetchCalls.filter((c) => c.url.includes('chat.postMessage'))).toHaveLength(postCountAfterFirst);
+    expect(mockCreateRoomCanvas).toHaveBeenCalledTimes(1);
+    expect(mockWireCanvasComments).toHaveBeenCalledTimes(1);
+    expect(mockNotifyWrite.mock.calls.length).toBe(notifyCountAfterFirst);
+    expect(notifyTexts().filter((t) => t.includes('introduction'))).toHaveLength(1);
+  });
+
+  it('finish path aborts before wiring DB rows if the multi-instance module is missing', async () => {
+    // Group exists (S1-S4 already ran) but the Slack leg never completed —
+    // same starting state as the "broker failure" case above.
+    brokerStatus = 500;
+    await runCreateAgent({ name: 'Research' });
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    brokerStatus = 200; // retry succeeds at the broker step this time
+    const mgCountBefore = (await getAllMessagingGroups()).length;
+
+    mockAssertSlackInstancesModuleInstalled.mockRejectedValueOnce(
+      new SlackFlowError(
+        'adapter-start',
+        'Slack channel payloads not installed — apply add-slack and slack-multi-instance first',
+      ),
+    );
+
+    await expect(
+      finishSlackAgentFlow({ slug: 'research', sourceGroupId: SRC_GROUP, newAgentGroupId: newGroup.id }),
+    ).rejects.toThrow(/multi-instance/);
+
+    // S6-S8 must not have run: no DM messaging group got wired for an
+    // instance the runtime still can't start.
+    expect((await getAllMessagingGroups()).length).toBe(mgCountBefore);
+  });
+});
+
+describe('slack-aware create_agent — workspace install approval', () => {
+  const INSTALL_URL = 'https://slack.com/oauth/v2/authorize?client_id=1.2&state=signed-state';
+
+  /** Auto-install refused: the app is real, but the workspace must approve it. */
+  function refuseAutoInstall(): void {
+    brokerBotToken = null;
+    brokerInstallUrl = INSTALL_URL;
+    process.env.SLACK_INSTALL_POLL_MS = '1';
+    process.env.SLACK_INSTALL_WAIT_MS = '120';
+  }
+
+  function env(): string {
+    return fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8');
+  }
+
+  function postedTexts(): string[] {
+    return fetchCalls
+      .filter((c) => c.url.includes('chat.postMessage'))
+      .map((c) => (JSON.parse(c.body) as { text: string }).text);
+  }
+
+  it('tells the operator what to approve, then finishes the flow on the token the approval releases', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }, { status: 'installed', bot_token: NEW_BOT_TOKEN }];
+
+    await runCreateAgent({ name: 'Research', instructions: 'dig deep' });
+
+    // The heads-up goes out as the ORIGIN bot, in the conversation the create
+    // was asked for — the origin agent's own reply could not be delivered
+    // while this handler still holds the session.
+    const notice = postedTexts()[0];
+    expect(notice).toContain('needs an admin to approve');
+    expect(notice).toContain(INSTALL_URL);
+    const noticeCall = fetchCalls.find((c) => c.url.includes('chat.postMessage'))!;
+    expect(noticeCall.token).toBe(ORIGIN_BOT_TOKEN);
+    expect((JSON.parse(noticeCall.body) as { channel: string }).channel).toBe('D0OPDM');
+
+    // From the token onward the flow is the ordinary one: adapter hot-add,
+    // DM row + wiring, room, welcome DM.
+    expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(env()).toMatch(/^SLACK_INSTANCES=.*research/m);
+    expect(fakeDeps.startChannelAdapter).toHaveBeenCalledWith('slack-research');
+    const newGroup = (await getAgentGroupByFolder('research'))!;
+    const dmMg = await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research');
+    expect(await getMessagingGroupAgentByPair(dmMg!.id, newGroup.id)).toBeDefined();
+    expect(postedTexts().some((t) => t.includes("I'm Research, your new agent"))).toBe(true);
+
+    // Exactly one app, and the consumed install link is retired.
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect(env()).toMatch(/^SLACK_INSTALL_URL_RESEARCH=$/m);
+
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('is live on Slack');
+    expect(success).toContain('approved the install');
+    assertNoTokenLeak();
+  });
+
+  it('parks the app when the approval never lands, keeping every part of it for a resume', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    // Nothing to re-create: app token, app id and the link are all on record.
+    expect(env()).toMatch(/^SLACK_APP_TOKEN_RESEARCH=/m);
+    expect(env()).toMatch(/^SLACK_APP_ID_RESEARCH=A0TEST$/m);
+    expect(env()).toContain(`SLACK_INSTALL_URL_RESEARCH=${INSTALL_URL}`);
+    expect(env()).not.toMatch(/^SLACK_BOT_TOKEN_RESEARCH=./m);
+    // The wait really ran rather than falling straight through.
+    expect(appStateReads).toBeGreaterThan(1);
+
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'install-wait'");
+    expect(failure).toContain('still waiting on a workspace install approval');
+    expect(failure).toContain('nothing needs re-creating');
+    expect(failure).toContain('finish setting up Research');
+    assertNoTokenLeak();
+  });
+
+  it('asking again after a park resumes the parked app instead of provisioning a second one', async () => {
+    refuseAutoInstall();
+    appStateQueue = [{ status: 'pending_install' }];
+    await runCreateAgent({ name: 'Research' });
+    const groupCountAfterPark = (await getAgentGroupByFolder('research'))!.id;
+    const postsAfterPark = postedTexts().length;
+
+    // The operator approves the install, then asks for the same agent again.
+    appStateQueue = [{ status: 'installed', bot_token: NEW_BOT_TOKEN }];
+    appStateReads = 0;
+    await runCreateAgent({ name: 'Research' });
+
+    // One Slack app, one agent group — the second ask finished the first.
+    expect(fetchCalls.filter((c) => c.url.endsWith('/v1/apps'))).toHaveLength(1);
+    expect((await getAgentGroupByFolder('research'))!.id).toBe(groupCountAfterPark);
+    expect(await getAgentGroupByFolder('research-2')).toBeUndefined();
+    // Upstream's name-collision answer must not be what the user hears.
+    expect(notifyTexts().at(-1)).not.toContain('already have a destination');
+    expect(notifyTexts().at(-1)).toContain('is live on Slack');
+
+    // A resume checks before it sleeps, so the standing approval is picked up
+    // on the first read.
+    expect(appStateReads).toBe(1);
+    expect(postedTexts()[postsAfterPark]).toContain('Still waiting on your workspace');
+    expect(env()).toMatch(/^SLACK_BOT_TOKEN_RESEARCH=/m);
+    expect(await getMessagingGroupByPlatform('slack', 'slack:D0NEWDM', 'slack-research')).toBeDefined();
+  });
+
+  it('SLACK_INSTALL_WAIT_MS=0 parks immediately — a slow approval queue need not hold delivery open', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '0';
+    appStateQueue = [{ status: 'pending_install' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(0);
+    // The operator still gets the link — the flow declines to wait, not to ask.
+    expect(postedTexts()[0]).toContain(INSTALL_URL);
+    expect(notifyTexts().at(-1)).toContain("failed at step 'install-wait'");
+    expect(env()).toMatch(/^SLACK_APP_ID_RESEARCH=A0TEST$/m);
+  });
+
+  it('a refusal with no install link keeps the hand-finish instructions — there is nothing to wait for', async () => {
+    brokerBotToken = null;
+    brokerInstallUrl = '';
+    process.env.SLACK_INSTALL_POLL_MS = '1';
+    process.env.SLACK_INSTALL_WAIT_MS = '120';
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(0);
+    expect(postedTexts()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'broker'");
+    expect(failure).toContain('SLACK_BOT_TOKEN_RESEARCH');
+  });
+
+  it('polls through a service hiccup instead of treating it as a refusal', async () => {
+    refuseAutoInstall();
+    appStateQueue = [
+      { http: 502, status: 'bad_gateway' },
+      { status: 'installed', bot_token: NEW_BOT_TOKEN },
+    ];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(2);
+    expect(notifyTexts().at(-1)).toContain('is live on Slack');
+  });
+
+  it('stops on a credential the service refuses — no later poll can change that answer', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '5000'; // never reached
+    appStateQueue = [{ http: 401, status: 'unauthorized' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(1);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain("failed at step 'install-wait'");
+    expect(failure).toContain('refused this install');
+    assertNoTokenLeak();
+  });
+
+  it('a token released to someone else stops the wait rather than burning the whole budget', async () => {
+    refuseAutoInstall();
+    process.env.SLACK_INSTALL_WAIT_MS = '5000'; // never reached
+    appStateQueue = [{ status: 'installed' }];
+
+    await runCreateAgent({ name: 'Research' });
+
+    expect(appStateReads).toBe(1);
+    expect(notifyTexts().at(-1)).toContain("failed at step 'install-wait'");
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/orchestrate.ts
@@ -1,0 +1,731 @@
+/**
+ * The Slack leg of create_agent — steps S1–S13 (one typed step id each).
+ *
+ * Ordering is load-bearing:
+ *  - S1/S2 are local/cheap prechecks — nothing external is created until the
+ *    operator identity and the origin bot token both resolve.
+ *  - S10 (SLACK_A2A_ROOMS append) runs strictly BEFORE the origin agent is
+ *    nudged to post the room intro, so every sibling instance's a2a
+ *    bridge admits the bot-authored intro instead of dropping it as a bot
+ *    sender.
+ *  - S13's DM intro and the origin intro nudge are gated on rows newly
+ *    created in S8/S11 — a retry (finish script) never double-posts or
+ *    double-nudges.
+ * Every step is idempotent: provision reuses .env tokens, messaging groups
+ * and wirings are get-before-create, conversations.open is idempotent on
+ * Slack's side.
+ *
+ * Slack HTTP plumbing comes from the shared channel-layer lib
+ * (src/channels/slack-lib.ts, installed with the Slack channel payload);
+ * access to the skill-installed adapter modules goes through
+ * loadSlackChannelDeps() so a partial install fails as a typed step error.
+ */
+import {
+  resolveUnknownSenderPolicy,
+  resolveWiringDefaults,
+  validateEngageAgainstChannel,
+} from '../../channels/channel-defaults.js';
+import {
+  SlackApiError,
+  botTokenKeyForInstance,
+  slackAuthTest,
+  slackConversationsOpen,
+  slackPostMessage,
+} from '../../channels/slack-lib.js';
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { MessagingGroup, MessagingGroupAgent, Session } from '../../types.js';
+import {
+  createDestination,
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { notifyAgent, pickApprover } from '../approvals/primitive.js';
+import { appendToEnvList, readEnvValue } from './env-file.js';
+import { provisionSlackApp } from './provision.js';
+import { createRoomCanvas, wireCanvasComments } from './room-canvas.js';
+import { assertSlackInstancesModuleInstalled, loadSlackChannelDeps } from './slack-deps.js';
+import { SlackFlowError, type OrchestrateSuccess, type SlackFlowStep } from './types.js';
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function envSuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/** Wrap a non-typed failure with the step it happened in. Never carries token
+ *  values. A SlackApiError keeps its own step — the shared Slack lib
+ *  (src/channels/slack-lib.ts) tags each call with the flow step id the call
+ *  site passed, which is more precise than the enclosing wrapper's step. */
+function asFlowError(err: unknown, step: SlackFlowStep): SlackFlowError {
+  if (err instanceof SlackFlowError) return err;
+  if (err instanceof SlackApiError) return new SlackFlowError(err.step as SlackFlowStep, err.message);
+  return new SlackFlowError(step, err instanceof Error ? err.message : String(err));
+}
+
+/** One canonical slugger — the same normalizeName the a2a destination namespace uses. */
+export function deriveInstanceSlug(name: string): string {
+  return normalizeName(name);
+}
+
+/**
+ * First approver with a Slack identity, 'slack:' prefix stripped. pickApprover
+ * order (scoped admins → global admins → owners) picks who gets the DM.
+ */
+export async function resolveOperatorSlackUserId(sourceAgentGroupId: string): Promise<string | null> {
+  const hit = (await pickApprover(sourceAgentGroupId)).find((id) => /^slack:U/i.test(id));
+  return hit ? hit.slice('slack:'.length) : null;
+}
+
+/**
+ * A slug conflicts when its .env footprint is already claimed (token key set
+ * or slug listed in SLACK_INSTANCES) AND its `slack-<slug>` instance is wired
+ * to a DIFFERENT agent group. Claimed-but-wired-to-this-group (or to nothing)
+ * is the retry path — reuse.
+ */
+async function slugConflicts(slug: string, newAgentGroupId: string, rootDir: string): Promise<boolean> {
+  const tokenExists = readEnvValue(rootDir, `SLACK_BOT_TOKEN_${envSuffix(slug)}`) !== undefined;
+  const instances = (readEnvValue(rootDir, 'SLACK_INSTANCES') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!tokenExists && !instances.includes(slug)) return false;
+
+  const instanceKey = `slack-${slug}`;
+  for (const mg of await getAllMessagingGroups()) {
+    if (mg.instance !== instanceKey) continue;
+    for (const wiring of await getMessagingGroupAgents(mg.id)) {
+      if (wiring.agent_group_id !== newAgentGroupId) return true;
+    }
+  }
+  return false;
+}
+
+export async function dedupeSlug(
+  base: string,
+  newAgentGroupId: string,
+  rootDir: string = process.cwd(),
+): Promise<string> {
+  let slug = base;
+  for (let n = 2; await slugConflicts(slug, newAgentGroupId, rootDir); n++) slug = `${base}-${n}`;
+  return slug;
+}
+
+async function ensureMessagingGroupRow(spec: {
+  platformId: string;
+  instance: string;
+  name: string;
+  isGroup: boolean;
+  unknownSenderPolicy: MessagingGroup['unknown_sender_policy'];
+}): Promise<{ mg: MessagingGroup; created: boolean }> {
+  const existing = await getMessagingGroupByPlatform('slack', spec.platformId, spec.instance);
+  if (existing) return { mg: existing, created: false };
+  const mg: MessagingGroup = {
+    id: generateId('mg'),
+    channel_type: 'slack',
+    platform_id: spec.platformId,
+    instance: spec.instance,
+    name: spec.name,
+    is_group: spec.isGroup ? 1 : 0,
+    unknown_sender_policy: spec.unknownSenderPolicy,
+    created_at: new Date().toISOString(),
+  };
+  await createMessagingGroup(mg);
+  return { mg, created: true };
+}
+
+/** Flow-chosen deviations from the channel-declared wiring defaults. */
+interface WiringOverrides {
+  /** Set together with engage_pattern to bypass resolveWiringDefaults. */
+  engage_mode?: MessagingGroupAgent['engage_mode'];
+  engage_pattern?: string | null;
+  ignored_message_policy?: MessagingGroupAgent['ignored_message_policy'];
+  session_mode?: MessagingGroupAgent['session_mode'];
+  /** 1/0 explicit stamp; null = explicitly leave the column NULL (inherit the
+   *  channel declaration at fanout time); omitted = follow the derived
+   *  creation-time stamp (resolveWiringDefaults stamps threads=1 when the
+   *  declared sessionMode is 'per-thread', else null). */
+  threads?: number | null;
+}
+
+/** Get-before-create wiring with channel-declared defaults (engage fields,
+ *  plus the B7 session-mode/threads creation-time stamps) unless overridden.
+ *  True iff newly created. */
+async function ensureWiring(
+  mg: MessagingGroup,
+  agentGroupId: string,
+  agentGroupName: string,
+  overrides: WiringOverrides = {},
+): Promise<boolean> {
+  if (await getMessagingGroupAgentByPair(mg.id, agentGroupId)) return false;
+  const channelKey = mg.instance ?? mg.channel_type;
+  // Overriding engage_mode bypasses the declaration entirely (flow-owned
+  // room semantics, D4); declaration-resolved wirings take the declared
+  // session_mode / threads stamps too (B7).
+  const resolved =
+    overrides.engage_mode !== undefined
+      ? undefined
+      : resolveWiringDefaults(channelKey, mg.is_group === 1, agentGroupName, mg.channel_type);
+  const engage = resolved ?? { engage_mode: overrides.engage_mode!, engage_pattern: overrides.engage_pattern ?? null };
+  const threads = overrides.threads !== undefined ? overrides.threads : (resolved?.threads ?? null);
+  const wiring: MessagingGroupAgent = {
+    id: generateId('mga'),
+    messaging_group_id: mg.id,
+    agent_group_id: agentGroupId,
+    engage_mode: engage.engage_mode,
+    engage_pattern: engage.engage_pattern,
+    sender_scope: 'all',
+    ignored_message_policy: overrides.ignored_message_policy ?? 'drop',
+    session_mode: overrides.session_mode ?? resolved?.session_mode ?? 'shared',
+    priority: 0,
+    ...(threads !== null ? { threads } : {}),
+    created_at: new Date().toISOString(),
+  };
+  validateEngageAgainstChannel(wiring, mg);
+  // createMessagingGroupAgent persists an explicit `threads` value itself
+  // (follow-up UPDATE in src/db/messaging-groups.ts) — the declared threads:1 stamp lands.
+  await createMessagingGroupAgent(wiring);
+  return true;
+}
+
+/**
+ * Room-wiring semantics for flow-created rooms (D4): each bot speaks only
+ * when @-mentioned; everything else accumulates as ambient context delivered
+ * with the next mention. Deliberately NOT the channel group default —
+ * flow-created rooms only.
+ */
+const ROOM_WIRING_OVERRIDES: WiringOverrides = {
+  engage_mode: 'mention',
+  engage_pattern: null,
+  ignored_message_policy: 'accumulate',
+};
+
+/** One bot in a shared room: its adapter instance and the agent group behind it. */
+export interface RoomParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  botUserId: string;
+  agentGroupId: string;
+  agentGroupName: string;
+}
+
+/**
+ * Idempotent agent→agent destination (= ACL grant + local name). No-op when
+ * a destination for the target already exists under any name (upstream
+ * create_agent's parent/child rows count). Name collisions get a numeric
+ * suffix, mirroring ensureAgentDestinationForWiring.
+ */
+async function ensureAgentDestination(fromGroupId: string, toGroupId: string, toName: string): Promise<void> {
+  if (fromGroupId === toGroupId) return;
+  if (await getDestinationByTarget(fromGroupId, 'agent', toGroupId)) return;
+  const base = normalizeName(toName) || toGroupId.slice(0, 8);
+  let localName = base;
+  let suffix = 2;
+  while (await getDestinationByName(fromGroupId, localName)) {
+    localName = `${base}-${suffix}`;
+    suffix++;
+  }
+  await createDestination({
+    agent_group_id: fromGroupId,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: toGroupId,
+    created_at: new Date().toISOString(),
+  });
+}
+
+/** Full pairwise a2a destination symmetry between every distinct agent group
+ *  in the room — "ask Devin" must be actionable from any participant. */
+async function ensurePairwiseAgentDestinations(participants: RoomParticipant[]): Promise<void> {
+  for (const a of participants) {
+    for (const b of participants) {
+      if (a.agentGroupId === b.agentGroupId) continue;
+      await ensureAgentDestination(a.agentGroupId, b.agentGroupId, b.agentGroupName);
+    }
+  }
+}
+
+/**
+ * Public purpose: ONLY the explicitly provided line (capped 80). No fallback
+ * from the instructions — the creation prompt is the agent's private persona
+ * and never appears on shared surfaces. No purpose = the intro simply
+ * doesn't state one.
+ */
+export function publicPurpose(explicit: string | undefined): string | undefined {
+  const cleaned = explicit?.trim();
+  if (!cleaned) return undefined;
+  return cleaned.length <= 80 ? cleaned : `${cleaned.slice(0, 80)}…`;
+}
+
+/**
+ * The ORIGIN agent — not a host template — introduces the new agent
+ * in the shared room. This is the instruction the origin session wakes to;
+ * the intro itself stays in the agent's own voice, and the room-contract
+ * data (purpose, members, created date) lives on the canvas, not in chat.
+ */
+function roomIntroNudgeText(args: {
+  newAgentName: string;
+  newBotUserId: string;
+  roomName: string;
+  /** The origin agent's local destination name for the room. */
+  roomDestination: string;
+  purpose?: string;
+}): string {
+  return (
+    `A shared Slack room "${args.roomName}" was just opened with you, the operator, and your new agent ${args.newAgentName}` +
+    `${args.purpose ? ` (${args.purpose})` : ''}. ` +
+    `Post a brief introduction of ${args.newAgentName} there now via send_message({ to: "${args.roomDestination}", ... }): ` +
+    `1-2 lines in your own voice saying what they're for, tagging them with <@${args.newBotUserId}> ` +
+    `(include that literally — it renders as a mention). Just the intro — no mechanics, no member lists.`
+  );
+}
+
+/**
+ * N-bot-capable room step (S9–S13's room half): open the MPIM as `creator`
+ * with the operator + every participating bot, allowlist it for a2a, create
+ * one mg row + mention/accumulate wiring PER participating instance, ensure
+ * pairwise a2a destinations, then (only when rows were newly created) create
+ * the room canvas — the room's pinned contract surface (no contract
+ * message, no link post; the channel canvas is already the room's canvas
+ * tab) — and wire its comment shadow channel for every participant. The
+ * conversational create_agent flow calls this with the 3-way default; any
+ * caller may pass a larger participant list.
+ */
+export async function ensureAgentRoom(args: {
+  /** Bot that opens the MPIM and creates the canvas. Must be one of `participants`. */
+  creator: RoomParticipant;
+  creatorBotToken: string;
+  operatorUserId: string;
+  /** All bots in the room, creator included. */
+  participants: RoomParticipant[];
+  /** Additional member user ids beyond the operator + participating bots —
+   *  e.g. Slack-UI-added humans carried over when add_to_room forks a room.
+   *  Members only; they get no mg rows or wirings. */
+  extraMemberUserIds?: string[];
+  roomName: string;
+  /** Creation prompt (room purpose) — the canvas contract excerpt. */
+  purpose?: string;
+  rootDir: string;
+}): Promise<{ roomChannelId: string; created: boolean }> {
+  const { creator, creatorBotToken, operatorUserId, participants, rootDir } = args;
+
+  // S9 mpim-open — operator + carried extra members + every other
+  // participating bot, opened AS the creator.
+  const otherBotIds = participants.filter((p) => p.botUserId !== creator.botUserId).map((p) => p.botUserId);
+  const roomChannelId = await slackConversationsOpen(
+    creatorBotToken,
+    [operatorUserId, ...(args.extraMemberUserIds ?? []), ...otherBotIds],
+    'mpim-open',
+  );
+
+  // S10 a2a-env — strictly before the origin agent can be nudged to post its
+  // intro: every sibling instance's a2a bridge must already allow the room
+  // or it drops bot-authored posts.
+  try {
+    appendToEnvList(rootDir, 'SLACK_A2A_ROOMS', roomChannelId);
+  } catch (err) {
+    throw asFlowError(err, 'a2a-env');
+  }
+
+  // S11 room-wire — one row PER participating instance (router lookup is
+  // exact-on-instance). unknown_sender_policy 'public' explicitly: sibling
+  // bridges' access gates must never approval-spam admitted bot messages.
+  // Wirings are mention/accumulate (D4 — flow-created rooms only).
+  let created = false;
+  try {
+    for (const p of participants) {
+      const row = await ensureMessagingGroupRow({
+        platformId: `slack:${roomChannelId}`,
+        instance: p.instanceKey,
+        name: args.roomName,
+        isGroup: true,
+        unknownSenderPolicy: 'public',
+      });
+      await ensureWiring(row.mg, p.agentGroupId, p.agentGroupName, ROOM_WIRING_OVERRIDES);
+      created = row.created || created;
+    }
+    await ensurePairwiseAgentDestinations(participants);
+  } catch (err) {
+    throw asFlowError(err, 'room-wire');
+  }
+
+  // S12 projections — in-host-process, so already-running containers see the
+  // auto-created destinations without waiting for the next spawn.
+  for (const groupId of new Set(participants.map((p) => p.agentGroupId))) {
+    await projectDestinationsToSessions(groupId);
+  }
+
+  // S13 room half — gated on newly created rows so a retry never grows a
+  // second canvas. No room-contract message: the canvas tab is the
+  // pinned surface and carries the contract data; the intro is authored by
+  // the ORIGIN agent (nudged by runFlow). Canvas failure is non-fatal
+  // (C2: createRoomCanvas never throws) — no canvas, no shadow channel.
+  if (created) {
+    const canvasId = await createRoomCanvas(creatorBotToken, roomChannelId, {
+      roomName: args.roomName,
+      purpose: args.purpose ?? args.roomName,
+      creatorUserId: operatorUserId,
+      agentNames: participants.map((p) => p.agentGroupName),
+    });
+    // Canvas comments arrive in a Slackbot-owned shadow channel (canvas id
+    // with F→C) — wire EVERY participating instance: creator as the
+    // pattern-engage default responder, siblings mention/accumulate.
+    // Non-throwing; no canvas id, nothing to wire.
+    if (canvasId) await wireCanvasComments(canvasId, creator, participants, args.roomName);
+  }
+
+  return { roomChannelId, created };
+}
+
+/**
+ * How long the flow waits inline for a workspace install approval, and how
+ * often it checks. The default is five minutes at a five-second cadence —
+ * long enough for someone already at their desk, short enough that the app
+ * parks (and stays resumable) rather than holding this session's delivery
+ * open indefinitely.
+ *
+ * `SLACK_INSTALL_WAIT_MS=0` skips the wait entirely: installs that always go
+ * through a slow approval queue are better served by parking immediately and
+ * finishing on a later ask. `SLACK_INSTALL_POLL_MS` moves the cadence.
+ */
+function resolveInstallWait(rootDir: string): { intervalMs?: number; timeoutMs?: number } | undefined {
+  const num = (key: string): number | undefined => {
+    const raw = readEnvValue(rootDir, key);
+    if (raw === undefined) return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  };
+  const timeoutMs = num('SLACK_INSTALL_WAIT_MS');
+  const intervalMs = num('SLACK_INSTALL_POLL_MS');
+  if (timeoutMs === undefined && intervalMs === undefined) return undefined;
+  return { ...(timeoutMs !== undefined ? { timeoutMs } : {}), ...(intervalMs !== undefined ? { intervalMs } : {}) };
+}
+
+/**
+ * The one line the human gets while the flow waits on a workspace install
+ * approval. Short on purpose: the link is the only actionable part, and the
+ * flow says nothing else until it either finishes or parks.
+ */
+export function installPendingText(displayName: string, info: { installUrl?: string; resumed: boolean }): string {
+  const where = info.installUrl ? ` Approve it here: ${info.installUrl}` : '';
+  return info.resumed
+    ? `Still waiting on your workspace to approve installing ${displayName}.${where} — I'll finish setting it up as soon as that lands.`
+    : `${displayName} is created, but your workspace needs an admin to approve installing it.${where} — I'll finish the setup automatically once it's approved.`;
+}
+
+interface FlowArgs {
+  slug: string;
+  displayName: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey: string;
+  /** Slack channel the create was asked for in — where the flow talks back
+   *  while it waits. Absent on the out-of-process finish path, which prints
+   *  to the operator's terminal instead. */
+  originChannelId?: string;
+  rootDir: string;
+  /** false on the out-of-process finish path — S5 needs the live host's registry. */
+  hotStart: boolean;
+  /** Agent instructions excerpt — drives the broker-generated avatar. */
+  description?: string;
+  /** Short PUBLIC line for the room contract + canvas ("what this agent is
+   *  for"). Falls back to a first-sentence excerpt of the instructions —
+   *  never the full creation prompt (it may carry private detail). */
+  purpose?: string;
+  /** true → plain manifest variant (guest-visible); false/absent → agent_view. */
+  allowGuests?: boolean;
+  /** The session whose create_agent call started the flow — receives the
+   *  room-intro nudge. Absent on the out-of-process finish path. */
+  originSession?: Session;
+  /**
+   * Room policy: 'own' (default) opens the shared origin+operator
+   * room; 'none' skips the room half entirely — the multi-create pattern is
+   * N creates with room:'none' followed by one create_room with all of them.
+   */
+  room?: 'own' | 'none';
+  /** Wait budget for a deferred workspace install. Tests shorten it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+  /** Extra sink for the pending-install line — the finish script prints it to
+   *  the operator's terminal, which has no Slack conversation to post into. */
+  onInstallPending?: (text: string) => void;
+}
+
+async function runFlow(args: FlowArgs): Promise<OrchestrateSuccess> {
+  const { slug, displayName, sourceGroupId, newAgentGroupId, originInstanceKey, rootDir } = args;
+  const instanceKey = `slack-${slug}`;
+
+  // S1 operator-identity
+  const operatorUserId = await resolveOperatorSlackUserId(sourceGroupId);
+  if (!operatorUserId) {
+    throw new SlackFlowError(
+      'operator-identity',
+      'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+    );
+  }
+
+  // S2 origin-auth — prove the origin instance's token before provisioning anything.
+  const originTokenKey = botTokenKeyForInstance(originInstanceKey);
+  const originBotToken = readEnvValue(rootDir, originTokenKey);
+  if (!originBotToken) {
+    throw new SlackFlowError(
+      'origin-auth',
+      `missing ${originTokenKey} in .env for origin instance '${originInstanceKey}'`,
+    );
+  }
+  const originAuth = await slackAuthTest(originBotToken, 'origin-auth');
+  const originBotUserId = originAuth.userId;
+
+  // S3/S4 provision. A workspace that requires an admin to approve installs
+  // refuses auto-install, and provisionSlackApp then waits for the human to
+  // finish it in the browser. That wait is silent from the outside, so it
+  // announces itself HERE, as the origin bot, in the conversation the create
+  // was asked for — the origin agent cannot relay it, since its own replies
+  // cannot be delivered while this handler is still running. A failed
+  // announcement is not worth abandoning the wait for.
+  const app = await provisionSlackApp({
+    slug,
+    displayName,
+    rootDir,
+    teamId: originAuth.teamId,
+    description: args.description,
+    allowGuests: args.allowGuests,
+    requestedBy: operatorUserId,
+    installWait: args.installWait ?? resolveInstallWait(rootDir),
+    onInstallPending: async (info) => {
+      const text = installPendingText(displayName, info);
+      log.info('Waiting on a Slack workspace install approval', { step: 'install-wait', appId: info.appId });
+      args.onInstallPending?.(text);
+      if (!args.originChannelId) return;
+      try {
+        await slackPostMessage(originBotToken, args.originChannelId, text, 'install-wait');
+      } catch (err) {
+        log.warn('Could not announce the pending Slack install', {
+          step: 'install-wait',
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  });
+
+  // S5 adapter-start. The multi-instance module must be installed regardless
+  // of hotStart: S6-S8 below wire DB rows to an instance name the runtime
+  // needs to be able to start after a restart, so the out-of-process finish
+  // path (hotStart: false) checks this too instead of silently skipping
+  // straight to DB writes for an instance nothing can ever connect.
+  await assertSlackInstancesModuleInstalled();
+  if (args.hotStart) {
+    // Hot-add the new instance into the live registry.
+    const deps = await loadSlackChannelDeps();
+    deps.registerChannelAdapter(instanceKey, {
+      factory: () => deps.slackInstanceBridgeFactory(slug),
+      defaults: deps.SLACK_DEFAULTS,
+    });
+    let started: 'started' | 'already-active' | 'no-credentials';
+    try {
+      started = await deps.startChannelAdapter(instanceKey);
+    } catch (err) {
+      throw asFlowError(err, 'adapter-start');
+    }
+    // 'already-active' is the retry path — the instance survived a previous attempt.
+    if (started === 'no-credentials') {
+      throw new SlackFlowError(
+        'adapter-start',
+        `adapter '${instanceKey}' found no credentials in .env (SLACK_BOT_TOKEN_${app.envSuffix} / SLACK_APP_TOKEN_${app.envSuffix})`,
+      );
+    }
+  }
+
+  // S6 new-bot identity (auth.test gates the DM open — same step id).
+  const newBotUserId = (await slackAuthTest(app.botToken, 'dm-open')).userId;
+
+  // S7 dm-open — the operator DM, opened AS the new bot.
+  const dmChannelId = await slackConversationsOpen(app.botToken, [operatorUserId], 'dm-open');
+
+  // S8 dm-wire. Agent-view apps (the default variant, allowGuests !== true)
+  // get thread-per-conversation DMs from the CHANNEL DECLARATION: the
+  // Slack adapter's SLACK_DEFAULTS declares dm.sessionMode 'per-thread',
+  // resolveWiringDefaults derives the threads=1 stamp from it (per-thread
+  // sessions structurally require honored thread ids), and ensureWiring
+  // stamps whatever it resolves — nothing is hardcoded here. The plain
+  // (allow_guests) variant has no agent-mode DM surface, so it pins
+  // session_mode 'shared' and leaves the threads column NULL explicitly.
+  let dmCreated = false;
+  try {
+    const dmRow = await ensureMessagingGroupRow({
+      platformId: `slack:${dmChannelId}`,
+      instance: instanceKey,
+      name: `${displayName} DM`,
+      isGroup: false,
+      unknownSenderPolicy: resolveUnknownSenderPolicy(instanceKey, false, 'slack'),
+    });
+    dmCreated = dmRow.created;
+    const agentView = args.allowGuests !== true;
+    await ensureWiring(
+      dmRow.mg,
+      newAgentGroupId,
+      displayName,
+      agentView ? {} : { session_mode: 'shared', threads: null },
+    );
+  } catch (err) {
+    throw asFlowError(err, 'dm-wire');
+  }
+
+  // S9–S13 room half: MPIM + allowlist + per-instance mention/accumulate
+  // wirings + pairwise destinations + canvas + room-contract intro. The
+  // conversational flow's 3-way default; ensureAgentRoom itself is N-capable.
+  // room:'none' skips the whole half — the DM is the entire surface
+  // and the caller composes a shared room later via create_room.
+  let roomChannelId: string | undefined;
+  if (args.room !== 'none') {
+    const sourceGroupName = (await getAgentGroup(sourceGroupId))?.name ?? sourceGroupId;
+    const newParticipant: RoomParticipant = {
+      instanceKey,
+      botUserId: newBotUserId,
+      agentGroupId: newAgentGroupId,
+      agentGroupName: displayName,
+    };
+    const roomName = `${displayName} room`;
+    const roomPurpose = publicPurpose(args.purpose);
+    const room = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: app.botToken,
+      operatorUserId,
+      participants: [
+        {
+          instanceKey: originInstanceKey,
+          botUserId: originBotUserId,
+          agentGroupId: sourceGroupId,
+          agentGroupName: sourceGroupName,
+        },
+        newParticipant,
+      ],
+      roomName,
+      purpose: roomPurpose,
+      rootDir,
+    });
+    roomChannelId = room.roomChannelId;
+
+    // The ORIGIN agent authors the room intro — an instruction-shaped
+    // system nudge (trigger=1 wake via notifyAgent) into the origin session,
+    // gated on the S13 created-gate so a flow retry never double-nudges. The
+    // wizard first-agent path never reaches here (it opens no room); the
+    // out-of-process finish path has no origin session to nudge. The room
+    // destination was projected into the live session in S12.
+    if (room.created && args.originSession) {
+      const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, originInstanceKey);
+      const roomDest = roomMg ? await getDestinationByTarget(sourceGroupId, 'channel', roomMg.id) : undefined;
+      await notifyAgent(
+        args.originSession,
+        roomIntroNudgeText({
+          newAgentName: displayName,
+          newBotUserId,
+          roomName,
+          roomDestination: roomDest?.local_name ?? normalizeName(roomName),
+          purpose: roomPurpose,
+        }),
+      );
+    }
+  }
+
+  // S13 DM half — gated on the row newly created in S8.
+  if (dmCreated) {
+    await slackPostMessage(
+      app.botToken,
+      dmChannelId,
+      `Hi <@${operatorUserId}> — I'm ${displayName}, your new agent. This DM is already wired up; just reply here to start.`,
+      'intro-post',
+    );
+  }
+
+  return {
+    slug,
+    newBotUserId,
+    operatorUserId,
+    dmChannelId,
+    roomChannelId,
+    ...(app.deferredInstall ? { deferredInstall: true } : {}),
+  };
+}
+
+/** In-host entry — the wrapped create_agent handler's Slack leg (hot-add active). */
+export async function runSlackAgentFlow(args: {
+  content: Record<string, unknown>;
+  session: Session;
+  newAgentGroupId: string;
+  slug: string;
+  /** Wait budget for a deferred workspace install. Tests shorten it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+}): Promise<OrchestrateSuccess> {
+  const { content, session, newAgentGroupId, slug } = args;
+  const displayName =
+    typeof content.name === 'string' && content.name
+      ? content.name
+      : ((await getAgentGroup(newAgentGroupId))?.name ?? slug);
+  const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  return runFlow({
+    slug,
+    displayName,
+    sourceGroupId: session.agent_group_id,
+    newAgentGroupId,
+    originInstanceKey: originMg?.instance ?? 'slack',
+    // messaging_groups store 'slack:<channelId>'; the Web API wants the bare id.
+    originChannelId: originMg?.platform_id?.replace(/^slack:/, ''),
+    installWait: args.installWait,
+    rootDir: process.cwd(),
+    hotStart: true,
+    description: typeof content.instructions === 'string' ? content.instructions.slice(0, 300) : undefined,
+    purpose: typeof content.purpose === 'string' ? content.purpose : undefined,
+    allowGuests: content.allow_guests === true,
+    originSession: session,
+    room: content.room === 'none' ? 'none' : 'own',
+  });
+}
+
+/**
+ * Out-of-process finish/retry entry (scripts/slack-agent-flow-finish.ts):
+ * S1–S13 minus the S5 hot-add — a separate process cannot start an adapter
+ * inside the live host, so the script restarts the service (or says how).
+ */
+export async function finishSlackAgentFlow(args: {
+  slug: string;
+  sourceGroupId: string;
+  newAgentGroupId: string;
+  originInstanceKey?: string;
+  rootDir?: string;
+  /** Pass true when the original create used allow_guests (plain variant) —
+   *  keeps the finish path's DM wiring congruent with the provisioned app. */
+  allowGuests?: boolean;
+  /** Pass 'none' when the original create used room:'none' — keeps the
+   *  finish path from growing a room the caller deliberately skipped. */
+  room?: 'own' | 'none';
+  /** Called with the pending-install line when the app is waiting on a
+   *  workspace install approval — the script prints it so a five-minute wait
+   *  does not read as a hang. */
+  onInstallPending?: (text: string) => void;
+}): Promise<OrchestrateSuccess> {
+  return runFlow({
+    slug: args.slug,
+    displayName: (await getAgentGroup(args.newAgentGroupId))?.name ?? args.slug,
+    sourceGroupId: args.sourceGroupId,
+    newAgentGroupId: args.newAgentGroupId,
+    originInstanceKey: args.originInstanceKey ?? 'slack',
+    rootDir: args.rootDir ?? process.cwd(),
+    hotStart: false,
+    allowGuests: args.allowGuests,
+    room: args.room,
+    onInstallPending: args.onInstallPending,
+  });
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.congruence.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Congruence pins for provision.ts, which deliberately duplicates its broker
+ * protocol and manifest out of the trunk provisioning module
+ * src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts.
+ *
+ * ALL transports carry the same
+ * template: BASE + canvas scopes, BASE + membership events, and the
+ * agent-mode (agent_view) variant pair — matching the broker's BOT_SCOPES /
+ * BOT_EVENTS / AGENT_BOT_* in nanocoai/infra: modules/nanoclaw-slack lambda
+ * service/index.mjs. The pins here hold the mirrors (read as source text —
+ * they are not importable from src/) equal to provision.ts's own sets, and
+ * provision.ts equal to the documented BASE + additions.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_BROKER_BASE,
+  MANAGED_AGENT_BOT_EVENTS,
+  MANAGED_AGENT_BOT_SCOPES,
+  MANAGED_APP_DESCRIPTION,
+  MANAGED_BOT_EVENTS,
+  MANAGED_BOT_SCOPES,
+  buildManagedAppManifest,
+  provisionSlackApp,
+  resolveProvisioningCredential,
+} from './provision.js';
+
+const CREATE_AGENT_SCRIPT = path.resolve(
+  process.cwd(),
+  '.claude/skills/slack-managed-agents/scripts/slack-create-agent.ts',
+);
+const SLACK_PROVISION = path.resolve(process.cwd(), 'src/provisioning/slack-app.ts');
+
+/**
+ * The base managed-app sets, before the additions below. Kept literal so
+ * drift in either direction is loud.
+ */
+const BASE_BOT_SCOPES = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+];
+const BASE_BOT_EVENTS = ['message.channels', 'message.groups', 'message.im', 'message.mpim', 'app_mention'];
+
+/** Additions over the base set (room canvas + read-back; membership events). */
+const CANVAS_SCOPES = ['canvases:read', 'canvases:write', 'files:read'];
+const MEMBERSHIP_EVENTS = ['member_joined_channel', 'member_left_channel'];
+
+/** send_file: files.upload needs files:write, distinct from the canvas read-back path. */
+const SEND_FILE_SCOPES = ['files:write'];
+
+/** All single-quoted strings inside `export const <name> = […]`, comments stripped. */
+function extractStringArray(src: string, name: string): string[] {
+  const m = src.match(new RegExp(`export const ${name}[^=]*= \\[([\\s\\S]*?)\\];`));
+  expect(m, `export const ${name} = […] not found in mirror source`).toBeTruthy();
+  const body = m![1].replace(/\/\/.*$/gm, '');
+  return [...body.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+// The slack-managed-agents skill is optional (its install leg is coupled to
+// the managed-app provisioning service) — the mirror pins run wherever its
+// skill directory is present and skip cleanly where it is not. When present
+// it MUST match; the path is pinned literally, so a moved script fails loudly.
+describe.skipIf(!fs.existsSync(CREATE_AGENT_SCRIPT))('provision.ts congruence with slack-create-agent.ts', () => {
+  it("the mirror's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(extractStringArray(src, 'MANAGED_BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'MANAGED_AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the mirror's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(CREATE_AGENT_SCRIPT, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+    expect(src).toContain('--allow-guests');
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts sets', () => {
+  it("the trunk provisioning module's scope/event sets match provision.ts exactly", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(extractStringArray(src, 'BOT_SCOPES')).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(extractStringArray(src, 'BOT_EVENTS')).toEqual([...MANAGED_BOT_EVENTS]);
+    expect(extractStringArray(src, 'AGENT_BOT_SCOPES')).toEqual([...MANAGED_AGENT_BOT_SCOPES]);
+    expect(extractStringArray(src, 'AGENT_BOT_EVENTS')).toEqual([...MANAGED_AGENT_BOT_EVENTS]);
+  });
+
+  it("the trunk provisioning module's manifest carries the agent_view variant pair", () => {
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    expect(src).toContain('agentView?: boolean');
+    expect(src).toContain('agent_view: { agent_description: MANAGED_APP_DESCRIPTION }');
+  });
+});
+
+describe('provision.ts manifest shape (broker-congruent, both variants)', () => {
+  it('MANAGED_BOT_SCOPES = base + canvas scopes + send_file scope, bot scopes only', () => {
+    expect([...MANAGED_BOT_SCOPES]).toEqual([...BASE_BOT_SCOPES, ...CANVAS_SCOPES, ...SEND_FILE_SCOPES]);
+  });
+
+  it('MANAGED_BOT_EVENTS = base + membership events', () => {
+    expect([...MANAGED_BOT_EVENTS]).toEqual([...BASE_BOT_EVENTS, ...MEMBERSHIP_EVENTS]);
+  });
+
+  it('agent-mode additions are exactly assistant:write + the two agent events', () => {
+    expect([...MANAGED_AGENT_BOT_SCOPES]).toEqual(['assistant:write']);
+    expect([...MANAGED_AGENT_BOT_EVENTS]).toEqual(['app_home_opened', 'app_context_changed']);
+  });
+
+  interface ManifestShape {
+    display_information: { name: string; description: string };
+    features: {
+      bot_user: { display_name: string; always_online: boolean };
+      agent_view?: { agent_description: string };
+    };
+    oauth_config: { scopes: { bot: string[]; user?: string[] } };
+    settings: {
+      event_subscriptions: { bot_events: string[] };
+      socket_mode_enabled: boolean;
+      interactivity: { is_enabled: boolean };
+    };
+  }
+
+  it('default variant is agent-mode: agent_view + assistant:write + agent events', () => {
+    const manifest = buildManagedAppManifest('Research') as unknown as ManifestShape;
+    expect(manifest.display_information.name).toBe('Research');
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+    expect(manifest.features.bot_user).toEqual({ display_name: 'Research', always_online: true });
+    // The agent_description doubles as the attribution line (≤300-char field).
+    expect(manifest.features.agent_view).toEqual({ agent_description: MANAGED_APP_DESCRIPTION });
+    expect(MANAGED_APP_DESCRIPTION.length).toBeLessThanOrEqual(300);
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES]);
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([
+      ...MANAGED_BOT_EVENTS,
+      ...MANAGED_AGENT_BOT_EVENTS,
+    ]);
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    expect(manifest.settings.interactivity.is_enabled).toBe(false);
+  });
+
+  it('plain variant (agentView:false) omits agent_view, assistant:write, and the agent events', () => {
+    const manifest = buildManagedAppManifest('Research', { agentView: false }) as unknown as ManifestShape;
+    expect(manifest.features.agent_view).toBeUndefined();
+    expect(manifest.oauth_config.scopes.bot).toEqual([...MANAGED_BOT_SCOPES]);
+    expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write');
+    expect(manifest.settings.event_subscriptions.bot_events).toEqual([...MANAGED_BOT_EVENTS]);
+    for (const ev of MANAGED_AGENT_BOT_EVENTS) {
+      expect(manifest.settings.event_subscriptions.bot_events).not.toContain(ev);
+    }
+    // Both still carry the always-on additions.
+    for (const scope of CANVAS_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const scope of SEND_FILE_SCOPES) expect(manifest.oauth_config.scopes.bot).toContain(scope);
+    for (const ev of MEMBERSHIP_EVENTS) expect(manifest.settings.event_subscriptions.bot_events).toContain(ev);
+    expect(manifest.display_information.description).toBe(MANAGED_APP_DESCRIPTION);
+  });
+
+  it('both variants stay bot-scopes-only (apps.managedInstall eligibility)', () => {
+    for (const agentView of [true, false]) {
+      const manifest = buildManagedAppManifest('Research', { agentView }) as unknown as ManifestShape;
+      expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['bot']);
+    }
+  });
+});
+
+describe('provision.ts congruence with src/provisioning/slack-app.ts', () => {
+  it('broker base + override key + endpoint match the trunk provisioning module', () => {
+    expect(fs.existsSync(SLACK_PROVISION), `${SLACK_PROVISION} not found — the trunk provisioning module moved?`).toBe(
+      true,
+    );
+    const src = fs.readFileSync(SLACK_PROVISION, 'utf-8');
+    const base = src.match(/export const DEFAULT_SLACK_SERVICE_BASE = '([^']+)'/);
+    expect(base?.[1]).toBe(DEFAULT_BROKER_BASE);
+    expect(src).toContain("'SLACK_SERVICE_BASE'");
+    expect(src).toContain("'/v1/apps'");
+  });
+});
+
+describe('provisionSlackApp broker body (allow_guests threading)', () => {
+  let rootDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-broker-'));
+    fs.writeFileSync(path.join(rootDir, '.env'), 'NANOCLAW_INSTALL_TOKEN=install-token-1\n');
+    for (const key of ['NANOCLAW_REGISTRY_TOKEN', 'SLACK_MANAGER_TOKEN', 'SLACK_SERVICE_BASE']) {
+      vi.stubEnv(key, '');
+    }
+    fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith('/v1/avatars')) {
+        // Generation unavailable → no avatar poll loop, no avatar_id in the create body.
+        return new Response(JSON.stringify({ avatar_id: null, status: 'unavailable' }), { status: 200 });
+      }
+      if (u.endsWith('/v1/apps')) {
+        return new Response(JSON.stringify({ app_id: 'A123', app_token: 'xapp-test', bot_token: 'xoxb-test' }), {
+          status: 201,
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  const createBody = (): Record<string, unknown> => {
+    const call = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/v1/apps'));
+    expect(call, 'POST /v1/apps was never called').toBeTruthy();
+    return JSON.parse((call![1] as RequestInit).body as string) as Record<string, unknown>;
+  };
+
+  it('omits allow_guests by default (broker provisions the agent-mode variant)', async () => {
+    const result = await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1' });
+    expect(result.reused).toBe(false);
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel' });
+  });
+
+  it('threads allowGuests:true into the body as allow_guests (plain variant)', async () => {
+    await provisionSlackApp({ slug: 'pixel', displayName: 'Pixel', rootDir, teamId: 'T1', allowGuests: true });
+    expect(createBody()).toEqual({ team_id: 'T1', name: 'Pixel', allow_guests: true });
+  });
+});
+
+describe('resolveProvisioningCredential', () => {
+  let rootDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-root-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-prov-home-'));
+    // Neutralize the real environment — every key this resolver consults.
+    for (const key of [
+      'NANOCLAW_REGISTRY_TOKEN',
+      'NANOCLAW_INSTALL_TOKEN',
+      'SLACK_MANAGER_TOKEN',
+      'SLACK_SERVICE_BASE',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  const writeEnv = (lines: string[]): void => fs.writeFileSync(path.join(rootDir, '.env'), lines.join('\n') + '\n');
+  const writeAccount = (content: string): void => {
+    const dir = path.join(homeDir, '.config', 'nanoclaw');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'account.json'), content);
+  };
+  const resolve = (): ReturnType<typeof resolveProvisioningCredential> =>
+    resolveProvisioningCredential(rootDir, { homeDir });
+
+  it('returns null when no credential exists anywhere', () => {
+    expect(resolve()).toBeNull();
+  });
+
+  it('process.env NANOCLAW_REGISTRY_TOKEN wins over every other source', () => {
+    vi.stubEnv('NANOCLAW_REGISTRY_TOKEN', 'registry-token-from-env');
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'registry-token-from-env',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('.env NANOCLAW_INSTALL_TOKEN beats account.json and the manager token', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: DEFAULT_BROKER_BASE,
+    });
+  });
+
+  it('falls back to ~/.config/nanoclaw/account.json before direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    writeAccount(JSON.stringify({ token: 'account-token' }));
+    expect(resolve()).toEqual({ mode: 'broker', installToken: 'account-token', baseUrl: DEFAULT_BROKER_BASE });
+  });
+
+  it('malformed account.json reads as not-enrolled, not an error', () => {
+    writeAccount('{not json');
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('account.json without a usable token field reads as not-enrolled', () => {
+    writeAccount(JSON.stringify({ token: '   ' }));
+    expect(resolve()).toBeNull();
+  });
+
+  it('SLACK_MANAGER_TOKEN alone selects direct mode', () => {
+    writeEnv(['SLACK_MANAGER_TOKEN=manager-token-1']);
+    expect(resolve()).toEqual({ mode: 'direct', managerToken: 'manager-token-1' });
+  });
+
+  it('SLACK_SERVICE_BASE overrides the broker base, trailing slashes stripped', () => {
+    writeEnv(['NANOCLAW_INSTALL_TOKEN=install-token-from-file', 'SLACK_SERVICE_BASE=https://broker.example.test///']);
+    expect(resolve()).toEqual({
+      mode: 'broker',
+      installToken: 'install-token-from-file',
+      baseUrl: 'https://broker.example.test',
+    });
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.prefetch.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.prefetch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Avatar prefetch (multi-agent creates): prefetchAvatar starts the broker job
+ * in the background; the flow's later requestAvatar with the same
+ * (displayName, description) consumes that in-flight job instead of starting
+ * a second generation. A key miss or an already-consumed entry falls back to
+ * a fresh request.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAvatarPrefetches, prefetchAvatar, requestAvatar } from './provision.js';
+
+const fetchMock = vi.fn();
+
+function avatarBrokerResponses(id: string): void {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.endsWith('/v1/avatars')) {
+      return Promise.resolve(new Response(JSON.stringify({ avatar_id: id }), { status: 200 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ status: 'ready' }), { status: 200 }));
+  });
+}
+
+function postCount(): number {
+  return fetchMock.mock.calls.filter((c) => (c as [string])[0].endsWith('/v1/avatars')).length;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  clearAvatarPrefetches();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearAvatarPrefetches();
+});
+
+describe('avatar prefetch', () => {
+  it('requestAvatar consumes a pending prefetch — exactly one generation job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBe('av-1');
+    expect(postCount()).toBe(1);
+  });
+
+  it('a prefetch is consumed once — the next same-key request goes fresh', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('different (name, description) keys never share a job', async () => {
+    avatarBrokerResponses('av-x');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    await requestAvatar('https://broker', 'tok', 'Maya', 'designer');
+
+    expect(postCount()).toBe(2);
+  });
+
+  it('duplicate prefetches for one key start one job', async () => {
+    avatarBrokerResponses('av-1');
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(postCount()).toBe(1);
+  });
+
+  it('a failed prefetch resolves undefined without throwing into the flow', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    prefetchAvatar('https://broker', 'tok', 'Maya', 'content writer');
+    const id = await requestAvatar('https://broker', 'tok', 'Maya', 'content writer');
+
+    expect(id).toBeUndefined();
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/provision.ts
@@ -1,0 +1,797 @@
+/**
+ * Managed Slack app provisioning for the slack-agent-flow leg.
+ *
+ * CONGRUENCE — this file deliberately duplicates:
+ * - src/provisioning/slack-app.ts (trunk provisioning module) — broker
+ *   protocol (install token from
+ *   ~/.config/nanoclaw/account.json or NANOCLAW_REGISTRY_TOKEN, base
+ *   SLACK_SERVICE_BASE else https://slack.nanoclaw.dev, POST /v1/apps) and the
+ *   direct apps.manifest.create + apps.managedInstall pair.
+ * - .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts —
+ *   MANAGED_BOT_SCOPES / MANAGED_BOT_EVENTS / buildManagedAppManifest,
+ *   credential resolution order, and the crash-safe persist-before-return
+ *   .env write (its step 1/3).
+ * This file, both mirrors, and the broker's server template all carry the
+ * SAME sets: base + canvas scopes, membership events, and the agent_view
+ * variant pair.
+ * provision.congruence.test.ts pins the mirrors against this file's sets and
+ * this file against the broker contract.
+ *
+ * The manager/install token is read, used as a Bearer header, and forgotten.
+ * Only the derived per-app bot/app tokens persist (to .env). No token value
+ * is ever logged or embedded in an error message.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { appendToEnvList, readEnvValue, upsertEnvKey } from './env-file.js';
+import { SlackFlowError, type ProvisionInput, type ProvisionResult } from './types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** The deployed managed-Slack broker. Overridable via SLACK_SERVICE_BASE. */
+export const DEFAULT_BROKER_BASE = 'https://slack.nanoclaw.dev';
+
+/**
+ * The managed-apps bot scope set — bot scopes only, no user scopes (that is
+ * the apps.managedInstall eligibility rule). Superset of MANAGED_BOT_SCOPES
+ * in slack-create-agent.ts (the base set) plus the canvas scopes; must stay
+ * identical to the broker's server-side BOT_SCOPES — apps provisioned via
+ * either transport must be scope-identical (pinned by
+ * provision.congruence.test.ts). im:write is what lets the new bot open the
+ * operator DM; mpim:* is what lets it open the three-way room; canvases:* +
+ * files:read is the room-canvas surface (files:read is the read-back path —
+ * canvases are files, the HTML download carries section ids).
+ */
+export const MANAGED_BOT_SCOPES: readonly string[] = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:write',
+  'mpim:write',
+  'mpim:history',
+  'mpim:read',
+  'im:write',
+  'canvases:read',
+  'canvases:write',
+  'files:read',
+  // send_file: agents deliver files they produce (charts, documents,
+  // generated artifacts) via files upload — live-verified missing_scope
+  // failure without it (filesUploadV2 needs files:write).
+  'files:write',
+];
+
+// member_joined/left_channel ride on the channels/groups/mpim:read scopes
+// already present (join-time adopt flow + membership bookkeeping).
+export const MANAGED_BOT_EVENTS: readonly string[] = [
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'app_mention',
+  'member_joined_channel',
+  'member_left_channel',
+];
+
+/**
+ * Agent-mode (features.agent_view) additions — the default variant. Slack
+ * auto-adds assistant:write when agent_view is enabled; declared explicitly
+ * so the manifest states what the app holds. Guests are hard-blocked from
+ * agent-enabled apps, so allowGuests selects the plain variant instead.
+ */
+export const MANAGED_AGENT_BOT_SCOPES: readonly string[] = ['assistant:write'];
+
+export const MANAGED_AGENT_BOT_EVENTS: readonly string[] = ['app_home_opened', 'app_context_changed'];
+
+/**
+ * Fixed attribution line: admins see this, never the creation prompt. Also
+ * the agent_view.agent_description (≤300 chars) on the agent-mode variant.
+ */
+export const MANAGED_APP_DESCRIPTION =
+  'Personal AI agent, provisioned and managed by the NanoClaw app. Learn more at nanoclaw.dev/slack.';
+
+/**
+ * Socket-Mode-only managed-app manifest (see the congruence note above).
+ * Two variants, chosen at provision time — agent_view is a one-way door:
+ * agent-mode (default; free workspaces degrade to a plain DM) and plain
+ * (agentView:false, for workspaces that need guest access).
+ */
+export function buildManagedAppManifest(
+  displayName: string,
+  opts: { agentView?: boolean } = {},
+): Record<string, unknown> {
+  const agentView = opts.agentView ?? true;
+  return {
+    display_information: {
+      name: displayName,
+      description: MANAGED_APP_DESCRIPTION,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: displayName,
+        always_online: true,
+      },
+      ...(agentView ? { agent_view: { agent_description: MANAGED_APP_DESCRIPTION } } : {}),
+    },
+    oauth_config: {
+      scopes: { bot: agentView ? [...MANAGED_BOT_SCOPES, ...MANAGED_AGENT_BOT_SCOPES] : [...MANAGED_BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: agentView ? [...MANAGED_BOT_EVENTS, ...MANAGED_AGENT_BOT_EVENTS] : [...MANAGED_BOT_EVENTS],
+      },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+/**
+ * Which provisioning credential this install holds, in the decisive order:
+ * process.env.NANOCLAW_REGISTRY_TOKEN → .env NANOCLAW_INSTALL_TOKEN →
+ * ~/.config/nanoclaw/account.json (broker mode; base = SLACK_SERVICE_BASE
+ * else DEFAULT_BROKER_BASE) → .env SLACK_MANAGER_TOKEN (direct mode) → null.
+ *
+ * `opts.homeDir` overrides os.homedir() for tests only — the account.json
+ * credential is deliberately per-user, not per-checkout.
+ */
+export function resolveProvisioningCredential(
+  rootDir: string,
+  opts: { homeDir?: string } = {},
+): { mode: 'broker'; installToken: string; baseUrl: string } | { mode: 'direct'; managerToken: string } | null {
+  const baseUrl = (readEnvValue(rootDir, 'SLACK_SERVICE_BASE') ?? DEFAULT_BROKER_BASE).replace(/\/+$/, '');
+
+  const fromEnv = process.env.NANOCLAW_REGISTRY_TOKEN?.trim();
+  if (fromEnv) return { mode: 'broker', installToken: fromEnv, baseUrl };
+
+  const installToken = readEnvValue(rootDir, 'NANOCLAW_INSTALL_TOKEN');
+  if (installToken) return { mode: 'broker', installToken, baseUrl };
+
+  // Enrollment persists the install token at ~/.config/nanoclaw/account.json
+  // ({ token: "…" }). Malformed or missing reads as "not enrolled".
+  try {
+    const accountPath = path.join(opts.homeDir ?? os.homedir(), '.config', 'nanoclaw', 'account.json');
+    const parsed: unknown = JSON.parse(fs.readFileSync(accountPath, 'utf-8'));
+    const token = (parsed as { token?: unknown } | null)?.token;
+    if (typeof token === 'string' && token.trim()) {
+      return { mode: 'broker', installToken: token.trim(), baseUrl };
+    }
+  } catch {
+    // fall through to direct mode
+  }
+
+  const managerToken = readEnvValue(rootDir, 'SLACK_MANAGER_TOKEN');
+  if (managerToken) return { mode: 'direct', managerToken };
+
+  return null;
+}
+
+interface RawProvisioned {
+  appId: string;
+  appToken: string;
+  botToken?: string;
+  installUrl?: string;
+  installError?: string;
+}
+
+/**
+ * Optional request-origin metadata on the broker's POST /v1/apps body
+ * (requested_by / parent_app_id / template / client_version on the wire).
+ * Sent only when defined; a broker that predates them ignores unknown body
+ * fields. Names and no-value-no-key behavior are pinned across every
+ * provisioning home by provision.congruence.test.ts. The direct transport has
+ * nowhere to record them and never forwards them.
+ */
+interface ProvisionAttribution {
+  requestedBy?: string;
+  parentAppId?: string;
+  template?: string;
+  clientVersion?: string;
+}
+
+/**
+ * The installing host's package.json version — the client_version metadata
+ * field. Optional-shaped: unreadable/absent → undefined and the field is
+ * simply omitted (never a placeholder value).
+ */
+function readClientVersion(rootDir: string): string | undefined {
+  try {
+    const pkg: unknown = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
+    const version = (pkg as { version?: unknown } | null)?.version;
+    return typeof version === 'string' && version.trim() ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Broker mode: POST /v1/apps with the install token; 60s budget. */
+/** Poll cap for the pre-create avatar job — beyond it the bot is born with the mascot. */
+const AVATAR_WAIT_MS = 75_000;
+// Generation measures ~20-23s at the broker's floor settings (quality 'low',
+// 1024px is the model's minimum) — a 2s poll wastes at most ~2s of that,
+// where the old 4s poll wasted up to 4.
+const AVATAR_POLL_MS = 2_000;
+
+// ── Avatar prefetch (multi-agent creates) ──
+//
+// Each generation is an independent async Lambda on the broker, so N avatars
+// CAN run concurrently — the serialization was ours: flows run one at a time,
+// each paying the full ~23s avatar wait. The delivery batch preview
+// (index.ts) starts a prefetch for every create_agent in the batch in
+// parallel; requestAvatar consumes the matching prefetch instead of starting
+// a fresh job, collapsing N waits to ~one. Keyed by the exact
+// (displayName, description) derivation the flow uses, so a miss just means
+// a normal fresh request.
+const avatarPrefetches = new Map<string, { promise: Promise<string | undefined>; at: number }>();
+const AVATAR_PREFETCH_TTL_MS = 10 * 60_000;
+
+function avatarKey(displayName: string, description: string | undefined): string {
+  return `${displayName}\u0000${description ?? ''}`;
+}
+
+/** Start an avatar generation in the background for a create that is about to
+ *  be processed. Fire-and-forget; never throws. Deduped per key. */
+export function prefetchAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): void {
+  const key = avatarKey(displayName, description);
+  const existing = avatarPrefetches.get(key);
+  if (existing && Date.now() - existing.at < AVATAR_PREFETCH_TTL_MS) return;
+  avatarPrefetches.set(key, {
+    promise: requestAvatarFresh(baseUrl, installToken, displayName, description).catch(() => undefined),
+    at: Date.now(),
+  });
+}
+
+/** Test seam: drop all pending prefetches. */
+export function clearAvatarPrefetches(): void {
+  avatarPrefetches.clear();
+}
+
+/**
+ * Ask the broker to generate the agent's avatar BEFORE the app exists, so the
+ * bot's very first workspace appearance wears its face — the mascot default
+ * never shows on the happy path. Consumes a matching prefetch when one is
+ * pending (multi-agent creates start them in parallel). Returns undefined
+ * when generation is unavailable, failed, or over the wait cap (degraded
+ * path: mascot).
+ */
+export async function requestAvatar(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  const key = avatarKey(displayName, description);
+  const hit = avatarPrefetches.get(key);
+  if (hit) {
+    avatarPrefetches.delete(key);
+    if (Date.now() - hit.at < AVATAR_PREFETCH_TTL_MS) return hit.promise;
+  }
+  return requestAvatarFresh(baseUrl, installToken, displayName, description);
+}
+
+async function requestAvatarFresh(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  description: string | undefined,
+): Promise<string | undefined> {
+  let avatarId: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/v1/avatars`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${installToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: displayName, ...(description ? { description } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = (await res.json()) as { avatar_id?: string | null };
+    avatarId = data.avatar_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+  if (!avatarId) return undefined;
+  const deadline = Date.now() + AVATAR_WAIT_MS;
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) await new Promise((r) => setTimeout(r, AVATAR_POLL_MS));
+    try {
+      const res = await fetch(`${baseUrl}/v1/avatars/${avatarId}`, {
+        headers: { Authorization: `Bearer ${installToken}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'ready') return avatarId;
+      if (data.status && data.status !== 'pending') return undefined;
+    } catch {
+      // Transient — bounded by the deadline.
+    }
+  }
+  return undefined;
+}
+
+async function provisionViaBroker(
+  baseUrl: string,
+  installToken: string,
+  displayName: string,
+  teamId: string | undefined,
+  description: string | undefined,
+  allowGuests = false,
+  attribution: ProvisionAttribution = {},
+): Promise<RawProvisioned> {
+  if (!teamId) {
+    throw new SlackFlowError(
+      'broker',
+      'broker mode needs the origin workspace team_id (origin auth.test returned none)',
+    );
+  }
+  const avatarId = await requestAvatar(baseUrl, installToken, displayName, description);
+  let res: Response;
+  let text: string;
+  try {
+    res = await fetch(`${baseUrl}/v1/apps`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${installToken}`,
+        'Content-Type': 'application/json',
+      },
+      // The deployed broker's contract (POST /v1/apps): it builds the manifest
+      // server-side (agent-mode variant unless allow_guests) and generates
+      // the per-agent avatar from the description.
+      body: JSON.stringify({
+        team_id: teamId,
+        name: displayName,
+        ...(avatarId ? { avatar_id: avatarId } : {}),
+        ...(allowGuests ? { allow_guests: true } : {}),
+        // Request-origin metadata — optional both ways: omitted when
+        // unknown, ignored by a broker that predates the fields.
+        ...(attribution.requestedBy ? { requested_by: attribution.requestedBy } : {}),
+        ...(attribution.parentAppId ? { parent_app_id: attribution.parentAppId } : {}),
+        ...(attribution.template ? { template: attribution.template } : {}),
+        ...(attribution.clientVersion ? { client_version: attribution.clientVersion } : {}),
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    text = await res.text();
+  } catch (err) {
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let data: Record<string, unknown>;
+  try {
+    data = (text ? JSON.parse(text) : {}) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('broker', `broker POST /v1/apps failed: HTTP ${res.status}, non-JSON body`);
+  }
+  if (!res.ok) {
+    // message is the human sentence, error the machine code — show the human one.
+    const detail = (data as { message?: string; error?: string }).message ?? (data as { error?: string }).error;
+    throw new SlackFlowError(
+      'broker',
+      `broker POST /v1/apps failed: HTTP ${res.status}${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+  // Contract shape is camelCase; the deployed broker speaks snake_case
+  // (BrokerAppResponse in src/provisioning/slack-app.ts) — accept both.
+  const pick = (a: unknown, b: unknown): string | undefined =>
+    typeof a === 'string' && a ? a : typeof b === 'string' && b ? b : undefined;
+  const appId = pick(data.appId, data.app_id);
+  const appToken = pick(data.appToken, data.app_token);
+  if (!appId || !appToken) {
+    throw new SlackFlowError('broker', 'broker POST /v1/apps failed: response missing app id or app token');
+  }
+  return {
+    appId,
+    appToken,
+    botToken: pick(data.botToken, data.bot_token),
+    installUrl: pick(data.installUrl, data.install_url),
+    installError: pick(data.installError, data.install_error),
+  };
+}
+
+// ── Deferred install completion (broker transport) ──
+//
+// A workspace with an admin-approval policy refuses auto-install: POST
+// /v1/apps answers with an install_url and no bot token. That URL carries its
+// own signed state and stays valid for days, so the app is not lost — it sits
+// at pending_install until a human completes the install in the browser, and
+// GET /v1/apps/{app_id} then releases the bot token exactly once. Mirrors
+// waitForInstall in src/provisioning/slack-app.ts.
+
+/** Poll cadence while a workspace install approval is outstanding. */
+export const INSTALL_POLL_INTERVAL_MS = 5_000;
+/** How long the flow waits inline before parking the app for a later resume. */
+export const INSTALL_POLL_TIMEOUT_MS = 5 * 60_000;
+
+type AppStatus = 'installed' | 'pending_install' | 'deleted';
+
+interface AppState {
+  status: AppStatus;
+  botToken?: string;
+}
+
+/**
+ * One app's state, or undefined when the service does not know it (404) —
+ * which for every caller here means the same as "stop waiting". Transport
+ * failures throw so the poll loop can decide whether they are worth retrying.
+ */
+async function fetchAppState(baseUrl: string, installToken: string, appId: string): Promise<AppState | undefined> {
+  const res = await fetch(`${baseUrl}/v1/apps/${encodeURIComponent(appId)}`, {
+    headers: { Authorization: `Bearer ${installToken}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (res.status === 404) return undefined;
+  if (res.status === 401 || res.status === 403) {
+    throw new SlackFlowError(
+      'install-wait',
+      `the Slack service refused this install's credentials (HTTP ${res.status})`,
+    );
+  }
+  if (!res.ok) throw new Error(`GET /v1/apps/${appId}: HTTP ${res.status}`);
+  const data = (await res.json()) as { status?: string; bot_token?: string | null; botToken?: string | null };
+  const status = data.status;
+  if (status !== 'installed' && status !== 'pending_install' && status !== 'deleted') {
+    throw new Error(`GET /v1/apps/${appId}: unrecognized status '${String(status)}'`);
+  }
+  // Contract shape is snake_case; accept camelCase the way the create call does.
+  const botToken = data.bot_token ?? data.botToken ?? undefined;
+  return { status, ...(botToken ? { botToken } : {}) };
+}
+
+/**
+ * Wait out a pending install and return the one-time bot token.
+ *
+ * Undefined means "stop waiting and park the app": the deadline passed, the
+ * service does not know the app, it was deleted, or it reads as installed with
+ * no token left to give (someone else already took it — no further poll
+ * recovers it). A credential refusal is the one failure worth surfacing, since
+ * the next poll cannot change that answer.
+ */
+export async function waitForInstall(
+  baseUrl: string,
+  installToken: string,
+  appId: string,
+  opts: { intervalMs?: number; timeoutMs?: number; checkImmediately?: boolean } = {},
+): Promise<string | undefined> {
+  const intervalMs = opts.intervalMs ?? INSTALL_POLL_INTERVAL_MS;
+  const deadline = Date.now() + (opts.timeoutMs ?? INSTALL_POLL_TIMEOUT_MS);
+  // A resume checks straight away — the approval may have landed while nobody
+  // was waiting, and that is worth one call even when the budget is zero. A
+  // fresh refusal sleeps first: nothing can have changed in the instant since
+  // the service said no.
+  let due = opts.checkImmediately === true;
+  while (due || Date.now() < deadline) {
+    if (!due) await new Promise((r) => setTimeout(r, intervalMs));
+    due = false;
+    let state: AppState | undefined;
+    try {
+      state = await fetchAppState(baseUrl, installToken, appId);
+    } catch (err) {
+      if (err instanceof SlackFlowError) throw err;
+      continue; // transient — the deadline already bounds this
+    }
+    if (!state || state.status === 'deleted') return undefined;
+    if (state.status === 'installed') return state.botToken;
+  }
+  return undefined;
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+async function slackApi<T extends SlackApiResponse>(
+  method: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API}/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(params).toString(),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new SlackFlowError('direct-create', `${method} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok && res.status !== 200) throw new SlackFlowError('direct-create', `${method}: HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+/** Direct mode: apps.manifest.create + apps.managedInstall with the manager token. */
+async function provisionDirect(
+  managerToken: string,
+  displayName: string,
+  allowGuests = false,
+): Promise<RawProvisioned> {
+  const created = await slackApi<
+    SlackApiResponse & { app_id?: string; app_token?: string; oauth_authorize_url?: string }
+  >('apps.manifest.create', managerToken, {
+    manifest: JSON.stringify(buildManagedAppManifest(displayName, { agentView: !allowGuests })),
+    generate_app_token: 'true',
+  });
+  if (!created.ok || !created.app_id) {
+    throw new SlackFlowError(
+      'direct-create',
+      `apps.manifest.create failed: ${created.error ?? 'no app_id in response'}`,
+    );
+  }
+  if (!created.app_token) {
+    throw new SlackFlowError(
+      'direct-create',
+      'apps.manifest.create returned no app-level token (generate_app_token unsupported?)',
+    );
+  }
+  const result: RawProvisioned = {
+    appId: created.app_id,
+    appToken: created.app_token,
+    installUrl: created.oauth_authorize_url ?? '',
+  };
+  const installed = await slackApi<SlackApiResponse & { api_access_tokens?: { bot_access_token?: string } }>(
+    'apps.managedInstall',
+    managerToken,
+    { app_id: created.app_id },
+  );
+  if (installed.ok && installed.api_access_tokens?.bot_access_token) {
+    result.botToken = installed.api_access_tokens.bot_access_token;
+  } else {
+    result.installError = installed.error ?? 'no bot token in response';
+  }
+  return result;
+}
+
+/** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix shape. */
+export function envKeySuffix(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * The .env keys one provisioned instance owns. The app id and install URL are
+ * the resume state for an app whose workspace has not approved the install
+ * yet: without them a retry has nothing to poll and can only create a second
+ * Slack app for the same agent.
+ */
+export function envKeysForSlug(slug: string): {
+  botKey: string;
+  appKey: string;
+  appIdKey: string;
+  installUrlKey: string;
+} {
+  const suffix = envKeySuffix(slug);
+  return {
+    botKey: `SLACK_BOT_TOKEN_${suffix}`,
+    appKey: `SLACK_APP_TOKEN_${suffix}`,
+    appIdKey: `SLACK_APP_ID_${suffix}`,
+    installUrlKey: `SLACK_INSTALL_URL_${suffix}`,
+  };
+}
+
+/**
+ * The app this slug has parked awaiting a workspace install approval, if any:
+ * an app token and an app id on record, no bot token yet. Callers use it to
+ * tell "finish what you started" apart from "start something new".
+ */
+export function pendingInstall(rootDir: string, slug: string): { appId: string; installUrl?: string } | undefined {
+  const { botKey, appKey, appIdKey, installUrlKey } = envKeysForSlug(slug);
+  if (readEnvValue(rootDir, botKey)) return undefined;
+  if (!readEnvValue(rootDir, appKey)) return undefined;
+  const appId = readEnvValue(rootDir, appIdKey);
+  if (!appId) return undefined;
+  return { appId, installUrl: readEnvValue(rootDir, installUrlKey) };
+}
+
+/** Best-effort: a caller's notification must never take the flow down with it. */
+async function announcePending(
+  input: ProvisionInput,
+  info: { appId: string; installUrl?: string; resumed: boolean },
+): Promise<void> {
+  try {
+    await input.onInstallPending?.(info);
+  } catch {
+    // The wait is the point; the announcement is a courtesy.
+  }
+}
+
+/** What the human is told when the wait runs out and the app stays parked. */
+function parkedError(displayName: string, appId: string, installUrl: string | undefined): SlackFlowError {
+  return new SlackFlowError(
+    'install-wait',
+    `Slack app ${appId} for "${displayName}" is still waiting on a workspace install approval. ` +
+      `Nothing was lost and nothing needs re-creating — the app is saved. ` +
+      `${installUrl ? `Approve the install at ${installUrl}, then ask` : 'Once the install is approved, ask'} ` +
+      `to finish setting up ${displayName} and it picks up from here.`,
+  );
+}
+
+/**
+ * Provision (or reuse, or finish) the named instance's Slack app and persist
+ * its tokens.
+ *
+ * Three entries, decided by what .env already holds:
+ *  - both tokens → reuse, no network.
+ *  - app token + app id, no bot token → an app parked awaiting a workspace
+ *    install approval: poll for it rather than provision a second one.
+ *  - nothing → provision. A refused auto-install is not the end of the road:
+ *    the app is real and its install URL stays valid, so the flow announces
+ *    the approval and waits inline for the install to land.
+ *
+ * .env is the resume state, so everything derivable is written the moment it
+ * exists (mirrors slack-create-agent.ts) — a failure after that point never
+ * re-provisions a duplicate Slack app on retry.
+ */
+export async function provisionSlackApp(input: ProvisionInput): Promise<ProvisionResult> {
+  const { slug, displayName, rootDir } = input;
+  const envSuffix = envKeySuffix(slug);
+  const { botKey, appKey, appIdKey, installUrlKey } = envKeysForSlug(slug);
+
+  const existingBot = readEnvValue(rootDir, botKey);
+  const existingApp = readEnvValue(rootDir, appKey);
+  if (existingBot && existingApp) {
+    return {
+      slug,
+      envSuffix,
+      botToken: existingBot,
+      appToken: existingApp,
+      // Recorded since the deferred-install work; older installs have no row,
+      // and nothing downstream of provisioning needs the id.
+      appId: readEnvValue(rootDir, appIdKey) ?? '',
+      reused: true,
+    };
+  }
+  if (existingBot && !existingApp) {
+    throw new SlackFlowError(
+      'no-credentials',
+      `${botKey} is set but ${appKey} is missing — add the app-level xapp-… token to .env as ${appKey} and retry.`,
+    );
+  }
+
+  const credential = resolveProvisioningCredential(rootDir);
+
+  if (existingApp && !existingBot) {
+    const parked = pendingInstall(rootDir, slug);
+    // No app id on record (or no broker to ask) leaves the hand-finish
+    // instructions as the only honest answer.
+    if (!parked || credential?.mode !== 'broker') {
+      throw new SlackFlowError(
+        'no-credentials',
+        `${appKey} is set but ${botKey} is missing — the app exists but was never installed. ` +
+          `Finish the install from the app's page in Slack, put the xoxb-… token in .env as ${botKey}, and retry.`,
+      );
+    }
+    await announcePending(input, { appId: parked.appId, installUrl: parked.installUrl, resumed: true });
+    const botToken = await waitForInstall(credential.baseUrl, credential.installToken, parked.appId, {
+      ...input.installWait,
+      checkImmediately: true,
+    });
+    if (!botToken) throw parkedError(displayName, parked.appId, parked.installUrl);
+    persistInstalled(rootDir, slug, botToken);
+    return {
+      slug,
+      envSuffix,
+      botToken,
+      appToken: existingApp,
+      appId: parked.appId,
+      reused: false,
+      deferredInstall: true,
+    };
+  }
+
+  if (!credential) {
+    throw new SlackFlowError(
+      'no-credentials',
+      'no Slack provisioning credential: set NANOCLAW_INSTALL_TOKEN (managed service) or ' +
+        'SLACK_MANAGER_TOKEN (direct) in .env, or enroll this install with the registry.',
+    );
+  }
+
+  const allowGuests = input.allowGuests ?? false;
+  const app =
+    credential.mode === 'broker'
+      ? await provisionViaBroker(
+          credential.baseUrl,
+          credential.installToken,
+          displayName,
+          input.teamId,
+          input.description,
+          allowGuests,
+          {
+            requestedBy: input.requestedBy,
+            parentAppId: input.parentAppId,
+            template: input.template,
+            clientVersion: readClientVersion(rootDir),
+          },
+        )
+      : await provisionDirect(credential.managerToken, displayName, allowGuests);
+
+  // Persist what we have before anything else can fail. App token, app id and
+  // instance slug land even when auto-install was refused, so a later run can
+  // finish this app instead of creating another.
+  try {
+    upsertEnvKey(rootDir, appKey, app.appToken);
+    if (app.appId) upsertEnvKey(rootDir, appIdKey, app.appId);
+    if (app.botToken) upsertEnvKey(rootDir, botKey, app.botToken);
+    else if (app.installUrl) upsertEnvKey(rootDir, installUrlKey, app.installUrl);
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${appKey}/${botKey}/SLACK_INSTANCES to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!app.botToken) {
+    // Usually a workspace admin-approval policy refusing auto-install. On the
+    // broker transport that is a wait, not a dead end — the install URL is
+    // signed and long-lived, and the service releases the bot token once the
+    // install lands. The direct transport has no such read-back.
+    if (credential.mode === 'broker' && app.installUrl) {
+      await announcePending(input, { appId: app.appId, installUrl: app.installUrl, resumed: false });
+      const botToken = await waitForInstall(
+        credential.baseUrl,
+        credential.installToken,
+        app.appId,
+        input.installWait ?? {},
+      );
+      if (!botToken) throw parkedError(displayName, app.appId, app.installUrl);
+      persistInstalled(rootDir, slug, botToken);
+      return {
+        slug,
+        envSuffix,
+        botToken,
+        appToken: app.appToken,
+        appId: app.appId,
+        reused: false,
+        deferredInstall: true,
+      };
+    }
+    throw new SlackFlowError(
+      credential.mode === 'broker' ? 'broker' : 'direct-create',
+      `Slack refused to auto-install app ${app.appId} (${app.installError ?? 'unknown reason'}). ` +
+        `Install it by hand${app.installUrl ? ` from ${app.installUrl}` : " from the app's page at api.slack.com/apps"}, ` +
+        `put the xoxb-… token in .env as ${botKey}, and retry — the app token is already saved.`,
+    );
+  }
+
+  return { slug, envSuffix, botToken: app.botToken, appToken: app.appToken, appId: app.appId, reused: false };
+}
+
+/**
+ * Record a bot token that arrived after the wait, and retire the install URL
+ * that produced it — a consumed link left on disk reads as work still to do.
+ */
+function persistInstalled(rootDir: string, slug: string, botToken: string): void {
+  const { botKey, installUrlKey } = envKeysForSlug(slug);
+  try {
+    upsertEnvKey(rootDir, botKey, botToken);
+    upsertEnvKey(rootDir, installUrlKey, '');
+    appendToEnvList(rootDir, 'SLACK_INSTANCES', slug);
+  } catch (err) {
+    throw new SlackFlowError(
+      'env-write',
+      `failed writing ${botKey} to .env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Tests for the agent-facing room actions: create_room and
+ * add_to_room, driven through the REAL guard-wrapped delivery entries
+ * (getDeliveryAction) over a real in-memory central DB. Slack traffic is a
+ * recorded fetch stub (auth.test + conversations.open only — room actions
+ * never provision apps); the canvas leg is mocked like orchestrate.test.ts.
+ * rootDir is process.cwd(), so each test runs chdir'd into its own tmpdir.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelDefaults } from '../../channels/adapter.js';
+import type { Session } from '../../types.js';
+
+const ANDY_BOT_TOKEN = 'xoxb-andy-secret-token';
+const PIXEL_BOT_TOKEN = 'xoxb-pixel-secret-token';
+const DEVIN_BOT_TOKEN = 'xoxb-devin-secret-token';
+
+const { mockNotifyWrite, mockRequestApproval, mockWriteDestinations, mockCreateRoomCanvas, mockWireCanvasComments } =
+  vi.hoisted(() => ({
+    mockNotifyWrite: vi.fn(),
+    mockRequestApproval: vi.fn().mockResolvedValue(undefined),
+    mockWriteDestinations: vi.fn(),
+    mockCreateRoomCanvas: vi.fn(),
+    mockWireCanvasComments: vi.fn(),
+  }));
+
+// Room canvas (contract C2) — non-throwing, returns the canvas id or undefined.
+vi.mock('./room-canvas.js', () => ({
+  createRoomCanvas: (...a: unknown[]) => mockCreateRoomCanvas(...a),
+  wireCanvasComments: (...a: unknown[]) => mockWireCanvasComments(...a),
+}));
+// notifyAgent writes to the session inbound.db + wakes the container; stub both.
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (...a: unknown[]) => mockNotifyWrite(...a),
+  openInboundDb: vi.fn(),
+  openOutboundDb: vi.fn(),
+  clearOutbox: vi.fn(),
+  readOutboxFiles: vi.fn().mockReturnValue([]),
+  resolveSession: vi.fn(),
+  sessionDir: vi.fn().mockReturnValue('/tmp/nowhere'),
+  inboundDbPath: vi.fn().mockReturnValue('/tmp/nowhere/inbound.db'),
+}));
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({ initGroupFilesystem: vi.fn() }));
+vi.mock('../agent-to-agent/write-destinations.js', () => ({
+  writeDestinations: (...a: unknown[]) => mockWriteDestinations(...a),
+}));
+// The approvals barrel drags in the response handler + OneCLI bridge; the
+// room actions only need these three. notifyAgent stays REAL (primitive.js)
+// so notify texts flow through the mocked writeSessionMessage above.
+vi.mock('../approvals/index.js', async () => {
+  const primitive = await vi.importActual<typeof import('../approvals/primitive.js')>('../approvals/primitive.js');
+  return {
+    requestApproval: (...a: unknown[]) => mockRequestApproval(...a),
+    notifyAgent: primitive.notifyAgent,
+    registerApprovalHandler: vi.fn(),
+  };
+});
+
+// Registers the create_room / add_to_room delivery actions — the path under
+// test. Deliberately NOT src/modules/index.ts: the upstream a2a barrel stays
+// unloaded.
+import './index.js';
+import { getDeliveryAction } from '../../delivery.js';
+import { listGuardedActions } from '../../guard/index.js';
+import { log } from '../../log.js';
+import { registerChannelAdapter } from '../../channels/channel-registry.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { createDestination, getDestinationByName } from '../agent-to-agent/db/agent-destinations.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUser } from '../permissions/db/users.js';
+
+const TEST_SLACK_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'strict' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+const SRC_GROUP = 'ag-src';
+const SLACK_SESSION: Session = {
+  id: 'sess-1',
+  agent_group_id: SRC_GROUP,
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'stopped',
+  last_active: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ── fetch stub ──
+
+interface RecordedFetch {
+  url: string;
+  token: string;
+  body: string;
+}
+let fetchCalls: RecordedFetch[] = [];
+let tmpDir = '';
+// conversations.members response for the add_to_room source-room read.
+let sourceRoomMembers: string[] = [];
+let membersFail = false;
+
+const BOT_IDS: Record<string, string> = {
+  [ANDY_BOT_TOKEN]: 'U0ANDYBOT',
+  [PIXEL_BOT_TOKEN]: 'U0PIXELBOT',
+  [DEVIN_BOT_TOKEN]: 'U0DEVINBOT',
+};
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch(
+  input: unknown,
+  init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Response> {
+  const url = String(input);
+  const token = String(init?.headers?.Authorization ?? '').replace(/^Bearer\s+/i, '');
+  const body = typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+  fetchCalls.push({ url, token, body });
+
+  if (url.includes('/api/auth.test')) {
+    const userId = BOT_IDS[token];
+    if (!userId) return Promise.resolve(jsonResponse({ ok: false, error: 'invalid_auth' }));
+    return Promise.resolve(jsonResponse({ ok: true, user_id: userId, team_id: 'T0TEST' }));
+  }
+  if (url.includes('/api/conversations.members')) {
+    if (membersFail) return Promise.resolve(jsonResponse({ ok: false, error: 'fetch_members_failed' }));
+    return Promise.resolve(jsonResponse({ ok: true, members: sourceRoomMembers }));
+  }
+  if (url.includes('/api/conversations.open')) {
+    // add_to_room opens the superset AS the newly added agent (Devin in
+    // these tests) — that open forks; every other open is the original room.
+    return Promise.resolve(
+      jsonResponse({ ok: true, channel: { id: token === DEVIN_BOT_TOKEN ? 'G0FORK' : 'G0TEAM' } }),
+    );
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url}`));
+}
+
+// ── harness ──
+
+const originalCwd = process.cwd();
+let logSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+function notifyTexts(): string[] {
+  return mockNotifyWrite.mock.calls.map((c) => JSON.parse((c[2] as { content: string }).content).text as string);
+}
+
+function roomOpens(): RecordedFetch[] {
+  return fetchCalls.filter((c) => c.url.includes('conversations.open'));
+}
+
+async function runAction(
+  action: string,
+  content: Record<string, unknown>,
+  session: Session = SLACK_SESSION,
+): Promise<void> {
+  const wrapped = getDeliveryAction(action);
+  expect(wrapped).toBeDefined();
+  await wrapped!({ action, ...content }, session);
+}
+
+function assertNoTokenLeak(): void {
+  const everything = JSON.stringify([notifyTexts(), logSpies.map((s) => s.mock.calls)]);
+  for (const secret of [ANDY_BOT_TOKEN, PIXEL_BOT_TOKEN, DEVIN_BOT_TOKEN]) {
+    expect(everything).not.toContain(secret);
+  }
+}
+
+/** A provisioned sub-agent: group + DM wiring on its own instance + the
+ *  caller's a2a destination for it (what create_agent leaves behind). */
+async function seedSubAgent(name: string, groupId: string, instanceKey: string): Promise<void> {
+  const now = new Date().toISOString();
+  const localName = name.toLowerCase();
+  await createAgentGroup({ id: groupId, name, folder: localName, agent_provider: null, created_at: now });
+  const dmMgId = `mg-${localName}-dm`;
+  await createMessagingGroup({
+    id: dmMgId,
+    channel_type: 'slack',
+    platform_id: `slack:D0${name.toUpperCase()}DM`,
+    instance: instanceKey,
+    name: `${name} DM`,
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createMessagingGroupAgent({
+    id: `mga-${localName}-dm`,
+    messaging_group_id: dmMgId,
+    agent_group_id: groupId,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+  await createDestination({
+    agent_group_id: SRC_GROUP,
+    local_name: localName,
+    target_type: 'agent',
+    target_id: groupId,
+    created_at: now,
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockCreateRoomCanvas.mockResolvedValue(undefined);
+  fetchCalls = [];
+  // Faithful default: the source room holds exactly the operator + its bots.
+  sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT'];
+  membersFail = false;
+  vi.stubGlobal('fetch', fakeFetch);
+  logSpies = [
+    vi.spyOn(log, 'debug').mockImplementation(() => {}),
+    vi.spyOn(log, 'info').mockImplementation(() => {}),
+    vi.spyOn(log, 'warn').mockImplementation(() => {}),
+    vi.spyOn(log, 'error').mockImplementation(() => {}),
+  ];
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-room-actions-'));
+  process.chdir(tmpDir);
+  fs.writeFileSync(
+    path.join(tmpDir, '.env'),
+    `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\nSLACK_BOT_TOKEN_PIXEL=${PIXEL_BOT_TOKEN}\nSLACK_BOT_TOKEN_DEVIN=${DEVIN_BOT_TOKEN}\n`,
+  );
+
+  const db = await initTestDb();
+  await runMigrations(db);
+
+  const now = new Date().toISOString();
+  await createAgentGroup({ id: SRC_GROUP, name: 'Andy', folder: 'andy', agent_provider: null, created_at: now });
+  await ensureContainerConfig(SRC_GROUP);
+  await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'global' }); // guard allows without a hold
+  await upsertUser({ id: 'slack:U0OPERATOR', kind: 'slack', display_name: 'Op', created_at: now });
+  await grantRole({
+    user_id: 'slack:U0OPERATOR',
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: now,
+  });
+  await createMessagingGroup({
+    id: 'mg-origin',
+    channel_type: 'slack',
+    platform_id: 'slack:D0OPDM',
+    name: 'Op DM',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now,
+  });
+  await createSession(SLACK_SESSION);
+  registerChannelAdapter('slack', { factory: () => null, defaults: TEST_SLACK_DEFAULTS });
+
+  await seedSubAgent('Pixel', 'ag-pixel', 'slack-pixel');
+  await seedSubAgent('Devin', 'ag-devin', 'slack-devin');
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('guard wiring', () => {
+  it('both room actions are in the guard catalog and their entries are guard-wrapped', () => {
+    const actions = new Set(listGuardedActions().map((s) => s.action));
+    expect(actions.has('rooms.create')).toBe(true);
+    expect(actions.has('rooms.add_agent')).toBe(true);
+    expect(getDeliveryAction('create_room')).toBeDefined();
+    expect(getDeliveryAction('add_to_room')).toBeDefined();
+  });
+
+  it('confined (group-scope) caller: create_room holds for approval, nothing runs', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel', 'Devin'] });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('create_room');
+    expect(opts.payload).toMatchObject({ name: 'Website Team', agents: ['Pixel', 'Devin'] });
+  });
+
+  it('confined (group-scope) caller: add_to_room holds for approval with the (room, agent) payload', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRequestApproval).toHaveBeenCalledTimes(1);
+    const opts = mockRequestApproval.mock.calls[0]![0] as { action: string; payload: Record<string, unknown> };
+    expect(opts.action).toBe('add_to_room');
+    expect(opts.payload).toEqual({ room: 'Website Team', agent: 'Devin' });
+  });
+});
+
+describe('create_room', () => {
+  it('resolves names and hands ensureAgentRoom the full participant list (caller included)', async () => {
+    mockCreateRoomCanvas.mockResolvedValue('F0CANVAS');
+
+    await runAction('create_room', { name: 'Website Team', purpose: 'ship the new site', agents: ['Pixel', 'Devin'] });
+
+    // MPIM opened AS the caller with the operator + every other bot.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(ANDY_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0PIXELBOT,U0DEVINBOT' });
+
+    // One mg row + mention/accumulate wiring PER participating instance.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        ignored_message_policy: 'accumulate',
+      });
+    }
+
+    // Pairwise a2a destinations between the sub-agents (caller already had both).
+    expect(await getDestinationByName('ag-pixel', 'devin')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-devin',
+    });
+    expect(await getDestinationByName('ag-devin', 'pixel')).toMatchObject({
+      target_type: 'agent',
+      target_id: 'ag-pixel',
+    });
+
+    // Canvas gets the contract data — every agent by plain name, caller first.
+    expect(mockCreateRoomCanvas).toHaveBeenCalledWith(ANDY_BOT_TOKEN, 'G0TEAM', {
+      roomName: 'Website Team',
+      purpose: 'ship the new site',
+      creatorUserId: 'U0OPERATOR',
+      agentNames: ['Andy', 'Pixel', 'Devin'],
+    });
+
+    // Allowlisted for a2a; success notify tells the CALLER to author the
+    // intro via its projected room destination, tagging both bots.
+    expect(fs.readFileSync(path.join(tmpDir, '.env'), 'utf-8')).toMatch(/^SLACK_A2A_ROOMS=.*G0TEAM/m);
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Room "Website Team" is live (G0TEAM)');
+    expect(success).toContain('send_message({ to: "website-team"');
+    expect(success).toContain('<@U0PIXELBOT>');
+    expect(success).toContain('<@U0DEVINBOT>');
+    expect(success).not.toContain('<@U0ANDYBOT>');
+    expect(success).toContain('no mechanics, no member lists');
+
+    assertNoTokenLeak();
+  });
+
+  it('include_me:false — first listed agent becomes creator, caller stays out', async () => {
+    await runAction('create_room', { name: 'Duo', agents: ['Pixel', 'Devin'], include_me: false });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(PIXEL_BOT_TOKEN);
+    expect(JSON.parse(opens[0]!.body)).toMatchObject({ users: 'U0OPERATOR,U0DEVINBOT' });
+
+    // No caller-instance row, no caller wiring.
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeUndefined();
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('You are not a member');
+    expect(success).not.toContain('send_message');
+  });
+
+  it('unknown agent name surfaces as a failure notify before anything is opened', async () => {
+    await runAction('create_room', { name: 'Website Team', agents: ['Ghost'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect((await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:G0TEAM')).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('create_room failed: unknown agent "Ghost"');
+  });
+
+  it('missing bot token surfaces as a failure notify naming the key, never the value', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.env'), `SLACK_BOT_TOKEN=${ANDY_BOT_TOKEN}\n`);
+
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+
+    expect(roomOpens()).toHaveLength(0);
+    const failure = notifyTexts().at(-1)!;
+    expect(failure).toContain('create_room failed: no bot token in .env for agent "Pixel"');
+    expect(failure).toContain('SLACK_BOT_TOKEN_PIXEL');
+    assertNoTokenLeak();
+  });
+
+  it('malformed request (no agents) is answered by the precheck without a hold', async () => {
+    await updateContainerConfigScalars(SRC_GROUP, { cli_scope: 'group' });
+
+    await runAction('create_room', { name: 'Website Team', agents: [] });
+
+    expect(mockRequestApproval).not.toHaveBeenCalled();
+    expect(notifyTexts().at(-1)).toContain('agents must be a non-empty list');
+  });
+});
+
+describe('add_to_room', () => {
+  beforeEach(async () => {
+    // An existing room: Andy + Pixel (+ operator), created through the real
+    // primitive so the wiring shape matches production.
+    await runAction('create_room', { name: 'Website Team', agents: ['Pixel'] });
+    mockNotifyWrite.mockClear();
+    fetchCalls = [];
+  });
+
+  it('opens the superset MPIM as the new agent and wires everyone onto the forked channel', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    // Superset open AS Devin: operator + both existing bots → fork id.
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    expect(opens[0]!.token).toBe(DEVIN_BOT_TOKEN);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(3);
+    expect(users).toContain('U0OPERATOR');
+    expect(users).toContain('U0ANDYBOT');
+    expect(users).toContain('U0PIXELBOT');
+
+    // Every participant wired onto the NEW channel; the old room untouched.
+    for (const [instanceKey, groupId] of [
+      ['slack', SRC_GROUP],
+      ['slack-pixel', 'ag-pixel'],
+      ['slack-devin', 'ag-devin'],
+    ] as const) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:G0FORK', instanceKey);
+      expect(mg).toMatchObject({ is_group: 1, unknown_sender_policy: 'public', name: 'Website Team' });
+      expect(await getMessagingGroupAgentByPair(mg!.id, groupId)).toMatchObject({
+        engage_mode: 'mention',
+        ignored_message_policy: 'accumulate',
+      });
+    }
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack')).toBeDefined();
+    expect(await getMessagingGroupByPlatform('slack', 'slack:G0TEAM', 'slack-devin')).toBeUndefined();
+
+    // The caller is a room member — the notify explains the fork and asks
+    // for an intro of the new agent in the NEW conversation.
+    const success = notifyTexts().at(-1)!;
+    expect(success).toContain('Devin was added to room "Website Team"');
+    expect(success).toContain('moved to a new conversation (G0FORK)');
+    expect(success).toContain('<@U0DEVINBOT>');
+
+    assertNoTokenLeak();
+  });
+
+  it('carries Slack-UI-added humans from the source room into the forked superset', async () => {
+    // A colleague was added to the room via the Slack UI — they exist only
+    // in the platform member list, never in wiring rows.
+    sourceRoomMembers = ['U0OPERATOR', 'U0ANDYBOT', 'U0PIXELBOT', 'U0COLLEAGUE'];
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    const opens = roomOpens();
+    expect(opens).toHaveLength(1);
+    const users = String((JSON.parse(opens[0]!.body) as { users: string }).users).split(',');
+    expect(users).toHaveLength(4);
+    expect(users).toContain('U0COLLEAGUE');
+    expect(notifyTexts().at(-1)).toContain('moved to a new conversation (G0FORK)');
+  });
+
+  it('source-room member read failure fails the action — never a fork that silently drops members', async () => {
+    membersFail = true;
+
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed');
+  });
+
+  it('agent already in the room: says so, opens nothing', async () => {
+    await runAction('add_to_room', { room: 'Website Team', agent: 'Pixel' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('already in room "Website Team"');
+  });
+
+  it('unknown room surfaces as a failure notify', async () => {
+    await runAction('add_to_room', { room: 'Nope', agent: 'Devin' });
+
+    expect(roomOpens()).toHaveLength(0);
+    expect(notifyTexts().at(-1)).toContain('add_to_room failed: no wired Slack room named "Nope"');
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-actions.ts
@@ -1,0 +1,467 @@
+/**
+ * Agent-facing room actions: `create_room` and `add_to_room`
+ * delivery-action bodies over the already-N-capable ensureAgentRoom.
+ *
+ * `create_room` is the "team room" primitive — the multi-agent pattern is N
+ * `create_agent` calls with room:'none' followed by ONE create_room naming
+ * all of them. Agent names resolve through the CALLER's a2a destination
+ * namespace (the same names send_message uses), so an agent can only room
+ * with agents it can already message. Each resolved agent group maps to its
+ * Slack adapter instance via its wired messaging groups; bot identities come
+ * from auth.test on the instance's .env token (botTokenKeyForInstance) —
+ * token values never appear in notify texts or logs.
+ *
+ * `add_to_room` grows an existing room by one agent. Slack platform fact:
+ * MPIMs NEVER grow in place — opening the superset member list FORKS a new
+ * conversation id. ensureAgentRoom wires every participant onto the new id
+ * directly, and the source room's actual member list is read first so
+ * Slack-UI-added humans carry into the fork; the slack-room-membership
+ * MPIM-fork carry-over (membership.ts) remains the path for Slack-UI adds
+ * and stays silent here because the rows
+ * already exist when its join-recheck fires. The old room is left untouched
+ * (both conversations stay alive). For planned teams, prefer one complete
+ * create_room over add_to_room chains.
+ *
+ * Failures surface to the requesting agent via notifyAgent — never silent.
+ */
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroup,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  getMessagingGroupsByAgentGroup,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
+import {
+  getDestinationByName,
+  getDestinationByTarget,
+  normalizeName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { botTokenKeyForInstance, slackAuthTest, slackConversationsMembers } from '../../channels/slack-lib.js';
+import { notifyAgent, requestApproval } from '../approvals/index.js';
+import { readEnvValue } from './env-file.js';
+import { ensureAgentRoom, publicPurpose, resolveOperatorSlackUserId, type RoomParticipant } from './orchestrate.js';
+
+/** Domain failure with an agent-presentable message (no token values, ever). */
+class RoomActionError extends Error {}
+
+/** A room participant plus the bot token that proves it — token stays local. */
+interface ResolvedParticipant extends RoomParticipant {
+  botToken: string;
+}
+
+// ── Participant resolution ──
+
+/**
+ * An agent name → its agent group, through the CALLER's destination
+ * namespace (normalizeName'd, same as send_message targets).
+ */
+async function resolveAgentByName(callerGroupId: string, name: string): Promise<AgentGroup> {
+  const localName = normalizeName(name);
+  const dest = await getDestinationByName(callerGroupId, localName);
+  if (!dest || dest.target_type !== 'agent') {
+    throw new RoomActionError(
+      `unknown agent "${name}" — you have no agent destination named "${localName}". ` +
+        `Use the names your send_message destinations use.`,
+    );
+  }
+  const group = await getAgentGroup(dest.target_id);
+  if (!group) throw new RoomActionError(`agent group behind destination "${localName}" no longer exists`);
+  return group;
+}
+
+/** Bot token + auth.test identity for one adapter instance. */
+async function identityForInstance(
+  instanceKey: string,
+  agentGroupName: string,
+  rootDir: string,
+): Promise<{ botToken: string; botUserId: string }> {
+  const tokenKey = botTokenKeyForInstance(instanceKey);
+  const botToken = readEnvValue(rootDir, tokenKey);
+  if (!botToken) {
+    throw new RoomActionError(`missing ${tokenKey} in .env for agent "${agentGroupName}" (instance '${instanceKey}')`);
+  }
+  const botUserId = (await slackAuthTest(botToken, 'room-resolve')).userId;
+  return { botToken, botUserId };
+}
+
+/** Build the participant for a known (group, instance) pair. */
+async function participantForInstance(
+  group: AgentGroup,
+  instanceKey: string,
+  rootDir: string,
+): Promise<ResolvedParticipant> {
+  const { botToken, botUserId } = await identityForInstance(instanceKey, group.name, rootDir);
+  return { instanceKey, botUserId, agentGroupId: group.id, agentGroupName: group.name, botToken };
+}
+
+/**
+ * Build the participant for an agent group by finding its Slack adapter
+ * instance among its wired messaging groups (a provisioned agent's DM and
+ * rooms all live on its dedicated `slack-<slug>` instance; the origin agent
+ * lives on its origin instance). Multiple distinct instances is a
+ * pathological state — the first (sorted) with a token in .env wins.
+ */
+async function participantForAgentGroup(group: AgentGroup, rootDir: string): Promise<ResolvedParticipant> {
+  const instances = [
+    ...new Set(
+      (await getMessagingGroupsByAgentGroup(group.id))
+        .filter((mg) => mg.channel_type === 'slack')
+        .map((mg) => mg.instance ?? 'slack'),
+    ),
+  ].sort();
+  if (instances.length === 0) {
+    throw new RoomActionError(
+      `agent "${group.name}" has no Slack presence (no Slack wiring found) — was its Slack bot provisioned?`,
+    );
+  }
+  const withToken = instances.find((key) => readEnvValue(rootDir, botTokenKeyForInstance(key)) !== undefined);
+  if (!withToken) {
+    throw new RoomActionError(
+      `no bot token in .env for agent "${group.name}" (looked for ${instances.map(botTokenKeyForInstance).join(', ')})`,
+    );
+  }
+  return participantForInstance(group, withToken, rootDir);
+}
+
+/**
+ * The CALLING agent as a participant — its instance is the session's origin
+ * instance when the request came in through Slack (mirrors runSlackAgentFlow),
+ * else resolved from its wired messaging groups (task/a2a sessions).
+ */
+async function callerParticipant(session: Session, rootDir: string): Promise<ResolvedParticipant> {
+  const group = await getAgentGroup(session.agent_group_id);
+  if (!group) throw new RoomActionError('source agent group not found');
+  const originMg = session.messaging_group_id ? await getMessagingGroup(session.messaging_group_id) : undefined;
+  if (originMg?.channel_type === 'slack') {
+    return participantForInstance(group, originMg.instance ?? 'slack', rootDir);
+  }
+  return participantForAgentGroup(group, rootDir);
+}
+
+/** The caller's local destination name for a room channel on its instance. */
+async function callerRoomDestination(
+  callerGroupId: string,
+  callerInstanceKey: string,
+  roomChannelId: string,
+  roomName: string,
+): Promise<string> {
+  const roomMg = await getMessagingGroupByPlatform('slack', `slack:${roomChannelId}`, callerInstanceKey);
+  const dest = roomMg ? await getDestinationByTarget(callerGroupId, 'channel', roomMg.id) : undefined;
+  return dest?.local_name ?? normalizeName(roomName);
+}
+
+/** `<@U…>, <@U…>` mention tags for every participant except the caller. */
+function mentionTags(participants: RoomParticipant[], excludeGroupId: string): string {
+  return participants
+    .filter((p) => p.agentGroupId !== excludeGroupId)
+    .map((p) => `<@${p.botUserId}>`)
+    .join(', ');
+}
+
+// ── create_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export async function validateCreateRoom(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  if (!name) {
+    await notifyAgent(session, 'create_room failed: name is required.');
+    return false;
+  }
+  const agents = Array.isArray(content.agents) ? content.agents : [];
+  if (agents.length === 0 || !agents.every((a) => typeof a === 'string' && a.trim())) {
+    await notifyAgent(session, 'create_room failed: agents must be a non-empty list of agent names.');
+    return false;
+  }
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'create_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestCreateRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const name = typeof content.name === 'string' ? content.name.trim() : '';
+  const agents = (Array.isArray(content.agents) ? content.agents : []).filter(
+    (a): a is string => typeof a === 'string',
+  );
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'create_room',
+    // Same payload shape as the tool call — the approved replay re-enters
+    // the wrapped action unchanged.
+    payload: {
+      name,
+      agents,
+      ...(typeof content.purpose === 'string' ? { purpose: content.purpose } : {}),
+      ...(content.include_me === false ? { include_me: false } : {}),
+    },
+    title: `Create room: ${name}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to open a shared Slack room "${name}" with you and ` +
+      `${agents.join(', ')}${content.include_me === false ? ' (without itself)' : ''}. Approve?`,
+  });
+}
+
+/**
+ * Guard allow body: resolve every named agent (+ the caller unless
+ * include_me:false), then hand the full participant list to ensureAgentRoom
+ * — one MPIM with ALL bots + the operator, one canvas, mention/accumulate
+ * wirings per instance, pairwise a2a destinations. The success notify tells
+ * the CALLER to author the room intro (no host-templated intro).
+ */
+export async function handleCreateRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const name = (content.name as string).trim();
+  const agentNames = (content.agents as string[]).map((a) => a.trim());
+  const includeMe = content.include_me !== false;
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = await resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    // Caller first when included — it becomes the creator (opens the MPIM,
+    // creates the canvas); otherwise the first listed agent does.
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    if (includeMe) {
+      const caller = await callerParticipant(session, rootDir);
+      seen.add(caller.agentGroupId);
+      participants.push(caller);
+    }
+    for (const agentName of agentNames) {
+      const group = await resolveAgentByName(session.agent_group_id, agentName);
+      if (seen.has(group.id)) continue;
+      seen.add(group.id);
+      participants.push(await participantForAgentGroup(group, rootDir));
+    }
+    if (participants.length === 0) throw new RoomActionError('no agents resolved');
+    const creator = participants[0]!;
+
+    const { roomChannelId, created } = await ensureAgentRoom({
+      creator,
+      creatorBotToken: creator.botToken,
+      operatorUserId,
+      participants,
+      roomName: name,
+      purpose: publicPurpose(typeof content.purpose === 'string' ? content.purpose : undefined),
+      rootDir,
+    });
+
+    const memberNames = participants.map((p) => p.agentGroupName).join(', ');
+    if (!includeMe) {
+      await notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with the operator and ${memberNames}. ` +
+          `You are not a member (include_me was false), so you cannot post there.`,
+      );
+    } else if (!created) {
+      await notifyAgent(session, `Room "${name}" already existed (${roomChannelId}) — nothing new was created.`);
+    } else {
+      // The calling agent authors the intro, in its own voice.
+      const roomDest = await callerRoomDestination(session.agent_group_id, creator.instanceKey, roomChannelId, name);
+      await notifyAgent(
+        session,
+        `Room "${name}" is live (${roomChannelId}) with you, the operator, and ${memberNames}. ` +
+          `Post a brief introduction there now via send_message({ to: "${roomDest}", ... }): ` +
+          `1-2 lines in your own voice on what this room is for, tagging each agent literally ` +
+          `(${mentionTags(participants, session.agent_group_id)}) — the tags render as mentions and are how you ` +
+          `engage them there. Just the intro — no mechanics, no member lists.`,
+      );
+    }
+    log.info('create_room completed', { roomChannelId, created, participantCount: participants.length });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(session, `create_room failed: ${message}`);
+    log.error('create_room failed', { name, err: message });
+  }
+}
+
+// ── add_to_room ──
+
+/** Guard precheck: malformed requests are answered without ever creating a hold. */
+export async function validateAddToRoom(content: Record<string, unknown>, session: Session): Promise<boolean> {
+  if (typeof content.room !== 'string' || !content.room.trim()) {
+    await notifyAgent(session, 'add_to_room failed: room is required.');
+    return false;
+  }
+  if (typeof content.agent !== 'string' || !content.agent.trim()) {
+    await notifyAgent(session, 'add_to_room failed: agent is required.');
+    return false;
+  }
+  if (!(await getAgentGroup(session.agent_group_id))) {
+    await notifyAgent(session, 'add_to_room failed: source agent group not found.');
+    return false;
+  }
+  return true;
+}
+
+/** Guard hold: card the requesting group's admin chain. */
+export async function requestAddToRoomHold(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = await getAgentGroup(session.agent_group_id);
+  if (!sourceGroup) return;
+  const room = typeof content.room === 'string' ? content.room.trim() : '';
+  const agent = typeof content.agent === 'string' ? content.agent.trim() : '';
+
+  await requestApproval({
+    session,
+    agentName: sourceGroup.name,
+    action: 'add_to_room',
+    payload: { room, agent },
+    title: `Add ${agent} to room: ${room}`,
+    question:
+      `Agent "${sourceGroup.name}" wants to add agent "${agent}" to the shared Slack room "${room}" ` +
+      `(this opens a new group conversation with everyone plus "${agent}"). Approve?`,
+  });
+}
+
+/**
+ * The room named by an add_to_room call: wired Slack group rooms whose
+ * messaging-group name matches (case-insensitive). Shadow channels never
+ * match — their names carry a "canvas comments" suffix. When several rooms
+ * share the name (e.g. earlier add_to_room forks keep the old room alive
+ * under the same name), the NEWEST family wins — "the room" means its latest
+ * incarnation.
+ */
+async function resolveRoomFamily(roomName: string): Promise<{ family: MessagingGroup[]; name: string }> {
+  const wanted = roomName.trim().toLowerCase();
+  const matches: MessagingGroup[] = [];
+  for (const m of await getAllMessagingGroups()) {
+    if (
+      m.channel_type === 'slack' &&
+      m.is_group === 1 &&
+      !m.denied_at &&
+      m.platform_id.startsWith('slack:') &&
+      (m.name ?? '').trim().toLowerCase() === wanted &&
+      (await getMessagingGroupAgents(m.id)).length > 0
+    ) {
+      matches.push(m);
+    }
+  }
+  if (matches.length === 0) throw new RoomActionError(`no wired Slack room named "${roomName}" found`);
+  const newestFirst = [...new Set(matches.map((m) => m.platform_id))]
+    .map((pid) => ({
+      pid,
+      createdAt: matches
+        .filter((m) => m.platform_id === pid)
+        .map((m) => m.created_at)
+        .sort()[0]!,
+    }))
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  const family = matches.filter((m) => m.platform_id === newestFirst[0]!.pid);
+  return { family, name: family[0]!.name ?? roomName };
+}
+
+/**
+ * Guard allow body: resolve the room's current participants from its wiring
+ * rows, resolve the named agent, and re-run ensureAgentRoom with the
+ * superset. The conversations.open on the superset member list FORKS a new
+ * MPIM (Slack never grows one in place); ensureAgentRoom wires everyone onto
+ * the new id, and the old room stays untouched — same shape the
+ * slack-room-membership fork carry-over produces for Slack-UI adds.
+ */
+export async function handleAddToRoom(content: Record<string, unknown>, session: Session): Promise<void> {
+  const roomArg = (content.room as string).trim();
+  const agentArg = (content.agent as string).trim();
+  const rootDir = process.cwd();
+
+  try {
+    const operatorUserId = await resolveOperatorSlackUserId(session.agent_group_id);
+    if (!operatorUserId) {
+      throw new RoomActionError(
+        'no approver with a Slack identity (slack:U…) found in user_roles — grant one with `ncl roles grant` and retry',
+      );
+    }
+
+    const { family, name: roomName } = await resolveRoomFamily(roomArg);
+
+    // Current participants — one per wired agent group, on the room row's
+    // own instance (router lookup is exact-on-instance, so the row is the
+    // authoritative instance mapping).
+    const participants: ResolvedParticipant[] = [];
+    const seen = new Set<string>();
+    for (const mg of family) {
+      for (const wiring of await getMessagingGroupAgents(mg.id)) {
+        if (seen.has(wiring.agent_group_id)) continue;
+        seen.add(wiring.agent_group_id);
+        const group = await getAgentGroup(wiring.agent_group_id);
+        if (!group) continue;
+        participants.push(await participantForInstance(group, mg.instance ?? 'slack', rootDir));
+      }
+    }
+
+    const newGroup = await resolveAgentByName(session.agent_group_id, agentArg);
+    if (seen.has(newGroup.id)) {
+      await notifyAgent(session, `add_to_room: agent "${newGroup.name}" is already in room "${roomName}".`);
+      return;
+    }
+    const newParticipant = await participantForAgentGroup(newGroup, rootDir);
+
+    // Members added via the Slack UI (extra humans, foreign bots) exist only
+    // on the platform — wiring rows carry agents alone. Read the source
+    // room's actual member list so the forked superset carries them instead
+    // of silently dropping them (the membership fork carry-over preserves
+    // members for UI adds; this path must too). A failed read fails the
+    // action (outer catch) — never a fork that quietly excludes someone.
+    let extraMemberUserIds: string[] = [];
+    if (participants.length > 0) {
+      const sourceChannelId = family[0]!.platform_id.slice('slack:'.length);
+      const knownIds = new Set([operatorUserId, newParticipant.botUserId, ...participants.map((p) => p.botUserId)]);
+      const sourceMembers = await slackConversationsMembers(participants[0]!.botToken, sourceChannelId, 'room-resolve');
+      extraMemberUserIds = sourceMembers.filter((id) => !knownIds.has(id));
+    }
+
+    // The NEW agent opens the superset MPIM (mirrors the create flow, where
+    // the newly arriving bot is the opener/canvas creator).
+    const { roomChannelId } = await ensureAgentRoom({
+      creator: newParticipant,
+      creatorBotToken: newParticipant.botToken,
+      operatorUserId,
+      participants: [...participants, newParticipant],
+      extraMemberUserIds,
+      roomName,
+      rootDir,
+    });
+
+    const callerInRoom = seen.has(session.agent_group_id);
+    let callerMg: MessagingGroup | undefined;
+    for (const mg of family) {
+      if ((await getMessagingGroupAgents(mg.id)).some((w) => w.agent_group_id === session.agent_group_id)) {
+        callerMg = mg;
+        break;
+      }
+    }
+    const roomDestination = callerMg
+      ? await callerRoomDestination(session.agent_group_id, callerMg.instance ?? 'slack', roomChannelId, roomName)
+      : undefined;
+    const intro =
+      callerInRoom && callerMg
+        ? ` Post a brief introduction of ${newParticipant.agentGroupName} there now via send_message({ to: ` +
+          `"${roomDestination}", ... }): ` +
+          `1-2 lines in your own voice, tagging them with <@${newParticipant.botUserId}> (include that literally — ` +
+          `it renders as a mention). Just the intro — no mechanics, no member lists.`
+        : '';
+    await notifyAgent(
+      session,
+      `${newParticipant.agentGroupName} was added to room "${roomName}". Slack group DMs never grow in place, ` +
+        `so the room moved to a new conversation (${roomChannelId}) — everyone is wired there and the old ` +
+        `conversation keeps working.${intro}`,
+    );
+    log.info('add_to_room completed', { roomChannelId, agentGroupId: newGroup.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await notifyAgent(session, `add_to_room failed: ${message}`);
+    log.error('add_to_room failed', { room: roomArg, agent: agentArg, err: message });
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.test.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Room canvas creation tests (contract C2): template shape (the canvas IS the
+ * room contract; no bot mentions in the body), the
+ * conversations.canvases.create call, and the non-throwing failure paths.
+ * Plus the canvas-comments shadow-channel wiring (F→C derivation, one mg row
+ * + wiring per participating instance, idempotence, non-throwing).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TIMEZONE } from '../../config.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { closeDb, initTestDb } from '../../db/connection.js';
+import {
+  getAllMessagingGroups,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { formatLocalTime } from '../../timezone.js';
+import {
+  createRoomCanvas,
+  deriveCanvasShadowChannelId,
+  roomCanvasMarkdown,
+  wireCanvasComments,
+} from './room-canvas.js';
+
+const OPTS = {
+  roomName: 'Pixel room',
+  purpose: 'Design work between Gavriel, Pixel, and Mark.\nSecond purpose line.',
+  creatorUserId: 'U0CREATOR',
+  agentNames: ['Pixel', 'Mark', 'Pixel'],
+  createdAt: '2026-08-01T12:00:00.000Z',
+};
+
+describe('roomCanvasMarkdown', () => {
+  const md = roomCanvasMarkdown(OPTS);
+
+  it('leads with the blockquoted purpose — no body H1 (the create-call `title` param renders the document title; a body heading duplicated it, live-observed)', () => {
+    expect(md.startsWith('> Design work between Gavriel, Pixel, and Mark.')).toBe(true);
+    expect(md).not.toContain('# Pixel room');
+    expect(md).toContain('> Second purpose line.');
+  });
+
+  it('carries the room-contract data: creator card, created date, Members table', () => {
+    expect(md).toContain(`Created by ![](@U0CREATOR) on ${formatLocalTime(OPTS.createdAt, TIMEZONE)}.`);
+    expect(md).toContain('## Members');
+    expect(md).toContain('| ![](@U0CREATOR) | creator |');
+  });
+
+  it('lists agents by PLAIN NAME, deduped — never as user cards', () => {
+    expect(md).toContain('| Pixel | agent |');
+    expect(md).toContain('| Mark | agent |');
+    expect(md.match(/\| Pixel \| agent \|/g)).toHaveLength(1);
+  });
+
+  it('never @-mentions a bot: the only user card is the human creator', () => {
+    const cards = md.match(/!\[\]\(@\w+\)/g) ?? [];
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) expect(card).toBe('![](@U0CREATOR)');
+    expect(md).not.toContain('<@');
+  });
+
+  it('carries the Tasks checklist and the Decisions / Notes sections', () => {
+    expect(md).toContain('## Tasks');
+    expect(md).toContain('- [ ] ');
+    expect(md).toContain('## Decisions');
+    expect(md).toContain('## Notes');
+  });
+});
+
+describe('createRoomCanvas', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the template to conversations.canvases.create and returns the canvas id', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true, canvas_id: 'F0CANVAS1' }), { status: 200 }),
+    );
+
+    const id = await createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS);
+
+    expect(id).toBe('F0CANVAS1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.com/api/conversations.canvases.create');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-test-token');
+    const body = JSON.parse(init.body as string);
+    expect(body.channel_id).toBe('C0ROOM');
+    expect(body.document_content).toEqual({ type: 'markdown', markdown: roomCanvasMarkdown(OPTS) });
+  });
+
+  it('returns undefined on a Slack error instead of throwing', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, error: 'free_team_not_allowed' }), { status: 200 }),
+    );
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when fetch itself rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when ok:true carries no canvas_id', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    await expect(createRoomCanvas('xoxb-test-token', 'C0ROOM', OPTS)).resolves.toBeUndefined();
+  });
+});
+
+describe('deriveCanvasShadowChannelId', () => {
+  it('swaps the leading F for C on a canvas-shaped id', () => {
+    expect(deriveCanvasShadowChannelId('F0BME4DL401')).toBe('C0BME4DL401');
+    expect(deriveCanvasShadowChannelId('F1')).toBe('C1');
+  });
+
+  it('returns undefined for anything not canvas-id shaped', () => {
+    for (const bad of ['C0BME4DL401', 'F', '', 'F0bme4dl401', 'F0BME-4DL401', 'X0BME4DL401', ' F0BME4DL401']) {
+      expect(deriveCanvasShadowChannelId(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe('wireCanvasComments', () => {
+  const CREATOR = { instanceKey: 'slack-pixel', agentGroupId: 'ag-pixel' };
+  // Creator deliberately ALSO present in the list — must not double-wire.
+  const PARTICIPANTS = [
+    { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+    { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    CREATOR,
+  ];
+
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    const now = new Date().toISOString();
+    for (const [id, name, folder] of [
+      ['ag-pixel', 'Pixel', 'pixel'],
+      ['ag-andy', 'Andy', 'andy'],
+      ['ag-mark', 'Mark', 'mark'],
+    ] as const) {
+      await createAgentGroup({ id, name, folder, agent_provider: null, created_at: now });
+    }
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it('wires EVERY participating instance: creator pattern-engage, siblings mention/accumulate', async () => {
+    const shadowId = await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(shadowId).toBe('C0CANVAS1');
+    // One mg row PER instance (router lookup is exact-on-instance), all public.
+    const all = (await getAllMessagingGroups()).filter((m) => m.platform_id === 'slack:C0CANVAS1');
+    expect(all).toHaveLength(3);
+    for (const p of PARTICIPANTS) {
+      const mg = await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', p.instanceKey);
+      expect(mg).toMatchObject({
+        channel_type: 'slack',
+        instance: p.instanceKey,
+        name: 'Pixel room canvas comments (canvas F0CANVAS1)',
+        is_group: 1,
+        unknown_sender_policy: 'public',
+      });
+      expect(await getMessagingGroupAgents(mg!.id)).toHaveLength(1);
+    }
+    // Creator = default responder for anchored comments.
+    const creatorMg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel'))!;
+    expect(await getMessagingGroupAgentByPair(creatorMg.id, 'ag-pixel')).toMatchObject({
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+    });
+    // Siblings = room semantics: mention to trigger, everything else context.
+    for (const sibling of [
+      { instanceKey: 'slack', agentGroupId: 'ag-andy' },
+      { instanceKey: 'slack-mark', agentGroupId: 'ag-mark' },
+    ]) {
+      const mg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', sibling.instanceKey))!;
+      expect(await getMessagingGroupAgentByPair(mg.id, sibling.agentGroupId)).toMatchObject({
+        engage_mode: 'mention',
+        engage_pattern: null,
+        sender_scope: 'all',
+        ignored_message_policy: 'accumulate',
+        session_mode: 'shared',
+        priority: 0,
+      });
+    }
+  });
+
+  it('is idempotent: a second call creates no new rows', async () => {
+    await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+    const mgCount = (await getAllMessagingGroups()).length;
+    const mg = (await getMessagingGroupByPlatform('slack', 'slack:C0CANVAS1', 'slack-pixel'))!;
+    const wiringId = (await getMessagingGroupAgentByPair(mg.id, 'ag-pixel'))!.id;
+
+    const second = await wireCanvasComments('F0CANVAS1', CREATOR, PARTICIPANTS, 'Pixel room');
+
+    expect(second).toBe('C0CANVAS1');
+    expect((await getAllMessagingGroups()).length).toBe(mgCount);
+    expect(await getMessagingGroupAgents(mg.id)).toHaveLength(1);
+    expect((await getMessagingGroupAgentByPair(mg.id, 'ag-pixel'))!.id).toBe(wiringId);
+  });
+
+  it('returns undefined and writes nothing on an invalid canvas id shape', async () => {
+    const before = (await getAllMessagingGroups()).length;
+    expect(await wireCanvasComments('not-a-canvas', CREATOR, PARTICIPANTS, 'Pixel room')).toBeUndefined();
+    expect((await getAllMessagingGroups()).length).toBe(before);
+  });
+
+  it('never throws: a DB failure (unknown agent group breaks the FK) returns undefined', async () => {
+    expect(
+      await wireCanvasComments('F0CANVAS2', { instanceKey: 'slack', agentGroupId: 'ag-missing' }, [], 'X'),
+    ).toBeUndefined();
+  });
+});

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/room-canvas.ts
@@ -1,0 +1,274 @@
+/**
+ * Room canvas creation — the room-contract template, written to the room's
+ * channel-tab canvas at room-creation time.
+ *
+ * Contract C2: `createRoomCanvas` is NON-THROWING — any failure (network,
+ * Slack error, malformed response) logs a warning and returns undefined. Room
+ * creation must never fail because the canvas leg did; the caller tolerates
+ * undefined and simply ships a room without a canvas.
+ *
+ * The Slack call is implemented locally (plain fetch, the shared slack-lib
+ * JSON-body conventions) — this file deliberately does not go through the
+ * lib's throwing helpers: canvas creation is contractually NON-THROWING (C2).
+ * Tokens travel only in the Authorization header and are never interpolated
+ * into messages or logs.
+ *
+ * Live-validated facts this leans on: `conversations.canvases.create`
+ * works on MPIMs and DMs (undocumented but confirmed); every markdown
+ * element in the template — checkboxes, tables with user cards, blockquote —
+ * is accepted; section headings are the later edit-addressing scheme
+ * (`canvases.sections.lookup` by contains_text), so heading text is part of
+ * the template's contract with the canvas-actions module.
+ */
+import { TIMEZONE } from '../../config.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import { formatLocalTime } from '../../timezone.js';
+import type { MessagingGroup } from '../../types.js';
+
+const SLACK_API = 'https://slack.com/api';
+
+export interface RoomCanvasOpts {
+  roomName: string;
+  purpose: string;
+  /** The human operator who created the room — the ONLY member the template
+   *  may reference by user card. Bot user cards render as @-mentions, and a
+   *  creation-time mention is what triggered every sibling instance and
+   *  generated the approval-card spam. */
+  creatorUserId: string;
+  /** Agent members by display name — rendered as PLAIN TEXT, never mentioned. */
+  agentNames: string[];
+  /** ISO creation timestamp; defaults to now. Rendered install-local. */
+  createdAt?: string;
+}
+
+/** `![](@U…)` — Slack renders this image syntax as an inline user card.
+ *  Humans only: a bot's user card delivers a mention to that bot's instance. */
+function userCard(userId: string): string {
+  return `![](@${userId})`;
+}
+
+/** Blockquote-prefix every line so a multi-line purpose stays one quote block. */
+function asBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+/**
+ * The room-contract template (modeled on a live-verified room-canvas
+ * example). With the room-contract MESSAGE retired, this canvas IS the room
+ * contract: purpose, creator, member list, created date — the canvas tab is
+ * the room's pinned surface. Heading texts ("Tasks", "Decisions", "Notes")
+ * are load-bearing: agents address sections by contains_text lookup, and the
+ * canvas instructions reference them by name.
+ *
+ * The body must never @-mention a BOT — agent members appear by plain
+ * name. Only the (human) creator gets a user card.
+ */
+export function roomCanvasMarkdown(opts: RoomCanvasOpts): string {
+  const memberRows = [
+    `| ${userCard(opts.creatorUserId)} | creator |`,
+    ...opts.agentNames.filter((name, i, arr) => arr.indexOf(name) === i).map((name) => `| ${name} | agent |`),
+  ];
+
+  // No `# <roomName>` heading here: the `title` param on
+  // conversations.canvases.create already renders the canvas title as the
+  // document's H1 — a body heading would duplicate it (live-observed).
+  return [
+    asBlockquote(opts.purpose),
+    '',
+    `Created by ${userCard(opts.creatorUserId)} on ${formatLocalTime(opts.createdAt ?? new Date().toISOString(), TIMEZONE)}.`,
+    '',
+    '## Members',
+    '',
+    '| Who | Role |',
+    '|---|---|',
+    ...memberRows,
+    '',
+    '## Tasks',
+    '',
+    '- [ ] Add the room’s first task',
+    '',
+    '## Decisions',
+    '',
+    '_No decisions recorded yet — quote them here as they land._',
+    '',
+    '## Notes',
+    '',
+    '_Working notes and links — anything worth keeping that isn’t a task or a decision._',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Create the room's channel-tab canvas from the room-contract template.
+ * Returns the canvas id, or undefined on ANY failure (never throws).
+ */
+export async function createRoomCanvas(
+  botToken: string,
+  channelId: string,
+  opts: RoomCanvasOpts,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${SLACK_API}/conversations.canvases.create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        channel_id: channelId,
+        // Undocumented but live-verified: conversations.canvases.create
+        // accepts `title` (otherwise the canvas lists as "Untitled").
+        title: opts.roomName,
+        document_content: { type: 'markdown', markdown: roomCanvasMarkdown(opts) },
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (json.ok !== true) {
+      log.warn('Room canvas create failed', {
+        channelId,
+        error: String(json.error ?? `HTTP ${res.status}`),
+      });
+      return undefined;
+    }
+    const canvasId = typeof json.canvas_id === 'string' ? json.canvas_id : undefined;
+    if (!canvasId) {
+      log.warn('Room canvas create returned no canvas_id', { channelId });
+      return undefined;
+    }
+    log.info('Room canvas created', { channelId, canvasId });
+    return canvasId;
+  } catch (err) {
+    log.warn('Room canvas create failed', {
+      channelId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+// ── Canvas comments (shadow channel) ──
+
+/** Canvas ids are `F` + the base-36-ish Slack id body. */
+const CANVAS_ID_RE = /^F[A-Z0-9]+$/;
+
+/**
+ * Live-probed platform fact: creating ANY canvas makes Slack materialize
+ * a hidden private "shadow channel" owned by USLACKBOT whose id is the canvas
+ * id with the leading `F` swapped for `C` (canvas F0BME4DL401 → channel
+ * C0BME4DL401). Canvas comments live there as threads; members of the canvas
+ * are members of the shadow channel and bots receive its messages as ordinary
+ * message.groups events. Returns undefined for anything not canvas-id shaped.
+ */
+export function deriveCanvasShadowChannelId(canvasId: string): string | undefined {
+  return CANVAS_ID_RE.test(canvasId) ? `C${canvasId.slice(1)}` : undefined;
+}
+
+/** One room bot's instance/group pair, for shadow-channel wiring. The flow's
+ *  RoomParticipant satisfies this structurally. */
+export interface CanvasCommentsParticipant {
+  /** Adapter-instance key ('slack' or 'slack-<slug>'). */
+  instanceKey: string;
+  agentGroupId: string;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Wire the canvas's shadow channel for EVERY participating instance — the
+ * shadow channel is the room's comment stream, so it gets room semantics for
+ * all room agents, not creator-only. Creator-only wiring is what turned
+ * every sibling's canvas events into unknown-channel approval-card spam.
+ *
+ * Per participant: one messaging-group row on ITS instance (router lookup is
+ * exact-on-instance) plus one wiring to its agent group. The CREATOR is the
+ * default responder — pattern `'.'` (always engage): a comment on the shared
+ * canvas is always addressed to the room's agents, unlike ambient room chat.
+ * Every SIBLING gets mention/accumulate — comments flow to all room agents
+ * as context, and tagging an agent in a comment actually triggers it with
+ * the anchor context. `unknown_sender_policy: 'public'` keeps access gates
+ * from approval-spamming on commenters.
+ *
+ * Idempotent (get-before-create on every row) and NON-THROWING — like
+ * createRoomCanvas, a failure here must never fail room creation. Returns the
+ * shadow channel id, or undefined on invalid canvas-id shape or any error.
+ */
+export async function wireCanvasComments(
+  canvasId: string,
+  creator: CanvasCommentsParticipant,
+  participants: CanvasCommentsParticipant[],
+  roomName: string,
+): Promise<string | undefined> {
+  try {
+    const shadowChannelId = deriveCanvasShadowChannelId(canvasId);
+    if (!shadowChannelId) {
+      log.warn('Canvas comments: unexpected canvas id shape — shadow channel not wired', { canvasId });
+      return undefined;
+    }
+    const platformId = `slack:${shadowChannelId}`;
+
+    // Creator first (its wiring must win even if it also appears in the list).
+    const isCreator = (p: CanvasCommentsParticipant): boolean =>
+      p.instanceKey === creator.instanceKey && p.agentGroupId === creator.agentGroupId;
+    const everyone = [creator, ...participants.filter((p) => !isCreator(p))];
+
+    for (const p of everyone) {
+      let mg = await getMessagingGroupByPlatform('slack', platformId, p.instanceKey);
+      if (!mg) {
+        const row: MessagingGroup = {
+          id: generateId('mg'),
+          channel_type: 'slack',
+          platform_id: platformId,
+          instance: p.instanceKey,
+          name: `${roomName} canvas comments (canvas ${canvasId})`,
+          is_group: 1,
+          unknown_sender_policy: 'public',
+          created_at: new Date().toISOString(),
+        };
+        await createMessagingGroup(row);
+        mg = row;
+      }
+
+      if (!(await getMessagingGroupAgentByPair(mg.id, p.agentGroupId))) {
+        const creatorRow = isCreator(p);
+        await createMessagingGroupAgent({
+          id: generateId('mga'),
+          messaging_group_id: mg.id,
+          agent_group_id: p.agentGroupId,
+          engage_mode: creatorRow ? 'pattern' : 'mention',
+          engage_pattern: creatorRow ? '.' : null,
+          sender_scope: 'all',
+          ignored_message_policy: creatorRow ? 'drop' : 'accumulate',
+          session_mode: 'shared',
+          priority: 0,
+          created_at: new Date().toISOString(),
+        });
+      }
+    }
+
+    log.info('Canvas comments shadow channel wired', {
+      canvasId,
+      shadowChannelId,
+      creatorInstance: creator.instanceKey,
+      participantCount: everyone.length,
+    });
+    return shadowChannelId;
+  } catch (err) {
+    log.warn('Canvas comments shadow-channel wiring failed', {
+      canvasId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/slack-deps.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/slack-deps.ts
@@ -1,0 +1,70 @@
+/**
+ * Optional-module seam — the ONLY file in the slack-agent-flow payload that
+ * touches the skill-installed Slack channel module (src/channels/slack.ts
+ * arrives via the add-slack skill) dynamically. The computed-specifier import
+ * keeps tsc from resolving a file that may not be in the tree, so a missing
+ * or outdated channel payload surfaces at runtime as a typed, actionable
+ * SlackFlowError instead of a crash. The hot-start entry
+ * (startChannelAdapter) is trunk registry API and is imported statically like
+ * registerChannelAdapter.
+ */
+import type { ChannelAdapter, ChannelDefaults } from '../../channels/adapter.js';
+import { registerChannelAdapter, startChannelAdapter } from '../../channels/channel-registry.js';
+import { SlackFlowError } from './types.js';
+
+export interface SlackChannelDeps {
+  slackInstanceBridgeFactory: (name: string) => ChannelAdapter | null;
+  SLACK_DEFAULTS: ChannelDefaults;
+  registerChannelAdapter: (
+    name: string,
+    registration: { factory: () => ChannelAdapter | null; defaults?: ChannelDefaults },
+  ) => void;
+  startChannelAdapter: (key: string) => Promise<'started' | 'already-active' | 'no-credentials'>;
+}
+
+const NOT_INSTALLED =
+  'Slack channel payload not installed or too old — apply add-slack first (multi-instance registration ships with the adapter)';
+
+/**
+ * Fails fast if the installed Slack adapter doesn't carry the multi-instance
+ * factory — checked regardless of hotStart. The adapter owns SLACK_INSTANCES
+ * natively (slackInstanceBridgeFactory + the import-time registration loop
+ * live in slack.ts); an older installed copy without that export would let
+ * S6-S8 wire DB rows to an instance name the runtime could never start, even
+ * after a restart. The out-of-process finish path (hotStart: false) needs
+ * this check just as much as the hot-add branch below.
+ */
+export async function assertSlackInstancesModuleInstalled(): Promise<void> {
+  try {
+    const slackSpec = '../../channels/slack.js';
+    const slackMod = (await import(slackSpec)) as Record<string, unknown>;
+    if (typeof slackMod.slackInstanceBridgeFactory !== 'function' || !slackMod.SLACK_DEFAULTS) {
+      throw new Error('missing exports');
+    }
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+}
+
+export async function loadSlackChannelDeps(): Promise<SlackChannelDeps> {
+  let slackMod: Record<string, unknown>;
+  try {
+    const slackSpec = '../../channels/slack.js';
+    slackMod = (await import(slackSpec)) as Record<string, unknown>;
+  } catch {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  const slackInstanceBridgeFactory = slackMod.slackInstanceBridgeFactory;
+  const SLACK_DEFAULTS = slackMod.SLACK_DEFAULTS;
+  if (typeof slackInstanceBridgeFactory !== 'function' || !SLACK_DEFAULTS) {
+    throw new SlackFlowError('adapter-start', NOT_INSTALLED);
+  }
+
+  return {
+    slackInstanceBridgeFactory: slackInstanceBridgeFactory as (name: string) => ChannelAdapter | null,
+    SLACK_DEFAULTS: SLACK_DEFAULTS as ChannelDefaults,
+    registerChannelAdapter,
+    startChannelAdapter,
+  };
+}

--- a/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
+++ b/.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/types.ts
@@ -1,0 +1,109 @@
+/**
+ * slack-agent-flow shared types.
+ * Congruence: env-key shapes mirror the adapter's native SLACK_INSTANCES
+ * conventions (src/channels/slack.ts, instanceEnvKeySuffix);
+ * broker protocol mirrors src/provisioning/slack-app.ts and
+ * .claude/skills/slack-managed-agents/scripts/slack-create-agent.ts. Pinned by
+ * provision.congruence.test.ts.
+ */
+
+export type SlackFlowStep =
+  | 'operator-identity'
+  | 'origin-auth'
+  | 'no-credentials'
+  | 'broker'
+  | 'direct-create'
+  /** Waiting out a workspace install approval before the bot token exists. */
+  | 'install-wait'
+  | 'env-write'
+  | 'adapter-start'
+  | 'dm-open'
+  | 'dm-wire'
+  | 'mpim-open'
+  | 'a2a-env'
+  | 'room-wire'
+  | 'intro-post'
+  /** room-actions module — create_room / add_to_room participant resolution. */
+  | 'room-resolve'
+  /** slack-room-membership module — join/left handling, not a create_agent flow step. */
+  | 'membership';
+
+/** Typed failure for the Slack leg. `message` MUST never contain a token value. */
+export class SlackFlowError extends Error {
+  constructor(
+    readonly step: SlackFlowStep,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SlackFlowError';
+  }
+}
+
+export interface ProvisionInput {
+  /** Instance slug: output of normalizeName(), post-dedupe. */
+  slug: string;
+  /** Display name for the Slack app/bot (the raw agent name). */
+  displayName: string;
+  /** Repo root; .env lives at `${rootDir}/.env`. */
+  rootDir: string;
+  /** Slack workspace the app is provisioned into (broker mode requires it). */
+  teamId?: string;
+  /** Agent description/instructions — drives the broker's generated avatar. */
+  description?: string;
+  /**
+   * true → plain manifest variant (no agent_view): workspace guests are
+   * hard-blocked from agent-enabled apps. Default false → agent mode, the
+   * default variant — a one-way door decided at provision time.
+   */
+  allowGuests?: boolean;
+  /**
+   * Request-origin metadata, all optional — sent on the broker's
+   * POST /v1/apps body only when defined (requested_by / parent_app_id /
+   * template on the wire; a broker that predates them ignores unknown body
+   * fields). client_version is derived from rootDir's package.json inside
+   * provisionSlackApp, not supplied here.
+   */
+  /** Slack user id (U…/W…) of the human who asked for this agent. */
+  requestedBy?: string;
+  /** The creating agent's own Slack app id (A…) when an agent created this one. */
+  parentAppId?: string;
+  /** Template name, when the agent was stamped from one. */
+  template?: string;
+  /**
+   * Called once when the workspace has not approved the app's install and the
+   * flow is about to wait for it — `resumed` distinguishes a fresh refusal
+   * from picking a parked app back up. Exceptions are swallowed: telling the
+   * human is best-effort, the wait happens either way.
+   */
+  onInstallPending?: (info: { appId: string; installUrl?: string; resumed: boolean }) => void | Promise<void>;
+  /** Wait budget for a deferred install. Tests shorten it; callers rarely set it. */
+  installWait?: { intervalMs?: number; timeoutMs?: number };
+}
+
+export interface ProvisionResult {
+  slug: string;
+  /** slug.toUpperCase().replace(/-/g, '_') — the .env key suffix. */
+  envSuffix: string;
+  botToken: string; // xoxb-… NEVER log
+  appToken: string; // xapp-… NEVER log
+  appId: string;
+  /** True when tokens were already in .env and no provisioning call was made. */
+  reused: boolean;
+  /**
+   * True when the bot token arrived only after waiting out a workspace install
+   * approval (auto-install was refused). Everything downstream is identical —
+   * the flag exists so the completion message can say what happened.
+   */
+  deferredInstall?: boolean;
+}
+
+export interface OrchestrateSuccess {
+  slug: string;
+  newBotUserId: string;
+  operatorUserId: string;
+  dmChannelId: string;
+  /** Absent when the create ran with room:'none' — no shared room. */
+  roomChannelId?: string;
+  /** True when the bot only came online after a workspace install approval. */
+  deferredInstall?: boolean;
+}

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -597,90 +597,30 @@ describe('backGate (first-prompt back-to-channel-selection)', () => {
   });
 });
 
-describe('materializeCompanionSkill (channels-branch fetch for absent skill dirs)', () => {
+describe('companionSkillPresent (in-tree presence check)', () => {
   const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'nc-companion-'));
 
-  it('skill already present (SKILL.md exists): true, no git traffic', async () => {
-    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+  it('SKILL.md in the checkout: true', async () => {
+    const { companionSkillPresent } = await import('./run-channel-skill.js');
     const root = makeRoot();
     mkdirSync(join(root, '.claude/skills/slack-a2a-rooms'), { recursive: true });
     writeFileSync(join(root, '.claude/skills/slack-a2a-rooms/SKILL.md'), '# x\n');
-    const exec = vi.fn();
-    expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(true);
-    expect(exec).not.toHaveBeenCalled();
+    expect(companionSkillPresent('slack-a2a-rooms', root)).toBe(true);
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('a leftover dir WITHOUT SKILL.md does not read as installed — it re-fetches', async () => {
-    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+  it('a directory WITHOUT SKILL.md does not read as installed — a missing document parses as zero directives', async () => {
+    const { companionSkillPresent } = await import('./run-channel-skill.js');
     const root = makeRoot();
     mkdirSync(join(root, '.claude/skills/slack-a2a-rooms/src'), { recursive: true });
-    const cmds: string[] = [];
-    const exec = (command: string): string => {
-      cmds.push(command);
-      return command.includes('ls-tree') ? '.claude/skills/slack-a2a-rooms/SKILL.md\n' : '';
-    };
-    expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(true);
-    expect(cmds[0]).toBe('git fetch origin channels');
+    expect(companionSkillPresent('slack-a2a-rooms', root)).toBe(false);
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('absent dir: fetches the channels branch and materializes every listed file, quoted', async () => {
-    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
+  it('absent dir: false — no fetch fallback, the caller warns and skips', async () => {
+    const { companionSkillPresent } = await import('./run-channel-skill.js');
     const root = makeRoot();
-    const cmds: string[] = [];
-    const exec = (command: string): string => {
-      cmds.push(command);
-      if (command.includes('ls-tree')) {
-        return '.claude/skills/slack-agent-flow/SKILL.md\n.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts\n';
-      }
-      return '';
-    };
-    expect(materializeCompanionSkill('slack-agent-flow', root, { exec, resolveRemote: () => 'upstream' })).toBe(true);
-    expect(cmds[0]).toBe('git fetch upstream channels');
-    expect(cmds[1]).toBe("git ls-tree -r --name-only 'upstream/channels' -- '.claude/skills/slack-agent-flow'");
-    // One git-show per listed file, into the same relative path — quoted so a
-    // future filename with spaces fails loudly instead of word-splitting.
-    expect(cmds.slice(2)).toEqual([
-      "git show 'upstream/channels:.claude/skills/slack-agent-flow/SKILL.md' > '.claude/skills/slack-agent-flow/SKILL.md'",
-      "git show 'upstream/channels:.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts' > '.claude/skills/slack-agent-flow/src/modules/slack-agent-flow/index.ts'",
-    ]);
-    rmSync(root, { recursive: true, force: true });
-  });
-
-  it('branch does not carry the skill: false', async () => {
-    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
-    const root = makeRoot();
-    const exec = (command: string): string => (command.includes('ls-tree') ? '\n' : '');
-    expect(materializeCompanionSkill('nope', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
-    rmSync(root, { recursive: true, force: true });
-  });
-
-  it('failure mid-materialization: false, and the partial dir is removed (no poisoned retry)', async () => {
-    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
-    const root = makeRoot();
-    const exec = (command: string): string => {
-      if (command.includes('ls-tree')) return '.claude/skills/slack-agent-flow/SKILL.md\n';
-      if (command.includes('git show')) {
-        // Simulate the redirect creating the parent dir then failing.
-        mkdirSync(join(root, '.claude/skills/slack-agent-flow'), { recursive: true });
-        throw new Error('fatal: bad object');
-      }
-      return '';
-    };
-    expect(materializeCompanionSkill('slack-agent-flow', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
-    // The dir created before the failing git-show must be gone.
-    expect(existsSync(join(root, '.claude/skills/slack-agent-flow'))).toBe(false);
-    rmSync(root, { recursive: true, force: true });
-  });
-
-  it('git failure: false, never throws', async () => {
-    const { materializeCompanionSkill } = await import('./run-channel-skill.js');
-    const root = makeRoot();
-    const exec = (): string => {
-      throw new Error('no network');
-    };
-    expect(materializeCompanionSkill('slack-a2a-rooms', root, { exec, resolveRemote: () => 'origin' })).toBe(false);
+    expect(companionSkillPresent('slack-agent-flow', root)).toBe(false);
     rmSync(root, { recursive: true, force: true });
   });
 });

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -15,9 +15,8 @@
  * So the wire lives in exactly one place (init-first-agent) and is never
  * duplicated across channel skills.
  */
-import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import * as p from '@clack/prompts';
 
@@ -26,59 +25,25 @@ import * as setupLog from '../logs.js';
 import { BACK_TO_CHANNEL_SELECTION, backGate, type ChannelFlowResult } from '../lib/back-nav.js';
 import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
-import { channelsRemote, hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
+import { hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
 import { clearTemplatePick } from '../templates.js';
 import { getChannelPreStep, getCompanionSkills } from './companions.js';
 
 const DEFAULT_AGENT_NAME = 'Nano';
 
-const CHANNELS_BRANCH = 'channels';
-
 /**
- * Trunk ships no channel payloads, and that includes companion skill
- * directories — a declared companion may exist only on the channels registry
- * branch (e.g. the flag-gated Slack agents skills). Materialize an absent
- * directory from there — the same remote resolution and fetch/show mechanics
- * the skill engine uses for `from-branch` payload copies — so runSkill has a
- * document to apply. A directory already in the checkout short-circuits with
- * no git traffic. Returns false when the skill can't be produced; the caller
- * warns and skips it.
+ * Companion skill directories ship in-tree — `.claude/skills/<name>` on trunk
+ * is their canonical home, and the wizard code that declares a companion
+ * travels in the same tree as the skill it names, so a checkout that carries
+ * this code carries the directory too. There is deliberately no branch-fetch
+ * fallback: the only way to reach false is a tree someone trimmed by hand,
+ * and quietly installing a substitute from elsewhere would paper over exactly
+ * that. The caller warns and skips.
  */
-export function materializeCompanionSkill(
-  skill: string,
-  projectRoot: string,
-  deps: { exec?: (command: string) => string; resolveRemote?: () => string } = {},
-): boolean {
-  const dir = `.claude/skills/${skill}`;
-  // Key the short-circuit on SKILL.md, not the directory: a directory left by
-  // an interrupted materialization would otherwise read as installed, and a
-  // missing SKILL.md parses as zero directives — "fully applied" while the
-  // feature is absent.
-  if (existsSync(join(projectRoot, dir, 'SKILL.md'))) return true;
-  const exec =
-    deps.exec ??
-    ((command: string) =>
-      execSync(command, { cwd: projectRoot, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
-  try {
-    const remote = (deps.resolveRemote ?? channelsRemote(projectRoot))();
-    exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
-    const files = exec(`git ls-tree -r --name-only '${remote}/${CHANNELS_BRANCH}' -- '${dir}'`)
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (files.length === 0) return false;
-    for (const file of files) {
-      mkdirSync(dirname(join(projectRoot, file)), { recursive: true });
-      exec(`git show '${remote}/${CHANNELS_BRANCH}:${file}' > '${file}'`);
-    }
-    return true;
-  } catch {
-    // Leave no partial directory behind — the SKILL.md short-circuit above
-    // makes a leftover half-fetched dir permanent on the next run. Deleting
-    // is safe here: this path only runs when the skill was absent on entry.
-    rmSync(join(projectRoot, dir), { recursive: true, force: true });
-    return false;
-  }
+export function companionSkillPresent(skill: string, projectRoot: string): boolean {
+  // Key presence on SKILL.md, not the directory: a directory without one
+  // parses as zero directives — "fully applied" while the feature is absent.
+  return existsSync(join(projectRoot, `.claude/skills/${skill}`, 'SKILL.md'));
 }
 
 /**
@@ -109,12 +74,12 @@ async function applyCompanionSkills(
   let applied = false;
   let degraded = false;
   for (const skill of companions) {
-    if (!materializeCompanionSkill(skill, projectRoot)) {
+    if (!companionSkillPresent(skill, projectRoot)) {
       degraded = true;
       p.log.warn(
-        `Companion skill ${skill} is not in this checkout and could not be fetched from the ` +
-          `${CHANNELS_BRANCH} branch. The ${channel} channel works, but the capability that ` +
-          `skill adds is missing until you fetch and apply it: ` +
+        `Companion skill ${skill} is missing from this checkout (.claude/skills/${skill}/SKILL.md). ` +
+          `The ${channel} channel works, but the capability that skill adds is missing until you ` +
+          `restore the directory (git checkout — it ships with this repo) and apply it: ` +
           `pnpm exec tsx setup/lib/skill-driver.ts .claude/skills/${skill}`,
       );
       continue;

--- a/setup/channels/slack-auto-register.test.ts
+++ b/setup/channels/slack-auto-register.test.ts
@@ -50,4 +50,15 @@ describe('companions registry wiring', () => {
     // agents install rides on this boot-time declaration.
     expect(companions.getCompanionSkills('slack')).toEqual(['slack-a2a-rooms', 'slack-agent-flow']);
   });
+
+  it('every declared companion ships in-tree — the wizard applies it from the checkout', async () => {
+    // The canonical companion documents live on main and there is no fetch
+    // fallback: a companion declared here but absent from .claude/skills/
+    // would be warned about and skipped at setup time. A deleted or renamed
+    // skill directory fails HERE, not in a fresh install's setup log.
+    const { companionSkillPresent } = await import('./run-channel-skill.js');
+    for (const skill of SLACK_AGENTS_COMPANION_SKILLS) {
+      expect(companionSkillPresent(skill, process.cwd())).toBe(true);
+    }
+  });
 });

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -14,12 +14,14 @@
  * alone is the base experience (one bot, DM/channel chat); the agents
  * feature — child bots provisioned from `create_agent`, shared a2a rooms,
  * canvases, DM onboarding — ships in the `slack-a2a-rooms` and
- * `slack-agent-flow` skills on the channels branch. Declaring them HERE, at
- * wizard boot, is load-bearing: the wizard imports the companion registry
- * once, so a registration appended to the registry file mid-run is invisible
- * to the process that would apply it. The channel flow materializes the
- * skill directories from the channels branch when this checkout doesn't
- * carry them.
+ * `slack-agent-flow` skills, in-tree under `.claude/skills/` (their canonical
+ * home; the channels branch keeps a compatibility copy for older checkouts).
+ * Declaring them HERE, at wizard boot, is load-bearing: the wizard imports
+ * the companion registry once, so a registration appended to the registry
+ * file mid-run is invisible to the process that would apply it. The channel
+ * flow applies each declared companion straight from the checkout — a
+ * missing directory is warned about and skipped, never fetched from
+ * elsewhere.
  *
  * The register functions are injected by the caller (companions.ts passes
  * `registerChannelPreStep` / `registerCompanionSkills`) so this module has


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Makes `main` the canonical home of the Slack agents companion skills, so consumers read them from the checkout instead of fetching a branch first.

- **Problem**: `.claude/skills/slack-a2a-rooms` and `.claude/skills/slack-agent-flow` lived only on the `channels` branch, so nothing could apply them without a fetch step first — the wizard materialized the directories at setup time, and a plain checkout had no `/slack-a2a-rooms` or `/slack-agent-flow` to read or invoke at all.
- **Fix**: both directories ship on `main`, verbatim from the channels tip (documents, payloads, fixtures, REMOVE.md), and the wizard applies declared companions straight from the checkout. The channels-branch materialization is deleted rather than kept as a fallback: a checkout carrying the wizard code carries the directories too, and a hand-trimmed tree deserves a loud warn-and-skip, not a quietly fetched substitute that could go stale.
- **Payload stays put**: the files the Apply steps fetch with `from-branch:channels` remain on the channels branch, exactly like `/add-slack`'s own — only the skill directories move.
- **Compatibility**: the channels-branch copy stays untouched as a mirror for existing clones whose older setup code fetches from there; both documents now state that edits land on `main`, never there.
- **Prose brought along**: `/add-slack` names the canonical home, and `slack-agent-flow`'s setup-wizard note drops the retired `--slack-agents` flag it still described.

## Related work

Closes #
<!-- No issue: additive files plus a small wizard simplification, with the new invariant pinned by tests — safe to review directly. -->

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run scripts/skill-conformance.test.ts scripts/skill-directives.test.ts setup/channels/run-channel-skill.test.ts setup/channels/slack-auto-register.test.ts` -> 271 passed. skill-conformance auto-discovers the two new directories and drives them end-to-end with their colocated fixtures.
- New test: every declared companion ships in-tree (`slack-auto-register.test.ts`) — deleting or renaming a skill directory fails CI, not a fresh install's setup log. `companionSkillPresent` unit tests replace the old materialization tests.
- Full suite (`vitest run` minus the two declared-red env-dependent files `setup/channels/slack-auto.test.ts`, `scripts/update/transaction.e2e.test.ts`) -> passing.
- `pnpm exec tsc --noEmit` -> clean.

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change

## Security and trust boundaries

Slightly tightened: setup no longer runs `git fetch`/`git show` to pull companion skill directories at install time — the wizard reads only files already in the checkout.

## Skill delivery

- [ ] Not a skill
- [x] Skill: apply/remove footprint and fresh-clone verification are described above

The two skills' apply/remove footprints are unchanged (their own SKILL.md/REMOVE.md); only their source location moves. Fresh-clone verification: `.claude/skills/slack-a2a-rooms/SKILL.md` and `.claude/skills/slack-agent-flow/SKILL.md` exist after clone, and the wizard's companion step applies them with no `git fetch channels` in `logs/setup-steps/`.

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [ ] A human has reviewed this PR and stands behind every change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
