### PR TITLE
fix(agent-runner): set busy_timeout before journal_mode on outbound open

### DIFF
--- a/container/agent-runner/src/mailbox/sqlite/connection.test.ts
+++ b/container/agent-runner/src/mailbox/sqlite/connection.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { openOutboundConnection } from './connection.js';
+
+// A sibling process (standing in for e.g. an MCP server holding a write
+// transaction) that opens the same file, takes an EXCLUSIVE lock, prints
+// "locked" once it has it, holds the lock briefly, then releases it.
+const HOLDER_SCRIPT = `
+  const { Database } = await import('bun:sqlite');
+  const db = new Database(process.argv[1]);
+  db.exec('PRAGMA busy_timeout = 5000');
+  db.exec('BEGIN EXCLUSIVE');
+  db.exec('CREATE TABLE IF NOT EXISTS t (x INTEGER)');
+  console.log('locked');
+  await new Promise((r) => setTimeout(r, 300));
+  db.exec('COMMIT');
+  console.log('released');
+`;
+
+async function waitForLine(stream: ReadableStream<Uint8Array>, needle: string): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`sibling process exited before printing "${needle}". Output so far: ${buf}`);
+      buf += decoder.decode(value, { stream: true });
+      if (buf.includes(needle)) return;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+describe('openOutboundConnection PRAGMA order', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  test('waits out a sibling holding an EXCLUSIVE lock instead of failing SQLITE_BUSY on open', async () => {
+    dir = mkdtempSync(join(tmpdir(), `nanoclaw-outbound-pragma-${randomUUID()}-`));
+    const dbPath = join(dir, 'outbound.db');
+
+    const holder = Bun.spawn({
+      cmd: ['bun', '-e', HOLDER_SCRIPT, dbPath],
+      stdout: 'pipe',
+      stderr: 'inherit',
+    });
+
+    try {
+      // Don't open our connection until the sibling actually holds the lock.
+      await waitForLine(holder.stdout, 'locked');
+
+      const start = Date.now();
+      const db = openOutboundConnection(dbPath);
+      const elapsed = Date.now() - start;
+
+      // busy_timeout is set before journal_mode, so the open blocks and
+      // retries through the sibling's ~300ms hold instead of throwing
+      // "database is locked" immediately (which the buggy order does in
+      // ~1ms — see the swapped-order regression this guards against).
+      expect(elapsed).toBeGreaterThan(150);
+      expect(elapsed).toBeLessThan(5000);
+
+      // The connection is fully usable afterward.
+      expect(db.prepare("SELECT name FROM sqlite_master WHERE name = 'session_state'").get()).toBeTruthy();
+      db.close();
+    } finally {
+      await holder.exited;
+    }
+  });
+});

--- a/container/agent-runner/src/mailbox/sqlite/connection.ts
+++ b/container/agent-runner/src/mailbox/sqlite/connection.ts
@@ -72,38 +72,46 @@ export function getInboundDb(): Database {
   return _inbound;
 }
 
