### PR TITLE
feat: add Keenable MCP tool skill

### DIFF
--- a/.claude/skills/add-keenable-tool/REMOVE.md
+++ b/.claude/skills/add-keenable-tool/REMOVE.md
@@ -1,0 +1,63 @@
+# Remove Keenable Tool
+
+Every step is idempotent when applied in order per the checks below. Apply this
+only to groups where `/add-keenable-tool` was installed.
+
+## 1. Unregister Keenable
+
+Work from the group list the install produced. If it is lost, rediscover it:
+
+```bash
+ncl groups list
+ncl groups config get --id <group-id>
+```
+
+For every group with a `keenable` MCP entry (see the `mcp_servers` field):
+
+```bash
+ncl groups config remove-mcp-server --id <group-id> --name keenable
+```
+
+On a second run this errors with "MCP server 'keenable' not found", which means
+the removal is already complete. The `config get` check above is what keeps the
+command off groups that never had the entry.
+
+## 2. Remove the guards
+
+```bash
+rm -f src/keenable-manifest.test.ts
+```
+
+## 3. Remove the MCP bridge, only if nothing else uses it
+
+`mcp-remote` is a shared bridge: other skills register their servers through
+the same command, and the manifest records no owner. Decide by what is
+configured now, not by who installed it.
+
+```bash
+ncl groups list
+ncl groups config get --id <group-id>   # for every group, not only ours
+```
+
+Keep the `mcp-remote` entry in `container/cli-tools.json` if any remaining MCP
+server on any group has `mcp-remote` as its command. Remove its complete object
+only when none does, keeping the top-level array valid.
+
+A rebuild is not required either way. Nothing invokes the bridge once the
+registrations are gone, and the smaller image arrives with the next
+`./container/build.sh` for whatever reason it is next run.
+
+## 4. Restart and verify
+
+Restart every group touched in step 1:
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+Confirm the server is absent:
+
+```bash
+ncl groups config get --id <group-id>
+test ! -e src/keenable-manifest.test.ts
+```

