### PR TITLE
feat(context-preview): revive the context-preview tool on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ For ad-hoc central queries from skills or scripts, use the in-tree wrapper rathe
 | `container/skills/` | Container skills mounted into every agent session (`agent-browser`, `frontend-engineer`, `onecli-gateway`, `self-customize`, `welcome`; opt-in skills like `vercel-cli`, `slack-formatting` and `whatsapp-formatting` install with the `/add-*` skill that adds their capability) |
 | `groups/<folder>/` | Per-agent-group filesystem (CLAUDE.md, skills) — agent-runner source is a shared read-only mount, not copied per group |
 | `scripts/init-first-agent.ts` | Bootstrap the first DM-wired agent (used by `/init-first-agent` skill) |
+| `scripts/context-preview.ts` | Render the exact context an agent sees for a scenario (first message, task fire, on-wake, a2a, a replayed real turn, …) using the real code paths — no container, no live-install writes. See [docs/context-preview.md](docs/context-preview.md). |
 | `scripts/skill-apply.ts` | Deterministic SKILL.md applier — executes `nc:` directive fences; declare/emit core, journaled + idempotent |
 | `scripts/skill-directives.ts` + `scripts/skill-policy.ts` | `nc:` grammar parser + lint; UI-free driver policy derived from document structure (gate confirm, URL offer) |
 | `setup/lib/skill-driver.ts` + `setup/channels/run-channel-skill.ts` | Setup wizard's skill consumer: clack rendering of engine events + the generic channel-install flow |
