### PR TITLE
fix(whatsapp): keep every pending question answerable in a chat

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -20,6 +20,7 @@ import {
   hasMentionPills,
   isBotMentionedInGroup,
   isBotTypedMention,
+  matchPendingQuestion,
   parseWhatsAppMentions,
   resolveSharedMode,
   rewriteBotLidMention,
@@ -329,5 +330,56 @@ describe('appendMediaFailureNote', () => {
     expect(appendMediaFailureNote('', ['image', 'document'])).toBe(
       '[image could not be downloaded] [document could not be downloaded]',
     );
+  });
+});
+
+describe('matchPendingQuestion', () => {
+  const opt = (label: string, value = label) => ({ label, selectedLabel: label, value });
+  const approval = (questionId: string, extra: string) => ({
+    questionId,
+    options: [opt('Approve', `approve:${questionId}`), opt('Reject', `reject:${questionId}`), opt(extra)],
+  });
+
+  it('keeps an earlier question answerable after a second one arrives', () => {
+    // The real failure: pendingQuestions was keyed by chat and held one entry,
+    // so a second card silently overwrote the first and no reply could ever
+    // reach it — the card stayed on screen and its row stayed pending forever.
+    const pendings = [approval('q1', 'Snooze'), approval('q2', 'Escalate')];
+    expect(matchPendingQuestion(pendings, '/snooze')?.pending.questionId).toBe('q1');
+  });
+
+  it('resolves the newest question when two cards share an option label', () => {
+    // Unavoidable ambiguity: WhatsApp replies are plain text, so nothing ties
+    // "/reject" to the card it came from. Newest wins — that is the card the
+    // user was just shown.
+    const pendings = [approval('q1', 'Snooze'), approval('q2', 'Escalate')];
+    const hit = matchPendingQuestion(pendings, '/reject');
+    expect(hit?.pending.questionId).toBe('q2');
+    expect(hit?.option.value).toBe('reject:q2');
+  });
+
+  it('reports the index so only the answered question is dropped', () => {
+    const pendings = [approval('q1', 'Snooze'), approval('q2', 'Escalate')];
+    const hit = matchPendingQuestion(pendings, '/snooze')!;
+    expect(hit.index).toBe(0);
+    pendings.splice(hit.index, 1);
+    // The other card survives and is still answerable.
+    expect(matchPendingQuestion(pendings, '/escalate')?.pending.questionId).toBe('q2');
+  });
+
+  it('returns undefined when no pending question offers the command', () => {
+    expect(matchPendingQuestion([approval('q1', 'Snooze')], '/nope')).toBeUndefined();
+  });
+
+  it('returns undefined when nothing is pending', () => {
+    expect(matchPendingQuestion([], '/approve')).toBeUndefined();
+  });
+
+  it('matches regardless of case and surrounding whitespace', () => {
+    expect(matchPendingQuestion([approval('q1', 'Snooze')], '  /APPROVE  ')?.option.value).toBe('approve:q1');
+  });
+
+  it('matches a multi-word label through its slash command form', () => {
+    expect(matchPendingQuestion([approval('q1', 'Ask Again')], '/ask-again')?.option.label).toBe('Ask Again');
   });
 });

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -107,10 +107,43 @@ const GROUP_METADATA_CACHE_TTL_MS = 60_000; // 1 min for outbound sends
 const SENT_MESSAGE_CACHE_MAX = 256;
 const RECONNECT_DELAY_MS = 5000;
 const PENDING_QUESTIONS_MAX = 64;
+/** Per chat. A chat can hold several unanswered cards at once, but not without
+ *  bound: nothing clears an entry whose question was resolved elsewhere. */
+const PENDING_QUESTIONS_PER_CHAT_MAX = 16;
 
 /** Normalize an option label to a slash command: "Approve" → "/approve" */
 function optionToCommand(option: string): string {
   return '/' + option.toLowerCase().replace(/\s+/g, '-');
+}
+
+export interface PendingQuestion {
+  questionId: string;
+  options: NormalizedOption[];
+}
+
+/**
+ * Match a slash-command reply against a chat's pending questions.
+ *
+ * Scanned newest first: two cards live in the same chat can offer the same
+ * option label (two approvals both rendering `/reject`), and nothing in the
+ * reply distinguishes them — WhatsApp gives us plain text, not a callback
+ * carrying the card it came from. The newest card is the one the user just
+ * saw, so it wins the ambiguity.
+ *
+ * Returns the array index so the caller can drop exactly the question that
+ * was answered and leave the others answerable.
+ */
+export function matchPendingQuestion(
+  pendings: PendingQuestion[],
+  content: string,
+): { index: number; pending: PendingQuestion; option: NormalizedOption } | undefined {
+  const cmd = content.trim().toLowerCase();
+  for (let index = pendings.length - 1; index >= 0; index--) {
+    const pending = pendings[index];
+    const option = pending.options.find((o) => optionToCommand(o.label) === cmd);
+    if (option) return { index, pending, option };
+  }
+  return undefined;
 }
 
 // --- Markdown → WhatsApp formatting ---