--- a/.claude/skills/add-keenable-tool/SKILL.md
+++ b/.claude/skills/add-keenable-tool/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: add-keenable-tool
+description: Add Keenable web search and page fetch as keyless remote MCP tools for selected NanoClaw agent groups. Use when installing web search or URL-to-markdown extraction without an API key or signup.
+---
+
+# Add Keenable Tool
+
+Install the pinned `mcp-remote` bridge in the agent image and register Keenable's
+remote MCP server for each selected agent group. The MCP server supplies its
+tool descriptions and input schemas at runtime.
+
+The registered server exposes:
+
+- `mcp__keenable__search_web_pages`
+- `mcp__keenable__fetch_page_content`
+
+The registration is provider-agnostic: any provider with MCP support picks it
+up (Claude, OpenCode, and Codex all do). Groups on the Claude provider already
+have the built-in `WebSearch` and `WebFetch` tools
+(`container/agent-runner/src/providers/claude.ts`), so the skill adds the most
+for groups on other providers, and anywhere the extra query controls matter:
+date filtering, point-in-time search, and instruction-driven extraction.
+
+The server answers anonymously. An optional API key raises the rate limit and
+changes nothing else.
+
+## Phase 1: Pre-flight
+
+Check whether the bridge is already in the image manifest, then list the groups:
+
+```bash
+grep -n '"mcp-remote"' container/cli-tools.json || true
+ncl groups list
+```
+
+Ask which agent groups should receive Keenable. Then take one of two paths:
+
+- **The manifest already has `mcp-remote` at an exact version.** Reuse that
+  entry. Keep whatever version is pinned, even when it differs from the
+  `0.1.38` below: it belongs to whichever skill installed it, and re-pinning it
+  changes another skill's dependency. Skip the edit and the rebuild in Phase 2,
+  and note the version you found when you report.
+- **The manifest has no `mcp-remote`.** Apply Phase 2 in full.
+
+## Phase 2: Install the MCP bridge
+
+Add this object to the top-level array in `container/cli-tools.json`:
+
+```json
+{
+  "name": "mcp-remote",
+  "version": "0.1.38"
+}
+```
+
+Keep the JSON valid and limit the entry to the two fields shown; this package
+does not require a native build-script opt-in.
+
+Copy the guards into the host test tree and run them:
+
+```bash
+cp .claude/skills/add-keenable-tool/keenable-manifest.test.ts src/keenable-manifest.test.ts
+pnpm exec vitest run src/keenable-manifest.test.ts
+```
+
+Run the guards before building. They read `container/cli-tools.json` off the
+host filesystem and never touch the image, so they catch a malformed entry in
+seconds instead of after a build.
+
+Then build the image so it carries the new global CLI tool:
+
+```bash
+./container/build.sh
+```
+
+On a standard install this is a full rebuild from the Node base image and takes
+several minutes; on a hardened install it applies a lightweight overlay. Build
+only when the manifest changed in this run. When Phase 1 found an existing
+pinned entry, the image already carries the bridge and no rebuild is due.
+
+## Phase 3: Register Keenable
+
+`config add-mcp-server` and `groups restart` are approval-gated. Run from
+inside a container they return `approval-pending` immediately; that is not an
+error. Wait for the admin's approval and the follow-up system message before
+moving on to Phase 4.
+
+Register one server named `keenable` for each selected `<group-id>`, then
+restart the same groups. Doing all the registrations first and all the restarts
+after keeps the approval round-trips to two waves rather than two per group.
+
+```bash
+ncl groups config add-mcp-server \
+  --id <group-id> \
+  --name keenable \
+  --command mcp-remote \
+  --args '["https://api.keenable.ai/mcp?keenable_title=nanoclaw","--transport","http-only","--enable-proxy"]' \
+  --env '{}'
+```
+
+`keenable_title` attributes the traffic to NanoClaw, which is how usage from
+this skill is distinguished from every other client. Keep it in the URL.
+
+```bash
+ncl groups restart \
+  --id <group-id> \
+  --message "Keenable web search and page fetch are installed. Run one Keenable search with max_results 1 and report whether it succeeds."
+```
+
+The restart command returns `{ "restarted": <count> }`. A `0` means the group
+has no running container right now, which is normal for a freshly configured
+group: the registration is stored and gets picked up on the group's next
+message. Record the count, it decides what Phase 4 can check.
+
+## Phase 4: Verify
+
+Confirm the stored configuration contains one `keenable` server:
+
+```bash
+ncl groups config get --id <group-id>
+```
+
+For a group whose restart reported `1` or higher, check the agent's test
+response. The call must use `mcp__keenable__search_web_pages`.
+
+For a group whose restart reported `0`, no test message was delivered. The
+stored configuration above is the whole verification available now; the smoke
+test runs on that group's next regular message.
+
+## Rate limits
+
+The anonymous tier allows 1,000 requests per hour and 10 per second, and the
+allowance is shared by every group on the host, since it is keyed on the host's
+IP address. See <https://docs.keenable.ai/rate-limits> for the current figures.
+
+A `429` sends a `retry-after` header and a JSON-RPC error whose message points
+at the authentication docs. The window is rolling, so retrying after the
+interval is a complete fix.
+
+An API key raises the ceiling and is created at
+<https://keenable.ai/console>. Store it through OneCLI on the host, so the
+gateway injects it per request and the agent never sees it. This needs OneCLI
+configured; run `/init-onecli` first if `command -v onecli` finds nothing.
+
+```bash
+onecli secrets create --name keenable --type generic \
+  --host-pattern api.keenable.ai --header-name X-API-Key --file <key-file>
+```
+
+## Troubleshooting
+
+- `command not found: mcp-remote`: rebuild the image, then restart the group.
+- Keenable tools are absent: verify the group has a `keenable` MCP entry, then
+  restart it.
+- Tool calls fail or hang: re-register the server with the exact URL and args
+  from Phase 3. Both the `--enable-proxy` flag and the query string are
+  load-bearing; the flag keeps the bridge routing through the OneCLI gateway
+  under `NANOCLAW_EGRESS_LOCKDOWN=true`.
+- `429`: the host's shared allowance is throttling. See
+  [Rate limits](#rate-limits).
+
+## Removal
+
+See [REMOVE.md](REMOVE.md) for the removal procedure.
+
+## References
+
+- [Keenable MCP server](https://docs.keenable.ai/mcp-server)
+- [Keenable API reference](https://docs.keenable.ai/api-reference)
+- [Keenable rate limits](https://docs.keenable.ai/rate-limits)
+- [`mcp-remote`](https://github.com/geelen/mcp-remote)

--- a/.claude/skills/add-keenable-tool/keenable-manifest.test.ts
+++ b/.claude/skills/add-keenable-tool/keenable-manifest.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Guards for the Keenable MCP tool skill.
+ *
+ * `mcp-remote` is a globally installed CLI, so neither an import nor a
+ * typecheck can detect its removal. The registration itself is runtime DB
+ * state, but the argument shape it is built from lives in SKILL.md, so that
+ * half is guarded structurally.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+function repoRoot(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    if (fs.existsSync(path.join(dir, 'container', 'cli-tools.json'))) return dir;
+    dir = path.dirname(dir);
+  }
+  throw new Error('container/cli-tools.json not found while walking up from ' + __dirname);
+}
+
+const root = repoRoot();
+
+describe('the Keenable MCP bridge is installed in the agent image', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, 'container', 'cli-tools.json'), 'utf8')) as Array<{
+    name: string;
+    version: string;
+  }>;
+
+  it('appears in the CLI manifest', () => {
+    expect(manifest.map((entry) => entry.name)).toContain('mcp-remote');
+  });
+
+  it('is pinned to an exact version, so the supply-chain policy still applies', () => {
+    const bridge = manifest.find((entry) => entry.name === 'mcp-remote');
+    expect(bridge?.version).toMatch(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
+  });
+});
+
+describe('the Keenable registration arguments are intact', () => {
+  const skillMd = fs.readFileSync(path.join(root, '.claude', 'skills', 'add-keenable-tool', 'SKILL.md'), 'utf8');
+
+  it('registers the hosted MCP endpoint', () => {
+    expect(skillMd).toContain('https://api.keenable.ai/mcp');
+  });
+
+  it('carries the attribution query parameter that identifies this traffic', () => {
+    expect(skillMd).toContain('keenable_title=nanoclaw');
+  });
+
+  it('pins the transport the bridge speaks', () => {
+    expect(skillMd).toContain('"--transport","http-only"');
+  });
+
+  it('keeps the bridge proxy-aware, so it reaches the gateway under egress lockdown', () => {
+    expect(skillMd).toContain('--enable-proxy');
+  });
+});


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Adds `/add-keenable-tool`, a skill that registers Keenable web search and page fetch as remote MCP tools for selected agent groups.

- **Installs**: the pinned `mcp-remote` bridge in `container/cli-tools.json`, two guards copied into `src/`, and one `keenable` MCP server per selected group via `ncl`.
- **Tools**: `mcp__keenable__search_web_pages`, `mcp__keenable__fetch_page_content`.
- **No account, no key, no signup.** The server answers anonymously, so the happy path has no credential step. A key raises the rate limit and changes nothing else; when a user wants one it goes through OneCLI, gated on `/init-onecli`.
- **No upgrade phase.** The anonymous allowance is a rolling window (1,000/hour, 10/second, per host IP), so a `429` sends `retry-after` and heals itself. A Rate limits section and a troubleshooting entry cover it.
- **Guards both integration points**: the pinned bridge in the manifest, and the registered argument shape read out of `SKILL.md` (endpoint, attribution parameter, transport pin, `--enable-proxy`). The second one follows the approach in #3418.
- **Out of scope**: promoting the paid key from inside the agent, which would need the vault deeplink machinery and is a separate change.

## Related work

No issue: this adds an optional skill and changes no existing behavior, so the diff can be reviewed directly. It follows `add-tavily-tool` (#3190).

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run src/keenable-manifest.test.ts` -> **6 passed** with the skill applied. Mutation-tested one element at a time: removing the attribution parameter, `--enable-proxy`, or the `--transport http-only` pin each turns exactly 1 of 6 red; removing the manifest entry reds the dependency half; restoring returns 6 green.
- `pnpm exec vitest run scripts/skill-conformance.test.ts scripts/skill-policy.test.ts scripts/skill-directives.test.ts` -> **274 passed** with the skill in the tree.
- `pnpm exec tsx scripts/skill-directives.ts .claude/skills/add-keenable-tool/SKILL.md` -> no problems, no warnings.
- `pnpm exec prettier --check "src/**/*.ts"` and `pnpm exec eslint src/keenable-manifest.test.ts` -> clean with the guards copied in, so `format:check` stays green after install.
- Outside CI: drove `mcp-remote@0.1.38` over stdio with the exact args Phase 3 registers -> `initialize`, `tools/list` and a live `tools/call` all returned anonymously, with page text in the result. A 25-call burst returned 10 x `200` and 15 x `429`, matching the rate limit the skill documents.

- [x] Tests cover the changed behavior (or Validation says why not)

Per-group MCP registration is runtime state stored through `ncl`, so it has no in-tree line to guard; the argument shape it is built from does, and that is what the second guard covers.

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
```

## Security and trust boundaries

No credentials. The server is called anonymously, `--env` is empty, and the default path stores nothing. An optional API key, if a user wants one, is stored through OneCLI so the gateway injects it per request and the agent never sees it. The bridge keeps `--enable-proxy`, so it stays proxy-aware under `NANOCLAW_EGRESS_LOCKDOWN=true`. Search results and fetched pages are untrusted web content and are consumed as data, same as any other web tool.

## Skill delivery

- [ ] Not a skill
- [x] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [x] A human has reviewed this PR and stands behind every change
