### PR TITLE
fix: tasks run feeds the reconcile queue so the run starts now, not at the next resync tick

### DIFF
--- a/src/cli/resources/tasks.test.ts
+++ b/src/cli/resources/tasks.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../../db/sessions.js';
 import { initSessionFolder, sessionDir, withMailboxSession } from '../../session-manager.js';
 import { inboundDbPath, outboundDbPath } from '../../mailbox/sqlite/paths.js';
+import { registerReconcileEnqueue } from '../../reconcile-feeds.js';
 import { dispatch } from '../dispatch.js';
 import { formatTasksTable } from '../format-tasks.js';
 import type { CallerContext } from '../frame.js';
@@ -388,6 +389,26 @@ describe('tasks CLI resource', () => {
     const runRow = pending.find((p) => p.id === fired.row_id);
     expect(runRow?.recurrence).toBeNull(); // never re-armed into a phantom series
     expect(new Date(runRow!.process_after).getTime()).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('run asks for a prompt reconcile of the task session, as an inbound message does', async () => {
+    const created = await dispatch(
+      { id: 'c', command: 'tasks-create', args: { prompt: 'x', name: 'promptly', process_after: '2999-01-01T00:00:00Z' } },
+      agentCtx('ag-1', 'chat-1'),
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const { series_id, session_id } = created.data as { series_id: string; session_id: string };
+
+    const enqueue = vi.fn();
+    registerReconcileEnqueue(enqueue);
+    try {
+      const run = await dispatch({ id: 'r', command: 'tasks-run', args: { id: series_id } }, agentCtx('ag-1', 'chat-1'));
+      expect(run.ok).toBe(true);
+      expect(enqueue).toHaveBeenCalledWith(session_id);
+    } finally {
+      registerReconcileEnqueue(null);
+    }
   });
 
   it('run snapshots the updated schedule instead of an older in-flight occurrence', async () => {

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -27,6 +27,7 @@ import {
 import { destroySessionMailbox, sessionDir, withExistingMailboxSession } from '../../session-manager.js';
 import { registerResource } from '../crud.js';
 import { appendRunLog, deleteRunLog } from '../../modules/scheduling/run-log.js';
+import { enqueueSessionReconcile } from '../../reconcile-feeds.js';
 import { formatTasksTable } from '../format-tasks.js';
 import type { CallerContext } from '../frame.js';
 import type { InboundMailbox } from '../../mailbox/index.js';
@@ -409,7 +410,13 @@ async function runTaskCommand(args: Record<string, unknown>, ctx: CallerContext)
       });
       return { series_id: seriesKey, row_id: rowId, status: 'pending' };
     });
-    if (fired) return fired;
+    if (fired) {
+      // The row is due now. Ask for a prompt reconcile, as an inbound message
+      // does, so the run starts within the queue's cadence instead of at the
+      // next resync tick. No-op when the sweep isn't running.
+      enqueueSessionReconcile(session.id);
+      return fired;
+    }
   }
   throw new Error(`task not found: ${id}`);
 }


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Makes `ncl tasks run` start the run now instead of at the next resync tick.
- **Problem**: `runTaskCommand` inserts a due row but never feeds the reconcile queue, so the run waits for the periodic resync (up to `SWEEP_INTERVAL_MS`, 60 s). An inbound message in the same session is reconciled within the queue's cadence because the inbound writer calls `enqueueSessionReconcile` (`session-manager.ts`).
- **Fix**: call `enqueueSessionReconcile(session.id)` once the row is durable, exactly as the inbound writer does. No-op when the sweep is not running; the resync floor still covers it.
- **Out of scope**: `tasks create` with an immediate `--process-after`.

## Related work

Closes #
No issue. Two lines that mirror an existing call site in the same process; safe to review directly.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run src/cli/resources/tasks.test.ts src/reconcile-feeds.test.ts` -> 2 files, 35 tests passed. New test: `run asks for a prompt reconcile of the task session, as an inbound message does` (registers an enqueue spy, asserts it is called with the task session id).
- `pnpm run typecheck` -> clean. `eslint` on the changed files -> clean.
- Manual: with a host driven by a desktop peer, run-now started about a second after the command instead of about forty seconds.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
`ncl tasks run` starts the run right away instead of waiting for the next resync tick (up to 60 s).
```

## Security and trust boundaries

None. Same permission checks as before; the enqueue is a hint the sweep re-reads, never a command.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [ ] A human has reviewed this PR and stands behind every change
