### PR TITLE
feat(setup): connect the host to its community cell and manage perks in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,33 @@ your machine.
 One opt-in exception: you can [fetch a prebuilt agent image](docs/hardened-image.md) instead of
 building it locally. Fetching ours needs a free account, so we see your email address and when
 you ask for an image — nothing about your agents, and nothing after the image lands. Building
-locally needs no account and contacts nothing, and is the default.
+locally needs no account and contacts nothing, and is the default. The same account unlocks the
+[perks](#perks) below.
+
+## Perks
+
+The free account also opens the **community portal** at [portal.nanoclaw.dev](https://portal.nanoclaw.dev),
+a dashboard where you switch on what the account offers. Today that is Echo's hardened agent
+image and a managed Slack app for your agent, created and installed for you with no tokens to
+paste. Everything else in NanoClaw works without it.
+
+Setup opens the portal once. You sign in in the browser, approve the terminal you are running
+setup from, and enable the perk; the wizard notices and continues on its own. Enabling Echo is
+where you agree to Echo's terms, including whether you want product and security email. Close
+the page without enabling anything and setup carries on without the perk, then offers it once
+more later.
+
+What stays on your machine: the sign-in record and install token in `~/.config/nanoclaw/account.json`,
+one device key per machine in `~/.config/nanoclaw/device-key.json`, and this checkout's journal in
+`data/community-portal.json` (which perks are on, setup progress, the credentials a perk handed
+you), all mode `0600`. The install token never passes through the browser: the browser sees only
+the one-time sign-in code, and the token reaches this machine from the account service directly.
+The host keeps one outbound connection to the portal so a perk you change in the browser reaches
+the running agent; it sends nothing about your agents, messages or files.
+
+Revisit a step with `pnpm exec tsx setup/portal.ts --stage echo` or `--stage slack`. To sign a
+machine out, forget it under **Devices** in the portal: its token stops working and the host
+disconnects. Files, recovery commands and troubleshooting: [docs/community-portal.md](docs/community-portal.md).
 
 ## Usage
 

--- a/docs/community-portal.md
+++ b/docs/community-portal.md
@@ -1,0 +1,124 @@
+# The community portal
+
+[portal.nanoclaw.dev](https://portal.nanoclaw.dev) is the dashboard for the free NanoClaw account:
+sign in, and switch on what the account offers. Today that is **Echo's hardened agent image** and a
+**managed Slack app** for your agent (its manifest, avatar and workspace install are created for
+you; no tokens to paste). No other perk is offered or started by the CLI. Everything else in
+NanoClaw works without an account; see [Accounts and what leaves your machine](../README.md#accounts-and-what-leaves-your-machine).
+
+Nothing here needs a special clone. Follow the [Quick Start](../README.md#quick-start) on `main`
+and the wizard opens the portal at the Echo and Slack steps. `NANOCLAW_PORTAL_ORIGIN` points a
+checkout at a different portal; leave it unset.
+
+## How setup uses it
+
+**Not signed in yet.** The wizard asks before opening a browser, then prints one link and opens
+it. The page, "Approve your terminal", shows a short code and one button, "Sign in and approve".
+Signing in there is the account sign-in (WorkOS, the OAuth device flow); approving binds this
+machine to your account. The dashboard then opens with the perk's activation modal. Enable it and
+the terminal continues on its own. Headless machine: the link, the code and the sign-in page are
+printed on their own lines so you can open them from a phone or laptop.
+
+**Already signed in** (from an earlier step, or from `bash setup/registry-login.sh`): the wizard
+skips sign-in, makes sure this machine is registered at the portal, and opens the dashboard link.
+
+**Enabling Echo** is where you agree to Echo's terms, including whether you want product and
+security email from NanoClaw and from Echo. Only Echo carries terms; Slack activation is a
+workspace connection and an app install.
+
+**Skipping.** Close the modal, press Escape or choose "Maybe later" and the terminal continues
+without the perk. Setup offers Echo once more before the service starts and Slack once more
+before verification; decline and it does not ask again (`pnpm exec tsx setup/portal.ts --stage
+echo` or `--stage slack` still works at any time).
+
+Under the hood, for every stage: sign in if needed, ensure the device key, register the device
+(`POST /api/v1/devices`, idempotent), start the stage, wait for the browser, apply the result,
+report completion. The wizard polls the portal; nothing calls back into your machine.
+
+## Files and locks on your machine
+
+| File | Mode | Holds |
+| --- | --- | --- |
+| `~/.config/nanoclaw/account.json` | 0600 | The sign-in record and the install token. Written by the sign-in, never by the portal client. Per user, shared by every checkout on the machine. |
+| `~/.config/nanoclaw/registry-auth.json` | 0600 | The docker credential helper's view of the same token. |
+| `~/.config/nanoclaw/host-id` | 0600 | The per-machine install id the sign-in enrolled with. |
+| `~/.config/nanoclaw/device-key.json` | 0600 | One P-256 key per machine, generated on first need. It signs the device proof on two requests only: device registration and the cell ticket. It never leaves the machine, and an unreadable file is an error, never a reason to mint a second identity. |
+| `<checkout>/data/community-portal.json` | 0600 | This checkout's journal: the portal origin, the device id, setup progress, and the credentials a perk handed you. No key and no token. |
+| `<checkout>/data/slack-install.json` | 0600 | The saved background Slack installation (below). |
+| `data/community-portal.json.lock`, `data/setup-mutation.lock`, `data/slack-install.json.lock`, `data/community-portal-runtime.lock` | | Owner-stamped lock files; a crashed owner is recognised by its process birth time and reclaimed. |
+
+The install token never passes through the browser: the browser sees the one-time sign-in code,
+and the token reaches this machine from the account service. Every request to the portal carries
+that token; the two requests above add the device proof. Never share or commit any of these
+files; keep them when recovering an interrupted setup.
+
+## Background Slack installation
+
+A Slack app may need a workspace admin's approval, which can take days. Setup saves the job in
+`data/slack-install.json` and starts a detached worker that survives closing the terminal. It checks
+approval at most once a minute for seven days, saves the bot credential before acknowledging
+delivery, then applies the Slack channel skill with the captured agent name, operator role and
+owner, and queues the welcome message. There are no further prompts. The worker and foreground
+setup serialise checkout changes through `data/setup-mutation.lock`.
+
+The running NanoClaw service supervises the saved job and resumes it after a service or machine
+restart, with the terminal and browser closed. Verification reports success while approval is
+pending (`SLACK_INSTALL: awaiting_approval` or `installing`, `WIRING: pending_slack_install`); a
+failed or expired job still fails it.
+
+Recovery:
+
+- Retry a failed job, or resume the Slack step after fixing what it reported:
+  `pnpm exec tsx setup/portal.ts --stage slack`. The saved app is reused; a resumed setup never
+  creates a duplicate.
+- Re-check and resume the worker: `pnpm exec tsx setup/index.ts --step verify`.
+- After the seven-day window expires the job is marked expired. Review or revoke the old app in
+  the portal, then start a new installation with the command above.
+- An ambiguous Slack create (the portal may have finished it) is held for you to review the agent
+  list in the portal before recovering; setup will not repeat it on its own.
+
+Agents created later from inside Slack wait five minutes for approval, then park the saved app;
+after a later approval, ask the existing agent in Slack to finish setting it up. They do not use
+the initial installer's worker.
+
+## Presence and the link
+
+**Devices** in the portal shows a machine as online while its host link is up. The host asks the
+portal for a short-lived ticket (with the device proof), dials `wss://portal.nanoclaw.dev/cell/link`,
+announces itself, pings every 20 seconds, and reconnects with a fresh ticket after a missed pong
+or a dropped connection, backing off from one second to at most thirty. The portal drops a link
+that stays silent for 65 seconds. Over the link the host receives only the account's perk
+snapshot and device presence; it sends nothing about your agents, messages or files. Foreground
+setup can hold the journal while the host stays connected; the service need not stop.
+
+## Signing a machine out
+
+Forget the machine under **Devices** in the portal. Its install token stops working at the
+account service, the host is disconnected and logs `sign_in_required`, and the perk credentials in
+the journal are dropped. Run a setup stage again to register the machine afresh under the same
+account; `pnpm exec tsx setup/index.ts --step registry -- --status` shows the sign-in state.
+Signing out of the browser only ends that browser session.
+
+## Troubleshooting
+
+- **The setup link expired.** Links are short-lived. Run the stage again for a fresh link and
+  code; the saved journal is reused.
+- **"Approve your terminal" keeps waiting.** The page advances once the terminal's sign-in has
+  landed. Check that the terminal is still running the stage and that you completed the sign-in
+  behind "Sign in and approve" (the code on the page must match the one the terminal printed). If
+  the terminal was closed, run the stage again; the old page stays parked and expires on its own.
+- **"This machine is registered under a different device key" (`device_pinned`).** The portal
+  pinned another key for this machine: `device-key.json` was deleted and regenerated, or
+  `account.json` was copied from another machine. Forget the device under **Devices**, then run
+  the stage again. Never copy `account.json` or `device-key.json` between machines.
+- **"Maximum number of devices" (`device_limit`).** An account holds ten live devices. Forget one
+  you no longer use, then retry.
+- **`sign_in_required` in the host log after forgetting a device.** Expected: the host stopped
+  dialling because the identity is no longer valid. Run a setup stage to register again.
+- **"Your NanoClaw sign-in is no longer valid here."** The token was revoked or expired. Sign in
+  again with `pnpm exec tsx setup/index.ts --step registry`, then retry the stage.
+- **"The device key at … could not be read."** The file exists but is unreadable or corrupt. Fix
+  its permissions or remove it; a removed key means a new device identity, so forget the old
+  device in the portal first.
+- **`installation_required` (403) from a perk request.** The machine is signed in but not
+  registered at the portal yet. Any setup stage registers it.

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -33,6 +33,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
+import { withSetupLock, launchSlackJob, readSlackJob, slackJobStatus } from '../src/community-portal/slack-job.js';
 // The pre-step-aware entry point consults each channel's registered wizard
 // extensions (setup/channels/companions.ts) before running its install skill
 // — the wizard itself stays free of channel-specific imports.
@@ -44,6 +45,7 @@ import {
   type ChannelChoice,
 } from './channels/initial-setup.js';
 import { runInheritScript } from './lib/inherit-script.js';
+import { offerPortalReminder, portalEnabled, runImagePortal } from './portal.js';
 import { pingCliAgent, PING_AGENT_FOLDER, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
@@ -523,6 +525,40 @@ async function main(): Promise<void> {
     }
   }
 
+  if (
+    portalEnabled() &&
+    !skip.has('echo-reminder') &&
+    readImageSource() !== 'hardened' &&
+    readAgentImagePin() &&
+    (process.env.NANOCLAW_AGENT_PROVIDER || readEnvKey('DEFAULT_AGENT_PROVIDER') || DEFAULT_AGENT_PROVIDER || 'claude')
+      .trim()
+      .toLowerCase() === 'claude'
+  ) {
+    try {
+      await offerPortalReminder('echo', () =>
+        runImagePortal({
+          browserConsent: true,
+          apply: async () => {
+            const res = await runWindowedStep('container', {
+              running: 'Fetching Echo’s hardened image…',
+              done: 'Hardened sandbox ready.',
+              failed: 'Could not fetch the hardened image.',
+            });
+            if (!res.ok)
+              throw new Error('The hardened image could not be prepared. Your previous image choice has been kept.');
+          },
+        }),
+      );
+      skip.add('echo-reminder');
+    } catch (error) {
+      await fail(
+        'container',
+        'Could not finish Echo setup.',
+        error instanceof Error ? error.message : 'Retry the image setup step.',
+      );
+    }
+  }
+
   if (!skip.has('service')) {
     const res = await runQuietStep('service', {
       running: 'Starting NanoClaw in the background…',
@@ -709,20 +745,30 @@ async function main(): Promise<void> {
       if (result === BACK_TO_CHANNEL_SELECTION) backed = true;
     }
   }
-  // Setup-selected targets are one-run-only. A later setup derives connect
-  // choices from current wirings instead of inheriting an old agent id.
-  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
-
   // Deferred wire (Teams): verify passes with zero groups because the
   // platform id only exists after the first DM. Tracked here so the ENDING
   // changes too — the last box must be the one remaining action, not a
   // premature "your assistant is saying hi" (no welcome DM exists yet).
   let wiringPending = false;
 
+  if (
+    portalEnabled() &&
+    !skip.has('slack-reminder') &&
+    !(process.env.SLACK_BOT_TOKEN || readEnvKey('SLACK_BOT_TOKEN'))?.trim()
+  ) {
+    await offerPortalReminder('slack', async () => {
+      const result = await runChannelSkillWithPreStep('slack', await resolveDisplayName(), { browserConsent: true });
+      if (result !== BACK_TO_CHANNEL_SELECTION) channelChoice = 'slack';
+    });
+    skip.add('slack-reminder');
+  }
+  // Keep the chosen agent through the later Slack offer as well. A later run
+  // derives connect choices from current wirings instead of inheriting this id.
+  delete process.env.NANOCLAW_TEMPLATE_AGENT_ID;
   if (!skip.has('verify')) {
     const res = await runQuietStep('verify', {
       running: 'Making sure everything works together…',
-      done: "Everything's connected.",
+      done: 'NanoClaw is running.',
       failed: 'A few things still need your attention.',
     });
     if (!res.ok) {
@@ -745,7 +791,17 @@ async function main(): Promise<void> {
           ),
         );
       }
-      if (!res.terminal?.fields.CONFIGURED_CHANNELS) {
+      const slackInstall = res.terminal?.fields.SLACK_INSTALL;
+      if (slackInstall === 'failed') {
+        notes.push(
+          '• Slack installation needs attention. Check its progress in the portal, then resume with `pnpm exec tsx setup/portal.ts --stage slack`.',
+        );
+      } else if (slackInstall === 'expired') {
+        notes.push('• Slack approval expired. Review the existing app in the portal before restarting Slack setup.');
+      } else if (
+        !res.terminal?.fields.CONFIGURED_CHANNELS &&
+        !['awaiting_approval', 'installing'].includes(slackInstall ?? '')
+      ) {
         notes.push(
           '• Want to chat from your phone? Add a messaging app with `/add-telegram`, `/add-slack`, or `/add-discord`.',
         );
@@ -795,11 +851,29 @@ async function main(): Promise<void> {
     'Heads up',
   );
 
+  const slackStatus = slackJobStatus(await readSlackJob());
+  if (slackStatus === 'failed' || slackStatus === 'expired') {
+    note(
+      slackStatus === 'expired'
+        ? 'Slack approval expired. Review the existing app in the portal before restarting Slack setup.'
+        : 'Slack installation needs attention. Check its progress in the portal, then resume with `pnpm exec tsx setup/portal.ts --stage slack`.',
+      'Slack setup',
+    );
+    p.outro(k.yellow('NanoClaw is running. Slack needs attention.'));
+    return;
+  }
+
   setupLog.complete(Date.now() - RUN_START);
   phEmit('setup_completed', { duration_ms: Date.now() - RUN_START });
 
   const dmTarget = channelDmLabel(channelChoice);
-  if (wiringPending) {
+  if (slackStatus === 'awaiting_approval' || slackStatus === 'installing') {
+    note(
+      'Slack is finishing in the background. Once approval and installation finish, your agent will DM you in Slack. Keep this machine online; no return to the terminal is needed while the background job is running. Follow progress in the portal.',
+      'Slack setup',
+    );
+    p.outro(k.green('NanoClaw is ready. Slack will connect when installation finishes.'));
+  } else if (wiringPending) {
     // No welcome DM exists yet — the one remaining action is the last thing
     // on screen, in the same bright framed style as the "go say hi" banner.
     note(
@@ -1312,6 +1386,10 @@ async function chooseImageSource(): Promise<void> {
   // whose install then has no image to pull — so don't ask a question whose
   // good answer cannot be honoured.
   if (!readAgentImagePin()) return;
+  if (portalEnabled()) {
+    await runImagePortal();
+    return;
+  }
 
   p.log.message(
     brandBody(
@@ -1425,13 +1503,16 @@ async function askAgentProviderChoice(): Promise<string> {
     })),
   ];
   const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
-  if (preset) {
-    if (!options.some((option) => option.value === preset)) {
+  // Fresh installs use Claude without another setup prompt. Explicit presets
+  // still win, and an existing non-Claude default keeps its provider picker.
+  const automatic = preset || (DEFAULT_AGENT_PROVIDER === 'claude' ? 'claude' : undefined);
+  if (automatic) {
+    if (!options.some((option) => option.value === automatic)) {
       throw new Error(`NANOCLAW_AGENT_PROVIDER=${preset} is not available in this NanoClaw install`);
     }
-    setupLog.userInput('agent_provider', preset);
-    phEmit('agent_provider_chosen', { provider: preset, preset: true });
-    return preset;
+    setupLog.userInput('agent_provider', automatic);
+    phEmit('agent_provider_chosen', { provider: automatic, preset: Boolean(preset) });
+    return automatic;
   }
   // The pick is persisted as the instance default (DEFAULT_AGENT_PROVIDER), so
   // pre-select the current default — a re-run Enter-through then preserves it
@@ -2019,7 +2100,10 @@ function initProgressionLog(): void {
   });
 }
 
-main().catch((err) => {
+withSetupLock(async () => {
+  await launchSlackJob();
+  await main();
+}).catch((err) => {
   p.log.error(err instanceof Error ? err.message : String(err));
   p.cancel('Setup aborted.');
   process.exit(1);

--- a/setup/channels/companions.ts
+++ b/setup/channels/companions.ts
@@ -32,7 +32,10 @@ import { registerTelegramPreStep } from './telegram-pre-step.js';
  * assistant name. Resolves to the skill inputs to pre-bind, or undefined for
  * the manual walkthrough.
  */
-export type ChannelPreStep = (agentName: string) => Promise<Record<string, string> | undefined>;
+export type ChannelPreStep = (
+  agentName: string,
+  options?: { browserConsent?: boolean },
+) => Promise<Record<string, string> | undefined>;
 
 const preSteps = new Map<string, ChannelPreStep>();
 const companionSkills = new Map<string, readonly string[]>();

--- a/setup/channels/run-channel-skill.test.ts
+++ b/setup/channels/run-channel-skill.test.ts
@@ -624,3 +624,21 @@ describe('companionSkillPresent (in-tree presence check)', () => {
     rmSync(root, { recursive: true, force: true });
   });
 });
+
+it('background Slack setup refuses to report ready when a required companion is missing', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'rcs-background-'));
+  try {
+    mkdirSync(join(root, 'src/channels'), { recursive: true });
+    writeFileSync(join(root, 'src/channels/index.ts'), '// barrel\n');
+    writeFileSync(join(root, '.env'), '');
+    writeFileSync(join(root, 'package.json'), '{"name":"scratch"}');
+    const wire = vi.fn(async () => true);
+    await expect(runChannelSkill('slack', 'User', {
+      projectRoot: root, agentName: 'Nova', role: 'owner', requireCompanions: true,
+      inputs: { connection: 'provisioned', bot_token: 'xoxb-test', app_token: 'xapp-test', owner_handle: 'U123456789' },
+      exec: async command => command.includes('auth.test') ? '@bot in Test' : command.includes('conversations.open') ? 'slack:D123456789' : '',
+      resolveRemote: () => 'origin', wire,
+    })).rejects.toThrow('companion installation needs attention');
+    expect(wire).not.toHaveBeenCalled();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/setup/channels/run-channel-skill.ts
+++ b/setup/channels/run-channel-skill.ts
@@ -27,6 +27,7 @@ import { askOperatorRole, type OperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
 import { hostExec, runSkill, type RunSkillOptions } from '../lib/skill-driver.js';
 import { clearTemplatePick } from '../templates.js';
+import { launchSlackJob, readSlackJob, queueSlackJob } from '../../src/community-portal/slack-job.js';
 import { getChannelPreStep, getCompanionSkills } from './companions.js';
 
 const DEFAULT_AGENT_NAME = 'Nano';
@@ -109,6 +110,8 @@ async function applyCompanionSkills(
     );
   }
 
+  if (degraded && overrides.requireCompanions)
+    throw new Error(`The ${channel} companion installation needs attention. Resume its setup step.`);
   if (!applied) return;
   if (degraded) {
     // A half-applied companion may have copied files and appended barrel
@@ -121,6 +124,7 @@ async function applyCompanionSkills(
     );
     return;
   }
+  if (overrides.skipEffects?.includes('restart')) return;
   try {
     await (overrides.exec ?? hostExec(projectRoot))('bash setup/lib/restart.sh');
   } catch {
@@ -128,6 +132,8 @@ async function applyCompanionSkills(
       'Applied the companion skills but could not restart the service. Their changes stay ' +
         'inactive until you restart it: bash setup/lib/restart.sh',
     );
+    if (overrides.requireCompanions)
+      throw new Error('The Slack service restart needs attention. Resume the Slack setup step.');
   }
 }
 
@@ -190,6 +196,10 @@ async function initFirstAgent(args: WireArgs): Promise<boolean> {
 }
 
 export interface ChannelSkillOverrides extends Partial<RunSkillOptions> {
+  /** A later perk offer already received consent for this browser handoff. */
+  browserConsent?: boolean;
+  /** Background jobs must not report ready after a partial companion install. */
+  requireCompanions?: boolean;
   agentName?: string;
   role?: OperatorRole;
   /** The shared wire; defaults to init-first-agent. Injectable for tests. */
@@ -392,11 +402,42 @@ export async function runChannelSkillWithPreStep(
     if (gate === BACK_TO_CHANNEL_SELECTION) return BACK_TO_CHANNEL_SELECTION;
   }
   const agentName = overrides.agentName ?? (await resolveAgentName());
-  const preBound = await preStep(agentName);
+  const root = overrides.projectRoot ?? process.cwd();
+  if (channel === 'slack') {
+    const pending = await readSlackJob(root);
+    if (pending && ['awaiting_approval', 'installing'].includes(pending.status)) {
+      if (pending.context.agentName !== agentName)
+        throw new Error(
+          `Finish the saved Slack installation for ${pending.context.agentName} before adding another agent in this checkout.`,
+        );
+      await launchSlackJob(root);
+      p.log.info('Your saved Slack installation is continuing in the background. Follow its progress in the portal.');
+      return;
+    }
+  }
+  const role = channel === 'slack' ? (overrides.role ?? (await askOperatorRole(channel))) : overrides.role;
+  const preBound = await (overrides.browserConsent ? preStep(agentName, { browserConsent: true }) : preStep(agentName));
+  if (preBound?.__portal_skip === 'slack') return BACK_TO_CHANNEL_SELECTION;
+  if (preBound?.__portal_pending === 'slack') {
+    if (!preBound.owner_handle) throw new Error('Reconnect Slack in the portal to identify the workspace owner.');
+    await queueSlackJob(
+      {
+        agentName,
+        displayName,
+        role: role!,
+        ownerHandle: preBound.owner_handle,
+        templateAgentId: process.env.NANOCLAW_TEMPLATE_AGENT_ID,
+      },
+      root,
+    );
+    p.log.info('Slack is finishing in the background. You can keep setting up NanoClaw or browse other perks.');
+    return;
+  }
   return runChannelSkill(channel, displayName, {
     ...overrides,
     offerBack: false,
     agentName,
+    role,
     inputs: { ...preBound, ...overrides.inputs },
   });
 }

--- a/setup/channels/slack-auto-register.ts
+++ b/setup/channels/slack-auto-register.ts
@@ -39,9 +39,11 @@ export function registerSlackAutoProvision(
   register: (channel: string, step: ChannelPreStep) => void,
   registerCompanions: (channel: string, skills: readonly string[]) => void,
 ): void {
-  register('slack', async (agentName) => {
+  register('slack', async (agentName, options) => {
     const { maybeAutoProvisionSlack } = await import('./slack-auto.js');
-    return maybeAutoProvisionSlack(agentName);
+    return options?.browserConsent
+      ? maybeAutoProvisionSlack(agentName, { browserConsent: true })
+      : maybeAutoProvisionSlack(agentName);
   });
   registerCompanions('slack', SLACK_AGENTS_COMPANION_SKILLS);
 }

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -6,6 +6,8 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({
+  portalEnabled: vi.fn(() => false),
+  runSlackPortal: vi.fn(),
   account: undefined as { api?: string; token: string } | undefined,
   installToken: undefined as string | undefined,
   selectLabels: [] as string[],
@@ -33,6 +35,8 @@ const state = vi.hoisted(() => ({
     installUrl: '',
   })),
 }));
+
+vi.mock('../portal.js', () => ({ portalEnabled: state.portalEnabled, runSlackPortal: state.runSlackPortal }));
 
 vi.mock('@clack/prompts', () => ({
   note: vi.fn((message: string, title: string) => state.notes.push({ message, title })),
@@ -797,5 +801,24 @@ describe('a workspace that has to approve the install', () => {
     expect(state.confirmThenOpen).not.toHaveBeenCalled();
     expect(result).toMatchObject({ connection: 'provisioned', app_token: 'xapp-test' });
     expect(result).not.toHaveProperty('bot_token');
+  });
+});
+
+
+describe('community portal entry point', () => {
+  it('uses browser setup for an unenrolled installation without legacy login or provisioning', async () => {
+    state.portalEnabled.mockReturnValue(true);
+    state.runSlackPortal.mockResolvedValue({ __portal_skip: 'slack' });
+    const root = track(rootWithModule());
+    const core = fakeCore();
+    state.installToken = undefined;
+    state.runInheritScript.mockClear(); state.brokerProvision.mockClear();
+    try {
+      const result = await maybeAutoProvisionSlack('Nano', { root, importModule: async () => core });
+      expect(result).toEqual({ __portal_skip: 'slack' });
+      expect(state.runSlackPortal).toHaveBeenCalledWith(core, 'Nano', undefined);
+      expect(state.runInheritScript).not.toHaveBeenCalled();
+      expect(state.brokerProvision).not.toHaveBeenCalled();
+    } finally { state.portalEnabled.mockReturnValue(false); }
   });
 });

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -50,6 +50,7 @@ import {
   writeImageSource,
 } from '../lib/registry-state.js';
 import { ensureAnswer } from '../lib/runner.js';
+import { portalEnabled, runSlackPortal } from '../portal.js';
 import { wrapForGutter } from '../lib/theme.js';
 
 // Both browser round-trips this file waits on — connecting a workspace, and
@@ -126,6 +127,7 @@ export interface ProvisioningCore {
 
 /** Injection seam for tests — the bootstrap never touches git or the loader in a unit test. */
 export interface BootstrapDeps {
+  browserConsent?: boolean;
   root?: string;
   /** Run a shell command at root; returns stdout, throws on failure. */
   exec?: (command: string) => string;
@@ -241,9 +243,15 @@ export async function maybeAutoProvisionSlack(
   // Offered even when not enrolled yet — signing in is a step of the flow,
   // not a precondition for seeing it. Hidden only when this copy has no way
   // to auto-provision at all.
-  if (!managerToken && !installToken && !loginScriptAvailable()) return undefined;
+  if (!portalEnabled() && !managerToken && !installToken && !loginScriptAvailable()) return undefined;
 
   const needsSignIn = !managerToken && !installToken;
+  if (portalEnabled() && !managerToken) {
+    const version = hostVersion(deps.root ?? process.cwd());
+    return deps.browserConsent
+      ? runSlackPortal(core, agentName, version, { browserConsent: true })
+      : runSlackPortal(core, agentName, version);
+  }
   // Automatic provisioning leads as the default; supplying your own bot
   // token stays available as the explicit, advanced alternative.
   const mode = ensureAnswer(

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -4,6 +4,7 @@
  */
 import { log } from '../src/log.js';
 import { emitStatus } from './status.js';
+import { withSetupLock, launchSlackJob } from '../src/community-portal/slack-job.js';
 
 const STEPS: Record<string, () => Promise<{ run: (args: string[]) => Promise<void> }>> = {
   timezone: () => import('./timezone.js'),
@@ -24,6 +25,7 @@ const STEPS: Record<string, () => Promise<{ run: (args: string[]) => Promise<voi
   'provider-auth': () => import('./provider-auth.js'),
   'cli-agent': () => import('./cli-agent.js'),
   registry: () => import('./registry.js'),
+  portal: () => import('./portal.js'),
   'registry-reconcile': () => import('./registry-reconcile.js'),
   // >>> nanoclaw:setup-steps
   // <<< nanoclaw:setup-steps
@@ -62,4 +64,4 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+withSetupLock(async () => { await launchSlackJob(); await main(); }).catch(() => { process.exitCode = 1; });

--- a/setup/portal.e2e.test.ts
+++ b/setup/portal.e2e.test.ts
@@ -1,0 +1,298 @@
+import { mkdtempSync } from 'node:fs';
+import { mkdir, readFile, rm, stat } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEVICE_PROOF_HEADER, verifyDeviceProof, type DevicePublicJwk } from '../src/community-portal/index.js';
+
+/**
+ * The single-visit enrollment path end to end, against loopback stand-ins for
+ * the portal, the registry broker and the WorkOS device endpoints. The real
+ * sign-in driver functions, the real portal client and the real files under a
+ * temporary HOME are exercised; only the browser opener, the docker credential
+ * helper installer and the prompts are doubles. Nothing here touches the network.
+ */
+const mock = vi.hoisted(() => ({ open: vi.fn(), confirm: vi.fn(), logs: vi.fn(), helper: vi.fn() }));
+vi.mock('./lib/browser.js', () => ({ openUrl: mock.open }));
+vi.mock('./install-cred-helper.js', () => ({ installCredentialHelper: mock.helper }));
+vi.mock('@clack/prompts', () => ({
+  confirm: mock.confirm,
+  isCancel: (v: unknown) => typeof v === 'symbol',
+  log: { info: mock.logs, success: mock.logs, warn: mock.logs, step: mock.logs, message: mock.logs },
+}));
+
+// The sign-in driver resolves ~/.config/nanoclaw when it loads, so HOME is set first.
+const home = mkdtempSync(path.join(os.tmpdir(), 'nc-portal-e2e-home-'));
+process.env.HOME = home;
+const { runImagePortal } = await import('./portal.js');
+
+const DEVICE_ID = 'dev_0123456789abcdef01234567';
+const USER_CODE = 'ABCD-EFGH';
+const ACTIVATE = 'https://auth.example.test/activate';
+interface Seen {
+  method: string;
+  route: string;
+  body?: unknown;
+  bearer?: string;
+  proofValid?: boolean;
+}
+let server: Server;
+let origin: string;
+let root: string;
+let stdout: string[];
+const seen: Seen[] = [];
+const fake = {
+  tokenPolls: 0,
+  tokenOutcome: 'approve' as 'approve' | 'deny',
+  flowStatus: undefined as string | undefined,
+  pinned: undefined as DevicePublicJwk | undefined,
+  statusPolls: 0,
+};
+const hostId = () => readFile(path.join(home, '.config/nanoclaw/host-id'), 'utf8').then((s) => s.trim());
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString();
+  const route = new URL(req.url ?? '/', origin).pathname;
+  const method = req.method ?? '';
+  const form = req.headers['content-type']?.includes('x-www-form-urlencoded');
+  const body: unknown = raw ? (form ? Object.fromEntries(new URLSearchParams(raw)) : JSON.parse(raw)) : undefined;
+  const auth = req.headers.authorization;
+  const bearer = auth?.startsWith('Bearer ') ? auth.slice(7) : undefined;
+  const record: Seen = { method, route, body, ...(bearer ? { bearer } : {}) };
+  seen.push(record);
+  const reply = (status: number, payload: unknown): void => {
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(payload));
+  };
+  const proofAgainst = (key: DevicePublicJwk | undefined): boolean => {
+    const proof = req.headers[DEVICE_PROOF_HEADER];
+    record.proofValid = typeof proof === 'string' && key !== undefined && verifyDeviceProof(proof, key).valid;
+    return record.proofValid;
+  };
+  const signedIn = bearer === 'install-token-test';
+
+  // WorkOS (device authorization grant, form-encoded, RFC 8628)
+  if (route === '/workos/device') {
+    expect(body).toEqual({ client_id: 'client-test' });
+    return reply(200, {
+      device_code: 'device-code-secret',
+      user_code: USER_CODE,
+      verification_uri: ACTIVATE,
+      verification_uri_complete: `${ACTIVATE}?user_code=${USER_CODE}`,
+      expires_in: 300,
+      interval: 1,
+    });
+  }
+  if (route === '/workos/token') {
+    expect(body).toEqual({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: 'device-code-secret',
+      client_id: 'client-test',
+    });
+    fake.tokenPolls++;
+    if (fake.tokenOutcome === 'deny') return reply(400, { error: 'access_denied' });
+    if (fake.tokenPolls < 3) return reply(400, { error: 'authorization_pending' });
+    return reply(200, { access_token: 'idp-access-token' });
+  }
+  // Registry broker
+  if (route === '/v1/auth-config')
+    return reply(200, {
+      device_flow_available: true,
+      client_id: 'client-test',
+      device_authorization_endpoint: `${origin}/workos/device`,
+      token_endpoint: `${origin}/workos/token`,
+    });
+  if (route === '/v1/enroll') {
+    expect(body).toMatchObject({
+      method: 'idp',
+      provider: 'workos',
+      workos_token: 'idp-access-token',
+      install_id: await hostId(),
+    });
+    return reply(201, {
+      account_id: 'acct-e2e',
+      token: 'install-token-test',
+      registry: 'images.example.test',
+      entitlements: ['echo'],
+      email: 'e2e@example.test',
+    });
+  }
+  // Portal
+  if (route === '/api/v1/catalog') return reply(200, { items: [{ id: 'echo', kind: 'account' }] });
+  if (route === '/api/v1/setup/start') {
+    if (bearer) return reply(400, { error: 'expected_anonymous' });
+    fake.flowStatus = 'awaiting_installation';
+    return reply(200, {
+      code: 'code-1',
+      id: 'flow-1',
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      url: `${origin}/?setup=code-1`,
+    });
+  }
+  if (route === '/api/v1/devices') {
+    const publicKey = (body as { publicKey?: DevicePublicJwk }).publicKey;
+    if (!signedIn) return reply(401, { error: 'invalid_token' });
+    if (!proofAgainst(publicKey)) return reply(401, { error: 'invalid_proof' });
+    fake.pinned = publicKey;
+    return reply(200, { deviceId: DEVICE_ID, accountId: 'acct-e2e', installId: await hostId() });
+  }
+  if (!signedIn) return reply(401, { error: 'invalid_token' });
+  if (!fake.pinned) return reply(403, { error: 'installation_required' });
+  const state = () => ({
+    id: 'flow-1',
+    stage: 'echo',
+    deviceId: DEVICE_ID,
+    status: fake.flowStatus,
+    choice: fake.flowStatus === 'approved' ? { imageSource: 'hardened', workspaceId: 'T1', name: 'Nano' } : undefined,
+  });
+  if (route === '/api/v1/setup/code-1/claim') {
+    if (fake.flowStatus !== 'awaiting_installation') return reply(409, { error: 'setup_claimed' });
+    fake.flowStatus = 'pending';
+    return reply(200, state());
+  }
+  if (route === '/api/v1/setup/code-1' && method === 'GET') {
+    if (++fake.statusPolls >= 2 && fake.flowStatus === 'pending') fake.flowStatus = 'approved';
+    return reply(200, state());
+  }
+  if (route === '/api/v1/setup/code-1/complete') return reply(200, { ok: true });
+  if (route === '/api/v1/device/state') return reply(200, { grants: [] });
+  return reply(404, { error: 'not_found' });
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'nc-portal-e2e-root-'));
+  await mkdir(path.join(root, 'data'));
+  seen.length = 0;
+  stdout = [];
+  Object.assign(fake, {
+    tokenPolls: 0,
+    tokenOutcome: 'approve',
+    flowStatus: undefined,
+    pinned: undefined,
+    statusPolls: 0,
+  });
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+  process.env.NANOCLAW_PORTAL_ORIGIN = origin;
+  process.env.NANOCLAW_REGISTRY_API = origin;
+  vi.spyOn(process, 'cwd').mockReturnValue(root);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  mock.confirm.mockResolvedValue(true);
+  mock.helper.mockReturnValue({ onPath: true, helperPath: '/tmp/helper' });
+});
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  delete process.env.NANOCLAW_PORTAL_ORIGIN;
+  delete process.env.NANOCLAW_REGISTRY_API;
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+  await rm(path.join(home, '.config'), { recursive: true, force: true });
+});
+afterAll(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+const mkdtemp = (prefix: string): Promise<string> => Promise.resolve(mkdtempSync(prefix));
+const mode = async (file: string): Promise<number> => (await stat(file)).mode & 0o777;
+
+describe('single-visit enrollment', () => {
+  it('signs in, registers, claims and finishes the stage with one portal link and no WorkOS page', async () => {
+    await runImagePortal();
+
+    const routes = seen.map((r) => r.route);
+    expect(routes).toEqual([
+      '/api/v1/catalog',
+      '/v1/auth-config',
+      '/workos/device',
+      '/api/v1/setup/start',
+      '/workos/token',
+      '/workos/token',
+      '/workos/token',
+      '/v1/enroll',
+      '/api/v1/devices',
+      '/api/v1/setup/code-1/claim',
+      '/api/v1/setup/code-1',
+      '/api/v1/setup/code-1',
+      '/api/v1/device/state',
+      '/api/v1/setup/code-1/complete',
+    ]);
+    const start = seen.find((r) => r.route === '/api/v1/setup/start');
+    expect(start?.bearer).toBeUndefined();
+    expect(start?.body).toEqual({
+      stage: 'echo',
+      name: 'Nano',
+      autoContinue: true,
+      label: expect.stringContaining(path.basename(root)),
+      verification: { userCode: USER_CODE, verificationUri: `${ACTIVATE}?user_code=${USER_CODE}` },
+    });
+    expect(seen.find((r) => r.route === '/api/v1/devices')).toMatchObject({
+      bearer: 'install-token-test',
+      proofValid: true,
+      body: { publicKey: { kty: 'EC', crv: 'P-256' } },
+    });
+    for (const route of ['/api/v1/setup/code-1/claim', '/api/v1/setup/code-1', '/api/v1/device/state'])
+      expect(seen.find((r) => r.route === route)?.bearer).toBe('install-token-test');
+
+    // One link, opened once, before the token polling; the code and the sign-in page on their own lines.
+    expect(mock.open).toHaveBeenCalledExactlyOnceWith(`${origin}/?setup=code-1`);
+    const out = stdout.join('');
+    expect(out).toContain(`\n${origin}/?setup=code-1\n`);
+    expect(out).toContain(`Code: ${USER_CODE}\n${ACTIVATE}?user_code=${USER_CODE}\n`);
+    expect(out).not.toContain('device-code-secret');
+
+    // Persisted exactly as the standalone sign-in does.
+    const account = JSON.parse(await readFile(path.join(home, '.config/nanoclaw/account.json'), 'utf8'));
+    expect(account).toMatchObject({
+      version: 1,
+      api: origin,
+      account_id: 'acct-e2e',
+      token: 'install-token-test',
+      registry: 'images.example.test',
+      entitlements: ['echo'],
+    });
+    expect(JSON.parse(await readFile(path.join(home, '.config/nanoclaw/registry-auth.json'), 'utf8'))).toEqual({
+      version: 1,
+      broker_url: origin,
+      registry: 'images.example.test',
+      token: 'install-token-test',
+    });
+    expect(mock.helper).toHaveBeenCalledWith({ registryHost: 'images.example.test' });
+    expect(await mode(path.join(home, '.config/nanoclaw/account.json'))).toBe(0o600);
+    expect(await mode(path.join(home, '.config/nanoclaw/device-key.json'))).toBe(0o600);
+    const journal = JSON.parse(await readFile(path.join(root, 'data/community-portal.json'), 'utf8'));
+    expect(journal).toMatchObject({ origin, deviceId: DEVICE_ID, credentials: {}, operations: {} });
+    expect(JSON.stringify(journal)).not.toMatch(/install-token-test|pkcs8|privateKey/);
+    expect(await readFile(path.join(root, '.env'), 'utf8')).toContain('NANOCLAW_HARDENED_IMAGE=true');
+  }, 20_000);
+
+  it('skips the stage when the sign-in is declined in the browser: nothing registered, nothing claimed', async () => {
+    fake.tokenOutcome = 'deny';
+    await runImagePortal();
+    const routes = seen.map((r) => r.route);
+    expect(routes).toEqual([
+      '/api/v1/catalog',
+      '/v1/auth-config',
+      '/workos/device',
+      '/api/v1/setup/start',
+      '/workos/token',
+    ]);
+    expect(mock.open).toHaveBeenCalledOnce();
+    expect(mock.logs.mock.calls.map((c) => String(c[0]))).toContainEqual(expect.stringContaining('declined'));
+    await expect(readFile(path.join(home, '.config/nanoclaw/account.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(readFile(path.join(home, '.config/nanoclaw/device-key.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect(await readFile(path.join(root, '.env'), 'utf8')).toContain('NANOCLAW_HARDENED_IMAGE=false');
+  }, 20_000);
+});

--- a/setup/portal.test.ts
+++ b/setup/portal.test.ts
@@ -1,0 +1,504 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProvisioningCore } from './channels/slack-auto.js';
+
+const mock = vi.hoisted(() => ({
+  local: {} as Record<string, any>,
+  saved: [] as Record<string, any>[],
+  options: [] as Record<string, any>[],
+  complete: vi.fn(),
+  open: vi.fn(),
+  confirm: vi.fn(),
+  resume: vi.fn(),
+  available: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  image: vi.fn(),
+  deviceStart: vi.fn(),
+  deviceFinish: vi.fn(),
+  claim: vi.fn(),
+  account: vi.fn(),
+  identity: vi.fn(),
+  key: vi.fn(),
+  register: vi.fn(),
+  reconcile: vi.fn(),
+  logs: vi.fn(),
+  request: vi.fn(),
+  result: {
+    status: 'approved',
+    id: 'setup-1',
+    choice: { imageSource: 'local', workspaceId: 'T1', name: 'Browser choice' },
+  },
+}));
+vi.mock('../src/community-portal/index.js', () => ({
+  SetupClient: class {
+    local = mock.local;
+    identity: any;
+    deviceKey: any;
+    constructor(options: Record<string, any>) {
+      mock.options.push(options);
+      this.identity = options.identity;
+      this.deviceKey = options.deviceKey;
+    }
+    get token() {
+      return this.identity?.token;
+    }
+    async initialize() {
+      return this;
+    }
+    async register() {
+      return mock.register();
+    }
+    async available(...args: any[]) {
+      return mock.available(...args);
+    }
+    async resumeEnabled(...args: any[]) {
+      return mock.resume(...args);
+    }
+    async start(...args: any[]) {
+      mock.start(...args);
+      return { url: 'https://portal.example.test/?setup=test' };
+    }
+    async claim() {
+      return mock.claim();
+    }
+    async wait() {
+      return mock.result;
+    }
+    async save() {
+      mock.saved.push(structuredClone(this.local));
+    }
+    async complete(...args: any[]) {
+      return mock.complete(...args);
+    }
+    async reconcile() {
+      mock.reconcile();
+    }
+    async request(...args: any[]) {
+      return mock.request(...args);
+    }
+    async stop() {
+      mock.stop();
+    }
+  },
+  ensureDeviceKey: mock.key,
+  readInstallIdentity: mock.identity,
+  errorCode: (error: any, fallback = 'unavailable') => (typeof error?.code === 'string' && error.code) || fallback,
+  errorStatus: (error: any) => (typeof error?.status === 'number' ? error.status : undefined),
+}));
+vi.mock('../src/community-portal/slack-job.js', () => ({
+  readSlackJob: vi.fn(async () => null),
+  launchSlackJob: vi.fn(),
+  queueSlackJob: vi.fn(),
+}));
+vi.mock('./lib/browser.js', () => ({ openUrl: mock.open }));
+vi.mock('./registry-login.js', () => ({
+  LoginError: class LoginError extends Error {
+    constructor(
+      message: string,
+      readonly hint?: string,
+    ) {
+      super(message);
+    }
+  },
+  startDeviceFlow: mock.deviceStart,
+  finishDeviceFlow: mock.deviceFinish,
+}));
+vi.mock('./lib/registry-state.js', () => ({
+  readRegistryAccount: mock.account,
+  readImageSource: () => 'local',
+  writeImageSource: mock.image,
+}));
+vi.mock('@clack/prompts', () => ({
+  confirm: mock.confirm,
+  isCancel: (v: unknown) => typeof v === 'symbol',
+  log: { info: mock.logs, success: mock.logs, warn: mock.logs, step: mock.logs, message: mock.logs },
+}));
+const { runImagePortal, runSlackPortal, offerPortalReminder } = await import('./portal.js');
+const { LoginError } = await import('./registry-login.js');
+const core = (extra = {}) =>
+  ({
+    brokerListWorkspaces: vi.fn(async () => [
+      { team_id: 'T1', team_name: 'Team', status: 'active', connected_as: 'U123456789' },
+    ]),
+    brokerProvision: vi.fn(async () => ({ appId: 'A1', appToken: 'xapp-private', botToken: 'xoxb-private' })),
+    ...extra,
+  }) as unknown as ProvisioningCore;
+const ACCOUNT = { token: 'test-install', account_id: 'acct-test', registry: 'image.example.test' };
+const IDENTITY = { token: 'test-install', accountId: 'acct-test', installId: 'install-test' };
+const KEY = { fingerprint: 'fp-test', publicKeyJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } };
+const DEVICE_FLOW = {
+  api: 'https://registry.example.test',
+  idp: {
+    clientId: 'client',
+    deviceEndpoint: 'https://auth.example.test/device',
+    tokenEndpoint: 'https://auth.example.test/token',
+  },
+  device: {
+    deviceCode: 'device-secret',
+    userCode: 'ABCD-EFGH',
+    verificationUri: 'https://auth.example.test/activate',
+    verificationUriComplete: 'https://auth.example.test/activate?user_code=ABCD-EFGH',
+    expiresInS: 300,
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    intervalS: 5,
+  },
+};
+const stdout: string[] = [];
+const warnings = () => mock.logs.mock.calls.map((call) => String(call[0]));
+
+describe('browser setup handoffs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    stdout.length = 0;
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    mock.local = {};
+    mock.saved = [];
+    mock.options = [];
+    mock.account.mockReturnValue(ACCOUNT);
+    mock.identity.mockResolvedValue(IDENTITY);
+    mock.key.mockReturnValue(KEY);
+    mock.deviceStart.mockResolvedValue(DEVICE_FLOW);
+    mock.deviceFinish.mockResolvedValue({ token: 'test-install', account_id: 'acct-test' });
+    mock.claim.mockResolvedValue({ id: 'setup-1', status: 'pending' });
+    mock.register.mockResolvedValue({ deviceId: 'dev_test', accountId: 'acct-test', installId: 'install-test' });
+    mock.resume.mockResolvedValue(false);
+    mock.available.mockResolvedValue(true);
+    mock.confirm.mockResolvedValue(true);
+    mock.result.status = 'approved';
+    mock.result.choice.imageSource = 'local';
+    mock.request.mockResolvedValue({ activations: { echo: { enabled: false }, slack: { enabled: false } } });
+  });
+  it('registers the signed-in machine with its device key and applies the image choice without a second sign-in', async () => {
+    await runImagePortal();
+    expect(mock.deviceStart).not.toHaveBeenCalled();
+    expect(mock.claim).not.toHaveBeenCalled();
+    expect(mock.start).toHaveBeenCalledExactlyOnceWith('echo', 'Nano');
+    expect(mock.key).toHaveBeenCalledOnce();
+    expect(mock.options[0]).toMatchObject({ identity: IDENTITY, deviceKey: KEY, exclusive: true });
+    expect(mock.register).toHaveBeenCalledOnce();
+    expect(mock.register.mock.invocationCallOrder[0]).toBeLessThan(mock.available.mock.invocationCallOrder[0]);
+    expect(mock.reconcile).toHaveBeenCalledOnce();
+    expect(mock.image).toHaveBeenCalledExactlyOnceWith('local');
+    expect(mock.complete).toHaveBeenCalled();
+  });
+  it('folds sign-in into one browser visit for a machine without an account: anonymous start, device flow, register, claim', async () => {
+    mock.account.mockReturnValue(undefined);
+    await runImagePortal();
+    expect(mock.options[0]).toMatchObject({ exclusive: true });
+    expect(mock.options[0].identity).toBeUndefined();
+    expect(mock.confirm).toHaveBeenCalledOnce();
+    expect(mock.deviceStart).toHaveBeenCalledOnce();
+    expect(mock.confirm.mock.invocationCallOrder[0]).toBeLessThan(mock.deviceStart.mock.invocationCallOrder[0]);
+    expect(mock.start).toHaveBeenCalledExactlyOnceWith('echo', 'Nano', {
+      verification: { userCode: 'ABCD-EFGH', verificationUri: DEVICE_FLOW.device.verificationUriComplete },
+    });
+    expect(mock.open).toHaveBeenCalledExactlyOnceWith('https://portal.example.test/?setup=test');
+    expect(stdout.join('')).toContain('https://portal.example.test/?setup=test\n');
+    expect(stdout.join('')).toContain('ABCD-EFGH\n');
+    expect(stdout.join('')).toContain(`${DEVICE_FLOW.device.verificationUriComplete}\n`);
+    expect(stdout.join('')).not.toContain('device-secret');
+    expect(mock.deviceFinish).toHaveBeenCalledExactlyOnceWith(DEVICE_FLOW);
+    expect(mock.open.mock.invocationCallOrder[0]).toBeLessThan(mock.deviceFinish.mock.invocationCallOrder[0]);
+    expect(mock.deviceFinish.mock.invocationCallOrder[0]).toBeLessThan(mock.key.mock.invocationCallOrder[0]);
+    expect(mock.key.mock.invocationCallOrder[0]).toBeLessThan(mock.register.mock.invocationCallOrder[0]);
+    expect(mock.register.mock.invocationCallOrder[0]).toBeLessThan(mock.claim.mock.invocationCallOrder[0]);
+    expect(mock.register).toHaveBeenCalledOnce();
+    expect(mock.claim).toHaveBeenCalledOnce();
+    expect(mock.reconcile).toHaveBeenCalledOnce();
+    expect(mock.image).toHaveBeenCalledExactlyOnceWith('local');
+    expect(mock.complete).toHaveBeenCalledOnce();
+  });
+  it('skips the stage when the device flow is declined, expires, fails to start, or the user declines the offer', async () => {
+    mock.account.mockReturnValue(undefined);
+    mock.deviceFinish.mockRejectedValueOnce(
+      new LoginError('The sign-in was declined in the browser.', 'Re-run setup.'),
+    );
+    await runImagePortal();
+    expect(warnings()).toContainEqual(expect.stringContaining('declined in the browser'));
+    expect(mock.image).toHaveBeenCalledExactlyOnceWith('local');
+    mock.deviceFinish.mockRejectedValueOnce(new LoginError('That sign-in code expired before it was approved.'));
+    expect(await runSlackPortal(core(), 'Nano')).toEqual({ __portal_skip: 'slack' });
+    expect(warnings()).toContainEqual(expect.stringContaining('expired'));
+    expect(mock.start).toHaveBeenCalledTimes(2);
+    expect(mock.open).toHaveBeenCalledTimes(2);
+    mock.deviceStart.mockRejectedValueOnce(
+      new LoginError('Browser authentication is not configured for this registry.'),
+    );
+    await runImagePortal();
+    expect(warnings()).toContainEqual(expect.stringContaining('not configured'));
+    expect(mock.start).toHaveBeenCalledTimes(2);
+    mock.confirm.mockResolvedValueOnce(false);
+    await runImagePortal();
+    expect(mock.deviceStart).toHaveBeenCalledTimes(3);
+    expect(mock.key).not.toHaveBeenCalled();
+    expect(mock.register).not.toHaveBeenCalled();
+    expect(mock.claim).not.toHaveBeenCalled();
+    expect(mock.complete).not.toHaveBeenCalled();
+    expect(mock.stop).toHaveBeenCalledTimes(4);
+    mock.deviceFinish.mockRejectedValueOnce(new Error('disk full'));
+    await expect(runImagePortal()).rejects.toThrow('disk full');
+  });
+  it('signs in a machine whose sign-in record is present but skips a stage the portal refuses to register', async () => {
+    mock.account.mockReturnValue(undefined);
+    mock.register.mockRejectedValueOnce(Object.assign(new Error('Too many.'), { status: 409, code: 'device_limit' }));
+    await runImagePortal();
+    expect(mock.deviceFinish).toHaveBeenCalledOnce();
+    expect(mock.claim).not.toHaveBeenCalled();
+    expect(warnings()).toContainEqual(expect.stringContaining('maximum number of devices'));
+    expect(mock.image).toHaveBeenCalledExactlyOnceWith('local');
+  });
+  it('skips the stage when the portal no longer accepts the sign-in or the device, and surfaces other failures', async () => {
+    mock.register.mockRejectedValueOnce(
+      Object.assign(new Error('Sign in again.'), { status: 401, code: 'invalid_token' }),
+    );
+    await runImagePortal();
+    expect(warnings()).toContainEqual(expect.stringContaining('no longer valid'));
+    expect(mock.image).toHaveBeenCalledExactlyOnceWith('local');
+    mock.register.mockRejectedValueOnce(Object.assign(new Error('Too many.'), { status: 409, code: 'device_limit' }));
+    expect(await runSlackPortal(core(), 'Nano')).toEqual({ __portal_skip: 'slack' });
+    expect(warnings()).toContainEqual(expect.stringContaining('maximum number of devices'));
+    mock.register.mockRejectedValueOnce(Object.assign(new Error('Pinned.'), { status: 409, code: 'device_pinned' }));
+    expect(await runSlackPortal(core(), 'Nano')).toEqual({ __portal_skip: 'slack' });
+    expect(warnings()).toContainEqual(expect.stringContaining('different device key'));
+    expect(mock.stop).toHaveBeenCalledTimes(3);
+    expect(mock.start).not.toHaveBeenCalled();
+    expect(mock.open).not.toHaveBeenCalled();
+    mock.register.mockRejectedValueOnce(new Error('offline'));
+    await expect(runImagePortal()).rejects.toThrow('offline');
+  });
+  it('uses the browser-selected workspace and name, saving credentials before completion', async () => {
+    const provider = core();
+    const result = await runSlackPortal(provider, 'CLI default');
+    expect(provider.brokerProvision).toHaveBeenCalledWith(
+      'test-install',
+      expect.objectContaining({ team_id: 'T1', name: 'Browser choice' }),
+    );
+    expect(mock.saved[0].slackSetup.status).toBe('creating');
+    expect(mock.saved.at(-1)?.slackSetup.app.appToken).toBe('xapp-private');
+    expect(result).toEqual({
+      connection: 'provisioned',
+      __portal_pending: 'slack',
+      app_token: 'xapp-private',
+      bot_token: 'xoxb-private',
+      owner_handle: 'U123456789',
+    });
+    expect(JSON.stringify(mock.logs.mock.calls)).not.toContain('xapp-private');
+  });
+  it('resumes a saved app awaiting browser approval without minting another one', async () => {
+    mock.local = {
+      slackSetup: { setupId: 'setup-1', status: 'received', app: { appId: 'A1', appToken: 'xapp-existing' } },
+    };
+    const provider = core({
+      waitForInstall: vi.fn(async () => ({ botToken: 'xoxb-approved' })),
+      brokerAppStatus: vi.fn(),
+    });
+    const result = await runSlackPortal(provider, 'Nano');
+    expect(provider.brokerProvision).not.toHaveBeenCalled();
+    expect(result.app_token).toBe('xapp-existing');
+    expect(mock.complete).toHaveBeenCalledWith('awaiting_approval', { appId: 'A1' });
+    expect(result.__portal_pending).toBe('slack');
+    expect(provider.waitForInstall).not.toHaveBeenCalled();
+    expect(mock.complete).not.toHaveBeenCalledWith('complete', expect.anything());
+  });
+  it('never repeats an ambiguous Slack create automatically', async () => {
+    mock.local = { slackSetup: { setupId: 'old', status: 'creating' } };
+    const provider = core();
+    await expect(runSlackPortal(provider, 'Nano')).rejects.toThrow('previous Slack create');
+    expect(provider.brokerProvision).not.toHaveBeenCalled();
+  });
+  it('does not create a flow or open the browser when the user declines', async () => {
+    mock.confirm.mockResolvedValue(false);
+    await runImagePortal();
+    expect(mock.start).not.toHaveBeenCalled();
+    expect(mock.open).not.toHaveBeenCalled();
+    expect(mock.image).toHaveBeenCalledWith('local');
+    expect(mock.stop).toHaveBeenCalledOnce();
+  });
+  it('treats cancelling the offer as skipping the Slack channel', async () => {
+    mock.confirm.mockResolvedValue(Symbol('cancel'));
+    const provider = core();
+    expect(await runSlackPortal(provider, 'Nano')).toEqual({ __portal_skip: 'slack' });
+    expect(provider.brokerProvision).not.toHaveBeenCalled();
+    expect(mock.open).not.toHaveBeenCalled();
+  });
+  it('skips a stage the catalog does not offer without prompting or creating a handoff', async () => {
+    mock.available.mockResolvedValue(false);
+    await runImagePortal();
+    expect(mock.confirm).not.toHaveBeenCalled();
+    expect(mock.start).not.toHaveBeenCalled();
+    expect(mock.open).not.toHaveBeenCalled();
+    expect(mock.available).toHaveBeenCalledExactlyOnceWith('echo');
+    expect(mock.image).toHaveBeenCalledExactlyOnceWith('local');
+    expect(mock.stop).toHaveBeenCalledOnce();
+  });
+  it('opens the browser only after consent', async () => {
+    await runImagePortal();
+    expect(mock.confirm).toHaveBeenCalledOnce();
+    expect(mock.confirm.mock.invocationCallOrder[0]).toBeLessThan(mock.start.mock.invocationCallOrder[0]);
+    expect(mock.start.mock.invocationCallOrder[0]).toBeLessThan(mock.open.mock.invocationCallOrder[0]);
+  });
+  it('uses a perk enabled earlier without prompting or reopening the browser', async () => {
+    mock.resume.mockResolvedValue(true);
+    await runImagePortal();
+    expect(mock.confirm).not.toHaveBeenCalled();
+    expect(mock.open).not.toHaveBeenCalled();
+    expect(mock.complete).toHaveBeenCalledOnce();
+  });
+  it('returns from the dashboard without a perk, keeping the local image and completing nothing', async () => {
+    mock.result.status = 'skipped';
+    await runImagePortal();
+    expect(mock.image).toHaveBeenCalledWith('local');
+    expect(mock.reconcile).toHaveBeenCalledOnce();
+    expect(mock.complete).not.toHaveBeenCalled();
+    const provider = core();
+    expect(await runSlackPortal(provider, 'Nano')).toEqual({ __portal_skip: 'slack' });
+    expect(provider.brokerProvision).not.toHaveBeenCalled();
+  });
+  it('reuses the same installed Slack agent on a later setup visit', async () => {
+    mock.local.slackSetup = {
+      setupId: 'previous',
+      workspaceId: 'T1',
+      name: 'Browser choice',
+      status: 'complete',
+      app: { appId: 'A1', appToken: 'xapp-existing', botToken: 'xoxb-existing' },
+    };
+    const provider = core({ brokerAppStatus: vi.fn(async () => ({ status: 'installed' })) });
+    const result = await runSlackPortal(provider, 'Nano');
+    expect(provider.brokerAppStatus).toHaveBeenCalledWith('test-install', 'A1');
+    expect(provider.brokerProvision).not.toHaveBeenCalled();
+    expect(result.bot_token).toBe('xoxb-existing');
+  });
+  it('returns to channel selection after declining, without entering the manual Slack skill', async () => {
+    const { registerChannelPreStep } = await import('./channels/companions.js');
+    const { runChannelSkillWithPreStep } = await import('./channels/run-channel-skill.js');
+    const { BACK_TO_CHANNEL_SELECTION } = await import('./lib/back-nav.js');
+    const exec = vi.fn(() => {
+      throw new Error('The channel skill must not run');
+    });
+    registerChannelPreStep('slack', async () => ({ __portal_skip: 'slack' }));
+    expect(await runChannelSkillWithPreStep('slack', 'User', { agentName: 'Nova', role: 'owner', exec })).toBe(
+      BACK_TO_CHANNEL_SELECTION,
+    );
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('offers skipped Echo once at a later milestone and applies the image before completing', async () => {
+    mock.confirm.mockResolvedValueOnce(false);
+    await runImagePortal();
+    mock.confirm.mockResolvedValueOnce(true);
+    mock.result.choice.imageSource = 'hardened';
+    const apply = vi.fn(async () => {
+      expect(mock.complete).not.toHaveBeenCalled();
+      expect(mock.image).toHaveBeenLastCalledWith('hardened');
+    });
+    const enable = vi.fn(() => runImagePortal({ browserConsent: true, apply }));
+    expect(await offerPortalReminder('echo', enable)).toBe(true);
+    expect(mock.confirm).toHaveBeenCalledTimes(2);
+    expect(apply).toHaveBeenCalledOnce();
+    expect(mock.open).toHaveBeenCalledOnce();
+    expect(mock.complete).toHaveBeenCalledOnce();
+    expect(mock.stop.mock.invocationCallOrder[1]).toBeLessThan(enable.mock.invocationCallOrder[0]);
+    expect(await offerPortalReminder('echo', enable)).toBe(false);
+    expect(enable).toHaveBeenCalledOnce();
+  });
+
+  it('persists a declined reminder and never opens the browser or starts installation', async () => {
+    mock.confirm.mockResolvedValue(false);
+    const enable = vi.fn();
+    expect(await offerPortalReminder('slack', enable)).toBe(false);
+    expect(await offerPortalReminder('slack', enable)).toBe(false);
+    expect(mock.local.reminders.slack).toBe(true);
+    expect(mock.confirm).toHaveBeenCalledOnce();
+    expect(mock.open).not.toHaveBeenCalled();
+    expect(enable).not.toHaveBeenCalled();
+  });
+
+  it('does not remind for an enabled account perk or a saved Slack installation', async () => {
+    mock.request.mockResolvedValue({ activations: { echo: { enabled: true } } });
+    const enable = vi.fn();
+    expect(await offerPortalReminder('echo', enable)).toBe(false);
+    mock.local.slackSetup = { status: 'received', app: { appId: 'A1' } };
+    expect(await offerPortalReminder('slack', enable)).toBe(false);
+    expect(mock.confirm).not.toHaveBeenCalled();
+    expect(enable).not.toHaveBeenCalled();
+  });
+
+  it('still offers the reminder on a machine that is not signed in or not registered, without signing in', async () => {
+    mock.identity.mockResolvedValue(null);
+    const enable = vi.fn();
+    expect(await offerPortalReminder('echo', enable)).toBe(true);
+    expect(mock.request).not.toHaveBeenCalled();
+    expect(mock.deviceStart).not.toHaveBeenCalled();
+    expect(mock.key).not.toHaveBeenCalled();
+    expect(enable).toHaveBeenCalledOnce();
+    mock.local = {};
+    mock.identity.mockResolvedValue(IDENTITY);
+    mock.request.mockRejectedValue(Object.assign(new Error('Register first.'), { status: 403 }));
+    expect(await offerPortalReminder('echo', enable)).toBe(true);
+    expect(mock.confirm).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the working image and leaves the reminder retryable if the late image pull fails', async () => {
+    mock.result.choice.imageSource = 'hardened';
+    const enable = () =>
+      runImagePortal({
+        browserConsent: true,
+        apply: async () => {
+          throw new Error('pull failed');
+        },
+      });
+    await expect(offerPortalReminder('echo', enable)).rejects.toThrow('pull failed');
+    expect(mock.image).toHaveBeenLastCalledWith('local');
+    expect(mock.complete).toHaveBeenCalledExactlyOnceWith('failed');
+    expect(mock.local.reminders?.echo).toBeUndefined();
+    expect(mock.local.reminderPending.echo).toBe(true);
+    mock.request.mockResolvedValue({ activations: { echo: { enabled: true } } });
+    mock.resume.mockResolvedValue(true);
+    const pull = vi.fn();
+    await offerPortalReminder('echo', () => runImagePortal({ browserConsent: true, apply: pull }));
+    expect(mock.confirm).toHaveBeenCalledOnce();
+    expect(pull).toHaveBeenCalledOnce();
+    expect(mock.local.reminderPending.echo).toBeUndefined();
+    expect(mock.local.reminders.echo).toBe(true);
+  });
+
+  it('keeps core setup running when optional perk status is temporarily unavailable', async () => {
+    mock.request.mockRejectedValue(new Error('offline'));
+    const enable = vi.fn();
+    expect(await offerPortalReminder('echo', enable)).toBe(false);
+    expect(mock.confirm).not.toHaveBeenCalled();
+    expect(enable).not.toHaveBeenCalled();
+    expect(mock.local.reminders?.echo).toBeUndefined();
+  });
+
+  it('does not change or pull the image after dismissing the later browser offer', async () => {
+    mock.result.status = 'skipped';
+    const apply = vi.fn();
+    await runImagePortal({ browserConsent: true, apply });
+    expect(mock.image).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    expect(mock.complete).not.toHaveBeenCalled();
+    expect(mock.confirm).not.toHaveBeenCalled();
+  });
+
+  it('passes consent to the Slack handoff once and still queues the saved background job', async () => {
+    const { registerChannelPreStep } = await import('./channels/companions.js');
+    const { runChannelSkillWithPreStep } = await import('./channels/run-channel-skill.js');
+    const { queueSlackJob } = await import('../src/community-portal/slack-job.js');
+    const provider = core();
+    registerChannelPreStep('slack', (_name, options) => runSlackPortal(provider, 'Nova', undefined, options));
+    await offerPortalReminder('slack', async () => {
+      await runChannelSkillWithPreStep('slack', 'Operator', { agentName: 'Nova', role: 'owner', browserConsent: true });
+    });
+    expect(mock.confirm).toHaveBeenCalledOnce();
+    expect(mock.open).toHaveBeenCalledOnce();
+    expect(queueSlackJob).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: 'Nova', role: 'owner', ownerHandle: 'U123456789' }),
+      expect.any(String),
+    );
+  });
+});

--- a/setup/portal.ts
+++ b/setup/portal.ts
@@ -1,0 +1,383 @@
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as p from '@clack/prompts';
+import { openUrl } from './lib/browser.js';
+import { readImageSource, readRegistryAccount, writeImageSource } from './lib/registry-state.js';
+import { LoginError, finishDeviceFlow, startDeviceFlow, type DeviceFlow } from './registry-login.js';
+import {
+  SetupClient,
+  ensureDeviceKey,
+  errorCode,
+  errorStatus,
+  readInstallIdentity,
+  type DeviceKey,
+  type InstallIdentity,
+} from '../src/community-portal/index.js';
+import type { ProvisioningCore } from './channels/slack-auto.js';
+import { readSlackJob } from '../src/community-portal/slack-job.js';
+
+/**
+ * The wizard's browser handoffs to the community portal. An enrolled machine
+ * makes sure it has its device key and is registered, then starts the stage,
+ * opens its link and waits for the browser. A machine without an account gets
+ * one browser visit for everything: the registry's device flow (WorkOS, RFC
+ * 8628) is started here but its page is not opened; the flow starts
+ * anonymously at the portal carrying the user code, the single portal link is
+ * printed and opened, and once the sign-in lands the machine registers,
+ * claims the flow and waits as usual. Sign-in writes account.json through the
+ * sign-in driver's own persist step; nothing here saves credentials.
+ */
+export type PortalStage = 'echo' | 'slack';
+export const portalEnabled = () => true;
+const REGISTRY_STEP = 'pnpm exec tsx setup/index.ts --step registry';
+
+async function portalIdentity(): Promise<{ identity: InstallIdentity; deviceKey: DeviceKey }> {
+  const identity = await readInstallIdentity();
+  if (!identity)
+    throw new Error(`The NanoClaw sign-in record is incomplete. Run \`${REGISTRY_STEP}\` to sign in again.`);
+  return { identity, deviceKey: ensureDeviceKey() };
+}
+
+function portalClient(options: { identity?: InstallIdentity; deviceKey?: DeviceKey } = {}): SetupClient {
+  return new SetupClient({
+    origin: process.env.NANOCLAW_PORTAL_ORIGIN || 'https://portal.nanoclaw.dev',
+    file: path.join(process.cwd(), 'data/community-portal.json'),
+    label: `${os.hostname()} · ${path.basename(process.cwd())}`,
+    exclusive: true,
+    waitForLockMs: 30_000,
+    autoContinue: true,
+    ...options,
+  });
+}
+
+/**
+ * Register (or re-affirm) this machine at the portal. Idempotent; the device
+ * id is cached in the journal. False, after saying why, when the portal
+ * refuses: a sign-in it no longer accepts, a device pinned to another key, or
+ * the account's device limit. Anything else is an ordinary failure.
+ */
+async function registerDevice(client: SetupClient): Promise<boolean> {
+  try {
+    await client.register();
+    return true;
+  } catch (error) {
+    const status = errorStatus(error);
+    if (status === 401 || status === 403) {
+      p.log.warn(
+        `Your NanoClaw sign-in is no longer valid here. Run \`${REGISTRY_STEP}\` to sign in again, then retry this step.`,
+      );
+      return false;
+    }
+    if (status === 409) {
+      p.log.warn(
+        errorCode(error) === 'device_limit'
+          ? 'This account already has its maximum number of devices. Forget one in the portal, then retry this step.'
+          : 'This machine is registered under a different device key. Forget the device in the portal, then retry this step.',
+      );
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** A sign-in that did not happen is a skipped stage, worded as the sign-in driver words it. */
+function skippedSignIn(error: unknown): void {
+  if (!(error instanceof LoginError)) throw error;
+  p.log.warn([error.message, error.hint, 'Skipping this step for now.'].filter(Boolean).join(' '));
+}
+
+/**
+ * The not-enrolled path: start the device flow without opening its page,
+ * start the stage anonymously with the user code, print and open the single
+ * portal link (plus the code and the provider's page on their own lines for
+ * headless users), wait for the sign-in, persist it, then register and claim.
+ * Declined, expired or failed → null; the stage is skipped and nothing else
+ * happens.
+ */
+async function signInThroughPortal(client: SetupClient, stage: PortalStage, name: string): Promise<boolean> {
+  let flow: DeviceFlow;
+  try {
+    flow = await startDeviceFlow();
+  } catch (error) {
+    skippedSignIn(error);
+    return false;
+  }
+  const verificationUri = flow.device.verificationUriComplete ?? flow.device.verificationUri;
+  const setup = await client.start(stage, name, { verification: { userCode: flow.device.userCode, verificationUri } });
+  p.log.info(
+    'Open the link below to sign in and approve this terminal. Setup continues automatically as soon as your perk is enabled.',
+  );
+  // Keep the URL unwrapped so it stays clickable and copyable. The code and
+  // the sign-in page are only for a machine without a browser: the portal page
+  // opens that sign-in itself.
+  process.stdout.write(`\n${setup.url}\n\n`);
+  process.stdout.write(
+    `No browser on this machine? Sign in from another device instead:\nCode: ${flow.device.userCode}\n${verificationUri}\n\n`,
+  );
+  openUrl(setup.url);
+  try {
+    await finishDeviceFlow(flow);
+  } catch (error) {
+    skippedSignIn(error);
+    return false;
+  }
+  const { identity, deviceKey } = await portalIdentity();
+  client.identity = identity;
+  client.deviceKey = deviceKey;
+  if (!(await registerDevice(client))) return false;
+  await client.claim();
+  return true;
+}
+
+/** One later offer per perk per checkout. Explicit setup commands still work. */
+export async function offerPortalReminder(stage: 'echo' | 'slack', enable: () => Promise<void>): Promise<boolean> {
+  const identity = await readInstallIdentity();
+  const client = await portalClient({ identity: identity ?? undefined }).initialize();
+  let consent = false;
+  try {
+    if (client.local.reminders?.[stage]) return false;
+    // A pending, completed, or failed install already has a recovery path. A
+    // reminder must never create another app or replace an existing channel.
+    if (stage === 'slack' && ((await readSlackJob()) || client.local.slackSetup)) return false;
+    const resuming = client.local.reminderPending?.[stage] === true;
+    try {
+      if (!(await client.available(stage))) return false;
+      if (client.token && !resuming) {
+        try {
+          const state = await client.request('GET', '/api/v1/device/state');
+          if (state.activations?.[stage]?.enabled) return false;
+        } catch (error: any) {
+          // Not signed in here, or not registered yet: the offer still stands.
+          if (![401, 403].includes(error.status)) throw error;
+        }
+      }
+    } catch {
+      p.log.warn('Could not check optional perks right now. You can enable them from the portal setup step later.');
+      return false;
+    }
+    const answer =
+      resuming ||
+      (await p.confirm({
+        message:
+          stage === 'echo'
+            ? 'Before starting NanoClaw, enable Echo’s hardened image? Open the perks dashboard?'
+            : 'Before you finish, enable Slack for your agent too? Open the perks dashboard?',
+        initialValue: false,
+      }));
+    consent = answer === true;
+    if (!consent) {
+      client.local.reminders = { ...client.local.reminders, [stage]: true };
+    } else {
+      // Keep the accepted choice through a failed download/installation so a
+      // retry finishes it even though the account perk is already activated.
+      client.local.reminderPending = { ...client.local.reminderPending, [stage]: true };
+    }
+    await client.save();
+  } finally {
+    await client.stop();
+  }
+  if (!consent) return false;
+  // The regular flow takes its own journal lock. Browser consent applies to
+  // this one handoff only; the normal name/role and activation choices remain.
+  await enable();
+  const latest = await portalClient().initialize();
+  try {
+    latest.local.reminders = { ...latest.local.reminders, [stage]: true };
+    if (latest.local.reminderPending) delete latest.local.reminderPending[stage];
+    await latest.save();
+  } finally {
+    await latest.stop();
+  }
+  return true;
+}
+
+export async function beginPortal(
+  stage: PortalStage,
+  name = 'Nano',
+  { browserConsent = false } = {},
+): Promise<SetupClient | null> {
+  const enrolled = Boolean(readRegistryAccount());
+  const client = await portalClient(enrolled ? await portalIdentity() : {}).initialize();
+  const skip = async (): Promise<null> => {
+    await client.stop();
+    return null;
+  };
+  try {
+    if (enrolled && !(await registerDevice(client))) return await skip();
+    if (stage === 'slack') {
+      const job = await readSlackJob();
+      if (job?.status === 'complete' && job.app.appId === client.local.slackSetup?.app?.appId) {
+        client.local.slackSetup.status = 'complete';
+        client.local.slackSetup.app = job.app;
+        await client.save();
+      }
+    }
+    if (!(await client.available(stage))) return await skip();
+    if (
+      enrolled &&
+      (stage !== 'slack' || client.local.slackSetup?.status === 'complete') &&
+      (await client.resumeEnabled(stage, name))
+    ) {
+      p.log.info(`${stage[0].toUpperCase() + stage.slice(1)} already enabled. Continuing setup.`);
+      return client;
+    }
+    const labels = { echo: 'Echo’s hardened agent image', slack: 'Slack for your agent' };
+    const consent =
+      browserConsent ||
+      (await p.confirm({
+        message: `Enable ${labels[stage]}? Open the perks dashboard in your browser?`,
+        initialValue: true,
+      }));
+    if (p.isCancel(consent) || !consent) {
+      p.log.info('Skipped for now. You can enable it later.');
+      return await skip();
+    }
+    if (!enrolled) return (await signInThroughPortal(client, stage, name)) ? client : await skip();
+    const flow = await client.start(stage, name);
+    p.log.info('Activate your perk in the dashboard. Setup continues automatically as soon as it is enabled.');
+    // Keep the URL unwrapped so headless users can copy it into another browser.
+    process.stdout.write(`\n${flow.url}\n\n`);
+    openUrl(flow.url);
+    return client;
+  } catch (error) {
+    await client.stop();
+    throw error;
+  }
+}
+
+export async function runImagePortal(
+  options: { browserConsent?: boolean; apply?: () => Promise<void> } = {},
+): Promise<void> {
+  const previous = readImageSource();
+  const client = await beginPortal('echo', 'Nano', options);
+  if (!client) {
+    if (!options.apply) writeImageSource('local');
+    return;
+  }
+  try {
+    const result = await client.wait();
+    await client.reconcile();
+    if (result.status === 'skipped' && options.apply) return;
+    writeImageSource(result.choice.imageSource || 'local');
+    if (result.status !== 'skipped') {
+      try {
+        await options.apply?.();
+      } catch (error) {
+        writeImageSource(previous);
+        await client.complete('failed').catch(() => {});
+        throw error;
+      }
+      await client.complete();
+    }
+    p.log.success('Image choice saved. Continuing setup.');
+  } finally {
+    await client.stop();
+  }
+}
+
+export async function runSlackPortal(
+  core: ProvisioningCore,
+  name: string,
+  clientVersion?: string,
+  options: { browserConsent?: boolean } = {},
+): Promise<Record<string, string>> {
+  const client = await beginPortal('slack', name, options);
+  if (!client) return { __portal_skip: 'slack' };
+  try {
+    const setup = await client.wait(),
+      choice = setup.choice;
+    await client.reconcile();
+    if (setup.status === 'skipped') return { __portal_skip: 'slack' };
+    const token = client.token;
+    if (!token) throw new Error('Sign in to NanoClaw before setting up Slack.');
+    const workspace = (await core.brokerListWorkspaces(token)).find(
+      (w) => w.team_id === choice.workspaceId && w.status === 'active',
+    );
+    if (!workspace) throw new Error('The selected workspace is no longer connected. Reconnect it in the portal.');
+    let saved = client.local.slackSetup;
+    if (
+      saved?.status === 'complete' &&
+      saved.workspaceId === choice.workspaceId &&
+      saved.name === choice.name &&
+      saved.app?.botToken &&
+      saved.app?.appToken
+    ) {
+      if (!core.brokerAppStatus) throw new Error('Update the Slack channel to verify the existing agent.');
+      const current = await core.brokerAppStatus(token, saved.app.appId);
+      if (current.status === 'installed') saved.setupId = setup.id;
+    }
+    // Slack create has no idempotency contract. Persist before calling it; a
+    // restart must never silently create a second app after an ambiguous result.
+    if (saved?.status === 'creating')
+      throw new Error(
+        'A previous Slack create may have finished. Review the agent list in the portal before recovering this setup.',
+      );
+    if (
+      saved?.setupId !== setup.id &&
+      !(saved?.status === 'received' && saved.workspaceId === choice.workspaceId && saved.name === choice.name)
+    ) {
+      saved = client.local.slackSetup = {
+        setupId: setup.id,
+        workspaceId: choice.workspaceId,
+        name: choice.name,
+        status: 'creating',
+        serviceBase: core.readServiceBase?.() || 'https://slack.nanoclaw.dev',
+      };
+      await client.save();
+      try {
+        saved.app = await core.brokerProvision(token, {
+          team_id: choice.workspaceId,
+          name: choice.name,
+          ...(workspace.connected_as ? { requested_by: workspace.connected_as } : {}),
+          ...(clientVersion ? { client_version: clientVersion } : {}),
+        });
+        saved.status = 'received';
+        await client.save();
+      } catch (error) {
+        await client.complete('failed').catch(() => {});
+        throw error;
+      }
+    }
+    const app = saved.app;
+    if (!app.botToken) {
+      await client.complete('awaiting_approval', { appId: app.appId });
+      p.log.info(
+        'Continue with the workspace installation in the portal. Slack approval will finish in the background.',
+      );
+    }
+
+    const inputs: Record<string, string> = {
+      connection: 'provisioned',
+      ...(app.botToken ? { bot_token: app.botToken } : {}),
+      __portal_pending: 'slack',
+      app_token: app.appToken,
+    };
+    if (workspace.connected_as && /^[UW][A-Z0-9]{8,}$/.test(workspace.connected_as))
+      inputs.owner_handle = workspace.connected_as;
+    await client.save();
+    return inputs;
+  } finally {
+    await client.stop();
+  }
+}
+
+export async function run(args: string[]): Promise<void> {
+  const i = args.indexOf('--stage'),
+    stage = i >= 0 ? args[i + 1] : undefined;
+  if (stage === 'echo') return runImagePortal();
+  if (stage === 'slack') {
+    const { runChannelSkillWithPreStep } = await import('./channels/run-channel-skill.js');
+    process.env.NANOCLAW_PORTAL_ORIGIN ||= 'https://portal.nanoclaw.dev';
+    await runChannelSkillWithPreStep('slack', process.env.NANOCLAW_DISPLAY_NAME || os.userInfo().username);
+    return;
+  }
+  throw new Error('Choose --stage echo or slack.');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : 'Browser setup failed.');
+    process.exitCode = 1;
+  });
+}

--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -145,13 +145,13 @@ export interface AccountCredential {
  * Deliberately not a field on `AccountCredential`: that shape is written to
  * disk, and a marketing preference has no business in a credential file.
  */
-interface EnrollResult {
+export interface EnrollResult {
   credential: AccountCredential;
   emailUpdates: boolean | null;
 }
 
 /** Sign-in failure with a sentence for the user and, where possible, a way out. */
-class LoginError extends Error {
+export class LoginError extends Error {
   constructor(
     message: string,
     readonly hint?: string,
@@ -373,7 +373,7 @@ function resolveRegistryHost(fromBroker: string | undefined): string | undefined
  * worth trusting. Any cached password the helper stashed there is dropped: a
  * new token invalidates it.
  */
-function persistCredential(cred: AccountCredential): void {
+export function persistCredential(cred: AccountCredential): void {
   const record: AccountCredential = { ...cred, registry: resolveRegistryHost(cred.registry) };
   writeSecretFile(ACCOUNT_FILE, `${JSON.stringify(record, null, 2)}\n`);
   ensureHostId();
@@ -427,7 +427,7 @@ function wireDockerCredentialHelper(registry?: string): void {
 // ---------------------------------------------------------------------------
 // Broker
 
-function resolveApiBase(override?: string): string {
+export function resolveApiBase(override?: string): string {
   // process.env, then .env, then the default — same order and same key as
   // setup/lib/registry-state.ts, which states outright that the two must stay
   // in lockstep. A process.env-only read diverges the moment an operator sets
@@ -443,7 +443,7 @@ interface ClientRecord {
   host_id: string;
 }
 
-function clientRecord(): ClientRecord {
+export function clientRecord(): ClientRecord {
   let version = 'unknown';
   try {
     const pkg: unknown = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
@@ -480,7 +480,7 @@ async function probeSession(api: string, token: string): Promise<ProbeState> {
   };
 }
 
-type EnrollBody =
+export type EnrollBody =
   | { method: 'code'; code: string; client: ClientRecord }
   | { method: 'idp'; provider: 'workos'; access_token: string; client: ClientRecord };
 
@@ -499,7 +499,7 @@ function enrollWire(body: EnrollBody): Record<string, unknown> {
   return body.method === 'idp' ? { ...common, workos_token: body.access_token } : common;
 }
 
-async function enroll(api: string, body: EnrollBody): Promise<EnrollResult> {
+export async function enroll(api: string, body: EnrollBody): Promise<EnrollResult> {
   let res: HttpResult;
   try {
     res = await http(`${api}/v1/enroll`, json(enrollWire(body)), HTTP_TIMEOUT_MS);
@@ -608,7 +608,7 @@ function enrollFailure(api: string, method: 'code' | 'idp', res: HttpResult): Lo
 // ---------------------------------------------------------------------------
 // Device flow
 
-interface IdpConfig {
+export interface IdpConfig {
   clientId: string;
   deviceEndpoint: string;
   tokenEndpoint: string;
@@ -631,9 +631,12 @@ interface IdpConfig {
  * and answers 404 from the marketing site, so "unreachable" is not a safe proxy
  * for "misconfigured" either.
  */
-type BrokerProbe = { kind: 'idp'; config: IdpConfig } | { kind: 'no-idp' } | { kind: 'not-a-broker'; detail: string };
+export type BrokerProbe =
+  | { kind: 'idp'; config: IdpConfig }
+  | { kind: 'no-idp' }
+  | { kind: 'not-a-broker'; detail: string };
 
-async function probeBroker(api: string): Promise<BrokerProbe> {
+export async function probeBroker(api: string): Promise<BrokerProbe> {
   const fromEnv = str(process.env[ENV.clientId]);
   if (fromEnv) {
     return {
@@ -685,16 +688,18 @@ function misconfiguredClient(): LoginError {
   );
 }
 
-interface DeviceAuthorization {
+export interface DeviceAuthorization {
   deviceCode: string;
   userCode: string;
   verificationUri: string;
   verificationUriComplete?: string;
   expiresInS: number;
+  /** ISO stamp of `expiresInS` from the moment the code was issued. */
+  expiresAt: string;
   intervalS: number;
 }
 
-async function requestDeviceAuthorization(cfg: IdpConfig): Promise<DeviceAuthorization> {
+export async function requestDeviceAuthorization(cfg: IdpConfig): Promise<DeviceAuthorization> {
   let res: HttpResult;
   try {
     res = await http(cfg.deviceEndpoint, form({ client_id: cfg.clientId }), HTTP_TIMEOUT_MS);
@@ -717,13 +722,15 @@ async function requestDeviceAuthorization(cfg: IdpConfig): Promise<DeviceAuthori
   if (!deviceCode || !userCode || !verificationUri) {
     throw new LoginError('The sign-in provider returned an incomplete device authorization response.');
   }
+  // Defaults are RFC 8628's own; a provider that omits them is unusual, not fatal.
+  const expiresInS = num(res.body?.expires_in) ?? 300;
   return {
     deviceCode,
     userCode,
     verificationUri,
     verificationUriComplete: str(res.body?.verification_uri_complete),
-    // Defaults are RFC 8628's own; a provider that omits them is unusual, not fatal.
-    expiresInS: num(res.body?.expires_in) ?? 300,
+    expiresInS,
+    expiresAt: new Date(Date.now() + expiresInS * 1000).toISOString(),
     intervalS: Math.max(1, num(res.body?.interval) ?? 5),
   };
 }
@@ -785,7 +792,7 @@ function openInBrowser(url: string): void {
   }
 }
 
-async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Promise<string> {
+export async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Promise<string> {
   let intervalMs = device.intervalS * 1000;
   const deadline = Date.now() + Math.min(device.expiresInS * 1000, MAX_DEVICE_WAIT_MS);
   let transportFailures = 0;
@@ -848,6 +855,57 @@ async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Pro
       }
     }
   }
+}
+
+function notABroker(api: string, detail: string): LoginError {
+  return new LoginError(
+    `No NanoClaw registry at ${api} (${detail}).`,
+    `Nothing at that address answers as a NanoClaw registry. If ${ENV.api} is set, check it points at one — unset, this reaches the hosted service. Either way \`./container/build.sh\` builds the image locally and needs no account.`,
+  );
+}
+
+/** A device flow in progress: where to poll and what the user must approve. */
+export interface DeviceFlow {
+  api: string;
+  idp: IdpConfig;
+  device: DeviceAuthorization;
+}
+
+/**
+ * The device flow's first step for a caller that presents the code its own
+ * way (setup/portal.ts folds sign-in into the portal's own page): probe the
+ * broker and request a device authorization. Prints and opens nothing. Every
+ * refusal is a LoginError worded as the standalone run would word it.
+ */
+export async function startDeviceFlow(apiOverride?: string): Promise<DeviceFlow> {
+  const api = resolveApiBase(apiOverride);
+  const probe = await probeBroker(api);
+  if (probe.kind === 'not-a-broker') throw notABroker(api, probe.detail);
+  if (probe.kind === 'no-idp') {
+    throw new LoginError(
+      'Browser authentication is not configured for this registry.',
+      'Run setup/registry-login.sh to sign in with an enrollment code instead.',
+    );
+  }
+  return { api, idp: probe.config, device: await requestDeviceAuthorization(probe.config) };
+}
+
+/**
+ * The rest of that flow: poll the token endpoint until the sign-in is approved
+ * (RFC 8628 §3.5 back-off), enroll at the broker, and persist the credential
+ * exactly as a standalone sign-in does (account.json, registry-auth.json, the
+ * docker credential helper).
+ */
+export async function finishDeviceFlow({ api, idp, device }: DeviceFlow): Promise<AccountCredential> {
+  const idpToken = await pollForIdpToken(idp, device);
+  const { credential } = await enroll(api, {
+    method: 'idp',
+    provider: 'workos',
+    access_token: idpToken,
+    client: clientRecord(),
+  });
+  persistCredential(credential);
+  return credential;
 }
 
 async function deviceLogin(api: string, cfg: IdpConfig): Promise<EnrollResult> {
@@ -1147,12 +1205,7 @@ export async function run(argv: string[]): Promise<void> {
   }
 
   const probe = await probeBroker(api);
-  if (probe.kind === 'not-a-broker') {
-    throw new LoginError(
-      `No NanoClaw registry at ${api} (${probe.detail}).`,
-      `Nothing at that address answers as a NanoClaw registry. If ${ENV.api} is set, check it points at one — unset, this reaches the hosted service. Either way \`./container/build.sh\` builds the image locally and needs no account.`,
-    );
-  }
+  if (probe.kind === 'not-a-broker') throw notABroker(api, probe.detail);
   const idp = probe.kind === 'idp' ? probe.config : undefined;
   if (!idp) {
     // A real registry with no identity provider. Supported: the enrollment-code

--- a/setup/slack-worker.test.ts
+++ b/setup/slack-worker.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, expect, it } from 'vitest';
+import { spawn, execFile, type ChildProcess } from 'node:child_process';
+import { createServer as createSocketServer } from 'node:net';
+import { promisify } from 'node:util';
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm, stat, writeFile, symlink } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+import Database from 'better-sqlite3';
+import { processLock, processLockOwner, writePrivate } from '../src/community-portal/index.js';
+import { launchSlackJob, readSlackJob, slackJobFile, type SlackJob } from '../src/community-portal/slack-job.js';
+import { runSlackJob } from './slack-worker.js';
+
+const cleanups: (() => Promise<unknown>)[] = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+async function fixture(): Promise<{ root: string; job: SlackJob }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nc-slack-job-'));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const job: SlackJob = {
+    id: 'job1',
+    status: 'awaiting_approval',
+    setupId: 'setup1',
+    origin: 'https://portal.example.test',
+    serviceBase: 'https://slack.example.test',
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+    identity: { token: 'install-test-only', account_id: 'acct-test', install_id: 'install-test', deviceId: 'dev_test' },
+    app: { appId: 'A1', appToken: 'xapp-test-only' },
+    context: { agentName: 'Nova', displayName: 'User', role: 'owner', ownerHandle: 'U123456789' },
+  };
+  await writePrivate(slackJobFile(root), job);
+  return { root, job };
+}
+async function until(check: () => Promise<boolean>, timeout = 10_000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await sleep(20);
+  }
+  throw new Error('Background job did not reach the expected state.');
+}
+async function stopped(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+}
+
+it('approval two days later finishes the saved app, wires the owner and hands off its welcome without a browser or terminal', async () => {
+  const { root, job } = await fixture();
+  const created = Date.now() - 2 * 86400_000;
+  job.createdAt = new Date(created).toISOString();
+  job.expiresAt = new Date(created + 7 * 86400_000).toISOString();
+  await writePrivate(slackJobFile(root), job);
+  let welcome: any;
+  const server = createSocketServer((socket) => {
+    let line = '';
+    socket.on('data', (chunk) => {
+      line += chunk;
+    });
+    socket.on('end', () => {
+      welcome = JSON.parse(line);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(path.join(root, 'data/cli.sock'), resolve));
+  cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  const reports: string[] = [];
+  let polls = 0;
+  await runSlackJob(root, {
+    now: Date.now,
+    sleep: async () => {},
+    report: async (current) => {
+      reports.push(current.status);
+    },
+    receive: async (current, body: any) => {
+      expect(current.app.appId).toBe('A1');
+      if (body.deliveryId) {
+        expect((await readSlackJob(root))?.app.botToken).toBe('xoxb-approved');
+        return {};
+      }
+      if (body.statusOnly) return { status: 'installed' };
+      if (++polls === 1) return { status: 'pending_install' };
+      return { status: 'installed', bot_token: 'xoxb-approved', delivery_id: 'receipt-two-days-later' };
+    },
+    install: async (current) => {
+      expect(current.context).toEqual(job.context);
+      await promisify(execFile)(
+        process.execPath,
+        [
+          '--import',
+          path.resolve('node_modules/tsx/dist/loader.mjs'),
+          path.resolve('scripts/init-first-agent.ts'),
+          '--channel',
+          'slack',
+          '--user-id',
+          current.context.ownerHandle,
+          '--platform-id',
+          'slack:D123456789',
+          '--display-name',
+          current.context.displayName,
+          '--agent-name',
+          current.context.agentName,
+          '--role',
+          current.context.role,
+        ],
+        { cwd: root, timeout: 30_000 },
+      );
+      await until(async () => Boolean(welcome));
+      expect(reports).not.toContain('complete');
+    },
+  });
+  expect((await readSlackJob(root))?.status).toBe('complete');
+  expect(reports.at(-1)).toBe('complete');
+  expect(polls).toBe(2);
+  expect(welcome).toMatchObject({
+    text: expect.stringContaining('run /welcome'),
+    senderId: 'slack:U123456789',
+    sender: 'User',
+    to: { channelType: 'slack', platformId: 'slack:D123456789', instance: 'slack' },
+  });
+  const db = new Database(path.join(root, 'data/v2.db'), { readonly: true });
+  try {
+    expect(db.prepare('SELECT channel_type, platform_id, instance FROM messaging_groups').all()).toEqual([
+      { channel_type: 'slack', platform_id: 'slack:D123456789', instance: 'slack' },
+    ]);
+  } finally {
+    db.close();
+  }
+}, 60_000);
+
+it('survives SIGKILL after durable delivery, retries ACK, serializes with setup and installs once across workers', async () => {
+  const { root, job } = await fixture();
+  let reads = 0,
+    acknowledgements = 0;
+  let first!: ChildProcess;
+  const server = createServer(async (req, res) => {
+    expect(req.url).toBe('/v1/apps/A1/install');
+    expect(req.headers.authorization).toBe('Bearer install-test-only');
+    let raw = '';
+    for await (const chunk of req) raw += chunk;
+    const body = JSON.parse(raw);
+    res.setHeader('content-type', 'application/json');
+    if (body.statusOnly) {
+      res.end('{"status":"installed"}');
+      return;
+    }
+    if (body.deliveryId) {
+      acknowledgements++;
+      const durable = await readSlackJob(root);
+      expect(durable?.app.botToken).toBe('xoxb-test-only');
+      expect(durable?.deliveryId).toBe('receipt1');
+      if (acknowledgements === 1) {
+        first.kill('SIGKILL');
+        res.destroy();
+        return;
+      }
+      res.end('{"acknowledged":true}');
+      return;
+    }
+    reads++;
+    res.end(JSON.stringify({ status: 'installed', bot_token: 'xoxb-test-only', delivery_id: 'receipt1' }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  job.serviceBase = `http://127.0.0.1:${(server.address() as any).port}`;
+  await writePrivate(slackJobFile(root), job);
+  const script = path.join(root, 'run.mts');
+  await writeFile(
+    script,
+    `import {appendFile} from 'node:fs/promises';
+import {runSlackJob} from ${JSON.stringify(pathToFileURL(path.resolve('setup/slack-worker.ts')).href)};
+await runSlackJob(${JSON.stringify(root)}, {
+ report: async j => { await appendFile(${JSON.stringify(path.join(root, 'progress'))}, j.status+'\\n'); },
+ install: async j => { if(j.app.botToken!=='xoxb-test-only')throw Error('missing token'); await appendFile(${JSON.stringify(path.join(root, 'installed'))}, j.app.appId+'\\n'); },
+ sleep: async () => new Promise(r=>setTimeout(r,20)),
+});`,
+  );
+  const launch = () => {
+    const child = spawn(
+      process.execPath,
+      ['--import', pathToFileURL(path.resolve('node_modules/tsx/dist/loader.mjs')).href, script],
+      { stdio: 'pipe', env: { ...process.env, NANOCLAW_SETUP_LOCK: '' } },
+    );
+    let error = '';
+    child.stderr?.on('data', (data) => {
+      error += data;
+    });
+    cleanups.push(async () => {
+      child.kill('SIGKILL');
+      await stopped(child);
+      if (child.exitCode && error) throw new Error(error);
+    });
+    return child;
+  };
+  const unlock = await processLock(path.join(root, 'data/setup-mutation.lock'));
+  expect(unlock).toBeTypeOf('function');
+  first = launch();
+  await until(async () => acknowledgements === 1);
+  await stopped(first);
+  expect((await stat(slackJobFile(root))).mode & 0o777).toBe(0o600);
+  const second = launch();
+  await until(async () => acknowledgements === 2);
+  const contender = launch();
+  await stopped(contender);
+  expect(contender.exitCode).toBe(0);
+  await expect(readFile(path.join(root, 'installed'))).rejects.toMatchObject({ code: 'ENOENT' });
+  unlock!();
+  await until(async () => (await readSlackJob(root))?.status === 'complete');
+  await stopped(second);
+  expect(second.exitCode).toBe(0);
+  expect(await readFile(path.join(root, 'installed'), 'utf8')).toBe('A1\n');
+  expect(reads).toBe(1);
+  expect(acknowledgements).toBe(2);
+  expect((await readSlackJob(root))?.reportedStatus).toBe('complete');
+  expect(await readFile(path.join(root, 'progress'), 'utf8')).toContain('complete');
+}, 20_000);
+
+it('keeps approval pending through a transient failure, then installs; an apply failure is visible and never loops', async () => {
+  const { root } = await fixture();
+  let polls = 0,
+    applies = 0;
+  const statuses: string[] = [];
+  await runSlackJob(root, {
+    report: async (j) => {
+      statuses.push(j.status);
+    },
+    receive: async (_j, body) => {
+      if ('statusOnly' in body) return { status: 'installed' };
+      if ('deliveryId' in body) return {};
+      polls++;
+      if (polls === 1) throw Object.assign(new Error('offline'), { status: 503 });
+      if (polls === 2) return { status: 'pending_install' };
+      return { status: 'installed', bot_token: 'xoxb-test-only', delivery_id: 'receipt1' };
+    },
+    sleep: async () => {},
+    install: async () => {
+      applies++;
+      throw new Error('build needs attention');
+    },
+  });
+  expect(polls).toBe(3);
+  expect(applies).toBe(1);
+  expect((await readSlackJob(root))?.status).toBe('failed');
+  expect(statuses.at(-1)).toBe('failed');
+});
+
+it('never applies after sign-out or expiry, and resumes completion reporting without reinstalling', async () => {
+  const { root, job } = await fixture();
+  let applies = 0;
+  await runSlackJob(root, {
+    report: async () => {
+      throw Object.assign(new Error('signed out'), { status: 401 });
+    },
+    install: async () => {
+      applies++;
+    },
+  });
+  expect((await readSlackJob(root))?.error).toBe('sign_in_required');
+  expect(applies).toBe(0);
+  await writePrivate(slackJobFile(root), { ...job, expiresAt: new Date(0).toISOString() });
+  await runSlackJob(root, {
+    report: async () => {},
+    install: async () => {
+      applies++;
+    },
+  });
+  expect((await readSlackJob(root))?.status).toBe('expired');
+  expect(applies).toBe(0);
+  await writePrivate(slackJobFile(root), { ...job, status: 'complete' });
+  await runSlackJob(root, {
+    report: async () => {},
+    install: async () => {
+      applies++;
+    },
+  });
+  expect((await readSlackJob(root))?.reportedStatus).toBe('complete');
+  expect(applies).toBe(0);
+});
+
+it('the production launcher starts a detached worker and waits for its ready handshake', async () => {
+  const { root, job } = await fixture();
+  let reports = 0,
+    polls = 0;
+  const server = createServer(async (req, res) => {
+    for await (const _ of req) {
+      /* drain the body */
+    }
+    res.setHeader('content-type', 'application/json');
+    if (req.url === '/api/v1/device/slack') {
+      reports++;
+      res.end('{"ok":true}');
+    } else {
+      expect(req.url).toBe('/v1/apps/A1/install');
+      polls++;
+      res.end('{"status":"pending_install"}');
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  cleanups.push(
+    () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  );
+  job.origin = job.serviceBase = `http://127.0.0.1:${(server.address() as any).port}`;
+  await writePrivate(slackJobFile(root), job);
+  await symlink(path.resolve('setup'), path.join(root, 'setup'));
+  await symlink(path.resolve('node_modules'), path.join(root, 'node_modules'));
+  expect(await launchSlackJob(root)).toBe(true);
+  const { pid } = processLockOwner(`${slackJobFile(root)}.lock`)!;
+  expect(pid).not.toBe(process.pid);
+  cleanups.push(async () => {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {}
+  });
+  await until(async () => reports > 0 && polls > 0);
+  expect((await readSlackJob(root))?.status).toBe('awaiting_approval');
+});
+
+it('recovers an owner from a previous process birth even when its PID has been reused', async () => {
+  const { root } = await fixture();
+  const file = path.join(root, 'data/reboot.lock');
+  const release = await processLock(file);
+  expect(release).not.toBeNull();
+  release!();
+  await writeFile(file, JSON.stringify({ pid: process.pid, nonce: 'old-owner', started: 'previous-boot' }));
+  const recovered = await processLock(file);
+  expect(recovered).not.toBeNull();
+  recovered!();
+});

--- a/setup/slack-worker.ts
+++ b/setup/slack-worker.ts
@@ -1,0 +1,184 @@
+import { realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { processLock, writePrivate } from '../src/community-portal/index.js';
+import {
+  readSlackJob,
+  slackJobFile,
+  slackProgressClient,
+  withSetupLock,
+  type SlackJob,
+} from '../src/community-portal/slack-job.js';
+
+type Delivery = { status?: string; bot_token?: string; delivery_id?: string };
+export interface WorkerDependencies {
+  receive(job: SlackJob, body: object): Promise<Delivery>;
+  install(job: SlackJob): Promise<void>;
+  report(job: SlackJob): Promise<void>;
+  sleep(ms: number): Promise<unknown>;
+  now(): number;
+}
+async function receive(job: SlackJob, body: object): Promise<Delivery> {
+  const base = new URL(job.serviceBase);
+  if (
+    base.username ||
+    base.password ||
+    base.search ||
+    base.hash ||
+    (base.protocol !== 'https:' &&
+      !(base.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(base.hostname)))
+  )
+    throw Object.assign(new Error('Invalid Slack service origin.'), { code: 'invalid_service' });
+  const response = await fetch(`${base.origin}/v1/apps/${encodeURIComponent(job.app.appId)}/install`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${job.identity.token}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+    redirect: 'error',
+  });
+  if (!response.ok) throw Object.assign(new Error('Slack installation request failed.'), { status: response.status });
+  return response.json() as Promise<Delivery>;
+}
+async function install(job: SlackJob): Promise<void> {
+  const { runChannelSkill } = await import('./channels/run-channel-skill.js');
+  if (job.context.templateAgentId) process.env.NANOCLAW_TEMPLATE_AGENT_ID = job.context.templateAgentId;
+  await runChannelSkill('slack', job.context.displayName, {
+    agentName: job.context.agentName,
+    role: job.context.role,
+    reuse: false,
+    requireCompanions: true,
+    inputs: {
+      connection: 'provisioned',
+      bot_token: job.app.botToken!,
+      app_token: job.app.appToken,
+      owner_handle: job.context.ownerHandle,
+    },
+    resolveInput: async () => {
+      throw new Error('Slack needs an additional input. Resume the Slack setup step.');
+    },
+    confirm: async () => false,
+    openUrl: async () => {},
+    fail: async () => {
+      throw new Error('Slack channel installation needs attention.');
+    },
+  });
+}
+export async function runSlackJob(
+  root = process.cwd(),
+  overrides: Partial<WorkerDependencies> = {},
+  ready: () => void = () => {},
+): Promise<void> {
+  const release = await processLock(`${slackJobFile(root)}.lock`);
+  ready();
+  if (!release) return;
+  try {
+    const job = await readSlackJob(root);
+    if (!job || ['failed', 'expired'].includes(job.status)) return;
+    const deps: WorkerDependencies = {
+      receive,
+      install,
+      sleep,
+      now: Date.now,
+      report: async (current) => {
+        await slackProgressClient(current).request('POST', '/api/v1/device/slack', {
+          appId: current.app.appId,
+          setupId: current.setupId,
+          status: current.status,
+        });
+      },
+      ...overrides,
+    };
+    const save = () => writePrivate(slackJobFile(root), job);
+    let reported = job.reportedStatus;
+    const report = async () => {
+      if (reported === job.status) return;
+      try {
+        await deps.report(job);
+        reported = job.status;
+        job.reportedStatus = reported;
+        await save();
+      } catch (error: any) {
+        if ([401, 403].includes(error.status)) throw error;
+      }
+    };
+    while (deps.now() < Date.parse(job.expiresAt)) {
+      let applying = false;
+      try {
+        await report();
+        if (job.status === 'complete') {
+          if (reported === 'complete') return;
+          await deps.sleep(30_000);
+          continue;
+        }
+        if (!job.app.botToken) {
+          const delivery = await deps.receive(job, {});
+          if (delivery.status === 'deleted') throw Object.assign(new Error(), { code: 'app_revoked' });
+          if (!delivery.bot_token) {
+            if (delivery.status === 'installed') throw Object.assign(new Error(), { code: 'credential_unavailable' });
+            await deps.sleep(30_000);
+            continue;
+          }
+          if (!delivery.delivery_id || !delivery.bot_token.startsWith('xoxb-'))
+            throw Object.assign(new Error(), { code: 'invalid_delivery' });
+          job.app.botToken = delivery.bot_token;
+          job.deliveryId = delivery.delivery_id;
+          job.status = 'installing';
+          // This fsync + atomic rename MUST precede acknowledgement. A lost
+          // response or crash replays the same receipt to this installation.
+          await save();
+        }
+        if (job.deliveryId && !job.acknowledged) {
+          await deps.receive(job, { deliveryId: job.deliveryId });
+          job.acknowledged = true;
+          await save();
+        }
+        job.status = 'installing';
+        await save();
+        await report();
+        await withSetupLock(async () => {
+          // Check revocation again after a potentially long wait for setup.
+          const current = await deps.receive(job, { statusOnly: true });
+          if (current.status !== 'installed') throw Object.assign(new Error(), { code: 'app_revoked' });
+          await deps.report(job);
+          applying = true;
+          await deps.install(job);
+          job.status = 'complete';
+          await save();
+        }, root);
+        await report();
+      } catch (error: any) {
+        if (
+          [401, 403, 404].includes(error.status) ||
+          ['app_revoked', 'credential_unavailable', 'invalid_delivery', 'invalid_service'].includes(error.code) ||
+          applying
+        ) {
+          job.status = 'failed';
+          job.error = [401, 403].includes(error.status) ? 'sign_in_required' : error.code || 'install_needs_attention';
+          await save();
+          await deps.report(job).catch(() => {});
+          return;
+        }
+        // Offline, rate limits, and temporary service errors are retryable.
+        await deps.sleep(30_000);
+      }
+    }
+    if (job.status !== 'complete') {
+      job.status = 'expired';
+      job.error = 'approval_window_expired';
+      await save();
+      await deps.report(job).catch(() => {});
+    }
+  } finally {
+    release();
+  }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href) {
+  runSlackJob(process.cwd(), {}, () => {
+    if (process.send) {
+      process.send({ type: 'slack-worker-ready' });
+      process.disconnect();
+    }
+  }).catch(() => {
+    process.exitCode = 1;
+  });
+}

--- a/setup/verify-slack.test.ts
+++ b/setup/verify-slack.test.ts
@@ -1,0 +1,207 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const host = vi.hoisted(() => ({ root: '', service: 'running', groups: 0, channels: {} as Record<string, string> }));
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
+  execSync: vi.fn((command: string) => {
+    if (command.includes(' is-active ') && host.service === 'stopped') throw new Error('stopped');
+    if (command.includes('MainPID')) return '123';
+    if (command.startsWith('ps ')) return `node ${host.service === 'other' ? '/other' : host.root}/dist/index.js`;
+    if (command.includes('list-unit-files')) return 'nanoclaw.service';
+    return '';
+  }),
+}));
+vi.mock('../src/install-slug.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/install-slug.js')>()),
+  getLaunchdLabel: () => 'dev.nanoclaw',
+  getSystemdUnit: () => 'nanoclaw.service',
+}));
+vi.mock('../src/env.js', () => ({ readEnvFile: () => host.channels }));
+vi.mock('./platform.js', () => ({
+  getPlatform: () => 'linux',
+  getServiceManager: () => 'systemd',
+  isRoot: () => false,
+  hasSystemd: () => true,
+}));
+vi.mock('./central-db-inspection.js', () => ({
+  inspectCentralDb: async () => ({ registeredGroups: host.groups, derivedGroups: 0 }),
+}));
+vi.mock('./lib/registry-state.js', () => ({
+  readImageSource: () => 'hardened',
+  inspectAgentImage: () => ({ source: 'hardened', registryDigest: 'sha256:fixture' }),
+}));
+vi.mock('./status.js', () => ({ emitStatus: vi.fn() }));
+
+import { emitStatus } from './status.js';
+import { run } from './verify.js';
+import { readSlackJob, withSetupLock } from '../src/community-portal/slack-job.js';
+
+beforeEach(() => {
+  host.root = fs.mkdtempSync(path.join(os.tmpdir(), 'nc-verify-slack-'));
+  host.service = 'running';
+  host.groups = 0;
+  host.channels = {};
+  fs.mkdirSync(path.join(host.root, 'data'));
+  fs.writeFileSync(path.join(host.root, '.env'), 'ANTHROPIC_API_KEY=fixture-only\n');
+  vi.spyOn(process, 'cwd').mockReturnValue(host.root);
+  vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('verify_exit');
+  });
+  vi.mocked(emitStatus).mockClear();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(host.root, { recursive: true, force: true });
+});
+
+function saveJob(status: string, expiresAt = new Date(Date.now() + 60_000).toISOString()): void {
+  fs.writeFileSync(
+    path.join(host.root, 'data/slack-install.json'),
+    JSON.stringify({
+      status,
+      expiresAt,
+      app: { appId: 'A_TEST', appToken: 'xapp-private-fixture' },
+      identity: { token: 'private-install-fixture', account_id: 'acct-fixture', install_id: 'install-fixture' },
+    }),
+    { mode: 0o600 },
+  );
+}
+const fields = () => vi.mocked(emitStatus).mock.calls.at(-1)?.[1];
+
+describe('verification during background Slack installation', () => {
+  it.each(['awaiting_approval', 'installing'])(
+    'finishes foreground setup while Slack is %s, before credentials or groups exist',
+    async (status) => {
+      saveJob(status);
+      await expect(run([])).resolves.toBeUndefined();
+      expect(fields()).toMatchObject({
+        STATUS: 'success',
+        SLACK_INSTALL: status,
+        WIRING: 'pending_slack_install',
+        CONFIGURED_CHANNELS: '',
+        CHANNEL_AUTH: '{}',
+        REGISTERED_GROUPS: 0,
+      });
+      expect(JSON.stringify(fields())).not.toMatch(/private-fixture|private-install-fixture/);
+    },
+  );
+
+  it.each(['failed', 'expired'])('reports a %s worker even if another group is wired', async (status) => {
+    saveJob(status);
+    host.groups = 1;
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ STATUS: 'failed', SLACK_INSTALL: status });
+  });
+
+  it('does not mistake an expired pending job for progress', async () => {
+    saveJob('awaiting_approval', new Date(Date.now() - 1000).toISOString());
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ STATUS: 'failed', SLACK_INSTALL: 'expired' });
+  });
+
+  it('does not hide an unwired different channel behind pending Slack', async () => {
+    saveJob('awaiting_approval');
+    host.channels = { TELEGRAM_BOT_TOKEN: 'fixture-only' };
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ STATUS: 'failed', CONFIGURED_CHANNELS: 'telegram' });
+  });
+
+  it.each(['stopped', 'other', 'missing_credentials'])('does not hide %s behind pending Slack', async (failure) => {
+    saveJob('awaiting_approval');
+    if (failure === 'missing_credentials') fs.unlinkSync(path.join(host.root, '.env'));
+    else host.service = failure;
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ STATUS: 'failed' });
+  });
+
+  it('still fails without a job or a wired group', async () => {
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ STATUS: 'failed' });
+  });
+
+  it('reports fully installed Slack normally', async () => {
+    saveJob('complete');
+    host.groups = 1;
+    host.channels = { SLACK_BOT_TOKEN: 'fixture-only', SLACK_APP_TOKEN: 'fixture-only' };
+    await expect(run([])).resolves.toBeUndefined();
+    expect(fields()).toMatchObject({
+      STATUS: 'success',
+      SLACK_INSTALL: 'complete',
+      CONFIGURED_CHANNELS: 'slack',
+      REGISTERED_GROUPS: 1,
+    });
+    expect(fields()).not.toHaveProperty('WIRING');
+  });
+
+  it('lets foreground verification finish and release the real checkout lock so the detached worker can install', async () => {
+    saveJob('awaiting_approval');
+    const script = path.join(host.root, 'worker.mts');
+    const workerModule = new URL('./slack-worker.ts', import.meta.url).href;
+    fs.writeFileSync(
+      script,
+      `import {writeFileSync} from 'node:fs';
+import {runSlackJob} from ${JSON.stringify(workerModule)};
+await runSlackJob(${JSON.stringify(host.root)}, {
+  receive: async (_job, body) => body.statusOnly ? {status:'installed'} : body.deliveryId ? {acknowledged:true} : {status:'installed',bot_token:'xoxb-fixture',delivery_id:'receipt-fixture'},
+  report: async () => {},
+  install: async () => { writeFileSync(${JSON.stringify(path.join(host.root, 'installed'))}, 'installed'); },
+});`,
+    );
+    let child: ReturnType<typeof spawn> | undefined;
+    let transcript = '';
+    const until = async (check: () => Promise<boolean>) => {
+      const deadline = Date.now() + 5000;
+      while (!(await check())) {
+        if (Date.now() > deadline) throw new Error(`worker timeout: ${transcript}`);
+        await sleep(20);
+      }
+    };
+    try {
+      await withSetupLock(async () => {
+        const env = { ...process.env };
+        delete env.NANOCLAW_SETUP_LOCK;
+        child = spawn(
+          process.execPath,
+          [
+            '--import',
+            pathToFileURL(path.resolve(import.meta.dirname, '../node_modules/tsx/dist/loader.mjs')).href,
+            script,
+          ],
+          { env, stdio: ['ignore', 'pipe', 'pipe'] },
+        );
+        child.stdout!.on('data', (data) => {
+          transcript += data;
+        });
+        child.stderr!.on('data', (data) => {
+          transcript += data;
+        });
+        await until(async () => (await readSlackJob(host.root))?.status === 'installing');
+        await run([]);
+        expect(fields()).toMatchObject({
+          STATUS: 'success',
+          SLACK_INSTALL: 'installing',
+          WIRING: 'pending_slack_install',
+        });
+        expect(fs.existsSync(path.join(host.root, 'installed'))).toBe(false);
+      }, host.root);
+      await until(async () => (await readSlackJob(host.root))?.status === 'complete');
+      expect(fs.readFileSync(path.join(host.root, 'installed'), 'utf8')).toBe('installed');
+      host.groups = 1;
+      host.channels = { SLACK_BOT_TOKEN: 'fixture-only', SLACK_APP_TOKEN: 'fixture-only' };
+      await run([]);
+      expect(fields()).toMatchObject({ STATUS: 'success', SLACK_INSTALL: 'complete', REGISTERED_GROUPS: 1 });
+      expect(fields()).not.toHaveProperty('WIRING');
+    } finally {
+      if (child && child.exitCode === null && child.signalCode === null) {
+        child.kill();
+        await new Promise<void>((resolve) => child!.once('exit', () => resolve()));
+      }
+    }
+  }, 10_000);
+});

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -16,6 +16,7 @@ import { inspectCentralDb } from './central-db-inspection.js';
 import { inspectAgentImage, readImageSource } from './lib/registry-state.js';
 import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
 import { emitStatus } from './status.js';
+import { readSlackJob, slackJobStatus, type SlackJob } from '../src/community-portal/slack-job.js';
 
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
@@ -215,6 +216,11 @@ export async function run(_args: string[]): Promise<void> {
     configuredChannels.length > 0 &&
     configuredChannels.every((c) => DEFER_WIRE_CHANNELS.has(c));
 
+  // The detached Slack worker applies the channel after foreground setup
+  // releases its checkout lock. No credentials/groups yet is expected here.
+  const slackInstall = slackJobStatus(await readSlackJob(projectRoot));
+  const slackWiringPending = registeredGroups === 0 && canDeferSlackWiring(slackInstall, configuredChannels);
+
   // Determine overall status. The cli-agent step earlier in setup already
   // proved the agent round-trip works; verify is a static health check.
   const status = determineVerifyStatus({
@@ -222,12 +228,15 @@ export async function run(_args: string[]): Promise<void> {
     credentials,
     registeredGroups,
     wiringPending,
+    slackInstall,
+    configuredChannels,
   });
 
   log.info('Verification complete', {
     status,
     channelAuth,
     wiringPending,
+    slackInstall,
     imageSource,
     imageSourceActual: image.source,
     derivedGroups,
@@ -253,7 +262,8 @@ export async function run(_args: string[]): Promise<void> {
     // versions.json. Empty for a locally built image — it has never had one.
     IMAGE_DIGEST: image.registryDigest ?? '',
     DERIVED_GROUPS: derivedGroups,
-    ...(wiringPending ? { WIRING: 'pending_first_dm' } : {}),
+    ...(slackInstall ? { SLACK_INSTALL: slackInstall } : {}),
+    ...(slackWiringPending ? { WIRING: 'pending_slack_install' } : wiringPending ? { WIRING: 'pending_first_dm' } : {}),
     STATUS: status,
     LOG: 'logs/setup.log',
   });
@@ -270,16 +280,29 @@ export async function run(_args: string[]): Promise<void> {
  */
 export const DEFER_WIRE_CHANNELS = new Set(['teams']);
 
+function canDeferSlackWiring(slackInstall: SlackJob['status'] | undefined, configuredChannels: string[]): boolean {
+  return (
+    (slackInstall === 'awaiting_approval' || slackInstall === 'installing') &&
+    configuredChannels.every((c) => c === 'slack' || DEFER_WIRE_CHANNELS.has(c))
+  );
+}
+
 export function determineVerifyStatus(input: {
   service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout';
   credentials: string;
   registeredGroups: number;
   /** Zero groups but every configured channel defers wiring to the first DM. */
   wiringPending?: boolean;
+  slackInstall?: SlackJob['status'];
+  configuredChannels?: string[];
 }): 'success' | 'failed' {
   return input.service === 'running' &&
     input.credentials !== 'missing' &&
-    (input.registeredGroups > 0 || input.wiringPending === true)
+    input.slackInstall !== 'failed' &&
+    input.slackInstall !== 'expired' &&
+    (input.registeredGroups > 0 ||
+      input.wiringPending === true ||
+      canDeferSlackWiring(input.slackInstall, input.configuredChannels ?? []))
     ? 'success'
     : 'failed';
 }

--- a/src/community-portal/device-client.test.ts
+++ b/src/community-portal/device-client.test.ts
@@ -1,0 +1,446 @@
+import { mkdtemp, readFile, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DeviceClient, type Journal } from './device-client.js';
+import {
+  DEVICE_PROOF_HEADER,
+  ensureDeviceKey,
+  verifyDeviceProof,
+  type DeviceKey,
+  type DevicePublicJwk,
+} from './device-key.js';
+import type { InstallIdentity } from './install-identity.js';
+import { SetupClient } from './setup-client.js';
+
+/**
+ * A stand-in portal: checks the device proof exactly where the contract puts
+ * it (device registration against the key in the body, cell tickets against
+ * the pinned key), records every request, and serves scripted responses.
+ * Nothing here talks to the real portal.
+ */
+type Handler = (request: { method: string; route: string; body: unknown; authorization?: string }) => {
+  status?: number;
+  body: unknown;
+};
+interface Seen {
+  method: string;
+  route: string;
+  body: unknown;
+  authorization?: string;
+  proof?: string;
+  proofValid?: boolean;
+}
+let server: Server;
+let origin: string;
+let root: string;
+let journalFile: string;
+let handler: Handler;
+let key: DeviceKey;
+let pinned: DevicePublicJwk | undefined;
+const identity: InstallIdentity = { token: 'tok', accountId: 'acct-1', installId: 'inst-1' };
+const seen: Seen[] = [];
+const DEVICE_ID = 'dev_0123456789abcdef01234567';
+
+async function journal(): Promise<Journal> {
+  return JSON.parse(await readFile(journalFile, 'utf8')) as Journal;
+}
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString();
+  const route = new URL(req.url ?? '/', origin).pathname;
+  const body: unknown = raw ? JSON.parse(raw) : undefined;
+  const request = { method: req.method ?? '', route, body, authorization: req.headers.authorization };
+  const proof = req.headers[DEVICE_PROOF_HEADER];
+  const record: Seen = { ...request, ...(typeof proof === 'string' ? { proof } : {}) };
+  seen.push(record);
+  const proofed = route === '/api/v1/devices' || route === '/api/v1/cell-ticket';
+  let reply: ReturnType<Handler>;
+  if (proofed) {
+    if (typeof proof !== 'string') reply = { status: 401, body: { error: 'device_proof_required' } };
+    else {
+      const against =
+        route === '/api/v1/devices' ? (body as { publicKey?: DevicePublicJwk } | undefined)?.publicKey : pinned;
+      record.proofValid = Boolean(against) && verifyDeviceProof(proof, against!).valid;
+      reply = record.proofValid ? handler(request) : { status: 401, body: { error: 'invalid_proof' } };
+    }
+  } else reply = handler(request);
+  res.writeHead(reply.status ?? 200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(reply.body));
+}
+const registration: Handler = ({ route, method, body }) => {
+  if (route === '/api/v1/devices' && method === 'POST') {
+    pinned = (body as { publicKey: DevicePublicJwk }).publicKey;
+    return { body: { deviceId: DEVICE_ID, accountId: identity.accountId, installId: identity.installId } };
+  }
+  if (route === '/api/v1/cell-ticket')
+    return { body: { ticket: 'tkt', expiresIn: 900, socketUrl: `${origin}/cell/link` } };
+  if (route === '/api/v1/device/state') return { body: { grants: [] } };
+  if (route.endsWith('/ack')) return { body: { ok: true } };
+  return { status: 404, body: { error: 'not_found' } };
+};
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'nc-portal-client-'));
+  journalFile = path.join(root, 'data/community-portal.json');
+  key = ensureDeviceKey({ file: path.join(root, 'device-key.json') });
+  pinned = undefined;
+  seen.length = 0;
+  handler = () => ({ status: 404, body: { error: 'not_found' } });
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+});
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('DeviceClient', () => {
+  it('keeps a keyless private journal, sends plain bearer requests, and proves only registration and tickets', async () => {
+    const client = await new DeviceClient({
+      origin,
+      file: journalFile,
+      identity,
+      deviceKey: key,
+      label: 'lab',
+    }).initialize();
+    expect((await stat(journalFile)).mode & 0o777).toBe(0o600);
+    expect(await journal()).toEqual({ origin, credentials: {}, operations: {} });
+    handler = registration;
+    await client.request('GET', '/api/v1/device/state');
+    expect(seen).toEqual([
+      { method: 'GET', route: '/api/v1/device/state', body: undefined, authorization: 'Bearer tok' },
+    ]);
+    const registered = await client.register();
+    expect(registered).toEqual({ deviceId: DEVICE_ID, accountId: 'acct-1', installId: 'inst-1' });
+    expect(seen.at(-1)).toMatchObject({
+      method: 'POST',
+      route: '/api/v1/devices',
+      body: { publicKey: key.publicKeyJwk, label: 'lab' },
+      authorization: 'Bearer tok',
+      proofValid: true,
+    });
+    expect(seen.at(-1)?.proof).toMatch(/^v1;kid=/);
+    expect((await journal()).deviceId).toBe(DEVICE_ID);
+    expect(client.local.deviceId).toBe(DEVICE_ID);
+    await client.register();
+    expect((await journal()).deviceId).toBe(DEVICE_ID);
+    const ticket = await client.ticket();
+    expect(ticket).toEqual({ ticket: 'tkt', expiresIn: 900, socketUrl: `${origin}/cell/link` });
+    expect(seen.at(-1)).toMatchObject({ route: '/api/v1/cell-ticket', body: {}, proofValid: true });
+    expect(seen.map((r) => r.proof !== undefined)).toEqual([false, true, true, true]);
+    await client.request('POST', '/api/v1/grants/echo/ack', { keyId: 'k' });
+    expect(seen.at(-1)).not.toHaveProperty('proof');
+    expect(JSON.stringify(await journal())).not.toMatch(/tok|pkcs8|privateKey|"d"/);
+    await client.stop();
+    const again = await new DeviceClient({ origin, file: journalFile, identity }).initialize();
+    expect(again.local.deviceId).toBe(DEVICE_ID);
+    expect(again.token).toBe('tok');
+    await again.stop();
+  });
+
+  it('refuses to prove without a device key or an identity, while plain requests still work', async () => {
+    handler = registration;
+    const keyless = await new DeviceClient({ origin, file: journalFile, identity }).initialize();
+    await expect(keyless.ticket()).rejects.toMatchObject({ code: 'device_key_required' });
+    await expect(keyless.register()).rejects.toMatchObject({ code: 'device_key_required' });
+    expect(await keyless.request('GET', '/api/v1/device/state')).toEqual({ grants: [] });
+    await keyless.stop();
+    const anonymous = await new DeviceClient({ origin, file: journalFile, deviceKey: key }).initialize();
+    await expect(anonymous.register()).rejects.toMatchObject({ code: 'installation_required' });
+    expect(anonymous.token).toBeUndefined();
+    await anonymous.stop();
+    expect(seen.filter((r) => r.route !== '/api/v1/device/state')).toEqual([]);
+    expect(seen[0].authorization).toBe('Bearer tok');
+  });
+
+  it('refuses a plaintext origin off loopback, and a journal from another portal', async () => {
+    expect(() => new DeviceClient({ origin: 'http://portal.example.test', file: journalFile })).toThrow('HTTPS');
+    expect(() => new DeviceClient({ origin: 'https://portal.example.test/path', file: journalFile })).toThrow('HTTPS');
+    const client = await new DeviceClient({ origin, file: journalFile }).initialize();
+    await client.stop();
+    await expect(
+      new DeviceClient({ origin: 'https://portal.example.test', file: journalFile }).initialize(),
+    ).rejects.toThrow('different portal');
+  });
+
+  it('surfaces the portal error code and status, and does not create a journal when told to use an existing one', async () => {
+    const client = await new DeviceClient({ origin, file: journalFile, identity }).initialize();
+    handler = () => ({ status: 401, body: { error: 'invalid_token', message: 'Sign in again.' } });
+    await expect(client.request('GET', '/api/v1/device/state')).rejects.toMatchObject({
+      message: 'Sign in again.',
+      code: 'invalid_token',
+      status: 401,
+    });
+    await client.stop();
+    await expect(
+      new DeviceClient({ origin, file: path.join(root, 'data/none.json'), existingOnly: true }).initialize(),
+    ).rejects.toMatchObject({ code: 'installation_required' });
+  });
+
+  it('drops the keys and account record a pre-cutover journal carried', async () => {
+    await mkdir(path.dirname(journalFile), { recursive: true });
+    await writeFile(
+      journalFile,
+      JSON.stringify({
+        origin,
+        installId: 'old',
+        deviceId: DEVICE_ID,
+        privateKey: { kty: 'EC', d: 'secret' },
+        publicKey: { kty: 'EC' },
+        wrappingPrivateKey: { kty: 'OKP', d: 'secret' },
+        wrappingPublicKey: { kty: 'OKP' },
+        registryAccount: { token: 'old-token' },
+        credentials: { echo: { keyId: 'k', operationId: 'o', resource: { label: 'Echo' } } },
+        operations: {},
+        reminders: { slack: true },
+      }),
+      { mode: 0o600 },
+    );
+    const client = await new DeviceClient({ origin, file: journalFile }).initialize();
+    await client.stop();
+    expect(await journal()).toEqual({
+      origin,
+      deviceId: DEVICE_ID,
+      credentials: { echo: { keyId: 'k', operationId: 'o', resource: { label: 'Echo' } } },
+      operations: {},
+      reminders: { slack: true },
+    });
+  });
+
+  it('exclusive clients wait for the journal lock and give up with journal_busy at the deadline', async () => {
+    const first = await new DeviceClient({ origin, file: journalFile, exclusive: true }).initialize();
+    first.local.deviceId = DEVICE_ID;
+    await first.save();
+    const started = Date.now();
+    await expect(
+      new DeviceClient({ origin, file: journalFile, exclusive: true, waitForLockMs: 250 }).initialize(),
+    ).rejects.toMatchObject({ code: 'journal_busy' });
+    expect(Date.now() - started).toBeGreaterThanOrEqual(200);
+    const waiting = new DeviceClient({ origin, file: journalFile, exclusive: true, waitForLockMs: 5_000 }).initialize();
+    setTimeout(() => void first.stop(), 100);
+    const second = await waiting;
+    expect(second.local.deviceId).toBe(DEVICE_ID);
+    await second.stop();
+  });
+
+  it('redeems an active grant once, acknowledges it, and forgets credentials for grants that end', async () => {
+    const client = await new DeviceClient({ origin, file: journalFile, identity }).initialize();
+    client.local.deviceId = DEVICE_ID;
+    let redemptions = 0;
+    const grant = {
+      id: 'g1',
+      perk: 'echo',
+      desired: 'active',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      redemptions: [] as { deviceId: string; state: string; keyId: string; operationId: string }[],
+    };
+    handler = ({ method, route, body }) => {
+      if (route === '/api/v1/device/state') return { body: { grants: [grant] } };
+      if (route === '/api/v1/grants/echo/redeem') {
+        redemptions++;
+        expect(body).toEqual({ idempotencyKey: expect.any(String) });
+        return { body: { keyId: 'k1', operationId: 'op1', secret: 'shh', resource: { label: 'Echo image' } } };
+      }
+      if (method === 'POST' && route === '/api/v1/grants/echo/ack') return { body: { ok: true } };
+      return { status: 404, body: { error: 'not_found' } };
+    };
+    await client.reconcile();
+    expect(redemptions).toBe(1);
+    expect(seen.map((r) => r.route)).toEqual([
+      '/api/v1/device/state',
+      '/api/v1/grants/echo/redeem',
+      '/api/v1/grants/echo/ack',
+    ]);
+    expect(seen.every((r) => r.authorization === 'Bearer tok' && r.proof === undefined)).toBe(true);
+    expect(seen.at(-1)?.body).toEqual({ operationId: 'op1', keyId: 'k1' });
+    expect((await journal()).credentials.echo).toMatchObject({ keyId: 'k1', secret: 'shh' });
+    // Delivered: nothing more to do. Same idempotency key would be reused otherwise.
+    grant.redemptions = [{ deviceId: DEVICE_ID, state: 'DELIVERED', keyId: 'k1', operationId: 'op1' }];
+    seen.length = 0;
+    await client.reconcile();
+    expect(seen.map((r) => r.route)).toEqual(['/api/v1/device/state']);
+    grant.desired = 'revoked';
+    await client.reconcile();
+    expect((await journal()).credentials).toEqual({});
+    expect(redemptions).toBe(1);
+    await client.stop();
+  });
+});
+
+describe('SetupClient', () => {
+  it('runs a browser handoff for the registered device: start, wait for approval, complete', async () => {
+    const client = await new SetupClient({
+      origin,
+      file: journalFile,
+      identity,
+      deviceKey: key,
+      autoContinue: true,
+      label: 'lab',
+    }).initialize();
+    let polls = 0;
+    handler = (request) => {
+      const { method, route, body } = request;
+      if (route === '/api/v1/catalog')
+        return {
+          body: {
+            items: [
+              { id: 'echo', kind: 'account' },
+              { id: 'sample', kind: 'partner', enabled: false },
+            ],
+          },
+        };
+      if (route === '/api/v1/setup/start') {
+        expect(body).toEqual({ stage: 'echo', name: 'Nano', reuseEnabled: false, autoContinue: true, label: 'lab' });
+        return {
+          body: {
+            id: 'flow-1',
+            code: 'code-1',
+            url: `${origin}/setup/code-1`,
+            installId: identity.installId,
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          },
+        };
+      }
+      if (route === '/api/v1/setup/code-1' && method === 'GET') {
+        polls++;
+        if (polls === 1) return { body: { id: 'flow-1', stage: 'echo', status: 'browsing', deviceId: DEVICE_ID } };
+        return {
+          body: {
+            id: 'flow-1',
+            stage: 'echo',
+            status: 'approved',
+            deviceId: DEVICE_ID,
+            label: 'lab',
+            name: 'Nano',
+            choice: { imageSource: 'hardened', workspaceId: 'T1', name: 'Nano' },
+          },
+        };
+      }
+      if (route === '/api/v1/setup/code-1/complete') return { body: { ok: true } };
+      return registration(request);
+    };
+    await client.register();
+    expect(await client.available('echo')).toBe(true);
+    expect(await client.available('sample')).toBe(false);
+    expect(await client.available('missing')).toBe(false);
+    const flow = await client.start('echo');
+    expect(flow.url).toBe(`${origin}/setup/code-1`);
+    expect((await journal()).setupFlow).toMatchObject({ code: 'code-1', stage: 'echo' });
+    const states: string[] = [];
+    const result = await client.wait({ pollMs: 5, onState: (state) => void states.push(state.status) });
+    expect(states).toEqual(['browsing', 'approved']);
+    expect(result).toEqual({
+      id: 'flow-1',
+      stage: 'echo',
+      status: 'approved',
+      deviceId: DEVICE_ID,
+      label: 'lab',
+      name: 'Nano',
+      choice: { imageSource: 'hardened', workspaceId: 'T1', name: 'Nano' },
+    });
+    expect((await journal()).deviceId).toBe(DEVICE_ID);
+    await client.complete('complete', { appId: 'A1' });
+    expect(seen.at(-1)).toMatchObject({
+      route: '/api/v1/setup/code-1/complete',
+      body: { status: 'complete', appId: 'A1' },
+      authorization: 'Bearer tok',
+    });
+    expect(seen.filter((r) => r.proof !== undefined).map((r) => r.route)).toEqual(['/api/v1/devices']);
+    await client.stop();
+  });
+
+  it('starts a flow anonymously with the sign-in verification data, then claims it once signed in', async () => {
+    const client = await new SetupClient({ origin, file: journalFile, label: 'lab' }).initialize();
+    const verification = {
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://auth.example.test/device?user_code=ABCD-EFGH',
+    };
+    handler = (request) => {
+      const { method, route } = request;
+      if (route === '/api/v1/setup/start')
+        return {
+          body: {
+            id: 'flow-3',
+            code: 'code-3',
+            url: `${origin}/?setup=code-3`,
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          },
+        };
+      if (route === '/api/v1/setup/code-3/claim' && method === 'POST')
+        return { body: { id: 'flow-3', stage: 'echo', status: 'pending', deviceId: DEVICE_ID, choice: {} } };
+      if (route === '/api/v1/setup/code-3' && method === 'GET')
+        return {
+          body: {
+            id: 'flow-3',
+            stage: 'echo',
+            status: 'approved',
+            deviceId: DEVICE_ID,
+            choice: { imageSource: 'hardened' },
+          },
+        };
+      return registration(request);
+    };
+    const flow = await client.start('echo', 'Nano', { verification });
+    expect(flow.url).toBe(`${origin}/?setup=code-3`);
+    expect(seen.at(-1)).toEqual({
+      method: 'POST',
+      route: '/api/v1/setup/start',
+      body: { stage: 'echo', name: 'Nano', autoContinue: false, label: 'lab', verification },
+    });
+    expect((await journal()).setupFlow).toMatchObject({ code: 'code-3', stage: 'echo' });
+    // Sign-in happened in the browser; the wizard now has an identity and a key.
+    client.identity = identity;
+    client.deviceKey = key;
+    await client.register();
+    expect(await client.claim()).toMatchObject({ id: 'flow-3', status: 'pending', deviceId: DEVICE_ID });
+    expect(seen.at(-1)).toMatchObject({ route: '/api/v1/setup/code-3/claim', body: {}, authorization: 'Bearer tok' });
+    expect(seen.at(-1)).not.toHaveProperty('proof');
+    expect(await client.wait({ pollMs: 5 })).toMatchObject({ status: 'approved' });
+    await client.stop();
+  });
+
+  it('reports failed flows and treats a rejected token or a missing perk as "not enabled"', async () => {
+    const client = await new SetupClient({ origin, file: journalFile, identity }).initialize();
+    let status = 'failed';
+    let start: ReturnType<Handler> = {
+      body: {
+        id: 'flow-2',
+        code: 'code-2',
+        url: `${origin}/setup/code-2`,
+        installId: identity.installId,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    };
+    handler = ({ route }) => {
+      if (route === '/api/v1/setup/start') return start;
+      if (route === '/api/v1/setup/code-2') return { body: { id: 'flow-2', status, deviceId: DEVICE_ID } };
+      return { status: 404, body: { error: 'not_found' } };
+    };
+    await client.start('slack');
+    await expect(client.wait({ pollMs: 5 })).rejects.toThrow('cancelled or failed');
+    status = 'skipped';
+    expect(await client.wait({ pollMs: 5 })).toMatchObject({ status: 'skipped' });
+    start = { status: 401, body: { error: 'installation_revoked' } };
+    expect(await client.resumeEnabled('slack')).toBe(false);
+    start = { status: 403, body: { error: 'perk_not_enabled' } };
+    expect(await client.resumeEnabled('slack')).toBe(false);
+    start = { status: 500, body: { error: 'boom' } };
+    await expect(client.resumeEnabled('slack')).rejects.toMatchObject({ status: 500 });
+    expect(
+      seen
+        .filter((r) => r.route === '/api/v1/setup/start')
+        .every((r) => r.body && !('publicKey' in (r.body as object))),
+    ).toBe(true);
+    await client.stop();
+    const anonymous = await new SetupClient({ origin, file: journalFile }).initialize();
+    expect(await anonymous.resumeEnabled('slack')).toBe(false);
+    await anonymous.stop();
+  });
+});

--- a/src/community-portal/device-client.ts
+++ b/src/community-portal/device-client.ts
@@ -1,0 +1,369 @@
+import { randomBytes } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { DEVICE_PROOF_HEADER, deviceProof, type DeviceKey } from './device-key.js';
+import { portalError } from './errors.js';
+import type { InstallIdentity } from './install-identity.js';
+import type { CellTicket, LinkLog } from './link.js';
+import { readJson, writePrivate } from './private-file.js';
+import { processLock } from './process-lock.js';
+
+/**
+ * A checkout's client for the community portal's HTTP API. Every request
+ * carries the install token as a bearer; device registration and cell tickets
+ * add the device proof, nothing else does. The checkout journal
+ * (`data/community-portal.json`, mode 0600) holds the portal origin, the
+ * cached device id, the perk credentials granted to this device and setup
+ * progress. No key and no token live in it: the token comes from the
+ * sign-in's account.json and the key from device-key.json, both handed in by
+ * the caller.
+ */
+export interface Redemption {
+  deviceId?: string;
+  state?: string;
+  keyId?: string;
+  operationId?: string;
+}
+
+export interface Grant {
+  id: string;
+  perk: string;
+  desired: string;
+  expiresAt: string;
+  redemptions: Redemption[];
+}
+
+export interface DeviceState {
+  grants: Grant[];
+  activations?: Record<string, { enabled?: boolean } | undefined>;
+  [key: string]: unknown;
+}
+
+export interface Credential {
+  keyId: string;
+  operationId: string;
+  secret?: string;
+  resource: { label: string; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+export interface SetupFlow {
+  id: string;
+  code: string;
+  url: string;
+  /** Absent on an anonymous start until the flow is claimed. */
+  installId?: string;
+  expiresAt: string;
+  stage?: string;
+  [key: string]: unknown;
+}
+
+export interface SlackSetup {
+  setupId: string;
+  workspaceId: string;
+  name: string;
+  status: 'creating' | 'received' | 'complete';
+  serviceBase?: string;
+  app?: { appId: string; appToken: string; botToken?: string };
+}
+
+export interface Journal {
+  origin?: string;
+  deviceId?: string;
+  credentials: Record<string, Credential>;
+  operations: Record<string, { grantId: string; idempotencyKey: string }>;
+  setupFlow?: SetupFlow;
+  slackSetup?: SlackSetup;
+  reminders?: Partial<Record<string, boolean>>;
+  reminderPending?: Partial<Record<string, boolean>>;
+}
+
+export interface DeviceRegistration {
+  deviceId: string;
+  accountId: string;
+  installId: string;
+}
+
+export interface DeviceClientOptions {
+  origin: string;
+  /** The private journal. Its lock file is `${file}.lock`. */
+  file: string;
+  /** The install token and ids from the sign-in's account.json. Absent: unauthenticated requests only. */
+  identity?: InstallIdentity;
+  /** The machine's device key; needed for `register()` and `ticket()`. */
+  deviceKey?: DeviceKey;
+  label?: string;
+  log?: LinkLog;
+  /** Hold the journal lock for the client's lifetime; other writers wait or fail. */
+  exclusive?: boolean;
+  waitForLockMs?: number;
+  signal?: AbortSignal;
+  /** Fail instead of creating a journal when none exists. */
+  existingOnly?: boolean;
+}
+
+export interface CallOptions {
+  body?: unknown;
+  signal?: AbortSignal;
+  /** Add the device proof header (device registration and cell tickets only). */
+  proof?: boolean;
+}
+
+export const REQUEST_TIMEOUT_MS = 25_000;
+/** Fields journals carried before the protocol cutover; dropped on load, never written again. */
+const RETIRED_FIELDS = [
+  'privateKey',
+  'publicKey',
+  'wrappingPrivateKey',
+  'wrappingPublicKey',
+  'registryAccount',
+  'installId',
+];
+
+export class DeviceClient {
+  readonly origin: string;
+  /** Set after a sign-in that happened while this client was open (the wizard's not-enrolled path). */
+  identity?: InstallIdentity;
+  deviceKey?: DeviceKey;
+  local!: Journal;
+  protected readonly file: string;
+  protected readonly label: string;
+  protected readonly log: LinkLog;
+  protected readonly signal?: AbortSignal;
+  private readonly exclusive: boolean;
+  private readonly waitForLockMs: number;
+  private readonly existingOnly: boolean;
+  private releaseLock: (() => void) | null = null;
+  private syncing: Promise<DeviceState> | null = null;
+  private again = false;
+  private stopped = false;
+
+  constructor({
+    origin,
+    file,
+    identity,
+    deviceKey,
+    label = 'NanoClaw installation',
+    log = () => {},
+    exclusive = false,
+    waitForLockMs = 0,
+    signal,
+    existingOnly = false,
+  }: DeviceClientOptions) {
+    const url = new URL(origin);
+    const loopback = url.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
+    if (
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      url.pathname !== '/' ||
+      (url.protocol !== 'https:' && !loopback)
+    )
+      throw new Error('Portal origin must use HTTPS, except on loopback.');
+    this.origin = url.origin;
+    this.identity = identity;
+    this.deviceKey = deviceKey;
+    this.file = file;
+    this.label = label;
+    this.log = log;
+    this.exclusive = exclusive;
+    this.waitForLockMs = waitForLockMs;
+    this.signal = signal;
+    this.existingOnly = existingOnly;
+  }
+
+  /** The install token, when signed in. */
+  get token(): string | undefined {
+    return this.identity?.token;
+  }
+
+  /** Load or create the journal. With `exclusive`, waits up to `waitForLockMs` for its lock. */
+  async initialize(): Promise<this> {
+    if (this.exclusive) {
+      const deadline = Date.now() + this.waitForLockMs;
+      while (!(this.releaseLock = await processLock(`${this.file}.lock`))) {
+        if (Date.now() >= deadline)
+          throw portalError(
+            'Another setup or receiver owns this installation journal. Retry after it finishes.',
+            'journal_busy',
+          );
+        await sleep(100, undefined, { signal: this.signal });
+      }
+    }
+    try {
+      const saved = await readJson<Partial<Journal> & Record<string, unknown>>(this.file);
+      if (!saved) {
+        if (this.existingOnly)
+          throw portalError('This checkout has not been set up with the portal.', 'installation_required');
+        this.local = { credentials: {}, operations: {} };
+      } else {
+        for (const field of RETIRED_FIELDS) delete saved[field];
+        this.local = { credentials: {}, operations: {}, ...saved };
+      }
+      if (this.local.origin && this.local.origin !== this.origin)
+        throw new Error('This installation belongs to a different portal. Use a separate state file.');
+      this.local.origin = this.origin;
+      await this.save();
+      return this;
+    } catch (error) {
+      await this.stop();
+      throw error;
+    }
+  }
+
+  save(): Promise<void> {
+    return writePrivate(this.file, this.local);
+  }
+
+  /** A bearer request. Non-2xx responses become errors carrying the portal's code and status. */
+  request<T = unknown>(method: string, route: string, body?: unknown, signal?: AbortSignal): Promise<T> {
+    return this.call<T>(method, route, { body, signal });
+  }
+
+  /** Register or re-affirm this machine (idempotent), caching the device id in the journal. */
+  async register(): Promise<DeviceRegistration> {
+    if (!this.identity) throw portalError('This machine is not signed in to NanoClaw.', 'installation_required');
+    const key = this.requireDeviceKey();
+    const result = await this.call<DeviceRegistration>('POST', '/api/v1/devices', {
+      body: { publicKey: key.publicKeyJwk, label: this.label },
+      proof: true,
+    });
+    if (typeof result.deviceId !== 'string' || !result.deviceId)
+      throw portalError('The portal did not return a device id.', 'invalid_response');
+    if (this.local.deviceId !== result.deviceId) {
+      this.local.deviceId = result.deviceId;
+      if (this.file) await this.save();
+    }
+    return result;
+  }
+
+  /** A short-lived ticket for the cell link, proved with the device key. */
+  ticket(signal?: AbortSignal): Promise<CellTicket> {
+    return this.call<CellTicket>('POST', '/api/v1/cell-ticket', { body: {}, signal, proof: true });
+  }
+
+  protected async call<T>(
+    method: string,
+    route: string,
+    { body, signal = this.signal, proof = false }: CallOptions = {},
+  ): Promise<T> {
+    const raw = body === undefined ? '' : JSON.stringify(body);
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (this.identity) headers.authorization = `Bearer ${this.identity.token}`;
+    if (proof) headers[DEVICE_PROOF_HEADER] = deviceProof(this.requireDeviceKey());
+    const response = await fetch(`${this.origin}${route}`, {
+      method,
+      headers,
+      ...(raw ? { body: raw } : {}),
+      signal: AbortSignal.any([AbortSignal.timeout(REQUEST_TIMEOUT_MS), ...(signal ? [signal] : [])]),
+      redirect: 'error',
+    });
+    const text = await response.text();
+    let result: T & { error?: string; message?: string };
+    try {
+      result = (text ? JSON.parse(text) : {}) as T & { error?: string; message?: string };
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      throw Object.assign(
+        new Error(`The portal returned an unreadable response (${response.status}).`, { cause: error }),
+        {
+          code: 'invalid_response',
+          status: response.status,
+        },
+      );
+    }
+    if (!response.ok)
+      throw portalError(
+        result.message || result.error || `The portal request failed (${response.status}).`,
+        result.error,
+        response.status,
+      );
+    return result;
+  }
+
+  private requireDeviceKey(): DeviceKey {
+    if (!this.deviceKey)
+      throw portalError('This machine has no device key. Run the portal setup step.', 'device_key_required');
+    return this.deviceKey;
+  }
+
+  /** Bring local credentials in line with the account's grants. Coalesces overlapping calls. */
+  reconcile(): Promise<DeviceState> {
+    if (this.syncing) {
+      this.again = true;
+      return this.syncing;
+    }
+    this.syncing = this.sync().finally(() => {
+      this.syncing = null;
+      if (this.again && !this.stopped) {
+        this.again = false;
+        void this.reconcile().catch((error: unknown) => this.log({ event: 'retry', code: errorCodeOf(error) }));
+      }
+    });
+    return this.syncing;
+  }
+
+  protected async sync(): Promise<DeviceState> {
+    const state = await this.request<DeviceState>('GET', '/api/v1/device/state');
+    const active = new Set(
+      state.grants
+        .filter((grant) => grant.desired === 'active' && Date.parse(grant.expiresAt) > Date.now())
+        .map((grant) => grant.perk),
+    );
+    for (const perk of Object.keys(this.local.credentials)) {
+      if (active.has(perk)) continue;
+      delete this.local.credentials[perk];
+      delete this.local.operations[perk];
+      await this.save();
+      this.log({ event: 'removed', perk });
+    }
+    for (const grant of state.grants) {
+      if (!active.has(grant.perk)) continue;
+      const redemption = grant.redemptions.find((r) => r.deviceId === this.local.deviceId);
+      if (redemption && ['REVOKING', 'REVOKED'].includes(redemption.state ?? '')) continue;
+      let credential = this.local.credentials[grant.perk];
+      if (credential && redemption?.keyId === credential.keyId && redemption.operationId === credential.operationId) {
+        if (redemption.state === 'DELIVERED') continue;
+      } else {
+        const previous = this.local.operations[grant.perk];
+        if (!previous || previous.grantId !== grant.id) {
+          this.local.operations[grant.perk] = {
+            grantId: grant.id,
+            idempotencyKey: randomBytes(24).toString('base64url'),
+          };
+          await this.save();
+        }
+        const result = await this.request<Credential>('POST', `/api/v1/grants/${grant.perk}/redeem`, {
+          idempotencyKey: this.local.operations[grant.perk].idempotencyKey,
+        });
+        if (!result.secret) {
+          this.log({ event: 'local_credential_missing', perk: grant.perk });
+          continue;
+        }
+        credential = this.local.credentials[grant.perk] = result;
+        await this.save();
+        this.log({ event: 'stored', perk: grant.perk, resource: result.resource.label });
+      }
+      await this.request('POST', `/api/v1/grants/${grant.perk}/ack`, {
+        operationId: credential.operationId,
+        keyId: credential.keyId,
+      });
+    }
+    return state;
+  }
+
+  /** Wait for an in-flight reconcile, then release the journal lock. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.syncing) await this.syncing.catch(() => undefined);
+    if (this.releaseLock) {
+      this.releaseLock();
+      this.releaseLock = null;
+    }
+  }
+}
+
+function errorCodeOf(error: unknown): string {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === 'string' && code ? code : 'unavailable';
+}

--- a/src/community-portal/device-key.test.ts
+++ b/src/community-portal/device-key.test.ts
@@ -1,0 +1,105 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEVICE_KEY_FILE_RELPATH,
+  deviceKeyFile,
+  deviceProof,
+  ensureDeviceKey,
+  makeProofNonce,
+  readDeviceKey,
+  verifyDeviceProof,
+} from './device-key.js';
+
+let home: string;
+beforeEach(async () => {
+  home = await mkdtemp(path.join(os.tmpdir(), 'nc-device-key-'));
+});
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('device key file', () => {
+  it('generates one P-256 key per machine in the remote-access file schema, mode 0600, and reuses it', async () => {
+    const file = deviceKeyFile(home);
+    expect(file).toBe(path.join(home, DEVICE_KEY_FILE_RELPATH));
+    expect(readDeviceKey({ homeDir: home })).toBeNull();
+    const key = ensureDeviceKey({ homeDir: home });
+    expect((await stat(file)).mode & 0o777).toBe(0o600);
+    expect((await stat(path.dirname(file))).mode & 0o777).toBe(0o700);
+    const record = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
+    expect(Object.keys(record).sort()).toEqual(['created_at', 'pkcs8_b64', 'v']);
+    expect(record.v).toBe(1);
+    expect(record.pkcs8_b64).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(Date.parse(String(record.created_at))).toBeGreaterThan(0);
+    expect(key.publicKeyJwk).toEqual({ kty: 'EC', crv: 'P-256', x: expect.any(String), y: expect.any(String) });
+    expect(key.fingerprint).toMatch(/^[\w-]{16}$/);
+    expect(key.createdAt).toBe(record.created_at);
+    expect(ensureDeviceKey({ homeDir: home }).fingerprint).toBe(key.fingerprint);
+    expect(readDeviceKey({ homeDir: home })?.fingerprint).toBe(key.fingerprint);
+    expect(await readFile(file, 'utf8')).toBe(JSON.stringify(record) + '\n');
+  });
+
+  it('treats an unreadable or corrupt file as an error, never as a reason to mint a new key', async () => {
+    const file = deviceKeyFile(home);
+    await mkdir(file, { recursive: true });
+    expect(() => readDeviceKey({ homeDir: home })).toThrow(expect.objectContaining({ code: 'device_key_unreadable' }));
+    expect(() => ensureDeviceKey({ homeDir: home })).toThrow(
+      expect.objectContaining({ code: 'device_key_unreadable' }),
+    );
+    await rm(file, { recursive: true });
+    const rsa = generateKeyPairSync('rsa', { modulusLength: 1024 })
+      .privateKey.export({ format: 'der', type: 'pkcs8' })
+      .toString('base64');
+    for (const content of [
+      'not json',
+      '{"v":2,"pkcs8_b64":"AAAA"}',
+      '{"v":1}',
+      '{"v":1,"pkcs8_b64":""}',
+      '{"v":1,"pkcs8_b64":"bm90IGEga2V5"}',
+      JSON.stringify({ v: 1, pkcs8_b64: rsa }),
+    ]) {
+      await writeFile(file, content, { mode: 0o600 });
+      expect(() => readDeviceKey({ homeDir: home })).toThrow(
+        expect.objectContaining({ code: 'device_key_unreadable' }),
+      );
+      expect(() => ensureDeviceKey({ homeDir: home })).toThrow(
+        expect.objectContaining({ code: 'device_key_unreadable' }),
+      );
+      expect(await readFile(file, 'utf8')).toBe(content);
+    }
+  });
+
+  it('honours an explicit file path', async () => {
+    const file = path.join(home, 'elsewhere', 'key.json');
+    const key = ensureDeviceKey({ file });
+    expect(readDeviceKey({ file })?.fingerprint).toBe(key.fingerprint);
+    expect(readDeviceKey({ homeDir: home })).toBeNull();
+  });
+});
+
+describe('device proof', () => {
+  it('produces a fresh, well-formed header that verifies now and not a minute later', () => {
+    const key = ensureDeviceKey({ homeDir: home });
+    const now = 1_788_825_600_000;
+    const header = deviceProof(key, () => now + 900);
+    expect(header).toMatch(/^v1;kid=[\w-]{16};ts=1788825600;nonce=[\w-]{22};sig=[\w-]{86}$/);
+    expect(header).toContain(`kid=${key.fingerprint};`);
+    expect(verifyDeviceProof(header, key.publicKeyJwk, { now })).toMatchObject({ valid: true });
+    expect(verifyDeviceProof(header, key.publicKeyJwk, { now: now + 60_999 })).toMatchObject({ valid: true });
+    expect(verifyDeviceProof(header, key.publicKeyJwk, { now: now + 61_000 })).toEqual({
+      valid: false,
+      reason: 'stale',
+    });
+    expect(deviceProof(key, () => now)).not.toBe(header);
+  });
+
+  it('nonces are 22 base64url characters of 16 bytes', () => {
+    expect(makeProofNonce((n) => Buffer.alloc(n, 0xab))).toBe(Buffer.alloc(16, 0xab).toString('base64url'));
+    const nonce = makeProofNonce();
+    expect(nonce).toMatch(/^[\w-]{22}$/);
+    expect(makeProofNonce()).not.toBe(nonce);
+  });
+});

--- a/src/community-portal/device-key.ts
+++ b/src/community-portal/device-key.ts
@@ -1,0 +1,199 @@
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  randomBytes,
+  sign,
+  verify,
+  type JsonWebKey,
+  type KeyObject,
+} from 'node:crypto';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { isErrno, portalError } from './errors.js';
+
+/**
+ * The host's device key: one ECDSA P-256 key per machine, kept at
+ * ~/.config/nanoclaw/device-key.json in the remote-access module's file schema
+ * ({ v: 1, pkcs8_b64, created_at }, mode 0600). It signs the device proof
+ * (`x-nc-device-proof`) that accompanies device registration and cell-ticket
+ * requests, and nothing else; the private key never leaves this machine.
+ *
+ * A read failure is not "no key". An unreadable or corrupt file raises an
+ * error instead of generating a second identity for the install.
+ */
+export const DEVICE_PROOF_HEADER = 'x-nc-device-proof';
+export const DEVICE_KEY_FILE_RELPATH = path.join('.config', 'nanoclaw', 'device-key.json');
+/** A proof is accepted when its `ts` is within this many seconds of the verifier's clock. */
+export const PROOF_MAX_SKEW_SECONDS = 60;
+const PROOF_SIGNING_PREFIX = 'nanoclaw-host-grant-v1';
+const NONCE_PATTERN = /^[\w-]{16,80}$/;
+
+export interface DevicePublicJwk {
+  kty: 'EC';
+  crv: 'P-256';
+  x: string;
+  y: string;
+}
+
+export interface DeviceKey {
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+  /** First 16 chars of base64url(sha256(SPKI DER)): the proof header's `kid`. */
+  fingerprint: string;
+  /** The public key as sent to the portal: `{ kty, crv, x, y }` and nothing else. */
+  publicKeyJwk: DevicePublicJwk;
+  createdAt?: string;
+}
+
+export interface DeviceProof {
+  kid: string;
+  ts: number;
+  nonce: string;
+  sig: string;
+}
+
+export type ProofVerdict =
+  | { valid: true; proof: DeviceProof }
+  | { valid: false; reason: 'malformed' | 'stale' | 'nonce' | 'kid' | 'signature' };
+
+export interface DeviceKeyOptions {
+  homeDir?: string;
+  /** Explicit key file path; overrides `homeDir`. */
+  file?: string;
+}
+
+export function deviceKeyFile(homeDir = os.homedir()): string {
+  return path.join(homeDir, DEVICE_KEY_FILE_RELPATH);
+}
+
+/** First 16 chars of base64url(sha256(SPKI DER)). */
+export function deviceKeyFingerprint(spki: Uint8Array): string {
+  return createHash('sha256').update(spki).digest('base64url').slice(0, 16);
+}
+
+/** 22-char base64url of 16 random bytes. */
+export function makeProofNonce(random: (bytes: number) => Buffer = randomBytes): string {
+  return random(16).toString('base64url');
+}
+
+export function proofSigningInput(ts: number, nonce: string): Buffer {
+  return Buffer.from(`${PROOF_SIGNING_PREFIX}\n${Math.floor(ts)}\n${nonce}`, 'utf-8');
+}
+
+/**
+ * The `x-nc-device-proof` value:
+ *   v1;kid=<fingerprint>;ts=<epoch seconds>;nonce=<22-char base64url>;sig=<base64url ES256, IEEE P1363>
+ * over the exact bytes "nanoclaw-host-grant-v1\n" + ts + "\n" + nonce.
+ */
+export function signProof(key: DeviceKey, opts: { ts: number; nonce: string }): string {
+  const ts = Math.floor(opts.ts);
+  const sig = sign('sha256', proofSigningInput(ts, opts.nonce), { key: key.privateKey, dsaEncoding: 'ieee-p1363' });
+  return `v1;kid=${key.fingerprint};ts=${ts};nonce=${opts.nonce};sig=${sig.toString('base64url')}`;
+}
+
+/** A fresh proof for the current moment. */
+export function deviceProof(key: DeviceKey, now: () => number = Date.now): string {
+  return signProof(key, { ts: Math.floor(now() / 1000), nonce: makeProofNonce() });
+}
+
+export function parseDeviceProof(value: string): DeviceProof | null {
+  const match = /^v1;kid=([\w-]{16});ts=(\d{1,12});nonce=([\w-]{16,80});sig=([\w-]{86})$/.exec(value);
+  if (!match) return null;
+  return { kid: match[1], ts: Number(match[2]), nonce: match[3], sig: match[4] };
+}
+
+/**
+ * The verifier's side of the proof, as the portal checks it: fresh within
+ * ±60 s, a well-formed nonce, `kid` equal to the key's fingerprint, and a
+ * signature that verifies under that key. Nonce single-use is the server's.
+ */
+export function verifyDeviceProof(
+  value: string,
+  publicKey: DevicePublicJwk | KeyObject,
+  { now = Date.now(), maxSkewSeconds = PROOF_MAX_SKEW_SECONDS }: { now?: number; maxSkewSeconds?: number } = {},
+): ProofVerdict {
+  const proof = parseDeviceProof(value);
+  if (!proof) return { valid: false, reason: 'malformed' };
+  if (Math.abs(proof.ts - Math.floor(now / 1000)) > maxSkewSeconds) return { valid: false, reason: 'stale' };
+  if (!NONCE_PATTERN.test(proof.nonce)) return { valid: false, reason: 'nonce' };
+  const key = 'x' in publicKey ? createPublicKey({ key: publicKey as JsonWebKey, format: 'jwk' }) : publicKey;
+  if (deviceKeyFingerprint(key.export({ format: 'der', type: 'spki' })) !== proof.kid)
+    return { valid: false, reason: 'kid' };
+  const ok = verify(
+    'sha256',
+    proofSigningInput(proof.ts, proof.nonce),
+    { key, dsaEncoding: 'ieee-p1363' },
+    Buffer.from(proof.sig, 'base64url'),
+  );
+  return ok ? { valid: true, proof } : { valid: false, reason: 'signature' };
+}
+
+/** Materialize a DeviceKey from PKCS#8 DER. Throws on anything but P-256. */
+export function deviceKeyFromPkcs8(pkcs8: Buffer, createdAt?: string): DeviceKey {
+  const privateKey = createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+  if (privateKey.asymmetricKeyType !== 'ec') throw new Error('device key is not an EC key');
+  const publicKey = createPublicKey(privateKey);
+  const jwk = publicKey.export({ format: 'jwk' }) as { kty?: string; crv?: string; x?: string; y?: string };
+  if (jwk.kty !== 'EC' || jwk.crv !== 'P-256' || !jwk.x || !jwk.y) throw new Error('device key is not P-256');
+  const spki = publicKey.export({ format: 'der', type: 'spki' });
+  return {
+    privateKey,
+    publicKey,
+    fingerprint: deviceKeyFingerprint(spki),
+    publicKeyJwk: { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y },
+    createdAt,
+  };
+}
+
+function unreadable(file: string, cause: unknown): Error {
+  return Object.assign(
+    new Error(`The device key at ${file} could not be read. Fix or remove it, then run the portal setup step again.`, {
+      cause,
+    }),
+    { code: 'device_key_unreadable' },
+  );
+}
+
+/**
+ * The stored device key, or null when the file does not exist. Any other
+ * outcome (unreadable, malformed, not a P-256 key) is an error, never a
+ * reason to mint a new key.
+ */
+export function readDeviceKey({ homeDir, file = deviceKeyFile(homeDir) }: DeviceKeyOptions = {}): DeviceKey | null {
+  let text: string;
+  try {
+    text = readFileSync(file, 'utf-8');
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return null;
+    throw unreadable(file, error);
+  }
+  try {
+    const parsed = JSON.parse(text) as { v?: unknown; pkcs8_b64?: unknown; created_at?: unknown } | null;
+    if (parsed?.v !== 1 || typeof parsed.pkcs8_b64 !== 'string' || !parsed.pkcs8_b64)
+      throw portalError('device key file has an unexpected shape', 'device_key_unreadable');
+    return deviceKeyFromPkcs8(
+      Buffer.from(parsed.pkcs8_b64, 'base64'),
+      typeof parsed.created_at === 'string' ? parsed.created_at : undefined,
+    );
+  } catch (error) {
+    throw unreadable(file, error);
+  }
+}
+
+/** The device key, generated and stored (0600) on first use. */
+export function ensureDeviceKey({ homeDir, file = deviceKeyFile(homeDir) }: DeviceKeyOptions = {}): DeviceKey {
+  const existing = readDeviceKey({ file });
+  if (existing) return existing;
+  const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const pkcs8 = privateKey.export({ format: 'der', type: 'pkcs8' });
+  const createdAt = new Date().toISOString();
+  const record = { v: 1 as const, pkcs8_b64: pkcs8.toString('base64'), created_at: createdAt };
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temp = `${file}.${randomBytes(8).toString('base64url')}.tmp`;
+  writeFileSync(temp, JSON.stringify(record) + '\n', { mode: 0o600 });
+  renameSync(temp, file);
+  return deviceKeyFromPkcs8(pkcs8, createdAt);
+}

--- a/src/community-portal/errors.ts
+++ b/src/community-portal/errors.ts
@@ -1,0 +1,23 @@
+/** Errors raised by the portal client carry the portal's error code and HTTP status when known. */
+export interface PortalError extends Error {
+  code?: string;
+  status?: number;
+}
+
+export function portalError(message: string, code?: string, status?: number): PortalError {
+  return Object.assign(new Error(message), { ...(code ? { code } : {}), ...(status ? { status } : {}) });
+}
+
+export function errorCode(error: unknown, fallback = 'unavailable'): string {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === 'string' && code ? code : fallback;
+}
+
+export function errorStatus(error: unknown): number | undefined {
+  const status = (error as { status?: unknown } | null)?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+export function isErrno(error: unknown, code: string): boolean {
+  return errorCode(error, '') === code;
+}

--- a/src/community-portal/frame-vectors.json
+++ b/src/community-portal/frame-vectors.json
@@ -1,0 +1,70 @@
+{
+  "note": "Frame protocol v1 as the cell speaks it. `valid` entries decode to `frame`; `invalid` entries decode to null.",
+  "valid": [
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"hello\",\"leg\":\"host\",\"caps\":[\"perks\"]}",
+      "frame": { "v": 1, "ch": 0, "seq": 1, "t": "hello", "leg": "host", "caps": ["perks"] }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"hello\",\"leg\":\"cell\",\"revision\":7}",
+      "frame": { "v": 1, "ch": 0, "seq": 1, "t": "hello", "leg": "cell", "revision": 7 }
+    },
+    { "raw": "{\"v\":1,\"ch\":0,\"seq\":2,\"t\":\"ping\"}", "frame": { "v": 1, "ch": 0, "seq": 2, "t": "ping" } },
+    { "raw": "{\"v\":1,\"ch\":0,\"seq\":2,\"t\":\"pong\"}", "frame": { "v": 1, "ch": 0, "seq": 2, "t": "pong" } },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":3,\"t\":\"status\",\"state\":\"presence\",\"presence\":[{\"deviceId\":\"dev_0123456789abcdef01234567\",\"connected\":true}]}",
+      "frame": {
+        "v": 1,
+        "ch": 0,
+        "seq": 3,
+        "t": "status",
+        "state": "presence",
+        "presence": [{ "deviceId": "dev_0123456789abcdef01234567", "connected": true }]
+      }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":4,\"t\":\"perks.changed\",\"revision\":8}",
+      "frame": { "v": 1, "ch": 0, "seq": 4, "t": "perks.changed", "revision": 8 }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":5,\"t\":\"error\",\"code\":\"read_only\"}",
+      "frame": { "v": 1, "ch": 0, "seq": 5, "t": "error", "code": "read_only" }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":1,\"seq\":1,\"t\":\"open\",\"kind\":\"perks\"}",
+      "frame": { "v": 1, "ch": 1, "seq": 1, "t": "open", "kind": "perks" }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":1,\"seq\":2,\"t\":\"data\",\"snapshot\":{\"revision\":7,\"grants\":[]},\"presence\":[]}",
+      "frame": { "v": 1, "ch": 1, "seq": 2, "t": "data", "snapshot": { "revision": 7, "grants": [] }, "presence": [] }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":1,\"seq\":3,\"t\":\"error\",\"code\":\"unsupported\"}",
+      "frame": { "v": 1, "ch": 1, "seq": 3, "t": "error", "code": "unsupported" }
+    },
+    { "raw": "{\"v\":1,\"ch\":1,\"seq\":4,\"t\":\"end\"}", "frame": { "v": 1, "ch": 1, "seq": 4, "t": "end" } },
+    { "raw": "{\"v\":1,\"ch\":1,\"seq\":5,\"t\":\"close\"}", "frame": { "v": 1, "ch": 1, "seq": 5, "t": "close" } }
+  ],
+  "invalid": [
+    "{not json",
+    "\"hi\"",
+    "[1,2]",
+    "null",
+    "{\"v\":2,\"ch\":0,\"seq\":1,\"t\":\"ping\"}",
+    "{\"ch\":0,\"seq\":1,\"t\":\"ping\"}",
+    "{\"v\":1,\"ch\":-1,\"seq\":1,\"t\":\"ping\"}",
+    "{\"v\":1,\"ch\":1.5,\"seq\":1,\"t\":\"data\"}",
+    "{\"v\":1,\"ch\":\"0\",\"seq\":1,\"t\":\"ping\"}",
+    "{\"v\":1,\"ch\":0,\"seq\":0,\"t\":\"ping\"}",
+    "{\"v\":1,\"ch\":0,\"t\":\"ping\"}",
+    "{\"v\":1,\"ch\":0,\"seq\":1}",
+    "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"\"}",
+    "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"open\"}",
+    "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"data\"}",
+    "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"hello\"}",
+    "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"ping\"}",
+    "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"perks.changed\"}",
+    "{\"type\":\"pong\"}",
+    "{\"type\":\"perks.changed\"}"
+  ]
+}

--- a/src/community-portal/index.ts
+++ b/src/community-portal/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Client for the NanoClaw community portal (https://portal.nanoclaw.dev).
+ *
+ * The portal itself is a hosted service; this is the open-source side of the
+ * contract: the install identity from the registry sign-in, a per-machine
+ * device key that proves device registration and cell tickets, bearer
+ * requests for everything else, the browser setup handoff, and the cell link
+ * (frame protocol v1) that tells a running host when its perks change.
+ * Everything here depends only on Node built-ins.
+ */
+export * from './device-client.js';
+export * from './device-key.js';
+export * from './errors.js';
+export * from './install-identity.js';
+export * from './link.js';
+export * from './mux.js';
+export * from './private-file.js';
+export * from './process-lock.js';
+export * from './setup-client.js';

--- a/src/community-portal/install-identity.ts
+++ b/src/community-portal/install-identity.ts
@@ -1,0 +1,58 @@
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { isErrno } from './errors.js';
+
+/**
+ * The install identity the portal client presents: the install token and the
+ * account and install ids from ~/.config/nanoclaw/account.json, which the
+ * registry sign-in (setup/registry-login.ts, the WorkOS device flow) writes.
+ * Nothing here writes; sign-in owns the file. The install id is the record's
+ * `install_id` when present, otherwise the per-machine id in
+ * ~/.config/nanoclaw/host-id that the sign-in enrolled with.
+ */
+export interface InstallIdentity {
+  token: string;
+  accountId: string;
+  installId: string;
+}
+
+export function accountFile(homeDir = os.homedir()): string {
+  return path.join(homeDir, '.config', 'nanoclaw', 'account.json');
+}
+
+export function hostIdFile(homeDir = os.homedir()): string {
+  return path.join(homeDir, '.config', 'nanoclaw', 'host-id');
+}
+
+async function readText(file: string): Promise<string | undefined> {
+  try {
+    return await readFile(file, 'utf8');
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+}
+
+const text = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
+/** The signed-in identity, or null when the machine is not signed in or the record is incomplete. */
+export async function readInstallIdentity({ homeDir = os.homedir() } = {}): Promise<InstallIdentity | null> {
+  const raw = await readText(accountFile(homeDir));
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const record = parsed as Record<string, unknown>;
+  const token = text(record.token);
+  const accountId = text(record.account_id);
+  const installId = text(record.install_id) ?? text(await readText(hostIdFile(homeDir)));
+  if (!token || !accountId || !installId) return null;
+  return { token, accountId, installId };
+}

--- a/src/community-portal/link.test.ts
+++ b/src/community-portal/link.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { CLOSE_FORBIDDEN, CellLink, computeBackoffDelay, type LinkSocket } from './link.js';
+
+type Listener = (event: { data: unknown; code?: number }) => void;
+
+/** A WHATWG-shaped socket the test drives by hand. */
+class FakeSocket implements LinkSocket {
+  static instances: FakeSocket[] = [];
+  readyState = 0;
+  sent: string[] = [];
+  closed = false;
+  private listeners = new Map<string, Listener[]>();
+  constructor(
+    readonly url: URL,
+    readonly protocols: string[],
+  ) {
+    FakeSocket.instances.push(this);
+  }
+  addEventListener(type: string, listener: Listener): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+  send(data: string): void {
+    if (this.readyState !== 1) throw new Error('not open');
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closed = true;
+    this.readyState = 3;
+  }
+  open(): void {
+    this.readyState = 1;
+    this.emit('open');
+  }
+  message(data: unknown): void {
+    this.emit('message', { data });
+  }
+  /** A frame from the cell: seq is stamped per channel like the cell does. */
+  frame(ch: number, t: string, fields: Record<string, unknown> = {}): void {
+    const seq = (this.seqs.get(ch) ?? 0) + 1;
+    this.seqs.set(ch, seq);
+    this.message(JSON.stringify({ v: 1, ch, seq, t, ...fields }));
+  }
+  frames(): Record<string, unknown>[] {
+    return this.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+  }
+  lost(code?: number): void {
+    this.readyState = 3;
+    this.emit('close', { data: undefined, ...(code === undefined ? {} : { code }) });
+  }
+  private seqs = new Map<number, number>();
+  private emit(type: string, event: { data: unknown; code?: number } = { data: undefined }): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+const ORIGIN = 'https://portal.example.test';
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+const links: CellLink[] = [];
+function connect(overrides: Partial<ConstructorParameters<typeof CellLink>[0]> = {}) {
+  const log = vi.fn();
+  const onSnapshot = vi.fn();
+  const onChange = vi.fn();
+  let tickets = 0;
+  const getTicket = vi.fn(async () => ({
+    ticket: `tkt.${++tickets}`,
+    socketUrl: `wss://portal.example.test/cell/link`,
+  }));
+  const link = new CellLink({
+    origin: ORIGIN,
+    getTicket,
+    onSnapshot,
+    onChange,
+    log,
+    Socket: FakeSocket,
+    random: () => 1,
+    ...overrides,
+  });
+  links.push(link);
+  return { link, log, onSnapshot, onChange, getTicket };
+}
+
+afterEach(() => {
+  for (const link of links.splice(0)) link.stop();
+  FakeSocket.instances = [];
+  vi.useRealTimers();
+});
+
+it('dials with the ticket as a subprotocol, says hello as the host leg first, and hands perks data to onSnapshot', async () => {
+  const { link, onSnapshot, onChange, log } = connect({ ver: '1.2.3' });
+  link.start();
+  await settle();
+  expect(FakeSocket.instances).toHaveLength(1);
+  const socket = FakeSocket.instances[0];
+  expect(socket.url.href).toBe('wss://portal.example.test/cell/link');
+  expect(socket.protocols).toEqual(['nc-cell', 'ticket.tkt.1']);
+  expect(link.connected).toBe(false);
+  socket.open();
+  expect(link.connected).toBe(true);
+  expect(socket.frames()).toEqual([{ v: 1, ch: 0, seq: 1, t: 'hello', leg: 'host', caps: ['perks'], ver: '1.2.3' }]);
+  expect(log).toHaveBeenCalledWith({ event: 'connected' });
+  socket.frame(0, 'hello', { leg: 'cell', revision: 3 });
+  socket.frame(1, 'open', { kind: 'perks' });
+  const snapshot = { revision: 3, grants: [{ perk: 'echo' }] };
+  const presence = [{ deviceId: 'dev_1', connected: true }];
+  socket.frame(1, 'data', { snapshot, presence });
+  expect(onSnapshot).toHaveBeenCalledExactlyOnceWith({ snapshot, presence });
+  socket.frame(0, 'status', { state: 'presence', presence });
+  // The data frame is the truth; the perks.changed that follows it is only a hint.
+  socket.frame(0, 'perks.changed', { revision: 3 });
+  expect(onChange).not.toHaveBeenCalled();
+  socket.frame(1, 'data', { snapshot: { revision: 4 }, presence });
+  socket.frame(0, 'perks.changed', { revision: 4 });
+  expect(onSnapshot).toHaveBeenCalledTimes(2);
+  expect(onChange).not.toHaveBeenCalled();
+  // A hint with no data frame before it is acted on.
+  socket.frame(0, 'perks.changed', { revision: 5 });
+  expect(onChange).toHaveBeenCalledTimes(1);
+  // The host never answers a cell ping: a pong would be refused as read_only.
+  socket.frame(0, 'ping');
+  expect(socket.frames()).toHaveLength(1);
+  // Anything unparseable, off-protocol or oversize is dropped; the host never answers it.
+  socket.message('not json');
+  socket.message(JSON.stringify({ type: 'perks.changed' }));
+  socket.message(Buffer.from('binary'));
+  socket.message(JSON.stringify({ v: 1, ch: 1, seq: 9, t: 'data', snapshot: 'x'.repeat(512_000) }));
+  expect(onSnapshot).toHaveBeenCalledTimes(2);
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(socket.frames()).toHaveLength(1);
+  socket.frame(0, 'error', { code: 'read_only' });
+  expect(log).toHaveBeenCalledWith({ event: 'cell_error', code: 'read_only' });
+  expect(JSON.stringify(log.mock.calls)).not.toContain('grants');
+  link.stop();
+  expect(socket.closed).toBe(true);
+  expect(link.connected).toBe(false);
+});
+
+it('refuses channel kinds it does not support and ignores their data', async () => {
+  const { link, onSnapshot } = connect();
+  link.start();
+  await settle();
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  socket.frame(2, 'open', { kind: 'ssh' });
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 2, seq: 1, t: 'error', code: 'unsupported' });
+  socket.frame(2, 'data', { snapshot: {}, presence: [] });
+  expect(onSnapshot).not.toHaveBeenCalled();
+  socket.frame(1, 'open', { kind: 'perks' });
+  socket.frame(1, 'open', { kind: 'perks' });
+  socket.frame(1, 'data', { snapshot: {}, presence: [] });
+  expect(onSnapshot).toHaveBeenCalledTimes(1);
+  socket.frame(1, 'close');
+  socket.frame(1, 'data', { snapshot: {}, presence: [] });
+  expect(onSnapshot).toHaveBeenCalledTimes(1);
+  expect(socket.frames().filter((f) => f.ch === 1)).toEqual([]);
+});
+
+it('refuses a socket address outside the portal origin or off the cell path', async () => {
+  for (const socketUrl of [
+    'wss://elsewhere.example.test/cell/link',
+    'wss://portal.example.test/other',
+    'wss://portal.example.test/cell/link?x=1',
+  ]) {
+    const { link, log } = connect({ getTicket: async () => ({ ticket: 't', socketUrl }) });
+    link.start();
+    await settle();
+    expect(FakeSocket.instances).toHaveLength(0);
+    expect(log).toHaveBeenCalledWith({ event: 'connection_retry', code: 'invalid_cell_url' });
+    link.stop();
+  }
+});
+
+it('retries with jittered exponential backoff when a ticket cannot be obtained', async () => {
+  vi.useFakeTimers();
+  const getTicket = vi.fn(async () => {
+    throw Object.assign(new Error('offline'), { code: 'ECONNREFUSED' });
+  });
+  const { link, log } = connect({ getTicket, backoffBaseMs: 100, backoffCapMs: 400, random: () => 1 });
+  link.start();
+  await settle();
+  expect(log).toHaveBeenCalledWith({ event: 'connection_retry', code: 'ECONNREFUSED' });
+  expect(getTicket).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(99);
+  expect(getTicket).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(getTicket).toHaveBeenCalledTimes(2);
+  await vi.advanceTimersByTimeAsync(200);
+  expect(getTicket).toHaveBeenCalledTimes(3);
+  await vi.advanceTimersByTimeAsync(400);
+  expect(getTicket).toHaveBeenCalledTimes(4);
+  // Capped: the next window is 400 again.
+  await vi.advanceTimersByTimeAsync(400);
+  expect(getTicket).toHaveBeenCalledTimes(5);
+  link.stop();
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(getTicket).toHaveBeenCalledTimes(5);
+});
+
+it('pings on the interval, drops a socket that misses its pong, and reconnects with a fresh ticket', async () => {
+  vi.useFakeTimers();
+  const { link, getTicket, log } = connect({
+    pingMs: 1_000,
+    pongTimeoutMs: 3_000,
+    backoffBaseMs: 100,
+    backoffCapMs: 100,
+  });
+  link.start();
+  await settle();
+  const first = FakeSocket.instances[0];
+  first.open();
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(first.frames().map((f) => f.t)).toEqual(['hello', 'ping']);
+  expect(first.frames()[1]).toEqual({ v: 1, ch: 0, seq: 2, t: 'ping' });
+  first.frame(0, 'pong');
+  await vi.advanceTimersByTimeAsync(2_500);
+  expect(first.frames().map((f) => f.t)).toEqual(['hello', 'ping', 'ping', 'ping']);
+  expect(first.closed).toBe(false);
+  // No pong for longer than the timeout: the socket is dropped and replaced.
+  await vi.advanceTimersByTimeAsync(2_000);
+  expect(first.closed).toBe(true);
+  expect(link.connected).toBe(false);
+  expect(log).toHaveBeenCalledWith({ event: 'pong_timeout' });
+  expect(log).toHaveBeenCalledWith({ event: 'disconnected' });
+  await vi.advanceTimersByTimeAsync(100);
+  expect(getTicket).toHaveBeenCalledTimes(2);
+  expect(FakeSocket.instances).toHaveLength(2);
+  expect(FakeSocket.instances[1].protocols).toEqual(['nc-cell', 'ticket.tkt.2']);
+  // A late close from the dropped socket changes nothing.
+  first.lost();
+  await vi.advanceTimersByTimeAsync(2_000);
+  expect(FakeSocket.instances).toHaveLength(2);
+});
+
+it('gives up on a handshake that does not open in time and reconnects', async () => {
+  vi.useFakeTimers();
+  const { link, log } = connect({ handshakeMs: 500, backoffBaseMs: 100, backoffCapMs: 100 });
+  link.start();
+  await settle();
+  const first = FakeSocket.instances[0];
+  await vi.advanceTimersByTimeAsync(499);
+  expect(first.closed).toBe(false);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(first.closed).toBe(true);
+  expect(log).toHaveBeenCalledWith({ event: 'handshake_timeout' });
+  await vi.advanceTimersByTimeAsync(100);
+  expect(FakeSocket.instances).toHaveLength(2);
+  FakeSocket.instances[1].open();
+  expect(link.connected).toBe(true);
+});
+
+it('reconnects after the cell closes the connection, resetting the backoff after a stable session', async () => {
+  vi.useFakeTimers();
+  const { link, log } = connect({ backoffBaseMs: 100, backoffCapMs: 1_000, random: () => 1 });
+  link.start();
+  await settle();
+  const first = FakeSocket.instances[0];
+  first.open();
+  first.lost();
+  expect(link.connected).toBe(false);
+  expect(log).toHaveBeenCalledWith({ event: 'disconnected' });
+  await vi.advanceTimersByTimeAsync(100);
+  expect(FakeSocket.instances).toHaveLength(2);
+  FakeSocket.instances[1].lost();
+  await vi.advanceTimersByTimeAsync(199);
+  expect(FakeSocket.instances).toHaveLength(2);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(FakeSocket.instances).toHaveLength(3);
+  const third = FakeSocket.instances[2];
+  third.open();
+  await vi.advanceTimersByTimeAsync(31_000);
+  third.lost();
+  await vi.advanceTimersByTimeAsync(100);
+  expect(FakeSocket.instances).toHaveLength(4);
+});
+
+it('reconnects on 4401 and 4008/4009 (logging the latter as a bug) and stops on 4403 until started again', async () => {
+  vi.useFakeTimers();
+  const onForbidden = vi.fn();
+  const { link, log, getTicket } = connect({ onForbidden, backoffBaseMs: 100, backoffCapMs: 100 });
+  link.start();
+  await settle();
+  const first = FakeSocket.instances[0];
+  first.open();
+  first.lost(4401);
+  expect(log).toHaveBeenCalledWith({ event: 'disconnected', closeCode: 4401 });
+  expect(log).not.toHaveBeenCalledWith(expect.objectContaining({ event: 'protocol_error' }));
+  await vi.advanceTimersByTimeAsync(100);
+  expect(FakeSocket.instances).toHaveLength(2);
+  expect(FakeSocket.instances[1].protocols).toEqual(['nc-cell', 'ticket.tkt.2']);
+  const second = FakeSocket.instances[1];
+  second.open();
+  second.lost(4008);
+  expect(log).toHaveBeenCalledWith({ event: 'protocol_error', closeCode: 4008 });
+  await vi.advanceTimersByTimeAsync(100);
+  expect(FakeSocket.instances).toHaveLength(3);
+  const third = FakeSocket.instances[2];
+  third.open();
+  third.lost(CLOSE_FORBIDDEN);
+  expect(onForbidden).toHaveBeenCalledOnce();
+  expect(log).toHaveBeenCalledWith({ event: 'forbidden' });
+  expect(link.connected).toBe(false);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(FakeSocket.instances).toHaveLength(3);
+  expect(getTicket).toHaveBeenCalledTimes(3);
+  link.start();
+  await settle();
+  expect(FakeSocket.instances).toHaveLength(4);
+});
+
+it('computes the jittered exponential backoff of the reference module', () => {
+  expect(computeBackoffDelay(0, { random: () => 0 })).toBe(500);
+  expect(computeBackoffDelay(0, { random: () => 1 })).toBe(1_000);
+  expect(computeBackoffDelay(3, { random: () => 0.5 })).toBe(6_000);
+  expect(computeBackoffDelay(10, { random: () => 1 })).toBe(30_000);
+  expect(computeBackoffDelay(-5, { random: () => 1 })).toBe(1_000);
+  expect(computeBackoffDelay(1, { baseMs: 100, capMs: 150, random: () => 1 })).toBe(150);
+});

--- a/src/community-portal/link.ts
+++ b/src/community-portal/link.ts
@@ -1,0 +1,354 @@
+import { errorCode, portalError } from './errors.js';
+import { CONTROL_CHANNEL, MAX_CELL_FRAME_CHARS, Mux, type Frame } from './mux.js';
+
+/**
+ * The host's link to its account cell (wss://<portal>/cell/link): the
+ * remote-access frame protocol v1 over the WebSocket client that ships with
+ * Node 22. Every dial asks for a fresh ticket, says hello as the host leg,
+ * pings every 20 s, drops a socket that stays silent for 60 s or does not open
+ * within 10 s, and reconnects with jittered exponential backoff (1 s base,
+ * 30 s cap). The cell opens a `perks` data channel whose `data` frames carry
+ * the perks snapshot and device presence; any other channel kind is refused
+ * with `error unsupported`. The `data` frame is the source of truth and
+ * `perks.changed` only a hint, acted on when no data frame preceded it. The
+ * host sends nothing but hello, ping, and error/close on a data channel. A
+ * close with 4403 (device forgotten) means "sign in required": the link stops
+ * dialling until it is started again; 4008/4009 are the host's own protocol
+ * bugs and are logged before the ordinary backoff. The socket constructor is
+ * injectable for tests.
+ */
+export interface CellTicket {
+  ticket: string;
+  socketUrl: string;
+  expiresIn?: number;
+}
+
+export interface LinkEvent {
+  event: string;
+  code?: string;
+  [field: string]: unknown;
+}
+export type LinkLog = (event: LinkEvent) => void;
+
+/** One `data` frame on the perks channel. */
+export interface PerksData {
+  snapshot: unknown;
+  presence: unknown;
+}
+
+export interface LinkSocket {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: 'open' | 'error', listener: () => void): void;
+  addEventListener(type: 'close', listener: (event: { code?: number }) => void): void;
+  addEventListener(type: 'message', listener: (event: { data: unknown }) => void): void;
+}
+export type LinkSocketConstructor = new (url: URL, protocols: string[]) => LinkSocket;
+
+export interface CellLinkOptions {
+  origin: string;
+  /** A fresh ticket for every dial. */
+  getTicket(signal: AbortSignal): Promise<CellTicket>;
+  /** Every `data` frame on the perks channel: right after hello and on every mirror change. */
+  onSnapshot?: (data: PerksData) => void;
+  /** The `perks.changed` control frame. */
+  onChange?: () => void;
+  /** The cell closed with 4403: this device was forgotten. The link stays down until `start()`. */
+  onForbidden?: () => void;
+  log?: LinkLog;
+  caps?: string[];
+  ver?: string;
+  pingMs?: number;
+  pongTimeoutMs?: number;
+  handshakeMs?: number;
+  backoffBaseMs?: number;
+  backoffCapMs?: number;
+  Socket?: LinkSocketConstructor;
+  random?: () => number;
+  now?: () => number;
+}
+
+export const PING_INTERVAL_MS = 20_000;
+export const PONG_TIMEOUT_MS = 60_000;
+export const HANDSHAKE_TIMEOUT_MS = 10_000;
+export const BACKOFF_BASE_MS = 1_000;
+export const BACKOFF_CAP_MS = 30_000;
+/** A socket that stayed open this long resets the backoff counter when it drops. */
+export const STABLE_RESET_MS = 30_000;
+export const CELL_PATH = '/cell/link';
+export const HOST_CAPS = ['perks'];
+/** Close codes the cell uses (its WebSocket layer permits only 1000 and 3000–4999). */
+export const CLOSE_EXPIRED = 4401;
+export const CLOSE_FORBIDDEN = 4403;
+export const CLOSE_PROTOCOL = 4008;
+export const CLOSE_OVERSIZE = 4009;
+
+const OPEN = 1;
+
+/**
+ * Jittered exponential backoff: the window is base * 2^attempt capped at
+ * `capMs`; the delay is uniform in [window/2, window]. Pure; inject `random`.
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  { baseMs = BACKOFF_BASE_MS, capMs = BACKOFF_CAP_MS, random = Math.random } = {},
+): number {
+  const window = Math.min(capMs, baseMs * 2 ** Math.max(0, Math.min(attempt, 30)));
+  return Math.floor(window / 2 + random() * (window / 2));
+}
+
+export class CellLink {
+  connected = false;
+  private readonly origin: string;
+  private readonly getTicket: (signal: AbortSignal) => Promise<CellTicket>;
+  private readonly onSnapshot: (data: PerksData) => void;
+  private readonly onChange: () => void;
+  private readonly onForbidden: () => void;
+  private readonly log: LinkLog;
+  private readonly caps: string[];
+  private readonly ver?: string;
+  private readonly pingMs: number;
+  private readonly pongTimeoutMs: number;
+  private readonly handshakeMs: number;
+  private readonly backoffBaseMs: number;
+  private readonly backoffCapMs: number;
+  private readonly Socket: LinkSocketConstructor;
+  private readonly random: () => number;
+  private readonly now: () => number;
+  private socket?: LinkSocket;
+  private mux?: Mux;
+  private stopped = true;
+  private connecting = false;
+  private attempt = 0;
+  private lastPong = 0;
+  private openedAt = 0;
+  /** A perks `data` frame arrived since the last `perks.changed`, which is then only a hint. */
+  private snapshotSeen = false;
+  private abort = new AbortController();
+  private pinger?: NodeJS.Timeout;
+  private handshake?: NodeJS.Timeout;
+  private reconnect?: NodeJS.Timeout;
+
+  constructor({
+    origin,
+    getTicket,
+    onSnapshot = () => {},
+    onChange = () => {},
+    onForbidden = () => {},
+    log = () => {},
+    caps = HOST_CAPS,
+    ver,
+    pingMs = PING_INTERVAL_MS,
+    pongTimeoutMs = PONG_TIMEOUT_MS,
+    handshakeMs = HANDSHAKE_TIMEOUT_MS,
+    backoffBaseMs = BACKOFF_BASE_MS,
+    backoffCapMs = BACKOFF_CAP_MS,
+    Socket = globalThis.WebSocket as unknown as LinkSocketConstructor,
+    random = Math.random,
+    now = Date.now,
+  }: CellLinkOptions) {
+    this.origin = origin;
+    this.getTicket = getTicket;
+    this.onSnapshot = onSnapshot;
+    this.onChange = onChange;
+    this.onForbidden = onForbidden;
+    this.log = log;
+    this.caps = caps;
+    this.ver = ver;
+    this.pingMs = pingMs;
+    this.pongTimeoutMs = pongTimeoutMs;
+    this.handshakeMs = handshakeMs;
+    this.backoffBaseMs = backoffBaseMs;
+    this.backoffCapMs = backoffCapMs;
+    this.Socket = Socket;
+    this.random = random;
+    this.now = now;
+  }
+
+  start(): void {
+    if (!this.stopped) return;
+    this.stopped = false;
+    this.abort = new AbortController();
+    void this.connect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abort.abort();
+    clearTimeout(this.reconnect);
+    this.reconnect = undefined;
+    const socket = this.socket;
+    this.detach();
+    if (socket) closeQuietly(socket, 1000, 'shutdown');
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped || this.connecting || this.socket) return;
+    this.connecting = true;
+    try {
+      const { ticket, socketUrl } = await this.getTicket(this.abort.signal);
+      if (this.stopped) return;
+      const url = new URL(socketUrl);
+      if (
+        url.origin !== this.origin.replace(/^http/, 'ws') ||
+        url.pathname !== CELL_PATH ||
+        url.search ||
+        url.hash ||
+        url.username ||
+        url.password
+      )
+        throw portalError('The cell returned an unexpected socket address.', 'invalid_cell_url');
+      this.dial(url, ticket);
+    } catch (error) {
+      if (!this.stopped) {
+        this.log({ event: 'connection_retry', code: errorCode(error) });
+        this.retry();
+      }
+    } finally {
+      this.connecting = false;
+    }
+  }
+
+  /** Nothing goes in the URL: the ticket travels as a subprotocol. */
+  private dial(url: URL, ticket: string): void {
+    const socket = new this.Socket(url, ['nc-cell', `ticket.${ticket}`]);
+    const mux = new Mux((raw) => {
+      try {
+        socket.send(raw);
+      } catch (_error) {
+        // A send on a socket that just went away; the close event handles it.
+      }
+    }, this.log);
+    this.socket = socket;
+    this.mux = mux;
+    this.openedAt = 0;
+    this.handshake = setTimeout(() => {
+      if (this.socket === socket && socket.readyState !== OPEN) {
+        this.log({ event: 'handshake_timeout' });
+        this.drop(socket);
+      }
+    }, this.handshakeMs);
+    socket.addEventListener('open', () => {
+      if (this.socket !== socket) return;
+      clearTimeout(this.handshake);
+      this.handshake = undefined;
+      this.openedAt = this.now();
+      this.lastPong = this.now();
+      this.connected = true;
+      mux.send(CONTROL_CHANNEL, 'hello', { leg: 'host', caps: this.caps, ...(this.ver ? { ver: this.ver } : {}) });
+      this.pinger = setInterval(() => this.beat(socket, mux), this.pingMs);
+      this.log({ event: 'connected' });
+    });
+    socket.addEventListener('message', (event) => {
+      if (this.socket !== socket) return;
+      if (typeof event.data !== 'string' || event.data.length > MAX_CELL_FRAME_CHARS) {
+        this.log({ event: 'dropped_invalid_frame', bytes: typeof event.data === 'string' ? event.data.length : -1 });
+        return;
+      }
+      const frame = mux.receive(event.data);
+      if (frame) this.handleFrame(mux, frame);
+    });
+    socket.addEventListener('error', () => {});
+    socket.addEventListener('close', (event) => this.drop(socket, event.code));
+  }
+
+  private beat(socket: LinkSocket, mux: Mux): void {
+    if (this.socket !== socket || socket.readyState !== OPEN) return;
+    if (this.now() - this.lastPong > this.pongTimeoutMs) {
+      this.log({ event: 'pong_timeout' });
+      this.drop(socket);
+      return;
+    }
+    mux.send(CONTROL_CHANNEL, 'ping');
+  }
+
+  private handleFrame(mux: Mux, frame: Frame): void {
+    if (frame.ch === CONTROL_CHANNEL) {
+      if (frame.t === 'pong') this.lastPong = this.now();
+      else if (frame.t === 'perks.changed') {
+        if (!this.snapshotSeen) this.onChange();
+        this.snapshotSeen = false;
+      } else if (frame.t === 'error') this.log({ event: 'cell_error', code: String(frame.code ?? 'unknown') });
+      // hello, status (presence) and a ping need no host action; the cell answers
+      // anything but hello, ping and data-channel error/close with `read_only`.
+      return;
+    }
+    const handler = mux.handlerFor(frame.ch);
+    if (frame.t === 'open') {
+      if (handler) return;
+      if (frame.kind !== 'perks') {
+        mux.send(frame.ch, 'error', { code: 'unsupported' });
+        return;
+      }
+      mux.openChannel(frame.ch, { onFrame: (data) => this.perksFrame(mux, data), onTeardown: () => {} });
+      return;
+    }
+    handler?.onFrame(frame);
+  }
+
+  private perksFrame(mux: Mux, frame: Frame): void {
+    if (frame.t === 'data') {
+      this.snapshotSeen = true;
+      this.onSnapshot({ snapshot: frame.snapshot, presence: frame.presence });
+    } else if (frame.t === 'error') {
+      this.log({ event: 'channel_error', code: String(frame.code ?? 'unknown') });
+      mux.closeChannel(frame.ch);
+    } else if (frame.t === 'end' || frame.t === 'close') mux.closeChannel(frame.ch);
+  }
+
+  /**
+   * Forget `socket` and schedule a reconnect; a 4403 close stops the link
+   * instead. A no-op for a socket already replaced.
+   */
+  private drop(socket: LinkSocket, closeCode?: number): void {
+    if (this.socket !== socket) return;
+    const wasConnected = this.connected;
+    const stable = this.openedAt > 0 && this.now() - this.openedAt > STABLE_RESET_MS;
+    this.detach();
+    closeQuietly(socket);
+    if (wasConnected) this.log({ event: 'disconnected', ...(closeCode === undefined ? {} : { closeCode }) });
+    if (closeCode === CLOSE_FORBIDDEN) {
+      this.log({ event: 'forbidden' });
+      this.stopped = true;
+      this.abort.abort();
+      this.onForbidden();
+      return;
+    }
+    if (closeCode === CLOSE_PROTOCOL || closeCode === CLOSE_OVERSIZE) this.log({ event: 'protocol_error', closeCode });
+    if (stable) this.attempt = 0;
+    this.retry();
+  }
+
+  private detach(): void {
+    clearInterval(this.pinger);
+    clearTimeout(this.handshake);
+    this.pinger = undefined;
+    this.handshake = undefined;
+    this.mux?.reset();
+    this.mux = undefined;
+    this.socket = undefined;
+    this.connected = false;
+    this.openedAt = 0;
+    this.snapshotSeen = false;
+  }
+
+  private retry(): void {
+    if (this.stopped) return;
+    clearTimeout(this.reconnect);
+    const delay = computeBackoffDelay(this.attempt++, {
+      baseMs: this.backoffBaseMs,
+      capMs: this.backoffCapMs,
+      random: this.random,
+    });
+    this.reconnect = setTimeout(() => void this.connect(), delay);
+  }
+}
+
+function closeQuietly(socket: LinkSocket, code?: number, reason?: string): void {
+  try {
+    socket.close(code, reason);
+  } catch (_error) {
+    // Already closing or closed.
+  }
+}

--- a/src/community-portal/mux.test.ts
+++ b/src/community-portal/mux.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CONTROL_CHANNEL,
+  CONTROL_TYPES,
+  DATA_TYPES,
+  Mux,
+  PROTOCOL_VERSION,
+  decodeFrame,
+  encodeFrame,
+  validateFrame,
+  type ChannelHandler,
+  type Frame,
+} from './mux.js';
+
+interface FrameVectors {
+  valid: { raw: string; frame: Frame }[];
+  invalid: string[];
+}
+const vectors = JSON.parse(readFileSync(new URL('./frame-vectors.json', import.meta.url), 'utf8')) as FrameVectors;
+
+describe('frame encode/decode', () => {
+  it('decodes every pinned cell frame and re-encodes it losslessly', () => {
+    for (const { raw, frame } of vectors.valid) {
+      expect(decodeFrame(raw)).toEqual(frame);
+      expect(decodeFrame(encodeFrame(frame))).toEqual(frame);
+    }
+  });
+
+  it('drops every pinned invalid message, including the pre-cutover flat messages', () => {
+    for (const raw of vectors.invalid) expect(decodeFrame(raw)).toBeNull();
+  });
+
+  it('rejects non-string raw input', () => {
+    expect(decodeFrame(Buffer.from('{}'))).toBeNull();
+    expect(decodeFrame(42)).toBeNull();
+    expect(decodeFrame(undefined)).toBeNull();
+  });
+
+  it('validateFrame accepts every declared type on its channel class only', () => {
+    expect(CONTROL_TYPES).toEqual(['hello', 'status', 'ping', 'pong', 'perks.changed', 'error']);
+    expect(DATA_TYPES).toEqual(['open', 'data', 'end', 'error', 'close']);
+    for (const t of CONTROL_TYPES) {
+      expect(validateFrame({ v: 1, ch: CONTROL_CHANNEL, seq: 1, t })).toBe(true);
+      if (t !== 'error') expect(validateFrame({ v: 1, ch: 9, seq: 1, t })).toBe(false);
+    }
+    for (const t of DATA_TYPES) {
+      expect(validateFrame({ v: 1, ch: 9, seq: 1, t })).toBe(true);
+      if (t !== 'error') expect(validateFrame({ v: 1, ch: CONTROL_CHANNEL, seq: 1, t })).toBe(false);
+    }
+  });
+});
+
+describe('Mux', () => {
+  function makeMux(): { mux: Mux; raws: string[]; frames: Frame[]; log: ReturnType<typeof vi.fn> } {
+    const raws: string[] = [];
+    const frames: Frame[] = [];
+    const log = vi.fn();
+    const mux = new Mux((raw) => {
+      raws.push(raw);
+      const f = decodeFrame(raw);
+      if (f) frames.push(f);
+    }, log);
+    return { mux, raws, frames, log };
+  }
+
+  it('stamps per-channel outbound seq starting at 1', () => {
+    const { mux, frames } = makeMux();
+    mux.send(0, 'hello', { leg: 'host', caps: ['perks'] });
+    mux.send(0, 'ping');
+    mux.send(4, 'error', { code: 'unsupported' });
+    mux.send(4, 'close');
+    expect(frames.map((f) => [f.ch, f.seq, f.t])).toEqual([
+      [0, 1, 'hello'],
+      [0, 2, 'ping'],
+      [4, 1, 'error'],
+      [4, 2, 'close'],
+    ]);
+    expect(frames[0]).toEqual({ v: PROTOCOL_VERSION, ch: 0, seq: 1, t: 'hello', leg: 'host', caps: ['perks'] });
+  });
+
+  it('always emits wire-valid frames (envelope wins over field collisions)', () => {
+    const { mux, frames } = makeMux();
+    mux.send(2, 'data', { v: 99, ch: 77, seq: 1234, t: 'error', b64: 'AA==' } as Record<string, unknown>);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({ v: 1, ch: 2, seq: 1, t: 'data', b64: 'AA==' });
+  });
+
+  it('receive returns decoded frames, tolerates seq gaps, and drops invalid frames without their payload', () => {
+    const { mux, log } = makeMux();
+    const a = mux.receive(JSON.stringify({ v: 1, ch: 5, seq: 1, t: 'open', kind: 'perks' }));
+    expect(a?.t).toBe('open');
+    const b = mux.receive(JSON.stringify({ v: 1, ch: 5, seq: 5, t: 'close' }));
+    expect(b?.t).toBe('close');
+    expect(log).toHaveBeenCalledWith({ event: 'inbound_seq_gap', ch: 5, expected: 2, got: 5 });
+    expect(mux.receive('nonsense')).toBeNull();
+    expect(mux.receive(Buffer.from('binary'))).toBeNull();
+    expect(mux.receive(JSON.stringify({ v: 1, ch: 0, seq: 1, t: 'open' }))).toBeNull();
+    expect(log).toHaveBeenCalledWith({ event: 'dropped_invalid_frame', bytes: 8 });
+    expect(log).toHaveBeenCalledWith({ event: 'dropped_invalid_frame', bytes: -1 });
+    expect(JSON.stringify(log.mock.calls)).not.toContain('nonsense');
+  });
+
+  it('channel registry: open/handlerFor/close with a single teardown', () => {
+    const { mux } = makeMux();
+    let teardowns = 0;
+    const handler: ChannelHandler = { onFrame: () => {}, onTeardown: () => teardowns++ };
+    mux.openChannel(3, handler);
+    expect(mux.handlerFor(3)).toBe(handler);
+    mux.closeChannel(3);
+    expect(mux.handlerFor(3)).toBeUndefined();
+    mux.closeChannel(3);
+    expect(teardowns).toBe(1);
+  });
+
+  it('reset tears down all channels and restarts seq counters', () => {
+    const { mux, frames } = makeMux();
+    const torn: number[] = [];
+    mux.openChannel(1, { onFrame: () => {}, onTeardown: () => torn.push(1) });
+    mux.openChannel(2, { onFrame: () => {}, onTeardown: () => torn.push(2) });
+    mux.send(1, 'data', { b64: 'AA==' });
+    mux.reset();
+    expect(torn.sort()).toEqual([1, 2]);
+    mux.send(1, 'data', { b64: 'AA==' });
+    expect(frames[frames.length - 1].seq).toBe(1);
+  });
+});

--- a/src/community-portal/mux.ts
+++ b/src/community-portal/mux.ts
@@ -1,0 +1,138 @@
+/**
+ * Frame protocol v1 for the cell link, ported from the remote-access module.
+ *
+ * Every WebSocket message is a single JSON text frame:
+ *   { "v":1, "ch":<int>, "seq":<int>, "t":"<type>", ...fields }
+ *
+ * - ch 0 is the control channel: "hello", "status", "ping"/"pong",
+ *   "perks.changed" and "error".
+ * - ch > 0 are data channels, opened by the cell with "open" {kind, ...};
+ *   "data", "end", "error" {code, msg} and "close" follow on the same ch.
+ * - seq is per channel, per sender, starts at 1, increments by 1. Receivers
+ *   tolerate gaps.
+ *
+ * Nothing in this file may log payload contents; envelope metadata only.
+ */
+export const PROTOCOL_VERSION = 1 as const;
+export const CONTROL_CHANNEL = 0;
+/** Frames from client legs are at most this long. */
+export const MAX_CLIENT_FRAME_CHARS = 4096;
+/** The cell may send larger frames (a snapshot), up to this long. */
+export const MAX_CELL_FRAME_CHARS = 512_000;
+
+/** Frame types valid on the control channel (ch 0). */
+export const CONTROL_TYPES = ['hello', 'status', 'ping', 'pong', 'perks.changed', 'error'] as const;
+/** Frame types valid on data channels (ch > 0). */
+export const DATA_TYPES = ['open', 'data', 'end', 'error', 'close'] as const;
+
+export interface Frame {
+  v: typeof PROTOCOL_VERSION;
+  ch: number;
+  seq: number;
+  t: string;
+  [field: string]: unknown;
+}
+
+export type MuxLog = (event: { event: string; [field: string]: unknown }) => void;
+
+/** Serialize a frame to the single-JSON-text wire form. */
+export function encodeFrame(frame: Frame): string {
+  return JSON.stringify(frame);
+}
+
+/**
+ * Structural validation of a decoded value against protocol v1: the envelope
+ * (v/ch/seq/t) and that the type is legal for the channel class.
+ */
+export function validateFrame(value: unknown): value is Frame {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const f = value as Record<string, unknown>;
+  if (f.v !== PROTOCOL_VERSION) return false;
+  if (typeof f.ch !== 'number' || !Number.isInteger(f.ch) || f.ch < 0) return false;
+  if (typeof f.seq !== 'number' || !Number.isInteger(f.seq) || f.seq < 1) return false;
+  if (typeof f.t !== 'string' || f.t.length === 0) return false;
+  const allowed: readonly string[] = f.ch === CONTROL_CHANNEL ? CONTROL_TYPES : DATA_TYPES;
+  return allowed.includes(f.t);
+}
+
+/** Parse one raw WS message. Returns null (never throws) on anything invalid. */
+export function decodeFrame(raw: unknown): Frame | null {
+  if (typeof raw !== 'string') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_error) {
+    return null;
+  }
+  return validateFrame(parsed) ? parsed : null;
+}
+
+/** A live data channel's frame consumer. */
+export interface ChannelHandler {
+  /** Inbound frame addressed to this channel (never "open"; dispatch handles that). */
+  onFrame(frame: Frame): void;
+  /** Channel torn down: "close" frame, error, or connection reset. Must be idempotent-safe. */
+  onTeardown(): void;
+}
+
+/**
+ * Per-connection multiplexer: outbound seq counters, inbound seq gap
+ * tracking, and the registry of open data channels. One Mux per WebSocket;
+ * throw it away (reset()) when the socket drops.
+ */
+export class Mux {
+  private readonly outSeq = new Map<number, number>();
+  private readonly inSeq = new Map<number, number>();
+  private readonly channels = new Map<number, ChannelHandler>();
+
+  constructor(
+    private readonly sendRaw: (raw: string) => void,
+    private readonly log: MuxLog = () => {},
+  ) {}
+
+  /** Send a frame on `ch`, stamping the next per-channel outbound seq. */
+  send(ch: number, t: string, fields: Record<string, unknown> = {}): void {
+    const seq = (this.outSeq.get(ch) ?? 0) + 1;
+    this.outSeq.set(ch, seq);
+    this.sendRaw(encodeFrame({ ...fields, v: PROTOCOL_VERSION, ch, seq, t }));
+  }
+
+  /**
+   * Decode + seq-track one raw inbound message. Invalid frames are dropped
+   * (logged without payload). Seq gaps are tolerated but logged.
+   */
+  receive(raw: unknown): Frame | null {
+    const frame = decodeFrame(raw);
+    if (frame === null) {
+      this.log({ event: 'dropped_invalid_frame', bytes: typeof raw === 'string' ? raw.length : -1 });
+      return null;
+    }
+    const last = this.inSeq.get(frame.ch) ?? 0;
+    if (frame.seq !== last + 1)
+      this.log({ event: 'inbound_seq_gap', ch: frame.ch, expected: last + 1, got: frame.seq });
+    if (frame.seq > last) this.inSeq.set(frame.ch, frame.seq);
+    return frame;
+  }
+
+  openChannel(ch: number, handler: ChannelHandler): void {
+    this.channels.set(ch, handler);
+  }
+
+  handlerFor(ch: number): ChannelHandler | undefined {
+    return this.channels.get(ch);
+  }
+
+  /** Remove + tear down one channel. Safe to call for unknown channels. */
+  closeChannel(ch: number): void {
+    const handler = this.channels.get(ch);
+    this.channels.delete(ch);
+    handler?.onTeardown();
+  }
+
+  /** Tear down every channel and forget all seq state (socket dropped). */
+  reset(): void {
+    for (const ch of [...this.channels.keys()]) this.closeChannel(ch);
+    this.outSeq.clear();
+    this.inSeq.clear();
+  }
+}

--- a/src/community-portal/private-file.ts
+++ b/src/community-portal/private-file.ts
@@ -1,0 +1,38 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, open, readFile, rename } from 'node:fs/promises';
+import path from 'node:path';
+import { isErrno } from './errors.js';
+
+/** Parse a JSON file, returning `fallback` when it does not exist. */
+export async function readJson<T = unknown>(file: string, fallback: T | null = null): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(file, 'utf8')) as T;
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return fallback;
+    throw error;
+  }
+}
+
+/**
+ * Write JSON with owner-only permissions and no torn reads: a fresh 0600 temp
+ * file, fsync, atomic rename, then fsync of the directory entry.
+ */
+export async function writePrivate(file: string, value: unknown): Promise<void> {
+  const directory = path.dirname(file);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temp = `${file}.${randomBytes(8).toString('base64url')}.tmp`;
+  const output = await open(temp, 'wx', 0o600);
+  try {
+    await output.writeFile(JSON.stringify(value, null, 2));
+    await output.sync();
+  } finally {
+    await output.close();
+  }
+  await rename(temp, file);
+  const entry = await open(directory, 'r');
+  try {
+    await entry.sync();
+  } finally {
+    await entry.close();
+  }
+}

--- a/src/community-portal/process-lock.test.ts
+++ b/src/community-portal/process-lock.test.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, it } from 'vitest';
+import { processIdentity, processLock, processLockOwner } from './process-lock.js';
+
+const dirs: string[] = [];
+afterEach(async () => {
+  for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
+});
+async function lockFile(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'nc-lock-'));
+  dirs.push(dir);
+  await mkdir(path.join(dir, 'data'));
+  return path.join(dir, 'data/test.lock');
+}
+
+it('claims a free lock, names its owner, and refuses a second claim until released', async () => {
+  const file = await lockFile();
+  const release = await processLock(file);
+  expect(release).toBeTypeOf('function');
+  expect(processLockOwner(file)).toMatchObject({ pid: process.pid, started: processIdentity(process.pid) ?? '' });
+  expect(await processLock(file)).toBeNull();
+  release!();
+  expect(processLockOwner(file)).toBeUndefined();
+  const again = await processLock(file);
+  expect(again).toBeTypeOf('function');
+  again!();
+});
+
+it('writes an owner-only file with a complete record and leaves no staging file behind', async () => {
+  const file = await lockFile();
+  const release = await processLock(file);
+  expect((await stat(file)).mode & 0o777).toBe(0o600);
+  const owner = JSON.parse(await readFile(file, 'utf8'));
+  expect(owner).toEqual({ pid: process.pid, nonce: expect.any(String), started: expect.any(String) });
+  expect(owner.nonce).toHaveLength(36);
+  expect(await readdir(path.dirname(file))).toEqual(['test.lock']);
+  release!();
+  expect(await readdir(path.dirname(file))).toEqual([]);
+});
+
+it('reclaims a lock whose owner process has exited', async () => {
+  const file = await lockFile();
+  const { pid } = spawnSync(process.execPath, ['-e', ''], { stdio: 'ignore' });
+  await writeFile(file, JSON.stringify({ pid, nonce: 'gone', started: 'whenever' }));
+  expect(processLockOwner(file)).toBeUndefined();
+  const release = await processLock(file);
+  expect(release).toBeTypeOf('function');
+  expect(processLockOwner(file)?.pid).toBe(process.pid);
+  release!();
+});
+
+it('reclaims a lock from a previous boot even when its PID is in use again', async () => {
+  const file = await lockFile();
+  await writeFile(file, JSON.stringify({ pid: process.pid, nonce: 'old-owner', started: 'previous-boot' }));
+  expect(processLockOwner(file)).toBeUndefined();
+  const release = await processLock(file);
+  expect(release).toBeTypeOf('function');
+  expect(processLockOwner(file)?.nonce).not.toBe('old-owner');
+  release!();
+});
+
+it('honours a live owner recorded with only a pid, and treats an unreadable record as stale', async () => {
+  const file = await lockFile();
+  await writeFile(file, JSON.stringify({ pid: process.pid }));
+  expect(processLockOwner(file)).toMatchObject({ pid: process.pid, nonce: '', started: '' });
+  expect(await processLock(file)).toBeNull();
+  await writeFile(file, 'not json');
+  expect(processLockOwner(file)).toBeUndefined();
+  const release = await processLock(file);
+  expect(release).toBeTypeOf('function');
+  release!();
+});
+
+it('release removes only the record this claim wrote', async () => {
+  const file = await lockFile();
+  const release = await processLock(file);
+  const other = { pid: process.pid, nonce: 'someone-else', started: processIdentity(process.pid) ?? '' };
+  await writeFile(file, JSON.stringify(other));
+  release!();
+  expect(JSON.parse(await readFile(file, 'utf8'))).toEqual(other);
+});

--- a/src/community-portal/process-lock.ts
+++ b/src/community-portal/process-lock.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { readFileSync, unlinkSync } from 'node:fs';
+import { link, mkdir, open, stat, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { isErrno } from './errors.js';
+
+/**
+ * One-owner lock files for the setup journal, the checkout mutation lock and
+ * the Slack install worker. The file holds its owner as JSON so a peer can
+ * tell a live owner from a crashed one; `started` is a per-boot process birth
+ * identity, so a reused PID after a reboot is not mistaken for the owner.
+ *
+ * Claims use link(2), which is atomic and fails when the file exists, so a
+ * reader never sees a half-written owner. Reclaiming a dead owner removes the
+ * file only if it is still the inode that was inspected.
+ */
+export interface LockOwner {
+  pid: number;
+  nonce: string;
+  started: string;
+}
+
+export function processIdentity(pid: number): string | undefined {
+  try {
+    if (process.platform === 'linux') {
+      const boot = readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim();
+      const status = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      return `${boot}:${status.slice(status.lastIndexOf(')') + 2).split(' ')[19]}`;
+    }
+    return (
+      execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+        encoding: 'utf8',
+        env: { ...process.env, TZ: 'UTC', LC_ALL: 'C' },
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim() || undefined
+    );
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function ownerAlive(owner: LockOwner): boolean {
+  try {
+    process.kill(owner.pid, 0);
+  } catch (error) {
+    if (isErrno(error, 'ESRCH')) return false;
+    // EPERM: the process exists but belongs to another user.
+  }
+  const current = processIdentity(owner.pid);
+  return !current || !owner.started || current === owner.started;
+}
+
+function readOwner(file: string): LockOwner | undefined {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const { pid, nonce = '', started = '' } = parsed as Partial<LockOwner>;
+    return typeof pid === 'number' ? { pid, nonce: String(nonce), started: String(started) } : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+async function inode(file: string): Promise<number | undefined> {
+  try {
+    return (await stat(file)).ino;
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+}
+
+/** The live owner of `file`, or undefined when the lock is free or its owner is gone. */
+export function processLockOwner(file: string): LockOwner | undefined {
+  const owner = readOwner(file);
+  return owner && ownerAlive(owner) ? owner : undefined;
+}
+
+/**
+ * Claim `file` for this process. Resolves to a release function, or null while
+ * another live process holds it. The lock is released on process exit as well.
+ */
+export async function processLock(file: string): Promise<(() => void) | null> {
+  await mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+  const owner: LockOwner = { pid: process.pid, nonce: randomUUID(), started: processIdentity(process.pid) || '' };
+  const staged = `${file}.${owner.nonce}.tmp`;
+  const handle = await open(staged, 'wx', 0o600);
+  try {
+    await handle.writeFile(JSON.stringify(owner));
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await link(staged, file);
+        return release(file, owner);
+      } catch (error) {
+        if (!isErrno(error, 'EEXIST')) throw error;
+      }
+      const seen = await inode(file);
+      const current = readOwner(file);
+      if (current && ownerAlive(current)) return null;
+      if (seen !== undefined && seen === (await inode(file))) {
+        try {
+          await unlink(file);
+        } catch (error) {
+          if (!isErrno(error, 'ENOENT')) throw error;
+        }
+      }
+    }
+    return null;
+  } finally {
+    await unlink(staged).catch(() => undefined);
+  }
+}
+
+function release(file: string, owner: LockOwner): () => void {
+  let released = false;
+  const run = (): void => {
+    if (released) return;
+    released = true;
+    process.removeListener('exit', run);
+    try {
+      const current = readOwner(file);
+      if (current?.pid === owner.pid && current.nonce === owner.nonce) unlinkSync(file);
+    } catch (error) {
+      if (!isErrno(error, 'ENOENT')) throw error;
+    }
+  };
+  process.once('exit', run);
+  return run;
+}

--- a/src/community-portal/setup-client.ts
+++ b/src/community-portal/setup-client.ts
@@ -1,0 +1,180 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { DeviceClient, type DeviceClientOptions, type SetupFlow } from './device-client.js';
+import { errorCode, errorStatus } from './errors.js';
+
+/**
+ * The setup wizard's side of a browser handoff: start a stage for the
+ * registered device (or anonymously, carrying the registry device flow's user
+ * code so one browser visit covers sign-in, terminal approval and the perk),
+ * print its link, claim the flow once signed in, poll until the browser
+ * finishes, and report the outcome. There is nothing to unseal and nothing to
+ * save into account.json here; the sign-in owns that file.
+ */
+export interface CatalogItem {
+  id: string;
+  kind: string;
+  enabled?: boolean;
+}
+
+export interface SetupChoice {
+  imageSource?: 'hardened' | 'local';
+  workspaceId: string;
+  name: string;
+}
+
+/** The public setup state (`GET /api/v1/setup/{code}`). */
+export interface SetupState {
+  id: string;
+  stage?: string;
+  deviceId?: string;
+  label?: string;
+  name?: string;
+  status: string;
+  choice: SetupChoice;
+  appId?: string;
+  error?: string;
+  createdAt?: string;
+  expiresAt?: string;
+  [key: string]: unknown;
+}
+
+/** The registry device flow's public display data for an anonymous start; never a secret. */
+export interface SetupVerification {
+  userCode: string;
+  verificationUri: string;
+}
+
+export interface StartOptions {
+  reuseEnabled?: boolean;
+  /** Start without a bearer: the flow waits in `awaiting_installation` until `claim()`. */
+  verification?: SetupVerification;
+}
+
+export interface SetupClientOptions extends DeviceClientOptions {
+  /** Ask the portal to return to the terminal as soon as the perk is enabled. */
+  autoContinue?: boolean;
+}
+
+const LIVE_FLOW_STATES = ['pending', 'authorizing', 'browsing', 'approved', 'awaiting_approval'];
+const FINISHED_STATES = ['approved', 'awaiting_approval', 'skipped'];
+
+export class SetupClient extends DeviceClient {
+  flow?: SetupFlow;
+  private readonly autoContinue: boolean;
+
+  constructor({ autoContinue = false, ...options }: SetupClientOptions) {
+    super(options);
+    this.autoContinue = autoContinue;
+  }
+
+  /** Whether the release catalog offers `stage` right now. */
+  async available(stage: string): Promise<boolean> {
+    const { items } = await this.request<{ items: CatalogItem[] }>('GET', '/api/v1/catalog');
+    return items.some((item) => item.id === stage && (item.kind === 'account' || item.enabled === true));
+  }
+
+  /** True when the signed-in installation already has `stage` enabled; never opens a browser. */
+  async resumeEnabled(stage: string, name = 'Nano'): Promise<boolean> {
+    if (!this.identity) return false;
+    try {
+      await this.start(stage, name, { reuseEnabled: true });
+      return true;
+    } catch (error) {
+      if (errorStatus(error) === 401) return false;
+      if (['perk_not_enabled', 'installation_required'].includes(errorCode(error, ''))) return false;
+      throw error;
+    }
+  }
+
+  /**
+   * Start (or resume an unexpired) browser flow for `stage`. With a bearer the
+   * flow binds to the registered device; with `verification` it is anonymous
+   * and binds to nothing until claimed.
+   */
+  async start(
+    stage: string,
+    name = 'Nano',
+    { reuseEnabled = false, verification }: StartOptions = {},
+  ): Promise<SetupFlow> {
+    if (verification) {
+      this.flow = await this.request<SetupFlow>('POST', '/api/v1/setup/start', {
+        stage,
+        name,
+        autoContinue: this.autoContinue,
+        label: this.label,
+        verification,
+      });
+      this.flow.stage = stage;
+      this.local.setupFlow = this.flow;
+      await this.save();
+      return this.flow;
+    }
+    const previous = this.local.setupFlow;
+    if (!reuseEnabled && previous?.stage === stage && Date.parse(previous.expiresAt) > Date.now()) {
+      this.flow = previous;
+      try {
+        if (LIVE_FLOW_STATES.includes((await this.status()).status)) return previous;
+      } catch (error) {
+        const status = errorStatus(error);
+        if (status !== 410 && status !== 401 && status !== 404) throw error;
+      }
+    }
+    this.flow = await this.request<SetupFlow>('POST', '/api/v1/setup/start', {
+      stage,
+      name,
+      reuseEnabled,
+      autoContinue: this.autoContinue,
+      label: this.label,
+    });
+    this.flow.stage = stage;
+    this.local.setupFlow = this.flow;
+    await this.save();
+    return this.flow;
+  }
+
+  status(): Promise<SetupState> {
+    return this.request<SetupState>('GET', `/api/v1/setup/${this.currentFlow().code}`);
+  }
+
+  /** Bind an anonymously started flow to this (now signed-in, registered) installation. */
+  claim(): Promise<SetupState> {
+    return this.request<SetupState>('POST', `/api/v1/setup/${this.currentFlow().code}/claim`, {});
+  }
+
+  /** Poll the flow until the browser finishes it; resolves to the public setup state. */
+  async wait({ pollMs = 1500, onState = (_state: SetupState): void => {} } = {}): Promise<SetupState> {
+    const flow = this.currentFlow();
+    while (Date.now() < Date.parse(flow.expiresAt)) {
+      let result: SetupState;
+      try {
+        result = await this.status();
+      } catch (error) {
+        const status = errorStatus(error);
+        if (status && status < 500 && status !== 429) throw error;
+        await sleep(pollMs);
+        continue;
+      }
+      onState(result);
+      if (FINISHED_STATES.includes(result.status)) {
+        if (result.deviceId && result.deviceId !== this.local.deviceId) {
+          this.local.deviceId = result.deviceId;
+          await this.save();
+        }
+        return result;
+      }
+      if (['cancelled', 'failed'].includes(result.status))
+        throw new Error('Setup was cancelled or failed. Restart this step.');
+      await sleep(pollMs);
+    }
+    throw new Error('Browser setup timed out. Restart this step to get a new link.');
+  }
+
+  complete(status = 'complete', detail: Record<string, unknown> = {}): Promise<unknown> {
+    return this.request('POST', `/api/v1/setup/${this.currentFlow().code}/complete`, { status, ...detail });
+  }
+
+  private currentFlow(): SetupFlow {
+    if (!this.flow) throw new Error('Start a setup stage before polling it.');
+    return this.flow;
+  }
+}

--- a/src/community-portal/slack-job.ts
+++ b/src/community-portal/slack-job.ts
@@ -1,0 +1,193 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { DeviceClient, type Journal } from './device-client.js';
+import { isErrno } from './errors.js';
+import { readInstallIdentity } from './install-identity.js';
+import { readJson, writePrivate } from './private-file.js';
+import { processLock, processLockOwner } from './process-lock.js';
+
+/**
+ * The saved Slack installation job (`data/slack-install.json`). Setup writes
+ * it after the browser hands over a managed app; a detached worker
+ * (setup/slack-worker.ts) finishes the install once the workspace approves,
+ * and the running host resumes that worker after a restart. The job carries
+ * an immutable snapshot of the install identity (the install token and ids
+ * from account.json plus the journal's device id, never a key) so the worker
+ * never opens the foreground setup journal.
+ */
+/** Mirrors OperatorRole in setup/lib/role-prompt.ts. */
+export type SlackOperatorRole = 'owner' | 'admin' | 'member';
+
+export interface SlackJobIdentity {
+  token: string;
+  account_id: string;
+  install_id: string;
+  deviceId?: string;
+}
+
+export interface SlackJob {
+  id: string;
+  status: 'awaiting_approval' | 'installing' | 'complete' | 'failed' | 'expired';
+  createdAt: string;
+  expiresAt: string;
+  setupId: string;
+  origin: string;
+  serviceBase: string;
+  identity: SlackJobIdentity;
+  app: { appId: string; appToken: string; botToken?: string };
+  deliveryId?: string;
+  acknowledged?: boolean;
+  context: {
+    agentName: string;
+    displayName: string;
+    role: SlackOperatorRole;
+    ownerHandle: string;
+    templateAgentId?: string;
+  };
+  error?: string;
+  reportedStatus?: string;
+}
+
+const JOB_STATUSES: readonly string[] = ['awaiting_approval', 'installing', 'complete', 'failed', 'expired'];
+const APPROVAL_WINDOW_MS = 7 * 86_400_000;
+export const DEFAULT_SLACK_SERVICE = 'https://slack.nanoclaw.dev';
+
+export const slackJobFile = (root = process.cwd()): string => path.join(root, 'data/slack-install.json');
+
+export function readSlackJob(root = process.cwd()): Promise<SlackJob | null> {
+  return readJson<SlackJob>(slackJobFile(root));
+}
+
+/** Public progress only; an abandoned or expired job must not look active. */
+export function slackJobStatus(job: SlackJob | null, now = Date.now()): SlackJob['status'] | undefined {
+  if (!job) return undefined;
+  if (!JOB_STATUSES.includes(job.status)) return 'failed';
+  if (['awaiting_approval', 'installing'].includes(job.status) && !(Date.parse(job.expiresAt) > now)) return 'expired';
+  return job.status;
+}
+
+/**
+ * Serialize checkout mutations between foreground setup and the worker. A
+ * child spawned by the holder inherits the claim through NANOCLAW_SETUP_LOCK.
+ */
+export async function withSetupLock<T>(run: () => Promise<T>, root = process.cwd()): Promise<T> {
+  const file = path.join(root, 'data/setup-mutation.lock');
+  const inherited = process.env.NANOCLAW_SETUP_LOCK;
+  if (inherited && processLockOwner(file)?.nonce === inherited) return run();
+  let release: (() => void) | null;
+  while (!(release = await processLock(file))) await sleep(1000);
+  process.env.NANOCLAW_SETUP_LOCK = processLockOwner(file)?.nonce;
+  try {
+    return await run();
+  } finally {
+    delete process.env.NANOCLAW_SETUP_LOCK;
+    release();
+  }
+}
+
+/** Start the detached worker for a saved job that still has work to do. */
+export async function launchSlackJob(root = process.cwd()): Promise<boolean> {
+  const job = await readSlackJob(root);
+  if (
+    !job ||
+    !(
+      ['awaiting_approval', 'installing'].includes(job.status) ||
+      (job.status === 'complete' && job.reportedStatus !== 'complete')
+    )
+  )
+    return false;
+  // The host supervisor may check on every cell update. A healthy owner is
+  // already polling Slack; do not spawn a losing process for each check.
+  if (processLockOwner(`${slackJobFile(root)}.lock`)) return false;
+  const env = { ...process.env };
+  delete env.NANOCLAW_SETUP_LOCK;
+  delete env.NANOCLAW_TEMPLATE_AGENT_ID;
+  // The worker applies the Slack channel skill, so it lives with the wizard
+  // and runs through tsx like every other setup entry point.
+  const child = spawn(process.execPath, ['--import', 'tsx', path.join(root, 'setup/slack-worker.ts')], {
+    cwd: root,
+    env,
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('The Slack background worker could not start. Resume the Slack setup step.'));
+    }, 10_000);
+    child.once('message', (message) => {
+      if ((message as { type?: string } | null)?.type !== 'slack-worker-ready') return;
+      clearTimeout(timer);
+      resolve();
+    });
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('exit', () => {
+      clearTimeout(timer);
+      reject(new Error('The Slack background worker failed to start. Resume the Slack setup step.'));
+    });
+  });
+  child.unref();
+  return true;
+}
+
+/** Persist the app the browser handed over as a job, then start its worker. */
+export async function queueSlackJob(context: SlackJob['context'], root = process.cwd()): Promise<void> {
+  let local: Journal;
+  try {
+    local = JSON.parse(await readFile(path.join(root, 'data/community-portal.json'), 'utf8')) as Journal;
+  } catch (error) {
+    if (!isErrno(error, 'ENOENT')) throw error;
+    throw new Error('Slack credentials were not saved. Restart the Slack step.', { cause: error });
+  }
+  const saved = local.slackSetup;
+  if (!saved?.app?.appToken || !local.origin)
+    throw new Error('Slack credentials were not saved. Restart the Slack step.');
+  const account = await readInstallIdentity();
+  if (!account) throw new Error('The NanoClaw sign-in is missing. Restart the Slack step.');
+  const app = saved.app;
+  const prior = await readSlackJob(root);
+  const samePrior = prior?.app.appId === app.appId ? prior : null;
+  if (prior && !samePrior && ['awaiting_approval', 'installing'].includes(prior.status))
+    throw new Error('A Slack installation is already running in this checkout.');
+  if (!samePrior || ['failed', 'expired'].includes(samePrior.status)) {
+    const job: SlackJob = {
+      id: randomUUID(),
+      status: app.botToken ? 'installing' : 'awaiting_approval',
+      createdAt: new Date().toISOString(),
+      expiresAt: samePrior ? samePrior.expiresAt : new Date(Date.now() + APPROVAL_WINDOW_MS).toISOString(),
+      setupId: saved.setupId,
+      origin: local.origin,
+      serviceBase: saved.serviceBase || DEFAULT_SLACK_SERVICE,
+      identity: {
+        token: account.token,
+        account_id: account.accountId,
+        install_id: account.installId,
+        deviceId: local.deviceId,
+      },
+      app: samePrior ? samePrior.app : app,
+      context,
+      ...(samePrior ? { deliveryId: samePrior.deliveryId, acknowledged: samePrior.acknowledged } : {}),
+    };
+    await writePrivate(slackJobFile(root), job);
+  }
+  await launchSlackJob(root);
+}
+
+/** A bearer client over the job's identity snapshot; never touches the foreground journal. */
+export function slackProgressClient(job: SlackJob): DeviceClient {
+  const { token, account_id: accountId, install_id: installId, deviceId } = job.identity;
+  const client = new DeviceClient({
+    origin: job.origin,
+    file: '',
+    label: '',
+    identity: { token, accountId, installId },
+  });
+  client.local = { origin: job.origin, deviceId, credentials: {}, operations: {} };
+  return client;
+}

--- a/src/community-portal/wire-vectors.json
+++ b/src/community-portal/wire-vectors.json
@@ -1,0 +1,33 @@
+{
+  "note": "Generated with the remote-access module signProof() as the reference signer. Throwaway key; grants nothing.",
+  "proof": {
+    "pkcs8_b64": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg/NiCsxXCtTZ5mdi20CJ7RoiOO1Sz4X/hFO8pnFNc+AuhRANCAARsUzkNcfNlgb1cGR5m5aanOfBd8Cge0VwZxaEoMOWJ2BNk15b5zvEjiy9zXpvS0oFxim5Nqlum1VohtSu1mD9Y",
+    "publicKey": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "bFM5DXHzZYG9XBkeZuWmpznwXfAoHtFcGcWhKDDlidg",
+      "y": "E2TXlvnO8SOLL3Nem9LSgXGKbk2qW6bVWiG1K7WYP1g"
+    },
+    "fingerprint": "8fBYMR5CR4CwkjdN",
+    "cases": [
+      {
+        "ts": 1788825600,
+        "nonce": "q6urq6urq6urq6urq6urqw",
+        "signingInput": "nanoclaw-host-grant-v1\n1788825600\nq6urq6urq6urq6urq6urqw",
+        "header": "v1;kid=8fBYMR5CR4CwkjdN;ts=1788825600;nonce=q6urq6urq6urq6urq6urqw;sig=L8sP_sx7B_Y_JdwwnFvXQMEoEXqqIZkajVikSezQi39UqHO2f8mtPgLv8dT2-YqKCCGEiq8cu44zcER3ZsEERg"
+      },
+      {
+        "ts": 1788825601.9,
+        "nonce": "JeZux7AVMDLtlhWZFDi1Pg",
+        "signingInput": "nanoclaw-host-grant-v1\n1788825601\nJeZux7AVMDLtlhWZFDi1Pg",
+        "header": "v1;kid=8fBYMR5CR4CwkjdN;ts=1788825601;nonce=JeZux7AVMDLtlhWZFDi1Pg;sig=tIIXaK7TAZPDw_59jXac7V7ggSLCRrE0UmSg98lnSJnMI37v9xKBFD4Ep7wHG_TJd95P-fYpjHxAev8eaTRXag"
+      },
+      {
+        "ts": 1788912000,
+        "nonce": "de7MMcXiA468sdrIoA-Vbg",
+        "signingInput": "nanoclaw-host-grant-v1\n1788912000\nde7MMcXiA468sdrIoA-Vbg",
+        "header": "v1;kid=8fBYMR5CR4CwkjdN;ts=1788912000;nonce=de7MMcXiA468sdrIoA-Vbg;sig=lCq0z0wVDkjUCGxIwWjGlAQS19jU4z6po5bH6fitrLbUIg4hndWdL3nGEud_qg_JFWG7g7xNXPOAI-gIUOgeAA"
+      }
+    ]
+  }
+}

--- a/src/community-portal/wire.test.ts
+++ b/src/community-portal/wire.test.ts
@@ -1,0 +1,101 @@
+import { createPublicKey, verify, type JsonWebKey } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  deviceKeyFingerprint,
+  deviceKeyFromPkcs8,
+  parseDeviceProof,
+  proofSigningInput,
+  signProof,
+  verifyDeviceProof,
+  type DevicePublicJwk,
+} from './device-key.js';
+
+/**
+ * wire-vectors.json was produced by running the remote-access module's
+ * signProof() (the reference implementation of the device proof) over a
+ * throwaway key. These tests pin this client to that format: fingerprint
+ * derivation, the signing input bytes, the header layout, and that the
+ * verifier the portal mirrors accepts both the reference proofs and ours.
+ */
+interface ProofCase {
+  ts: number;
+  nonce: string;
+  signingInput: string;
+  header: string;
+}
+interface Vectors {
+  proof: { pkcs8_b64: string; publicKey: DevicePublicJwk; fingerprint: string; cases: ProofCase[] };
+}
+const vectors = JSON.parse(readFileSync(new URL('./wire-vectors.json', import.meta.url), 'utf8')) as Vectors;
+const { pkcs8_b64, publicKey, fingerprint, cases } = vectors.proof;
+const key = deviceKeyFromPkcs8(Buffer.from(pkcs8_b64, 'base64'));
+const publicKeyObject = createPublicKey({ key: publicKey as JsonWebKey, format: 'jwk' });
+const HEADER = /^v1;kid=[\w-]{16};ts=\d+;nonce=[\w-]{22};sig=[\w-]{86}$/;
+
+describe('device proof wire contract', () => {
+  it('derives the reference fingerprint and public JWK from the pinned key', () => {
+    expect(key.fingerprint).toBe(fingerprint);
+    expect(key.publicKeyJwk).toEqual(publicKey);
+    expect(Object.keys(key.publicKeyJwk).sort()).toEqual(['crv', 'kty', 'x', 'y']);
+    expect(deviceKeyFingerprint(publicKeyObject.export({ format: 'der', type: 'spki' }))).toBe(fingerprint);
+  });
+
+  it('signs exactly the reference input bytes', () => {
+    for (const c of cases) expect(proofSigningInput(c.ts, c.nonce).toString('utf-8')).toBe(c.signingInput);
+  });
+
+  it('lays the header out as the reference does', () => {
+    for (const c of cases) {
+      expect(c.header).toMatch(HEADER);
+      expect(parseDeviceProof(c.header)).toMatchObject({ kid: fingerprint, ts: Math.floor(c.ts), nonce: c.nonce });
+      const mine = signProof(key, c);
+      expect(mine).toMatch(HEADER);
+      expect(mine.split(';sig=')[0]).toBe(c.header.split(';sig=')[0]);
+    }
+  });
+
+  it('accepts the reference-signed proofs, and its own, under the verifier the portal mirrors', () => {
+    for (const c of cases) {
+      const now = Math.floor(c.ts) * 1000;
+      const parsed = parseDeviceProof(c.header);
+      expect(parsed).not.toBeNull();
+      expect(
+        verify(
+          'sha256',
+          proofSigningInput(c.ts, c.nonce),
+          { key: publicKeyObject, dsaEncoding: 'ieee-p1363' },
+          Buffer.from(parsed!.sig, 'base64url'),
+        ),
+      ).toBe(true);
+      expect(verifyDeviceProof(c.header, publicKey, { now })).toMatchObject({ valid: true });
+      expect(verifyDeviceProof(c.header, publicKeyObject, { now: now + 59_000 })).toMatchObject({ valid: true });
+      expect(verifyDeviceProof(signProof(key, c), publicKey, { now })).toMatchObject({ valid: true });
+    }
+  });
+
+  it('rejects a stale, tampered, foreign or malformed proof', () => {
+    const c = cases[0];
+    const now = c.ts * 1000;
+    expect(verifyDeviceProof(c.header, publicKey, { now: now + 61_000 })).toEqual({ valid: false, reason: 'stale' });
+    expect(verifyDeviceProof(c.header, publicKey, { now: now - 61_000 })).toEqual({ valid: false, reason: 'stale' });
+    const other = c.nonce.endsWith('w') ? `${c.nonce.slice(0, -1)}x` : `${c.nonce.slice(0, -1)}w`;
+    expect(verifyDeviceProof(c.header.replace(`nonce=${c.nonce}`, `nonce=${other}`), publicKey, { now })).toEqual({
+      valid: false,
+      reason: 'signature',
+    });
+    const foreign = deviceKeyFromPkcs8(
+      Buffer.from(
+        'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgX64TMuXXyRVW907yOnnIHJKEIMVdACsxj63qlUgl2FGhRANCAAR+90tBU+706xLzUgIBY/LTgBwTS88YbH1tzFQIHpZWshPymySfvOgV80xlGCLGYnu5TV2UD6X/NN9u5ldcufj0',
+        'base64',
+      ),
+    );
+    expect(verifyDeviceProof(c.header, foreign.publicKeyJwk, { now })).toEqual({ valid: false, reason: 'kid' });
+    expect(verifyDeviceProof(signProof(foreign, c), publicKey, { now })).toEqual({ valid: false, reason: 'kid' });
+    expect(verifyDeviceProof(c.header.replace('v1;', 'v2;'), publicKey, { now })).toEqual({
+      valid: false,
+      reason: 'malformed',
+    });
+    expect(verifyDeviceProof('', publicKey, { now })).toEqual({ valid: false, reason: 'malformed' });
+  });
+});

--- a/src/modules/community-portal/index.ts
+++ b/src/modules/community-portal/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Community portal module — keeps the host connected to its account cell.
+ *
+ * Optional tier. Does nothing until the setup wizard has signed this checkout
+ * in at the portal (data/community-portal.json). Registers the runtime with
+ * the host lifecycle so perk changes made in the browser reach the running
+ * host, and the saved Slack install worker is resumed after a restart.
+ */
+import { onHostStart, onHostShutdown } from '../../host-lifecycle.js';
+import { log } from '../../log.js';
+import { startPortalRuntime } from './runtime.js';
+
+let runtime: ReturnType<typeof startPortalRuntime> | undefined;
+
+onHostStart(({ signal }) => {
+  runtime = startPortalRuntime({
+    signal,
+    log: (event) => log.info('Community portal', event),
+  });
+});
+
+onHostShutdown(async () => {
+  await runtime?.stop();
+  runtime = undefined;
+});

--- a/src/modules/community-portal/registration.test.ts
+++ b/src/modules/community-portal/registration.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({ stop: vi.fn(async () => {}), start: vi.fn() }));
+vi.mock('./runtime.js', () => ({ startPortalRuntime: runtime.start }));
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  runtime.start.mockReturnValue({ stop: runtime.stop });
+});
+
+it('the real modules barrel registers the portal connection with host start and shutdown', async () => {
+  const lifecycle = await import('../../host-lifecycle.js');
+  await import('../index.js');
+  expect(runtime.start).not.toHaveBeenCalled();
+  const signal = new AbortController().signal;
+  await lifecycle.getHostStartCallbacks().at(-1)!({ signal, db: {} as never });
+  expect(runtime.start).toHaveBeenCalledWith({ signal, log: expect.any(Function) });
+  await lifecycle.getHostShutdownCallbacks().at(-1)!();
+  expect(runtime.stop).toHaveBeenCalledOnce();
+});

--- a/src/modules/community-portal/runtime.test.ts
+++ b/src/modules/community-portal/runtime.test.ts
@@ -1,0 +1,210 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import {
+  DEVICE_PROOF_HEADER,
+  ensureDeviceKey,
+  verifyDeviceProof,
+  writePrivate,
+  type LinkSocket,
+} from '../../community-portal/index.js';
+import { startPortalRuntime } from './runtime.js';
+
+/**
+ * The runtime against a loopback stand-in for the portal and a hand-driven
+ * socket: the identity is account.json + host-id + device-key.json + the
+ * journal's device id, tickets carry bearer plus a valid proof, reconciling is
+ * plain bearer, and the link dials with the ticket as a subprotocol.
+ */
+type Listener = (event: { data: unknown; code?: number }) => void;
+class FakeSocket implements LinkSocket {
+  static instances: FakeSocket[] = [];
+  readyState = 0;
+  sent: string[] = [];
+  private listeners = new Map<string, Listener[]>();
+  constructor(
+    readonly url: URL,
+    readonly protocols: string[],
+  ) {
+    FakeSocket.instances.push(this);
+  }
+  addEventListener(type: string, listener: Listener): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 3;
+  }
+  open(): void {
+    this.readyState = 1;
+    for (const listener of this.listeners.get('open') ?? []) listener({ data: undefined });
+  }
+  lost(code: number): void {
+    this.readyState = 3;
+    for (const listener of this.listeners.get('close') ?? []) listener({ data: undefined, code });
+  }
+  frame(ch: number, seq: number, t: string, fields: Record<string, unknown> = {}): void {
+    for (const listener of this.listeners.get('message') ?? [])
+      listener({ data: JSON.stringify({ v: 1, ch, seq, t, ...fields }) });
+  }
+}
+
+interface Seen {
+  method: string;
+  route: string;
+  authorization?: string;
+  proofValid?: boolean;
+}
+let server: Server;
+let origin: string;
+let root: string;
+let home: string;
+let ticketStatus = 200;
+const seen: Seen[] = [];
+const DEVICE_ID = 'dev_0123456789abcdef01234567';
+const state = { grants: [] as unknown[] };
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  for await (const _chunk of req) {
+    /* drain */
+  }
+  const route = new URL(req.url ?? '/', origin).pathname;
+  const record: Seen = { method: req.method ?? '', route, authorization: req.headers.authorization };
+  const proof = req.headers[DEVICE_PROOF_HEADER];
+  if (typeof proof === 'string') {
+    const key = ensureDeviceKey({ homeDir: home });
+    record.proofValid = verifyDeviceProof(proof, key.publicKeyJwk).valid;
+  }
+  seen.push(record);
+  res.setHeader('content-type', 'application/json');
+  if (route === '/api/v1/cell-ticket') {
+    if (!record.proofValid) {
+      res.writeHead(401);
+      res.end(JSON.stringify({ error: 'invalid_proof' }));
+      return;
+    }
+    res.writeHead(ticketStatus);
+    res.end(
+      ticketStatus === 200
+        ? JSON.stringify({ ticket: 'tkt', expiresIn: 900, socketUrl: `${origin.replace('http', 'ws')}/cell/link` })
+        : JSON.stringify({ error: 'installation_revoked' }),
+    );
+    return;
+  }
+  if (route === '/api/v1/device/state') {
+    res.end(JSON.stringify(state));
+    return;
+  }
+  res.writeHead(404);
+  res.end(JSON.stringify({ error: 'not_found' }));
+}
+async function until(check: () => boolean, timeout = 5_000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (!check()) {
+    if (Date.now() > deadline) throw new Error('timed out');
+    await sleep(10);
+  }
+}
+const journalFile = (): string => path.join(root, 'data/community-portal.json');
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'nc-portal-runtime-'));
+  home = await mkdtemp(path.join(os.tmpdir(), 'nc-portal-home-'));
+  seen.length = 0;
+  ticketStatus = 200;
+  FakeSocket.instances = [];
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+});
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+  await rm(home, { recursive: true, force: true });
+});
+
+async function signIn(): Promise<void> {
+  await mkdir(path.join(home, '.config/nanoclaw'), { recursive: true, mode: 0o700 });
+  await writeFile(
+    path.join(home, '.config/nanoclaw/account.json'),
+    JSON.stringify({ version: 1, api: 'https://registry.example.test', account_id: 'acct-1', token: 'tok' }),
+    { mode: 0o600 },
+  );
+  await writeFile(path.join(home, '.config/nanoclaw/host-id'), 'install-1\n', { mode: 0o600 });
+}
+
+it('stays idle without a registered device, then dials with a proofed ticket and reconciles over bearer', async () => {
+  const log = vi.fn();
+  await signIn();
+  const runtime = startPortalRuntime({ root, homeDir: home, log, intervalMs: 50, Socket: FakeSocket });
+  await sleep(200);
+  expect(seen).toEqual([]);
+  expect(FakeSocket.instances).toEqual([]);
+  // Setup registers the device: the journal gains its id, the machine its key.
+  ensureDeviceKey({ homeDir: home });
+  await writePrivate(journalFile(), { origin, deviceId: DEVICE_ID, credentials: {}, operations: {} });
+  await until(() => FakeSocket.instances.length === 1);
+  const socket = FakeSocket.instances[0];
+  expect(socket.url.href).toBe(`${origin.replace('http', 'ws')}/cell/link`);
+  expect(socket.protocols).toEqual(['nc-cell', 'ticket.tkt']);
+  const ticket = seen.find((r) => r.route === '/api/v1/cell-ticket');
+  expect(ticket).toEqual({
+    method: 'POST',
+    route: '/api/v1/cell-ticket',
+    authorization: 'Bearer tok',
+    proofValid: true,
+  });
+  await until(() => seen.some((r) => r.route === '/api/v1/device/state'));
+  expect(seen.find((r) => r.route === '/api/v1/device/state')).toEqual({
+    method: 'GET',
+    route: '/api/v1/device/state',
+    authorization: 'Bearer tok',
+  });
+  socket.open();
+  expect(JSON.parse(socket.sent[0])).toEqual({ v: 1, ch: 0, seq: 1, t: 'hello', leg: 'host', caps: ['perks'] });
+  expect(log).toHaveBeenCalledWith({ event: 'connected', deviceId: DEVICE_ID });
+  // A perks snapshot from the cell triggers another bearer reconcile.
+  const before = seen.filter((r) => r.route === '/api/v1/device/state').length;
+  socket.frame(1, 1, 'open', { kind: 'perks' });
+  socket.frame(1, 2, 'data', { snapshot: { revision: 2 }, presence: [] });
+  await until(() => seen.filter((r) => r.route === '/api/v1/device/state').length > before);
+  expect(seen.every((r) => r.route !== '/api/v1/device/state' || r.proofValid === undefined)).toBe(true);
+  // The cell forgets the device: sign-in required, no redial, credentials dropped.
+  socket.lost(4403);
+  await until(() => log.mock.calls.some(([event]) => event.event === 'sign_in_required'));
+  await sleep(300);
+  expect(FakeSocket.instances).toHaveLength(1);
+  expect(seen.filter((r) => r.route === '/api/v1/cell-ticket')).toHaveLength(1);
+  await runtime.stop();
+  expect(socket.readyState).toBe(3);
+});
+
+it('reports sign_in_required and clears local credentials when the portal refuses the device', async () => {
+  const log = vi.fn();
+  await signIn();
+  ensureDeviceKey({ homeDir: home });
+  await writePrivate(journalFile(), {
+    origin,
+    deviceId: DEVICE_ID,
+    credentials: { echo: { keyId: 'k', operationId: 'o', secret: 'shh', resource: { label: 'Echo' } } },
+    operations: { echo: { grantId: 'g', idempotencyKey: 'i' } },
+  });
+  ticketStatus = 401;
+  const runtime = startPortalRuntime({ root, homeDir: home, log, intervalMs: 50, Socket: FakeSocket });
+  await until(() => log.mock.calls.some(([event]) => event.event === 'sign_in_required'));
+  await sleep(200);
+  const journal = JSON.parse(await readFile(journalFile(), 'utf8')) as { credentials: object; operations: object };
+  expect(journal.credentials).toEqual({});
+  expect(journal.operations).toEqual({});
+  expect(FakeSocket.instances).toEqual([]);
+  expect(JSON.stringify(await readFile(journalFile(), 'utf8'))).not.toContain('tok');
+  await runtime.stop();
+});