-/** Outbound DB — container owns this file (sole writer). */
-export function getOutboundDb(): Database {
-  if (!_outbound) {
-    _outbound = new Database(DEFAULT_OUTBOUND_PATH);
-    _outbound.exec('PRAGMA journal_mode = DELETE');
-    _outbound.exec('PRAGMA busy_timeout = 5000');
-    _outbound.exec('PRAGMA foreign_keys = ON');
-    // Lightweight forward-compat: session_state was added after the initial
-    // v2 schema, so older session DBs don't have it. Create it on demand
-    // instead of requiring a formal migration pass. Also handle the case
-    // where an earlier revision of this table existed without updated_at —
-    // ALTER TABLE to add any missing columns.
-    _outbound.exec(`
+/**
+ * Opens and initializes the outbound connection at `path`. Exported (in
+ * addition to `getOutboundDb`, which memoizes this against the container's
+ * single real outbound.db) so tests can open a real on-disk file directly
+ * and exercise the exact opener body — including its PRAGMA order — without
+ * going through the process-wide singleton.
+ */
+export function openOutboundConnection(path: string): Database {
+  const db = new Database(path);
+  // busy_timeout must be set BEFORE journal_mode: switching journal mode
+  // takes an exclusive lock, and a connection that hasn't set busy_timeout
+  // yet fails that lock attempt immediately with SQLITE_BUSY instead of
+  // waiting — observed against a sibling process (e.g. an MCP server) mid
+  // write-transaction on this same file.
+  db.exec('PRAGMA busy_timeout = 5000');
+  db.exec('PRAGMA journal_mode = DELETE');
+  db.exec('PRAGMA foreign_keys = ON');
+  // Lightweight forward-compat: session_state was added after the initial
+  // v2 schema, so older session DBs don't have it. Create it on demand
+  // instead of requiring a formal migration pass. Also handle the case
+  // where an earlier revision of this table existed without updated_at —
+  // ALTER TABLE to add any missing columns.
+  db.exec(`
       CREATE TABLE IF NOT EXISTS session_state (
         key        TEXT PRIMARY KEY,
         value      TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
     `);
-    const cols = new Set(
-      (_outbound.prepare("PRAGMA table_info('session_state')").all() as Array<{ name: string }>).map((c) => c.name),
-    );
-    if (!cols.has('updated_at')) {
-      _outbound.exec(
-        `ALTER TABLE session_state ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z'`,
-      );
-    }
-    _outbound.exec(`UPDATE session_state SET updated_at = '1970-01-01T00:00:00.000Z' WHERE updated_at = ''`);
-    // container_state: tracks the current tool in flight (if any) so the host
-    // sweep can widen its stuck tolerance when Bash is running with a user-
-    // declared long timeout. Forward-compat for older outbound.db files.
-    _outbound.exec(`
+  const cols = new Set(
+    (db.prepare("PRAGMA table_info('session_state')").all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  if (!cols.has('updated_at')) {
+    db.exec(`ALTER TABLE session_state ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z'`);
+  }
+  db.exec(`UPDATE session_state SET updated_at = '1970-01-01T00:00:00.000Z' WHERE updated_at = ''`);
+  // container_state: tracks the current tool in flight (if any) so the host
+  // sweep can widen its stuck tolerance when Bash is running with a user-
+  // declared long timeout. Forward-compat for older outbound.db files.
+  db.exec(`
       CREATE TABLE IF NOT EXISTS container_state (
         id                       INTEGER PRIMARY KEY CHECK (id = 1),
         current_tool             TEXT,
@@ -112,6 +120,13 @@ export function getOutboundDb(): Database {
         updated_at               TEXT NOT NULL
       );
     `);
+  return db;
+}
+
+/** Outbound DB — container owns this file (sole writer). */
+export function getOutboundDb(): Database {
+  if (!_outbound) {
+    _outbound = openOutboundConnection(DEFAULT_OUTBOUND_PATH);
   }
   return _outbound;
 }


### PR DESCRIPTION
## What

Swaps the order of two PRAGMA statements in `getOutboundDb()`
(`container/agent-runner/src/mailbox/sqlite/connection.ts`): `busy_timeout`
now runs before `journal_mode`, not after.

## Why

Setting `journal_mode` takes an exclusive lock on the database file.
`busy_timeout` is what makes a connection *wait* for a lock instead of
failing immediately. With the old order, the connection hits the
journal_mode lock request before busy_timeout has been configured, so if a
sibling writer (e.g. an MCP server mid write-transaction on the same file)
already holds the lock, the open throws `SQLiteError: database is locked`
right away instead of waiting it out.

Confirmed empirically with two Bun processes sharing a temp file: a sibling
holding `BEGIN EXCLUSIVE` for 300ms causes the old order to throw in ~1ms,
and the fixed order to block for ~330ms and then succeed.

`openInboundDb()`/`getInboundDb()` were checked and don't set `journal_mode`
at all, so they're unaffected — this PR touches only the outbound opener.

## Change

The outbound opener body (PRAGMAs + forward-compat schema setup) is factored
out into an exported `openOutboundConnection(path)`; `getOutboundDb()` is now
a one-line memoization wrapper around it. This is not a behavior change — it
exists so the new test can open a real on-disk file directly, against a real
sibling-process lock, without going through the in-memory test-mode
singleton that `getOutboundDb()` uses in every other test.

## Tests

`connection.test.ts`: spawns a second Bun process that opens the same temp
file, takes `BEGIN EXCLUSIVE`, holds it ~300ms, then releases it. Asserts
that `openOutboundConnection()` called against that file while the lock is
held blocks (elapsed > 150ms) rather than throwing, and that the resulting
connection is usable afterward.
