### PR TITLE
fix(agent-runner): a spent usage allowance is said in a sentence

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -10,6 +10,7 @@ import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { clearStaleProcessingAcks } from './db/container-state.js';
 import { resolveDestinationThread } from './db/session-routing.js';
 import { touchHeartbeat } from './heartbeat.js';
+import { usageBlockNotice } from './usage-block-notice.js';
 import { getAgentMailbox } from './mailbox/index.js';
 import {
   clearContinuation,
@@ -289,14 +290,17 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         clearContinuation(config.providerName);
       }
 
-      // Write error response so the user knows something went wrong
+      // Write error response so the user knows something went wrong. A
+      // spent usage allowance is the one failure we can name in plain words
+      // instead of handing over a problem document.
+      const notice = usageBlockNotice(errMsg);
       await writeMessageOut({
         id: generateId(),
         kind: 'chat',
         platform_id: routing.platformId,
         channel_type: routing.channelType,
         thread_id: routing.threadId,
-        content: JSON.stringify({ text: `Error: ${errMsg}` }),
+        content: JSON.stringify({ text: notice ?? `Error: ${errMsg}` }),
       });
 
       // The batch is still acked completed below (no redelivery). Without
@@ -758,6 +762,10 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  */
 async function deliverErrorResult(text: string, routing: RoutingContext): Promise<void> {
   log('Error result with no <message> envelope — delivering to channel');
+  // The refusal a spent allowance produces is a problem document. Say what
+  // happened instead, and keep the document in the log for whoever debugs it.
+  const notice = usageBlockNotice(text);
+  if (notice) log(`Usage block delivered as a notice — provider text: ${text}`);
   await writeMessageOut({
     id: generateId(),
     in_reply_to: routing.inReplyTo,
@@ -765,7 +773,7 @@ async function deliverErrorResult(text: string, routing: RoutingContext): Promis
     platform_id: routing.platformId,
     channel_type: routing.channelType,
     thread_id: routing.threadId,
-    content: JSON.stringify({ text: stripHarnessTagArtifacts(text) }),
+    content: JSON.stringify({ text: notice ?? stripHarnessTagArtifacts(text) }),
   });
 }
 

--- a/container/agent-runner/src/usage-block-notice.test.ts
+++ b/container/agent-runner/src/usage-block-notice.test.ts
@@ -1,0 +1,55 @@
+/**
+ * A budget that enforces correctly used to present as an agent that stops
+ * talking: the Gateway answered 429, every client retried it silently, and
+ * nothing reached the person. The Gateway now refuses with 403 so the turn
+ * ends (nanoco-gw#152); these pin what the person then reads.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { usageBlockNotice } from './usage-block-notice.js';
+
+const problem = (code: string) =>
+  'API Error: 403 {"type":"https://nanoco.ai/problems/usage-enforcement",'
+  + `"title":"Usage enforcement blocked the request","status":403,"code":"${code}"}`;
+
+describe('usageBlockNotice', () => {
+  it('says a spent monthly budget in a sentence, and when it lifts', () => {
+    const notice = usageBlockNotice(problem('usage_budget_reached'));
+    expect(notice).toContain('monthly usage budget');
+    expect(notice).toContain('next month');
+    expect(notice).not.toContain('403');
+    expect(notice).not.toContain('usage_budget_reached');
+  });
+
+  it('distinguishes the rolling cap, which clears on its own', () => {
+    const notice = usageBlockNotice(problem('usage_cap_reached'));
+    expect(notice).toContain('usage cap');
+    expect(notice).toContain('ages out');
+    expect(notice).not.toContain('next month');
+  });
+
+  /**
+   * The enforcement contract keeps totals, limits and prices out of the
+   * response. A notice built from it must not invent them either.
+   */
+  it('names no figure, because the refusal carries none', () => {
+    for (const code of ['usage_budget_reached', 'usage_cap_reached']) {
+      expect(usageBlockNotice(problem(code))).not.toMatch(/\d/u);
+    }
+  });
+
+  it('leaves every other failure alone', () => {
+    expect(usageBlockNotice('API Error: 500 upstream unavailable')).toBeNull();
+    expect(usageBlockNotice('API Error: 403 {"code":"policy_denied"}')).toBeNull();
+    expect(usageBlockNotice('')).toBeNull();
+  });
+
+  /**
+   * The code is matched wherever it sits, because the runtime decides how much
+   * of the body survives into the turn's error text.
+   */
+  it('finds the reason code in a truncated or reworded rendering', () => {
+    expect(usageBlockNotice('403 usage_budget_reached')).toContain('monthly usage budget');
+    expect(usageBlockNotice('request failed: usage_cap_reached ...')).toContain('usage cap');
+  });
+});

