### PR TITLE
refactor(providers): render provider instructions from core-owned canon

### DIFF
--- a/container/CLAUDE.md
+++ b/container/CLAUDE.md
@@ -20,6 +20,8 @@ Your persistent memory lives under `/workspace/agent/memory/`. The session-start
 
 Standing role, persona, and behavioral instructions belong in `/workspace/agent/instructions.prepend.md`; durable facts belong in memory. Changes to standing instructions take effect after the group container restarts, so say that when confirming an edit.
 
+{{provider-memory-note}}
+
 ## Conversation history
 
 The `conversations/` folder in your workspace holds searchable transcripts of past sessions with this group. Use it to recall prior context when a request references something that happened before. For structured long-lived data, prefer dedicated files (`customers.md`, `preferences.md`, etc.); split any file over ~500 lines into a folder with an index.

--- a/container/agent-runner/src/compact-instructions.test.ts
+++ b/container/agent-runner/src/compact-instructions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildCompactInstructions } from './compact-instructions.js';
+import { buildCompactInstructions, buildPostCompactionReminder } from './compact-instructions.js';
 
 describe('compaction delivery reminder', () => {
   it('preserves final-output addressing in chat sessions', () => {
@@ -17,5 +17,45 @@ describe('compaction delivery reminder', () => {
     expect(instructions).toContain('explicit to destination');
     expect(instructions).toContain('tasks/daily-digest-a1b2.md');
     expect(instructions).not.toContain('<message to="name">');
+  });
+
+  it('renders the delivery reminder byte-identically to the pre-extraction wording', () => {
+    const chat = buildCompactInstructions(['family', 'ops'], null);
+    expect(chat).toContain(
+      [
+        '   "You MUST wrap all responses in <message to="name">...</message> blocks.',
+        '   Available destinations: `family`, `ops`."',
+      ].join('\n'),
+    );
+
+    const task = buildCompactInstructions(['family'], 'daily-digest-a1b2');
+    expect(task).toContain(
+      [
+        '   "This is an isolated task run. If you need to send the user a message, use send_message with an explicit to destination.',
+        '   Final output is not delivered; it becomes the automatic summary in tasks/daily-digest-a1b2.md.',
+        '   Available destinations: `family`."',
+      ].join('\n'),
+    );
+  });
+});
+
+describe('post-compaction reminder', () => {
+  it('re-states the canonical delivery sentences with the live destinations', () => {
+    const reminder = buildPostCompactionReminder(['family', 'ops'], null);
+
+    expect(reminder).toBe(
+      '<system>The conversation was just compacted into a summary. Delivery instructions can be lost in ' +
+        'that summary, so as a reminder: You MUST wrap all responses in <message to="name">...</message> blocks. ' +
+        'Available destinations: `family`, `ops`.</system>',
+    );
+  });
+
+  it('teaches explicit-tool delivery in task sessions', () => {
+    const reminder = buildPostCompactionReminder([], 'daily-digest-a1b2');
+
+    expect(reminder).toContain('send_message');
+    expect(reminder).toContain('tasks/daily-digest-a1b2.md');
+    expect(reminder).toContain('Available destinations: (none).');
+    expect(reminder).not.toContain('<message to="name">');
   });
 });

--- a/container/agent-runner/src/compact-instructions.ts
+++ b/container/agent-runner/src/compact-instructions.ts
@@ -12,17 +12,45 @@
 import { getAllDestinations } from './destinations.js';
 import { getTaskSeriesId } from './db/session-routing.js';
 
-export function buildCompactInstructions(names: string[], taskId: string | null): string {
-  const deliveryReminder = taskId
+/**
+ * The canonical delivery-discipline sentences, shared by the pre-compaction
+ * steering below and the post-compaction reminder some providers inject when
+ * their runtime offers no compaction-prompt hook. Core owns this wording;
+ * providers must not restate it in their own words.
+ */
+export function buildDeliverySentences(names: string[], taskId: string | null): string[] {
+  return taskId
     ? [
-        '   "This is an isolated task run. If you need to send the user a message, use send_message with an explicit to destination.',
-        `   Final output is not delivered; it becomes the automatic summary in tasks/${taskId}.md.`,
-        `   Available destinations: ${formatDestinationNames(names)}."`,
+        'This is an isolated task run. If you need to send the user a message, use send_message with an explicit to destination.',
+        `Final output is not delivered; it becomes the automatic summary in tasks/${taskId}.md.`,
+        `Available destinations: ${formatDestinationNames(names)}.`,
       ]
     : [
-        '   "You MUST wrap all responses in <message to="name">...</message> blocks.',
-        `   Available destinations: ${formatDestinationNames(names)}."`,
+        'You MUST wrap all responses in <message to="name">...</message> blocks.',
+        `Available destinations: ${formatDestinationNames(names)}.`,
       ];
+}
+
+/**
+ * Reminder a provider injects on the first prompt AFTER its runtime
+ * auto-compacted the session, for runtimes (e.g. OpenCode) that expose no
+ * pre-compaction instruction hook: the summary can silently drop the delivery
+ * discipline, so it is re-stated — in the same canonical wording as the
+ * pre-compaction path — before the next turn.
+ */
+export function buildPostCompactionReminder(names: string[], taskId: string | null): string {
+  return (
+    '<system>The conversation was just compacted into a summary. Delivery instructions can be lost in ' +
+    `that summary, so as a reminder: ${buildDeliverySentences(names, taskId).join(' ')}</system>`
+  );
+}
+
+export function buildCompactInstructions(names: string[], taskId: string | null): string {
+  const sentences = buildDeliverySentences(names, taskId);
+  const deliveryReminder = sentences.map(
+    (sentence, index) =>
+      `   ${index === 0 ? '"' : ''}${sentence}${index === sentences.length - 1 ? '"' : ''}`,
+  );
 
   return [
     'Preserve the following in the compaction summary:',

--- a/src/project-doc-compose.test.ts
+++ b/src/project-doc-compose.test.ts
@@ -16,12 +16,18 @@ import {
 import { closeDb, createAgentGroup, getDb, initTestDb, runMigrations } from './db/index.js';
 import { PERSONA_PREPEND_FILE } from './group-persona.js';
 import { log } from './log.js';
-import { composeGroupProjectDoc, DEFAULT_PROJECT_DOC, type ProjectDocSpec } from './project-doc-compose.js';
+import {
+  BASE_INSTRUCTIONS_PATH,
+  composeGroupProjectDoc,
+  DEFAULT_PROJECT_DOC,
+  MEMORY_NOTE_PLACEHOLDER,
+  renderBaseInstructions,
+  type ProjectDocSpec,
+} from './project-doc-compose.js';
 import type { AgentGroup } from './types.js';
 
 const CLAUDE_SPEC: ProjectDocSpec = {
   fileName: 'CLAUDE.md',
-  baseDocPath: path.join('container', 'CLAUDE.md'),
 };
 
 function group(id: string, folder: string): AgentGroup {
@@ -92,7 +98,7 @@ describe('composeGroupProjectDoc delivery', () => {
     // emitted, only the body proves the file was read, and reading the source
     // here means adding a paragraph to it cannot break this test.
     const read = (...p: string[]): string => fs.readFileSync(path.join(process.cwd(), ...p), 'utf-8').trim();
-    expect(doc).toContain(read('container', 'CLAUDE.md'));
+    expect(doc).toContain(renderBaseInstructions(read('container', 'CLAUDE.md')));
     expect(doc).toContain(read('container', 'skills', 'onecli-gateway', 'instructions.md'));
     expect(doc).toContain(read('container', 'agent-runner', 'src', 'mcp-tools', 'cli.instructions.md'));
     expect(doc).toContain(read('container', 'agent-runner', 'src', 'mcp-tools', 'core.instructions.md'));
@@ -292,32 +298,82 @@ describe('composeGroupProjectDoc cli_scope', () => {
 });
 
 describe('composeGroupProjectDoc spec', () => {
-  it('places extra sections after the base document and before the module sections', async () => {
-    const ag = await seed('ag-extra', 'extra-group');
-
-    const doc = await compose(ag, {
-      ...CLAUDE_SPEC,
-      extraSections: [{ name: 'Memory System', body: 'memory pointer body' }],
-    });
-
-    expect(doc.indexOf('# NanoClaw Runtime Contract')).toBeLessThan(doc.indexOf('# Memory System'));
-    expect(doc.indexOf('# Memory System')).toBeLessThan(doc.indexOf('# NanoClaw Module: agents'));
+  // The instruction prose is core-owned canon: with no provider facts the
+  // rendered base must be byte-identical to the template minus its placeholder
+  // paragraph, so the Claude document never changes when facts are added for
+  // other providers.
+  it('renders the canonical base byte-identically when no provider facts are declared', () => {
+    const template = fs.readFileSync(path.join(process.cwd(), BASE_INSTRUCTIONS_PATH), 'utf-8');
+    expect(template.split(MEMORY_NOTE_PLACEHOLDER)).toHaveLength(2);
+    expect(renderBaseInstructions(template)).toBe(template.replace(`\n\n${MEMORY_NOTE_PLACEHOLDER}`, ''));
+    expect(renderBaseInstructions(template)).not.toContain(MEMORY_NOTE_PLACEHOLDER);
   });
 
-  // Tolerated so a partial payload install still spawns, but never silent: an
-  // absent runtime contract is the same shape as the bug this replaced, and it
-  // is what a wrong-cwd host looks like. Red if the warn is dropped.
+  it('renders provider facts as canonical prose in the declared slots', async () => {
+    const ag = await seed('ag-facts', 'facts-group');
+
+    const doc = await compose(ag, {
+      fileName: 'AGENTS.md',
+      instructions: {
+        nativeOverrideFiles: ['AGENTS.local.md', 'AGENTS.override.md'],
+        nativeSkills: {
+          discoveryPath: '/workspace/agent/.agents/skills',
+          sharedSource: '/app/skills',
+          selfAuthoredHome: '~/.codex/skills',
+          persistentRoots: ['~/.codex', '~/.agents'],
+          ruleBearingInlined: true,
+        },
+      },
+    });
+
+    expect(doc).toContain('Do not use `AGENTS.local.md` or `AGENTS.override.md` for memory.');
+    expect(doc).not.toContain(MEMORY_NOTE_PLACEHOLDER);
+    expect(doc).toContain('provider-native skills at `/workspace/agent/.agents/skills`');
+    expect(doc).toContain('`~/.codex/skills/<name>/SKILL.md`');
+    expect(doc).toContain('inlined as `NanoClaw Skill:` sections');
+    expect(doc.indexOf('# NanoClaw Runtime Contract')).toBeLessThan(doc.indexOf('# Native Runtime Skills'));
+    expect(doc.indexOf('# Native Runtime Skills')).toBeLessThan(doc.indexOf('# NanoClaw Module: agents'));
+  });
+
+  it('keeps pre-contract payload base documents and sections working', async () => {
+    const ag = await seed('ag-legacy-spec', 'legacy-spec-group');
+    const baseDocPath = path.join(TEST_ROOT, 'legacy-base.md');
+    fs.writeFileSync(baseDocPath, 'legacy provider instructions');
+
+    const doc = await compose(ag, {
+      fileName: 'AGENTS.md',
+      baseDocPath,
+      extraSections: [{ name: 'Legacy Pointer', body: 'legacy pointer text' }],
+    });
+
+    expect(doc).toContain('# NanoClaw Runtime Contract\n\nlegacy provider instructions');
+    expect(doc).toContain('# Legacy Pointer\n\nlegacy pointer text');
+  });
+
+  // Tolerated so a partial checkout still spawns, but never silent: an absent
+  // runtime contract is the same shape as the bug this replaced, and it is
+  // what a wrong-cwd host looks like. Red if the warn is dropped.
   it('writes the file named by the spec and warns loudly on a missing base document', async () => {
     const ag = await seed('ag-nobase', 'nobase-group');
+    const root = fs.mkdtempSync(path.join(TEST_ROOT, 'nobase-root-'));
+    fs.mkdirSync(path.join(root, 'container'));
+    fs.symlinkSync(path.join(process.cwd(), 'container', 'agent-runner'), path.join(root, 'container', 'agent-runner'));
+    fs.symlinkSync(path.join(process.cwd(), 'container', 'skills'), path.join(root, 'container', 'skills'));
+    const previousCwd = process.cwd();
+    process.chdir(root);
 
-    const doc = await compose(ag, { fileName: 'AGENTS.md', baseDocPath: path.join('container', 'nope.md') });
+    try {
+      const doc = await compose(ag, { fileName: 'AGENTS.md' });
 
-    expect(doc).not.toContain('# NanoClaw Runtime Contract');
-    expect(doc).toContain('# NanoClaw Module: core');
-    expect(log.warn).toHaveBeenCalledWith(
-      'Project document composed without its base document',
-      expect.objectContaining({ file: 'AGENTS.md' }),
-    );
+      expect(doc).not.toContain('# NanoClaw Runtime Contract');
+      expect(doc).toContain('# NanoClaw Module: core');
+      expect(log.warn).toHaveBeenCalledWith(
+        'Project document composed without its base document',
+        expect.objectContaining({ file: 'AGENTS.md' }),
+      );
+    } finally {
+      process.chdir(previousCwd);
+    }
   });
 });
 

--- a/src/project-doc-compose.ts
+++ b/src/project-doc-compose.ts
@@ -35,19 +35,92 @@ interface ProjectDocSection {
   droppable: boolean;
 }
 
+/**
+ * Typed provider variables rendered into the canonical instruction template.
+ * The template prose is core-owned (`container/CLAUDE.md` is the canon);
+ * providers supply only the facts below — paths, filenames, and flags — never
+ * their own instruction text, so every provider's agent reads the same ideas.
+ */
+export interface ProviderInstructionFacts {
+  /**
+   * Provider-native override files agents must not use for memory storage
+   * (e.g. files the provider's own runtime auto-loads). Rendered as one
+   * canonical sentence inside the Memory section.
+   */
+  nativeOverrideFiles?: readonly string[];
+  /**
+   * Provider-native skill discovery, rendered as the canonical runtime-skills
+   * section. Absent when the provider's runtime discovers the shared skills
+   * without document guidance.
+   */
+  nativeSkills?: {
+    /** Where the selected runtime skills appear inside the container. */
+    discoveryPath: string;
+    /** The read-only shared skill source the entries point back to. */
+    sharedSource: string;
+    /** Where agent-authored skills go, e.g. `~/.codex/skills`. */
+    selfAuthoredHome: string;
+    /** The only roots where skills persist and are discovered. */
+    persistentRoots: readonly string[];
+    /** Whether rule-bearing skills arrive inlined as sections of this document. */
+    ruleBearingInlined?: boolean;
+  };
+}
+
 /** Everything that differs between providers. The composition itself does not. */
 export interface ProjectDocSpec {
   /** File written into the group directory, e.g. `CLAUDE.md`. */
   fileName: string;
-  /** Shared base document, relative to the project root. A missing file is not an error. */
-  baseDocPath: string;
-  /**
-   * Provider-owned blocks, emitted after the base document and before the
-   * capability sections. Never droppable, which is why they carry no flag.
-   */
+  /** Provider variables for the canonical instruction template. */
+  instructions?: ProviderInstructionFacts;
+  /** @deprecated Pre-contract payload input; new contracts use the core-owned canon. */
+  baseDocPath?: string;
+  /** @deprecated Pre-contract payload input; new contracts use typed instruction facts. */
   extraSections?: { name: string; body: string }[];
   /** Hard byte cap. Undefined means no cap and no degradation ladder. */
   maxBytes?: number;
+}
+
+/** The canonical instruction template, relative to the project root. */
+export const BASE_INSTRUCTIONS_PATH = path.join('container', 'CLAUDE.md');
+
+/** Placeholder inside the canon's Memory section for the provider override-files note. */
+export const MEMORY_NOTE_PLACEHOLDER = '{{provider-memory-note}}';
+
+/**
+ * Render the canonical base instructions with the provider's memory note
+ * substituted (or the placeholder stripped without a trace). The no-facts
+ * render is byte-identical to the template minus the placeholder paragraph.
+ */
+export function renderBaseInstructions(template: string, facts?: ProviderInstructionFacts): string {
+  const files = facts?.nativeOverrideFiles ?? [];
+  const note =
+    files.length > 0 ? `Do not use ${files.map((file) => `\`${file}\``).join(' or ')} for memory.` : undefined;
+  return template.replace(`\n\n${MEMORY_NOTE_PLACEHOLDER}`, note ? `\n\n${note}` : '');
+}
+
+/**
+ * Render the canonical runtime-skills section from the provider's declared
+ * discovery facts. One prose for every provider; only the paths differ.
+ */
+export function renderNativeSkillsSection(
+  facts?: ProviderInstructionFacts,
+): { name: string; body: string } | undefined {
+  const skills = facts?.nativeSkills;
+  if (!skills) return undefined;
+  const roots = skills.persistentRoots.map((root) => `\`${root}\``).join(' and ');
+  return {
+    name: 'Native Runtime Skills',
+    body: [
+      `Selected NanoClaw runtime skills are available as provider-native skills at \`${skills.discoveryPath}\`.`,
+      `Each skill directory contains a \`SKILL.md\` with its trigger description plus any supporting files, and points to the read-only shared skill source under \`${skills.sharedSource}\`.`,
+      'Use skill discovery to load these skills only when their descriptions match the task.' +
+        (skills.ruleBearingInlined
+          ? ' A skill whose rules must hold before the task is recognised ships an `instructions.md` instead, and those arrive inlined as `NanoClaw Skill:` sections of this document.'
+          : ''),
+      `Skills YOU author or install yourself go in \`${skills.selfAuthoredHome}/<name>/SKILL.md\` — persistent across sessions and discovered automatically. Never write skills elsewhere: paths outside ${roots} are ephemeral or not discovered.`,
+    ].join('\n\n'),
+  };
 }
 
 /**
@@ -63,7 +136,6 @@ const CLAUDE_PROJECT_DOC_MAX_BYTES = 4 * 1024 * 1024;
 /** The spec for any provider that has not declared its own agent surfaces. */
 export const DEFAULT_PROJECT_DOC: ProjectDocSpec = {
   fileName: 'CLAUDE.md',
-  baseDocPath: path.join('container', 'CLAUDE.md'),
   maxBytes: CLAUDE_PROJECT_DOC_MAX_BYTES,
 };
 
@@ -114,14 +186,15 @@ export async function composeGroupProjectDoc(group: AgentGroup, groupDir: string
   const persona = readGroupPersona(groupDir);
   if (persona) push('Persona', persona);
 
-  const baseDoc = path.resolve(process.cwd(), spec.baseDocPath);
+  const legacySpec = spec.baseDocPath !== undefined;
+  const baseDoc = path.resolve(process.cwd(), spec.baseDocPath ?? BASE_INSTRUCTIONS_PATH);
   if (fs.existsSync(baseDoc)) {
-    push(BASE_DOC_SECTION, fs.readFileSync(baseDoc, 'utf-8'));
+    const template = fs.readFileSync(baseDoc, 'utf-8');
+    push(BASE_DOC_SECTION, legacySpec ? template : renderBaseInstructions(template, spec.instructions));
   } else {
-    // Tolerated (a partial payload install has no base document yet) but never
-    // silent: losing the runtime contract with no signal is the exact shape of
-    // the bug this composer replaced, and it is also what a wrong-cwd host
-    // looks like.
+    // Tolerated (a partial checkout has no template yet) but never silent:
+    // losing the runtime contract with no signal is the exact shape of the bug
+    // this composer replaced, and it is also what a wrong-cwd host looks like.
     log.warn('Project document composed without its base document', {
       file: spec.fileName,
       group: group.name,
@@ -129,7 +202,10 @@ export async function composeGroupProjectDoc(group: AgentGroup, groupDir: string
     });
   }
 
-  for (const extra of spec.extraSections ?? []) push(extra.name, extra.body);
+  for (const section of spec.extraSections ?? []) push(section.name, section.body);
+
+  const nativeSkills = renderNativeSkillsSection(spec.instructions);
+  if (nativeSkills) push(nativeSkills.name, nativeSkills.body);
 
   // Module instructions — every MCP/CLI module shipping a sibling
   // `<name>.instructions.md`, describing how to use that module's tools.

--- a/src/provider-contracts/claude.ts
+++ b/src/provider-contracts/claude.ts
@@ -11,7 +11,6 @@ import {
 export const CLAUDE_COMPATIBLE_HOST_SURFACES = {
   projectDocument: {
     fileName: DEFAULT_PROJECT_DOC.fileName,
-    baseDocumentFile: 'CLAUDE.md',
     maxBytes: DEFAULT_PROJECT_DOC.maxBytes,
     containerPath: '/workspace/agent/CLAUDE.md',
     mountClass: 'group-state',

--- a/src/provider-contracts/realize.test.ts
+++ b/src/provider-contracts/realize.test.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import './index.js';
+import { protectedProviderDocumentSourcePaths, providerDocumentSourcePath } from './realize.js';
+import { PROVIDER_HOST_CONTRACT_SEAM_VERSION, getProviderHostContract, type ProviderHostContract } from './registry.js';
+
+const ROOT = '/srv/nanoclaw';
+const CANON = path.resolve(ROOT, 'container', 'CLAUDE.md');
+
+function fakeContract(): ProviderHostContract {
+  return {
+    seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
+    projectDocument: {
+      fileName: 'AGENTS.md',
+      containerPath: '/workspace/agent/AGENTS.md',
+      mountClass: 'group-state',
+    },
+    stateVolumes: [],
+    skillBackings: [],
+    skillViews: [],
+    files: [],
+  };
+}
+
+describe('protectedProviderDocumentSourcePaths', () => {
+  it('protects the canonical template for the installed Claude contract', () => {
+    expect(protectedProviderDocumentSourcePaths(ROOT)).toEqual([CANON]);
+  });
+
+  it('protects the canon regardless of which contracts are registered', () => {
+    // Protection is core-owned since every contract renders from the one
+    // canonical template; no declaration switches it on or off.
+    expect(getProviderHostContract('claude')).toBeDefined();
+    expect(providerDocumentSourcePath(ROOT, fakeContract())).toBe(CANON);
+    expect(protectedProviderDocumentSourcePaths(ROOT)).toEqual([CANON]);
+  });
+});

--- a/src/provider-contracts/realize.ts
+++ b/src/provider-contracts/realize.ts
@@ -5,7 +5,7 @@ import { DATA_DIR } from '../config.js';
 import { materializeTemplateSkills } from '../group-skills.js';
 import { log } from '../log.js';
 import { writeAtomic } from '../migrate-claude-memory-settings.js';
-import { DEFAULT_PROJECT_DOC, type ProjectDocSpec } from '../project-doc-compose.js';
+import { BASE_INSTRUCTIONS_PATH, type ProjectDocSpec } from '../project-doc-compose.js';
 
 import {
   describeRegisteredProviderFileTransformers,
@@ -20,20 +20,28 @@ import {
   type ProviderStateVolume,
 } from './registry.js';
 
-// Core-owned: the shipped base document is protected unconditionally; no
-// provider contract switches this on or off.
+/**
+ * The host file a contract's project document is rendered from. Every
+ * contract renders from core's canonical instruction template; a contract
+ * declares facts for it, never a document of its own.
+ */
+export function providerDocumentSourcePath(projectRoot: string, contract: ProviderHostContract): string | undefined {
+  if (contract.projectDocument === undefined) return undefined;
+  return path.resolve(projectRoot, BASE_INSTRUCTIONS_PATH);
+}
+
+// Core-owned: the canonical instruction template is protected unconditionally;
+// no provider contract switches this on or off.
 export function protectedProviderDocumentSourcePaths(projectRoot: string): string[] {
-  return [path.resolve(projectRoot, DEFAULT_PROJECT_DOC.baseDocPath)];
+  return [path.resolve(projectRoot, BASE_INSTRUCTIONS_PATH)];
 }
 
 export function providerProjectDocSpec(contract: ProviderHostContract): ProjectDocSpec | undefined {
   if (contract.projectDocument === undefined) return undefined;
-  const { fileName, baseDocumentFile, extraSections, maxBytes } = contract.projectDocument;
-  resolveWithinRoot(path.resolve(process.cwd(), 'container'), baseDocumentFile);
+  const { fileName, instructions, maxBytes } = contract.projectDocument;
   return {
     fileName,
-    baseDocPath: path.join('container', baseDocumentFile),
-    ...(extraSections ? { extraSections } : {}),
+    ...(instructions ? { instructions } : {}),
     ...(maxBytes === undefined ? {} : { maxBytes }),
   };
 }

--- a/src/provider-contracts/registry.test.ts
+++ b/src/provider-contracts/registry.test.ts
@@ -15,7 +15,6 @@ function emptyContract(): ProviderHostContract {
     seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
     projectDocument: {
       fileName: 'AGENTS.md',
-      baseDocumentFile: 'AGENTS.md',
       containerPath: '/workspace/agent/AGENTS.md',
       mountClass: 'group-state',
     },
@@ -156,14 +155,14 @@ describe('provider host contracts', () => {
 
   it.each([
     [
-      'host path',
+      'host path in override files',
       () => ({
         ...emptyContract(),
         projectDocument: {
           fileName: 'AGENTS.md',
-          baseDocumentFile: '/tmp/AGENTS.md',
           containerPath: '/workspace/agent/AGENTS.md',
           mountClass: 'group-state' as const,
+          instructions: { nativeOverrideFiles: ['/tmp/AGENTS.local.md'] },
         },
       }),
       /one file or directory name/,
@@ -215,16 +214,59 @@ describe('provider host contracts', () => {
   });
 
   it.each([
-    ['not an array', {}, /projectDocument\.extraSections must be an array/],
-    ['missing name', [{ body: 'body' }], /extraSections\[0\]\.name must be a non-empty string/],
-    ['missing body', [{ name: 'name' }], /extraSections\[0\]\.body must be a non-empty string/],
-    ['blank name', [{ name: ' ', body: 'body' }], /extraSections\[0\]\.name must be a non-empty string/],
-    ['blank body', [{ name: 'name', body: ' ' }], /extraSections\[0\]\.body must be a non-empty string/],
-  ])('rejects malformed project-document extra sections: %s', (_label, value, expected) => {
+    ['baseDocumentFile', 'CLAUDE.md'],
+    ['extraSections', [{ name: 'Extra', body: 'Provider prose.' }]],
+  ])('rejects the removed project-document key %s with an operator fix', (key, value) => {
     expect(() =>
       registerProviderHostContract(
-        contractName(`extra-sections-${_label}`, 'invalid'),
-        claudeContractWith('projectDocument.extraSections', value),
+        contractName(`removed-${key}`, 'stale'),
+        claudeContractWith(`projectDocument.${key}`, value),
+      ),
+    ).toThrow(
+      `.projectDocument.${key} is no longer part of the host contract; instructions are core-owned (run /update-skills)`,
+    );
+  });
+
+  it.each([
+    ['non-object facts', 'projectDocument.instructions', 'invalid', /instructions must be an object/],
+    ['null skills facts', 'projectDocument.instructions', { nativeSkills: null }, /nativeSkills must be an object/],
+    [
+      'empty override files',
+      'projectDocument.instructions',
+      { nativeOverrideFiles: [] },
+      /nativeOverrideFiles must be a non-empty array/,
+    ],
+    [
+      'relative skills discovery path',
+      'projectDocument.instructions',
+      {
+        nativeSkills: {
+          discoveryPath: 'skills',
+          sharedSource: '/app/skills',
+          selfAuthoredHome: '~/.codex/skills',
+          persistentRoots: ['~/.codex'],
+        },
+      },
+      /nativeSkills\.discoveryPath/,
+    ],
+    [
+      'empty persistent roots',
+      'projectDocument.instructions',
+      {
+        nativeSkills: {
+          discoveryPath: '/workspace/agent/.agents/skills',
+          sharedSource: '/app/skills',
+          selfAuthoredHome: '~/.codex/skills',
+          persistentRoots: [],
+        },
+      },
+      /persistentRoots must be a non-empty array/,
+    ],
+  ])('rejects malformed project-document instruction facts: %s', (_label, field, value, expected) => {
+    expect(() =>
+      registerProviderHostContract(
+        contractName(`instruction-facts-${_label}`, 'invalid'),
+        claudeContractWith(field, value),
       ),
     ).toThrow(expected);
   });

--- a/src/provider-contracts/registry.ts
+++ b/src/provider-contracts/registry.ts
@@ -14,6 +14,7 @@
 
 import path from 'path';
 
+import type { ProviderInstructionFacts } from '../project-doc-compose.js';
 import { listProviderContainerConfigNames } from '../providers/provider-container-registry.js';
 
 import { describeRegisteredProviderFileTransformers, getProviderFileTransformer } from './file-transformers.js';
@@ -28,9 +29,11 @@ export const PROVIDER_HOST_CONTRACT_SEAM_VERSION = 1;
 
 export interface ProviderProjectDocument {
   fileName: string;
-  /** Shipped filename under core's container document root; never a host path. */
-  baseDocumentFile: string;
-  extraSections?: { name: string; body: string }[];
+  /**
+   * Typed variables for core's canonical instruction template. The prose is
+   * core-owned; a provider declares only paths, filenames, and flags.
+   */
+  instructions?: ProviderInstructionFacts;
   maxBytes?: number;
   /** Destination inside the agent container. */
   containerPath: string;
@@ -203,17 +206,50 @@ export function assertProviderHostContractShape(provider: string, contract: Prov
   const doc = contract.projectDocument;
   if (doc === undefined) throw new Error(`${provider}.projectDocument is required`);
   if (doc === null || typeof doc !== 'object') throw new Error(`${provider}.projectDocument must be an object`);
+  // Removed with the core-owned canon: a payload still declaring them is
+  // stale, and its instructions would silently render without them.
+  for (const key of ['baseDocumentFile', 'extraSections']) {
+    if (Object.hasOwn(doc, key)) {
+      throw new Error(
+        `${provider}.projectDocument.${key} is no longer part of the host contract; instructions are core-owned (run /update-skills)`,
+      );
+    }
+  }
   assertFileName(doc.fileName, `${provider}.projectDocument.fileName`);
-  assertFileName(doc.baseDocumentFile, `${provider}.projectDocument.baseDocumentFile`);
   assertContainerPath(doc.containerPath, `${provider}.projectDocument.containerPath`);
   assertAllowed(doc.mountClass, ['group-state', 'allowlisted-extra'], `${provider}.projectDocument.mountClass`);
-  if (doc.extraSections !== undefined) {
-    if (!Array.isArray(doc.extraSections)) {
-      throw new Error(`${provider}.projectDocument.extraSections must be an array`);
+  if (doc.instructions !== undefined) {
+    const facts = doc.instructions;
+    if (facts === null || typeof facts !== 'object') {
+      throw new Error(`${provider}.projectDocument.instructions must be an object`);
     }
-    for (const [index, section] of doc.extraSections.entries()) {
-      assertNonEmptyString(section?.name, `${provider}.projectDocument.extraSections[${index}].name`);
-      assertNonEmptyString(section?.body, `${provider}.projectDocument.extraSections[${index}].body`);
+    if (facts.nativeOverrideFiles !== undefined) {
+      if (!Array.isArray(facts.nativeOverrideFiles) || facts.nativeOverrideFiles.length === 0) {
+        throw new Error(`${provider}.projectDocument.instructions.nativeOverrideFiles must be a non-empty array`);
+      }
+      for (const file of facts.nativeOverrideFiles) {
+        assertFileName(file, `${provider}.projectDocument.instructions.nativeOverrideFiles[]`);
+      }
+    }
+    if (facts.nativeSkills !== undefined) {
+      const skills = facts.nativeSkills;
+      if (skills === null || typeof skills !== 'object') {
+        throw new Error(`${provider}.projectDocument.instructions.nativeSkills must be an object`);
+      }
+      assertContainerPath(skills.discoveryPath, `${provider}.projectDocument.instructions.nativeSkills.discoveryPath`);
+      assertContainerPath(skills.sharedSource, `${provider}.projectDocument.instructions.nativeSkills.sharedSource`);
+      assertNonEmptyString(
+        skills.selfAuthoredHome,
+        `${provider}.projectDocument.instructions.nativeSkills.selfAuthoredHome`,
+      );
+      if (!Array.isArray(skills.persistentRoots) || skills.persistentRoots.length === 0) {
+        throw new Error(
+          `${provider}.projectDocument.instructions.nativeSkills.persistentRoots must be a non-empty array`,
+        );
+      }
+      for (const root of skills.persistentRoots) {
+        assertNonEmptyString(root, `${provider}.projectDocument.instructions.nativeSkills.persistentRoots[]`);
+      }
     }
   }
   if (doc.maxBytes !== undefined && (!Number.isInteger(doc.maxBytes) || doc.maxBytes <= 0)) {

--- a/src/provider-surfaces.test.ts
+++ b/src/provider-surfaces.test.ts
@@ -67,7 +67,6 @@ registerProviderHostContract('ordered-mount-provider', {
   seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
   projectDocument: {
     fileName: 'AGENTS.md',
-    baseDocumentFile: 'CLAUDE.md',
     containerPath: '/workspace/agent/AGENTS.md',
     mountClass: 'allowlisted-extra',
   },
@@ -112,7 +111,6 @@ registerProviderHostContract('partial-install-provider', {
   seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
   projectDocument: {
     fileName: 'AGENTS.md',
-    baseDocumentFile: 'AGENTS.md',
     containerPath: '/workspace/agent/AGENTS.md',
     mountClass: 'group-state',
   },
@@ -484,7 +482,6 @@ describe('derived provider spawn surfaces', () => {
       seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
       projectDocument: {
         fileName: 'AGENTS.md',
-        baseDocumentFile: 'AGENTS.md',
         containerPath: '/workspace/agent/AGENTS.md',
         mountClass: 'group-state',
       },
@@ -501,7 +498,6 @@ describe('derived provider spawn surfaces', () => {
       seamVersion: PROVIDER_HOST_CONTRACT_SEAM_VERSION,
       projectDocument: {
         fileName: 'AGENTS.md',
-        baseDocumentFile: 'AGENTS.md',
         containerPath: '/workspace/agent/AGENTS.md',
         mountClass: 'group-state',
       },


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Makes agent instruction prose core-owned: providers declare typed facts, core renders the canon.

- **Problem**: a provider could supply free-form instruction sections and its own base document, restating core semantics in different words.
- **Fix**: a provider's project document declares only native override files (not to be used for memory) and native skill-discovery paths. Core renders them into canonical sentences and the canonical runtime-skills section. `extraSections` and per-provider base documents are gone from the contract; a stale contract carrying them is rejected at registration with an operator fix.
- **Also**: the opaque context pass-through is removed from the managed-file seam; transforms consume only rendered sections.
- **Compatibility**: pre-contract payloads that call the composer with a base document keep the legacy path.
- **Protection is core's**: with one canonical template, protecting it no longer depends on any contract declaring it.

## Related work

Replaces #3591 at the same tested head. GitHub automatically closed the previous PR when its former base was restacked above this commit. The instructions change still requires review and has not landed on main.

On nanocoai/nanoclaw#3585, before #3592 and the installer in #3586. Merge order: #3584 → #3581 → #3585 → #3727 → #3592 → #3586. OpenCode (#3588 and #3722) and Cursor remain deferred.

## Change kind

- [ ] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [x] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

Current reordered head passed provider install and refresh using the final Codex payload. The final core tree is unchanged. Earlier implementation checks:

- `pnpm run build` -> clean
- `pnpm test` -> 2,278 passed, 1 skipped
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` -> clean
- `cd container/agent-runner && bun test` -> 393 passed, 3 skipped
- Claude project document rendered at base and head for plain, persona, and `cli_scope=disabled` groups -> identical bytes
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

## Security and trust boundaries

None. Providers lose a free-text channel into the instructions core writes.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
