### PR TITLE
feat(channels): add native Proton Mail adapter via Proton Mail Bridge

### DIFF
--- a/.claude/skills/add-proton-mail/REMOVE.md
+++ b/.claude/skills/add-proton-mail/REMOVE.md
@@ -1,0 +1,79 @@
+# Remove Proton Mail
+
+Every step is idempotent — safe to re-run.
+
+## 1. Remove the adapter
+
+Delete the self-registration import from `src/channels/index.ts` (skip if already gone):
+
+```typescript
+import './proton-mail.js';
+```
+
+Then delete the copied adapter and its tests:
+
+```bash
+rm -f src/channels/proton-mail.ts src/channels/proton-mail-registration.test.ts src/channels/proton-mail.test.ts
+```
+
+## 2. Remove the dependencies
+
+```bash
+pnpm remove imapflow mailparser nodemailer @types/mailparser @types/nodemailer
+```
+
+## 3. Remove credentials and state
+
+Remove the `PROTON_MAIL_*` lines from `.env`:
+
+```bash
+PROTON_MAIL_ADDRESS
+PROTON_MAIL_BRIDGE_PASSWORD
+PROTON_MAIL_FROM_NAME
+PROTON_MAIL_IMAP_HOST
+PROTON_MAIL_IMAP_PORT
+PROTON_MAIL_SMTP_HOST
+PROTON_MAIL_SMTP_PORT
+PROTON_MAIL_TLS_REJECT_UNAUTHORIZED
+PROTON_MAIL_MAILBOX
+PROTON_MAIL_POLL_SECONDS
+PROTON_MAIL_MARK_SEEN
+PROTON_MAIL_PROCESS_BACKLOG
+PROTON_MAIL_DEFAULT_SUBJECT
+```
+
+Delete the adapter's cursor/thread state:
+
+```bash
+rm -rf store/proton-mail
+```
+
+## 4. Stop and remove Proton Mail Bridge
+
+Stop the Bridge container and delete its image. The named volume holds the
+Proton login — removing it signs the device out of the account (Proton also
+lists it under Settings → Security → Sessions, where it can be revoked):
+
+```bash
+docker rm -f nanoclaw-proton-bridge
+docker rmi nanoclaw-proton-bridge:latest nanoclaw-proton-bridge:v3.26.0
+docker volume rm nanoclaw-proton-bridge
+```
+
+## 5. Rebuild and restart
+
+Run from your NanoClaw project root:
+
+```bash
+pnpm run build
+source setup/lib/install-slug.sh
+
+# Linux
+systemctl --user restart $(systemd_unit)
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
+```
+
+Messaging groups, users and wirings for `proton-mail` are runtime data and are
+left in the central DB; delete them with `ncl` if you want them gone.