--- a/src/modules/community-portal/runtime.ts
+++ b/src/modules/community-portal/runtime.ts
@@ -1,0 +1,248 @@
+import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+import {
+  CellLink,
+  DeviceClient,
+  errorCode,
+  errorStatus,
+  type Journal,
+  type LinkEvent,
+  type LinkSocketConstructor,
+  portalError,
+  processLock,
+  readDeviceKey,
+  readInstallIdentity,
+  readJson,
+} from '../../community-portal/index.js';
+import { launchSlackJob, readSlackJob } from '../../community-portal/slack-job.js';
+
+/**
+ * Keeps a running host connected to its account cell for as long as the
+ * machine is signed in and the checkout has a registered device. The identity
+ * is account.json (install token and ids) + device-key.json + the journal's
+ * device id; the runtime reads all three without taking the journal lock, so
+ * the link survives while foreground setup owns it. One link per checkout,
+ * guarded by `data/community-portal-runtime.lock`. Reconciling goes over
+ * bearer routes through a locked DeviceClient; the link dials with a proofed
+ * ticket. Cell pushes only trigger a fresh read of locally saved, authorized
+ * work: perk credentials and the saved Slack install worker.
+ */
+export interface PortalRuntimeOptions {
+  root?: string;
+  homeDir?: string;
+  signal?: AbortSignal;
+  log?: (event: LinkEvent) => void;
+  intervalMs?: number;
+  /** Test seam: the WebSocket constructor the link dials with. */
+  Socket?: LinkSocketConstructor;
+}
+
+interface Identity {
+  origin: string;
+  token: string;
+  accountId: string;
+  installId: string;
+  deviceId: string;
+  fingerprint: string;
+}
+
+const RECONCILE_INTERVAL_MS = 60_000;
+
+export function startPortalRuntime({
+  root = process.cwd(),
+  homeDir,
+  signal,
+  log = () => {},
+  intervalMs = 5000,
+  Socket,
+}: PortalRuntimeOptions = {}): { stop(): Promise<void> } {
+  const abort = new AbortController();
+  const file = path.join(root, 'data/community-portal.json');
+  let link: CellLink | undefined;
+  let identity: Identity | undefined;
+  let rejected = false;
+  let release: (() => void) | null = null;
+  let pending: Promise<void> | undefined;
+  let again = false;
+  let dirty = true;
+  let nextSync = 0;
+  let stopped = false;
+  let stopping: Promise<void> | undefined;
+  let lastError = '';
+  const denied = (error: unknown): boolean => [401, 403].includes(errorStatus(error) ?? 0);
+  const rejectIdentity = (): void => {
+    if (!rejected) log({ event: 'sign_in_required' });
+    rejected = true;
+    dirty = true;
+    link?.stop();
+    wake();
+  };
+
+  async function check(): Promise<void> {
+    release ||= await processLock(path.join(root, 'data/community-portal-runtime.lock'));
+    if (!release || stopped) return;
+    const local = await readJson<Partial<Journal>>(file);
+    const account = local?.deviceId && local.origin ? await readInstallIdentity({ homeDir }) : null;
+    const key = account ? readDeviceKey({ homeDir }) : null;
+    if (account && !key) {
+      link?.stop();
+      link = undefined;
+      identity = undefined;
+      throw portalError('The device key is missing. Run the portal setup step again.', 'device_key_missing');
+    }
+    const current: Identity | undefined =
+      local?.deviceId && local.origin && account && key
+        ? {
+            origin: local.origin,
+            token: account.token,
+            accountId: account.accountId,
+            installId: account.installId,
+            deviceId: local.deviceId,
+            fingerprint: key.fingerprint,
+          }
+        : undefined;
+    if (!isDeepStrictEqual(current, identity)) {
+      link?.stop();
+      link = undefined;
+      identity = current;
+      rejected = false;
+      dirty = true;
+      if (current && key) {
+        const tickets = new DeviceClient({
+          origin: current.origin,
+          identity: account ?? undefined,
+          deviceKey: key,
+          file,
+          signal: abort.signal,
+        });
+        tickets.local = { origin: current.origin, deviceId: current.deviceId, credentials: {}, operations: {} };
+        const changed = (): void => {
+          dirty = true;
+          wake();
+        };
+        link = new CellLink({
+          origin: tickets.origin,
+          getTicket: async (requestSignal) => {
+            try {
+              return await tickets.ticket(requestSignal);
+            } catch (error) {
+              if (denied(error) && isDeepStrictEqual(identity, current)) rejectIdentity();
+              throw error;
+            }
+          },
+          onSnapshot: changed,
+          onChange: changed,
+          onForbidden: () => {
+            if (isDeepStrictEqual(identity, current)) rejectIdentity();
+          },
+          log: (event) => log({ ...event, deviceId: current.deviceId }),
+          ...(Socket ? { Socket } : {}),
+        });
+        link.start();
+      }
+    }
+    if (!current || stopped) return;
+    const job = await readSlackJob(root);
+    // Supervise only the saved installation bound to this account/checkout.
+    // A live worker keeps its existing approval polling; no duplicate spawns.
+    if (
+      !rejected &&
+      job &&
+      job.identity.deviceId === current.deviceId &&
+      job.identity.install_id === current.installId &&
+      job.identity.account_id === current.accountId &&
+      job.origin === current.origin
+    ) {
+      if (await launchSlackJob(root)) log({ event: 'slack_install_resumed', deviceId: current.deviceId });
+    }
+    if (stopped || (!dirty && Date.now() < nextSync)) return;
+    const client = new DeviceClient({
+      origin: current.origin,
+      identity: account ?? undefined,
+      file,
+      exclusive: true,
+      existingOnly: true,
+      signal: abort.signal,
+      log,
+    });
+    try {
+      await client.initialize();
+      // The CLI may have changed identity while we acquired the journal.
+      if (client.local.deviceId !== current.deviceId) return;
+      if (rejected) {
+        client.local.credentials = {};
+        client.local.operations = {};
+        await client.save();
+        dirty = false;
+        nextSync = Infinity;
+        return;
+      }
+      dirty = false;
+      await client.reconcile();
+      nextSync = Date.now() + RECONCILE_INTERVAL_MS;
+    } catch (error) {
+      if (errorCode(error, '') === 'journal_busy') return;
+      if (denied(error)) {
+        rejectIdentity();
+        if (client.local) {
+          client.local.credentials = {};
+          client.local.operations = {};
+          await client.save();
+        }
+        return;
+      }
+      dirty = true;
+      throw error;
+    } finally {
+      await client.stop();
+    }
+  }
+
+  function wake(): void {
+    if (stopped) return;
+    if (pending) {
+      again = true;
+      return;
+    }
+    pending = check()
+      .then(() => {
+        lastError = '';
+      })
+      .catch((error: unknown) => {
+        if (stopped) return;
+        const code = errorCode(error);
+        if (code !== lastError) log({ event: 'runtime_retry', code });
+        lastError = code;
+      })
+      .finally(() => {
+        pending = undefined;
+        if (again) {
+          again = false;
+          wake();
+        }
+      });
+  }
+
+  const timer = setInterval(wake, intervalMs);
+  function stop(): Promise<void> {
+    if (stopping) return stopping;
+    stopped = true;
+    abort.abort();
+    clearInterval(timer);
+    link?.stop();
+    signal?.removeEventListener('abort', onAbort);
+    stopping = (async () => {
+      await pending;
+      release?.();
+      release = null;
+    })();
+    return stopping;
+  }
+  const onAbort = (): void => {
+    void stop();
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
+  if (signal?.aborted) void stop();
+  else wake();
+  return { stop };
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -24,3 +24,4 @@ import './interactive/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './community-portal/index.js';


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->
<!-- Suggested title: feat(setup): connect the host to its community cell and manage perks in the browser -->

## Summary

Moves Echo and Slack setup into the community portal with a single browser visit, and keeps the running host linked to its account cell.

- **Sign-in is one browser visit.** A machine without an account starts the WorkOS device flow (the same public-client flow `setup/registry-login.sh` runs), starts the setup stage anonymously at the portal carrying the public user code, and prints and opens one portal link. The page ("Approve your terminal") signs the user in and approves the terminal; the wizard polls for the token, persists it exactly as the standalone sign-in does, registers the machine, claims the flow and continues. The link, code and sign-in page are also printed for headless machines. A signed-in machine skips straight to registration.
- **Device key and proof.** One P-256 key per machine at `~/.config/nanoclaw/device-key.json` (the remote-access module's file format, mode 0600, never regenerated over an unreadable file). Its `x-nc-device-proof` header (`v1;kid;ts;nonce;sig` over `nanoclaw-host-grant-v1\n<ts>\n<nonce>`, ES256 P1363) is sent on exactly two routes: `POST /api/v1/devices` and `POST /api/v1/cell-ticket`. Every other request is a plain bearer install token. There is no install envelope and no per-request signing; the checkout journal holds no key and no token.
- **The link is the remote-access frame protocol v1.** `wss://portal.nanoclaw.dev/cell/link`, dialled with the ticket as a subprotocol; control on channel 0 (hello, ping/pong, status, perks.changed, error), a cell-opened `perks` data channel carrying the snapshot and presence. The host pings every 20 s, drops a socket after 60 s without a pong or 10 s without opening, reconnects with jittered backoff (1 s base, 30 s cap) and a fresh ticket, and treats close 4403 (device forgotten) as "sign in required". A new host module, `src/modules/community-portal`, owns the link and supervises the saved Slack worker; it does nothing until the machine is signed in at the portal.
- **Echo terms.** Enabling Echo in the dashboard is the agreement to Echo's terms, including the product-and-security-email choice, recorded before the perk turns on; the portal path does not run the terminal email prompt.
- **Background Slack installation.** The saved worker survives the terminal, saves the bot credential before acknowledging delivery, serialises checkout changes with the wizard, and is resumed by the host after a restart; verification accepts a healthy install while approval is pending.
- **Not offered:** Dial and Tavily. The catalog lists Echo and Slack only; the wizard has no partner-perks stage.
- **Out of scope:** the portal service and cell (other repo); the Slack agents created later from inside Slack keep their five-minute wait and park behaviour.

## Related work

Closes #: none. Reviewable directly: the wire contract is pinned by `src/community-portal/wire-vectors.json` (generated with the remote-access module's `signProof()` as the reference signer) and `frame-vectors.json`, and every host path is exercised against loopback fakes.

Portal: https://portal.nanoclaw.dev. User documentation: `docs/community-portal.md`.

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- [x] Tests cover the changed behavior.
- `pnpm exec tsc --noEmit` -> clean. `pnpm exec eslint src/community-portal src/modules/community-portal` -> 0 errors (7 warnings, deliberate catch-alls). `pnpm run format:check` -> clean. `pnpm build` -> ok; `dist/modules/community-portal/runtime.js` loads.
- `pnpm exec vitest run src/community-portal src/modules/community-portal setup/portal.test.ts setup/portal.e2e.test.ts setup/slack-worker.test.ts setup/verify-slack.test.ts setup/registry-login.test.ts setup/channels/run-channel-skill.test.ts setup/channels/slack-auto.test.ts` -> 15 files, 139 tests, all pass. That covers: the device key file (generation, 0600, unreadable and corrupt files raise instead of regenerating), the proof pinned against the reference signer's vectors plus stale/tampered/foreign/malformed rejection, the frame protocol vectors and mux, the link (hello first, ping/pong, missed-pong and handshake timeouts, jittered backoff, perks channel dispatch, `unsupported` on other kinds, 4401/4008/4403 handling), the portal client against a loopback portal that verifies the proof on exactly the two routes, the runtime against a loopback portal and fake socket (identity assembly, proofed ticket, bearer reconcile, 4403), the wizard against doubles, and the single-visit path end to end against one loopback server standing in for the portal, the registry broker and WorkOS (device code, `authorization_pending` twice, token; and the declined case).
- Real detached workers, SIGKILL after durable delivery, replayed acknowledgement, competing workers and the checkout lock are covered by the existing Slack worker suite (included above).
- `pnpm exec vitest run` (full) -> 2464 passed, 1 skipped; 5 timeouts in `scripts/update*`, `scripts/add-dial-tool-scope.test.ts` and `setup/channels/mattermost-guidance.test.ts` under load, each passing in isolation (38/38).
- Manual acceptance still needed: a completed WorkOS sign-in, an Echo image pull and a real Slack reply on a fresh machine. The portal and cell have their own suite in their repository.

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change

Existing installs need no action: installs enrolled by the standalone sign-in keep working, the Node floor stays at 22, and the module is inert until the machine is signed in at the portal.

```release-note
Echo's hardened image and a managed Slack app are set up through the community portal with one browser sign-in; the install token never passes through the browser, and a per-machine device key proves the machine on device registration and cell tickets only. The running host keeps one link to your account's cell, so a perk changed in the browser reaches the running agent and a Slack install approved days later finishes on its own. Dial and Tavily are not offered.
```

## Security and trust boundaries

- The install token reaches the machine from the account service over the device flow and is stored at `~/.config/nanoclaw/account.json` (0600); the browser only ever sees the public user code.
- The device private key never leaves the machine; the proof is a fresh timestamp and nonce per request, accepted within ±60 s, single-use per device server-side, and required on two routes only.
- The checkout journal (`data/community-portal.json`, 0600) holds the device id, setup progress and perk credentials, no key and no token. Journals written before this change have their key and account fields dropped on load.
- The link carries only the account's perk snapshot and device presence inbound, and hello/ping outbound. Cell notifications only wake locally saved, authorised work (reconcile, resume the saved Slack worker).
- Forgetting a device in the portal revokes its install epoch at the registry; the host stops dialling on 4403 and drops perk credentials.
- No new admin scopes, no remote access, no inbound connections to the machine.

## Approval scope and limits

Each managed Slack app may require workspace approval. The initial install worker watches for seven days, saves the credential before acknowledging delivery, and installs once across competing workers. Agents created later from inside Slack wait five minutes and then park; after approval, the existing agent finishes the saved app on request. Completion means the welcome was handed to the service, not that Slack acknowledged the agent's reply. Existing device registrations are retained; reconnecting never enrols another device.

## Skill delivery

- [x] Not a skill

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change
