### PR TITLE
feat(skills): add opt-in source installation with guarded recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,11 @@ ncl help
 | user-dms | list | Cold-DM cache (read-only) |
 | dropped-messages | list | Messages from unregistered senders (read-only) |
 | approvals | list, get | Pending approval requests (read-only) |
+| skills | list, plan, apply | Install skills for channels, providers, tools. `apply` runs the `nc:` steps on the host; restarts and interactive steps are reported, not run. Global scope; agents need approval and cannot pass secrets |
 
-Key files: `src/cli/dispatch.ts` (dispatcher + approval handler), `src/cli/crud.ts` (generic CRUD registration), `src/cli/resources/` (per-resource definitions).
+Key files: `src/cli/dispatch.ts` (dispatcher + approval handler), `src/cli/crud.ts` (generic CRUD registration), `src/cli/resources/` (per-resource definitions). `ncl skills` runs the headless engine `scripts/skill-headless.ts` (list / plan / apply as JSON, rollback on failure) as a child process via `src/cli/skill-runner.ts`.
+
+`ncl skills apply` is disabled by default. A source-checkout operator must explicitly set `NANOCLAW_SOURCE_INSTALL=enabled` in the host service environment (or the terminal environment for the headless script). Packaged deployments use their release workflow. Agent approval cannot enable this capability; the setup wizard and build-time composition keep their existing path. `needs-setup` means code was installed but the operator must finish the reported credentials or interactive steps at the host terminal, following `.claude/skills/<name>/SKILL.md`. The headless script exits nonzero, and the host is not restarted. Failed installs restore journaled files and dependency manifests under the shared checkout lock; arbitrary command effects and generated build output are not a full-system snapshot. A crash leaves a lock for the operator to clear after verifying no installer is running.
 
 ## Channels and Providers (skill-installed)
 

--- a/container/agent-runner/src/mcp-tools/cli.instructions.md
+++ b/container/agent-runner/src/mcp-tools/cli.instructions.md
@@ -27,7 +27,7 @@ Run `ncl help` for the full list. Common resources:
 | tasks        | list, get, create, update, cancel, pause, resume, delete, append-log                                                                      | Scheduled tasks for your agent group                    |
 | wirings      | get, update                                                                                                                               | Response policy for the current chat                    |
 
-Additional resources (available under `global` scope only): messaging-groups, users, roles, user-dms, dropped-messages, approvals.
+Additional resources (available under `global` scope only): messaging-groups, users, roles, user-dms, dropped-messages, approvals, skills (see below).
 
 Under `group` scope, `wirings get/update` always targets the current chat. Updates may only change `engage_mode` and `engage_pattern` and require human approval.
 
@@ -86,6 +86,16 @@ ncl groups config add-package --npm some-package
 ncl members add --user telegram:jane
 ncl wirings update --engage-mode pattern --engage-pattern "."
 ```
+
+### Installing a capability (global scope only)
+
+When the user asks for a new channel, provider, or tool, do not edit source or send them to a terminal:
+
+1. `ncl skills list` — find the install skill.
+2. `ncl skills plan <name>` — preview its steps and inputs.
+3. `ncl skills apply <name> --restart` — request the install (approval-gated, like any write). Answer non-secret prompts with `--inputs '{"var":"value"}'`.
+
+Never pass tokens or passwords — secret inputs are refused. A `needs-setup` result means code was installed but credentials, external setup, pairing, or wiring remain pending. Relay the missing inputs, pending commands, and `.claude/skills/<name>/SKILL.md` to the operator to finish at the host terminal; do not run credential or interactive setup from chat or claim the capability is ready. The host is not restarted while setup is pending. Packaged or source-install-disabled deployments must use their release workflow.
 
 ### Important
 

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -1685,3 +1685,94 @@ describe('referenceProse (reference-floor slice)', () => {
     expect(res.referenceProse).not.toContain('## Apply');
   });
 });
+
+describe('failure recovery and shared checkout locking', () => {
+  it('restores an overwritten file when a later file in the same copy block fails', async () => {
+    const original = Buffer.from([0, 1, 255, 10]);
+    writeFileSync(join(root, 'src/sample.ts'), original, { mode: 0o750 });
+    writeFileSync(join(skillDir, 'SKILL.md'), '```nc:copy\nresources/sample.ts -> src/sample.ts\nmissing.ts -> src/missing.ts\n```');
+    const result = await applySkill(skillDir, root, { exec: () => {}, rollbackOnFailure: true });
+    expect(result.agentTasks).toHaveLength(1);
+    expect(result.rollback).toEqual({});
+    expect(readFileSync(join(root, 'src/sample.ts'))).toEqual(original);
+    expect(existsSync(join(root, 'src/missing.ts'))).toBe(false);
+  });
+
+  it('records a remote copy before a failed command can truncate the destination', async () => {
+    writeFileSync(join(root, 'src/sample.ts'), 'original');
+    writeFileSync(join(skillDir, 'SKILL.md'), '```nc:copy from-branch:payload\nsample.ts -> src/sample.ts\nmissing.ts -> src/missing.ts\n```');
+    const result = await applySkill(skillDir, root, {
+      rollbackOnFailure: true,
+      resolveRemote: () => 'origin',
+      exec: (cmd) => {
+        if (cmd.startsWith('git show')) {
+          writeFileSync(join(root, 'src/sample.ts'), '');
+          throw new Error('git show failed after redirection');
+        }
+      },
+    });
+    expect(result.rollback).toEqual({});
+    expect(readFileSync(join(root, 'src/sample.ts'), 'utf8')).toBe('original');
+  });
+
+  it('restores exact text and absence, including files without a final newline', async () => {
+    writeFileSync(join(root, 'src/barrel.ts'), '// existing');
+    rmSync(join(root, '.env'));
+    writeFileSync(join(skillDir, 'SKILL.md'), SKILL);
+    const result = await applySkill(skillDir, root, {
+      inputs: { token: 'secret' }, exec: () => {}, rollbackOnFailure: true,
+    });
+    expect(result.rollback).toEqual({});
+    expect(readFileSync(join(root, 'src/barrel.ts'), 'utf8')).toBe('// existing');
+    expect(existsSync(join(root, '.env'))).toBe(false);
+  });
+
+  it('restores manifests after a partial dependency failure and keeps restoring if reinstall fails', async () => {
+    const manifest = '{"dependencies":{"demo":"1.0.0"}}\n';
+    writeFileSync(join(root, 'package.json'), manifest);
+    writeFileSync(join(root, 'pnpm-lock.yaml'), 'original lock\n');
+    writeFileSync(join(skillDir, 'SKILL.md'), '```nc:copy\nresources/sample.ts -> src/sample.ts\n```\n```nc:dep\ndemo@2.0.0\n```');
+    const commands: string[] = [];
+    const result = await applySkill(skillDir, root, {
+      rollbackOnFailure: true, mode: 'refresh',
+      exec: (cmd) => {
+        commands.push(cmd);
+        if (cmd.includes(' install ')) {
+          expect(readFileSync(join(root, 'package.json'), 'utf8')).toBe(manifest);
+          expect(readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8')).toBe('original lock\n');
+        }
+        writeFileSync(join(root, 'package.json'), 'partial change');
+        writeFileSync(join(root, 'pnpm-lock.yaml'), 'partial lock');
+        throw new Error('package manager failed');
+      },
+    });
+    expect(result.rollback?.error).toMatch(/package manager failed/);
+    expect(commands).toEqual(['pnpm add demo@2.0.0', 'pnpm install --frozen-lockfile']);
+    expect(readFileSync(join(root, 'package.json'), 'utf8')).toBe(manifest);
+    expect(readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8')).toBe('original lock\n');
+    expect(existsSync(join(root, 'src/sample.ts'))).toBe(false);
+  });
+
+  it('holds the shared lock through rollback and rejects a direct engine caller', async () => {
+    writeFileSync(join(skillDir, 'SKILL.md'), '```nc:dep\ndemo@2.0.0\n```');
+    let entered!: () => void;
+    const rollingBack = new Promise<void>((resolve) => { entered = resolve; });
+    let release!: () => void;
+    const resume = new Promise<void>((resolve) => { release = resolve; });
+    const first = applySkill(skillDir, root, {
+      rollbackOnFailure: true,
+      exec: async (cmd) => {
+        if (cmd.includes(' add ')) throw new Error('partial install');
+        entered();
+        await resume;
+      },
+    });
+    await rollingBack;
+    try {
+      await expect(applySkill(skillDir, root, { exec: () => {} })).rejects.toThrow(/another skill apply/);
+      await expect(removeSkill(root, [])).rejects.toThrow(/another skill apply/);
+    } finally { release(); }
+    expect((await first).rollback).toEqual({});
+    await expect(applySkill(skillDir, root, { exec: () => {} })).resolves.toBeDefined();
+  });
+});

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -23,27 +23,18 @@
 // Usage: pnpm exec tsx scripts/skill-apply.ts <skillDir>     # plan (no writes)
 
 import { execSync } from 'node:child_process';
-import { readFileSync, existsSync, writeFileSync, appendFileSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, appendFileSync, copyFileSync, mkdirSync, rmSync, lstatSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { parseDirectives, promptVar, type Directive } from './skill-directives.js';
+import { withApplyLock } from './skill-lock.js';
+import { CALLER_OWNED_EFFECTS, type InputMeta } from '../src/cli/skill-report.js';
+
+export type { InputMeta };
+import { parseDirectives, promptVar, type Directive, isSecretPrompt } from './skill-directives.js';
 
 // What an `nc:prompt` DECLARES about the value it needs — the core seam's input
 // contract, passed to `resolveInput` so a consumer can run its OWN re-ask loop
 // (clack validate, a chat exchange). Declaration only: how the value is
 // ACQUIRED (a masked TTY prompt, a chat message) is the consumer's business.
-export interface InputMeta {
-  question: string; // the prompt body (verbatim)
-  secret: boolean; // consumer must mask
-  validate?: string; // regex source (nc:prompt validate:<re>)
-  flags?: string; // regex flags   (nc:prompt flags:<f>)
-  normalize?: 'trim' | 'rstrip-slash' | 'lower'; // applied by the ENGINE at bind
-  // Interactive select options, `|`-separated (nc:prompt choices:a|b). When a
-  // value is legal only via pre-bound inputs (e.g. slack's `provisioned`
-  // connection), validate stays wider than the offered set — so a consumer
-  // must prefer this over options derived from the validate alternation.
-  choices?: string;
-}
-
 // Everything the engine EMITS — the core seam's output contract. Every
 // `onEvent` call is AWAITED before the engine proceeds; that ordering guarantee
 // is what lets a consumer implement gating (hold the operator event until the
@@ -216,7 +207,7 @@ export function planSkill(
   const steps: PlanStep[] = self.map(({ d, status, detail }, i) => {
     if (d.kind !== 'prompt') return { n: i + 1, kind: d.kind, line: d.line, status, detail };
     const v = promptVar(d) ?? '?';
-    const tag = `${v}${d.args.includes('secret') ? ' (secret)' : ''}`;
+    const tag = `${v}${isSecretPrompt(d) ? ' (secret)' : ''}`;
     const cons = consumers.get(v) ?? [];
     const satisfied = cons.length > 0 && cons.every((j) => self[j].status === 'skip');
     return satisfied
@@ -235,12 +226,14 @@ export function planSkill(
 // Apply (phases 3–5) + journal-derived remove.
 // ---------------------------------------------------------------------------
 
+type FileSnapshot = { path: string; before?: { data: Buffer; mode: number } };
+
 export type JournalEntry =
-  | { op: 'wrote'; path: string }
-  | { op: 'appended'; path: string; line: string }
-  | { op: 'set-env'; key: string }
-  | { op: 'json-merge'; path: string; key: string; value: unknown; previous?: unknown }
-  | { op: 'ran'; cmd: string; undo?: string };
+  | ({ op: 'wrote' } & FileSnapshot)
+  | ({ op: 'appended'; line: string } & FileSnapshot)
+  | { op: 'set-env'; key: string; snapshot: FileSnapshot }
+  | { op: 'json-merge'; path: string; key: string; value: unknown; previous?: unknown; snapshot: FileSnapshot }
+  | { op: 'ran'; cmd: string; undo?: string; files?: FileSnapshot[] };
 
 export interface AgentTask {
   kind: string;
@@ -260,6 +253,11 @@ export interface ApplyResult {
   // `owner_handle` + `platform_id`, the setup flow reads them to wire the agent.
   vars: Record<string, string>;
   journal: JournalEntry[];
+  rollback?: { error?: string };
+  // Runs the caller declared it owns (`skipEffects`) and the engine therefore did
+  // not execute — the structured twin of the `skipped` line, so the caller can
+  // perform them (a restart, an interactive step, a wire) with line and command.
+  callerOwned: Array<{ effect: string; line: number; command: string }>;
   // The skill's author-written REFERENCE floor — its `## Alternatives`,
   // `## Optional configuration`, and `## Troubleshooting` sections, sliced
   // verbatim from the RAW markdown (see `referenceProse`). The driver surfaces