--- a/.claude/skills/add-proton-mail/SKILL.md
+++ b/.claude/skills/add-proton-mail/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: add-proton-mail
+description: Add Proton Mail as a channel via a local Proton Mail Bridge — native IMAP/SMTP adapter, no Chat SDK bridge. Builds Bridge from source in Docker so it runs on arm64 (Raspberry Pi) as well as x86. Agents receive mail as messages and reply by email. Requires a paid Proton plan.
+---
+
+# Add Proton Mail Channel
+
+Adds Proton Mail as a channel: incoming mail to your Proton address wakes the
+agent as an inbound message, and the agent's reply goes back out as email,
+threaded onto the sender's message. NanoClaw doesn't ship channels in trunk —
+this skill copies the adapter in from the `channels` branch.
+
+Proton encrypts mail end-to-end, so there is no IMAP server to connect to
+directly. **Proton Mail Bridge** runs on this machine, holds the account's keys,
+and exposes ordinary IMAP/SMTP on loopback. Proton only ships Bridge binaries for
+x86; this skill builds it from source inside Docker, which works on arm64
+(Raspberry Pi 4/5) and x86 alike. The host process is the only thing that talks
+to Bridge — its ports are published on `127.0.0.1` only, never to containers or
+the network.
+
+The mechanical steps under **Apply** carry `nc:` directive fences: an agent
+reads the prose and applies them, and a parser can apply them deterministically
+from the same document. Every directive is idempotent, so the whole skill is
+safe to re-run; anything a parser can't apply falls back to the prose beside it.
+
+## Prerequisites (required)
+
+**Bridge only works on a paid Proton plan** — Mail Plus, Proton Unlimited,
+Proton Family/Duo, or Proton for Business. Proton Free accounts cannot sign in
+to Bridge at all. Confirm this before building anything; if the user is on Free,
+stop here and tell them so — nothing below will work.
+
+```nc:prompt plan_ok validate:^yes$ flags:i normalize:lower
+Proton Mail Bridge requires a paid Proton plan (Mail Plus, Unlimited, Family/Duo, or Business) — it cannot sign in to a Proton Free account. Type `yes` to confirm you have a paid plan. If you're on Proton Free, stop here: this channel won't work.
+```
+
+```nc:run effect:check
+[ "{{plan_ok}}" = "yes" ]
+```
+
+Bridge runs as a Docker container, so Docker must be installed and the current
+user able to run it (NanoClaw's own agent containers already need this):
+
+```nc:run effect:check
+docker info >/dev/null 2>&1
+```
+
+## Apply
+
+### 1. Copy the adapter and its tests
+
+Fetch the `channels` branch and copy the Proton Mail adapter, its registration
+test, and its unit tests (overwrite — the branch is canonical). The Bridge
+container files (`bridge/Dockerfile`, `bridge/entrypoint.sh`, `bridge/gpgparams`)
+ship in this skill's own directory and are used in place:
+
+```nc:copy from-branch:channels
+src/channels/proton-mail.ts
+src/channels/proton-mail-registration.test.ts
+src/channels/proton-mail.test.ts
+```
+
+### 2. Register the adapter
+
+Append the self-registration import to the channel barrel (skipped if the line
+is already present). This one line is the skill's only reach-in into core:
+
+```nc:append to:src/channels/index.ts
+import './proton-mail.js';
+```
+
+### 3. Install the adapter packages
+
+Pinned to exact versions — the supply-chain policy rejects ranges and `latest`.
+`imapflow` is the IMAP client (IDLE-capable), `mailparser` turns raw RFC 822
+into text/attachments, `nodemailer` sends over SMTP:
+
+```nc:dep
+imapflow@1.7.8
+mailparser@3.9.20
+nodemailer@9.1.1
+@types/mailparser@3.4.6
+@types/nodemailer@8.0.1
+```
+
+### 4. Build and validate
+
+Build first: it typechecks the adapter against core and proves the dependencies
+are installed. Then run the integration test and the adapter's unit tests.
+
+```nc:run effect:build
+pnpm run build
+```
+```nc:run effect:test
+pnpm exec vitest run src/channels/proton-mail-registration.test.ts src/channels/proton-mail.test.ts
+```
+
+`proton-mail-registration.test.ts` imports the real channel barrel and asserts
+the registry contains `proton-mail`. It goes red if the `import './proton-mail.js';`
+line is deleted or drifts, if the barrel fails to evaluate, or if any of the mail
+packages isn't installed (the import throws) — so it also covers the dependencies
+from step 3. End-to-end delivery against a real Proton account is verified once
+the service runs (below).
+
+## Build Proton Mail Bridge
+
+Build the Bridge image from the pinned upstream release. This compiles Go from
+source and takes **15–30 minutes on a Raspberry Pi** (a few minutes on x86);
+re-runs are cached and return immediately. The version is pinned in the
+Dockerfile's `BRIDGE_VERSION` argument:
+
+```nc:run effect:external
+docker build -t nanoclaw-proton-bridge:latest .claude/skills/add-proton-mail/bridge
+```
+
+Bridge stores the account login in a `pass` keyring inside the container. It
+lives in a named Docker volume, `nanoclaw-proton-bridge`, so it survives
+container and image replacement. The login itself is interactive (Proton asks
+for the account password, a 2FA code if enabled, and the mailbox password on
+two-password accounts), so it has to run in a real terminal. Tell the user:
+
+```nc:operator
+Sign the Bridge in to your Proton account. In a real terminal (SSH session or local shell — the login needs a TTY):
+
+    docker run --rm -it -v nanoclaw-proton-bridge:/root nanoclaw-proton-bridge:latest init
+
+At the `>>>` prompt:
+  1. Type `login` and follow the prompts (Proton username, password, 2FA code if you use one, mailbox password on two-password accounts).
+  2. Wait for "Account <you> was added successfully" — the first sync can take a minute.
+  3. Type `exit`.
+
+Nothing to copy: the bridge password is read from Bridge's vault in the next step.
+```
+
+Bridge authenticates IMAP/SMTP with a **bridge password** — a random string it
+generates, not the Proton account password. Read it straight from the vault with
+the `vault-editor` tool built alongside Bridge, so it is never transcribed by
+hand (the displayed form is the vault's raw bytes as unpadded base64, which is
+what the `sed` reproduces). The Proton account password is never stored anywhere
+in NanoClaw:
+
+```nc:run effect:fetch capture:bridge_password validate:^[A-Za-z0-9+/_-]{20,}$
+docker run --rm -v nanoclaw-proton-bridge:/root --entrypoint /protonmail/vault-editor nanoclaw-proton-bridge:latest read | grep -o '"BridgePass": *"[^"]*"' | head -1 | sed 's/.*: *"//; s/"$//; s/=*$//'
+```
+
+The account's primary address is in the vault too. Read it, then confirm which
+address the agent should send from — the primary, or any alias on the same
+account (all aliases share one inbox and one bridge password):
+
+```nc:run effect:fetch capture:primary_email validate:^[^@\s]+@[^@\s]+\.[^@\s]+$
+docker run --rm -v nanoclaw-proton-bridge:/root --entrypoint /protonmail/vault-editor nanoclaw-proton-bridge:latest read | grep -o '"PrimaryEmail": *"[^"]*"' | head -1 | sed 's/.*: *"//; s/"$//' | tr 'A-Z' 'a-z'
+```
+
+```nc:prompt proton_address normalize:lower validate:^[^@\s]+@[^@\s]+\.[^@\s]+$
+Which address should the agent use? Bridge signed in as `{{primary_email}}` — press through with that, or give an alias on the same Proton account (e.g. `assistant@proton.me`) to send from instead.
+```
+
+Write both to `.env` (set-if-absent; edit `.env` directly to rotate them later):
+
+```nc:env-set
+PROTON_MAIL_ADDRESS={{proton_address}}
+PROTON_MAIL_BRIDGE_PASSWORD={{bridge_password}}
+```
+
+## Run Bridge
+
+Start Bridge as a long-lived container. Its IMAP (1143) and SMTP (1025) ports are
+published on `127.0.0.1` only — anyone who can reach them with the bridge
+password can read the whole mailbox, so they must never be exposed on `0.0.0.0`.
+`--restart unless-stopped` brings it back across reboots. Re-running replaces
+the container in place (the login lives in the volume, not the container):
+
+```nc:run effect:external
+docker rm -f nanoclaw-proton-bridge >/dev/null 2>&1; docker run -d --name nanoclaw-proton-bridge --restart unless-stopped -p 127.0.0.1:1025:2025 -p 127.0.0.1:1143:2143 -v nanoclaw-proton-bridge:/root nanoclaw-proton-bridge:latest
+```
+
+Bridge takes a few seconds to load the vault and open its listeners. Wait for
+the IMAP greeting (`* OK`) before restarting NanoClaw — a bare TCP connect is
+not enough, since the container's forwarder accepts connections before Bridge
+itself is listening. An adapter that connects early would only retry, but a
+failed check here points straight at Bridge rather than at the adapter:
+
+```nc:run effect:check
+for i in $(seq 1 30); do timeout 5 bash -c 'exec 3<>/dev/tcp/127.0.0.1/1143; head -c 64 <&3' 2>/dev/null | grep -q '^\* OK' && exit 0; sleep 2; done; docker logs --tail 20 nanoclaw-proton-bridge; exit 1
+```
+
+## Restart
+
+Restart NanoClaw so it loads the Proton Mail adapter and sees the credentials,
+and wait for its CLI socket before resolving:
+
+```nc:run effect:restart
+bash setup/lib/restart.sh
+```
+
+After the restart, `logs/nanoclaw.log` should show `Proton Mail adapter connected`.
+
+## Resolve your DM channel
+
+Email has no "self-chat": you write to the agent's Proton address from a
+different address of your own, and the agent replies there. That address is
+both the conversation id and your owner handle. Collect it:
+
+```nc:prompt owner_email normalize:lower validate:^[^@\s]+@[^@\s]+\.[^@\s]+$
+Your own email address — the one you'll write to the agent from (any provider). Not the agent's Proton address.
+```
+
+```nc:run capture:platform_id effect:fetch
+echo "{{owner_email}}"
+```
+```nc:run capture:owner_handle effect:fetch
+echo "{{platform_id}}"
+```
+
+`owner_handle` and `platform_id` are what the owner-wiring step needs. The
+welcome message goes out as an email to that address as soon as the wiring
+exists.
+
+## Next Steps
+
+If you're in the middle of `/setup`, return to the setup flow now. Otherwise wire
+this channel with `/init-first-agent` (or `/manage-channels`).
+
+Tell the user what to expect:
+
+```nc:operator
+Proton Mail is connected as {{proton_address}}. Send it an email from {{owner_email}} and the agent replies in the same thread.
+
+Mail from anyone else is held for your approval the first time they write (unknown_sender_policy: request_approval) — nothing reaches the agent until you approve the sender. Bounces, auto-replies and the agent's own mail are filtered out automatically.
+```
+
+## Channel Info
+
+- **type**: `proton-mail`
+- **terminology**: Email has correspondents, not chats or groups. Each sender address is its own conversation.
+- **platform-id-format**: the correspondent's address, lowercased, as-is — `someone@example.com`. Native adapter — no `proton-mail:` prefix. User ids are `proton-mail:someone@example.com`.
+- **how-to-find-id**: It's the sender's email address. Auto-discovered on first mail — check `pnpm exec tsx scripts/q.ts data/v2.db "SELECT platform_id, name FROM messaging_groups WHERE channel_type='proton-mail'"`.
+- **supports-threads**: no — one session per correspondent. Replies are threaded in the correspondent's mail client via `In-Reply-To`/`References`.
+- **typical-use**: Email in, email out. Forward a document for summary; email the agent a question; let it send scheduled reports.
+- **default-isolation**: One agent group per Proton address is the natural unit. Multiple correspondents share the agent but get separate sessions.
+
+### Features
+
+- Inbound: subject + body (quoted reply history stripped), attachments saved to the session inbox (up to 15 MB each), HTML-only mail flattened to text
+- Outbound: plain-text replies, `Re:` subject, threaded onto the correspondent's last mail; file attachments from the session outbox
+- Approval questions — `ask_user_question` renders as a mail with `/approve`-style slash commands; reply with the command on the first line
+- Loop safety — the agent's own mail carries an `X-NanoClaw-Agent` header and is never re-ingested; `Auto-Submitted`, `Precedence: bulk`, `mailer-daemon`/`noreply` senders are dropped
+- Live delivery via IMAP IDLE, with a 60 s fallback poll
+
+Not supported: reactions, typing indicators, edit/delete, groups/mailing-list semantics (a CC'd thread is still one conversation per sender).
+
+## Optional configuration
+
+All `.env` keys the adapter reads. Only the first two are required.
+
+```bash
+PROTON_MAIL_ADDRESS=assistant@proton.me     # Bridge account
+PROTON_MAIL_BRIDGE_PASSWORD=...             # from `info` in the Bridge CLI
+PROTON_MAIL_FROM_NAME=Nano                  # display name on outbound mail
+PROTON_MAIL_IMAP_HOST=127.0.0.1             # Bridge IMAP (default 127.0.0.1:1143)
+PROTON_MAIL_IMAP_PORT=1143
+PROTON_MAIL_SMTP_HOST=127.0.0.1             # Bridge SMTP (default 127.0.0.1:1025)
+PROTON_MAIL_SMTP_PORT=1025
+PROTON_MAIL_TLS_REJECT_UNAUTHORIZED=false   # Bridge uses a self-signed cert on loopback
+PROTON_MAIL_MAILBOX=INBOX                   # folder to watch
+PROTON_MAIL_POLL_SECONDS=60                 # fallback poll behind IDLE
+PROTON_MAIL_MARK_SEEN=true                  # mark ingested mail read in Proton
+PROTON_MAIL_PROCESS_BACKLOG=false           # true: ingest existing mail on first start
+PROTON_MAIL_DEFAULT_SUBJECT=Message from your assistant   # for agent-initiated mail with no thread
+```
+
+On first connect the adapter records the mailbox's current position and only
+processes mail that arrives afterwards; set `PROTON_MAIL_PROCESS_BACKLOG=true`
+(and delete `store/proton-mail/state.json`) to ingest what's already there.
+
+### Upgrading Bridge
+
+Bump `BRIDGE_VERSION` in `.claude/skills/add-proton-mail/bridge/Dockerfile` to a
+newer [upstream release](https://github.com/ProtonMail/proton-bridge/releases),
+then re-run the **Build** and **Run Bridge** steps. The login in the volume
+carries over.
+
+## Troubleshooting
+
+### `login` fails or asks for something unexpected
+
+- **"Invalid credentials" on a correct password** — the account is on Proton Free, or the password has a leading/trailing space. Bridge needs a paid plan.
+- **Two-password mode** — Bridge asks for the mailbox password after the account password. Both are needed.
+- **2FA** — enter the TOTP code from your authenticator when prompted. Passkey/FIDO2 sign-in works if the hardware key is passed to the container; TOTP is simpler.
+- **Captcha / "human verification"** — Proton sometimes demands a browser captcha for a new device. Sign in once at mail.proton.me from the same network, then retry `login`.
+
+### Adapter logs `IMAP connect failed` / `ECONNREFUSED`
+
+Bridge isn't listening. `docker ps --filter name=nanoclaw-proton-bridge` should
+show it running; `docker logs nanoclaw-proton-bridge` shows why not. Common
+cause: the container was started before `init` completed, so the vault is empty
+— finish `login`, then re-run the **Run Bridge** step.
+
+### Adapter logs `IMAP connect failed … Command failed`; Bridge log says `no such user`
+
+`PROTON_MAIL_BRIDGE_PASSWORD` doesn't match. Bridge's `no such user` is its
+answer to *any* credential mismatch, not just an unknown address. The bridge
+password is a 22-character unpadded-base64 string; a hand-copied value with a
+stray character is the usual cause. Re-derive it from the vault rather than
+retyping (this is what the install step does):
+
+```bash
+docker run --rm -v nanoclaw-proton-bridge:/root --entrypoint /protonmail/vault-editor nanoclaw-proton-bridge:latest read | grep -o '"BridgePass": *"[^"]*"' | head -1 | sed 's/.*: *"//; s/"$//; s/=*$//'
+```
+
+Put that value on the `PROTON_MAIL_BRIDGE_PASSWORD=` line in `.env` and
+restart. Bridge regenerates the password if you `delete` and re-add the account,
+so repeat this after any re-login. Bridge also rate-limits after a few failures
+(`too many login attempts`); the adapter's backoff rides that out on its own.
+
+### Mail arrives in Proton but the agent never wakes
+
+1. Adapter connected: `grep "Proton Mail adapter connected" logs/nanoclaw.log | tail -1`
+2. Sender wired or approved: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT platform_id, unknown_sender_policy, denied_at FROM messaging_groups WHERE channel_type='proton-mail'"` — a first-time sender is held for approval; check `ncl approvals list`.
+3. Not filtered: the adapter drops `Auto-Submitted`, `Precedence: bulk/junk`, and `noreply@`/`mailer-daemon@` senders (`logs/nanoclaw.log` at debug: `Proton Mail inbound skipped`).
+4. Right folder: the adapter watches `PROTON_MAIL_MAILBOX` (`INBOX`). Proton's spam filter or a custom filter may have moved the mail.
+5. Backlog: mail that was already in the inbox when the adapter first connected is skipped by design — see `PROTON_MAIL_PROCESS_BACKLOG`.
+
+### Replies not sending (`SMTP` errors in `logs/nanoclaw.error.log`)
+
+- `Must issue a STARTTLS command first` — the SMTP port is right but TLS is off in Bridge; leave Bridge on its default STARTTLS setting.
+- `self signed certificate` — `PROTON_MAIL_TLS_REJECT_UNAUTHORIZED` was set to `true`; Bridge's loopback cert is self-signed. Set it back to `false` (the default).
+- Rate limits — Proton caps outbound mail per day by plan. The error names the limit.
+
+### Bridge container keeps restarting
+
+`docker logs nanoclaw-proton-bridge`. A vault that can't be unlocked (the `pass`
+keyring in the volume is damaged) prints GPG errors; recover by removing the
+volume and logging in again: `docker rm -f nanoclaw-proton-bridge; docker volume rm nanoclaw-proton-bridge`, then the **init** step.
+
+### Bot not responding — service side
+
+- Service running: `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux) / `launchctl print gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"` (macOS)
+- `logs/nanoclaw.error.log` for `No adapter for channel type channelType="proton-mail"` — the factory returned `null`, which means `PROTON_MAIL_ADDRESS` or `PROTON_MAIL_BRIDGE_PASSWORD` is missing from `.env`.

--- a/.claude/skills/add-proton-mail/apply-fixtures.json
+++ b/.claude/skills/add-proton-mail/apply-fixtures.json
@@ -1,0 +1,22 @@
+{
+  "notes": "Conformance fixtures for scripts/skill-conformance.test.ts — shaped fake values only, never real credentials. One scenario: the paid-plan confirmation, a Bridge login already done by the operator, and the owner's own address. The vault-editor stubs answer the bridge_password / primary_email captures (a 22-char unpadded-base64 shape and an address); the echo stub answers the platform_id/owner_handle captures; docker and the port wait are stubbed to succeed.",
+  "scenarios": [
+    {
+      "name": "paid-plan",
+      "inputs": {
+        "plan_ok": "yes",
+        "proton_address": "assistant@proton.me",
+        "owner_email": "owner@example.com"
+      },
+      "exec": [
+        { "match": "docker info", "stdout": "" },
+        { "match": "docker build", "stdout": "" },
+        { "match": "\"BridgePass\"", "stdout": "ZmFrZS1icmlkZ2UtcGFzc3dvcmQ" },
+        { "match": "\"PrimaryEmail\"", "stdout": "assistant@pm.me" },
+        { "match": "docker run", "stdout": "0123456789abcdef" },
+        { "match": "/dev/tcp/127.0.0.1/1143", "stdout": "* OK [CAPABILITY IMAP4rev1] Proton Mail Bridge" },
+        { "match": "owner@example.com", "stdout": "owner@example.com" }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/add-proton-mail/bridge/Dockerfile
+++ b/.claude/skills/add-proton-mail/bridge/Dockerfile
@@ -1,0 +1,26 @@
+# Proton Mail Bridge, headless, built from source so it runs on arm64 (Raspberry
+# Pi) where Proton ships no binary. Two stages: compile with the Go toolchain the
+# release's go.mod asks for, then copy the binaries onto a slim runtime.
+ARG BRIDGE_VERSION=v3.26.0
+ARG GO_IMAGE=golang:1.26.8-bookworm
+
+FROM ${GO_IMAGE} AS build
+ARG BRIDGE_VERSION
+RUN apt-get update && apt-get install -y --no-install-recommends git build-essential pkg-config libsecret-1-dev libfido2-dev libcbor-dev libssl-dev libudev-dev libpcsclite-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+RUN git clone --depth 1 --branch "${BRIDGE_VERSION}" https://github.com/ProtonMail/proton-bridge.git . \
+    && make build-nogui vault-editor
+
+FROM debian:bookworm-slim
+# pass + gnupg back the credential store the bridge writes its account into;
+# socat re-exposes the bridge's loopback-only listeners on the container
+# interface as 2025/2143 so a published port reaches them.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pass gnupg socat libsecret-1-0 libfido2-1 ca-certificates procps \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/bridge /src/proton-bridge /src/vault-editor /protonmail/
+COPY entrypoint.sh gpgparams /protonmail/
+EXPOSE 2025/tcp 2143/tcp
+VOLUME ["/root"]
+ENTRYPOINT ["bash", "/protonmail/entrypoint.sh"]

--- a/.claude/skills/add-proton-mail/bridge/entrypoint.sh
+++ b/.claude/skills/add-proton-mail/bridge/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Two modes:
+#   init   — one-time interactive login: run `login`, then `info` to read the
+#            bridge's local IMAP/SMTP password. Creates the pass keyring on
+#            first use.
+#   (none) — run the bridge headless, forever.
+set -euo pipefail
+
+if [[ "${1:-}" == "init" ]]; then
+  shift
+  if ! pass ls >/dev/null 2>&1; then
+    gpg --batch --generate-key /protonmail/gpgparams
+    pass init nanoclaw-bridge
+  fi
+  # Only one bridge may run against the vault at a time.
+  pkill -x bridge 2>/dev/null || true
+  exec /protonmail/proton-bridge --cli "$@"
+fi
+
+# Bridge binds 127.0.0.1:1025/1143 only. socat re-exposes them on the container
+# interface under DIFFERENT ports (2025/2143): same-port forwarding would
+# connect socat to itself until the bridge is up — a fork storm. Publish
+# with -p 127.0.0.1:1025:2025 -p 127.0.0.1:1143:2143.
+socat TCP-LISTEN:2025,fork,reuseaddr TCP:127.0.0.1:1025 &
+socat TCP-LISTEN:2143,fork,reuseaddr TCP:127.0.0.1:1143 &
+exec /protonmail/proton-bridge --noninteractive "$@"

--- a/.claude/skills/add-proton-mail/bridge/gpgparams
+++ b/.claude/skills/add-proton-mail/bridge/gpgparams
@@ -1,0 +1,6 @@
+%no-protection
+Key-Type: RSA
+Key-Length: 3072
+Name-Real: nanoclaw-bridge
+Expire-Date: 0
+%commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Key files: `src/cli/dispatch.ts` (dispatcher + approval handler), `src/cli/crud.
 
 Trunk does not ship any specific channel adapter or non-default agent provider. The codebase is the registry/infra; the actual adapters and providers live on long-lived sibling branches and get copied in by skills:
 
-- **`channels` branch** — Discord, Slack, Telegram, WhatsApp, Teams, Linear, GitHub, iMessage, Webex, Resend, Matrix, Google Chat, WhatsApp Cloud, Signal, WeChat, DeltaChat, Emacs (+ helpers, tests, channel-specific setup steps). Installed via `/add-<channel>` skills.
+- **`channels` branch** — Discord, Slack, Telegram, WhatsApp, Teams, Linear, GitHub, iMessage, Webex, Resend, Matrix, Google Chat, WhatsApp Cloud, Signal, WeChat, DeltaChat, Emacs, Proton Mail (+ helpers, tests, channel-specific setup steps). Installed via `/add-<channel>` skills.
 - **`providers` branch** — OpenCode (and any future non-default agent providers). Installed via `/add-opencode`.
 
 Each `/add-<name>` skill is idempotent: `git fetch origin <branch>` → copy module(s) into the standard paths → append a self-registration import to the relevant barrel → `pnpm install <pkg>@<pinned-version>` → build. Channel skills carry these steps as `nc:` directive fences: setup applies them via the engine (`scripts/skill-apply.ts`), an agent applies the prose — same install either way. See [docs/skill-directives.md](docs/skill-directives.md).

--- a/package.json
+++ b/package.json
@@ -36,10 +36,15 @@
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
     "@onecli-sh/sdk": "2.2.1",
+    "@types/mailparser": "3.4.6",
+    "@types/nodemailer": "8.0.1",
     "better-sqlite3": "13.0.3",
     "chat": "4.29.0",
     "cron-parser": "5.5.0",
+    "imapflow": "1.7.8",
     "kleur": "^4.1.5",
+    "mailparser": "3.9.20",
+    "nodemailer": "9.1.1",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@onecli-sh/sdk':
         specifier: 2.2.1
         version: 2.2.1
+      '@types/mailparser':
+        specifier: 3.4.6
+        version: 3.4.6
+      '@types/nodemailer':
+        specifier: 8.0.1
+        version: 8.0.1
       better-sqlite3:
         specifier: 13.0.3
         version: 13.0.3
@@ -26,9 +32,18 @@ importers:
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
+      imapflow:
+        specifier: 1.7.8
+        version: 1.7.8
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      mailparser:
+        specifier: 3.9.20
+        version: 3.9.20
+      nodemailer:
+        specifier: 9.1.1
+        version: 9.1.1
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -313,6 +328,9 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -411,6 +429,11 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@selderee/plugin-htmlparser2@0.12.0':
+    resolution: {integrity: sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==}
+    peerDependencies:
+      selderee: ~0.12.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -435,6 +458,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/mailparser@3.4.6':
+    resolution: {integrity: sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -443,6 +469,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -538,6 +567,9 @@ packages:
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
+  '@zone-eu/mailsplit@5.4.16':
+    resolution: {integrity: sha512-zQ9iXvlT3Wi/hazeC1MdI4rQc1UJwJ6IQ6QzSZ5KDxLZZWQSazWLOzImLFluXadKShJ9WJvI1xH+AyVS8b9azg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -561,6 +593,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -649,6 +685,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge-ts@8.0.2:
+    resolution: {integrity: sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==}
+    engines: {node: '>=16.9.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -659,6 +699,31 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  encoding-japanese@2.3.0:
+    resolution: {integrity: sha512-eQyh1vzHz13DUkZcJO+0IOAoKXRQwKV5IBffeuYsWZyRLGiSzfzXObCqWvqFXdX0UU8qOk+lBXbkUhMCpdJe4Q==}
+    engines: {node: '>=18.0.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -803,10 +868,29 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  html-to-text@10.0.1:
+    resolution: {integrity: sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==}
+    engines: {node: '>=20.19.0'}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -816,6 +900,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  imapflow@1.7.8:
+    resolution: {integrity: sha512-dJoCIdZOJh26Rn2PdwEzwj0bRDgGBxxX38pio534FagIHVuR2l0SAfLr6sJo32YfuJHiSs/U2ntNDHnMg3/Hlg==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -823,6 +910,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -859,9 +950,21 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  leac@0.7.0:
+    resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libbase64@1.3.0:
+    resolution: {integrity: sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==}
+
+  libmime@5.4.3:
+    resolution: {integrity: sha512-di9BoDabBUMqjeD/wGj+hHpSgdqAph5ui7w6OdY6NpzU6O6VFLQsMOg9tqCjm/zf9OHzAM9EZxSOF7uIb8O8Hw==}
+
+  libqp@2.1.1:
+    resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -937,6 +1040,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -953,6 +1059,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mailparser@3.9.20:
+    resolution: {integrity: sha512-PZ9RD6B7SkmyQ9rj8JvYNS18rL6pWoNkSw9KGVuJQrrdouFxFIB05ugnR3ubInlnjLXV3KHXhGyz8MlTz1VGzw==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1096,8 +1205,16 @@ packages:
     resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  nodemailer@9.1.1:
+    resolution: {integrity: sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==}
+    engines: {node: '>=6.0.0'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1115,6 +1232,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseley@0.13.1:
+    resolution: {integrity: sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1126,12 +1246,25 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  peberminta@0.10.0:
+    resolution: {integrity: sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -1146,9 +1279,26 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -1174,6 +1324,16 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  selderee@0.12.0:
+    resolution: {integrity: sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1193,9 +1353,24 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1211,6 +1386,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1225,6 +1404,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -1258,6 +1441,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1574,6 +1760,8 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
@@ -1625,6 +1813,12 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@selderee/plugin-htmlparser2@0.12.0(selderee@0.12.0)':
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      selderee: 0.12.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1651,6 +1845,11 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/mailparser@3.4.6':
+    dependencies:
+      '@types/node': 22.19.17
+      iconv-lite: 0.6.3
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -1660,6 +1859,10 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@types/unist@3.0.3': {}
 
@@ -1797,6 +2000,12 @@ snapshots:
 
   '@workflow/serde@4.1.0-beta.2': {}
 
+  '@zone-eu/mailsplit@5.4.16':
+    dependencies:
+      libbase64: 1.3.0
+      libmime: 5.4.3
+      libqp: 2.1.1
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -1817,6 +2026,8 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  atomic-sleep@1.0.0: {}
 
   bail@2.0.2: {}
 
@@ -1892,6 +2103,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge-ts@8.0.2: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -1899,6 +2112,30 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  encoding-japanese@2.3.0: {}
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -2068,11 +2305,47 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  he@1.2.0: {}
+
+  html-to-text@10.0.1:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
+      deepmerge-ts: 8.0.2
+      dom-serializer: 2.0.0
+      htmlparser2: 10.1.0
+      selderee: 0.12.0
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  imapflow@1.7.8:
+    dependencies:
+      '@zone-eu/mailsplit': 5.4.16
+      encoding-japanese: 2.3.0
+      iconv-lite: 0.7.3
+      libbase64: 1.3.0
+      libmime: 5.4.3
+      libqp: 2.1.1
+      pino: 10.3.1
+      socks: 2.8.9
 
   import-fresh@3.3.1:
     dependencies:
@@ -2080,6 +2353,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  ip-address@10.7.0: {}
 
   is-extglob@2.1.1: {}
 
@@ -2107,10 +2382,23 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  leac@0.7.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libbase64@1.3.0: {}
+
+  libmime@5.4.3:
+    dependencies:
+      encoding-japanese: 2.3.0
+      iconv-lite: 0.7.3
+      libbase64: 1.3.0
+      libqp: 2.1.1
+
+  libqp@2.1.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2161,6 +2449,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -2174,6 +2466,19 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mailparser@3.9.20:
+    dependencies:
+      '@zone-eu/mailsplit': 5.4.16
+      encoding-japanese: 2.3.0
+      he: 1.2.0
+      html-to-text: 10.0.1
+      iconv-lite: 0.7.3
+      libmime: 5.4.3
+      linkify-it: 5.0.2
+      nodemailer: 9.1.1
+      punycode.js: 2.3.1
+      tlds: 1.261.0
 
   markdown-table@3.0.4: {}
 
@@ -2486,7 +2791,11 @@ snapshots:
 
   node-addon-api@8.9.2: {}
 
+  nodemailer@9.1.1: {}
+
   obug@2.1.1: {}
+
+  on-exit-leak-free@2.1.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2509,15 +2818,42 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseley@0.13.1:
+    dependencies:
+      leac: 0.7.0
+      peberminta: 0.10.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
+  peberminta@0.10.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
 
   postcss@8.5.10:
     dependencies:
@@ -2529,7 +2865,17 @@ snapshots:
 
   prettier@3.8.2: {}
 
+  process-warning@5.1.0: {}
+
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   remark-gfm@4.0.1:
     dependencies:
@@ -2584,6 +2930,14 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  selderee@0.12.0:
+    dependencies:
+      parseley: 0.13.1
+
   semver@7.7.4: {}
 
   shebang-command@2.0.0:
@@ -2596,7 +2950,20 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  smart-buffer@4.2.0: {}
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.7.0
+      smart-buffer: 4.2.0
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -2608,6 +2975,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -2618,6 +2989,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tlds@1.261.0: {}
 
   trough@2.2.0: {}
 
@@ -2651,6 +3024,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@6.21.0: {}
 

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -7,3 +7,4 @@
 // self-registration import below.
 
 import './cli.js';
+import './proton-mail.js';

--- a/src/channels/proton-mail-registration.test.ts
+++ b/src/channels/proton-mail-registration.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Integration test for the proton-mail channel's single reach-in: the
+ * self-registration import in the `src/channels/index.ts` barrel. Importing the
+ * barrel runs proton-mail.ts's top-level `registerChannelAdapter('proton-mail', …)`;
+ * without the import the channel is silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. If the `import './proton-mail.js';` line is
+ * deleted, or the barrel fails to evaluate for any reason, this goes red.
+ *
+ * proton-mail is a native adapter (no Chat SDK bridge). Importing the barrel is
+ * safe: registration is a pure top-level call and the adapter opens IMAP/SMTP
+ * connections only inside setup(), never at import. It does require the mail
+ * packages (`imapflow`, `mailparser`, `nodemailer`) to be installed — an
+ * unmocked import throws if any is missing, so this also guards the dependency.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('proton-mail channel registration', () => {
+  it('registers proton-mail via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('proton-mail');
+  });
+});

--- a/src/channels/proton-mail.test.ts
+++ b/src/channels/proton-mail.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the proton-mail adapter's pure helpers — the parts that decide
+ * what reaches the agent (quote stripping, auto-reply filtering) and how replies
+ * thread back (subjects, slash-command answers). No network.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  classifyAttachment,
+  htmlToText,
+  matchCommandReply,
+  normalizeAddress,
+  optionToCommand,
+  renderAskQuestion,
+  replySubject,
+  shouldSkipInbound,
+  stripQuotedReply,
+} from './proton-mail.js';
+import { normalizeOptions } from './ask-question.js';
+
+describe('normalizeAddress', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeAddress('  Someone@Example.COM ')).toBe('someone@example.com');
+  });
+});
+
+describe('replySubject', () => {
+  it('prefixes Re: once', () => {
+    expect(replySubject('Hello')).toBe('Re: Hello');
+    expect(replySubject('Re: Hello')).toBe('Re: Hello');
+    expect(replySubject('RE: Hello')).toBe('RE: Hello');
+    expect(replySubject('AW: Hallo')).toBe('AW: Hallo');
+  });
+  it('handles a missing subject', () => {
+    expect(replySubject(undefined)).toBe('Re: (no subject)');
+    expect(replySubject('   ')).toBe('Re: (no subject)');
+  });
+});
+
+describe('stripQuotedReply', () => {
+  it('cuts at an "On … wrote:" marker', () => {
+    const text = 'Yes, do it.\n\nOn Mon, 1 Sep 2026 at 10:00, Agent <a@x.com> wrote:\n> Shall I proceed?\n> Thanks';
+    expect(stripQuotedReply(text)).toBe('Yes, do it.');
+  });
+  it('cuts at an Outlook "Original Message" marker', () => {
+    const text = 'Approved\r\n\r\n-----Original Message-----\r\nFrom: Agent\r\nSubject: Plan';
+    expect(stripQuotedReply(text)).toBe('Approved');
+  });
+  it('cuts at an Outlook web rule followed by a From: header block', () => {
+    const text =
+      'Hello testing your reply. \n\n\nS\n\n\n\n' +
+      '-'.repeat(80) +
+      '\n\nFrom: agentsmk@proton.me <agentsmk@proton.me>\nSent: Sunday, 06 September 2026 06:29\nTo: Kennedy\nSubject: Message\n\nHi Steven';
+    expect(stripQuotedReply(text)).toBe('Hello testing your reply. \n\n\nS'.trimEnd());
+  });
+  it('cuts at a bare From:/Sent: header block', () => {
+    expect(stripQuotedReply('Yes\n\nFrom: A <a@x.com>\nDate: Mon\nSubject: hi\n\nold')).toBe('Yes');
+  });
+  it('does not treat a From: mention in prose as a quote header', () => {
+    const text = 'From: my point of view this is fine.\nLet me know.';
+    expect(stripQuotedReply(text)).toBe(text);
+  });
+  it('drops a trailing quoted block without a marker', () => {
+    expect(stripQuotedReply('Sounds good\n\n> earlier\n> lines\n')).toBe('Sounds good');
+  });
+  it('keeps a message that is only a quote', () => {
+    expect(stripQuotedReply('> just forwarding this\n> as is')).toBe('> just forwarding this\n> as is');
+  });
+});
+
+describe('htmlToText', () => {
+  it('flattens tags and entities', () => {
+    const html = '<html><style>p{}</style><body><p>Hi &amp; bye</p><div>Line<br>two</div></body></html>';
+    expect(htmlToText(html)).toBe('Hi & bye\nLine\ntwo');
+  });
+});
+
+describe('shouldSkipInbound', () => {
+  it('keeps ordinary mail', () => {
+    expect(shouldSkipInbound({ fromAddress: 'friend@example.com' })).toBeNull();
+    expect(shouldSkipInbound({ fromAddress: 'friend@example.com', autoSubmitted: 'no' })).toBeNull();
+  });
+  it('drops our own echo', () => {
+    expect(shouldSkipInbound({ fromAddress: 'me@proton.me', loopHeader: 'proton-mail' })).toBe('own echo');
+  });
+  it('drops bounces and auto-replies', () => {
+    expect(shouldSkipInbound({ fromAddress: 'MAILER-DAEMON@mx.proton.me' })).toBe('system sender');
+    expect(shouldSkipInbound({ fromAddress: 'noreply@shop.example' })).toBe('system sender');
+    expect(shouldSkipInbound({ fromAddress: 'x@y.z', autoSubmitted: 'auto-replied' })).toMatch(/auto-submitted/);
+    expect(shouldSkipInbound({ fromAddress: 'x@y.z', precedence: 'bulk' })).toBe('precedence: bulk');
+  });
+  it('drops mail with no sender', () => {
+    expect(shouldSkipInbound({})).toBe('no sender');
+  });
+});
+
+describe('classifyAttachment', () => {
+  it('maps content types', () => {
+    expect(classifyAttachment('image/png')).toBe('image');
+    expect(classifyAttachment('video/mp4')).toBe('video');
+    expect(classifyAttachment('audio/ogg')).toBe('audio');
+    expect(classifyAttachment('application/pdf')).toBe('document');
+    expect(classifyAttachment(undefined)).toBe('document');
+  });
+});
+
+describe('ask_question over email', () => {
+  const options = normalizeOptions(['Approve', 'Reject all']);
+
+  it('renders slash commands per option', () => {
+    expect(optionToCommand('Reject all')).toBe('/reject-all');
+    const body = renderAskQuestion('Deploy?', 'Ship v2 now?', options);
+    expect(body).toContain('Deploy?');
+    expect(body).toContain('Ship v2 now?');
+    expect(body).toContain('  /approve');
+    expect(body).toContain('  /reject-all');
+  });
+
+  it('matches the first non-empty line as a command', () => {
+    expect(matchCommandReply('\n  /Approve \n\nthanks', options)?.value).toBe('Approve');
+    expect(matchCommandReply('/reject-all', options)?.value).toBe('Reject all');
+  });
+
+  it('ignores prose and unknown commands', () => {
+    expect(matchCommandReply('approve', options)).toBeUndefined();
+    expect(matchCommandReply('/maybe', options)).toBeUndefined();
+    expect(matchCommandReply('', options)).toBeUndefined();
+  });
+});

--- a/src/channels/proton-mail.ts
+++ b/src/channels/proton-mail.ts
@@ -1,0 +1,628 @@
+/**
+ * Proton Mail channel adapter (v2) — native IMAP/SMTP against a local Proton
+ * Mail Bridge. Self-registers on import.
+ *
+ * The Bridge terminates Proton's end-to-end encryption on this machine and
+ * speaks ordinary IMAP/SMTP (STARTTLS, self-signed cert) on loopback. This
+ * adapter is the only thing that talks to it: inbound mail arrives over IMAP
+ * IDLE with a fallback poll, replies leave over SMTP threaded onto the
+ * correspondent's last message.
+ *
+ * Every correspondent is a DM. platformId is the sender's address (lowercased),
+ * so one session per address and user ids of the form `proton-mail:<address>`.
+ * Email carries no mention metadata, so every inbound is flagged isMention —
+ * a stranger's first mail auto-creates a messaging group under the declared
+ * unknown-sender policy (request_approval) instead of being silently dropped.
+ *
+ * All side effects (connections, state file) live in the factory and setup();
+ * importing this module only registers the adapter.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { ImapFlow } from 'imapflow';
+import { simpleParser, type AddressObject, type ParsedMail } from 'mailparser';
+import nodemailer, { type Transporter } from 'nodemailer';
+
+import { isSafeAttachmentName } from '../attachment-safety.js';
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import type {
+  ChannelAdapter,
+  ChannelDefaults,
+  ChannelSetup,
+  InboundMessage,
+  OutboundMessage,
+  ResolvedConversation,
+} from './adapter.js';
+import { normalizeOptions, type NormalizedOption } from './ask-question.js';
+import { registerChannelAdapter } from './channel-registry.js';
+
+const STATE_DIR = path.join(process.cwd(), 'store', 'proton-mail');
+const STATE_FILE = path.join(STATE_DIR, 'state.json');
+const THREADS_MAX = 512;
+const PENDING_QUESTIONS_MAX = 64;
+const ATTACHMENT_MAX_BYTES = 15 * 1024 * 1024;
+const BODY_MAX_CHARS = 50_000;
+const RECONNECT_DELAY_MS = 5_000;
+const RECONNECT_MAX_MS = 5 * 60_000;
+/** Stamped on every outbound mail; an inbound carrying it is our own echo. */
+const LOOP_HEADER = 'x-nanoclaw-agent';
+
+/**
+ * Email: every conversation is a DM addressed to the bridge account — the
+ * group branch is inert but required by the type. 'dm-only' because email has
+ * no mention metadata. request_approval so a stranger's first mail raises an
+ * approval card rather than reaching the agent or vanishing.
+ */
+export const PROTON_MAIL_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  group: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  mentions: 'dm-only',
+};
+
+// --- Pure helpers (exported for tests) ---
+
+export function normalizeAddress(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+/** "Re: X" unless the subject already carries a reply prefix in a common locale. */
+export function replySubject(subject: string | undefined): string {
+  const s = (subject ?? '').trim();
+  if (!s) return 'Re: (no subject)';
+  if (/^(re|aw|sv|antw|ref)\s*:/i.test(s)) return s;
+  return `Re: ${s}`;
+}
+
+/**
+ * Drop the quoted history a mail client appends to a reply: everything from
+ * the "On … wrote:" / "-----Original Message-----" marker on, plus any trailing
+ * `>`-quoted lines. Returns the original when stripping would leave nothing —
+ * a message that is only a quote is still a message.
+ */
+export function stripQuotedReply(text: string): string {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const nextNonEmpty = (from: number): string => {
+    for (let j = from; j < lines.length; j++) {
+      const t = lines[j].trim();
+      if (t) return t;
+    }
+    return '';
+  };
+  let cut = lines.length;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (
+      /^On\b.*\bwrote:\s*$/.test(line) ||
+      /^-{2,}\s*Original Message\s*-{2,}$/i.test(line) ||
+      /^-{2,}\s*Forwarded message\s*-{2,}$/i.test(line) ||
+      /^_{5,}$/.test(line) ||
+      // Outlook (web/mobile): a bare rule, then a From:/Sent: header block.
+      (/^-{10,}$/.test(line) && /^From:\s/i.test(nextNonEmpty(i + 1))) ||
+      // Outlook without the rule: a From: header followed by Sent:/Date:/To:.
+      (/^From:\s.+/i.test(line) && /^(Sent|Date|To):\s/i.test(nextNonEmpty(i + 1)))
+    ) {
+      cut = i;
+      break;
+    }
+  }
+  const kept = lines.slice(0, cut);
+  // Trailing quoted block without a marker line.
+  while (kept.length > 0 && (kept[kept.length - 1].trim() === '' || kept[kept.length - 1].startsWith('>'))) {
+    kept.pop();
+  }
+  const out = kept.join('\n').trim();
+  return out || text.trim();
+}
+
+/** Crude text extraction for HTML-only mail; mailparser only fills `text` from a text/plain part. */
+export function htmlToText(html: string): string {
+  return html
+    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|tr|h[1-6]|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export interface SkipInput {
+  fromAddress?: string;
+  autoSubmitted?: string;
+  precedence?: string;
+  loopHeader?: string;
+}
+
+/**
+ * Reason to drop an inbound before it reaches the router, or null to keep it.
+ * Bounces, vacation auto-replies and our own echoes must never wake an agent —
+ * an agent answering a bounce answers it forever.
+ */
+export function shouldSkipInbound(input: SkipInput): string | null {
+  if (input.loopHeader) return 'own echo';
+  if (!input.fromAddress) return 'no sender';
+  if (/^(mailer-daemon|postmaster|no-?reply|do-?not-?reply)@/i.test(input.fromAddress)) return 'system sender';
+  const auto = (input.autoSubmitted ?? '').trim().toLowerCase();
+  if (auto && auto !== 'no') return `auto-submitted: ${auto}`;
+  const prec = (input.precedence ?? '').trim().toLowerCase();
+  if (prec === 'bulk' || prec === 'junk' || prec === 'auto_reply') return `precedence: ${prec}`;
+  return null;
+}
+
+export function classifyAttachment(contentType: string | undefined): string {
+  const ct = (contentType ?? '').toLowerCase();
+  if (ct.startsWith('image/')) return 'image';
+  if (ct.startsWith('video/')) return 'video';
+  if (ct.startsWith('audio/')) return 'audio';
+  return 'document';
+}
+
+export function optionToCommand(option: string): string {
+  return '/' + option.toLowerCase().replace(/\s+/g, '-');
+}
+
+/** Render an ask_question card as a plain-text mail body with slash-command replies. */
+export function renderAskQuestion(title: string, question: string, options: NormalizedOption[]): string {
+  const optionLines = options.map((o) => `  ${optionToCommand(o.label)}`).join('\n');
+  return `${title}\n\n${question}\n\nReply with one of:\n${optionLines}`;
+}
+
+/** First non-empty line of a reply, if it is a slash command matching an option. */
+export function matchCommandReply(body: string, options: NormalizedOption[]): NormalizedOption | undefined {
+  const first = body
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!first || !first.startsWith('/')) return undefined;
+  const cmd = first.toLowerCase();
+  return options.find((o) => optionToCommand(o.label) === cmd);
+}
+
+// --- Persistent adapter state ---
+
+interface ThreadRef {
+  messageId: string;
+  references: string[];
+  subject?: string;
+  name?: string;
+  at: string;
+}
+
+interface AdapterState {
+  uidValidity?: number;
+  lastUid?: number;
+  threads: Record<string, ThreadRef>;
+}
+
+function loadState(): AdapterState {
+  try {
+    const raw = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8')) as Partial<AdapterState>;
+    return { uidValidity: raw.uidValidity, lastUid: raw.lastUid, threads: raw.threads ?? {} };
+  } catch (err) {
+    log.debug('No Proton Mail adapter state yet, starting fresh', { err });
+    return { threads: {} };
+  }
+}
+
+function saveState(state: AdapterState): void {
+  try {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  } catch (err) {
+    log.error('Failed to persist Proton Mail adapter state', { err });
+  }
+}
+
+function rememberThread(state: AdapterState, address: string, ref: Omit<ThreadRef, 'at'>): void {
+  state.threads[address] = { ...ref, at: new Date().toISOString() };
+  const keys = Object.keys(state.threads);
+  if (keys.length > THREADS_MAX) {
+    keys
+      .sort((a, b) => state.threads[a].at.localeCompare(state.threads[b].at))
+      .slice(0, keys.length - THREADS_MAX)
+      .forEach((k) => delete state.threads[k]);
+  }
+}
+
+function firstAddress(obj: AddressObject | AddressObject[] | undefined): { address?: string; name?: string } {
+  const one = Array.isArray(obj) ? obj[0] : obj;
+  const v = one?.value?.[0];
+  return { address: v?.address, name: v?.name || undefined };
+}
+
+function allAddresses(obj: AddressObject | AddressObject[] | undefined): string[] {
+  const list = Array.isArray(obj) ? obj : obj ? [obj] : [];
+  return list.flatMap((o) => o.value.map((v) => v.address).filter((a): a is string => !!a));
+}
+
+function headerString(parsed: ParsedMail, name: string): string | undefined {
+  const v = parsed.headers.get(name);
+  if (v == null) return undefined;
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v.map(String).join(', ');
+  return String(v);
+}
+
+// --- Registration ---
+
+registerChannelAdapter('proton-mail', {
+  factory: () => {
+    const env = readEnvFile([
+      'PROTON_MAIL_ADDRESS',
+      'PROTON_MAIL_BRIDGE_PASSWORD',
+      'PROTON_MAIL_FROM_NAME',
+      'PROTON_MAIL_IMAP_HOST',
+      'PROTON_MAIL_IMAP_PORT',
+      'PROTON_MAIL_SMTP_HOST',
+      'PROTON_MAIL_SMTP_PORT',
+      'PROTON_MAIL_TLS_REJECT_UNAUTHORIZED',
+      'PROTON_MAIL_MAILBOX',
+      'PROTON_MAIL_POLL_SECONDS',
+      'PROTON_MAIL_MARK_SEEN',
+      'PROTON_MAIL_PROCESS_BACKLOG',
+      'PROTON_MAIL_DEFAULT_SUBJECT',
+    ]);
+    const address = env.PROTON_MAIL_ADDRESS ? normalizeAddress(env.PROTON_MAIL_ADDRESS) : '';
+    const password = env.PROTON_MAIL_BRIDGE_PASSWORD;
+    if (!address || !password) return null;
+
+    const cfg = {
+      address,
+      password,
+      fromName: env.PROTON_MAIL_FROM_NAME || undefined,
+      imapHost: env.PROTON_MAIL_IMAP_HOST || '127.0.0.1',
+      imapPort: Number(env.PROTON_MAIL_IMAP_PORT) || 1143,
+      smtpHost: env.PROTON_MAIL_SMTP_HOST || '127.0.0.1',
+      smtpPort: Number(env.PROTON_MAIL_SMTP_PORT) || 1025,
+      // The Bridge presents a self-signed certificate on loopback; verifying
+      // it would need the operator to export and trust it. Off by default,
+      // and only sensible to turn on when the bridge is not on loopback.
+      rejectUnauthorized: env.PROTON_MAIL_TLS_REJECT_UNAUTHORIZED === 'true',
+      mailbox: env.PROTON_MAIL_MAILBOX || 'INBOX',
+      pollMs: (Number(env.PROTON_MAIL_POLL_SECONDS) || 60) * 1000,
+      markSeen: env.PROTON_MAIL_MARK_SEEN !== 'false',
+      processBacklog: env.PROTON_MAIL_PROCESS_BACKLOG === 'true',
+      defaultSubject: env.PROTON_MAIL_DEFAULT_SUBJECT || 'Message from your assistant',
+    };
+
+    const state = loadState();
+    let setupConfig: ChannelSetup;
+    let client: ImapFlow | undefined;
+    let transporter: Transporter | undefined;
+    let connected = false;
+    let shuttingDown = false;
+    let draining = false;
+    let reconnectDelay = RECONNECT_DELAY_MS;
+    let pollTimer: NodeJS.Timeout | undefined;
+    let reconnectTimer: NodeJS.Timeout | undefined;
+
+    // Pending ask_question cards: address → { questionId, options }.
+    const pendingQuestions = new Map<string, { questionId: string; options: NormalizedOption[] }>();
+
+    // --- Outbound ---
+
+    function getTransporter(): Transporter {
+      transporter ??= nodemailer.createTransport({
+        host: cfg.smtpHost,
+        port: cfg.smtpPort,
+        secure: false,
+        requireTLS: true,
+        auth: { user: cfg.address, pass: cfg.password },
+        tls: { rejectUnauthorized: cfg.rejectUnauthorized },
+      });
+      return transporter;
+    }
+
+    async function sendMail(
+      to: string,
+      text: string,
+      files: Array<{ filename: string; content: Buffer }> = [],
+    ): Promise<string | undefined> {
+      const addr = normalizeAddress(to);
+      const thread = state.threads[addr];
+      const info = await getTransporter().sendMail({
+        from: cfg.fromName ? { name: cfg.fromName, address: cfg.address } : cfg.address,
+        to: addr,
+        subject: thread ? replySubject(thread.subject) : cfg.defaultSubject,
+        text,
+        attachments: files,
+        headers: { 'X-NanoClaw-Agent': 'proton-mail' },
+        ...(thread && { inReplyTo: thread.messageId, references: thread.references.join(' ') }),
+      });
+      const sentId: string | undefined = info?.messageId;
+      if (sentId) {
+        // Chain our own message into the thread so the next agent-initiated
+        // mail (a scheduled task, say) lands in the same conversation.
+        rememberThread(state, addr, {
+          messageId: sentId,
+          references: [...(thread?.references ?? []), sentId].slice(-20),
+          subject: thread?.subject ?? cfg.defaultSubject,
+          name: thread?.name,
+        });
+        saveState(state);
+      }
+      return sentId;
+    }
+
+    // --- Inbound ---
+
+    async function handleMessage(uid: number, source: Buffer): Promise<void> {
+      const parsed = await simpleParser(source);
+      const from = firstAddress(parsed.from);
+      const fromAddr = from.address ? normalizeAddress(from.address) : undefined;
+
+      const skip = shouldSkipInbound({
+        fromAddress: fromAddr,
+        autoSubmitted: headerString(parsed, 'auto-submitted'),
+        precedence: headerString(parsed, 'precedence'),
+        loopHeader: headerString(parsed, LOOP_HEADER),
+      });
+      if (skip || !fromAddr) {
+        log.debug('Proton Mail inbound skipped', { uid, reason: skip, from: fromAddr });
+        return;
+      }
+
+      const rawText = parsed.text || (parsed.html ? htmlToText(parsed.html) : '');
+      let body = stripQuotedReply(rawText);
+      if (body.length > BODY_MAX_CHARS) {
+        body = body.slice(0, BODY_MAX_CHARS) + `\n\n[… truncated, ${rawText.length} characters in total]`;
+      }
+      const subject = parsed.subject?.trim() || undefined;
+      const senderName = from.name || fromAddr;
+      const messageId = parsed.messageId || `<mail-${uid}@nanoclaw.local>`;
+
+      // Thread bookkeeping happens before the question check so a confirmation
+      // reply threads correctly too.
+      rememberThread(state, fromAddr, {
+        messageId,
+        references: [...(parsed.references ? [parsed.references].flat() : []), messageId].slice(-20),
+        subject,
+        name: from.name,
+      });
+
+      const pending = pendingQuestions.get(fromAddr);
+      if (pending) {
+        const matched = matchCommandReply(body, pending.options);
+        if (matched) {
+          setupConfig.onAction(pending.questionId, matched.value, fromAddr);
+          pendingQuestions.delete(fromAddr);
+          saveState(state);
+          await sendMail(fromAddr, `${matched.selectedLabel} by ${senderName}`);
+          log.info('Proton Mail question answered', { questionId: pending.questionId, value: matched.value });
+          return;
+        }
+      }
+
+      const attachments: Array<{ type: string; name: string; data: string }> = [];
+      const failures: string[] = [];
+      for (const att of parsed.attachments ?? []) {
+        const type = classifyAttachment(att.contentType);
+        if (att.size > ATTACHMENT_MAX_BYTES) {
+          failures.push(`${att.filename ?? type} (too large)`);
+          continue;
+        }
+        const fallback = `${type}-${uid}-${attachments.length + 1}`;
+        const rawName = att.filename ?? '';
+        const name = isSafeAttachmentName(rawName) ? rawName : fallback;
+        if (rawName && name !== rawName) {
+          log.warn('Refused unsafe attachment filename — would escape the inbox', { rawName, replacement: name });
+        }
+        attachments.push({ type, name, data: att.content.toString('base64') });
+      }
+
+      let text = subject ? `Subject: ${subject}\n\n${body}` : body;
+      if (failures.length > 0) text += `\n\n[attachments not delivered: ${failures.join(', ')}]`;
+      if (!text.trim() && attachments.length === 0) return;
+
+      setupConfig.onMetadata(fromAddr, senderName, false);
+
+      const inbound: InboundMessage = {
+        id: messageId,
+        kind: 'chat',
+        // A mail to the bridge account is addressed to the bot by definition.
+        isMention: true,
+        isGroup: false,
+        content: {
+          text,
+          sender: fromAddr,
+          senderName,
+          subject,
+          messageId,
+          to: allAddresses(parsed.to),
+          cc: allAddresses(parsed.cc),
+          ...(attachments.length > 0 && { attachments }),
+          fromMe: false,
+          isGroup: false,
+        },
+        timestamp: (parsed.date ?? new Date()).toISOString(),
+      };
+      saveState(state);
+      await setupConfig.onInbound(fromAddr, null, inbound);
+    }
+
+    /**
+     * Fetch everything above the last processed UID. Messages are collected
+     * first and handled after the fetch completes: imapflow serializes
+     * commands, so issuing another one (flags, a send-confirmation) while the
+     * fetch iterator is open would deadlock.
+     */
+    async function drain(): Promise<void> {
+      if (!client || !connected || draining) return;
+      draining = true;
+      try {
+        const lastUid = state.lastUid ?? 0;
+        const pending: Array<{ uid: number; source: Buffer }> = [];
+        // `N:*` returns the highest-UID message even when N exceeds it, hence
+        // the explicit uid guard on each result.
+        for await (const msg of client.fetch(`${lastUid + 1}:*`, { uid: true, source: true }, { uid: true })) {
+          if (msg.uid > lastUid && msg.source) pending.push({ uid: msg.uid, source: msg.source });
+        }
+        pending.sort((a, b) => a.uid - b.uid);
+        for (const { uid, source } of pending) {
+          try {
+            await handleMessage(uid, source);
+          } catch (err) {
+            log.error('Error processing inbound mail', { uid, err });
+          }
+          state.lastUid = uid;
+          saveState(state);
+          if (cfg.markSeen) {
+            try {
+              await client.messageFlagsAdd(String(uid), ['\\Seen'], { uid: true });
+            } catch (err) {
+              log.debug('Failed to mark mail seen', { uid, err });
+            }
+          }
+        }
+      } catch (err) {
+        log.error('Proton Mail fetch failed', { err });
+      } finally {
+        draining = false;
+      }
+    }
+
+    function scheduleReconnect(): void {
+      if (shuttingDown || reconnectTimer) return;
+      log.info('Proton Mail IMAP reconnecting', { inMs: reconnectDelay });
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        void connect();
+      }, reconnectDelay);
+      reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
+    }
+
+    async function connect(): Promise<void> {
+      if (shuttingDown) return;
+      const imap = new ImapFlow({
+        host: cfg.imapHost,
+        port: cfg.imapPort,
+        secure: false,
+        auth: { user: cfg.address, pass: cfg.password },
+        tls: { rejectUnauthorized: cfg.rejectUnauthorized },
+        logger: false,
+      });
+      imap.on('error', (err: Error) => log.error('Proton Mail IMAP error', { err }));
+      imap.on('close', () => {
+        if (client !== imap) return;
+        connected = false;
+        log.warn('Proton Mail IMAP connection closed');
+        scheduleReconnect();
+      });
+      imap.on('exists', () => void drain());
+
+      try {
+        await imap.connect();
+        await imap.mailboxOpen(cfg.mailbox);
+        client = imap;
+
+        const mailbox = imap.mailbox;
+        if (mailbox) {
+          const validity = Number(mailbox.uidValidity);
+          if (state.uidValidity !== validity) {
+            // Fresh mailbox (first run) or UIDs were renumbered. Start at the
+            // top unless the operator asked for the existing unread backlog.
+            state.uidValidity = validity;
+            state.lastUid = cfg.processBacklog ? 0 : Math.max(0, mailbox.uidNext - 1);
+            saveState(state);
+            log.info('Proton Mail mailbox opened', {
+              mailbox: cfg.mailbox,
+              startingAfterUid: state.lastUid,
+              backlog: cfg.processBacklog,
+            });
+          }
+        }
+        connected = true;
+        reconnectDelay = RECONNECT_DELAY_MS;
+        log.info('Proton Mail adapter connected', { address: cfg.address, imap: `${cfg.imapHost}:${cfg.imapPort}` });
+        await drain();
+      } catch (err) {
+        log.error('Proton Mail IMAP connect failed', { err, imap: `${cfg.imapHost}:${cfg.imapPort}` });
+        try {
+          imap.close();
+        } catch (closeErr) {
+          log.debug('IMAP close after failed connect threw', { err: closeErr });
+        }
+        scheduleReconnect();
+      }
+    }
+
+    const adapter: ChannelAdapter = {
+      name: 'Proton Mail',
+      channelType: 'proton-mail',
+      supportsThreads: false,
+
+      async setup(config: ChannelSetup): Promise<void> {
+        setupConfig = config;
+        fs.mkdirSync(STATE_DIR, { recursive: true });
+        await connect();
+        // IDLE delivers `exists` promptly; the poll is the safety net for a
+        // bridge that drops IDLE or a missed notification.
+        pollTimer = setInterval(() => void drain(), cfg.pollMs);
+      },
+
+      async deliver(platformId: string, _threadId: string | null, message: OutboundMessage) {
+        const content = message.content as Record<string, unknown>;
+
+        if (content.type === 'ask_question' && content.questionId && content.options) {
+          const questionId = content.questionId as string;
+          const title = content.title as string;
+          if (!title) {
+            log.error('ask_question missing required title — skipping delivery', { questionId });
+            return;
+          }
+          const options = normalizeOptions(content.options as never);
+          const text = renderAskQuestion(title, content.question as string, options);
+          const id = await sendMail(platformId, text);
+          if (id) {
+            pendingQuestions.set(normalizeAddress(platformId), { questionId, options });
+            if (pendingQuestions.size > PENDING_QUESTIONS_MAX) {
+              pendingQuestions.delete(pendingQuestions.keys().next().value!);
+            }
+          }
+          return id;
+        }
+
+        // Email has no reactions.
+        if (content.operation === 'reaction') return;
+
+        const text = ((content.markdown as string) || (content.text as string) || '').trim();
+        const files = (message.files ?? []).map((f) => ({ filename: f.filename, content: f.data }));
+        if (!text && files.length === 0) return;
+        return sendMail(platformId, text || '(see attached)', files);
+      },
+
+      async teardown() {
+        shuttingDown = true;
+        connected = false;
+        if (pollTimer) clearInterval(pollTimer);
+        if (reconnectTimer) clearTimeout(reconnectTimer);
+        try {
+          await client?.logout();
+        } catch (err) {
+          log.debug('IMAP logout threw during teardown', { err });
+        }
+        transporter?.close();
+        log.info('Proton Mail adapter shut down');
+      },
+
+      isConnected() {
+        return connected;
+      },
+
+      async resolveConversation(platformId: string): Promise<ResolvedConversation | null> {
+        const addr = normalizeAddress(platformId);
+        return { type: 'direct', name: state.threads[addr]?.name ?? addr };
+      },
+    };
+
+    return adapter;
+  },
+  defaults: PROTON_MAIL_DEFAULTS,
+});


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Adds Proton Mail as a channel: incoming mail wakes the agent, its reply goes back out as email in the same thread.
- **Problem**: no way to email an agent. Proton exposes no IMAP/SMTP, and Proton Mail Bridge ships no ARM binary, so Raspberry Pi installs had no path at all.
- **Fix**: a native IMAP/SMTP adapter (`src/channels/proton-mail.ts`) that talks only to a local Bridge on `127.0.0.1`, plus `/add-proton-mail`, which builds Bridge headless from the pinned upstream release in Docker (arm64 and x86), signs it in, and wires the channel.
- **Shape**: every correspondent is a DM — `platformId` is the lowercased sender address, user ids are `proton-mail:<address>`, strangers default to `request_approval`. `supportsThreads: false`; email threading is done with `In-Reply-To`/`References` on the reply.
- **Inbound**: IMAP IDLE with a 60 s fallback poll; quoted history stripped (Gmail and Outlook shapes); HTML-only mail flattened; attachments staged to the session inbox (15 MB cap, filename safety via `isSafeAttachmentName`); cursor persisted in `store/proton-mail/state.json`, existing mail skipped on first connect.
- **Outbound**: SMTP with `Re:` subject and thread headers; session outbox files as attachments; `ask_user_question` rendered with slash-command replies.
- **Loop safety**: `X-NanoClaw-Agent` header on outbound and dropped on inbound; `Auto-Submitted`, `Precedence: bulk/junk`, `mailer-daemon`/`noreply` senders dropped.
- **Out of scope**: landing the adapter on the `channels` registry branch (maintainers); group/mailing-list semantics; HTML outbound.

<details>
<summary>Bridge container notes</summary>

- Bridge 3.26 links `libfido2` for passkey login; the Dockerfile carries it and its link-time deps (`libcbor`, `libssl`, `libudev`, `libpcsclite`, `zlib`).
- `socat` re-exposes Bridge's loopback listeners on distinct internal ports (2025/2143). Same-port forwarding connects socat to itself until Bridge is up — a fork storm, observed at load average 236 on a Pi 5 before the fix.
- The bridge password and primary address are read from Bridge's vault with `vault-editor` (built alongside Bridge) instead of transcribed from `info`. Bridge's `no such user` is its answer to any credential mismatch; a hand-copied password with one stray character produced exactly that.
- Readiness check waits for the IMAP `* OK` greeting, not a bare TCP accept (the forwarder accepts before Bridge listens).
</details>

## Related work

No issue. Safe to review directly: purely additive — new files, one appended barrel import, five pinned deps. Trunk behavior is unchanged unless the skill is applied.

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec tsc --noEmit` on a worktree off `origin/main` with only this commit → clean
- `pnpm exec vitest run src/channels/proton-mail.test.ts src/channels/proton-mail-registration.test.ts scripts/skill-conformance.test.ts` → 225 passed (adapter units, registration through the real barrel, full conformance suite including this skill's `apply-fixtures.json`)
- `pnpm exec tsx scripts/skill-directives.ts .claude/skills/add-proton-mail/SKILL.md` → no problems, no warnings
- `pnpm exec eslint` + `prettier --check` on the new files → clean
- Full host suite on the install branch → 2254 passed; the 11 failures in `scripts/add-dial-tool-scope.test.ts` reproduce identically on a clean `origin/main` checkout (pre-existing, unrelated)
- Manual, end to end on a Raspberry Pi 5 (Debian 13, Docker 29.8): image built from source (v3.26.0), Bridge signed in, `init-first-agent` wiring, welcome email delivered via Bridge SMTP, reply from an Outlook account ingested via IMAP IDLE within seconds, agent answer delivered threaded under it
- New tests: `proton-mail-registration.test.ts` (barrel → registry, also guards the deps: an unmocked import throws if a package is missing), `proton-mail.test.ts` (quote stripping incl. Outlook web rule, auto-reply/bounce filter, subject handling, slash-command replies, attachment classification)

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
New channel: Proton Mail via a local Proton Mail Bridge (`/add-proton-mail`). Native IMAP/SMTP adapter; Bridge is built from source in Docker so it works on arm64 (Raspberry Pi) as well as x86. Requires a paid Proton plan.
```

## Security and trust boundaries

- Bridge's IMAP/SMTP ports are published on `127.0.0.1` only; the skill states why they must never be exposed on `0.0.0.0` (anyone with the bridge password reads the mailbox). Only the host process connects; containers never see Bridge.
- The Proton account password is never stored — Bridge holds the session in its vault (a `pass`/GPG store in a named Docker volume). Only the Bridge-generated local password goes to `.env`, written by the skill's `env-set` from a `vault-editor` capture, never echoed.
- Bridge presents a self-signed certificate on loopback; the adapter accepts it by default and `PROTON_MAIL_TLS_REJECT_UNAUTHORIZED=true` enforces verification for non-loopback setups.
- Inbound email is untrusted input: attachment filenames pass `isSafeAttachmentName` before staging; bodies are capped at 50k chars; unknown senders are held under `request_approval`; automated senders and our own echoes are dropped before the router.
- Dependencies pinned exactly (`imapflow`, `mailparser`, `nodemailer`, two `@types`), all past the 3-day `minimumReleaseAge` gate; no build-script approvals added.

## Skill delivery

- [ ] Not a skill
- [x] Skill: apply/remove footprint and fresh-clone verification are described above

Apply: copies 3 files from the `channels` branch, appends 1 barrel line, installs 5 pinned deps, builds a Docker image from `bridge/` in the skill dir, writes 2 `.env` keys, runs 1 container. Remove (`REMOVE.md`): reverses each — barrel line, files, deps, `.env` keys, `store/proton-mail`, container, image, volume. Fresh-clone verification: the branch was assembled and validated in a worktree checked out from `origin/main` containing nothing but this commit (see Validation).

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [x] A human has reviewed this PR and stands behind every change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4ZoRKZQ2RDdUNk7Ek2xNT
