### PR TITLE
feat(router): defer expensive inbound content until an agent will receive it

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -62,6 +62,13 @@ export interface InboundEvent {
     isMention?: boolean;
     /** True when the source is a group/channel thread, false for DMs. */
     isGroup?: boolean;
+    /**
+     * Deferred delivery content — see `InboundMessage.resolveContent`. The
+     * host wraps the adapter's object-returning resolver into one that
+     * returns the JSON blob, so the router can drop the result straight
+     * into `content`. Absent means `content` is already complete.
+     */
+    resolveContent?: () => Promise<string>;
   };
   replyTo?: DeliveryAddress;
 }
@@ -90,6 +97,26 @@ export interface InboundMessage {
   isMention?: boolean;
   /** True when the source is a group/channel thread, false for DMs. */
   isGroup?: boolean;
+  /**
+   * Optional deferred content resolver, for adapters whose full content is
+   * expensive to build — the WhatsApp adapter downloads attachment bytes
+   * from WhatsApp's CDN, and most inbound traffic arrives in chats no agent
+   * is wired to, or fails the wiring's engage test.
+   *
+   * Split of responsibilities when set:
+   *   - `content` is the ROUTING view: cheap, always present, and complete
+   *     enough for every routing decision (text for pattern matching, sender,
+   *     plus attachment metadata with no `data`).
+   *   - `resolveContent()` returns the DELIVERY view: the same object with
+   *     the expensive parts filled in (attachment bytes, and any text the
+   *     adapter can only append once the fetch has been attempted).
+   *
+   * The router calls it at most once per message, only when at least one
+   * agent will actually receive it, and persists the result instead of
+   * `content`. It must be safe to never call. Adapters that leave it
+   * undefined are unaffected — `content` is delivered as-is.
+   */
+  resolveContent?: () => Promise<unknown>;
 }
 
 /** A file attachment to deliver alongside a message. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,11 @@ async function main(): Promise<void> {
             timestamp: message.timestamp,
             isMention: message.isMention,
             isGroup: message.isGroup,
+            // Adapters resolve to a content object; the session DB stores a
+            // JSON blob. Same stringify seam as `content` above, deferred.
+            resolveContent: message.resolveContent
+              ? async () => JSON.stringify(await message.resolveContent!())
+              : undefined,
           },
         }).catch((err) => {
           log.error('Failed to route inbound message', { channelType: adapter.channelType, err });

--- a/src/router-deferred-content.test.ts
+++ b/src/router-deferred-content.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Deferred delivery content (adapter.ts: InboundMessage.resolveContent).
+ *
+ * The router decides on the cheap routing view and pulls the expensive one
+ * only when an agent is actually going to persist the message. For WhatsApp
+ * that expensive step is downloading attachment bytes from the CDN — most
+ * inbound traffic is in chats with no wiring at all, and every one of those
+ * downloads was wasted before this seam existed.
+ */
+import fs from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  initTestDb,
+  closeDb,
+  runMigrations,
+  createAgentGroup,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+} from './db/index.js';
+import { findSessionForAgent } from './db/sessions.js';
+import { withExistingMailboxSession } from './session-manager.js';
+import type { InboundEvent } from './channels/adapter.js';
+import type { IgnoredMessagePolicy } from './types.js';
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-deferred' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-deferred';
+
+function now() {
+  return new Date().toISOString();
+}
+
+/** Routing view: text + attachment metadata, no bytes. */
+const ROUTING = JSON.stringify({
+  sender: 'User',
+  text: '@Jarbas read this',
+  attachments: [{ type: 'document', name: 'report.pdf' }],
+});
+
+/** Delivery view: the same, with the bytes filled in. */
+const DELIVERED = JSON.stringify({
+  sender: 'User',
+  text: '@Jarbas read this',
+  attachments: [{ type: 'document', name: 'report.pdf', data: 'YmFzZTY0' }],
+});
+
+function makeEvent(overrides: {
+  platformId?: string;
+  text?: string;
+  resolveContent?: () => Promise<string>;
+}): InboundEvent {
+  const content = overrides.text ? JSON.stringify({ sender: 'User', text: overrides.text }) : ROUTING;
+  return {
+    channelType: 'discord',
+    platformId: overrides.platformId ?? 'chan-123',
+    threadId: null,
+    message: {
+      id: `msg-${Math.random().toString(36).slice(2, 10)}`,
+      kind: 'chat',
+      content,
+      timestamp: now(),
+      resolveContent: overrides.resolveContent,
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function storedContent(agentGroupId: string): Promise<any[]> {
+  const session = await findSessionForAgent(agentGroupId, 'mg-1', null);
+  if (!session) return [];
+  // Storage layout is mailbox-private now — read the inbox through the
+  // mailbox seam rather than opening inbound.db directly.
+  const rows = await withExistingMailboxSession(agentGroupId, session.id, (mailbox) => mailbox.getInboundHistory(100));
+  return (rows ?? []).map((r) => JSON.parse(r.content));
+}
+
+/**
+ * writeSessionMessage stages inline `data` into the session inbox and
+ * rewrites it to a container-visible `localPath` — so a staged localPath (and
+ * no leftover base64) is the proof that the bytes actually arrived.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function expectBytesStaged(att: any) {
+  expect(att.localPath).toBeTruthy();
+  expect(att.data).toBeUndefined();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  await runMigrations(await initTestDb());
+
+  await createAgentGroup({ id: 'ag-1', name: 'Jarbas', folder: 'jarbas', agent_provider: null, created_at: now() });
+  await createMessagingGroup({
+    id: 'mg-1',
+    channel_type: 'discord',
+    platform_id: 'chan-123',
+    name: 'General',
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+});
+
+afterEach(async () => {
+  await closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+/** Wire an agent group to mg-1 with the given engage pattern. */
+async function wire(id: string, agentGroupId: string, pattern: string, ignored: IgnoredMessagePolicy = 'drop') {
+  await createMessagingGroupAgent({
+    id,
+    messaging_group_id: 'mg-1',
+    agent_group_id: agentGroupId,
+    engage_mode: 'pattern',
+    engage_pattern: pattern,
+    sender_scope: 'all',
+    ignored_message_policy: ignored,
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now(),
+  });
+}
+
+describe('deferred delivery content', () => {
+  it('resolves and persists the delivery view when an agent engages', async () => {
+    const { routeInbound } = await import('./router.js');
+    await wire('mga-1', 'ag-1', '.');
+
+    const resolveContent = vi.fn().mockResolvedValue(DELIVERED);
+    await routeInbound(makeEvent({ resolveContent }));
+
+    expect(resolveContent).toHaveBeenCalledTimes(1);
+    const stored = await storedContent('ag-1');
+    expect(stored).toHaveLength(1);
+    expectBytesStaged(stored[0].attachments[0]);
+  });
+
+  it('never resolves when no agent engages', async () => {
+    const { routeInbound } = await import('./router.js');
+    await wire('mga-1', 'ag-1', '@[Jj]arbas');
+
+    const resolveContent = vi.fn().mockResolvedValue(DELIVERED);
+    await routeInbound(makeEvent({ text: 'just chatting', resolveContent }));
+
+    expect(resolveContent).not.toHaveBeenCalled();
+    expect(await storedContent('ag-1')).toHaveLength(0);
+  });
+
+  it('never resolves for a chat with no wiring at all', async () => {
+    const { routeInbound } = await import('./router.js');
+    await wire('mga-1', 'ag-1', '.');
+
+    const resolveContent = vi.fn().mockResolvedValue(DELIVERED);
+    await routeInbound(makeEvent({ platformId: 'chan-unwired', resolveContent }));
+
+    expect(resolveContent).not.toHaveBeenCalled();
+  });
+
+  it('resolves once for a fan-out to several engaged agents', async () => {
+    const { routeInbound } = await import('./router.js');
+    await createAgentGroup({ id: 'ag-2', name: 'Second', folder: 'second', agent_provider: null, created_at: now() });
+    await wire('mga-1', 'ag-1', '.');
+    await wire('mga-2', 'ag-2', '.');
+
+    const resolveContent = vi.fn().mockResolvedValue(DELIVERED);
+    await routeInbound(makeEvent({ resolveContent }));
+
+    // One download, two sessions fed from it.
+    expect(resolveContent).toHaveBeenCalledTimes(1);
+    expectBytesStaged((await storedContent('ag-1'))[0].attachments[0]);
+    expectBytesStaged((await storedContent('ag-2'))[0].attachments[0]);
+  });
+
+  it('resolves for an accumulating agent — the message is still persisted', async () => {
+    const { routeInbound } = await import('./router.js');
+    await wire('mga-1', 'ag-1', '@[Jj]arbas', 'accumulate');
+
+    const resolveContent = vi.fn().mockResolvedValue(DELIVERED);
+    await routeInbound(makeEvent({ text: 'just chatting', resolveContent }));
+
+    expect(resolveContent).toHaveBeenCalledTimes(1);
+    expect(await storedContent('ag-1')).toHaveLength(1);
+  });
+
+  it('falls back to the routing view when resolution fails', async () => {
+    const { routeInbound } = await import('./router.js');
+    await wire('mga-1', 'ag-1', '.');
+
+    const resolveContent = vi.fn().mockRejectedValue(new Error('CDN fetch failed'));
+    await routeInbound(makeEvent({ resolveContent }));
+
+    // The bytes are lost; the message and its metadata are not.
+    const parsed = (await storedContent('ag-1'))[0];
+    expect(parsed.text).toBe('@Jarbas read this');
+    expect(parsed.attachments[0].name).toBe('report.pdf');
+    expect(parsed.attachments[0].localPath).toBeUndefined();
+  });
+
+  it('delivers content as-is for adapters that set no resolver', async () => {
+    const { routeInbound } = await import('./router.js');
+    await wire('mga-1', 'ag-1', '.');
+
+    await routeInbound(makeEvent({}));
+
+    expect((await storedContent('ag-1'))[0].attachments[0].name).toBe('report.pdf');
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -359,6 +359,34 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   const parsed = safeParseContent(event.message.content);
   const messageText = parsed.text ?? '';
 
+  // Deferred delivery content (adapter.ts: InboundMessage.resolveContent).
+  // `event.message.content` is the routing view and drives every decision
+  // below; the expensive view is pulled at most once, and only from
+  // deliverToAgent — i.e. only once some agent is actually going to persist
+  // this message. A chat with no wiring, or a message that fails every
+  // engage test, never pays for it. Memoized on the promise, not the value,
+  // so a second caller during an in-flight fetch joins it instead of
+  // starting a second download.
+  let deliveryContent: Promise<string> | undefined;
+  const resolveDeliveryContent = (): Promise<string> => {
+    if (!deliveryContent) {
+      deliveryContent = event.message.resolveContent
+        ? event.message.resolveContent().catch((err) => {
+            // Losing the resolved view costs the attachment bytes, not the
+            // message: fall back to the routing content so the agent still
+            // sees the text and the metadata rather than nothing at all.
+            log.warn('Deferred content resolution failed, delivering routing content', {
+              channelType: event.channelType,
+              platformId: event.platformId,
+              err,
+            });
+            return event.message.content;
+          })
+        : Promise.resolve(event.message.content);
+    }
+    return deliveryContent;
+  };
+
   // Per-wiring thread policy inputs, resolved once per event. Each wiring's
   // threads override (NULL = inherit) resolves against the channel's declared
   // defaults, hard-bounded by the live adapter's raw capability. Undeclared
@@ -396,7 +424,17 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     const scopeOk = engages && (!senderScopeGate || (await senderScopeGate(event, userId, mg, agent)).allowed);
 
     if (engages && accessOk && scopeOk) {
-      await deliverToAgent(agent, agentGroup, mg, event, userId, threadsEnabled, effectiveThreadId, true);
+      await deliverToAgent(
+        agent,
+        agentGroup,
+        mg,
+        event,
+        userId,
+        threadsEnabled,
+        effectiveThreadId,
+        true,
+        resolveDeliveryContent,
+      );
       engagedCount++;
 
       // Mention-sticky: ask the adapter to subscribe the thread so the
@@ -428,7 +466,17 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
       // message (which also stages their attachments to disk via
       // writeSessionMessage → extractAttachmentFiles) is exactly what the
       // gate is meant to prevent.
-      await deliverToAgent(agent, agentGroup, mg, event, userId, threadsEnabled, effectiveThreadId, false);
+      await deliverToAgent(
+        agent,
+        agentGroup,
+        mg,
+        event,
+        userId,
+        threadsEnabled,
+        effectiveThreadId,
+        false,
+        resolveDeliveryContent,
+      );
       accumulatedCount++;
     } else {
       log.debug('Message not engaged for agent (drop policy)', {
@@ -523,6 +571,7 @@ async function deliverToAgent(
   threadsEnabled: boolean,
   effectiveThreadId: string | null,
   wake: boolean,
+  resolveDeliveryContent: () => Promise<string>,
 ): Promise<void> {
   // Apply the resolved thread policy (wiring override AND channel declaration
   // AND adapter capability — resolveThreadPolicy at fanout): thread-enabled
@@ -585,6 +634,15 @@ async function deliverToAgent(
     await backfillNewSession(agentGroup, session, mg);
   }
 
+  // Past every gate — this message is being persisted, so the expensive
+  // content is now worth fetching. Deliberately after the command gate: a
+  // filtered or denied slash command shouldn't pull attachment bytes, and
+  // the gate only ever reads text, which both views share. Kept after the
+  // backfill too — that reads sibling sessions, never this message's
+  // content, so the download stays behind everything that can still abort
+  // the write.
+  const content = await resolveDeliveryContent();
+
   const messageId = messageIdForAgent(event.message.id, agent.agent_group_id);
   await writeSessionMessage(session.agent_group_id, session.id, {
     id: messageId,
@@ -593,7 +651,7 @@ async function deliverToAgent(
     platformId: deliveryAddr.platformId,
     channelType: deliveryAddr.channelType,
     threadId: deliveryAddr.threadId,
-    content: event.message.content,
+    content,
     trigger: wake,
   });
 


### PR DESCRIPTION
## Problem

An adapter that has to do real work to produce a message's full content — a network fetch, a download — has nowhere to put it. `InboundMessage.content` must be complete before `routeInbound` ever sees it, so the work happens for **every** message that arrives: including the ones in chats no agent is wired to, and the ones that fail their wiring's engage test.

On a personal WhatsApp number that means every image, video and document across every chat the account is in, fetched from WhatsApp's CDN on arrival and thrown away moments later.

## Approach

An optional second view of the same message:

- **`content`** — the ROUTING view. Cheap, always present, complete enough for every routing decision: text to match an engage pattern against, sender, attachment metadata with no bytes.
- **`resolveContent()`** — the DELIVERY view. The same object with the expensive parts filled in.

The router calls the resolver at most once per message, and only from `deliverToAgent` — i.e. only once some agent is actually going to persist the message — then writes that result instead of `content`.

Details worth reviewing:

- **Memoized on the promise, not the value**, so a fan-out to several engaged agents shares one fetch rather than racing several.
- **Placement is deliberate.** After the command gate (a filtered or denied slash command shouldn't pull attachment bytes, and the gate only reads text, which both views share) and after `backfillNewSession` (which reads sibling sessions, never this message's content) — so the work sits behind everything that can still abort the write.
- **Fail-soft.** If the resolver rejects, the router logs and persists the routing view. The agent loses the bytes, not the message; the container formatter already renders metadata-only attachments as `[document: report.pdf]`.
- **`fanInboundMessage` and `dispatchSessionCreated` keep the routing view on purpose.** Session-echo rows and hook payloads want to know an attachment exists; they shouldn't each carry another copy of it.

## Compatibility

Adapters that leave `resolveContent` undefined are completely unaffected — `content` is delivered as-is. That is every adapter in trunk today, so this lands as a no-op for existing installs.

## Tests

`src/router-deferred-content.test.ts` covers the laziness contract itself, through the real `routeInbound` path:

- never resolved for a chat with no wiring at all
- never resolved when the engage test fails
- resolved exactly once across a fan-out to several engaged agents
- resolved on the accumulate path (that message is still persisted)
- falls back to the routing view when resolution throws

Full suite: 188 files, 2247 tests passing.

## Follow-up

The WhatsApp adapter is the first consumer — mmv/nanoclaw@`feat/whatsapp-lazy-media`, which I'll open against `channels` once this lands. It also fixes a `documentMessage.caption` omission that was dropping captioned PDFs outright.

## Note

I could not run the full suite on this machine (linux/arm64, Node v23.1.0) without temporarily pinning `better-sqlite3` back to 11.10.0 — the 13.0.3 prebuild loads but segfaults in `new Database()`, killing the vitest workers. That pin was local to verification only and is **not** in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsvzUu75Dm3ThLUSRwi99k