@@ -303,6 +304,7 @@ This project uses pnpm with `minimumReleaseAge: 4320` (3 days) in `pnpm-workspac
 | [docs/skill-engine-seam.md](docs/skill-engine-seam.md) | Skill-engine consumer contract (wizard / pipeline / agent-relay) + boundary-rule rationale |
 | [docs/templates.md](docs/templates.md) | Agent templates: what they are, stamping via `ncl groups create --template` + the setup wizard, the OneCLI/MCP-credential model, supported providers, and how to contribute one |
 | [docs/hardened-image.md](docs/hardened-image.md) | Opt-in: pull the agent image from a registry instead of building it |
+| [docs/context-preview.md](docs/context-preview.md) | Context preview tool: simulate a scenario (or replay a real session dump) and render the exact agent-visible context (composed CLAUDE.md, system prompt, SDK options, MCP tools, prompt string) |
 
 ## Container Build Cache
 

--- a/container/agent-runner/scripts/context-preview-runner.ts
+++ b/container/agent-runner/scripts/context-preview-runner.ts
@@ -1,0 +1,300 @@
+/**
+ * Bun half of the context-preview tool. Never run directly — spawned by
+ * `scripts/context-preview.ts` (host side), which stages a session (inbound.db
+ * + outbound.db) in a sandbox and passes a spec file describing where.
+ *
+ * Reproduces the container-side context assembly with the REAL production
+ * code paths — no agent-visible string is duplicated. The tool-module list
+ * is read from the MCP barrel (mcp-tools/index.ts) at run time, so an
+ * installed or removed tool module is reflected without editing this file;
+ * one piece of WIRING is mirrored from src/index.ts main() (commented at its
+ * use site): the mcpServers/cwd assembly.
+ *   - `runnerConfigFromRaw()` parses the staged container.json exactly as
+ *     `loadConfig()` does; `setTestConfig()` installs it.
+ *   - `initTestSessionDb()` swaps the /workspace/*.db singletons for
+ *     in-memory DBs; the staged rows are copied in byte-identical.
+ *   - `runPollLoop()` (the real loop) runs against a capturing provider, so
+ *     batching, on_wake first-poll gating, the accumulate gate, and slash
+ *     command splitting are exactly what a real container does.
+ *   - `buildSystemPromptAddendum()` renders the runtime system-prompt
+ *     addendum from the staged destinations table + session routing (task
+ *     mode is derived from the routing thread, as in production).
+ *   - `createProvider('claude')` + `ClaudeProvider.buildQueryOptions()`
+ *     render the exact SDK options, contract-resolved like production.
+ *   - `listRegisteredTools()` renders the nanoclaw MCP tool surface.
+ *
+ * Emits one JSON object on stdout; all logging goes to stderr.
+ */
+import { Database } from 'bun:sqlite';
+import fs from 'fs';
+
+import { runnerConfigFromRaw, setTestConfig } from '../src/config.js';
+import { buildSystemPromptAddendum } from '../src/destinations.js';
+import { getTaskSeriesId } from '../src/db/session-routing.js';
+import { initTestSessionDb } from '../src/mailbox/sqlite/connection.js';
+import { MEMORY_SESSION_HOOK } from '../src/memory/session-hook.js';
+// Module barrel — registers the singular mailbox slot (same as index.ts).
+import '../src/modules/index.js';
+import { listRegisteredTools } from '../src/mcp-tools/server.js';
+import { resolvePluginServer } from '../src/plugin-mcp.js';
+import { runPollLoop } from '../src/poll-loop.js';
+import { registerProviderMemorySessionHook } from '../src/provider-contracts/realize.js';
+// Providers + contracts barrels — each provider self-registers (same as index.ts).
+import '../src/providers/index.js';
+import '../src/provider-contracts/index.js';
+import type { ClaudeProvider } from '../src/providers/claude.js';
+import { createProvider } from '../src/providers/factory.js';
+import { getProviderRuntimeContract } from '../src/providers/provider-registry.js';
+import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, QueryInput } from '../src/providers/types.js';
+
+interface PreviewSpec {
+  inboundDbPath: string;
+  outboundDbPath: string;
+  /** Parsed groups/<folder>/container.json, as materialized by the host. */
+  containerConfig: Record<string, unknown>;
+  /** Container paths of /workspace/extra/* mounts — what index.ts would
+   *  discover by scanning that directory in a real container. */
+  additionalDirectories?: string[];
+}
+
+function log(msg: string): void {
+  console.error(`[context-preview-runner] ${msg}`);
+}
+
+/**
+ * Load every tool module the MCP barrel loads, in barrel order, so the
+ * registered tool surface is exactly the server's. The barrel itself cannot
+ * be imported (it starts the MCP server on import), so its side-effect
+ * import lines are read from the file — the one list, no mirror.
+ */
+async function loadToolModulesFromBarrel(): Promise<string[]> {
+  const barrel = new URL('../src/mcp-tools/index.ts', import.meta.url);
+  const source = await Bun.file(barrel).text();
+  const specifiers = [...source.matchAll(/^import '(\.[^']+)';/gm)].map((m) => m[1]);
+  for (const spec of specifiers) await import(new URL(spec, barrel).href);
+  return specifiers;
+}
+
+/** Copy all rows of `table` between DBs, matching columns by name. */
+function copyTable(src: Database, dst: Database, table: string): number {
+  const exists = src.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table);
+  if (!exists) return 0;
+  const dstCols = new Set(
+    (dst.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  const rows = src.prepare(`SELECT * FROM ${table}`).all() as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const cols = Object.keys(row).filter((c) => dstCols.has(c));
+    dst
+      .prepare(`INSERT INTO ${table} (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`)
+      .run(...cols.map((c) => row[c] as never));
+  }
+  return rows.length;
+}
+
+/**
+ * Records the QueryInput the poll loop hands the provider, then completes
+ * the turn like a provider would. Slash-command splitting and mid-turn text
+ * delivery come from the previewed provider's runtime contract (passed to
+ * runPollLoop as `providerContract`, as index.ts does); the legacy instance
+ * flag below only matters for a contractless provider.
+ */
+class CapturingProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+  captured: QueryInput[] = [];
+  onCapture: () => void = () => {};
+
+  registerMemorySessionHook(): void {}
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query(input: QueryInput): AgentQuery {
+    this.captured.push(input);
+    const notify = this.onCapture;
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'activity' };
+        // Null text completes the turn without dispatch (and without the
+        // re-wrap nudge); ending the stream lets processQuery return, after
+        // which the abort signal stops the outer loop.
+        yield { type: 'result', text: null };
+        notify();
+      },
+    };
+    return { push: () => {}, end: () => {}, abort: () => {}, events };
+  }
+}
+
+/** JSON-safe copy of the SDK options: functions → descriptive placeholders. */
+function sanitizeSdkOptions(options: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (key === 'hooks' && value && typeof value === 'object') {
+      out.hooks = Object.keys(value);
+    } else if (key === 'mcpServers' && value && typeof value === 'object') {
+      // Per-server env can carry credentials from a live container config —
+      // never print the values.
+      out.mcpServers = Object.fromEntries(
+        Object.entries(value as Record<string, { env?: Record<string, string> }>).map(([name, server]) => [
+          name,
+          {
+            ...server,
+            env: Object.fromEntries(Object.keys(server.env ?? {}).map((k) => [k, '<redacted>'])),
+          },
+        ]),
+      );
+    } else if (key === 'env' && value && typeof value === 'object') {
+      // Env is inherited from the real container process; here it's the
+      // harness env, so render only what the provider itself set or changed.
+      const env = value as Record<string, string | undefined>;
+      out.env = Object.fromEntries(Object.entries(env).filter(([k, v]) => process.env[k] !== v));
+      out.envNote =
+        'Remaining env inherited from the container process (TZ + OneCLI proxy vars; see src/container-runner.ts buildContainerArgs).';
+    } else if (typeof value === 'function') {
+      out[key] = '<function>';
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const specPath = process.argv[2];
+  if (!specPath) {
+    console.error('Usage: bun context-preview-runner.ts <spec.json>');
+    process.exit(2);
+  }
+  const spec = JSON.parse(fs.readFileSync(specPath, 'utf8')) as PreviewSpec;
+
+  log(`Tool modules from barrel: ${(await loadToolModulesFromBarrel()).join(', ')}`);
+
+  // Same parse as loadConfig() — defaults included.
+  const config = runnerConfigFromRaw(spec.containerConfig);
+  setTestConfig(config);
+
+  // In-memory session DBs seeded from the staged files. The test schema is
+  // the poll-loop tests' one; add the two host-written pieces the preview
+  // reads (session routing → task mode; a2a return path).
+  const { inbound, outbound } = initTestSessionDb();
+  inbound.exec(`
+    CREATE TABLE IF NOT EXISTS session_routing (
+      id INTEGER PRIMARY KEY CHECK (id = 1), channel_type TEXT, platform_id TEXT, thread_id TEXT
+    );
+    ALTER TABLE messages_in ADD COLUMN source_session_id TEXT;
+  `);
+  const stagedInbound = new Database(spec.inboundDbPath, { readonly: true });
+  const stagedOutbound = new Database(spec.outboundDbPath, { readonly: true });
+  const nIn = copyTable(stagedInbound, inbound, 'messages_in');
+  copyTable(stagedInbound, inbound, 'destinations');
+  copyTable(stagedInbound, inbound, 'session_routing');
+  copyTable(stagedOutbound, outbound, 'session_state');
+  copyTable(stagedOutbound, outbound, 'processing_ack');
+  stagedInbound.close();
+  stagedOutbound.close();
+  log(`Seeded ${nIn} messages_in rows from staged session`);
+
+  // Same assembly as index.ts main(). In the container, index.ts resolves the
+  // MCP server path from its own location under /app/src — render that truth,
+  // not this script's host location.
+  const taskId = getTaskSeriesId();
+  const instructions = buildSystemPromptAddendum(
+    config.assistantName || undefined,
+    taskId ? { kind: 'task', taskId } : { kind: 'chat' },
+  );
+  const cwd = '/workspace/agent';
+  const mcpServers: Record<string, McpServerConfig> = {
+    nanoclaw: { command: 'bun', args: ['run', '/app/src/mcp-tools/index.ts'], env: {} },
+  };
+  for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
+    mcpServers[name] = resolvePluginServer(serverConfig);
+  }
+
+  // Drive the real poll loop until the first query is captured. Scenarios
+  // with no wake-eligible rows (e.g. subagent) skip the loop — it would
+  // never query (the accumulate gate holds trigger=0-only batches).
+  const provider = new CapturingProvider();
+  const hasWakeEligible =
+    (
+      inbound.prepare("SELECT COUNT(*) AS n FROM messages_in WHERE status = 'pending' AND trigger = 1").get() as {
+        n: number;
+      }
+    ).n > 0;
+  if (hasWakeEligible) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    provider.onCapture = () => controller.abort();
+    await runPollLoop({
+      provider,
+      providerContract: getProviderRuntimeContract(config.provider),
+      providerName: config.provider,
+      cwd,
+      systemContext: { instructions },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  }
+
+  const captured = provider.captured[0] ?? null;
+
+  // The exact SDK options ClaudeProvider would run this query with — built
+  // through createProvider so the contract resolves execution policy,
+  // inference, and MCP servers exactly as index.ts does.
+  let sdkOptions: Record<string, unknown> | null = null;
+  if (config.provider === 'claude') {
+    const claude = createProvider('claude', {
+      assistantName: config.assistantName || undefined,
+      mcpServers,
+      env: { ...process.env },
+      additionalDirectories: spec.additionalDirectories?.length ? spec.additionalDirectories : undefined,
+      model: config.model,
+      effort: config.effort,
+      speed: config.speed,
+    }) as ClaudeProvider;
+    registerProviderMemorySessionHook('claude', claude, MEMORY_SESSION_HOOK);
+    sdkOptions = sanitizeSdkOptions(
+      claude.buildQueryOptions({
+        prompt: captured?.prompt ?? '',
+        continuation: captured?.continuation,
+        cwd,
+        systemContext: { instructions },
+      }) as unknown as Record<string, unknown>,
+    );
+  }
+
+  const batch = inbound
+    .prepare(
+      'SELECT id, seq, kind, timestamp, status, trigger, on_wake, channel_type, platform_id FROM messages_in ORDER BY seq',
+    )
+    .all();
+
+  process.stdout.write(
+    JSON.stringify(
+      {
+        captured: captured !== null,
+        prompt: captured?.prompt ?? null,
+        continuation: captured?.continuation ?? null,
+        systemPromptAddendum: instructions,
+        sessionMode: taskId ? { kind: 'task', taskId } : { kind: 'chat' },
+        sdkOptions,
+        mcpTools: listRegisteredTools().map((t) => ({
+          name: t.tool.name,
+          description: t.tool.description,
+          inputSchema: t.tool.inputSchema,
+        })),
+        provider: config.provider,
+        batch,
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[context-preview-runner] Fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+  process.exit(1);
+});

--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -46,6 +46,11 @@ export function loadConfig(): RunnerConfig {
   return _config;
 }
 
+/** Inject a config directly — for tests and the context-preview harness. */
+export function setTestConfig(config: RunnerConfig): void {
+  _config = config;
+}
+
 /** Build the runner config from a parsed container.json; missing fields take their defaults. */
 export function runnerConfigFromRaw(raw: Record<string, unknown>): RunnerConfig {
   return {

--- a/container/agent-runner/src/mcp-tools/server.ts
+++ b/container/agent-runner/src/mcp-tools/server.ts
@@ -28,6 +28,11 @@ function log(msg: string): void {
 const allTools: McpToolDefinition[] = [];
 const toolMap = new Map<string, McpToolDefinition>();
 
+/** Everything registered so far — read by the context-preview harness. */
+export function listRegisteredTools(): McpToolDefinition[] {
+  return [...allTools];
+}
+
 export function registerTools(tools: McpToolDefinition[]): void {
   for (const t of tools) {
     if (toolMap.has(t.tool.name)) {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -316,7 +316,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
  * passthrough commands are sent raw (no XML wrapping) so the SDK can
  * dispatch them. Otherwise they fall through to standard XML formatting.
  */
-function formatMessagesWithCommands(
+export function formatMessagesWithCommands(
   messages: MessageInRow[],
   nativeSlashCommands: boolean,
   providerName: string,

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -243,44 +243,52 @@ export class ClaudeProvider implements AgentProvider {
     return rotateClaudeContinuation({ continuation, assistantName: this.assistantName, log }, REAL_CLOCK);
   }
 
+  /**
+   * The exact SDK options a query runs with. Public so the context-preview
+   * tool (scripts/context-preview.ts) can render the agent-visible
+   * configuration without spawning the SDK subprocess.
+   */
+  buildQueryOptions(input: QueryInput): NonNullable<Parameters<typeof sdkQuery>[0]['options']> {
+    const instructions = input.systemContext?.instructions;
+    return {
+      cwd: input.cwd,
+      additionalDirectories: this.additionalDirectories,
+      resume: input.continuation,
+      pathToClaudeCodeExecutable: '/pnpm/claude',
+      systemPrompt: instructions
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions }
+        : undefined,
+      allowedTools: [...this.mcp.allowedTools],
+      disallowedTools: [...this.executionPolicy.disallowedTools],
+      env: this.env,
+      model: this.inference.model,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      effort: this.inference.effort as any,
+      permissionMode: this.executionPolicy.permissionMode,
+      allowDangerouslySkipPermissions: this.executionPolicy.allowDangerouslySkipPermissions,
+      settingSources: ['project', 'user', 'local'],
+      // Only sent when enabled, so an install that never turns it on passes
+      // exactly the options it always did. `fastMode` is a Settings member
+      // rather than a query option, which is why it rides `settings`.
+      ...(this.inference.settings ? { settings: this.inference.settings } : {}),
+      mcpServers: this.mcp.mcpServers,
+      hooks: {
+        PreToolUse: [{ hooks: [preToolUseHook] }],
+        PostToolUse: [{ hooks: [postToolUseHook] }],
+        PostToolUseFailure: [{ hooks: [postToolUseHook] }],
+        PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
+      },
+    };
+  }
+
   query(input: QueryInput): AgentQuery {
     if (!this.memorySessionHook) throw new Error('Claude memory session hook was not registered');
     const stream = new MessageStream();
     stream.push(input.prompt);
 
-    const instructions = input.systemContext?.instructions;
-
     const sdkResult = sdkQuery({
       prompt: stream,
-      options: {
-        cwd: input.cwd,
-        additionalDirectories: this.additionalDirectories,
-        resume: input.continuation,
-        pathToClaudeCodeExecutable: '/pnpm/claude',
-        systemPrompt: instructions
-          ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions }
-          : undefined,
-        allowedTools: [...this.mcp.allowedTools],
-        disallowedTools: [...this.executionPolicy.disallowedTools],
-        env: this.env,
-        model: this.inference.model,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        effort: this.inference.effort as any,
-        permissionMode: this.executionPolicy.permissionMode,
-        allowDangerouslySkipPermissions: this.executionPolicy.allowDangerouslySkipPermissions,
-        settingSources: ['project', 'user', 'local'],
-        // Only sent when enabled, so an install that never turns it on passes
-        // exactly the options it always did. `fastMode` is a Settings member
-        // rather than a query option, which is why it rides `settings`.
-        ...(this.inference.settings ? { settings: this.inference.settings } : {}),
-        mcpServers: this.mcp.mcpServers,
-        hooks: {
-          PreToolUse: [{ hooks: [preToolUseHook] }],
-          PostToolUse: [{ hooks: [postToolUseHook] }],
-          PostToolUseFailure: [{ hooks: [postToolUseHook] }],
-          PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
-        },
-      },
+      options: this.buildQueryOptions(input),
     });
 
     let aborted = false;

--- a/docs/context-preview.md
+++ b/docs/context-preview.md
@@ -1,0 +1,164 @@
+# Context Preview
+
+`scripts/context-preview.ts` renders the **exact context an agent sees** for a
+given scenario — the composed project document (`/workspace/agent/CLAUDE.md`,
+every instruction source inlined), the runtime system-prompt addendum, the
+SDK options, the MCP tool surface, the container mount table, and the exact
+prompt string the poll loop hands the provider.
+
+```bash
+pnpm exec tsx scripts/context-preview.ts <scenario> [flags]
+```
+
+Use it to answer questions like *"when a scheduled task fires, does the agent
+have enough context to know it must address the user explicitly?"*, *"what
+exactly changes in the agent's context when I edit `container/CLAUDE.md` / a
+module's `instructions.md` / the formatter?"*, or *"what did the agent
+actually read on that turn?"* (replay a real session dump) — without spawning
+a container or sending a real message.
+
+## Fidelity model
+
+The tool **imports the production code paths instead of duplicating strings**,
+so any edit to the composer, formatter, addendum builder, instruction sources,
+or SDK options is reflected on the next run:
+
+- Host half (Node/tsx): runs the real scaffold + spawn steps, in spawn order —
+  `initGroupFilesystem` (the once-per-lifetime creation scaffold; it stages
+  `--persona-file` through `stageGroupPersona`), `materializeContainerJson`,
+  `resolveProviderContribution` (which realizes the provider's surfaces and
+  composes the project document via `composeGroupProjectDoc`), then
+  `buildMounts` — in a throwaway sandbox with an in-memory central DB
+  (`initTestDb` + `runMigrations`). Scenario rows are staged with the same
+  writers the host uses (`writeSessionMessage`, `createScheduledTask`,
+  `writeDestinations`, `writeSessionRouting`). **Nothing in the live install
+  is read-write touched**; `--group` opens `data/v2.db` read-only.
+- Container half (Bun): `container/agent-runner/scripts/context-preview-runner.ts`
+  parses the staged `container.json` with `runnerConfigFromRaw`, seeds the
+  in-memory test session DBs (`initTestSessionDb`) with the staged rows, and
+  drives the **real `runPollLoop`** with a capturing provider under the
+  previewed provider's runtime contract — batching, `on_wake` first-poll
+  gating, the accumulate gate, and slash-command splitting are all production
+  behavior. The addendum comes from `buildSystemPromptAddendum()` in the mode
+  `getTaskSeriesId()` derives from the staged session routing (task mode for
+  task sessions, exactly as `index.ts` does); SDK options from a provider
+  built through `createProvider('claude')` + `ClaudeProvider.buildQueryOptions()`;
+  the tool list from `listRegisteredTools()`.
+
+## Scenarios
+
+| Scenario | What it stages |
+|----------|----------------|
+| `first-message` | Fresh session, first user chat message (default) |
+| `followup` | Existing session: prior completed turn + stored continuation → SDK `resume` |
+| `accumulate` | Group chat: three `trigger=0` context-only rows riding in with a `trigger=1` mention |
+| `task-fire` | A due task row exactly as `ncl tasks create` writes it (`createScheduledTask`: isolated per-series task session; the task contract is rendered in the system prompt's task mode) |
+| `on-wake` | The `on_wake=1` restart message `ncl groups restart --message` / self-mod apply writes |
+| `a2a` | A message from another agent group, as `performAgentRoute` writes it (verbatim `{text}`, `source_session_id` return path) |
+| `subagent` | No messages — explains SDK-native subagents (Task tool) and points at the surfaces that enable them |
+
+## Flags
+
+| Flag | Meaning |
+|------|---------|
+| `--group <folder\|id>` | Preview a **real agent group**: its container config, cli_scope, persona, plugins, and destinations are snapshotted (read-only) from `data/v2.db` and `groups/<folder>/`. Default is a synthetic group named `preview`. |
+| `--persona-file <path>` | Stage this file as the group's standing instructions (`instructions.prepend.md`, the file the composer leads the document with). Replaces the group's own persona for the run. |
+| `--replay <jsonl>` | Stage real inbound rows from a **session dump** instead of the scenario's synthetic message — one `{"recordType": …, "record": {…}}` object per line, the mailbox record format (`InboundRecord` fields: `id, sequence, kind, timestamp, trigger, platformId, channelType, threadId, content, …`). `sessionRouting`, `destination` and `state` (`continuation:<provider>`) records in the dump are staged too, so the `from=` names, the addendum's destination map and the SDK `resume` match the real session. Only with `first-message` (default) or `followup`. |
+| `--turn <seq\|a-b>` | With `--replay`: which record(s) form the pending batch. Records before the turn are staged as completed history (and the dump's continuation applies); records after it are dropped. Default: the last inbound record. |
+| `--message <text>` | Override the staged message/task/wake text |
+| `--sender <name>` / `--channel <type>` | Sender display name and channel type for chat scenarios |
+| `--section <name>` | Print one section: `scenario`, `environment`, `claude-md`, `system-prompt`, `sdk-options`, `mcp-tools`, `prompt`, `notes` |
+| `--json` | Machine-readable dump of everything (`claudeMd`, `systemPrompt`, `sdkOptions`, `mcpTools`, `prompt`, plus `batch`, `mounts`, `persona`, `replay`, `notes`) |
+| `--keep` | Keep the sandbox dir for inspection (path printed to stderr) |
+
+The `claude-md` section prints a section index (`# <name>: <words> words`) before
+the full document — the same shape as `awk` over the file inside a running pod,
+so the two can be compared line by line.
+
+## Example: a real turn from an e2e lane
+
+Given a session dump in the mailbox record format (e.g. what a lane's
+`context-live.sh <agentGroupId> <sessionId>` reads from its S3 mailbox — inbound
+records, the `sessionRouting` and `destination` records, and the
+`continuation:claude` state row) and the persona the lane's composer staged for
+that session:
+
+```bash
+TZ=UTC pnpm exec tsx scripts/context-preview.ts \
+  --persona-file /path/to/persona.md \
+  --replay /path/to/session-dump.jsonl --turn 22 \
+  --section prompt
+```
+
+renders the exact `<message …>` block of record #22, with the dump's stored
+continuation as the SDK `resume` and `from="<the session's destination>"`.
+`--section claude-md` then prints the composed document whose `Persona` body
+is byte-identical to the staged file; compare its section index with the pod's
+(`kubectl exec … -- awk '/^# /…' /workspace/agent/CLAUDE.md`). Set `TZ` to the
+deployment's timezone so `<context timezone>` and `time=` match the pod.
+
+Run the tool from the host tree that produced the deployment (or a copy of it)
+so the instruction sources it composes are the deployed ones.
+
+## What is NOT simulated
+
+The preview starts at the session inbound mailbox — everything upstream of it
+and some side flows are out of scope. When reasoning about those, read the
+real paths:
+
+- **Router-side gating** — engage-mode evaluation (mention/pattern),
+  `unknown_sender_policy`, command gating (`/help` filtering, admin denial),
+  and channel-registration escalation happen before a row is ever written
+  (`src/router.ts`, `src/command-gate.ts`). The preview stages rows as if they
+  passed.
+- **Content enrichment by real adapters** — the chat-sdk bridge writes the
+  full message serialization (author, replyTo, attachments) into `content`
+  (`src/channels/chat-sdk-bridge.ts` `messageToInbound`); synthetic scenarios
+  stage the minimal `{text, sender, senderId}` shape. `--replay` renders real
+  rows.
+- **Attachment staging** — base64 → `inbox/<msgId>/<file>` extraction and
+  safety renames (`src/session-manager.ts` `extractAttachmentFiles`) run, but
+  replayed dumps normally carry paths, not payloads.
+- **Approval flows** — approval-outcome notifications
+  (`src/modules/approvals/`), the a2a message gate, and the `ncl` cli_request
+  round-trip all inject further context into sessions.
+- **Task pre-scripts** — a task's `script` runs before the wake and injects
+  `scriptOutput` into the `<task>` block
+  (`container/agent-runner/src/scheduling/task-script.ts`).
+- **Memory session context** — the provider's session-start hook
+  (`container/agent-runner/src/memory/hook.ts`) injects the memory index on a
+  fresh context window; the preview shows the hook's env, not its output.
+- **Real container env** — OneCLI proxy vars, egress lockdown, and image
+  contents; the SDK-options `env` is rendered as the keys the provider itself
+  sets plus a note.
+- **Non-default providers** — the SDK options section is Claude-specific;
+  providers that own their agent surfaces skip the composed-CLAUDE.md path
+  entirely.
+- **Deployment-specific composers** — a deployment whose init container
+  composes the workspace from a release bundle may add or drop instruction
+  sources relative to the source tree; run the tool on that tree to compare.
+
+## Maintenance seams
+
+These production exports exist specifically so no agent-visible string is
+duplicated. If you rename or restructure them, update both halves — the smoke
+test (`scripts/context-preview.test.ts`, runs `first-message --json` under
+vitest with the Bun half) goes red when one drifts:
+
+- `ClaudeProvider.buildQueryOptions()` (`container/agent-runner/src/providers/claude.ts`)
+- `formatMessagesWithCommands` (`container/agent-runner/src/poll-loop.ts`)
+- `listRegisteredTools` (`container/agent-runner/src/mcp-tools/server.ts`)
+- `setTestConfig` + `runnerConfigFromRaw` (`container/agent-runner/src/config.ts`)
+- `initTestSessionDb` (`container/agent-runner/src/mailbox/sqlite/connection.ts`)
+- `createScheduledTask` / `prepareScheduledTask` (`src/modules/scheduling/create.ts`)
+  and `resolveProviderContribution` / `buildMounts` (`src/container-runner.ts`)
+  — host-side production functions the tool calls directly.
+
+The tool-module list is not mirrored: the Bun harness reads the side-effect
+`import './…'` lines of `container/agent-runner/src/mcp-tools/index.ts` (the
+barrel cannot be imported — it starts the MCP server) and loads exactly those,
+so an installed or removed tool module shows up on the next run. One piece of
+wiring is mirrored (not imported) and must be kept in sync by hand:
+
+- the `mcpServers`/`cwd` assembly from `container/agent-runner/src/index.ts`
+  `main()`

--- a/scripts/context-preview.test.ts
+++ b/scripts/context-preview.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+/**
+ * Smoke test for scripts/context-preview.ts: the tool imports production
+ * seams from both halves (host: spawn path + writers; container: poll loop,
+ * provider options, tool registry), so any rename or signature drift breaks
+ * it. Running the default scenario end to end — the container half under
+ * Bun, as in CI — and checking every surface is non-empty catches that
+ * before it rots silently.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'context-preview.ts');
+
+describe('scripts/context-preview.ts', () => {
+  it('renders all five surfaces for first-message --json', { timeout: 180_000 }, () => {
+    const r = spawnSync('pnpm', ['exec', 'tsx', SCRIPT, 'first-message', '--json'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, LOG_LEVEL: 'warn' },
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    expect(r.status, `context-preview failed:\n${r.stderr}`).toBe(0);
+    const out = JSON.parse(r.stdout);
+
+    // 1. Composed project document — sections + the runtime contract.
+    expect(out.claudeMd.sections.length).toBeGreaterThan(0);
+    expect(out.claudeMd.content).toContain('# NanoClaw Runtime Contract');
+    // 2. Runtime system-prompt addendum — identity + destinations.
+    expect(out.systemPrompt.append).toContain('## Sending messages');
+    // 3. SDK options — the exact Claude query options.
+    expect(Array.isArray(out.sdkOptions?.allowedTools)).toBe(true);
+    expect(out.sdkOptions.allowedTools.length).toBeGreaterThan(0);
+    expect(out.sdkOptions.cwd).toBe('/workspace/agent');
+    // 4. MCP tool surface — registered nanoclaw tools.
+    const toolNames = out.mcpTools.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain('send_message');
+    // 5. The exact prompt the real poll loop handed the provider.
+    expect(out.prompt).toContain('<message ');
+    expect(out.prompt).toContain('birthday dinner');
+  });
+});

--- a/scripts/context-preview.ts
+++ b/scripts/context-preview.ts
@@ -1,0 +1,1016 @@
+/**
+ * scripts/context-preview.ts — render the exact context an agent sees.
+ *
+ * For maintainers: simulates a scenario (first message, scheduled task fire,
+ * restart wake, agent-to-agent message, a replayed real turn, …) and prints
+ * every context surface the agent would receive — the composed project doc
+ * (CLAUDE.md), the runtime system-prompt addendum, the SDK options, the MCP
+ * tool list, and the exact prompt string — using the REAL production code
+ * paths, so edits to instruction sources, the formatter, the composer, etc.
+ * are reflected immediately. Nothing is duplicated and nothing in the live
+ * install is touched: the whole run happens in a throwaway sandbox with an
+ * in-memory central DB, and the container half runs the real poll loop under
+ * Bun (container/agent-runner/scripts/context-preview-runner.ts).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/context-preview.ts <scenario> [flags]
+ *
+ * Scenarios:
+ *   first-message   Fresh session, first user message         (default)
+ *   followup        Existing session (continuation on file), next message
+ *   accumulate      Group chat: silent trigger=0 rows ride in with a mention
+ *   task-fire       A scheduled task (`ncl tasks create`) comes due
+ *   on-wake         Container restart with an on_wake message
+ *   a2a             Message arriving from another agent group
+ *   subagent        What SDK-native subagents (Task tool) inherit
+ *
+ * Flags:
+ *   --group <folder|id>     Use a real agent group from data/v2.db (read-only
+ *                           snapshot of its config, persona, destinations).
+ *                           Default: a synthetic group named "preview".
+ *   --persona-file <path>   Stage this file as the group's standing
+ *                           instructions (instructions.prepend.md).
+ *   --replay <jsonl>        Stage real inbound rows from a session dump (the
+ *                           mailbox record format: one {recordType, record}
+ *                           JSON object per line) instead of the scenario's
+ *                           synthetic message. Destination, routing and
+ *                           continuation records in the dump are staged too.
+ *   --turn <seq|a-b>        With --replay: which record(s) form the batch
+ *                           being previewed. Earlier records are staged as
+ *                           already-handled history; later ones are dropped.
+ *                           Default: the last inbound record.
+ *   --message <text>        User/task/wake message text.
+ *   --sender <name>         Sender display name (default "Dana").
+ *   --channel <type>        Channel type for the messaging group (default "whatsapp").
+ *   --section <name>        Print one section: scenario|environment|claude-md|
+ *                           system-prompt|sdk-options|mcp-tools|prompt|notes
+ *   --json                  Machine-readable output of everything.
+ *   --keep                  Keep the sandbox dir (path printed) for inspection.
+ */
+import Database from 'better-sqlite3';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import type { DbDriver } from '../src/db/driver.js';
+import type { AgentGroup, ContainerConfigRow, Session } from '../src/types.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const SCENARIOS = ['first-message', 'followup', 'accumulate', 'task-fire', 'on-wake', 'a2a', 'subagent'] as const;
+type Scenario = (typeof SCENARIOS)[number];
+const SECTIONS = [
+  'scenario',
+  'environment',
+  'claude-md',
+  'system-prompt',
+  'sdk-options',
+  'mcp-tools',
+  'prompt',
+  'notes',
+];
+
+interface Args {
+  scenario: Scenario;
+  group?: string;
+  personaFile?: string;
+  replay?: string;
+  turn?: [number, number];
+  message?: string;
+  sender: string;
+  channel: string;
+  section?: string;
+  json: boolean;
+  keep: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { scenario: 'first-message', sender: 'Dana', channel: 'whatsapp', json: false, keep: false };
+  const positional: string[] = [];
+  const value = (flag: string, v: string | undefined): string => {
+    if (v === undefined || v.startsWith('--')) fail(`${flag} requires a value`);
+    return v;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') args.json = true;
+    else if (a === '--keep') args.keep = true;
+    else if (a === '--group') args.group = value(a, argv[++i]);
+    else if (a === '--persona-file') args.personaFile = value(a, argv[++i]);
+    else if (a === '--replay') args.replay = value(a, argv[++i]);
+    else if (a === '--turn') args.turn = parseTurn(value(a, argv[++i]));
+    else if (a === '--message') args.message = value(a, argv[++i]);
+    else if (a === '--sender') args.sender = value(a, argv[++i]);
+    else if (a === '--channel') args.channel = value(a, argv[++i]);
+    else if (a === '--section') args.section = value(a, argv[++i]);
+    else if (a.startsWith('--')) fail(`Unknown flag: ${a}`);
+    else positional.push(a);
+  }
+  if (args.section && !SECTIONS.includes(args.section)) {
+    fail(`Unknown section "${args.section}". Sections: ${SECTIONS.join(', ')}`);
+  }
+  if (args.turn && !args.replay) fail('--turn only applies with --replay');
+  if (positional.length > 1) fail(`Expected one scenario, got: ${positional.join(' ')}`);
+  if (positional[0]) {
+    if (!SCENARIOS.includes(positional[0] as Scenario)) {
+      fail(`Unknown scenario "${positional[0]}". Scenarios: ${SCENARIOS.join(', ')}`);
+    }
+    args.scenario = positional[0] as Scenario;
+  }
+  if (args.replay && args.scenario !== 'first-message' && args.scenario !== 'followup') {
+    fail('--replay stages the dump as the session; use it with first-message (default) or followup');
+  }
+  for (const f of [args.personaFile, args.replay]) {
+    if (f && !fs.existsSync(f)) fail(`File not found: ${f}`);
+  }
+  return args;
+}
+
+function parseTurn(spec: string): [number, number] {
+  const m = spec.match(/^(\d+)(?:-(\d+))?$/);
+  if (!m) fail(`--turn expects <seq> or <from>-<to>, got "${spec}"`);
+  const a = Number(m[1]);
+  const b = m[2] ? Number(m[2]) : a;
+  if (b < a) fail(`--turn range is reversed: ${spec}`);
+  return [a, b];
+}
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(2);
+}
+
+/** Snapshot of a real group read from the live central DB (read-only). */
+interface LiveGroup {
+  group: AgentGroup;
+  configRow: ContainerConfigRow | null;
+  destinations: Array<Record<string, unknown>>;
+  messagingGroups: Array<Record<string, unknown>>;
+  /** Agent groups referenced by agent-type destinations — writeDestinations
+   *  silently drops a destination whose target group row is missing. */
+  targetAgentGroups: Array<Record<string, unknown>>;
+}
+
+function snapshotLiveGroup(ref: string): LiveGroup {
+  const dbPath = path.join(REPO_ROOT, 'data', 'v2.db');
+  if (!fs.existsSync(dbPath)) fail(`--group requires a live SQLite install (${dbPath} not found)`);
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const group = db.prepare('SELECT * FROM agent_groups WHERE folder = ? OR id = ?').get(ref, ref) as
+      | AgentGroup
+      | undefined;
+    if (!group) {
+      const known = (db.prepare('SELECT folder FROM agent_groups').all() as Array<{ folder: string }>)
+        .map((r) => r.folder)
+        .join(', ');
+      fail(`Agent group "${ref}" not found. Known folders: ${known || '(none)'}`);
+    }
+    const configRow = db.prepare('SELECT * FROM container_configs WHERE agent_group_id = ?').get(group.id) as
+      | ContainerConfigRow
+      | undefined;
+    const hasDest = db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='agent_destinations'").get();
+    const destinations = hasDest
+      ? (db.prepare('SELECT * FROM agent_destinations WHERE agent_group_id = ?').all(group.id) as Array<
+          Record<string, unknown>
+        >)
+      : [];
+    const mgIds = destinations.filter((d) => d.target_type === 'channel').map((d) => d.target_id as string);
+    const messagingGroups = mgIds.length
+      ? (db
+          .prepare(`SELECT * FROM messaging_groups WHERE id IN (${mgIds.map(() => '?').join(',')})`)
+          .all(...mgIds) as Array<Record<string, unknown>>)
+      : [];
+    const agIds = destinations.filter((d) => d.target_type === 'agent').map((d) => d.target_id as string);
+    const targetAgentGroups = agIds.length
+      ? (db
+          .prepare(`SELECT * FROM agent_groups WHERE id IN (${agIds.map(() => '?').join(',')})`)
+          .all(...agIds) as Array<Record<string, unknown>>)
+      : [];
+    return { group, configRow: configRow ?? null, destinations, messagingGroups, targetAgentGroups };
+  } finally {
+    db.close();
+  }
+}
+
+/** Insert a raw row into the in-memory central DB, keeping only columns that exist. */
+async function insertRaw(db: DbDriver, table: string, row: Record<string, unknown>): Promise<void> {
+  const cols = new Set((await db.all<{ name: string }>(`PRAGMA table_info('${table}')`)).map((c) => c.name));
+  const keys = Object.keys(row).filter((k) => cols.has(k));
+  await db.run(
+    `INSERT OR REPLACE INTO ${table} (${keys.join(', ')}) VALUES (${keys.map(() => '?').join(', ')})`,
+    ...keys.map((k) => row[k]),
+  );
+}
+
+// ── Replay: a session dump in the mailbox record format ──
+
+/** One inbound row as the mailbox serializes it (camelCase InboundRecord). */
+interface ReplayInbound {
+  id: string;
+  sequence: number;
+  kind: string;
+  timestamp: string;
+  status?: string;
+  trigger?: boolean;
+  onWake?: boolean;
+  platformId: string | null;
+  channelType: string | null;
+  threadId: string | null;
+  content: string;
+  processAfter?: string | null;
+  recurrence?: string | null;
+  sourceSessionId?: string | null;
+}
+
+interface ReplayDump {
+  inbound: ReplayInbound[];
+  routing: { channelType: string | null; platformId: string | null; threadId: string | null } | null;
+  destinations: Array<{
+    name: string;
+    displayName: string | null;
+    type: string;
+    channelType: string | null;
+    platformId: string | null;
+    agentGroupId: string | null;
+  }>;
+  /** session_state rows, e.g. continuation:<provider>. */
+  state: Array<{ key: string; value: string; updatedAt?: string }>;
+}
+
+function readReplayDump(file: string): ReplayDump {
+  const dump: ReplayDump = { inbound: [], routing: null, destinations: [], state: [] };
+  let n = 0;
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    n++;
+    let obj: { recordType?: string; record?: Record<string, unknown> };
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      fail(`--replay: line ${n} is not JSON`);
+    }
+    const rec = obj.record;
+    if (!rec) continue;
+    switch (obj.recordType) {
+      case 'inbound':
+        dump.inbound.push(rec as unknown as ReplayInbound);
+        break;
+      case 'sessionRouting':
+        dump.routing = rec as ReplayDump['routing'];
+        break;
+      case 'destination':
+        dump.destinations.push(rec as ReplayDump['destinations'][number]);
+        break;
+      case 'state':
+        dump.state.push(rec as ReplayDump['state'][number]);
+        break;
+      default:
+        break; // outbound, deliveries, acks, container: not context inputs
+    }
+  }
+  if (dump.inbound.length === 0) fail(`--replay: no inbound records in ${file}`);
+  dump.inbound.sort((a, b) => a.sequence - b.sequence || a.timestamp.localeCompare(b.timestamp));
+  return dump;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Keep stdout clean for the rendered preview — src/log.ts logs info to
+  // stdout. Must be set before the first src import evaluates the threshold.
+  if (!process.env.LOG_LEVEL) process.env.LOG_LEVEL = 'warn';
+
+  // Inputs that live outside the sandbox — read BEFORE chdir.
+  const live = args.group ? snapshotLiveGroup(args.group) : null;
+  const persona = args.personaFile ? fs.readFileSync(path.resolve(args.personaFile), 'utf8') : null;
+  const replay = args.replay ? readReplayDump(path.resolve(args.replay)) : null;
+
+  // ── Sandbox ──
+  // GROUPS_DIR / DATA_DIR resolve from process.cwd() at src/config.js import
+  // time, and the composer discovers instruction sources under cwd/container/.
+  // Chdir into a throwaway root (with container/ symlinked back to the repo)
+  // before importing any src module, so every host-side write lands in the
+  // sandbox.
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-context-preview-'));
+  fs.mkdirSync(path.join(sandbox, 'groups'));
+  fs.mkdirSync(path.join(sandbox, 'data'));
+  fs.symlinkSync(path.join(REPO_ROOT, 'container'), path.join(sandbox, 'container'));
+  // Carry over only the non-secret .env keys the preview actually renders
+  // (identity + timezone). Never copy the whole file — the sandbox lives in
+  // tmp and credentials (ONECLI_API_KEY etc.) must not leave the repo.
+  const ENV_WHITELIST = new Set(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER', 'TZ', 'DEFAULT_AGENT_PROVIDER']);
+  const liveEnvFile = path.join(REPO_ROOT, '.env');
+  if (fs.existsSync(liveEnvFile)) {
+    const kept = fs
+      .readFileSync(liveEnvFile, 'utf8')
+      .split('\n')
+      .filter((line) => ENV_WHITELIST.has(line.split('=')[0]?.trim()));
+    fs.writeFileSync(path.join(sandbox, '.env'), kept.join('\n') + '\n');
+  }
+  process.chdir(sandbox);
+
+  const cleanup = () => {
+    if (args.keep) {
+      console.error(`Sandbox kept: ${sandbox}`);
+    } else {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  };
+
+  try {
+    // Host modules — imported only now, with cwd = sandbox. The modules barrel
+    // first: it registers the mailbox implementation (same as src/index.ts).
+    await import('../src/modules/index.js');
+    const dbMod = await import('../src/db/index.js');
+    const sessionManager = await import('../src/session-manager.js');
+    const mailboxPaths = await import('../src/mailbox/sqlite/index.js');
+    const sessionDb = await import('../src/mailbox/sqlite/session-db.js');
+    const groupInit = await import('../src/group-init.js');
+    const groupPersona = await import('../src/group-persona.js');
+    const containerConfigMod = await import('../src/container-config.js');
+    const containerRunner = await import('../src/container-runner.js');
+    const scheduling = await import('../src/modules/scheduling/create.js');
+    const writeDestMod = await import('../src/modules/agent-to-agent/write-destinations.js');
+    const configMod = await import('../src/config.js');
+
+    const central = await dbMod.initTestDb();
+    // initTestDb migrates only on backends that own a test schema; the SQLite
+    // composition does not, and runMigrations is idempotent either way.
+    await dbMod.runMigrations(central);
+
+    // ── Seed the agent group ──
+    let group: AgentGroup;
+    if (live) {
+      group = live.group;
+      await insertRaw(central, 'agent_groups', group as unknown as Record<string, unknown>);
+      if (live.configRow) {
+        await insertRaw(central, 'container_configs', live.configRow as unknown as Record<string, unknown>);
+      }
+      for (const mg of live.messagingGroups) await insertRaw(central, 'messaging_groups', mg);
+      for (const ag of live.targetAgentGroups) await insertRaw(central, 'agent_groups', ag);
+      for (const d of live.destinations) await insertRaw(central, 'agent_destinations', d);
+      // Copy the group's real files (persona, memory, plugins) so the composed
+      // doc matches the install. The composed doc is regenerated in the sandbox.
+      const liveGroupDir = path.join(REPO_ROOT, 'groups', group.folder);
+      if (fs.existsSync(liveGroupDir)) {
+        fs.cpSync(liveGroupDir, path.join(sandbox, 'groups', group.folder), { recursive: true });
+      }
+      // Per-group provider state (settings, skill links) — the default Claude layout.
+      const liveClaudeShared = path.join(REPO_ROOT, 'data', 'v2-sessions', group.id, '.claude-shared');
+      if (fs.existsSync(liveClaudeShared)) {
+        fs.cpSync(liveClaudeShared, path.join(sandbox, 'data', 'v2-sessions', group.id, '.claude-shared'), {
+          recursive: true,
+        });
+      }
+    } else {
+      group = {
+        id: 'preview-group',
+        name: 'preview',
+        folder: 'preview',
+        agent_provider: null,
+        created_at: new Date().toISOString(),
+      };
+      await dbMod.createAgentGroup(group);
+    }
+    const groupDir = path.join(sandbox, 'groups', group.folder);
+
+    // --persona-file: the staged standing instructions replace whatever the
+    // group had, through the same writer group creation uses (stageGroupPersona
+    // via initGroupFilesystem below).
+    if (persona !== null) {
+      fs.rmSync(path.join(groupDir, groupPersona.PERSONA_PREPEND_FILE), { force: true });
+    }
+
+    // ── Messaging group + destinations ──
+    // Synthetic mode: one DM (or group chat) the agent is wired to, plus the
+    // destination row /init-first-agent and /manage-channels create. A replay
+    // dump carries the real session routing and destination map, so the
+    // synthetic rows take their channel/platform/name from it.
+    const liveMg = live?.messagingGroups[0] as { id?: string; channel_type?: string; platform_id?: string } | undefined;
+    let mgId: string;
+    let mgChannel: string;
+    let mgPlatformId: string;
+    if (liveMg?.id) {
+      mgId = liveMg.id;
+      mgChannel = liveMg.channel_type as string;
+      mgPlatformId = liveMg.platform_id as string;
+    } else {
+      const routing = replay?.routing ?? replay?.inbound.find((r) => r.channelType && r.platformId) ?? null;
+      mgId = 'preview-mg';
+      mgChannel = routing?.channelType ?? args.channel;
+      mgPlatformId = routing?.platformId ?? (args.scenario === 'accumulate' ? 'preview-group-chat' : 'preview-dm');
+      const ownDest = replay?.destinations.find(
+        (d) => d.type === 'channel' && d.channelType === mgChannel && d.platformId === mgPlatformId,
+      );
+      await dbMod.createMessagingGroup({
+        id: mgId,
+        channel_type: mgChannel,
+        platform_id: mgPlatformId,
+        name: ownDest?.displayName ?? (args.scenario === 'accumulate' ? 'Preview Group Chat' : 'Preview DM'),
+        is_group: args.scenario === 'accumulate' ? 1 : 0,
+        unknown_sender_policy: 'strict',
+        created_at: new Date().toISOString(),
+      });
+      await insertRaw(central, 'agent_destinations', {
+        agent_group_id: group.id,
+        local_name: ownDest?.name ?? `${mgChannel}-main`,
+        target_type: 'channel',
+        target_id: mgId,
+        created_at: new Date().toISOString(),
+      });
+      // Every other destination in the dump, so the addendum's map matches.
+      let n = 0;
+      for (const d of replay?.destinations ?? []) {
+        if (d === ownDest) continue;
+        n++;
+        if (d.type === 'channel' && d.channelType && d.platformId) {
+          const id = `preview-mg-${n}`;
+          await dbMod.createMessagingGroup({
+            id,
+            channel_type: d.channelType,
+            platform_id: d.platformId,
+            name: d.displayName ?? d.name,
+            is_group: 0,
+            unknown_sender_policy: 'strict',
+            created_at: new Date().toISOString(),
+          });
+          await insertRaw(central, 'agent_destinations', {
+            agent_group_id: group.id,
+            local_name: d.name,
+            target_type: 'channel',
+            target_id: id,
+            created_at: new Date().toISOString(),
+          });
+        } else if (d.type === 'agent') {
+          const id = d.agentGroupId ?? `preview-agent-${n}`;
+          await dbMod.createAgentGroup({
+            id,
+            name: d.displayName ?? d.name,
+            folder: id,
+            agent_provider: null,
+            created_at: new Date().toISOString(),
+          });
+          await insertRaw(central, 'agent_destinations', {
+            agent_group_id: group.id,
+            local_name: d.name,
+            target_type: 'agent',
+            target_id: id,
+            created_at: new Date().toISOString(),
+          });
+        }
+      }
+    }
+
+    // ── Filesystem scaffold ──
+    // initGroupFilesystem is the once-per-lifetime creation scaffold (also run
+    // defensively at spawn); materializeContainerJson + resolveProviderContribution
+    // + buildMounts below are the per-spawn steps, in spawn order.
+    const providerHint = live?.configRow?.provider ?? null;
+    await groupInit.initGroupFilesystem(group, { provider: providerHint, instructions: persona ?? undefined });
+    const containerConfig = await containerConfigMod.materializeContainerJson(group.id);
+    const runnerProvider = containerRunner.resolveProviderName(null, containerConfig.provider);
+
+    // ── Session + scenario staging ──
+    const senderId = `${mgChannel}:15551230000`;
+    const text = args.message ?? defaultMessage(args.scenario);
+    let session: Session;
+    const notes: string[] = [];
+    const chatContent = (t: string, sender: string, sid: string) => JSON.stringify({ text: t, sender, senderId: sid });
+    const now = () => new Date().toISOString();
+
+    if (args.scenario === 'task-fire') {
+      // The exact writer behind `ncl tasks create`: series id, isolated task
+      // session (thread system:tasks:<id>), content shape.
+      const prepared = scheduling.prepareScheduledTask({
+        name: 'preview-task',
+        prompt: text,
+        processAfter: now(),
+        timezone: configMod.TIMEZONE,
+      });
+      const created = await scheduling.createScheduledTask(group.id, prepared);
+      const full = await dbMod.getSession(created.session.id);
+      if (!full) throw new Error('task session not found after create');
+      session = full;
+      notes.push(
+        'Tasks run in an isolated per-series session (thread system:tasks:<seriesId>, no messaging group). The runner derives task mode from that thread id (getTaskSeriesId) and buildSystemPromptAddendum renders the task contract — explicit `to`, run-log summary — in the SYSTEM PROMPT, not in the task prompt (the pre-#3004 run-log directive appended to the prompt is gone; formatter.ts strips it from legacy rows).',
+        'Tasks with a `script` run it BEFORE the agent wakes and inject scriptOutput into the <task> block (container/agent-runner/src/scheduling/task-script.ts); not staged here.',
+      );
+    } else {
+      session = (await sessionManager.resolveSession(group.id, mgId, null, 'shared')).session;
+    }
+
+    const inboundPath = mailboxPaths.inboundDbPath(group.id, session.id);
+    const outboundPath = mailboxPaths.outboundDbPath(group.id, session.id);
+    const setContinuation = (value: string) => {
+      // Keyed per provider — the poll loop looks up continuation:<provider
+      // from container.json> (container/agent-runner/src/db/session-state.ts).
+      const outb = sessionDb.openOutboundDbRw(outboundPath);
+      outb
+        .prepare('INSERT OR REPLACE INTO session_state (key, value, updated_at) VALUES (?, ?, ?)')
+        .run(`continuation:${runnerProvider}`, value, now());
+      outb.close();
+    };
+    const markCompleted = (ids: string[]) => {
+      if (ids.length === 0) return;
+      const inb = sessionDb.openInboundDb(inboundPath);
+      inb
+        .prepare(`UPDATE messages_in SET status = 'completed' WHERE id IN (${ids.map(() => '?').join(',')})`)
+        .run(...ids);
+      inb.close();
+    };
+
+    let replayInfo: {
+      file: string;
+      turn: [number, number];
+      staged: string[];
+      history: string[];
+      dropped: number;
+    } | null = null;
+
+    if (replay) {
+      // Real rows, through the real host writer, in sequence order. Records
+      // before the turn are history (already handled), the turn's records are
+      // the pending batch, later records never happened yet.
+      const last = replay.inbound[replay.inbound.length - 1].sequence;
+      const turn = args.turn ?? [last, last];
+      const history: string[] = [];
+      const staged: string[] = [];
+      let dropped = 0;
+      for (const r of replay.inbound) {
+        if (r.sequence > turn[1]) {
+          dropped++;
+          continue;
+        }
+        await sessionManager.writeSessionMessage(group.id, session.id, {
+          id: r.id,
+          kind: r.kind as Parameters<typeof sessionManager.writeSessionMessage>[2]['kind'],
+          timestamp: r.timestamp,
+          platformId: r.platformId,
+          channelType: r.channelType,
+          threadId: r.threadId,
+          content: r.content,
+          processAfter: r.processAfter ?? null,
+          recurrence: r.recurrence ?? null,
+          trigger: r.trigger ?? true,
+          sourceSessionId: r.sourceSessionId ?? null,
+          onWake: r.onWake ?? false,
+        });
+        (r.sequence < turn[0] ? history : staged).push(r.id);
+      }
+      if (staged.length === 0) fail(`--turn ${turn[0]}-${turn[1]} matches no inbound record in the dump`);
+      markCompleted(history);
+      // A resumed turn: the dump's stored continuation becomes the SDK resume.
+      const cont = replay.state.find((s) => s.key === `continuation:${runnerProvider}`);
+      if (history.length > 0 && cont) setContinuation(cont.value);
+      replayInfo = { file: path.resolve(args.replay!), turn, staged, history, dropped };
+      notes.push(
+        `Replayed ${staged.length} real inbound row(s) as the pending batch (seq ${turn[0]}${turn[1] !== turn[0] ? `-${turn[1]}` : ''}); ${history.length} earlier row(s) staged as completed history, ${dropped} later row(s) dropped.`,
+        history.length > 0 && cont
+          ? `The dump's stored continuation (${cont.key}) is staged, so this renders as a resumed turn.`
+          : 'No stored continuation applies to this turn: it renders as a fresh SDK conversation.',
+      );
+    } else {
+      switch (args.scenario) {
+        case 'first-message':
+          await sessionManager.writeSessionMessage(group.id, session.id, {
+            id: 'preview-1',
+            kind: 'chat',
+            timestamp: now(),
+            platformId: mgPlatformId,
+            channelType: mgChannel,
+            threadId: null,
+            content: chatContent(text, args.sender, senderId),
+          });
+          notes.push(
+            'Fresh session: no continuation in session_state, so the SDK starts a new conversation (no `resume`).',
+            'Content shape here is the minimal {text, sender, senderId} that e.g. the CLI channel writes; real adapters write richer content — the chat-sdk bridge adds author/replyTo/attachments (src/channels/chat-sdk-bridge.ts messageToInbound). Use --replay to render a real row.',
+          );
+          break;
+        case 'followup': {
+          await sessionManager.writeSessionMessage(group.id, session.id, {
+            id: 'preview-prior',
+            kind: 'chat',
+            timestamp: now(),
+            platformId: mgPlatformId,
+            channelType: mgChannel,
+            threadId: null,
+            content: chatContent('An earlier message, already handled.', args.sender, senderId),
+          });
+          markCompleted(['preview-prior']);
+          setContinuation('preview-continuation-id');
+          await sessionManager.writeSessionMessage(group.id, session.id, {
+            id: 'preview-2',
+            kind: 'chat',
+            timestamp: now(),
+            platformId: mgPlatformId,
+            channelType: mgChannel,
+            threadId: null,
+            content: chatContent(text, args.sender, senderId),
+          });
+          notes.push(
+            `The stored continuation (outbound.db session_state, key continuation:${runnerProvider}) becomes the SDK \`resume\` option — the agent keeps its full prior conversation.`,
+            'A message arriving while the container is mid-turn takes a different path: it is pushed into the open query via formatMessages (its own <context> header), not a new query. See container/agent-runner/src/poll-loop.ts processQuery.',
+          );
+          break;
+        }
+        case 'accumulate':
+          for (let i = 1; i <= 3; i++) {
+            await sessionManager.writeSessionMessage(group.id, session.id, {
+              id: `preview-acc-${i}`,
+              kind: 'chat',
+              timestamp: now(),
+              platformId: mgPlatformId,
+              channelType: mgChannel,
+              threadId: null,
+              content: chatContent(
+                `Group chatter #${i} the agent was not mentioned in.`,
+                `Member ${i}`,
+                `${mgChannel}:1555999000${i}`,
+              ),
+              trigger: false,
+            });
+          }
+          await sessionManager.writeSessionMessage(group.id, session.id, {
+            id: 'preview-mention',
+            kind: 'chat',
+            timestamp: now(),
+            platformId: mgPlatformId,
+            channelType: mgChannel,
+            threadId: null,
+            content: chatContent(text, args.sender, senderId),
+          });
+          notes.push(
+            'trigger=0 rows are stored by the router under ignored_message_policy=accumulate (engage_mode mention/pattern) and do NOT wake the agent; when the trigger=1 mention lands, the most recent rows ride into the same prompt as ordinary <message> blocks — the batch cap (maxMessagesPerPrompt, mention included) bounds the total, and older accumulated rows fall out of the window. See src/router.ts + container/agent-runner/src/db/messages-in.ts.',
+          );
+          break;
+        case 'task-fire':
+          break; // staged above, through createScheduledTask
+        case 'on-wake':
+          // Exact payload restartAgentGroupContainers writes (src/container-restart.ts).
+          await sessionManager.writeSessionMessage(group.id, session.id, {
+            id: 'preview-wake',
+            kind: 'chat',
+            timestamp: now(),
+            platformId: group.id,
+            channelType: 'agent',
+            threadId: null,
+            content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
+            onWake: true,
+          });
+          notes.push(
+            "on_wake=1 rows are only visible to a fresh container's FIRST poll (container/agent-runner/src/db/messages-in.ts) — a dying container in its SIGTERM grace period can never steal them.",
+            'Used by ncl groups restart --message and the self-mod apply flow (src/modules/self-mod/apply.ts).',
+          );
+          break;
+        case 'a2a': {
+          // A message from another agent group, as performAgentRoute writes it
+          // (src/modules/agent-to-agent/agent-route.ts): content is the source's
+          // verbatim {text}, channel_type='agent', platform_id=<source group id>.
+          const parent: AgentGroup = {
+            id: 'preview-parent',
+            name: 'parent-agent',
+            folder: 'preview-parent',
+            agent_provider: null,
+            created_at: now(),
+          };
+          await dbMod.createAgentGroup(parent);
+          await insertRaw(central, 'agent_destinations', {
+            agent_group_id: group.id,
+            local_name: 'parent-agent',
+            target_type: 'agent',
+            target_id: parent.id,
+            created_at: now(),
+          });
+          await sessionManager.writeSessionMessage(group.id, session.id, {
+            id: 'preview-a2a',
+            kind: 'chat',
+            timestamp: now(),
+            platformId: parent.id,
+            channelType: 'agent',
+            threadId: null,
+            content: JSON.stringify({ text }),
+            sourceSessionId: 'sess-parent-origin',
+          });
+          notes.push(
+            'A2A content carries no sender field, so the block renders sender="Unknown" with from=<the local destination name for the source agent>. source_session_id is the return path for replies.',
+            "If a message policy exists for this edge, the send is held for approval by the policy's approver first (routeAgentMessage in src/modules/agent-to-agent/agent-route.ts; message-gate.ts is the approve-side handler) — not simulated here.",
+          );
+          break;
+        }
+        case 'subagent':
+          notes.push(
+            'SDK-native subagents (Task tool / agent teams) run INSIDE the same container and the same provider query — there is no new NanoClaw session. They are enabled by the per-group settings.json (see ENVIRONMENT section) and by the Task/TaskOutput/TaskStop/TeamCreate/TeamDelete/SendMessage entries in the SDK allowedTools (see SDK OPTIONS).',
+            "A subagent gets the same project doc (cwd /workspace/agent → composed CLAUDE.md), the same tools and MCP servers, but NOT the parent's conversation history — only the prompt the parent passes to Task.",
+            'The other "agent spawns an agent" mechanism is create_agent (mcp__nanoclaw__create_agent): a full new agent group with its own container, workspace, and composed context — preview that with: context-preview first-message.',
+          );
+          break;
+      }
+    }
+
+    // ── Destinations + routing into the inbound mailbox (same as every wake) ──
+    await writeDestMod.writeDestinations(group.id, session.id);
+    await sessionManager.writeSessionRouting(group.id, session.id);
+
+    // ── Provider surfaces + mounts (side effects: skill links + project-doc composition) ──
+    const { provider, contribution, surfaces } = await containerRunner.resolveProviderContribution(
+      session,
+      group,
+      containerConfig,
+    );
+    const mounts = await containerRunner.buildMounts(group, session, containerConfig, provider, contribution, surfaces);
+
+    // ── Container half: real poll loop under Bun ──
+    const spec = {
+      inboundDbPath: inboundPath,
+      outboundDbPath: outboundPath,
+      containerConfig: JSON.parse(fs.readFileSync(path.join(groupDir, 'container.json'), 'utf8')),
+      // index.ts discovers these by scanning /workspace/extra/* — derive the
+      // same set from the mount table so the SDK options match a real spawn.
+      additionalDirectories: mounts.map((m) => m.containerPath).filter((p) => p.startsWith('/workspace/extra/')),
+    };
+    const specPath = path.join(sandbox, 'preview-spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    let runner: {
+      captured: boolean;
+      prompt: string | null;
+      continuation: string | null;
+      systemPromptAddendum: string;
+      sessionMode: { kind: string; taskId?: string };
+      sdkOptions: Record<string, unknown> | null;
+      mcpTools: Array<{ name: string; description?: string; inputSchema?: unknown }>;
+      provider: string;
+      batch: Array<Record<string, unknown>>;
+    };
+    try {
+      // Strip host-shell CLAUDE_* overrides — a real container's env is only
+      // TZ + OneCLI vars (src/container-runner.ts buildContainerArgs), so e.g.
+      // an exported CLAUDE_CODE_AUTO_COMPACT_WINDOW must not leak into the
+      // rendered options. The heartbeat goes to the sandbox, never /workspace.
+      const bunEnv: Record<string, string | undefined> = {
+        ...process.env,
+        TZ: configMod.TIMEZONE,
+        NANOCLAW_HEARTBEAT_PATH: path.join(sandbox, '.heartbeat'),
+      };
+      for (const key of Object.keys(bunEnv)) {
+        if (key.startsWith('CLAUDE_')) delete bunEnv[key];
+      }
+      const out = execFileSync(
+        'bun',
+        [path.join(REPO_ROOT, 'container', 'agent-runner', 'scripts', 'context-preview-runner.ts'), specPath],
+        { env: bunEnv, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 64 * 1024 * 1024 },
+      );
+      runner = JSON.parse(out);
+    } catch (err) {
+      const e = err as { stderr?: string; message?: string; code?: string };
+      // Throw (not fail/exit) so the finally-cleanup removes the sandbox.
+      if (e.code === 'ENOENT')
+        throw new Error('bun not found on PATH — the container half of the preview runs under Bun.');
+      throw new Error(`context-preview-runner failed:\n${e.stderr || e.message}`);
+    }
+
+    // ── Read back the composed surfaces ──
+    // The composed project document is the read-only file mount nested on top
+    // of the group dir — found from the real mount table, not by name.
+    const docMount = mounts.find(
+      (m) =>
+        m.readonly &&
+        path.dirname(m.hostPath) === groupDir &&
+        fs.statSync(m.hostPath, { throwIfNoEntry: false })?.isFile(),
+    );
+    const docFile = docMount?.hostPath ?? path.join(groupDir, 'CLAUDE.md');
+    const composed = fs.existsSync(docFile) ? fs.readFileSync(docFile, 'utf8') : '';
+    // Section index: the composer's `# <name>` blocks (fenced code skipped),
+    // with word counts — the same shape a pod-side `awk` over the file gives.
+    const sections: Array<{ name: string; words: number }> = [];
+    let fenced = false;
+    for (const line of composed.split('\n')) {
+      if (line.startsWith('```')) fenced = !fenced;
+      if (!fenced && line.startsWith('# ')) sections.push({ name: line.slice(2), words: 0 });
+      else if (sections.length > 0 && line.trim())
+        sections[sections.length - 1].words += line.trim().split(/\s+/).length;
+    }
+
+    // Provider home (Claude: /home/node/.claude) — settings + skill links.
+    const homeMount = mounts.find((m) => m.containerPath === '/home/node/.claude');
+    const settingsFile = homeMount ? path.join(homeMount.hostPath, 'settings.json') : null;
+    const settingsJson = settingsFile && fs.existsSync(settingsFile) ? fs.readFileSync(settingsFile, 'utf8') : '(none)';
+    const skills: string[] = [];
+    const skillsDir = homeMount ? path.join(homeMount.hostPath, 'skills') : null;
+    if (skillsDir && fs.existsSync(skillsDir)) {
+      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        skills.push(
+          entry.isSymbolicLink()
+            ? `${entry.name} → ${fs.readlinkSync(path.join(skillsDir, entry.name))}`
+            : `${entry.name} (group-private dir, template-stamped)`,
+        );
+      }
+    }
+
+    const result = {
+      scenario: args.scenario,
+      group: { id: group.id, name: group.name, folder: group.folder, provider, source: live ? 'live' : 'synthetic' },
+      session: { id: session.id, thread_id: session.thread_id, messaging_group_id: session.messaging_group_id },
+      replay: replayInfo,
+      batch: runner.batch,
+      mounts,
+      settingsJson,
+      skills,
+      persona: {
+        file: path.join(groupDir, groupPersona.PERSONA_PREPEND_FILE),
+        source: args.personaFile ? path.resolve(args.personaFile) : live ? 'live group dir' : null,
+        content: groupPersona.readGroupPersona(groupDir),
+      },
+      claudeMd: {
+        containerPath: docMount?.containerPath ?? '/workspace/agent/CLAUDE.md',
+        hostPath: docFile,
+        sections,
+        content: composed,
+      },
+      systemPrompt: {
+        base: "Claude Code preset ({ type: 'preset', preset: 'claude_code' }) — the SDK's built-in system prompt",
+        mode: runner.sessionMode,
+        append: runner.systemPromptAddendum,
+      },
+      sdkOptions: runner.sdkOptions,
+      mcpTools: runner.mcpTools,
+      continuation: runner.continuation,
+      prompt: runner.prompt,
+      notes,
+    };
+
+    if (args.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      render(result, args.section);
+    }
+  } finally {
+    cleanup();
+  }
+}
+
+function defaultMessage(scenario: Scenario): string {
+  switch (scenario) {
+    case 'followup':
+      return 'And one more thing — can you also check the weather for tomorrow?';
+    case 'accumulate':
+      return '@preview can you summarize what everyone just said?';
+    case 'task-fire':
+      return 'Check the team calendar and flag any conflicts for today.';
+    case 'on-wake':
+      return 'Your install_packages request was applied. Verify that `jq --version` works and report the result to the user.';
+    case 'a2a':
+      return 'Parent agent here — please compile the weekly metrics and send them back to me.';
+    default:
+      return 'Hey, can you help me plan a birthday dinner for Saturday?';
+  }
+}
+
+// ── Rendering ──
+
+const HR = '─'.repeat(78);
+
+function heading(title: string, provenance: string): string {
+  return `\n${HR}\n  ${title}\n  ${provenance}\n${HR}`;
+}
+
+type Result = {
+  scenario: string;
+  group: { id: string; name: string; folder: string; provider: string; source: string };
+  session: { id: string; thread_id: string | null; messaging_group_id: string | null };
+  replay: { file: string; turn: [number, number]; staged: string[]; history: string[]; dropped: number } | null;
+  batch: Array<Record<string, unknown>>;
+  mounts: Array<{ hostPath: string; containerPath: string; readonly: boolean }>;
+  settingsJson: string;
+  skills: string[];
+  persona: { file: string; source: string | null; content: string | null };
+  claudeMd: {
+    containerPath: string;
+    hostPath: string;
+    sections: Array<{ name: string; words: number }>;
+    content: string;
+  };
+  systemPrompt: { base: string; mode: { kind: string; taskId?: string }; append: string };
+  sdkOptions: Record<string, unknown> | null;
+  mcpTools: Array<{ name: string; description?: string }>;
+  continuation: string | null;
+  prompt: string | null;
+  notes: string[];
+};
+
+function render(r: Result, only?: string): void {
+  const want = (name: string) => !only || only === name;
+  const p = (s: string) => console.log(s);
+
+  if (want('scenario')) {
+    p(heading('SCENARIO', 'staged into a sandboxed session by scripts/context-preview.ts'));
+    p(`  ${r.scenario} — agent group "${r.group.name}" (${r.group.source}), provider ${r.group.provider}`);
+    p(
+      `  session ${r.session.id}  thread=${r.session.thread_id ?? '-'}  messaging_group=${r.session.messaging_group_id ?? '- (system session)'}`,
+    );
+    if (r.replay) {
+      p(`  replay ${r.replay.file}`);
+      p(
+        `    turn seq ${r.replay.turn[0]}${r.replay.turn[1] !== r.replay.turn[0] ? `-${r.replay.turn[1]}` : ''}: ${r.replay.staged.length} pending, ${r.replay.history.length} history, ${r.replay.dropped} dropped`,
+      );
+    }
+    p('');
+    p('  messages_in staged:');
+    for (const m of r.batch) {
+      p(
+        `    seq=${m.seq} kind=${m.kind} trigger=${m.trigger} on_wake=${m.on_wake} status=${m.status} channel=${m.channel_type ?? '-'} id=${m.id}`,
+      );
+    }
+  }
+
+  if (want('environment')) {
+    p(heading('CONTAINER ENVIRONMENT', 'src/container-runner.ts buildMounts() — exact mount table for this spawn'));
+    for (const m of r.mounts) {
+      p(`  ${m.containerPath}${m.readonly ? '  (ro)' : '  (rw)'}`);
+      p(`    ← ${m.hostPath}`);
+    }
+    p('');
+    p('  /home/node/.claude/settings.json (src/group-init.ts — SDK user settings):');
+    p(indent(r.settingsJson, 4));
+    p('  /home/node/.claude/skills/ (src/container-runner.ts syncSkillSymlinks + template-stamped dirs):');
+    for (const s of r.skills) p(`    ${s}`);
+    if (r.skills.length === 0) p('    (none)');
+  }
+
+  if (want('claude-md')) {
+    p(
+      heading(
+        `PROJECT DOC — ${r.claudeMd.containerPath}`,
+        'composed per spawn by src/project-doc-compose.ts composeGroupProjectDoc(); one flat file, no imports',
+      ),
+    );
+    p(`  source file: ${r.claudeMd.hostPath}`);
+    p(
+      `  persona (${r.persona.file}): ${r.persona.content ? `${r.persona.content.split(/\s+/).length} words${r.persona.source ? ` from ${r.persona.source}` : ''}` : '(none)'}`,
+    );
+    p('  sections:');
+    for (const s of r.claudeMd.sections) p(`    ${s.name}: ${s.words} words`);
+    p('');
+    p(indent(r.claudeMd.content.trimEnd() || '(empty)', 2));
+  }
+
+  if (want('system-prompt')) {
+    p(
+      heading(
+        'SYSTEM PROMPT',
+        'base: SDK preset; append: container/agent-runner/src/destinations.ts buildSystemPromptAddendum()',
+      ),
+    );
+    p(`  base: ${r.systemPrompt.base}`);
+    p(
+      `  mode: ${r.systemPrompt.mode.kind}${r.systemPrompt.mode.taskId ? ` (task ${r.systemPrompt.mode.taskId})` : ''}`,
+    );
+    p('  append:');
+    p(indent(r.systemPrompt.append, 4));
+  }
+
+  if (want('sdk-options')) {
+    p(
+      heading(
+        'SDK OPTIONS',
+        'container/agent-runner/src/providers/claude.ts buildQueryOptions() — exact options object',
+      ),
+    );
+    p(indent(JSON.stringify(r.sdkOptions, null, 2), 2));
+  }
+
+  if (want('mcp-tools')) {
+    p(heading('MCP TOOLS (mcp__nanoclaw__*)', 'container/agent-runner/src/mcp-tools/* — the registered tool surface'));
+    for (const t of r.mcpTools) {
+      p(`  ${t.name}`);
+      if (t.description) p(indent(t.description.split('\n')[0], 6));
+    }
+  }
+
+  if (want('prompt')) {
+    p(heading('PROMPT', 'the exact string the poll loop hands the provider — captured from the real runPollLoop'));
+    if (r.continuation) p(`  (SDK resume: ${r.continuation})\n`);
+    p(indent(r.prompt ?? '(no query captured — no wake-eligible messages staged)', 2));
+  }
+
+  if (want('notes') && r.notes.length > 0) {
+    p(heading('NOTES', 'scenario-specific caveats'));
+    for (const n of r.notes) p(`  • ${n}`);
+  }
+  p('');
+}
+
+function indent(s: string, n: number): string {
+  const pad = ' '.repeat(n);
+  return s
+    .split('\n')
+    .map((l) => pad + l)
+    .join('\n');
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Revives `scripts/context-preview.ts` (the "see what the agent sees" tool) on today's main, so a maintainer or an e2e run can print the exact context an agent reads without spawning a container.

- **Problem**: the tool lived on `context-preview-tool` (#3004, closed unmerged), 717 commits behind; four of its seams were gone and its host half predates the async DB boundary, the provider contracts, and the flat composed project document.
- **Fix**: port both halves to the current code paths (`initTestDb`, `resolveProviderContribution` + `buildMounts`, `createScheduledTask`, `createProvider('claude')`) and re-add the seams it imports instead of copying strings: `ClaudeProvider.buildQueryOptions()`, `formatMessagesWithCommands` (now exported), `listRegisteredTools()`, `setTestConfig()`.
- **Not re-added**: `taskPromptWithLog` — the task contract now lives in the system prompt's task mode (`buildSystemPromptAddendum`), which the tool renders through the same path `index.ts` uses.
- **New flags**: `--persona-file` stages standing instructions through `stageGroupPersona`; `--replay <jsonl> [--turn <seq|a-b>]` stages real inbound rows, routing, destinations and the stored continuation from a mailbox-format session dump, so a real turn's exact prompt renders (with the SDK `resume` it ran with).
- **No more mirror**: the Bun half reads the tool-module list from the MCP barrel file instead of duplicating it, so an installed or removed tool module shows up on the next run.
- **Out of scope**: a central-DB target other than the in-memory SQLite sandbox (a Postgres-only deployment migration cannot run there), and a container-config override for the synthetic group.

Design and maintenance seams: `docs/context-preview.md`. Background: the hub page [NanoClaw context-preview — see what the agent sees](https://team-metabase.tailc2ca02.ts.net/htmlit/p/engineering/tools/nanoclaw-context-preview) (tailnet).

## Related work

Supersedes #3004. No issue: the production diff is four small exports plus one extract-method refactor (`query()` now calls `buildQueryOptions()`), all covered by the existing provider and poll-loop suites.

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec tsc --noEmit` and `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` → clean; both new scripts also typecheck under an ad-hoc tsconfig that includes them.
- `pnpm exec vitest run` → the new `scripts/context-preview.test.ts` runs `first-message --json` end to end with the Bun half and asserts the five surfaces are non-empty. Its first CI run failed on Linux: the composed doc was located as "first read-only file mount in the group dir", which is `container.json` there; macOS masked it because mount paths are realpaths (`/private/var`) and never matched. Fixed by matching the provider contract's project-doc file name (the name `buildMounts` uses), and the test now runs with a realpath'd `TMPDIR` so macOS reproduces Linux (old code: `container.json`, 0 sections; new: `CLAUDE.md`, 9 sections). Re-verified on the branch merged onto current `main`: both typechecks clean, smoke test passes, all seven scenarios run.
- `cd container/agent-runner && bun test` → 429 pass, 0 fail.
- All seven scenarios run and print every surface (`first-message`, `followup`, `accumulate`, `task-fire`, `on-wake`, `a2a`, `subagent`), plus `--json` and `--section claude-md`; nine `mcp__nanoclaw__*` tools listed on trunk.
- Replay of a real session dump (a k3s e2e lane, Claude provider): the connect-nudge turn renders with the dump's stored continuation as `resume`, the session's real destination in `from=` and in the addendum, and the `Persona` section byte-identical to the persona the deployment's composer staged. Run on a copy of that deployment's host tree, the tool composes the tree's own module and skill sections (canvas, rooms, nanoco-gw, slack-construct) and lists its twelve tools.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
```

## Security and trust boundaries

The tool never touches the live install read-write: the whole run happens in a throwaway sandbox with an in-memory central DB; `--group` opens `data/v2.db` read-only. Only `ASSISTANT_NAME`, `ASSISTANT_HAS_OWN_NUMBER`, `TZ` and `DEFAULT_AGENT_PROVIDER` are copied from `.env` into the sandbox (never credentials); per-MCP-server env values are redacted in the output; `CLAUDE_*` host-shell overrides are stripped from the Bun half's env. No workflow or container changes.

## Skill delivery

- [x] Not a skill

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [ ] A human has reviewed this PR and stands behind every change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvAdmUb11pudvGUJN5rX3j

