### PR TITLE
Update retired model id in the add-opencode Anthropic example

### DIFF
--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -174,7 +174,7 @@ When `OPENCODE_PROVIDER` is `anthropic`, OpenCode uses normal Anthropic env insi
 
 ```env
 OPENCODE_PROVIDER=anthropic
-OPENCODE_MODEL=anthropic/claude-sonnet-4-20250514
+OPENCODE_MODEL=anthropic/claude-sonnet-5
 OPENCODE_SMALL_MODEL=anthropic/claude-haiku-4-5-20251001
 ```
 


### PR DESCRIPTION
The Anthropic example in the `add-opencode` skill hands out a model id that Anthropic retired on 15 June 2026.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `.claude/skills/add-opencode/SKILL.md` | 177 | `anthropic/claude-sonnet-4-20250514` | `anthropic/claude-sonnet-5` |

Retirement date is from the Anthropic deprecation page, https://platform.claude.com/docs/en/about-claude/model-deprecations.

Two things made this look like a leftover rather than a deliberate pin. The line right below it, `OPENCODE_SMALL_MODEL`, already carries `claude-haiku-4-5-20251001`, so the small model in that same `.env` block was refreshed at some point and the main one was not. And OpenCode resolves `provider/model` against the models.dev catalog, where the Anthropic entry today lists `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-sonnet-4-5` and the Opus and Haiku lines, with no `claude-sonnet-4-20250514`. I read that catalog from https://models.dev/api.json while writing this.

Nothing else in the repository carries a retired id, so this is the whole change. I left `OPENCODE_SMALL_MODEL` alone because it is current, and I did not touch the Zen or OpenRouter blocks since their model ids belong to those providers.

I have not run OpenCode against the Anthropic provider to reproduce a failure. The claim rests on the published retirement date and on the catalog contents linked above.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
