### PR TITLE
ci(registry-skills): a `registry gate` check the ruleset can require, and a build that survives a Docker Hub 5xx

### DIFF
--- a/.github/workflows/registry-skills.yml
+++ b/.github/workflows/registry-skills.yml
@@ -173,3 +173,26 @@ jobs:
           test "${{ needs.combined-providers.result }}" = success
           test "${{ needs.pre-contract-providers.result }}" = success
           test "${{ needs.old-provider-refresh.result }}" = success
+
+  # The one check the main ruleset will require from this workflow, in the
+  # shape of `gate` in ci.yml. It needs every job above, provider-promotion
+  # included, so the older verdict and this one cannot disagree. if: always()
+  # because a skipped required check is not a failed one. Nothing in this
+  # workflow is conditional on the event: every job runs on pull_request, push
+  # and workflow_dispatch alike, so only `success` passes and a skip fails.
+  registry-gate:
+    name: registry gate
+    if: always()
+    needs: [discover, test, combined-providers, pre-contract-providers, old-provider-refresh, provider-promotion]
+    permissions: {}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: every needed job succeeded
+        run: |
+          test "${{ needs.discover.result }}" = success
+          test "${{ needs.test.result }}" = success
+          test "${{ needs.combined-providers.result }}" = success
+          test "${{ needs.pre-contract-providers.result }}" = success
+          test "${{ needs.old-provider-refresh.result }}" = success
+          test "${{ needs.provider-promotion.result }}" = success

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,10 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+# The BuildKit frontend above is pinned by digest, so a build fetches it by
+# content address and never asks Docker Hub to resolve the `1.7` tag first. The
+# tag lookup is the HEAD request that returned 500 and took two registry-skills
+# legs down on 2026-09-07 with the code untouched. Resolved with
+# `crane digest docker/dockerfile:1.7` (docker buildx imagetools inspect agrees).
+# Bump the tag and digest together.
 # NanoClaw Agent Container
 # Runs Claude Agent SDK in isolated Linux VM with browser automation.
 #

--- a/container/build.sh
+++ b/container/build.sh
@@ -146,6 +146,41 @@ if [ -n "$LOCK_SHA" ]; then
     BUILD_ARGS+=(--build-arg "AGENT_RUNNER_LOCK_SHA256=$LOCK_SHA")
 fi
 
+# Docker Hub returns the occasional 5xx on a manifest request (two registry-
+# skills legs went red on one on 2026-09-07 with the code untouched) and BuildKit
+# gives up on the first. Three attempts, ten seconds apart, and only when the
+# failure reads as a registry status error: a 429 or a 5xx after "unexpected
+# status". Anything else is a real build failure and fails once, on the first
+# attempt, with the same exit code docker gave. Output streams through tee onto
+# stderr, where BuildKit already writes it, so a watcher still sees progress and
+# no caller sees a stream it did not see before.
+BUILD_ATTEMPTS=3
+BUILD_RETRY_WAIT=10
+build_image() {
+    local attempt=1 status log
+    log="$(mktemp)"
+    while :; do
+        # No pipefail in this script, so the pipeline's status is tee's and
+        # `set -e` stays quiet; docker's own status is read from PIPESTATUS.
+        "${CONTAINER_RUNTIME}" build "$@" 2>&1 | tee "$log" >&2
+        status=${PIPESTATUS[0]}
+        if [ "$status" -eq 0 ]; then
+            rm -f "$log"
+            return 0
+        fi
+        if [ "$attempt" -ge "$BUILD_ATTEMPTS" ] \
+            || ! grep -qE 'unexpected status.*: (429|5[0-9][0-9])( |$)' "$log"; then
+            rm -f "$log"
+            return "$status"
+        fi
+        echo "" >&2
+        echo "The registry answered with a transient error (attempt ${attempt}/${BUILD_ATTEMPTS})." >&2
+        echo "Retrying in ${BUILD_RETRY_WAIT}s..." >&2
+        sleep "$BUILD_RETRY_WAIT"
+        attempt=$((attempt + 1))
+    done
+}
+
 if [ "$PULL" = "true" ]; then
     echo "Pulling NanoClaw agent container image..."
     # Not exec'd: pull.sh runs as a child so `set -e` still carries its exit