@@ -438,15 +471,11 @@ registerChannelAdapter('whatsapp', {
     // Group metadata cache with TTL
     const groupMetadataCache = new Map<string, { metadata: GroupMetadata; expiresAt: number }>();
 
-    // Pending questions: chatJid → { questionId, options }
-    // User replies with /approve, /reject, etc. to answer
-    const pendingQuestions = new Map<
-      string,
-      {
-        questionId: string;
-        options: NormalizedOption[];
-      }
-    >();
+    // Pending questions: chatJid → questions awaiting an answer, oldest first.
+    // User replies with /approve, /reject, etc. to answer.
+    // A list, not a single entry: nothing stops the agent asking a second
+    // question before the first is answered, and each has to stay answerable.
+    const pendingQuestions = new Map<string, PendingQuestion[]>();
 
     // Group sync tracking
     let lastGroupSync = 0;
@@ -888,18 +917,20 @@ registerChannelAdapter('whatsapp', {
             const isBotMessage = WHATSAPP_SHARED ? content.startsWith(`${ASSISTANT_NAME}:`) : false;
 
             // Check if this reply answers a pending question via slash command
-            const pending = pendingQuestions.get(chatJid);
-            if (pending && content.startsWith('/')) {
-              const cmd = content.trim().toLowerCase();
-              const matched = pending.options.find((o) => optionToCommand(o.label) === cmd);
-              if (matched) {
+            const pendings = pendingQuestions.get(chatJid);
+            if (pendings && content.startsWith('/')) {
+              const hit = matchPendingQuestion(pendings, content);
+              if (hit) {
                 const voterName = msg.pushName || sender.split('@')[0];
-                setupConfig.onAction(pending.questionId, matched.value, sender);
-                pendingQuestions.delete(chatJid);
-                await sendRawMessage(chatJid, `${matched.selectedLabel} by ${voterName}`);
+                setupConfig.onAction(hit.pending.questionId, hit.option.value, sender);
+                // Drop only the question that was answered — any other card
+                // open in this chat stays answerable.
+                pendings.splice(hit.index, 1);
+                if (pendings.length === 0) pendingQuestions.delete(chatJid);
+                await sendRawMessage(chatJid, `${hit.option.selectedLabel} by ${voterName}`);
                 log.info('Question answered', {
-                  questionId: pending.questionId,
-                  value: matched.value,
+                  questionId: hit.pending.questionId,
+                  value: hit.option.value,
                   voterName,
                 });
                 continue; // Don't forward this reply to the agent
@@ -1009,7 +1040,10 @@ registerChannelAdapter('whatsapp', {
           const text = `*${title}*\n\n${question}\n\nReply with:\n${optionLines}`;
           const msgId = await sendRawMessage(platformId, text);
           if (msgId) {
-            pendingQuestions.set(platformId, { questionId, options });
+            const pendings = pendingQuestions.get(platformId) ?? [];
+            pendings.push({ questionId, options });
+            if (pendings.length > PENDING_QUESTIONS_PER_CHAT_MAX) pendings.shift();
+            pendingQuestions.set(platformId, pendings);
             if (pendingQuestions.size > PENDING_QUESTIONS_MAX) {
               const oldest = pendingQuestions.keys().next().value!;
               pendingQuestions.delete(oldest);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

A second `ask_question` card delivered to a WhatsApp chat silently disables the
first one. The earlier card stays on screen, its slash commands stop working,
and its approval row is left pending with nothing to clear it.

`pendingQuestions` is keyed by chat and holds one entry:

```ts
const pendingQuestions = new Map<string, { questionId: string; options: NormalizedOption[] }>();
...
pendingQuestions.set(platformId, { questionId, options });   // deliver — overwrites
...
const pending = pendingQuestions.get(chatJid);               // inbound — newest only
```

So the inbound side can only ever see the most recent question in a chat. A
reply aimed at the earlier card matches nothing and is forwarded to the agent as
plain text — or, if the two cards share an option label, is silently counted as
an answer to the newer question.

Nothing recovers the abandoned row: `pending_approvals.expires_at` exists in the
schema, but nothing outside its migration reads or writes it.

### Observed

Three cards sent to one DM; only the last could be answered. The other two
stayed on screen with unresponsive commands and their rows stayed pending.

### Fix

Hold a list per chat. On delivery the question is appended; on reply,
`matchPendingQuestion` scans newest first and returns the array index, so only
the question that was answered is removed and the rest stay answerable. The key
is deleted once its list empties.

```ts
export function matchPendingQuestion(
  pendings: PendingQuestion[],
  content: string,
): { index: number; pending: PendingQuestion; option: NormalizedOption } | undefined
```

**On ambiguity.** Two cards live in the same chat can offer the same option
label — two approvals both rendering `/reject` — and a WhatsApp reply is plain
text with nothing tying it to the card it came from. That ambiguity is not
resolvable, so newest wins: it is the card the user was just shown.

**On bounds.** `PENDING_QUESTIONS_MAX` bounds how many *chats* hold a question;
because the map was keyed by chat, it never bounded questions *within* one. A
list per chat needs its own bound, since an entry whose question was resolved
elsewhere is never cleared — hence `PENDING_QUESTIONS_PER_CHAT_MAX`.

### How it was tested

Matching is extracted as an exported pure helper and unit-tested (7 cases:
earlier question still answerable, newest-wins on a shared label, index reported
so siblings survive, no match, empty list, case/whitespace, multi-word label).
This matches how the other pure helpers in this file are covered — the map
itself lives in the adapter setup closure and is not reachable from tests.

Full host suite run against this branch and against the unmodified base: same 16
failing files / 20 failing tests either way (the `channels` branch does not
currently typecheck or fully pass on its own), with the 7 new tests as the only
difference in the pass count.

Note: `src/channels/imessage.ts` has the same one-entry-per-chat shape and looks
to have the same bug. Left out deliberately to keep this PR to one thing.
