### PR TITLE
feat(agent-runner): add registerAdmissionGate poll-loop seam

### DIFF
--- a/container/agent-runner/src/admission-gate.test.ts
+++ b/container/agent-runner/src/admission-gate.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { evaluateAdmission, registerAdmissionGate, resetAdmissionGatesForTesting } from './admission-gate.js';
+import { closeSessionDb, getInboundDb, initTestSessionDb } from './mailbox/sqlite/connection.js';
+import { getPendingMessages } from './db/messages-in.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { MockProvider } from './providers/mock.js';
+import { runPollLoop } from './poll-loop.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+  resetAdmissionGatesForTesting();
+});
+
+afterEach(() => {
+  closeSessionDb();
+  resetAdmissionGatesForTesting();
+});
+
+describe('admission gate', () => {
+  it('runs every registered gate and holds when any holds', () => {
+    expect(evaluateAdmission()).toBe(false);
+
+    let secondCalls = 0;
+    registerAdmissionGate(() => true);
+    registerAdmissionGate(() => {
+      secondCalls += 1;
+      return false;
+    });
+
+    // Both gates ran even though the first already decided the outcome.
+    expect(evaluateAdmission()).toBe(true);
+    expect(secondCalls).toBe(1);
+  });
+
+  it('treats a throwing gate as not holding, and reports it once per distinct message', () => {
+    const errors = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      let laterCalls = 0;
+      registerAdmissionGate(() => {
+        throw new Error('gate exploded');
+      });
+      registerAdmissionGate(() => {
+        laterCalls += 1;
+        return false;
+      });
+
+      // The throwing gate never holds admission, and the gate registered
+      // after it still runs.
+      expect(evaluateAdmission()).toBe(false);
+      expect(laterCalls).toBe(1);
+      expect(errors.mock.calls.length).toBe(1);
+
+      // Repeating the same failure does not add another log line.
+      expect(evaluateAdmission()).toBe(false);
+      expect(laterCalls).toBe(2);
+      expect(errors.mock.calls.length).toBe(1);
+
+      // A different gate throwing a different message gets its own report.
+      registerAdmissionGate(() => {
+        throw new Error('gate exploded differently');
+      });
+      expect(evaluateAdmission()).toBe(false);
+      expect(errors.mock.calls.length).toBe(2);
+    } finally {
+      errors.mockRestore();
+    }
+  });
+});
+
+function insertMessage(id: string, content: object) {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, trigger, platform_id, channel_type, thread_id, content)
+       VALUES (?, 'chat', datetime('now'), 'pending', 1, 'chan-1', 'discord', 'thread-1', ?)`,
+    )
+    .run(id, JSON.stringify(content));
+}
+
+async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
+  return Promise.race([
+    runPollLoop({ provider, providerName: 'mock', cwd: '/tmp', signal }),
+    new Promise<void>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('aborted')));
+    }),
+    new Promise<void>((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
+  ]);
+}
+
+async function waitFor(condition: () => boolean, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timeout');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+describe('admission gate — poll loop wiring', () => {
+  it('a held gate stops dispatch, and a released gate resumes it', async () => {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+         VALUES ('discord-test', 'Discord Test', 'channel', 'discord', 'chan-1', NULL)`,
+      )
+      .run();
+    insertMessage('m1', { sender: 'Alice', text: 'ping' });
+
+    let held = true;
+    registerAdmissionGate(() => held);
+
+    const provider = new MockProvider({}, () => '<message to="discord-test">pong</message>');
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 3000);
+
+    // While held, the message is never picked off the queue.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(getPendingMessages().some((m) => m.id === 'm1')).toBe(true);
+    expect(getUndeliveredMessages()).toHaveLength(0);
+
+    // Releasing the gate lets the same still-pending message dispatch.
+    held = false;
+    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
+    controller.abort();
+
+    expect(getPendingMessages().some((m) => m.id === 'm1')).toBe(false);
+
+    await loopPromise.catch(() => {});
+  });
+});

