### PR TITLE
fix(whatsapp): ignore @newsletter JIDs at the inbound boundary

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -20,6 +20,7 @@ import {
   hasMentionPills,
   isBotMentionedInGroup,
   isBotTypedMention,
+  isIgnorableChatJid,
   parseWhatsAppMentions,
   resolveSharedMode,
   rewriteBotLidMention,
@@ -329,5 +330,31 @@ describe('appendMediaFailureNote', () => {
     expect(appendMediaFailureNote('', ['image', 'document'])).toBe(
       '[image could not be downloaded] [document could not be downloaded]',
     );
+  });
+});
+
+describe('isIgnorableChatJid', () => {
+  it('ignores status broadcasts', () => {
+    expect(isIgnorableChatJid('status@broadcast')).toBe(true);
+  });
+
+  it('ignores WhatsApp Channel (newsletter) broadcasts', () => {
+    // Regression guard for the real failure: a newsletter JID is neither
+    // @g.us nor @s.whatsapp.net, so routing one takes it for a DM and opens a
+    // channel-approval card per broadcast — endlessly, since a channel keeps
+    // publishing and the bot can never reply to it.
+    expect(isIgnorableChatJid('120363144038483540@newsletter')).toBe(true);
+  });
+
+  it('routes group chats', () => {
+    expect(isIgnorableChatJid('120363410609152463@g.us')).toBe(false);
+  });
+
+  it('routes direct messages', () => {
+    expect(isIgnorableChatJid('15550009999@s.whatsapp.net')).toBe(false);
+  });
+
+  it('does not ignore a JID that merely contains the word newsletter', () => {
+    expect(isIgnorableChatJid('newsletter@s.whatsapp.net')).toBe(false);
   });
 });

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -361,6 +361,22 @@ function buildMediaMessage(data: Buffer, filename: string, ext: string, caption?
 }
 
 /**
+ * Chat JIDs that are not conversations and must never be routed.
+ *
+ * `status@broadcast` carries status updates. `@newsletter` is a WhatsApp
+ * Channel: a read-only broadcast the bot cannot reply to, delivered on the
+ * same messages.upsert stream as real chats. A newsletter JID is neither
+ * `@g.us` nor `@s.whatsapp.net`, so `isGroup` is false downstream and each
+ * broadcast is taken for a fresh DM — creating a messaging_groups row and a
+ * channel-approval card per channel, again every time it publishes.
+ *
+ * Exported for unit testing both suffixes.
+ */
+export function isIgnorableChatJid(jid: string): boolean {
+  return jid === 'status@broadcast' || jid.endsWith('@newsletter');
+}
+
+/**
  * Shared vs dedicated number mode. Only an explicit ASSISTANT_HAS_OWN_NUMBER=true
  * means the bot has its own number (dedicated); anything else — absent, empty,
  * 'false', any other string — means the bot rides the operator's personal
@@ -833,7 +849,7 @@ registerChannelAdapter('whatsapp', {
             const normalized = normalizeMessageContent(msg.message);
             if (!normalized) continue;
             const rawJid = msg.key.remoteJid;
-            if (!rawJid || rawJid === 'status@broadcast') continue;
+            if (!rawJid || isIgnorableChatJid(rawJid)) continue;
 
             // Translate LID → phone JID using v7's alt JID from extractAddressingContext
             const chatJid = await translateJid(rawJid, msg.key.remoteJidAlt);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

WhatsApp Channel (newsletter) broadcasts are routed as direct messages, so each
one opens a channel-approval card that can never be resolved usefully.

`messages.upsert` drops `status@broadcast` but nothing else:

```ts
if (!rawJid || rawJid === 'status@broadcast') continue;
```

A WhatsApp Channel delivers on the same stream with a JID ending in
`@newsletter`. That is neither `@g.us` nor `@s.whatsapp.net`, so `isGroup` is
false a few lines down and the router takes the broadcast for a fresh DM: a
`messaging_groups` row is created and `buildQuestionText` renders
"<id> sent your bot a DM on whatsapp". Channels are read-only, so the bot can
never act on one — and since a channel keeps publishing, the cards keep coming.

### Observed

A newly provisioned Singapore number auto-followed three local channels. In
16 hours that produced 6 `messaging_groups` rows and 3 stuck
`pending_channel_approvals`, from The Straits Times, Zaobao and WhatsApp's own
announcements channel. Sample of what arrived as a "DM":

```
platform_id : 120363144038483540@newsletter
content     : "*Polls that keep up with the group chat* ... blog.whatsapp.com/..."
question    : "120363144038483540 sent your bot a DM on whatsapp."
```

Unfollowing the channels on the phone stops the inflow, but that is a
per-install workaround for something the adapter can decide on its own.

### Fix

Extract the boundary predicate and add the `@newsletter` suffix:

```ts
export function isIgnorableChatJid(jid: string): boolean {
  return jid === 'status@broadcast' || jid.endsWith('@newsletter');
}
```

`!rawJid` stays ahead of the call so the existing narrowing to `string` is
unchanged. The predicate is exported and unit-tested, matching how the other
pure helpers in this file are covered (`isBotMentionedInGroup`,
`computeWhatsappDefaults`, …).

Tests cover both ignored suffixes, that group and DM JIDs still route, and that
a JID merely containing the word "newsletter" is not ignored.

No behaviour change for any JID that reaches the router today.
