### PR TITLE
fix: recover uvx-installed pnpm after bootstrap

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -423,10 +423,17 @@ fi
 # wipe it.
 export NANOCLAW_BOOTSTRAPPED=1
 
-# setup.sh may have just installed pnpm via npm into a prefix that's not on
-# our PATH (custom `npm config set prefix`, or the default prefix missing
-# from the shell's login PATH). Its PATH mutation doesn't propagate back
-# to us — so replay the same lookup here before the exec.
+# setup.sh may have just installed Node/npm/pnpm under ~/.local/bin via
+# uvx-nodeenv. Its PATH mutation doesn't propagate back to this parent shell,
+# so make that standard user bin directory discoverable before probing npm.
+# Keep an existing PATH entry in place rather than adding duplicates.
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
+# pnpm may instead have landed in npm's configured global prefix. Replay that
+# lookup here as a second recovery path before the final exec.
 if ! command -v pnpm >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
   NPM_PREFIX="$(npm config get prefix 2>/dev/null)"
   if [ -n "$NPM_PREFIX" ] && [ -x "$NPM_PREFIX/bin/pnpm" ]; then

--- a/setup/lib/setup-config-parse.test.ts
+++ b/setup/lib/setup-config-parse.test.ts
@@ -30,6 +30,17 @@ describe('public setup flags', () => {
     }
   });
 
+  it('adds the uvx install directory before probing npm and executing pnpm', () => {
+    const entrypoint = fs.readFileSync(path.join(process.cwd(), 'nanoclaw.sh'), 'utf8');
+    const localBinRecovery = entrypoint.indexOf('export PATH="$HOME/.local/bin:$PATH"');
+    const npmProbe = entrypoint.indexOf('command -v npm', localBinRecovery);
+    const handoff = entrypoint.indexOf('exec pnpm --silent run setup:auto', npmProbe);
+
+    expect(localBinRecovery).toBeGreaterThan(-1);
+    expect(npmProbe).toBeGreaterThan(localBinRecovery);
+    expect(handoff).toBeGreaterThan(npmProbe);
+  });
+
   it('parses the template path exposed by the entrypoint', () => {
     expect(parseFlags(['--template-path', 'sales/sdr'])).toEqual({
       values: { templatePath: 'sales/sdr' },


### PR DESCRIPTION
Restores the public installer handoff after uvx-nodeenv installs Node and pnpm under ~/.local/bin.

- **Problem**: the bootstrap child updates its own PATH, but the parent launcher cannot find npm or pnpm and exits 127.
- **Fix**: prepend ~/.local/bin once before the npm-prefix fallback and final pnpm exec.

Closes #3769

## Change kind
- [x] `kind/bug`

## Validation
- [x] Tests cover the changed behavior
- `pnpm exec vitest run setup/lib/setup-config-parse.test.ts` - 4 passed
- `bash -n nanoclaw.sh` - passed

## User and release impact
- [x] User-visible change - fresh uvx bootstraps continue into the setup wizard without a shell restart.

## Security and trust boundaries
None. The change only adds the standard per-user executable directory to PATH after the repository bootstrap succeeds.

## Skill delivery
- [x] Not a skill

## AI assistance
- [x] AI tools or agents helped produce this change

- [x] A human has reviewed this PR and stands behind every change