### PR TITLE
fix(cli): add-mount --rw, so a read-write mount is expressible (--ro is currently a no-op)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -95,6 +95,7 @@ private_key, .secret
 - The real path is rejected if it matches a blocked pattern, and rejected unless it sits under one of `allowedRoots`.
 - The container path is validated: relative, non-empty, no `..`, no leading `/`, no `:` (blocks Docker `-v` option injection). It is mounted under `/workspace/extra/`.
 - **Read-write is granted only when the mount requests it (`readonly: false`) *and* the matched root has `allowReadWrite: true`.** Otherwise the mount is forced read-only.
+  Both halves are expressible from the CLI: `ncl groups config add-mount --rw` records `readonly: false` (omitting it, or passing `--ro`, keeps the mount read-only), and the root gate still decides whether that request is honored.
 
 ### 3. Session Isolation
 

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -340,6 +340,71 @@ describe('groups config (host-only)', () => {
     expect(JSON.parse((await getContainerConfig(GID))!.additional_mounts)).toEqual([]);
   });
 
+  // Regression tests for #3690 — `--ro` was the only flag, so it produced either
+  // `readonly: true` or (when omitted) no key at all. `validateMount` treats an
+  // absent key exactly like `readonly: true`, which made `--ro` a no-op and left
+  // no sanctioned way to create a read-write mount. `--rw` is the opt-in; the
+  // conservative default is unchanged.
+  describe('add-mount readonly flags (#3690)', () => {
+    const GID = 'ag-mount-rw';
+    const mountsOf = async () => JSON.parse((await getContainerConfig(GID))!.additional_mounts);
+    const addMount = (id: string, extra: Record<string, unknown>) =>
+      dispatch(
+        {
+          id,
+          command: 'groups-config-add-mount',
+          args: { id: GID, host: '/data/shared', container: 'shared', ...extra },
+        },
+        { caller: 'host' },
+      );
+
+    beforeEach(async () => {
+      await createAgentGroup({ id: GID, name: 'mrw', folder: 'mrw', agent_provider: null, created_at: now() });
+      await ensureContainerConfig(GID);
+    });
+
+    it('--rw stores readonly: false, the only value mount-security reads as a read-write request', async () => {
+      const res = await addMount('rw-1', { rw: true });
+      expect(res.ok).toBe(true);
+      expect(await mountsOf()).toEqual([{ hostPath: '/data/shared', containerPath: 'shared', readonly: false }]);
+    });
+
+    it('with neither flag stores no readonly key — the conservative default, unchanged', async () => {
+      const res = await addMount('def-1', {});
+      expect(res.ok).toBe(true);
+      const mounts = await mountsOf();
+      expect(mounts).toEqual([{ hostPath: '/data/shared', containerPath: 'shared' }]);
+      expect('readonly' in mounts[0]).toBe(false);
+    });
+
+    it('--ro stores readonly: true', async () => {
+      const res = await addMount('ro-1', { ro: true });
+      expect(res.ok).toBe(true);
+      expect(await mountsOf()).toEqual([{ hostPath: '/data/shared', containerPath: 'shared', readonly: true }]);
+    });
+
+    it('flips an existing mount to read-write instead of silently doing nothing', async () => {
+      // The likeliest first use of --rw: a mount added read-only that now needs
+      // writes. The dedupe used to skip the write and still report success, so the
+      // operator restarted and got a still-read-only mount with nothing to say why.
+      expect((await addMount('flip-1', {})).ok).toBe(true);
+      expect((await mountsOf())[0].readonly).toBeUndefined();
+
+      const res = await addMount('flip-2', { rw: true });
+      expect(res.ok).toBe(true);
+      const mounts = await mountsOf();
+      expect(mounts).toHaveLength(1);
+      expect(mounts[0].readonly).toBe(false);
+    });
+
+    it('rejects --ro together with --rw and writes nothing', async () => {
+      const res = await addMount('both-1', { ro: true, rw: true });
+      expect(res.ok).toBe(false);
+      expect(errorMessage(res)).toBe('--ro and --rw are mutually exclusive');
+      expect(await mountsOf()).toEqual([]);
+    });
+  });
+
   describe("--speed validates against the tiers the group's provider declares", () => {
     const GID = 'ag-speed';
     const speedOf = async (): Promise<string | null> => (await getContainerConfig(GID))!.speed;

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -587,7 +587,10 @@ registerResource({
       description:
         "Mount a host directory into a group's containers. OPERATOR-ONLY — never runnable from " +
         'inside a container (mounting host paths is a filesystem-access boundary). Requires ' +
-        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> [--ro].',
+        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> ' +
+        '[--ro | --rw]. Mounts are read-only by default; --ro states that explicitly. --rw requests read-write, which ' +
+        'is granted only when the matched mount-allowlist root also has `allowReadWrite: true` — otherwise the mount ' +
+        'is still created but forced read-only at spawn time.',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
@@ -598,17 +601,36 @@ registerResource({
         const row = await getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
+        // Read-only remains the default: with neither flag, no `readonly` key is
+        // stored, and `validateMount` treats an absent key as a read-only request.
+        // `--rw` is the explicit opt-in that stores `readonly: false` — the only
+        // value the mount-security gate accepts as a read-write *request*, and
+        // still granted only if the matched allowlist root allows read-write.
+        const readWrite = args.rw === true || args.readonly === false;
+        const readOnly = args.ro === true || args.readonly === true;
+        if (readWrite && readOnly) throw new Error('--ro and --rw are mutually exclusive');
+
         const mount: AdditionalMountConfig = {
           hostPath,
           containerPath,
-          ...(args.ro || args.readonly ? { readonly: true } : {}),
+          ...(readWrite ? { readonly: false } : args.ro || args.readonly ? { readonly: true } : {}),
         };
         const existing = JSON.parse(row.additional_mounts) as AdditionalMountConfig[];
-        if (!existing.some((m) => m.hostPath === hostPath && m.containerPath === containerPath)) {
-          existing.push(mount);
-          await updateContainerConfigJson(id, 'additional_mounts', existing);
-        }
-        return { added: mount, note: `Run \`ncl groups restart --id ${id}\` for the mount to take effect.` };
+        const at = existing.findIndex((m) => m.hostPath === hostPath && m.containerPath === containerPath);
+        // Re-adding an existing mount used to be a silent no-op that still reported
+        // success. That makes the most likely use of these flags — "I mounted this
+        // read-only, now make it read-write" — restart the group and come back to a
+        // still-read-only mount with nothing to explain why. Update the access mode
+        // in place instead, and say which of the two happened.
+        const updated = at !== -1;
+        if (updated) existing[at] = mount;
+        else existing.push(mount);
+        await updateContainerConfigJson(id, 'additional_mounts', existing);
+        const note = readWrite
+          ? `Read-write requested. It is granted only if the matched mount-allowlist root has \`allowReadWrite: true\`; ` +
+            `otherwise the mount is forced read-only. Run \`ncl groups restart --id ${id}\` to apply.`
+          : `Run \`ncl groups restart --id ${id}\` for the mount to take effect.`;
+        return updated ? { updated: mount, note } : { added: mount, note };
       },
     },
     'config remove-mount': {


### PR DESCRIPTION
Fixes #3690.

## The bug, plus one part #3690 doesn't mention

`ncl groups config add-mount` cannot create a read-write mount — and **`--ro` is currently a no-op**.

The handler stores `readonly: true` when `--ro` is passed and **omits the key otherwise** (`src/cli/resources/groups.ts`). `validateMount` computes `requestedReadWrite = mount.readonly === false` and starts from `effectiveReadonly = true` (`src/modules/mount-security/index.ts`), so an *absent* key is a read-only request. The two shapes the CLI can produce are therefore identical at spawn time: passing `--ro` and omitting it do the same thing, and no CLI-created mount can ever be read-write — even when the matched allowlist root has `allowReadWrite: true`.

The help text points the other way: `[--ro]` reads as "read-write by default, opt out", the inverse of what the validator does.

**There is no sanctioned path to a read-write mount today.** `/manage-mounts` manages only the allowlist and never attaches a mount to a group; templates cannot declare mounts; the setup wizard doesn't write them. What remains is hand-editing `container.json` before a `container_configs` row exists, or raw SQL into that table — which `docs/skill-guidelines.md` calls "a smell, not a workaround". So an operator can grant `allowReadWrite: true` on a root and still have no supported way to use it.

## The change

Keep the conservative default exactly as it is and add an explicit opt-in.

```ts
const readWrite = args.rw === true || args.readonly === false;
const readOnly = args.ro === true || args.readonly === true;
if (readWrite && readOnly) throw new Error('--ro and --rw are mutually exclusive');
...(readWrite ? { readonly: false } : args.ro || args.readonly ? { readonly: true } : {}),
```

- **No default changes.** With neither flag, no `readonly` key is stored — byte-for-byte today's behaviour.
- `mount-security` is untouched. The two-gate design stays: the allowlist root is the operator's standing policy, the per-mount flag is the caller's request, and requiring both still stops a caller inheriting write access from a permissive root by accident. The bug was only that the CLI couldn't express one of the two gates.
- Help text now documents `[--ro | --rw]` and states that `--rw` is granted only when the matched root also has `allowReadWrite: true`.

### Deliberately different from the issue's first suggestion

#3690 proposes storing `readonly: false` by default when `--ro` is absent. That fixes the same breakage but flips the default to read-write, which changes behaviour for every existing caller and for hand-edited configs. An explicit `--rw` fixes it with no default change. Happy to switch if maintainers prefer the other shape.

### On the issue's second suggestion (echo the effective mode)

Not done, deliberately. Knowing the effective mode at add time means calling `validateMount()`, which loads the allowlist and `realpathSync`es the host path. That would make a pure DB-write handler fail (or report "read-only") for a path that doesn't exist yet but will by restart time, and would read a possibly-stale module-cached allowlist. Both are snapshots that can be wrong by spawn — a confidently wrong answer. Instead the `--rw` path returns a `note` naming the remaining gate, alongside `added`, which already shows what was stored.

## Why this is safe

`add-mount` is `hostOnly`, and `src/cli/guard.ts` denies `hostOnly` commands **before** scope and **before** approval, at any `cli_scope`. There is also no mount surface in the agent-side tool set — `container/agent-runner/src/mcp-tools/` has `install_packages` and `add_mcp_server` only — and `config update` handles scalars, so there's no back door to `additional_mounts`. Worst case is an operator writing a mount to a directory they have already marked `allowReadWrite: true` in a file that lives outside the project root precisely so containers can't reach it.

## Tests

Four new cases in `src/cli/resources/groups.test.ts`: `--rw` ⇒ `readonly: false`; neither flag ⇒ **no `readonly` key at all** (asserted with `'readonly' in mount === false`, which is what actually pins the default — the existing test only ever passed `ro: true`); `--ro` ⇒ `readonly: true`; `--ro` + `--rw` ⇒ rejected with nothing written.

`vitest run src/cli/resources/groups.test.ts src/modules/mount-security` → 2 files, 20 passed. `tsc --noEmit` clean, eslint clean on both changed files.

Note: `docs/SECURITY.md` does not pass `prettier --check`, but that is pre-existing on unmodified `main` — I left the formatting alone rather than balloon the diff. Also left alone as out of scope: `--ro false` parses as the truthy string `"false"` and still sets read-only. `--rw` is unaffected, being checked with `=== true`.