--- a/container/agent-runner/src/admission-gate.ts
+++ b/container/agent-runner/src/admission-gate.ts
@@ -1,0 +1,39 @@
+/** A boundary observer runs at the provider-idle boundary of the poll loop, never mid-query.
+ *  It returns true to hold admission. Observers MAY record that they observed the boundary
+ *  (that is the point of the seam); they must be cheap and must not throw.
+ *
+ *  A gate that throws anyway is caught, reported once per gate per distinct message (the
+ *  boundary runs every second — a repeated failure must not become a log flood) and treated
+ *  as NOT holding, so one broken observer cannot wedge every container. */
+export type AdmissionGate = () => boolean;
+
+const gates: AdmissionGate[] = [];
+const reported = new Map<AdmissionGate, Set<string>>();
+
+export function registerAdmissionGate(gate: AdmissionGate): void {
+  gates.push(gate);
+}
+
+/** Runs EVERY registered gate (no short-circuit) and returns whether any holds. */
+export function evaluateAdmission(): boolean {
+  let held = false;
+  for (const gate of gates) {
+    try {
+      if (gate()) held = true;
+    } catch (error) {
+      const message = String(error);
+      let seen = reported.get(gate);
+      if (!seen) reported.set(gate, (seen = new Set()));
+      if (!seen.has(message)) {
+        seen.add(message);
+        console.error(`[admission-gate] gate threw and is treated as not holding: ${message}`);
+      }
+    }
+  }
+  return held;
+}
+
+export function resetAdmissionGatesForTesting(): void {
+  gates.length = 0;
+  reported.clear();
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,3 +1,4 @@
+import { evaluateAdmission } from './admission-gate.js';
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
 import {
   getPendingMessages,
@@ -108,6 +109,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
   let isFirstPoll = true;
   while (true) {
     if (config.signal?.aborted) return;
+    // Provider-idle admission boundary: registered gates decide whether this
+    // container may start a turn. The loop itself knows nothing about them —
+    // see admission-gate.ts.
+    if (evaluateAdmission()) {
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
     // Skip system messages — they're responses for MCP tools (e.g., ask_user_question)
     const messages = getPendingMessages(isFirstPoll).filter((m) => m.kind !== 'system');
     isFirstPoll = false;


### PR DESCRIPTION
## What

Adds `container/agent-runner/src/admission-gate.ts` (`registerAdmissionGate`,
`evaluateAdmission`, `resetAdmissionGatesForTesting`) and wires one call into
the top of the outer poll loop, right after the existing abort check
(`poll-loop.ts:110-111`).

## Why

`getPendingMessages` (called at `poll-loop.ts:112` in the outer idle loop and
again at `poll-loop.ts:417` when pushing follow-ups into an active query)
answers *which rows are due*. It has no way to express *don't start a turn
yet* independently of row selection — a caller that needs to hold dispatch
for a reason unrelated to message content (a maintenance window, an external
readiness check, a migration still in flight) has nowhere to hook in short of
patching the loop itself.

`registerAdmissionGate` adds a small, generic seam at the one place all
dispatch already funnels through: the provider-idle boundary at the top of
the outer loop. A gate is a cheap, synchronous, non-throwing predicate;
`evaluateAdmission()` runs every registered gate (no short-circuit, so a
second gate is never starved by the first) and holds admission if any one
returns true. A gate that throws anyway is caught, logged once per distinct
message (the boundary runs every second, so a repeating failure must not
become a log flood), and treated as not holding — one broken observer can't
wedge every container.

This PR ports only the generic seam. It has no consumers in this repo; it's
infrastructure for extensions (an admission policy specific to some fork/
deployment) to register against without touching `poll-loop.ts` again.

## Contract

```ts
export type AdmissionGate = () => boolean;
export function registerAdmissionGate(gate: AdmissionGate): void;
export function evaluateAdmission(): boolean;
```

## Cost

Measured on a downstream fork carrying one gate: ~148 µs/evaluation on the
poll loop's existing 1s cadence — not a measurable addition to CPU or
latency budget.

## Tests

`admission-gate.test.ts`:
- every registered gate runs on every evaluation; holds when any holds
- a throwing gate is treated as not holding and logged once per distinct
  message, without stopping later gates from running
- poll-loop wiring: a held gate stops a pending message from dispatching;
  releasing the gate lets the same message dispatch on the next poll
