### PR TITLE
fix(db): recheck migrations under SQLite write lock

### DIFF
--- a/src/db/migrations/concurrency.test.ts
+++ b/src/db/migrations/concurrency.test.ts
@@ -1,0 +1,95 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { log } from '../../log.js';
+import { SqliteDriver } from '../drivers/sqlite.js';
+import { migrations, runMigrations } from './index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('concurrent SQLite migrations', () => {
+  it.each([
+    ['fresh database', 0],
+    ['existing database with pending migrations', migrations.length - 1],
+  ])(
+    'does not reapply a migration completed by another process: %s',
+    async (_name, appliedCount) => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-migrations-'));
+      const databasePath = path.join(directory, 'central.db');
+      const raw = new Database(databasePath);
+      raw.pragma('journal_mode = WAL');
+      const db = new SqliteDriver(raw);
+
+      try {
+        await runMigrations(db, migrations.slice(0, appliedCount));
+        const info = vi.spyOn(log, 'info');
+        const all = db.all.bind(db);
+        let otherProcessRan = false;
+
+        vi.spyOn(db, 'all').mockImplementation(async <T>(sql: string, ...params: unknown[]): Promise<T[]> => {
+          const rows = await all<T>(sql, ...params);
+          if (sql === 'SELECT name FROM schema_version' && !otherProcessRan) {
+            // Freeze this caller's applied-migration snapshot while another
+            // process completes the pending work, then resume with stale rows.
+            otherProcessRan = true;
+            const result = await migrateInOtherProcess(databasePath);
+            expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
+          }
+          return rows;
+        });
+
+        await runMigrations(db);
+
+        expect(otherProcessRan).toBe(true);
+        expect(await db.all('SELECT name FROM schema_version ORDER BY version')).toEqual(
+          migrations.map(({ name }) => ({ name })),
+        );
+        expect(info.mock.calls.filter(([message]) => message === 'Migration applied')).toEqual([]);
+        expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+        expect(raw.pragma('integrity_check')).toEqual([{ integrity_check: 'ok' }]);
+      } finally {
+        await db.close();
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
+    15_000,
+  );
+});
+
+function migrateInOtherProcess(
+  databasePath: string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stderr: string }> {
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      import.meta.resolve('tsx'),
+      fileURLToPath(new URL('./fixtures/migrate.ts', import.meta.url)),
+      databasePath,
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => (stderr += chunk));
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 10_000);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal, stderr });
+    });
+  });
+}

--- a/src/db/migrations/fixtures/migrate.ts
+++ b/src/db/migrations/fixtures/migrate.ts
@@ -1,0 +1,15 @@
+// Separate migration caller for the cross-process SQLite regression.
+import Database from 'better-sqlite3';
+
+import { SqliteDriver } from '../../drivers/sqlite.js';
+import { runMigrations } from '../index.js';
+
+const raw = new Database(process.argv[2]);
+raw.pragma('journal_mode = WAL');
+const db = new SqliteDriver(raw);
+
+try {
+  await runMigrations(db);
+} finally {
+  await db.close();
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -204,8 +204,13 @@ async function applyMigration(db: DbDriver, migration: Migration): Promise<void>
   // no-op inside one); foreign_key_check runs INSIDE so a violating
   // recreate rolls back atomically with nothing committed.
   if (disableForeignKeys) raw!.pragma('foreign_keys = OFF');
+  let applied = false;
   try {
-    await db.transaction(async () => {
+    applied = await db.transaction(async () => {
+      // Another process may have migrated since we selected the pending list.
+      // SQLite's BEGIN IMMEDIATE holds the write lock for this recheck and up().
+      if (await db.get('SELECT name FROM schema_version WHERE name = ?', migration.name)) return false;
+
       // Snapshot violations BEFORE up() runs: live DBs can carry latent
       // FK orphans. A migration must fail only for violations it introduces.
       const preexisting = disableForeignKeys
@@ -235,9 +240,10 @@ async function applyMigration(db: DbDriver, migration: Migration): Promise<void>
         migration.name,
         new Date().toISOString(),
       );
+      return true;
     });
   } finally {
     if (disableForeignKeys) raw!.pragma('foreign_keys = ON');
   }
-  log.info('Migration applied', { name: migration.name });
+  if (applied) log.info('Migration applied', { name: migration.name });
 }


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Prevents two SQLite migration callers from applying the same pending migration during setup or upgrade.

- **Problem**: the host and CLI-agent initializer can both read the migration ledger before either finishes. The second caller then repeats completed DDL and fails with errors such as `table agent_destinations already exists`.
- **Fix**: recheck each migration inside the existing transaction, where SQLite's `BEGIN IMMEDIATE` holds the write lock through the migration and ledger insert. Skip work completed by another caller and log only migrations this caller applies.

## Related work

Closes #3765

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- Two deterministic regressions run a separate process against a real SQLite file after the first caller reads its migration snapshot. Both fresh installation and an existing database with a pending upgrade fail on unchanged `74224f62` and pass with this fix. They also check the complete ledger, foreign-key enforcement, database integrity, and application logging.
- `pnpm exec vitest run src/db/migrations src/db/db-v2.test.ts src/db/drivers`: 70 passed.
- Full host suite and isolated fixture rerun: 2,474 passed, 1 skipped. See environment details below.
- `pnpm run typecheck`, `pnpm run format:check`, and ESLint on all three changed files: passed.
- Live macOS E2E at exact commit `1d5179b28ce7b76afef6a23b7c21f981e51cfdad` on 2026-09-11: passed in 49.7 seconds on an M4 Pro Mac mini running macOS 26.6.2 / arm64. Used a fresh checkout and the original installer ordering, with `init-cli-agent.ts` before the CLI socket wait. Proved a real agent reply, successful setup verification, a running native LaunchAgent, and unchanged existing services, containers, and shared gateway state. Dependencies and image layers were cached.
- `pnpm exec vitest run src/db/migrations/concurrency.test.ts` on that Mac: both deterministic cross-process regressions passed. The live install's logs do not establish migration overlap; these tests explicitly reproduce the stale-snapshot race.

<details>
<summary>Host test environment</summary>

Node 24.20.0 on Linux. `pnpm test -- --maxWorkers=4` passed 2,466 tests and skipped one; eight tests in two unrelated update test files could not create their temporary Git fixtures because of workstation-wide Git hooks. The update transaction tests also encountered the workstation's existing free-space guard.

Re-running both affected files with `GIT_CONFIG_GLOBAL=/dev/null` and `TMPDIR` in a fresh directory on `/dev/shm` passed all 11 tests:

```sh
GIT_CONFIG_GLOBAL=/dev/null TMPDIR="$fixture_temp" pnpm exec vitest run scripts/update-skills.test.ts scripts/update/transaction.e2e.test.ts
```

No source changes were needed for those fixture failures. The PR repository's commit hooks remained enabled.

</details>

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Fix setup and upgrade failures when concurrent SQLite migration callers attempt to apply the same migration.
```

## Security and trust boundaries

None. Uses the existing database transaction and locking mechanism; no changes to permissions, credentials, workflows, or container boundaries.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

Implementation and independent source review used Codex.

- [x] A human has reviewed this PR and stands behind every change
