### PR TITLE
fix: delivery spends no attempt on an adapter that reports itself disconnected

### DIFF
--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -86,6 +86,18 @@ export class MissingChannelAdapterError extends Error {
   }
 }
 
+/** Thrown by the delivery bridge when the adapter is registered but reports
+ *  itself disconnected (a client mid-reconnect, a desktop peer that is away).
+ *  Delivery leaves the row where it is and counts no attempt: nothing was
+ *  sent, so nothing failed, and spending the attempts on a short reconnect
+ *  would mark the message failed for good. */
+export class ChannelAdapterOfflineError extends Error {
+  constructor(readonly key: string) {
+    super(`Channel adapter '${key}' is not connected — the message waits for it to come back.`);
+    this.name = 'ChannelAdapterOfflineError';
+  }
+}
+
 /**
  * Build the host's outbound delivery bridge: dispatches delivery-poll and
  * typing traffic into the adapter registry. Resolution is EXACT-key only —
@@ -110,6 +122,9 @@ export function createChannelDeliveryAdapter(): ChannelDeliveryAdapter {
       const adapter = getChannelAdapterExact(instance ?? channelType);
       if (!adapter) {
         throw new MissingChannelAdapterError(channelType, instance);
+      }
+      if (!adapter.isConnected()) {
+        throw new ChannelAdapterOfflineError(instance ?? channelType);
       }
       return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
     },

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -36,7 +36,15 @@ import {
   registerPostDeliveryHook,
   setDeliveryAdapter,
 } from './delivery.js';
-import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
+import {
+  createChannelDeliveryAdapter,
+  fallbackChannelDefaults,
+  initChannelAdapters,
+  registerChannelAdapter,
+  teardownChannelAdapters,
+} from './channels/channel-registry.js';
+import type { ChannelAdapter, ChannelSetup } from './channels/adapter.js';
+import { getDeliveryAttempt } from './db/coordination.js';
 import { createDestination } from './modules/agent-to-agent/db/agent-destinations.js';
 import { getAgentMailbox } from './mailbox/index.js';
 import { log } from './log.js';
@@ -737,5 +745,49 @@ describe('deliverSessionMessages — post-delivery hooks', () => {
     const delivered = getDeliveredIds(openInboundDb('ag-1', session.id));
     expect(delivered.has('th-1')).toBe(true);
     expect(delivered.has('th-2')).toBe(true);
+  });
+});
+
+describe('deliverSessionMessages — adapter reports disconnected', () => {
+  it('spends no attempt while the adapter is away; delivers once it is back', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'out-away');
+
+    let connected = false;
+    let sent = 0;
+    const adapter: ChannelAdapter = {
+      name: 'telegram',
+      channelType: 'telegram',
+      supportsThreads: false,
+      defaults: fallbackChannelDefaults(false),
+      async setup() {},
+      async teardown() {},
+      isConnected: () => connected,
+      async deliver() {
+        sent += 1;
+        return 'pm-1';
+      },
+    };
+    registerChannelAdapter('telegram', { factory: () => adapter, defaults: fallbackChannelDefaults(false) });
+    await initChannelAdapters(() => ({ onInbound: async () => {}, onAction: () => {} }) as unknown as ChannelSetup);
+    setDeliveryAdapter(createChannelDeliveryAdapter());
+    try {
+      for (let i = 0; i < 4; i += 1) await deliverSessionMessages(session);
+      expect(sent).toBe(0);
+      const idle = new Database(inboundDbPath('ag-1', session.id), { readonly: true });
+      expect(idle.prepare('SELECT * FROM delivered WHERE message_out_id = ?').get('out-away')).toBeUndefined();
+      idle.close();
+      expect(await getDeliveryAttempt('out-away')).toBeUndefined();
+
+      connected = true;
+      await deliverSessionMessages(session);
+      expect(sent).toBe(1);
+      expect(
+        await withMailboxSession('ag-1', session.id, (mailbox) => mailbox.getDeliveredIds().has('out-away')),
+      ).toBe(true);
+    } finally {
+      await teardownChannelAdapters();
+    }
   });
 });

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -18,6 +18,7 @@ import {
   getMessagingGroupByPlatform,
   getMessagingGroupForOwnDestination,
 } from './db/messaging-groups.js';
+import { ChannelAdapterOfflineError } from './channels/channel-registry.js';
 import { clearDeliveryAttempt, recordDeliveryAttempt } from './db/coordination.js';
 import { runGuarded, type DeliveryGuardSpec, type GuardedDeliveryHandler } from './delivery-guard.js';
 import { isUnguarded, type Unguarded } from './guard/index.js';
@@ -286,6 +287,11 @@ async function drainSession(session: Session): Promise<void> {
         }
       }
     } catch (err) {
+      if (err instanceof ChannelAdapterOfflineError) {
+        // Nothing was sent, so this is not an attempt. The row waits for the adapter.
+        log.debug('Channel adapter offline; message waits', { messageId: msg.id, sessionId: session.id, key: err.key });
+        continue;
+      }
       const attempts = await recordAttemptRow(msg.id, session.id, err);
       if (attempts !== null && attempts >= MAX_DELIVERY_ATTEMPTS) {
         log.error('Message delivery failed permanently, giving up', {


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Stops delivery spending its three attempts on an adapter that is merely disconnected.
- **Problem**: `ChannelAdapter.isConnected()` is part of the contract, but delivery never consults it. An adapter mid-reconnect throws from `deliver()`; each throw is one of `MAX_DELIVERY_ATTEMPTS = 3`, and the active poll runs every second, so about three seconds without a connection marks a message `failed` for good although nothing was ever sent.
- **Fix**: the delivery bridge throws `ChannelAdapterOfflineError` when `isConnected()` is false, and `drainSession` treats it as "not an attempt": no `delivery_attempts` row, the message stays due for the next poll. The mailbox is the queue until the adapter is back. Every other error path is unchanged.
- **Out of scope**: adapters that answer `isConnected() === true` while their client is down.

## Related work

Closes #
No issue. A small change on the existing retry path, with a test that drives the real bridge through a registered adapter.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run src/delivery.test.ts src/channels/` -> all passed. New test: `spends no attempt while the adapter is away; delivers once it is back` (four polls with `isConnected() === false`: nothing sent, no `delivered` row, no attempt row; then connected: delivered on the next poll).
- `pnpm run typecheck` -> clean. `eslint` on the changed files -> clean.
- Manual: a desktop peer whose socket dropped for a few seconds kept its replies; they arrived when the link came back instead of being marked failed.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
A message is no longer marked failed while its channel adapter is disconnected; it waits in the mailbox and is delivered when the adapter reconnects.
```

## Security and trust boundaries

None. No new path delivers anything; an offline adapter delivers nothing, as before. The permission check on destinations runs unchanged when the adapter is connected.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [ ] A human has reviewed this PR and stands behind every change
