### PR TITLE
test: remove the temp directories the suite leaves behind

### DIFF
--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +14,29 @@ import {
   type InputMeta,
 } from './skill-apply.js';
 import { parseDirectives, validate } from './skill-directives.js';
+
+/**
+ * Every temp dir this file creates, removed once the file finishes.
+ *
+ * The cases here mkdtemp a skill dir and a project root apiece — some in
+ * `beforeEach`, some at module scope, some inline — and only one block used to
+ * clean up after itself. The rest accumulated in the OS temp dir on every run
+ * (~294 directories per run of this file alone), not reclaimed until a reboot
+ * or the 30-day tmpfiles sweep.
+ *
+ * Cleanup is `afterAll`, not `afterEach`: the module-scope roots below are
+ * built once and shared by the cases that reference them, so per-test removal
+ * would delete a fixture still in use.
+ */
+const tempRoots: string[] = [];
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+afterAll(() => {
+  while (tempRoots.length) rmSync(tempRoots.pop()!, { recursive: true, force: true });
+});
 
 // A synthetic skill exercising the fs handlers for real (no network), plus one
 // directive the engine can't handle — to prove it bounces to an agent, not abort.
@@ -57,8 +80,8 @@ const recordingExec = () => {
 };
 
 beforeEach(() => {
-  skillDir = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-  root = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+  skillDir = tempDir('nc-skill-');
+  root = tempDir('nc-proj-');
   mkdirSync(join(skillDir, 'resources'), { recursive: true });
   writeFileSync(join(skillDir, 'SKILL.md'), SKILL);
   writeFileSync(join(skillDir, 'resources/sample.ts'), 'export const sample = true;\n');
@@ -201,8 +224,8 @@ container/skills/demo-formatting/SKILL.md
 
 describe('from-branch copy apply path', () => {
   it('creates the missing dest parent dir before the git-show redirect', async () => {
-    const fskill = mkdtempSync(join(tmpdir(), 'nc-skill-fb-'));
-    const froot = mkdtempSync(join(tmpdir(), 'nc-proj-fb-'));
+    const fskill = tempDir('nc-skill-fb-');
+    const froot = tempDir('nc-proj-fb-');
     writeFileSync(join(fskill, 'SKILL.md'), FROM_BRANCH_SKILL);
     writeFileSync(join(froot, '.env'), '');
     writeFileSync(join(froot, 'package.json'), '{"name":"scratch"}');
@@ -242,8 +265,8 @@ describe('json-merge directive', () => {
   let jroot: string;
   let jskill: string;
   beforeEach(() => {
-    jskill = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-    jroot = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+    jskill = tempDir('nc-skill-');
+    jroot = tempDir('nc-proj-');
     writeFileSync(join(jskill, 'SKILL.md'), JSON_MERGE_SKILL);
     mkdirSync(join(jroot, 'container'), { recursive: true });
     writeFileSync(join(jroot, 'container/cli-tools.json'), '[\n  { "name": "vercel", "version": "52.2.1" }\n]\n');
@@ -336,8 +359,8 @@ describe('append at:<marker>', () => {
   let aroot: string;
   let askill: string;
   beforeEach(() => {
-    askill = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-    aroot = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+    askill = tempDir('nc-skill-');
+    aroot = tempDir('nc-proj-');
     mkdirSync(join(aroot, 'setup'), { recursive: true });
     writeFileSync(join(aroot, 'setup/index.ts'), MARKER_FILE);
   });
@@ -402,8 +425,8 @@ describe('nc:run variable substitution', () => {
   let rroot: string;
   let rskill: string;
   beforeEach(() => {
-    rskill = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-    rroot = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+    rskill = tempDir('nc-skill-');
+    rroot = tempDir('nc-proj-');
     writeFileSync(join(rskill, 'SKILL.md'), RUN_WIRE_SKILL);
     writeFileSync(join(rroot, 'package.json'), '{"name":"scratch"}');
   });
@@ -464,8 +487,8 @@ describe('nc:run capture', () => {
   let croot: string;
   let cskill: string;
   beforeEach(() => {
-    cskill = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-    croot = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+    cskill = tempDir('nc-skill-');
+    croot = tempDir('nc-proj-');
     writeFileSync(join(cskill, 'SKILL.md'), CAPTURE_SKILL);
     writeFileSync(join(croot, 'package.json'), '{"name":"scratch"}');
   });
@@ -525,8 +548,8 @@ describe('nc:run multi-field JSON capture + validate', () => {
   let mroot: string;
   let mskill: string;
   beforeEach(() => {
-    mskill = mkdtempSync(join(tmpdir(), 'nc-multi-skill-'));
-    mroot = mkdtempSync(join(tmpdir(), 'nc-multi-proj-'));
+    mskill = tempDir('nc-multi-skill-');
+    mroot = tempDir('nc-multi-proj-');
     writeFileSync(join(mroot, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(mroot, '.env'), '');
   });
@@ -594,8 +617,8 @@ describe('nc:operator', () => {
   let oroot: string;
   let oskill: string;
   beforeEach(() => {
-    oskill = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-    oroot = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+    oskill = tempDir('nc-skill-');
+    oroot = tempDir('nc-proj-');
     writeFileSync(join(oroot, 'package.json'), '{"name":"scratch"}');
   });
 
@@ -648,8 +671,8 @@ describe('programmatic apply via inputs', () => {
   let proot: string;
   let pskill: string;
   beforeEach(() => {
-    pskill = mkdtempSync(join(tmpdir(), 'nc-skill-'));
-    proot = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+    pskill = tempDir('nc-skill-');
+    proot = tempDir('nc-proj-');
     writeFileSync(join(proot, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(proot, '.env'), '');
   });
@@ -761,8 +784,8 @@ IMESSAGE_LOCAL=true
 `;
 
 function modeScratch(): { sdir: string; rdir: string } {
-  const sdir = mkdtempSync(join(tmpdir(), 'nc-when-skill-'));
-  const rdir = mkdtempSync(join(tmpdir(), 'nc-when-proj-'));
+  const sdir = tempDir('nc-when-skill-');
+  const rdir = tempDir('nc-when-proj-');
   writeFileSync(join(sdir, 'SKILL.md'), MODE_SKILL);
   writeFileSync(join(rdir, '.env'), '');
   writeFileSync(join(rdir, 'package.json'), '{"name":"scratch"}');
@@ -820,8 +843,8 @@ DEMO_PLATFORM={{platform_id}}
 `;
 
 function stepScratch(): { sdir: string; rdir: string } {
-  const sdir = mkdtempSync(join(tmpdir(), 'nc-step-skill-'));
-  const rdir = mkdtempSync(join(tmpdir(), 'nc-step-proj-'));
+  const sdir = tempDir('nc-step-skill-');
+  const rdir = tempDir('nc-step-proj-');
   writeFileSync(join(sdir, 'SKILL.md'), STEP_SKILL);
   writeFileSync(join(rdir, '.env'), '');
   writeFileSync(join(rdir, 'package.json'), '{"name":"scratch"}');
@@ -905,8 +928,8 @@ describe('run-health gate (a bounce blocks later side effects)', () => {
   let groot: string;
   let gskill: string;
   beforeEach(() => {
-    gskill = mkdtempSync(join(tmpdir(), 'nc-gate-skill-'));
-    groot = mkdtempSync(join(tmpdir(), 'nc-gate-proj-'));
+    gskill = tempDir('nc-gate-skill-');
+    groot = tempDir('nc-gate-proj-');
     writeFileSync(join(groot, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(groot, '.env'), '');
   });
@@ -1050,8 +1073,8 @@ describe('nc:run effect:check (precondition gate)', () => {
   let chkSkill: string;
   let chkRoot: string;
   beforeEach(() => {
-    chkSkill = mkdtempSync(join(tmpdir(), 'nc-check-skill-'));
-    chkRoot = mkdtempSync(join(tmpdir(), 'nc-check-proj-'));
+    chkSkill = tempDir('nc-check-skill-');
+    chkRoot = tempDir('nc-check-proj-');
     writeFileSync(join(chkRoot, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(chkRoot, '.env'), '');
   });
@@ -1128,8 +1151,8 @@ describe('onEvent (core event seam)', () => {
   let eroot: string;
   let eskill: string;
   beforeEach(() => {
-    eskill = mkdtempSync(join(tmpdir(), 'nc-ev-skill-'));
-    eroot = mkdtempSync(join(tmpdir(), 'nc-ev-proj-'));
+    eskill = tempDir('nc-ev-skill-');
+    eroot = tempDir('nc-ev-proj-');
     writeFileSync(join(eroot, '.env'), '');
     writeFileSync(join(eroot, 'package.json'), '{"name":"scratch"}');
   });
@@ -1312,8 +1335,8 @@ describe('firstFailureHint', () => {
   let froot: string;
   let fskill: string;
   beforeEach(() => {
-    fskill = mkdtempSync(join(tmpdir(), 'nc-fh-skill-'));
-    froot = mkdtempSync(join(tmpdir(), 'nc-fh-proj-'));
+    fskill = tempDir('nc-fh-skill-');
+    froot = tempDir('nc-fh-proj-');
     writeFileSync(join(froot, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(froot, '.env'), '');
   });
@@ -1358,8 +1381,8 @@ describe('nc:prompt normalize at bind + InputMeta declaration', () => {
   let nroot: string;
   let nskill: string;
   beforeEach(() => {
-    nskill = mkdtempSync(join(tmpdir(), 'nc-opts-skill-'));
-    nroot = mkdtempSync(join(tmpdir(), 'nc-opts-proj-'));
+    nskill = tempDir('nc-opts-skill-');
+    nroot = tempDir('nc-opts-proj-');
     writeFileSync(join(nskill, 'SKILL.md'), NORMALIZE_SKILL);
     writeFileSync(join(nroot, '.env'), '');
     writeFileSync(join(nroot, 'package.json'), '{"name":"scratch"}');
@@ -1416,8 +1439,8 @@ describe('resolveInput (core input seam)', () => {
   let iroot: string;
   let iskill: string;
   beforeEach(() => {
-    iskill = mkdtempSync(join(tmpdir(), 'nc-ri-skill-'));
-    iroot = mkdtempSync(join(tmpdir(), 'nc-ri-proj-'));
+    iskill = tempDir('nc-ri-skill-');
+    iroot = tempDir('nc-ri-proj-');
     writeFileSync(join(iroot, '.env'), '');
     writeFileSync(join(iroot, 'package.json'), '{"name":"scratch"}');
   });
@@ -1501,8 +1524,8 @@ describe('validate-at-bind (inputs + resolveInput answers)', () => {
   let vroot: string;
   let vskill: string;
   beforeEach(() => {
-    vskill = mkdtempSync(join(tmpdir(), 'nc-vb-skill-'));
-    vroot = mkdtempSync(join(tmpdir(), 'nc-vb-proj-'));
+    vskill = tempDir('nc-vb-skill-');
+    vroot = tempDir('nc-vb-proj-');
     writeFileSync(join(vskill, 'SKILL.md'), VALIDATE_BIND_SKILL);
     writeFileSync(join(vroot, '.env'), '');
     writeFileSync(join(vroot, 'package.json'), '{"name":"scratch"}');
@@ -1674,8 +1697,8 @@ describe('referenceProse (reference-floor slice)', () => {
   });
 
   it('is carried on ApplyResult.referenceProse through a real apply', async () => {
-    const sdir = mkdtempSync(join(tmpdir(), 'nc-ref-skill-'));
-    const rdir = mkdtempSync(join(tmpdir(), 'nc-ref-proj-'));
+    const sdir = tempDir('nc-ref-skill-');
+    const rdir = tempDir('nc-ref-proj-');
     writeFileSync(join(rdir, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(rdir, '.env'), '');
     writeFileSync(join(sdir, 'SKILL.md'), REFERENCE_SKILL);

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
 import { execSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -23,6 +23,21 @@ vi.mock('../lib/bright-select.js', async (importActual) => {
 
 afterEach(() => delete process.env.NANOCLAW_TEMPLATE_AGENT_ID);
 
+// Every case builds a scratch checkout under the OS temp dir. Route them
+// through one recorder and drop the lot at the end of the file, the way
+// skill-apply.test.ts does: afterAll rather than afterEach because several
+// roots outlive the case that created them (the exec recorders close over
+// them), so per-test removal would delete a fixture still in use.
+const tempRoots: string[] = [];
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+afterAll(() => {
+  while (tempRoots.length) rmSync(tempRoots.pop()!, { recursive: true, force: true });
+});
+
 // Drives the real add-slack skill through the adapter with every side effect
 // injected (no real ncl/git/clack/init-first-agent): confirms it runs the skill
 // (install + creds + resolve), reads the resolved owner_handle + platform_id from
@@ -30,7 +45,7 @@ afterEach(() => delete process.env.NANOCLAW_TEMPLATE_AGENT_ID);
 describe('runChannelSkill adapter (Option A)', () => {
   it('resolves via the skill, then wires through init-first-agent', async () => {
     process.env.NANOCLAW_TEMPLATE_AGENT_ID = 'ag-template';
-    const root = mkdtempSync(join(tmpdir(), 'rcs-'));
+    const root = tempDir('rcs-');
     mkdirSync(join(root, 'src/channels'), { recursive: true });
     writeFileSync(join(root, 'src/channels/index.ts'), '// barrel\n');
     writeFileSync(join(root, '.env'), '');
@@ -98,7 +113,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   // the install-link operator — is when:-skipped, the wire inputs stay
   // unresolved, and the run drops through to restart without wiring.
   it('wireIfResolved (Teams): existing credentials skip the whole CLI create flow, never reach the shared wire', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'rcs-teams-'));
+    const root = tempDir('rcs-teams-');
     mkdirSync(join(root, 'src/channels'), { recursive: true });
     writeFileSync(join(root, 'src/channels/index.ts'), '// barrel\n');
     writeFileSync(join(root, '.env'), 'TEAMS_APP_ID=existing\nTEAMS_APP_PASSWORD=existing-password\n');
@@ -175,7 +190,7 @@ describe('runChannelSkill adapter (Option A)', () => {
       [null, 'no'], // no .env at all
     ];
     for (const [env, expected] of cases) {
-      const dir = mkdtempSync(join(tmpdir(), 'rcs-probe-'));
+      const dir = tempDir('rcs-probe-');
       if (env !== null) writeFileSync(join(dir, '.env'), env);
       const out = execSync(cmd, { cwd: dir, shell: '/bin/bash', encoding: 'utf8' }).trim();
       expect(out, `env=${JSON.stringify(env)}`).toBe(expected);
@@ -189,7 +204,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   // CLI-first chain end-to-end: login step → create's JSON multi-capture → the
   // env writes → the substituted install link surviving into the URL offer.
   it('Teams fresh create: login step + JSON capture drive the env writes and the install-link offer', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'rcs-teams-create-'));
+    const root = tempDir('rcs-teams-create-');
     mkdirSync(join(root, 'src/channels'), { recursive: true });
     writeFileSync(join(root, 'src/channels/index.ts'), '// barrel\n');
     writeFileSync(join(root, '.env'), '');
@@ -308,7 +323,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   // account's), and the wire inputs resolve to that person — the assistant
   // messages the desired user first. There is no skip: someone is always wired.
   it('Teams fresh create, wiring another account by Entra object ID: the chain runs against the target user', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'rcs-teams-target-'));
+    const root = tempDir('rcs-teams-target-');
     mkdirSync(join(root, 'src/channels'), { recursive: true });
     writeFileSync(join(root, 'src/channels/index.ts'), '// barrel\n');
     writeFileSync(join(root, '.env'), '');
@@ -369,7 +384,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   // branch back to yes with the CLI account's own id — same outcome as a yes
   // at the first ask, no ID ever typed or shown.
   it('Teams fresh create, no then logged-in-account: the chain runs against the CLI account', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'rcs-teams-loggedin-'));
+    const root = tempDir('rcs-teams-loggedin-');
     mkdirSync(join(root, 'src/channels'), { recursive: true });
     writeFileSync(join(root, 'src/channels/index.ts'), '// barrel\n');
     writeFileSync(join(root, '.env'), '');
@@ -432,7 +447,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   afterEach(() => rmSync(wireSkillDir, { recursive: true, force: true }));
 
   it('wireIfResolved: a run that resolves owner_handle + platform_id wires through init-first-agent', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'rcs-wiretest-'));
+    const root = tempDir('rcs-wiretest-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(root, '.env'), '');
     mkdirSync(wireSkillDir, { recursive: true });
@@ -503,7 +518,7 @@ describe('runChannelSkill adapter (Option A)', () => {
   // prose becomes the dimmed hint (which fail() also forwards to the Claude
   // handoff). Asserted via an injected fail spy (the real fail() process.exits).
   it('threads the bounced step prose into fail() when the skill does not fully apply', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'rcs-fail-'));
+    const root = tempDir('rcs-fail-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(root, '.env'), '');
     // A skill whose only directive bounces — the engine has no handler for
@@ -598,7 +613,7 @@ describe('backGate (first-prompt back-to-channel-selection)', () => {
 });
 
 describe('companionSkillPresent (in-tree presence check)', () => {
-  const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'nc-companion-'));
+  const makeRoot = (): string => tempDir('nc-companion-');
 
   it('SKILL.md in the checkout: true', async () => {
     const { companionSkillPresent } = await import('./run-channel-skill.js');

--- a/setup/channels/whatsapp.test.ts
+++ b/setup/channels/whatsapp.test.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { parseDirectives, type Directive } from '../../scripts/skill-directives.js';
 
@@ -35,7 +35,10 @@ function bash(body: string[], vars: Record<string, string>, cwd: string): string
 
 describe('self-chat engage pattern fence', () => {
   const fence = runFence((d) => d.attrs.capture === 'engage_pattern');
+  // Built once and shared by every case below, so it is reclaimed in afterAll
+  // rather than afterEach — per-test removal would delete a live fixture.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-engage-'));
+  afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
   const patternFor = (name: string): string => bash(fence.body, { agent_name: name }, dir).trim();
 
   it('matches messages starting with @<name> and nothing else', () => {

--- a/setup/lib/skill-driver.test.ts
+++ b/setup/lib/skill-driver.test.ts
@@ -1,8 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterAll, describe, it, expect, vi } from 'vitest';
 import * as p from '@clack/prompts';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+/**
+ * Every temp dir this file creates, removed once the file finishes — the cases
+ * below mkdtemp a project root (and often a skill dir) apiece and none of them
+ * cleaned up, leaving ~30 directories in the OS temp dir per run.
+ *
+ * `afterAll` rather than `afterEach`: the roots built at module scope are
+ * shared by the cases that reference them.
+ */
+const tempRoots: string[] = [];
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+afterAll(() => {
+  while (tempRoots.length) rmSync(tempRoots.pop()!, { recursive: true, force: true });
+});
 
 import {
   runSkill,
@@ -75,8 +93,8 @@ ncl wire --token {{token}}
 `;
 
 function scratch(): { root: string; skill: string } {
-  const root = mkdtempSync(join(tmpdir(), 'driver-'));
-  const skill = mkdtempSync(join(tmpdir(), 'driver-skill-'));
+  const root = tempDir('driver-');
+  const skill = tempDir('driver-skill-');
   writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
   writeFileSync(join(root, '.env'), '');
   writeFileSync(join(skill, 'SKILL.md'), SKILL);
@@ -137,7 +155,7 @@ describe('thin skill driver', () => {
   });
 
   it('hostExec puts the project bin/ on PATH so a bare command resolves to it', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'driver-bin-'));
+    const root = tempDir('driver-bin-');
     mkdirSync(join(root, 'bin'));
     writeFileSync(join(root, 'bin/greet'), '#!/usr/bin/env bash\necho hi-from-bin\n');
     chmodSync(join(root, 'bin/greet'), 0o755);
@@ -146,19 +164,19 @@ describe('thin skill driver', () => {
   });
 
   it('hostExec returns stdout so a capture run can bind it', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'driver-cap-'));
+    const root = tempDir('driver-cap-');
     expect(String(await hostExec(root)('echo D0CHANNEL')).trim()).toBe('D0CHANNEL');
   });
 
   it('hostExec recomposes a failure as `exit <code>: <first stderr line>` with the full stderr kept below', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'driver-fail-'));
+    const root = tempDir('driver-fail-');
     const run = (): Promise<string> => hostExec(root)('echo "boom: first line" >&2; echo "stack line two" >&2; exit 7');
     await expect(run).rejects.toThrow(/^exit 7: boom: first line/); // one-line consumers read this
     await expect(run).rejects.toThrow(/stack line two/); // full stderr survives for the agentTask reason
   });
 
   it('hostExec tees each command + stdout/stderr to the raw log, success and failure alike', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'driver-tee-'));
+    const root = tempDir('driver-tee-');
     const rawLog = join(root, 'raw.log');
     const exec = hostExec(root, rawLog);
     await exec('echo out-line; echo warn-line >&2');
@@ -172,7 +190,7 @@ describe('thin skill driver', () => {
   });
 
   it('hostExecStream runs a step and captures the terminal status block fields (for effect:step)', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'driver-step-'));
+    const root = tempDir('driver-step-');
     const out = await hostExecStream(root)(
       'echo show-this-to-the-operator; echo "=== NANOCLAW SETUP: PAIR ==="; echo "STATUS: success"; echo "PLATFORM_ID: telegram:42"; echo "=== END ==="',
     );
@@ -181,7 +199,7 @@ describe('thin skill driver', () => {
   });
 
   it('hostExecStream children run with LOG_LEVEL=warn — host logger info noise stays off the wizard', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'driver-loglevel-'));
+    const root = tempDir('driver-loglevel-');
     const prev = process.env.LOG_LEVEL;
     delete process.env.LOG_LEVEL; // simulate an operator who didn't set one
     try {
@@ -195,8 +213,8 @@ describe('thin skill driver', () => {
   });
 
   function reuseScratch(): { root: string; skill: string } {
-    const root = mkdtempSync(join(tmpdir(), 'reuse-'));
-    const skill = mkdtempSync(join(tmpdir(), 'reuse-skill-'));
+    const root = tempDir('reuse-');
+    const skill = tempDir('reuse-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(root, '.env'), 'SLACK_BOT_TOKEN=xoxb-existing-token\n');
     // a skill whose env-set maps bot_token → SLACK_BOT_TOKEN (the reuse linkage)
@@ -247,8 +265,8 @@ describe('thin skill driver', () => {
   // env-set→ENV_KEY linkage to infer. An explicit `nc:prompt … reuse:<ENV_KEY>`
   // restores the masked reuse offer — the imessage Photon case.
   function helperReuseScratch(): { root: string; skill: string } {
-    const root = mkdtempSync(join(tmpdir(), 'reuse-helper-'));
-    const skill = mkdtempSync(join(tmpdir(), 'reuse-helper-skill-'));
+    const root = tempDir('reuse-helper-');
+    const skill = tempDir('reuse-helper-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     // present in .env, but NOT written by any nc:env-set in the skill below
     writeFileSync(join(root, '.env'), 'IMESSAGE_SERVER_URL=https://photon.example.com\n');
@@ -286,8 +304,8 @@ describe('thin skill driver', () => {
   // validate-at-bind is NEVER offered — the operator is prompted fresh instead
   // of the reused input rejecting loudly with no interactive recovery.
   it('reuse: a stale .env value failing the prompt validate is never offered — prompted fresh', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'reuse-stale-'));
-    const skill = mkdtempSync(join(tmpdir(), 'reuse-stale-skill-'));
+    const root = tempDir('reuse-stale-');
+    const skill = tempDir('reuse-stale-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(root, '.env'), 'SLACK_BOT_TOKEN=legacy-not-a-bot-token\n'); // fails ^xoxb-
     writeFileSync(
@@ -315,8 +333,8 @@ describe('thin skill driver', () => {
   });
 
   it('reuse pre-filter mirrors bind order: normalize-then-validate, so a normalizable value still offers', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'reuse-norm-'));
-    const skill = mkdtempSync(join(tmpdir(), 'reuse-norm-skill-'));
+    const root = tempDir('reuse-norm-');
+    const skill = tempDir('reuse-norm-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(join(root, '.env'), 'BASE_URL=https://x.example/\n'); // trailing slash — valid only after rstrip-slash
     writeFileSync(
@@ -342,8 +360,8 @@ describe('thin skill driver', () => {
   // would replace the policy, §5.0): note → URL offer (confirm → openUrl) →
   // natural-barrier confirm, all through the injectable confirm/openUrl seams.
   it('default handler: offers the operator-body URL, then the barrier confirm — in that order', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'offer-'));
-    const skill = mkdtempSync(join(tmpdir(), 'offer-skill-'));
+    const root = tempDir('offer-');
+    const skill = tempDir('offer-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(
       join(skill, 'SKILL.md'),
@@ -369,8 +387,8 @@ describe('thin skill driver', () => {
   });
 
   it('default handler: readiness flavor before an effect:step; decline = proceed (never an abort)', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'gate-step-'));
-    const skill = mkdtempSync(join(tmpdir(), 'gate-step-skill-'));
+    const root = tempDir('gate-step-');
+    const skill = tempDir('gate-step-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(
       join(skill, 'SKILL.md'),
@@ -393,8 +411,8 @@ describe('thin skill driver', () => {
   });
 
   it('default handler: declining the URL offer skips the open', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'offer-no-'));
-    const skill = mkdtempSync(join(tmpdir(), 'offer-no-skill-'));
+    const root = tempDir('offer-no-');
+    const skill = tempDir('offer-no-skill-');
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
     writeFileSync(
       join(skill, 'SKILL.md'),
@@ -567,7 +585,7 @@ describe('non-TTY step lines (CI logs, a nested apply under the parent driver)',
   it('prints one plain line per finished step when stdout is not a TTY, instead of silence', async () => {
     // vitest's stdout is a pipe, so the default handler takes the non-TTY path.
     expect(process.stdout.isTTY).toBeFalsy();
-    const root = mkdtempSync(join(tmpdir(), 'sd-plain-'));
+    const root = tempDir('sd-plain-');
     const skill = join(root, '.claude/skills/plain');
     mkdirSync(skill, { recursive: true });
     writeFileSync(join(root, 'package.json'), '{"name":"scratch"}\n');
@@ -612,7 +630,7 @@ describe('parseDriverArgv (the CLI argv contract behind nested `--input` handoff
 
 describe('unknownInputKeys (a typoed --input key must refuse, not fall through to a piped prompt)', () => {
   it('flags keys naming no nc:prompt var and accepts ones that do', () => {
-    const skill = mkdtempSync(join(tmpdir(), 'driver-keys-'));
+    const skill = tempDir('driver-keys-');
     writeFileSync(
       join(skill, 'SKILL.md'),
       ['# Keys', '', '## Ask', '', '```nc:prompt dial_agents validate:^(all|none)$', 'Which agents?', '```', ''].join(

--- a/src/cli/socket-server.test.ts
+++ b/src/cli/socket-server.test.ts
@@ -8,13 +8,19 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { startCliServer, stopCliServer } from './socket-server.js';
 
 // Unix socket paths have a small OS limit — keep them short.
+// Each case gets its own directory; they are reclaimed per-test rather than in
+// an afterAll, because nothing here is shared between cases.
+const socketDirs: string[] = [];
 function tmpSocketPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-'));
+  socketDirs.push(dir);
   return path.join(dir, 's.sock');
 }
 
 afterEach(async () => {
   await stopCliServer();
+  // After the server is down, so the socket inode is gone before its directory.
+  while (socketDirs.length) fs.rmSync(socketDirs.pop()!, { recursive: true, force: true });
 });
 
 describe('startCliServer single-bind', () => {

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -10,7 +10,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 
 import { CONTAINER_CPU_LIMIT, CONTAINER_MEMORY_LIMIT } from './config.js';
 import type { ContainerConfig } from './container-config.js';
@@ -455,9 +455,17 @@ describe('armSessionLifecycle', () => {
 });
 
 describe('syncSkillSymlinks', () => {
+  // Each case gets a fresh dir; remove them when the block finishes rather
+  // than leaving one per case in the OS temp dir on every run.
+  const claudeDirs: string[] = [];
   function tmpClaudeDir(): string {
-    return fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-skills-'));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-skills-'));
+    claudeDirs.push(dir);
+    return dir;
   }
+  afterAll(() => {
+    while (claudeDirs.length) fs.rmSync(claudeDirs.pop()!, { recursive: true, force: true });
+  });
 
   it('links every selected skill to its container path', () => {
     const dir = tmpClaudeDir();

--- a/src/drivers/driver-selection.test.ts
+++ b/src/drivers/driver-selection.test.ts
@@ -76,6 +76,8 @@ beforeEach(() => {
 afterEach(() => {
   resetSessionDriver(null);
   process.chdir(previous);
+  // Remove the temp cwd too — chdir'ing away leaves it behind, one per case.
+  fs.rmSync(cwd, { recursive: true, force: true });
 });
 
 describe('configuredDriverKind', () => {

--- a/src/liveness.test.ts
+++ b/src/liveness.test.ts
@@ -2,13 +2,20 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { describe, it, expect } from 'vitest';
+import { afterAll, describe, it, expect } from 'vitest';
 
 import { createHeartbeatFileLivenessSource } from './liveness.js';
 
 describe('heartbeat-file liveness source', () => {
+  // Recorded rather than removed inline, so a failing assertion still reclaims it.
+  const tempRoots: string[] = [];
+  afterAll(() => {
+    while (tempRoots.length) fs.rmSync(tempRoots.pop()!, { recursive: true, force: true });
+  });
+
   it('reports the heartbeat mtime, and null when the file is absent', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'liveness-'));
+    tempRoots.push(dir);
     const hb = path.join(dir, '.heartbeat');
     const source = createHeartbeatFileLivenessSource(() => hb);
     const session = { id: 's-1', agent_group_id: 'g-1' };


### PR DESCRIPTION
## Problem

A full `pnpm test` leaves **~355 directories in the OS temp dir, every run**. Nothing reclaims them until a reboot or the 30-day `systemd-tmpfiles` sweep, so on a long-lived dev box or a persistent CI runner they just accumulate — and where `/tmp` is a tmpfs (the default on many distros) that accumulation is RAM.

Measured on a clean checkout of `main`, per test file:

| File | Dirs leaked per run |
|---|---|
| `scripts/skill-apply.test.ts` | 294 |
| `setup/lib/skill-driver.test.ts` | 30 |
| `src/drivers/driver-selection.test.ts` | 16 |
| `setup/channels/run-channel-skill.test.ts` | 7 |
| `src/cli/socket-server.test.ts` | 3 |
| `src/container-runner.test.ts` | 3 |
| `setup/channels/whatsapp.test.ts` | 1 |
| `src/liveness.test.ts` | 1 |

Reproduce:

```bash
before=$(ls -1A /tmp | wc -l)
pnpm exec vitest run scripts/skill-apply.test.ts
after=$(ls -1A /tmp | wc -l)
echo "leaked: $((after-before))"   # 294
```

## Fix

Two commits. The first covers the top four files, the second the remaining four — which were found by diffing the OS temp dir across a run rather than by reading for `mkdtempSync`, so what the first commit left behind was measured, not guessed.

The two skill files create a skill dir and a project root per case — some in `beforeEach`, some at module scope, some inline — across ~20 describe blocks. Exactly one block (the from-branch copy path) already cleaned up after itself; this is what the rest now do too. Both route their `mkdtemp` calls through a small `tempDir()` helper that records what it made, and drop the lot in `afterAll`. `run-channel-skill` gets the same recorder across its nine call sites.

Cleanup is `afterAll` rather than `afterEach` **on purpose** wherever a root outlives the case that created it: several are built once at module scope and shared by the cases that reference them, and `run-channel-skill`'s exec recorders close over theirs — so per-test removal would delete a fixture still in use. Where nothing is shared, cleanup is per-test and reclaims sooner: `socket-server` extends the `afterEach` it already has, removing the directory only after the server is down so the socket inode goes first; `driver-selection` already had an `afterEach` that chdir'd back out of its temp cwd but never removed it — one line.

`container-runner`'s `tmpClaudeDir()` helper gets the record-and-drop treatment scoped to its describe block. `liveness` records its one root instead of removing it inline, so a failing assertion still reclaims it. `whatsapp`'s engage-fence root is describe-scoped and shared, so `afterAll`.

`src/modules/mount-security/index.test.ts` already cleans up correctly and is untouched.

**No test logic or assertions change** — the bulk of the diff is a mechanical rewrite of `mkdtempSync(join(tmpdir(), 'x-'))` to `tempDir('x-')`.

## Verification

Per file, unchanged pass counts and zero leak:

| File | Tests | Leak after |
|---|---|---|
| `scripts/skill-apply.test.ts` | 81 passed | 0 |
| `setup/lib/skill-driver.test.ts` | 33 passed | 0 |
| `src/drivers/driver-selection.test.ts` | 16 passed | 0 |
| `src/container-runner.test.ts` | 35 passed | 0 |
| the four files of the second commit, together | 26 passed | 0 |

Full suite after both commits: **193 files, 2284 tests passing, temp-dir delta 0** — the run now reclaims everything it creates. Baseline was +355. (That run is on a checkout carrying installed channel adapters, so it has more test files than `main`; the per-file numbers above are the ones to check against a clean tree.)

## Related

#3709 reports a different `/tmp` problem — the mailbox SQLite tests use a fixed fixture root, so concurrent vitest runs delete each other's databases. Different files, different fix; this PR is purely about cleanup, keeping to one thing per PR.

## Note for maintainers

I could not run the full suite on this machine (linux/arm64, Node v23.1.0) without temporarily pinning `better-sqlite3` back to 11.10.0 — the 13.0.3 prebuild loads but segfaults in `new Database()`, killing the vitest workers. That pin was local to my verification only and is **not** part of this diff; `package.json` here is byte-identical to `main`. Happy to file that separately if it is not already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JC7DxMjAescrd8CbTnitd
