### PR TITLE
fix(verify): don't let an ambient credential env var invent a channel

### DIFF
--- a/setup/verify-slack.test.ts
+++ b/setup/verify-slack.test.ts
@@ -39,10 +39,15 @@ vi.mock('./lib/registry-state.js', () => ({
 vi.mock('./status.js', () => ({ emitStatus: vi.fn() }));
 
 import { emitStatus } from './status.js';
-import { run } from './verify.js';
+import { CHANNEL_ENV_KEYS, run } from './verify.js';
 import { readSlackJob, withSetupLock } from '../src/community-portal/slack-job.js';
 
 beforeEach(() => {
+  // These assertions compare CONFIGURED_CHANNELS exactly, and verify() detects a
+  // channel from process.env before the install's .env — so an ambient
+  // GITHUB_TOKEN (every Actions runner sets one; so do most shells with `gh`)
+  // adds a channel the fixture never configured and fails five of these.
+  for (const key of CHANNEL_ENV_KEYS) vi.stubEnv(key, '');
   host.root = fs.mkdtempSync(path.join(os.tmpdir(), 'nc-verify-slack-'));
   host.service = 'running';
   host.groups = 0;
@@ -56,6 +61,7 @@ beforeEach(() => {
   vi.mocked(emitStatus).mockClear();
 });
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
   fs.rmSync(host.root, { recursive: true, force: true });
 });

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -18,6 +18,34 @@ import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.j
 import { emitStatus } from './status.js';
 import { readSlackJob, slackJobStatus, type SlackJob } from '../src/community-portal/slack-job.js';
 
+/**
+ * Credential env vars that mark a channel as configured.
+ *
+ * Exported so a test can neutralise exactly these — `has()` below reads
+ * `process.env` before the install's own `.env`, so any of them present in the
+ * ambient environment makes verify report a channel the install has not
+ * configured. `GITHUB_TOKEN` is the one that bites in practice: CI runners and
+ * plenty of developer shells export it for the `gh` CLI.
+ */
+export const CHANNEL_ENV_KEYS = [
+  'TELEGRAM_BOT_TOKEN',
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  'DISCORD_BOT_TOKEN',
+  'GITHUB_TOKEN',
+  'LINEAR_API_KEY',
+  'GCHAT_CREDENTIALS',
+  'TEAMS_APP_ID',
+  'TEAMS_APP_PASSWORD',
+  'WEBEX_BOT_TOKEN',
+  'MATRIX_ACCESS_TOKEN',
+  'RESEND_API_KEY',
+  'WHATSAPP_ACCESS_TOKEN',
+  'IMESSAGE_ENABLED',
+  'PHOTON_PROJECT_ID',
+  'PHOTON_PROJECT_SECRET',
+] as const;
+
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
   const platform = getPlatform();
@@ -129,24 +157,7 @@ export async function run(_args: string[]): Promise<void> {
   }
 
   // 4. Check channel auth (detect configured channels by credentials)
-  const envVars = readEnvFile([
-    'TELEGRAM_BOT_TOKEN',
-    'SLACK_BOT_TOKEN',
-    'SLACK_APP_TOKEN',
-    'DISCORD_BOT_TOKEN',
-    'GITHUB_TOKEN',
-    'LINEAR_API_KEY',
-    'GCHAT_CREDENTIALS',
-    'TEAMS_APP_ID',
-    'TEAMS_APP_PASSWORD',
-    'WEBEX_BOT_TOKEN',
-    'MATRIX_ACCESS_TOKEN',
-    'RESEND_API_KEY',
-    'WHATSAPP_ACCESS_TOKEN',
-    'IMESSAGE_ENABLED',
-    'PHOTON_PROJECT_ID',
-    'PHOTON_PROJECT_SECRET',
-  ]);
+  const envVars = readEnvFile([...CHANNEL_ENV_KEYS]);
 
   const has = (key: string) => !!(process.env[key] || envVars[key]);
   const channelAuth: Record<string, string> = {};


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

fix(verify.ts): don't let an ambient credential env var invent a channel

## Summary

- **Problem**: Because readEnvFile in verify.ts reads in environment variables, if that value is set when that channel isn't actually configured then the tests will fail. Was happening in my local CI environment. 
- **Fix**: The key list moves to an exported const so a test can neutralise exactly those keys and no others; the test stubs then empty in `beforeEach` and calls `vi.unstubAllEnvs()` in `afterEach`.

## Details
Why didn't it show up before?

It's a latent bug, not a regression — and the two halves are five months apart.

57a6491c (2026-04-09) — the v2 channel-isolation work introduced both has = (key) => !!(process.env[key] || envVars[key]) and the GITHUB_TOKEN → channelAuth.github line. So verify() has been reading ambient env for 152 days.
84eefd46 (2026-09-08) — the community-portal commit added setup/verify-slack.test.ts, the first test to assert CONFIGURED_CHANNELS exactly.

Reading process.env is appropriate for a real install — a channel could legitimately be configured that way — so the check is left alone and the test is isolated instead. 

## Related work

none yet, can open an issue accordingly.

## Change kind

<!-- Check exactly one. -->
- [X] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

This is a change in order to do run the tests successfully  (i.e. CI tests running locally on my forgejo instance)

- [ ] Tests cover the changed behavior (or Validation says why not)

## User and release impact

<!-- Maintainers own CHANGELOG.md — do not edit it in this PR. -->
- [X] No user-visible behavior change
- [ ] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Optional: one user-facing line for the changelog. Skip it and a maintainer will write one.
```

## Security and trust boundaries

None

## Skill delivery

- [X] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [X] AI tools or agents helped produce this change

<!-- Required. -->
- [X] A human has reviewed this PR and stands behind every change