@@ -270,6 +268,8 @@ export interface ApplyResult {
 }
 
 export interface ApplyOptions {
+  // Restore journaled changes before releasing the checkout lock on failure.
+  rollbackOnFailure?: boolean;
   // Install skips already-present payloads. Refresh deliberately reapplies
   // copy and dependency directives so registry bytes and exact pins advance.
   mode?: 'install' | 'refresh';
@@ -318,7 +318,7 @@ export interface ApplyOptions {
 export interface DependencyCommandRequest {
   manager: string;
   cwd: string;
-  action: 'add' | 'remove';
+  action: 'add' | 'remove' | 'install';
   packages: string[];
 }
 
@@ -551,6 +551,11 @@ const NORMALIZE_KINDS: ReadonlySet<string> = new Set(['trim', 'rstrip-slash', 'l
 // consumer can run its own re-ask loop against the same semantics the engine
 // enforces at bind. The attrs live on the directive fence, so they're stripped
 // along with the fence when a skill degrades to prose — invisible to the agent.
+/** The declared input semantics of a `prompt` directive — what any consumer asking for its value must know. */
+export function promptMeta(d: Directive): InputMeta {
+  return inputMetaOf(d, isSecretPrompt(d), typeof d.attrs.validate === 'string' ? d.attrs.validate : undefined);
+}
+
 function inputMetaOf(d: Directive, secret: boolean, validate: string | undefined): InputMeta {
   const meta: InputMeta = { question: d.body.join('\n'), secret };
   if (validate !== undefined) meta.validate = validate;
@@ -628,6 +633,26 @@ function bindCapture(
   }
 }
 
+// Before-images stay in memory and never enter the public apply report.
+function snapshotFile(root: string, path: string): FileSnapshot {
+  try {
+    const stat = lstatSync(join(root, path));
+    if (!stat.isFile()) throw new Error(`mutation target is not a regular file: ${path}`);
+    return { path, before: { data: readFileSync(join(root, path)), mode: stat.mode } };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    return { path };
+  }
+}
+
+function restoreFile(root: string, snapshot: FileSnapshot): void {
+  const target = join(root, snapshot.path);
+  if (snapshot.before) {
+    writeFileSync(target, snapshot.before.data);
+    chmodSync(target, snapshot.before.mode);
+  } else rmSync(target, { force: true });
+}
+
 // The mutating twin of selfStatus. Records what it did to the journal so remove
 // is derivable. Throws on failure → caught and bounced to an agent.
 async function applyOne(
@@ -646,7 +671,8 @@ async function applyOne(
 ): Promise<void> {
   const { root, skillDir, exec, vars, journal } = ctx;
   switch (d.kind) {
-    case 'copy':
+    case 'copy': {
+      const save = (line: string) => journal.push({ op: 'wrote', ...snapshotFile(root, destOf(line)) });
       if (d.attrs['from-branch']) {
         const b = String(d.attrs['from-branch']);
         const remote = ctx.resolveRemote(b);
@@ -656,25 +682,26 @@ async function applyOne(
           // may not exist on trunk (e.g. container skills that live only on
           // the channels branch). Mirror the local-copy path's mkdir.
           mkdirSync(dirname(join(root, destOf(l))), { recursive: true });
+          save(l);
           await exec(`git show ${remote}/${b}:${srcOf(l)} > ${destOf(l)}`);
         }
       } else {
         for (const l of d.body) {
           const dst = join(root, destOf(l));
           mkdirSync(dirname(dst), { recursive: true });
+          save(l);
           copyFileSync(join(skillDir, srcOf(l)), dst);
         }
       }
-      for (const l of d.body) journal.push({ op: 'wrote', path: destOf(l) });
       break;
+    }
     case 'append': {
       const to = String(d.attrs.to);
       const marker = typeof d.attrs.at === 'string' ? d.attrs.at : undefined;
       const target = join(root, to);
       if (marker) {
         // Insert before the `// <<< <marker>` closing line of a dormant marker
-        // region, matching that line's indentation. removeSkill still deletes
-        // by line (position-agnostic), so the journal entry is unchanged.
+        // region, matching that line's indentation. Rollback restores its bytes.
         const close = `<<< ${marker}`;
         for (const line of d.body) {
           const lines = read(target).split('\n');
@@ -682,13 +709,13 @@ async function applyOne(
           if (idx === -1) throw new Error(`append marker "${marker}" not found in ${to}`);
           const indent = lines[idx].match(/^\s*/)?.[0] ?? '';
           lines.splice(idx, 0, indent + line);
+          journal.push({ op: 'appended', line, ...snapshotFile(root, to) });
           writeFileSync(target, lines.join('\n'));
-          journal.push({ op: 'appended', path: to, line });
         }
       } else {
         for (const line of d.body) {
+          journal.push({ op: 'appended', line, ...snapshotFile(root, to) });
           appendFileSync(target, (read(target).endsWith('\n') || read(target) === '' ? '' : '\n') + line + '\n');
-          journal.push({ op: 'appended', path: to, line });
         }
       }
       break;
@@ -697,19 +724,19 @@ async function applyOne(
       const manager = typeof d.attrs.manager === 'string' ? d.attrs.manager : 'pnpm';
       const cwd = typeof d.attrs.cwd === 'string' ? d.attrs.cwd : '';
       const prefix = cwd ? `cd ${cwd} && ` : '';
-      const names = d.body.map((s) => s.slice(0, s.lastIndexOf('@'))).join(' ');
       const add =
         ctx.resolveDependencyCommand?.({ manager, cwd, action: 'add', packages: d.body }) ??
         `${prefix}${manager} add ${d.body.join(' ')}`;
-      const remove =
-        ctx.resolveDependencyCommand?.({ manager, cwd, action: 'remove', packages: names.split(' ') }) ??
-        `${prefix}${manager} remove ${names}`;
+      // Restore exact manifests/lockfiles, then reconcile dependencies. Removing
+      // package names would delete dependencies that existed before this apply.
+      const lockfiles = ['pnpm-lock.yaml', 'bun.lock', 'bun.lockb', 'package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'];
+      const files = [...new Set(['', cwd].flatMap((dir) => ['package.json', ...lockfiles].map((file) => join(dir, file))))]
+        .map((file) => snapshotFile(root, file));
+      const flags = manager === 'npm' ? [] : ['--frozen-lockfile'];
+      const undo = ctx.resolveDependencyCommand?.({ manager, cwd, action: 'install', packages: flags }) ??
+        `${prefix}${manager} install ${flags.join(' ')}`.trim();
+      journal.push({ op: 'ran', cmd: add, undo, files });
       await exec(add);
-      journal.push({
-        op: 'ran',
-        cmd: add,
-        undo: remove,
-      });
       break;
     }
     case 'run': {
@@ -781,11 +808,11 @@ async function applyOne(
         const key = entry.slice(0, eq).trim();
         const value = substitute(entry.slice(eq + 1).trim(), vars); // throws if a {{var}} is unresolved
         if (!envKeySet(root, key)) {
+          journal.push({ op: 'set-env', key, snapshot: snapshotFile(root, '.env') });
           appendFileSync(
             envPath,
             (read(envPath).endsWith('\n') || read(envPath) === '' ? '' : '\n') + `${key}=${value}\n`,
           );
-          journal.push({ op: 'set-env', key });
         }
       }
       break;
@@ -803,13 +830,13 @@ async function applyOne(
       );
       if (existingIndex === -1) {
         arr.push(obj);
+        journal.push({ op: 'json-merge', path: into, key, value, snapshot: snapshotFile(root, into) });
         writeFileSync(target, JSON.stringify(arr, null, 2) + '\n');
-        journal.push({ op: 'json-merge', path: into, key, value });
       } else if (ctx.mode === 'refresh' && JSON.stringify(arr[existingIndex]) !== JSON.stringify(obj)) {
         const previous = arr[existingIndex];
         arr[existingIndex] = obj;
+        journal.push({ op: 'json-merge', path: into, key, value, previous, snapshot: snapshotFile(root, into) });
         writeFileSync(target, JSON.stringify(arr, null, 2) + '\n');
-        journal.push({ op: 'json-merge', path: into, key, value, previous });
       }
       break;
     }
@@ -819,6 +846,21 @@ async function applyOne(
 }
 
 export async function applySkill(skillDir: string, root: string, opts: ApplyOptions): Promise<ApplyResult> {
+  return withApplyLock(root, async () => {
+    const res = await applyUnlocked(skillDir, root, opts);
+    if (opts.rollbackOnFailure && res.agentTasks.length > 0) {
+      res.rollback = {};
+      try {
+        await removeUnlocked(root, res.journal, opts.exec ? async (cmd) => { await opts.exec!(cmd); } : undefined);
+      } catch (error) {
+        res.rollback.error = error instanceof Error ? error.message : String(error);
+      }
+    }
+    return res;
+  });
+}
+
+async function applyUnlocked(skillDir: string, root: string, opts: ApplyOptions): Promise<ApplyResult> {
   // Lint (validate()) is the authoring/CI gate, run before a skill ships — NOT
   // here. Apply is best-effort: an unknown directive (a typo lint should have
   // caught, or one newer than this engine) bounces to an agent, never blocks.
@@ -839,6 +881,7 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
     operatorMessages: [],
     vars: {},
     journal: [],
+    callerOwned: [],
     referenceProse: referenceProse(md),
   };
   // A run-health gate: once ANY directive bounces to an agent, the skill is no
@@ -851,7 +894,7 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
   // prompt (headless rebuild, no answer) is not a failure — it never bounces, so
   // `blocked` stays false and a later restart remains runnable.
   let blocked = false;
-  const SIDE_EFFECTS = new Set(['restart', 'step', 'wire']);
+  const SIDE_EFFECTS = new Set(CALLER_OWNED_EFFECTS);
   const bounce = (d: Directive, reason: string) => {
     blocked = true;
     res.agentTasks.push({ kind: d.kind, line: d.line, reason, prose: proseFor(md, d.line) });
@@ -886,7 +929,7 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
       }
       if (d.kind === 'prompt') {
         const v = promptVar(d)!;
-        const secret = d.args.includes('secret');
+        const secret = isSecretPrompt(d);
         const validate = typeof d.attrs.validate === 'string' ? d.attrs.validate : undefined;
         const flags = typeof d.attrs.flags === 'string' ? d.attrs.flags : undefined;
         const normalize = typeof d.attrs.normalize === 'string' ? d.attrs.normalize : undefined;
@@ -951,6 +994,7 @@ export async function applySkill(skillDir: string, root: string, opts: ApplyOpti
       // A run whose effect the caller owns (e.g. restart) is skipped here.
       if (d.kind === 'run' && typeof d.attrs.effect === 'string' && opts.skipEffects?.includes(d.attrs.effect)) {
         res.skipped.push(`run ${d.attrs.effect}: owned by the caller`);
+        res.callerOwned.push({ effect: d.attrs.effect, line: d.line, command: d.body.join('\n') });
         continue;
       }
       // Run-health gate: after an earlier bounce, never fire a dangerous side
@@ -1033,41 +1077,32 @@ export async function removeSkill(
   journal: JournalEntry[],
   exec?: (c: string) => void | Promise<void>,
 ): Promise<void> {
+  return withApplyLock(root, () => removeUnlocked(root, journal, exec));
+}
+
+async function removeUnlocked(root: string, journal: JournalEntry[], exec?: (c: string) => void | Promise<void>): Promise<void> {
+  const errors: string[] = [];
   for (const e of [...journal].reverse()) {
-    if (e.op === 'wrote') rmSync(join(root, e.path), { force: true });
-    else if (e.op === 'appended') {
-      const p = join(root, e.path);
-      writeFileSync(
-        p,
-        read(p)
-          .split('\n')
-          .filter((l) => l.trim() !== e.line.trim())
-          .join('\n'),
-      );
-    } else if (e.op === 'set-env') {
-      const p = join(root, '.env');
-      writeFileSync(
-        p,
-        read(p)
-          .split('\n')
-          .filter((l) => !l.startsWith(`${e.key}=`))
-          .join('\n'),
-      );
-    } else if (e.op === 'json-merge') {
-      const p = join(root, e.path);
-      const arr = JSON.parse(read(p) || '[]') as unknown[];
-      if (Array.isArray(arr)) {
-        const index = arr.findIndex(
-          (el) => el !== null && typeof el === 'object' && (el as Record<string, unknown>)[e.key] === e.value,
-        );
-        if (e.previous !== undefined && index >= 0) arr[index] = e.previous;
-        else if (index >= 0) arr.splice(index, 1);
-        writeFileSync(p, JSON.stringify(arr, null, 2) + '\n');
+    try {
+      if (e.op === 'wrote' || e.op === 'appended') restoreFile(root, e);
+      else if (e.op === 'set-env' || e.op === 'json-merge') {
+        restoreFile(root, e.snapshot);
+      } else if (e.op === 'ran' && e.undo) {
+        for (const file of e.files ?? []) restoreFile(root, file);
+        try {
+          if (!exec) throw new Error('rollback requires a command runner');
+          await exec(e.undo);
+        } finally {
+          // A failed reinstall must not leave manifests changed by that attempt.
+          for (const file of e.files ?? []) restoreFile(root, file);
+        }
       }
-    } else if (e.op === 'ran' && e.undo && exec) {
-      await exec(e.undo);
+    } catch (error) {
+      // Keep restoring independent files even if dependency recovery fails.
+      errors.push(error instanceof Error ? error.message : String(error));
     }
   }
+  if (errors.length) throw new Error(errors.join('; '));
 }
 
 // CLI — the planner (no writes)

--- a/scripts/skill-directives.ts
+++ b/scripts/skill-directives.ts
@@ -166,6 +166,22 @@ export function promptVar(d: Directive): string | undefined {
   return d.args.find((a) => !PROMPT_FLAGS.has(a));
 }
 
+/** A `prompt` whose answer is a credential — never shown, never relayed through an agent. */
+export function isSecretPrompt(d: Directive): boolean {
+  return d.kind === 'prompt' && d.args.includes('secret');
+}
+
+/** The registry branches a skill's `copy from-branch:` fences draw from, sorted and unique. */
+export function registryBranches(directives: Directive[]): string[] {
+  return [
+    ...new Set(
+      directives
+        .filter((d) => d.kind === 'copy' && typeof d.attrs['from-branch'] === 'string')
+        .map((d) => String(d.attrs['from-branch'])),
+    ),
+  ].sort();
+}
+
 /**
  * The variable name(s) a `run capture:<spec>` binds. `capture:dm_channel` →
  * `['dm_channel']` (stdout form); `capture:platform_id=PLATFORM_ID,owner=ACCOUNT`
@@ -358,7 +374,7 @@ export function validate(directives: Directive[], ctx?: { chatVersion?: string }
 export function lintReferenceFloor(markdown: string): Problem[] {
   const directives = parseDirectives(markdown);
   const isFloorBearing = (d: Directive): boolean =>
-    (d.kind === 'prompt' && d.args.includes('secret')) || (d.kind === 'run' && d.attrs.effect === 'step');
+    isSecretPrompt(d) || (d.kind === 'run' && d.attrs.effect === 'step');
   const anchor = directives.find(isFloorBearing);
   if (!anchor) return []; // no credential / interactive step ⇒ no floor expected
   const hasTroubleshooting = markdown.split('\n').some((l) => /^##\s+Troubleshooting\s*$/.test(l.trim()));

--- a/scripts/skill-headless.test.ts
+++ b/scripts/skill-headless.test.ts
@@ -1,0 +1,427 @@
+// The headless engine entry `ncl skills` and pipelines drive: list / plan /
+// apply as JSON, with the preconditions, the checkout lock, and the journal
+// rollback that keep a host checkout from ending up half-installed. Everything
+// runs against a scratch root with a recording exec — no network, no real
+// commands.
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { assertSkillName } from '../src/cli/skill-report.js';
+import { applyHeadless, applyLockPath, listSkills, parseCli, planHeadless } from './skill-headless.js';
+import * as registry from './update-skills.js';
+
+const DEMO_SKILL = `---
+name: add-demo
+description: "Demo install skill for the headless engine tests."
+---
+
+# Demo
+
+## Copy
+\`\`\`nc:copy
+resources/demo.ts -> src/channels/demo.ts
+\`\`\`
+
+## Register
+\`\`\`nc:append to:src/channels/index.ts
+import './demo.js';
+\`\`\`
+
+## Credentials
+\`\`\`nc:prompt handle
+Your demo handle.
+\`\`\`
+\`\`\`nc:prompt token secret
+Paste the demo token.
+\`\`\`
+\`\`\`nc:env-set
+DEMO_HANDLE={{handle}}
+\`\`\`
+\`\`\`nc:env-set
+DEMO_TOKEN={{token}}
+\`\`\`
+
+## Build and validate
+\`\`\`nc:run effect:build
+pnpm run build
+\`\`\`
+\`\`\`nc:run effect:test
+pnpm exec vitest run src/channels/demo.test.ts
+\`\`\`
+
+## Restart
+\`\`\`nc:run effect:restart
+bash setup/lib/restart.sh
+\`\`\`
+`;
+
+/** The shape of a channel skill: copy, register, a pinned dependency (whose undo is a command), a test. */
+const DEP_SKILL = `---
+name: add-dep
+description: Install skill with a pinned dependency.
+---
+
+# Dep
+
+## Copy
+\`\`\`nc:copy
+resources/dep.ts -> src/channels/dep.ts
+\`\`\`
+\`\`\`nc:append to:src/channels/index.ts
+import './dep.js';
+\`\`\`
+
+## Dependencies
+\`\`\`nc:dep
+left-pad@1.3.0
+\`\`\`
+
+## Validate
+\`\`\`nc:run effect:test
+pnpm exec vitest run src/channels/dep.test.ts
+\`\`\`
+`;
+
+const PROSE_SKILL = `---
+name: prose-only
+description: A workflow with no structured steps.
+---
+
+# Prose only
+
+Read the logs and think hard.
+`;
+
+const DEMO_INPUTS = { handle: 'U1', token: 'shh' };
+
+const recording = (failOn?: RegExp) => {
+  const cmds: string[] = [];
+  return {
+    cmds,
+    exec: (c: string): string | void => {
+      cmds.push(c);
+      if (failOn && failOn.test(c)) throw new Error(`boom: ${c}`);
+    },
+  };
+};
+
+describe('skill names', () => {
+  it('accepts directory names and rejects anything that could escape .claude/skills', () => {
+    expect(() => assertSkillName('add-demo')).not.toThrow();
+    for (const bad of ['../etc', 'Add-Demo', 'a b', '', '-x', 'x/y'])
+      expect(() => assertSkillName(bad)).toThrow(/invalid skill name/);
+  });
+});
+
+describe('cli parsing', () => {
+  it('reads the subcommand, skill, and flags', () => {
+    const cli = parseCli([
+      'apply',
+      'add-demo',
+      '--root',
+      '/tmp/x',
+      '--inputs',
+      '{"handle":"U1"}',
+      '--refresh',
+      '--no-secret-inputs',
+    ]);
+    expect(cli).toMatchObject({
+      command: 'apply',
+      skill: 'add-demo',
+      root: '/tmp/x',
+      inputs: { handle: 'U1' },
+      refresh: true,
+      noSecretInputs: true,
+    });
+  });
+
+  it('rejects non-object inputs and unknown flags', () => {
+    expect(() => parseCli(['apply', 'x', '--inputs', '[1]'])).toThrow(/JSON object/);
+    expect(() => parseCli(['apply', 'x', '--bogus'])).toThrow(/unknown flag/);
+    expect(() => parseCli(['apply', 'x', '--keep-partial'])).toThrow(/unknown flag/);
+  });
+});
+
+describe('against a scratch checkout', () => {
+  let root: string;
+
+  function skill(name: string, md: string, files: Record<string, string> = {}): void {
+    const dir = join(root, '.claude', 'skills', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'SKILL.md'), md);
+    for (const [rel, content] of Object.entries(files)) {
+      mkdirSync(join(dir, rel, '..'), { recursive: true });
+      writeFileSync(join(dir, rel), content);
+    }
+  }
+
+  /** Make the scratch root a clean git work tree — what a refresh requires. */
+  function gitClean(): void {
+    const git = (...args: string[]) =>
+      execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', '-c', 'commit.gpgsign=false', ...args], {
+        cwd: root,
+        stdio: 'ignore',
+      });
+    git('init', '-q');
+    git('add', '-A');
+    git('-c', 'core.hooksPath=/dev/null', 'commit', '-qm', 'seed');
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'enabled');
+    root = mkdtempSync(join(tmpdir(), 'nc-headless-'));
+    execFileSync('git', ['init', '-q', root]);
+    mkdirSync(join(root, 'src', 'channels'), { recursive: true });
+    mkdirSync(join(root, 'src', 'providers'), { recursive: true });
+    mkdirSync(join(root, 'container', 'agent-runner', 'src', 'providers'), { recursive: true });
+    writeFileSync(join(root, 'src', 'channels', 'index.ts'), "import './cli.js';\n");
+    writeFileSync(join(root, 'src', 'providers', 'index.ts'), '// provider barrel\n');
+    writeFileSync(join(root, 'container', 'agent-runner', 'src', 'providers', 'index.ts'), "import './claude.js';\n");
+    writeFileSync(join(root, '.env'), 'EXISTING=1\n');
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}\n');
+    skill('add-demo', DEMO_SKILL, { 'resources/demo.ts': 'export const demo = true;\n' });
+    skill('add-dep', DEP_SKILL, { 'resources/dep.ts': 'export const dep = 2;\n' });
+    skill('prose-only', PROSE_SKILL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    rmSync(applyLockPath(root), { force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  describe('list', () => {
+    it('reports only structured skills, with kind, install state, prompts, and caller-owned effects', () => {
+      const rows = listSkills(root);
+      expect(rows.map((r) => r.name)).toEqual(['add-demo', 'add-dep']);
+      expect(rows[0]).toMatchObject({
+        description: 'Demo install skill for the headless engine tests.',
+        kind: 'other',
+        installed: false,
+        prompts: 2,
+        secretPrompts: 1,
+        callerOwnedEffects: ['restart'],
+      });
+      expect(rows[1].callerOwnedEffects).toEqual([]);
+    });
+
+    it('marks a skill installed once its barrel import is present', () => {
+      writeFileSync(join(root, 'src', 'channels', 'index.ts'), "import './cli.js';\nimport './demo.js';\n");
+      expect(listSkills(root)[0]).toMatchObject({ installed: true, kind: 'channel' });
+    });
+
+    it('keeps the catalog when one skill’s frontmatter does not parse', () => {
+      skill(
+        'bad-yaml',
+        "---\nname: bad-yaml\ndescription: Deploy: staging\n---\n\n```nc:append to:src/channels/index.ts\nimport './bad.js';\n```\n",
+      );
+      const rows = listSkills(root);
+      expect(rows.map((r) => r.name)).toEqual(['add-demo', 'add-dep', 'bad-yaml']);
+      expect(rows[2].description).toBe('');
+    });
+  });
+
+  describe('plan', () => {
+    it('lists the steps and the prompts with their secret flag, without writing', () => {
+      const plan = planHeadless(root, 'add-demo');
+      expect(plan.prompts).toEqual([
+        { var: 'handle', secret: false, question: 'Your demo handle.' },
+        { var: 'token', secret: true, question: 'Paste the demo token.' },
+      ]);
+      expect(plan.callerOwnedEffects).toEqual(['restart']);
+      expect(plan.steps.some((s) => s.kind === 'copy' && s.status === 'apply')).toBe(true);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(false);
+    });
+
+    it('rejects an unknown skill', () => {
+      expect(() => planHeadless(root, 'add-nope')).toThrow(/unknown skill/);
+    });
+  });
+
+  describe('apply', () => {
+    it('applies the structured steps, leaves caller-owned effects pending, and hides the secret', async () => {
+      const { cmds, exec } = recording();
+      const report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec });
+      expect(report.status).toBe('applied');
+      expect(readFileSync(join(root, 'src', 'channels', 'demo.ts'), 'utf8')).toContain('demo = true');
+      expect(readFileSync(join(root, 'src', 'channels', 'index.ts'), 'utf8')).toContain("import './demo.js';");
+      const env = readFileSync(join(root, '.env'), 'utf8');
+      expect(env).toContain('DEMO_HANDLE=U1');
+      expect(env).toContain('DEMO_TOKEN=shh');
+      expect(cmds).toEqual(['pnpm run build', 'pnpm exec vitest run src/channels/demo.test.ts']);
+      expect(report.pendingEffects).toEqual([
+        { effect: 'restart', line: expect.any(Number), command: 'bash setup/lib/restart.sh' },
+      ]);
+      expect(report.vars).toEqual({ handle: 'U1' }); // the secret never surfaces
+      expect(existsSync(applyLockPath(root))).toBe(false); // the checkout lock is released
+    });
+
+    it('refuses secret inputs on the agent path before touching anything', async () => {
+      const { cmds, exec } = recording();
+      const report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, noSecretInputs: true, exec });
+      expect(report.status).toBe('failed');
+      expect(report.error).toMatch(/secret inputs are refused.*token/);
+      expect(cmds).toEqual([]);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(false);
+      expect(readFileSync(join(root, '.env'), 'utf8')).toBe('EXISTING=1\n');
+    });
+
+    it('rolls the journal back when a step fails, leaving the tree as it was', async () => {
+      const { exec } = recording(/vitest/);
+      const report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec });
+      expect(report.status).toBe('rolled-back');
+      expect(report.failure?.headline).toMatch(/Build and validate/);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(false);
+      expect(readFileSync(join(root, 'src', 'channels', 'index.ts'), 'utf8')).toBe("import './cli.js';\n");
+      expect(readFileSync(join(root, '.env'), 'utf8')).toBe('EXISTING=1\n');
+    });
+
+    it('reports a rollback that fails instead of throwing the report away', async () => {
+      const { exec } = recording(/vitest|pnpm install/);
+      const report = await applyHeadless(root, 'add-dep', { exec });
+      expect(report.status).toBe('failed');
+      expect(report.error).toMatch(/rollback failed: .*pnpm install/);
+      expect(report.failure?.headline).toMatch(/Validate/);
+      expect(report.applied.length).toBeGreaterThan(0);
+    });
+
+    it('keeps tested code pending when credentials must be completed by the operator', async () => {
+      const { exec } = recording();
+      const report = await applyHeadless(root, 'add-demo', { inputs: { handle: 'U1' }, noSecretInputs: true, exec });
+      expect(report.status).toBe('needs-setup');
+      expect(report.deferred.join(' ')).toMatch(/token/);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(true);
+      expect(readFileSync(join(root, '.env'), 'utf8')).not.toContain('DEMO_TOKEN=');
+
+      // The operator supplies the credential on the host; code steps are
+      // idempotent and the already installed payload stays present.
+      const completed = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec });
+      expect(completed.status).toBe('applied');
+      expect(readFileSync(join(root, '.env'), 'utf8')).toContain('DEMO_TOKEN=shh');
+      expect(JSON.stringify(completed)).not.toContain('shh');
+    });
+
+    it('reports external authentication and interactive steps without running either', async () => {
+      skill('add-auth', DEMO_SKILL + '\n```nc:run effect:external\nauth-wizard\n```\n```nc:run effect:step\npair-device\n```', {
+        'resources/demo.ts': 'export const demo = true;\n',
+      });
+      const { exec, cmds } = recording();
+      const report = await applyHeadless(root, 'add-auth', { inputs: DEMO_INPUTS, exec });
+      expect(report.status).toBe('needs-setup');
+      expect(cmds).toEqual(['pnpm run build', 'pnpm exec vitest run src/channels/demo.test.ts']);
+      expect(report.pendingEffects.map((s) => s.effect)).toEqual(['restart', 'external', 'step']);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(true);
+      expect(planHeadless(root, 'add-auth').callerOwnedEffects).toContain('external');
+    });
+
+    it('refuses a disabled deployment before any engine command or file mutation', async () => {
+      vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'disabled');
+      const { exec, cmds } = recording();
+      const report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec });
+      expect(report.status).toBe('failed');
+      expect(report.error).toMatch(/release deployment workflow/);
+      expect(cmds).toEqual([]);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(false);
+      expect(readFileSync(join(root, '.env'), 'utf8')).toBe('EXISTING=1\n');
+    });
+
+    it.each([
+      ['add-codex', 'needs-setup'],
+      ['add-telegram', 'needs-setup'],
+      ['add-emacs', 'applied'],
+    ])('runs the real %s directives and reports %s without credentials or interactive commands', async (name, status) => {
+      const md = readFileSync(join(process.cwd(), '.claude', 'skills', name, 'SKILL.md'), 'utf8');
+      skill(name, md);
+      mkdirSync(join(root, 'setup', 'providers'), { recursive: true });
+      writeFileSync(join(root, 'setup', 'providers', 'index.ts'), '// providers\n');
+      writeFileSync(join(root, 'setup', 'index.ts'), "const STEPS = {\n'pair-telegram': () => import('./pair-telegram.js'),\n};\n");
+      writeFileSync(join(root, 'container', 'cli-tools.json'), '[]\n');
+      vi.spyOn(registry, 'resolveRegistryRemote').mockReturnValue('origin');
+      const cmds: string[] = [];
+      const report = await applyHeadless(root, name, {
+        noSecretInputs: true,
+        exec: (command) => {
+          cmds.push(command);
+          // Model the registry copy only. Builds, tests and network commands
+          // are recorded; this check proves the real document's control flow.
+          const destination = command.match(/^git show \S+ > (.+)$/)?.[1];
+          if (destination) writeFileSync(join(root, destination), 'export {};\n');
+          if (command.includes('echo yes || echo no')) return 'no';
+        },
+      });
+      expect(report.status).toBe(status);
+      expect(report.agentTasks).toEqual([]);
+      expect(cmds).toContain('pnpm run build');
+      expect(cmds.some((c) => c.includes('vitest'))).toBe(true);
+      expect(cmds.some((c) => /provider-auth|--step pair-telegram/.test(c))).toBe(false);
+      if (name === 'add-codex') {
+        expect(existsSync(join(root, 'src', 'providers', 'codex.ts'))).toBe(true);
+        expect(report.pendingEffects).toContainEqual(expect.objectContaining({
+          effect: 'external', command: 'pnpm exec tsx setup/index.ts --step provider-auth codex',
+        }));
+      }
+      if (name === 'add-telegram') {
+        expect(existsSync(join(root, 'src', 'channels', 'telegram.ts'))).toBe(true);
+        expect(report.deferred).toContain('bot_token');
+        expect(readFileSync(join(root, '.env'), 'utf8')).not.toContain('TELEGRAM_BOT_TOKEN=');
+      }
+    });
+
+    it('refuses a prose-only skill instead of guessing', async () => {
+      const report = await applyHeadless(root, 'prose-only', { exec: recording().exec });
+      expect(report.status).toBe('failed');
+      expect(report.error).toMatch(/no structured apply directives/);
+    });
+
+    it('refuses live and stale locks until an operator clears them', async () => {
+      const lock = applyLockPath(root);
+      writeFileSync(lock, String(process.pid)); // a live owner
+      let report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec: recording().exec });
+      expect(report.status).toBe('failed');
+      expect(report.error).toMatch(/another skill apply may be running/);
+      expect(existsSync(join(root, 'src', 'channels', 'demo.ts'))).toBe(false);
+
+      writeFileSync(lock, '999999999'); // an owner that no longer exists
+      report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec: recording().exec });
+      expect(report.status).toBe('failed');
+      expect(existsSync(lock)).toBe(true);
+      rmSync(lock);
+      report = await applyHeadless(root, 'add-demo', { inputs: DEMO_INPUTS, exec: recording().exec });
+      expect(report.status).toBe('applied');
+      expect(existsSync(lock)).toBe(false);
+    });
+
+    describe('refresh', () => {
+      it('needs a git work tree', async () => {
+        rmSync(join(root, '.git'), { recursive: true, force: true });
+        const report = await applyHeadless(root, 'add-dep', { refresh: true, exec: recording().exec });
+        expect(report.status).toBe('failed');
+        expect(report.error).toMatch(/root of a Git checkout/);
+      });
+
+      it('needs a clean one', async () => {
+        gitClean();
+        writeFileSync(join(root, '.env'), 'EXISTING=1\nEDITED=1\n');
+        const report = await applyHeadless(root, 'add-dep', { refresh: true, exec: recording().exec });
+        expect(report.status).toBe('failed');
+        expect(report.error).toMatch(/working tree must be clean/);
+      });
+
+      it('is never rolled back — the files it overwrote were already installed', async () => {
+        writeFileSync(join(root, 'src', 'channels', 'dep.ts'), 'export const dep = 1; // installed earlier\n');
+        writeFileSync(join(root, 'src', 'channels', 'index.ts'), "import './cli.js';\nimport './dep.js';\n");
+        gitClean();
+        const { exec } = recording(/pnpm (add|install)/);
+        const report = await applyHeadless(root, 'add-dep', { refresh: true, exec });
+        expect(report.status).toBe('failed');
+        expect(report.error).toMatch(/never rolled back/);
+        expect(readFileSync(join(root, 'src', 'channels', 'dep.ts'), 'utf8')).toContain('dep = 2'); // re-copied, kept
+        expect(readFileSync(join(root, 'src', 'channels', 'index.ts'), 'utf8')).toContain("import './dep.js';");
+      });
+    });
+  });
+});

