### PR TITLE
fix(agent-runner): sweep processing_ack rows whose message no longer exists

### DIFF
--- a/container/agent-runner/src/mailbox/sqlite/connection.ts
+++ b/container/agent-runner/src/mailbox/sqlite/connection.ts
@@ -153,12 +153,54 @@ export function sqliteClearContainerToolInFlight(): void {
 }
 
 /**
- * Clear stale processing_ack entries on container startup.
- * If the previous container crashed, 'processing' entries are leftover.
- * Clearing them lets the new container re-process those messages.
+ * Clear stale processing_ack entries on container startup. Two kinds:
+ *
+ * 1. 'processing' entries left behind by a container that crashed mid-turn.
+ *    Clearing them lets the new container re-process those messages.
+ *
+ * 2. Entries whose message no longer exists in messages_in. An ack's only job
+ *    is to keep one message from being processed twice; once its row is gone
+ *    the ack can never be consumed, and it becomes a landmine — because
+ *    `sqliteGetPendingMessages` filters pending messages against every ack row
+ *    ever written, with no time bound. A platform whose message ids restart
+ *    (a recreated bot, a re-added integration, any channel numbering per
+ *    conversation) then produces a *new* message carrying an id an old ack
+ *    already holds, and it is dropped before the agent sees it. The host
+ *    marks it completed from the same stale row, so nothing errors and nothing
+ *    reaches the dropped-message log: the message is silently swallowed.
+ *
+ *    This is not hypothetical, and the workaround — send it again — is what
+ *    keeps it unreported. A recreated Telegram bot restarted its per-DM
+ *    counter; a later message reusing id 32 matched an ack written sixteen
+ *    days earlier and was never delivered. Asked about it, the agent
+ *    truthfully said nothing had arrived, so the loss read as a flaky network.
+ *
+ *    It also bounds a table that otherwise grows for the life of a session:
+ *    the host prunes messages_in (expired and overflow `pending` rows), and
+ *    every prune leaves acks behind with nothing to sweep them.
  */
 export function sqliteClearStaleProcessingAcks(): void {
-  getOutboundDb().prepare("DELETE FROM processing_ack WHERE status = 'processing'").run();
+  const outbound = getOutboundDb();
+  outbound.prepare("DELETE FROM processing_ack WHERE status = 'processing'").run();
+
+  const inbound = openInboundDb();
+  try {
+    const live = new Set(
+      (inbound.prepare('SELECT id FROM messages_in').all() as Array<{ id: string }>).map(({ id }) => id),
+    );
+    const orphans = (
+      outbound.prepare('SELECT message_id FROM processing_ack').all() as Array<{ message_id: string }>
+    )
+      .map(({ message_id }) => message_id)
+      .filter((id) => !live.has(id));
+    if (orphans.length === 0) return;
+    const remove = outbound.prepare('DELETE FROM processing_ack WHERE message_id = ?');
+    outbound.transaction(() => {
+      for (const id of orphans) remove.run(id);
+    })();
+  } finally {
+    inbound.close();
+  }
 }
 
 /** For tests — creates in-memory DBs with the session schemas. */

--- a/container/agent-runner/src/mailbox/sqlite/sqlite.test.ts
+++ b/container/agent-runner/src/mailbox/sqlite/sqlite.test.ts
@@ -157,4 +157,73 @@ describe('SQLite runner mailbox canonical serialization', () => {
     const mailbox = new SqliteAgentMailbox();
     expect(mailbox.getPendingMessages(10, false)).toEqual([]);
   });