@@ -176,12 +211,12 @@ elif [ "$OVERLAY" = "true" ]; then
         echo "LABEL dev.nanoclaw.unhardened-additions=\"cli-tools.json\""
     } > "$OVERLAY_DOCKERFILE"
 
-    ${CONTAINER_RUNTIME} build -f "$OVERLAY_DOCKERFILE" -t "${IMAGE_NAME}:${TAG}" .
+    build_image -f "$OVERLAY_DOCKERFILE" -t "${IMAGE_NAME}:${TAG}" .
 else
     echo "Building NanoClaw agent container image..."
     echo "Image: ${IMAGE_NAME}:${TAG}"
 
-    ${CONTAINER_RUNTIME} build "${BUILD_ARGS[@]}" -t "${IMAGE_NAME}:${TAG}" .
+    build_image "${BUILD_ARGS[@]}" -t "${IMAGE_NAME}:${TAG}" .
 fi
 
 echo ""


### PR DESCRIPTION
## Why

#3737 auto-merged this afternoon while three jobs of the Registry skills workflow were red (`old-provider-refresh`, `test (add-codex, true, true)`, `provider-promotion`). None of them is a required context, and `gate` in `ci.yml` cannot `needs` a job in another workflow, so nothing stood in the way. All three failed on the same line while `./container/build.sh` ran (run 34135982154):

```
#2 ERROR: unexpected status from HEAD request to https://registry-1.docker.io/v2/docker/dockerfile/manifests/1.7: 500 Internal Server Error
```

Docker Hub was down, not the code.

## What the gate needs

A new job `registry-gate` (check name **`registry gate`**) at the end of `registry-skills.yml`, in the exact shape of `gate` in `ci.yml`: `if: always()`, `permissions: {}`, `timeout-minutes: 5`, one step that runs `test "${{ needs.<job>.result }}" = success` for every other job in the workflow:

- `discover`
- `test` (the whole matrix; any red leg makes the result `failure`)
- `combined-providers`
- `pre-contract-providers`
- `old-provider-refresh`
- `provider-promotion`

No job in this workflow is conditional on the event. All of them run on `pull_request`, `push` to main and `workflow_dispatch` alike, so the gate accepts only `success`; a `skipped` or `cancelled` result fails it. The existing `gate` in `ci.yml` and every other job are untouched.

## The digest pin

`container/Dockerfile` line 1 now reads:

```
# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
```

Resolved on 2026-09-07 with `crane digest docker/dockerfile:1.7`; `docker buildx imagetools inspect docker/dockerfile:1.7` returns the same index digest. With the digest, BuildKit fetches the frontend by content address and never issues the tag-resolving HEAD request that returned 500. `docker build --check` against the pinned Dockerfile completes clean locally. That is the only Docker Hub reference by tag that the build resolves before it can start; `node:22-slim` is the other Docker Hub image and is left on its tag on purpose, so base-image security updates keep flowing (the retry below covers it). The repo has no mirror or GHCR copy of either base image; the only registry it publishes to is ECR, and that holds the finished agent image, not its bases.

## The retry

`container/build.sh` gains one helper, `build_image`, which both `docker build` invocations (the full build and the overlay) now go through:

- three attempts, ten seconds apart;
- a retry happens only when the build output matches `unexpected status.*: (429|5[0-9][0-9])( |$)`, i.e. a registry status error; a 401, a failing `RUN`, or any other error fails once, on the first attempt;
- the exit code returned is docker's own;
- output is tee'd onto stderr, where BuildKit already writes it, so callers see the same stream they did before.

Exercised locally with a fake runtime: a 500 on attempts one and two then success builds in three attempts and prints `Build complete!`; a persistent 503 fails after three attempts with docker's exit code; a 401 and a compile error each fail after one attempt. The build arguments pass through unchanged, so what gets built is the same.

## After this merges

The main ruleset will require `registry gate` as a third required context alongside `gate` and `verify`; the coordinator makes that change once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
