### PR TITLE
feat: add AgentMail email channel adapter

### DIFF
--- a/.claude/skills/add-agentmail/REMOVE.md
+++ b/.claude/skills/add-agentmail/REMOVE.md
@@ -1,0 +1,38 @@
+# Remove AgentMail Email Channel
+
+Every step is idempotent — safe to re-run.
+
+## 1. Remove the adapter
+
+Delete the self-registration import from `src/channels/index.ts` (skip if
+already gone):
+
+```typescript
+import './agentmail.js';
+```
+
+Then delete the copied adapter and its registration test:
+
+```bash
+rm -f src/channels/agentmail.ts src/channels/agentmail-registration.test.ts
+```
+
+## 2. Remove credentials
+
+Remove `AGENTMAIL_API_KEY`, `AGENTMAIL_INBOX_ID`, and
+`AGENTMAIL_WEBHOOK_SECRET` from `.env`.
+
+## 3. Remove the packages
+
+```bash
+pnpm uninstall agentmail svix
+```
+
+## 4. Rebuild and restart
+
+```bash
+pnpm run build
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+# Linux: systemctl --user restart $(systemd_unit)
+```

--- a/.claude/skills/add-agentmail/REMOVE.md
+++ b/.claude/skills/add-agentmail/REMOVE.md
@@ -19,13 +19,14 @@ rm -f src/channels/agentmail.ts src/channels/agentmail-registration.test.ts
 
 ## 2. Remove credentials
 
-Remove `AGENTMAIL_API_KEY`, `AGENTMAIL_INBOX_ID`, and
-`AGENTMAIL_POLL_SCHEDULE` (if set) from `.env`.
+Remove `AGENTMAIL_API_KEY`, `AGENTMAIL_INBOX_ID`, `AGENTMAIL_MODE`,
+`AGENTMAIL_POLL_SCHEDULE`, and `AGENTMAIL_WEBHOOK_SECRET` (whichever are set —
+only one mode's variables will be) from `.env`.
 
-## 3. Remove the package
+## 3. Remove the packages
 
 ```bash
-pnpm uninstall agentmail
+pnpm uninstall agentmail svix
 ```
 
 ## 4. Rebuild and restart

--- a/.claude/skills/add-agentmail/REMOVE.md
+++ b/.claude/skills/add-agentmail/REMOVE.md
@@ -20,12 +20,12 @@ rm -f src/channels/agentmail.ts src/channels/agentmail-registration.test.ts
 ## 2. Remove credentials
 
 Remove `AGENTMAIL_API_KEY`, `AGENTMAIL_INBOX_ID`, and
-`AGENTMAIL_WEBHOOK_SECRET` from `.env`.
+`AGENTMAIL_POLL_INTERVAL_MS` (if set) from `.env`.
 
-## 3. Remove the packages
+## 3. Remove the package
 
 ```bash
-pnpm uninstall agentmail svix
+pnpm uninstall agentmail
 ```
 
 ## 4. Rebuild and restart

--- a/.claude/skills/add-agentmail/REMOVE.md
+++ b/.claude/skills/add-agentmail/REMOVE.md
@@ -20,7 +20,7 @@ rm -f src/channels/agentmail.ts src/channels/agentmail-registration.test.ts
 ## 2. Remove credentials
 
 Remove `AGENTMAIL_API_KEY`, `AGENTMAIL_INBOX_ID`, and
-`AGENTMAIL_POLL_INTERVAL_MS` (if set) from `.env`.
+`AGENTMAIL_POLL_SCHEDULE` (if set) from `.env`.
 
 ## 3. Remove the package
 

--- a/.claude/skills/add-agentmail/SKILL.md
+++ b/.claude/skills/add-agentmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-agentmail
-description: Add AgentMail (email) channel integration — a fully-managed agent inbox via API, no DNS/MX ownership and no public webhook endpoint required.
+description: Add AgentMail (email) channel integration — a fully-managed agent inbox via API. Choose polling (no public endpoint needed) or webhook (instant delivery) at install time.
 ---
 
 # Add AgentMail Email Channel
@@ -16,16 +16,35 @@ adapter in from the `channels` branch. There is no official Chat SDK adapter
 for AgentMail, so this is a **native** adapter (like DeltaChat, WhatsApp,
 Signal): it talks to the `agentmail` SDK directly.
 
-**Polling, not webhooks.** AgentMail supports both, but a webhook needs a
-public HTTPS endpoint reachable from AgentMail's servers — infrastructure not
-every install has. This adapter polls instead: no public endpoint, no DNS, no
-tunnel. The tradeoff is latency (new mail arrives on the poll schedule, not
-instantly) and a small periodic API call at each scheduled time.
+## Choose a mode
 
-Polling runs on a cron schedule (default: 4am/10am/4pm/10pm daily, install
-timezone) rather than a fixed interval, reusing the same `cron-parser`
-dependency already used for scheduled tasks — no new dependency to install for
-this part.
+AgentMail supports both webhooks and polling for inbound mail. Ask the user
+which one fits their install, before touching credentials:
+
+- **Polling (recommended, default)** — no public endpoint, no DNS, nothing to
+  expose. Checks for new mail on a schedule instead of instantly. Pick this
+  unless the install already has a public HTTPS endpoint reachable from the
+  internet.
+- **Webhook** — instant delivery, but requires a public HTTPS endpoint
+  reachable from AgentMail's servers (a reverse proxy, tunnel, or public
+  domain pointed at this host's port 3000). Pick this only if that already
+  exists.
+
+If polling, also ask **how often to check** — offer common presets and
+convert to the underlying cron expression (`AGENTMAIL_POLL_SCHEDULE`, install
+timezone):
+
+| User choice | Cron expression |
+|---|---|
+| Every 5 minutes | `*/5 * * * *` |
+| Every 15 minutes | `*/15 * * * *` |
+| Every 30 minutes | `*/30 * * * *` |
+| Hourly | `0 * * * *` |
+| Four times a day (4am/10am/4pm/10pm) — **default** | `0 4,10,16,22 * * *` |
+| Custom | ask for a raw cron expression |
+
+More frequent polling means faster replies but more periodic API calls —
+there's no wrong answer, just a latency/traffic tradeoff.
 
 ## Apply
 
@@ -50,23 +69,25 @@ is already present):
 import './agentmail.js';
 ```
 
-### 3. Install the adapter's dependency
+### 3. Install the adapter's dependencies
 
-Pinned to an exact version — the supply-chain policy rejects ranges and
+Pinned to exact versions — the supply-chain policy rejects ranges and
 `latest`:
 
 ```bash
-pnpm add agentmail@0.5.23
+pnpm add agentmail@0.5.23 svix@2.3.0
 ```
 
 `agentmail` is AgentMail's own Node SDK (inbox and message management, used
-here for both polling and sending).
+for both modes and for sending). `svix` verifies inbound webhook signatures —
+only exercised in webhook mode, but always installed so switching modes later
+never requires a fresh `pnpm add`.
 
 ### 4. Build and validate
 
-Build guards the adapter's typed use of the `agentmail` SDK; the registration
-test proves the dependency is actually installed (the adapter imports it — if
-missing, the barrel throws on import).
+Build guards the adapter's typed use of both SDKs; the registration test
+proves both dependencies are actually installed (the adapter imports both —
+if either is missing, the barrel throws on import).
 
 ```bash
 pnpm run build
@@ -75,8 +96,8 @@ pnpm exec vitest run src/channels/agentmail-registration.test.ts
 
 `agentmail-registration.test.ts` imports the real channel barrel and asserts
 the registry contains `agentmail`. It goes red if the import line is deleted
-or drifts, if the barrel fails to evaluate, or if `agentmail` isn't installed
-(the import throws).
+or drifts, if the barrel fails to evaluate, or if either package isn't
+installed (the import throws).
 
 ## Credentials
 
