### PR TITLE
fix(db): stop the nested-continuation conformance test from racing its own watchdog

### DIFF
--- a/src/db/testing/driver-conformance.ts
+++ b/src/db/testing/driver-conformance.ts
@@ -130,25 +130,28 @@ export function defineDriverConformance(name: string, factory: DriverConformance
       expect(await db.all<{ id: string }>('SELECT id FROM items')).toEqual([{ id: 'after' }]);
     });
 
-    it('cannot let a timed-out nested continuation roll back the next transaction', async () => {
-      await db.close();
-      db = await factory.create({ watchdogMs: 25 });
-      await db.exec('CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT, n INTEGER NOT NULL)');
+    it('cannot let a nested continuation from a rolled-back transaction roll back the next transaction', async () => {
+      // The stale transaction is rolled back by a thrown error, not by the
+      // watchdog: the watchdog budget is driver-wide, so a budget short enough
+      // to keep this test fast would also govern the next transaction, which
+      // performs real round trips on network drivers. Both paths close the
+      // scope identically; the watchdog's own rollback is covered above.
+      const staleSavepointReady = deferred();
       const releaseStale = deferred();
-      const staleFinished = deferred();
       const currentSavepointReady = deferred();
       const finishCurrent = deferred();
+      let stale!: Promise<void>;
 
-      const timedOut = db.transaction(async () => {
-        try {
-          await db.transaction(async () => {
+      await expect(
+        db.transaction(async () => {
+          stale = db.transaction(async () => {
+            staleSavepointReady.resolve();
             await releaseStale.promise;
           });
-        } finally {
-          staleFinished.resolve();
-        }
-      });
-      await expect(timedOut).rejects.toThrow('watchdog');
+          await staleSavepointReady.promise;
+          throw new Error('outer failure');
+        }),
+      ).rejects.toThrow('outer failure');
 
       const current = db.transaction(async () => {
         await db.run('INSERT INTO items (id, value, n) VALUES (?, ?, ?)', 'current-outer', null, 1);
@@ -160,7 +163,7 @@ export function defineDriverConformance(name: string, factory: DriverConformance
       });
       await currentSavepointReady.promise;
       releaseStale.resolve();
-      await staleFinished.promise;
+      await expect(stale).rejects.toThrow('transaction scope is closed');
       finishCurrent.resolve();
 
       await expect(current).resolves.toBeUndefined();


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Stops the shared driver-conformance test "cannot let a timed-out nested continuation roll back the next transaction" from timing out on PostgreSQL.

- **Problem**: the test created the driver with a 25 ms watchdog to time out the stale transaction, but the watchdog is driver-wide, so the *next* transaction ran under the same 25 ms budget. On SQLite every step inside a transaction is synchronous, so the timer can never interleave. On PostgreSQL the next transaction needs five real round trips: once the first three exceed 25 ms the test hangs on a barrier that is never resolved (the `Test timed out in 5000ms` seen in the 2026-09-07 gate run, 4171 pass / 2 fail / 3 skip), and once all five exceed it the commit assertion fails instead.
- **Fix**: inject the fault by throwing from the outer callback while the nested savepoint callback is still suspended. This closes the scope through the same rollback path as the watchdog, keeps the reused-connection hazard (same pooled connection, same savepoint name), and lets the next transaction run under the default watchdog. The stale continuation is now asserted to reject with the closed-scope error rather than merely awaited. The watchdog's own rollback stays covered by the preceding test.
- **Out of scope**: the other failure in that gate run (a recipes gateway-approvals test) and its single unhandled worker error, which did not reproduce here (details below).

## Related work

Closes #
No issue: the failure is a test-design race with a deterministic reproduction, and the change is confined to one test in the shared conformance suite. The PostgreSQL entry point for this suite lives in nanoco-recipes (`skills/add-central-postgresql`) and is unchanged.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

Measured on macOS, Node 22.22, Vitest 4.1.4, PostgreSQL 17.11 in Docker with C collation, 20 runs per condition, each bounded by a 120 s timeout. Latency was injected with a TCP proxy between Vitest and Postgres to stand in for a slower CI database. Before and after refer to this commit.

| Condition | Round trip | Before (fail / 20) | After (fail / 20) |
|---|---|---|---|
| Direct, idle machine | 0.7 ms | 0 | 0 |
| Direct, full host suite running concurrently (load average 7 to 9) | 0.7 ms | 0 | not re-run |
| Proxied | 7.6 ms | 20, commit assertion: `current` rejected by the 25 ms watchdog | 0 |
| Proxied | 21 ms | 20, `Test timed out in 5000ms` (the CI signature) | 0 |
| SQLite twin, direct | n/a | passes | 0 |

- Negative control: removing the `if (!parent.closed)` guard from the nested-transaction catch in each driver makes the rewritten test fail on both SQLite (`no such savepoint: nanoclaw_sp_1`) and PostgreSQL (`savepoint "nanoclaw_sp_1" does not exist`), so the hazard is still detected.
- `pnpm exec vitest run` (host suite, with the locally staged PostgreSQL skill files excluded): 2373 passed, 2 failed. Both failures are pre-existing on main in this environment (`scripts/update-skills.test.ts`, `scripts/update/transaction.e2e.test.ts`; both need upstream network access) and failed identically before the change.
- `pnpm typecheck`, and eslint plus prettier on the changed file: clean.
- [x] Tests cover the changed behavior (or Validation says why not)

<details>
<summary>Prior attempts read, and whether they held up</summary>

- nanoclaw `hero/20260907/host-watchdog-fixture-ordering` (0a40b9bf) reached the same diagnosis and kept the watchdog as the fault injector by faking `setTimeout` and `clearTimeout` around live PostgreSQL I/O, plus a barrier helper (+59/-26). The diagnosis held up. The approach was not adopted because fake timers around a live socket are fragile, and the throw-based injector needs no timers at all.
- nanoclaw `hero/20260907/host-unit-gate-fixes` (a216c1c4 integer-width migration, 7c163049 and 61aa3d4b fixture coherence) and nanoco-recipes `hero/20260907/recipes-host-unit-gate-fixes` (0a44f94a, 1a6bf080, fixture isolation from parallel writers) do not touch this test or the transaction path. The failure reproduces with a single Vitest worker, a fresh schema per test, and an otherwise idle database, so parallel writers and integer width are not the cause here.
- The unhandled worker error from the gate run did not reproduce in 100 single-file runs or two full-suite runs. In the failing runs the only "Unhandled rejection" line is the host's process-level handler in `src/log.ts` logging the `current` transaction's watchdog rejection while the test was stuck on its barrier; Vitest did not count it as an error.

</details>

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

## Security and trust boundaries

None.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
