### PR TITLE
fix(setup): skip portal reminders the operator already answered

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -258,7 +258,9 @@ async function main(): Promise<void> {
       brandBody(dimWrap('Your assistant lives in its own sandbox. It can only see what you explicitly share.', 4)),
     );
     // Asked before the step runs, because the step is what acts on the answer.
-    await chooseImageSource();
+    // An explicit "build it here" is a decision; the perk reminder for this
+    // question is only for installs that fell back to a local build unasked.
+    if ((await chooseImageSource()) === 'local') skip.add('echo-reminder');
     p.log.message(
       brandBody(
         dimWrap(
@@ -744,6 +746,9 @@ async function main(): Promise<void> {
       }
       if (result === BACK_TO_CHANNEL_SELECTION) backed = true;
     }
+    // Any answer to the chooser is a decision. The perk reminder for this
+    // question is only for runs that never reached the chooser.
+    skip.add('slack-reminder');
   }
   // Deferred wire (Teams): verify passes with zero groups because the
   // platform id only exists after the first DM. Tracked here so the ENDING
@@ -1361,7 +1366,8 @@ async function askNewTemplateAgentName(agents: readonly AgentGroup[], initialVal
  * Returns having done nothing when the question is already settled, which also
  * covers `NANOCLAW_HARDENED_IMAGE=true` passed in by a packaged flow.
  */
-async function chooseImageSource(): Promise<void> {
+/** Resolves to the operator's pick when the question was asked, else undefined. */
+async function chooseImageSource(): Promise<ImageSource | undefined> {
   if (imageSourceDecided()) return;
 
   // The runtime pick happens later (the auth step), so this is the best signal
@@ -1438,7 +1444,7 @@ async function chooseImageSource(): Promise<void> {
   phEmit('image_source_chosen', { source: choice });
 
   writeImageSource(choice);
-  if (choice === 'local') return;
+  if (choice === 'local') return choice;
 
   if (!loginScriptAvailable()) {
     p.log.warn(brandBody(`This copy of NanoClaw has no ${REGISTRY_LOGIN_SCRIPT} — building the sandbox here instead.`));


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Setup's portal reminders no longer re-ask a question the operator already answered.

- **Problem**: setup asks a question, and a portal perk later re-offers the same thing. Today there are two: "Where should your assistant's sandbox image come from?" (Echo's hardened image) and "Want to connect a messaging app?" (Slack is one of the options). Each reminder only looked at the resulting state (image source, bot token), so an explicit answer and a run that never reached the question were the same to it. Picking "Build it here" still produced "Before starting NanoClaw, enable Echo's hardened image?". Pairing Telegram still produced "Before you finish, enable Slack for your agent too?". Both hit on a fresh headless install 2026-09-10.
- **Fix**: each reminder is keyed to the question it would repeat, and the step that asks the question adds that reminder to the wizard's existing skip set once it has an answer. `chooseImageSource` in `setup/auto.ts` resolves to the operator's pick when the question was asked; the container step skips `echo-reminder` on an explicit local pick. The channel step skips `slack-reminder` after the chooser loop, whatever the answer (a channel, "other", or no messaging app).
- **Kept**: a reminder still fires for runs that never reached its question. Image source: setup fell back to a local build after the operator chose the hardened image (sign-in skipped or failed, or no sign-in script in this copy). Channel: the step was skipped or a template agent was restamped. Declining a reminder is still remembered per checkout, and `pnpm exec tsx setup/portal.ts --stage <echo|slack>` still works at any time.
- **Future perks**: a new perk reminder attaches to whichever setup question it belongs to the same way: the step that asks adds the reminder's skip key once answered. No registry; there is nothing to enumerate yet.
- **Out of scope**: a resumed run where the image pick was made in an earlier run (`imageSourceDecided()` is true) is treated as "not asked" and may still see the Echo reminder once. Whether the channel reminder should exist at all, given Slack is already in the chooser, is a product question and not decided here.

## Related work

Closes #: none. 4 production lines in one file; the reminder function in `setup/portal.ts` is untouched. Independent of #3754.

## Change kind

- [x] `kind/bug`

## Validation

- `pnpm exec tsc --noEmit -p tsconfig.json` -> clean
- `pnpm exec vitest run setup/portal.test.ts setup/portal.e2e.test.ts` -> 26 passed, unchanged from main
- No test added: `setup/auto.ts` has no test file and both changed sites drive interactive prompts through the wizard; a harness for them would be larger than the fix. Manual path: run setup on a fresh checkout, pick "Build it here", then pair Telegram. Expected: no Echo reminder before the service starts, no Slack reminder before verification.
- [ ] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] User-visible change — release note below

```release-note
Setup's portal reminders (Echo's hardened image, Slack) now appear only when setup never reached the question they repeat; an answered question is no longer re-asked.
```

## Security and trust boundaries

None. No credential handling, no new input; the skip set already existed.

## Skill delivery

- [x] Not a skill

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change
