### PR TITLE
fix(setup): preserve files when registry copies fail

### DIFF
--- a/docs/skill-directives.md
+++ b/docs/skill-directives.md
@@ -36,7 +36,9 @@ Every directive is idempotent — apply is safe to re-run, per the skills model.
 
 ### `copy [from-branch:<b>]`
 
-Body: one path per line — `PATH` (source == destination) or `SRC -> DST`. Copies the file in; with `from-branch:` the source is fetched from a registry branch (`git show origin/<b>:<path>`). **Idempotency: skip when every destination is present; when any is missing, all listed files are (re)copied — copying overwrites.**
+Body: one path per line — `PATH` (source == destination) or `SRC -> DST`. Copies the file in; with `from-branch:` the source is fetched from a registry branch (`git show refs/remotes/<remote>/<b>:<path>`). **Idempotency: skip when every destination is present; when any is missing, all listed files are (re)copied — copying overwrites.**
+
+Registry copies explicitly fetch `+refs/heads/<b>:refs/remotes/<remote>/<b>` from the selected remote before reading it. This also works in single-branch clones and updates stale registry refs without changing the checkout or its configured fetch mapping. A failed fetch stops the copy; cached registry content is not used as a fallback.
 
 ### `append to:<file> [at:<marker>]`
 

--- a/scripts/git-fetch-branch.ts
+++ b/scripts/git-fetch-branch.ts
@@ -1,0 +1,9 @@
+// Fetch the branch into the ref used by registry copies, even in a single-branch clone.
+function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+export function gitFetchBranchCommand(remote: string, branch: string): string {
+  const refspec = `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`;
+  return `git fetch ${shellQuote(remote)} ${shellQuote(refspec)}`;
+}

--- a/scripts/git-show-to-file.ts
+++ b/scripts/git-show-to-file.ts
@@ -1,0 +1,22 @@
+import { posix } from 'node:path';
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+// Keep redirection away from the destination until Git has succeeded. The
+// sibling temporary directory keeps the final move on the same filesystem;
+// its payload gets normal file permissions, or preserves the existing mode.
+// Use a subshell so cleanup never replaces the caller's EXIT trap.
+export function gitShowToFileCommand(revision: string, source: string, destination: string): string {
+  const target = shellQuote(destination);
+  const pattern = posix.join(posix.dirname(destination), `.${posix.basename(destination)}.XXXXXX`);
+  return `( ${[
+    `[ ! -d ${target} ]`,
+    `nc_copy_dir=$(mktemp -d ${shellQuote(pattern)})`,
+    `trap 'rm -rf -- "$nc_copy_dir"' EXIT`,
+    `{ if [ -f ${target} ]; then cp -p -- ${target} "$nc_copy_dir/payload"; fi; }`,
+    `git show ${shellQuote(`${revision}:${source}`)} > "$nc_copy_dir/payload"`,
+    `mv -- "$nc_copy_dir/payload" ${target}`,
+  ].join(' && ')} )`;
+}