@@ -87,15 +108,15 @@ receive a message until they're done.
 1. Go to [agentmail.to](https://www.agentmail.to) and create an account.
 2. In the dashboard, go to **Inboxes** → **+ Create Inbox**. On the free plan
    the domain defaults to `agentmail.to` (e.g. `yourbot@agentmail.to`); pick a
-   username, or bring a verified custom domain if you have one. Copy the
-   **Inbox ID**.
+   username, or bring a verified custom domain if you have one. The inbox's
+   own email address **is** its Inbox ID — there's no separate opaque ID to
+   look up.
 3. Go to **API Keys** → **Create New API Key**. Copy it immediately — it is
    shown only once.
-
-No webhook to set up — polling only needs the API key and inbox ID. The inbox
-ID is the inbox's own email address (e.g. `yourbot@agentmail.to`) — there is
-no separate opaque ID to look up. If the dashboard only shows the address,
-that address *is* the inbox ID.
+4. **Webhook mode only** — go to **Webhooks** → **Create Webhook**:
+   - URL: `https://your-domain/webhook/agentmail`
+   - Event types: `message.received`
+   - Copy the webhook's **secret** (used for Svix signature verification).
 
 ### Store the credentials
 
@@ -103,38 +124,68 @@ that address *is* the inbox ID.
 # Ensure .env has these (set-if-absent — never overwrite a value you've already filled in)
 grep -q '^AGENTMAIL_API_KEY=' .env || echo 'AGENTMAIL_API_KEY=<paste API key>' >> .env
 grep -q '^AGENTMAIL_INBOX_ID=' .env || echo 'AGENTMAIL_INBOX_ID=<your inbox address>' >> .env
-# Optional — cron expression, install timezone; default is 4am/10am/4pm/10pm daily:
-grep -q '^AGENTMAIL_POLL_SCHEDULE=' .env || echo 'AGENTMAIL_POLL_SCHEDULE=0 4,10,16,22 * * *' >> .env
 ```
 
-Restart the service so it picks up the new `.env` values and starts polling:
+**Polling mode** (default — omit `AGENTMAIL_MODE` entirely, or set it explicitly):
+
+```bash
+grep -q '^AGENTMAIL_MODE=' .env || echo 'AGENTMAIL_MODE=polling' >> .env
+# Cron expression from the "Choose a mode" table above:
+grep -q '^AGENTMAIL_POLL_SCHEDULE=' .env || echo 'AGENTMAIL_POLL_SCHEDULE=<chosen cron expression>' >> .env
+```
+
+**Webhook mode**:
+
+```bash
+grep -q '^AGENTMAIL_MODE=' .env || echo 'AGENTMAIL_MODE=webhook' >> .env
+grep -q '^AGENTMAIL_WEBHOOK_SECRET=' .env || echo 'AGENTMAIL_WEBHOOK_SECRET=<paste webhook secret>' >> .env
+```
+
+Restart the service so it picks up the new `.env` values:
 
 ```bash
 launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
 # systemctl --user restart nanoclaw                # Linux
 ```
 
+Confirm the mode actually started as intended — the log line differs per
+mode: `AgentMail: adapter ready (polling mode)` (with `pollSchedule` and
+`nextPollAt`) or `AgentMail: adapter ready (webhook mode)`.
+
 ## Connect yourself
 
 Because AgentMail can originate a new thread (unlike a Resend-style adapter,
 which can only reply within a thread it received), the bot really can write
-to you first. Wire your own address as owner and have it email you a hello.
-Tell it your address and which agent should answer your email (`ncl groups
-list` shows their folders):
+to you first. Wire your own address as owner and trigger its welcome
+behavior. Tell it your address and which agent should answer your email
+(`ncl groups list` shows their folders):
 
 ```bash
 ncl users create --id agentmail:<your-address> --kind agentmail --display-name Owner
 ncl roles grant --user agentmail:<your-address> --role owner
 ncl messaging-groups create --channel-type agentmail --platform-id agentmail:<your-address> --is-group 0
 ncl wirings create --channel-type agentmail --platform-id agentmail:<your-address> --agent-group <agent-folder> --engage-mode pattern --engage-pattern .
-ncl messaging-groups send --channel-type agentmail --platform-id agentmail:<your-address> --sender-id agentmail:<your-address> --sender Owner --text "Hi — I'm your NanoClaw assistant, reachable by email now. Reply to this thread anytime."
+ncl messaging-groups send --channel-type agentmail --platform-id agentmail:<your-address> --sender-id agentmail:<your-address> --sender Owner --text "This email channel was just connected. Follow the welcome skill exactly: introduce yourself and confirm email works by sending me a short welcome email now, then reply to any follow-up in this same thread."
 ```
 
-The last command injects a synthetic inbound message to wake the agent, which
-then composes and sends the real first email via `messages.send`. Reply to
-that email to keep the conversation going — your reply is picked up at the
-next scheduled poll (`AGENTMAIL_POLL_SCHEDULE`), which may be several hours
-away on the default schedule.
+**Why the `--text` reads as a third-person instruction, not a greeting to
+relay verbatim:** `ncl messaging-groups send` (see `ncl messaging-groups help
+send`) injects its `--text` as an *inbound* message — the agent receives it as
+something someone said to it, not as a script to read aloud. Phrasing it as
+the literal greeting ("Hi, I'm your assistant...") backfires: the agent reads
+that as the owner narrating in the bot's own voice, treats it as a passive FYI
+about the channel, and never actually sends anything. Every other channel's
+first-contact trigger in this codebase uses the same third-person-event +
+explicit-instruction shape (see `src/channels/telegram.ts`'s own connect
+message: *"This Telegram group was just connected. Follow the welcome skill
+exactly..."*) — mirror that shape for any channel's hello step, don't write
+the greeting text directly into `--text`.
+
+The command wakes the agent, which composes and sends the real welcome email
+via `messages.send`. Reply to that email to keep the conversation going — in
+polling mode, your reply is picked up at the next scheduled poll (which may
+be hours away on the default four-times-a-day schedule); in webhook mode, it
+arrives instantly.
 
 Consider granting a role scoped to one agent group instead of a global
 `owner`, per your own risk tolerance — see `ncl roles help grant`.
@@ -156,15 +207,16 @@ approval card fires.)
   is a separate conversation, keyed by *their* address.
 - **how-to-find-id**: the platform ID is the **correspondent's** email
   address, prefixed — `agentmail:<their-address>` — **not** the inbox's own
-  address. The adapter derives it from the polled message's `from` field.
+  address. The adapter derives it from the sender's `from` field, whichever
+  mode delivered it.
 - **supports-threads**: no — every email from one correspondent (regardless
   of subject) lands in the same NanoClaw session, matching the Resend
   adapter's model. AgentMail's own thread/message IDs are still used
   internally so replies land in the correct email thread from the
   correspondent's point of view.
 - **typical-use**: async communication — email conversations with longer
-  response expectations; polling adds up to one interval of extra latency on
-  top of that.
+  response expectations; polling mode adds up to one poll interval of extra
+  latency on top of that.
 - **default-isolation**: same agent group if you want your agent to handle
   email alongside other channels. Separate agent group if email contains
   sensitive correspondence that shouldn't be accessible from other channels.
@@ -175,15 +227,27 @@ approval card fires.)
 **API Keys** page and is shown only once at creation — if in doubt, create a
 new one and update `AGENTMAIL_API_KEY` in `.env`.
 
-**Replies never arrive, or arrive very late.** Confirm the service actually
-restarted after `.env` was updated (check the log line `AgentMail: adapter
-ready, polling scheduled` — it also logs `nextPollAt`, so you can see exactly
-when the next check happens). Otherwise it's most likely just poll latency —
-add more times to `AGENTMAIL_POLL_SCHEDULE` if the default four-times-a-day
-cadence is too slow, at the cost of more frequent API calls.
+**Replies never arrive, or arrive very late (polling mode).** Confirm the
+service actually restarted after `.env` was updated (check for the log line
+`AgentMail: adapter ready (polling mode)` — it also logs `nextPollAt`, so you
+can see exactly when the next check happens). Otherwise it's just poll
+latency — tighten `AGENTMAIL_POLL_SCHEDULE` if the chosen cadence is too slow,
+at the cost of more frequent API calls.
+
+**Webhook signature verification fails (every inbound email is dropped with a
+`401`), webhook mode.** `AGENTMAIL_WEBHOOK_SECRET` must match the secret shown
+for the *specific* webhook pointed at `/webhook/agentmail` — each webhook has
+its own secret. Re-copy it from the dashboard's **Webhooks** page if in doubt.
+
+**Replies never reach the agent, webhook mode.** Confirm the webhook in the
+dashboard is enabled, points at your public host's `/webhook/agentmail`
+(shared webhook server, port 3000), and has `message.received` selected. The
+dashboard's webhook page lists recent delivery attempts — a run of failures
+usually means the URL is unreachable from AgentMail's servers (check
+firewall/reverse proxy in front of port 3000).
 
 **Adapter installed but nothing flows.** Run `pnpm exec vitest run
 src/channels/agentmail-registration.test.ts` — red means the barrel import or
-the `agentmail` package install drifted, so re-run the Apply steps. If green,
-restart the service so it loads the adapter and `.env`, then re-send the
-hello.
+one of the two package installs (`agentmail`, `svix`) drifted, so re-run the
+Apply steps. If green, restart the service so it loads the adapter and
+`.env`, then re-send the hello.

--- a/.claude/skills/add-agentmail/SKILL.md
+++ b/.claude/skills/add-agentmail/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: add-agentmail
+description: Add AgentMail (email) channel integration — a fully-managed agent inbox via API, no DNS/MX ownership required.
+---
+
+# Add AgentMail Email Channel
+
+Connect NanoClaw to email via [AgentMail](https://www.agentmail.to) — an email
+inbox API built specifically for AI agents. Unlike a channel built on your own
+domain's mail routing (e.g. Resend), AgentMail provisions and hosts the inbox
+itself, so there is no MX record to add or conflict with an existing mail
+provider on your domain.
+
+NanoClaw doesn't ship channels in trunk — this skill copies the AgentMail
+adapter in from the `channels` branch. There is no official Chat SDK adapter
+for AgentMail, so this is a **native** adapter (like DeltaChat, WhatsApp,
+Signal): it talks to the `agentmail` SDK directly and registers its own raw
+webhook route.
+
+## Apply
+
+### 1. Copy the adapter
+
+Fetch the `channels` branch and copy the AgentMail adapter into
+`src/channels/` (overwrite — the branch is canonical):
+
+```bash
+git fetch origin channels
+git show origin/channels:src/channels/agentmail.ts > src/channels/agentmail.ts
+git show origin/channels:src/channels/agentmail-registration.test.ts > src/channels/agentmail-registration.test.ts
+```
+
+### 2. Register the adapter
+
+Append the self-registration import to the channel barrel (skip if the line
+is already present):
+
+```typescript
+// src/channels/index.ts
+import './agentmail.js';
+```
+
+### 3. Install the adapter's dependencies
+
+Pinned to exact versions — the supply-chain policy rejects ranges and
+`latest`:
+
+```bash
+pnpm add agentmail@0.5.23 svix@2.3.0
+```
+
+`agentmail` is AgentMail's own Node SDK (inbox, message, and webhook
+management). `svix` verifies inbound webhook signatures — AgentMail delivers
+webhooks via Svix and hands you a per-webhook secret to verify against.
+
+### 4. Build and validate
+
+Build guards the adapter's typed use of the `agentmail` SDK; the registration
+test proves both dependencies are actually installed (the adapter imports
+both — if either is missing, the barrel throws on import).
+
+```bash
+pnpm run build
+pnpm exec vitest run src/channels/agentmail-registration.test.ts
+```
+
+`agentmail-registration.test.ts` imports the real channel barrel and asserts
+the registry contains `agentmail`. It goes red if the import line is deleted
+or drifts, if the barrel fails to evaluate, or if either `agentmail` or
+`svix` isn't installed (the import throws).
+
+## Credentials
+
+Inbox and webhook setup is human and interactive — these steps are prose, not
+a script. A recipe rebuild produces a compiling, registered adapter that
+cannot receive a message until they're done.
+
+1. Go to [agentmail.to](https://www.agentmail.to) and create an account.
+2. In the dashboard, go to **Inboxes** → **+ Create Inbox**. On the free plan
+   the domain defaults to `agentmail.to` (e.g. `yourbot@agentmail.to`); pick a
+   username, or bring a verified custom domain if you have one. Copy the
+   **Inbox ID**.
+3. Go to **API Keys** → **Create New API Key**. Copy it immediately — it is
+   shown only once.
+4. Go to **Webhooks** → **Create Webhook**:
+   - URL: `https://your-domain/webhook/agentmail`
+   - Event types: `message.received`
+   - Copy the webhook's **secret** (used for Svix signature verification).
+
+### Store the credentials
+
+```bash
+# Ensure .env has these three (set-if-absent — never overwrite a value you've already filled in)
+grep -q '^AGENTMAIL_API_KEY=' .env || echo 'AGENTMAIL_API_KEY=<paste API key>' >> .env
+grep -q '^AGENTMAIL_INBOX_ID=' .env || echo 'AGENTMAIL_INBOX_ID=<paste inbox id>' >> .env
+grep -q '^AGENTMAIL_WEBHOOK_SECRET=' .env || echo 'AGENTMAIL_WEBHOOK_SECRET=<paste webhook secret>' >> .env
+```
+
+Rebuild the container image if any group needs it, then restart the service so
+it picks up the new `.env` values and the registered `agentmail` webhook
+route:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+# systemctl --user restart nanoclaw                # Linux
+```
+
+## Connect yourself
+
+Because AgentMail can originate a new thread (unlike a Resend-style adapter,
+which can only reply within a thread it received), the bot really can write
+to you first. Wire your own address as owner and have it email you a hello.
+Tell it your address and which agent should answer your email (`ncl groups
+list` shows their folders):
+
+```bash
+ncl users create --id agentmail:<your-address> --kind agentmail --display-name Owner
+ncl roles grant --user agentmail:<your-address> --role owner
+ncl messaging-groups create --channel-type agentmail --platform-id agentmail:<your-address> --is-group 0
+ncl wirings create --channel-type agentmail --platform-id agentmail:<your-address> --agent-group <agent-folder> --engage-mode pattern --engage-pattern .
+ncl messaging-groups send --channel-type agentmail --platform-id agentmail:<your-address> --sender-id agentmail:<your-address> --sender Owner --text "Hi — I'm your NanoClaw assistant, reachable by email now. Reply to this thread anytime."
+```
+
+The last command injects a synthetic inbound message to wake the agent, which
+then composes and sends the real first email via `messages.send`. Reply to
+that email to keep the conversation going.
+
+Consider granting a role scoped to one agent group instead of a global
+`owner`, per your own risk tolerance — see `ncl roles help grant`.
+
+## Next Steps
+
+If you're in the middle of `/setup`, return to the setup flow now. (Answering
+an *open* inbox — anyone who emails in, not just you — is a separate,
+not-yet-wired case: email is plain-message, so the router never auto-creates
+a group for an unknown sender; each correspondent's `agentmail:<their-address>`
+must be wired explicitly, or use `ncl members add` after an unknown-sender
+approval card fires.)
+
+## Channel Info
+
+- **type**: `agentmail`
+- **terminology**: one AgentMail inbox (`AGENTMAIL_INBOX_ID`) is the bot's
+  fixed sending identity; every *external correspondent* the bot emails with
+  is a separate conversation, keyed by *their* address.
+- **how-to-find-id**: the platform ID is the **correspondent's** email
+  address, prefixed — `agentmail:<their-address>` — **not** the inbox's own
+  address. The adapter derives it from the webhook's `message.from` field.
+- **supports-threads**: no — every email from one correspondent (regardless
+  of subject) lands in the same NanoClaw session, matching the Resend
+  adapter's model. AgentMail's own thread/message IDs are still used
+  internally so replies land in the correct email thread from the
+  correspondent's point of view.
+- **typical-use**: async communication — email conversations with longer
+  response expectations.
+- **default-isolation**: same agent group if you want your agent to handle
+  email alongside other channels. Separate agent group if email contains
+  sensitive correspondence that shouldn't be accessible from other channels.
+
+## Troubleshooting
+
+**Sends fail with 401 from AgentMail.** The API key comes from the dashboard's
+**API Keys** page and is shown only once at creation — if in doubt, create a
+new one and update `AGENTMAIL_API_KEY` in `.env`.
+
+**Webhook signature verification fails (every inbound email is dropped with a
+`401`).** `AGENTMAIL_WEBHOOK_SECRET` must match the secret shown for the
+*specific* webhook pointed at `/webhook/agentmail` — each webhook has its own
+secret. Re-copy it from the dashboard's **Webhooks** page if in doubt.
+
+**Replies never reach the agent.** Confirm the webhook in the dashboard is
+enabled, points at your public host's `/webhook/agentmail` (shared webhook
+server, port 3000), and has `message.received` selected. The dashboard's
+webhook page lists recent delivery attempts — a run of failures usually means
+the URL is unreachable from AgentMail's servers (check firewall/reverse proxy
+in front of port 3000).
+
+**Adapter installed but nothing flows.** Run `pnpm exec vitest run
+src/channels/agentmail-registration.test.ts` — red means the barrel import or
+one of the two package installs (`agentmail`, `svix`) drifted, so re-run the
+Apply steps. If green, restart the service so it loads the adapter and
+`.env`, then re-send the hello.

--- a/.claude/skills/add-agentmail/SKILL.md
+++ b/.claude/skills/add-agentmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-agentmail
-description: Add AgentMail (email) channel integration — a fully-managed agent inbox via API, no DNS/MX ownership required.
+description: Add AgentMail (email) channel integration — a fully-managed agent inbox via API, no DNS/MX ownership and no public webhook endpoint required.
 ---
 
 # Add AgentMail Email Channel
@@ -14,8 +14,13 @@ provider on your domain.
 NanoClaw doesn't ship channels in trunk — this skill copies the AgentMail
 adapter in from the `channels` branch. There is no official Chat SDK adapter
 for AgentMail, so this is a **native** adapter (like DeltaChat, WhatsApp,
-Signal): it talks to the `agentmail` SDK directly and registers its own raw
-webhook route.
+Signal): it talks to the `agentmail` SDK directly.
+
+**Polling, not webhooks.** AgentMail supports both, but a webhook needs a
+public HTTPS endpoint reachable from AgentMail's servers — infrastructure not
+every install has. This adapter polls instead: no public endpoint, no DNS, no
+tunnel. The tradeoff is latency (new mail arrives on the poll interval, not
+instantly) and a small periodic API call even when nothing's happening.
 
 ## Apply
 
@@ -40,24 +45,23 @@ is already present):
 import './agentmail.js';
 ```
 
-### 3. Install the adapter's dependencies
+### 3. Install the adapter's dependency
 
-Pinned to exact versions — the supply-chain policy rejects ranges and
+Pinned to an exact version — the supply-chain policy rejects ranges and
 `latest`:
 
 ```bash
-pnpm add agentmail@0.5.23 svix@2.3.0
+pnpm add agentmail@0.5.23
 ```
 
-`agentmail` is AgentMail's own Node SDK (inbox, message, and webhook
-management). `svix` verifies inbound webhook signatures — AgentMail delivers
-webhooks via Svix and hands you a per-webhook secret to verify against.
+`agentmail` is AgentMail's own Node SDK (inbox and message management, used
+here for both polling and sending).
 
 ### 4. Build and validate
 
 Build guards the adapter's typed use of the `agentmail` SDK; the registration