+
+  /** Insert a messages_in row with just the columns these tests care about. */
+  function seedMessage(inbound: ReturnType<typeof initTestSessionDb>['inbound'], id: string, seq: number): void {
+    inbound
+      .prepare(
+        `INSERT INTO messages_in
+           (id, seq, kind, timestamp, status, tries, trigger, content, on_wake)
+         VALUES (?, ?, 'chat', ?, 'pending', 0, 1, '{}', 0)`,
+      )
+      .run(id, seq, new Date().toISOString());
+  }
+
+  test('clearStaleProcessingAcks drops acks whose message is gone, keeping the live ones', () => {
+    const { inbound, outbound } = initTestSessionDb();
+    seedMessage(inbound, 'chat:32:group', 2);
+
+    const ack = outbound.prepare(
+      'INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)',
+    );
+    ack.run('chat:32:group', 'completed', '2026-09-09T00:00:00.000Z'); // live — message exists
+    ack.run('chat:12:group', 'completed', '2026-08-12T00:00:00.000Z'); // orphan — pruned message
+    ack.run('chat:70:group', 'completed', '2026-08-27T00:00:00.000Z'); // orphan — pruned message
+
+    new SqliteAgentMailbox().operations.clearStaleProcessingAcks();
+
+    const left = (
+      outbound.prepare('SELECT message_id FROM processing_ack ORDER BY message_id').all() as Array<{
+        message_id: string;
+      }>
+    ).map(({ message_id }) => message_id);
+    expect(left).toEqual(['chat:32:group']);
+  });
+
+  test('a message reusing a pruned id is delivered, not swallowed by the old ack', () => {
+    const { inbound, outbound } = initTestSessionDb();
+    // The 2026-09 incident in miniature: a recreated bot restarts its counter,
+    // so a brand-new message arrives carrying an id an old ack already holds.
+    outbound
+      .prepare('INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)')
+      .run('chat:32:group', 'completed', '2026-08-24T17:32:07.539Z');
+
+    const mailbox = new SqliteAgentMailbox();
+    seedMessage(inbound, 'chat:32:group', 2);
+    // Without the sweep the stale ack hides it: the agent never sees the message.
+    expect(mailbox.getPendingMessages(10, false)).toEqual([]);
+
+    // The sweep runs at container start and removes the ack, because at that
+    // point no messages_in row carried that id.
+    outbound.prepare('DELETE FROM processing_ack').run();
+    outbound
+      .prepare('INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)')
+      .run('chat:99:gone', 'completed', '2026-08-24T17:32:07.539Z');
+    mailbox.operations.clearStaleProcessingAcks();
+
+    expect(mailbox.getPendingMessages(10, false).map((m) => m.id)).toEqual(['chat:32:group']);
+  });
+
+  test('clearStaleProcessingAcks still clears processing entries from a crashed turn', () => {
+    const { inbound, outbound } = initTestSessionDb();
+    seedMessage(inbound, 'chat:5:group', 2);
+    outbound
+      .prepare('INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)')
+      .run('chat:5:group', 'processing', new Date().toISOString());
+
+    const mailbox = new SqliteAgentMailbox();
+    expect(mailbox.getPendingMessages(10, false)).toEqual([]); // claimed, so hidden
+    mailbox.operations.clearStaleProcessingAcks();
+    expect(mailbox.getPendingMessages(10, false).map((m) => m.id)).toEqual(['chat:5:group']);
+  });
 });


### PR DESCRIPTION
`sqliteGetPendingMessages` filters pending messages against every row in `processing_ack`, with no time bound:

```js
const acked = new Set(
  (outbound.prepare('SELECT message_id FROM processing_ack').all() as Array<{ message_id: string }>).map(
    ({ message_id }) => message_id,
  ),
);
const unclaimed = pending.filter(({ id }) => !acked.has(id));
```

An ack's only job is to stop one message being processed twice. Once its `messages_in` row is gone the ack can never be consumed again — but it stays in the table forever, as a filter against an id that may come back.

## The failure

`processing_ack` is keyed on the platform message id, which is assumed unique for the life of a session. When that assumption breaks, a **new** message arrives carrying an id an old ack already holds and is dropped before the agent ever sees it. The host reads the same stale row and marks the message completed, so nothing errors and nothing reaches the dropped-message log. Asked about it, the agent truthfully reports that nothing arrived.

Ids repeat more easily than the design assumes. Recreating a Telegram bot restarts its per-DM counter at 1; so does re-adding an integration, and so does any channel that numbers per conversation rather than globally.

On the install where this surfaced, a bot recreated on 2026-08-28 reset its counter, and a later message reusing id 32 matched an ack written sixteen days earlier and was never delivered. It went unnoticed for eight days — because the workaround (send it again) works, which makes the loss look like a flaky network. That is the part that seems worth fixing rather than documenting: the failure trains users not to report it.

## The fix

`sqliteClearStaleProcessingAcks` already runs at container startup to clear `processing` entries left by a crashed turn. It now also deletes acks with no corresponding `messages_in` row — no new call site, and nothing on the hot path.

That is enough for the case above: the stale rows would have been swept on the first container start after the messages they referred to were pruned, and the later message would have been delivered normally.

It also bounds a table that otherwise grows for the life of a session. The host prunes `messages_in` (expired and overflow `pending` rows) and nothing swept the acks left behind — 899 rows on one long-running session in that install.

## Tests

Three, in `sqlite.test.ts`:

- orphaned acks are removed while acks whose message still exists are kept
- a message reusing a pruned id is hidden by the stale ack, and delivered after the sweep
- `processing` entries from a crashed turn are still cleared (the existing behavior)

`bun test` in the agent-runner tree: 450 pass, 3 skip, 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4cveDRQw9mEWBgZuibpNe