--- a/scripts/registry-copy.integration.test.ts
+++ b/scripts/registry-copy.integration.test.ts
@@ -51,8 +51,26 @@ function exec(command: string): string {
   return execSync(command, { cwd: root, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
-function copySkill(source: string, destination: string): void {
-  put(skill, 'SKILL.md', `# Copy fixture\n\n\`\`\`nc:copy from-branch:channels\n${source} -> ${destination}\n\`\`\`\n`);
+function copySkill(source: string, destination: string, branch = 'channels'): void {
+  put(skill, 'SKILL.md', `# Copy fixture\n\n\`\`\`nc:copy from-branch:${branch}\n${source} -> ${destination}\n\`\`\`\n`);
+}
+
+function singleBranchClone(): void {
+  root = join(sandbox, 'single-branch');
+  git(sandbox, 'clone', '--no-local', '--single-branch', '--branch', 'main', registry, root);
+}
+
+function githubInstaller(): () => ReturnType<typeof spawnSync> {
+  mkdirSync(join(root, 'setup'));
+  copyFileSync(new URL('../setup/install-github.sh', import.meta.url), join(root, 'setup/install-github.sh'));
+  put(root, 'test-bin/pnpm', '#!/bin/sh\nprintf "%s\\n" "$*" >> pnpm-called\n');
+  chmodSync(join(root, 'test-bin/pnpm'), 0o755);
+  return () =>
+    spawnSync('bash', ['setup/install-github.sh'], {
+      cwd: root,
+      env: { ...env, PATH: `${join(root, 'test-bin')}:${env.PATH}` },
+      encoding: 'utf8',
+    });
 }
 
 beforeEach(() => {
@@ -71,6 +89,7 @@ beforeEach(() => {
     GIT_COMMITTER_EMAIL: 'copy@example.invalid',
   };
   delete env.NANOCLAW_CHANNELS_REMOTE;
+  vi.stubEnv('NANOCLAW_CHANNELS_REMOTE', '');
   mkdirSync(registry);
   git(registry, 'init', '-b', 'main');
   put(registry, 'package.json', '{"name":"copy-fixture"}\n');
@@ -82,7 +101,10 @@ beforeEach(() => {
   git(sandbox, 'clone', '--no-local', registry, root);
 });
 
-afterEach(() => rmSync(sandbox, { recursive: true, force: true }));
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(sandbox, { recursive: true, force: true });
+});
 
 describe('registry copy failures and retries', () => {
   it.each([false, true])('preserves a skill destination on failure (existing=%s), then retries', async (existing) => {
@@ -136,18 +158,104 @@ describe('registry copy failures and retries', () => {
     expect(existsSync(join(root, 'injected'))).toBe(false);
   });
 
-  it('does not poison install-mode retry when the remote-tracking ref is absent', async () => {
-    git(root, 'config', 'remote.origin.fetch', '+refs/heads/main:refs/remotes/origin/main');
-    git(root, 'update-ref', '-d', 'refs/remotes/origin/channels');
+  it.each(['channels', 'providers'])('materializes %s in a fresh single-branch checkout', async (branch) => {
+    if (branch === 'providers') git(registry, 'branch', branch, 'channels');
+    singleBranchClone();
+    copySkill('payload.ts', 'src/copied.ts', branch);
+    const head = git(root, 'rev-parse', 'HEAD');
+    expect(() => git(root, 'rev-parse', '--verify', `refs/remotes/origin/${branch}`)).toThrow();
+
+    expect(fullyApplied(await applySkill(skill, root, { exec }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+    expect(git(root, 'rev-parse', `refs/remotes/origin/${branch}`)).toBe(git(registry, 'rev-parse', branch));
+    expect(git(root, 'config', '--get-all', 'remote.origin.fetch').trim()).toBe(
+      '+refs/heads/main:refs/remotes/origin/main',
+    );
+    expect(git(root, 'rev-parse', 'HEAD')).toBe(head);
+  });
+
+  it('materializes the selected upstream ref when a fork has only main', async () => {
+    singleBranchClone();
+    git(root, 'fetch', 'origin', 'channels');
+    const stale = git(root, 'rev-parse', 'FETCH_HEAD').trim();
+    git(root, 'update-ref', 'refs/remotes/origin/channels', stale);
+    publish('payload.ts', 'export const upstream = true;\n');
+    const fork = join(sandbox, 'fork.git');
+    git(sandbox, 'clone', '--bare', '--no-local', '--single-branch', '--branch', 'main', registry, fork);
+    git(root, 'remote', 'set-url', 'origin', fork);
+    git(root, 'remote', 'add', '-t', 'main', 'upstream', registry);
     copySkill('payload.ts', 'src/copied.ts');
-    const options = { exec, resolveRemote: () => 'origin' };
+
+    expect(fullyApplied(await applySkill(skill, root, { exec }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('export const upstream = true;\n');
+    expect(git(root, 'rev-parse', 'refs/remotes/upstream/channels')).toBe(git(registry, 'rev-parse', 'channels'));
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels').trim()).toBe(stale);
+  });
+
+  it('quotes the selected remote name when fetching its tracking ref', async () => {
+    singleBranchClone();
+    const remote = "upstream'copy";
+    git(root, 'remote', 'rename', 'origin', remote);
+    copySkill('payload.ts', 'src/copied.ts');
+
+    expect(fullyApplied(await applySkill(skill, root, { exec, resolveRemote: () => remote }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+    expect(git(root, 'rev-parse', `refs/remotes/${remote}/channels`)).toBe(git(registry, 'rev-parse', 'channels'));
+  });
+
+  it('refreshes a stale ref after the registry branch is rewritten', async () => {
+    singleBranchClone();
+    git(root, 'fetch', 'origin', 'channels');
+    git(root, 'update-ref', 'refs/remotes/origin/channels', git(root, 'rev-parse', 'FETCH_HEAD').trim());
+    put(root, 'src/copied.ts', payload);
+    git(registry, 'checkout', '-B', 'channels', 'main');
+    publish('payload.ts', 'export const replaced = true;\n');
+    copySkill('payload.ts', 'src/copied.ts');
+
+    expect(fullyApplied(await applySkill(skill, root, { exec, mode: 'refresh' }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('export const replaced = true;\n');
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels')).toBe(git(registry, 'rev-parse', 'channels'));
+  });
+
+  it.each([false, true])('does not copy a stale ref after a failed fetch (existing=%s)', async (existing) => {
+    singleBranchClone();
+    git(root, 'fetch', 'origin', 'channels');
+    git(root, 'update-ref', 'refs/remotes/origin/channels', git(root, 'rev-parse', 'FETCH_HEAD').trim());
+    if (existing) put(root, 'src/copied.ts', 'local content\n');
+    git(root, 'remote', 'set-url', 'origin', join(sandbox, 'unavailable'));
+    copySkill('payload.ts', 'src/copied.ts');
+    const options = { exec, resolveRemote: () => 'origin', mode: 'refresh' as const };
     const failed = await applySkill(skill, root, options);
     expect(fullyApplied(failed)).toBe(false);
-    expect(existsSync(join(root, 'src/copied.ts'))).toBe(false);
-    // Repair the separate CORE-04 prerequisite, then retry without file cleanup.
-    git(root, 'fetch', 'origin', 'channels:refs/remotes/origin/channels');
+    expect(failed.journal).toEqual([]);
+    if (existing) expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('local content\n');
+    else expect(existsSync(join(root, 'src/copied.ts'))).toBe(false);
+
+    publish('payload.ts', 'export const recovered = true;\n');
+    git(root, 'remote', 'set-url', 'origin', registry);
     expect(fullyApplied(await applySkill(skill, root, options))).toBe(true);
-    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('export const recovered = true;\n');
+  });
+
+  it('bootstraps Slack provisioning in a fresh single-branch checkout', async () => {
+    publish(PROVISIONING_MODULE);
+    singleBranchClone();
+    const core = {} as ProvisioningCore;
+    const importModule = vi.fn(async () => core);
+
+    expect(await loadProvisioningCore({ root, exec, importModule })).toBe(core);
+    expect(readFileSync(join(root, PROVISIONING_MODULE), 'utf8')).toBe(payload);
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels')).toBe(git(registry, 'rev-parse', 'channels'));
+  });
+
+  it('installs the GitHub adapter in a fresh single-branch checkout', () => {
+    publish('src/channels/github.ts');
+    singleBranchClone();
+    const run = githubInstaller();
+    expect(run().status).toBe(0);
+    expect(readFileSync(join(root, 'src/channels/github.ts'), 'utf8')).toBe(payload);
+    expect(readFileSync(join(root, 'pnpm-called'), 'utf8')).toContain('run build');
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels')).toBe(git(registry, 'rev-parse', 'channels'));
   });
 
   it('retries Slack provisioning after a missing registry file without importing a placeholder', async () => {
@@ -165,21 +273,12 @@ describe('registry copy failures and retries', () => {
   });
 
   it.each([false, true])('preserves the GitHub adapter on failure (existing=%s), then retries', (existing) => {
-    mkdirSync(join(root, 'setup'));
-    copyFileSync(new URL('../setup/install-github.sh', import.meta.url), join(root, 'setup/install-github.sh'));
+    const run = githubInstaller();
     const adapter = 'src/channels/github.ts';
     if (existing) {
       put(root, adapter, 'local adapter\n');
       chmodSync(join(root, adapter), 0o755);
     }
-    put(root, 'test-bin/pnpm', '#!/bin/sh\nprintf "%s\\n" "$*" >> pnpm-called\n');
-    chmodSync(join(root, 'test-bin/pnpm'), 0o755);
-    const run = () =>
-      spawnSync('bash', ['setup/install-github.sh'], {
-        cwd: root,
-        env: { ...env, PATH: `${join(root, 'test-bin')}:${env.PATH}` },
-        encoding: 'utf8',
-      });
     const failed = run();
     expect(failed.status).not.toBe(0);
     if (existing) expect(readFileSync(join(root, adapter), 'utf8')).toBe('local adapter\n');

--- a/scripts/registry-copy.integration.test.ts
+++ b/scripts/registry-copy.integration.test.ts
@@ -1,0 +1,200 @@
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadProvisioningCore, PROVISIONING_MODULE, type ProvisioningCore } from '../setup/channels/slack-auto.js';
+import { applySkill, fullyApplied } from './skill-apply.js';
+
+// Real Git repositories and shell commands reproduce failed registry copies.
+// Only the Slack import and GitHub dependency/build commands are substitutes;
+// no network, platform accounts, or agent credentials are used here.
+vi.mock('../setup/logs.js', () => ({ step: vi.fn() }));
+
+let sandbox: string;
+let registry: string;
+let root: string;
+let skill: string;
+let env: NodeJS.ProcessEnv;
+const payload = 'export const installed = true;\n';
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function put(base: string, file: string, body: string): void {
+  mkdirSync(dirname(join(base, file)), { recursive: true });
+  writeFileSync(join(base, file), body);
+}
+
+function publish(file: string, body = payload): void {
+  git(registry, 'checkout', 'channels');
+  put(registry, file, body);
+  git(registry, 'add', '.');
+  git(registry, 'commit', '-qm', 'Update registry fixture');
+  git(registry, 'checkout', 'main');
+}
+
+function exec(command: string): string {
+  return execSync(command, { cwd: root, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function copySkill(source: string, destination: string): void {
+  put(skill, 'SKILL.md', `# Copy fixture\n\n\`\`\`nc:copy from-branch:channels\n${source} -> ${destination}\n\`\`\`\n`);
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'nc-registry-copy-'));
+  registry = join(sandbox, 'registry');
+  root = join(sandbox, 'install');
+  skill = join(sandbox, 'skill');
+  // Ignore operator Git hooks, signing, and URL rewrites in disposable fixtures.
+  env = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_AUTHOR_NAME: 'Copy test',
+    GIT_AUTHOR_EMAIL: 'copy@example.invalid',
+    GIT_COMMITTER_NAME: 'Copy test',
+    GIT_COMMITTER_EMAIL: 'copy@example.invalid',
+  };
+  delete env.NANOCLAW_CHANNELS_REMOTE;
+  mkdirSync(registry);
+  git(registry, 'init', '-b', 'main');
+  put(registry, 'package.json', '{"name":"copy-fixture"}\n');
+  put(registry, 'src/channels/index.ts', '// channel registrations\n');
+  git(registry, 'add', '.');
+  git(registry, 'commit', '-qm', 'Initial fixture');
+  git(registry, 'branch', 'channels');
+  publish('payload.ts');
+  git(sandbox, 'clone', '--no-local', registry, root);
+});
+
+afterEach(() => rmSync(sandbox, { recursive: true, force: true }));
+
+describe('registry copy failures and retries', () => {
+  it.each([false, true])('preserves a skill destination on failure (existing=%s), then retries', async (existing) => {
+    const destination = 'src/copied.ts';
+    if (existing) {
+      put(root, destination, 'local content\n');
+      chmodSync(join(root, destination), 0o755);
+    }
+    copySkill('missing.ts', destination);
+    const options = { exec, resolveRemote: () => 'origin', mode: 'refresh' as const };
+    const failed = await applySkill(skill, root, options);
+    expect(fullyApplied(failed)).toBe(false);
+    expect(failed.journal).toEqual([]);
+    if (existing) expect(readFileSync(join(root, destination), 'utf8')).toBe('local content\n');
+    else expect(existsSync(join(root, destination))).toBe(false);
+    expect(readdirSync(join(root, 'src')).sort()).toEqual(existing ? ['channels', 'copied.ts'] : ['channels']);
+
+    copySkill('payload.ts', destination);
+    const retried = await applySkill(skill, root, options);
+    expect(fullyApplied(retried)).toBe(true);
+    expect(readFileSync(join(root, destination), 'utf8')).toBe(payload);
+    // A new file follows the normal umask, so mounted source remains readable.
+    const expectedMode = existing ? 0o755 : statSync(join(root, 'src/channels/index.ts')).mode & 0o777;
+    expect(statSync(join(root, destination)).mode & 0o777).toBe(expectedMode);
+  });
+
+  it.each([false, true])('discards partial producer output on failure (existing=%s)', async (existing) => {
+    const destination = 'src/copied.ts';
+    if (existing) put(root, destination, 'keep me\n');
+    copySkill('payload.ts', destination);
+    const failed = await applySkill(skill, root, {
+      mode: 'refresh',
+      resolveRemote: () => 'origin',
+      exec: (command) =>
+        exec(command.includes('git show ') ? `git() { printf partial; return 23; }\n${command}` : command),
+    });
+    expect(fullyApplied(failed)).toBe(false);
+    if (existing) expect(readFileSync(join(root, destination), 'utf8')).toBe('keep me\n');
+    else expect(existsSync(join(root, destination))).toBe(false);
+    expect(readdirSync(join(root, 'src')).sort()).toEqual(existing ? ['channels', 'copied.ts'] : ['channels']);
+  });
+
+  it('copies literal paths containing spaces, quotes, and shell substitutions', async () => {
+    const source = "payload '$(touch injected).ts";
+    const destination = "src/copied '$(touch injected).ts";
+    publish(source);
+    copySkill(source, destination);
+    const result = await applySkill(skill, root, { exec, resolveRemote: () => 'origin' });
+    expect(fullyApplied(result)).toBe(true);
+    expect(readFileSync(join(root, destination), 'utf8')).toBe(payload);
+    expect(existsSync(join(root, 'injected'))).toBe(false);
+  });
+
+  it('does not poison install-mode retry when the remote-tracking ref is absent', async () => {
+    git(root, 'config', 'remote.origin.fetch', '+refs/heads/main:refs/remotes/origin/main');
+    git(root, 'update-ref', '-d', 'refs/remotes/origin/channels');
+    copySkill('payload.ts', 'src/copied.ts');
+    const options = { exec, resolveRemote: () => 'origin' };
+    const failed = await applySkill(skill, root, options);
+    expect(fullyApplied(failed)).toBe(false);
+    expect(existsSync(join(root, 'src/copied.ts'))).toBe(false);
+    // Repair the separate CORE-04 prerequisite, then retry without file cleanup.
+    git(root, 'fetch', 'origin', 'channels:refs/remotes/origin/channels');
+    expect(fullyApplied(await applySkill(skill, root, options))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+  });
+
+  it('retries Slack provisioning after a missing registry file without importing a placeholder', async () => {
+    const core = {} as ProvisioningCore;
+    const importModule = vi.fn(async () => core);
+    expect(await loadProvisioningCore({ root, exec, importModule })).toBeUndefined();
+    expect(importModule).not.toHaveBeenCalled();
+    expect(existsSync(join(root, PROVISIONING_MODULE))).toBe(false);
+    expect(readdirSync(join(root, 'src/provisioning'))).toEqual([]);
+
+    publish(PROVISIONING_MODULE);
+    expect(await loadProvisioningCore({ root, exec, importModule })).toBe(core);
+    expect(importModule).toHaveBeenCalledTimes(1);
+    expect(readFileSync(join(root, PROVISIONING_MODULE), 'utf8')).toBe(payload);
+  });
+
+  it.each([false, true])('preserves the GitHub adapter on failure (existing=%s), then retries', (existing) => {
+    mkdirSync(join(root, 'setup'));
+    copyFileSync(new URL('../setup/install-github.sh', import.meta.url), join(root, 'setup/install-github.sh'));
+    const adapter = 'src/channels/github.ts';
+    if (existing) {
+      put(root, adapter, 'local adapter\n');
+      chmodSync(join(root, adapter), 0o755);
+    }
+    put(root, 'test-bin/pnpm', '#!/bin/sh\nprintf "%s\\n" "$*" >> pnpm-called\n');
+    chmodSync(join(root, 'test-bin/pnpm'), 0o755);
+    const run = () =>
+      spawnSync('bash', ['setup/install-github.sh'], {
+        cwd: root,
+        env: { ...env, PATH: `${join(root, 'test-bin')}:${env.PATH}` },
+        encoding: 'utf8',
+      });
+    const failed = run();
+    expect(failed.status).not.toBe(0);
+    if (existing) expect(readFileSync(join(root, adapter), 'utf8')).toBe('local adapter\n');
+    else expect(existsSync(join(root, adapter))).toBe(false);
+    expect(readdirSync(join(root, 'src/channels')).sort()).toEqual(existing ? ['github.ts', 'index.ts'] : ['index.ts']);
+    expect(readFileSync(join(root, 'src/channels/index.ts'), 'utf8')).not.toContain("import './github.js'");
+    expect(existsSync(join(root, 'pnpm-called'))).toBe(false);
+
+    publish(adapter);
+    expect(run().status).toBe(0);
+    expect(readFileSync(join(root, adapter), 'utf8')).toBe(payload);
+    expect(statSync(join(root, adapter)).mode & 0o777).toBe(
+      existing ? 0o755 : statSync(join(root, 'src/channels/index.ts')).mode & 0o777,
+    );
+    expect(readFileSync(join(root, 'src/channels/index.ts'), 'utf8')).toContain("import './github.js'");
+    expect(readFileSync(join(root, 'pnpm-called'), 'utf8')).toContain('run build');
+  });
+});

--- a/scripts/registry-copy.integration.test.ts
+++ b/scripts/registry-copy.integration.test.ts
@@ -197,4 +197,24 @@ describe('registry copy failures and retries', () => {
     expect(readFileSync(join(root, 'src/channels/index.ts'), 'utf8')).toContain("import './github.js'");
     expect(readFileSync(join(root, 'pnpm-called'), 'utf8')).toContain('run build');
   });
+
+  it('refuses a directory at the GitHub adapter path', () => {
+    mkdirSync(join(root, 'setup'));
+    copyFileSync(new URL('../setup/install-github.sh', import.meta.url), join(root, 'setup/install-github.sh'));
+    publish('src/channels/github.ts');
+    mkdirSync(join(root, 'src/channels/github.ts'));
+    put(root, 'test-bin/pnpm', '#!/bin/sh\nprintf "%s\\n" "$*" >> pnpm-called\n');
+    chmodSync(join(root, 'test-bin/pnpm'), 0o755);
+
+    const failed = spawnSync('bash', ['setup/install-github.sh'], {
+      cwd: root,
+      env: { ...env, PATH: `${join(root, 'test-bin')}:${env.PATH}` },
+      encoding: 'utf8',
+    });
+
+    expect(failed.status).not.toBe(0);
+    expect(failed.stderr).toContain('is a directory');
+    expect(readdirSync(join(root, 'src/channels/github.ts'))).toEqual([]);
+    expect(existsSync(join(root, 'pnpm-called'))).toBe(false);
+  });
 });

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -215,13 +215,9 @@ describe('from-branch copy apply path', () => {
     // (mocked here) would not fail with ENOENT on a real run
     expect(existsSync(join(froot, 'container/skills/demo-formatting'))).toBe(true);
     expect(cmds).toContain('git fetch origin channels');
-    expect(
-      cmds.some((c) =>
-        /^git show origin\/channels:container\/skills\/demo-formatting\/SKILL\.md > container\/skills\/demo-formatting\/SKILL\.md$/.test(
-          c,
-        ),
-      ),
-    ).toBe(true);
+    expect(cmds.some((c) => c.includes("git show 'origin/channels:container/skills/demo-formatting/SKILL.md'"))).toBe(
+      true,
+    );
     expect(res.journal).toContainEqual({ op: 'wrote', path: 'container/skills/demo-formatting/SKILL.md' });
 
     rmSync(fskill, { recursive: true, force: true });

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -214,8 +214,8 @@ describe('from-branch copy apply path', () => {
     // the redirect target's parent now exists, so the exec'd `git show … > dest`
     // (mocked here) would not fail with ENOENT on a real run
     expect(existsSync(join(froot, 'container/skills/demo-formatting'))).toBe(true);
-    expect(cmds).toContain('git fetch origin channels');
-    expect(cmds.some((c) => c.includes("git show 'origin/channels:container/skills/demo-formatting/SKILL.md'"))).toBe(
+    expect(cmds).toContain("git fetch 'origin' '+refs/heads/channels:refs/remotes/origin/channels'");
+    expect(cmds.some((c) => c.includes("git show 'refs/remotes/origin/channels:container/skills/demo-formatting/SKILL.md'"))).toBe(
       true,
     );
     expect(res.journal).toContainEqual({ op: 'wrote', path: 'container/skills/demo-formatting/SKILL.md' });

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -25,6 +25,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, appendFileSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { gitShowToFileCommand } from './git-show-to-file.js';
 import { parseDirectives, promptVar, type Directive } from './skill-directives.js';
 
 // What an `nc:prompt` DECLARES about the value it needs — the core seam's input
@@ -656,7 +657,7 @@ async function applyOne(
           // may not exist on trunk (e.g. container skills that live only on
           // the channels branch). Mirror the local-copy path's mkdir.
           mkdirSync(dirname(join(root, destOf(l))), { recursive: true });
-          await exec(`git show ${remote}/${b}:${srcOf(l)} > ${destOf(l)}`);
+          await exec(gitShowToFileCommand(`${remote}/${b}`, srcOf(l), destOf(l)));
         }
       } else {
         for (const l of d.body) {

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -25,6 +25,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, appendFileSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { gitFetchBranchCommand } from './git-fetch-branch.js';
 import { gitShowToFileCommand } from './git-show-to-file.js';
 import { parseDirectives, promptVar, type Directive } from './skill-directives.js';
 
@@ -651,13 +652,13 @@ async function applyOne(
       if (d.attrs['from-branch']) {
         const b = String(d.attrs['from-branch']);
         const remote = ctx.resolveRemote(b);
-        await exec(`git fetch ${remote} ${b}`);
+        await exec(gitFetchBranchCommand(remote, b));
         for (const l of d.body) {
           // The shell redirect can't create parent directories, and the dest
           // may not exist on trunk (e.g. container skills that live only on
           // the channels branch). Mirror the local-copy path's mkdir.
           mkdirSync(dirname(join(root, destOf(l))), { recursive: true });
-          await exec(gitShowToFileCommand(`${remote}/${b}`, srcOf(l), destOf(l)));
+          await exec(gitShowToFileCommand(`refs/remotes/${remote}/${b}`, srcOf(l), destOf(l)));
         }
       } else {
         for (const l of d.body) {

--- a/scripts/test-registry-skills.ts
+++ b/scripts/test-registry-skills.ts
@@ -28,6 +28,7 @@ import {
   resolveChatCoreVersion,
   validate,
 } from './skill-directives.js';
+import { gitFetchBranchCommand } from './git-fetch-branch.js';
 import { refreshInstalledSkills, resolveRegistryRemote } from './update-skills.js';
 import { verifyProviderContracts } from './provider-contract-verifier.js';
 import { parseProviderDescriptor } from '../setup/providers/skill-descriptor.js';
@@ -329,7 +330,8 @@ async function testSkill(
         if (event.type === 'step-start') current = byLine.get(event.line);
       },
       exec: (cmd) => {
-        if (/^git fetch skill-ci (channels|providers)$/.test(cmd)) return '';
+        // These refs are pinned above; skill-ci is not a network remote here.
+        if ([...REGISTRY_BRANCHES].some((branch) => cmd === gitFetchBranchCommand('skill-ci', branch))) return '';
         const stub = fixture.exec?.find((candidate) => cmd.includes(candidate.match));
         if (stub) return stub.stdout;
         if (current?.kind === 'run' && STUBBED_EFFECTS.has(String(current.attrs.effect))) {

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -191,7 +191,7 @@ describe('provisioning-core bootstrap', () => {
       'git remote',
       'git ls-remote --heads origin channels',
       'git fetch origin channels',
-      `git show origin/channels:${PROVISIONING_MODULE} > ${PROVISIONING_MODULE}`,
+      expect.stringContaining(`git show 'origin/channels:${PROVISIONING_MODULE}'`),
     ]);
     // the parent directory exists before the git show redirect runs
     expect(fs.existsSync(path.join(root, 'src/provisioning'))).toBe(true);

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -190,8 +190,8 @@ describe('provisioning-core bootstrap', () => {
     expect(exec.mock.calls.map(([c]) => c)).toEqual([
       'git remote',
       'git ls-remote --heads origin channels',
-      'git fetch origin channels',
-      expect.stringContaining(`git show 'origin/channels:${PROVISIONING_MODULE}'`),
+      "git fetch 'origin' '+refs/heads/channels:refs/remotes/origin/channels'",
+      expect.stringContaining(`git show 'refs/remotes/origin/channels:${PROVISIONING_MODULE}'`),
     ]);
     // the parent directory exists before the git show redirect runs
     expect(fs.existsSync(path.join(root, 'src/provisioning'))).toBe(true);

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -36,6 +36,7 @@ import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
+import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
 import * as setupLog from '../logs.js';
 import { brightSelect } from '../lib/bright-select.js';
 import { confirmThenOpen } from '../lib/browser.js';
@@ -205,7 +206,7 @@ export async function loadProvisioningCore(deps: BootstrapDeps = {}): Promise<Pr
       const remote = resolveChannelsRemote(exec);
       exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
       fs.mkdirSync(path.dirname(modulePath), { recursive: true });
-      exec(`git show ${remote}/${CHANNELS_BRANCH}:${PROVISIONING_MODULE} > ${PROVISIONING_MODULE}`);
+      exec(gitShowToFileCommand(`${remote}/${CHANNELS_BRANCH}`, PROVISIONING_MODULE, PROVISIONING_MODULE));
       setupLog.step('slack-provision-bootstrap', 'success', Date.now() - start, { REMOTE: remote });
     }
     return await importModule(pathToFileURL(modulePath).href);

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -36,6 +36,7 @@ import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
+import { gitFetchBranchCommand } from '../../scripts/git-fetch-branch.js';
 import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
 import * as setupLog from '../logs.js';
 import { brightSelect } from '../lib/bright-select.js';
@@ -204,9 +205,9 @@ export async function loadProvisioningCore(deps: BootstrapDeps = {}): Promise<Pr
   try {
     if (!fs.existsSync(modulePath)) {
       const remote = resolveChannelsRemote(exec);
-      exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
+      exec(gitFetchBranchCommand(remote, CHANNELS_BRANCH));
       fs.mkdirSync(path.dirname(modulePath), { recursive: true });
-      exec(gitShowToFileCommand(`${remote}/${CHANNELS_BRANCH}`, PROVISIONING_MODULE, PROVISIONING_MODULE));
+      exec(gitShowToFileCommand(`refs/remotes/${remote}/${CHANNELS_BRANCH}`, PROVISIONING_MODULE, PROVISIONING_MODULE));
       setupLog.step('slack-provision-bootstrap', 'success', Date.now() - start, { REMOTE: remote });
     }
     return await importModule(pathToFileURL(modulePath).href);

--- a/setup/channels/telegram-flow.test.ts
+++ b/setup/channels/telegram-flow.test.ts
@@ -64,7 +64,7 @@ async function run(
     inputs,
     exec: (cmd) => {
       execs.push(cmd);
-      if (/^(git|pnpm|bash)\b/.test(cmd)) return '';
+      if (/^(git|pnpm|bash)\b/.test(cmd) || cmd.includes('git show ')) return '';
       if (cmd.startsWith('curl')) return getMe(cmd);
       return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
     },

--- a/setup/channels/telegram-pre-step.test.ts
+++ b/setup/channels/telegram-pre-step.test.ts
@@ -167,7 +167,7 @@ async function runTelegramWizard(root: string) {
     projectRoot: root,
     exec: (cmd: string): string => {
       execs.push(cmd);
-      if (/^(git|pnpm|bash)\b/.test(cmd)) return '';
+      if (/^(git|pnpm|bash)\b/.test(cmd) || cmd.includes('git show ')) return '';
       if (cmd.startsWith('curl')) return cmd.includes(NEW_TOKEN) ? 'mega_bot' : 'nanoclaw_bot';
       return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
     },

--- a/setup/channels/whatsapp-flow.test.ts
+++ b/setup/channels/whatsapp-flow.test.ts
@@ -39,7 +39,13 @@ async function run(inputs: Record<string, string>): Promise<Recorded> {
     inputs,
     exec: (cmd: string) => {
       seq.push({ type: 'exec', text: cmd });
-      if (/^(git|pnpm|bash)\b/.test(cmd) || cmd.startsWith('grep') || cmd.startsWith('touch')) return '';
+      if (
+        /^(git|pnpm|bash)\b/.test(cmd) ||
+        cmd.includes('git show ') ||
+        cmd.startsWith('grep') ||
+        cmd.startsWith('touch')
+      )
+        return '';
       return execFileSync('bash', ['-c', cmd], { cwd: root, encoding: 'utf-8' });
     },
     execStream: async () => ({ ok: true, fields: { PHONE: BOT_PHONE } }),

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -29,7 +29,17 @@ echo "STEP: fetch-channels-branch"
 git fetch origin channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/github.ts > src/channels/github.ts
+# Publish only a complete Git result; a failed copy must remain retryable.
+(
+  [[ ! -d src/channels/github.ts ]]
+  nc_copy_dir="$(mktemp -d src/channels/.github.ts.XXXXXX)"
+  trap 'rm -rf -- "$nc_copy_dir"' EXIT
+  if [[ -f src/channels/github.ts ]]; then
+    cp -p -- src/channels/github.ts "$nc_copy_dir/payload"
+  fi
+  git show origin/channels:src/channels/github.ts > "$nc_copy_dir/payload"
+  mv -- "$nc_copy_dir/payload" src/channels/github.ts
+)
 
 echo "STEP: register-import"
 if ! grep -q "import './github.js';" src/channels/index.ts; then

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -26,7 +26,7 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch origin '+refs/heads/channels:refs/remotes/origin/channels'
 
 echo "STEP: copy-files"
 # Publish only a complete Git result; a failed copy must remain retryable.
@@ -37,7 +37,7 @@ echo "STEP: copy-files"
   if [[ -f src/channels/github.ts ]]; then
     cp -p -- src/channels/github.ts "$nc_copy_dir/payload"
   fi
-  git show origin/channels:src/channels/github.ts > "$nc_copy_dir/payload"
+  git show refs/remotes/origin/channels:src/channels/github.ts > "$nc_copy_dir/payload"
   mv -- "$nc_copy_dir/payload" src/channels/github.ts
 )
 

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -31,7 +31,10 @@ git fetch origin channels
 echo "STEP: copy-files"
 # Publish only a complete Git result; a failed copy must remain retryable.
 (
-  [[ ! -d src/channels/github.ts ]]
+  [[ ! -d src/channels/github.ts ]] || {
+    echo "ERROR: src/channels/github.ts is a directory; refusing to copy the adapter into it" >&2
+    exit 1
+  }
   nc_copy_dir="$(mktemp -d src/channels/.github.ts.XXXXXX)"
   trap 'rm -rf -- "$nc_copy_dir"' EXIT
   if [[ -f src/channels/github.ts ]]; then


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Preserves destination files and allows retries when a registry copy fails during setup.

- **Problem**: redirecting `git show` into the destination truncates existing files or leaves empty placeholders when a ref or path is missing. Retries can then skip the placeholder.
- **Fix**: copy into a temporary sibling directory, publish only after Git succeeds, and clean up on success or failure. Existing file permissions are preserved; new files retain normal permissions.
- **Coverage**: the skill engine, Slack provisioning bootstrap, and GitHub installer use the safe copy sequence.

## Related work

Addresses the failed-copy portion of #3354. Its separate OneCLI PATH problem remains outside this change, so this PR does not close the whole issue. Builds on the closed, unmerged #3441. Registry-ref creation and multi-file install transactions remain separate work.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run scripts/registry-copy.integration.test.ts` → nine real-Git/shell regressions pass, including a repeat on the fresh E2E VM. The original six regressions failed on unchanged upstream.
- Focused skill-engine and channel-flow tests → 138 passed.
- Host `vitest run` with isolated global Git configuration, plus a targeted rerun of seven disk-sensitive tests using RAM-backed temporary storage → 2,481 passed, one skipped overall. The initial full run lacked the updater fixtures' required free disk space.
- `pnpm run build` and scoped helper/skill-engine TypeScript checks → passed. Extended setup typechecking reports the same 21 diagnostics on unchanged upstream and this candidate.
- Native macOS and Linux shell probes → permissions, cleanup, quoted paths, and partial-output failures preserve the expected result.
- Official OSS dev-tools 0.4.0 E2E installer on a fresh Linux VM at `705c6b9e627ac36a8b4bbc280e5804c6debf9a25` → real Claude reply, service running, final verification successful. The run used system commands first on PATH to avoid an image-specific false port-conflict check, and the installer's documented fallback startup. This validates the headless CLI-agent path; interactive-wizard startup remains separate.

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Failed setup registry copies now preserve existing files and avoid empty placeholders that prevent successful retries.
```

## Security and trust boundaries

No changes to permissions, credentials, or container access. Git operands and filesystem paths are shell-quoted; temporary files are cleaned within an isolated subshell.

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change