--- a/scripts/skill-headless.ts
+++ b/scripts/skill-headless.ts
@@ -1,0 +1,344 @@
+#!/usr/bin/env tsx
+// Headless skill engine entry: list / plan / apply, JSON in and out.
+//
+// The consumer of the skill-engine seam for callers with no human at a TTY —
+// `ncl skills` on the host (an agent's request, held for admin approval) and
+// pipelines. The prose in each SKILL.md stays authoritative: anything the
+// engine cannot do deterministically is reported as an agent task, never
+// improvised. Failed code steps roll back through the engine's journal;
+// missing inputs and operator-owned setup leave the installed code pending.
+//
+// Usage (always prints one JSON document to stdout):
+//   pnpm exec tsx scripts/skill-headless.ts list [--root <dir>]
+//   pnpm exec tsx scripts/skill-headless.ts plan <skill> [--root <dir>]
+//   pnpm exec tsx scripts/skill-headless.ts apply <skill> [--root <dir>] [--inputs <json>]
+//        [--refresh] [--no-secret-inputs]
+//
+// Exit code 0 for list, plan, or a fully applied skill; 1 for failure or pending
+// operator setup — the JSON distinguishes them.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  CALLER_OWNED_EFFECTS,
+  SKILL_APPLY_SCHEMA,
+  assertSkillName,
+  errorMessage,
+  isPlainObject,
+  parseFrontmatter,
+  type SkillApplyReport,
+  type SkillKind,
+  type SkillPlan,
+  type SkillPromptSummary,
+  type SkillSummary,
+} from '../src/cli/skill-report.js';
+import {
+  applySkill,
+  firstFailureHint,
+  fullyApplied,
+  planSkill,
+  promptMeta,
+  type ApplyOptions,
+  type ApplyResult,
+} from './skill-apply.js';
+import { isSecretPrompt, parseDirectives, promptVar, registryBranches, type Directive } from './skill-directives.js';
+import { sourceInstallRefusal } from '../src/cli/source-install.js';
+import {
+  commandAvailable,
+  detectInstalledSkills,
+  git,
+  hostShellExec,
+  portableDependencyCommand,
+  resolveRegistryRemote,
+} from './update-skills.js';
+
+export interface ApplyHeadlessOptions {
+  inputs?: Record<string, string>;
+  /** Re-copy an installed skill's files and re-pin its dependencies. Needs a clean tree; never rolled back. */
+  refresh?: boolean;
+  /** Refuse inputs that answer a `secret` prompt (an agent caller must never carry a credential). */
+  noSecretInputs?: boolean;
+  /** Command runner; defaults to a shell in `root`. */
+  exec?: ApplyOptions['exec'];
+}
+
+const skillsRoot = (root: string) => path.join(root, '.claude', 'skills');
+// External commands can open auth flows or mutate system state. A headless
+// consumer cannot complete or roll back those; the terminal driver owns them.
+const HEADLESS_EFFECTS = [...CALLER_OWNED_EFFECTS, 'external'];
+
+function readSkillMarkdown(root: string, name: string): { dir: string; md: string } {
+  assertSkillName(name);
+  const dir = path.join(skillsRoot(root), name);
+  const file = path.join(dir, 'SKILL.md');
+  if (!existsSync(file)) throw new Error(`unknown skill "${name}" — no .claude/skills/${name}/SKILL.md`);
+  return { dir, md: readFileSync(file, 'utf8') };
+}
+
+/** The frontmatter `description`; empty when absent or unparseable — one hand-edited skill must not hide the catalog. */
+function frontmatterDescription(md: string): string {
+  const description = parseFrontmatter(md)?.description;
+  return typeof description === 'string' ? description.trim() : '';
+}
+
+const isPrompt = (d: Directive) => d.kind === 'prompt';
+const runEffect = (d: Directive): string | undefined =>
+  d.kind === 'run' && typeof d.attrs.effect === 'string' ? d.attrs.effect : undefined;
+
+/** The caller-owned effects a skill declares — what `list` and `plan` report, and an apply hands back instead of running. */
+function callerOwnedEffects(directives: Directive[]): string[] {
+  const declared = new Set(directives.map(runEffect));
+  return HEADLESS_EFFECTS.filter((effect) => declared.has(effect));
+}
+
+function inferKind(directives: Directive[], installedKind?: SkillKind): SkillKind {
+  if (installedKind) return installedKind;
+  const branches = registryBranches(directives);
+  if (branches.includes('channels')) return 'channel';
+  if (branches.includes('providers')) return 'provider';
+  return 'other';
+}
+
+/** Every fence-carrying skill in the checkout — the ones the engine can apply. */
+export function listSkills(root: string): SkillSummary[] {
+  const dir = skillsRoot(root);
+  if (!existsSync(dir)) return [];
+  const installed = new Map(detectInstalledSkills(root).map((s) => [s.skillName, s.kind as SkillKind]));
+  const out: SkillSummary[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    const file = path.join(dir, name, 'SKILL.md');
+    if (!existsSync(file)) continue;
+    const md = readFileSync(file, 'utf8');
+    const directives = parseDirectives(md);
+    if (directives.length === 0) continue;
+    out.push({
+      name,
+      description: frontmatterDescription(md),
+      kind: inferKind(directives, installed.get(name)),
+      installed: installed.has(name),
+      prompts: directives.filter(isPrompt).length,
+      secretPrompts: directives.filter(isSecretPrompt).length,
+      callerOwnedEffects: callerOwnedEffects(directives),
+    });
+  }
+  return out;
+}
+
+function promptSummaries(directives: Directive[]): SkillPromptSummary[] {
+  return directives.filter(isPrompt).map((d) => ({ var: promptVar(d) ?? '?', ...promptMeta(d) }));
+}
+
+/** What an apply would do, without writing anything. */
+export function planHeadless(root: string, name: string): SkillPlan {
+  const { dir, md } = readSkillMarkdown(root, name);
+  const directives = parseDirectives(md);
+  const plan = planSkill(dir, root);
+  return {
+    skill: name,
+    steps: plan.steps,
+    prompts: promptSummaries(directives),
+    needsInput: plan.needsInput,
+    agentSteps: plan.agentSteps,
+    callerOwnedEffects: callerOwnedEffects(directives),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+/** `git status --porcelain`, or null when `root` is not a git work tree. */
+function porcelain(root: string): string | null {
+  try {
+    return git(root, ['status', '--porcelain']);
+  } catch {
+    return null;
+  }
+}
+
+export { applyLockPath } from './skill-lock.js';
+
+function report(
+  skill: string,
+  status: SkillApplyReport['status'],
+  res?: ApplyResult,
+  error?: string,
+): SkillApplyReport {
+  return {
+    schema: SKILL_APPLY_SCHEMA,
+    skill,
+    status,
+    applied: res?.applied ?? [],
+    skipped: res?.skipped ?? [],
+    deferred: res?.deferred ?? [],
+    agentTasks: res?.agentTasks.map(({ kind, line, reason }) => ({ kind, line, reason })) ?? [],
+    operatorMessages: res?.operatorMessages ?? [],
+    vars: res?.vars ?? {},
+    pendingEffects: res?.callerOwned ?? [],
+    failure: res ? firstFailureHint(res) : undefined,
+    error,
+  };
+}
+
+const failed = (skill: string, error: string): SkillApplyReport => report(skill, 'failed', undefined, error);
+
+/**
+ * Apply one skill headlessly. Preconditions (a structured skill, no secret
+ * inputs when forbidden, a clean tree for a refresh, no other apply on this
+ * checkout) fail before any write. Failed code steps are rolled back through
+ * the engine's journal. Missing inputs and caller-owned setup are reported as
+ * needs-setup; the operator finishes the reported steps from the skill. A refresh
+ * is never rolled back: its journal records
+ * overwrites of files that were already installed, and undoing those would
+ * delete them.
+ */
+export async function applyHeadless(
+  root: string,
+  name: string,
+  opts: ApplyHeadlessOptions = {},
+): Promise<SkillApplyReport> {
+  const refusal = sourceInstallRefusal(root);
+  if (refusal) return failed(name, refusal);
+  const { dir, md } = readSkillMarkdown(root, name);
+  const directives = parseDirectives(md);
+  if (directives.length === 0) {
+    return failed(name, 'skill has no structured apply directives — it needs a coding agent to apply its prose');
+  }
+
+  if (opts.refresh) {
+    const status = porcelain(root);
+    if (status === null)
+      return failed(name, `${root} is not a git work tree — a refresh needs one to protect uncommitted edits`);
+    if (status) {
+      return failed(
+        name,
+        'a refresh overwrites installed files, so the working tree must be clean first (commit or stash)',
+      );
+    }
+  }
+
+  const inputs = opts.inputs ?? {};
+  if (opts.noSecretInputs) {
+    const secret = new Set(directives.filter(isSecretPrompt).map((d) => promptVar(d) ?? ''));
+    const offending = Object.keys(inputs).filter((k) => secret.has(k));
+    if (offending.length > 0) {
+      return failed(
+        name,
+        `secret inputs are refused on this path: ${offending.join(', ')} — credentials are entered by the operator on the host, never relayed through chat`,
+      );
+    }
+  }
+
+  try {
+    const exec = opts.exec ?? hostShellExec(root);
+    let bunOnHost: boolean | undefined; // probed only if a dependency fence asks for Bun, and only once
+    const remotes: Record<string, string> = {}; // one ls-remote per registry branch
+    const res = await applySkill(dir, root, {
+      mode: opts.refresh ? 'refresh' : 'install',
+      rollbackOnFailure: !opts.refresh,
+      inputs,
+      exec,
+      skipEffects: HEADLESS_EFFECTS,
+      resolveDependencyCommand: (request) => {
+        if (request.manager === 'bun') bunOnHost ??= commandAvailable('bun', root);
+        return portableDependencyCommand(root, bunOnHost ?? false, request);
+      },
+      resolveRemote: (branch) => (remotes[branch] ??= resolveRegistryRemote(root, branch)),
+    });
+
+    if (res.agentTasks.length === 0) {
+      const pending = !fullyApplied(res) || res.callerOwned.some((step) => step.effect !== 'restart');
+      return report(name, pending ? 'needs-setup' : 'applied', res);
+    }
+    if (opts.refresh) {
+      return report(
+        name,
+        'failed',
+        res,
+        'the refresh stopped part-way; files re-copied so far were left in place (a refresh is never rolled back)',
+      );
+    }
+    if (res.rollback?.error) {
+      return report(name, 'failed', res, `rollback failed: ${res.rollback.error} — inspect the tree before retrying`);
+    }
+    return report(name, 'rolled-back', res);
+  } catch (err) {
+    return failed(name, errorMessage(err));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+type Cli = ApplyHeadlessOptions & { command: string; skill?: string; root: string };
+
+export function parseCli(argv: string[]): Cli {
+  const [command = '', ...rest] = argv;
+  const cli: Cli = { command, root: process.cwd() };
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    switch (a) {
+      case '--root':
+        cli.root = path.resolve(rest[++i] ?? '');
+        break;
+      case '--inputs': {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(rest[++i] ?? '');
+        } catch {
+          parsed = undefined;
+        }
+        if (!isPlainObject(parsed)) throw new Error('--inputs must be a JSON object of prompt var → value');
+        cli.inputs = Object.fromEntries(Object.entries(parsed).map(([k, v]) => [k, String(v)]));
+        break;
+      }
+      case '--refresh':
+        cli.refresh = true;
+        break;
+      case '--no-secret-inputs':
+        cli.noSecretInputs = true;
+        break;
+      default:
+        if (a.startsWith('--')) throw new Error(`unknown flag ${a}`);
+        if (cli.skill !== undefined) throw new Error(`unexpected argument ${a}`);
+        cli.skill = a;
+    }
+  }
+  return cli;
+}
+
+async function main(): Promise<void> {
+  const cli = parseCli(process.argv.slice(2));
+  let out: unknown;
+  let ok = true;
+  switch (cli.command) {
+    case 'list':
+      out = listSkills(cli.root);
+      break;
+    case 'plan':
+      if (!cli.skill) throw new Error('plan needs a skill name');
+      out = planHeadless(cli.root, cli.skill);
+      break;
+    case 'apply': {
+      if (!cli.skill) throw new Error('apply needs a skill name');
+      const report = await applyHeadless(cli.root, cli.skill, cli);
+      out = report;
+      ok = report.status === 'applied';
+      break;
+    }
+    default:
+      throw new Error('usage: skill-headless.ts list | plan <skill> | apply <skill> [flags]');
+  }
+  process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+  if (!ok) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((err) => {
+    process.stdout.write(`${JSON.stringify({ schema: SKILL_APPLY_SCHEMA, error: errorMessage(err) })}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/skill-lock.ts
+++ b/scripts/skill-lock.ts
@@ -1,0 +1,30 @@
+import { createHash } from 'node:crypto';
+import { closeSync, openSync, realpathSync, unlinkSync, writeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function applyLockPath(root: string): string {
+  const key = createHash('sha256').update(realpathSync(root)).digest('hex');
+  return join(tmpdir(), `nanoclaw-skill-apply-${key}.lock`);
+}
+
+/** One writer per physical checkout, including rollback. */
+export async function withApplyLock<T>(root: string, run: () => Promise<T>): Promise<T> {
+  const file = applyLockPath(root);
+  let fd: number;
+  try {
+    fd = openSync(file, 'wx', 0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    // Never reclaim automatically: two stale-lock contenders can delete a new
+    // owner's lock. After a crash the operator verifies no installer is running.
+    throw new Error(`another skill apply may be running on this checkout; after verifying it has stopped, remove ${file}`);
+  }
+  try {
+    writeSync(fd, String(process.pid));
+    return await run();
+  } finally {
+    closeSync(fd);
+    unlinkSync(file);
+  }
+}

--- a/scripts/test-registry-skills.ts
+++ b/scripts/test-registry-skills.ts
@@ -13,6 +13,7 @@ import {
   lintGateAmbiguity,
   lintReferenceFloor,
   parseDirectives,
+  registryBranches,
   resolveChatCoreVersion,
   validate,
 } from './skill-directives.js';
@@ -70,13 +71,7 @@ function discover(): RegistrySkill[] {
       const markdown = readFileSync(path, 'utf8');
       if (![...markdown.matchAll(REGISTRY_MENTION)].length) return [];
       const directives = parseDirectives(markdown);
-      const branches = [
-        ...new Set(
-          directives
-            .filter((d) => d.kind === 'copy' && typeof d.attrs['from-branch'] === 'string')
-            .map((d) => String(d.attrs['from-branch'])),
-        ),
-      ].sort();
+      const branches = registryBranches(directives);
       if (branches.some((branch) => !REGISTRY_BRANCHES.has(branch))) return [];
       return [
         {

--- a/scripts/update-skills.ts
+++ b/scripts/update-skills.ts
@@ -38,7 +38,7 @@ interface RefreshOptions {
   exec?: (command: string, cwd: string) => string | void | Promise<string | void>;
 }
 
-function commandAvailable(command: string, cwd: string): boolean {
+export function commandAvailable(command: string, cwd: string): boolean {
   try {
     execFileSync(command, ['--version'], {
       cwd,
@@ -65,12 +65,18 @@ export function portableDependencyCommand(root: string, bunOnHost: boolean, requ
   return `${prefix}${manager} ${request.action} ${request.packages.join(' ')}`;
 }
 
-function git(root: string, args: string[]): string {
+/** Run git in `root`; throws when git fails (including: not a work tree). */
+export function git(root: string, args: string[]): string {
   return execFileSync('git', args, {
     cwd: root,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   }).trim();
+}
+
+/** The engine's default command runner on the host: a shell in `root`, stdout captured, stderr passed to the error. */
+export function hostShellExec(root: string): (command: string) => string {
+  return (command) => execSync(command, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
 function tryGit(root: string, args: string[]): string {
@@ -172,14 +178,7 @@ export async function refreshInstalledSkills(
     try {
       const result = await applySkill(skillDir, root, {
         mode: 'refresh',
-        exec: (command) => {
-          if (options.exec) return options.exec(command, root);
-          return execSync(command, {
-            cwd: root,
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'pipe'],
-          });
-        },
+        exec: (command) => (options.exec ? options.exec(command, root) : hostShellExec(root)(command)),
         resolveDependencyCommand: (request) => portableDependencyCommand(root, bunOnHost, request),
         resolveRemote: (branch) => {
           const remote = remotes[branch] ?? resolveRegistryRemote(root, branch);

--- a/src/cli/crud-validate.test.ts
+++ b/src/cli/crud-validate.test.ts
@@ -8,7 +8,7 @@ vi.mock('../db/container-configs.js', () => ({
 import { registerResource, validateArgs } from './crud.js';
 import { registerResourceHelpCommands } from './commands/help.js';
 import { lookup } from './registry.js';
-import type { CallerContext } from './frame.js';
+import type { HandlerContext } from './registry.js';
 
 // --- validateArgs unit ---
 
@@ -136,12 +136,13 @@ describe('lenient ops (no declared args) keep legacy behavior', () => {
 
 describe('resource help command', () => {
   const helpCmd = lookup('widgets-help')!;
-  const host: CallerContext = { caller: 'host' };
-  const agent: CallerContext = {
+  const host: HandlerContext = { caller: 'host', defer: (run) => run() };
+  const agent: HandlerContext = {
     caller: 'agent',
     sessionId: 'sess-1',
     agentGroupId: 'ag-1',
     messagingGroupId: 'mg-1',
+    defer: (run) => run(),
   };
 
   it('renders the resource overview with verb summaries', async () => {

--- a/src/cli/crud.test.ts
+++ b/src/cli/crud.test.ts
@@ -42,7 +42,7 @@ import { lookup } from './registry.js';
 import '../cli/resources/groups.js';
 import '../cli/resources/wirings.js';
 
-const hostCtx = { caller: 'host' as const };
+const hostCtx = { caller: 'host' as const, defer: (run: () => void) => run() };
 
 // Synthetic resource exercising the two-pass create: pass 1 collects explicit
 // args, pass 2 runs the resolveDefaults hook, pass 3 fills static defaults.

--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'crypto';
 import { getDb } from '../db/connection.js';
 import { isUniqueViolation } from '../db/errors.js';
 import { renderVerbHelp } from './help-render.js';
-import { register } from './registry.js';
+import { register, type CommandDef, type HandlerContext } from './registry.js';
 import type { Access } from './registry.js';
 import type { CallerContext } from './frame.js';
 
@@ -53,7 +53,9 @@ export interface CustomOperation {
   examples?: string[];
   /** Operator-only: never runnable from inside a container (see CommandDef.hostOnly). */
   hostOnly?: boolean;
-  handler: (args: Record<string, unknown>, ctx: CallerContext) => Promise<unknown>;
+  /** Refuse the request before a hold (see CommandDef.refuse). */
+  refuse?: CommandDef['refuse'];
+  handler: (args: Record<string, unknown>, ctx: HandlerContext) => Promise<unknown>;
   /** Presentational renderer for human mode — see CommandDef.formatHuman. */
   formatHuman?: (data: unknown) => string;
 }
@@ -63,12 +65,16 @@ export interface ResourceDef {
   name: string;
   /** Plural name: 'groups'. Used in command names. */
   plural: string;
-  /** DB table name. */
-  table: string;
+  /**
+   * DB table backing the generic CRUD verbs. Optional for a resource that
+   * declares only custom operations (e.g. `skills`, which fronts the skill
+   * engine, not a table); registering a generic verb without one throws.
+   */
+  table?: string;
   /** One-line description shown in help. */
   description: string;
-  /** Primary key column name. */
-  idColumn: string;
+  /** Primary key column name. Required with `table`, i.e. for the generic verbs. */
+  idColumn?: string;
   /**
    * Column that carries the agent group ID for group-scope enforcement.
    * Required on every resource in the CLI whitelist (groups, sessions,
@@ -186,7 +192,9 @@ function coerceListFilter(column: ColumnDef, value: unknown): unknown {
 function listOrder(def: ResourceDef): string {
   if (def.listOrder) return def.listOrder;
   const timestamp = def.columns.find((column) => column.name.endsWith('_at'))?.name;
-  return timestamp ? `${timestamp} DESC, ${def.idColumn}` : def.idColumn;
+  // Generic verbs are registered only with an idColumn (registerResource enforces it).
+  const id = def.idColumn as string;
+  return timestamp ? `${timestamp} DESC, ${id}` : id;
 }
 
 function genericList(def: ResourceDef) {
@@ -457,6 +465,12 @@ export function validateArgs(
 // ---------------------------------------------------------------------------
 
 export function registerResource(def: ResourceDef): void {
+  const generic = Object.keys(def.operations).filter((verb) => def.operations[verb as keyof typeof def.operations]);
+  if (generic.length > 0 && (!def.table || !def.idColumn)) {
+    throw new Error(
+      `resource "${def.plural}" declares generic verbs (${generic.join(', ')}) but no table and idColumn`,
+    );
+  }
   resources.set(def.plural, def);
 
   if (def.operations.list) {
@@ -533,6 +547,7 @@ export function registerResource(def: ResourceDef): void {
         description: op.description,
         access: op.access,
         hostOnly: op.hostOnly,
+        refuse: op.refuse,
         resource: def.plural,
         parseArgs: declared
           ? (raw) => {

--- a/src/cli/delivery-action.ts
+++ b/src/cli/delivery-action.ts
@@ -53,6 +53,8 @@ registerDeliveryAction(
     });
 
     log.info('CLI response written', { requestId, ok: response.ok, sessionId: session.id });
+    // The reply is in the mailbox; work the handler deferred until then may run.
+    response.afterReply?.();
   },
   unguarded('transport envelope — every inner command is guarded at dispatch'),
 );

--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -635,7 +635,8 @@ describe('CLI scope enforcement', () => {
       notify: vi.fn(),
     });
 
-    expect(approvalState.observedContexts).toEqual([ctx]);
+    // The identity is the original agent context; dispatch adds only its per-request `defer` sink.
+    expect(approvalState.observedContexts).toEqual([expect.objectContaining(ctx)]);
     expect(approvalState.requestApproval).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -22,13 +22,37 @@ import type { PendingApproval } from '../types.js';
 import type { CallerContext, ErrorCode, RequestFrame, ResponseFrame } from './frame.js';
 import { localizeIsoTimestamps } from './format.js';
 import { getResource } from './crud.js';
+import { log } from '../log.js';
 import { listVerbs, renderVerbHelp } from './help-render.js';
-import { commandGuard, listCommands, lookup } from './registry.js';
+import { commandGuard, listCommands, lookup, type HandlerContext } from './registry.js';
 
 type DispatchOptions = {
   /** Verified approval row when a command is replayed after approval. */
   grant?: PendingApproval;
 };
+
+/**
+ * A response frame plus the work its handler deferred until the reply has
+ * left (HandlerContext.defer). `afterReply` is a function, so JSON.stringify
+ * keeps it off the wire.
+ */
+export type DispatchResult = ResponseFrame & { afterReply?: () => void };
+
+function withDeferred(frame: ResponseFrame, deferred: Array<() => void>, command: string): DispatchResult {
+  if (deferred.length === 0) return frame;
+  return {
+    ...frame,
+    afterReply: () => {
+      for (const run of deferred) {
+        try {
+          run();
+        } catch (err) {
+          log.error('Deferred post-reply work failed', { command, err });
+        }
+      }
+    },
+  };
+}
 
 function actorFor(ctx: CallerContext): GuardActor {
   return ctx.caller === 'host'
@@ -40,7 +64,7 @@ export async function dispatch(
   req: RequestFrame,
   ctx: CallerContext,
   opts: DispatchOptions = {},
-): Promise<ResponseFrame> {
+): Promise<DispatchResult> {
   let cmd = lookup(req.command);
 
   // Fallback: if the full command isn't registered, find the LONGEST registered
@@ -150,7 +174,7 @@ export async function dispatch(
     const agentName = agentGroup?.name ?? ctx.agentGroupId;
 
     const argSummary = Object.entries(req.args)
-      .map(([k, v]) => `--${k} ${v}`)
+      .map(([k, v]) => `--${k} ${typeof v === 'string' ? v : JSON.stringify(v)}`)
       .join(' ');
 
     await requestApproval({
@@ -172,8 +196,10 @@ export async function dispatch(
     return err(req.id, 'invalid-args', errMsg(e));
   }
 
+  const deferred: Array<() => void> = [];
+  const handlerCtx: HandlerContext = { ...ctx, defer: (run) => deferred.push(run) };
   try {
-    let data = await cmd.handler(parsed, ctx);
+    let data = await cmd.handler(parsed, handlerCtx);
 
     // Post-handler group-scope enforcement. Applies only to the auto-generated
     // `list` / `get` handlers (`cmd.generic`), which return raw DB rows carrying
@@ -218,12 +244,12 @@ export async function dispatch(
     // formatter degrades to plain `data`, never fails the response.
     if (cmd.formatHuman) {
       try {
-        return { id: req.id, ok: true, data, human: cmd.formatHuman(data) };
+        return withDeferred({ id: req.id, ok: true, data, human: cmd.formatHuman(data) }, deferred, cmd.name);
       } catch {
         // fall through to the plain frame
       }
     }
-    return { id: req.id, ok: true, data };
+    return withDeferred({ id: req.id, ok: true, data }, deferred, cmd.name);
   } catch (e) {
     return err(req.id, 'handler-error', errMsg(e));
   }
@@ -241,6 +267,8 @@ registerApprovalHandler('cli_command', async ({ payload, approval, notify }) => 
   } else {
     await notify(`Your \`ncl ${frame.command}\` request was approved but failed: ${response.error.message}`);
   }
+  // Deferred work runs once the approval is fully resolved (HandlerContext.defer).
+  return { afterResolved: response.afterReply };
 });
 
 function parseCallerContext(value: unknown): CallerContext | undefined {

--- a/src/cli/guard.ts
+++ b/src/cli/guard.ts
@@ -99,6 +99,11 @@ async function commandDecide(cmd: CommandDef, input: GuardInput) {
     }
   }
 
+  if (cmd.refuse) {
+    const reason = await cmd.refuse(args, actor, { replay: input.grant != null });
+    if (reason) return DENY(reason);
+  }
+
   if (cmd.access === 'approval') {
     return HOLD(`agent-initiated "${cmd.name}" requires admin approval`);
   }

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -10,6 +10,7 @@
  */
 import { defineGuardedAction, type GuardedAction } from '../guard/index.js';
 import { commandGuardSpec } from './guard.js';
+import type { GuardActor } from '../guard/index.js';
 import type { CallerContext } from './frame.js';
 
 /**
@@ -20,6 +21,15 @@ import type { CallerContext } from './frame.js';
 export const GROUP_SCOPE_RESOURCES = new Set(['groups', 'sessions', 'destinations', 'members', 'tasks']);
 
 export type Access = 'open' | 'approval' | 'hidden';
+
+/**
+ * What a handler receives: the caller's identity plus `defer(run)` for work
+ * that must wait until the reply has left the host — a service restart would
+ * kill the reply. Dispatch collects the deferred work and returns it with the
+ * response as `afterReply`; the transport that carried the reply runs it after
+ * its own egress, and the approval flow runs it once the approval is resolved.
+ */
+export type HandlerContext = CallerContext & { defer: (run: () => void) => void };
 
 export type CommandDef<TArgs = unknown, TData = unknown> = {
   name: string;
@@ -54,9 +64,20 @@ export type CommandDef<TArgs = unknown, TData = unknown> = {
    * Custom operations return ad-hoc shapes and leave this undefined.
    */
   generic?: 'list' | 'get';
+  /**
+   * Agent callers only, consulted before a hold: return a reason to deny the
+   * request outright (nothing is carded), or undefined to proceed. Runs again
+   * on the approved replay (`replay: true`). Return a reason rather than
+   * throwing — a throw fails closed as an opaque guard error.
+   */
+  refuse?: (
+    args: Record<string, unknown>,
+    actor: GuardActor,
+    ctx: { replay: boolean },
+  ) => Promise<string | undefined> | string | undefined;
   /** Validates `frame.args` and produces the typed handler input. Throws on invalid. */
   parseArgs: (raw: Record<string, unknown>) => TArgs;
-  handler: (args: TArgs, ctx: CallerContext) => Promise<TData>;
+  handler: (args: TArgs, ctx: HandlerContext) => Promise<TData>;
   /**
    * Optional presentational renderer. When set, dispatch attaches its output
    * as the response frame's `human` field (server-rendered once, printed

--- a/src/cli/resources/index.ts
+++ b/src/cli/resources/index.ts
@@ -15,3 +15,4 @@ import './dropped-messages.js';
 import './approvals.js';
 import './sessions.js';
 import './tasks.js';
+import './skills.js';

--- a/src/cli/resources/skills.test.ts
+++ b/src/cli/resources/skills.test.ts
@@ -1,0 +1,323 @@
+/**
+ * `ncl skills` — registration, the trailing-positional skill name as the CLI
+ * sends it, the guard refusal that keeps malformed requests and secret inputs
+ * out of any approval card, the approval hold and replay, the argv the
+ * resource hands the headless engine, and the deferred, honest host restart.
+ * The engine itself is covered in scripts/skill-headless.test.ts; here it is a
+ * mock so the CLI seams are exercised in isolation.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CallerContext } from '../frame.js';
+
+const engine = vi.hoisted(() => ({
+  runSkillHeadless: vi.fn(),
+  hostServiceDefined: vi.fn(),
+  restartHost: vi.fn(),
+}));
+vi.mock('../skill-runner.js', () => engine);
+
+type ApprovalHandler = (args: {
+  payload: Record<string, unknown>;
+  approval: Record<string, unknown>;
+  notify: (text: string) => void;
+}) => Promise<unknown>;
+
+const approvalState = vi.hoisted(() => ({
+  requestApproval: vi.fn(),
+  approvalHandler: null as null | ApprovalHandler,
+  registerApprovalHandler: vi.fn((action: string, handler: ApprovalHandler) => {
+    if (action === 'cli_command') approvalState.approvalHandler = handler;
+  }),
+}));
+vi.mock('../../modules/approvals/index.js', () => ({
+  registerApprovalHandler: approvalState.registerApprovalHandler,
+  requestApproval: approvalState.requestApproval,
+}));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+const mockGetContainerConfig = vi.fn();
+vi.mock('../../db/container-configs.js', () => ({
+  getContainerConfig: (...args: unknown[]) => mockGetContainerConfig(...args),
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  getAgentGroup: vi.fn().mockResolvedValue({ id: 'ag-1', name: 'Nano' }),
+}));
+const mockGetPendingApproval = vi.fn();
+vi.mock('../../db/sessions.js', () => ({
+  getSession: vi.fn().mockResolvedValue({ id: 'sess-1', agent_group_id: 'ag-1', messaging_group_id: 'mg-1' }),
+  getPendingApproval: (...args: unknown[]) => mockGetPendingApproval(...args),
+}));
+vi.mock('../../db/messaging-groups.js', () => ({
+  getMessagingGroupAgentByPair: vi.fn(),
+}));
+
+import { dispatch } from '../dispatch.js';
+import { parseArgv } from '../parse-argv.js';
+import { GROUP_SCOPE_RESOURCES, commandGuard, lookup } from '../registry.js';
+// Side-effect import: registers the `skills-*` commands.
+import './skills.js';
+
+const HOST: CallerContext = { caller: 'host' };
+const AGENT: CallerContext = { caller: 'agent', sessionId: 'sess-1', agentGroupId: 'ag-1', messagingGroupId: 'mg-1' };
+
+const appliedReport = (skill: string) => ({
+  schema: 'nanoclaw-skill-apply/v1',
+  skill,
+  status: 'applied',
+  applied: ['copy: src/x.ts'],
+  skipped: ['run restart: owned by the caller'],
+  deferred: [],
+  agentTasks: [],
+  operatorMessages: [],
+  vars: {},
+  pendingEffects: [{ effect: 'restart', line: 40, command: 'bash setup/lib/restart.sh' }],
+});
+
+const plan = (skill: string) => ({
+  skill,
+  steps: [],
+  prompts: [
+    { var: 'owner_handle', question: 'Your handle.', secret: false },
+    { var: 'bot_token', question: 'Paste the bot token.', secret: true },
+  ],
+  needsInput: ['owner_handle', 'bot_token'],
+  agentSteps: 0,
+  callerOwnedEffects: ['restart'],
+});
+
+/** The engine mock answers `plan` and `apply` by their first argv word. */
+function engineAnswers(report = appliedReport('add-slack')) {
+  engine.runSkillHeadless.mockImplementation(async (argv: string[]) => {
+    if (argv[0] === 'plan') return plan(argv[1]);
+    if (argv[0] === 'list') return [];
+    return report;
+  });
+}
+
+/** What the `ncl` binary would send for these words. */
+const cli = (...words: string[]) => {
+  const parsed = parseArgv(words);
+  return { id: words.join('-'), command: parsed.command, args: parsed.args };
+};
+
+const dataOf = (res: Awaited<ReturnType<typeof dispatch>>) => (res.ok ? (res.data as { restart: string }) : undefined);
+const planCalls = () => engine.runSkillHeadless.mock.calls.filter((c) => (c[0] as string[])[0] === 'plan');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'enabled');
+  engineAnswers();
+  engine.hostServiceDefined.mockReturnValue(true);
+  mockGetContainerConfig.mockResolvedValue({ cli_scope: 'global' });
+});
+
+describe('registration', () => {
+  it('registers list, plan, and apply with the intended access', () => {
+    expect(lookup('skills-list')?.access).toBe('open');
+    expect(lookup('skills-plan')?.access).toBe('open');
+    expect(lookup('skills-apply')?.access).toBe('approval');
+    for (const name of ['skills-list', 'skills-plan', 'skills-apply']) expect(lookup(name)?.resource).toBe('skills');
+  });
+
+  it('apply holds through the cli_command approval channel and carries a refusal hook', () => {
+    expect(commandGuard('skills-apply').grantActionName).toBe('cli_command');
+    expect(typeof lookup('skills-apply')?.refuse).toBe('function');
+  });
+
+  it('is not reachable under group scope', () => {
+    expect(GROUP_SCOPE_RESOURCES.has('skills')).toBe(false);
+  });
+});
+
+describe('host caller', () => {
+  it('takes the skill as the trailing positional, the way the CLI sends it', async () => {
+    const planned = await dispatch(cli('skills', 'plan', 'add-slack'), HOST);
+    expect(planned.ok).toBe(true);
+    expect(engine.runSkillHeadless).toHaveBeenLastCalledWith(['plan', 'add-slack']);
+
+    const applied = await dispatch(cli('skills', 'apply', 'add-codex', '--restart'), HOST);
+    expect(applied.ok).toBe(true);
+    expect(engine.runSkillHeadless).toHaveBeenLastCalledWith(['apply', 'add-codex']);
+  });
+
+  it('applies and defers the restart until the reply has left', async () => {
+    const res = await dispatch(
+      cli('skills', 'apply', 'add-slack', '--inputs', '{"owner_handle":"U1"}', '--restart'),
+      HOST,
+    );
+    expect(res.ok).toBe(true);
+    expect(engine.runSkillHeadless).toHaveBeenCalledWith(['apply', 'add-slack', '--inputs', '{"owner_handle":"U1"}']);
+    expect(dataOf(res)?.restart).toBe('requested');
+    // Not yet — the transport runs it after its own egress.
+    expect(engine.restartHost).not.toHaveBeenCalled();
+    expect(res.afterReply).toEqual(expect.any(Function));
+    res.afterReply!();
+    expect(engine.restartHost).toHaveBeenCalledTimes(1);
+  });
+
+  it('says so instead of claiming a restart when no service is defined for this checkout', async () => {
+    engine.hostServiceDefined.mockReturnValue(false);
+    const res = await dispatch(cli('skills', 'apply', 'add-slack', '--restart'), HOST);
+    expect(res.ok).toBe(true);
+    expect(dataOf(res)?.restart).toBe('unmanaged');
+    expect(res.afterReply).toBeUndefined();
+    if (res.ok) expect(res.human).toMatch(/restart the host by hand/);
+    expect(engine.restartHost).not.toHaveBeenCalled();
+  });
+
+  it('may pass secret inputs — credentials are entered on the host', async () => {
+    const res = await dispatch(cli('skills', 'apply', 'add-slack', '--inputs', '{"bot_token":"xoxb-1"}'), HOST);
+    expect(res.ok).toBe(true);
+    const argv = engine.runSkillHeadless.mock.calls.at(-1)?.[0] as string[];
+    expect(argv).not.toContain('--no-secret-inputs');
+    expect(planCalls()).toHaveLength(0); // host callers are not refused, so nothing is checked
+  });
+
+  it.each(['rolled-back', 'needs-setup'])('does not request a restart after a %s apply', async (status) => {
+    engineAnswers({ ...appliedReport('add-slack'), status });
+    const res = await dispatch(cli('skills', 'apply', 'add-slack', '--restart'), HOST);
+    expect(res.ok).toBe(true);
+    expect(dataOf(res)?.restart).toBe('not-requested');
+    expect(res.afterReply).toBeUndefined();
+    if (status === 'needs-setup' && res.ok) expect(res.human).toContain('setup is pending');
+  });
+
+  it('refuses host callers on a disabled deployment without starting the engine', async () => {
+    vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'disabled');
+    const res = await dispatch(cli('skills', 'apply', 'add-slack', '--restart'), HOST);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.message).toMatch(/release deployment workflow/);
+    expect(engine.runSkillHeadless).not.toHaveBeenCalled();
+    expect(engine.restartHost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a name that could escape the skills directory', async () => {
+    const res = await dispatch({ id: 'r3', command: 'skills-apply', args: { id: '../etc' } }, HOST);
+    expect(res.ok).toBe(false);
+    expect(engine.runSkillHeadless).not.toHaveBeenCalled();
+  });
+
+  it('lists through the engine', async () => {
+    await dispatch(cli('skills', 'list'), HOST);
+    expect(engine.runSkillHeadless).toHaveBeenLastCalledWith(['list']);
+  });
+});
+
+describe('agent caller', () => {
+  it('refuses a disabled deployment before creating any approval card', async () => {
+    vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'disabled');
+    const res = await dispatch(cli('skills', 'apply', 'add-slack', '--restart'), AGENT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('forbidden');
+    expect(approvalState.requestApproval).not.toHaveBeenCalled();
+    expect(engine.runSkillHeadless).not.toHaveBeenCalled();
+  });
+
+  it('rechecks deployment policy when replaying an existing approval', async () => {
+    await dispatch(cli('skills', 'apply', 'add-slack', '--restart'), AGENT);
+    const { payload } = approvalState.requestApproval.mock.calls[0][0];
+    const grant = { approval_id: 'appr-disabled', action: 'cli_command', payload: JSON.stringify(payload) };
+    mockGetPendingApproval.mockResolvedValue(grant);
+    vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'disabled');
+    const notify = vi.fn();
+    const result = await approvalState.approvalHandler!({ payload, approval: grant, notify });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('release deployment workflow'));
+    expect(engine.runSkillHeadless).not.toHaveBeenCalled();
+    expect(result).toEqual({ afterResolved: undefined });
+    expect(engine.restartHost).not.toHaveBeenCalled();
+  });
+
+  it('is denied under group scope', async () => {
+    mockGetContainerConfig.mockResolvedValue({ cli_scope: 'group' });
+    const res = await dispatch(cli('skills', 'apply', 'add-slack'), AGENT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('forbidden');
+    expect(engine.runSkillHeadless).not.toHaveBeenCalled();
+  });
+
+  it('is refused before any card when an input answers a secret prompt', async () => {
+    const res = await dispatch(
+      cli('skills', 'apply', 'add-slack', '--inputs', '{"owner_handle":"U1","bot_token":"xoxb-1"}'),
+      AGENT,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('forbidden');
+      expect(res.error.message).toMatch(/bot_token/);
+      expect(res.error.message).not.toMatch(/xoxb-1/);
+    }
+    expect(approvalState.requestApproval).not.toHaveBeenCalled();
+    // The refusal consulted the skill's declared prompts; nothing was applied.
+    expect(engine.runSkillHeadless).toHaveBeenCalledWith(['plan', 'add-slack']);
+    expect(engine.runSkillHeadless).not.toHaveBeenCalledWith(expect.arrayContaining(['apply']));
+  });
+
+  it('is refused before any card when the request is malformed', async () => {
+    const badName = await dispatch(cli('skills', 'apply', 'Add_Slack'), AGENT);
+    if (!badName.ok) expect(badName.error.message).toMatch(/invalid skill name/);
+    const badJson = await dispatch(cli('skills', 'apply', 'add-slack', '--inputs', '{not json'), AGENT);
+    if (!badJson.ok) expect(badJson.error.message).toMatch(/valid JSON/);
+    const badShape = await dispatch(cli('skills', 'apply', 'add-slack', '--inputs', '[1]'), AGENT);
+    if (!badShape.ok) expect(badShape.error.message).toMatch(/JSON object/);
+    const badFlag = await dispatch(cli('skills', 'apply', 'add-slack', '--bogus', 'x'), AGENT);
+    if (!badFlag.ok) expect(badFlag.error.message).toMatch(/unknown flag --bogus/);
+
+    for (const res of [badName, badJson, badShape, badFlag]) expect(res.ok).toBe(false);
+    expect(approvalState.requestApproval).not.toHaveBeenCalled();
+    expect(engine.runSkillHeadless).not.toHaveBeenCalled();
+  });
+
+  it('answers with the engine’s own message when the prompts cannot be checked', async () => {
+    engine.runSkillHeadless.mockRejectedValue(
+      new Error('unknown skill "add-slack" — no .claude/skills/add-slack/SKILL.md'),
+    );
+    const res = await dispatch(cli('skills', 'apply', 'add-slack', '--inputs', '{"owner_handle":"U1"}'), AGENT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('forbidden');
+      expect(res.error.message).toMatch(/cannot check the inputs for add-slack: unknown skill/);
+    }
+    expect(approvalState.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('is held with plain inputs shown, then applied on the agent path with the restart deferred past resolution', async () => {
+    const res = await dispatch(
+      cli('skills', 'apply', 'add-slack', '--inputs', '{"owner_handle":"U1"}', '--restart'),
+      AGENT,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('approval-pending');
+
+    const request = approvalState.requestApproval.mock.calls[0][0] as {
+      question: string;
+      payload: Record<string, unknown>;
+    };
+    expect(request.question).toContain('--inputs {"owner_handle":"U1"}');
+
+    const grant = { approval_id: 'appr-1', action: 'cli_command', payload: JSON.stringify(request.payload) };
+    mockGetPendingApproval.mockResolvedValue(grant);
+    const notify = vi.fn();
+    const result = (await approvalState.approvalHandler!({ payload: request.payload, approval: grant, notify })) as {
+      afterResolved?: () => void;
+    };
+
+    expect(engine.runSkillHeadless).toHaveBeenCalledWith([
+      'apply',
+      'add-slack',
+      '--inputs',
+      '{"owner_handle":"U1"}',
+      '--no-secret-inputs',
+    ]);
+    // The prompt check ran once, at card time; the replay leaves secrets to the engine.
+    expect(planCalls()).toHaveLength(1);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('approved and executed'));
+    // The restart is handed back to the approval flow, which runs it once the
+    // approval is fully resolved — never inside the handler.
+    expect(engine.restartHost).not.toHaveBeenCalled();
+    expect(result.afterResolved).toEqual(expect.any(Function));
+    result.afterResolved!();
+    expect(engine.restartHost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/resources/skills.ts
+++ b/src/cli/resources/skills.ts
@@ -1,0 +1,206 @@
+/**
+ * `ncl skills` — the install path for capability skills, exposed to agents
+ * with admin approval.
+ *
+ * Trunk ships channels, providers, and other capabilities as install skills
+ * whose mechanical steps are `nc:` directive fences. The setup wizard applies
+ * them through the directive engine; this resource gives the same engine an
+ * `ncl` surface, so a NanoClaw agent can request an install from chat (held
+ * for an admin's approval like every other write verb), an operator can run
+ * one from a terminal, and a pipeline can script it. The host applies the
+ * skill to its own checkout; the caller-owned effects — the service restart,
+ * interactive steps, wiring — are reported back instead of executed.
+ *
+ * Credentials never ride this path from an agent: an input that answers a
+ * `secret` prompt is refused by the guard before any approval card or row
+ * exists, and the engine refuses it again as defense in depth.
+ */
+import { registerResource, validateArgs, type ColumnDef } from '../crud.js';
+import {
+  assertSkillName,
+  errorMessage,
+  isPlainObject,
+  needsRestart,
+  type SkillApplyReport,
+  type SkillPlan,
+  type SkillSummary,
+} from '../skill-report.js';
+import { hostServiceDefined, restartHost, runSkillHeadless } from '../skill-runner.js';
+import { sourceInstallRefusal } from '../source-install.js';
+
+/** The skill directory name — the trailing positional, which the dispatcher hands over as `id`. */
+function skillId(args: Record<string, unknown>): string {
+  const id = String(args.id ?? '');
+  assertSkillName(id);
+  return id;
+}
+
+const APPLY_ARGS: ColumnDef[] = [
+  { name: 'id', type: 'string', description: 'Skill directory name, e.g. add-codex.', required: true },
+  { name: 'inputs', type: 'json', description: 'JSON object of prompt var → answer.' },
+  {
+    name: 'refresh',
+    type: 'boolean',
+    description: 'Re-copy payload files and re-pin dependencies even when present (clean tree required).',
+    default: false,
+  },
+  {
+    name: 'restart',
+    type: 'boolean',
+    description: 'Restart the host service after a successful apply.',
+    default: false,
+  },
+];
+
+type RestartOutcome =
+  | 'requested' // deferred until this reply has left; runs setup/lib/restart.sh
+  | 'unmanaged' // asked for, but no launchd/systemd definition exists for this checkout
+  | 'not-requested';
+
+type SkillApplyResponse = SkillApplyReport & { restart: RestartOutcome };
+
+function formatPlan(data: unknown): string {
+  const plan = data as SkillPlan;
+  const lines = plan.steps.map(
+    (s) => `${String(s.n).padStart(2)}. ${s.status.padEnd(11)} ${s.kind.padEnd(9)} ${s.detail}`,
+  );
+  if (plan.prompts.length > 0) {
+    lines.push('', 'Inputs:');
+    for (const p of plan.prompts) lines.push(`  ${p.var}${p.secret ? ' (secret — operator only)' : ''}: ${p.question}`);
+  }
+  const effects = plan.callerOwnedEffects;
+  if (effects.length > 0) lines.push('');
+  if (effects.includes('restart')) lines.push('Requires a host restart after apply (--restart).');
+  if (effects.includes('step')) lines.push('Has an interactive step — finish it with the setup wizard.');
+  if (effects.includes('wire')) lines.push('Wires a chat to an agent — the wiring is reported, not run.');
+  if (effects.includes('external')) lines.push('External setup (including authentication) must be completed on the host.');
+  return lines.join('\n');
+}
+
+function formatApply(data: unknown): string {
+  const r = data as SkillApplyResponse;
+  const lines = [`${r.skill}: ${r.status}`];
+  if (r.error) lines.push(`  ${r.error}`);
+  if (r.failure) {
+    lines.push(`  failed at: ${r.failure.headline}`);
+    // The hint opens with the section heading again; show its first line of substance.
+    const detail = r.failure.hint.split('\n').find((l) => l.trim() && !l.startsWith('#') && l !== r.failure?.headline);
+    if (detail) lines.push(`  ${detail}`);
+  }
+  if (r.applied.length) lines.push(`  applied ${r.applied.length} step(s), skipped ${r.skipped.length}`);
+  if (r.deferred.length) lines.push(`  waiting for input: ${r.deferred.join('; ')}`);
+  for (const t of r.agentTasks) lines.push(`  needs an agent (line ${t.line}): ${t.reason}`);
+  for (const p of r.pendingEffects) lines.push(`  not run (${p.effect}): ${p.command.split('\n')[0]}`);
+  if (r.status === 'rolled-back') lines.push('  journaled files restored; build output and arbitrary command effects are not covered — verify before restarting');
+  if (r.status === 'needs-setup') {
+    lines.push('  code installed; setup is pending — the host was not restarted');
+    lines.push(`  finish the pending steps at the host terminal using .claude/skills/${r.skill}/SKILL.md`);
+  }
+  if (r.restart === 'requested') lines.push('  host restart requested');
+  else if (r.restart === 'unmanaged') {
+    lines.push('  no launchd/systemd service is defined for this checkout — restart the host by hand to load it');
+  } else if (r.status === 'applied' && needsRestart(r)) lines.push('  restart the host to load it (or pass --restart)');
+  return lines.join('\n');
+}
+
+registerResource({
+  name: 'skill',
+  plural: 'skills',
+  description:
+    'Capability install skills (channels, providers, tools) and the engine that applies them. ' +
+    "`apply` runs a skill's structured steps on the host: copy its files, wire its registration, install its pinned " +
+    'dependencies, build, and run its tests. Credentials, external setup, interactive steps, and wiring stay with the operator. ' +
+    'Packaged or source-install-disabled deployments must use their release workflow. ' +
+    'From a container, apply is held for admin approval and credential inputs are refused; those are entered on the host.',
+  columns: [],
+  operations: {},
+  customOperations: {
+    list: {
+      access: 'open',
+      description:
+        'List the install skills the engine can apply, with whether each is already installed.\n\n' +
+        'Only skills with structured (nc:) steps appear — a prose-only skill needs a coding agent.',
+      examples: ['ncl skills list'],
+      args: [],
+      handler: async () => await runSkillHeadless<SkillSummary[]>(['list']),
+    },
+    plan: {
+      access: 'open',
+      description:
+        'Show what applying a skill would do, without writing anything: each step and whether it is already ' +
+        'satisfied, the inputs it asks for (secret ones are operator-only), and whether a restart follows.',
+      examples: ['ncl skills plan add-telegram'],
+      args: [{ name: 'id', type: 'string', description: 'Skill directory name, e.g. add-telegram.', required: true }],
+      handler: async (args) => await runSkillHeadless<SkillPlan>(['plan', skillId(args)]),
+      formatHuman: formatPlan,
+    },
+    apply: {
+      access: 'approval',
+      description:
+        'Apply an install skill to this NanoClaw checkout: copy files, append registrations, install pinned ' +
+        'dependencies, build, test. Failed code steps use the rollback journal. Missing inputs and external or interactive ' +
+        'setup leave code installed with status needs-setup and the pending steps to finish on the host. Wiring is also operator-owned; ' +
+        'pass --restart to restart only after a fully applied result (needs a launchd or ' +
+        "systemd service). --inputs answers the skill's prompts as a JSON object; from a container, inputs for " +
+        'secret prompts are refused — the operator enters credentials on the host. --refresh re-copies an installed ' +
+        "skill's files and re-pins its dependencies; it needs a clean working tree and is never rolled back.",
+      examples: [
+        'ncl skills apply add-codex --restart',
+        'ncl skills apply add-telegram --inputs \'{"owner_handle":"12345678"}\'',
+      ],
+      args: APPLY_ARGS,
+      // Before the hold, so nothing malformed is carded and a credential never
+      // reaches a card or the pending_approvals row: an agent's inputs may
+      // answer plain prompts, never secret ones. The approved replay skips the
+      // prompt check — the engine refuses secrets itself on the agent path.
+      refuse: async (args, _actor, { replay }) => {
+        const refusal = sourceInstallRefusal();
+        if (refusal) return refusal;
+        let inputs: unknown;
+        try {
+          skillId(args);
+          inputs = validateArgs(APPLY_ARGS, args).inputs;
+        } catch (e) {
+          return errorMessage(e);
+        }
+        if (inputs !== undefined && !isPlainObject(inputs))
+          return '--inputs must be a JSON object of prompt var → answer';
+        const keys = Object.keys(inputs ?? {});
+        if (replay || keys.length === 0) return undefined;
+        let plan: SkillPlan;
+        try {
+          plan = await runSkillHeadless<SkillPlan>(['plan', skillId(args)]);
+        } catch (e) {
+          return `cannot check the inputs for ${String(args.id)}: ${errorMessage(e)}`;
+        }
+        const secret = plan.prompts.filter((p) => p.secret && keys.includes(p.var)).map((p) => p.var);
+        if (secret.length === 0) return undefined;
+        return `--inputs answers secret prompt(s) ${secret.join(', ')}: credentials are entered by the operator on the host, never relayed through chat`;
+      },
+      handler: async (args, ctx): Promise<SkillApplyResponse> => {
+        const refusal = sourceInstallRefusal();
+        if (refusal) throw new Error(refusal);
+        const argv = ['apply', skillId(args)];
+        if (args.inputs !== undefined) {
+          if (!isPlainObject(args.inputs)) throw new Error('--inputs must be a JSON object of prompt var → answer');
+          argv.push('--inputs', JSON.stringify(args.inputs));
+        }
+        if (args.refresh === true) argv.push('--refresh');
+        if (ctx.caller === 'agent') argv.push('--no-secret-inputs');
+        const report = await runSkillHeadless<SkillApplyReport>(argv);
+
+        let restart: RestartOutcome = 'not-requested';
+        if (report.status === 'applied' && args.restart === true) {
+          if (hostServiceDefined()) {
+            ctx.defer(restartHost); // after the reply has left (HandlerContext.defer)
+            restart = 'requested';
+          } else {
+            restart = 'unmanaged';
+          }
+        }
+        return { ...report, restart };
+      },
+      formatHuman: formatApply,
+    },
+  },
+});

--- a/src/cli/resources/wirings.test.ts
+++ b/src/cli/resources/wirings.test.ts
@@ -26,7 +26,7 @@ import { lookup } from '../registry.js';
 // Side-effect import: registers wirings-create / wirings-update.
 import './wirings.js';
 
-const hostCtx = { caller: 'host' as const };
+const hostCtx = { caller: 'host' as const, defer: (run: () => void) => run() };
 const now = () => new Date().toISOString();
 
 // Registration-tier declarations only — no adapter is live, which is exactly

--- a/src/cli/skill-report.ts
+++ b/src/cli/skill-report.ts
@@ -1,0 +1,116 @@
+/**
+ * The contract between `ncl skills` and the headless skill engine
+ * (`scripts/skill-headless.ts`).
+ *
+ * The engine is tsx-run TypeScript under `scripts/`, while the host runs the
+ * compiled `dist/`, so `src/` never imports `scripts/`; the host spawns the
+ * script and parses the one JSON document it prints. Scripts do import from
+ * `src/`, so the constants and types both sides share live here, once.
+ */
+import { parse as parseYaml } from 'yaml';
+
+export const SKILL_APPLY_SCHEMA = 'nanoclaw-skill-apply/v1';
+
+/**
+ * Run effects the engine leaves to whoever drives it — a live service
+ * restart, an interactive step, a wiring call — and, for the same reason, the
+ * effects the engine's run-health gate refuses to fire after an earlier step
+ * failed. One list, both meanings: each needs a live host, a human, or `ncl`.
+ */
+export const CALLER_OWNED_EFFECTS: readonly string[] = ['restart', 'step', 'wire'];
+
+/** A skill directory name: lowercase, digits, hyphens — nothing that could leave `.claude/skills/`. */
+export const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export function assertSkillName(name: string): void {
+  if (!SKILL_NAME_RE.test(name)) {
+    throw new Error(`invalid skill name "${name}" — lowercase letters, digits, and hyphens only`);
+  }
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export const errorMessage = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/** A markdown document's YAML frontmatter as a mapping; undefined when absent, unparseable, or not a mapping. */
+export function parseFrontmatter(md: string): Record<string, unknown> | undefined {
+  const lines = md.split(/\r?\n/);
+  if (lines[0] !== '---') return undefined;
+  const close = lines.indexOf('---', 1);
+  if (close === -1) return undefined;
+  try {
+    const parsed: unknown = parseYaml(lines.slice(1, close).join('\n'));
+    return isPlainObject(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export type SkillKind = 'channel' | 'provider' | 'other';
+
+export interface SkillSummary {
+  name: string;
+  description: string;
+  kind: SkillKind;
+  /** The skill's registration is present in the relevant barrel(s). */
+  installed: boolean;
+  prompts: number;
+  secretPrompts: number;
+  /** The caller-owned effects the skill declares (`restart`, `step`, `wire`) — reported back by an apply, never run by it. */
+  callerOwnedEffects: string[];
+}
+
+/** What an `nc:prompt` declares about the value it needs — the engine's own prompt semantics. */
+export interface InputMeta {
+  question: string; // the prompt body (verbatim)
+  secret: boolean; // consumer must mask
+  validate?: string; // regex source (nc:prompt validate:<re>)
+  flags?: string; // regex flags   (nc:prompt flags:<f>)
+  normalize?: 'trim' | 'rstrip-slash' | 'lower'; // applied by the ENGINE at bind
+  // Interactive select options, `|`-separated (nc:prompt choices:a|b). When a
+  // value is legal only via pre-bound inputs (e.g. slack's `provisioned`
+  // connection), validate stays wider than the offered set — so a consumer
+  // must prefer this over options derived from the validate alternation.
+  choices?: string;
+}
+
+/** A skill's declared input, named. */
+export type SkillPromptSummary = { var: string } & InputMeta;
+
+export interface SkillPlan {
+  skill: string;
+  steps: Array<{ n: number; kind: string; line: number; status: string; detail: string }>;
+  prompts: SkillPromptSummary[];
+  needsInput: string[];
+  agentSteps: number;
+  callerOwnedEffects: string[];
+}
+
+/** A caller-owned run the engine skipped, for the caller to perform. */
+export interface PendingEffect {
+  effect: string;
+  line: number;
+  command: string;
+}
+
+export interface SkillApplyReport {
+  schema: typeof SKILL_APPLY_SCHEMA;
+  skill: string;
+  /** `needs-setup` keeps installed code but requires operator completion before restart. */
+  status: 'applied' | 'needs-setup' | 'rolled-back' | 'failed';
+  applied: string[];
+  skipped: string[];
+  deferred: string[];
+  agentTasks: Array<{ kind: string; line: number; reason: string }>;
+  operatorMessages: string[];
+  /** Non-secret resolved values (prompt answers, captures). */
+  vars: Record<string, string>;
+  pendingEffects: PendingEffect[];
+  failure?: { headline: string; hint: string };
+  error?: string;
+}
+
+export const needsRestart = (report: Pick<SkillApplyReport, 'pendingEffects'>): boolean =>
+  report.pendingEffects.some((p) => p.effect === 'restart');

--- a/src/cli/skill-runner.test.ts
+++ b/src/cli/skill-runner.test.ts
@@ -1,0 +1,29 @@
+/**
+ * The engine's child environment: a service host's PATH has no node or pnpm,
+ * so the runner puts the directories they realistically live in first.
+ */
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../log.js', () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+import { engineEnv } from './skill-runner.js';
+
+describe('engineEnv', () => {
+  it('puts the running node and the checkout bin dir ahead of the service PATH, once each', () => {
+    const root = process.cwd();
+    const env = engineEnv(root, { PATH: '/usr/local/bin:/usr/bin:/bin', HOME: '/nowhere' });
+    const dirs = (env.PATH ?? '').split(path.delimiter);
+    expect(dirs.indexOf(path.dirname(process.execPath))).toBeGreaterThanOrEqual(0);
+    expect(dirs.indexOf(path.dirname(process.execPath))).toBeLessThan(dirs.indexOf('/usr/bin'));
+    expect(dirs).toContain(path.join(root, 'node_modules', '.bin'));
+    expect(dirs.slice(-3)).toEqual(['/usr/local/bin', '/usr/bin', '/bin']);
+    expect(new Set(dirs).size).toBe(dirs.length);
+  });
+
+  it('honours a configured pnpm home and drops directories that do not exist', () => {
+    const env = engineEnv(process.cwd(), { PATH: '/bin', PNPM_HOME: '/definitely/not/here' });
+    expect(env.PATH).not.toContain('/definitely/not/here');
+    expect(env.PATH?.endsWith('/bin')).toBe(true);
+  });
+});

--- a/src/cli/skill-runner.ts
+++ b/src/cli/skill-runner.ts
@@ -1,0 +1,116 @@
+/**
+ * Bridge from `ncl skills` to the headless skill engine.
+ *
+ * The engine (`scripts/skill-headless.ts`) is tsx-run TypeScript outside the
+ * compiled host tree, so the host does not import it: it spawns the script and
+ * parses the one JSON document it prints. A child process also keeps a
+ * minutes-long `pnpm run build` off the host's event loop.
+ */
+import { execFile, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { serviceDefinitionPaths } from '../install-slug.js';
+import { log } from '../log.js';
+import { isPlainObject } from './skill-report.js';
+
+const execFileAsync = promisify(execFile);
+
+const SCRIPT = 'scripts/skill-headless.ts';
+const MAX_OUTPUT = 64 * 1024 * 1024;
+/** `list` and `plan` read the checkout and exit. */
+const READ_TIMEOUT_MS = 60 * 1000;
+/** An apply may build a container image; a hung child must still end eventually. */
+const APPLY_TIMEOUT_MS = 60 * 60 * 1000;
+
+function tail(text: string, lines = 12): string {
+  return text.trim().split('\n').slice(-lines).join('\n');
+}
+
+/**
+ * The tsx CLI entry, resolved through the checkout's package graph — not the
+ * `node_modules/.bin/tsx` shell shim, which looks `node` up on a PATH that a
+ * service host (launchd, systemd) rarely has it on.
+ */
+function tsxCli(root: string): string {
+  try {
+    return createRequire(path.join(root, 'package.json')).resolve('tsx/cli');
+  } catch {
+    throw new Error('the skill engine needs tsx (a dev dependency) — run `pnpm install` in the checkout');
+  }
+}
+
+/**
+ * The child environment. A service host's PATH rarely has node or pnpm, so the
+ * directories they realistically live in go first — missing ones dropped —
+ * followed by whatever PATH the service was started with.
+ */
+export function engineEnv(root: string, env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const home = os.homedir();
+  const candidates = [
+    // node as launched (argv0 keeps the symlink's dir — under launchd the Homebrew
+    // or nvm bin dir, where pnpm sits next to it) and as resolved (execPath).
+    path.isAbsolute(process.argv0) ? path.dirname(process.argv0) : '',
+    path.dirname(process.execPath),
+    env.PNPM_HOME ?? '',
+    path.join(home, process.platform === 'darwin' ? 'Library/pnpm' : '.local/share/pnpm'),
+    path.join(home, '.local', 'bin'),
+    path.join(root, 'node_modules', '.bin'),
+  ].filter((dir) => dir && existsSync(dir));
+  const prepend = [...new Set(candidates)];
+  const rest = (env.PATH ?? '').split(path.delimiter).filter((p) => p && !prepend.includes(p));
+  return { ...env, PATH: [...prepend, ...rest].join(path.delimiter) };
+}
+
+/** Run one headless engine command and return its parsed JSON output. */
+export async function runSkillHeadless<T>(args: string[]): Promise<T> {
+  const root = process.cwd();
+  let stdout = '';
+  let stderr = '';
+  try {
+    const out = await execFileAsync(process.execPath, [tsxCli(root), SCRIPT, ...args], {
+      cwd: root,
+      maxBuffer: MAX_OUTPUT,
+      timeout: args[0] === 'apply' ? APPLY_TIMEOUT_MS : READ_TIMEOUT_MS,
+      env: engineEnv(root),
+    });
+    stdout = out.stdout;
+    stderr = out.stderr;
+  } catch (err) {
+    // A non-zero exit still carries the engine's JSON (a failed or rolled-back apply).
+    const e = err as { stdout?: string; stderr?: string; message?: string };
+    stdout = e.stdout ?? '';
+    stderr = e.stderr ?? '';
+    if (!stdout.trim()) throw new Error(`skill engine failed: ${tail(stderr || e.message || 'no output')}`);
+  }
+  let doc: unknown;
+  try {
+    doc = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error(`skill engine returned no JSON: ${tail(stderr || stdout)}`);
+  }
+  // The engine reports a refused or failed apply as a full report; anything it
+  // could not even start (bad arguments, unknown skill) arrives as `{ error }`.
+  if (isPlainObject(doc) && typeof doc.error === 'string' && doc.status === undefined) throw new Error(doc.error);
+  return doc as T;
+}
+
+/**
+ * Whether a launchd or systemd definition exists for this checkout — what
+ * `setup/lib/restart.sh` acts on. A host started by hand has none, and the
+ * script would restart nothing, so the caller reports that instead.
+ */
+export function hostServiceDefined(): boolean {
+  return serviceDefinitionPaths().some((file) => existsSync(file));
+}
+
+/** Restart the host service the way `nc:run effect:restart` does — detached, so it survives this process being replaced. */
+export function restartHost(): void {
+  log.info('Restarting the host to load an applied skill');
+  const child = spawn('bash', ['setup/lib/restart.sh'], { cwd: process.cwd(), detached: true, stdio: 'ignore' });
+  child.on('error', (err) => log.error('Host restart failed to start', { err }));
+  child.unref();
+}

--- a/src/cli/socket-server.ts
+++ b/src/cli/socket-server.ts
@@ -125,13 +125,14 @@ async function handleFrame(conn: net.Socket, line: string): Promise<void> {
   // itself as the auth boundary.
   const ctx: CallerContext = { caller: 'host' };
   const res = await dispatch(req, ctx);
-  write(conn, res);
+  write(conn, res, res.afterReply);
 }
 
-function write(conn: net.Socket, frame: ResponseFrame): void {
+function write(conn: net.Socket, frame: ResponseFrame, afterReply?: () => void): void {
   try {
     conn.write(JSON.stringify(frame) + '\n');
-    conn.end();
+    // The reply has left once the frame is flushed (HandlerContext.defer).
+    conn.end(afterReply);
   } catch (err) {
     log.warn('Failed to write ncl CLI response', { err });
   }

--- a/src/cli/source-install.test.ts
+++ b/src/cli/source-install.test.ts
@@ -1,0 +1,29 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { sourceInstallRefusal } from './source-install.js';
+
+const roots: string[] = [];
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+it('allows a checkout root but refuses packaged runtimes and checkout subdirectories', () => {
+  vi.stubEnv('NANOCLAW_SOURCE_INSTALL', 'enabled');
+  const root = mkdtempSync(join(tmpdir(), 'source-install-'));
+  roots.push(root);
+  expect(sourceInstallRefusal(root)).toMatch(/Git checkout/);
+  execFileSync('git', ['init', '-q', root]);
+  expect(sourceInstallRefusal(root)).toBeUndefined();
+  mkdirSync(join(root, 'nested'));
+  expect(sourceInstallRefusal(join(root, 'nested'))).toMatch(/root of a Git checkout/);
+});
+
+it.each([undefined, 'disabled', '', 'typo'])('refuses an operator policy of %j even in a source checkout', (policy) => {
+  vi.stubEnv('NANOCLAW_SOURCE_INSTALL', policy);
+  expect(sourceInstallRefusal()).toMatch(/disabled.*deployment/);
+});

--- a/src/cli/source-install.ts
+++ b/src/cli/source-install.ts
@@ -1,0 +1,22 @@
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+
+/** Source installation is an operator capability, separate from agent approval. */
+export function sourceInstallRefusal(root: string = process.cwd()): string | undefined {
+  const policy = process.env.NANOCLAW_SOURCE_INSTALL;
+  if (policy !== 'enabled') {
+    return 'Source installation is disabled for this deployment. Use its release deployment workflow, or have the operator enable NANOCLAW_SOURCE_INSTALL=enabled for a source checkout.';
+  }
+  try {
+    const top = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim();
+    if (realpathSync(top) === realpathSync(root)) return undefined;
+  } catch {
+    // Packaged runtimes have no source checkout (and may not ship git).
+  }
+  return 'Source installation requires the root of a Git checkout. Use the deployment workflow for packaged runtimes.';
+}

--- a/src/install-slug.ts
+++ b/src/install-slug.ts
@@ -13,6 +13,8 @@
  * conservative charset. Unset = today's behavior, byte-identical.
  */
 import { createHash } from 'crypto';
+import os from 'os';
+import path from 'path';
 
 const INSTALL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
 
@@ -35,6 +37,20 @@ export function getLaunchdLabel(projectRoot?: string): string {
 /** systemd unit name (no .service suffix). e.g. `nanoclaw-v2-ab12cd34`. */
 export function getSystemdUnit(projectRoot?: string): string {
   return `nanoclaw-v2-${getInstallSlug(projectRoot)}`;
+}
+
+/**
+ * Where this checkout's service definition lives when one exists: the launchd
+ * plist on macOS, the user or system systemd unit elsewhere.
+ */
+export function serviceDefinitionPaths(projectRoot?: string): string[] {
+  const home = os.homedir();
+  return process.platform === 'darwin'
+    ? [path.join(home, 'Library', 'LaunchAgents', `${getLaunchdLabel(projectRoot)}.plist`)]
+    : [
+        path.join(home, '.config', 'systemd', 'user', `${getSystemdUnit(projectRoot)}.service`),
+        `/etc/systemd/system/${getSystemdUnit(projectRoot)}.service`,
+      ];
 }
 
 /** Docker image base (no tag). e.g. `nanoclaw-agent-v2-ab12cd34`. */

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -71,7 +71,12 @@ export interface ApprovalHandlerContext {
   notify: (text: string) => Promise<void>;
 }
 
-export type ApprovalHandler = (ctx: ApprovalHandlerContext) => Promise<void>;
+/** What a handler may hand back: work to run once the approval is fully resolved (row deleted, resolution announced, wake requested). */
+export interface ApprovalHandlerResult {
+  afterResolved?: () => void;
+}
+
+export type ApprovalHandler = (ctx: ApprovalHandlerContext) => Promise<void | ApprovalHandlerResult>;
 
 const approvalHandlers = new Map<string, ApprovalHandler>();
 

--- a/src/modules/approvals/response-handler.test.ts
+++ b/src/modules/approvals/response-handler.test.ts
@@ -127,6 +127,47 @@ describe('approval response authorization', () => {
     expect(await getPendingApproval('appr-2')).toBeUndefined();
   });
 
+  it("runs a handler's afterResolved work once, after the approval is resolved", async () => {
+    await upsertUser({ id: 'telegram:owner-after', kind: 'telegram', display_name: 'Owner', created_at: now() });
+    await grantRole({
+      user_id: 'telegram:owner-after',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
+
+    const { registerApprovalHandler } = await import('./primitive.js');
+    const { handleApprovalsResponse } = await import('./response-handler.js');
+    const afterResolved = vi.fn();
+    const handler = vi.fn(async () => ({ afterResolved }));
+    registerApprovalHandler('after_resolved_action', handler);
+
+    await createPendingApproval({
+      approval_id: 'appr-after',
+      session_id: 'sess-1',
+      request_id: 'appr-after',
+      action: 'after_resolved_action',
+      payload: JSON.stringify({}),
+      created_at: now(),
+      title: 'Deferred work',
+      options_json: JSON.stringify([]),
+    });
+
+    await handleApprovalsResponse({
+      questionId: 'appr-after',
+      value: 'approve',
+      userId: 'owner-after',
+      channelType: 'telegram',
+      platformId: 'dm-owner',
+      threadId: null,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(afterResolved).toHaveBeenCalledTimes(1);
+    expect(await getPendingApproval('appr-after')).toBeUndefined();
+  });
+
   it('lets only one concurrent approval response run the action handler', async () => {
     await upsertUser({ id: 'telegram:owner-race', kind: 'telegram', display_name: 'Owner', created_at: now() });
     await grantRole({

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -117,8 +117,9 @@ async function handleRegisteredApproval(
   }
 
   const payload = JSON.parse(approval.payload);
+  let afterResolved: (() => void) | undefined;
   try {
-    await handler({ session, payload, approval, userId, notify });
+    afterResolved = (await handler({ session, payload, approval, userId, notify }))?.afterResolved;
     log.info('Approval handled', { approvalId: approval.approval_id, action: approval.action, userId });
   } catch (err) {
     log.error('Approval handler threw', { approvalId: approval.approval_id, action: approval.action, err });
@@ -130,6 +131,15 @@ async function handleRegisteredApproval(
   await deletePendingApproval(approval.approval_id);
   await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
   await requestWake(session, 'approval-response');
+  // Work the handler deferred until resolution is complete — a host restart
+  // must not cut the row delete, the resolution notice, or the wake.
+  if (afterResolved) {
+    try {
+      afterResolved();
+    } catch (err) {
+      log.error('Post-resolution work failed', { approvalId: approval.approval_id, action: approval.action, err });
+    }
+  }
 }
 
 function namespacedUserId(payload: ResponsePayload): string | null {


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->
## Summary
Add `ncl skills list`, `plan`, and operator-enabled `apply` for structured capability installation.

- **Boundary**: source installation is disabled by default, requires an explicitly enabled Git checkout, and cannot be enabled by agent approval.
- **Recovery**: one checkout lock covers all engine callers and failed-install rollback. Save file contents before mutation; restore dependency manifests and lockfiles before reinstalling.
- **Setup**: keep tested code as `needs-setup` when credentials or interactive steps remain. Report those steps to the operator and restart only after `applied`.
- **Limit**: rollback covers journaled files, not process crashes, generated build output, or arbitrary command effects. A crash leaves a lock requiring operator inspection.

## Change kind
- [x] `kind/feature`

## Validation
- 447 focused tests passed on this branch, including partial copy failures, dependency restoration, lock contention during rollback, policy refusal, approval replay, and pending credentials.
- Host and engine TypeScript checks passed.
- Actual headless CLI refused an install with the default policy before mutation.
- [x] Tests cover the changed behavior

## User and release impact
- [x] User-visible change — release note below

```release-note
Source-checkout operators can enable NANOCLAW_SOURCE_INSTALL=enabled in the host service environment to use approval-gated capability installation from chat. Missing setup remains pending without restarting the host.
```

## Security and trust boundaries
Agent credentials are refused before approval and again in the child. External and interactive setup remain operator-owned. Deployment policy is rechecked on approval replay and execution.

## Skill delivery
- [x] Not a skill

## AI assistance
- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change
