### PR TITLE
fix(setup): fetch explicit registry tracking refs

### DIFF
--- a/docs/skill-directives.md
+++ b/docs/skill-directives.md
@@ -36,7 +36,9 @@ Every directive is idempotent — apply is safe to re-run, per the skills model.
 
 ### `copy [from-branch:<b>]`
 
-Body: one path per line — `PATH` (source == destination) or `SRC -> DST`. Copies the file in; with `from-branch:` the source is fetched from a registry branch (`git show origin/<b>:<path>`). **Idempotency: skip when every destination is present; when any is missing, all listed files are (re)copied — copying overwrites.**
+Body: one path per line — `PATH` (source == destination) or `SRC -> DST`. Copies the file in; with `from-branch:` the source is fetched from a registry branch (`git show refs/remotes/<remote>/<b>:<path>`). **Idempotency: skip when every destination is present; when any is missing, all listed files are (re)copied — copying overwrites.**
+
+Registry copies explicitly fetch `+refs/heads/<b>:refs/remotes/<remote>/<b>` from the selected remote before reading it. This also works in single-branch clones and updates stale registry refs without changing the checkout or its configured fetch mapping. A failed fetch stops the copy; cached registry content is not used as a fallback.
 
 ### `append to:<file> [at:<marker>]`
 

--- a/scripts/git-fetch-branch.ts
+++ b/scripts/git-fetch-branch.ts
@@ -1,0 +1,9 @@
+// Fetch the branch into the ref used by registry copies, even in a single-branch clone.
+function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+export function gitFetchBranchCommand(remote: string, branch: string): string {
+  const refspec = `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`;
+  return `git fetch ${shellQuote(remote)} ${shellQuote(refspec)}`;
+}

