### PR TITLE
fix: persist OneCLI gateway files across restarts

### DIFF
--- a/docs/onecli-upgrades.md
+++ b/docs/onecli-upgrades.md
@@ -81,3 +81,21 @@ onecli --version                                            # verify: must match
 ```
 
 To roll back, run the same block after reverting `versions.json` (or checking out the previous NanoClaw version). The CLI is stateless — vault data lives in the gateway, so swapping the binary in either direction loses nothing.
+
+## Certificate and credential-stub files
+
+The OneCLI provider fetches fresh typed container configuration on every spawn
+and stages its CA, optional combined system trust bundle, and credential stubs
+under `data/onecli/`. It mounts individual files read-only; the directory stays
+private to the host user (mode `0700`), and credential stubs use mode `0600`.
+The SDK's shared temporary paths are not used, so clearing `/tmp` or restarting
+WSL does not remove the bind sources. Existing temporary files or directories
+are left untouched.
+
+Files are named by kind and content hash. Unchanged configuration reuses the
+same files; a rotated CA or stub gets a new path so existing sessions retain
+their original bytes. Old versions are retained because another session may
+still mount them. Do not remove these files while agent containers are running.
+An unexpected file type, owner, permissions, or content stops the spawn instead
+of replacing existing data. A gateway fetch or staging failure also stops the
+spawn; the provider never falls back to a cached credential configuration.

--- a/src/gateway-providers/onecli-files.test.ts
+++ b/src/gateway-providers/onecli-files.test.ts
@@ -1,0 +1,88 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { stageOnecliFile } from './onecli-files.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-onecli-files-'));
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('persistent OneCLI files', () => {
+  it('publishes only a complete file when several processes stage the same content', async () => {
+    const moduleUrl = new URL('./onecli-files.ts', import.meta.url).href;
+    const script = `import {stageOnecliFile} from ${JSON.stringify(moduleUrl)}; console.log(stageOnecliFile(process.argv[1], 'ca', 'CA'.repeat(50000)));`;
+    const outputs = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        promisify(execFile)(process.execPath, ['--import', 'tsx', '--input-type=module', '-e', script, dir]),
+      ),
+    );
+    const destinations = outputs.map((o) => o.stdout.trim());
+    expect(new Set(destinations).size).toBe(1);
+    expect(fs.readFileSync(destinations[0], 'utf8')).toBe('CA'.repeat(50000));
+    expect(fs.readdirSync(path.join(dir, 'onecli'))).toEqual([path.basename(destinations[0])]);
+    expect(fs.statSync(path.join(dir, 'onecli')).mode & 0o777).toBe(0o700);
+  });
+
+  it.each(['directory', 'symlink', 'content', 'permissions'] as const)(
+    'refuses an existing %s collision without replacing it or unrelated files',
+    (collision) => {
+      const file = stageOnecliFile(dir, 'ca', 'CA');
+      const unrelated = path.join(dir, 'keep');
+      fs.writeFileSync(unrelated, 'keep');
+      if (collision === 'permissions') fs.chmodSync(file, 0o666);
+      else if (collision === 'content') fs.writeFileSync(file, 'wrong');
+      else {
+        fs.unlinkSync(file);
+        if (collision === 'directory') fs.mkdirSync(file);
+        else fs.symlinkSync(unrelated, file);
+      }
+      const before = fs.lstatSync(file);
+      expect(() => stageOnecliFile(dir, 'ca', 'CA')).toThrow(/OneCLI staged file/);
+      expect(fs.lstatSync(file).ino).toBe(before.ino);
+      expect(fs.readFileSync(unrelated, 'utf8')).toBe('keep');
+      expect(fs.readdirSync(path.join(dir, 'onecli'))).toEqual([path.basename(file)]);
+    },
+  );
+
+  it('refuses a staged file owned by another user', () => {
+    const file = stageOnecliFile(dir, 'ca', 'CA');
+    const stat = fs.lstatSync;
+    vi.spyOn(fs, 'lstatSync').mockImplementation(((target: fs.PathLike, ...args: unknown[]) => {
+      const result = Reflect.apply(stat, fs, [target, ...args]) as fs.Stats;
+      if (target === file) result.uid += 1;
+      return result;
+    }) as typeof fs.lstatSync);
+    expect(() => stageOnecliFile(dir, 'ca', 'CA')).toThrow(/owner/);
+    expect(fs.readFileSync(file, 'utf8')).toBe('CA');
+  });
+
+  it.each(['symlink', 'permissions'] as const)('refuses an unsafe staging directory: %s', (kind) => {
+    const directory = path.join(dir, 'onecli');
+    if (kind === 'symlink') fs.symlinkSync(dir, directory);
+    else fs.mkdirSync(directory, { mode: 0o755 });
+    expect(() => stageOnecliFile(dir, 'ca', 'CA')).toThrow(/OneCLI file directory/);
+    expect(fs.readdirSync(dir)).toEqual(['onecli']);
+  });
+
+  it('removes only its unpublished temporary file after a failed write', () => {
+    fs.mkdirSync(path.join(dir, 'onecli'), { mode: 0o700 });
+    const unrelated = path.join(dir, 'onecli', '.pending-unrelated');
+    fs.writeFileSync(unrelated, 'keep');
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw Object.assign(new Error('full'), { code: 'ENOSPC' });
+    });
+    expect(() => stageOnecliFile(dir, 'stub', 'sensitive')).toThrow('full');
+    expect(fs.readdirSync(path.join(dir, 'onecli'))).toEqual(['.pending-unrelated']);
+    expect(fs.readFileSync(unrelated, 'utf8')).toBe('keep');
+  });
+});

--- a/src/gateway-providers/onecli-files.test.ts
+++ b/src/gateway-providers/onecli-files.test.ts
@@ -33,19 +33,15 @@ describe('persistent OneCLI files', () => {
     expect(fs.statSync(path.join(dir, 'onecli')).mode & 0o777).toBe(0o700);
   });
 
-  it.each(['directory', 'symlink', 'content', 'permissions'] as const)(
+  it.each(['directory', 'symlink'] as const)(
     'refuses an existing %s collision without replacing it or unrelated files',
     (collision) => {
       const file = stageOnecliFile(dir, 'ca', 'CA');
       const unrelated = path.join(dir, 'keep');
       fs.writeFileSync(unrelated, 'keep');
-      if (collision === 'permissions') fs.chmodSync(file, 0o666);
-      else if (collision === 'content') fs.writeFileSync(file, 'wrong');
-      else {
-        fs.unlinkSync(file);
-        if (collision === 'directory') fs.mkdirSync(file);
-        else fs.symlinkSync(unrelated, file);
-      }
+      fs.unlinkSync(file);
+      if (collision === 'directory') fs.mkdirSync(file);
+      else fs.symlinkSync(unrelated, file);
       const before = fs.lstatSync(file);
       expect(() => stageOnecliFile(dir, 'ca', 'CA')).toThrow(/OneCLI staged file/);
       expect(fs.lstatSync(file).ino).toBe(before.ino);
@@ -53,6 +49,19 @@ describe('persistent OneCLI files', () => {
       expect(fs.readdirSync(path.join(dir, 'onecli'))).toEqual([path.basename(file)]);
     },
   );
+
+  it.each(['content', 'permissions'] as const)('repairs an owned regular file with mismatched %s', (mismatch) => {
+    const file = stageOnecliFile(dir, 'ca', 'CA');
+    const before = fs.lstatSync(file).ino;
+    if (mismatch === 'content') fs.writeFileSync(file, 'wrong');
+    else fs.chmodSync(file, 0o600);
+
+    expect(stageOnecliFile(dir, 'ca', 'CA')).toBe(file);
+    expect(fs.readFileSync(file, 'utf8')).toBe('CA');
+    expect(fs.statSync(file).mode & 0o777).toBe(0o644);
+    expect(fs.lstatSync(file).ino).not.toBe(before);
+    expect(fs.readdirSync(path.join(dir, 'onecli'))).toEqual([path.basename(file)]);
+  });
 
   it('refuses a staged file owned by another user', () => {
     const file = stageOnecliFile(dir, 'ca', 'CA');

--- a/src/gateway-providers/onecli-files.ts
+++ b/src/gateway-providers/onecli-files.ts
@@ -1,0 +1,81 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Keep the SDK's system trust order and its proxy-only fallback.
+const SYSTEM_CA_PATHS = ['/etc/ssl/cert.pem', '/etc/ssl/certs/ca-certificates.crt', '/etc/pki/tls/certs/ca-bundle.crt'];
+
+export function combinedCaBundle(certificate: string): string | undefined {
+  for (const file of SYSTEM_CA_PATHS) {
+    let system: string;
+    try {
+      system = fs.readFileSync(file, 'utf8');
+    } catch (error) {
+      // Unavailable host trust stores are optional, as in the SDK. Do not
+      // include staging here: a failed write must abort the contribution.
+      if (!(error instanceof Error && 'code' in error)) throw error;
+      continue;
+    }
+    return `${system.trimEnd()}\n${certificate.trimEnd()}\n`;
+  }
+}
+
+/**
+ * Content-addressed files remain stable for existing read-only bind mounts.
+ * A new CA/stub publishes a new path; retries reuse it. Never remove old
+ * versions here: another session may still have one mounted.
+ */
+export function stageOnecliFile(dataDir: string, kind: 'ca' | 'combined' | 'stub', content: string): string {
+  const directory = path.join(dataDir, 'onecli');
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryStat = fs.lstatSync(directory);
+  if (
+    !directoryStat.isDirectory() ||
+    directoryStat.uid !== process.getuid?.() ||
+    (directoryStat.mode & 0o777) !== 0o700
+  ) {
+    throw new Error('OneCLI file directory must be owned by the current user with mode 0700');
+  }
+  const digest = createHash('sha256').update(content).digest('hex');
+  const destination = path.join(directory, `${kind}-${digest}${kind === 'stub' ? '' : '.pem'}`);
+  const mode = kind === 'stub' ? 0o600 : 0o644;
+  const validate = () => {
+    const stat = fs.lstatSync(destination);
+    if (!stat.isFile() || stat.uid !== directoryStat.uid || (stat.mode & 0o777) !== mode) {
+      throw new Error('OneCLI staged file has an unexpected type, owner, or permissions');
+    }
+    const fd = fs.openSync(destination, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try {
+      if (fs.readFileSync(fd, 'utf8') !== content) throw new Error('OneCLI staged file content does not match');
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+  try {
+    validate();
+    return destination;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  // Publish a complete file without replacing a concurrent writer's file or
+  // following a symlink. Cleanup is limited to this invocation's temp file.
+  const temporary = path.join(directory, `.pending-${randomUUID()}`);
+  const fd = fs.openSync(temporary, 'wx', mode);
+  try {
+    try {
+      fs.writeFileSync(fd, content);
+      fs.fchmodSync(fd, mode);
+    } finally {
+      fs.closeSync(fd);
+    }
+    try {
+      fs.linkSync(temporary, destination);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    }
+    validate();
+    return destination;
+  } finally {
+    fs.unlinkSync(temporary);
+  }
+}

--- a/src/gateway-providers/onecli-files.ts
+++ b/src/gateway-providers/onecli-files.ts
@@ -39,43 +39,68 @@ export function stageOnecliFile(dataDir: string, kind: 'ca' | 'combined' | 'stub
   const digest = createHash('sha256').update(content).digest('hex');
   const destination = path.join(directory, `${kind}-${digest}${kind === 'stub' ? '' : '.pem'}`);
   const mode = kind === 'stub' ? 0o600 : 0o644;
-  const validate = () => {
+  const validate = (): boolean => {
     const stat = fs.lstatSync(destination);
-    if (!stat.isFile() || stat.uid !== directoryStat.uid || (stat.mode & 0o777) !== mode) {
-      throw new Error('OneCLI staged file has an unexpected type, owner, or permissions');
+    if (!stat.isFile() || stat.uid !== directoryStat.uid) {
+      throw new Error(`OneCLI staged file has an unexpected type or owner: ${destination}`);
     }
     const fd = fs.openSync(destination, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
     try {
-      if (fs.readFileSync(fd, 'utf8') !== content) throw new Error('OneCLI staged file content does not match');
+      return (stat.mode & 0o777) === mode && fs.readFileSync(fd, 'utf8') === content;
     } finally {
       fs.closeSync(fd);
     }
   };
   try {
-    validate();
-    return destination;
+    if (validate()) return destination;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
-  // Publish a complete file without replacing a concurrent writer's file or
-  // following a symlink. Cleanup is limited to this invocation's temp file.
+  // Publish a complete, flushed file with an atomic rename. The temporary and
+  // destination paths share a directory, so rename works on filesystems that
+  // do not support hard links (exFAT, SMB and DrvFs included). Concurrent
+  // writers publish the same content-addressed bytes. A regular file owned by
+  // this user but left incomplete or with the wrong mode is repaired for
+  // future mounts; existing bind mounts keep their old inode.
   const temporary = path.join(directory, `.pending-${randomUUID()}`);
   const fd = fs.openSync(temporary, 'wx', mode);
   try {
     try {
       fs.writeFileSync(fd, content);
       fs.fchmodSync(fd, mode);
+      fs.fsyncSync(fd);
     } finally {
       fs.closeSync(fd);
     }
-    try {
-      fs.linkSync(temporary, destination);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        fs.renameSync(temporary, destination);
+        break;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (!['EEXIST', 'EPERM', 'ENOTEMPTY'].includes(code ?? '')) throw error;
+
+        // Windows does not replace an existing destination with rename. A
+        // concurrent valid publisher wins; an owned regular mismatch is
+        // removed and retried. validate() still refuses symlinks/directories
+        // and files owned by another user.
+        try {
+          if (validate()) return destination;
+          fs.unlinkSync(destination);
+        } catch (validationError) {
+          if ((validationError as NodeJS.ErrnoException).code !== 'ENOENT') throw validationError;
+        }
+        if (attempt === 2) throw new Error(`Could not publish OneCLI staged file: ${destination}`, { cause: error });
+      }
     }
-    validate();
+    if (!validate()) throw new Error(`OneCLI staged file validation failed after publish: ${destination}`);
     return destination;
   } finally {
-    fs.unlinkSync(temporary);
+    try {
+      fs.unlinkSync(temporary);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
   }
 }

--- a/src/gateway-providers/onecli.test.ts
+++ b/src/gateway-providers/onecli.test.ts
@@ -1,54 +1,163 @@
-import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
-vi.mock('../log.js', () => ({
-  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+import type { ContainerConfig } from '@onecli-sh/sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({ ensureAgent: vi.fn(), getContainerConfig: vi.fn(), applyContainerConfig: vi.fn() }));
+vi.mock('@onecli-sh/sdk', () => ({
+  OneCLI: class {
+    constructor() {
+      return sdk;
+    }
+  },
 }));
-vi.mock('../config.js', () => ({ ONECLI_URL: 'http://localhost:1', ONECLI_API_KEY: 'unused' }));
+vi.mock('../log.js', () => ({ log: { info: vi.fn() } }));
+vi.mock('../config.js', () => ({
+  ONECLI_URL: 'http://localhost:1',
+  ONECLI_API_KEY: 'unused',
+  get DATA_DIR() {
+    return path.join(os.tmpdir(), 'data');
+  },
+}));
 
-import { contributionFromArgs } from './onecli.js';
+import { getGatewayProviderFactory, type GatewayProviderInput } from './gateway-provider-registry.js';
+import './onecli.js';
 
-describe('contributionFromArgs', () => {
-  it('types the closed grammar the SDK emits: -e pairs and ro mounts', () => {
-    const contribution = contributionFromArgs(
-      [
-        '-e',
-        'HTTPS_PROXY=http://host.docker.internal:15001',
-        '-e',
-        'SSL_CERT_FILE=/tmp/onecli-combined-ca.pem',
-        '-v',
-        '/tmp/onecli/ca.pem:/usr/local/share/ca.pem:ro',
-        '-v',
-        '/tmp/onecli/stub.json:/workspace/.config/creds.json:ro',
-      ],
-      'g1',
-    );
+const input: GatewayProviderInput = {
+  key: { installSlug: 'test', agentGroupId: 'group-1', sessionId: 'session-1' },
+  groupName: 'Test group',
+  capabilities: {
+    isolationTiers: ['container'],
+    admissionEnforced: true,
+    networkPolicy: 'topology',
+    encryptedVolumes: false,
+    unrealized: [],
+    sharedNetworkNamespace: true,
+    auxiliaryContainers: false,
+    imageBuild: true,
+  },
+};
+const caPath = '/tmp/onecli-proxy-ca.pem';
+const systemPaths = ['/etc/ssl/cert.pem', '/etc/ssl/certs/ca-certificates.crt', '/etc/pki/tls/certs/ca-bundle.crt'];
+let dir: string;
+let config: ContainerConfig;
+const provider = () => getGatewayProviderFactory('onecli')!();
 
-    expect(contribution.env).toEqual({
-      HTTPS_PROXY: 'http://host.docker.internal:15001',
-      SSL_CERT_FILE: '/tmp/onecli-combined-ca.pem',
-    });
-    expect(contribution.mounts).toEqual([
-      {
-        class: 'allowlisted-extra',
-        hostPath: '/tmp/onecli/ca.pem',
-        containerPath: '/usr/local/share/ca.pem',
-        mode: 'ro',
-        groupScope: 'g1',
-      },
-      {
-        class: 'allowlisted-extra',
-        hostPath: '/tmp/onecli/stub.json',
-        containerPath: '/workspace/.config/creds.json',
-        mode: 'ro',
-        groupScope: 'g1',
-      },
-    ]);
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-onecli-test-'));
+  vi.stubEnv('TMPDIR', dir);
+  config = {
+    env: { HTTPS_PROXY: 'http://example.invalid:15001', SSL_CERT_FILE: caPath, DENO_CERT: caPath },
+    caCertificate: 'SYNTHETIC CA\n',
+    caCertificateContainerPath: caPath,
+  };
+  sdk.ensureAgent.mockReset().mockResolvedValue({});
+  sdk.getContainerConfig.mockReset().mockImplementation(async () => config);
+  sdk.applyContainerConfig.mockReset().mockRejectedValue(new Error('legacy temporary CA path'));
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('OneCLI gateway contribution', () => {
+  it('survives a stale legacy CA directory without touching it or changing TMPDIR', async () => {
+    const legacy = path.join(dir, 'onecli-proxy-ca.pem');
+    fs.mkdirSync(legacy);
+    fs.writeFileSync(path.join(legacy, 'unrelated'), 'keep');
+    const result = await provider().contribute(input);
+    expect(sdk.ensureAgent).toHaveBeenCalledWith({ name: 'Test group', identifier: 'group-1' });
+    expect(sdk.getContainerConfig).toHaveBeenCalledWith({ agent: 'group-1' });
+    expect(sdk.applyContainerConfig).not.toHaveBeenCalled();
+    expect(process.env.TMPDIR).toBe(dir);
+    expect(fs.readFileSync(path.join(legacy, 'unrelated'), 'utf8')).toBe('keep');
+    const ca = result.mounts!.find((m) => m.containerPath === caPath)!;
+    expect(ca).toMatchObject({ class: 'allowlisted-extra', mode: 'ro', groupScope: 'group-1' });
+    expect(ca.hostPath.startsWith(path.join(dir, 'data', 'onecli') + path.sep)).toBe(true);
+    expect(fs.readFileSync(ca.hostPath, 'utf8')).toBe(config.caCertificate);
+    expect(fs.lstatSync(ca.hostPath).isFile()).toBe(true);
   });
 
-  it('refuses argv outside the grammar — nothing rides raw around the spec again', () => {
-    // Grammar drift in the SDK must break the spawn loudly, not smuggle flags.
-    expect(() => contributionFromArgs(['--network', 'something'], 'g1')).toThrow(/cannot type/);
-    expect(() => contributionFromArgs(['-v', '/odd'], 'g1')).toThrow(/cannot type/);
-    expect(() => contributionFromArgs(['-v', 'h:c:rw:extra'], 'g1')).toThrow(/cannot type/);
+  it('does not follow a symlink at the old temporary CA path', async () => {
+    const target = path.join(dir, 'unrelated');
+    fs.writeFileSync(target, 'keep');
+    fs.symlinkSync(target, path.join(dir, 'onecli-proxy-ca.pem'));
+    await provider().contribute(input);
+    expect(fs.readFileSync(target, 'utf8')).toBe('keep');
+    expect(fs.lstatSync(path.join(dir, 'onecli-proxy-ca.pem')).isSymbolicLink()).toBe(true);
+  });
+
+  it('preserves SDK env and combines system trust with the proxy certificate', async () => {
+    const read = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation(((file: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (file === systemPaths[0]) return 'SYSTEM CA\n\n';
+      return Reflect.apply(read, fs, [file, ...args]);
+    }) as typeof fs.readFileSync);
+    const result = await provider().contribute(input);
+    expect(result.env).toEqual({
+      HTTPS_PROXY: 'http://example.invalid:15001',
+      SSL_CERT_FILE: '/tmp/onecli-combined-ca.pem',
+      DENO_CERT: '/tmp/onecli-combined-ca.pem',
+    });
+    const bundle = result.mounts!.find((m) => m.containerPath === '/tmp/onecli-combined-ca.pem')!;
+    expect(fs.readFileSync(bundle.hostPath, 'utf8')).toBe('SYSTEM CA\nSYNTHETIC CA\n');
+    expect(config.env.SSL_CERT_FILE).toBe(caPath);
+  });
+
+  it('keeps the SDK fallback when no host system trust bundle can be read', async () => {
+    const read = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation(((file: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (typeof file === 'string' && systemPaths.includes(file))
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+      return Reflect.apply(read, fs, [file, ...args]);
+    }) as typeof fs.readFileSync);
+    const result = await provider().contribute(input);
+    expect(result.env).toEqual(config.env);
+    expect(result.mounts).toHaveLength(1);
+  });
+
+  it('stages credential stubs independently even when container basenames match', async () => {
+    config.credentialStubs = [
+      { containerPath: '/first/credentials.json', content: 'FIRST' },
+      { containerPath: '/second/credentials.json', content: 'SECOND' },
+    ];
+    const result = await provider().contribute(input);
+    const stubs = result.mounts!.filter((m) => m.containerPath.endsWith('credentials.json'));
+    expect(stubs).toHaveLength(2);
+    expect(stubs[0].hostPath).not.toBe(stubs[1].hostPath);
+    expect(stubs.map((m) => fs.readFileSync(m.hostPath, 'utf8'))).toEqual(['FIRST', 'SECOND']);
+    for (const stub of stubs) expect(fs.statSync(stub.hostPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('reuses unchanged files and preserves previous mounts when the CA rotates', async () => {
+    const first = await provider().contribute(input);
+    const second = await provider().contribute({ ...input, key: { ...input.key, sessionId: 'session-2' } });
+    expect(first.mounts).toEqual(second.mounts);
+    const before = first.mounts!.map((m) => fs.readFileSync(m.hostPath, 'utf8'));
+    config.caCertificate = 'ROTATED CA\n';
+    const rotated = await provider().contribute(input);
+    expect(rotated.mounts![0].hostPath).not.toBe(first.mounts![0].hostPath);
+    expect(first.mounts!.map((m) => fs.readFileSync(m.hostPath, 'utf8'))).toEqual(before);
+    expect(fs.readFileSync(rotated.mounts![0].hostPath, 'utf8')).toBe('ROTATED CA\n');
+    expect(sdk.getContainerConfig).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed when registration or configuration fetching fails, even after a successful spawn', async () => {
+    await provider().contribute(input);
+    sdk.getContainerConfig.mockRejectedValueOnce(new Error('gateway unavailable'));
+    await expect(provider().contribute(input)).rejects.toThrow('gateway unavailable');
+    sdk.ensureAgent.mockRejectedValueOnce(new Error('registration rejected'));
+    await expect(provider().contribute(input)).rejects.toThrow('registration rejected');
+    expect(sdk.getContainerConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when persistent staging is blocked', async () => {
+    fs.mkdirSync(path.join(dir, 'data'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'data', 'onecli'), 'unrelated');
+    await expect(provider().contribute(input)).rejects.toThrow();
+    expect(fs.readFileSync(path.join(dir, 'data', 'onecli'), 'utf8')).toBe('unrelated');
   });
 });

--- a/src/gateway-providers/onecli.ts
+++ b/src/gateway-providers/onecli.ts
@@ -1,23 +1,11 @@
 /**
- * OneCLI — the built-in gateway provider.
- *
- * The same wiring the spawn path always did (ensure the agent exists
- * gateway-side, fetch the per-session container config, treat "not applied" as
- * a transient hard failure), with one change: the contribution crosses into
- * the spec as TYPED env and mounts, merged before validation, instead of raw
- * docker flags appended after it.
- *
- * The SDK's apply surface still emits argv, so this provider parses it at the
- * boundary. The grammar is closed and known from the SDK source: with
- * `addHostMapping: false` it emits exactly `-e KEY=VALUE` pairs (proxy env,
- * CA bundle pointers) and `-v host:container[:ro]` mounts (the CA
- * certificate, credential stub FILES — stubs never ride env). Anything else
- * refuses the spawn: nothing gets to ride raw argv around the spec again. A
- * typed SDK config surface is the successor that deletes this parser.
+ * OneCLI contributes typed environment and read-only file mounts, before spec
+ * validation. Persist its CA and credential stubs across host restarts; the
+ * SDK's argv helper stages shared paths in the host temporary directory.
  */
-import { OneCLI } from '@onecli-sh/sdk';
+import { OneCLI, type ContainerConfig } from '@onecli-sh/sdk';
 
-import { ONECLI_API_KEY, ONECLI_URL } from '../config.js';
+import { DATA_DIR, ONECLI_API_KEY, ONECLI_URL } from '../config.js';
 import type { MountSpec } from '../drivers/types.js';
 import { log } from '../log.js';
 
@@ -28,36 +16,33 @@ import {
   type GatewayContribution,
 } from './gateway-provider-registry.js';
 
+import { combinedCaBundle, stageOnecliFile } from './onecli-files.js';
+
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
-/** Argv → typed contribution. Exported for its tests; the grammar is closed. */
-export function contributionFromArgs(args: readonly string[], groupScope: string): GatewayContribution {
-  const env: Record<string, string> = {};
+/** Convert the typed SDK response without its shared temporary-file side effects. */
+function contributionFromConfig(config: ContainerConfig, groupScope: string): GatewayContribution {
+  const env = { ...config.env };
   const mounts: MountSpec[] = [];
-  for (let i = 0; i < args.length; i += 2) {
-    const flag = args[i];
-    const value = args[i + 1];
-    if (flag === '-e' && value?.includes('=')) {
-      const eq = value.indexOf('=');
-      env[value.slice(0, eq)] = value.slice(eq + 1);
-      continue;
-    }
-    if (flag === '-v' && value) {
-      const parts = value.split(':');
-      if (parts.length >= 2 && parts.length <= 3 && (parts[2] === undefined || parts[2] === 'ro')) {
-        mounts.push({
-          class: 'allowlisted-extra',
-          hostPath: parts[0],
-          containerPath: parts[1],
-          mode: parts[2] === 'ro' ? 'ro' : 'rw',
-          groupScope,
-        });
-        continue;
-      }
-    }
-    // Fail-closed on grammar drift: an SDK that starts emitting a flag this
-    // parser cannot type must break the spawn loudly, not smuggle argv.
-    throw new Error(`OneCLI gateway emitted argv this seam cannot type: '${flag} ${value ?? ''}'`);
+  const mount = (kind: 'ca' | 'combined' | 'stub', content: string, containerPath: string) => {
+    mounts.push({
+      class: 'allowlisted-extra',
+      hostPath: stageOnecliFile(DATA_DIR, kind, content),
+      containerPath,
+      mode: 'ro',
+      groupScope,
+    });
+  };
+  mount('ca', config.caCertificate, config.caCertificateContainerPath);
+  const combined = combinedCaBundle(config.caCertificate);
+  if (combined !== undefined) {
+    const containerPath = '/tmp/onecli-combined-ca.pem';
+    mount('combined', combined, containerPath);
+    env.SSL_CERT_FILE = containerPath;
+    env.DENO_CERT = containerPath;
+  }
+  for (const stub of config.credentialStubs ?? []) {
+    mount('stub', stub.content, stub.containerPath);
   }
   return { env, mounts };
 }
@@ -89,12 +74,9 @@ registerGatewayProvider('onecli', () => ({
     // OneCLI agent identifier is always the agent group id — stable across
     // sessions and reversible via getAgentGroup() for approval routing.
     await onecli.ensureAgent({ name: groupName, identifier: key.agentGroupId });
-    const args: string[] = [];
-    const applied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: key.agentGroupId });
-    if (!applied) {
-      throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
-    }
+    const config = await onecli.getContainerConfig({ agent: key.agentGroupId });
+    const contribution = contributionFromConfig(config, key.agentGroupId);
     log.info('OneCLI gateway applied', { agentGroupId: key.agentGroupId, sessionId: key.sessionId });
-    return contributionFromArgs(args, key.agentGroupId);
+    return contribution;
   },
 }));


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Keeps OneCLI certificate and credential-stub mounts usable after host temporary files disappear.

- **Problem**: Docker can recreate a missing temporary CA file as a root-owned directory. The SDK then throws `EISDIR`, preventing fresh agent launches.
- **Fix**: fetch the existing SDK's typed configuration and stage immutable files under `data/onecli/`, mounting each file read-only.
- **Lifecycle**: unchanged content reuses files; rotated content gets a new path so running sessions retain their original files. The host trust bundle and credential-stub behavior are preserved.

## Related work

Adapts the recovery intent of https://github.com/nanocoai/nanoclaw/pull/3027 by [caburi00](https://github.com/caburi00) to the current gateway-provider boundary. That PR currently conflicts with `main`. This is a focused port with regression tests and live restart evidence.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run src/gateway-providers/onecli.test.ts src/gateway-providers/onecli-files.test.ts` → 17 passed, including concurrent publication, rotation, unsafe path collisions, trust-bundle parity, and same-basename credential stubs.
- `pnpm test` → 2,488 passed, 1 skipped. `pnpm run typecheck`, `pnpm run build`, `pnpm run lint`, and `pnpm run format:check` passed.
- Pinned SDK 2.2.1 baseline reproduced `EISDIR` with a directory at its legacy CA path.
- Windows/WSL fixture at `705c6b9e627ac36a8b4bbc280e5804c6debf9a25`, with the exact five reviewed files applied: a fresh agent returned the correct computed answer while the legacy CA path remained a root-owned directory. Its baseline provider matched the PR base by file hash.
- Real replies passed after WSL recovery and after a Windows reboot. Both persistent CA files retained their hashes and permissions; inspection confirmed the post-reboot container mounted them read-only from `data/onecli/`.
- **Runtime prerequisite**: WSL termination removed the Docker socket, requiring `docker desktop restart` before the recovery reply. After Windows reboot, Docker Desktop was launched normally. This does not establish unattended Docker Desktop recovery.
- Independent agent review found no actionable issues.

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Keep OneCLI certificate and credential-stub mounts available across host restarts and temporary-directory cleanup.
```

## Security and trust boundaries

The staging directory is host-owned with mode `0700`; credential stubs use `0600`. Only individual files are mounted, read-only, through the existing typed mount-validation boundary. Unexpected file types, ownership, permissions, or contents abort the spawn. Gateway fetch or staging failures also abort; cached credentials are not used. Existing temporary paths are left untouched, and published file versions are retained for running sessions.

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change

Implemented and independently reviewed with Codex. Human review is pending; this PR is a draft.

