### PR TITLE
fix(setup): start and verify the Linux fallback service

### DIFF
--- a/docs/setup-wiring.md
+++ b/docs/setup-wiring.md
@@ -13,8 +13,9 @@ failure makes the setup step fail; inspect `logs/nanoclaw.error.log`.
 
 Re-running the launcher stops the recorded host from this checkout and waits
 up to 10 seconds for it to exit before starting a replacement. A stale PID
-belonging to another process is ignored. Nohup keeps the host running after the
-setup shell exits; it does not provide automatic restart or boot persistence.
+belonging to another process is ignored. The launcher uses Linux `setsid` to
+detach the host from the setup terminal so it survives that terminal exiting.
+It does not provide automatic restart or boot persistence.
 
 ### Two-DB Split (session DB write isolation)
 - Session DB split into `inbound.db` (host-owned) and `outbound.db` (container-owned)

--- a/docs/setup-wiring.md
+++ b/docs/setup-wiring.md
@@ -4,6 +4,18 @@ Last updated: 2026-07-10
 
 ## What's Done
 
+### Linux fallback service startup
+
+When systemd is absent or its user session is unavailable, the service setup
+step writes and runs `start-nanoclaw.sh`. It reports success after the process
+is alive and `data/ncl.sock` accepts connections (up to 30 seconds). Startup
+failure makes the setup step fail; inspect `logs/nanoclaw.error.log`.
+
+Re-running the launcher stops the recorded host from this checkout and waits
+up to 10 seconds for it to exit before starting a replacement. A stale PID
+belonging to another process is ignored. Nohup keeps the host running after the
+setup shell exits; it does not provide automatic restart or boot persistence.
+
 ### Two-DB Split (session DB write isolation)
 - Session DB split into `inbound.db` (host-owned) and `outbound.db` (container-owned)
 - Each file has exactly one writer — eliminates SQLite write contention across host-container mount

--- a/setup/lib/restart.sh
+++ b/setup/lib/restart.sh
@@ -10,11 +10,35 @@ root="$(cd "$here/../.." && pwd)"
 # shellcheck source=/dev/null
 source "$here/install-slug.sh"
 
+restarted=false
 case "$(uname -s)" in
-  Darwin) launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" 2>/dev/null || true ;;
-  Linux) systemctl --user restart "$(systemd_unit)" 2>/dev/null \
-    || sudo systemctl restart "$(systemd_unit)" 2>/dev/null || true ;;
+  Darwin)
+    if launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" 2>/dev/null; then restarted=true; fi
+    ;;
+  Linux)
+    if systemctl --user restart "$(systemd_unit)" 2>/dev/null \
+      || sudo systemctl restart "$(systemd_unit)" 2>/dev/null; then
+      restarted=true
+    fi
+    ;;
 esac
+
+# Linux installs without a usable systemd user bus run through the generated
+# nohup wrapper. Restart that exact checkout when no service manager accepted
+# the request; otherwise channel installs would leave the old host running and
+# the old socket could make the following readiness wait pass falsely.
+if [ "$restarted" = false ] && [ -x "$root/start-nanoclaw.sh" ]; then
+  if "$root/start-nanoclaw.sh"; then
+    restarted=true
+  else
+    echo "nanoclaw: nohup fallback restart failed" >&2
+    exit 1
+  fi
+fi
+
+if [ "$restarted" = false ]; then
+  echo "nanoclaw: no installed service or nohup launcher to restart" >&2
+fi
 
 # Wait up to ~30s for the CLI socket so `ncl` can connect on the next directive.
 for _ in $(seq 1 60); do

