### PR TITLE
fix(setup): verify sees a nohup-started host when systemd has no user instance

### DIFF
--- a/setup/verify-nohup.test.ts
+++ b/setup/verify-nohup.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// systemd is PID 1 but the user instance is unreachable — the shape of an
+// exe.dev VM, a CI runner, or an SSH-only box without a user session bus.
+// setup/service.ts falls back to the nohup wrapper there; verify must agree.
+const host = vi.hoisted(() => ({ root: '', userBus: false }));
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
+  execSync: vi.fn((command: string) => {
+    if (command.startsWith('systemctl --user')) {
+      if (!host.userBus) throw new Error('Failed to connect to bus: No medium found');
+      throw new Error('inactive');
+    }
+    if (command.startsWith('ps ')) return `node ${host.root}/dist/index.js`;
+    return '';
+  }),
+}));
+vi.mock('../src/install-slug.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/install-slug.js')>()),
+  getLaunchdLabel: () => 'dev.nanoclaw',
+  getSystemdUnit: () => 'nanoclaw.service',
+}));
+vi.mock('../src/env.js', () => ({ readEnvFile: () => ({}) }));
+vi.mock('./platform.js', () => ({
+  getPlatform: () => 'linux',
+  getServiceManager: () => 'systemd',
+  isRoot: () => false,
+  hasSystemd: () => true,
+}));
+vi.mock('./central-db-inspection.js', () => ({
+  inspectCentralDb: async () => ({ registeredGroups: 1, derivedGroups: 0 }),
+}));
+vi.mock('./lib/registry-state.js', () => ({
+  readImageSource: () => 'build',
+  inspectAgentImage: () => ({ source: 'local', registryDigest: null }),
+}));
+vi.mock('./status.js', () => ({ emitStatus: vi.fn() }));
+
+import { emitStatus } from './status.js';
+import { run } from './verify.js';
+
+beforeEach(() => {
+  host.root = fs.mkdtempSync(path.join(os.tmpdir(), 'nc-verify-nohup-'));
+  host.userBus = false;
+  fs.mkdirSync(path.join(host.root, 'data'));
+  fs.writeFileSync(path.join(host.root, '.env'), 'ANTHROPIC_API_KEY=fixture-only\n');
+  vi.spyOn(process, 'cwd').mockReturnValue(host.root);
+  vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('verify_exit');
+  });
+  vi.mocked(emitStatus).mockClear();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(host.root, { recursive: true, force: true });
+});
+
+const fields = () => vi.mocked(emitStatus).mock.calls.at(-1)?.[1];
+
+describe('verify with systemd present but no user instance', () => {
+  it('sees a host started by the nohup wrapper as running', async () => {
+    // Our own pid is alive, so the `kill -0` liveness probe passes.
+    fs.writeFileSync(path.join(host.root, 'nanoclaw.pid'), `${process.pid}\n`);
+    await expect(run([])).resolves.toBeUndefined();
+    expect(fields()).toMatchObject({ SERVICE: 'running', STATUS: 'success' });
+  });
+
+  it('reports a stale pid file as stopped, not not_found', async () => {
+    fs.writeFileSync(path.join(host.root, 'nanoclaw.pid'), '999999999\n');
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ SERVICE: 'stopped', STATUS: 'failed' });
+  });
+
+  it('still reports not_found when there is no pid file either', async () => {
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ SERVICE: 'not_found', STATUS: 'failed' });
+  });
+
+  it('does not consult the pid file when the systemd unit itself answers', async () => {
+    host.userBus = true; // unit exists but is inactive → the manager branch decides
+    fs.writeFileSync(path.join(host.root, 'nanoclaw.pid'), `${process.pid}\n`);
+    vi.mocked((await import('child_process')).execSync).mockImplementation(((command: string) => {
+      if (command.includes('is-active')) throw new Error('inactive');
+      if (command.includes('list-unit-files')) return 'nanoclaw.service';
+      if (command.startsWith('ps ')) return `node ${host.root}/dist/index.js`;
+      return '';
+    }) as never);
+    await expect(run([])).rejects.toThrow('verify_exit');
+    expect(fields()).toMatchObject({ SERVICE: 'stopped' });
+  });
+});

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -85,8 +85,14 @@ export async function run(_args: string[]): Promise<void> {
         // systemctl not available
       }
     }
-  } else {
-    // Check for nohup PID file
+  }
+
+  // Nohup wrapper (setup/service.ts setupNohupFallback). Reached two ways:
+  // no service manager at all, or systemd is PID 1 but the user instance is
+  // unreachable (`systemctl --user` → "Failed to connect to bus") — the case
+  // service.ts already falls back from. Consult the pid file whenever the
+  // manager branch found nothing, so both detectors agree.
+  if (service === 'not_found') {
     const pidFile = path.join(projectRoot, 'nanoclaw.pid');
     if (fs.existsSync(pidFile)) {
       try {


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Makes `verify` see a host that `service` started through the nohup wrapper.
- **Problem**: on a host where systemd is PID 1 but the user instance is unreachable (`systemctl --user` → `Failed to connect to bus`), `setup/service.ts` falls back to the nohup wrapper, but `setup/verify.ts` only consulted `nanoclaw.pid` in its *no-systemd* branch — so the same host came back `SERVICE: not_found` and the end-of-run check failed while the host was answering messages.
- **Fix**: consult the pid file whenever the service-manager branch finds nothing, so both detectors agree.
- **Out of scope**: #3618's `service-health.ts` has the same gap in `inspectSystemd`; noted on the issue, not touched here.

## Related work

Closes #3759

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run setup/verify-nohup.test.ts setup/verify.test.ts setup/verify-slack.test.ts` → 3 files, 22 tests passed (4 new: running via pid file, stale pid → `stopped`, no pid → `not_found`, systemd unit answering → pid file ignored).
- `pnpm exec tsc --noEmit` → clean. `prettier --check` on both files → clean.
- Manual, on a fresh exe.dev VM (systemd PID 1, no user bus): before the change `--step verify` → `SERVICE: not_found / STATUS: failed`; after copying the patched `verify.ts` onto the same VM → `SERVICE: running / STATUS: success`, exit 0. The host had just replied over the cli channel in both cases.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [x] User-visible change — release note below
- [ ] No user-visible behavior change
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Setup's final verification now recognises a host started by the nohup fallback on systems that have systemd but no user session (CI runners, some VMs and SSH-only servers), instead of reporting the service as not found.
```

## Security and trust boundaries

None. Reads `nanoclaw.pid` and probes the pid with `kill -0`, exactly as the existing no-systemd branch already did.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [x] A human has reviewed this PR and stands behind every change
