### PR TITLE
fix(update): extract the whole scripts/ tree for the update controller

### DIFF
--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -75,10 +75,11 @@ an older local skill still executes the newest safety code before any mutation.
 # symlinked argv defeats Node's import.meta main-module guard — the controller
 # then exits 0 having done NOTHING. Canonicalize before use.
 controller_dir="$(cd "$(mktemp -d)" && pwd -P)"
-git archive "$upstream_ref" \
-  scripts/update-nanoclaw.ts scripts/update scripts/update-skills.ts \
-  scripts/skill-apply.ts scripts/skill-directives.ts src/install-slug.ts \
-  | tar -x -C "$controller_dir"
+# Extract all of scripts/, not a hand-listed subset: the controller's import
+# graph reaches across that tree, and a list has to be edited every time a
+# module it loads gains a sibling import. src/install-slug.ts is the one file
+# outside scripts/ that the controller imports.
+git archive "$upstream_ref" scripts src/install-slug.ts | tar -x -C "$controller_dir"
 ```
 
 ## 2. Choose the Git strategy and prepare


### PR DESCRIPTION
## Summary

Restores `/update-nanoclaw`: the controller it extracts from upstream cannot load.

- **Problem**: the `git archive` list in the skill omits `scripts/provider-contract-verifier.ts`, which `scripts/update-skills.ts` imports for `pinnedBunVersion`. The controller dies at module load with `MODULE_NOT_FOUND`.
- **Blast radius**: `prepare` is the first controller call the skill makes, so the update fails before it does anything. Reproduced against `main` at 6656b326.
- **Why it matters**: the extraction is the self-update seam — an older local skill is meant to run the newest safety code before any mutation. A missing sibling import defeats that entirely.
- **Fix**: extract all of `scripts/` rather than a hand-listed subset. `src/install-slug.ts` stays named because it is the only file outside `scripts/` the controller imports, and it imports nothing but node builtins.
- **Why not just add the one file**: the list has been patched this way once already — b76b11d0 added `src/install-slug.ts` when `scripts/update/transaction.ts` began importing it. A list that must be edited whenever an imported module gains a sibling will break the same way again.
- **Out of scope**: the coupling itself. `update-skills.ts` reaches into `provider-contract-verifier.ts` for one four-line parse of `ARG BUN_VERSION`. Worth untangling, but that is a different change.
- **Known limit**: this cannot miss a sibling *inside* `scripts/`. A future `scripts/` module importing a new `src/` file would still need that file named.

<details>
<summary>The import chain</summary>

```
scripts/update-nanoclaw.ts     -> ./update/transaction.js
scripts/update/transaction.ts  -> ../../src/install-slug.js  ../update-skills.js  ./service.js
scripts/update-skills.ts       -> ./skill-apply.js  ./skill-directives.js  ./provider-contract-verifier.js
```

`provider-contract-verifier.ts` appears zero times in the archive the current list produces.
</details>

## Related work

No existing issue — searched open PRs and issues for `update-nanoclaw`, `controller`, `archive`, `MODULE_NOT_FOUND`, and `provider-contract-verifier`, and found none covering this. Safe to review directly: the change is one line of the extraction command, the failure reproduces from a clean clone in three commands, and both before and after states are shown below.

Does not conflict with the two open `fix(update)` PRs — #3452 touches `scripts/update-skills.ts` and `scripts/update/service.ts`, #3499 touches `scripts/update-nanoclaw.ts` and `scripts/update/transaction.ts`; this touches only `SKILL.md`. Both sit inside the import graph that currently fails to load, so neither can be exercised through the skill until the extraction is fixed.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

Run from a clone with `node_modules` installed. Both invocations pass no subcommand, so the controller parses arguments and exits without mutating anything.

- **Before** — the list as it stands on `main`:

  ```bash
  d=$(mktemp -d)
  git archive origin/main \
    scripts/update-nanoclaw.ts scripts/update scripts/update-skills.ts \
    scripts/skill-apply.ts scripts/skill-directives.ts src/install-slug.ts | tar -x -C "$d"
  pnpm exec tsx "$d/scripts/update-nanoclaw.ts"
  ```

  →
  ```
  Error: Cannot find module './provider-contract-verifier.js'
    code: 'MODULE_NOT_FOUND',
  ```

- **After** — this branch's command, run verbatim from the skill:

  ```bash
  d=$(mktemp -d)
  git archive HEAD scripts src/install-slug.ts | tar -x -C "$d"
  pnpm exec tsx "$d/scripts/update-nanoclaw.ts"
  ```

  →
  ```json
  {"schema": "nanoclaw-update-error/v1", "error": "Missing command"}
  ```

  The controller reached its own argument parsing, which means the whole import graph resolved.

- **Archive contents** → 9 files before, 45 after; 610 KB, all from the same ref.
- **No test covers this.** The extraction command lives in prose inside `SKILL.md` and is executed by the agent following it, so nothing in the suite runs it. `src/memory-migration-contract.test.ts` reads this file but asserts only on the requirements section.

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change

```release-note
Fix /update-nanoclaw failing at the first step with "Cannot find module './provider-contract-verifier.js'".
```

## Security and trust boundaries

The extraction writes `git archive` output from an already-fetched upstream ref into a fresh `mktemp -d`. This widens what lands there from 9 files to 45 (610 KB) — same ref, same trust, no network beyond the fetch that already happened. Nothing new is executed: the skill still invokes only `scripts/update-nanoclaw.ts` from that directory, and the extra files are inert unless imported. No credentials, permissions, workflows, or containers touched.

## Skill delivery

- [ ] Not a skill
- [x] Skill: edits one line of the existing `/update-nanoclaw` operational skill. No apply/remove footprint — the skill ships no files and this changes only the command it runs. Verified by extracting from a clean ref and loading the controller, as above.

## AI assistance

- [x] AI tools or agents helped produce this change
- [x] A human has reviewed this PR and stands behind every change
