### PR TITLE
refactor(providers): adopt the OpenCode contract in its install skill

### DIFF
--- a/.claude/skills/add-opencode/REMOVE.md
+++ b/.claude/skills/add-opencode/REMOVE.md
@@ -3,12 +3,22 @@
 Idempotent — safe to run even if some steps were never applied. Reverses both
 provider trees, the agent-runner dependency, and the global CLI manifest entry.
 
+Before deleting the payload, switch every OpenCode group back to Claude:
+
+```bash
+ncl groups list
+ncl groups config update --id <group-id> --provider claude
+ncl groups restart --id <group-id>
+```
+
 ## 1. Delete the barrel import lines (both trees)
 
 Delete (do not comment out) the `import './opencode.js';` line from each barrel:
 
 - `src/providers/index.ts`
+- `src/provider-contracts/index.ts`
 - `container/agent-runner/src/providers/index.ts`
+- `container/agent-runner/src/provider-contracts/index.ts`
 
 This unregisters the provider from both `listProviderContainerConfigNames()` (host) and `listProviderNames()` (container).
 
@@ -17,6 +27,7 @@ This unregisters the provider from both `listProviderContainerConfigNames()` (ho
 ```bash
 rm -f src/providers/opencode.ts \
       src/providers/opencode-registration.test.ts \
+      src/provider-contracts/opencode.ts \
       src/opencode-cli-tools.test.ts \
       container/agent-runner/src/providers/opencode.ts \
       container/agent-runner/src/providers/mcp-to-opencode.ts \
@@ -25,9 +36,12 @@ rm -f src/providers/opencode.ts \
       container/agent-runner/src/providers/opencode.compaction.test.ts \
       container/agent-runner/src/providers/opencode.config.test.ts \
       container/agent-runner/src/providers/opencode.factory.test.ts \
+      container/agent-runner/src/providers/opencode.empty-resume.test.ts \
       container/agent-runner/src/providers/opencode.memory.test.ts \
       container/agent-runner/src/providers/opencode.question.test.ts \
-      container/agent-runner/src/providers/opencode-registration.test.ts
+      container/agent-runner/src/providers/opencode-registration.test.ts \
+      container/agent-runner/src/providers/opencode.conformance.test.ts \
+      container/agent-runner/src/provider-contracts/opencode.ts
 ```
 
 ## 3. Remove the agent-runner dependency
@@ -46,8 +60,6 @@ Delete the object whose `name` is `opencode-ai` from
 ## 5. Unset OpenCode env vars
 
 Remove any OpenCode-specific lines you added to `.env` (`OPENCODE_PROVIDER`, `OPENCODE_MODEL`, `OPENCODE_SMALL_MODEL`, and `ANTHROPIC_BASE_URL` if no other integration uses it) if no other integration needs them.
-
-Switch any group still on OpenCode back to the default provider — set `"provider": "claude"` in `groups/<folder>/container.json` and clear `agent_provider` on the group/session in the DB.
 
 ## 6. Rebuild and restart
 
@@ -72,8 +84,8 @@ After removal, the registration guards no longer apply (their files are gone). C
 
 ```bash
 grep -R "opencode.js" src/providers/index.ts container/agent-runner/src/providers/index.ts   # no output
+grep -R "opencode.js" src/provider-contracts/index.ts container/agent-runner/src/provider-contracts/index.ts   # no output
 grep "@opencode-ai/sdk" container/agent-runner/package.json                                   # no output
 grep '"opencode-ai"' container/cli-tools.json                                                  # no output
+pnpm exec tsx scripts/provider-contract-verifier.ts
 ```
-
-In a wired agent, requesting `agent_provider = 'opencode'` should fall back to the default provider since `opencode` is no longer in the registry.

--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -25,16 +25,20 @@ overwrite every skill-owned provider file with its canonical registry copy:
 ```nc:copy from-branch:providers
 src/providers/opencode.ts
 src/providers/opencode-registration.test.ts
+src/provider-contracts/opencode.ts
 container/agent-runner/src/providers/opencode.ts
 container/agent-runner/src/providers/mcp-to-opencode.ts
 container/agent-runner/src/providers/mcp-to-opencode.test.ts
 container/agent-runner/src/providers/opencode-registration.test.ts
+container/agent-runner/src/providers/opencode.conformance.test.ts
 container/agent-runner/src/providers/opencode.attachments.test.ts
 container/agent-runner/src/providers/opencode.compaction.test.ts
 container/agent-runner/src/providers/opencode.config.test.ts
 container/agent-runner/src/providers/opencode.factory.test.ts
+container/agent-runner/src/providers/opencode.empty-resume.test.ts
 container/agent-runner/src/providers/opencode.memory.test.ts
 container/agent-runner/src/providers/opencode.question.test.ts
+container/agent-runner/src/provider-contracts/opencode.ts
 ```
 
 (`cwd-shim.ts` and its test are deliberately **not** in this payload even though `mcp-to-opencode.ts` imports the shim: trunk ships and owns them — the default provider imports `cwd-shim.ts` — and every path listed here becomes a skill-owned file that removal deletes.)
@@ -44,6 +48,14 @@ container/agent-runner/src/providers/opencode.question.test.ts
 Each barrel gets one line appended at the end — skip if the line is already present.
 
 ```nc:append to:src/providers/index.ts
+import './opencode.js';
+```
+
+```nc:append to:src/provider-contracts/index.ts
+import './opencode.js';
+```
+
+```nc:append to:container/agent-runner/src/provider-contracts/index.ts
 import './opencode.js';
 ```
 
@@ -95,6 +107,10 @@ pnpm exec vitest run src/providers/opencode-registration.test.ts src/opencode-cl
 
 ```nc:run effect:test
 cd container/agent-runner && bun test src/providers/opencode-registration.test.ts
+```
+
+```nc:run effect:test
+pnpm exec tsx scripts/provider-contract-verifier.ts --required-declared opencode
 ```
 
 ```nc:run effect:build

--- a/scripts/test-registry-skills.ts
+++ b/scripts/test-registry-skills.ts
@@ -403,9 +403,7 @@ async function testCombinedProviders(skills: RegistrySkill[]): Promise<void> {
       throw new Error(`update-skills refresh failed: ${JSON.stringify(report)}`);
     }
     const verification = await verifyProviderContracts(root, {
-      // OpenCode retains its existing payload until its contract skill lands.
-      // Every other installed provider must already declare its contract.
-      expectedLegacyProviders: ['opencode'],
+      requiredDeclaredProviders: expected,
       exec: (cmd, cwd) => command(cmd, cwd),
     });
     if (verification.status !== 'passed') {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Move OpenCode's contract adoption out of #3586 so the core and Codex stack can land independently. `/add-opencode` copies the host/runtime contracts and conformance tests, wires the contract barrels, and requires its declared contract during verification. The removal instructions reverse this footprint. Combined-provider CI then requires every selected provider to declare its contract.

Depends on core #3586 and OpenCode payload #3588. Keep this draft until the OpenCode work is ready; merge #3588 before this skill change. No Cursor changes are included.

Validation: fresh combined install, refresh, builds, typecheck, provider suites, and contract inventory passed on current main plus the core stack, using payload `8b412b5e9574e9b0fb001b25e89d077e0cd2adc7`. This amendment only restacks the same patch after the reordered core; the prior validation above used the previous equivalent tree. The install/removal instructions are unchanged from the previously verified OpenCode contract skill.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
