### PR TITLE
gateway providers: pass the session's container name in the provider input

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -337,6 +337,7 @@ async function spawnContainer(session: Session): Promise<void> {
   const gateway = await getGatewayProvider().contribute({
     key: { installSlug: INSTALL_SLUG, agentGroupId: agentGroup.id, sessionId: session.id },
     groupName: agentGroup.name,
+    containerName,
     capabilities: driver.capabilities(),
   });
   if (gateway.containers?.length && !driver.capabilities().auxiliaryContainers) {

--- a/src/gateway-providers/gateway-provider-registry.ts
+++ b/src/gateway-providers/gateway-provider-registry.ts
@@ -42,6 +42,8 @@ export interface GatewayProviderInput {
   key: SessionKey;
   /** The agent group's display name — gateway-side agent registration wants it. */
   groupName: string;
+  /** The runtime container this session runs in, as the driver named it; providers key per-session resources on it. */
+  containerName: string;
   /**
    * The selected driver's capabilities. `sharedNetworkNamespace` decides the
    * proxy URL shape a contribution puts in the agent's env; a provider that

--- a/src/gateway-providers/onecli.test.ts
+++ b/src/gateway-providers/onecli.test.ts
@@ -28,6 +28,7 @@ import './onecli.js';
 const input: GatewayProviderInput = {
   key: { installSlug: 'test', agentGroupId: 'group-1', sessionId: 'session-1' },
   groupName: 'Test group',
+  containerName: 'nanoclaw-v2-agent-group-1-session-1',
   capabilities: {
     isolationTiers: ['container'],
     admissionEnforced: true,


### PR DESCRIPTION
## What

- `GatewayProviderInput` gains a required `containerName: string` field, placed beside `key` and `groupName`.
- The single call site in `src/container-runner.ts` passes the container name it already computes for the session.
- The one fixture that constructs a `GatewayProviderInput` (`src/gateway-providers/onecli.test.ts`) is updated.

## Why

Providers that create per-session gateway resources (client identities, sockets, files) key them on the runtime's container name so they can name them and reconcile them later. Today a provider that wants that name has to re-derive it. Passing it in the input removes the re-derivation and makes the container name part of the provider contract.

## Tests

```
pnpm install --frozen-lockfile
pnpm run typecheck
pnpm exec vitest run src/gateway-providers/onecli.test.ts
pnpm exec vitest run src/container-runner.test.ts src/container-runner.claims.test.ts src/gateway-providers/onecli-files.test.ts
pnpm exec prettier --check src/gateway-providers/gateway-provider-registry.ts src/container-runner.ts src/gateway-providers/onecli.test.ts
pnpm exec eslint src/gateway-providers/gateway-provider-registry.ts src/container-runner.ts src/gateway-providers/onecli.test.ts
```

Typecheck clean. 8/8 in the touched test file and 46/46 across the container-runner and onecli-files tests. Prettier clean. ESLint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