-test proves both dependencies are actually installed (the adapter imports
-both — if either is missing, the barrel throws on import).
+test proves the dependency is actually installed (the adapter imports it — if
+missing, the barrel throws on import).
 
 ```bash
 pnpm run build
@@ -66,14 +70,14 @@ pnpm exec vitest run src/channels/agentmail-registration.test.ts
 
 `agentmail-registration.test.ts` imports the real channel barrel and asserts
 the registry contains `agentmail`. It goes red if the import line is deleted
-or drifts, if the barrel fails to evaluate, or if either `agentmail` or
-`svix` isn't installed (the import throws).
+or drifts, if the barrel fails to evaluate, or if `agentmail` isn't installed
+(the import throws).
 
 ## Credentials
 
-Inbox and webhook setup is human and interactive — these steps are prose, not
-a script. A recipe rebuild produces a compiling, registered adapter that
-cannot receive a message until they're done.
+Inbox setup is human and interactive — these steps are prose, not a script. A
+recipe rebuild produces a compiling, registered adapter that cannot send or
+receive a message until they're done.
 
 1. Go to [agentmail.to](https://www.agentmail.to) and create an account.
 2. In the dashboard, go to **Inboxes** → **+ Create Inbox**. On the free plan
@@ -82,23 +86,20 @@ cannot receive a message until they're done.
    **Inbox ID**.
 3. Go to **API Keys** → **Create New API Key**. Copy it immediately — it is
    shown only once.
-4. Go to **Webhooks** → **Create Webhook**:
-   - URL: `https://your-domain/webhook/agentmail`
-   - Event types: `message.received`
-   - Copy the webhook's **secret** (used for Svix signature verification).
+
+No webhook to set up — polling only needs the API key and inbox ID.
 
 ### Store the credentials
 
 ```bash
-# Ensure .env has these three (set-if-absent — never overwrite a value you've already filled in)
+# Ensure .env has these (set-if-absent — never overwrite a value you've already filled in)
 grep -q '^AGENTMAIL_API_KEY=' .env || echo 'AGENTMAIL_API_KEY=<paste API key>' >> .env
 grep -q '^AGENTMAIL_INBOX_ID=' .env || echo 'AGENTMAIL_INBOX_ID=<paste inbox id>' >> .env
-grep -q '^AGENTMAIL_WEBHOOK_SECRET=' .env || echo 'AGENTMAIL_WEBHOOK_SECRET=<paste webhook secret>' >> .env
+# Optional — poll interval in ms, default 30000 (30s) if omitted:
+grep -q '^AGENTMAIL_POLL_INTERVAL_MS=' .env || echo 'AGENTMAIL_POLL_INTERVAL_MS=30000' >> .env
 ```
 
