### PR TITLE
fix(slack): keep DM thread_ts for reply delivery (#3730)

### DIFF
--- a/src/channels/slack-dm-thread-policy.test.ts
+++ b/src/channels/slack-dm-thread-policy.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression: nanocoai/nanoclaw#3730 — a Slack DM wiring with
+ * session_mode='shared' / threads=NULL must still honor the platform thread
+ * id for REPLY DELIVERY.
+ *
+ * Slack's "Agents & Assistants" DM surface materializes a thread per
+ * conversation, and the incoming thread_ts IS that conversation's visible
+ * identity. When dm.threads was false the router stripped the delivery
+ * thread id, so every agent reply posted top-level and rendered as a fresh
+ * History card even though the backend session was correctly shared. The fix
+ * is a capability statement: dm.threads = true, so resolveThreadPolicy keeps
+ * the thread id for delivery. Session identity is governed independently by
+ * session_mode ('shared' still collapses to one session — resolveSession
+ * ignores threadId under 'shared', and the router's per-thread promotion is
+ * short-circuited for is_group=0).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { resolveThreadPolicy } from './channel-defaults.js';
+import { SLACK_DEFAULTS } from './slack.js';
+
+describe('Slack DM thread policy (#3730)', () => {
+  it('declares dm.threads: true so the assistant thread_ts survives to delivery', () => {
+    expect(SLACK_DEFAULTS.dm.threads).toBe(true);
+  });
+
+  it('a shared DM wiring (threads column NULL) inherits thread policy ON', () => {
+    // wiringThreads NULL → inherit SLACK_DEFAULTS.dm.threads; Slack supports threads.
+    expect(resolveThreadPolicy(null, SLACK_DEFAULTS, /* isGroup */ false, /* supportsThreads */ true)).toBe(true);
+  });
+
+  it('an explicit --threads false still opts a DM wiring out (flat top-level replies)', () => {
+    expect(resolveThreadPolicy(0, SLACK_DEFAULTS, false, true)).toBe(false);
+  });
+
+  it('new DM wirings are unchanged: sessionMode per-thread still drives the threads=1 stamp', () => {
+    // The derivation itself (sessionMode 'per-thread' → threads: 1) is covered
+    // in channel-session-defaults.test.ts; here we pin the declaration it reads.
+    expect(SLACK_DEFAULTS.dm.sessionMode).toBe('per-thread');
+  });
+});

--- a/src/channels/slack-instances-registration.test.ts
+++ b/src/channels/slack-instances-registration.test.ts
@@ -69,7 +69,7 @@ describe('slack multi-instance registration', () => {
       // would resolve threads:false. Engagement fields ride along.
       expect(defaults.group.threads).toBe(true);
       expect(defaults.group.engageMode).toBe('mention-sticky');
-      expect(defaults.dm).toMatchObject({ engageMode: 'pattern', engagePattern: '.', threads: false });
+      expect(defaults.dm).toMatchObject({ engageMode: 'pattern', engagePattern: '.', threads: true });
       expect(defaults.mentions).toBe('platform');
     }
   });

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -25,23 +25,31 @@ import { extractSlackRawText } from './slack-raw-text.js';
 /**
  * Dedicated bot app on a threaded platform. group threads:true keeps
  * mention-sticky bounded — engagement sticks per-thread, not forever.
- * dm.threads:false is a deliberate policy choice, not a capability limit:
- * Slack users can open sub-threads inside a DM, but by default the agent
- * replies top-level and all DM sub-threads collapse into the one DM session.
- * This declaration owns that judgment (it used to be hardcoded router
- * behavior); operators who want in-thread DM replies override per wiring
- * with `--threads true`.
+ *
+ * dm.threads:true is a capability statement, not a session-model choice:
+ * Slack's DM surface for an assistant-enabled app materializes a thread per
+ * conversation, and the incoming thread_ts IS that conversation's visible
+ * identity in the "Agents & Assistants" panel. A reply delivered with no
+ * thread_ts lands as a brand-new History card instead of in the chat the
+ * user typed in (nanocoai/nanoclaw#3730), so the delivery address must keep
+ * the platform thread id. Session identity is governed independently by
+ * session_mode: a `shared` DM wiring still resolves to one continuous
+ * session (resolveSession ignores threadId under `shared`; the router's
+ * group-only per-thread promotion is short-circuited for is_group=0) — the
+ * thread id now only steers where each reply is rendered. Operators who want
+ * flat top-level DM replies opt out per wiring with `--threads false`.
  *
  * Agent-DM anchors (the settled Slack DM shape) — creation-time stamps, so
  * they apply to wirings/rows created from this declaration onward and never
  * flip existing installs:
- * - dm.sessionMode 'per-thread': Slack's agent-mode DM surface materializes
- *   a thread per conversation, so a new DM wiring roots a session per thread.
+ * - dm.sessionMode 'per-thread': a NEW DM wiring roots a session per
+ *   conversation thread (continuity comes from cross-session backfill).
  *   resolveWiringDefaults derives the threads=1 stamp from this at creation
  *   (per-thread sessions structurally require honored thread ids — no
- *   separate field to declare). The live inherit value dm.threads stays
- *   false, so wirings created earlier (threads column NULL) keep collapsing
- *   DM sub-threads into the one DM session.
+ *   separate field to declare). Wirings created earlier (threads column
+ *   NULL, session_mode 'shared') keep their single continuous session and
+ *   inherit dm.threads:true, so their replies now thread back into the
+ *   conversation the user is looking at instead of scattering.
  * - dm.unknownSenderPolicy 'decline_notify': an unknown DM sender gets a
  *   polite decline and the owner a one-line FYI — no approval card; access
  *   grants stay explicit (`ncl members add`). A deliberate, reviewed default
@@ -51,7 +59,7 @@ export const SLACK_DEFAULTS: ChannelDefaults = {
   dm: {
     engageMode: 'pattern',
     engagePattern: '.',
-    threads: false,
+    threads: true,
     sessionMode: 'per-thread',
     unknownSenderPolicy: 'decline_notify',
   },


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3730.

**What** — Flip `SLACK_DEFAULTS.dm.threads` from `false` to `true` so a Slack DM
reply is delivered with the incoming `thread_ts` instead of top-level, and rewrite
the declaration comment to match.

**Why** — Slack's assistant-enabled DM surface ("Agents & Assistants") materializes
a thread per conversation, and that `thread_ts` is the conversation's visible
identity in the panel. With `dm.threads: false` the router stripped the delivery
thread id, so every agent reply posted top-level and rendered as a brand-new
History card even when the backend session was correctly `shared` — the DM reads as
"starting a new chat" on every top-level message (#3730).

**How it works** — `dm.threads` is treated as a capability statement (Slack DMs
*can* thread), not a session-model choice. Session identity stays governed
independently by `session_mode`: a `shared` DM wiring still resolves to one
continuous session (`resolveSession` ignores `threadId` under `shared`; the
router's group-only per-thread promotion is short-circuited for `is_group=0`). The
thread id now only steers where each reply renders. Wirings created earlier
(threads column `NULL`, `session_mode 'shared'`) inherit `dm.threads: true` and
thread their replies back into the conversation the user is looking at instead of
scattering. `sessionMode: 'per-thread'` still drives the `threads=1` creation-time
stamp for new wirings, so new-wiring behavior is unchanged. Operators who want flat
top-level DM replies opt out per wiring with `--threads false`.

**How it was tested**
- New `src/channels/slack-dm-thread-policy.test.ts` (4 cases): the declaration is
  `true`; a `NULL`-threads DM wiring inherits thread policy ON via
  `resolveThreadPolicy`; an explicit `--threads false` still opts a DM wiring out;
  `sessionMode` stays `per-thread`.
- Updated `src/channels/slack-instances-registration.test.ts` to expect
  `threads: true` in the derived DM defaults.
- `npx vitest run src/channels/slack-dm-thread-policy.test.ts src/channels/slack-instances-registration.test.ts`
  → 2 files, 8 tests passed.
- Full `src/channels/` suite shows no new failures relative to the `channels`
  base (the 16 pre-existing failing files — wechat/webex registration, local-web
  mailbox paths — are unrelated to this change).
