### PR TITLE
fix(threads): one agent invocation per thread so every thread gets it…

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -13,7 +13,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb } from './mailbox/sqlite/connection.js';
 import { getPendingMessages } from './db/messages-in.js';
-import { formatMessages, stripInternalTags, stripLegacyTaskContract } from './formatter.js';
+import {
+  formatMessages,
+  stripInternalTags,
+  stripLegacyTaskContract,
+  partitionByThread,
+  extractGroupRouting,
+} from './formatter.js';
 import { TIMEZONE, formatLocalTime } from './timezone.js';
 
 beforeEach(() => {
@@ -325,5 +331,109 @@ describe('app_context rendering (Slack agent mode, contract C4)', () => {
     });
     const result = formatMessages(getPendingMessages());
     expect(result).toContain('(viewing: channel C1&lt;&amp;&gt;)');
+  });
+});
+
+describe('partitionByThread (#1568)', () => {
+  function row(id: string, opts?: Partial<import('./db/messages-in.js').MessageInRow>) {
+    return {
+      id,
+      seq: nextSeq++,
+      kind: 'chat' as const,
+      timestamp: new Date().toISOString(),
+      status: 'pending',
+      process_after: null,
+      recurrence: null,
+      series_id: null,
+      tries: 0,
+      trigger: 1,
+      platform_id: 'chan-1',
+      channel_type: 'slack',
+      thread_id: null,
+      content: JSON.stringify({ sender: 'Alice', text: id }),
+      source_session_id: null,
+      on_wake: 0,
+      ...opts,
+    };
+  }
+
+  it('keeps a single-thread batch as one group', () => {
+    const batch = [row('m1', { thread_id: 't1' }), row('m2', { thread_id: 't1' })];
+    const groups = partitionByThread(batch);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].map((m) => m.id)).toEqual(['m1', 'm2']);
+  });
+
+  it('keeps non-threaded messages together under the null key', () => {
+    const batch = [row('m1'), row('m2')];
+    expect(partitionByThread(batch)).toHaveLength(1);
+  });
+
+  it('splits triggers from different threads into separate groups, in arrival order', () => {
+    const batch = [
+      row('a1', { thread_id: 'thread-a' }),
+      row('b1', { thread_id: 'thread-b' }),
+      row('a2', { thread_id: 'thread-a' }),
+    ];
+    const groups = partitionByThread(batch);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].map((m) => m.id)).toEqual(['a1', 'a2']);
+    expect(groups[1].map((m) => m.id)).toEqual(['b1']);
+  });
+
+  it('treats null and threaded triggers as distinct groups', () => {
+    const batch = [row('dm1'), row('t1', { thread_id: 'thread-x' })];
+    const groups = partitionByThread(batch);
+    expect(groups).toHaveLength(2);
+    expect(groups[0][0].id).toBe('dm1');
+    expect(groups[1][0].id).toBe('t1');
+  });
+
+  it('context rows join their own thread group when one exists', () => {
+    const batch = [
+      row('a1', { thread_id: 'thread-a' }),
+      row('ctx-b', { thread_id: 'thread-b', trigger: 0 }),
+      row('b1', { thread_id: 'thread-b' }),
+    ];
+    const groups = partitionByThread(batch);
+    expect(groups).toHaveLength(2);
+    expect(groups[1].map((m) => m.id)).toEqual(['ctx-b', 'b1']);
+  });
+
+  it('stray context with no trigger for its thread rides along with the first group', () => {
+    const batch = [
+      row('a1', { thread_id: 'thread-a' }),
+      row('ctx-c', { thread_id: 'thread-c', trigger: 0 }),
+      row('b1', { thread_id: 'thread-b' }),
+    ];
+    const groups = partitionByThread(batch);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].map((m) => m.id)).toEqual(['a1', 'ctx-c']);
+  });
+
+  it('a batch with no trigger rows stays one group', () => {
+    const batch = [row('c1', { trigger: 0, thread_id: 't1' }), row('c2', { trigger: 0, thread_id: 't2' })];
+    expect(partitionByThread(batch)).toHaveLength(1);
+  });
+
+  it('extractGroupRouting takes reply routing from the first trigger row, not stray context', () => {
+    const group = [
+      row('ctx-c', { thread_id: 'thread-c', trigger: 0 }),
+      row('a1', { thread_id: 'thread-a' }),
+    ];
+    const routing = extractGroupRouting(group);
+    expect(routing.threadId).toBe('thread-a');
+    expect(routing.inReplyTo).toBe('a1');
+    expect(routing.platformId).toBe('chan-1');
+  });
+
+  it('extractGroupRouting ignores session-echo rows when picking the trigger', () => {
+    const group = [
+      row('echo', { channel_type: 'session-echo', thread_id: 'echo-thread' }),
+      row('real', { thread_id: 'thread-r' }),
+    ];
+    const routing = extractGroupRouting(group);
+    expect(routing.threadId).toBe('thread-r');
+    expect(routing.inReplyTo).toBe('real');
   });
 });

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -179,6 +179,62 @@ export function extractRouting(messages: MessageInRow[]): RoutingContext {
 }
 
 /**
+ * Split a batch into per-thread invocation groups (issue #1568).
+ *
+ * Trigger messages from different threads must never share one agent
+ * invocation: a single invocation produces replies routed to a single
+ * thread, so every thread but one is silently ignored. Groups are keyed by
+ * the thread_id of the batch's trigger (trigger=1) rows, in first-arrival
+ * order. Non-trigger rows (accumulated context, cross-session echoes) join
+ * their own thread's group when one exists, and otherwise ride along with
+ * the first group so ambient context is still seen exactly once.
+ *
+ * A batch whose triggers all share one thread key (including the null key —
+ * DMs and non-threaded channels) comes back as a single group, preserving
+ * existing behavior. Messages already in the same thread stay batched
+ * together as one invocation.
+ */
+export function partitionByThread(messages: MessageInRow[]): MessageInRow[][] {
+  const keys: Array<string | null> = [];
+  const byKey = new Map<string | null, MessageInRow[]>();
+  for (const msg of messages) {
+    if (msg.trigger !== 1) continue;
+    const key = msg.thread_id ?? null;
+    if (!byKey.has(key)) {
+      byKey.set(key, []);
+      keys.push(key);
+    }
+  }
+  if (keys.length <= 1) return [messages];
+  for (const msg of messages) {
+    const key = msg.thread_id ?? null;
+    const group = byKey.get(key) ?? byKey.get(keys[0])!;
+    group.push(msg);
+  }
+  return keys.map((key) => byKey.get(key)!);
+}
+
+/**
+ * Routing for one per-thread invocation group. Same shape as
+ * `extractRouting`, but the reply target comes from the group's first
+ * non-echo TRIGGER row: the first group also carries stray context rows from
+ * threads that had no trigger, and a context row must never decide where the
+ * group's reply goes.
+ */
+export function extractGroupRouting(group: MessageInRow[]): RoutingContext {
+  const base = extractRouting(group);
+  const firstTrigger = group.find((m) => !isSessionEcho(m) && m.trigger === 1);
+  if (!firstTrigger) return base;
+  return {
+    ...base,
+    platformId: firstTrigger.platform_id ?? null,
+    channelType: firstTrigger.channel_type ?? null,
+    threadId: firstTrigger.thread_id ?? null,
+    inReplyTo: firstTrigger.id ?? null,
+  };
+}
+
+/**
  * Format a batch of messages_in rows into a prompt string.
  *
  * Prepends a `<context timezone="<IANA>" />` header so the agent always knows

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -226,22 +226,28 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
-  it('resolves most recent thread_id when destination has multiple inbound messages', async () => {
-    // Two messages from same destination, different threads
+  it('splits a batch spanning multiple threads into per-thread invocations (#1568)', async () => {
+    // Two trigger messages from the same destination, different threads —
+    // each thread must get its own invocation and its own reply, instead of
+    // one invocation whose single reply lands only in the newest thread.
     insertMessage('m-old', { sender: 'Alice', text: 'old' }, { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-old' });
     insertMessage('m-new', { sender: 'Alice', text: 'new' }, { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-new' });
 
     const provider = new MockProvider({}, () => '<message to="discord-test">reply</message>');
     const controller = new AbortController();
-    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 2000);
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 4000);
 
-    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
+    await waitFor(() => getUndeliveredMessages().length >= 2, 3000);
     controller.abort();
 
     const out = getUndeliveredMessages();
-    expect(out).toHaveLength(1);
-    expect(out[0].thread_id).toBe('thread-new');
-    expect(out[0].in_reply_to).toBe('m-new');
+    expect(out).toHaveLength(2);
+    const oldReply = out.find((m) => m.thread_id === 'thread-old');
+    const newReply = out.find((m) => m.thread_id === 'thread-new');
+    expect(oldReply).toBeDefined();
+    expect(oldReply!.in_reply_to).toBe('m-old');
+    expect(newReply).toBeDefined();
+    expect(newReply!.in_reply_to).toBe('m-new');
 
     await loopPromise.catch(() => {});
   });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -20,6 +20,8 @@ import {
 import {
   formatMessages,
   extractRouting,
+  extractGroupRouting,
+  partitionByThread,
   categorizeMessage,
   isClearCommand,
   isRunnerCommand,
@@ -228,84 +230,105 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       continue;
     }
 
-    // Format messages: passthrough commands get raw text (only if the
-    // provider natively handles slash commands), others get XML.
-    const prompt = formatMessagesWithCommands(keep, nativeSlashCommands, config.providerName);
-
-    log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
-
-    const query = config.provider.query({
-      prompt,
-      continuation,
-      cwd: config.cwd,
-      systemContext: config.systemContext,
-    });
-    // Process the query while concurrently polling for new messages
-    const skippedSet = new Set(skipped.map((s) => s.id));
-    const processingIds = ids.filter((id) => !commandIds.includes(id) && !skippedSet.has(id));
-    // Publish the batch's in_reply_to so MCP tools (send_message, send_file)
-    // can stamp it on outbound rows — needed for a2a return-path routing.
-    setCurrentInReplyTo(routing.inReplyTo);
-    // Forward a loop stop to the ACTIVE query. The stream deliberately stays
-    // open between turns, so the loop can be parked inside processQuery when
-    // config.signal fires; without this, the "stopped" loop's query — and its
-    // 500ms follow-up poller — outlives the stop and keeps polling (and
-    // claiming) messages from whatever inbound DB the process points at. In
-    // tests that leaked one immortal poller per loop-driven test, which could
-    // steal a later test's follow-up message into a dead query.
-    const abortActiveQuery = () => query.abort();
-    if (config.signal?.aborted) abortActiveQuery();
-    else config.signal?.addEventListener('abort', abortActiveQuery, { once: true });
-    try {
-      const result = await processQuery(
-        query,
-        routing,
-        processingIds,
-        config.providerName,
-        config.provider.onExchangeComplete?.bind(config.provider),
-        prompt,
-        continuation,
-        midTurnCompleteDelivery,
-      );
-      if (result.continuation && result.continuation !== continuation) {
-        continuation = result.continuation;
-        setContinuation(config.providerName, continuation);
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      log(`Query error: ${errMsg}`);
-
-      // Stale/corrupt continuation recovery: ask the provider whether
-      // this error means the stored continuation is unusable, and clear
-      // it so the next attempt starts fresh.
-      if (continuation && config.provider.isSessionInvalid(err)) {
-        log(`Stale session detected (${continuation}) — clearing for next retry`);
-        continuation = undefined;
-        clearContinuation(config.providerName);
-      }
-
-      // Write error response so the user knows something went wrong
-      await writeMessageOut({
-        id: generateId(),
-        kind: 'chat',
-        platform_id: routing.platformId,
-        channel_type: routing.channelType,
-        thread_id: routing.threadId,
-        content: JSON.stringify({ text: `Error: ${errMsg}` }),
-      });
-
-      // The batch is still acked completed below (no redelivery). Without
-      // this line the only log trace of the errored turn is "Query error"
-      // followed by a "Completed" line that reads like success.
-      log(`Errored batch will be acked completed — ${processingIds.length} message(s), no redelivery`);
-    } finally {
-      clearCurrentInReplyTo();
-      config.signal?.removeEventListener('abort', abortActiveQuery);
+    // Per-thread invocations (issue #1568): triggers from different threads
+    // in one batch must not share an agent invocation — a single invocation
+    // routes its replies to a single thread, so every other thread would be
+    // silently ignored. One group per trigger thread, processed sequentially
+    // (same continuation, so conversational memory is shared). The common
+    // single-thread batch stays exactly one invocation with the full-batch
+    // routing, as before.
+    const threadGroups = partitionByThread(keep);
+    if (threadGroups.length > 1) {
+      log(`Batch spans ${threadGroups.length} threads — processing one invocation per thread`);
     }
 
-    // Ensure completed even if processQuery ended without a result event
-    // (e.g. stream closed unexpectedly).
-    markCompleted(processingIds);
+    for (const [groupIndex, group] of threadGroups.entries()) {
+      // Loop stop between groups: leave the remaining rows claimed — the
+      // host's processing-claim sweep resets them to pending for redelivery.
+      if (config.signal?.aborted) return;
+
+      const isLastGroup = groupIndex === threadGroups.length - 1;
+      const groupRouting = threadGroups.length === 1 ? routing : extractGroupRouting(group);
+
+      // Format messages: passthrough commands get raw text (only if the
+      // provider natively handles slash commands), others get XML.
+      const prompt = formatMessagesWithCommands(group, nativeSlashCommands, config.providerName);
+
+      log(`Processing ${group.length} message(s), kinds: ${[...new Set(group.map((m) => m.kind))].join(',')}`);
+
+      const query = config.provider.query({
+        prompt,
+        continuation,
+        cwd: config.cwd,
+        systemContext: config.systemContext,
+      });
+      // Process the query while concurrently polling for new messages
+      const processingIds = group.map((m) => m.id);
+      // Publish the batch's in_reply_to so MCP tools (send_message, send_file)
+      // can stamp it on outbound rows — needed for a2a return-path routing.
+      setCurrentInReplyTo(groupRouting.inReplyTo);
+      // Forward a loop stop to the ACTIVE query. The stream deliberately stays
+      // open between turns, so the loop can be parked inside processQuery when
+      // config.signal fires; without this, the "stopped" loop's query — and its
+      // 500ms follow-up poller — outlives the stop and keeps polling (and
+      // claiming) messages from whatever inbound DB the process points at. In
+      // tests that leaked one immortal poller per loop-driven test, which could
+      // steal a later test's follow-up message into a dead query.
+      const abortActiveQuery = () => query.abort();
+      if (config.signal?.aborted) abortActiveQuery();
+      else config.signal?.addEventListener('abort', abortActiveQuery, { once: true });
+      try {
+        const result = await processQuery(
+          query,
+          groupRouting,
+          processingIds,
+          config.providerName,
+          config.provider.onExchangeComplete?.bind(config.provider),
+          prompt,
+          continuation,
+          midTurnCompleteDelivery,
+          !isLastGroup,
+        );
+        if (result.continuation && result.continuation !== continuation) {
+          continuation = result.continuation;
+          setContinuation(config.providerName, continuation);
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log(`Query error: ${errMsg}`);
+
+        // Stale/corrupt continuation recovery: ask the provider whether
+        // this error means the stored continuation is unusable, and clear
+        // it so the next attempt starts fresh.
+        if (continuation && config.provider.isSessionInvalid(err)) {
+          log(`Stale session detected (${continuation}) — clearing for next retry`);
+          continuation = undefined;
+          clearContinuation(config.providerName);
+        }
+
+        // Write error response so the user knows something went wrong
+        await writeMessageOut({
+          id: generateId(),
+          kind: 'chat',
+          platform_id: groupRouting.platformId,
+          channel_type: groupRouting.channelType,
+          thread_id: groupRouting.threadId,
+          content: JSON.stringify({ text: `Error: ${errMsg}` }),
+        });
+
+        // The batch is still acked completed below (no redelivery). Without
+        // this line the only log trace of the errored turn is "Query error"
+        // followed by a "Completed" line that reads like success.
+        log(`Errored batch will be acked completed — ${processingIds.length} message(s), no redelivery`);
+      } finally {
+        clearCurrentInReplyTo();
+        config.signal?.removeEventListener('abort', abortActiveQuery);
+      }
+
+      // Ensure completed even if processQuery ended without a result event
+      // (e.g. stream closed unexpectedly).
+      markCompleted(processingIds);
+    }
     log(`Completed ${ids.length} message(s)`);
   }
 }
@@ -370,6 +393,16 @@ export async function processQuery(
    * delivery-inert and the final result stays the single delivery door.
    */
   midTurnCompleteDelivery = false,