-Rebuild the container image if any group needs it, then restart the service so
-it picks up the new `.env` values and the registered `agentmail` webhook
-route:
+Restart the service so it picks up the new `.env` values and starts polling:
 
 ```bash
 launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
@@ -123,7 +124,8 @@ ncl messaging-groups send --channel-type agentmail --platform-id agentmail:<your
 
 The last command injects a synthetic inbound message to wake the agent, which
 then composes and sends the real first email via `messages.send`. Reply to
-that email to keep the conversation going.
+that email to keep the conversation going — your reply is picked up on the
+next poll tick (up to `AGENTMAIL_POLL_INTERVAL_MS` later).
 
 Consider granting a role scoped to one agent group instead of a global
 `owner`, per your own risk tolerance — see `ncl roles help grant`.
@@ -145,14 +147,15 @@ approval card fires.)
   is a separate conversation, keyed by *their* address.
 - **how-to-find-id**: the platform ID is the **correspondent's** email
   address, prefixed — `agentmail:<their-address>` — **not** the inbox's own
-  address. The adapter derives it from the webhook's `message.from` field.
+  address. The adapter derives it from the polled message's `from` field.
 - **supports-threads**: no — every email from one correspondent (regardless
   of subject) lands in the same NanoClaw session, matching the Resend
   adapter's model. AgentMail's own thread/message IDs are still used
   internally so replies land in the correct email thread from the
   correspondent's point of view.
 - **typical-use**: async communication — email conversations with longer
-  response expectations.
+  response expectations; polling adds up to one interval of extra latency on
+  top of that.
 - **default-isolation**: same agent group if you want your agent to handle
   email alongside other channels. Separate agent group if email contains
   sensitive correspondence that shouldn't be accessible from other channels.
@@ -163,20 +166,14 @@ approval card fires.)
 **API Keys** page and is shown only once at creation — if in doubt, create a
 new one and update `AGENTMAIL_API_KEY` in `.env`.
 
-**Webhook signature verification fails (every inbound email is dropped with a
-`401`).** `AGENTMAIL_WEBHOOK_SECRET` must match the secret shown for the
-*specific* webhook pointed at `/webhook/agentmail` — each webhook has its own
-secret. Re-copy it from the dashboard's **Webhooks** page if in doubt.
-
-**Replies never reach the agent.** Confirm the webhook in the dashboard is
-enabled, points at your public host's `/webhook/agentmail` (shared webhook
-server, port 3000), and has `message.received` selected. The dashboard's
-webhook page lists recent delivery attempts — a run of failures usually means
-the URL is unreachable from AgentMail's servers (check firewall/reverse proxy
-in front of port 3000).
+**Replies never arrive, or arrive very late.** Confirm the service actually
+restarted after `.env` was updated (check the log line `AgentMail: adapter
+ready, polling started`). Otherwise it's most likely just poll latency —
+lower `AGENTMAIL_POLL_INTERVAL_MS` if the default 30s is too slow, at the cost
+of more frequent API calls.
 
 **Adapter installed but nothing flows.** Run `pnpm exec vitest run
 src/channels/agentmail-registration.test.ts` — red means the barrel import or
-one of the two package installs (`agentmail`, `svix`) drifted, so re-run the
-Apply steps. If green, restart the service so it loads the adapter and
-`.env`, then re-send the hello.
+the `agentmail` package install drifted, so re-run the Apply steps. If green,
+restart the service so it loads the adapter and `.env`, then re-send the
+hello.

--- a/.claude/skills/add-agentmail/SKILL.md
+++ b/.claude/skills/add-agentmail/SKILL.md
@@ -19,8 +19,13 @@ Signal): it talks to the `agentmail` SDK directly.
 **Polling, not webhooks.** AgentMail supports both, but a webhook needs a
 public HTTPS endpoint reachable from AgentMail's servers — infrastructure not
 every install has. This adapter polls instead: no public endpoint, no DNS, no
-tunnel. The tradeoff is latency (new mail arrives on the poll interval, not
-instantly) and a small periodic API call even when nothing's happening.
+tunnel. The tradeoff is latency (new mail arrives on the poll schedule, not
+instantly) and a small periodic API call at each scheduled time.
+
+Polling runs on a cron schedule (default: 4am/10am/4pm/10pm daily, install
+timezone) rather than a fixed interval, reusing the same `cron-parser`
+dependency already used for scheduled tasks — no new dependency to install for
+this part.
 
 ## Apply
 
@@ -87,16 +92,19 @@ receive a message until they're done.
 3. Go to **API Keys** → **Create New API Key**. Copy it immediately — it is
    shown only once.
 
-No webhook to set up — polling only needs the API key and inbox ID.
+No webhook to set up — polling only needs the API key and inbox ID. The inbox
+ID is the inbox's own email address (e.g. `yourbot@agentmail.to`) — there is
+no separate opaque ID to look up. If the dashboard only shows the address,
+that address *is* the inbox ID.
 
 ### Store the credentials
 
 ```bash
 # Ensure .env has these (set-if-absent — never overwrite a value you've already filled in)
 grep -q '^AGENTMAIL_API_KEY=' .env || echo 'AGENTMAIL_API_KEY=<paste API key>' >> .env
-grep -q '^AGENTMAIL_INBOX_ID=' .env || echo 'AGENTMAIL_INBOX_ID=<paste inbox id>' >> .env
-# Optional — poll interval in ms, default 30000 (30s) if omitted:
-grep -q '^AGENTMAIL_POLL_INTERVAL_MS=' .env || echo 'AGENTMAIL_POLL_INTERVAL_MS=30000' >> .env
+grep -q '^AGENTMAIL_INBOX_ID=' .env || echo 'AGENTMAIL_INBOX_ID=<your inbox address>' >> .env
+# Optional — cron expression, install timezone; default is 4am/10am/4pm/10pm daily:
+grep -q '^AGENTMAIL_POLL_SCHEDULE=' .env || echo 'AGENTMAIL_POLL_SCHEDULE=0 4,10,16,22 * * *' >> .env
 ```
 
 Restart the service so it picks up the new `.env` values and starts polling:
@@ -124,8 +132,9 @@ ncl messaging-groups send --channel-type agentmail --platform-id agentmail:<your
 
 The last command injects a synthetic inbound message to wake the agent, which
 then composes and sends the real first email via `messages.send`. Reply to
-that email to keep the conversation going — your reply is picked up on the
-next poll tick (up to `AGENTMAIL_POLL_INTERVAL_MS` later).
+that email to keep the conversation going — your reply is picked up at the
+next scheduled poll (`AGENTMAIL_POLL_SCHEDULE`), which may be several hours
+away on the default schedule.
 
 Consider granting a role scoped to one agent group instead of a global
 `owner`, per your own risk tolerance — see `ncl roles help grant`.
@@ -168,9 +177,10 @@ new one and update `AGENTMAIL_API_KEY` in `.env`.
 
 **Replies never arrive, or arrive very late.** Confirm the service actually
 restarted after `.env` was updated (check the log line `AgentMail: adapter
-ready, polling started`). Otherwise it's most likely just poll latency —
-lower `AGENTMAIL_POLL_INTERVAL_MS` if the default 30s is too slow, at the cost
-of more frequent API calls.
+ready, polling scheduled` — it also logs `nextPollAt`, so you can see exactly
+when the next check happens). Otherwise it's most likely just poll latency —
+add more times to `AGENTMAIL_POLL_SCHEDULE` if the default four-times-a-day
+cadence is too slow, at the cost of more frequent API calls.
 
 **Adapter installed but nothing flows.** Run `pnpm exec vitest run
 src/channels/agentmail-registration.test.ts` — red means the barrel import or

--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
     "@onecli-sh/sdk": "2.2.1",
+    "agentmail": "0.5.23",
     "better-sqlite3": "13.0.3",
     "chat": "4.29.0",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
+    "svix": "2.3.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chat": "4.29.0",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
+    "svix": "2.3.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chat": "4.29.0",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
-    "svix": "2.3.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@onecli-sh/sdk':
         specifier: 2.2.1
         version: 2.2.1
+      agentmail:
+        specifier: 0.5.23
+        version: 0.5.23
       better-sqlite3:
         specifier: 13.0.3
         version: 13.0.3
