### PR TITLE
fix(add-opencode): drop the pre-cli-tools Dockerfile guard on refresh and remove

### DIFF
--- a/.claude/skills/add-opencode/REMOVE.md
+++ b/.claude/skills/add-opencode/REMOVE.md
@@ -14,10 +14,14 @@ This unregisters the provider from both `listProviderContainerConfigNames()` (ho
 
 ## 2. Delete the copied files (both trees)
 
+`src/opencode-dockerfile.test.ts` is the guard the skill installed before the
+`cli-tools.json` migration; it is listed so removal also cleans older installs.
+
 ```bash
 rm -f src/providers/opencode.ts \
       src/providers/opencode-registration.test.ts \
       src/opencode-cli-tools.test.ts \
+      src/opencode-dockerfile.test.ts \
       container/agent-runner/src/providers/opencode.ts \
       container/agent-runner/src/providers/mcp-to-opencode.ts \
       container/agent-runner/src/providers/mcp-to-opencode.test.ts \

--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -72,14 +72,6 @@ lockstep before; mismatched versions can build cleanly and fail at runtime.
 
 ### 4. Install the pin guard
 
-Installs made before the `cli-tools.json` migration carried a Dockerfile guard
-(`src/opencode-dockerfile.test.ts`) that asserts `ARG`/`RUN` lines the image no
-longer has. Drop it so an upgraded checkout does not keep a failing test:
-
-```nc:run effect:refresh
-rm -f src/opencode-dockerfile.test.ts
-```
-
 Copy the structural test that asserts the CLI manifest and SDK package stay on
 the same exact version:
 

--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -72,6 +72,14 @@ lockstep before; mismatched versions can build cleanly and fail at runtime.
 
 ### 4. Install the pin guard
 
+Installs made before the `cli-tools.json` migration carried a Dockerfile guard
+(`src/opencode-dockerfile.test.ts`) that asserts `ARG`/`RUN` lines the image no
+longer has. Drop it so an upgraded checkout does not keep a failing test:
+
+```nc:run effect:refresh
+rm -f src/opencode-dockerfile.test.ts
+```
+
 Copy the structural test that asserts the CLI manifest and SDK package stay on
 the same exact version:
 

--- a/scripts/skill-conformance.test.ts
+++ b/scripts/skill-conformance.test.ts
@@ -187,12 +187,6 @@ describe('retired mechanisms', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('keeps the legacy OpenCode Dockerfile guard cleanup in install and removal docs', () => {
-    const install = readFileSync(join(SKILLS_DIR, 'add-opencode', 'SKILL.md'), 'utf8');
-    const remove = readFileSync(join(SKILLS_DIR, 'add-opencode', 'REMOVE.md'), 'utf8');
-    expect(install).toContain('rm -f src/opencode-dockerfile.test.ts');
-    expect(remove).toContain('src/opencode-dockerfile.test.ts');
-  });
 });
 
 describe('add-dial ↔ add-dial-tool agent-scope duplication', () => {

--- a/scripts/skill-conformance.test.ts
+++ b/scripts/skill-conformance.test.ts
@@ -186,6 +186,13 @@ describe('retired mechanisms', () => {
     const offenders = SKILL_DOCS.filter((d) => d.text.includes('data/env')).map((d) => d.doc);
     expect(offenders).toEqual([]);
   });
+
+  it('keeps the legacy OpenCode Dockerfile guard cleanup in install and removal docs', () => {
+    const install = readFileSync(join(SKILLS_DIR, 'add-opencode', 'SKILL.md'), 'utf8');
+    const remove = readFileSync(join(SKILLS_DIR, 'add-opencode', 'REMOVE.md'), 'utf8');
+    expect(install).toContain('rm -f src/opencode-dockerfile.test.ts');
+    expect(remove).toContain('src/opencode-dockerfile.test.ts');
+  });
 });
 
 describe('add-dial ↔ add-dial-tool agent-scope duplication', () => {


### PR DESCRIPTION
## Summary

Installs of `/add-opencode` made before 8772ec97 carry `src/opencode-dockerfile.test.ts`, which asserts `ARG OPENCODE_VERSION` and a `pnpm install -g` line that `container/Dockerfile` no longer has. Nothing on main removed it: REMOVE.md dropped the path from its `rm -f` list in that same commit, and SKILL.md has no migration step. An upgraded checkout therefore keeps a vitest file that fails on every `pnpm test`.

## Changes

- `SKILL.md` step 4: an `nc:run effect:refresh` block deletes the old guard before the `nc:copy` of the new one. `effect:refresh` is the only run effect the refresh path executes, so `/update-skills` cleans upgraded installs too (same shape as add-matrix's refresh run).
- `REMOVE.md` section 2: the old path is back in the `rm -f` list, with a sentence saying why, so removal stays idempotent across both install shapes.

## Verification

- `pnpm exec vitest run scripts/skill-conformance.test.ts scripts/skill-apply.test.ts`: 279 passed.
- Reproduced the bug on main first (see #3762), then re-ran the same steps on this branch: copied the 358f1a81 guard to `src/opencode-dockerfile.test.ts`, ran the REMOVE.md section 2 block, file gone; copied it again, ran the new SKILL.md step 4 refresh block, file gone.

Closes #3762