+  /**
+   * End the provider stream once this batch's turn completes (after any
+   * wrap/task-block nudge retry). Used for all but the last of a batch's
+   * per-thread invocation groups (#1568): the outer loop only regains
+   * control when the stream ends, so a non-final group must close its
+   * stream for the next thread's invocation to start. The last group keeps
+   * the stream open for follow-up pushes, exactly as a single-group batch
+   * always has.
+   */
+  endAfterTurn = false,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
@@ -498,6 +531,18 @@ export async function processQuery(
 
         const keptIds = keep.map((m) => m.id);
         const prompt = formatMessages(keep);
+        // Keep same-channel reply routing aligned with the latest prompt the
+        // agent was handed: a follow-up from another thread of the same
+        // channel moves the reply thread with it (this mirrors the previous
+        // latest-inbound-row resolution in sendToDestination, which now
+        // prefers the invocation's routing — see issue #1568). Follow-ups
+        // from a different channel don't clobber the batch channel; their
+        // replies still resolve per-destination.
+        const followRouting = extractGroupRouting(keep);
+        if (followRouting.channelType === routing.channelType && followRouting.platformId === routing.platformId) {
+          routing.threadId = followRouting.threadId;
+          routing.inReplyTo = followRouting.inReplyTo;
+        }
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         unwrappedNudged = false;
         taskBlockNudged = false;
@@ -571,6 +616,9 @@ export async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        // Whether this result's turn continues via a nudge retry — an
+        // endAfterTurn stream must survive until the retry's own result.
+        let turnWillRetry = false;
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks, resultBlocks } = await dispatchResultText(event.text, routing, {
             midTurnSent,
@@ -643,6 +691,7 @@ export async function processQuery(
             // user prompt — keep it queued so the retry archives against it,
             // not the nudge text.
             if (!willRetryWrapping && !willRetryTaskBlocks) archivePrompts.shift();
+            turnWillRetry = willRetryWrapping || willRetryTaskBlocks;
           }
         } else archivePrompts.shift();
         // Turn boundary: reset the per-turn sent count after the result's
@@ -657,6 +706,14 @@ export async function processQuery(
         midTurnSent = 0;
         turnStartSeq = maxOutboundSeq();
         midTurnTail = '';
+        // Non-final per-thread group: this turn is finished (no retry
+        // pending), so close the stream gracefully — processQuery returns
+        // once the provider drains, and the outer loop starts the next
+        // thread's invocation.
+        if (endAfterTurn && !turnWillRetry) {
+          log('Per-thread turn complete — ending stream so the next thread group can run');
+          query.end();
+        }
       }
     }
   } catch (err) {
@@ -1151,6 +1208,24 @@ export async function autoAppendTaskLog(text: string): Promise<void> {
 async function sendToDestination(dest: DestinationEntry, body: string, routing: RoutingContext): Promise<void> {
   const platformId = dest.type === 'channel' ? dest.platformId! : dest.agentGroupId!;
   const channelType = dest.type === 'channel' ? dest.channelType! : 'agent';
+  // The channel the invocation's batch came from replies to the invocation's
+  // own thread (issue #1568): a batch can be one of several per-thread
+  // groups, and the newest inbound row may belong to a *different* thread's
+  // group — resolving from it would stamp that thread onto this reply.
+  // Follow-ups pushed into a live query keep this fresh by updating
+  // routing.threadId (see the follow-up poller in processQuery).
+  if (channelType === routing.channelType && platformId === routing.platformId) {
+    await writeMessageOut({
+      id: generateId(),
+      in_reply_to: routing.inReplyTo,
+      kind: 'chat',
+      platform_id: platformId,
+      channel_type: channelType,
+      thread_id: routing.threadId,
+      content: JSON.stringify({ text: body }),
+    });
+    return;
+  }
   // Resolve thread_id per-destination from the most recent inbound message
   // that came from this same channel+platform. In agent-shared sessions,
   // different destinations have different thread contexts — using a single


### PR DESCRIPTION
fix: process one agent invocation per thread so every thread gets its reply

Summary

Stops replies from being dropped when trigger messages from different threads land in the same processing window.
                                                                                                          - Problem: runPollLoop sent the whole pending batch to one agent invocation, and sendToDestination stamped the
  reply with the newest inbound row's thread_id — with two Slack threads in one window, one invocation ran
  and its single reply landed only in the last thread; every earlier thread was silently ignored. (This is  v2 home of the v1 bug reported against processGroupMessages / reply_thread_ts.)
- Fix — batching: partitionByThread (formatter.ts) splits a batch into per-thread invocation groups, keyed by 
  trigger rows' thread_id in arrival order; context rows join their own thread's group or ride along with the first one. Groups run sequentially against the same continuation.                                           Fix — stream lifecycle: each non-final group passes endAfterTurn to processQuery, which gracefully ends the
  provider stream once that group's turn completes (surviving any wrap/task-block nudge retry) so the outer   loop can start the next thread's invocation. The last group keeps the stream open for follow-up pushes, as always.
- Fix — reply stamping: for the batch's originating channel, sendToDestination replies to the invocation's ownthread_id/in_reply_to instead of resolving from the newest inbound row (which can belong to another
  thread's group). Same-channel follow-ups pushed into a live query update the routing context, preserving     warm-container thread-drift behavior. Other destinations keep the per-destination latest-inbound resUnchanged: single-thread batches, DMs (null thread_id), and same-thread bursts stay one invocation on the
  exact prior code path; cross-channel resolution in agent-shared sessions is untouched.                       Out of scope: follow-ups pushed into an already-active query are not split per thread — the live turboundary to split on; the reply follows the latest follow-up's thread, matching prior warm behavior.     

Related work

Closes #1568

Change kind

- [x] kind/bug

Validation

- npx bun@1.2.20 test (container/agent-runner) → 440 pass, 3 skip; the sole failure (memory/scaffold.test.ts)
  is pre-existing and fails identically on clean main.
- pnpm test (host, vitest) → 2375 pass, 1 skip.
- pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit → clean.
- New tests: 9 unit tests for partitionByThread / extractGroupRouting in formatter.test.ts (single-thread     batches, null-key DMs, arrival-order splitting, context-row placement, echo-row exclusion).
- Changed test: integration.test.ts — the old resolves most recent thread_id when destination has multiple inbound messages asserted the buggy behavior (only the newest thread got the one reply); replaced with splits a batch spanning multiple threads into per-thread invocations (#1568), asserting each thread receives its own reply with the correct thread_id and in_reply_to.
- [x] Tests cover the changed behavior (or Validation says why not)

User and release impact

- [x] User-visible change — release note below

release-note
Simultaneous mentions from different threads (e.g. Slack) now each get a reply in their own thread instead of only the last thread being answered.

Security and trust boundaries

None. No changes to permissions, credentials, or trust boundaries; the change only re-groups already-routed session messages and their reply thread ids inside the agent-runner.

Skill delivery

- [x] Not a skill

AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change