### PR TITLE
ci: add a gate job and a post-merge run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # A post-merge run on main, so main itself carries a verdict and not only the
+  # pull requests that fed it. Nothing below reads the pull_request payload.
+  push:
+    branches: [main]
 
 jobs:
   test:
@@ -49,3 +53,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: test "${{ needs.test.result }}" = success
+
+  # The single check the main ruleset will require, in every repo under the same
+  # name. It needs `ci` as well as `test` so the older required context and the
+  # new one cannot disagree. if: always() because a skipped required check is
+  # not a failed one.
+  gate:
+    name: gate
+    if: always()
+    needs: [test, ci]
+    permissions: {}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: every needed job succeeded
+        run: |
+          test "${{ needs.test.result }}" = success
+          test "${{ needs.ci.result }}" = success


### PR DESCRIPTION
## What

Two changes to `.github/workflows/ci.yml`:

1. A `gate` job that needs `test` (both node versions, by job id) and the existing `ci` job, and runs with `if: always()`, so it fails when a dependency fails instead of being skipped. `ci` is kept as is, so the context the current ruleset requires keeps reporting until the ruleset moves to `gate`.
2. A `push: branches: [main]` trigger, so main gets a post-merge run and carries its own verdict. Nothing in this workflow reads `github.event.pull_request`, so the push run needs no guards.

`verify-agent-image.yml` (job `verify`) is untouched. It does read the pull_request payload and is pull_request-only on purpose.

## Why

Every repo in the org is getting one check with the same name, `gate`, so a branch ruleset can require exactly that one context instead of a per-repo list of job names. A skipped required check is not a failed one, which is why the job runs unconditionally and inspects the `needs` results itself.

## Verification

- The workflow run on this PR should show `test (22)`, `test (24)`, `ci` and `gate`.
- `gate` must match `ci`: green only when both test entries are green.

No ruleset or repository setting is changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
