### PR TITLE
fix(setup): pin Linux signal-cli to 0.14.7

### DIFF
--- a/setup/install-signal-cli.sh
+++ b/setup/install-signal-cli.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-VERSION="0.14.3"
+VERSION="0.14.7"
 INSTALL_DIR="${HOME}/.local/bin"
 
 emit_status() {


### PR DESCRIPTION
## Summary

Stops new Linux Signal installs from shipping `signal-cli` 0.14.3, which can hang forever when sending to a contact with no existing session.
- **Problem**: `setup/install-signal-cli.sh` pins `VERSION="0.14.3"` for the native Linux tarball.
- **Fix**: pin `VERSION="0.14.7"` (current AsamK/signal-cli release; same `Linux-native.tar.gz` URL shape).
- **Out of scope**: replacing binaries already on disk; macOS Homebrew (unpinned `brew install signal-cli`); live Signal send hangs (fixed upstream).

## Related work

Closes #3671

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- Confirmed `setup/install-signal-cli.sh` previously set `VERSION="0.14.3"`.
- After the change, `VERSION="0.14.7"` and the interpolated URL is `https://github.com/AsamK/signal-cli/releases/download/v0.14.7/signal-cli-0.14.7-Linux-native.tar.gz`.
- `curl -sI` on that URL returns HTTP 302 to the GitHub release asset (`signal-cli-0.14.7-Linux-native.tar.gz`).
- No automated test: this is a single installer version pin; CI does not download the ~100MB native tarball.

- [ ] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Linux Signal setup now installs signal-cli 0.14.7 instead of 0.14.3. Re-run setup/install-signal-cli.sh to replace an existing 0.14.3 binary.
```

## Security and trust boundaries

None. Same GitHub release host and tarball naming as before; only the version pin changes.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change