@@ -29,6 +32,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      svix:
+        specifier: 2.3.0
+        version: 2.3.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -411,6 +417,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -547,6 +556,15 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentmail@0.5.23:
+    resolution: {integrity: sha512-s1ZfwNlsaH9JYaHbqhsl7zuFwxdByGWvXUnKyK/aMekFUmLg5QXBc+s7aXSutKv1wWHM3SAi8s4VljoQpaoAPA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@x402/fetch': ^2
+    peerDependenciesMeta:
+      '@x402/fetch':
+        optional: true
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -745,6 +763,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
@@ -1200,6 +1221,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.1.1:
+    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -1210,6 +1234,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  svix@2.3.0:
+    resolution: {integrity: sha512-p7z7VEJ+C/3D6NvY61E3I8VEqXy1nNiNliG2HjQ1G6ykRTUoCwGzwh0SQfeJ51k89OSpdJuQmO4QF6fMeylHDQ==}
+    engines: {node: '>=22'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1383,6 +1411,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -1625,6 +1665,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1802,6 +1844,13 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agentmail@0.5.23:
+    dependencies:
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ajv@6.14.0:
     dependencies:
@@ -2020,6 +2069,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@1.2.1: {}
 
@@ -2600,6 +2651,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.1.1:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -2607,6 +2663,10 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  svix@2.3.0:
+    dependencies:
+      standardwebhooks: 1.1.1
 
   tinybench@2.9.0: {}
 
@@ -2748,6 +2808,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.21.3: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
-      svix:
-        specifier: 2.3.0
-        version: 2.3.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -417,9 +414,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
-  '@stablelib/base64@1.0.1':
-    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -763,9 +757,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
@@ -1221,9 +1212,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  standardwebhooks@1.1.1:
-    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
-
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -1234,10 +1222,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  svix@2.3.0:
-    resolution: {integrity: sha512-p7z7VEJ+C/3D6NvY61E3I8VEqXy1nNiNliG2HjQ1G6ykRTUoCwGzwh0SQfeJ51k89OSpdJuQmO4QF6fMeylHDQ==}
-    engines: {node: '>=22'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1665,8 +1649,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
-  '@stablelib/base64@1.0.1': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -2069,8 +2051,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@1.2.1: {}
 
@@ -2651,11 +2631,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standardwebhooks@1.1.1:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      fast-sha256: 1.3.0
-
   std-env@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -2663,10 +2638,6 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  svix@2.3.0:
-    dependencies:
-      standardwebhooks: 1.1.1
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      svix:
+        specifier: 2.3.0
+        version: 2.3.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -414,6 +417,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -757,6 +763,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
@@ -1212,6 +1221,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.1.1:
+    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -1222,6 +1234,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  svix@2.3.0:
+    resolution: {integrity: sha512-p7z7VEJ+C/3D6NvY61E3I8VEqXy1nNiNliG2HjQ1G6ykRTUoCwGzwh0SQfeJ51k89OSpdJuQmO4QF6fMeylHDQ==}
+    engines: {node: '>=22'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1649,6 +1665,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -2051,6 +2069,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@1.2.1: {}
 
@@ -2631,6 +2651,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.1.1:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -2638,6 +2663,10 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  svix@2.3.0:
+    dependencies:
+      standardwebhooks: 1.1.1
 
   tinybench@2.9.0: {}
 

--- a/src/channels/agentmail-registration.test.ts
+++ b/src/channels/agentmail-registration.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Integration test for the agentmail channel's single reach-in: the
+ * self-registration import in the `src/channels/index.ts` barrel. Importing the
+ * barrel runs agentmail.ts's top-level `registerChannelAdapter('agentmail', …)`;
+ * without the import the channel is silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. This reflects what happens at host boot — if the
+ * `import './agentmail.js';` line is deleted, or the barrel fails to evaluate for
+ * any reason (so the channel genuinely would not register), this goes red. A
+ * structural check of the import line would falsely pass in that second case.
+ *
+ * Importing the barrel is safe: registration is a pure top-level call, and
+ * agentmail.ts only constructs AgentMailClient / SvixWebhook inside the
+ * factory (invoked at host startup, not at import) and only calls the
+ * AgentMail API inside setup() — nothing network-bound happens here. It does
+ * require both adapter packages (`agentmail`, `svix`) to be installed, which
+ * holds in a composed install: the skill's `pnpm install` step runs before
+ * this test — so this test also implicitly guards those dependencies (an
+ * unmocked import throws if either package is missing).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('agentmail channel registration', () => {
+  it('registers agentmail via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('agentmail');
+  });
+});

--- a/src/channels/agentmail-registration.test.ts
+++ b/src/channels/agentmail-registration.test.ts
@@ -11,13 +11,13 @@
  * structural check of the import line would falsely pass in that second case.
  *
  * Importing the barrel is safe: registration is a pure top-level call, and
- * agentmail.ts only constructs AgentMailClient / SvixWebhook inside the
- * factory (invoked at host startup, not at import) and only calls the
- * AgentMail API inside setup() — nothing network-bound happens here. It does
- * require both adapter packages (`agentmail`, `svix`) to be installed, which
+ * agentmail.ts only constructs AgentMailClient inside the factory (invoked at
+ * host startup, not at import) and only calls the AgentMail API inside
+ * setup() (poll loop starts there too) — nothing network-bound happens here.
+ * It does require the adapter package (`agentmail`) to be installed, which
  * holds in a composed install: the skill's `pnpm install` step runs before
- * this test — so this test also implicitly guards those dependencies (an
- * unmocked import throws if either package is missing).
+ * this test — so this test also implicitly guards that dependency (an
+ * unmocked import throws if the package is missing).
  */
 import { describe, it, expect } from 'vitest';
 

--- a/src/channels/agentmail.ts
+++ b/src/channels/agentmail.ts
@@ -5,25 +5,36 @@
  * external correspondent is a separate messaging group, platformId
  * "agentmail:<their-address>" — same flattened model as the Resend adapter,
  * chosen for parity: one NanoClaw session per correspondent, regardless of how
- * many distinct email subject-threads they start. Unlike Resend's adapter,
- * AgentMail's SDK can originate a brand-new thread (`messages.send`) as well as
- * reply within one (`messages.reply`), so there is no cold-start limitation —
- * the bot can email a correspondent first.
+ * many distinct email subject-threads they start.
  *
- * Required env vars (.env): AGENTMAIL_API_KEY, AGENTMAIL_INBOX_ID,
- *                           AGENTMAIL_WEBHOOK_SECRET
+ * Polling, not webhooks: AgentMail supports both, but a webhook needs a public
+ * HTTPS endpoint reachable from AgentMail's servers, which not every install
+ * has. Polling needs nothing but outbound API calls. Unlike Resend's adapter,
+ * AgentMail's SDK can originate a brand-new thread (`messages.send`) as well
+ * as reply within one (`messages.reply`), so there is no cold-start
+ * limitation — the bot can email a correspondent first.
+ *
+ * Required env vars (.env): AGENTMAIL_API_KEY, AGENTMAIL_INBOX_ID
+ * Optional env vars (.env): AGENTMAIL_POLL_INTERVAL_MS (default: 30000)
  */
 import { AgentMailClient } from 'agentmail';
-import { Webhook as SvixWebhook } from 'svix';
 
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
-import { registerWebhookHandler } from '../webhook-server.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
-const REQUIRED_ENV = ['AGENTMAIL_API_KEY', 'AGENTMAIL_INBOX_ID', 'AGENTMAIL_WEBHOOK_SECRET'] as const;
-type AgentMailEnv = { [K in (typeof REQUIRED_ENV)[number]]: string };
+const REQUIRED_ENV = ['AGENTMAIL_API_KEY', 'AGENTMAIL_INBOX_ID'] as const;
+const OPTIONAL_ENV = ['AGENTMAIL_POLL_INTERVAL_MS'] as const;
+type AgentMailEnv = { [K in (typeof REQUIRED_ENV)[number]]: string } & {
+  [K in (typeof OPTIONAL_ENV)[number]]?: string;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+// Safety-net dedup across poll ticks — boundary messages at the exact
+// `after` cutoff could otherwise be delivered twice. Bounded so it never
+// grows unbounded over a long-running process.
+const MAX_SEEN_IDS = 500;
 
 /** "user@domain.com" or "Display Name <user@domain.com>" → bare address. */
 function extractAddress(from: string): string | null {
@@ -32,33 +43,94 @@ function extractAddress(from: string): string | null {
   return addr.includes('@') ? addr : null;
 }
 
-interface WireMessage {
-  message_id: string;
-  thread_id: string;
-  from: string;
-  subject?: string | null;
-  text?: string | null;
-  extracted_text?: string | null;
-}
-
-interface WireEvent {
-  type: 'event';
-  event_type: string;
-  event_id: string;
-  message?: WireMessage;
-}
-
 function createAdapter(env: AgentMailEnv): ChannelAdapter {
   const client = new AgentMailClient({ apiKey: env.AGENTMAIL_API_KEY });
   const inboxId = env.AGENTMAIL_INBOX_ID;
-  const verifier = new SvixWebhook(env.AGENTMAIL_WEBHOOK_SECRET);
+  const pollIntervalMs = env.AGENTMAIL_POLL_INTERVAL_MS
+    ? parseInt(env.AGENTMAIL_POLL_INTERVAL_MS, 10)
+    : DEFAULT_POLL_INTERVAL_MS;
 
   // Reply-vs-cold-send state: the last inbound message id per correspondent,
   // so a reply threads properly via AgentMail's own In-Reply-To handling.
   // In-memory only — a host restart falls back to a cold send for that
   // correspondent's next reply, same tradeoff as Resend's ThreadResolver.
   const lastInboundMessageId = new Map<string, string>();
+  const seenMessageIds = new Set<string>();
+  let lastPollTime = new Date();
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let polling = false;
   let connected = false;
+
+  async function pollOnce(config: ChannelSetup): Promise<void> {
+    if (polling) return;
+    polling = true;
+    try {
+      const since = lastPollTime;
+      let pageToken: string | undefined;
+      const items: Array<{
+        messageId: string;
+        from: string;
+        createdAt: Date;
+      }> = [];
+
+      do {
+        const res = await client.inboxes.messages.list(inboxId, {
+          after: since,
+          labels: ['received'],
+          limit: 50,
+          pageToken,
+        });
+        for (const m of res.messages) items.push({ messageId: m.messageId, from: m.from, createdAt: m.createdAt });
+        pageToken = res.nextPageToken;
+      } while (pageToken);
+
+      if (items.length === 0) return;
+
+      items.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+      for (const item of items) {
+        if (seenMessageIds.has(item.messageId)) continue;
+        seenMessageIds.add(item.messageId);
+        if (seenMessageIds.size > MAX_SEEN_IDS) {
+          const oldest = seenMessageIds.values().next().value;
+          if (oldest !== undefined) seenMessageIds.delete(oldest);
+        }
+
+        const address = extractAddress(item.from);
+        if (!address) {
+          log.warn('AgentMail: could not extract sender address', { from: item.from });
+          continue;
+        }
+
+        const platformId = `agentmail:${address}`;
+        lastInboundMessageId.set(platformId, item.messageId);
+
+        try {
+          const full = await client.inboxes.messages.get(inboxId, item.messageId);
+          await config.onInbound(platformId, null, {
+            id: item.messageId,
+            kind: 'chat',
+            content: {
+              text: full.text || full.extractedText || '',
+              sender: address,
+              senderId: address,
+            },
+            timestamp: item.createdAt.toISOString(),
+            isGroup: false,
+            isMention: true,
+          });
+        } catch (err) {
+          log.error('AgentMail: error handling incoming message', { err, messageId: item.messageId });
+        }
+      }
+
+      lastPollTime = items[items.length - 1].createdAt;
+    } catch (err) {
+      log.error('AgentMail: poll failed', { err });
+    } finally {
+      polling = false;
+    }
+  }
 
   return {
     name: 'agentmail',
@@ -67,75 +139,20 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
     defaults: AGENTMAIL_DEFAULTS,
 
     async setup(config: ChannelSetup): Promise<void> {
-      // Fail fast on bad credentials / unknown inbox before registering the route.
+      // Fail fast on bad credentials / unknown inbox before starting the poll loop.
       await client.inboxes.get(inboxId);
       connected = true;
+      lastPollTime = new Date();
 
-      registerWebhookHandler('agentmail', async (req, res) => {
-        const chunks: Buffer[] = [];
-        for await (const chunk of req) chunks.push(chunk as Buffer);
-        const payload = Buffer.concat(chunks).toString('utf-8');
+      pollTimer = setInterval(() => {
+        void pollOnce(config);
+      }, pollIntervalMs);
 
-        const svixId = req.headers['svix-id'];
-        const svixTimestamp = req.headers['svix-timestamp'];
-        const svixSignature = req.headers['svix-signature'];
-        try {
-          verifier.verify(payload, {
-            'svix-id': Array.isArray(svixId) ? svixId[0] : (svixId ?? ''),
-            'svix-timestamp': Array.isArray(svixTimestamp) ? svixTimestamp[0] : (svixTimestamp ?? ''),
-            'svix-signature': Array.isArray(svixSignature) ? svixSignature[0] : (svixSignature ?? ''),
-          });
-        } catch (err) {
-          log.warn('AgentMail: webhook signature verification failed', { err });
-          res.writeHead(401, { 'Content-Type': 'text/plain' });
-          res.end('invalid signature');
-          return;
-        }
-
-        res.writeHead(200, { 'Content-Type': 'text/plain' });
-        res.end('ok');
-
-        let event: WireEvent;
-        try {
-          event = JSON.parse(payload);
-        } catch (err) {
-          log.error('AgentMail: unparseable webhook payload', { err });
-          return;
-        }
-
-        if (event.event_type !== 'message.received' || !event.message) return;
-        const msg = event.message;
-        const address = extractAddress(msg.from);
-        if (!address) {
-          log.warn('AgentMail: could not extract sender address', { from: msg.from });
-          return;
-        }
-
-        const platformId = `agentmail:${address}`;
-        lastInboundMessageId.set(platformId, msg.message_id);
-
-        try {
-          await config.onInbound(platformId, null, {
-            id: msg.message_id,
-            kind: 'chat',
-            content: {
-              text: msg.text || msg.extracted_text || '',
-              sender: address,
-              senderId: address,
-            },
-            timestamp: new Date().toISOString(),
-            isGroup: false,
-            isMention: true,
-          });
-        } catch (err) {
-          log.error('AgentMail: error handling incoming message', { err });
-        }
-      });
-
-      log.info('AgentMail: adapter ready', { inboxId });
+      log.info('AgentMail: adapter ready, polling started', { inboxId, pollIntervalMs });
     },
 
     async teardown(): Promise<void> {
+      if (pollTimer) clearInterval(pollTimer);
       connected = false;
     },
 
@@ -184,8 +201,8 @@ const AGENTMAIL_DEFAULTS: ChannelDefaults = {
 
 registerChannelAdapter('agentmail', {
   factory: () => {
-    const env = readEnvFile([...REQUIRED_ENV]);
-    if (!env.AGENTMAIL_API_KEY || !env.AGENTMAIL_INBOX_ID || !env.AGENTMAIL_WEBHOOK_SECRET) return null;
+    const env = readEnvFile([...REQUIRED_ENV, ...OPTIONAL_ENV]);
+    if (!env.AGENTMAIL_API_KEY || !env.AGENTMAIL_INBOX_ID) return null;
     return createAdapter(env as AgentMailEnv);
   },
   defaults: AGENTMAIL_DEFAULTS,

--- a/src/channels/agentmail.ts
+++ b/src/channels/agentmail.ts
@@ -1,0 +1,192 @@
+/**
+ * AgentMail channel adapter (native — no Chat SDK bridge exists for AgentMail).
+ *
+ * Bridges NanoClaw with an AgentMail-managed inbox (https://agentmail.to). Each
+ * external correspondent is a separate messaging group, platformId
+ * "agentmail:<their-address>" — same flattened model as the Resend adapter,
+ * chosen for parity: one NanoClaw session per correspondent, regardless of how
+ * many distinct email subject-threads they start. Unlike Resend's adapter,
+ * AgentMail's SDK can originate a brand-new thread (`messages.send`) as well as
+ * reply within one (`messages.reply`), so there is no cold-start limitation —
+ * the bot can email a correspondent first.
+ *
+ * Required env vars (.env): AGENTMAIL_API_KEY, AGENTMAIL_INBOX_ID,
+ *                           AGENTMAIL_WEBHOOK_SECRET
+ */
+import { AgentMailClient } from 'agentmail';
+import { Webhook as SvixWebhook } from 'svix';
+
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { registerWebhookHandler } from '../webhook-server.js';
+import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
+import { registerChannelAdapter } from './channel-registry.js';
+
+const REQUIRED_ENV = ['AGENTMAIL_API_KEY', 'AGENTMAIL_INBOX_ID', 'AGENTMAIL_WEBHOOK_SECRET'] as const;
+type AgentMailEnv = { [K in (typeof REQUIRED_ENV)[number]]: string };
+
+/** "user@domain.com" or "Display Name <user@domain.com>" → bare address. */
+function extractAddress(from: string): string | null {
+  const angleMatch = from.match(/<([^>]+)>/);
+  const addr = (angleMatch ? angleMatch[1] : from).trim();
+  return addr.includes('@') ? addr : null;
+}
+
+interface WireMessage {
+  message_id: string;
+  thread_id: string;
+  from: string;
+  subject?: string | null;
+  text?: string | null;
+  extracted_text?: string | null;
+}
+
+interface WireEvent {
+  type: 'event';
+  event_type: string;
+  event_id: string;
+  message?: WireMessage;
+}
+
+function createAdapter(env: AgentMailEnv): ChannelAdapter {
+  const client = new AgentMailClient({ apiKey: env.AGENTMAIL_API_KEY });
+  const inboxId = env.AGENTMAIL_INBOX_ID;
+  const verifier = new SvixWebhook(env.AGENTMAIL_WEBHOOK_SECRET);
+
+  // Reply-vs-cold-send state: the last inbound message id per correspondent,
+  // so a reply threads properly via AgentMail's own In-Reply-To handling.
+  // In-memory only — a host restart falls back to a cold send for that
+  // correspondent's next reply, same tradeoff as Resend's ThreadResolver.
+  const lastInboundMessageId = new Map<string, string>();
+  let connected = false;
+
+  return {
+    name: 'agentmail',
+    channelType: 'agentmail',
+    supportsThreads: false,
+    defaults: AGENTMAIL_DEFAULTS,
+
+    async setup(config: ChannelSetup): Promise<void> {
+      // Fail fast on bad credentials / unknown inbox before registering the route.
+      await client.inboxes.get(inboxId);
+      connected = true;
+
+      registerWebhookHandler('agentmail', async (req, res) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(chunk as Buffer);
+        const payload = Buffer.concat(chunks).toString('utf-8');
+
+        const svixId = req.headers['svix-id'];
+        const svixTimestamp = req.headers['svix-timestamp'];
+        const svixSignature = req.headers['svix-signature'];
+        try {
+          verifier.verify(payload, {
+            'svix-id': Array.isArray(svixId) ? svixId[0] : (svixId ?? ''),
+            'svix-timestamp': Array.isArray(svixTimestamp) ? svixTimestamp[0] : (svixTimestamp ?? ''),
+            'svix-signature': Array.isArray(svixSignature) ? svixSignature[0] : (svixSignature ?? ''),
+          });
+        } catch (err) {
+          log.warn('AgentMail: webhook signature verification failed', { err });
+          res.writeHead(401, { 'Content-Type': 'text/plain' });
+          res.end('invalid signature');
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('ok');
+
+        let event: WireEvent;
+        try {
+          event = JSON.parse(payload);
+        } catch (err) {
+          log.error('AgentMail: unparseable webhook payload', { err });
+          return;
+        }
+
+        if (event.event_type !== 'message.received' || !event.message) return;
+        const msg = event.message;
+        const address = extractAddress(msg.from);
+        if (!address) {
+          log.warn('AgentMail: could not extract sender address', { from: msg.from });
+          return;
+        }
+
+        const platformId = `agentmail:${address}`;
+        lastInboundMessageId.set(platformId, msg.message_id);
+
+        try {
+          await config.onInbound(platformId, null, {
+            id: msg.message_id,
+            kind: 'chat',
+            content: {
+              text: msg.text || msg.extracted_text || '',
+              sender: address,
+              senderId: address,
+            },
+            timestamp: new Date().toISOString(),
+            isGroup: false,
+            isMention: true,
+          });
+        } catch (err) {
+          log.error('AgentMail: error handling incoming message', { err });
+        }
+      });
+
+      log.info('AgentMail: adapter ready', { inboxId });
+    },
+
+    async teardown(): Promise<void> {
+      connected = false;
+    },
+
+    isConnected(): boolean {
+      return connected;
+    },
+
+    async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
+      const address = platformId.replace(/^agentmail:/, '');
+      const content = message.content as Record<string, unknown>;
+      const text = typeof content.text === 'string' ? content.text : '';
+      if (!text) return undefined;
+
+      const replyToId = lastInboundMessageId.get(platformId);
+      if (replyToId) {
+        const res = await client.inboxes.messages.reply(inboxId, replyToId, { text });
+        return res.messageId;
+      }
+
+      const res = await client.inboxes.messages.send(inboxId, {
+        to: [address],
+        subject: 'Message from your NanoClaw assistant',
+        text,
+      });
+      return res.messageId;
+    },
+  };
+}
+
+/**
+ * Dedicated inbox identity, so request_approval is sound. Email carries no
+ * mention metadata ('dm-only'; the adapter flags DMs only), so group wirings
+ * default to a name-pattern trigger. supportsThreads: false — see the adapter
+ * doc comment for the flattened-per-correspondent model.
+ */
+const AGENTMAIL_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  group: {
+    engageMode: 'pattern',
+    engagePattern: '\\b{name}\\b',
+    threads: false,
+    unknownSenderPolicy: 'request_approval',
+  },
+  mentions: 'dm-only',
+};
+
+registerChannelAdapter('agentmail', {
+  factory: () => {
+    const env = readEnvFile([...REQUIRED_ENV]);
+    if (!env.AGENTMAIL_API_KEY || !env.AGENTMAIL_INBOX_ID || !env.AGENTMAIL_WEBHOOK_SECRET) return null;
+    return createAdapter(env as AgentMailEnv);
+  },
+  defaults: AGENTMAIL_DEFAULTS,
+});

--- a/src/channels/agentmail.ts
+++ b/src/channels/agentmail.ts
@@ -14,23 +14,35 @@
  * as reply within one (`messages.reply`), so there is no cold-start
  * limitation — the bot can email a correspondent first.
  *
+ * Polling runs on a cron schedule (default: 4am/10am/4pm/10pm daily, install
+ * timezone), not a fixed interval — reuses the same `cron-parser` dependency
+ * already used for scheduled tasks (src/modules/scheduling/recurrence.ts) and
+ * the resolved install timezone (TIMEZONE, src/config.ts). A self-rescheduling
+ * setTimeout chain (compute next occurrence, sleep, poll, repeat) rather than
+ * setInterval, since the gaps between occurrences aren't uniform (4am→10am is
+ * 6h, but the schedule itself is arbitrary cron, not always evenly spaced).
+ *
  * Required env vars (.env): AGENTMAIL_API_KEY, AGENTMAIL_INBOX_ID
- * Optional env vars (.env): AGENTMAIL_POLL_INTERVAL_MS (default: 30000)
+ * Optional env vars (.env): AGENTMAIL_POLL_SCHEDULE (cron expression,
+ *                           default: "0 4,10,16,22 * * *")
  */
+import { CronExpressionParser } from 'cron-parser';
+
 import { AgentMailClient } from 'agentmail';
 
+import { TIMEZONE } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
 const REQUIRED_ENV = ['AGENTMAIL_API_KEY', 'AGENTMAIL_INBOX_ID'] as const;
-const OPTIONAL_ENV = ['AGENTMAIL_POLL_INTERVAL_MS'] as const;
+const OPTIONAL_ENV = ['AGENTMAIL_POLL_SCHEDULE'] as const;
 type AgentMailEnv = { [K in (typeof REQUIRED_ENV)[number]]: string } & {
   [K in (typeof OPTIONAL_ENV)[number]]?: string;
 };
 
-const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_POLL_SCHEDULE = '0 4,10,16,22 * * *';
 // Safety-net dedup across poll ticks — boundary messages at the exact
 // `after` cutoff could otherwise be delivered twice. Bounded so it never
 // grows unbounded over a long-running process.
@@ -46,9 +58,7 @@ function extractAddress(from: string): string | null {
 function createAdapter(env: AgentMailEnv): ChannelAdapter {
   const client = new AgentMailClient({ apiKey: env.AGENTMAIL_API_KEY });
   const inboxId = env.AGENTMAIL_INBOX_ID;
-  const pollIntervalMs = env.AGENTMAIL_POLL_INTERVAL_MS
-    ? parseInt(env.AGENTMAIL_POLL_INTERVAL_MS, 10)
-    : DEFAULT_POLL_INTERVAL_MS;
+  const pollSchedule = env.AGENTMAIL_POLL_SCHEDULE || DEFAULT_POLL_SCHEDULE;
 
   // Reply-vs-cold-send state: the last inbound message id per correspondent,
   // so a reply threads properly via AgentMail's own In-Reply-To handling.
@@ -57,9 +67,25 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
   const lastInboundMessageId = new Map<string, string>();
   const seenMessageIds = new Set<string>();
   let lastPollTime = new Date();
-  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let pollTimeout: ReturnType<typeof setTimeout> | null = null;
   let polling = false;
   let connected = false;
+
+  function nextOccurrence(): Date {
+    try {
+      return CronExpressionParser.parse(pollSchedule, { tz: TIMEZONE }).next().toDate();
+    } catch (err) {
+      log.error('AgentMail: invalid AGENTMAIL_POLL_SCHEDULE, falling back to default', { pollSchedule, err });
+      return CronExpressionParser.parse(DEFAULT_POLL_SCHEDULE, { tz: TIMEZONE }).next().toDate();
+    }
+  }
+
+  function scheduleNextPoll(config: ChannelSetup): void {
+    const delayMs = Math.max(0, nextOccurrence().getTime() - Date.now());
+    pollTimeout = setTimeout(() => {
+      void pollOnce(config).finally(() => scheduleNextPoll(config));
+    }, delayMs);
+  }
 
   async function pollOnce(config: ChannelSetup): Promise<void> {
     if (polling) return;
@@ -144,15 +170,17 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
       connected = true;
       lastPollTime = new Date();
 
-      pollTimer = setInterval(() => {
-        void pollOnce(config);
-      }, pollIntervalMs);
+      scheduleNextPoll(config);
 
-      log.info('AgentMail: adapter ready, polling started', { inboxId, pollIntervalMs });
+      log.info('AgentMail: adapter ready, polling scheduled', {
+        inboxId,
+        pollSchedule,
+        nextPollAt: nextOccurrence().toISOString(),
+      });
     },
 
     async teardown(): Promise<void> {
-      if (pollTimer) clearInterval(pollTimer);
+      if (pollTimeout) clearTimeout(pollTimeout);
       connected = false;
     },
 

--- a/src/channels/agentmail.ts
+++ b/src/channels/agentmail.ts
@@ -5,39 +5,46 @@
  * external correspondent is a separate messaging group, platformId
  * "agentmail:<their-address>" — same flattened model as the Resend adapter,
  * chosen for parity: one NanoClaw session per correspondent, regardless of how
- * many distinct email subject-threads they start.
- *
- * Polling, not webhooks: AgentMail supports both, but a webhook needs a public
- * HTTPS endpoint reachable from AgentMail's servers, which not every install
- * has. Polling needs nothing but outbound API calls. Unlike Resend's adapter,
+ * many distinct email subject-threads they start. Unlike Resend's adapter,
  * AgentMail's SDK can originate a brand-new thread (`messages.send`) as well
  * as reply within one (`messages.reply`), so there is no cold-start
- * limitation — the bot can email a correspondent first.
+ * limitation — the bot can email a correspondent first, in either mode below.
  *
- * Polling runs on a cron schedule (default: 4am/10am/4pm/10pm daily, install
- * timezone), not a fixed interval — reuses the same `cron-parser` dependency
- * already used for scheduled tasks (src/modules/scheduling/recurrence.ts) and
- * the resolved install timezone (TIMEZONE, src/config.ts). A self-rescheduling
- * setTimeout chain (compute next occurrence, sleep, poll, repeat) rather than
- * setInterval, since the gaps between occurrences aren't uniform (4am→10am is
- * 6h, but the schedule itself is arbitrary cron, not always evenly spaced).
+ * Two inbound modes, chosen by AGENTMAIL_MODE (default: polling):
+ *
+ *  - polling: no public endpoint needed. Runs on a cron schedule (default
+ *    4am/10am/4pm/10pm daily, install timezone) rather than a fixed interval
+ *    — reuses the same `cron-parser` dependency already used for scheduled
+ *    tasks (src/modules/scheduling/recurrence.ts) and the resolved install
+ *    timezone (TIMEZONE, src/config.ts). A self-rescheduling setTimeout chain
+ *    (compute next occurrence, sleep, poll, repeat) rather than setInterval,
+ *    since cron occurrences aren't necessarily evenly spaced.
+ *  - webhook: instant delivery, but needs a public HTTPS endpoint reachable
+ *    from AgentMail's servers. Registers a raw route on the shared webhook
+ *    server (registerWebhookHandler) and verifies signatures with `svix`
+ *    (AgentMail delivers webhooks via Svix).
  *
  * Required env vars (.env): AGENTMAIL_API_KEY, AGENTMAIL_INBOX_ID
- * Optional env vars (.env): AGENTMAIL_POLL_SCHEDULE (cron expression,
- *                           default: "0 4,10,16,22 * * *")
+ * Optional env vars (.env): AGENTMAIL_MODE ("polling" | "webhook", default
+ *                           "polling"), AGENTMAIL_POLL_SCHEDULE (cron
+ *                           expression, polling mode only, default
+ *                           "0 4,10,16,22 * * *"), AGENTMAIL_WEBHOOK_SECRET
+ *                           (webhook mode only, required in that mode)
  */
 import { CronExpressionParser } from 'cron-parser';
 
 import { AgentMailClient } from 'agentmail';
+import { Webhook as SvixWebhook } from 'svix';
 
 import { TIMEZONE } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
+import { registerWebhookHandler } from '../webhook-server.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
 const REQUIRED_ENV = ['AGENTMAIL_API_KEY', 'AGENTMAIL_INBOX_ID'] as const;
-const OPTIONAL_ENV = ['AGENTMAIL_POLL_SCHEDULE'] as const;
+const OPTIONAL_ENV = ['AGENTMAIL_MODE', 'AGENTMAIL_POLL_SCHEDULE', 'AGENTMAIL_WEBHOOK_SECRET'] as const;
 type AgentMailEnv = { [K in (typeof REQUIRED_ENV)[number]]: string } & {
   [K in (typeof OPTIONAL_ENV)[number]]?: string;
 };
@@ -55,9 +62,26 @@ function extractAddress(from: string): string | null {
   return addr.includes('@') ? addr : null;
 }
 
+interface WireMessage {
+  message_id: string;
+  thread_id: string;
+  from: string;
+  subject?: string | null;
+  text?: string | null;
+  extracted_text?: string | null;
+}
+
+interface WireEvent {
+  type: 'event';
+  event_type: string;
+  event_id: string;
+  message?: WireMessage;
+}
+
 function createAdapter(env: AgentMailEnv): ChannelAdapter {
   const client = new AgentMailClient({ apiKey: env.AGENTMAIL_API_KEY });
   const inboxId = env.AGENTMAIL_INBOX_ID;
+  const mode = env.AGENTMAIL_MODE === 'webhook' ? 'webhook' : 'polling';
   const pollSchedule = env.AGENTMAIL_POLL_SCHEDULE || DEFAULT_POLL_SCHEDULE;
 
   // Reply-vs-cold-send state: the last inbound message id per correspondent,
@@ -65,11 +89,13 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
   // In-memory only — a host restart falls back to a cold send for that
   // correspondent's next reply, same tradeoff as Resend's ThreadResolver.
   const lastInboundMessageId = new Map<string, string>();
+  let connected = false;
+
+  // --- polling mode state ---
   const seenMessageIds = new Set<string>();
   let lastPollTime = new Date();
   let pollTimeout: ReturnType<typeof setTimeout> | null = null;
   let polling = false;
-  let connected = false;
 
   function nextOccurrence(): Date {
     try {
@@ -87,17 +113,35 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
     }, delayMs);
   }
 
+  async function deliverInbound(config: ChannelSetup, messageId: string, from: string, text: string): Promise<void> {
+    const address = extractAddress(from);
+    if (!address) {
+      log.warn('AgentMail: could not extract sender address', { from });
+      return;
+    }
+    const platformId = `agentmail:${address}`;
+    lastInboundMessageId.set(platformId, messageId);
+    try {
+      await config.onInbound(platformId, null, {
+        id: messageId,
+        kind: 'chat',
+        content: { text, sender: address, senderId: address },
+        timestamp: new Date().toISOString(),
+        isGroup: false,
+        isMention: true,
+      });
+    } catch (err) {
+      log.error('AgentMail: error handling incoming message', { err, messageId });
+    }
+  }
+
   async function pollOnce(config: ChannelSetup): Promise<void> {
     if (polling) return;
     polling = true;
     try {
       const since = lastPollTime;
       let pageToken: string | undefined;
-      const items: Array<{
-        messageId: string;
-        from: string;
-        createdAt: Date;
-      }> = [];
+      const items: Array<{ messageId: string; from: string; createdAt: Date }> = [];
 
       do {
         const res = await client.inboxes.messages.list(inboxId, {
@@ -122,32 +166,8 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
           if (oldest !== undefined) seenMessageIds.delete(oldest);
         }
 
-        const address = extractAddress(item.from);
-        if (!address) {
-          log.warn('AgentMail: could not extract sender address', { from: item.from });
-          continue;
-        }
-
-        const platformId = `agentmail:${address}`;
-        lastInboundMessageId.set(platformId, item.messageId);
-
-        try {
-          const full = await client.inboxes.messages.get(inboxId, item.messageId);
-          await config.onInbound(platformId, null, {
-            id: item.messageId,
-            kind: 'chat',
-            content: {
-              text: full.text || full.extractedText || '',
-              sender: address,
-              senderId: address,
-            },
-            timestamp: item.createdAt.toISOString(),
-            isGroup: false,
-            isMention: true,
-          });
-        } catch (err) {
-          log.error('AgentMail: error handling incoming message', { err, messageId: item.messageId });
-        }
+        const full = await client.inboxes.messages.get(inboxId, item.messageId);
+        await deliverInbound(config, item.messageId, item.from, full.text || full.extractedText || '');
       }
 
       lastPollTime = items[items.length - 1].createdAt;
@@ -158,6 +178,47 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
     }
   }
 
+  function setupWebhook(config: ChannelSetup): void {
+    const verifier = new SvixWebhook(env.AGENTMAIL_WEBHOOK_SECRET as string);
+
+    registerWebhookHandler('agentmail', async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      const payload = Buffer.concat(chunks).toString('utf-8');
+
+      const svixId = req.headers['svix-id'];
+      const svixTimestamp = req.headers['svix-timestamp'];
+      const svixSignature = req.headers['svix-signature'];
+      try {
+        verifier.verify(payload, {
+          'svix-id': Array.isArray(svixId) ? svixId[0] : (svixId ?? ''),
+          'svix-timestamp': Array.isArray(svixTimestamp) ? svixTimestamp[0] : (svixTimestamp ?? ''),
+          'svix-signature': Array.isArray(svixSignature) ? svixSignature[0] : (svixSignature ?? ''),
+        });
+      } catch (err) {
+        log.warn('AgentMail: webhook signature verification failed', { err });
+        res.writeHead(401, { 'Content-Type': 'text/plain' });
+        res.end('invalid signature');
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+
+      let event: WireEvent;
+      try {
+        event = JSON.parse(payload);
+      } catch (err) {
+        log.error('AgentMail: unparseable webhook payload', { err });
+        return;
+      }
+
+      if (event.event_type !== 'message.received' || !event.message) return;
+      const msg = event.message;
+      await deliverInbound(config, msg.message_id, msg.from, msg.text || msg.extracted_text || '');
+    });
+  }
+
   return {
     name: 'agentmail',
     channelType: 'agentmail',
@@ -165,18 +226,22 @@ function createAdapter(env: AgentMailEnv): ChannelAdapter {
     defaults: AGENTMAIL_DEFAULTS,
 
     async setup(config: ChannelSetup): Promise<void> {
-      // Fail fast on bad credentials / unknown inbox before starting the poll loop.
+      // Fail fast on bad credentials / unknown inbox before starting either mode.
       await client.inboxes.get(inboxId);
       connected = true;
-      lastPollTime = new Date();
 
-      scheduleNextPoll(config);
-
-      log.info('AgentMail: adapter ready, polling scheduled', {
-        inboxId,
-        pollSchedule,
-        nextPollAt: nextOccurrence().toISOString(),
-      });
+      if (mode === 'webhook') {
+        setupWebhook(config);
+        log.info('AgentMail: adapter ready (webhook mode)', { inboxId });
+      } else {
+        lastPollTime = new Date();
+        scheduleNextPoll(config);
+        log.info('AgentMail: adapter ready (polling mode)', {
+          inboxId,
+          pollSchedule,
+          nextPollAt: nextOccurrence().toISOString(),
+        });
+      }
     },
 
     async teardown(): Promise<void> {
@@ -231,6 +296,7 @@ registerChannelAdapter('agentmail', {
   factory: () => {
     const env = readEnvFile([...REQUIRED_ENV, ...OPTIONAL_ENV]);
     if (!env.AGENTMAIL_API_KEY || !env.AGENTMAIL_INBOX_ID) return null;
+    if (env.AGENTMAIL_MODE === 'webhook' && !env.AGENTMAIL_WEBHOOK_SECRET) return null;
     return createAdapter(env as AgentMailEnv);
   },
   defaults: AGENTMAIL_DEFAULTS,

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -7,3 +7,4 @@
 // self-registration import below.
 
 import './cli.js';
+import './agentmail.js';


### PR DESCRIPTION
## Summary

Adds a native AgentMail channel adapter — a fully-managed agent email inbox via API (https://agentmail.to), with no MX record to own or conflict with an existing mail provider on your domain.

- **Problem**: NanoClaw has no email channel that avoids the DNS/MX ownership problem inherent to routing email through your own domain.
- **Fix**: a native adapter (no official Chat SDK adapter exists for AgentMail) talking directly to the `agentmail` SDK, registering a raw webhook route via the existing shared webhook server (`registerWebhookHandler`), and verifying inbound signatures with `svix` (AgentMail delivers webhooks via Svix).
- **Note**: AgentMail's SDK can both cold-send a new thread (`messages.send`) and reply within one (`messages.reply`), so the bot can email a correspondent first — no cold-start limitation.

**Supersedes #809.** That PR used `curl` + on-demand polling because "NanoClaw has no inbound webhook gateway" at the time it was written. v2 has since grown a shared webhook server (the same one Slack and Resend already use), which is what this adapter is built on instead — a proper channel (users/roles/wiring/sessions), not a polling tool the agent calls. Its branch (`feat/agentmail-skill`) was reused and force-pushed with this new content, which is why #809 itself couldn't be reopened (GitHub blocks reopening a PR whose branch was force-pushed after close).

PR #287 (open, unrelated) targets pre-rewrite v1 NanoClaw (`src/ipc.ts`, `container/agent-runner/src/ipc-mcp-stdio.ts`) and is incompatible with current trunk.

## Change kind

- [x] `kind/feature` — new capability

## Validation

- `pnpm run build` → clean, no errors
- `pnpm exec vitest run src/channels/agentmail-registration.test.ts` → 1 passed (registry contains `agentmail`; also guards both new deps via unmocked import)
- `pnpm test` (full suite) → 2376 passed, 1 skipped (pre-existing, unrelated), 195 files

## Security and trust boundaries

- Inbound webhook signature verified via `svix` (`Webhook.verify`) before any payload parsing; unverified requests get a `401` and are dropped.
- API key and webhook secret only ever read from `.env` (`readEnvFile`), never placed in `process.env` or forwarded to the container — same pattern as every other channel adapter.
- Adapter does no network I/O at import time — only inside `setup()` and `deliver()` — so importing the barrel in tests is safe (confirmed by the registration test passing without live credentials).

## Skill delivery

- [x] Ships `.claude/skills/add-agentmail/{SKILL.md,REMOVE.md}` (`delivery/skill`)

## AI assistance

- [x] AI-assisted — built with Claude Code. I've reviewed every change and stand behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)