--- a/setup/lib/restart.test.ts
+++ b/setup/lib/restart.test.ts
@@ -1,0 +1,56 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    const pidFile = path.join(root, 'fixture.pid');
+    if (fs.existsSync(pidFile)) {
+      try {
+        process.kill(Number(fs.readFileSync(pidFile, 'utf8')), 'SIGKILL');
+      } catch {
+        // The fixture listener already exited.
+      }
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe.runIf(process.platform !== 'win32')('restart helper', () => {
+  it('uses the nohup launcher when systemd cannot restart the install', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-restart-'));
+    roots.push(root);
+    const lib = path.join(root, 'setup', 'lib');
+    const bin = path.join(root, 'fixture-bin');
+    fs.mkdirSync(lib, { recursive: true });
+    fs.mkdirSync(bin);
+    fs.mkdirSync(path.join(root, 'data'));
+    fs.copyFileSync(new URL('./restart.sh', import.meta.url), path.join(lib, 'restart.sh'));
+    fs.copyFileSync(new URL('./install-slug.sh', import.meta.url), path.join(lib, 'install-slug.sh'));
+
+    fs.writeFileSync(path.join(bin, 'uname'), '#!/bin/sh\necho Linux\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(bin, 'systemctl'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(bin, 'sudo'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(root, 'start-nanoclaw.sh'),
+      `#!/bin/bash\nset -e\ntouch ${JSON.stringify(path.join(root, 'launcher-ran'))}\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+        "const fs=require('fs');const net=require('net');const p=process.argv[1];try{fs.unlinkSync(p)}catch{};net.createServer(()=>{}).listen(p);",
+      )} ${JSON.stringify(path.join(root, 'data', 'ncl.sock'))} </dev/null >/dev/null 2>&1 &\necho $! > ${JSON.stringify(path.join(root, 'fixture.pid'))}\n`,
+      { mode: 0o755 },
+    );
+
+    execFileSync('/bin/bash', [path.join(lib, 'restart.sh')], {
+      cwd: root,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+
+    expect(fs.existsSync(path.join(root, 'launcher-ran'))).toBe(true);
+    expect(fs.statSync(path.join(root, 'data', 'ncl.sock')).isSocket()).toBe(true);
+  });
+});

--- a/setup/service-nohup.test.ts
+++ b/setup/service-nohup.test.ts
@@ -1,0 +1,164 @@
+import { execFileSync, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const host = vi.hoisted(() => ({ root: '', manager: 'none', nodePath: process.execPath }));
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
+  execSync: vi.fn((command: string) => {
+    if (command === 'pnpm run build') return '';
+    if (command === 'systemctl --user daemon-reload') throw new Error('No user bus');
+    throw new Error(`Unexpected service command: ${command}`);
+  }),
+}));
+vi.mock('./platform.js', () => ({
+  getPlatform: () => 'linux',
+  getNodePath: () => host.nodePath,
+  getServiceManager: () => host.manager,
+  isRoot: () => false,
+}));
+vi.mock('../src/log.js', () => ({ log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('../src/upgrade-state.js', () => ({ writeUpgradeState: () => ({ version: 'fixture' }) }));
+vi.mock('./peer-cleanup.js', () => ({ cleanupUnhealthyPeers: () => ({ unloaded: [], removed: [] }) }));
+vi.mock('./status.js', () => ({ emitStatus: vi.fn() }));
+
+import { emitStatus } from './status.js';
+import { run, waitForNohupStartup } from './service.js';
+
+const fields = () => vi.mocked(emitStatus).mock.calls.at(-1)?.[1];
+const pidFile = () => path.join(host.root, 'nanoclaw.pid');
+const readPid = () => Number(fs.readFileSync(pidFile(), 'utf8').trim());
+const fixture = (source: string) => fs.writeFileSync(path.join(host.root, 'dist/index.js'), source);
+const acceptingHost = (delay = 0, shutdownDelay = 0) =>
+  fixture(`
+  const net = require('net');
+  const fs = require('fs');
+  setTimeout(() => {
+    const server = net.createServer(c => c.end());
+    server.listen('data/ncl.sock');
+    process.on('SIGTERM', () => setTimeout(() => server.close(() => process.exit(0)), ${shutdownDelay}));
+  }, ${delay});
+`);
+
+beforeEach(() => {
+  // Shell metacharacters are literal path characters, including in the generated launcher.
+  host.root = fs.mkdtempSync(path.join(os.tmpdir(), "nc-'$()-"));
+  host.manager = 'none';
+  host.nodePath = process.execPath;
+  fs.mkdirSync(path.join(host.root, 'dist'));
+  fs.mkdirSync(path.join(host.root, 'data'));
+  vi.spyOn(process, 'cwd').mockReturnValue(host.root);
+  vi.spyOn(os, 'homedir').mockReturnValue(path.join(host.root, 'home'));
+  vi.mocked(emitStatus).mockClear();
+});
+afterEach(async () => {
+  // Only signal fixture-owned hosts, never whatever an intentionally stale PID file names.
+  if (fs.existsSync(pidFile())) {
+    const pid = readPid();
+    try {
+      const args = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8').split('\0');
+      if (args[1] === path.join(host.root, 'dist/index.js')) {
+        process.kill(pid, 'SIGKILL');
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    } catch {
+      /* exited */
+    }
+  }
+  vi.restoreAllMocks();
+  fs.rmSync(host.root, { recursive: true, force: true });
+});
+
+// The production fallback is Linux-only and checks Linux process ownership.
+describe.runIf(process.platform === 'linux')('nohup service startup', () => {
+  it.each(['none', 'systemd'])('starts the actual launcher when manager is %s', async (manager) => {
+    host.manager = manager;
+    acceptingHost(150);
+    await run([]);
+    expect(fields()).toMatchObject({ SERVICE_TYPE: 'nohup', SERVICE_LOADED: true, STATUS: 'success' });
+    expect(fs.statSync(path.join(host.root, 'data/ncl.sock')).isSocket()).toBe(true);
+    process.kill(readPid(), 0);
+    execFileSync('/bin/bash', ['-n', path.join(host.root, 'start-nanoclaw.sh')]);
+  });
+
+  it('restarts the recorded host and waits for the replacement to be ready', async () => {
+    acceptingHost(0, 250);
+    await run([]);
+    const oldPid = readPid();
+    await run([]);
+    expect(readPid()).not.toBe(oldPid);
+    expect(fields()).toMatchObject({ SERVICE_LOADED: true, STATUS: 'success' });
+    let oldArgs = '';
+    try {
+      oldArgs = fs.readFileSync(`/proc/${oldPid}/cmdline`, 'utf8');
+    } catch {
+      /* exited */
+    }
+    expect(oldArgs).not.toContain(path.join(host.root, 'dist/index.js'));
+  });
+
+  it.each(['missing', 'unrelated'])('rejects an existing listener with a %s PID file', async (pidState) => {
+    acceptingHost();
+    await run([]);
+    const oldPid = readPid();
+    if (pidState === 'missing') fs.unlinkSync(pidFile());
+    else fs.writeFileSync(pidFile(), String(process.pid));
+    try {
+      await expect(run([])).rejects.toThrow('failed to start');
+      expect(fields()).toMatchObject({ SERVICE_LOADED: false, STATUS: 'failed' });
+      process.kill(oldPid, 0);
+    } finally {
+      fs.writeFileSync(pidFile(), String(oldPid));
+    }
+  });
+
+  it('restarts its previous host after the Node installation path changes', async () => {
+    acceptingHost();
+    await run([]);
+    const oldPid = readPid();
+    host.nodePath = path.join(host.root, 'node-alias');
+    fs.symlinkSync(process.execPath, host.nodePath);
+    await run([]);
+    expect(readPid()).not.toBe(oldPid);
+    expect(fields()).toMatchObject({ SERVICE_LOADED: true, STATUS: 'success' });
+  });
+
+  it('refuses to replace a host that does not finish shutting down', async () => {
+    acceptingHost(0, 60_000);
+    await run([]);
+    const oldPid = readPid();
+    await expect(run([])).rejects.toThrow('failed to start');
+    expect(readPid()).toBe(oldPid);
+    expect(fields()).toMatchObject({ SERVICE_LOADED: false, STATUS: 'failed' });
+  }, 15_000);
+
+  it('reports a host startup error instead of success', async () => {
+    fixture('process.exit(17);');
+    await expect(run([])).rejects.toThrow();
+    expect(fields()).toMatchObject({ SERVICE_TYPE: 'nohup', SERVICE_LOADED: false, STATUS: 'failed' });
+  });
+
+  it('bounds readiness when a live process never opens the admin socket', async () => {
+    fixture('setInterval(() => {}, 1000);');
+    const child = spawn(process.execPath, [path.join(host.root, 'dist/index.js')], { stdio: 'ignore' });
+    fs.writeFileSync(pidFile(), String(child.pid));
+    await expect(waitForNohupStartup(host.root, child.pid!, 100)).rejects.toThrow('Timed out');
+  });
+
+  it('does not signal an unrelated process referenced by a stale PID file', async () => {
+    fs.writeFileSync(pidFile(), `${process.pid}\n`);
+    acceptingHost();
+    await run([]);
+    expect(readPid()).not.toBe(process.pid);
+    expect(fields()).toMatchObject({ SERVICE_LOADED: true, STATUS: 'success' });
+  });
+
+  it('fails when the configured Node binary cannot start', async () => {
+    host.nodePath = path.join(host.root, 'missing-node');
+    acceptingHost();
+    await expect(run([])).rejects.toThrow();
+    expect(fields()).toMatchObject({ SERVICE_LOADED: false, STATUS: 'failed' });
+  });
+});

--- a/setup/service-nohup.test.ts
+++ b/setup/service-nohup.test.ts
@@ -99,6 +99,33 @@ describe.runIf(process.platform === 'linux')('nohup service startup', () => {
     expect(oldArgs).not.toContain(path.join(host.root, 'dist/index.js'));
   });
 
+  it('keeps the host alive after the interactive terminal session exits', async () => {
+    acceptingHost();
+    await run([]);
+    const previousPid = readPid();
+    const wrapper = path.join(host.root, 'start-nanoclaw.sh');
+    const quoted = (value: string) => "'" + value.replace(/'/g, "'\\''") + "'";
+    // util-linux script starts a real controlling terminal. Its shell must
+    // exit after Node has started, not while nohup still owns the process.
+    execFileSync(
+      'script',
+      [
+        '-q',
+        '-e',
+        '-c',
+        `/bin/bash ${quoted(wrapper)} && while [ ! -S ${quoted(path.join(host.root, 'data/ncl.sock'))} ]; do sleep 0.05; done`,
+        '/dev/null',
+      ],
+      {
+        stdio: 'pipe',
+        timeout: 15_000,
+      },
+    );
+    const pid = readPid();
+    expect(pid).not.toBe(previousPid);
+    await expect(waitForNohupStartup(host.root, pid, 1000)).resolves.toBeUndefined();
+  });
+
   it.each(['missing', 'unrelated'])('rejects an existing listener with a %s PID file', async (pidState) => {
     acceptingHost();
     await run([]);

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import path from 'path';
 
 import { getLaunchdLabel } from '../src/install-slug.js';
 
@@ -116,25 +115,5 @@ describe('systemd unit generation', () => {
   it('sets correct ExecStart', () => {
     const unit = generateSystemdUnit('/usr/bin/node', '/srv/nanoclaw', '/home/user', false);
     expect(unit).toContain('ExecStart=/usr/bin/node /srv/nanoclaw/dist/index.js');
-  });
-});
-
-describe('WSL nohup fallback', () => {
-  it('generates a valid wrapper script', () => {
-    const projectRoot = '/home/user/nanoclaw';
-    const nodePath = '/usr/bin/node';
-    const pidFile = path.join(projectRoot, 'nanoclaw.pid');
-
-    // Simulate what service.ts generates
-    const wrapper = `#!/bin/bash
-set -euo pipefail
-cd ${JSON.stringify(projectRoot)}
-nohup ${JSON.stringify(nodePath)} ${JSON.stringify(projectRoot)}/dist/index.js >> ${JSON.stringify(projectRoot)}/logs/nanoclaw.log 2>> ${JSON.stringify(projectRoot)}/logs/nanoclaw.error.log &
-echo $! > ${JSON.stringify(pidFile)}`;
-
-    expect(wrapper).toContain('#!/bin/bash');
-    expect(wrapper).toContain('nohup');
-    expect(wrapper).toContain(nodePath);
-    expect(wrapper).toContain('nanoclaw.pid');
   });
 });

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -505,7 +505,8 @@ socket.setTimeout(1000, () => {
 `)} ${shellQuote(path.join(projectRoot, 'data', 'ncl.sock'))}`,
     '',
     'echo "Starting NanoClaw..."',
-    `nohup ${shellQuote(nodePath)} ${shellQuote(entrypoint)} \\`,
+    // Node resets the inherited SIGHUP ignore; detach from the wizard terminal.
+    `setsid nohup ${shellQuote(nodePath)} ${shellQuote(entrypoint)} \\`,
     `  >> ${shellQuote(projectRoot + '/logs/nanoclaw.log')} \\`,
     `  2>> ${shellQuote(projectRoot + '/logs/nanoclaw.error.log')} < /dev/null &`,
     `echo $! > ${shellQuote(pidFile)}`,

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -4,8 +4,9 @@
  *
  * Fixes: Root→system systemd, WSL nohup fallback, no `|| true` swallowing errors.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import fs from 'fs';
+import net from 'net';
 import os from 'os';
 import path from 'path';
 
@@ -13,7 +14,7 @@ import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { writeUpgradeState } from '../src/upgrade-state.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
-import { commandExists, getPlatform, getNodePath, getServiceManager, hasSystemd, isRoot, isWSL } from './platform.js';
+import { commandExists, getPlatform, getNodePath, getServiceManager, isRoot } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -74,7 +75,7 @@ export async function run(_args: string[]): Promise<void> {
   if (platform === 'macos') {
     setupLaunchd(projectRoot, nodePath, homeDir);
   } else if (platform === 'linux') {
-    setupLinux(projectRoot, nodePath, homeDir);
+    await setupLinux(projectRoot, nodePath, homeDir);
   } else {
     emitStatus('SETUP_SERVICE', {
       SERVICE_TYPE: 'unknown',
@@ -221,14 +222,14 @@ function setupLaunchd(projectRoot: string, nodePath: string, homeDir: string): v
   });
 }
 
-function setupLinux(projectRoot: string, nodePath: string, homeDir: string): void {
+async function setupLinux(projectRoot: string, nodePath: string, homeDir: string): Promise<void> {
   const serviceManager = getServiceManager();
 
   if (serviceManager === 'systemd') {
-    setupSystemd(projectRoot, nodePath, homeDir);
+    await setupSystemd(projectRoot, nodePath, homeDir);
   } else {
     // WSL without systemd or other Linux without systemd
-    setupNohupFallback(projectRoot, nodePath, homeDir);
+    await setupNohupFallback(projectRoot, nodePath);
   }
 }
 
@@ -274,7 +275,7 @@ function checkDockerGroupStale(): boolean {
   }
 }
 
-function setupSystemd(projectRoot: string, nodePath: string, homeDir: string): void {
+async function setupSystemd(projectRoot: string, nodePath: string, homeDir: string): Promise<void> {
   const runningAsRoot = isRoot();
   const unitName = getSystemdUnit(projectRoot);
   const unitFileName = `${unitName}.service`;
@@ -293,7 +294,7 @@ function setupSystemd(projectRoot: string, nodePath: string, homeDir: string): v
       execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
     } catch {
       log.warn('systemd user session not available — falling back to nohup wrapper');
-      setupNohupFallback(projectRoot, nodePath, homeDir);
+      await setupNohupFallback(projectRoot, nodePath);
       return;
     }
     const unitDir = path.join(homeDir, '.config', 'systemd', 'user');
@@ -411,53 +412,129 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   });
 }
 
-function setupNohupFallback(projectRoot: string, nodePath: string, homeDir: string): void {
-  log.warn('No systemd detected — generating nohup wrapper script');
+// Single quotes keep checkout paths literal in the generated shell script.
+function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+function processRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    // kill -0 also succeeds for an exited child waiting to be reaped on Linux.
+    return !/\) Z /.test(fs.readFileSync(`/proc/${pid}/stat`, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+/** The admin socket opens at the end of host startup, after channels and polls. */
+export async function waitForNohupStartup(projectRoot: string, pid: number, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processRunning(pid)) throw new Error('NanoClaw exited during startup');
+    const ready = await new Promise<boolean>((resolve) => {
+      // Do not probe cli.sock: connecting there replaces the interactive chat client.
+      const socket = net.createConnection(path.join(projectRoot, 'data', 'ncl.sock'));
+      const done = (connected: boolean): void => {
+        socket.destroy();
+        resolve(connected);
+      };
+      socket.once('connect', () => done(true));
+      socket.once('error', () => done(false));
+      socket.setTimeout(Math.min(500, Math.max(1, deadline - Date.now())), () => done(false));
+    });
+    if (ready && processRunning(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Timed out waiting for NanoClaw admin socket');
+}
+
+async function setupNohupFallback(projectRoot: string, nodePath: string): Promise<void> {
+  log.warn('No usable systemd service — starting with nohup');
 
   const wrapperPath = path.join(projectRoot, 'start-nanoclaw.sh');
   const pidFile = path.join(projectRoot, 'nanoclaw.pid');
+  const entrypoint = path.join(projectRoot, 'dist', 'index.js');
 
   const lines = [
     '#!/bin/bash',
     '# start-nanoclaw.sh — Start NanoClaw without systemd',
-    `# To stop: kill \\$(cat ${pidFile})`,
+    `# To stop: kill "$(cat ${shellQuote(pidFile)})"`,
     '',
     'set -euo pipefail',
+    `cd ${shellQuote(projectRoot)}`,
     '',
-    `cd ${JSON.stringify(projectRoot)}`,
-    '',
-    '# Stop existing instance if running',
-    `if [ -f ${JSON.stringify(pidFile)} ]; then`,
-    `  OLD_PID=$(cat ${JSON.stringify(pidFile)} 2>/dev/null || echo "")`,
-    '  if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then',
-    '    echo "Stopping existing NanoClaw (PID $OLD_PID)..."',
-    '    kill "$OLD_PID" 2>/dev/null || true',
-    '    sleep 2',
+    '# Only stop the recorded host from this checkout; a PID can be reused.',
+    'is_previous_host() {',
+    '  [[ "$OLD_PID" =~ ^[1-9][0-9]*$ ]] || return 1',
+    '  [ -r "/proc/$OLD_PID/cmdline" ] || return 1',
+    '  local -a args=()',
+    '  mapfile -d "" -t args < "/proc/$OLD_PID/cmdline" 2>/dev/null || return 1',
+    `  [ "\${args[1]:-}" = ${shellQuote(entrypoint)} ]`,
+    '}',
+    `OLD_PID=$(cat ${shellQuote(pidFile)} 2>/dev/null || true)`,
+    'if is_previous_host; then',
+    '  echo "Stopping existing NanoClaw (PID $OLD_PID)..."',
+    '  kill "$OLD_PID"',
+    '  for ((i=0; i<100; i++)); do',
+    '    is_previous_host || break',
+    '    sleep 0.1',
+    '  done',
+    '  if is_previous_host; then',
+    '    echo "Previous NanoClaw did not stop; refusing to start another host" >&2',
+    '    exit 1',
     '  fi',
     'fi',
     '',
-    'echo "Starting NanoClaw..."',
-    `nohup ${JSON.stringify(nodePath)} ${JSON.stringify(projectRoot + '/dist/index.js')} \\`,
-    `  >> ${JSON.stringify(projectRoot + '/logs/nanoclaw.log')} \\`,
-    `  2>> ${JSON.stringify(projectRoot + '/logs/nanoclaw.error.log')} &`,
+    '# A missing/stale PID file must not let an existing listener fake readiness.',
+    `${shellQuote(nodePath)} -e ${shellQuote(`
+const socket = require('net').createConnection(process.argv[1]);
+socket.once('connect', () => {
+  console.error('NanoClaw admin socket is already in use; stop the existing host first');
+  process.exit(1);
+});
+socket.once('error', (err) => {
+  if (err.code === 'ENOENT' || err.code === 'ECONNREFUSED') process.exit(0);
+  console.error('Cannot check NanoClaw admin socket:', err.message);
+  process.exit(1);
+});
+socket.setTimeout(1000, () => {
+  console.error('Timed out checking existing NanoClaw admin socket');
+  process.exit(1);
+});
+`)} ${shellQuote(path.join(projectRoot, 'data', 'ncl.sock'))}`,
     '',
-    `echo $! > ${JSON.stringify(pidFile)}`,
-    'echo "NanoClaw started (PID $!)"',
-    `echo "Logs: tail -f ${projectRoot}/logs/nanoclaw.log"`,
+    'echo "Starting NanoClaw..."',
+    `nohup ${shellQuote(nodePath)} ${shellQuote(entrypoint)} \\`,
+    `  >> ${shellQuote(projectRoot + '/logs/nanoclaw.log')} \\`,
+    `  2>> ${shellQuote(projectRoot + '/logs/nanoclaw.error.log')} < /dev/null &`,
+    `echo $! > ${shellQuote(pidFile)}`,
+    'echo "NanoClaw launched (PID $!)"',
   ];
-  const wrapper = lines.join('\n') + '\n';
-
-  fs.writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+  fs.writeFileSync(wrapperPath, lines.join('\n') + '\n', { mode: 0o755 });
   log.info('Wrote nohup wrapper script', { wrapperPath });
+
+  let failure: unknown;
+  try {
+    execFileSync('/bin/bash', [wrapperPath], { cwd: projectRoot, stdio: 'pipe', timeout: 15_000 });
+    const pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+    if (!Number.isInteger(pid) || pid <= 0) throw new Error('Invalid NanoClaw PID file');
+    await waitForNohupStartup(projectRoot, pid);
+  } catch (err) {
+    failure = err;
+    log.error('Nohup service failed to start; see logs/nanoclaw.error.log', { err });
+  }
 
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: 'nohup',
     NODE_PATH: nodePath,
     PROJECT_PATH: projectRoot,
     WRAPPER_PATH: wrapperPath,
-    SERVICE_LOADED: false,
-    FALLBACK: 'wsl_no_systemd',
-    STATUS: 'success',
+    SERVICE_LOADED: !failure,
+    FALLBACK: 'no_usable_systemd',
+    STATUS: failure ? 'failed' : 'success',
+    ...(failure ? { ERROR: 'service_start_failed' } : {}),
     LOG: 'logs/setup.log',
   });
+  if (failure) throw new Error('NanoClaw failed to start; see logs/nanoclaw.error.log', { cause: failure });
 }


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->
## Summary

Starts and verifies NanoClaw during setup when Linux selects the nohup fallback.

- **Problem**: the fallback writes a launcher but leaves the host stopped, so the wizard cannot reach its first agent.
- **Fix**: execute the launcher and wait up to 30 seconds for a live host and an accepting admin socket; report startup failures as failed setup steps.
- **Terminal lifetime**: detach the host with `setsid` so it survives the wizard terminal closing.
- **Restart handling**: verify the recorded process belongs to this checkout, wait up to 10 seconds for shutdown, and reject an existing untracked admin listener.

## Related work

Related to the fallback-startup defect described in #2482. #2494 addresses systemd user-session detection; this change handles startup after the fallback is selected.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm test` → 2,483 passed, one skipped. The 12 tests in `setup/service-nohup.test.ts` exercise the generated launcher with real processes, Unix sockets, restarts, startup failures, and a controlling terminal.
- `pnpm run build` → passed; separate typecheck of `setup/service.ts` → zero diagnostics.
- Regression controls → six startup cases failed against unchanged upstream; the controlling-terminal test failed before the detachment fix.
- Fresh Ubuntu VM, exact commit `8d75571abfcf2486ceeef9b302ddc21ca69955b1`: standard `bash nanoclaw.sh` wizard completed bootstrap, image build, OneCLI, authentication, fallback startup, first ping, retained terminal agent, and final verification.
- Real inference → the retained agent answered `79508 * 47` with `3736876`; a separate SSH connection after the wizard terminal exited verified the same host PID and a successful admin request.
- [x] Tests cover the changed behavior (or Validation says why not)

<details>
<summary>Live test details</summary>

The interactive test used a PTY driver with a task-only adapter for a completed status line and nohup service verification. The product wizard, prompt paths, inference checks, and normal PTY cleanup were unchanged; the test did not manually start the host.

Environment: Node v24.21.0, pnpm 10.34.5, Docker 29.1.3. Sanitized evidence was exported and checked before deleting all disposable test VMs.

</details>

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Linux setup now starts and verifies the fallback service when user systemd is unavailable, and keeps it running after the setup terminal closes.
```

The fallback does not provide automatic restart or boot persistence.

## Security and trust boundaries

The launcher checks the absolute checkout entrypoint before signaling a recorded PID and refuses to start over an untracked admin listener. No credential, container-isolation, or permission model changes.

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change

