### PR TITLE
fix(channels): return inbound routing completion to adapters

### DIFF
--- a/src/channel-inbound.test.ts
+++ b/src/channel-inbound.test.ts
@@ -56,6 +56,23 @@ it.each(['throw', 'reject'])('logs a routing %s while returning failure to the a
   expect(log.error).toHaveBeenCalledOnce();
 });
 
+it('observes routing failure when an existing adapter ignores the returned promise', async () => {
+  const error = new Error('mailbox unavailable');
+  vi.mocked(routeInbound).mockRejectedValue(error);
+
+  // Existing adapters may call this without awaiting or attaching a catch.
+  // Vitest also fails this test if the ignored promise becomes unhandled.
+  channelInboundHandler({ channelType: 'test' })('peer', null, message);
+
+  await vi.waitFor(() =>
+    expect(log.error).toHaveBeenCalledWith('Failed to route inbound message', {
+      channelType: 'test',
+      err: error,
+    }),
+  );
+  expect(routeInbound).toHaveBeenCalledWith(expect.objectContaining({ instance: 'test' }));
+});
+
 it('wires the acceptance-preserving handler at the real channel startup boundary', () => {
   const file = ts.createSourceFile('index.ts', fs.readFileSync('src/index.ts', 'utf8'), ts.ScriptTarget.Latest, true);
   const imports = file.statements.filter(ts.isImportDeclaration);

--- a/src/channel-inbound.test.ts
+++ b/src/channel-inbound.test.ts
@@ -109,3 +109,28 @@ it('wires the acceptance-preserving handler at the real channel startup boundary
   visit(file);
   expect(wired).toBe(true);
 });
+
+it('snapshots caller-owned data before returning the completion promise', async () => {
+  vi.mocked(routeInbound).mockResolvedValue(undefined);
+  const adapter = { channelType: 'test', instance: 'original' };
+  const input = { ...message, content: { text: 'original' } };
+  const completion = channelInboundHandler(adapter)('peer', 'thread', input);
+  input.id = 'changed';
+  input.content.text = 'changed';
+  adapter.instance = 'changed';
+  await completion;
+  expect(routeInbound).toHaveBeenCalledWith({
+    channelType: 'test',
+    instance: 'original',
+    platformId: 'peer',
+    threadId: 'thread',
+    message: {
+      id: 'message',
+      kind: 'chat',
+      content: '{"text":"original"}',
+      timestamp: message.timestamp,
+      isMention: undefined,
+      isGroup: undefined,
+    },
+  });
+});

--- a/src/channel-inbound.test.ts
+++ b/src/channel-inbound.test.ts
@@ -62,7 +62,7 @@ it('observes routing failure when an existing adapter ignores the returned promi
 
   // Existing adapters may call this without awaiting or attaching a catch.
   // Vitest also fails this test if the ignored promise becomes unhandled.
-  channelInboundHandler({ channelType: 'test' })('peer', null, message);
+  void channelInboundHandler({ channelType: 'test' })('peer', null, message);
 
   await vi.waitFor(() =>
     expect(log.error).toHaveBeenCalledWith('Failed to route inbound message', {

--- a/src/channel-inbound.test.ts
+++ b/src/channel-inbound.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import ts from 'typescript';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+vi.mock('./router.js', () => ({ routeInbound: vi.fn() }));
+vi.mock('./log.js', () => ({ log: { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), fatal: vi.fn() } }));
+import { routeInbound } from './router.js';
+import { channelInboundHandler } from './channel-inbound.js';
+import { log } from './log.js';
+
+beforeEach(() => vi.resetAllMocks());
+const message = {
+  id: 'message',
+  kind: 'chat' as const,
+  content: { text: 'hello' },
+  timestamp: '2026-09-07T00:00:00.000Z',
+};
+
+it('returns pending host acceptance and preserves instance context', async () => {
+  let accept!: () => void;
+  vi.mocked(routeInbound).mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        accept = resolve;
+      }),
+  );
+  const promise = channelInboundHandler({ channelType: 'nostr', instance: 'personal' })('peer', null, {
+    ...message,
+  });
+  let settled = false;
+  void Promise.resolve(promise).then(() => {
+    settled = true;
+  });
+  await vi.waitFor(() => expect(routeInbound).toHaveBeenCalledOnce());
+  expect(settled).toBe(false);
+  expect(routeInbound).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channelType: 'nostr',
+      instance: 'personal',
+      platformId: 'peer',
+      message: expect.objectContaining({ content: '{"text":"hello"}' }),
+    }),
+  );
+  accept();
+  await promise;
+  expect(settled).toBe(true);
+});
+
+it.each(['throw', 'reject'])('logs a routing %s while returning failure to the adapter', async (failure) => {
+  const error = new Error('mailbox write failed');
+  vi.mocked(routeInbound).mockImplementation(() => {
+    if (failure === 'throw') throw error;
+    return Promise.reject(error);
+  });
+  await expect(channelInboundHandler({ channelType: 'nostr' })('peer', null, message)).rejects.toBe(error);
+  expect(log.error).toHaveBeenCalledOnce();
+});
+
+it('wires the acceptance-preserving handler at the real channel startup boundary', () => {
+  const file = ts.createSourceFile('index.ts', fs.readFileSync('src/index.ts', 'utf8'), ts.ScriptTarget.Latest, true);
+  const imports = file.statements.filter(ts.isImportDeclaration);
+  expect(
+    imports.some(
+      (node) => ts.isStringLiteral(node.moduleSpecifier) && node.moduleSpecifier.text === './channel-inbound.js',
+    ),
+  ).toBe(true);
+  let wired = false;
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node) && node.expression.getText(file) === 'initChannelAdapters') {
+      const setup = node.arguments[0];
+      if (setup && ts.isArrowFunction(setup) && ts.isBlock(setup.body)) {
+        for (const statement of setup.body.statements) {
+          if (
+            !ts.isReturnStatement(statement) ||
+            !statement.expression ||
+            !ts.isObjectLiteralExpression(statement.expression)
+          )
+            continue;
+          wired = statement.expression.properties.some(
+            (prop) =>
+              ts.isPropertyAssignment(prop) &&
+              prop.name.getText(file) === 'onInbound' &&
+              ts.isCallExpression(prop.initializer) &&
+              prop.initializer.expression.getText(file) === 'channelInboundHandler' &&
+              prop.initializer.arguments[0]?.getText(file) === 'adapter',
+          );
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(file);
+  expect(wired).toBe(true);
+});

--- a/src/channel-inbound.ts
+++ b/src/channel-inbound.ts
@@ -8,7 +8,7 @@ export function channelInboundHandler(
   adapter: Pick<ChannelAdapter, 'channelType' | 'instance'>,
 ): ChannelSetup['onInbound'] {
   return (platformId, threadId, message) => {
-    const routed = Promise.resolve().then(() =>
+    const routed = (async () =>
       routeInbound({
         channelType: adapter.channelType,
         instance: adapter.instance ?? adapter.channelType,
@@ -22,8 +22,7 @@ export function channelInboundHandler(
           isMention: message.isMention,
           isGroup: message.isGroup,
         },
-      }),
-    );
+      }))();
     void routed.catch((err) => {
       log.error('Failed to route inbound message', { channelType: adapter.channelType, err });
     });

--- a/src/channel-inbound.ts
+++ b/src/channel-inbound.ts
@@ -1,0 +1,32 @@
+import type { ChannelAdapter, ChannelSetup } from './channels/adapter.js';
+import { log } from './log.js';
+import { routeInbound } from './router.js';
+
+/** Preserve host acceptance for adapters that await delivery. Attach logging
+ * separately so fire-and-forget adapters also have a rejection observer. */
+export function channelInboundHandler(
+  adapter: Pick<ChannelAdapter, 'channelType' | 'instance'>,
+): ChannelSetup['onInbound'] {
+  return (platformId, threadId, message) => {
+    const routed = Promise.resolve().then(() =>
+      routeInbound({
+        channelType: adapter.channelType,
+        instance: adapter.instance ?? adapter.channelType,
+        platformId,
+        threadId,
+        message: {
+          id: message.id,
+          kind: message.kind,
+          content: JSON.stringify(message.content),
+          timestamp: message.timestamp,
+          isMention: message.isMention,
+          isGroup: message.isGroup,
+        },
+      }),
+    );
+    void routed.catch((err) => {
+      log.error('Failed to route inbound message', { channelType: adapter.channelType, err });
+    });
+    return routed;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { startHostInstanceLease, stopHostInstanceLease } from './host-instance.j
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { startHostModules, stopHostModules } from './host-lifecycle.js';
 import { routeInbound } from './router.js';
+import { channelInboundHandler } from './channel-inbound.js';
 import { log } from './log.js';
 import { enforceUpgradeTripwire } from './upgrade-state.js';
 
@@ -89,26 +90,7 @@ async function main(): Promise<void> {
   // 3. Channel adapters
   await initChannelAdapters((adapter: ChannelAdapter): ChannelSetup => {
     return {
-      onInbound(platformId, threadId, message) {
-        routeInbound({
-          channelType: adapter.channelType,
-          // The one host-side stamping seam: adapters stay instance-blind,
-          // the host stamps the receiving instance on every inbound event.
-          instance: adapter.instance ?? adapter.channelType,
-          platformId,
-          threadId,
-          message: {
-            id: message.id,
-            kind: message.kind,
-            content: JSON.stringify(message.content),
-            timestamp: message.timestamp,
-            isMention: message.isMention,
-            isGroup: message.isGroup,
-          },
-        }).catch((err) => {
-          log.error('Failed to route inbound message', { channelType: adapter.channelType, err });
-        });
-      },
+      onInbound: channelInboundHandler(adapter),
       onInboundEvent(event) {
         routeInbound(event).catch((err) => {
           log.error('Failed to route inbound event', {


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Return the host routing promise so channel adapters can retain retry eligibility when inbound handling fails.

- **Problem**: bootstrap currently discards routing completion, so an adapter can mark a message handled before a mailbox write fails.
- **Fix**: return completion to awaiting adapters while keeping a separate rejection logger for adapters that ignore it.
- **Context**: preserve the existing receiving instance, message identity and router policy.

## Related work

This is a standalone host bug fix identified while preparing an optional Nostr channel. Open PR #3711 separately introduces deferred content and also touches bootstrap; if it lands first, preserve its resolver when reconciling this callback. It requires no channel installation or registry payload. The existing ChannelSetup interface already permits a routing promise, and existing adapters await it.

## Change kind

- [x] `kind/bug`

## Validation

- [x] Tests cover the changed behavior.
- `pnpm run build`: passed on the upstream base with this fix.
- `pnpm exec vitest run src/channel-inbound.test.ts`: six tests passed, including bootstrap wiring, rejected routing, ignored completion and synchronous capture of caller-owned message data.
- The composed generic host stack passed 2,391 tests with one existing skip on Node 24. The clean Linux/Node 24 library composition passed 135 focused tests. These supplement the isolated callback build and six tests.
- Rebased onto official `acc69a70`; only the official CI workflow changed from the source used for the composed host run.

## User and release impact

- [x] User-visible change — adapters that await inbound handling can detect routing failure and preserve retry eligibility.

## Security and trust boundaries

The adapter-to-host completion signal reflects the existing router's promise. Routing policy, caller access and container isolation are unchanged. A resolved callback still means the host handled the message according to its policy, including deliberate drops; it is not an end-to-end delivery receipt.

## Skill delivery

- [x] Not a skill.

## AI assistance

- [x] AI tools or agents helped produce this change.
- [ ] A human has reviewed this PR and stands behind every change.
