### PR TITLE
fix(setup): print one portal link for the not-enrolled browser handoff

### DIFF
--- a/setup/portal.e2e.test.ts
+++ b/setup/portal.e2e.test.ts
@@ -244,11 +244,12 @@ describe('single-visit enrollment', () => {
     for (const route of ['/api/v1/setup/code-1/claim', '/api/v1/setup/code-1', '/api/v1/device/state'])
       expect(seen.find((r) => r.route === route)?.bearer).toBe('install-token-test');
 
-    // One link, opened once, before the token polling; the code and the sign-in page on their own lines.
+    // One link, opened once, before the token polling. No bare sign-in link: it would sign in and leave the perk undecided.
     expect(mock.open).toHaveBeenCalledExactlyOnceWith(`${origin}/?setup=code-1`);
     const out = stdout.join('');
     expect(out).toContain(`\n${origin}/?setup=code-1\n`);
-    expect(out).toContain(`Code: ${USER_CODE}\n${ACTIVATE}?user_code=${USER_CODE}\n`);
+    expect(out).not.toContain(USER_CODE);
+    expect(out).not.toContain(ACTIVATE);
     expect(out).not.toContain('device-code-secret');
 
     // Persisted exactly as the standalone sign-in does.

--- a/setup/portal.test.ts
+++ b/setup/portal.test.ts
@@ -198,8 +198,9 @@ describe('browser setup handoffs', () => {
     });
     expect(mock.open).toHaveBeenCalledExactlyOnceWith('https://portal.example.test/?setup=test');
     expect(stdout.join('')).toContain('https://portal.example.test/?setup=test\n');
-    expect(stdout.join('')).toContain('ABCD-EFGH\n');
-    expect(stdout.join('')).toContain(`${DEVICE_FLOW.device.verificationUriComplete}\n`);
+    // One link only: a bare sign-in link signs in and then leaves the perk undecided.
+    expect(stdout.join('')).not.toContain('ABCD-EFGH');
+    expect(stdout.join('')).not.toContain(DEVICE_FLOW.device.verificationUriComplete);
     expect(stdout.join('')).not.toContain('device-secret');
     expect(mock.deviceFinish).toHaveBeenCalledExactlyOnceWith(DEVICE_FLOW);
     expect(mock.open.mock.invocationCallOrder[0]).toBeLessThan(mock.deviceFinish.mock.invocationCallOrder[0]);

--- a/setup/portal.ts
+++ b/setup/portal.ts
@@ -90,8 +90,7 @@ function skippedSignIn(error: unknown): void {
 /**
  * The not-enrolled path: start the device flow without opening its page,
  * start the stage anonymously with the user code, print and open the single
- * portal link (plus the code and the provider's page on their own lines for
- * headless users), wait for the sign-in, persist it, then register and claim.
+ * portal link, wait for the sign-in, persist it, then register and claim.
  * Declined, expired or failed → null; the stage is skipped and nothing else
  * happens.
  */
@@ -106,15 +105,12 @@ async function signInThroughPortal(client: SetupClient, stage: PortalStage, name
   const verificationUri = flow.device.verificationUriComplete ?? flow.device.verificationUri;
   const setup = await client.start(stage, name, { verification: { userCode: flow.device.userCode, verificationUri } });
   p.log.info(
-    'Open the link below to sign in and approve this terminal. Setup continues automatically as soon as your perk is enabled.',
+    'Open the link below to sign in, approve this terminal, and choose your perk. Setup continues automatically once you decide.',
   );
-  // Keep the URL unwrapped so it stays clickable and copyable. The code and
-  // the sign-in page are only for a machine without a browser: the portal page
-  // opens that sign-in itself.
+  // Keep the URL unwrapped so it stays clickable and copyable. It is the only
+  // link: the portal page carries the user code and opens the sign-in itself,
+  // from any device. A bare sign-in link would leave the perk undecided.
   process.stdout.write(`\n${setup.url}\n\n`);
-  process.stdout.write(
-    `No browser on this machine? Sign in from another device instead:\nCode: ${flow.device.userCode}\n${verificationUri}\n\n`,
-  );
   openUrl(setup.url);
   try {
     await finishDeviceFlow(flow);


### PR DESCRIPTION
The not-enrolled portal handoff prints one link.

## Summary

- **Problem**: the handoff printed the portal link plus a "No browser on this machine? Sign in from another device instead" block with the WorkOS code and page. That block reads as a complete alternative but only signs in; the perk decision lives on the portal link. A user who approved the code there saw WorkOS say done while setup waited for the Echo choice until the 30-minute flow expired. Hit on a headless install 2026-09-09.
- **Fix**: `signInThroughPortal` in `setup/portal.ts` prints the portal link only, and the message says the link covers sign-in, terminal approval and the perk choice. The portal page carries the user code and opens the sign-in itself, so the link works from any device. The device flow still starts and the user code still rides the setup start call. 5 production lines.
- **Out of scope**: a console-only user who cannot copy the link. The old block did not help them either: after the code sign-in the perk decision still needs the `?setup=` link, and the portal lists undecided flows nowhere else. A typeable entry point is a portal-side change.

## Related work

No issue. Wording-only change on one function; the standalone registry sign-in keeps its code display.

## Change kind

- [x] `kind/bug`

## Validation

- `pnpm exec vitest run setup/portal.test.ts setup/portal.e2e.test.ts` -> 26 passed
- Same command with the previous `setup/portal.ts` -> 2 failed, 24 passed (the two updated assertions)
- `pnpm exec tsc --noEmit -p tsconfig.json` -> clean
- [x] Tests cover the changed behavior

## User and release impact

- [x] User-visible change — release note below

```release-note
Setup's first-time portal sign-in prints one link that covers sign-in, terminal approval and the perk choice; the separate code-and-WorkOS-page block, which signed in and then left the perk undecided, is gone.
```

## Security

None. No new input, no credential handling change; the user code is still sent only in the setup start payload as before.

## AI assistance

Drafted with Claude Code; the author reviewed the diff and ran the verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCdsdVZBuiryEFe3P9MRGR
