### PR TITLE
feat(tasks): --fresh-session, so a scheduled series can run stateless

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,7 +4,7 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { processQuery } from './poll-loop.js';
+import { processQuery, shouldStartFreshSession, wantsFreshSession } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -189,6 +189,60 @@ describe('on_wake filtering', () => {
       .run();
     // Should be returned even on non-first poll (on_wake=0)
     expect(getPendingMessages(false)).toHaveLength(1);
+  });
+});
+
+describe('fresh-session task occurrences', () => {
+  // Opt-in per series (`ncl tasks create --fresh-session`). A recurring
+  // series' session is never closed, so by default every fire resumes — and
+  // re-sends — the previous run's whole conversation.
+  it('is off unless the task content asks for it', () => {
+    insertMessage('m1', 'task', { prompt: 'nightly sweep' });
+    expect(getPendingMessages().every(wantsFreshSession)).toBe(false);
+  });
+
+  it('is on when the task content carries freshSession', () => {
+    insertMessage('m1', 'task', { prompt: 'nightly sweep', freshSession: true });
+    expect(getPendingMessages().some(wantsFreshSession)).toBe(true);
+  });
+
+  it('never fires for a chat message, whatever its content says', () => {
+    insertMessage('m1', 'chat', { sender: 'John', text: 'hi', freshSession: true });
+    expect(getPendingMessages().some(wantsFreshSession)).toBe(false);
+  });
+
+  // These call the real decision function the poll loop uses. An earlier version
+  // asserted `some`/`every` on a local array instead, which tested
+  // Array.prototype and passed identically with the fix reverted.
+  it('does not reset a mixed batch — chat context must survive a co-batched task', () => {
+    insertMessage('m1', 'task', { prompt: 'nightly sweep', freshSession: true });
+    insertMessage('m2', 'chat', { sender: 'John', text: 'what did we decide?' });
+    expect(shouldStartFreshSession(getPendingMessages())).toBe(false);
+  });
+
+  it('resets a batch that is entirely fresh-session task rows', () => {
+    insertMessage('m1', 'task', { prompt: 'sweep a', freshSession: true });
+    insertMessage('m2', 'task', { prompt: 'sweep b', freshSession: true });
+    expect(shouldStartFreshSession(getPendingMessages())).toBe(true);
+  });
+
+  it('does not reset an empty batch', () => {
+    expect(shouldStartFreshSession([])).toBe(false);
+  });
+
+  it('does not reset when the only task row has not opted in', () => {
+    insertMessage('m1', 'task', { prompt: 'nightly sweep' });
+    expect(shouldStartFreshSession(getPendingMessages())).toBe(false);
+  });
+
+  it('tolerates legacy plain-string task content', () => {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, kind, timestamp, status, trigger, on_wake, content)
+         VALUES ('m1', 'task', datetime('now'), 'pending', 1, 0, 'do the thing')`,
+      )
+      .run();
+    expect(getPendingMessages().some(wantsFreshSession)).toBe(false);
   });
 });
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -78,6 +78,40 @@ export interface PollLoopConfig {
  * 5. Mark messages completed
  * 6. Loop
  */
+/**
+ * True for a task row whose content asks each occurrence to start a fresh
+ * agent conversation. Tolerates legacy plain-string task content (pre-JSON
+ * envelope), which never carries the flag.
+ */
+/**
+ * Whether this batch should start a fresh conversation.
+ *
+ * Separate from `wantsFreshSession` and exported deliberately: the reset's
+ * effect is BATCH-WIDE (`clearContinuation` drops the conversation for
+ * everything being processed), so the decision is a property of the batch, not
+ * of any one row. Testing the predicate alone proves nothing about it — an
+ * earlier version of these tests asserted `some`/`every` on a local array and
+ * passed identically against the unfixed code.
+ *
+ * `every`, not `some`: a fresh-session task row co-batched with chat messages
+ * would otherwise answer those with no history and discard the user's context
+ * without saying so. Task sessions are normally one row at a time, but a task
+ * row created into a chat session makes the mixed batch reachable, and when it
+ * happens, resuming is the safe side of the trade.
+ */
+export function shouldStartFreshSession(batch: MessageInRow[]): boolean {
+  return batch.length > 0 && batch.every(wantsFreshSession);
+}
+
+export function wantsFreshSession(msg: MessageInRow): boolean {
+  if (msg.kind !== 'task') return false;
+  try {
+    return (JSON.parse(msg.content) as { freshSession?: unknown }).freshSession === true;
+  } catch {
+    return false;
+  }
+}
+
 export async function runPollLoop(config: PollLoopConfig): Promise<void> {
   // Contract providers declare these; a contractless (legacy payload)
   // provider keeps declaring them as instance flags, exactly as before.
@@ -226,6 +260,27 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     if (keep.length === 0) {
       log(`All ${normalMessages.length} non-command message(s) gated by script, skipping query`);
       continue;
+    }
+
+    // Opt-in stateless task occurrences (`ncl tasks create --fresh-session`).
+    // A recurring series' session is never closed, so by default every fire
+    // resumes the previous one and re-sends the whole prior conversation.
+    // Checked after the pre-task gate so a fire the script skipped costs
+    // nothing. Same reset the /clear path performs, plus a chance for the
+    // provider to retire the transcript we are walking away from — nothing
+    // else ever rotates it.
+    //
+    // Scoped to batches that are ENTIRELY fresh-session task rows. Dropping the
+    // continuation is batch-wide, so a task row co-batched with chat messages
+    // would answer those with no history and discard the user's context without
+    // saying so. Task sessions are normally one row at a time, but a task row
+    // created into a chat session makes the mixed batch reachable; when it
+    // happens, resuming is the safe side of the trade.
+    if (continuation && shouldStartFreshSession(keep)) {
+      log('Fresh-session task: starting a new conversation instead of resuming');
+      config.provider.abandonContinuation?.(continuation, 'fresh-session task occurrence');
+      continuation = undefined;
+      clearContinuation(config.providerName);
     }
 
     // Format messages: passthrough commands get raw text (only if the

--- a/container/agent-runner/src/providers/claude-history.ts
+++ b/container/agent-runner/src/providers/claude-history.ts
@@ -234,23 +234,56 @@ export function rotateClaudeContinuation(
     const decision = decideContinuationRotation({ size, firstLine }, fx);
     if (!decision?.reason) return null;
 
-    archiveClaudeTranscript(
-      {
-        transcriptPath,
-        sessionId: input.continuation,
-        assistantName: input.assistantName,
-        log: input.log,
-      },
-      fx,
-    );
-    try {
-      fs.renameSync(transcriptPath, `${transcriptPath}.rotated-${fx.now()}`);
-    } catch (error) {
-      input.log(`Failed to move rotated transcript aside: ${error instanceof Error ? error.message : String(error)}`);
-    }
+    retireTranscriptFile(transcriptPath, input, fx);
     return decision.reason;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Retire a continuation unconditionally — no rotation decision. A caller that
+ * has already decided to walk away from a resumable session (a `--fresh-session`
+ * task occurrence, say) needs the same archive-then-move-aside tail rotation
+ * uses, so the transcript is preserved as prose and the `.jsonl` leaves the
+ * resume path instead of accumulating one file per occurrence.
+ *
+ * Returns false when no transcript for that continuation exists.
+ */
+export function retireClaudeContinuation(
+  input: ClaudeContinuationRotationInput,
+  fx: ClaudeHistoryClock,
+  reason?: string,
+): boolean {
+  const transcriptPath = findContinuationFile(
+    path.join(claudeConfigDirectory(), 'projects'),
+    `${input.continuation}.jsonl`,
+  );
+  if (!transcriptPath) return false;
+  if (reason) input.log(`Abandoning session ${input.continuation} — ${reason}`);
+  retireTranscriptFile(transcriptPath, input, fx);
+  return true;
+}
+
+/** The shared tail: preserve a readable archive, then move the `.jsonl` aside. */
+function retireTranscriptFile(
+  transcriptPath: string,
+  input: ClaudeContinuationRotationInput,
+  fx: ClaudeHistoryClock,
+): void {
+  archiveClaudeTranscript(
+    {
+      transcriptPath,
+      sessionId: input.continuation,
+      assistantName: input.assistantName,
+      log: input.log,
+    },
+    fx,
+  );
+  try {
+    fs.renameSync(transcriptPath, `${transcriptPath}.rotated-${fx.now()}`);
+  } catch (error) {
+    input.log(`Failed to move rotated transcript aside: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 

--- a/container/agent-runner/src/providers/claude.rotate.test.ts
+++ b/container/agent-runner/src/providers/claude.rotate.test.ts
@@ -132,3 +132,24 @@ describe('claude maybeRotateContinuation', () => {
     expect(provider.maybeRotateContinuation!('does-not-exist', CWD)).toBeNull();
   });
 });
+
+describe('claude abandonContinuation', () => {
+  // A --fresh-session task occurrence drops a perfectly resumable
+  // continuation on purpose. maybeRotateContinuation only ever inspects the
+  // transcript it is about to resume, so nothing else would ever retire this
+  // one and the projects dir would grow a .jsonl per occurrence, forever.
+  it('archives and moves the abandoned transcript out of the resume path', () => {
+    const p = writeTranscript('sess-abandoned', 4096);
+    const provider = createProvider('claude');
+    provider.abandonContinuation!('sess-abandoned', 'fresh-session task occurrence');
+    expect(fs.existsSync(p)).toBe(false);
+    const dir = path.dirname(p);
+    expect(fs.readdirSync(dir).some((f) => f.startsWith('sess-abandoned.jsonl.rotated-'))).toBe(true);
+    expect(fs.readdirSync(path.join(tmp, 'conversations')).length).toBeGreaterThan(0);
+  });
+
+  it('is a no-op for an unknown session id', () => {
+    const provider = createProvider('claude');
+    expect(() => provider.abandonContinuation!('does-not-exist', 'why')).not.toThrow();
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -17,7 +17,7 @@ import {
 } from './claude-config.js';
 // Transcript archiving and rotation are this provider's own concern: both
 // read the SDK's on-disk .jsonl, which no other provider has.
-import { archiveClaudeTranscript, rotateClaudeContinuation } from './claude-history.js';
+import { archiveClaudeTranscript, retireClaudeContinuation, rotateClaudeContinuation } from './claude-history.js';
 import { registerProvider } from './provider-registry.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 
@@ -241,6 +241,15 @@ export class ClaudeProvider implements AgentProvider {
    */
   maybeRotateContinuation(continuation: string, _cwd: string): string | null {
     return rotateClaudeContinuation({ continuation, assistantName: this.assistantName, log }, REAL_CLOCK);
+  }
+
+  /**
+   * Walk away from a resumable continuation on purpose (a `--fresh-session`
+   * task occurrence). Rotation only ever inspects the transcript it is about
+   * to resume, so without this the abandoned `.jsonl` would never be retired.
+   */
+  abandonContinuation(continuation: string, reason: string): void {
+    retireClaudeContinuation({ continuation, assistantName: this.assistantName, log }, REAL_CLOCK, reason);
   }
 
   query(input: QueryInput): AgentQuery {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -55,6 +55,17 @@ export interface AgentProvider {
    * before it ever replies. Providers without an on-disk transcript omit this.
    */
   maybeRotateContinuation?(continuation: string, cwd: string): string | null;
+
+  /**
+   * Optional. Called when the caller drops a still-valid continuation on
+   * purpose — e.g. a `--fresh-session` task occurrence that must not resume
+   * the previous run. Gives the provider a chance to archive and retire the
+   * abandoned transcript; `maybeRotateContinuation` only ever inspects the
+   * transcript it is about to resume, so without this the abandoned .jsonl is
+   * never rotated and the transcript directory grows without bound.
+   * Best-effort: implementations must not throw.
+   */
+  abandonContinuation?(continuation: string, reason: string): void;
 }
 
 /** One prompt/result round-trip, as reported to `onExchangeComplete`. */

--- a/src/cli/resources/tasks.test.ts
+++ b/src/cli/resources/tasks.test.ts
@@ -448,6 +448,87 @@ describe('tasks CLI resource', () => {
     expect(d.created_at).toBeTruthy();
   });
 
+  describe('--fresh-session (stateless occurrences)', () => {
+    async function createWith(args: Record<string, unknown>) {
+      const r = await dispatch(
+        { id: 'fs', command: 'tasks-create', args: { prompt: 'nightly sweep', ...args } },
+        agentCtx('ag-1', 'chat-1'),
+      );
+      expect(r.ok).toBe(true);
+      if (!r.ok) throw new Error('create failed');
+      const out = r.data as { series_id: string; session_id: string; fresh_session: number };
+      const db = new Database(inboundDbPath('ag-1', out.session_id), { readonly: true });
+      const row = db.prepare("SELECT content FROM messages_in WHERE kind = 'task'").get() as { content: string };
+      db.close();
+      return { out, content: JSON.parse(row.content) as Record<string, unknown> };
+    }
+
+    it('defaults off — an existing install keeps resuming its task session', async () => {
+      const { out, content } = await createWith({ process_after: '2999-01-01T00:00:00Z' });
+      expect(content.freshSession).toBe(false);
+      expect(out.fresh_session).toBe(0);
+    });
+
+    it('persists the flag into task content when asked for', async () => {
+      const { out, content } = await createWith({ process_after: '2999-01-01T00:00:00Z', fresh_session: true });
+      expect(content.freshSession).toBe(true);
+      expect(out.fresh_session).toBe(1);
+    });
+
+    function contentOf(sessionId: string): Record<string, unknown> {
+      const db = new Database(inboundDbPath('ag-1', sessionId), { readonly: true });
+      const row = db.prepare("SELECT content FROM messages_in WHERE kind = 'task'").get() as { content: string };
+      db.close();
+      return JSON.parse(row.content) as Record<string, unknown>;
+    }
+
+    async function update(args: Record<string, unknown>) {
+      const r = await dispatch({ id: 'u', command: 'tasks-update', args }, agentCtx('ag-1', 'chat-1'));
+      expect(r.ok).toBe(true);
+      if (!r.ok) throw new Error(`update failed: ${r.error}`);
+      return r.data as { series_id: string; touched: number; fields: string[] };
+    }
+
+    it('turns a live series stateless in place — no cancel-and-recreate', async () => {
+      const { out } = await createWith({ recurrence: '0 3 * * *' });
+      expect(contentOf(out.session_id).freshSession).toBe(false);
+
+      const res = await update({ id: out.series_id, fresh_session: true });
+      expect(res.series_id).toBe(out.series_id);
+      expect(res.touched).toBe(1);
+      expect(res.fields).toContain('freshSession');
+      expect(contentOf(out.session_id).freshSession).toBe(true);
+    });
+
+    it('turns it back off with an explicit false', async () => {
+      const { out } = await createWith({ recurrence: '0 3 * * *', fresh_session: true });
+      expect(contentOf(out.session_id).freshSession).toBe(true);
+
+      // A value-less --fresh-session means true, so "off" is the explicit
+      // value form the boolean columns already use elsewhere.
+      await update({ id: out.series_id, fresh_session: 'false' });
+      expect(contentOf(out.session_id).freshSession).toBe(false);
+    });
+
+    it('leaves the current setting alone when the flag is omitted', async () => {
+      const { out } = await createWith({ recurrence: '0 3 * * *', fresh_session: true });
+
+      await update({ id: out.series_id, prompt: 'nightly sweep v2' });
+
+      const content = contentOf(out.session_id);
+      expect(content.prompt).toBe('nightly sweep v2');
+      expect(content.freshSession).toBe(true);
+    });
+
+    it('surfaces on get so an operator can see which series are stateless', async () => {
+      const { out } = await createWith({ process_after: '2999-01-01T00:00:00Z', fresh_session: true });
+      const got = await dispatch({ id: 'g', command: 'tasks-get', args: { id: out.series_id } }, agentCtx());
+      expect(got.ok).toBe(true);
+      if (!got.ok) return;
+      expect((got.data as { fresh_session: number }).fresh_session).toBe(1);
+    });
+  });
+
   it('each task gets its own isolated session, and list fans out across them', async () => {
     const a = await dispatch(
       { id: 'r-a', command: 'tasks-create', args: { prompt: 'task A', process_after: '2026-01-15T09:00:00Z' } },

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -49,6 +49,16 @@ function bool(value: unknown): boolean {
   return value === true || value === 'true' || value === '1';
 }
 
+/**
+ * Tri-state read of a declared boolean flag: `undefined` when the caller did
+ * not pass it at all, so `update` can tell "leave it alone" apart from
+ * "set it to false". The declared-arg validator has already coerced a passed
+ * value to a real boolean (`--fresh-session false` / `--fresh-session 0`).
+ */
+function optionalBool(value: unknown): boolean | undefined {
+  return value === undefined ? undefined : bool(value);
+}
+
 function normalizeNullableString(value: unknown): string | null | undefined {
   if (value === undefined) return undefined;
   if (value === null) return null;
@@ -118,6 +128,7 @@ function toOutput(session: ScopedSession, row: TaskRow) {
     recurrence: row.recurrence,
     prompt: content.prompt.length > 120 ? content.prompt.slice(0, 117) + '...' : content.prompt,
     has_script: content.script ? 1 : 0,
+    fresh_session: content.freshSession ? 1 : 0,
     origin_session_id: content.originSessionId, // which session created the task (null for CLI-created)
     created_at: row.timestamp,
     tries: row.tries,
@@ -153,6 +164,7 @@ async function createTask(args: Record<string, unknown>, ctx: CallerContext) {
     script,
     dangerouslyOverrideRecurrenceLimit: bool(args.dangerously_override_recurrence_limit),
     timezone: await resolveGroupTimezone(group),
+    freshSession: bool(args.fresh_session),
   });
   const { session, row } = await createScheduledTask(group, prepared, {
     originSessionId: ctx.caller === 'agent' ? ctx.sessionId : null,
@@ -260,6 +272,7 @@ async function getTask(args: Record<string, unknown>, ctx: CallerContext) {
         ...toOutput(session, row),
         prompt: content.prompt,
         script: content.script,
+        fresh_session: content.freshSession ? 1 : 0,
         origin_session_id: content.originSessionId,
         completed_runs: stats.runs,
         failed_runs: stats.failedRuns,
@@ -360,6 +373,10 @@ async function updateTaskCommand(args: Record<string, unknown>, ctx: CallerConte
     update.recurrence = recurrence;
   }
   if (script !== undefined) update.script = script;
+  // Tri-state: an omitted --fresh-session leaves the series as it is; only an
+  // explicit value (including `--fresh-session false`) changes it.
+  const freshSession = optionalBool(args.fresh_session);
+  if (freshSession !== undefined) update.freshSession = freshSession;
   const fields = Object.keys(update);
   if (fields.length === 0) throw new Error('nothing to update');
 
@@ -440,6 +457,12 @@ registerResource({
     { name: 'recurrence', type: 'string', description: 'Optional cron expression.', updatable: true },
     { name: 'prompt', type: 'string', description: 'Task prompt.', required: true, updatable: true },
     { name: 'script', type: 'string', description: 'Optional pre-task bash script.', updatable: true },
+    {
+      name: 'fresh_session',
+      type: 'boolean',
+      description: 'Start each occurrence in a fresh agent conversation instead of resuming. Default off.',
+      updatable: true,
+    },
   ],
   operations: {},
   customOperations: {
@@ -499,6 +522,11 @@ registerResource({
         `carries a --script gate (the script decides whether each fire needs you — a gated fire that\n` +
         `finds nothing costs zero tokens) or you pass --dangerously-override-recurrence-limit after\n` +
         `the user explicitly confirmed they want an ungated frequent task.\n\n` +
+        `Session continuity: by default every occurrence of a series resumes the previous one, so the\n` +
+        `agent remembers what it did last time — and the conversation grows without bound, since a live\n` +
+        `recurring series' session is never reset. Pass --fresh-session for stateless jobs that redo the\n` +
+        `same work each fire; each occurrence then starts a clean conversation. It can be turned on or off\n` +
+        `later on a live series with \`ncl tasks update <id> --fresh-session [true|false]\`.\n\n` +
         `Failure backoff: a script that ERRORS repeatedly backs the series off (2,4,8,…60 min between fires; each errored fire counts as a failed run); after 8 consecutive failures the series is auto-paused with a note in its run log — fix the script, then \`ncl tasks resume <id>\`. A deliberate wakeAgent=false is a normal run and never backs off. \`ncl tasks get <id>\` shows failed_runs and the run log.`,
       args: [
         {
@@ -528,6 +556,15 @@ registerResource({
           name: 'script',
           type: 'string',
           description: 'Pre-task gate script (bash) — see the --script contract above.',
+        },
+        {
+          name: 'fresh_session',
+          type: 'boolean',
+          description:
+            'Run each occurrence in a fresh agent conversation instead of resuming the previous run. ' +
+            'Off by default (occurrences resume, so the agent remembers prior runs). Turn it on for ' +
+            'stateless jobs that do the same work every time — a resuming series never resets, so its ' +
+            'context (and token cost) grows with every fire.',
         },
         {
           name: 'group',
@@ -585,6 +622,13 @@ registerResource({
             'Schedule more than 4 fires/day anyway. Only after the user explicitly confirmed they understand the quota/token cost and you agree it is right.',
         },
         { name: 'script', type: 'string', description: 'New pre-task script; "null"/"none" removes it.' },
+        {
+          name: 'fresh_session',
+          type: 'boolean',
+          description:
+            'Turn stateless occurrences on (--fresh-session) or off (--fresh-session false) for a live ' +
+            'series, keeping its id, run counts, and run log. Omit to leave the current setting alone.',
+        },
         {
           name: 'group',
           type: 'string',

--- a/src/mailbox/sqlite/tasks.test.ts
+++ b/src/mailbox/sqlite/tasks.test.ts
@@ -268,6 +268,61 @@ describe('updateTask', () => {
     db.close();
   });
 
+  it('sets freshSession on a live series without recreating it', () => {
+    const db = freshDb();
+    insertTaskRow(db, {
+      id: 'task-1',
+      seriesId: 'task-1',
+      processAfter: '2999-01-01T00:00:00.000Z',
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'nightly', script: null, originSessionId: null }),
+    });
+
+    expect(updateTask(db, 'task-1', { freshSession: true })).toBe(1);
+
+    const row = db.prepare('SELECT content FROM messages_in WHERE id = ?').get('task-1') as { content: string };
+    const parsed = JSON.parse(row.content);
+    expect(parsed.freshSession).toBe(true);
+    // Everything else in the envelope survives the merge.
+    expect(parsed.prompt).toBe('nightly');
+  });
+
+  it('clears freshSession when false is passed', () => {
+    const db = freshDb();
+    insertTaskRow(db, {
+      id: 'task-1',
+      seriesId: 'task-1',
+      processAfter: '2999-01-01T00:00:00.000Z',
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'nightly', freshSession: true }),
+    });
+
+    expect(updateTask(db, 'task-1', { freshSession: false })).toBe(1);
+
+    const row = db.prepare('SELECT content FROM messages_in WHERE id = ?').get('task-1') as { content: string };
+    expect(JSON.parse(row.content).freshSession).toBe(false);
+  });
+
+  it('leaves freshSession alone when the flag is omitted', () => {
+    const db = freshDb();
+    insertTaskRow(db, {
+      id: 'task-1',
+      seriesId: 'task-1',
+      processAfter: '2999-01-01T00:00:00.000Z',
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'nightly', freshSession: true }),
+    });
+
+    // An unrelated edit must not silently turn a stateless series back into a
+    // resuming one.
+    updateTask(db, 'task-1', { prompt: 'nightly v2' });
+
+    const row = db.prepare('SELECT content FROM messages_in WHERE id = ?').get('task-1') as { content: string };
+    const parsed = JSON.parse(row.content);
+    expect(parsed.prompt).toBe('nightly v2');
+    expect(parsed.freshSession).toBe(true);
+  });
+
   it('returns 0 when no live task matches', () => {
     const db = freshDb();
     insertTaskRow(db, {

--- a/src/mailbox/sqlite/tasks.ts
+++ b/src/mailbox/sqlite/tasks.ts
@@ -83,10 +83,12 @@ export interface TaskUpdate {
   script?: string | null;
   recurrence?: string | null;
   processAfter?: string;
+  /** Tri-state: omit to leave the series' current setting alone. */
+  freshSession?: boolean;
 }
 
-// Merges content JSON in-place so callers can update prompt/script without
-// clobbering other fields. Matches by id OR series_id so the live next
+// Merges content JSON in-place so callers can update prompt/script/freshSession
+// without clobbering other fields. Matches by id OR series_id so the live next
 // occurrence of a recurring task is updated, not just the completed row the
 // agent last saw. Due occurrences are already execution candidates and remain
 // immutable; only future pending or paused occurrences are updated. Returns
@@ -105,7 +107,7 @@ export function updateTask(db: Database.Database, taskId: string, update: TaskUp
 
   const setProcessAfter = update.processAfter !== undefined;
   const setRecurrence = update.recurrence !== undefined;
-  const mergeContent = update.prompt !== undefined || update.script !== undefined;
+  const mergeContent = update.prompt !== undefined || update.script !== undefined || update.freshSession !== undefined;
 
   const tx = db.transaction(() => {
     for (const row of rows) {
@@ -114,6 +116,10 @@ export function updateTask(db: Database.Database, taskId: string, update: TaskUp
         const parsed = JSON.parse(row.content) as Record<string, unknown>;
         if (update.prompt !== undefined) parsed.prompt = update.prompt;
         if (update.script !== undefined) parsed.script = update.script;
+        // Undefined leaves the stored value alone — omitting the flag on an
+        // update must not silently turn a stateless series back into a
+        // resuming one.
+        if (update.freshSession !== undefined) parsed.freshSession = update.freshSession;
         content = JSON.stringify(parsed);
       }
 

--- a/src/mailbox/types.ts
+++ b/src/mailbox/types.ts
@@ -61,6 +61,8 @@ export interface TaskUpdate {
   script?: string | null;
   recurrence?: string | null;
   processAfter?: string;
+  /** Tri-state: omit to leave the series' current setting alone. */
+  freshSession?: boolean;
 }
 
 export type TaskRecord = CanonicalTaskRecord;

--- a/src/modules/scheduling/create.ts
+++ b/src/modules/scheduling/create.ts
@@ -28,6 +28,8 @@ export interface PreparedScheduledTask {
   recurrence: string | null;
   script: string | null;
   processAfter: string;
+  /** Opt-in: each occurrence starts a fresh agent conversation. Default false. */
+  freshSession?: boolean;
 }
 
 export type ScheduledTaskRow = TaskRecord;
@@ -108,6 +110,7 @@ export function prepareScheduledTask(input: {
   script?: string | null;
   dangerouslyOverrideRecurrenceLimit?: boolean;
   timezone?: string;
+  freshSession?: boolean;
 }): PreparedScheduledTask {
   if (!input.prompt) throw new Error('--prompt is required');
   const recurrence = input.recurrence ?? null;
@@ -125,7 +128,14 @@ export function prepareScheduledTask(input: {
     processAfter = parseProcessAfter(input.processAfter, tz);
   }
 
-  return { name: input.name, prompt: input.prompt, recurrence, script, processAfter };
+  return {
+    name: input.name,
+    prompt: input.prompt,
+    recurrence,
+    script,
+    processAfter,
+    freshSession: input.freshSession === true,
+  };
 }
 
 /** Persist a prepared task through NanoClaw's single task/session representation. */
@@ -147,6 +157,9 @@ export async function createScheduledTask(
         prompt: task.prompt,
         script: task.script,
         originSessionId: options?.originSessionId ?? null,
+        // `armNextTask` copies `content` forward verbatim, so the flag rides
+        // along to every future occurrence with no schema change.
+        freshSession: task.freshSession === true,
       }),
       status: options?.status ?? 'pending',
     });

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -14,6 +14,7 @@ import { ensureSchema, openInboundDb } from '../../mailbox/sqlite/session-db.js'
 import { insertTaskRow } from '../../mailbox/sqlite/tasks.js';
 import { wrapSqliteInbound } from '../../mailbox/sqlite/index.js';
 import { handleRecurrence, scriptBackoffMinutes } from './recurrence.js';
+import { parseTaskContent } from './task-content.js';
 import type { Session } from '../../types.js';
 
 // Pin a non-UTC zone so the tz-interpretation test is exact even on UTC CI.
@@ -139,6 +140,25 @@ describe('handleRecurrence', () => {
       process_after: string;
     };
     expect(follow.process_after).toMatch(/T03:30:00/);
+  });
+
+  it('carries freshSession forward to the next occurrence (no schema change)', async () => {
+    const db = freshDb();
+    insertTaskRow(db, {
+      id: 'task-fresh',
+      seriesId: 'task-fresh',
+      processAfter: '2020-01-01T00:00:00.000Z',
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'nightly sweep', script: null, originSessionId: null, freshSession: true }),
+    });
+    db.prepare(`UPDATE messages_in SET status='completed' WHERE id='task-fresh'`).run();
+
+    await handleRecurrence(wrapSqliteInbound(db), fakeSession());
+
+    const follow = db.prepare(`SELECT content FROM messages_in WHERE id != 'task-fresh'`).get() as {
+      content: string;
+    };
+    expect(parseTaskContent(follow.content).freshSession).toBe(true);
   });
 
   it('does not clone rows whose recurrence is already cleared', async () => {

--- a/src/modules/scheduling/task-content.ts
+++ b/src/modules/scheduling/task-content.ts
@@ -2,6 +2,14 @@ export interface TaskContent {
   prompt: string;
   script: string | null;
   originSessionId: string | null;
+  /**
+   * Opt-in, default false. When true, each occurrence of the series starts a
+   * fresh agent conversation instead of resuming the previous one. Recurring
+   * task sessions are never closed (a live series always has a next
+   * occurrence), so without this every fire resumes — and re-sends — every
+   * prior run's transcript.
+   */
+  freshSession: boolean;
 }
 
 /** Decode the storage-neutral task content envelope. */
@@ -12,9 +20,10 @@ export function parseTaskContent(raw: string): TaskContent {
       prompt: typeof parsed.prompt === 'string' ? parsed.prompt : '',
       script: typeof parsed.script === 'string' ? parsed.script : null,
       originSessionId: typeof parsed.originSessionId === 'string' ? parsed.originSessionId : null,
+      freshSession: parsed.freshSession === true,
     };
     // eslint-disable-next-line no-catch-all/no-catch-all -- LEGACY-COMPAT(v1-tasks): plain-string content predating the JSON envelope
   } catch {
-    return { prompt: raw, script: null, originSessionId: null };
+    return { prompt: raw, script: null, originSessionId: null, freshSession: false };
   }
 }


### PR DESCRIPTION
Scheduled jobs keep one long conversation going forever, so every night the agent re-reads everything it said on all the previous nights – which means a job doing the identical task each night costs more every night - one of mine grew 15% in a single week).

This change adds an optional setting that tells a job "start fresh each time," so it stops carrying that history.

It's off unless you turn it on, so nobody's existing setup changes, and you can switch it on or off for a job you already have without losing its run history.



## The problem

Every recurring task series owns a system session that is never reset — `shouldCloseTaskSession` only closes a task session when no live task remains, which for a recurring series is never. So occurrence N+1 resumes occurrence N's conversation and re-reads everything every prior run said.

For a job that does the same work every night, that history is pure cost. Measured on one such series: **343k tokens on 2026-08-30, 395k on 2026-09-05 — +15% in a week, for identical work.** Compaction doesn't bound it (the window is 165K and these sessions peak well below it), so the only ceiling is the 14-day transcript rotation, which produces a sawtooth rather than a fix.

Resuming is the right default for a series where run N should remember run N-1. It's the wrong default for the large class of scheduled jobs that are pure functions of the world at fire time.

## The change

`--fresh-session` marks a series as stateless: each occurrence starts a clean agent conversation instead of resuming. **Off by default** — existing installs behave exactly as before.

```
ncl tasks create --name nightly --recurrence "0 4 * * *" --prompt "..." --fresh-session
ncl tasks update <series-id> --fresh-session true|false
```

- The flag rides the task's content JSON. `armNextTask` copies `content` forward verbatim, so it propagates to every future occurrence with **no schema change and no migration**.
- Settable on an existing series, not just at create — turning it on shouldn't cost you the run history, run log, and series id that cancel-and-recreate destroys. Omitting the flag on an update leaves the current value untouched (tri-state), which is tested explicitly.
- In the container, the poll-loop performs the same reset the `/clear` path already does, placed *after* the pre-task script gate so a fire the gate skipped costs nothing.
- Deliberately abandoning a continuation leaves a transcript nothing would ever rotate — `maybeRotateContinuation` only inspects the one it is about to resume. So `AgentProvider` gains an optional `abandonContinuation(continuation, reason)`; the Claude provider archives a summary and moves the `.jsonl` out of the resume path, reusing the retire tail rotation already had (extracted, behavior unchanged). Without this the projects dir grows one orphaned transcript per occurrence, forever.

## Tests

Host (vitest): default-off; flag persisted into content and echoed on create/get; carried forward by `handleRecurrence`; set/cleared/preserved through `updateTask`; CLI update path exercised through `dispatch` so the boolean arg validator runs.

Container (`bun:test`): the fresh-session predicate (off by default, on when set, never for chat rows, tolerant of legacy plain-string task content) and `abandonContinuation` archiving + retiring the transcript, no-op on an unknown session.

`tsc --noEmit` clean for both trees. Container suite 435 pass / 3 pre-existing skips.