--- a/scripts/registry-copy.integration.test.ts
+++ b/scripts/registry-copy.integration.test.ts
@@ -51,8 +51,26 @@ function exec(command: string): string {
   return execSync(command, { cwd: root, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
-function copySkill(source: string, destination: string): void {
-  put(skill, 'SKILL.md', `# Copy fixture\n\n\`\`\`nc:copy from-branch:channels\n${source} -> ${destination}\n\`\`\`\n`);
+function copySkill(source: string, destination: string, branch = 'channels'): void {
+  put(skill, 'SKILL.md', `# Copy fixture\n\n\`\`\`nc:copy from-branch:${branch}\n${source} -> ${destination}\n\`\`\`\n`);
+}
+
+function singleBranchClone(): void {
+  root = join(sandbox, 'single-branch');
+  git(sandbox, 'clone', '--no-local', '--single-branch', '--branch', 'main', registry, root);
+}
+
+function githubInstaller(): () => ReturnType<typeof spawnSync> {
+  mkdirSync(join(root, 'setup'));
+  copyFileSync(new URL('../setup/install-github.sh', import.meta.url), join(root, 'setup/install-github.sh'));
+  put(root, 'test-bin/pnpm', '#!/bin/sh\nprintf "%s\\n" "$*" >> pnpm-called\n');
+  chmodSync(join(root, 'test-bin/pnpm'), 0o755);
+  return () =>
+    spawnSync('bash', ['setup/install-github.sh'], {
+      cwd: root,
+      env: { ...env, PATH: `${join(root, 'test-bin')}:${env.PATH}` },
+      encoding: 'utf8',
+    });
 }
 
 beforeEach(() => {
@@ -71,6 +89,7 @@ beforeEach(() => {
     GIT_COMMITTER_EMAIL: 'copy@example.invalid',
   };
   delete env.NANOCLAW_CHANNELS_REMOTE;
+  vi.stubEnv('NANOCLAW_CHANNELS_REMOTE', '');
   mkdirSync(registry);
   git(registry, 'init', '-b', 'main');
   put(registry, 'package.json', '{"name":"copy-fixture"}\n');
@@ -82,7 +101,10 @@ beforeEach(() => {
   git(sandbox, 'clone', '--no-local', registry, root);
 });
 
-afterEach(() => rmSync(sandbox, { recursive: true, force: true }));
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(sandbox, { recursive: true, force: true });
+});
 
 describe('registry copy failures and retries', () => {
   it.each([false, true])('preserves a skill destination on failure (existing=%s), then retries', async (existing) => {
@@ -136,18 +158,104 @@ describe('registry copy failures and retries', () => {
     expect(existsSync(join(root, 'injected'))).toBe(false);
   });
 
-  it('does not poison install-mode retry when the remote-tracking ref is absent', async () => {
-    git(root, 'config', 'remote.origin.fetch', '+refs/heads/main:refs/remotes/origin/main');
-    git(root, 'update-ref', '-d', 'refs/remotes/origin/channels');
+  it.each(['channels', 'providers'])('materializes %s in a fresh single-branch checkout', async (branch) => {
+    if (branch === 'providers') git(registry, 'branch', branch, 'channels');
+    singleBranchClone();
+    copySkill('payload.ts', 'src/copied.ts', branch);
+    const head = git(root, 'rev-parse', 'HEAD');
+    expect(() => git(root, 'rev-parse', '--verify', `refs/remotes/origin/${branch}`)).toThrow();
+
+    expect(fullyApplied(await applySkill(skill, root, { exec }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+    expect(git(root, 'rev-parse', `refs/remotes/origin/${branch}`)).toBe(git(registry, 'rev-parse', branch));
+    expect(git(root, 'config', '--get-all', 'remote.origin.fetch').trim()).toBe(
+      '+refs/heads/main:refs/remotes/origin/main',
+    );
+    expect(git(root, 'rev-parse', 'HEAD')).toBe(head);
+  });
+
+  it('materializes the selected upstream ref when a fork has only main', async () => {
+    singleBranchClone();
+    git(root, 'fetch', 'origin', 'channels');
+    const stale = git(root, 'rev-parse', 'FETCH_HEAD').trim();
+    git(root, 'update-ref', 'refs/remotes/origin/channels', stale);
+    publish('payload.ts', 'export const upstream = true;\n');
+    const fork = join(sandbox, 'fork.git');
+    git(sandbox, 'clone', '--bare', '--no-local', '--single-branch', '--branch', 'main', registry, fork);
+    git(root, 'remote', 'set-url', 'origin', fork);
+    git(root, 'remote', 'add', '-t', 'main', 'upstream', registry);
     copySkill('payload.ts', 'src/copied.ts');
-    const options = { exec, resolveRemote: () => 'origin' };
+
+    expect(fullyApplied(await applySkill(skill, root, { exec }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('export const upstream = true;\n');
+    expect(git(root, 'rev-parse', 'refs/remotes/upstream/channels')).toBe(git(registry, 'rev-parse', 'channels'));
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels').trim()).toBe(stale);
+  });
+
+  it('quotes the selected remote name when fetching its tracking ref', async () => {
+    singleBranchClone();
+    const remote = "upstream'copy";
+    git(root, 'remote', 'rename', 'origin', remote);
+    copySkill('payload.ts', 'src/copied.ts');
+
+    expect(fullyApplied(await applySkill(skill, root, { exec, resolveRemote: () => remote }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+    expect(git(root, 'rev-parse', `refs/remotes/${remote}/channels`)).toBe(git(registry, 'rev-parse', 'channels'));
+  });
+
+  it('refreshes a stale ref after the registry branch is rewritten', async () => {
+    singleBranchClone();
+    git(root, 'fetch', 'origin', 'channels');
+    git(root, 'update-ref', 'refs/remotes/origin/channels', git(root, 'rev-parse', 'FETCH_HEAD').trim());
+    put(root, 'src/copied.ts', payload);
+    git(registry, 'checkout', '-B', 'channels', 'main');
+    publish('payload.ts', 'export const replaced = true;\n');
+    copySkill('payload.ts', 'src/copied.ts');
+
+    expect(fullyApplied(await applySkill(skill, root, { exec, mode: 'refresh' }))).toBe(true);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('export const replaced = true;\n');
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels')).toBe(git(registry, 'rev-parse', 'channels'));
+  });
+
+  it.each([false, true])('does not copy a stale ref after a failed fetch (existing=%s)', async (existing) => {
+    singleBranchClone();
+    git(root, 'fetch', 'origin', 'channels');
+    git(root, 'update-ref', 'refs/remotes/origin/channels', git(root, 'rev-parse', 'FETCH_HEAD').trim());
+    if (existing) put(root, 'src/copied.ts', 'local content\n');
+    git(root, 'remote', 'set-url', 'origin', join(sandbox, 'unavailable'));
+    copySkill('payload.ts', 'src/copied.ts');
+    const options = { exec, resolveRemote: () => 'origin', mode: 'refresh' as const };
     const failed = await applySkill(skill, root, options);
     expect(fullyApplied(failed)).toBe(false);
-    expect(existsSync(join(root, 'src/copied.ts'))).toBe(false);
-    // Repair the separate CORE-04 prerequisite, then retry without file cleanup.
-    git(root, 'fetch', 'origin', 'channels:refs/remotes/origin/channels');
+    expect(failed.journal).toEqual([]);
+    if (existing) expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('local content\n');
+    else expect(existsSync(join(root, 'src/copied.ts'))).toBe(false);
+
+    publish('payload.ts', 'export const recovered = true;\n');
+    git(root, 'remote', 'set-url', 'origin', registry);
     expect(fullyApplied(await applySkill(skill, root, options))).toBe(true);
-    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe(payload);
+    expect(readFileSync(join(root, 'src/copied.ts'), 'utf8')).toBe('export const recovered = true;\n');
+  });
+
+  it('bootstraps Slack provisioning in a fresh single-branch checkout', async () => {
+    publish(PROVISIONING_MODULE);
+    singleBranchClone();
+    const core = {} as ProvisioningCore;
+    const importModule = vi.fn(async () => core);
+
+    expect(await loadProvisioningCore({ root, exec, importModule })).toBe(core);
+    expect(readFileSync(join(root, PROVISIONING_MODULE), 'utf8')).toBe(payload);
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels')).toBe(git(registry, 'rev-parse', 'channels'));
+  });
+
+  it('installs the GitHub adapter in a fresh single-branch checkout', () => {
+    publish('src/channels/github.ts');
+    singleBranchClone();
+    const run = githubInstaller();
+    expect(run().status).toBe(0);
+    expect(readFileSync(join(root, 'src/channels/github.ts'), 'utf8')).toBe(payload);
+    expect(readFileSync(join(root, 'pnpm-called'), 'utf8')).toContain('run build');
+    expect(git(root, 'rev-parse', 'refs/remotes/origin/channels')).toBe(git(registry, 'rev-parse', 'channels'));
   });
 
   it('retries Slack provisioning after a missing registry file without importing a placeholder', async () => {
@@ -165,21 +273,12 @@ describe('registry copy failures and retries', () => {
   });
 
   it.each([false, true])('preserves the GitHub adapter on failure (existing=%s), then retries', (existing) => {
-    mkdirSync(join(root, 'setup'));
-    copyFileSync(new URL('../setup/install-github.sh', import.meta.url), join(root, 'setup/install-github.sh'));
+    const run = githubInstaller();
     const adapter = 'src/channels/github.ts';
     if (existing) {
       put(root, adapter, 'local adapter\n');
       chmodSync(join(root, adapter), 0o755);
     }
-    put(root, 'test-bin/pnpm', '#!/bin/sh\nprintf "%s\\n" "$*" >> pnpm-called\n');
-    chmodSync(join(root, 'test-bin/pnpm'), 0o755);
-    const run = () =>
-      spawnSync('bash', ['setup/install-github.sh'], {
-        cwd: root,
-        env: { ...env, PATH: `${join(root, 'test-bin')}:${env.PATH}` },
-        encoding: 'utf8',
-      });
     const failed = run();
     expect(failed.status).not.toBe(0);
     if (existing) expect(readFileSync(join(root, adapter), 'utf8')).toBe('local adapter\n');

--- a/scripts/skill-apply.test.ts
+++ b/scripts/skill-apply.test.ts
@@ -214,8 +214,8 @@ describe('from-branch copy apply path', () => {
     // the redirect target's parent now exists, so the exec'd `git show … > dest`
     // (mocked here) would not fail with ENOENT on a real run
     expect(existsSync(join(froot, 'container/skills/demo-formatting'))).toBe(true);
-    expect(cmds).toContain('git fetch origin channels');
-    expect(cmds.some((c) => c.includes("git show 'origin/channels:container/skills/demo-formatting/SKILL.md'"))).toBe(
+    expect(cmds).toContain("git fetch 'origin' '+refs/heads/channels:refs/remotes/origin/channels'");
+    expect(cmds.some((c) => c.includes("git show 'refs/remotes/origin/channels:container/skills/demo-formatting/SKILL.md'"))).toBe(
       true,
     );
     expect(res.journal).toContainEqual({ op: 'wrote', path: 'container/skills/demo-formatting/SKILL.md' });

--- a/scripts/skill-apply.ts
+++ b/scripts/skill-apply.ts
@@ -25,6 +25,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, appendFileSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { gitFetchBranchCommand } from './git-fetch-branch.js';
 import { gitShowToFileCommand } from './git-show-to-file.js';
 import { parseDirectives, promptVar, type Directive } from './skill-directives.js';
 
@@ -651,13 +652,13 @@ async function applyOne(
       if (d.attrs['from-branch']) {
         const b = String(d.attrs['from-branch']);
         const remote = ctx.resolveRemote(b);
-        await exec(`git fetch ${remote} ${b}`);
+        await exec(gitFetchBranchCommand(remote, b));
         for (const l of d.body) {
           // The shell redirect can't create parent directories, and the dest
           // may not exist on trunk (e.g. container skills that live only on
           // the channels branch). Mirror the local-copy path's mkdir.
           mkdirSync(dirname(join(root, destOf(l))), { recursive: true });
-          await exec(gitShowToFileCommand(`${remote}/${b}`, srcOf(l), destOf(l)));
+          await exec(gitShowToFileCommand(`refs/remotes/${remote}/${b}`, srcOf(l), destOf(l)));
         }
       } else {
         for (const l of d.body) {

--- a/scripts/test-registry-skills.ts
+++ b/scripts/test-registry-skills.ts
@@ -28,6 +28,7 @@ import {
   resolveChatCoreVersion,
   validate,
 } from './skill-directives.js';
+import { gitFetchBranchCommand } from './git-fetch-branch.js';
 import { refreshInstalledSkills, resolveRegistryRemote } from './update-skills.js';
 import { verifyProviderContracts } from './provider-contract-verifier.js';
 import { parseProviderDescriptor } from '../setup/providers/skill-descriptor.js';
@@ -329,7 +330,8 @@ async function testSkill(
         if (event.type === 'step-start') current = byLine.get(event.line);
       },
       exec: (cmd) => {
-        if (/^git fetch skill-ci (channels|providers)$/.test(cmd)) return '';
+        // These refs are pinned above; skill-ci is not a network remote here.
+        if ([...REGISTRY_BRANCHES].some((branch) => cmd === gitFetchBranchCommand('skill-ci', branch))) return '';
         const stub = fixture.exec?.find((candidate) => cmd.includes(candidate.match));
         if (stub) return stub.stdout;
         if (current?.kind === 'run' && STUBBED_EFFECTS.has(String(current.attrs.effect))) {

--- a/setup/channels/slack-auto.test.ts
+++ b/setup/channels/slack-auto.test.ts
@@ -190,8 +190,8 @@ describe('provisioning-core bootstrap', () => {
     expect(exec.mock.calls.map(([c]) => c)).toEqual([
       'git remote',
       'git ls-remote --heads origin channels',
-      'git fetch origin channels',
-      expect.stringContaining(`git show 'origin/channels:${PROVISIONING_MODULE}'`),
+      "git fetch 'origin' '+refs/heads/channels:refs/remotes/origin/channels'",
+      expect.stringContaining(`git show 'refs/remotes/origin/channels:${PROVISIONING_MODULE}'`),
     ]);
     // the parent directory exists before the git show redirect runs
     expect(fs.existsSync(path.join(root, 'src/provisioning'))).toBe(true);

--- a/setup/channels/slack-auto.ts
+++ b/setup/channels/slack-auto.ts
@@ -36,6 +36,7 @@ import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
+import { gitFetchBranchCommand } from '../../scripts/git-fetch-branch.js';
 import { gitShowToFileCommand } from '../../scripts/git-show-to-file.js';
 import * as setupLog from '../logs.js';
 import { brightSelect } from '../lib/bright-select.js';
@@ -204,9 +205,9 @@ export async function loadProvisioningCore(deps: BootstrapDeps = {}): Promise<Pr
   try {
     if (!fs.existsSync(modulePath)) {
       const remote = resolveChannelsRemote(exec);
-      exec(`git fetch ${remote} ${CHANNELS_BRANCH}`);
+      exec(gitFetchBranchCommand(remote, CHANNELS_BRANCH));
       fs.mkdirSync(path.dirname(modulePath), { recursive: true });
-      exec(gitShowToFileCommand(`${remote}/${CHANNELS_BRANCH}`, PROVISIONING_MODULE, PROVISIONING_MODULE));
+      exec(gitShowToFileCommand(`refs/remotes/${remote}/${CHANNELS_BRANCH}`, PROVISIONING_MODULE, PROVISIONING_MODULE));
       setupLog.step('slack-provision-bootstrap', 'success', Date.now() - start, { REMOTE: remote });
     }
     return await importModule(pathToFileURL(modulePath).href);

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -26,7 +26,7 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch origin '+refs/heads/channels:refs/remotes/origin/channels'
 
 echo "STEP: copy-files"
 # Publish only a complete Git result; a failed copy must remain retryable.
@@ -37,7 +37,7 @@ echo "STEP: copy-files"
   if [[ -f src/channels/github.ts ]]; then
     cp -p -- src/channels/github.ts "$nc_copy_dir/payload"
   fi
-  git show origin/channels:src/channels/github.ts > "$nc_copy_dir/payload"
+  git show refs/remotes/origin/channels:src/channels/github.ts > "$nc_copy_dir/payload"
   mv -- "$nc_copy_dir/payload" src/channels/github.ts
 )
 


### PR DESCRIPTION
## Summary

Makes registry-backed skill installation work from single-branch clones where the channel or provider tracking ref does not exist locally.

- **Problem**: `git fetch <remote> <branch>` updates `FETCH_HEAD`, but a later `git show <remote>/<branch>:<path>` still fails when the clone has no matching remote-tracking ref.
- **Fix**: fetch the exact branch into `refs/remotes/<remote>/<branch>` in the skill engine, Slack bootstrap, GitHub installer, and registry test helper.
- **Safety**: quote validated Git arguments and force-update only the explicitly named registry tracking ref, so refreshes also handle rewritten registry history.
- **Scope**: this is stacked on #3767 because it extends that PR's real-Git copy tests and safe-copy helper.

## Related work

Depends on #3767. There is no separate public issue; the fresh-clone failure and regression are described here.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- [x] Tests cover the changed behavior (or Validation says why not)
- `pnpm test` — 2,489 passed, one skipped.
- Real-Git registry-copy suite — all 17 cases passed, including absent tracking refs and rewritten registry history.
- `pnpm run build` and setup typecheck passed.
- Fresh single-branch VM — unchanged public wizard completed, actual channels/providers payload install and refresh completed without manual ref repair, and the retained agent replied after service restart.
- Independent review found no actionable issues.

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Registry-backed skills now install and refresh correctly from single-branch clones.
```

## Security and trust boundaries

No credential or permission changes. Remote and branch arguments are shell-quoted, and the forced update is limited to the explicitly requested registry tracking ref.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