--- a/container/agent-runner/src/usage-block-notice.ts
+++ b/container/agent-runner/src/usage-block-notice.ts
@@ -1,0 +1,42 @@
+/**
+ * A spent usage allowance, said in a sentence.
+ *
+ * The Gateway refuses a request whose owner has spent an allowance and names
+ * the reason with a code from the usage-enforcement contract:
+ * `usage_budget_reached` for the calendar-month dollar budget,
+ * `usage_cap_reached` for the rolling daily token cap. The provider hands that
+ * refusal on as the turn's error text, which is an RFC 9457 problem document.
+ * Accurate, and unreadable to the person waiting for a reply.
+ *
+ * That contract carries no totals, limits or prices in the response on
+ * purpose, so a notice may name the condition but never the numbers. Those
+ * stay in the console, where the person who set the limit can see them.
+ *
+ * Matching is on the reason code alone. It is a token that contract defines,
+ * it appears in no other provider error, and keying on it rather than on the
+ * prose around it keeps this working when the runtime changes how it renders
+ * an HTTP failure.
+ */
+const USAGE_BLOCK_NOTICES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'usage_budget_reached',
+    "I've reached the monthly usage budget for this account, so I can't reply right now. "
+      + 'An administrator can raise it, and it resets at the start of next month.',
+  ],
+  [
+    'usage_cap_reached',
+    "I've reached the usage cap for this account, so I can't reply right now. "
+      + 'An administrator can raise it, and it clears as earlier usage ages out.',
+  ],
+];
+
+/**
+ * The plain notice for a turn that failed because an allowance was spent, or
+ * null when the text is any other error and must reach the user as it is.
+ */
+export function usageBlockNotice(text: string): string | null {
+  for (const [code, notice] of USAGE_BLOCK_NOTICES) {
+    if (text.includes(code)) return notice;
+  }
+  return null;
+}


### PR DESCRIPTION
Third of three. **nanoco-gw#152** makes a usage block a 403 so the turn ends;
**nanoco#534** carries that through the cross-repo contract; this one decides
what the person actually reads.

## Why

When the Gateway refuses a request because its owner has spent a usage
allowance, the turn's error text is an RFC 9457 problem document, and it
reached the chat verbatim:

```
API Error: 403 {"type":"https://nanoco.ai/problems/usage-enforcement",
"title":"Usage enforcement blocked the request","status":403,
"code":"usage_budget_reached"}
```

Accurate, and useless to the person waiting for a reply. On nancy-v3 today the
owner of an over-budget account had no idea a limit had stopped their agent.

## What it says now

> I've reached the monthly usage budget for this account, so I can't reply
> right now. An administrator can raise it, and it resets at the start of next
> month.

The rolling daily cap gets its own sentence, because it lifts differently:

> I've reached the usage cap for this account, so I can't reply right now. An
> administrator can raise it, and it clears as earlier usage ages out.

Neither names a figure. The usage-enforcement contract keeps totals, limits and
prices out of the response on purpose, so a notice built from it must not
invent them; a test pins that the notice contains no digit at all. The numbers
stay in the console, where the person who set the limit can see them.

## Shape

`usage-block-notice.ts` is a pure function beside `harness-tag-strip.ts`, the
same shape and the same job: last-mile shaping of text bound for a human. It is
called on both paths that carry a failed turn to the user, which had drifted
apart:

- `deliverErrorResult`, the error result with no `<message>` envelope
- the thrown-error write in the poll loop's catch

The problem document still goes to the log when it is substituted, so nobody
debugging loses it.

Matching is on the reason code alone (`usage_budget_reached`,
`usage_cap_reached`). Those are tokens the enforcement contract defines and they
appear in no other provider error, so this keeps working when the runtime
changes how it renders an HTTP failure. The tests cover a truncated and a
reworded rendering for exactly that reason.

## Testing

`bun test` in `container/agent-runner`: **452 pass, 3 skip, 0 fail** on a clean
worktree of `origin/main`. `bun run typecheck` clean.

Note for anyone running this locally on a tree with the in-flight
`mcp-tools/rooms.ts` work: that file throws `extendTool: property "purpose"
already exists on tool "create_agent"` at import time and takes the suite with
it. It is unrelated to this change and does not occur on a clean checkout.

## Sequencing

Independent of the other two. On its own it is dormant, because today's 429 is
retried rather than surfaced. After nanoco-gw#152 deploys, the block ends the
turn and this decides what that turn says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5ayFfBX9K9vu3V62AxJCH
